### PR TITLE
Medical - Use default value instead of 0 for getVar

### DIFF
--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -248,7 +248,7 @@ if (USE_WOUND_EVENT_SYNC) then {
 };
 
 [
-    {(((_this select 0) getvariable [QGVAR(bloodVolume), 0]) < 65)},
+    {(((_this select 0) getvariable [QGVAR(bloodVolume), 100]) < 65)},
     {(((_this select 0) getvariable [QGVAR(pain), 0]) > 0.9)},
     {(((_this select 0) call FUNC(getBloodLoss)) > 0.25)},
     {((_this select 0) getvariable [QGVAR(inReviveState), false])},

--- a/addons/medical/functions/fnc_addToInjuredCollection.sqf
+++ b/addons/medical/functions/fnc_addToInjuredCollection.sqf
@@ -33,10 +33,10 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
            [_this select 1] call CBA_fnc_removePerFrameHandler;
            if (!local _unit) then {
                 if (GVAR(level) >= 2) then {
-                    _unit setvariable [QGVAR(heartRate), _unit getvariable [QGVAR(heartRate), 0], true];
-                    _unit setvariable [QGVAR(bloodPressure), _unit getvariable [QGVAR(bloodPressure), [0, 0]], true];
+                    _unit setvariable [QGVAR(heartRate), _unit getvariable [QGVAR(heartRate), 80], true];
+                    _unit setvariable [QGVAR(bloodPressure), _unit getvariable [QGVAR(bloodPressure), [80, 120]], true];
                 };
-                _unit setvariable [QGVAR(bloodVolume), _unit getvariable [QGVAR(bloodVolume), 0], true];
+                _unit setvariable [QGVAR(bloodVolume), _unit getvariable [QGVAR(bloodVolume), 100], true];
            };
         } else {
             [_unit] call FUNC(handleUnitVitals);

--- a/addons/medical/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical/functions/fnc_handleUnitVitals.sqf
@@ -27,7 +27,7 @@ if (_syncValues) then {
     _unit setvariable [QGVAR(lastMomentValuesSynced), time];
 };
 
-_bloodVolume = (_unit getvariable [QGVAR(bloodVolume), 0]) + ([_unit] call FUNC(getBloodVolumeChange));
+_bloodVolume = (_unit getvariable [QGVAR(bloodVolume), 100]) + ([_unit] call FUNC(getBloodVolumeChange));
 _bloodVolume = _bloodVolume max 0;
 
 _unit setvariable  [QGVAR(bloodVolume), _bloodVolume, _syncValues];
@@ -100,7 +100,7 @@ if (GVAR(level) >= 2) then {
     };
 
     // Set the vitals
-    _heartRate = (_unit getvariable [QGVAR(heartRate), 0]) + (([_unit] call FUNC(getHeartRateChange)) * _interval);
+    _heartRate = (_unit getvariable [QGVAR(heartRate), 80]) + (([_unit] call FUNC(getHeartRateChange)) * _interval);
     _unit setvariable  [QGVAR(heartRate), _heartRate, _syncValues];
 
     _bloodPressure = [_unit] call FUNC(getBloodPressure);

--- a/addons/medical/functions/fnc_setCardiacArrest.sqf
+++ b/addons/medical/functions/fnc_setCardiacArrest.sqf
@@ -33,7 +33,7 @@ _timeInCardiacArrest = 120 + round(random(600));
     _startTime = _args select 1;
     _timeInCardiacArrest = _args select 2;
 
-    _heartRate = _unit getvariable [QGVAR(heartRate), 0];
+    _heartRate = _unit getvariable [QGVAR(heartRate), 80];
     if (_heartRate > 0 || !alive _unit) exitwith {
         [(_this select 1)] call cba_fnc_removePerFrameHandler;
         _unit setvariable [QGVAR(inCardiacArrest), nil,true];


### PR DESCRIPTION
There's an issue with locality and some var's not behing propaged.
![image](https://cloud.githubusercontent.com/assets/9376747/7206908/4925ec74-e4fb-11e4-94d1-f21c331b6e46.png)

This is more of a bandaid than a full fix.  It just changes getVariables to use a default number instead of 0 for stuff like hear rate.