### PR TITLE
match to exact directory name (case-sensitive)

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(AFTER "common")
 
 # Add extensions to build here
 add_subdirectory(fcs)
-add_subdirectory(breakline)
+add_subdirectory(breakLine)
 add_subdirectory(advanced_ballistics)
 
 message("Build Type: ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
Cmake is case-sensitive for the directory name.