### PR TITLE
Added realistic tracer burn times for several ammo types

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -98,8 +98,8 @@ class CfgAmmo {
         deflecting=18;
         hit=7;
         typicalSpeed=883;
-        tracerStartTime = 0.073;        //7T3M tracer burns out to 850m
-        tracerEndTime = 1.736;          //Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073;            //7T3M tracer burns out to 850m
+        tracerEndTime = 1.736;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.220;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
@@ -168,7 +168,7 @@ class CfgAmmo {
         typicalSpeed=833;
         hit=9;
         tracerStartTime = 0.073;		//Based on the British L5A1 which burns out to 1000m 
-        tracerEndTime = 2.058; 			//Time in seconds calculated with ballistics calculator
+        tracerEndTime = 2.058;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -98,8 +98,8 @@ class CfgAmmo {
         deflecting=18;
         hit=7;
         typicalSpeed=883;
-        tracerStartTime = 0.073;        	//7T3M tracer burns out to 850m
-        tracerEndTime = 1.736;  		//Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073;        //7T3M tracer burns out to 850m
+        tracerEndTime = 1.736;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.220;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
@@ -168,7 +168,7 @@ class CfgAmmo {
         typicalSpeed=833;
         hit=9;
         tracerStartTime = 0.073;		//Based on the British L5A1 which burns out to 1000m 
-    	tracerEndTime = 2.058; 			//Time in seconds calculated with ballistics calculator
+        tracerEndTime = 2.058; 			//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -23,8 +23,8 @@ class CfgAmmo {
         airFriction=-0.001265;
         hit=8;
         typicalSpeed=750;
-        tracerStartTime = 0.073; 		//M856 tracer burns out to 800m
-        tracerEndTime = 1.579;			//Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073;        //M856 tracer burns out to 800m
+        tracerEndTime = 1.579;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.224;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
@@ -167,8 +167,8 @@ class CfgAmmo {
         airFriction=-0.001035;
         typicalSpeed=833;
         hit=9;
-        tracerStartTime = 0.073;		//Based on the British L5A1 which burns out to 1000m 
-        tracerEndTime = 2.058;          //Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073;            //Based on the British L5A1 which burns out to 1000m 
+        tracerEndTime = 2.058;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
@@ -364,7 +364,7 @@ class CfgAmmo {
         caliber=0.9;
         hit=15;
         typicalSpeed=800;
-        tracerStartTime = 0.073; 		//Based on the 7T2 which burns three seconds
+        tracerStartTime = 0.073;            //Based on the 7T2 which burns three seconds
         tracerEndTime = 3;
         ACE_caliber=0.312;
         ACE_bulletLength=1.14;
@@ -412,8 +412,8 @@ class CfgAmmo {
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
-        tracerStartTime = 0.073; 		//57N231P tracer burns out to 800m
-        tracerEndTime = 2.082;  		//Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073;            //57N231P tracer burns out to 800m
+        tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -23,8 +23,8 @@ class CfgAmmo {
         airFriction=-0.001265;
         hit=8;
         typicalSpeed=750;
-    	tracerStartTime = 0.073; 		//M856 tracer burns out to 800m
-	tracerEndTime = 1.579;			//Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073; 		//M856 tracer burns out to 800m
+        tracerEndTime = 1.579;			//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.224;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
@@ -99,7 +99,7 @@ class CfgAmmo {
         hit=7;
         typicalSpeed=883;
         tracerStartTime = 0.073;        	//7T3M tracer burns out to 850m
-	tracerEndTime = 1.736;  		 //Time in seconds calculated with ballistics calculator
+        tracerEndTime = 1.736;  		//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.220;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
@@ -167,7 +167,7 @@ class CfgAmmo {
         airFriction=-0.001035;
         typicalSpeed=833;
         hit=9;
-    	tracerStartTime = 0.073;		//Based on the British L5A1 which burns out to 1000m 
+        tracerStartTime = 0.073;		//Based on the British L5A1 which burns out to 1000m 
     	tracerEndTime = 2.058; 			//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
@@ -365,7 +365,7 @@ class CfgAmmo {
         hit=15;
         typicalSpeed=800;
         tracerStartTime = 0.073; 		//Based on the 7T2 which burns three seconds
-	tracerEndTime = 3;
+        tracerEndTime = 3;
         ACE_caliber=0.312;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
@@ -413,7 +413,7 @@ class CfgAmmo {
         hit=12;
         typicalSpeed=716;
         tracerStartTime = 0.073; 		//57N231P tracer burns out to 800m
-	tracerEndTime = 2.082;  		//Time in seconds calculated with ballistics calculator
+        tracerEndTime = 2.082;  		//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -24,7 +24,7 @@ class CfgAmmo {
         hit=8;
         typicalSpeed=750;
     	tracerStartTime = 0.073; 		//M856 tracer burns out to 800m
-	    tracerEndTime = 1.579;			//Time in seconds calculated with ballistics calculator
+	tracerEndTime = 1.579;			//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.224;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
@@ -98,8 +98,8 @@ class CfgAmmo {
         deflecting=18;
         hit=7;
         typicalSpeed=883;
-        tracerStartTime = 0.073;        //7T3M tracer burns out to 850m
-		tracerEndTime = 1.736;          //Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073;        	//7T3M tracer burns out to 850m
+	tracerEndTime = 1.736;  		 //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.220;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
@@ -364,8 +364,8 @@ class CfgAmmo {
         caliber=0.9;
         hit=15;
         typicalSpeed=800;
-        tracerStartTime = 0.073; 	//Based on the 7T2 which burns three seconds
-		tracerEndTime = 3;
+        tracerStartTime = 0.073; 		//Based on the 7T2 which burns three seconds
+	tracerEndTime = 3;
         ACE_caliber=0.312;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
@@ -412,8 +412,8 @@ class CfgAmmo {
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
-        tracerStartTime = 0.073; 	//57N231P tracer burns out to 800m
-		tracerEndTime = 2.082;      //Time in seconds calculated with ballistics calculator
+        tracerStartTime = 0.073; 		//57N231P tracer burns out to 800m
+	tracerEndTime = 2.082;  		//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -23,6 +23,8 @@ class CfgAmmo {
         airFriction=-0.001265;
         hit=8;
         typicalSpeed=750;
+    	tracerStartTime = 0.073; 		//M856 tracer burns out to 800m
+	    tracerEndTime = 1.579;			//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.224;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
@@ -89,13 +91,15 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={780, 880, 920};
         ACE_barrelLengths[]={10, 16.3, 20};
     };
-    class B_556x45_Ball_Tracer_Yellow;
-    class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Yellow {
+    class B_556x45_Ball_Tracer_Green;
+    class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Green {
         airFriction=-0.001162;
         caliber=0.5;
         deflecting=18;
         hit=7;
         typicalSpeed=883;
+        tracerStartTime = 0.073;        //7T3M tracer burns out to 850m
+		tracerEndTime = 1.736;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.220;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
@@ -163,6 +167,8 @@ class CfgAmmo {
         airFriction=-0.001035;
         typicalSpeed=833;
         hit=9;
+    	tracerStartTime = 0.073;		//Based on the British L5A1 which burns out to 1000m 
+    	tracerEndTime = 2.058; 			//Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
@@ -358,6 +364,8 @@ class CfgAmmo {
         caliber=0.9;
         hit=15;
         typicalSpeed=800;
+        tracerStartTime = 0.073; 	//Based on the 7T2 which burns three seconds
+		tracerEndTime = 3;
         ACE_caliber=0.312;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
@@ -400,10 +408,12 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={650, 716, 750};
         ACE_barrelLengths[]={10, 16.3, 20};
     };
-    class ACE_762x39_Ball_57N231P : B_762x51_Tracer_Yellow {
+    class ACE_762x39_Ball_57N231P : B_762x54_Tracer_Green {
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
+        tracerStartTime = 0.073; 	//57N231P tracer burns out to 800m
+		tracerEndTime = 2.082;      //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.308;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;


### PR DESCRIPTION
Added realistic tracer burn times for several ammo types: 
B_556x45_Ball (parent for several tracer rounds)
ACE_545x39_Ball_7T3M
B_762x51_Ball (parent for several tracer rounds)
ACE_762x54_Ball_7T2
ACE_762x39_Ball_57N231P

Also changed color of russian tracer rounds from yellow to green, which is what they are in the real world.