### PR TITLE
Make Signature Key Building + enhancements

### DIFF
--- a/tools/make.cfg
+++ b/tools/make.cfg
@@ -17,6 +17,11 @@ project = @ace
 # Default: None
 # key = D:\Program Files (x86)\Bohemia Interactive\Tools\DSSignFile Tools\keys\ace_preAlpha.biprivatekey
 
+# Path to where private keys are automatically created if the command-line parameter "key" is used 
+# Make sure this isn't in your public repository!
+# Default: <work_drive>\private_keys
+# private_key_path = P:\private_keys
+
 # If set to True, the make system will attempt to autodetect addons in the
 # current folder by looking for directories with 'config.cpp' in them.
 # Default: True

--- a/tools/make.py
+++ b/tools/make.py
@@ -60,6 +60,7 @@ module_root = ""
 release_dir = ""
 module_root_parent = ""
 optionals_root = ""
+key_name = "ace_preAlpha"
 
 ###############################################################################
 # http://akiscode.com/articles/sha-1directoryhash.shtml
@@ -416,7 +417,14 @@ def cleanup_optionals(mod,pbos):
 def main(argv):
     """Build an Arma addon suite in a directory from rules in a make.cfg file."""
     print_blue(("\nmake.py for Arma, modified for Advanced Combat Environment v" + __version__))
-
+    
+    global work_drive
+    global module_root
+    global release_dir
+    global module_root_parent
+    global optionals_root
+    global key_name
+    
     if sys.platform != "win32":
         print_error("Non-Windows platform (Cygwin?). Please re-run from cmd.")
         sys.exit(1)
@@ -436,7 +444,7 @@ def main(argv):
     release_version = 0 # Version of release
     use_pboproject = True # Default to pboProject build tool
     make_target = "DEFAULT" # Which section in make.cfg to use for the build
-    new_key = False # Make a new key and use it to sign?
+    new_key = True # Make a new key and use it to sign?
     quiet = False # Suppress output from build tool?
 
     # Parse arguments
@@ -524,18 +532,13 @@ See the make.cfg file for additional build options.
 
         commit_id = subprocess.check_output(["git", "rev-parse", "HEAD"])
         commit_id = str(commit_id, "utf-8")[:8]
+        key_name = str(key_name+"-"+commit_id)
     except:
         print_error("FAILED TO DETERMINE COMMIT ID.")
         commit_id = "NOGIT"
 
     cfg = configparser.ConfigParser();
     try:
-        global work_drive
-        global module_root
-        global release_dir
-        global module_root_parent
-        global optionals_root
-
         cfg.read(os.path.join(make_root, "make.cfg"))
 
         # Project name (with @ symbol)
@@ -663,7 +666,7 @@ See the make.cfg file for additional build options.
             print_green("\nRequested key does not exist.")
             ret = subprocess.call([dscreatekey, key_name]) # Created in make_root
             if ret == 0:
-                print_blue("Created: " + os.path.join(module_root, key_name + ".biprivatekey"))
+                print_green("Created: " + os.path.join(module_root, key_name + ".biprivatekey"))
             else:
                 print_error("Failed to create key!")
 

--- a/tools/make.py
+++ b/tools/make.py
@@ -584,6 +584,9 @@ See the make.cfg file for additional build options.
         # Project name (with @ symbol)
         project = cfg.get(make_target, "project", fallback="@"+os.path.basename(os.getcwd()))
 
+        # BI Tools work drive on Windows
+        work_drive = cfg.get(make_target, "work_drive",  fallback="P:\\")
+
         # Private key path
         key = cfg.get(make_target, "key", fallback=None)
 
@@ -606,9 +609,6 @@ See the make.cfg file for additional build options.
 
         # List of directories to ignore when detecting
         ignore = [x.strip() for x in cfg.get(make_target, "ignore",  fallback="release").split(',')]
-
-        # BI Tools work drive on Windows
-        work_drive = cfg.get(make_target, "work_drive",  fallback="P:\\")
 
         # Which build tool should we use?
         build_tool = cfg.get(make_target, "build_tool", fallback="addonbuilder").lower()

--- a/tools/make.py
+++ b/tools/make.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+﻿#!/usr/bin/env python3
 # vim: set fileencoding=utf-8 :
 
 # make.py

--- a/tools/make.py
+++ b/tools/make.py
@@ -587,6 +587,9 @@ See the make.cfg file for additional build options.
         # Private key path
         key = cfg.get(make_target, "key", fallback=None)
 
+        # Private key creation directory
+        private_key_path = cfg.get(make_target, "private_key_path", fallback=os.path.join(work_drive, "private_keys"))
+
         # Project prefix (folder path)
         prefix = cfg.get(make_target, "prefix", fallback="")
 
@@ -704,9 +707,16 @@ See the make.cfg file for additional build options.
     if new_key:
         if not os.path.isfile(os.path.join(module_root, key_name + ".biprivatekey")):
             print_yellow("\nRequested key does not exist.")
+            try:
+                os.makedirs(private_key_path)
+            except:
+                pass
+            curDir = os.getcwd()
+            os.chdir(private_key_path)
             ret = subprocess.call([dscreatekey, key_name]) # Created in make_root
+            os.chdir(curDir)
             if ret == 0:
-                print_green("Created: " + os.path.join(module_root, key_name + ".biprivatekey"))
+                print_green("Created: " + os.path.join(private_key_path, key_name + ".biprivatekey"))
                 print("Removing any old signature keys...")
                 purge(os.path.join(module_root, release_dir, project, "Addons"), "^.*\.bisign$","*.bisign")
             else:
@@ -720,16 +730,16 @@ See the make.cfg file for additional build options.
                 except:
                     pass
 
-                shutil.copyfile(os.path.join(module_root, key_name + ".bikey"), os.path.join(module_root, release_dir, project, "keys", key_name + ".bikey"))
+                shutil.copyfile(os.path.join(private_key_path, key_name + ".bikey"), os.path.join(module_root, release_dir, project, "keys", key_name + ".bikey"))
 
             except:
                 print_error("Could not copy key to release directory.")
                 raise
 
         else:
-            print_green("\nNOTE: Using key " + os.path.join(module_root, key_name + ".biprivatekey"))
+            print_green("\nNOTE: Using key " + os.path.join(private_key_path, key_name + ".biprivatekey"))
 
-        key = os.path.join(module_root, key_name + ".biprivatekey")
+        key = os.path.join(private_key_path, key_name + ".biprivatekey")
 
 
     # For each module, prep files and then build.

--- a/tools/make.py
+++ b/tools/make.py
@@ -1046,6 +1046,9 @@ See the make.cfg file for additional build options.
 
     print_green("\nDone.")
 
+    copy_important_files(module_root_parent,os.path.join(release_dir, "@ace"))
+    cleanup_optionals(optionals_modules)
+
     # Make release
     if make_release:
         print_blue("\nMaking release: " + project + "-" + release_version + ".zip")
@@ -1084,10 +1087,6 @@ See the make.cfg file for additional build options.
                 shutil.copytree(os.path.join(module_root, release_dir, project), os.path.join(a3_path, project))
             except:
                 print_error("Could not copy files. Is Arma 3 running?")
-
-    copy_important_files(module_root_parent,os.path.join(release_dir, "@ace"))
-    cleanup_optionals(optionals_modules)
-
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/tools/make.py
+++ b/tools/make.py
@@ -719,6 +719,8 @@ See the make.cfg file for additional build options.
                 print_green("Created: " + os.path.join(private_key_path, key_name + ".biprivatekey"))
                 print("Removing any old signature keys...")
                 purge(os.path.join(module_root, release_dir, project, "Addons"), "^.*\.bisign$","*.bisign")
+                purge(os.path.join(module_root, release_dir, project, "optionals"), "^.*\.bisign$","*.bisign")
+                purge(os.path.join(module_root, release_dir, project, "keys"), "^.*\.bikey$","*.bikey")
             else:
                 print_error("Failed to create key!")
 

--- a/tools/make.py
+++ b/tools/make.py
@@ -686,6 +686,20 @@ See the make.cfg file for additional build options.
         print ("No cache found.")
         cache = {}
 
+    if not os.path.isdir(os.path.join(release_dir, project, "addons")):
+        try:
+            os.makedirs(os.path.join(release_dir, project, "addons"))
+        except:
+            print_error("Cannot create release directory")
+            raise
+
+    if not os.path.isdir(os.path.join(release_dir, project, "keys")):
+        try:
+            os.makedirs(os.path.join(release_dir, project, "keys"))
+        except:
+            print_error("Cannot create release directory")
+            raise
+
     #Temporarily copy optionals_root for building. They will be removed later.
     optionals_modules = []
     optional_files = []

--- a/tools/make.py
+++ b/tools/make.py
@@ -718,7 +718,7 @@ See the make.cfg file for additional build options.
             if ret == 0:
                 print_green("Created: " + os.path.join(private_key_path, key_name + ".biprivatekey"))
                 print("Removing any old signature keys...")
-                purge(os.path.join(module_root, release_dir, project, "Addons"), "^.*\.bisign$","*.bisign")
+                purge(os.path.join(module_root, release_dir, project, "addons"), "^.*\.bisign$","*.bisign")
                 purge(os.path.join(module_root, release_dir, project, "optionals"), "^.*\.bisign$","*.bisign")
                 purge(os.path.join(module_root, release_dir, project, "keys"), "^.*\.bikey$","*.bikey")
             else:
@@ -780,7 +780,7 @@ See the make.cfg file for additional build options.
                 if sigMissing:
                     if key:
                         print("Missing Signature key " + sigFile)
-                        build_signature_file(os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix + module + ".pbo"))
+                        build_signature_file(os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo"))
                 # Skip everything else
                 continue
 
@@ -805,13 +805,13 @@ See the make.cfg file for additional build options.
 
         try:
             # Remove the old pbo, key, and log
-            old = os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix+module) + "*"
+            old = os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix+module) + "*"
             files = glob.glob(old)
             for f in files:
                 os.remove(f)
 
             if pbo_name_prefix:
-                old = os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix+module) + "*"
+                old = os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix+module) + "*"
                 files = glob.glob(old)
                 for f in files:
                     os.remove(f)
@@ -824,11 +824,11 @@ See the make.cfg file for additional build options.
 
         # Build the module into a pbo
         print_blue("Building: " + os.path.join(work_drive, prefix, module))
-        print_blue("Destination: " + os.path.join(module_root, release_dir, project, "Addons"))
+        print_blue("Destination: " + os.path.join(module_root, release_dir, project, "addons"))
 
         # Make destination folder (if needed)
         try:
-            os.makedirs(os.path.join(module_root, release_dir, project, "Addons"))
+            os.makedirs(os.path.join(module_root, release_dir, project, "addons"))
         except:
             pass
 
@@ -880,7 +880,7 @@ See the make.cfg file for additional build options.
 
                 if os.path.isfile(os.path.join(work_drive, prefix, module, "$NOBIN$")):
                     print_green("$NOBIN$ Found. Proceeding with non-binarizing!")
-                    cmd = [makepboTool, "-P","-A","-L","-N","-G", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"Addons")]
+                    cmd = [makepboTool, "-P","-A","-L","-N","-G", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"addons")]
 
                 else:
                     if check_external:
@@ -902,7 +902,7 @@ See the make.cfg file for additional build options.
                     # Prettyprefix rename the PBO if requested.
                     if pbo_name_prefix:
                         try:
-                            os.rename(os.path.join(module_root, release_dir, project, "Addons", module+".pbo"), os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix+module+".pbo"))
+                            os.rename(os.path.join(module_root, release_dir, project, "addons", module+".pbo"), os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix+module+".pbo"))
                         except:
                             raise
                             print_error("Could not rename built PBO with prefix.")
@@ -910,9 +910,9 @@ See the make.cfg file for additional build options.
                     if key:
                         print("Signing with " + key + ".")
                         if pbo_name_prefix:
-                            ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix + module + ".pbo")])
+                            ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo")])
                         else:
-                            ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "Addons", module + ".pbo")])
+                            ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "addons", module + ".pbo")])
 
                         if ret == 0:
                             build_successful = True
@@ -952,7 +952,7 @@ See the make.cfg file for additional build options.
                 # Call AddonBuilder
                 os.chdir("P:\\")
 
-                cmd = [addonbuilder, os.path.join(work_drive, prefix, module), os.path.join(make_root, release_dir, project, "Addons"), "-clear", "-project="+work_drive]
+                cmd = [addonbuilder, os.path.join(work_drive, prefix, module), os.path.join(make_root, release_dir, project, "addons"), "-clear", "-project="+work_drive]
                 if not do_binarize:
                     cmd.append("-packonly")
 
@@ -975,7 +975,7 @@ See the make.cfg file for additional build options.
                 # Prettyprefix rename the PBO if requested.
                 if pbo_name_prefix:
                     try:
-                        os.rename(os.path.join(make_root, release_dir, project, "Addons", module+".pbo"), os.path.join(make_root, release_dir, project, "Addons", pbo_name_prefix+module+".pbo"))
+                        os.rename(os.path.join(make_root, release_dir, project, "addons", module+".pbo"), os.path.join(make_root, release_dir, project, "addons", pbo_name_prefix+module+".pbo"))
                     except:
                         raise
                         print_error("Could not rename built PBO with prefix.")
@@ -985,9 +985,9 @@ See the make.cfg file for additional build options.
                     if key:
                         print("Signing with " + key + ".")
                         if pbo_name_prefix:
-                            ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "Addons", pbo_name_prefix + module + ".pbo")])
+                            ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo")])
                         else:
-                            ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "Addons", module + ".pbo")])
+                            ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons", module + ".pbo")])
 
                         if ret == 0:
                             build_successful = True
@@ -1036,7 +1036,7 @@ See the make.cfg file for additional build options.
 
         try:
             # Delete all log files
-            for root, dirs, files in os.walk(os.path.join(module_root, release_dir, project, "Addons")):
+            for root, dirs, files in os.walk(os.path.join(module_root, release_dir, project, "addons")):
                 for currentFile in files:
                     if currentFile.lower().endswith("log"):
                         os.remove(os.path.join(root, currentFile))

--- a/tools/make.py
+++ b/tools/make.py
@@ -767,7 +767,7 @@ See the make.cfg file for additional build options.
                 print("Module has not changed.")
                 if sigMissing:
                     if key:
-                        print_yellow("Missing Signature key " + sigFile)
+                        print("Missing Signature key " + sigFile)
                         build_signature_file(os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix + module + ".pbo"))
                 # Skip everything else
                 continue

--- a/tools/make.py
+++ b/tools/make.py
@@ -356,10 +356,15 @@ def copy_optionals_for_building(mod,pbos):
             #print ("Adding the following file: " + file_name)
             pbos.append(file_name)
             pbo_path = os.path.join(release_dir, "@ace","optionals",file_name)
+            sigFile_name = file_name +"."+ key_name + ".bisign"
+            sig_path = os.path.join(release_dir, "@ace","optionals",sigFile_name)
             if (os.path.isfile(pbo_path)):
                 print("Moving " + pbo_path + " for processing.")
                 shutil.move(pbo_path, os.path.join(release_dir,"@ace","addons",file_name))
-
+                
+            if (os.path.isfile(sig_path)):
+                #print("Moving " + sig_path + " for processing.")
+                shutil.move(sig_path, os.path.join(release_dir,"@ace","addons",sigFile_name))
     except:
         print_error("Error in moving")
         raise
@@ -407,9 +412,17 @@ def cleanup_optionals(mod):
                 file_name = "ace_{}.pbo".format(dir_name)
                 src_file_path = os.path.join(release_dir, "@ace","addons",file_name)
                 dst_file_path = os.path.join(release_dir, "@ace","optionals",file_name)
+                
+                sigFile_name = file_name +"."+ key_name + ".bisign"
+                src_sig_path = os.path.join(release_dir, "@ace","addons",sigFile_name)
+                dst_sig_path = os.path.join(release_dir, "@ace","optionals",sigFile_name)
+                
                 if (os.path.isfile(src_file_path)):
                     #print("Preserving " + file_name)
                     os.renames(src_file_path,dst_file_path)
+                if (os.path.isfile(src_sig_path)):
+                    #print("Preserving " + sigFile_name)
+                    os.renames(src_sig_path,dst_sig_path)
             except FileExistsError:
                 print_error(file_name + " already exists")
                 continue
@@ -421,11 +434,10 @@ def cleanup_optionals(mod):
 
 
 def purge(dir, pattern, friendlyPattern="files"):
-    print_yellow("Deleting " + friendlyPattern + " files from directory: " + dir)
+    print_green("Deleting " + friendlyPattern + " files from directory: " + dir)
     for f in os.listdir(dir):
         if re.search(pattern, f):
             os.remove(os.path.join(dir, f))
-            print_yellow("Deleting file => " + f)
 
 
 def build_signature_file(file_name):
@@ -735,7 +747,7 @@ See the make.cfg file for additional build options.
 
         #We always build ACE_common so we can properly show the correct version stamp in the RPT file.
         if module == "common":
-            old_sha = ""
+            old_sha = old_sha
 
         # Hash the module
         new_sha = get_directory_hash(os.path.join(module_root, module))
@@ -743,11 +755,10 @@ See the make.cfg file for additional build options.
         # Is the pbo or sig file missing?
         missing = not os.path.isfile(os.path.join(release_dir, project, "addons", "ace_{}.pbo".format(module)))
         sigFile = pbo_name_prefix+module + ".pbo." + key_name + ".bisign"
-        print("Checking sig file => " + sigFile)
         sigMissing = not os.path.isfile(os.path.join(release_dir, project, "addons", sigFile ))
 
         if missing:
-            print("ace_{}.pbo".format(module) + " is missing. Building...")
+            print_yellow("Missing PBO file ace_{}.pbo".format(module) + ". Building...")
 
         # Check if it needs rebuilt
         # print ("Hash:", new_sha)
@@ -756,7 +767,7 @@ See the make.cfg file for additional build options.
                 print("Module has not changed.")
                 if sigMissing:
                     if key:
-                        print_yellow("Signature key " + sigFile + " is missing.")
+                        print_yellow("Missing Signature key " + sigFile)
                         build_signature_file(os.path.join(module_root, release_dir, project, "Addons", pbo_name_prefix + module + ".pbo"))
                 # Skip everything else
                 continue
@@ -1047,7 +1058,7 @@ See the make.cfg file for additional build options.
                 print_error("Could not copy files. Is Arma 3 running?")
 
     copy_important_files(module_root_parent,os.path.join(release_dir, "@ace"))
-    cleanup_optionals(optionals_modules,optional_files)
+    cleanup_optionals(optionals_modules)
 
 
 if __name__ == "__main__":

--- a/tools/make.py
+++ b/tools/make.py
@@ -560,6 +560,8 @@ See the make.cfg file for additional build options.
     else:
         check_external = False
 
+    print_yellow("\nCheck external references is set to " + str(check_external))
+
     # Get the directory the make script is in.
     make_root = os.path.dirname(os.path.realpath(__file__))
     make_root_parent = os.path.abspath(os.path.join(os.getcwd(), os.pardir))

--- a/tools/make.py
+++ b/tools/make.py
@@ -361,7 +361,7 @@ def copy_optionals_for_building(mod,pbos):
             if (os.path.isfile(pbo_path)):
                 print("Moving " + pbo_path + " for processing.")
                 shutil.move(pbo_path, os.path.join(release_dir,"@ace","addons",file_name))
-                
+
             if (os.path.isfile(sig_path)):
                 #print("Moving " + sig_path + " for processing.")
                 shutil.move(sig_path, os.path.join(release_dir,"@ace","addons",sigFile_name))
@@ -412,11 +412,11 @@ def cleanup_optionals(mod):
                 file_name = "ace_{}.pbo".format(dir_name)
                 src_file_path = os.path.join(release_dir, "@ace","addons",file_name)
                 dst_file_path = os.path.join(release_dir, "@ace","optionals",file_name)
-                
+
                 sigFile_name = file_name +"."+ key_name + ".bisign"
                 src_sig_path = os.path.join(release_dir, "@ace","addons",sigFile_name)
                 dst_sig_path = os.path.join(release_dir, "@ace","optionals",sigFile_name)
-                
+
                 if (os.path.isfile(src_file_path)):
                     #print("Preserving " + file_name)
                     os.renames(src_file_path,dst_file_path)
@@ -747,7 +747,7 @@ See the make.cfg file for additional build options.
 
         #We always build ACE_common so we can properly show the correct version stamp in the RPT file.
         if module == "common":
-            old_sha = old_sha
+            old_sha = ""
 
         # Hash the module
         new_sha = get_directory_hash(os.path.join(module_root, module))

--- a/tools/make.py
+++ b/tools/make.py
@@ -199,6 +199,7 @@ def find_bi_tools(work_drive):
     else:
         raise Exception("BadTools","Arma 3 Tools are not installed correctly or the P: drive needs to be created.")
 
+
 def find_depbo_tools(regKey):
     """Use registry entries to find DePBO-based tools."""
     stop = False
@@ -250,6 +251,7 @@ def find_depbo_tools(regKey):
 
     #Strip any quotations from the path due to a MikeRo tool bug which leaves a trailing space in some of its registry paths.
     return [pboproject_path.strip('"'),rapify_path.strip('"'),makepbo_path.strip('"')]
+
 
 def color(color):
     """Set the color. Works on Win32 and normal terminals."""
@@ -339,6 +341,7 @@ def copy_important_files(source_dir,destination_dir):
     finally:
         os.chdir(originalDir)
 
+
 def copy_optionals_for_building(mod,pbos):
     src_directories = os.listdir(optionals_root)
     current_dir = os.getcwd()
@@ -387,7 +390,8 @@ def copy_optionals_for_building(mod,pbos):
     finally:
         os.chdir(current_dir)
 
-def cleanup_optionals(mod,pbos):
+
+def cleanup_optionals(mod):
     print("")
     try:
         for dir_name in mod:
@@ -434,6 +438,7 @@ def build_signature_file(file_name):
     else:
         return False
 ###############################################################################
+
 
 def main(argv):
     """Build an Arma addon suite in a directory from rules in a make.cfg file."""
@@ -1043,6 +1048,8 @@ See the make.cfg file for additional build options.
 
     copy_important_files(module_root_parent,os.path.join(release_dir, "@ace"))
     cleanup_optionals(optionals_modules,optional_files)
+
+
 if __name__ == "__main__":
     main(sys.argv)
 input("Press Enter to continue...")

--- a/tools/make.py
+++ b/tools/make.py
@@ -716,15 +716,15 @@ See the make.cfg file for additional build options.
                 print("Copying public key to release directory.")
 
                 try:
-                    os.makedirs(os.path.join(module_root, release_dir, "Keys"))
+                    os.makedirs(os.path.join(module_root, release_dir, project, "keys"))
                 except:
                     pass
 
-                shutil.copyfile(os.path.join(module_root, key_name + ".bikey"), os.path.join(module_root, release_dir, "Keys", key_name + ".bikey"))
+                shutil.copyfile(os.path.join(module_root, key_name + ".bikey"), os.path.join(module_root, release_dir, project, "keys", key_name + ".bikey"))
 
             except:
-                raise
                 print_error("Could not copy key to release directory.")
+                raise
 
         else:
             print_green("\nNOTE: Using key " + os.path.join(module_root, key_name + ".biprivatekey"))

--- a/tools/make.py
+++ b/tools/make.py
@@ -412,6 +412,14 @@ def cleanup_optionals(mod,pbos):
     except:
         print_error("Cleaning Optionals Failed")
         raise
+
+
+def purge(dir, pattern, friendlyPattern="files"):
+    print_yellow("Deleting " + friendlyPattern + " files from directory: " + dir)
+    for f in os.listdir(dir):
+        if re.search(pattern, f):
+            os.remove(os.path.join(dir, f))
+            print_yellow("Deleting file => " + f)
 ###############################################################################
 
 def main(argv):
@@ -663,15 +671,17 @@ See the make.cfg file for additional build options.
     # Make the key specified from command line if necessary.
     if new_key:
         if not os.path.isfile(os.path.join(module_root, key_name + ".biprivatekey")):
-            print_green("\nRequested key does not exist.")
+            print_yellow("\nRequested key does not exist.")
             ret = subprocess.call([dscreatekey, key_name]) # Created in make_root
             if ret == 0:
                 print_green("Created: " + os.path.join(module_root, key_name + ".biprivatekey"))
+                print("Removing any old signature keys...")
+                purge(os.path.join(module_root, release_dir, project, "Addons"), "^.*\.bisign$","*.bisign")
             else:
                 print_error("Failed to create key!")
 
             try:
-                print_blue("Copying public key to release directory.")
+                print("Copying public key to release directory.")
 
                 try:
                     os.makedirs(os.path.join(module_root, release_dir, "Keys"))


### PR DESCRIPTION
Make python build script now creates signature keys by default. 
Public Key folder now resides inside the @ace release folder.
Private Keys are now created at the P:\private_keys by default. This is configurable.
Switch to all lower case folder names. 
Added a notification for the Check External References setting.
Reference: http://gyazo.com/042a5ad655921b87618c05e7addd1b09