### PR TITLE
Extension that provides random number generators (with seeds)

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -57,6 +57,7 @@ set(GLOBAL_SOURCES ${GLOBAL_RC})
 add_subdirectory(fcs)
 add_subdirectory(break_line)
 add_subdirectory(clipboard)
+add_subdirectory(random)
 add_subdirectory(advanced_ballistics)
 
 message("Build Type: ${CMAKE_BUILD_TYPE}")

--- a/extensions/random/CMakeLists.txt
+++ b/extensions/random/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(ACE_EXTENSION_NAME "ace_random")
+
+file(GLOB SOURCES *.h *.hpp *.c *.cpp)
+add_library( ${ACE_EXTENSION_NAME} SHARED ${SOURCES} ${GLOBAL_SOURCES})
+target_link_libraries(${ACE_EXTENSION_NAME} ace_common)
+set_target_properties(${ACE_EXTENSION_NAME} PROPERTIES PREFIX "")
+set_target_properties(${ACE_EXTENSION_NAME} PROPERTIES FOLDER Extensions)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set_target_properties(${ACE_EXTENSION_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+	set_target_properties(${ACE_EXTENSION_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+endif()

--- a/extensions/random/ace_random.cpp
+++ b/extensions/random/ace_random.cpp
@@ -1,0 +1,80 @@
+/*
+ * ace_random.cpp
+ *
+ * Provides an interface to std::default_random_engine
+ *
+ * Arguments:
+ * 1: Command
+ * 2: ID
+ * 3: Seed | Discard notches
+ *
+ * Examples:
+ * "ace_random" callExtension "seed:weatherGenerator:10498103";
+ * "ace_random" callExtension "generate:weatherGenerator";
+ * "ace_random" callExtension "discard:weatherGenerator:10";
+ * "ace_random" callExtension "delete:weatherGenerator";
+ *
+ */
+#include "ace_common.h"
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include <map>
+#include <random>
+
+std::vector<std::string> split(std::string input) {
+    std::istringstream ss(input);
+    std::string token;
+
+    std::vector<std::string> output;
+    while (std::getline(ss, token, ':')) {
+        output.push_back(token);
+    }
+
+    return output;
+}
+
+std::map<std::string, std::default_random_engine> random_engines;
+
+extern "C"
+{
+    __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+}
+
+void __stdcall RVExtension(char *output, int outputSize, const char *function)
+{
+    std::uniform_real_distribution<float> distribution(0.0, 1.0);
+    std::vector<std::string> args = split(function);
+
+    if (args.size() > 0) {
+        if (args[0] == "version") {
+            int n = sprintf_s(output, outputSize, "%s", ACE_FULL_VERSION_STR);
+            return;
+        }
+        if (args[0] == "seed" && args.size() == 3) {
+            std::string id = args[1];
+            std::default_random_engine::result_type seed = std::stoi(args[2]);
+            random_engines[id].seed(seed);
+        }
+        if (args[0] == "generate" && args.size() == 2) {
+            std::string id = args[1];
+            float rand = distribution(random_engines[id]);
+            int n = sprintf_s(output, outputSize, "%f", rand);
+            return;
+        }
+        if (args[0] == "discard" && args.size() == 3) {
+            std::string id = args[1];
+            int discard = std::stoi(args[2]);
+            random_engines[id].discard(discard);
+        }
+        if (args[0] == "delete" && args.size() == 2) {
+            std::string id = args[1];
+            random_engines.erase(id);
+        }
+    }
+
+    int n = sprintf_s(output, outputSize, "%s", "");
+    return;
+}
+


### PR DESCRIPTION
For use in the weather module:
* Reduces the amount of synchronized data to the random seed
* Allows extensive wind simulation with minimal overhead

For use in the overheating module:
* Use already existing data (e.g. magazine count) to calculate identical seeds on every client
* Randomize dispersion / muzzle velocity reduction with a seeded random generator

...