### PR TITLE
close all dialogs

### DIFF
--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -13,7 +13,7 @@
 #include "script_component.hpp"
 
 if(!GVAR(keyDown)) then {
-    closeDialog 0;
+    while {dialog} do {closeDialog 0};
 
     // Only interact with others if on foot
     if (vehicle ACE_player != ACE_player) exitWith {};

--- a/addons/interact_menu/functions/fnc_keyDownSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_keyDownSelfAction.sqf
@@ -13,7 +13,7 @@
 #include "script_component.hpp"
 
 if(!GVAR(keyDownSelfAction)) then {
-    closeDialog 0;
+    while {dialog} do {closeDialog 0};
 
     GVAR(keyDownSelfAction) = true;
     GVAR(keyDown) = false;


### PR DESCRIPTION
This closes all dialogs instead of only the currently active one. Most of BI's menues are spawned (pause menu, TeamSwitch) and therefore it's possible to have multiple opened. Also mission makers...
