### PR TITLE
German translations fixes

### DIFF
--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -5,7 +5,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_mag_Tracer_DimName">
             <English>6.5mm 30Rnd Tracer IR-DIM Mag</English>
             <Hungarian>6,5 mm Nyomjelző IR-DIM 30-as Tár</Hungarian>
-            <German>6,5 mm 30-Schuss-Magazin Leuchtspur IR-DIM</German>
+            <German>6,5mm 30-Schuss-Magazin Leuchtspur IR-DIM</German>
             <Spanish>Cargador de 30 balas trazadoras IR-DIM de 6,5mm</Spanish>
             <French>Ch. 6,5mm 30Cps Traçantes IR-DIM</French>
             <Polish>Magazynek 6,5mm 30rd Smugacz IR-DIM</Polish>
@@ -29,7 +29,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_mag_Tracer_DimDescription">
             <English>Caliber: 6.5x39 mm Tracer IR-DIM&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
             <Hungarian>Kaliber: 6,5x39 mm Nyomjelző IR-DIM&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: MX/C/M/SW/3GL</Hungarian>
-            <German>Kaliber: 6,5x39 mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MX/C/M/SW/3GL</German>
+            <German>Kaliber: 6,5x39mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MX/C/M/SW/3GL</German>
             <Spanish>Calibre: 6,5x39 mm Trazadoras IR-DIM&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: MX/C/M/SW/3GL</Spanish>
             <French>Calibre: 6,5x39 mm Traçantes IR-DIM&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: MX/C/M/SW/3GL</French>
             <Polish>Kaliber: 6,5x39 mm Smugacz IR-DIM&lt;br /&gt;Pociski: 30&lt;br /&gt;Używane w: MX/C/M/SW/3GL</Polish>
@@ -41,7 +41,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_mag_SDName">
             <English>6.5mm 30Rnd SD Mag</English>
             <Hungarian>6,5 mm Halk 30-as Tár</Hungarian>
-            <German>6,5 mm 30-Schuss-Magazin SD</German>
+            <German>6,5mm 30-Schuss-Magazin SD</German>
             <Spanish>Cargador de 30 balas SD de 6,5mm</Spanish>
             <French>Ch. 6,5mm 30Cps SD</French>
             <Polish>Magazynek 6,5mm 30rd SD</Polish>
@@ -65,7 +65,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_mag_SDDescription">
             <English>Caliber: 6.5x39 mm SD&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
             <Hungarian>Kaliber: 6,5x39 mm Halk&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: MX/C/M/SW/3GL</Hungarian>
-            <German>Kaliber: 6,5x39 mm SD&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MX/C/M/SW/3GL</German>
+            <German>Kaliber: 6,5x39mm SD&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MX/C/M/SW/3GL</German>
             <Spanish>Calibre: 6,5x39 mm SD&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: MX/C/M/SW/3GL</Spanish>
             <French>Calibre: 6,5x39 mm SD&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: MX/C/M/SW/3GL</French>
             <Polish>Kaliber: 6,5x39 mm SD&lt;br /&gt;Pociski: 30&lt;br /&gt;Używane w: MX/C/M/SW/3GL</Polish>
@@ -77,7 +77,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_mag_APName">
             <English>6.5mm 30Rnd AP Mag</English>
             <Hungarian>6,5 mm Páncéltörő 30-as Tár</Hungarian>
-            <German>6,5 mm 30-Schuss-Magazin AP</German>
+            <German>6,5mm 30-Schuss-Magazin AP</German>
             <Spanish>Cargador de 30 balas AP de 6,5mm</Spanish>
             <French>Ch. 6,5mm 30Cps AP</French>
             <Polish>Magazynek 6,5mm 30rd AP</Polish>
@@ -101,7 +101,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_mag_APDescription">
             <English>Caliber: 6.5x39 mm AP&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
             <Hungarian>Kaliber: 6,5x39 mm Páncéltörő&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: MX/C/M/SW/3GL</Hungarian>
-            <German>Kaliber: 6,5x39 mm AP&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MX/C/M/SW/3GL</German>
+            <German>Kaliber: 6,5x39mm AP&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MX/C/M/SW/3GL</German>
             <Spanish>Calibre: 6,5x39 mm AP&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: MX/C/M/SW/3GL</Spanish>
             <French>Calibre: 6,5x39 mm AP&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: MX/C/M/SW/3GL</French>
             <Polish>Kaliber: 6,5x39 mm AP&lt;br /&gt;Pociski: 30&lt;br /&gt;Używane w: MX/C/M/SW/3GL</Polish>
@@ -114,7 +114,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_green_mag_Tracer_DimName">
             <English>6.5mm 30Rnd Tracer IR-DIM Mag</English>
             <Hungarian>6,5mm IR-DIM Nyomjelző 30-as Tár</Hungarian>
-            <German>6,5 mm 30-Schuss-Magazin Leuchtspur IR-DIM</German>
+            <German>6,5mm 30-Schuss-Magazin Leuchtspur IR-DIM</German>
             <Spanish>Cargador de 30 balas trazadoras IR-DIM de 6,5mm</Spanish>
             <French>Ch. 6,5mm 30Cps Traçantes IR-DIM</French>
             <Polish>Magazynek 6,5mm 30rd Smugacz IR-DIM</Polish>
@@ -138,7 +138,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_green_mag_Tracer_DimDescription">
             <English>Caliber: 6.5x39 mm Tracer IR-DIM&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba</English>
             <Hungarian>Kaliber: 6,5x39 mm Nyomjelző IR-DIM&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: Katiba</Hungarian>
-            <German>Kaliber: 6,5x39 mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba</German>
+            <German>Kaliber: 6,5x39mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba</German>
             <Spanish>Calibre: 6,5x39 mm Trazadoras IR-DIM&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: Katiba</Spanish>
             <French>Calibre: 6,5x39 mm Traçantes IR-DIM&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: Katiba</French>
             <Polish>Kaliber: 6,5x39 mm Smugacz IR-DIM&lt;br /&gt;Pociski: 30&lt;br /&gt;Używane w: Katiba</Polish>
@@ -150,7 +150,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_green_mag_SDName">
             <English>6.5mm 30Rnd SD Mag</English>
             <Hungarian>6,5 mm Halk 30-as Tár</Hungarian>
-            <German>6,5 mm 30-Schuss-Magazin SD</German>
+            <German>6,5mm 30-Schuss-Magazin SD</German>
             <Spanish>Cargador de 30 balas SD de 6,5mm</Spanish>
             <French>Ch. 6,5mm 30Cps SD</French>
             <Polish>Magazynek 6,5mm 30rd SD</Polish>
@@ -174,7 +174,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_green_mag_SDDescription">
             <English>Caliber: 6.5x39 mm SD&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba</English>
             <Hungarian>Kaliber: 6,5x39 mm Halk&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: Katiba</Hungarian>
-            <German>Kaliber: 6,5x39 mm SD&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba</German>
+            <German>Kaliber: 6,5x39mm SD&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba</German>
             <Spanish>Calibre: 6,5x39 mm SD&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: Katiba</Spanish>
             <French>Calibre: 6,5x39 mm SD&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: Katiba</French>
             <Polish>Kaliber: 6,5x39 mm SD&lt;br /&gt;Naboje: 30&lt;br /&gt;Używane w: Katiba</Polish>
@@ -186,7 +186,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_green_mag_APName">
             <English>6.5mm 30Rnd AP Mag</English>
             <Hungarian>6,5 mm Páncéltörő 30-as Tár</Hungarian>
-            <German>6,5 mm 30-Schuss-Magazin AP</German>
+            <German>6,5mm 30-Schuss-Magazin AP</German>
             <Spanish>Cargador de 30 balas AP de 6,5mm</Spanish>
             <French>Ch. 6,5mm 30Cps AP</French>
             <Polish>Magazynek 6,5mm 30rd AP</Polish>
@@ -210,7 +210,7 @@
         <Key ID="STR_ACE_30Rnd_65x39_caseless_green_mag_APDescription">
             <English>Caliber: 6.5x39 mm AP&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba</English>
             <Hungarian>Kaliber: 6,5x39 mm Páncéltörő&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: Katiba</Hungarian>
-            <German>Kaliber: 6,5x39 mm AP&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba</German>
+            <German>Kaliber: 6,5x39mm AP&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba</German>
             <Spanish>Calibre: 6,5x39 mm AP&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: Katiba</Spanish>
             <French>Calibre: 6,5x39 mm AP&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: Katiba</French>
             <Polish>Kaliber: 6,5x39 mm AP&lt;br /&gt;Pociski: 30&lt;br /&gt;Używane w: Katiba</Polish>
@@ -223,7 +223,7 @@
         <Key ID="STR_ACE_30Rnd_556x45_mag_Tracer_DimName">
             <English>5.56mm 30rnd Tracer IR-DIM Mag</English>
             <Hungarian>5,56 mm Nyomjelző IR-DIM 30-as Tár</Hungarian>
-            <German>5,56 mm 30-Schuss-Magazin Leuchtspur IR-DIM</German>
+            <German>5,56mm 30-Schuss-Magazin Leuchtspur IR-DIM</German>
             <Spanish>Cargador de 30 balas trazadoras IR-DIM de 5,56mm</Spanish>
             <French>Ch. 5,56mm 30Cps Traçantes IR-DIM</French>
             <Polish>Magazynek 5,56mm 30rd Smugacz IR-DIM</Polish>
@@ -247,7 +247,7 @@
         <Key ID="STR_ACE_30Rnd_556x45_mag_Tracer_DimDescription">
             <English>Caliber: 5.56x45 mm Tracer IR-DIM&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</English>
             <Hungarian>Kaliber: 5,56x45 mm Nyomjelző IR-DIM&lt;br /&gt;Lövedékek: 30&lt;br /&gt;Használható: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</Hungarian>
-            <German>Kaliber: 5,56x45 mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</German>
+            <German>Kaliber: 5,56x45mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</German>
             <Spanish>Calibre: 5,56x45 mm Trazadoras IR-DIM&lt;br /&gt;Balas: 30&lt;br /&gt;Se usa en: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</Spanish>
             <French>Calibre: 5,56x45 mm Traçantes IR-DIM&lt;br /&gt;Cartouches: 30&lt;br /&gt;Utilisé dans: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</French>
             <Polish>Kaliber: 5,56x45 mm Smugacz IR-DIM&lt;br /&gt;Pociski: 30&lt;br /&gt;Używane w: TRG-20, TRG-21/EGLM, Mk20/C/EGLM, SDAR</Polish>
@@ -260,7 +260,7 @@
         <Key ID="STR_ACE_20Rnd_762x51_mag_TracerName">
             <English>7.62mm 20rnd Tracer Mag</English>
             <Hungarian>7,62 mm Nyomjelző IR-DIM 20-as Tár</Hungarian>
-            <German>7,62 mm 20-Schuss-Magazin Leuchtspur</German>
+            <German>7,62mm 20-Schuss-Magazin Leuchtspur</German>
             <Spanish>Cargador de 20 balas trazadores de 7,62mm</Spanish>
             <French>Ch. 7,62mm 20Cps Traçantes </French>
             <Polish>Magazynek 7,62mm 20rd Smugacz</Polish>
@@ -284,7 +284,7 @@
         <Key ID="STR_ACE_20Rnd_762x51_mag_TracerDescription">
             <English>Caliber: 7.62x51 mm Tracer&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR</English>
             <Hungarian>Kaliber: 7,62x51 mm Nyomjelző&lt;br /&gt;Lövedékek: 20&lt;br /&gt;Használható: Mk18 ABR</Hungarian>
-            <German>Kaliber: 7,62x51 mm Leuchtspur&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: EBR</German>
+            <German>Kaliber: 7,62x51mm Leuchtspur&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: EBR</German>
             <Spanish>Calibre: 7,62x51 mm Trazadora&lt;br /&gt;Balas: 20&lt;br /&gt;Se usa en: Mk18 ABR</Spanish>
             <French>Calibre: 7,62x51 mm Traçantes&lt;br /&gt;Cartouches: 20&lt;br /&gt;Utilisé dans: EBR</French>
             <Polish>Kaliber: 7,62x51 mm Smugacz&lt;br /&gt;Pociski: 20&lt;br /&gt;Używane w: Mk18 ABR</Polish>
@@ -320,7 +320,7 @@
         <Key ID="STR_ACE_20Rnd_762x51_mag_Tracer_DimDescription">
             <English>Caliber: 7.62x51 mm Tracer IR-DIM&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR</English>
             <Hungarian>Kaliber: 7,62x51 mm Nyomjelző IR-DIM&lt;br /&gt;Lövedékek: 20&lt;br /&gt;Használható: Mk18 ABR</Hungarian>
-            <German>Kaliber: 7,62x51 mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: EBR</German>
+            <German>Kaliber: 7,62x51mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: EBR</German>
             <Spanish>Calibre: 7,62x51 mm Trazadoras IR-DIM&lt;br /&gt;Balas: 20&lt;br /&gt;Se usa en: Mk18 ABR</Spanish>
             <French>Calibre: 7,62x51 mm Traçantes IR-DIM&lt;br /&gt;Cartouches: 20&lt;br /&gt;Utilisé dans: EBR</French>
             <Polish>Kaliber: 7,62x51 mm Smugacz IR-DIM&lt;br /&gt;Pociski: 20&lt;br /&gt;Używane w: Mk18 ABR</Polish>
@@ -332,7 +332,7 @@
         <Key ID="STR_ACE_20Rnd_762x51_mag_SDName">
             <English>7.62mm 20Rnd SD Mag</English>
             <Hungarian>7,62 mm Halk 20-as Tár</Hungarian>
-            <German>7,62 mm 20-Schuss-Magazin SD</German>
+            <German>7,62mm 20-Schuss-Magazin SD</German>
             <Spanish>Cargador de 20 balas SD de 7,62mm</Spanish>
             <French>Ch. 7,62mm 20Cps SD</French>
             <Polish>Magazynek 7,62mm 20rd SD</Polish>
@@ -356,7 +356,7 @@
         <Key ID="STR_ACE_20Rnd_762x51_mag_SDDescription">
             <English>Caliber: 7.62x51 mm SD&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR</English>
             <Hungarian>Kaliber: 7,62x51 mm Halk&lt;br /&gt;Lövedékek: 20&lt;br /&gt;Használható: Mk18 ABR</Hungarian>
-            <German>Kaliber: 7,62x51 mm SD&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: EBR</German>
+            <German>Kaliber: 7,62x51mm SD&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: EBR</German>
             <Spanish>Calibre: 7,62x51 mm SD&lt;br /&gt;Balas: 20&lt;br /&gt;Se usa en: Mk18 ABR</Spanish>
             <French>Calibre: 7,62x51 mm SD&lt;br /&gt;Cartouches: 20&lt;br /&gt;Utilisé dans: EBR</French>
             <Polish>Kaliber: 7,62x51 mm SD&lt;br /&gt;Pociski: 20&lt;br /&gt;Używane w: Mk18 ABR</Polish>
@@ -385,7 +385,7 @@
         </Key>
         <Key ID="STR_ACE_130Rnd_338_Mag_TracerDescription">
             <English>Caliber: .338 Norma Magnum Tracer&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
-            <German>Kaliber: .338 Norma Magnum Leuchtspur&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
+            <German>Kaliber: .338 Norma Magnum Leuchtspur&lt;br /&gt;Patronen: 130&lt;br /&gt;Eingesetzt von: SPMG</German>
             <Polish>Kaliber: .338 Norma Magnum Smugacz&lt;br /&gt;Pociski: 130&lt;br /&gt;Używany w: SPMG</Polish>
             <French>Calibre: .338 Norma Magnum Traçante&lt;br /&gt;Cartouches: 130&lt;br /&gt;Utilisé dans: SPMG</French>
             <Spanish>Calibre: .338 Norma Magnum trazadora&lt;br /&gt;Balas: 130&lt;br /&gt;Se usa en: SPMG</Spanish>
@@ -410,7 +410,7 @@
         </Key>
         <Key ID="STR_ACE_130Rnd_338_Mag_Tracer_DimDescription">
             <English>Caliber: .338 Norma Magnum Tracer IR-DIM&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
-            <German>Kaliber: .338 Norma Magnum Leuchtspur IR-DIM&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
+            <German>Kaliber: .338 Norma Magnum Leuchtspur IR-DIM&lt;br /&gt;Patronen: 130&lt;br /&gt;Eingesetzt von: SPMG</German>
             <Polish>Kaliber: .338 Norma Magnum Smugacz IR-DIM&lt;br /&gt;Pociski: 130&lt;br /&gt;Używany w: SPMG</Polish>
             <French>Calibre: .338 Norma Magnum Traçante IR-DIM&lt;br /&gt;Cartouches: 130&lt;br /&gt;Utilisé dans: SPMG</French>
             <Spanish>Calibre: .338 Norma Magnum trazadora IR-DIM&lt;br /&gt;Balas: 130&lt;br /&gt;Se usa en: SPMG</Spanish>
@@ -435,7 +435,7 @@
         </Key>
         <Key ID="STR_ACE_130Rnd_338_Mag_APDescription">
             <English>Caliber: .338 Norma Magnum AP&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
-            <German>Kaliber: .338 Norma Magnum Hartkern&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
+            <German>Kaliber: .338 Norma Magnum Hartkern&lt;br /&gt;Patronen: 130&lt;br /&gt;Eingesetzt von: SPMG</German>
             <Polish>Kaliber: .338 Norma Magnum AP&lt;br /&gt;Pociski: 130&lt;br /&gt;Używane w: SPMG</Polish>
             <French>Calibre: .338 Norma Magnum AP&lt;br /&gt;Cartouches: 130&lt;br /&gt;Utilisé dans: SPMG</French>
             <Spanish>Calibre: .338 Norma Magnum AP&lt;br /&gt;Balas: 130&lt;br /&gt;Se usa en: SPMG</Spanish>
@@ -461,7 +461,7 @@
         </Key>
         <Key ID="STR_ACE_10Rnd_93x64_DMR_05_Mag_TracerDescription">
             <English>Caliber: 9.3x64mm Tracer&lt;br /&gt;Rounds: 10&lt;br /&gt;Used in: Cyrus</English>
-            <German>Kaliber: 9,3x64mm Leuchtspur&lt;br /&gt;Schuss: 10&lt;br /&gt;Verwendet für: Cyrus</German>
+            <German>Kaliber: 9,3x64mm Leuchtspur&lt;br /&gt;Patronen: 10&lt;br /&gt;Eingesetzt von: Cyrus</German>
             <Polish>Kaliber: 9,3x64 mm Smugacz&lt;br /&gt;Pociski: 10&lt;br /&gt;Używany w: Cyrus</Polish>
             <French>Calibre: 9.3x64mm Traçante&lt;br /&gt;Cartouches: 10&lt;br /&gt;Utilisé dans: Cyrus</French>
             <Spanish>Calibre: 9.3x64mm trazadora&lt;br /&gt;Balas: 10&lt;br /&gt;Se usa en: Cyrus</Spanish>
@@ -486,7 +486,7 @@
         </Key>
         <Key ID="STR_ACE_10Rnd_93x64_DMR_05_Mag_Tracer_DimDescription">
             <English>Caliber: 9.3x64mm Tracer IR-DIM&lt;br /&gt;Rounds: 10&lt;br /&gt;Used in: Cyrus</English>
-            <German>Kaliber: 9,3x64mm Leuchtspur IR-DIM&lt;br /&gt;Schuss: 10&lt;br /&gt;Verwendet für: Cyrus</German>
+            <German>Kaliber: 9,3x64mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 10&lt;br /&gt;Eingesetzt von: Cyrus</German>
             <Polish>Kaliber: 9,3x64 mm Smugacz IR-DIM&lt;br /&gt;Pociski: 10&lt;br /&gt;Używany w: Cyrus</Polish>
             <French>Calibre: 9.3x64mm Traçante IR-DIM&lt;br /&gt;Cartouches: 10&lt;br /&gt;Utilisé dans: Cyrus</French>
             <Spanish>Calibre: 9.3x64mm trazadora IR-DIM&lt;br /&gt;Balas: 10&lt;br /&gt;Se usa en: Cyrus</Spanish>
@@ -512,7 +512,7 @@
         </Key>
         <Key ID="STR_ACE_150Rnd_93x64_Mag_TracerDescription">
             <English>Caliber: 9.3x64mm Tracer&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
-            <German>Kaliber: 9,3x64mm Leuchtspur&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
+            <German>Kaliber: 9,3x64mm Leuchtspur&lt;br /&gt;Patronen: 150&lt;br /&gt;Eingesetzt von: Navid</German>
             <Polish>Kaliber: 9,3x64 mm Smugacz&lt;br /&gt;Pociski: 150&lt;br /&gt;Używane w: Navid</Polish>
             <French>Calibre: 9.3x64mm Traçante&lt;br /&gt;Cartouches: 150&lt;br /&gt;Utilisé dans: Navid</French>
             <Spanish>Calibre: 9.3x64mm trazadora&lt;br /&gt;Balas: 150&lt;br /&gt;Se usa en: Navid</Spanish>
@@ -537,7 +537,7 @@
         </Key>
         <Key ID="STR_ACE_150Rnd_93x64_Mag_Tracer_DimDescription">
             <English>Caliber: 9.3x64mm Tracer IR-DIM&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
-            <German>Kaliber: 9,3x64mm Leuchtspur IR-DIM&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
+            <German>Kaliber: 9,3x64mm Leuchtspur IR-DIM&lt;br /&gt;Patronen: 150&lt;br /&gt;Eingesetzt von: Navid</German>
             <Polish>Kaliber: 9,3x64 mm Smugacz IR-DIM&lt;br /&gt;Pociski: 150&lt;br /&gt;Używane w: Navid</Polish>
             <French>Calibre: 9.3x64mm Traçante IR-DIM&lt;br /&gt;Cartouches: 150&lt;br /&gt;Utilisé dans: Navid</French>
             <Spanish>Calibre: 9.3x64mm trazadora IR-DIM&lt;br /&gt;Balas: 150&lt;br /&gt;Se usa en: Navid</Spanish>
@@ -562,7 +562,7 @@
         </Key>
         <Key ID="STR_ACE_150Rnd_93x64_Mag_APDescription">
             <English>Caliber: 9.3x64mm AP&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
-            <German>Kaliber: 9,3x64mm Hartkern&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
+            <German>Kaliber: 9,3x64mm Hartkern&lt;br /&gt;Patronen: 150&lt;br /&gt;Eingesetzt von: Navid</German>
             <Polish>Kaliber: 9,3x64 mm AP&lt;br /&gt;Pociski: 150&lt;br /&gt;Używane w: Navid</Polish>
             <French>Calibre: 9.3x64mm AP&lt;br /&gt;Cartouches: 150&lt;br /&gt;Utilisé dans: Navid</French>
             <Spanish>Calibre: 9.3x64mm AP&lt;br /&gt;Balas: 150&lt;br /&gt;Se usa en: Navid</Spanish>
@@ -622,7 +622,7 @@
             <French>Chargeur 7.62x54mm 10Rnd Traçante IR-DIM</French>
             <Spanish>Cargador de 10 balas trazadoras IR-DIM de 7.62x54mm</Spanish>
             <Russian>Магазин из 10-ти 7,62 мм ИК-трассирующих</Russian>
-            <German>7,62x54 10-Schuss-Magazin IR-DIM Leuchtspur</German>
+            <German>7,62x54mm 10-Schuss-Magazin IR-DIM Leuchtspur</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x54_Tracer_mag_NameShort">
             <English>7.62mm IR-DIM</English>
@@ -630,7 +630,7 @@
             <French>7.62mm IR-DIM</French>
             <Spanish>7.62mm IR-DIM</Spanish>
             <Russian>7,62 мм ИК-трассирующие</Russian>
-            <German>7,62x54 IR-DIM </German>
+            <German>7,62x54mm IR-DIM </German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x54_Tracer_mag_Description">
             <English>7.62x54mm 10Rnd Tracer IR-DIM Mag</English>
@@ -638,7 +638,7 @@
             <French>Chargeur 7.62x54mm 10Cps Traçante IR-DIM</French>
             <Spanish>Cargador de 10 balas trazadoras IR-DIM de 7.62x54mm</Spanish>
             <Russian>Магазин из 10-ти 7,62 мм ИК-трассирующих</Russian>
-            <German>7,62x54 10-Schuss-Magazin IR-DIM Leuchtspur</German>
+            <German>7,62x54mm 10-Schuss-Magazin IR-DIM Leuchtspur</German>
         </Key>
         <Key ID="STR_ACE_100Rnd_65x39_caseless_mag_Tracer_DimName">
             <English>6.5mm 100Rnd Tracer IR-DIM Mag</English>
@@ -662,7 +662,7 @@
             <French>Chargeur 6.5mm 100Rnd Traçante IR-DIM</French>
             <Spanish>Cargador de 100 balas trazadoras IR-DIM de 6.5mm</Spanish>
             <Russian>Магазин из 100 6,5 мм ИК-трассирующих</Russian>
-            <German>6,5mm 100-Schuss-Magazin IR-DIM Leuchtspur&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet für: MXLSW</German>
+            <German>6,5mm 100-Schuss-Magazin IR-DIM Leuchtspur&lt;br /&gt;Patronen: 100&lt;br /&gt;Eingesetzt von: MXLSW</German>
         </Key>
         <Key ID="STR_ACE_200Rnd_65x39_cased_Box_Tracer_DimName">
             <English>6.5mm 200Rnd Tracer IR-DIM Belt</English>
@@ -686,7 +686,7 @@
             <French>Bande 6.5mm 200Cps Traçante IR-DIM</French>
             <Spanish>Cinta de 200 balas trazadoras IR-DIM de 6.5mm</Spanish>
             <Russian>Магазин из 200-т 6,5 мм ИК-трассирующих</Russian>
-            <German>6,5mm 200-Schuss-Gurt IR-DIM Leuchtspur&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet für: Stoner 99 LMG</German>
+            <German>6,5mm 200-Schuss-Gurt IR-DIM Leuchtspur&lt;br /&gt;Patronen: 200&lt;br /&gt;Eingesetzt von: Stoner 99 LMG</German>
         </Key>
         <Key ID="STR_ACE_30Rnd_556x45_Stanag_Mk262_mag_Name">
             <English>5.56mm 30Rnd Mag (Mk262)</English>
@@ -734,7 +734,7 @@
             <French>Calibre: 5.56x45 mm NATO (Mk318)&lt;br /&gt;Cartouches: 30</French>
             <Spanish>Calibre: 5.56x45 mm NATO (Mk318)&lt;br /&gt;Balas: 30</Spanish>
             <Russian>Калибр: 5,56x45 мм NATO (Mk318)&lt;br /&gt;Патронов: 30</Russian>
-            <German>Kaliber: 5,56x45mm NATO (Mk318)&lt;br /&gt;Schuss: 30</German>
+            <German>Kaliber: 5,56x45mm NATO (Mk318)&lt;br /&gt;Patronen: 30</German>
         </Key>
         <Key ID="STR_ACE_30Rnd_556x45_Stanag_M995_AP_mag_Name">
             <English>5.56mm 30Rnd Mag (M995 AP)</English>
@@ -758,7 +758,7 @@
             <French>Calibre: 5.56x45 mm NATO (M995 AP)&lt;br /&gt;Cartouches: 30</French>
             <Spanish>Calibre: 5.56x45 mm NATO (M995 AP)&lt;br /&gt;Balas: 30</Spanish>
             <Russian>Калибр: 5,56x45 мм NATO (M995 AP)&lt;br /&gt;Патронов: 30</Russian>
-            <German>Kaliber: 5,56x45mm NATO (M995 AP)&lt;br /&gt;Schuss: 30</German>
+            <German>Kaliber: 5,56x45mm NATO (M995 AP)&lt;br /&gt;Patronen: 30</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x51_M118LR_Mag_Name">
             <English>7.62mm 10Rnd Mag (M118LR)</English>
@@ -782,7 +782,7 @@
             <French>Calibre: 7.62x51 mm NATO (M118LR)&lt;br /&gt;Cartouches: 10</French>
             <Spanish>Calibre: 7.62x51 mm NATO (M118LR)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M118LR)&lt;br /&gt;Патронов: 10</Russian>
-            <German>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Schuss: 10</German>
+            <German>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Patronen: 10</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x51_M118LR_Mag_Name">
             <English>7.62mm 20Rnd Mag (M118LR)</English>
@@ -806,7 +806,7 @@
             <French>Calibre: 7.62x51 mm NATO (M118LR)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x51 mm NATO (M118LR)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M118LR)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x51_Mk316_Mod_0_Mag_Name">
             <English>7.62mm 10Rnd Mag (Mk316 Mod 0)</English>
@@ -830,7 +830,7 @@
             <French>Calibre: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Cartouches: 10</French>
             <Spanish>Calibre: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk316 Mod 0)&lt;br /&gt;Патронов: 10</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Schuss: 10</German>
+            <German>Kaliber: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Patronen: 10</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x51_Mk316_Mod_0_Mag_Name">
             <English>7.62mm 20Rnd Mag (Mk316 Mod 0)</English>
@@ -854,7 +854,7 @@
             <French>Calibre: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk316 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x51_Mk319_Mod_0_Mag_Name">
             <English>7.62mm 10Rnd Mag (Mk319 Mod 0)</English>
@@ -870,7 +870,7 @@
             <French>7.62mm Mk319</French>
             <Spanish>7.62mm Mk319</Spanish>
             <Russian>7,62mm Mk319</Russian>
-            <German>7.62mm Mk319</German>
+            <German>7,62mm Mk319</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x51_Mk319_Mod_0_Mag_Description">
             <English>Caliber: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Rounds: 10</English>
@@ -878,7 +878,7 @@
             <French>Calibre: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Cartouches: 10</French>
             <Spanish>Calibre: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk319 Mod 0)&lt;br /&gt;Патронов: 10</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Schuss: 10</German>
+            <German>Kaliber: 7,62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Patronen: 10</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x51_Mk319_Mod_0_Mag_Name">
             <English>7.62mm 20Rnd Mag (Mk319 Mod 0)</English>
@@ -894,7 +894,7 @@
             <French>7.62mm Mk319</French>
             <Spanish>7.62mm Mk319</Spanish>
             <Russian>7,62 мм Mk319</Russian>
-            <German>7.62mm Mk319</German>
+            <German>7,62mm Mk319</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x51_Mk319_Mod_0_Mag_Description">
             <English>Caliber: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Rounds: 20</English>
@@ -902,7 +902,7 @@
             <French>Calibre: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk319 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7,62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_762x51_M993_AP_Mag_Name">
             <English>7.62mm 10Rnd Mag (M993 AP)</English>
@@ -926,7 +926,7 @@
             <French>Calibre: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Cartouches: 10</French>
             <Spanish>Calibre: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M993 AP)&lt;br /&gt;Патронов: 10</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Schuss: 10</German>
+            <German>Kaliber: 7,62x51mm NATO (M993 AP)&lt;br /&gt;Patronen: 10</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x51_M993_AP_Mag_Name">
             <English>7.62mm 20Rnd Mag (M993 AP)</English>
@@ -950,7 +950,7 @@
             <French>Calibre: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M993 AP)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7,62x51mm NATO (M993 AP)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x67_Mk248_Mod_0_Mag_Name">
             <English>7.62mm 20Rnd Mag (Mk248 Mod 0)</English>
@@ -974,7 +974,7 @@
             <French>Calibre: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x67 mm NATO (Mk248 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x67 мм NATO (Mk248 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (Mk248 Mod 0)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7,62x51mm NATO (Mk248 Mod 0)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x67_Mk248_Mod_1_Mag_Name">
             <English>7.62mm 20Rnd Mag (Mk248 Mod 1)</English>
@@ -998,7 +998,7 @@
             <French>Calibre: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x67 mm NATO (Mk248 Mod 1)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x67 мм NATO (Mk248 Mod 1)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7.62x51 mm NATO (Mk248 Mod 1)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7.62x51mm NATO (Mk248 Mod 1)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag_Name">
             <English>7.62mm 20Rnd Mag (Berger Hybrid OTM)</English>
@@ -1022,7 +1022,7 @@
             <French>Calibre: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Cartouches: 20</French>
             <Spanish>Calibre: 7.62x67 mm NATO (Berger Hybrid OTM)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x67 мм NATO (Berger Hybrid OTM)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7.62x67 mm NATO (Berger Hybrid OTM)&lt;br /&gt;Schuss: 20</German>
+            <German>Kaliber: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Patronen: 20</German>
         </Key>
         <Key ID="STR_ACE_30Rnd_65x47_Scenar_mag_Name">
             <English>6.5x47mm 30Rnd Mag (HPBT Scenar)</English>
@@ -1038,7 +1038,7 @@
             <Spanish>6.5mm Lapua</Spanish>
             <Polish>6,5mm Lapua</Polish>
             <Russian>6,5 мм Lapua</Russian>
-            <German>6,5 Lapua</German>
+            <German>6,5mm Lapua</German>
         </Key>
         <Key ID="STR_ACE_30Rnd_65x47_Scenar_mag_Description">
             <English>Caliber: 6.5x47mm (HPBT Scenar)&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MXM</English>
@@ -1046,7 +1046,7 @@
             <Spanish>Calibre: 6.5x47mm (HPBT Scenar)&lt;br /&gt;Balas: 30</Spanish>
             <Polish>Kaliber: 6,5x47 mm (HPBT Scenar)&lt;br /&gt;Pociski: 30</Polish>
             <Russian>Калибр: 6,5x47 мм (HPBT Scenar)&lt;br /&gt;Патронов: 30</Russian>
-            <German>Kaliber: 6,5x47 mm (HPBT Scenar)&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet für: MXM</German>
+            <German>Kaliber: 6,5x47mm (HPBT Scenar)&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MXM</German>
         </Key>
         <Key ID="STR_ACE_30Rnd_65_Creedmor_mag_Name">
             <English>6.5mm Creedmor 30Rnd Mag</English>
@@ -1064,7 +1064,7 @@
         <Key ID="STR_ACE_30Rnd_65_Creedmor_mag_Description">
             <English>Caliber: 6.5mm Creedmor&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MXM</English>
             <Polish>Kaliber: 6,5mm Creedmor&lt;br /&gt;Pociski: 30&lt;br /&gt;Używany w: MXM</Polish>
-            <German>Kaliber: 6,5x47 mm  Creedmor&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet für: MXM</German>
+            <German>Kaliber: 6,5x47mm  Creedmor&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: MXM</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_338_300gr_HPBT_Mag_Name">
             <English>.338 10Rnd Mag (300gr Sierra MatchKing HPBT)</English>
@@ -1088,7 +1088,7 @@
             <Spanish>Calibre: 8.6x70mm (300gr Sierra MatchKing HPBT)&lt;br /&gt;Balas: 10</Spanish>
             <Polish>Kaliber: 8,6x70 mm (300gr Sierra MatchKing HPBT)&lt;br /&gt;Pociski: 10</Polish>
             <Russian>Калибр: .338 (300 гран Sierra MatchKing HPBT)&lt;br /&gt;Патронов: 10</Russian>
-            <German>Kaliber: 8,6x70 mm (300gr Sierra MatchKing HPBT)&lt;br /&gt;Schuss: 10</German>
+            <German>Kaliber: 8,6x70mm (300gr Sierra MatchKing HPBT)&lt;br /&gt;Patronen: 10</German>
         </Key>
         <Key ID="STR_ACE_10Rnd_338_API526_Mag_Name">
             <English>.338 10Rnd Mag (API526)</English>
@@ -1112,7 +1112,7 @@
             <Spanish>Calibre: 8.6x70mm (API526)&lt;br /&gt;Balas: 10</Spanish>
             <Polish>Kaliber: 8,6x70 mm (API526)&lt;br /&gt;Pociski: 10</Polish>
             <Russian>Калибр: .338 (API526)&lt;br /&gt;Патронов: 10</Russian>
-            <German>Kaliber: 8,6x70 mm (API526)&lt;br /&gt;Schuss: 10</German>
+            <German>Kaliber: 8,6x70mm (API526)&lt;br /&gt;Patronen: 10</German>
         </Key>
         <Key ID="STR_ACE_5Rnd_127x99_Mag_Name">
             <English>12.7x99mm 5Rnd Mag</English>
@@ -1136,7 +1136,7 @@
             <Spanish>Calibre: 12.7x99mm&lt;br /&gt;Balas: 5</Spanish>
             <Polish>Kaliber: 12,7x99 mm&lt;br /&gt;Pociski: 5</Polish>
             <Russian>Калибр: 12,7x99 мм&lt;br /&gt;Патронов: 5</Russian>
-            <German>Kaliber: 12,7x99mm&lt;br /&gt;Schuss: 5</German>
+            <German>Kaliber: 12,7x99mm&lt;br /&gt;Patronen: 5</German>
         </Key>
         <Key ID="STR_ACE_5Rnd_127x99_API_Mag_Name">
             <English>12.7x99mm API 5Rnd Mag</English>
@@ -1157,7 +1157,7 @@
             <French>Calibre: 12.7x99mm API&lt;br /&gt;Cartouches: 5</French>
             <Spanish>Calibre: 12.7x99mm API&lt;br /&gt;Balas: 5</Spanish>
             <Polish>Kaliber: 12,7x99 mm API&lt;br /&gt;Pociski: 5</Polish>
-            <German>Kaliber:12,7x99mm API&lt;br /&gt;Schuss: 5</German>
+            <German>Kaliber:12,7x99mm API&lt;br /&gt;Patronen: 5</German>
         </Key>
         <Key ID="STR_ACE_5Rnd_127x99_AMAX_Mag_Name">
             <English>12.7x99mm 5Rnd Mag (AMAX)</English>
@@ -1181,7 +1181,7 @@
             <Spanish>Calibre: 12.7x99mm (AMAX)&lt;br /&gt;Balas: 5</Spanish>
             <Polish>Kaliber: 12,7x99 mm (AMAX)&lt;br /&gt;Pociski: 5</Polish>
             <Russian>Калибр: 12,7x99 мм (A-MAX)&lt;br /&gt;Патронов: 5</Russian>
-            <German>Kaliber:12,7x99mm (AMAX)&lt;br /&gt;Schuss: 5</German>
+            <German>Kaliber:12,7x99mm (AMAX)&lt;br /&gt;Patronen: 5</German>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Unified some translations in "ballistics" e.g. unit spacing, Schuss=>Patronen, decimal seperator. I checked it three times but please review it!