### PR TITLE
Fixing missing inheritance: class HLC_762x54_tracer: HLC_762x51_tracer

### DIFF
--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -4,6 +4,7 @@ class CfgAmmo
     class B_556x45_Ball;
     class B_127x99_Ball;
     class B_127x99_Ball_Tracer_Red;
+    class HLC_762x51_tracer;
     class HLC_762x51_ball;
     class HLC_556NATO_EPR: B_556x45_Ball
     {


### PR DESCRIPTION
Fixing missing inheritance: class HLC_762x54_tracer: HLC_762x51_tracer
Now it will build.