### PR TITLE
Medical performance improvements

### DIFF
--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -102,4 +102,7 @@ GVAR(IVBags) = [];
 
 call FUNC(parseConfigForInjuries);
 
+GVAR(HITPOINTS) = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
+GVAR(SELECTIONS) = ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"];
+
 ADDON = true;

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -17,7 +17,7 @@
 
 #include "script_component.hpp"
 
-private ["_unit", "_selection", "_damage", "_shooter", "_projectile", "_damageReturn", "_hitPoints",  "_typeOfDamage"];
+private ["_unit", "_selection", "_damage", "_shooter", "_projectile", "_damageReturn",  "_typeOfDamage"];
 _unit         = _this select 0;
 _selection    = _this select 1;
 _damage       = _this select 2;
@@ -32,8 +32,7 @@ if (typeName _projectile == "OBJECT") then {
 };
 
 // If the damage is being weird, we just tell it to fuck off.
-_hitSelections = ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"];
-if !(_selection in (_hitSelections + [""])) exitWith {0};
+if !(_selection in (GVAR(SELECTIONS) + [""])) exitWith {0};
 
 _damageReturn = _damage;
 if (GVAR(level) < 2) then {
@@ -46,8 +45,7 @@ if (GVAR(level) >= 2) then {
         // lets use basic for the time being..
         _damageReturn = _this call FUNC(handleDamage_basic);
     };
-
-    [_unit, _selection, _damage, _source, _projectile] call FUNC(handleDamage_caching);
+    _newDamage = _this call FUNC(handleDamage_caching);
 
     if (_damageReturn > 0.9) then {
 
@@ -57,12 +55,6 @@ if (GVAR(level) >= 2) then {
         _minLethalDamage = 0.01;
         if (_typeIndex >= 0) then {
             _minLethalDamage = GVAR(minLethalDamages) select _typeIndex;
-        };
-
-        _hitPoints = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
-        _newDamage = _damage - (damage _unit);
-        if (_selection in _hitSelections) then {
-            _newDamage = _damage - (_unit getHitPointDamage (_hitPoints select (_hitSelections find _selection)));
         };
 
         if ((_minLethalDamage <= _newDamage) && {[_unit, [_selection] call FUNC(selectionNameToNumber), _newDamage] call FUNC(determineIfFatal)} && {_selection in ["", "head", "body"]}) then {

--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -25,21 +25,21 @@ _selectionName = _this select 1;
 _amountOfDamage = _this select 2;
 _sourceOfDamage = _this select 3;
 _typeOfProjectile = _this select 4;
+_newDamage = _this select 5;
 
 // Most likely taking exessive fire damage. Lets exit.
-if (isNull _sourceOfDamage && (_selectionName == "head" || isBurning _unit) && _typeOfProjectile == "" && vehicle _unit == _unit) exitwith {
+if (isNull _sourceOfDamage && {_typeOfProjectile == ""} && {vehicle _unit == _unit} && {(_selectionName == "head" || isBurning _unit)}) exitwith {
     0
 };
-
 _typeOfDamage = [_typeOfProjectile] call FUNC(getTypeOfDamage);
 _part = [_selectionName] call FUNC(selectionNameToNumber);
 
 _hitPoints = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
 // Sorting out the damage
 _damageBodyParts = _unit getvariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
-_newDamage = _amountOfDamage - (_unit getHitPointDamage (_hitPoints select _part));
 _damageBodyParts set [_part, (_damageBodyParts select _part) + _newDamage];
 _unit setvariable [QGVAR(bodyPartStatus), _damageBodyParts, true];
+
 [_unit] call FUNC(handleDamage_advancedSetDamage);
 
 [_unit, _selectionName, _newDamage, _typeOfProjectile, _typeOfDamage] call FUNC(handleDamage_wounds);

--- a/addons/medical/functions/fnc_handleDamage_advancedSetDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advancedSetDamage.sqf
@@ -16,9 +16,7 @@
 private ["_unit", "_bodyStatus", "_headDamage", "_torsoDamage", "_handsDamage", "_legsDamage"];
 _unit = _this select 0;
 
-if (!local _unit) exitwith {
-    // execute only local
-};
+if (!local _unit) exitwith {};
 
 _bodyStatus = _unit getvariable [QGVAR(bodyPartStatus),[0,0,0,0,0,0]];
 // ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"]

--- a/addons/medical/functions/fnc_handleDamage_basic.sqf
+++ b/addons/medical/functions/fnc_handleDamage_basic.sqf
@@ -44,13 +44,9 @@ if (diag_frameno > (_unit getVariable [QGVAR(frameNo), -3]) + 2) then {
     _unit setVariable [QGVAR(preventDeath), false];
 };
 
-
-_hitSelections = ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"];
-_hitPoints = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
-
 _newDamage = _damage - (damage _unit);
-if (_selectionName in _hitSelections) then {
-    _newDamage = _damage - (_unit getHitPointDamage (_hitPoints select (_hitSelections find _selectionName)));
+if (_selectionName in GVAR(SELECTIONS)) then {
+    _newDamage = _damage - (_unit getHitPointDamage (GVAR(HITPOINTS) select (GVAR(SELECTIONS) find _selectionName)));
 };
 
 _damage = _damage - _newDamage;
@@ -61,7 +57,7 @@ if (((velocity _unit) select 2 < -5) and (vehicle _unit == _unit)) then {
     _unit setVariable [QGVAR(isFalling), true];
 };
 if (_unit getVariable [QGVAR(isFalling), false] and !(_selectionName in ["", "leg_l", "leg_r"])) exitWith {
-    (_unit getHitPointDamage (_hitPoints select (_hitSelections find _selectionName))) max 0.01;
+    (_unit getHitPointDamage (GVAR(HITPOINTS) select (GVAR(SELECTIONS) find _selectionName))) max 0.01;
 };
 if (_unit getVariable [QGVAR(isFalling), false]) then {
     _newDamage = _newDamage * 0.7;
@@ -85,12 +81,12 @@ if (_selectionName != "" and !(_unit getVariable QGVAR(isFalling))) then {
             // Make entry unfindable
             _cache_projectiles set [_index, objNull];
             _cache_projectiles pushBack _projectile;
-            _cache_hitpoints pushBack (_hitPoints select (_hitSelections find _selectionName));
+            _cache_hitpoints pushBack (GVAR(HITPOINTS) select (GVAR(SELECTIONS) find _selectionName));
             _cache_damages pushBack _newDamage;
         };
     } else {
         _cache_projectiles pushBack _projectile;
-        _cache_hitpoints pushBack (_hitPoints select (_hitSelections find _selectionName));
+        _cache_hitpoints pushBack (GVAR(HITPOINTS) select (GVAR(SELECTIONS) find _selectionName));
         _cache_damages pushBack _newDamage;
     };
     _unit setVariable [QGVAR(projectiles), _cache_projectiles];

--- a/addons/medical/functions/fnc_handleDamage_basic.sqf
+++ b/addons/medical/functions/fnc_handleDamage_basic.sqf
@@ -42,6 +42,20 @@ if (diag_frameno > (_unit getVariable [QGVAR(frameNo), -3]) + 2) then {
     _unit setVariable [QGVAR(damages), []];
     _unit setVariable [QGVAR(structDamage), 0];
     _unit setVariable [QGVAR(preventDeath), false];
+    // Assign orphan structural damage to torso
+    [{
+        private ["_unit", "_damagesum"];
+        _unit = _this select 0;
+        _damagesum = (_unit getHitPointDamage "HitHead") +
+            (_unit getHitPointDamage "HitBody") +
+            (_unit getHitPointDamage "HitLeftArm") +
+            (_unit getHitPointDamage "HitRightArm") +
+            (_unit getHitPointDamage "HitLeftLeg") +
+            (_unit getHitPointDamage "HitRightLeg");
+        if (_damagesum < 0.06 and damage _unit > 0.06 and alive _unit) then {
+            _unit setHitPointDamage ["HitBody", damage _unit];
+        };
+    }, [_unit], 2, 0.1] call EFUNC(common,waitAndExecute);
 };
 
 _newDamage = _damage - (damage _unit);
@@ -105,29 +119,11 @@ if (_selectionName == "") then {
     };
 };
 
-
-// Assign orphan structural damage to torso
-[{
-    private ["_unit", "_damagesum"];
-    _unit = _this select 0;
-    _damagesum = (_unit getHitPointDamage "HitHead") +
-        (_unit getHitPointDamage "HitBody") +
-        (_unit getHitPointDamage "HitLeftArm") +
-        (_unit getHitPointDamage "HitRightArm") +
-        (_unit getHitPointDamage "HitLeftLeg") +
-        (_unit getHitPointDamage "HitRightLeg");
-    if (_damagesum < 0.06 and damage _unit > 0.06 and alive _unit) then {
-        _unit setHitPointDamage ["HitBody", damage _unit];
-    };
-}, [_unit], 2, 0.1] call EFUNC(common,waitAndExecute);
-
-
 if (_selectionName == "") then {
     _damage = _damage + (_unit getVariable QGVAR(structDamage));
 } else {
     _damage = _damage + _newDamage;
 };
-
 
 // Leg Damage
 _legdamage = (_unit getHitPointDamage "HitLeftLeg") + (_unit getHitPointDamage "HitRightLeg");
@@ -139,9 +135,9 @@ if (_selectionName == "leg_r") then {
 };
 
 if (_legdamage >= LEGDAMAGETRESHOLD1) then {
-    if (_unit getHitPointDamage "HitLegs" != 1) then {_unit setHitPointDamage ["HitLegs", 1]};
+    _unit setHitPointDamage ["HitLegs", 1];
 } else {
-    if (_unit getHitPointDamage "HitLegs" != 0) then {_unit setHitPointDamage ["HitLegs", 0]};
+    _unit setHitPointDamage ["HitLegs", 0];
 };
 // @todo: force prone for completely fucked up legs.
 
@@ -156,9 +152,9 @@ if (_selectionName == "hand_r") then {
 };
 
 if (_armdamage >= ARMDAMAGETRESHOLD1) then {
-    if (_unit getHitPointDamage "HitHands" != 1) then {_unit setHitPointDamage ["HitHands", 1]};
+    _unit setHitPointDamage ["HitHands", 1];
 } else {
-    if (_unit getHitPointDamage "HitHands" != 0) then {_unit setHitPointDamage ["HitHands", 0]};
+    _unit setHitPointDamage ["HitHands", 0];
 };
 // @todo: Drop weapon for full damage.
 
@@ -169,7 +165,6 @@ if (_selectionName == "") then {
     _pain = _pain + _newDamage * (1 - (_unit getVariable [QGVAR(morphine), 0]));
     _unit setVariable [QGVAR(pain), _pain min 1, true];
 };
-
 
 // Unconsciousness
 if (_selectionName == "" and

--- a/addons/medical/functions/fnc_handleDamage_caching.sqf
+++ b/addons/medical/functions/fnc_handleDamage_caching.sqf
@@ -25,14 +25,16 @@ _damage        = _this select 2;
 _source        = _this select 3;
 _projectile    = _this select 4;
 
-_hitSelections = ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"];
-_hitPoints = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
+_hitSelections = GVAR(SELECTIONS);
+_hitPoints = GVAR(HITPOINTS);
 
 // Calculate change in damage.
 _newDamage = _damage - (damage _unit);
 if (_selectionName in _hitSelections) then {
     _newDamage = _damage - (_unit getHitPointDamage (_hitPoints select (_hitSelections find _selectionName)));
 };
+
+//_damage = _damage + _newDamage;
 
 // Check for vehicle crash
 if (vehicle _unit != _unit && {!(vehicle _unit isKindOf "StaticWeapon")} && {isNull _source} && {_projectile == ""} && {_selectionName == ""}) then {
@@ -60,13 +62,15 @@ if (diag_frameno > (_unit getVariable [QGVAR(frameNo_damageCaching), -3]) + 2) t
 
     // handle the cached damages 3 frames later
     [{
-        private "_args";
+        private ["_args", "_params"];
         _args = _this select 0;
 
         if (diag_frameno > (_args select 1) + 2) then {
             _cache_params = (_args select 0) getVariable [QGVAR(cachedHandleDamageParams), []];
+            _cache_damages = (_args select 0) getVariable QGVAR(cachedDamages);
             {
-                _x call FUNC(handleDamage_advanced);
+                _params = _x + [_cache_damages select _foreachIndex];
+                _params call FUNC(handleDamage_advanced);
             }foreach _cache_params;
             [(_this select 1)] call cba_fnc_removePerFrameHandler;
         };
@@ -78,23 +82,22 @@ if (diag_frameno > (_unit getVariable [QGVAR(frameNo_damageCaching), -3]) + 2) t
     _unit setVariable [QGVAR(cachedHandleDamageParams), []];
 };
 
-// Make sure there's only one damaged selection per projectile per frame.
-_cache_projectiles = _unit getVariable QGVAR(cachedProjectiles);
-_cache_hitpoints = _unit getVariable QGVAR(cachedHitPoints);
-_cache_damages = _unit getVariable QGVAR(cachedDamages);
-_cache_params = _unit getVariable QGVAR(cachedHandleDamageParams);
-
 // Caching of the damage events
 if (_selectionName != "") then {
+    _cache_projectiles = _unit getVariable QGVAR(cachedProjectiles);
     private ["_index","_otherDamage"];
     _index = _cache_projectiles find _projectile;
     // Check if the current projectile has already been handled once
     if (_index >= 0) exitwith {
+        _cache_damages = _unit getVariable QGVAR(cachedDamages);
         // Find the previous damage this projectile has done
         _otherDamage = (_cache_damages select _index);
 
         // Take the highest damage of the two
         if (_newDamage > _otherDamage) then {
+            _cache_params = _unit getVariable QGVAR(cachedHandleDamageParams);
+            _cache_hitpoints = _unit getVariable QGVAR(cachedHitPoints);
+
             private ["_hitPoint", "_restore"];
             // Restore the damage before the previous damage was processed
             _hitPoint = _cache_hitpoints select _index;
@@ -104,18 +107,29 @@ if (_selectionName != "") then {
             _cache_hitpoints set [_index, (_hitPoints select (_hitSelections find _selectionName))];
             _cache_damages set [_index, _newDamage];
             _cache_params set[_index, _this];
+
+            _unit setVariable [QGVAR(cachedProjectiles), _cache_projectiles];
+            _unit setVariable [QGVAR(cachedHitPoints), _cache_hitpoints];
+            _unit setVariable [QGVAR(cachedDamages), _cache_damages];
+            _unit setVariable [QGVAR(cachedHandleDamageParams), _cache_params];
         };
     };
+
+    _cache_hitpoints = _unit getVariable QGVAR(cachedHitPoints);
+    _cache_damages = _unit getVariable QGVAR(cachedDamages);
+    _cache_params = _unit getVariable QGVAR(cachedHandleDamageParams);
 
     // This is an unhandled projectile
     _cache_projectiles pushBack _projectile;
     _cache_hitpoints pushBack (_hitPoints select (_hitSelections find _selectionName));
     _cache_damages pushBack _newDamage;
     _cache_params pushBack _this;
+
+    // Store the new cached values
+    _unit setVariable [QGVAR(cachedProjectiles), _cache_projectiles];
+    _unit setVariable [QGVAR(cachedHitPoints), _cache_hitpoints];
+    _unit setVariable [QGVAR(cachedDamages), _cache_damages];
+    _unit setVariable [QGVAR(cachedHandleDamageParams), _cache_params];
 };
 
-// Store the new cached values
-_unit setVariable [QGVAR(cachedProjectiles), _cache_projectiles];
-_unit setVariable [QGVAR(cachedHitPoints), _cache_hitpoints];
-_unit setVariable [QGVAR(cachedDamages), _cache_damages];
-_unit setVariable [QGVAR(cachedHandleDamageParams), _cache_params];
+_newDamage;

--- a/addons/medical/functions/fnc_handleDamage_wounds.sqf
+++ b/addons/medical/functions/fnc_handleDamage_wounds.sqf
@@ -52,10 +52,10 @@ _allPossibleInjuries = [];
 
     // Check if the damage is higher as the min damage for the specific injury
     if (_damage >= _minDamage && {_damage <= _maxDamage || _maxDamage < 0}) then {
-        _classType = _x select 0;
+        //_classType = _x select 0;
         _selections = _x select 1;
-        _bloodLoss = _x select 2;
-        _pain = _x select 3;
+        //_bloodLoss = _x select 2;
+        //_pain = _x select 3;
 
         // Check if the injury can be applied to the given selection name
         if ("All" in _selections || _selectionName in _selections) then {
@@ -73,9 +73,7 @@ _allPossibleInjuries = [];
 }foreach _allInjuriesForDamageType;
 
 // No possible wounds available for this damage type or damage amount.
-if (_highestPossibleSpot < 0) exitwith {
-
-};
+if (_highestPossibleSpot < 0) exitwith {};
 
 // Administration for open wounds and ids
 _openWounds = _unit getvariable[QGVAR(openWounds), []];
@@ -125,7 +123,7 @@ _woundsCreated = [];
             _painToAdd = _painToAdd + (_toAddInjury select 3);
         };
     };
-}foreach (_injuryTypeInfo select 0);
+}foreach (_injuryTypeInfo select 0); // foreach damage thresholds
 
 _unit setvariable [QGVAR(openWounds), _openWounds, !USE_WOUND_EVENT_SYNC];
 


### PR DESCRIPTION
Reduced performance issues when a lot of units (15+) are taking damage within a few frames from each other.

Should reduce/eliminate the game freeze with basic medical and improve advanced medical performance by ~30% on average.
