### PR TITLE
This should handle FFV interactions for turned out units Refs #398

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -232,6 +232,8 @@ GVAR(OldIsCamera) = false;
     vehicle (_this select 0) == (_this select 0) ||
     // Players can always interact with his vehicle
     {vehicle (_this select 0) == (_this select 1)} ||
+    // Player can interact turned out
+    { vehicle (_this select 0) != (_this select 0) && isTurnedOut (_this select 0) } ||
     // Players can always interact with passengers of the same vehicle
     {!((_this select 0) isEqualTo (_this select 1)) && {vehicle (_this select 0) == vehicle (_this select 1)}}
 }] call FUNC(addCanInteractWithCondition);


### PR DESCRIPTION
Fixes #398 whree isTurnedout wasn't being checked for isNotInside interactions. Turned out players should be able to interact outside of the vehicle (and with the vector specifically).