### PR TITLE
#940 - Map Tweak (contor legend) for brefing

### DIFF
--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -154,7 +154,7 @@ class RscDisplayGetReady: RscDisplayMainMap {
     class controlsBackground {
         class CA_Map: RscMapControl {
             onDraw = QUOTE([ctrlParent (_this select 0)] call DFUNC(onDrawMap));
-            //#include "MapTweaks.hpp" @todo Shouldn't this apply to briefing too?
+            #include "MapTweaks.hpp"
         };
     };
     // get rid of the "center to player position" - button (as it works even on elite)


### PR DESCRIPTION
fix #940
on brefing screen, current contour interval legend is blocked by cancel button, and blocks chat

Moving it to the right, it's still semi-blocked by button, but the important parts are all readable (tried 2 different aspect ratios)

![untitled](https://cloud.githubusercontent.com/assets/9376747/7467192/547c9030-f2b8-11e4-9f6f-bbe2f54a7f5a.jpg)