### PR TITLE
Translation fixes/improvements (RU)

### DIFF
--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -35,7 +35,7 @@
             <Italian>Mostra i nomi solo se puntati (richiede mostra nomi abilitato)</Italian>
             <Portuguese>Mostrar nome de jogador somente no cursor (requer nome de jogadores)</Portuguese>
             <Hungarian>Játékosok nevének mutatása csak a kurzoron (a nevek mutatása szükséges)</Hungarian>
-            <Russian>Показать имена игроков только под курсором (при включенных именах)</Russian>
+            <Russian>Показать имена игроков только под курсором (при вкл. именах)</Russian>
         </Key>
         <Key ID="STR_ACE_NameTags_ShowPlayerNamesOnlyOnKeyPress">
             <English>Show player name only on keypress (requires player names)</English>
@@ -45,7 +45,7 @@
             <Czech>Zobrazit jména hráčů jen na klávesu (vyžaduje jména hráčů)</Czech>
             <Polish>Pokaż imiona graczy tylko po przytrzymaniu klawisza (wymagana opcja Pokaż imiona graczy)</Polish>
             <Hungarian>Játékosnevek mutatása csak gombnyomásra (a nevek mutatása szükséges)</Hungarian>
-            <Russian>Показать имена игроков только по нажатию клавиши (при включенных именах)</Russian>
+            <Russian>Показать имена игроков только по нажатию клавиши (при вкл. именах)</Russian>
             <Italian>Mostra i nomi solo se si preme il tasto (richiede mostra nomi abilitato)</Italian>
             <Portuguese>Mostrar nomes somente ao pressionar teclar (requer nome de jogadores)</Portuguese>
         </Key>
@@ -59,7 +59,7 @@
             <Italian>Mostra i gradi (richiede mostra nomi abilitato)</Italian>
             <Portuguese>Mostrar patente de jogadores (requer nome de jogadores)</Portuguese>
             <Hungarian>Játékosok rendfokozatának mutatása (a nevek mutatása szükséges)</Hungarian>
-            <Russian>Показывать звания игроков (при включенных именах)</Russian>
+            <Russian>Показывать звания игроков (при вкл. именах)</Russian>
         </Key>
         <Key ID="STR_ACE_NameTags_ShowVehicleCrewInfo">
             <English>Show vehicle crew info</English>
@@ -89,7 +89,7 @@
             <English>Show SoundWaves (requires player names)</English>
             <German>Schallwellen anzeigen  (benötigt Spielernamen)</German>
             <Spanish>Mostrar onda sonora  (requiere Mostrar nombres de jugadores)</Spanish>
-            <Russian>Индикатор разговора (при включенных именах)</Russian>
+            <Russian>Индикатор разговора (при вкл. именах)</Russian>
             <Czech>Zobrazit SoundWaves (vyžaduje jména hráčů)</Czech>
             <Polish>Pokaż fale dźwiękowe (wymagana opcja Pokaż imiona graczy)</Polish>
             <French>Afficher "qui parle" (si noms affichés)</French>

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -59,7 +59,7 @@
             <Italian>Mostra i gradi (richiede mostra nomi abilitato)</Italian>
             <Portuguese>Mostrar patente de jogadores (requer nome de jogadores)</Portuguese>
             <Hungarian>Játékosok rendfokozatának mutatása (a nevek mutatása szükséges)</Hungarian>
-            <Russian>Показывать звания игроков (при вкл. именах)</Russian>
+            <Russian>Показывать звания игроков (при включенных именах)</Russian>
         </Key>
         <Key ID="STR_ACE_NameTags_ShowVehicleCrewInfo">
             <English>Show vehicle crew info</English>
@@ -89,7 +89,7 @@
             <English>Show SoundWaves (requires player names)</English>
             <German>Schallwellen anzeigen  (benötigt Spielernamen)</German>
             <Spanish>Mostrar onda sonora  (requiere Mostrar nombres de jugadores)</Spanish>
-            <Russian>Индикатор разговора (при вкл. именах)</Russian>
+            <Russian>Индикатор разговора (при включенных именах)</Russian>
             <Czech>Zobrazit SoundWaves (vyžaduje jména hráčů)</Czech>
             <Polish>Pokaż fale dźwiękowe (wymagana opcja Pokaż imiona graczy)</Polish>
             <French>Afficher "qui parle" (si noms affichés)</French>

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -35,7 +35,7 @@
             <Italian>Mostra i nomi solo se puntati (richiede mostra nomi abilitato)</Italian>
             <Portuguese>Mostrar nome de jogador somente no cursor (requer nome de jogadores)</Portuguese>
             <Hungarian>Játékosok nevének mutatása csak a kurzoron (a nevek mutatása szükséges)</Hungarian>
-            <Russian>Показать имена игроков только под курсором (при вкл. именах)</Russian>
+            <Russian>Показать имена игроков только под курсором (при включенных именах)</Russian>
         </Key>
         <Key ID="STR_ACE_NameTags_ShowPlayerNamesOnlyOnKeyPress">
             <English>Show player name only on keypress (requires player names)</English>
@@ -45,7 +45,7 @@
             <Czech>Zobrazit jména hráčů jen na klávesu (vyžaduje jména hráčů)</Czech>
             <Polish>Pokaż imiona graczy tylko po przytrzymaniu klawisza (wymagana opcja Pokaż imiona graczy)</Polish>
             <Hungarian>Játékosnevek mutatása csak gombnyomásra (a nevek mutatása szükséges)</Hungarian>
-            <Russian>Показать имена игроков только по нажатию клавиши (при вкл. именах)</Russian>
+            <Russian>Показать имена игроков только по нажатию клавиши (при включенных именах)</Russian>
             <Italian>Mostra i nomi solo se si preme il tasto (richiede mostra nomi abilitato)</Italian>
             <Portuguese>Mostrar nomes somente ao pressionar teclar (requer nome de jogadores)</Portuguese>
         </Key>

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -45,7 +45,7 @@
             <Italian>Occhiali notturni (Gen3, marroni)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, brązowe)</Polish>
             <Portuguese>Óculos de visão noturna (Gen3, marrons)</Portuguese>
-            <Russian>ПНВ (Gen3, коричневый)</Russian>
+            <Russian>ПНВ (Gen3, Коричневый)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, marrón)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., barna)</Hungarian>
         </Key>
@@ -57,7 +57,7 @@
             <Italian>Occhiali notturni (Gen3, verdi)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, zielone)</Polish>
             <Portuguese>Óculos de visão noturna (Gen3, verdes)</Portuguese>
-            <Russian>ПНВ (Gen3, зеленый)</Russian>
+            <Russian>ПНВ (Gen3, Зёленый)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, verde)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., zöld)</Hungarian>
         </Key>
@@ -69,7 +69,7 @@
             <Italian>Occhiali notturni (Gen3, neri)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, czarne)</Polish>
             <Portuguese>Óculos de visão noturna (Gen3, pretos)</Portuguese>
-            <Russian>ПНВ (Gen3, черный)</Russian>
+            <Russian>ПНВ (Gen3, Чёрный)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, negro)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., fekete)</Hungarian>
         </Key>

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -57,7 +57,7 @@
             <Italian>Occhiali notturni (Gen3, verdi)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, zielone)</Polish>
             <Portuguese>Óculos de visão noturna (Gen3, verdes)</Portuguese>
-            <Russian>ПНВ (Gen3, Зёленый)</Russian>
+            <Russian>ПНВ (Gen3, Зелёный)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, verde)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., zöld)</Hungarian>
         </Key>

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -116,7 +116,7 @@
             <Polish>Lufa wymieniona</Polish>
             <Czech>Hlaveň vyměněna</Czech>
             <French>Canon changé</French>
-            <Russian>Ствол сменён</Russian>
+            <Russian>Ствол заменён</Russian>
             <Hungarian>Cső kicserélve</Hungarian>
             <Portuguese>Cano substituído</Portuguese>
             <Italian>Canna sostituita</Italian>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1533,7 +1533,7 @@
             <French>GM6 Lynx (Camo)</French>
             <Hungarian>GM6 Gepárd (Terepmintás)</Hungarian>
             <Spanish>GM6 Lynx (Camuflaje)</Spanish>
-            <Russian>GM6 Lynx (камо)</Russian>
+            <Russian>GM6 Lynx (Камо)</Russian>
             <Portuguese>GM6 Lynx (Camo)</Portuguese>
             <Italian>GM6 Lynx (Camo)</Italian>
         </Key>
@@ -1557,7 +1557,7 @@
             <French>M200 Intervention (Camo)</French>
             <Hungarian>M200 Intervention (Terepmintás)</Hungarian>
             <Spanish>M200 Intervention (Camuflaje)</Spanish>
-            <Russian>M200 Intervention (камо)</Russian>
+            <Russian>M200 Intervention (Камо)</Russian>
             <Portuguese>M200 Intervention (Camo)</Portuguese>
             <Italian>M200 Intervention (Camo)</Italian>
         </Key>

--- a/addons/respawn/stringtable.xml
+++ b/addons/respawn/stringtable.xml
@@ -52,7 +52,7 @@
             <French>Téléporté à la base</French>
             <German>Zur Basis teleportiert</German>
             <Spanish>Teletransportado a base</Spanish>
-            <Russian>Телепорт на базу</Russian>
+            <Russian>Вы были телепортированы на базу</Russian>
             <Polish>Przeteleportowano do bazy</Polish>
             <Czech>Teleportován na základnu</Czech>
             <Hungarian>Bázisra teleportálva</Hungarian>
@@ -64,7 +64,7 @@
             <French>Téléporté au point de déploiement</French>
             <German>Zum Sammelpunkt teleportiert</German>
             <Spanish>Teletransportado al punto de reunión</Spanish>
-            <Russian>Телепорт на точку сбора</Russian>
+            <Russian>Вы были телепортированы на точку сбора</Russian>
             <Polish>Przeteleportowano do punktu zbiórki</Polish>
             <Czech>Teleportován na rallypoint</Czech>
             <Hungarian>Gyülekezőpontra teleportálva</Hungarian>

--- a/addons/switchunits/stringtable.xml
+++ b/addons/switchunits/stringtable.xml
@@ -4,7 +4,7 @@
         <Key ID="STR_ACE_SwitchUnits_SwitchedUnit">
             <English>Switched unit</English>
             <German>Einheit gewechselt</German>
-            <Russian>Юнит переключен</Russian>
+            <Russian>Юнит переключён</Russian>
             <Czech>Prohozená jednotka</Czech>
             <Polish>Przełącz jednostkę</Polish>
             <Spanish>Cambiado de unidad</Spanish>


### PR DESCRIPTION
Fixed the last few (hopefully) spelling mistakes and capitalization inconsistencies in the:

-nightvision
-realisticnames
-switchunits

Improved phrasing in the:

-respawn
-overheating

to increase clarity.

Replaced couple of abbreviations in the:

-nametags

for consistency with the translations in the same section (should either keep all of them abbreviated or none, IMO).