### PR TITLE
common: it's no longer valid to call getAllGear for empty units

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -82,7 +82,10 @@ enableCamShake true;
 
 }] call FUNC(addEventhandler);
 
-GVAR(OldPlayerInventory) = [ACE_player] call FUNC(getAllGear);
+GVAR(OldPlayerInventory) = objNull;
+if !(isNull ACE_player) then {
+    GVAR(OldPlayerInventory) = [ACE_player] call FUNC(getAllGear);
+};
 GVAR(OldPlayerVisionMode) = currentVisionMode ACE_player;
 GVAR(OldZeusDisplayIsOpen) = !(isNull findDisplay 312);
 GVAR(OldCameraView) = cameraView;
@@ -93,12 +96,15 @@ GVAR(OldPlayerTurret) = [ACE_player] call FUNC(getTurretIndex);
 [{
 
     // "playerInventoryChanged" event
-    _newPlayerInventory = [ACE_player] call FUNC(getAllGear);
-    if !(_newPlayerInventory isEqualTo GVAR(OldPlayerInventory)) then {
+    _newPlayerInventory = objNull;
+    if !(isNull ACE_player) then {
+        _newPlayerInventory = [ACE_player] call FUNC(getAllGear);
+
+        if !(_newPlayerInventory isEqualTo GVAR(OldPlayerInventory)) then {
         // Raise ACE event locally
-        GVAR(OldPlayerInventory) = _newPlayerInventory;
         ["playerInventoryChanged", [ACE_player, _newPlayerInventory]] call FUNC(localEvent);
     };
+    GVAR(OldPlayerInventory) = _newPlayerInventory;
 
     // "playerVisionModeChanged" event
     _newPlayerVisionMode = currentVisionMode ACE_player;

--- a/addons/common/functions/fnc_getAllGear.sqf
+++ b/addons/common/functions/fnc_getAllGear.sqf
@@ -13,8 +13,6 @@
 
 EXPLODE_1_PVT(_this,_unit);
 
-if (isNull _unit) exitWith {[]};
-
 [
     (headgear _unit),
     (goggles _unit),


### PR DESCRIPTION
Cleaner but less convenient?
