### PR TITLE
[compat_asdg] fix MRCO PiP compatibility

### DIFF
--- a/optionals/compat_asdg/config.cpp
+++ b/optionals/compat_asdg/config.cpp
@@ -28,6 +28,7 @@ class asdg_OpticRail1913: asdg_OpticRail {
         ACE_optic_Arco_2D = 1;
         ACE_optic_Arco_PIP = 1;
         ACE_optic_MRCO_2D = 1;
+        ACE_optic_MRCO_PIP = 1;
         ACE_optic_SOS_2D = 1;
         ACE_optic_SOS_PIP = 1;
         ACE_optic_LRPS_2D = 1;


### PR DESCRIPTION
According to https://github.com/acemod/ACE3/blob/master/addons/optics/CfgWeapons.hpp#L196 there is MRCO PiP version (i can't see it in arsenal anyway, but that's different issue #918), but it's missing from ASDG_JR compatibility module.
