### PR TITLE
Map styling

### DIFF
--- a/addons/map/MapTweaks.hpp
+++ b/addons/map/MapTweaks.hpp
@@ -1,0 +1,38 @@
+// Hide Bushes
+class Bush {
+    icon = "";
+    color[] = {0.450000, 0.640000, 0.330000, 0.0};
+    size = 14;
+    importance = "0.2 * 14 * 0.05";
+    coefMin = 0.250000;
+    coefMax = 4;
+};
+
+// Hide Trees
+class SmallTree {
+    icon = "";
+    color[] = {0.450000, 0.640000, 0.330000, 0.0};
+    size = 12;
+    importance = "0.6 * 12 * 0.05";
+    coefMin = 0.250000;
+    coefMax = 4;
+};
+class Tree {
+    icon = "";
+    color[] = {0.450000, 0.640000, 0.330000, 0.0};
+    size = 12;
+    importance = "0.9 * 16 * 0.05";
+    coefMin = 0.250000;
+    coefMax = 4;
+};
+
+class Legend {
+    x = SafeZoneX+SafeZoneW-.340;
+    y = SafeZoneY+SafeZoneH-.152;
+    font = "PuristaMedium";
+    w = .340;
+    h = .152;
+    sizeEx = 0.039210;
+    colorBackground[] = {0.906000, 0.901000, 0.880000, 0.5};
+    color[] = {0, 0, 0, 0.75};
+};

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -50,11 +50,39 @@ class ACE_Settings {
 
 
 class RscMapControl {
+  maxSatelliteAlpha = 0.5;
+
+  // From Arma 2
+  colorTracks[] = {1.0,0.0,0.0,1};
+  colorTracksFill[] = {1.0,1.0,0.0,1};
+  colorRoads[] = {0.0,0.0,0.0,1};
+  colorRoadsFill[] = {1,1,0,1};
+  colorMainRoads[] = {0.0,0.0,0.0,1};
+  colorMainRoadsFill[] = {1,0.6,0.4,1};
+  colorRailWay[] = {0.8,0.2,0,1};
+
+  // From ACE2
+  colorBackground[] = {0.929412, 0.929412, 0.929412, 1.0};
+  colorOutside[] = {0.929412, 0.929412, 0.929412, 1.0};
+  colorCountlines[] = {0.647059, 0.533333, 0.286275, 1};
+  colorMainCountlines[] = {0.858824, 0, 0,1};
+  colorForest[] = {0.6, 0.8, 0.2, 0.25};
+  colorLevels[] = {0.0, 0.0, 0.0, 1.0};
+  colorRocks[] = {0.50, 0.50, 0.50, 0.50};
+
+  sizeExLevel = 0.03;
+  showCountourInterval = 1; // refs #13673
+
   sizeExGrid = 0.032;
 };
 
 // REGULAR MAP
 class RscDisplayMainMap {
+  class controlsBackground {
+    class CA_Map : RscMapControl {
+      #include "MapTweaks.hpp"
+    };
+  };
   // get rid of the "center to player position" - button (as it works even on elite)
   class controls {
     class TopRight: RscControlsGroup {


### PR DESCRIPTION
Ported from ACE2 `sys_map`:
- Bring scale legend to ingame map
- Tweak map colors to make them exactly the same as ACE2 (had to import road colors directly from Arma 2, cause ACE just used defaults).
- Hide bushes and trees from the ingame map (they remain visible on the editor)
- Keep sattelite texture toogable, but with a opacity of 50%.

![map](https://cloud.githubusercontent.com/assets/7674951/6648447/92def5e4-c9b8-11e4-8467-dad36a2b6145.jpg)

![maptext](https://cloud.githubusercontent.com/assets/7674951/6648482/edaa1a3a-c9b8-11e4-8db2-fc3a704786c8.jpg)

Vanilla for comparison:

![mapvanilla](https://cloud.githubusercontent.com/assets/7674951/6648528/77532024-c9b9-11e4-82ca-2b8087d4d664.jpg)
