### PR TITLE
Missing medical localization

### DIFF
--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_tourniquet", "ACE_morphine", "ACE_atropine", "ACE_epinephrine", "ACE_plasmaIV", "ACE_plasmaIV_500", "ACE_plasmaIV_250", "ACE_bloodIV", "ACE_bloodIV_500", "ACE_bloodIV_250", "ACE_salineIV", "ACE_salineIV_500", "ACE_salineIV_250", "ACE_quikclot", "ACE_personalAidKit", "ACE_surgicalKit", "ACE_bodyBag"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction","ace_modules", "ace_apl"};
-        author[] = {"Glowbal", "KoffienFlummi"};
+        author[] = {"Glowbal", "KoffeinFlummi"};
         authorUrl = "";
         VERSION_CONFIG;
     };

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_tourniquet", "ACE_morphine", "ACE_atropine", "ACE_epinephrine", "ACE_plasmaIV", "ACE_plasmaIV_500", "ACE_plasmaIV_250", "ACE_bloodIV", "ACE_bloodIV_500", "ACE_bloodIV_250", "ACE_salineIV", "ACE_salineIV_500", "ACE_salineIV_250", "ACE_quikclot", "ACE_personalAidKit", "ACE_surgicalKit", "ACE_bodyBag"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction","ace_modules", "ace_apl"};
-        author[] = {"Glowbal", "KoffeinFlummi"};
+        author[] = {"Glowbal", "KoffeinFlummi", "GieNkoV"};
         authorUrl = "";
         VERSION_CONFIG;
     };

--- a/addons/medical/functions/fnc_actionCheckPulseLocal.sqf
+++ b/addons/medical/functions/fnc_actionCheckPulseLocal.sqf
@@ -24,7 +24,7 @@ if (!alive _unit) then {
     _heartRate = 0;
 };
 _heartRateOutput = "STR_ACE_Medical_Check_Pulse_Output_5";
-_logOutPut = "No heart rate";
+_logOutPut = localize "STR_ACE_Medical_Check_Pulse_None";
 
 if (_heartRate > 1.0) then {
     if ([_caller] call FUNC(isMedic)) then {

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -1541,6 +1541,10 @@
             <Hungarian>%1 ellenőrizte a szívverés-számot: %2</Hungarian>
             <Czech>%1 zkontroloval srdeční tep: %2</Czech>
         </Key>
+        <Key ID="STR_ACE_Medical_Check_Pulse_None">
+            <English>None</English>
+            <Polish>Brak</Polish>
+        </Key>
         <Key ID="STR_ACE_Medical_Check_Pulse_Weak">
             <English>Weak</English>
             <German>Schwach</German>


### PR DESCRIPTION
Previously this was:
```%1 checked heart rate: No heart rate```

This:
```_logOutPut = localize "STR_ACE_Medical_Check_Pulse_None";```
Will then show up on patient medical history as:
```%1 checked heart rate: None```