### PR TITLE
Allow 3rd party to add laser pointers

### DIFF
--- a/addons/laserpointer/CfgWeapons.hpp
+++ b/addons/laserpointer/CfgWeapons.hpp
@@ -20,6 +20,8 @@ class CfgWeapons {
         ACE_nextModeClass = "acc_pointer_IR";
         ACE_modeDescription = "$STR_ACE_Laserpointer_Laser";
 
+        ACE_laserpointer = 1;
+
         author = "$STR_ACE_Common_ACETeam";
         _generalMacro = "ACE_acc_pointer_red";
         scope = 1;
@@ -78,6 +80,8 @@ class CfgWeapons {
     class ACE_acc_pointer_green: ACE_acc_pointer_red {
         ACE_nextModeClass = "ACE_acc_pointer_green_IR";
         ACE_modeDescription = "$STR_ACE_Laserpointer_Laser";
+
+        ACE_laserpointer = 2;
 
         author = "$STR_ACE_Common_ACETeam";
         _generalMacro = "ACE_acc_pointer_green";

--- a/addons/laserpointer/functions/fnc_onDraw.sqf
+++ b/addons/laserpointer/functions/fnc_onDraw.sqf
@@ -26,7 +26,7 @@ _isIR = _isIR == 1;
     };
 
     if (_laser != "") then {
-        _cacheName = format ["ACE_laserpointer_%1", _laser];
+        _cacheName = format [QGVAR(laser_%1), _laser];
         _laserID = missionNamespace getVariable [_cacheName, -1];
         if (missionNamespace getVariable [_cacheName, -1] == -1) then {
             _laserID = getNumber (configFile >> "CfgWeapons" >> _laser >> "ACE_laserpointer");

--- a/addons/laserpointer/functions/fnc_onDraw.sqf
+++ b/addons/laserpointer/functions/fnc_onDraw.sqf
@@ -25,10 +25,17 @@ _isIR = _isIR == 1;
         default {""};
     };
 
-    _laserID = ["ACE_acc_pointer_red", "ACE_acc_pointer_green"] find _laser;
+    if (_laser != "") then {
+        _cacheName = format ["ACE_laserpointer_%1", _laser];
+        _laserID = missionNamespace getVariable [_cacheName, -1];
+        if (missionNamespace getVariable [_cacheName, -1] == -1) then {
+            _laserID = getNumber (configFile >> "CfgWeapons" >> _laser >> "ACE_laserpointer");
+            missionNamespace setVariable [_cacheName, _laserID];
+        };
 
-    if (_laserID > -1 && {_x isFlashlightOn _weapon}) then {
-        [_x, 50, _laserID == 1 || _isIR] call FUNC(drawLaserpoint);
+        if (_laserID > 0 && {_x isFlashlightOn _weapon}) then {
+            [_x, 50, _laserID == 2 || _isIR] call FUNC(drawLaserpoint);
+        };
     };
 
 } forEach GVAR(nearUnits);

--- a/documentation/development/ace3-config-entries.md
+++ b/documentation/development/ace3-config-entries.md
@@ -54,6 +54,9 @@ ace_detonator
 ace_barrelTwist
 ace_twistDirection
 ace_barrelLength
+ace_laserpointer
+ace_nextmodeclass
+ace_modedescription
 ```
 
 


### PR DESCRIPTION
- Caches the value to not overload the game with config access.
- adds new CfgWeapons configuration value: `ace_laserpointer` value: 1 = red laser, 2 = green laser.