### PR TITLE
fix falling over static weapons

### DIFF
--- a/addons/vehicles/CfgEventHandlers.hpp
+++ b/addons/vehicles/CfgEventHandlers.hpp
@@ -18,3 +18,12 @@ class Extended_Engine_EventHandlers {
         };
     };
 };
+
+class Extended_Init_EventHandlers {
+    class StaticWeapon {
+        class ACE_FixMass {
+            init = QUOTE(if (local (_this select 0)) then {(_this select 0) setMass (getMass (_this select 0) max 250)};);
+            exclude[] = {"TargetSoldierBase","Static_Designator_01_base_F","Static_Designator_02_base_F","Pod_Heli_Transport_04_base_F"};
+        };
+    };
+};


### PR DESCRIPTION
Ensures every static weapon to have a mass of at least 250