### PR TITLE
Move main interactions to pelvis; leave torso for medical

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -31,7 +31,7 @@ class CfgVehicles {
         condition = QUOTE(true);
         statement = "";
         icon = "\a3\ui_f\data\IGUI\Cfg\Actions\eject_ca.paa";
-        selection = "spine3";
+        selection = "pelvis";
 
         class ACE_TeamManagement {
           displayName = "$STR_ACE_Interaction_TeamManagement";
@@ -140,45 +140,52 @@ class CfgVehicles {
           enableInside = 1;
         };
       };
+      class ACE_Torso {
+        displayName = "$STR_ACE_Interaction_Torso";
+        selection = "spine3";
+        distance = 1.50;
+        condition = "";
+        statement = "";
+      };
       class ACE_Head {
         displayName = "$STR_ACE_Interaction_Head";
         selection = "pilot";
-        distance = 2.0;
+        distance = 1.50;
         condition = "";
         statement = "";
       };
       class ACE_ArmLeft {
         displayName = "$STR_ACE_Interaction_ArmLeft";
         selection = "LeftForeArm";
-        distance = 2.0;
+        distance = 1.50;
         condition = "";
         statement = "";
       };
       class ACE_ArmRight {
         displayName = "$STR_ACE_Interaction_ArmRight";
         selection = "RightForeArm";
-        distance = 2.0;
+        distance = 1.50;
         condition = "";
         statement = "";
       };
       class ACE_LegLeft {
         displayName = "$STR_ACE_Interaction_LegLeft";
         selection = "LKnee";
-        distance = 2.0;
+        distance = 1.50;
         condition = "";
         statement = "";
       };
       class ACE_LegRight {
         displayName = "$STR_ACE_Interaction_LegRight";
         selection = "RKnee";
-        distance = 2.0;
+        distance = 1.50;
         condition = "";
         statement = "";
       };
       class ACE_Weapon {
         displayName = "$STR_ACE_Interaction_Weapon";
         selection = "weapon";
-        distance = 2.0;
+        distance = 1.50;
         condition = "";
         statement = "";
       };

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -5,6 +5,9 @@
     <Key ID="STR_ACE_Interaction_MainAction">
       <English>Interactions &gt;&gt;</English>
     </Key>
+    <Key ID="STR_ACE_Interaction_Torso">
+      <English>Torso &gt;&gt;</English>
+    </Key>
     <Key ID="STR_ACE_Interaction_Head">
       <English>Head &gt;&gt;</English>
     </Key>

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -402,7 +402,7 @@ class CfgVehicles {
                     statement = QUOTE([ARR_4(_player, _target, 'head', 'CheckResponse')] call DFUNC(treatment));
                 };
             };
-            class ACE_MainActions {
+            class ACE_Torso {
                 class Medical {
                     displayName = "Medical";
                     distance = 5.0;


### PR DESCRIPTION
By request of the medical guys. It helps to keep main actions (which aren't used that often) into a slightly less populated part of the model
