### PR TITLE
User changeable text/shadow colors for interaction

### DIFF
--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -3,6 +3,15 @@
 
 if (!hasInterface) exitWith {};
 
+//Setup text/shadow color matrix
+[] call FUNC(setupTextColors);
+["SettingChanged", {
+    PARAMS_2(_name,_value);
+    if ((_name == QGVAR(colorTextMax)) || {_name == QGVAR(colorTextMin)} || {_name == QGVAR(colorShadowMax)} || {_name == QGVAR(colorShadowMin)}) then {
+        [] call FUNC(setupTextColors);
+    };
+}] call EFUNC(common,addEventhandler);
+
 // Install the render EH on the main display
 addMissionEventHandler ["Draw3D", DFUNC(render)];
 

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -21,6 +21,7 @@ PREP(renderBaseMenu);
 PREP(renderIcon);
 PREP(renderMenu);
 PREP(renderSelector);
+PREP(setupTextColors);
 PREP(splitPath);
 
 GVAR(keyDown) = false;

--- a/addons/interact_menu/config.cpp
+++ b/addons/interact_menu/config.cpp
@@ -37,6 +37,30 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = "$STR_ACE_Interact_Menu_UseListMenu";
     };
+    class GVAR(colorTextMax) {
+        value[] = {1, 1, 1, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = "$STR_ACE_Interact_Menu_ColorTextMax";
+    };    
+    class GVAR(colorTextMin) {
+        value[] = {1, 1, 1, 0.25};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = "$STR_ACE_Interact_Menu_ColorTextMin";
+    };   
+    class GVAR(colorShadowMax) {
+        value[] = {1, 1, 1, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = "$STR_ACE_Interact_Menu_ColorShadowMax";
+    };    
+    class GVAR(colorShadowMin) {
+        value[] = {1, 1, 1, 0.25};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = "$STR_ACE_Interact_Menu_ColorShadowMin";
+    };
 };
 
 class ACE_Extensions {

--- a/addons/interact_menu/functions/fnc_renderIcon.sqf
+++ b/addons/interact_menu/functions/fnc_renderIcon.sqf
@@ -4,12 +4,11 @@
  *
  * Argument:
  * 0: Text <STRING>
- * 1: Color <STRING>
+ * 1: Icon <STRING>
  * 2: 2d position <ARRAY>
- * 3: ?
- * 4: ?
- * 5: ?
- * 6: Icon <STRING>
+ * 3: Color <STRING>
+ * 4: Shadow Color <STRING>
+ * 5: Icon Color <STRING>
  *
  * Return value:
  * None
@@ -18,11 +17,8 @@
  */
 #include "script_component.hpp"
 #define DEFAULT_ICON QUOTE(\z\ace\addons\interaction\ui\dot_ca.paa)
-private ["_color", "_sPos", "_ctrl", "_icon"];
-_text = _this select 0;
-_color = _this select 1;
-_sPos = _this select 2;
-_icon = _this select 6;
+private ["_ctrl"];
+PARAMS_6(_text,_icon,_sPos,_textColor,_shadowColor,_iconColor);
 
 //systemChat format ["Icon %1 - %2,%3", _text, _sPos select 0, _sPos select 1];
 
@@ -37,16 +33,15 @@ if(_icon == "") then {
 };
 
 _text = if (GVAR(UseListMenu)) then {
-	format ["<img image='%1' color='%2' align='left'/><t color='%3' size='0.80' shadow='1' shadowColor='#000000' shadowOffset='0.07'>%4</t>", _icon, _color, _color, _text]
+    format ["<img image='%1' color='%2' align='left'/><t color='%3' size='0.80' shadow='1' shadowColor='%4' shadowOffset='0.06'>%5</t>", _icon, _iconColor, _textColor, _shadowColor, _text]
 } else {
-	format ["<img image='%1' color='%2' align='center'/><br/><t color='%3' size='0.80' align='center' shadow='1' shadowColor='#000000' shadowOffset='0.07'>%4</t>", _icon, _color, _color, "ace_breakLine" callExtension _text];
+    format ["<img image='%1' color='%2' align='center'/><br/><t color='%3' size='0.80' align='center' shadow='1' shadowColor='%4' shadowOffset='0.06'>%5</t>", _icon, _iconColor, _textColor, _shadowColor, "ace_breakLine" callExtension _text];
 };
 
 _ctrl ctrlSetStructuredText (parseText _text);
 _text = if (GVAR(UseListMenu)) then {
-	_ctrl ctrlSetPosition [(_sPos select 0)-(0.0095*SafeZoneW), (_sPos select 1)-(0.0095*SafeZoneW), 0.20*SafeZoneW, 0.035*SafeZoneW];
+    _ctrl ctrlSetPosition [(_sPos select 0)-(0.0095*SafeZoneW), (_sPos select 1)-(0.0095*SafeZoneW), 0.20*SafeZoneW, 0.035*SafeZoneW];
 } else {
-	_ctrl ctrlSetPosition [(_sPos select 0)-(0.0750*SafeZoneW), (_sPos select 1)-(0.0095*SafeZoneW), 0.15*SafeZoneW, 0.100*SafeZoneW];
+    _ctrl ctrlSetPosition [(_sPos select 0)-(0.0750*SafeZoneW), (_sPos select 1)-(0.0095*SafeZoneW), 0.15*SafeZoneW, 0.100*SafeZoneW];
 };
-//_ctrl ctrlSetBackgroundColor [0, 1, 0, 0.1];
 _ctrl ctrlCommit 0;

--- a/addons/interact_menu/functions/fnc_renderMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderMenu.sqf
@@ -45,19 +45,17 @@ _menuInSelectedPath = true;
 
 // Render icon
 // ARGB Color (First Hex Pair is transparancy)
-_color = "#FFFFFFFF";
+_textColor = GVAR(colorSelected);
+_shadowColor = GVAR(colorSelectedShadow);
 if(!_menuInSelectedPath) then {
-    if (_menuDepth > 0) then {
-        _color = format ["#%1FFFFFF", [255 * ((((count _path) - 1)/_menuDepth) max 0.25)] call EFUNC(common,toHex)];
-    } else {
-        _color = format ["#%1FFFFFF", [255 * 0.75] call EFUNC(common,toHex)];
-    };
+    _textColor = (GVAR(colorNotSelectedMatrix) select (count _path)) select _menuDepth;
+    _shadowColor = (GVAR(colorShadowNotSelectedMatrix) select (count _path)) select _menuDepth;
 };
 
 //END_COUNTER(constructing_colors);
 //BEGIN_COUNTER(fnc_renderIcons);
 
-[_actionData select 1, _color, _sPos, 1, 1, 0, _actionData select 2, 0.5, 0.025, "TahomaB"] call FUNC(renderIcon);
+[_actionData select 1, _actionData select 2, _sPos, _textColor, _shadowColor, "#FFFFFFFF"] call FUNC(renderIcon);
 
 //END_COUNTER(fnc_renderIcons);
 

--- a/addons/interact_menu/functions/fnc_setupTextColors.sqf
+++ b/addons/interact_menu/functions/fnc_setupTextColors.sqf
@@ -1,0 +1,52 @@
+/*
+ * Author: PabstMirror
+ * Builds color strings needed for displaying interaction text
+ *
+ * Argument:
+ * None
+ *
+ * Return value:
+ * None
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+private ["_mixColor", "_rowT", "_rowS", "_menuDepth", "_pathCount", "_menuInSelectedPath", "_color", "_path"];
+
+//Mixes 2 colors (number arrays) and makes a color string "#AARRGGBB" for structured text
+_mixColor = {
+    PARAMS_3(_color1,_color2,_ratio);
+    private ["_return", "_mix", "_index"];
+    _return = "";
+    for "_index" from 0 to 3 do {
+        _mix = linearConversion [0, 1, _ratio, (_color1 select _index), (_color2 select _index)];
+        if (_index != 3) then {
+            _return = _return + ([255 * _mix] call EFUNC(common,toHex));
+        } else {
+            _return = "#" + ([255 * _mix] call EFUNC(common,toHex)) + _return;
+        };
+    };
+    _return
+};
+
+GVAR(colorSelected) = [GVAR(colorTextMin), GVAR(colorTextMax), 1] call _mixColor;
+GVAR(colorSelectedShadow) = [GVAR(colorShadowMin), GVAR(colorShadowMax), 1] call _mixColor;
+GVAR(colorNotSelectedMatrix) = [];
+GVAR(colorShadowNotSelectedMatrix) = [];
+
+for "_pathCount" from 0 to 15 do {
+    _rowT = [];
+    _rowS = [];
+    for "_menuDepth" from 0 to 15 do {
+        if (_menuDepth > 0) then {
+            _rowT pushBack ([GVAR(colorTextMin), GVAR(colorTextMax), (((_pathCount - 1) / _menuDepth) max 0.25)] call _mixColor);
+            _rowS pushBack ([GVAR(colorShadowMin), GVAR(colorShadowMax), (((_pathCount - 1) / _menuDepth) max 0.25)] call _mixColor);
+        } else {
+            _rowT pushBack ([GVAR(colorTextMin), GVAR(colorTextMax), 0] call _mixColor);
+            _rowS pushBack ([GVAR(colorShadowMin), GVAR(colorShadowMax), 0] call _mixColor);
+        };
+    };
+    GVAR(colorNotSelectedMatrix) pushBack _rowT;
+    GVAR(colorShadowNotSelectedMatrix) pushBack _rowS;
+};

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -71,5 +71,17 @@
             <Hungarian>Járműves cselekvések</Hungarian>
             <Italian>Interazioni con veicoli</Italian>
         </Key>
+        <Key ID="STR_ACE_Interact_Menu_ColorTextMax">
+            <English>Interaction - Text Max</English>
+        </Key>
+        <Key ID="STR_ACE_Interact_Menu_ColorTextMin">
+            <English>Interaction - Text Min</English>
+        </Key>
+        <Key ID="STR_ACE_Interact_Menu_ColorShadowMax">
+            <English>Interaction - Shadow Max</English>
+        </Key>
+        <Key ID="STR_ACE_Interact_Menu_ColorShadowMin">
+            <English>Interaction - Shadow Min</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
#682

Adds 4 options to change the text and shadow colors:

![2015-04-20_00002](https://cloud.githubusercontent.com/assets/9376747/7242828/f772ee3e-e78b-11e4-82bf-bd096adbd932.jpg)

Just changing the default min alpha from 0.25 to 0.5 seems about perfect for me, but this should allow people to do whatever they want if they have trouble seeing.