### PR TITLE
sorting out required addons for modularity

### DIFF
--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common","ace_interaction","ace_interact_menu"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"Garth 'L-H' de Wet","commy2"};
         authorUrl = "https://github.com/commy2/";
         VERSION_CONFIG;

--- a/addons/fcs/config.cpp
+++ b/addons/fcs/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {ace_common, ace_interaction};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"KoffeinFlummi","BadGuy (simon84)","commy2"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;

--- a/addons/frag/config.cpp
+++ b/addons/frag/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "A3_Misc_F", "A3_Weapons_F" };
+        requiredAddons[] = {"ace_common"};
         author[] = {"Nou"};
         VERSION_CONFIG;
     };

--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {"ACE_EarPlugs"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "ace_interaction"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;

--- a/addons/kestrel/config.cpp
+++ b/addons/kestrel/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {"ACE_Item_Kestrel"};
         weapons[] = {"ACE_Kestrel"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common","ace_interaction"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"Falke","commy2","KoffeinFlummi","esteldunedain"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;

--- a/addons/laser_selfdesignate/config.cpp
+++ b/addons/laser_selfdesignate/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interaction", "ace_laser"};
+        requiredAddons[] = {"ace_laser"};
         version = VERSION;
     };
 };

--- a/addons/logistics_uavbattery/config.cpp
+++ b/addons/logistics_uavbattery/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {"ACE_UAVBattery"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "ace_interaction"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"marc_book"};
         authorUrl = "";
         VERSION_CONFIG;

--- a/addons/logistics_wirecutter/config.cpp
+++ b/addons/logistics_wirecutter/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interact_menu"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"gpgpgpgp", "PabstMirror"};
         authorUrl = "";
         VERSION_CONFIG;

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "ace_interaction"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"KoffeinFlummi","Rocko","esteldunedain"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;

--- a/addons/maptools/config.cpp
+++ b/addons/maptools/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {"ACE_MapTools"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "ace_interaction"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"esteldunedain"};
         authorUrl = "https://github.com/esteldunedain/";
         VERSION_CONFIG;

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {"ACE_medicalSupplyCrate", "ACE_fieldDressingItem", "ACE_packingBandageItem", "ACE_elasticBandageItem", "ACE_tourniquetItem", "ACE_morphineItem", "ACE_atropineItem", "ACE_epinephrineItem", "ACE_plasmaIVItem", "ACE_bloodIVItem", "ACE_salineIVItem", "ACE_quikclotItem", "ACE_personalAidKitItem", "ACE_surgicalKitItem", "ACE_bodyBagItem", "ACE_bodyBagObject"};
         weapons[] = {"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_tourniquet", "ACE_morphine", "ACE_atropine", "ACE_epinephrine", "ACE_plasmaIV", "ACE_plasmaIV_500", "ACE_plasmaIV_250", "ACE_bloodIV", "ACE_bloodIV_500", "ACE_bloodIV_250", "ACE_salineIV", "ACE_salineIV_500", "ACE_salineIV_250", "ACE_quikclot", "ACE_personalAidKit", "ACE_surgicalKit", "ACE_bodyBag"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {ace_common, ace_interaction, ace_modules};
+        requiredAddons[] = {"ace_interaction","ace_modules"};
         author[] = {"Glowbal", "KoffienFlummi"};
         authorUrl = "";
         VERSION_CONFIG;

--- a/addons/missileguidance/config.cpp
+++ b/addons/missileguidance/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "ace_common", "ace_laser" };
+        requiredAddons[] = {"ace_laser"};
         VERSION_CONFIG;
     };
 };

--- a/addons/nametags/config.cpp
+++ b/addons/nametags/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "ace_main", "ace_common", "ace_interaction" };
+        requiredAddons[] = {"ace_interaction"};
         author[] = { "commy2", "esteldunedain" };
         authorUrl = "https://github.com/commy2/";
         VERSION_CONFIG;

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {"ACE_SpareBarrel"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "ace_interaction"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {"commy2", "KoffeinFlummi", "esteldunedain"};
         authorUrl = "https://github.com/commy2/";
         VERSION_CONFIG;

--- a/addons/reloadlaunchers/config.cpp
+++ b/addons/reloadlaunchers/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common","ace_interaction","ace_interact_menu"};
+        requiredAddons[] = {"ace_interaction"};
         author[] = {""};
         authorUrl = "";
         VERSION_CONFIG;

--- a/addons/switchunits/config.cpp
+++ b/addons/switchunits/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
     units[] = {};
     weapons[] = {};
     requiredVersion = REQUIRED_VERSION;
-    requiredAddons[] = {"ace_main", "ace_common"};
+    requiredAddons[] = {"ace_common"};
     author[] = {"bux578"};
     authorUrl = "https://github.com/bux578/";
     VERSION_CONFIG;

--- a/addons/switchunits/script_component.hpp
+++ b/addons/switchunits/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT SwitchUnits
+#define COMPONENT switchunits
 #include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_SWITCHUNITS

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
     units[] = {};
     weapons[] = {};
     requiredVersion = REQUIRED_VERSION;
-    requiredAddons[] = {"ace_common", "ace_interaction"};
+    requiredAddons[] = {"ace_interaction"};
     author[] = {"PabstMirror"};
     authorUrl = "https://github.com/PabstMirror/";
     VERSION_CONFIG;

--- a/addons/wep_javelin/config.cpp
+++ b/addons/wep_javelin/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "ace_main", "ace_common", "ace_laser" };
+        requiredAddons[] = {"ace_laser"};
         VERSION_CONFIG;
     };
 };

--- a/addons/winddeflection/config.cpp
+++ b/addons/winddeflection/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ACE_common", "ACE_weather"};
+        requiredAddons[] = {"ace_weather"};
         versionDesc = "ACE Wind Deflection";
         version = VERSION;
         author[] = {$STR_ACE_Common_ACETeam, "Glowbal", "Ruthberg"};


### PR DESCRIPTION
Requested by esteldunedain. To keep things simple, every module should only require one addon. (No need to require main and interaction, when interaction requires main anyway etc.)

```
ace_main
ace_common - ["ace_main"]

ace_difficulties - ["ace_common"]
ace_disposable - ["ace_common"]
ace_flashsuppressors - ["ace_common"]
ace_frag - ["ace_common"]
ace_gforces - ["ace_common"]
ace_goggles - ["ace_common"]
ace_grenades - ["ace_common"]
ace_hitreactions - ["ace_common"]
ace_inventory - ["ace_common"]
ace_laserpointer - ["ace_common"]
ace_magazines - ["ace_common"]
ace_markers - ["ace_common"]
ace_microdagr - ["ace_common"]
ace_missionModules - ["ace_common"]
ace_movement - ["ace_common"]
ace_nightvision - ["ace_common"]
ace_noidle - ["ace_common"]
ace_noradio - ["ace_common"]
ace_norearm - ["ace_common"]
ace_optics - ["ace_common"]
ace_optionsmenu - ["ace_common"]
ace_overpressure - ["ace_common"]
ace_protection - ["ace_common"]
ace_ragdolls - ["ace_common"]
ace_realisticnames - ["ace_common"]
ace_recoil - ["ace_common"]
ace_respawn - ["ace_common"]
ace_safemode - ["ace_common"]
ace_scopes - ["ace_common"]
ace_smallarms - ["ace_common"]
ace_switchunits - ["ace_common"]
ace_testmissions - ["ace_common"]
ace_thermals - ["ace_common"]
ace_vector - ["ace_common"]
ace_vehicles - ["ace_common"]
ace_weaponselect - ["ace_common"]
ace_ai - ["ace_common"]
ace_aircraft - ["ace_common"]
ace_backpacks - ["ace_common"]
ace_ballistics - ["ace_common"]

ace_interact_menu - ["ace_common"]
ace_interaction - ["ace_interact_menu"]

ace_kestrel - ["ace_interaction"]
ace_logistics_uavbattery - ["ace_interaction"]
ace_logistics_wirecutter - ["ace_interaction"]
ace_magazinerepack - ["ace_interaction"]
ace_map - ["ace_interaction"]
ace_maptools - ["ace_interaction"]
ace_nametags - ["ace_interaction"]
ace_overheating - ["ace_interaction"]
ace_reload - ["ace_interaction"]
ace_reloadlaunchers - ["ace_interaction"]
ace_vehiclelock - ["ace_interaction"]
ace_attach - ["ace_interaction"]
ace_captives - ["ACE_Interaction"]
ace_dragging - ["ace_interaction"]
ace_explosives - ["ace_interaction"]
ace_fcs - ["ace_interaction"]
ace_hearing - ["ace_interaction"]


ace_laser - ["ace_common"]
ace_laser_selfdesignate - ["ace_laser"]
ace_missileguidance - ["ace_laser"]
ace_wep_javelin - ["ace_laser"]


ace_weather - ["ace_common"]
ace_winddeflection - ["ace_weather"]


ace_modules - ["ace_common"]
ace_medical - ["ace_interaction","ace_modules"]
```
