### PR TITLE
MissleGuidance - fix Inheritance check

### DIFF
--- a/addons/missileguidance/functions/fnc_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_onFired.sqf
@@ -16,7 +16,7 @@ PARAMS_7(_shooter,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile);
 if(! (_ammo isKindOf "MissileBase") ) exitWith { false }; 
 
 //Verify ammo has explicity added guidance config (ignore inheritances)
-_configs = configProperties [(configFile >> "CfgAmmo" >> _ammo), QUOTE(configName _x == QUOTE(QGVAR(enabled))), false];
+_configs = configProperties [(configFile >> "CfgAmmo" >> _ammo), QUOTE(configName _x == QUOTE(QUOTE(ADDON))), false];
 if( (count _configs) < 1) exitWith {};
 
 _config = (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON));

--- a/addons/missileguidance/functions/fnc_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_onFired.sqf
@@ -15,8 +15,10 @@ PARAMS_7(_shooter,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile);
 // Bail on not missile
 if(! (_ammo isKindOf "MissileBase") ) exitWith { false }; 
 
-_configs = configProperties [configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON), "true", false];
+//Verify ammo has explicity added guidance config (ignore inheritances)
+_configs = configProperties [(configFile >> "CfgAmmo" >> _ammo), QUOTE(configName _x == QUOTE(QGVAR(enabled))), false];
 if( (count _configs) < 1) exitWith {};
+
 _config = (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON));
 _enabled = getNumber ( _config >> "enabled");
 


### PR DESCRIPTION
RHS javelin broken right now,
Same as other fix for the ace javelin

```
x3 = configProperties [configFile >> "CfgAmmo" >> "rhs_ammo_M_fgm148_AT" >> "ace_missileguidance", "true", false];
count x3 = 15
```