### PR TITLE
Dynamic action positions

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -26,7 +26,7 @@ if !(isNil {missionNamespace getVariable [_actionsVarName, nil]}) exitWith {};
 
 private "_recurseFnc";
 _recurseFnc = {
-    private ["_actions", "_displayName", "_distance", "_icon", "_statement", "_selection", "_condition", "_showDisabled", "_enableInside", "_canCollapse", "_runOnHover", "_children", "_entry", "_entryCfg", "_insertChildren", "_modifierFunction", "_i"];
+    private ["_actions", "_displayName", "_distance", "_icon", "_statement", "_position", "_condition", "_showDisabled", "_enableInside", "_canCollapse", "_runOnHover", "_children", "_entry", "_entryCfg", "_insertChildren", "_modifierFunction", "_i"];
     EXPLODE_1_PVT(_this,_actionsCfg);
     _actions = [];
 
@@ -38,13 +38,18 @@ _recurseFnc = {
             _icon = getText (_entryCfg >> "icon");
             _statement = compile (getText (_entryCfg >> "statement"));
 
-            _selection = "";
-            if (isArray ( _entryCfg >> "selection" )) then {
-                _selection = getArray ( _entryCfg >> "selection" )
+            // If the position entry is present, compile it
+            _position = getText (_entryCfg >> "position");
+            if (_position != "") then {
+                _position = compile _position;
             } else {
-                _selection = getText (_entryCfg >> "selection");
-                if (_selection == "") then {
-                    _selection = [0,0,0];
+                // If the not, but the selection entry is present use that
+                _position = getText (_entryCfg >> "selection");
+                if (_position != "") then {
+                    _position = compile format ["_target selectionPosition '%1'", _position];
+                } else {
+                    // Otherwise, just use the origin
+                    _position = {[0,0,0]};
                 };
             };
 
@@ -76,7 +81,7 @@ _recurseFnc = {
                             _condition,
                             _insertChildren,
                             [],
-                            _selection,
+                            _position,
                             _distance,
                             [_showDisabled,_enableInside,_canCollapse,_runOnHover],
                             _modifierFunction
@@ -105,7 +110,7 @@ missionNamespace setVariable [_actionsVarName, [_actionsCfg] call _recurseFnc];
             { true },
             {},
             [],
-            [0,0,0],
+            {[0,0,0]},
             1,
             [false,false,false]
         ],

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -64,7 +64,7 @@ _recurseFnc = {
                             _statement,
                             _condition,
                             _insertChildren,
-                            [],
+                            {},
                             [0,0,0],
                             10, //distace
                             [_showDisabled,_enableInside,_canCollapse,_runOnHover],
@@ -113,7 +113,7 @@ _actions = [
             },
             {[ACE_player, _target, ["isNotInside","isNotDragging", "isNotCarrying", "isNotSwimming", "notOnMap", "isNotEscorting", "isNotSurrendering"]] call EFUNC(common,canInteractWith)},
             {},
-            [],
+            {},
             "Spine3",
             10,
             [false,true,false]

--- a/addons/interact_menu/functions/fnc_createAction.sqf
+++ b/addons/interact_menu/functions/fnc_createAction.sqf
@@ -11,7 +11,7 @@
  * 4: Condition <CODE>
  * 5: Insert children code <CODE> (Optional)
  * 6: Action parameters <ANY> (Optional)
- * 7: Position (Position or Selection Name) <POSITION> or <STRING> (Optional)
+ * 7: Position (Position array, Position code or Selection Name) <ARRAY>, <CODE> or <STRING> (Optional)
  * 8: Distance <NUMBER> (Optional)
  * 9: Other parameters <ARRAY> (Optional)
  * 10: Modifier function <CODE> (Optional)
@@ -44,9 +44,19 @@ _customParams = if (count _this > 6) then {
 };
 
 _position = if (count _this > 7) then {
-    _this select 7
+    if (typeName (_this select 7) == "STRING") then {
+        // If the action is set to a selection, create the suitable code
+        compile format ["_target selectionPosition '%1'", _this select 7];
+    } else {
+        if (typeName (_this select 7) == "ARRAY") then {
+            // If the action is set to a array position, create the suitable code
+            compile format ["%1", _this select 7];
+        } else {
+            _this select 7
+        };
+    }
 } else {
-    [0,0,0]
+    {[0,0,0]}
 };
 
 _distance = if (count _this > 8) then {

--- a/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
@@ -24,21 +24,15 @@ EXPLODE_1_PVT(_baseActionNode,_actionData);
 _distance = _actionData select 8;
 
 // Obtain a 3D position for the action
-if((count _this) > 2) then {
-    _pos = _this select 2;
+_pos = if((count _this) > 2) then {
+    _this select 2
 } else {
-    if(typeName (_actionData select 7) == "ARRAY") then {
-        _pos = _object modelToWorldVisual (_actionData select 7);
-    } else {
-        if ((_actionData select 7) == "weapon") then {
-            // Craft a suitable position for weapon interaction
-            _weaponDir = _object weaponDirection currentWeapon _object;
-            _ref = _weaponDir call EFUNC(common,createOrthonormalReference);
-            _pos = (_object modelToWorldVisual (_object selectionPosition "righthand")) vectorAdd ((_ref select 2) vectorMultiply 0.1);
-        } else {
-            _pos = _object modelToWorldVisual (_object selectionPosition (_actionData select 7));
-        };
-    };
+    // Setup scope variables for position code
+    private ["_target"];
+    _target = _object;
+
+    // Get action position
+    _object modelToWorldVisual (call (_actionData select 7))
 };
 
 // For non-self actions, exit if the action is too far away or ocluded

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -166,7 +166,7 @@ class CfgVehicles {
       };
       class ACE_Weapon {
         displayName = "$STR_ACE_Interaction_Weapon";
-        selection = "weapon";
+        position = QUOTE(call FUNC(getWeaponPos));
         distance = 1.50;
         condition = "";
         statement = "";

--- a/addons/interaction/XEH_preInit.sqf
+++ b/addons/interaction/XEH_preInit.sqf
@@ -16,6 +16,7 @@ PREP(getDoor);
 PREP(getDoorAnimations);
 PREP(getDown);
 PREP(getSelectedButton);
+PREP(getWeaponPos);
 PREP(hideMenu);
 PREP(hideMouseHint);
 PREP(isInRange);

--- a/addons/interaction/functions/fnc_getWeaponPos.sqf
+++ b/addons/interaction/functions/fnc_getWeaponPos.sqf
@@ -1,0 +1,21 @@
+/*
+ * Author: esteldunedain
+ * Return a suitable position for the action point for the current weapon
+ *
+ * Argument:
+ * None
+ *
+ * Return value:
+ * Children actions <ARRAY>
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+// IGNORE_PRIVATE_WARNING(_target);
+
+private ["_weaponDir","_refSystem"];
+
+_weaponDir = _target weaponDirection currentWeapon _target;
+_refSystem = _weaponDir call EFUNC(common,createOrthonormalReference);
+
+(_target selectionPosition "righthand") vectorAdd ((_refSystem select 2) vectorMultiply 0.1);

--- a/addons/respawn/CfgVehicles.hpp
+++ b/addons/respawn/CfgVehicles.hpp
@@ -100,7 +100,7 @@ class CfgVehicles {
                 distance = 4;
                 condition = QUOTE(side group _player == west);
                 statement = QUOTE([ARR_3(_player,side group _player,'ACE_Rallypoint_West')] call FUNC(teleportToRallypoint));
-                position = "[0,0,-1]";
+                position = "[-0.05,-0.35,-2.6]";
                 showDisabled = 1;
                 priority = 1;
             };
@@ -120,7 +120,7 @@ class CfgVehicles {
                 distance = 4;
                 condition = QUOTE(side group _player == east);
                 statement = QUOTE([ARR_3(_player,side group _player,'ACE_Rallypoint_East')] call FUNC(teleportToRallypoint));
-                position = "[0,0,-1]";
+                position = "[-0.05,-0.35,-2.6]";
                 showDisabled = 1;
                 priority = 1;
             };
@@ -140,7 +140,7 @@ class CfgVehicles {
                 distance = 4;
                 condition = QUOTE(side group _player == independent);
                 statement = QUOTE([ARR_3(_player,side group _player,'ACE_Rallypoint_Independent')] call FUNC(teleportToRallypoint));
-                position = "[0,0,-1]";
+                position = "[-0.05,-0.35,-2.6]";
                 showDisabled = 1;
                 priority = 1;
             };
@@ -161,7 +161,7 @@ class CfgVehicles {
                 distance = 4;
                 condition = QUOTE(side group _player == west);
                 statement = QUOTE([ARR_3(_player,side group _player,'ACE_Rallypoint_West_Base')] call FUNC(teleportToRallypoint));
-                position = "[0,0,-1]";
+                position = "[-0.05,-0.35,-2.6]";
                 showDisabled = 1;
                 priority = 1;
             };
@@ -181,7 +181,7 @@ class CfgVehicles {
                 distance = 4;
                 condition = QUOTE(side group _player == east);
                 statement = QUOTE([ARR_3(_player,side group _player,'ACE_Rallypoint_East_Base')] call FUNC(teleportToRallypoint));
-                position = "[0,0,-1]";
+                position = "[-0.05,-0.35,-2.6]";
                 showDisabled = 1;
                 priority = 1;
             };
@@ -201,7 +201,7 @@ class CfgVehicles {
                 distance = 4;
                 condition = QUOTE(side group _player == independent);
                 statement = QUOTE([ARR_3(_player,side group _player,'ACE_Rallypoint_Independent_Base')] call FUNC(teleportToRallypoint));
-                position = "[0,0,-1]";
+                position = "[-0.05,-0.35,-2.6]";
                 showDisabled = 1;
                 priority = 1;
             };


### PR DESCRIPTION
- Allow positions for actions to be computed dynamically. 

- Leverage that for the position of the "Weapon" action, instead of hard coding an exception for that.

- Tweak the position for rally point actions. Fix #837
