### PR TITLE
Improve map colors by taking them from A2

### DIFF
--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -58,13 +58,15 @@ class RscMapControl {
     maxSatelliteAlpha = 0.5;
 
     // From Arma 2
-    colorTracks[] = {1.0,0.0,0.0,1};
-    colorTracksFill[] = {1.0,1.0,0.0,1};
-    colorRoads[] = {0.0,0.0,0.0,1};
-    colorRoadsFill[] = {1,1,0,1};
+    colorTracks[] = {0.2,0.13,0,1};
+    colorTracksFill[] = {1,0.88,0.65,0.3};
+    colorRoads[] = {0.2,0.13,0,1};
+    colorRoadsFill[] = {1,0.88,0.65,1};
     colorMainRoads[] = {0.0,0.0,0.0,1};
-    colorMainRoadsFill[] = {1,0.6,0.4,1};
+    colorMainRoadsFill[] = {0.94,0.69,0.2,1};
     colorRailWay[] = {0.8,0.2,0,1};
+    colorGrid[] = {0.05,0.1,0,0.6};
+    colorGridMap[] = {0.05,0.1,0,0.4};
 
     // From ACE2
     colorBackground[] = {0.929412, 0.929412, 0.929412, 1.0};


### PR DESCRIPTION
I rechecked Arma 2/ACE 2 configs to see where those yellow road were coming from and I couldn't find those values anymore; I'm honestly not sure how I got those wrong values on the first place.

They've now been replaced by the correct ones. I've also imported the colors for the grid from A2, which makes them a little lighter (prettier).

Arma 2 / ACE2:
![arma2oa 2015-04-09 00-57-21-235](https://cloud.githubusercontent.com/assets/7674951/7060480/0783a742-de58-11e4-8550-3cec67b5449c.jpg)

Arma 3 / ACE3
![arma3 2015-04-09 01-26-44-719](https://cloud.githubusercontent.com/assets/7674951/7060483/1361c9c2-de58-11e4-9a68-db2ff6e0879a.jpg)

![arma3 2015-04-09 01-24-28-021](https://cloud.githubusercontent.com/assets/7674951/7060486/1793f8ee-de58-11e4-8b9e-fe40937b3e70.jpg)

![arma3 2015-04-09 01-32-28-029](https://cloud.githubusercontent.com/assets/7674951/7060493/4c63728e-de58-11e4-9f54-b5a575b94800.jpg)
