### PR TITLE
Fix settings localization is done by the server instead of client

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -4,6 +4,7 @@
 // Load settings from profile
 if (hasInterface) then {
     call FUNC(loadSettingsFromProfile);
+    call FUNC(loadSettingsLocalizedText);
 };
 
 // Listens for global "SettingChanged" events, to update the force status locally

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -119,6 +119,7 @@ PREP(loadPerson);
 PREP(loadPersonLocal);
 PREP(loadSettingsFromProfile);
 PREP(loadSettingsOnServer);
+PREP(loadSettingsLocalizedText);
 PREP(map);
 PREP(moduleCheckPBOs);
 PREP(moduleLSDVehicles);

--- a/addons/common/functions/fnc_loadSettingsFromProfile.sqf
+++ b/addons/common/functions/fnc_loadSettingsFromProfile.sqf
@@ -13,6 +13,29 @@
  */
 #include "script_component.hpp"
 
+private ["_parseConfigForDisplayNames", "_name", "_isClientSetable", "_isForced", "_profileValue"];
+
+_parseConfigForDisplayNames = {
+    private "_optionEntry";
+    _optionEntry = _this select 0;
+    if !(isClass _optionEntry) exitwith {false};
+    _x set [3, getText (_optionEntry >> "displayName")];
+    _x set [4, getText (_optionEntry >> "description")];
+
+    private "_values";
+    _values = _x select 5;
+    {
+        private "_text";
+        _text = _x;
+        if (((typeName _text) == "STRING") && {(count _text) > 1} && {(_text select [0,1]) == "$"}) then {
+            _text = localize (_text select [1, ((count _text) - 1)]); //chop off the leading $
+            _values set [_forEachIndex, _text];
+        };
+    } forEach _values;
+    true;
+};
+
+
 // Iterate through settings
 {
     _name = _x select 0;
@@ -34,4 +57,11 @@
             };
         };
     };
+
+    if !([configFile >> "ACE_Settings" >> _name] call _parseConfigForDisplayNames) then {
+        if !([configFile >> "ACE_ServerSettings" >> _name] call _parseConfigForDisplayNames) then {
+            [missionConfigFile >> "ACE_Settings" >> _name] call _parseConfigForDisplayNames;
+        };
+    };
+
 } forEach GVAR(settings);

--- a/addons/common/functions/fnc_loadSettingsFromProfile.sqf
+++ b/addons/common/functions/fnc_loadSettingsFromProfile.sqf
@@ -13,28 +13,7 @@
  */
 #include "script_component.hpp"
 
-private ["_parseConfigForDisplayNames", "_name", "_isClientSetable", "_isForced", "_profileValue"];
-
-_parseConfigForDisplayNames = {
-    private "_optionEntry";
-    _optionEntry = _this select 0;
-    if !(isClass _optionEntry) exitwith {false};
-    _x set [3, getText (_optionEntry >> "displayName")];
-    _x set [4, getText (_optionEntry >> "description")];
-
-    private "_values";
-    _values = _x select 5;
-    {
-        private "_text";
-        _text = _x;
-        if (((typeName _text) == "STRING") && {(count _text) > 1} && {(_text select [0,1]) == "$"}) then {
-            _text = localize (_text select [1, ((count _text) - 1)]); //chop off the leading $
-            _values set [_forEachIndex, _text];
-        };
-    } forEach _values;
-    true;
-};
-
+private ["_name", "_isClientSetable", "_isForced", "_profileValue"];
 
 // Iterate through settings
 {
@@ -55,12 +34,6 @@ _parseConfigForDisplayNames = {
                     missionNamespace setvariable [_name, _profileValue];
                 };
             };
-        };
-    };
-
-    if !([configFile >> "ACE_Settings" >> _name] call _parseConfigForDisplayNames) then {
-        if !([configFile >> "ACE_ServerSettings" >> _name] call _parseConfigForDisplayNames) then {
-            [missionConfigFile >> "ACE_Settings" >> _name] call _parseConfigForDisplayNames;
         };
     };
 

--- a/addons/common/functions/fnc_loadSettingsLocalizedText.sqf
+++ b/addons/common/functions/fnc_loadSettingsLocalizedText.sqf
@@ -1,0 +1,48 @@
+/*
+ * Author: Glowbal
+ * Parse all settings and load the localized displayName and description for all text
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+private ["_parseConfigForDisplayNames", "_name"];
+
+_parseConfigForDisplayNames = {
+    private "_optionEntry";
+    _optionEntry = _this select 0;
+    if !(isClass _optionEntry) exitwith {false};
+    _x set [3, getText (_optionEntry >> "displayName")];
+    _x set [4, getText (_optionEntry >> "description")];
+
+    private "_values";
+    _values = _x select 5;
+    {
+        private "_text";
+        _text = _x;
+        if (((typeName _text) == "STRING") && {(count _text) > 1} && {(_text select [0,1]) == "$"}) then {
+            _text = localize (_text select [1, ((count _text) - 1)]); //chop off the leading $
+            _values set [_forEachIndex, _text];
+        };
+    } forEach _values;
+    true;
+};
+
+
+// Iterate through settings
+{
+    _name = _x select 0;
+
+    if !([configFile >> "ACE_Settings" >> _name] call _parseConfigForDisplayNames) then {
+        if !([configFile >> "ACE_ServerSettings" >> _name] call _parseConfigForDisplayNames) then {
+            [missionConfigFile >> "ACE_Settings" >> _name] call _parseConfigForDisplayNames;
+        };
+    };
+
+} forEach GVAR(settings);

--- a/addons/common/functions/fnc_setSettingFromConfig.sqf
+++ b/addons/common/functions/fnc_setSettingFromConfig.sqf
@@ -75,9 +75,9 @@ if (isNil _name) then {
         getNumber (_optionEntry >> "force") > 0,
         _value
     ];
-    
+
     //Strings in the values array won't be localized from the config, so just do that now:
-    private "_values";
+    /*private "_values";
     _values = _settingData select 5;
     {
         _text = _x;
@@ -85,8 +85,8 @@ if (isNil _name) then {
             _text = localize (_text select [1, ((count _text) - 1)]); //chop off the leading $
             _values set [_forEachIndex, _text];
         };
-    } forEach _values;
-    
+    } forEach _values;*/
+
 
     GVAR(settings) pushBack _settingData;
 


### PR DESCRIPTION
Fixes #744

* Overrides displayName and description on postInit for each client
* Does not do localization of the values on server anymore.

This was the easiest solution I could come up with atm, without having to remove the `$` infront of every settings displayName or description.
