### PR TITLE
Stronger shadow for the interact_menu text

### DIFF
--- a/addons/interact_menu/functions/fnc_renderIcon.sqf
+++ b/addons/interact_menu/functions/fnc_renderIcon.sqf
@@ -35,7 +35,7 @@ GVAR(iconCount) = GVAR(iconCount) + 1;
 if(_icon == "") then {
     _icon = DEFAULT_ICON;
 };
-_text = format ["<img image='%1' color='%2' align='center'/><br/><t color='%3' size='0.80' align='center'>%4</t>", _icon, _color, _color, _text];
+_text = format ["<img image='%1' color='%2' align='center'/><br/><t color='%3' size='0.80' align='center' shadow='1' shadowColor='#000000' shadowOffset='0.07'>%4</t>", _icon, _color, _color, _text];
 _ctrl ctrlSetStructuredText (parseText _text);
 _ctrl ctrlSetPosition [(_sPos select 0)-(0.125*SafeZoneW), (_sPos select 1)-(0.0095*SafeZoneW), 0.25*SafeZoneW, 0.1*SafeZoneW];
 //_ctrl ctrlSetBackgroundColor [1, 0, 0, 0.1];


### PR DESCRIPTION
It enhanced the readability on bright light conditions, while IMO looking a bit more ugly. I'd say we should keep it for usability's sake.

Before:
![arma3 2015-04-04 00-51-59-601](https://cloud.githubusercontent.com/assets/7674951/6991371/d685efb4-da66-11e4-837a-d7170e04c2b6.jpg)

After:
![arma3 2015-04-04 00-56-29-609](https://cloud.githubusercontent.com/assets/7674951/6991372/d779f2d0-da66-11e4-8699-26b2d7997cc4.jpg)
