### PR TITLE
Fixes for fcs

### DIFF
--- a/addons/medical/functions/fnc_actionCheckBloodPressure.sqf
+++ b/addons/medical/functions/fnc_actionCheckBloodPressure.sqf
@@ -1,0 +1,18 @@
+/*
+* Author: Glowbal
+* Action for checking the blood pressure of the patient
+*
+* Arguments:
+* 0: The medic <OBJECT>
+* 1: The patient <OBJECT>
+*
+* Return Value:
+* NONE
+*
+* Public: No
+*/
+#include "script_component.hpp"
+private ["_caller","_target"];
+_caller = _this select 0;
+_target = _this select 1;
+[[_caller, _target], QUOTE(DFUNC(actionCheckBloodPressureLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */

--- a/addons/medical/functions/fnc_actionCheckBloodPressureLocal.sqf
+++ b/addons/medical/functions/fnc_actionCheckBloodPressureLocal.sqf
@@ -1,0 +1,60 @@
+/*
+ * Author: Glowbal
+ * Local callback for checking the blood pressure of a patient
+ *
+ * Arguments:
+ * 0: The medic <OBJECT>
+ * 1: The patient <OBJECT>
+ *
+ * Return Value:
+ * NONE
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+
+private ["_caller","_target","_bloodPressure","_bloodPressureHigh","_bloodPressureLow","_title","_content"];
+_caller = _this select 0;
+_target = _this select 1;
+
+_bloodPressure = [_target] call FUNC(getBloodPressure);
+if (!alive _target) then {
+    _bloodPressure = [0,0];
+};
+
+_bloodPressureHigh = _bloodPressure select 1;
+_bloodPressureLow = _bloodPressure select 0;
+_output = "";
+_logOutPut = "";
+if ([_caller] call FUNC(isMedic)) then {
+    _output = "STR_ACE_MEDICAL_CHECK_BLOODPRESSURE_OUTPUT_1";
+    _logOutPut = format["%1/%2",round(_bloodPressureHigh),round(_bloodPressureLow)];
+} else {
+    if (_bloodPressureHigh > 20) then {
+        _output = "STR_ACE_MEDICAL_CHECK_BLOODPRESSURE_OUTPUT_2";
+        _logOutPut = "Low";
+        if (_bloodPressureHigh > 100) then {
+            _output = "STR_ACE_MEDICAL_CHECK_BLOODPRESSURE_OUTPUT_3";
+            _logOutPut = "Normal";
+            if (_bloodPressureHigh > 160) then {
+                _output = "STR_ACE_MEDICAL_CHECK_BLOODPRESSURE_OUTPUT_4";
+                _logOutPut = "High";
+            };
+
+        };
+    } else {
+        if (random(10) > 3) then {
+            _output = "STR_ACE_MEDICAL_CHECK_BLOODPRESSURE_OUTPUT_5";
+            _logOutPut = "No Blood Pressure";
+        } else {
+            _output = "STR_ACE_MEDICAL_CHECK_BLOODPRESSURE_OUTPUT_6";
+        };
+    };
+};
+
+["displayTextStructured", [_caller], [[_output, [_target] call EFUNC(common,getName), round(_bloodPressureHigh),round(_bloodPressureLow)], 1.75, _caller]] call EFUNC(common,targetEvent);
+
+if (_logOutPut != "") then {
+    [_target,"examine", format["%1 checked Blood Pressure: %2", [_caller] call EFUNC(common,getName), _logOutPut]] call FUNC(addToLog);
+};

--- a/addons/medical/functions/fnc_actionCheckPulse.sqf
+++ b/addons/medical/functions/fnc_actionCheckPulse.sqf
@@ -1,0 +1,18 @@
+/*
+* Author: Glowbal
+* Action for checking the pulse or heart rate of the patient
+*
+* Arguments:
+* 0: The medic <OBJECT>
+* 1: The patient <OBJECT>
+*
+* Return Value:
+* NONE
+*
+* Public: No
+*/
+#include "script_component.hpp"
+private ["_caller","_target","_title","_content"];
+_caller = _this select 0;
+_target = _this select 1;
+[[_caller, _target], QUOTE(DFUNC(actionCheckPulseLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */


### PR DESCRIPTION
Found multiple bugs in FCS, that I tried to adress here:
- You could adjust range up/down even if you didn't have a fcs (as long as your weapon had a rangefinder).
- There were **a lot** of `call` statement missing before `FUNC(XX)`. TBH, the keybinds kinda worked out of shear luck.
- Laser distance was recomputed when adjusting the range manually (unneccesary).
- You couldn't configure FCSs for static weapons.
- The Vector was blocking FCS keyUp EH from triggering (at least on my machine).

Even with all this fixed, the FCS extension still works like crap for me (the same or worst than I reported on https://github.com/KoffeinFlummi/ACE3/issues/65):
- The aiming is not accurate.
- I've observed multiple times how changing the range manually (while keeping the turret steady) sometimes changes the lateral deflection!
- a LOT of crashes
