### PR TITLE
fix shitty initSpeed definitions breaking SD mags, fix #182

### DIFF
--- a/addons/magazines/CfgEventHandlers.hpp
+++ b/addons/magazines/CfgEventHandlers.hpp
@@ -1,0 +1,13 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_FiredBIS_EventHandlers {
+    class AllVehicles {
+        class ADDON {
+            firedBIS = QUOTE(_this call FUNC(forceMagazineMuzzleVelocity));
+        };
+    };
+};

--- a/addons/magazines/CfgMagazines.hpp
+++ b/addons/magazines/CfgMagazines.hpp
@@ -22,6 +22,7 @@ class CfgMagazines {
         descriptionShort = "$STR_ACE_30Rnd_65x39_caseless_mag_SDDescription";
         picture = "\A3\weapons_f\data\ui\m_30stanag_caseless_green_CA.paa";
         initSpeed = 320;
+        GVAR(forceMagazineMuzzleVelocity) = 1;
     };
 
     class ACE_30Rnd_65x39_caseless_mag_AP: 30Rnd_65x39_caseless_mag {
@@ -57,6 +58,7 @@ class CfgMagazines {
         displayNameShort = "$STR_ACE_30Rnd_65x39_caseless_green_mag_SDNameShort";
         descriptionShort = "$STR_ACE_30Rnd_65x39_caseless_green_mag_SDDescription";
         initSpeed = 320;
+        GVAR(forceMagazineMuzzleVelocity) = 1;
     };
 
     class ACE_30Rnd_65x39_caseless_green_mag_AP: 30Rnd_65x39_caseless_green {
@@ -88,6 +90,7 @@ class CfgMagazines {
         displayNameShort = "$STR_ACE_30Rnd_556x45_mag_SDNameShort";
         descriptionShort = "$STR_ACE_30Rnd_556x45_mag_SDDescription";
         initSpeed = 320;
+        GVAR(forceMagazineMuzzleVelocity) = 1;
         picture = "\A3\weapons_f\data\ui\m_30stanag_green_ca.paa";
     };
 
@@ -127,6 +130,7 @@ class CfgMagazines {
         displayNameShort = "$STR_ACE_20Rnd_762x51_mag_SDNameShort";
         descriptionShort = "$STR_ACE_20Rnd_762x51_mag_SDDescription";
         initSpeed = 320;
+        GVAR(forceMagazineMuzzleVelocity) = 1;
     };
 
     class ACE_20Rnd_762x51_Mag_AP: 20Rnd_762x51_Mag {

--- a/addons/magazines/XEH_preInit.sqf
+++ b/addons/magazines/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP(forceMagazineMuzzleVelocity);
+
+ADDON = true;

--- a/addons/magazines/config.cpp
+++ b/addons/magazines/config.cpp
@@ -12,6 +12,8 @@ class CfgPatches {
     };
 };
 
+#include "CfgEventHandlers.hpp"
+
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/magazines/functions/fnc_forceMagazineMuzzleVelocity.sqf
+++ b/addons/magazines/functions/fnc_forceMagazineMuzzleVelocity.sqf
@@ -1,0 +1,41 @@
+/*
+ * Author: commy2
+ *
+ * DESCRIPTION.
+ *
+ * Arguments:
+ * firedBIS
+ *
+ * Return Value:
+ * None
+ */
+
+#include "script_component.hpp"
+
+private ["_weapon", "_magazine", "_projectile"];
+
+_weapon = _this select 1;
+_magazine = _this select 5;
+_projectile = _this select 6;
+
+if (getNumber (configFile >> "CfgMagazines" >> _magazine >> QGVAR(forceMagazineMuzzleVelocity)) != 1) exitWith {
+    //hint str (speed _projectile / 3.6);
+};
+
+private ["_initSpeedWeapon", "_initSpeedMagazine"];
+
+_initSpeedWeapon = getNumber (configFile >> "CfgWeapons" >> _weapon >> "initSpeed");
+_initSpeedMagazine = getNumber (configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
+
+//systemChat format ["W: %1m/s, M: %2m/s", _initSpeedWeapon, _initSpeedMagazine];
+
+// force magazine initSpeed
+
+private ["_credit", "_debit"];
+
+_credit = vectorMagnitude velocity _projectile;
+_debit = _credit + (_initSpeedMagazine - _initSpeedWeapon);
+
+_projectile setVelocity ((velocity _projectile) vectorMultiply (_debit / _credit));
+
+//hint str (speed _projectile / 3.6);

--- a/addons/magazines/functions/script_component.hpp
+++ b/addons/magazines/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\ace\addons\magazines\script_component.hpp"


### PR DESCRIPTION
This was pushed to `master` without any review. I reverted it on master.

This limits certain ammo types to a certain `initSpeed` via script. Potential concerns:
- Fired EH for a negligible gain (a difference of a few m/s)
- Potentially fucks up AI aim (could easily be prevented)