### PR TITLE
Interact_menu with cursor: Replace dialogs by displays

### DIFF
--- a/addons/interact_menu/CursorMenus.hpp
+++ b/addons/interact_menu/CursorMenus.hpp
@@ -1,47 +1,8 @@
 class GVAR(cursorMenu) {
     idd = 91919;
-    movingEnable = false;
+    access = 0;
+    movingEnable = 0;
+    enableSimulation = 1;
     onLoad = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(dlgCursorMenu)),_this select 0)]; uiNamespace setVariable [ARR_2(QUOTE(QGVAR(cursorMenuOpened)),true)]);
     onUnload = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(cursorMenuOpened)),false)]);
-    objects[] = {};
-    /*class controlsBackground {
-        class Background {
-            idc = 91920;
-            moving = 0;
-            font = "TahomaB";
-            text = "";
-            sizeEx = 0;
-            lineSpacing = 0;
-            access = 0;
-            type = 0;
-            style = 0;
-            size = 1;
-            colorBackground[] = {0, 0, 0, 0.5};
-            colorText[] = {0, 0, 0, 0};
-            x = "safezoneX";
-            y = "safezoneY";
-            w = "safezoneW";
-            h = "safezoneH";
-        };
-    };*/
-    class controls {
-        class Canvas {
-            idc = 91921;
-            moving = 0;
-            font = "TahomaB";
-            text = "";
-            sizeEx = 0;
-            lineSpacing = 0;
-            access = 0;
-            type = 0;
-            style = 0;
-            size = 1;
-            colorBackground[] = {0, 0, 0, 0};
-            colorText[] = {0, 0, 0, 0};
-            x = "safezoneX";
-            y = "safezoneY";
-            w = "safezoneW";
-            h = "safezoneH";
-        };
-    };
 };

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -25,6 +25,21 @@ PREP(renderSelector);
 PREP(setupTextColors);
 PREP(splitPath);
 
+// Event handlers for all interact menu controls
+DFUNC(handleMouseMovement) = {
+    if (GVAR(cursorKeepCentered)) then {
+        GVAR(cursorPos) = GVAR(cursorPos) vectorAdd [_this select 1, _this select 2, 0] vectorDiff [0.5, 0.5, 0];
+        setMousePosition [0.5, 0.5];
+    } else {
+        GVAR(cursorPos) = [_this select 1, _this select 2, 0];
+    };
+};
+DFUNC(handleMouseButtonDown) = {
+    if !(GVAR(actionOnKeyRelease)) then {
+        [GVAR(openedMenuType),true] call FUNC(keyUp);
+    };
+};
+
 GVAR(keyDown) = false;
 GVAR(keyDownSelfAction) = false;
 GVAR(keyDownTime) = 0;

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -37,27 +37,30 @@ GVAR(useCursorMenu) = (vehicle ACE_player != ACE_player) ||
                       {(_menuType == 1) && {(isWeaponDeployed ACE_player) || GVAR(AlwaysUseCursorSelfInteraction) || {cameraView == "GUNNER"}}} ||
                       {(_menuType == 0) && GVAR(AlwaysUseCursorInteraction)};
 
+// Delete existing controls in case there's any left
+GVAR(iconCount) = 0;
+for "_i" from 0 to (count GVAR(iconCtrls))-1 do {
+    ctrlDelete (GVAR(iconCtrls) select _i);
+    GVAR(ParsedTextCached) set [_i, ""];
+};
+GVAR(iconCtrls) resize GVAR(iconCount);
+
 if (GVAR(useCursorMenu)) then {
-    createDialog QGVAR(cursorMenu);
+    (findDisplay 46) createDisplay QGVAR(cursorMenu); //"RscCinemaBorder";//
+    (finddisplay 91919) displayAddEventHandler ["KeyUp", {[_this,'keyup'] call CBA_events_fnc_keyHandler}];
+    (finddisplay 91919) displayAddEventHandler ["KeyDown", {[_this,'keydown'] call CBA_events_fnc_keyHandler}];
     // The dialog sets:
     // uiNamespace getVariable QGVAR(dlgCursorMenu);
     // uiNamespace getVariable QGVAR(cursorMenuOpened);
-    ctrlEnable [91921, true];
     GVAR(cursorPos) = [0.5,0.5,0];
-    ((finddisplay 91919) displayctrl 91921) ctrlAddEventHandler ["MouseMoving", {
-        if (GVAR(cursorKeepCentered)) then {
-            GVAR(cursorPos) = GVAR(cursorPos) vectorAdd [_this select 1, _this select 2, 0] vectorDiff [0.5, 0.5, 0];
-            setMousePosition [0.5, 0.5];
-        } else {
-            GVAR(cursorPos) = [_this select 1, _this select 2, 0];
-        };
-    }];
-    // handles LMB in cursor mode when action on keyrelease is disabled
-    ((finddisplay 91919) displayctrl 91921) ctrlAddEventHandler ["MouseButtonDown", {
-        if !(GVAR(actionOnKeyRelease)) then {
-            [GVAR(openedMenuType),true] call FUNC(keyUp);
-        };
-    }];
+
+    _ctrl = (findDisplay 91919) ctrlCreate ["RscStructuredText", 9922];
+    _ctrl ctrlSetPosition [safeZoneX, safeZoneY, safeZoneW, safeZoneH];
+    _ctrl ctrlCommit 0;
+
+    // handles Mouse moving and LMB in cursor mode when action on keyrelease is disabled
+    ((finddisplay 91919) displayctrl 9922) ctrlAddEventHandler ["MouseMoving", DFUNC(handleMouseMovement)];
+    ((finddisplay 91919) displayctrl 9922) ctrlAddEventHandler ["MouseButtonDown", DFUNC(handleMouseButtonDown)];
     setMousePosition [0.5, 0.5];
 };
 

--- a/addons/interact_menu/functions/fnc_keyUp.sqf
+++ b/addons/interact_menu/functions/fnc_keyUp.sqf
@@ -19,7 +19,7 @@ _calledByClicking = _this select 1;
 if (GVAR(openedMenuType) < 0) exitWith {true};
 
 if (uiNamespace getVariable [QGVAR(cursorMenuOpened),false]) then {
-    closeDialog 0;
+    (findDisplay 91919) closeDisplay 2;
 };
 
 if(GVAR(actionSelected)) then {

--- a/addons/interact_menu/functions/fnc_renderIcon.sqf
+++ b/addons/interact_menu/functions/fnc_renderIcon.sqf
@@ -23,6 +23,10 @@ PARAMS_4(_text,_icon,_sPos,_textSettings);
 if(GVAR(iconCount) > (count GVAR(iconCtrls))-1) then {
     _displayNum = [[46, 12] select visibleMap,91919] select (uiNamespace getVariable [QGVAR(cursorMenuOpened),false]);
     GVAR(iconCtrls) pushBack ((findDisplay _displayNum) ctrlCreate ["RscStructuredText", 54021+GVAR(iconCount)]);
+    if (GVAR(useCursorMenu)) then {
+        ((finddisplay _displayNum) displayctrl (54021+GVAR(iconCount))) ctrlAddEventHandler ["MouseMoving", DFUNC(handleMouseMovement)];
+        ((finddisplay _displayNum) displayctrl (54021+GVAR(iconCount))) ctrlAddEventHandler ["MouseButtonDown", DFUNC(handleMouseButtonDown)];
+    };
 };
 _ctrl = GVAR(iconCtrls) select GVAR(iconCount);
 

--- a/addons/interact_menu/functions/fnc_renderSelector.sqf
+++ b/addons/interact_menu/functions/fnc_renderSelector.sqf
@@ -20,6 +20,10 @@ private ["_displayNum", "_ctrl", "_pos"];
 if(GVAR(iconCount) > (count GVAR(iconCtrls))-1) then {
     _displayNum = [[46, 12] select visibleMap,91919] select (uiNamespace getVariable [QGVAR(cursorMenuOpened),false]);
     GVAR(iconCtrls) pushBack ((findDisplay _displayNum) ctrlCreate ["RscStructuredText", 54021+GVAR(iconCount)]);
+    if (GVAR(useCursorMenu)) then {
+        ((finddisplay _displayNum) displayctrl (54021+GVAR(iconCount))) ctrlAddEventHandler ["MouseMoving", DFUNC(handleMouseMovement)];
+        ((finddisplay _displayNum) displayctrl (54021+GVAR(iconCount))) ctrlAddEventHandler ["MouseButtonDown", DFUNC(handleMouseButtonDown)];
+    };
 };
 
 _ctrl = GVAR(iconCtrls) select GVAR(iconCount);


### PR DESCRIPTION
Replaces dialogs by displays, allowing the player to move while using the mouse. Credit to @zx64 for the key idea behind this.

Seems to work pretty well, except that using the default bindings you cannot move while self interacting (e.g. Ctrl+L Win+W makes you change stances instead of walking forward). That can of course be fixed by users by changing the keybinds.

Close #311