### PR TITLE
Interact menu: Increase the minimum distance required for LOS checks to 1.5m

### DIFF
--- a/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
@@ -44,8 +44,8 @@ if (GVAR(openedMenuType) == 0 && vehicle ACE_player == ACE_player &&
 
         if (_actualDistance > _distance) exitWith {true};
 
-        if (_actualDistance > 1.0) exitWith {
-            // If distance to action is greater than 1.0 m, check LOS
+        if (_actualDistance > 1.5) exitWith {
+            // If distance to action is greater than 1.5 m, check LOS
             _line = [_headPos call EFUNC(common,positionToASL), _pos call EFUNC(common,positionToASL), _object, ACE_player];
             lineIntersects _line
         };


### PR DESCRIPTION
Should avoid LOS checks for medical bodyparts entirely, thus avoiding problems with weaponholders obstructing actions.