### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+


### PR DESCRIPTION
For those not familiar, this is a file added to the root of the project which tells various text editors (if the corresponding plugin is installed) and allows you to easily switch between, say, AGM and ACE or ACRE and ACE or CSE and ACE without having to memorize different standards.

Plugins are available for everything from Notepad++ to vim: https://github.com/editorconfig/
