### PR TITLE
Option menu stuff

### DIFF
--- a/addons/common/functions/fnc_setSettingFromConfig.sqf
+++ b/addons/common/functions/fnc_setSettingFromConfig.sqf
@@ -75,6 +75,18 @@ if (isNil _name) then {
         getNumber (_optionEntry >> "force") > 0,
         _value
     ];
+    
+    //Strings in the values array won't be localized from the config, so just do that now:
+    private "_values";
+    _values = _settingData select 5;
+    {
+        _text = _x;
+        if (((typeName _text) == "STRING") && {(count _text) > 1} && {(_text select [0,1]) == "$"}) then {
+            _text = localize (_text select [1, ((count _text) - 1)]); //chop off the leading $
+            _values set [_forEachIndex, _text];
+        };
+    } forEach _values;
+    
 
     GVAR(settings) pushBack _settingData;
 

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -21,7 +21,7 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = "$STR_ACE_Inventory_SettingName";
         description = "$STR_ACE_Inventory_SettingDescription";
-        values[] = {"Normal (Default Size)", "Medium", "Bigger"};
+        values[] = {"$str_medium", "$str_large", "$str_very_large"};
     };
 };
 

--- a/addons/optionsmenu/config.cpp
+++ b/addons/optionsmenu/config.cpp
@@ -26,4 +26,14 @@ class CfgAddons {
 #include "gui\settingsMenu.hpp"
 #include "gui\pauseMenu.hpp"
 
-#include "CFgVehicles.hpp"
+#include "CfgVehicles.hpp"
+
+class ACE_Settings {
+    class GVAR(optionMenuDisplaySize) {
+        value = 0;
+        typeName = "SCALAR";
+        isClientSettable = 1;
+        displayName = "$STR_ACE_optionsMenu_uiScaing";
+        values[] = {"$str_medium", "$str_large", "$str_very_large"};
+    };
+};

--- a/addons/optionsmenu/functions/fnc_exportSettings.sqf
+++ b/addons/optionsmenu/functions/fnc_exportSettings.sqf
@@ -16,6 +16,8 @@
 
 #include "script_component.hpp"
 
+private ["_compiledConfig", "_name", "_typeName", "_isClientSetable", "_localizedName", "_localizedDescription", "_possibleValues", "_defaultValue", "_value", "_compiledConfigEntry"];
+
 _compiledConfig = "
 ";
 {
@@ -52,6 +54,10 @@ class %1 {
     typeName = %3;
     force = 1;
 };", _name, _value, format['"%1"', _typeName]];
+
+        //clipboard seems to be getting cuttoff, so do a backup dump to rpt:
+        diag_log text _compiledConfigEntry;
+        
         _compiledConfig = _compiledConfig + _compiledConfigEntry;
     };
 } forEach EGVAR(common,settings);

--- a/addons/optionsmenu/functions/fnc_onServerSaveInputField.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerSaveInputField.sqf
@@ -16,28 +16,28 @@
 
 #include "script_component.hpp"
 
-private ["_settingIndex", "_inputText"];
+private ["_settingIndex", "_inputText", "_setting", "_settingName", "_convertedValue"];
 
 _settingIndex =  lbCurSel 200;  //Index of left list
 _inputText = ctrlText 414;  //Index of right drop down
 
 switch (GVAR(optionMenu_openTab)) do {
     case (MENU_TAB_SERVER_VALUES): {
-    if ((_settingIndex >= 0) && (_settingIndex < (count GVAR(serverSideValues)))) then {
-        try {
-            _setting = (GVAR(serverSideValues) select _settingIndex);
-            _settingName = _setting select 0;
+        if ((_settingIndex >= 0) && (_settingIndex < (count GVAR(serverSideValues)))) then {
+            try {
+                _setting = (GVAR(serverSideValues) select _settingIndex);
+                _settingName = _setting select 0;
 
-            _convertedValue = switch (toUpper (_setting select 1)) do {
+                _convertedValue = switch (toUpper (_setting select 1)) do {
                 case "STRING": {format ['"%1"', _inputText]};
                 case "ARRAY": {format [call compile "[%1]", _inputText]};
                 case "SCALAR": {parseNumber _inputText;};
-                default {throw "Error"};
+                    default {throw "Error"};
+                };
+                [MENU_TAB_SERVER_VALUES, _settingName, _convertedValue] call FUNC(updateSetting);
+            } catch {
             };
-            [MENU_TAB_SERVER_VALUES, _settingName, _convertedValue] call FUNC(updateSetting);
-        } catch {
         };
+        [false] call FUNC(serverSettingsMenuUpdateList);
     };
-    [false] call FUNC(serverSettingsMenuUpdateList);
-  };
 };

--- a/addons/optionsmenu/functions/fnc_onServerSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerSettingsMenuOpen.sqf
@@ -16,6 +16,8 @@
 
 #include "script_component.hpp"
 
+private ["_name", "_typeName", "_isClientSetable", "_localizedName", "_localizedDescription", "_possibleValues", "_defaultValue", "_setting", "_menu", "_settingsMenu"];
+
 if (GVAR(serverConfigGeneration) == 0 || isMultiplayer) exitwith {closeDialog 145246;};
 
 // Filter only user setable setting
@@ -54,7 +56,6 @@ GVAR(serverSideValues) = [];
 //Delay a frame
 [{ [MENU_TAB_SERVER_OPTIONS] call FUNC(onServerListBoxShowSelectionChanged) }, []] call EFUNC(common,execNextFrame);
 
-private "_menu";
 disableSerialization;
 _menu = uiNamespace getvariable "ACE_serverSettingsMenu";
 (_menu displayCtrl 1003) ctrlEnable false;

--- a/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
@@ -16,9 +16,12 @@
 
 #include "script_component.hpp"
 
+private ["_setting", "_menu"];
+
 // Filter only user setable setting
 GVAR(clientSideOptions) = [];
 GVAR(clientSideColors) = [];
+
 {
     // If the setting is user setable and not forced
     if ((_x select 2) && !(_x select 6)) then {
@@ -40,7 +43,6 @@ GVAR(clientSideColors) = [];
 //Delay a frame
 [{ [MENU_TAB_OPTIONS] call FUNC(onListBoxShowSelectionChanged) }, []] call EFUNC(common,execNextFrame);
 
-private "_menu";
 disableSerialization;
 _menu = uiNamespace getvariable "ACE_settingsMenu";
 (_menu displayCtrl 1002) ctrlEnable false;

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateKeyView.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateKeyView.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu", "_ctrlList", "_collection", "_settingIndex", "_setting", "_entryName", "_localizedName", "_localizedDescription", "_possibleValues", "_settingsValue", "_currentColor"];
+private ["_settingsMenu", "_ctrlList", "_collection", "_settingIndex", "_setting", "_entryName", "_localizedName", "_localizedDescription", "_possibleValues", "_settingsValue", "_currentColor", "_expectedType"];
 disableSerialization;
 
 _settingsMenu = uiNamespace getVariable 'ACE_serverSettingsMenu';

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView"];
+private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView", "_settingsValue"];
 DEFAULT_PARAM(0,_updateKeyView,true);
 
 disableSerialization;

--- a/addons/optionsmenu/functions/fnc_settingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_settingsMenuUpdateList.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView"];
+private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView", "_settingsValue"];
 DEFAULT_PARAM(0,_updateKeyView,true);
 
 disableSerialization;

--- a/addons/optionsmenu/gui/settingsMenu.hpp
+++ b/addons/optionsmenu/gui/settingsMenu.hpp
@@ -1,8 +1,8 @@
 class ACE_settingsMenu {
-  idd = 145246;
-  movingEnable = false;
-  onLoad = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', _this select 0)]; [] call FUNC(onSettingsMenuOpen););
-  onUnload = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', nil)]; saveProfileNamespace;);
+    idd = 145246;
+    movingEnable = false;
+    onLoad = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', _this select 0)]; [] call FUNC(onSettingsMenuOpen););
+    onUnload = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', nil)]; saveProfileNamespace;);
 
 #define SIZEX (((safezoneW / safezoneH) min 1.2))
 #define SIZEY (SIZEX / 1.2)
@@ -20,433 +20,433 @@ class ACE_settingsMenu {
 #define Y_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), Y_ORIGINAL(num), Y_MAKEITBIGGA(num))])
 #define W_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), W_ORIGINAL(num), W_MAKEITBIGGA(num))])
 #define H_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), H_ORIGINAL(num), H_MAKEITBIGGA(num))])
-  
-  class controlsBackground {
-    class HeaderBackground: ACE_gui_backgroundBase {
-      idc = -1;
-      type = CT_STATIC;
-      x = X_PART(1);
-      y = Y_PART(1);
-      w = W_PART(38);
-      h = H_PART(1);
-      style = ST_LEFT + ST_SHADOW;
-      font = "PuristaMedium";
-      SizeEx = H_PART(1);
-      colorText[] = {0.95, 0.95, 0.95, 0.75};
-      colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.69])","(profilenamespace getvariable ['GUI_BCG_RGB_G',0.75])","(profilenamespace getvariable ['GUI_BCG_RGB_B',0.5])", "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
-      text = "";
-    };
-    class CenterBackground: HeaderBackground {
-      y = Y_PART(2.1);
-      h = H_PART(2.5);
-      text = "";
-      colorText[] = {0, 0, 0, "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
-      colorBackground[] = {0,0,0,"(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
-    };
-    class LeftBackground: CenterBackground {
-      y = Y_PART(4.8);
-      h = H_PART(17.4);
-      w = W_PART(25);
-    };
-    class RightBackground: LeftBackground {
-      x = X_PART(26.1);
-      w = W_PART(12.9);
-    };
-    class RightBackgroundHeader: RightBackground {
-      h = H_PART(1.4);
-      colorBackground[] = {0,0,0,1};
-    };
-  };
 
-  class controls {
-    class HeaderName {
-      idc = 1;
-      type = CT_STATIC;
-      x = X_PART(1);
-      y = Y_PART(1);
-      w = W_PART(38);
-      h = H_PART(1);
-      style = ST_LEFT + ST_SHADOW;
-      font = "PuristaMedium";
-      SizeEx = H_PART(1);
-      colorText[] = {0.95, 0.95, 0.95, 0.75};
-      colorBackground[] = {0,0,0,0};
-      text = "$STR_ACE_OptionsMenu_OpenConfigMenu";
+    class controlsBackground {
+        class HeaderBackground: ACE_gui_backgroundBase {
+            idc = -1;
+            type = CT_STATIC;
+            x = X_PART(1);
+            y = Y_PART(1);
+            w = W_PART(38);
+            h = H_PART(1);
+            style = ST_LEFT + ST_SHADOW;
+            font = "PuristaMedium";
+            SizeEx = H_PART(1);
+            colorText[] = {0.95, 0.95, 0.95, 0.75};
+            colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.69])","(profilenamespace getvariable ['GUI_BCG_RGB_G',0.75])","(profilenamespace getvariable ['GUI_BCG_RGB_B',0.5])", "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
+            text = "";
+        };
+        class CenterBackground: HeaderBackground {
+            y = Y_PART(2.1);
+            h = H_PART(2.5);
+            text = "";
+            colorText[] = {0, 0, 0, "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
+            colorBackground[] = {0,0,0,"(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
+        };
+        class LeftBackground: CenterBackground {
+            y = Y_PART(4.8);
+            h = H_PART(17.4);
+            w = W_PART(25);
+        };
+        class RightBackground: LeftBackground {
+            x = X_PART(26.1);
+            w = W_PART(12.9);
+        };
+        class RightBackgroundHeader: RightBackground {
+            h = H_PART(1.4);
+            colorBackground[] = {0,0,0,1};
+        };
     };
-    class labelSubHeader: ACE_gui_staticBase {
-      idc = 13;
-      x = X_PART(2);
-      y = Y_PART(3.4);
-      w = W_PART(30);
-      h = H_PART(1);
-      text = "";
+
+    class controls {
+        class HeaderName {
+            idc = 1;
+            type = CT_STATIC;
+            x = X_PART(1);
+            y = Y_PART(1);
+            w = W_PART(38);
+            h = H_PART(1);
+            style = ST_LEFT + ST_SHADOW;
+            font = "PuristaMedium";
+            SizeEx = H_PART(1);
+            colorText[] = {0.95, 0.95, 0.95, 0.75};
+            colorBackground[] = {0,0,0,0};
+            text = "$STR_ACE_OptionsMenu_OpenConfigMenu";
+        };
+        class labelSubHeader: ACE_gui_staticBase {
+            idc = 13;
+            x = X_PART(2);
+            y = Y_PART(3.4);
+            w = W_PART(30);
+            h = H_PART(1);
+            text = "";
+        };
+        class selectionAction_1: ACE_gui_buttonBase {
+            idc = 1000;
+            text = "$STR_ACE_OptionsMenu_TabOptions";
+            x = X_PART(1);
+            y = Y_PART(2.1);
+            w = W_PART(9.5);
+            h = H_PART(1);
+            animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.9)";
+            animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.8)";
+            animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
+            animTextureFocused = "#(argb,8,8,3)color(1,1,1,1)";
+            animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
+            animTextureDefault = "#(argb,8,8,3)color(1,1,1,1)";
+            color[] = {1, 1, 1, 1};
+            color2[] = {0,0,0, 1};
+            colorBackgroundFocused[] = {1,1,1,1};
+            colorBackground[] = {1,1,1,1};
+            colorbackground2[] = {1,1,1,1};
+            colorDisabled[] = {1,1,1,1};
+            colorFocused[] = {0,0,0,1};
+            periodFocus = 1;
+            periodOver = 1;
+            action = QUOTE([MENU_TAB_OPTIONS] call FUNC(onListBoxShowSelectionChanged););
+            SizeEx = H_PART(1);
+            Size = H_PART(1);
+        };
+        class selectionAction_2: selectionAction_1 {
+            idc = 1001;
+            text = "$STR_ACE_OptionsMenu_TabColors";
+            x = X_PART(10.5);
+            action = QUOTE([MENU_TAB_COLORS] call FUNC(onListBoxShowSelectionChanged););
+        };
+        class selectionAction_3: selectionAction_1 {
+            idc = 1002;
+            text = "";
+            x = X_PART(20);
+            action = "";
+        };
+        class selectionAction_4: selectionAction_1 {
+            idc = 1003;
+            text = "";
+            x = X_PART(29.5);
+            action = "";
+        };
+        class listBoxSettingsList: ACE_gui_listNBox {
+            idc = 200;
+            x = X_PART(2);
+            y = Y_PART(5.5);
+            w = W_PART(23);
+            h = H_PART(15);
+            SizeEx = H_ORIGINAL(0.8);
+            colorBackground[] = {0, 0, 0, 0.9};
+            colorSelectBackground[] = {0, 0, 0, 0.9};
+            columns[] = {0.0, 0.6};
+            onLBSelChanged = QUOTE(_this call FUNC(settingsMenuUpdateKeyView));
+        };
+        class labelTitle: ACE_gui_staticBase {
+            idc = 250;
+            x = X_PART(27.1);
+            y = Y_PART(5.1);
+            w = W_PART(11);
+            h = H_PART(1);
+            text = "";
+            SizeEx = H_PART(1);
+        };
+        class labelKey: ACE_gui_staticBase {  //Variable Name
+            idc = 300;
+            x = X_PART(27.1);
+            y = Y_PART(6.2);
+            w = W_PART(11);
+            h = H_PART(1);
+            text = "";
+            SizeEx = H_PART(0.65);
+        };
+        class Label2: labelKey {
+            idc = 301;
+            y = Y_PART(7.3);
+            text = "$STR_ACE_OptionsMenu_Setting";
+            SizeEx = H_PART(1);
+        };
+        class comboBox1: ACE_gui_comboBoxBase {
+            idc = 400;
+            x = X_PART(31.1);
+            y = Y_PART(7.3);
+            w = W_PART(7);
+            h = H_PART(1);
+            onLBSelChanged = QUOTE( call FUNC(onListBoxSettingsChanged));
+            SizeEx = H_PART(0.9);
+        };
+        class sliderBar1: RscXSliderH {
+            idc = 410;
+            x = X_PART(27.1);
+            y = Y_PART(7.3);
+            w = W_PART(11);
+            h = H_PART(0.75);
+            onSliderPosChanged = QUOTE(_this call FUNC(onSliderPosChanged));
+            color[] = {1,0,0,0.4};
+            colorActive[] = {1,0,0,1};
+        };
+        class sliderBar2: sliderBar1 {
+            idc = 411;
+            y = Y_PART(8.2);
+            color[] = {0,1,0,0.4};
+            colorActive[] = {0,1,0,1};
+        };
+        class sliderBar3: sliderBar1 {
+            idc = 412;
+            y = Y_PART(9.1);
+            color[] = {0,0,1,0.4};
+            colorActive[] = {0,0,1,1};
+        };
+        class sliderBar4: sliderBar1 {
+            idc = 413;
+            y = Y_PART(10);
+            color[] = {1,1,1,0.4};
+            colorActive[] = {1,1,1,1};
+        };
+        class labelDesc: ACE_gui_staticBase {
+            idc = 251;
+            x = X_PART(27.1);
+            y = Y_PART(11);
+            w = W_PART(11);
+            h = H_PART(11);
+            text = "";
+            style = ST_LEFT + ST_MULTI;
+            lineSpacing = 1;
+            SizeEx = H_PART(0.8);
+        };
+        class actionClose: ACE_gui_buttonBase {
+            idc = 10;
+            text = "$STR_DISP_CLOSE";
+            x = X_PART(1);
+            y = Y_PART(22.3);
+            w = W_PART(7.5);
+            h = H_PART(1);
+            style = ST_LEFT;
+            animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.8)";
+            animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.5)";
+            animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
+            animTextureFocused = "#(argb,8,8,3)color(1,1,1,1)";
+            animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
+            animTextureDefault = "#(argb,8,8,3)color(1,1,1,1)";
+            color[] = {1, 1, 1, 1};
+            color2[] = {0,0,0, 1};
+            colorBackgroundFocused[] = {1,1,1,1};
+            colorBackground[] = {1,1,1,1};
+            colorbackground2[] = {1,1,1,1};
+            colorDisabled[] = {0.5,0.5,0.5,0.8};
+            colorFocused[] = {0,0,0,1};
+            periodFocus = 1;
+            periodOver = 1;
+            action = "closedialog 0;";
+            SizeEx = H_PART(1);
+            Size = H_PART(1);
+        };
+        class action_reset: actionClose {
+            idc = 1100;
+            text = "$STR_ACE_OptionsMenu_ResetAll";
+            x = X_PART(9.5);
+            action = QUOTE([] call FUNC(resetSettings));
+        };
+        class action_exportServerConfig: actionClose {
+            idc = 1102;
+            text = "$STR_ACE_OptionsMenu_OpenExport";
+            x = X_PART(18);
+            action = QUOTE(if (GVAR(serverConfigGeneration) > 0) then {createDialog 'ACE_serverSettingsMenu'; });
+        };
     };
-    class selectionAction_1: ACE_gui_buttonBase {
-      idc = 1000;
-      text = "$STR_ACE_OptionsMenu_TabOptions";
-      x = X_PART(1);
-      y = Y_PART(2.1);
-      w = W_PART(9.5);
-      h = H_PART(1);
-      animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.9)";
-      animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.8)";
-      animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
-      animTextureFocused = "#(argb,8,8,3)color(1,1,1,1)";
-      animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
-      animTextureDefault = "#(argb,8,8,3)color(1,1,1,1)";
-      color[] = {1, 1, 1, 1};
-      color2[] = {0,0,0, 1};
-      colorBackgroundFocused[] = {1,1,1,1};
-      colorBackground[] = {1,1,1,1};
-      colorbackground2[] = {1,1,1,1};
-      colorDisabled[] = {1,1,1,1};
-      colorFocused[] = {0,0,0,1};
-      periodFocus = 1;
-      periodOver = 1;
-      action = QUOTE([MENU_TAB_OPTIONS] call FUNC(onListBoxShowSelectionChanged););
-      SizeEx = H_PART(1);
-      Size = H_PART(1);
-    };
-    class selectionAction_2: selectionAction_1 {
-      idc = 1001;
-      text = "$STR_ACE_OptionsMenu_TabColors";
-      x = X_PART(10.5);
-      action = QUOTE([MENU_TAB_COLORS] call FUNC(onListBoxShowSelectionChanged););
-    };
-    class selectionAction_3: selectionAction_1 {
-      idc = 1002;
-      text = "";
-      x = X_PART(20);
-      action = "";
-    };
-    class selectionAction_4: selectionAction_1 {
-      idc = 1003;
-      text = "";
-      x = X_PART(29.5);
-      action = "";
-    };
-    class listBoxSettingsList: ACE_gui_listNBox {
-      idc = 200;
-      x = X_PART(2);
-      y = Y_PART(5.5);
-      w = W_PART(23);
-      h = H_PART(15);
-      SizeEx = H_ORIGINAL(0.8);
-      colorBackground[] = {0, 0, 0, 0.9};
-      colorSelectBackground[] = {0, 0, 0, 0.9};
-      columns[] = {0.0, 0.6};
-      onLBSelChanged = QUOTE(_this call FUNC(settingsMenuUpdateKeyView));
-    };
-    class labelTitle: ACE_gui_staticBase {
-      idc = 250;
-      x = X_PART(27.1);
-      y = Y_PART(5.1);
-      w = W_PART(11);
-      h = H_PART(1);
-      text = "";
-      SizeEx = H_PART(1);
-    };
-    class labelKey: ACE_gui_staticBase {  //Variable Name
-      idc = 300;
-      x = X_PART(27.1);
-      y = Y_PART(6.2);
-      w = W_PART(11);
-      h = H_PART(1);
-      text = "";
-      SizeEx = H_PART(0.65);
-    };
-    class Label2: labelKey {
-      idc = 301;
-      y = Y_PART(7.3);
-      text = "$STR_ACE_OptionsMenu_Setting";
-      SizeEx = H_PART(1);
-    };
-    class comboBox1: ACE_gui_comboBoxBase {
-      idc = 400;
-      x = X_PART(31.1);
-      y = Y_PART(7.3);
-      w = W_PART(7);
-      h = H_PART(1);
-      onLBSelChanged = QUOTE( call FUNC(onListBoxSettingsChanged));
-      SizeEx = H_PART(0.9);
-    };
-    class sliderBar1: RscXSliderH {
-      idc = 410;
-      x = X_PART(27.1);
-      y = Y_PART(7.3);
-      w = W_PART(11);
-      h = H_PART(0.75);
-      onSliderPosChanged = QUOTE(_this call FUNC(onSliderPosChanged));
-      color[] = {1,0,0,0.4};
-      colorActive[] = {1,0,0,1};
-    };
-    class sliderBar2: sliderBar1 {
-      idc = 411;
-      y = Y_PART(8.2);
-      color[] = {0,1,0,0.4};
-      colorActive[] = {0,1,0,1};
-    };
-    class sliderBar3: sliderBar1 {
-      idc = 412;
-      y = Y_PART(9.1);
-      color[] = {0,0,1,0.4};
-      colorActive[] = {0,0,1,1};
-    };
-    class sliderBar4: sliderBar1 {
-      idc = 413;
-      y = Y_PART(10);
-      color[] = {1,1,1,0.4};
-      colorActive[] = {1,1,1,1};
-    };
-    class labelDesc: ACE_gui_staticBase {
-      idc = 251;
-      x = X_PART(27.1);
-      y = Y_PART(11);
-      w = W_PART(11);
-      h = H_PART(11);
-      text = "";
-      style = ST_LEFT + ST_MULTI;
-      lineSpacing = 1;
-      SizeEx = H_PART(0.8);
-    };
-    class actionClose: ACE_gui_buttonBase {
-      idc = 10;
-      text = "$STR_DISP_CLOSE";
-      x = X_PART(1);
-      y = Y_PART(22.3);
-      w = W_PART(7.5);
-      h = H_PART(1);
-      style = ST_LEFT;
-      animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.8)";
-      animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.5)";
-      animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
-      animTextureFocused = "#(argb,8,8,3)color(1,1,1,1)";
-      animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
-      animTextureDefault = "#(argb,8,8,3)color(1,1,1,1)";
-      color[] = {1, 1, 1, 1};
-      color2[] = {0,0,0, 1};
-      colorBackgroundFocused[] = {1,1,1,1};
-      colorBackground[] = {1,1,1,1};
-      colorbackground2[] = {1,1,1,1};
-      colorDisabled[] = {0.5,0.5,0.5,0.8};
-      colorFocused[] = {0,0,0,1};
-      periodFocus = 1;
-      periodOver = 1;
-      action = "closedialog 0;";
-      SizeEx = H_PART(1);
-      Size = H_PART(1);
-    };
-    class action_reset: actionClose {
-      idc = 1100;
-      text = "$STR_ACE_OptionsMenu_ResetAll";
-      x = X_PART(9.5);
-      action = QUOTE([] call FUNC(resetSettings));
-    };
-    class action_exportServerConfig: actionClose {
-      idc = 1102;
-      text = "$STR_ACE_OptionsMenu_OpenExport";
-      x = X_PART(18);
-      action = QUOTE(if (GVAR(serverConfigGeneration) > 0) then {createDialog 'ACE_serverSettingsMenu'; });
-    };
-  };
 };
 class ACE_serverSettingsMenu: ACE_settingsMenu {
     onLoad = QUOTE(uiNamespace setVariable [ARR_2('ACE_serverSettingsMenu', _this select 0)]; [] call FUNC(onServerSettingsMenuOpen););
     onUnload = QUOTE(uiNamespace setVariable [ARR_2('ACE_serverSettingsMenu', nil)];);
-  class controls: controls {
-    class HeaderName {
-      idc = 1;
-      type = CT_STATIC;
-      x = X_PART(1);
-      y = Y_PART(1);
-      w = W_PART(38);
-      h = H_PART(1);
-      style = ST_LEFT + ST_SHADOW;
-      font = "PuristaMedium";
-      SizeEx = H_PART(1);
-      colorText[] = {0.95, 0.95, 0.95, 0.75};
-      colorBackground[] = {0,0,0,0};
-      text = "$STR_ACE_OptionsMenu_OpenConfigMenu";
+    class controls: controls {
+        class HeaderName {
+            idc = 1;
+            type = CT_STATIC;
+            x = X_PART(1);
+            y = Y_PART(1);
+            w = W_PART(38);
+            h = H_PART(1);
+            style = ST_LEFT + ST_SHADOW;
+            font = "PuristaMedium";
+            SizeEx = H_PART(1);
+            colorText[] = {0.95, 0.95, 0.95, 0.75};
+            colorBackground[] = {0,0,0,0};
+            text = "$STR_ACE_OptionsMenu_OpenConfigMenu";
+        };
+        class labelSubHeader: ACE_gui_staticBase {
+            idc = 13;
+            x = X_PART(2);
+            y = Y_PART(3.4);
+            w = W_PART(30);
+            h = H_PART(1);
+            text = "";
+        };
+        class selectionAction_1: ACE_gui_buttonBase {
+            idc = 1000;
+            text = "$STR_ACE_OptionsMenu_TabOptions";
+            x = X_PART(1);
+            y = Y_PART(2.1);
+            w = W_PART(9.5);
+            h = H_PART(1);
+            animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.9)";
+            animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.8)";
+            animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
+            animTextureFocused = "#(argb,8,8,3)color(1,1,1,1)";
+            animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
+            animTextureDefault = "#(argb,8,8,3)color(1,1,1,1)";
+            color[] = {1, 1, 1, 1};
+            color2[] = {0,0,0, 1};
+            colorBackgroundFocused[] = {1,1,1,1};
+            colorBackground[] = {1,1,1,1};
+            colorbackground2[] = {1,1,1,1};
+            colorDisabled[] = {1,1,1,1};
+            colorFocused[] = {0,0,0,1};
+            periodFocus = 1;
+            periodOver = 1;
+            action = QUOTE([MENU_TAB_SERVER_OPTIONS] call FUNC(onServerListBoxShowSelectionChanged););
+        };
+        class selectionAction_2: selectionAction_1 {
+            idc = 1001;
+            text = "$STR_ACE_OptionsMenu_TabColors";
+            x = X_PART(10.5);
+            action = QUOTE([MENU_TAB_SERVER_COLORS] call FUNC(onServerListBoxShowSelectionChanged););
+        };
+        class selectionAction_3: selectionAction_1 {
+            idc = 1002;
+            text = "$STR_ACE_OptionsMenu_TabValues";
+            x = X_PART(20);
+            action = QUOTE([MENU_TAB_SERVER_VALUES] call FUNC(onServerListBoxShowSelectionChanged););
+        };
+        class selectionAction_4: selectionAction_1 {
+            idc = 1003;
+            text = "";
+            x = X_PART(29.5);
+            action = "";
+        };
+        class listBoxSettingsList: ACE_gui_listNBox {
+            idc = 200;
+            x = X_PART(2);
+            y = Y_PART(5.5);
+            w = W_PART(23);
+            h = H_PART(15);
+            SizeEx = H_ORIGINAL(0.8);
+            colorBackground[] = {0, 0, 0, 0.9};
+            colorSelectBackground[] = {0, 0, 0, 0.9};
+            columns[] = {0.0, 0.6};
+            onLBSelChanged = QUOTE(_this call FUNC(serverSettingsMenuUpdateKeyView));
+        };
+        class labelTitle: ACE_gui_staticBase {
+            idc = 250;
+            x = X_PART(27.1);
+            y = Y_PART(5.1);
+            w = W_PART(11);
+            h = H_PART(1);
+            text = "";
+            SizeEx = H_PART(1);
+        };
+        class labelKey: ACE_gui_staticBase {  //Variable Name
+            idc = 300;
+            x = X_PART(27.1);
+            y = Y_PART(6.2);
+            w = W_PART(11);
+            h = H_PART(1);
+            text = "";
+            SizeEx = H_PART(0.65);
+        };
+        class Label2: labelKey {
+            idc = 301;
+            y = Y_PART(7.3);
+            text = "$STR_ACE_OptionsMenu_Setting";
+            SizeEx = H_PART(1);
+        };
+        class comboBox1: ACE_gui_comboBoxBase {
+            idc = 400;
+            x = X_PART(31.1);
+            y = Y_PART(7.3);
+            w = W_PART(7);
+            h = H_PART(1);
+            onLBSelChanged = QUOTE( call FUNC(onListBoxSettingsChanged));
+            SizeEx = H_PART(0.9);
+        };
+        class sliderBar1: RscXSliderH {
+            idc = 410;
+            x = X_PART(27.1);
+            y = Y_PART(7.3);
+            w = W_PART(11);
+            h = H_PART(0.75);
+            onSliderPosChanged = QUOTE(_this call FUNC(onSliderPosChanged));
+            color[] = {1,0,0,0.4};
+            colorActive[] = {1,0,0,1};
+        };
+        class sliderBar2: sliderBar1 {
+            idc = 411;
+            y = Y_PART(8.2);
+            color[] = {0,1,0,0.4};
+            colorActive[] = {0,1,0,1};
+        };
+        class sliderBar3: sliderBar1 {
+            idc = 412;
+            y = Y_PART(9.1);
+            color[] = {0,0,1,0.4};
+            colorActive[] = {0,0,1,1};
+        };
+        class sliderBar4: sliderBar1 {
+            idc = 413;
+            y = Y_PART(10);
+            color[] = {1,1,1,0.4};
+            colorActive[] = {1,1,1,1};
+        };
+        class inputField1: ACE_gui_editBase {
+            idc = 414;
+            x = X_PART(27.1);
+            y = Y_PART(7.3);
+            w = W_PART(11);
+            h = H_PART(0.75);
+        };
+        class inputFieldTypeLabel: ACE_gui_staticBase {
+            idc = 415;
+            x = X_PART(27.1);
+            y = Y_PART(8.2);
+            w = W_PART(11);
+            h = H_PART(0.75);
+            text = "";
+            style = ST_LEFT + ST_MULTI;
+            lineSpacing = 1;
+            SizeEx = H_PART(0.8);
+        };
+        class saveInputButton: selectionAction_1 {
+            idc = 416;
+            text = "$STR_ACE_OptionsMenu_SaveInput";
+            x = X_PART(27.1);
+            y = Y_PART(9.1);
+            w = W_PART(11);
+            h = H_PART(1);
+            action = QUOTE([] call FUNC(onServerSaveInputField););
+        };
+        class labelDesc: ACE_gui_staticBase {
+            idc = 251;
+            x = X_PART(27.1);
+            y = Y_PART(11);
+            w = W_PART(11);
+            h = H_PART(11);
+            text = "";
+            style = ST_LEFT + ST_MULTI;
+            lineSpacing = 1;
+            SizeEx = H_PART(0.8);
+        };
+        class actionClose;
+        class action_reset: actionClose {
+            idc = 1100;
+            text = "$STR_ACE_OptionsMenu_ResetAll";
+            x = X_PART(26.1);
+            action = QUOTE([] call FUNC(serverResetSettings));
+        };
+        class action_exportServerConfig: actionClose {
+            idc = 1101;
+            text = "$STR_ACE_OptionsMenu_Export";
+            x = X_PART(1);
+            action = QUOTE([] call FUNC(exportSettings));
+        };
+        class action_toggleIncludeClientSettings: actionClose {
+            idc = 1102;
+            text = "$STR_ACE_OptionsMenu_inClientSettings";
+            x = X_PART(9);
+            action = QUOTE([] call FUNC(toggleIncludeClientSettings));
+        };
     };
-    class labelSubHeader: ACE_gui_staticBase {
-      idc = 13;
-      x = X_PART(2);
-      y = Y_PART(3.4);
-      w = W_PART(30);
-      h = H_PART(1);
-      text = "";
-    };
-    class selectionAction_1: ACE_gui_buttonBase {
-      idc = 1000;
-      text = "$STR_ACE_OptionsMenu_TabOptions";
-      x = X_PART(1);
-      y = Y_PART(2.1);
-      w = W_PART(9.5);
-      h = H_PART(1);
-      animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.9)";
-      animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.8)";
-      animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
-      animTextureFocused = "#(argb,8,8,3)color(1,1,1,1)";
-      animTexturePressed = "#(argb,8,8,3)color(1,1,1,1)";
-      animTextureDefault = "#(argb,8,8,3)color(1,1,1,1)";
-      color[] = {1, 1, 1, 1};
-      color2[] = {0,0,0, 1};
-      colorBackgroundFocused[] = {1,1,1,1};
-      colorBackground[] = {1,1,1,1};
-      colorbackground2[] = {1,1,1,1};
-      colorDisabled[] = {1,1,1,1};
-      colorFocused[] = {0,0,0,1};
-      periodFocus = 1;
-      periodOver = 1;
-      action = QUOTE([MENU_TAB_SERVER_OPTIONS] call FUNC(onServerListBoxShowSelectionChanged););
-    };
-    class selectionAction_2: selectionAction_1 {
-      idc = 1001;
-      text = "$STR_ACE_OptionsMenu_TabColors";
-      x = X_PART(10.5);
-      action = QUOTE([MENU_TAB_SERVER_COLORS] call FUNC(onServerListBoxShowSelectionChanged););
-    };
-    class selectionAction_3: selectionAction_1 {
-      idc = 1002;
-      text = "$STR_ACE_OptionsMenu_TabValues";
-      x = X_PART(20);
-      action = QUOTE([MENU_TAB_SERVER_VALUES] call FUNC(onServerListBoxShowSelectionChanged););
-    };
-    class selectionAction_4: selectionAction_1 {
-      idc = 1003;
-      text = "";
-      x = X_PART(29.5);
-      action = "";
-    };
-    class listBoxSettingsList: ACE_gui_listNBox {
-      idc = 200;
-      x = X_PART(2);
-      y = Y_PART(5.5);
-      w = W_PART(23);
-      h = H_PART(15);
-      SizeEx = H_PART(0.8);
-      colorBackground[] = {0, 0, 0, 0.9};
-      colorSelectBackground[] = {0, 0, 0, 0.9};
-      columns[] = {0.0, 0.6};
-      onLBSelChanged = QUOTE(_this call FUNC(serverSettingsMenuUpdateKeyView));
-    };
-    class labelTitle: ACE_gui_staticBase {
-      idc = 250;
-      x = X_PART(27.1);
-      y = Y_PART(5.1);
-      w = W_PART(11);
-      h = H_PART(1);
-      text = "";
-      SizeEx = H_PART(1);
-    };
-    class labelKey: ACE_gui_staticBase {  //Variable Name
-      idc = 300;
-      x = X_PART(27.1);
-      y = Y_PART(6.2);
-      w = W_PART(11);
-      h = H_PART(1);
-      text = "";
-      SizeEx = H_PART(0.65);
-    };
-    class Label2: labelKey {
-      idc = 301;
-      y = Y_PART(7.3);
-      text = "$STR_ACE_OptionsMenu_Setting";
-      SizeEx = H_PART(1);
-    };
-    class comboBox1: ACE_gui_comboBoxBase {
-      idc = 400;
-      x = X_PART(31.1);
-      y = Y_PART(7.3);
-      w = W_PART(7);
-      h = H_PART(1);
-      onLBSelChanged = QUOTE( call FUNC(onListBoxSettingsChanged));
-      SizeEx = H_PART(0.9);
-    };
-    class sliderBar1: RscXSliderH {
-      idc = 410;
-      x = X_PART(27.1);
-      y = Y_PART(7.3);
-      w = W_PART(11);
-      h = H_PART(0.75);
-      onSliderPosChanged = QUOTE(_this call FUNC(onSliderPosChanged));
-      color[] = {1,0,0,0.4};
-      colorActive[] = {1,0,0,1};
-    };
-    class sliderBar2: sliderBar1 {
-      idc = 411;
-      y = Y_PART(8.2);
-      color[] = {0,1,0,0.4};
-      colorActive[] = {0,1,0,1};
-    };
-    class sliderBar3: sliderBar1 {
-      idc = 412;
-      y = Y_PART(9.1);
-      color[] = {0,0,1,0.4};
-      colorActive[] = {0,0,1,1};
-    };
-    class sliderBar4: sliderBar1 {
-      idc = 413;
-      y = Y_PART(10);
-      color[] = {1,1,1,0.4};
-      colorActive[] = {1,1,1,1};
-    };
-    class inputField1: ACE_gui_editBase {
-      idc = 414;
-      x = X_PART(27.1);
-      y = Y_PART(7.3);
-      w = W_PART(11);
-      h = H_PART(0.75);
-    };
-    class inputFieldTypeLabel: ACE_gui_staticBase {
-      idc = 415;
-      x = X_PART(27.1);
-      y = Y_PART(8.2);
-      w = W_PART(11);
-      h = H_PART(0.75);
-      text = "";
-      style = ST_LEFT + ST_MULTI;
-      lineSpacing = 1;
-      SizeEx = H_PART(0.8);
-    };
-    class saveInputButton: selectionAction_1 {
-      idc = 416;
-      text = "$STR_ACE_OptionsMenu_SaveInput";
-      x = X_PART(27.1);
-      y = Y_PART(9.1);
-      w = W_PART(11);
-      h = H_PART(1);
-      action = QUOTE([] call FUNC(onServerSaveInputField););
-    };
-    class labelDesc: ACE_gui_staticBase {
-      idc = 251;
-      x = X_PART(27.1);
-      y = Y_PART(11);
-      w = W_PART(11);
-      h = H_PART(11);
-      text = "";
-      style = ST_LEFT + ST_MULTI;
-      lineSpacing = 1;
-      SizeEx = H_PART(0.8);
-    };
-    class actionClose;
-    class action_reset: actionClose {
-      idc = 1100;
-      text = "$STR_ACE_OptionsMenu_ResetAll";
-      x = X_PART(26.1);
-      action = QUOTE([] call FUNC(serverResetSettings));
-    };
-    class action_exportServerConfig: actionClose {
-      idc = 1101;
-      text = "$STR_ACE_OptionsMenu_Export";
-      x = X_PART(1);
-      action = QUOTE([] call FUNC(exportSettings));
-    };
-    class action_toggleIncludeClientSettings: actionClose {
-      idc = 1102;
-      text = "$STR_ACE_OptionsMenu_inClientSettings";
-      x = X_PART(9);
-      action = QUOTE([] call FUNC(toggleIncludeClientSettings));
-    };
-  };
 };

--- a/addons/optionsmenu/gui/settingsMenu.hpp
+++ b/addons/optionsmenu/gui/settingsMenu.hpp
@@ -4,46 +4,56 @@ class ACE_settingsMenu {
   onLoad = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', _this select 0)]; [] call FUNC(onSettingsMenuOpen););
   onUnload = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', nil)]; saveProfileNamespace;);
 
-  #define SIZEX (((safezoneW / safezoneH) min 1.2))
-  #define SIZEY (SIZEX / 1.2)
-  #define UNITX (SIZEX / 40)
-  #define UNITY (SIZEY / 25)
-  #define OFFSETX (safezoneX + (safezoneW - SIZEX)/2)
-  #define OFFSETY (safezoneY + (safezoneH - (SIZEX / 1.2))/2)
+#define SIZEX (((safezoneW / safezoneH) min 1.2))
+#define SIZEY (SIZEX / 1.2)
+#define X_ORIGINAL(num) (num * (SIZEX / 40) + (safezoneX + (safezoneW - SIZEX)/2))
+#define Y_ORIGINAL(num) (num * (SIZEY / 25) + (safezoneY + (safezoneH - (SIZEX / 1.2))/2))
+#define W_ORIGINAL(num) (num * (SIZEX / 40))
+#define H_ORIGINAL(num) (num * (SIZEY / 25))
 
+#define X_MAKEITBIGGA(num) (num * (safeZoneH / 40) + (safezoneX + (safezoneW - safeZoneH)/2))
+#define Y_MAKEITBIGGA(num) (num * (safeZoneH / 30) + (safezoneY + (safezoneH - (safeZoneH / 1.2))/2))
+#define W_MAKEITBIGGA(num) (num * (safeZoneH / 40))
+#define H_MAKEITBIGGA(num) (num * (safeZoneH / 30))
+
+#define X_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), X_ORIGINAL(num), X_MAKEITBIGGA(num))])
+#define Y_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), Y_ORIGINAL(num), Y_MAKEITBIGGA(num))])
+#define W_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), W_ORIGINAL(num), W_MAKEITBIGGA(num))])
+#define H_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), H_ORIGINAL(num), H_MAKEITBIGGA(num))])
+  
   class controlsBackground {
     class HeaderBackground: ACE_gui_backgroundBase {
       idc = -1;
       type = CT_STATIC;
-      x = 1 * UNITX + OFFSETX;
-      y = 1 * UNITY + OFFSETY;
-      w = 38 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(1);
+      y = Y_PART(1);
+      w = W_PART(38);
+      h = H_PART(1);
       style = ST_LEFT + ST_SHADOW;
       font = "PuristaMedium";
-      SizeEx = (UNITY * 1);
+      SizeEx = H_PART(1);
       colorText[] = {0.95, 0.95, 0.95, 0.75};
       colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.69])","(profilenamespace getvariable ['GUI_BCG_RGB_G',0.75])","(profilenamespace getvariable ['GUI_BCG_RGB_B',0.5])", "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
       text = "";
     };
     class CenterBackground: HeaderBackground {
-      y = 2.1 * UNITY + OFFSETY;
-      h = 2.5 * UNITY;
+      y = Y_PART(2.1);
+      h = H_PART(2.5);
       text = "";
       colorText[] = {0, 0, 0, "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
       colorBackground[] = {0,0,0,"(profilenamespace getvariable ['GUI_BCG_RGB_A',0.9])"};
     };
     class LeftBackground: CenterBackground {
-      y = 4.8 * UNITY + OFFSETY;
-      h = 17.4 * UNITY;
-      w = 25 * UNITX;
+      y = Y_PART(4.8);
+      h = H_PART(17.4);
+      w = W_PART(25);
     };
     class RightBackground: LeftBackground {
-      x = 26.1 * UNITX + OFFSETX;
-      w = 12.9 * UNITX;
+      x = X_PART(26.1);
+      w = W_PART(12.9);
     };
     class RightBackgroundHeader: RightBackground {
-      h = 1.4 * UNITY;
+      h = H_PART(1.4);
       colorBackground[] = {0,0,0,1};
     };
   };
@@ -52,32 +62,32 @@ class ACE_settingsMenu {
     class HeaderName {
       idc = 1;
       type = CT_STATIC;
-      x = 1 * UNITX + OFFSETX;
-      y = 1 * UNITY + OFFSETY;
-      w = 38 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(1);
+      y = Y_PART(1);
+      w = W_PART(38);
+      h = H_PART(1);
       style = ST_LEFT + ST_SHADOW;
       font = "PuristaMedium";
-      SizeEx = (UNITY * 1);
+      SizeEx = H_PART(1);
       colorText[] = {0.95, 0.95, 0.95, 0.75};
       colorBackground[] = {0,0,0,0};
       text = "$STR_ACE_OptionsMenu_OpenConfigMenu";
     };
     class labelSubHeader: ACE_gui_staticBase {
       idc = 13;
-      x = 2 * UNITX + OFFSETX;
-      y = 3.4 * UNITY + OFFSETY;
-      w = 30 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(2);
+      y = Y_PART(3.4);
+      w = W_PART(30);
+      h = H_PART(1);
       text = "";
     };
     class selectionAction_1: ACE_gui_buttonBase {
       idc = 1000;
       text = "$STR_ACE_OptionsMenu_TabOptions";
-      x = 1 * UNITX + OFFSETX;
-      y = 2.1 * UNITY + OFFSETY;
-      w = 9.5 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(1);
+      y = Y_PART(2.1);
+      w = W_PART(9.5);
+      h = H_PART(1);
       animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.9)";
       animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.8)";
       animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
@@ -94,34 +104,34 @@ class ACE_settingsMenu {
       periodFocus = 1;
       periodOver = 1;
       action = QUOTE([MENU_TAB_OPTIONS] call FUNC(onListBoxShowSelectionChanged););
-      SizeEx = (UNITY * 1);
-      Size = (UNITY * 1);
+      SizeEx = H_PART(1);
+      Size = H_PART(1);
     };
     class selectionAction_2: selectionAction_1 {
       idc = 1001;
       text = "$STR_ACE_OptionsMenu_TabColors";
-      x = 10.5 * UNITX + OFFSETX;
+      x = X_PART(10.5);
       action = QUOTE([MENU_TAB_COLORS] call FUNC(onListBoxShowSelectionChanged););
     };
     class selectionAction_3: selectionAction_1 {
       idc = 1002;
       text = "";
-      x = 20 * UNITX + OFFSETX;
+      x = X_PART(20);
       action = "";
     };
     class selectionAction_4: selectionAction_1 {
       idc = 1003;
       text = "";
-      x = 29.5 * UNITX + OFFSETX;
+      x = X_PART(29.5);
       action = "";
     };
     class listBoxSettingsList: ACE_gui_listNBox {
       idc = 200;
-      x = 2 * UNITX + OFFSETX;
-      y = 5.5 * UNITY + OFFSETY;
-      w = 23 * UNITX;
-      h = 15 * UNITY;
-      SizeEx = (UNITY * 0.8);
+      x = X_PART(2);
+      y = Y_PART(5.5);
+      w = W_PART(23);
+      h = H_PART(15);
+      SizeEx = H_ORIGINAL(0.8);
       colorBackground[] = {0, 0, 0, 0.9};
       colorSelectBackground[] = {0, 0, 0, 0.9};
       columns[] = {0.0, 0.6};
@@ -129,83 +139,83 @@ class ACE_settingsMenu {
     };
     class labelTitle: ACE_gui_staticBase {
       idc = 250;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 5.1 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(5.1);
+      w = W_PART(11);
+      h = H_PART(1);
       text = "";
-      SizeEx = (UNITY *1);
+      SizeEx = H_PART(1);
     };
     class labelKey: ACE_gui_staticBase {  //Variable Name
       idc = 300;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 6.2 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(6.2);
+      w = W_PART(11);
+      h = H_PART(1);
       text = "";
-      SizeEx = (UNITY * 0.65);
+      SizeEx = H_PART(0.65);
     };
     class Label2: labelKey {
       idc = 301;
-      y = 7.3 * UNITY + OFFSETY;
+      y = Y_PART(7.3);
       text = "$STR_ACE_OptionsMenu_Setting";
-      SizeEx = (UNITY * 1);
+      SizeEx = H_PART(1);
     };
     class comboBox1: ACE_gui_comboBoxBase {
       idc = 400;
-      x = 31.1 * UNITX + OFFSETX;
-      y = 7.3 * UNITY + OFFSETY;
-      w = 7 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(31.1);
+      y = Y_PART(7.3);
+      w = W_PART(7);
+      h = H_PART(1);
       onLBSelChanged = QUOTE( call FUNC(onListBoxSettingsChanged));
-      SizeEx = (UNITY * 0.9);
+      SizeEx = H_PART(0.9);
     };
     class sliderBar1: RscXSliderH {
       idc = 410;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 7.3 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 0.75 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(7.3);
+      w = W_PART(11);
+      h = H_PART(0.75);
       onSliderPosChanged = QUOTE(_this call FUNC(onSliderPosChanged));
       color[] = {1,0,0,0.4};
       colorActive[] = {1,0,0,1};
     };
     class sliderBar2: sliderBar1 {
       idc = 411;
-      y = 8.2 * UNITY + OFFSETY;
+      y = Y_PART(8.2);
       color[] = {0,1,0,0.4};
       colorActive[] = {0,1,0,1};
     };
     class sliderBar3: sliderBar1 {
       idc = 412;
-      y = 9.1 * UNITY + OFFSETY;
+      y = Y_PART(9.1);
       color[] = {0,0,1,0.4};
       colorActive[] = {0,0,1,1};
     };
     class sliderBar4: sliderBar1 {
       idc = 413;
-      y = 10 * UNITY + OFFSETY;
+      y = Y_PART(10);
       color[] = {1,1,1,0.4};
       colorActive[] = {1,1,1,1};
     };
     class labelDesc: ACE_gui_staticBase {
       idc = 251;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 11 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 11 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(11);
+      w = W_PART(11);
+      h = H_PART(11);
       text = "";
       style = ST_LEFT + ST_MULTI;
       lineSpacing = 1;
-      SizeEx = (UNITY * 0.8);
+      SizeEx = H_PART(0.8);
     };
     class actionClose: ACE_gui_buttonBase {
       idc = 10;
       text = "$STR_DISP_CLOSE";
-      x = 1 * UNITX + OFFSETX;
-      y = 22.3 * UNITY + OFFSETY;
-      w = 7.5 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(1);
+      y = Y_PART(22.3);
+      w = W_PART(7.5);
+      h = H_PART(1);
       style = ST_LEFT;
       animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.8)";
       animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.5)";
@@ -223,19 +233,19 @@ class ACE_settingsMenu {
       periodFocus = 1;
       periodOver = 1;
       action = "closedialog 0;";
-      SizeEx = (UNITY * 1);
-      Size = (UNITY * 1);
+      SizeEx = H_PART(1);
+      Size = H_PART(1);
     };
     class action_reset: actionClose {
       idc = 1100;
       text = "$STR_ACE_OptionsMenu_ResetAll";
-      x = 26.1 * (SIZEX / 40) + OFFSETX;
+      x = X_PART(9.5);
       action = QUOTE([] call FUNC(resetSettings));
     };
     class action_exportServerConfig: actionClose {
       idc = 1102;
       text = "$STR_ACE_OptionsMenu_OpenExport";
-      x = 1 * (SIZEX / 40) + OFFSETX;
+      x = X_PART(18);
       action = QUOTE(if (GVAR(serverConfigGeneration) > 0) then {createDialog 'ACE_serverSettingsMenu'; });
     };
   };
@@ -247,32 +257,32 @@ class ACE_serverSettingsMenu: ACE_settingsMenu {
     class HeaderName {
       idc = 1;
       type = CT_STATIC;
-      x = 1 * UNITX + OFFSETX;
-      y = 1 * UNITY + OFFSETY;
-      w = 38 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(1);
+      y = Y_PART(1);
+      w = W_PART(38);
+      h = H_PART(1);
       style = ST_LEFT + ST_SHADOW;
       font = "PuristaMedium";
-      SizeEx = (UNITY * 1);
+      SizeEx = H_PART(1);
       colorText[] = {0.95, 0.95, 0.95, 0.75};
       colorBackground[] = {0,0,0,0};
       text = "$STR_ACE_OptionsMenu_OpenConfigMenu";
     };
     class labelSubHeader: ACE_gui_staticBase {
       idc = 13;
-      x = 2 * UNITX + OFFSETX;
-      y = 3.4 * UNITY + OFFSETY;
-      w = 30 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(2);
+      y = Y_PART(3.4);
+      w = W_PART(30);
+      h = H_PART(1);
       text = "";
     };
     class selectionAction_1: ACE_gui_buttonBase {
       idc = 1000;
       text = "$STR_ACE_OptionsMenu_TabOptions";
-      x = 1 * UNITX + OFFSETX;
-      y = 2.1 * UNITY + OFFSETY;
-      w = 9.5 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(1);
+      y = Y_PART(2.1);
+      w = W_PART(9.5);
+      h = H_PART(1);
       animTextureNormal = "#(argb,8,8,3)color(0,0,0,0.9)";
       animTextureDisabled = "#(argb,8,8,3)color(0,0,0,0.8)";
       animTextureOver = "#(argb,8,8,3)color(1,1,1,1)";
@@ -293,28 +303,28 @@ class ACE_serverSettingsMenu: ACE_settingsMenu {
     class selectionAction_2: selectionAction_1 {
       idc = 1001;
       text = "$STR_ACE_OptionsMenu_TabColors";
-      x = 10.5 * UNITX + OFFSETX;
+      x = X_PART(10.5);
       action = QUOTE([MENU_TAB_SERVER_COLORS] call FUNC(onServerListBoxShowSelectionChanged););
     };
     class selectionAction_3: selectionAction_1 {
       idc = 1002;
       text = "$STR_ACE_OptionsMenu_TabValues";
-      x = 20 * UNITX + OFFSETX;
+      x = X_PART(20);
       action = QUOTE([MENU_TAB_SERVER_VALUES] call FUNC(onServerListBoxShowSelectionChanged););
     };
     class selectionAction_4: selectionAction_1 {
       idc = 1003;
       text = "";
-      x = 29.5 * UNITX + OFFSETX;
+      x = X_PART(29.5);
       action = "";
     };
     class listBoxSettingsList: ACE_gui_listNBox {
       idc = 200;
-      x = 2 * UNITX + OFFSETX;
-      y = 5.5 * UNITY + OFFSETY;
-      w = 23 * UNITX;
-      h = 15 * UNITY;
-      SizeEx = (UNITY * 0.8);
+      x = X_PART(2);
+      y = Y_PART(5.5);
+      w = W_PART(23);
+      h = H_PART(15);
+      SizeEx = H_PART(0.8);
       colorBackground[] = {0, 0, 0, 0.9};
       colorSelectBackground[] = {0, 0, 0, 0.9};
       columns[] = {0.0, 0.6};
@@ -322,120 +332,120 @@ class ACE_serverSettingsMenu: ACE_settingsMenu {
     };
     class labelTitle: ACE_gui_staticBase {
       idc = 250;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 5.1 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(5.1);
+      w = W_PART(11);
+      h = H_PART(1);
       text = "";
-      SizeEx = (UNITY *1);
+      SizeEx = H_PART(1);
     };
     class labelKey: ACE_gui_staticBase {  //Variable Name
       idc = 300;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 6.2 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(6.2);
+      w = W_PART(11);
+      h = H_PART(1);
       text = "";
-      SizeEx = (UNITY * 0.65);
+      SizeEx = H_PART(0.65);
     };
     class Label2: labelKey {
       idc = 301;
-      y = 7.3 * UNITY + OFFSETY;
+      y = Y_PART(7.3);
       text = "$STR_ACE_OptionsMenu_Setting";
-      SizeEx = (UNITY * 1);
+      SizeEx = H_PART(1);
     };
     class comboBox1: ACE_gui_comboBoxBase {
       idc = 400;
-      x = 31.1 * UNITX + OFFSETX;
-      y = 7.3 * UNITY + OFFSETY;
-      w = 7 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(31.1);
+      y = Y_PART(7.3);
+      w = W_PART(7);
+      h = H_PART(1);
       onLBSelChanged = QUOTE( call FUNC(onListBoxSettingsChanged));
-      SizeEx = (UNITY * 0.9);
+      SizeEx = H_PART(0.9);
     };
     class sliderBar1: RscXSliderH {
       idc = 410;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 7.3 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 0.75 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(7.3);
+      w = W_PART(11);
+      h = H_PART(0.75);
       onSliderPosChanged = QUOTE(_this call FUNC(onSliderPosChanged));
       color[] = {1,0,0,0.4};
       colorActive[] = {1,0,0,1};
     };
     class sliderBar2: sliderBar1 {
       idc = 411;
-      y = 8.2 * UNITY + OFFSETY;
+      y = Y_PART(8.2);
       color[] = {0,1,0,0.4};
       colorActive[] = {0,1,0,1};
     };
     class sliderBar3: sliderBar1 {
       idc = 412;
-      y = 9.1 * UNITY + OFFSETY;
+      y = Y_PART(9.1);
       color[] = {0,0,1,0.4};
       colorActive[] = {0,0,1,1};
     };
     class sliderBar4: sliderBar1 {
       idc = 413;
-      y = 10 * UNITY + OFFSETY;
+      y = Y_PART(10);
       color[] = {1,1,1,0.4};
       colorActive[] = {1,1,1,1};
     };
     class inputField1: ACE_gui_editBase {
       idc = 414;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 7.3 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 0.75 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(7.3);
+      w = W_PART(11);
+      h = H_PART(0.75);
     };
     class inputFieldTypeLabel: ACE_gui_staticBase {
       idc = 415;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 8.2 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 0.75 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(8.2);
+      w = W_PART(11);
+      h = H_PART(0.75);
       text = "";
       style = ST_LEFT + ST_MULTI;
       lineSpacing = 1;
-      SizeEx = (UNITY * 0.8);
+      SizeEx = H_PART(0.8);
     };
     class saveInputButton: selectionAction_1 {
       idc = 416;
       text = "$STR_ACE_OptionsMenu_SaveInput";
-      x = 27.1 * UNITX + OFFSETX;
-      y = 9.1 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 1 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(9.1);
+      w = W_PART(11);
+      h = H_PART(1);
       action = QUOTE([] call FUNC(onServerSaveInputField););
     };
     class labelDesc: ACE_gui_staticBase {
       idc = 251;
-      x = 27.1 * UNITX + OFFSETX;
-      y = 11 * UNITY + OFFSETY;
-      w = 11 * UNITX;
-      h = 11 * UNITY;
+      x = X_PART(27.1);
+      y = Y_PART(11);
+      w = W_PART(11);
+      h = H_PART(11);
       text = "";
       style = ST_LEFT + ST_MULTI;
       lineSpacing = 1;
-      SizeEx = (UNITY * 0.8);
+      SizeEx = H_PART(0.8);
     };
     class actionClose;
     class action_reset: actionClose {
       idc = 1100;
       text = "$STR_ACE_OptionsMenu_ResetAll";
-      x = 26.1 * (SIZEX / 40) + OFFSETX;
+      x = X_PART(26.1);
       action = QUOTE([] call FUNC(serverResetSettings));
     };
     class action_exportServerConfig: actionClose {
       idc = 1101;
       text = "$STR_ACE_OptionsMenu_Export";
-      x = 1 * (SIZEX / 40) + OFFSETX;
+      x = X_PART(1);
       action = QUOTE([] call FUNC(exportSettings));
     };
     class action_toggleIncludeClientSettings: actionClose {
       idc = 1102;
       text = "$STR_ACE_OptionsMenu_inClientSettings";
-      x = 9 * (SIZEX / 40) + OFFSETX;
+      x = X_PART(9);
       action = QUOTE([] call FUNC(toggleIncludeClientSettings));
     };
   };

--- a/addons/optionsmenu/stringtable.xml
+++ b/addons/optionsmenu/stringtable.xml
@@ -198,5 +198,8 @@
             <French>Paramètres exportés dans le presse papier</French>
             <Hungarian>Beállítások exportálva a vágólapba</Hungarian>
         </Key>
+        <Key ID="STR_ACE_optionsMenu_uiScaing">
+            <English>Option Menu UI Scaling</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
The game doesn't seem to localize text in arrays from a config.
e.g.: values[] = {"$str_medium", "$str_large", "$str_very_large"}; won't be translated.
I remember this breaking AGM repair somehow, anyways I just added something to detect and localize them in setSettingFromConfig when we load from config.

Lets you scale the options menu (allowing more rows), just like inventory stuff.

I seemed to be hitting a max string/clipboard limit when exporting server config with user settings via clipboard (I get 423 lines and it ends mid class).  Adds a backup method to dump to rpt.