### PR TITLE
Added Obsolete PBO removal support added to build.py

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -19,6 +19,11 @@ def check_for_changes(addonspath, module):
         return True
     return mod_time(os.path.join(addonspath, module)) > mod_time(os.path.join(addonspath, "ace_{}.pbo".format(module)))
 
+def check_for_obsolete_pbos(addonspath, file):
+    module = file[4:-4]
+    if not os.path.exists(os.path.join(addonspath, module)):
+        return True
+    return False
 
 def main():
     print("""
@@ -36,6 +41,16 @@ def main():
     made = 0
     failed = 0
     skipped = 0
+    removed = 0
+    
+    for file in os.listdir(addonspath):
+        if os.path.isfile(file):
+            if check_for_obsolete_pbos(addonspath, file):
+                removed += 1
+                print("  Removing obsolete file => " + file)
+                os.remove(file)
+    print("")        
+    
     for p in os.listdir(addonspath):
         path = os.path.join(addonspath, p)
         if not os.path.isdir(path):
@@ -65,7 +80,7 @@ def main():
             print("  Successfully made {}.".format(p))
 
     print("\n# Done.")
-    print("  Made {}, skipped {}, failed to make {}.".format(made, skipped, failed))
+    print("  Made {}, skipped {}, removed {}, failed to make {}.".format(made, skipped, removed, failed))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#576 - Obsolete PBO removal support added to build.py
If a PBO is found but there is no module directory associated it will then be removed. 
Support for empty module folders may be added later. 
Removed statistics are reported 