### PR TITLE
Veh lock fix

### DIFF
--- a/addons/vehiclelock/CfgEventHandlers.hpp
+++ b/addons/vehiclelock/CfgEventHandlers.hpp
@@ -15,3 +15,26 @@ class Extended_InventoryOpened_EventHandlers {
         };
     };
 };
+class Extended_InitPost_EventHandlers {
+    class CAManBase {
+        class ADDON {
+            serverInit = QUOTE(_this call FUNC(handleUnitInitPost));
+        };
+    };
+    class Car {
+        class ADDON {
+            serverInit = QUOTE(_this call FUNC(handleVehicleInitPost));
+        };
+    };
+    class Tank {
+        class ADDON {
+            serverInit = QUOTE(_this call FUNC(handleVehicleInitPost));
+        };
+    };
+    class Helicopter {
+        class ADDON {
+            serverInit = QUOTE(_this call FUNC(handleVehicleInitPost));
+        };
+    };
+};
+

--- a/addons/vehiclelock/CfgEventHandlers.hpp
+++ b/addons/vehiclelock/CfgEventHandlers.hpp
@@ -16,11 +16,6 @@ class Extended_InventoryOpened_EventHandlers {
     };
 };
 class Extended_InitPost_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            serverInit = QUOTE(_this call FUNC(handleUnitInitPost));
-        };
-    };
     class Car {
         class ADDON {
             serverInit = QUOTE(_this call FUNC(handleVehicleInitPost));
@@ -37,4 +32,3 @@ class Extended_InitPost_EventHandlers {
         };
     };
 };
-

--- a/addons/vehiclelock/CfgVehicles.hpp
+++ b/addons/vehiclelock/CfgVehicles.hpp
@@ -1,50 +1,65 @@
 #define MACRO_LOCK_ACTIONS \
-    class ACE_MainActions { \
+    class ACE_SelfActions { \
         class ACE_unlockVehicle { \
             displayName = "$STR_ACE_Vehicle_Action_UnLock"; \
-            distance = 4; \
             condition = QUOTE(([ARR_2(_player, _target)] call FUNC(hasKeyForVehicle)) && {(locked _target) in [ARR_2(2,3)]}); \
             statement = QUOTE([ARR_3('VehicleLock_SetVehicleLock', [_target], [ARR_2(_target,false)])] call EFUNC(common,targetEvent)); \
-            showDisabled = 0; \
             priority = 0.3; \
             icon = QUOTE(PATHTOF(UI\key_menuIcon_ca.paa)); \
         }; \
         class ACE_lockVehicle { \
             displayName = "$STR_ACE_Vehicle_Action_Lock"; \
-            distance = 4; \
             condition = QUOTE(([ARR_2(_player, _target)] call FUNC(hasKeyForVehicle)) && {(locked _target) in [ARR_2(0,1)]}); \
             statement = QUOTE([ARR_3('VehicleLock_SetVehicleLock', [_target], [ARR_2(_target,true)])] call EFUNC(common,targetEvent)); \
-            showDisabled = 0; \
             priority = 0.2; \
             icon = QUOTE(PATHTOF(UI\key_menuIcon_ca.paa)); \
         }; \
         class ACE_lockpickVehicle { \
             displayName = "$STR_ACE_Vehicle_Action_Lockpick"; \
-            distance = 4; \
             condition = QUOTE([ARR_3(_player, _target, 'canLockpick')] call FUNC(lockpick)); \
             statement = QUOTE([ARR_3(_player, _target, 'startLockpick')] call FUNC(lockpick)); \
-            showDisabled = 0; \
             priority = 0.1; \
+        }; \
+    }; \
+    class ACE_Actions { \
+        class ACE_MainActions { \
+            class ACE_unlockVehicle { \
+                displayName = "$STR_ACE_Vehicle_Action_UnLock"; \
+                distance = 4; \
+                condition = QUOTE(([ARR_2(_player, _target)] call FUNC(hasKeyForVehicle)) && {(locked _target) in [ARR_2(2,3)]}); \
+                statement = QUOTE([ARR_3('VehicleLock_SetVehicleLock', [_target], [ARR_2(_target,false)])] call EFUNC(common,targetEvent)); \
+                priority = 0.3; \
+                icon = QUOTE(PATHTOF(UI\key_menuIcon_ca.paa)); \
+            }; \
+            class ACE_lockVehicle { \
+                displayName = "$STR_ACE_Vehicle_Action_Lock"; \
+                distance = 4; \
+                condition = QUOTE(([ARR_2(_player, _target)] call FUNC(hasKeyForVehicle)) && {(locked _target) in [ARR_2(0,1)]}); \
+                statement = QUOTE([ARR_3('VehicleLock_SetVehicleLock', [_target], [ARR_2(_target,true)])] call EFUNC(common,targetEvent)); \
+                priority = 0.2; \
+                icon = QUOTE(PATHTOF(UI\key_menuIcon_ca.paa)); \
+            }; \
+            class ACE_lockpickVehicle { \
+                displayName = "$STR_ACE_Vehicle_Action_Lockpick"; \
+                distance = 4; \
+                condition = QUOTE([ARR_3(_player, _target, 'canLockpick')] call FUNC(lockpick)); \
+                statement = QUOTE([ARR_3(_player, _target, 'startLockpick')] call FUNC(lockpick)); \
+                priority = 0.1; \
+            }; \
         }; \
     };
 
 class CfgVehicles {
     class LandVehicle;
     class Car: LandVehicle {
-        class ACE_Actions {
-            MACRO_LOCK_ACTIONS
-        };
+        MACRO_LOCK_ACTIONS
     };
     class Tank: LandVehicle {
-        class ACE_Actions {
-            MACRO_LOCK_ACTIONS
-        };
+        MACRO_LOCK_ACTIONS
     };
     class Air;
     class Helicopter: Air {
-        class ACE_Actions {
-            MACRO_LOCK_ACTIONS
-        };
+        MACRO_LOCK_ACTIONS
     };
 
     class Logic;
@@ -55,7 +70,7 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "Vehicle Lock Setup";
-        function = QUOTE(DFUNC(moduleInit));
+        function = QFUNC(moduleInit);
         scope = 2;
         isGlobal = 0;
         icon = QUOTE(PATHTOF(UI\Icon_Module_VehicleLock_ca.paa));
@@ -67,9 +82,9 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 0;
             };
-            class SetLockState {
-                displayName = "Set Lock State"; // Argument label
-                description = "Set lock state for all vehicles on map at start"; // Tooltip description
+            class VehicleStartingLockState {
+                displayName = "Vehicle Starting Lock State"; // Argument label
+                description = "Set lock state for all vehicles (removes ambiguous lock states)"; // Tooltip description
                 typeName = "NUMBER"; // Value type, can be "NUMBER", "STRING" or "BOOL"
                 class values {
                     class None {name = "As Is"; value = 0; default = 1;};
@@ -93,7 +108,7 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "Vehicle Key Assign";
-        function = QUOTE(DFUNC(moduleSync));
+        function = QFUNC(moduleSync);
         scope = 2;
         isGlobal = 0;
         icon = QUOTE(PATHTOF(UI\Icon_Module_VehicleKey_ca.paa));

--- a/addons/vehiclelock/XEH_preInit.sqf
+++ b/addons/vehiclelock/XEH_preInit.sqf
@@ -4,6 +4,7 @@ ADDON = false;
 
 PREP(addKeyForVehicle);
 PREP(getVehicleSideKey);
+PREP(handleVehicleInitPost);
 PREP(hasKeyForVehicle);
 PREP(lockpick);
 PREP(moduleInit);

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
     requiredVersion = REQUIRED_VERSION;
     requiredAddons[] = {"ace_interaction"};
     author[] = {"PabstMirror"};
-    authorUrl = "https://github.com/PabstMirror/";
+    authorUrl = "https://github.com/acemod/ACE3";
     VERSION_CONFIG;
   };
 };

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -20,6 +20,10 @@ class ACE_Settings {
     class GVAR(LockVehicleInventory) {
         value = 0;
         typeName = "BOOL";
+    };    
+    class GVAR(VehicleStartingLockState) {
+        value = -1;
+        typeName = "SCALAR";
     };
 };
 

--- a/addons/vehiclelock/functions/fnc_handleVehicleInitPost.sqf
+++ b/addons/vehiclelock/functions/fnc_handleVehicleInitPost.sqf
@@ -1,0 +1,39 @@
+/*
+ * Author: PabstMirror
+ * Function for sync module.  Assigns keys for all synced vehicles to any players that are synced.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [car] call ACE_VehicleLock_fnc_handleVehicleInitPost
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+PARAMS_1(_vehicle);
+
+if (!isServer) exitWith {};
+if (GVAR(VehicleStartingLockState) == -1) exitWith {};
+
+[{
+    private ["_lock"];
+    PARAMS_1(_vehicle);
+    if ((_vehicle isKindOf "Car") || {_vehicle isKindOf "Tank"} || {_vehicle isKindOf "Helicopter"}) then {
+        //set lock state (eliminates the ambigious 1-"Default" and 3-"Locked for Player" states)
+        _lock = switch (GVAR(VehicleStartingLockState)) do {
+        case (0): {(locked _vehicle) in [2, 3]};
+        case (1):{true};
+        case (2):{false};
+        };
+        if (((_lock) && {(locked _vehicle) != 2}) || {(!_lock) && {(locked _vehicle) != 0}}) then {
+            TRACE_3("Setting Lock State",_lock,(typeOf _vehicle),_vehicle);
+            ["VehicleLock_SetVehicleLock", [_vehicle], [_vehicle, _lock]] call EFUNC(common,targetEvent);
+        };
+    };
+    //Delay call until mission start (so everyone has the eventHandler's installed)
+}, [_vehicle], 0.25, 0.25] call EFUNC(common,waitAndExecute);

--- a/addons/vehiclelock/functions/fnc_handleVehicleInitPost.sqf
+++ b/addons/vehiclelock/functions/fnc_handleVehicleInitPost.sqf
@@ -1,6 +1,7 @@
 /*
  * Author: PabstMirror
- * Function for sync module.  Assigns keys for all synced vehicles to any players that are synced.
+ * For every lockable vehicle, sets the starting lock state to a sane value.
+ * Only run if the InitModule is placed.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
@@ -18,9 +19,10 @@
 PARAMS_1(_vehicle);
 
 if (!isServer) exitWith {};
-if (GVAR(VehicleStartingLockState) == -1) exitWith {};
 
 [{
+    //If the module wasn't placed, just exit (needs to be in wait because objectInitEH is before moduleInit)
+    if (GVAR(VehicleStartingLockState) == -1) exitWith {};
     private ["_lock"];
     PARAMS_1(_vehicle);
     if ((_vehicle isKindOf "Car") || {_vehicle isKindOf "Tank"} || {_vehicle isKindOf "Helicopter"}) then {

--- a/addons/vehiclelock/functions/fnc_moduleInit.sqf
+++ b/addons/vehiclelock/functions/fnc_moduleInit.sqf
@@ -17,8 +17,6 @@
  */
 #include "script_component.hpp"
 
-private ["_sideKeysAssignment", "_setLockState", "_lock"];
-
 PARAMS_3(_logic,_syncedUnits,_activated);
 
 if (!_activated) exitWith {WARNING("Vehicle Lock Init Module - placed but not active");};
@@ -27,23 +25,4 @@ if (!isServer) exitWith {};
 //Set the GVAR for default lockpick strength
 [_logic, QGVAR(DefaultLockpickStrength), "DefaultLockpickStrength"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(LockVehicleInventory), "LockVehicleInventory"] call EFUNC(common,readSettingFromModule);
-
-_setLockState = _logic getVariable["SetLockState", 0];
-[{
-    PARAMS_1(_setLockState);
-    {
-        if ((_x isKindOf "Car") || {_x isKindOf "Tank"} || {_x isKindOf "Helicopter"}) then {
-            //set lock state (eliminates the ambigious 1-"Default" and 3-"Locked for Player" states)
-            _lock = switch (_setLockState) do {
-            case (0): {(locked _x) in [2, 3]};
-            case (1):{true};
-            case (2):{false};
-            };
-            if (((_lock) && {(locked _x) != 2}) || {(!_lock) && {(locked _x) != 0}}) then {
-                TRACE_3("Setting Lock State", _lock, (typeOf _x), _x);
-                ["VehicleLock_SetVehicleLock", [_x], [_x, _lock]] call EFUNC(common,targetEvent);
-            };
-        };
-    } forEach vehicles;
-    //Delay call until mission start (so everyone has the eventHandler's installed)
-}, [_setLockState], 0.25, 0.25] call EFUNC(common,waitAndExecute);
+[_logic, QGVAR(VehicleStartingLockState), "VehicleStartingLockState"] call EFUNC(common,readSettingFromModule);

--- a/addons/vehiclelock/functions/fnc_onOpenInventory.sqf
+++ b/addons/vehiclelock/functions/fnc_onOpenInventory.sqf
@@ -34,7 +34,7 @@ if (GVAR(LockVehicleInventory) && //if setting not enabled
     playSound "ACE_Sound_Click";
     //don't open the vehicles inventory
     _handeled = true;
-    //Just opens a dummy groundContainer
+    //Just opens a dummy groundContainer (so the player can still see their own inventory)
     ACE_player action ["Gear", objNull];
 };
 


### PR DESCRIPTION
Fix for #428

Changes setting default lock from once at start to a per-vehicle postInitEH so it works on spawned vehicles.
Also allows locking/unlocking from inside vehicle.
