### PR TITLE
Metric units

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_calculateStabilityFactor.sqf
+++ b/addons/advanced_ballistics/functions/fnc_calculateStabilityFactor.sqf
@@ -4,10 +4,10 @@
  * Calculates the stability factor of a bullet
  *
  * Arguments:
- * 0: caliber - inches <NUMBER>
- * 1: bullet length - inches <NUMBER>
- * 2: bullet mass - grains <NUMBER>
- * 3: barrel twist - inches <NUMBER>
+ * 0: caliber - mm <NUMBER>
+ * 1: bullet length - mm <NUMBER>
+ * 2: bullet mass - grams <NUMBER>
+ * 3: barrel twist - mm <NUMBER>
  * 4: muzzle velocity shift - m/s <NUMBER>
  * 5: temperature - degrees celcius <NUMBER>
  * 6: barometric Pressure - hPA <NUMBER>
@@ -17,7 +17,8 @@
  *
  * Public: No
  */
- 
+#include "script_component.hpp"
+
 private ["_caliber", "_bulletLength", "_bulletMass", "_barrelTwist", "_muzzleVelocity", "_temperature", "_barometricPressure", "_l", "_t", "_stabilityFactor"];
 _caliber            = _this select 0;
 _bulletLength       = _this select 1;
@@ -31,15 +32,14 @@ _barometricPressure = _this select 6;
 _t = _barrelTwist / _caliber;
 _l = _bulletLength / _caliber;
 
-_stabilityFactor = 30 * _bulletMass / (_t^2 * _caliber^3 * _l * (1 + _l^2));
+_stabilityFactor = 7587000 * _bulletMass / (_t^2 * _caliber^3 * _l * (1 + _l^2));
 
-_muzzleVelocity = _muzzleVelocity * 3.2808399;
-if (_muzzleVelocity > 1120) then {
-    _stabilityFactor = _stabilityFactor * (_muzzleVelocity / 2800) ^ (1/3);
+if (_muzzleVelocity > 341.376) then {
+    _stabilityFactor = _stabilityFactor * (_muzzleVelocity / 853.44) ^ (1/3);
 } else {
-    _stabilityFactor = _stabilityFactor * (_muzzleVelocity / 1120) ^ (1/3);
+    _stabilityFactor = _stabilityFactor * (_muzzleVelocity / 341.376) ^ (1/3);
 };
 
-_stabilityFactor = _stabilityFactor * (_temperature + 273) / (15 + 273) * 1013.25 / _barometricPressure;
+_stabilityFactor = _stabilityFactor * KELVIN(_temperature) / KELVIN(15) * 1013.25 / _barometricPressure;
 
 _stabilityFactor

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -94,7 +94,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
 _caliber = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
 _bulletLength = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
 _bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
-_barrelTwist = 1000 * getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
+_barrelTwist = getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
 _stabilityFactor = 1.5;
 
 if (_caliber > 0 && _bulletLength > 0 && _bulletMass > 0 && _barrelTwist > 0) then {

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -94,7 +94,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
 _caliber = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
 _bulletLength = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
 _bulletMass = 15.432 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
-_barrelTwist = getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
+_barrelTwist = 39.37 * getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
 _stabilityFactor = 1.5;
 
 if (_caliber > 0 && _bulletLength > 0 && _bulletMass > 0 && _barrelTwist > 0) then {

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -92,7 +92,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
 };
 
 _caliber = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
-_bulletLength = 1000 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
+_bulletLength = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
 _bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
 _barrelTwist = 1000 * getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
 _stabilityFactor = 1.5;

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -92,7 +92,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
 };
 
 _caliber = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
-_bulletLength = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
+_bulletLength = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
 _bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
 _barrelTwist = getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
 _stabilityFactor = 1.5;

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -91,7 +91,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
     };
 };
 
-_caliber = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
+_caliber = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
 _bulletLength = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
 _bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
 _barrelTwist = getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -91,10 +91,10 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
     };
 };
 
-_caliber = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
-_bulletLength = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
-_bulletMass = 15.432 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
-_barrelTwist = 39.37 * getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
+_caliber = 1000 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
+_bulletLength = 1000 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
+_bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
+_barrelTwist = 1000 * getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
 _stabilityFactor = 1.5;
 
 if (_caliber > 0 && _bulletLength > 0 && _bulletMass > 0 && _barrelTwist > 0) then {

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -91,7 +91,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
     };
 };
 
-_caliber = 1000 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
+_caliber = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
 _bulletLength = 1000 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
 _bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
 _barrelTwist = 1000 * getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -93,7 +93,7 @@ if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
 
 _caliber = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_caliber");
 _bulletLength = 39.37 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletLength");
-_bulletMass = getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
+_bulletMass = 15.432 * getNumber(configFile >> "cfgAmmo" >> _ammo >> "ACE_bulletMass");
 _barrelTwist = getNumber(configFile >> "cfgWeapons" >> _weapon >> "ACE_barrelTwist");
 _stabilityFactor = 1.5;
 

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -26,7 +26,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;        //M856 tracer burns out to 800m
         tracerEndTime = 1.579;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -43,7 +43,7 @@ class CfgAmmo {
         hit=11;
         typicalSpeed=836;
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -60,7 +60,7 @@ class CfgAmmo {
         hit=9;
         typicalSpeed=886;
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -77,7 +77,7 @@ class CfgAmmo {
         hit=6;
         typicalSpeed=886;
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=2.9808;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.151};
@@ -98,7 +98,7 @@ class CfgAmmo {
         hit=7;
         typicalSpeed=880;
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -118,7 +118,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //7T3M tracer burns out to 850m
         tracerEndTime = 1.736;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -132,7 +132,7 @@ class CfgAmmo {
         airFriction=-0.000785;
         typicalSpeed=800;
         ACE_caliber=6.706;
-        ACE_bulletLength=0.032893;
+        ACE_bulletLength=32.893;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.263};
@@ -155,7 +155,7 @@ class CfgAmmo {
         typicalSpeed=820 ;
         caliber=0.9;
         ACE_caliber=6.706;
-        ACE_bulletLength=0.034646;
+        ACE_bulletLength=34.646;
         ACE_bulletMass=9.0072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -170,7 +170,7 @@ class CfgAmmo {
         typicalSpeed=860 ;
         caliber=1.1;
         ACE_caliber=6.706;
-        ACE_bulletLength=0.03622;
+        ACE_bulletLength=36.22;
         ACE_bulletMass=9.072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.317};
@@ -187,7 +187,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //Based on the British L5A1 which burns out to 1000m 
         tracerEndTime = 2.058;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -207,7 +207,7 @@ class CfgAmmo {
         hit=16;
         typicalSpeed=790;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -223,7 +223,7 @@ class CfgAmmo {
         hit=16;
         typicalSpeed=790;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.243};
@@ -239,7 +239,7 @@ class CfgAmmo {
         hit=14;
         typicalSpeed=900;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
@@ -255,7 +255,7 @@ class CfgAmmo {
         hit=11;
         typicalSpeed=930;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=8.2296;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.377};
@@ -271,7 +271,7 @@ class CfgAmmo {
         hit=6;
         typicalSpeed=320;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034036;
+        ACE_bulletLength=34.036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -287,7 +287,7 @@ class CfgAmmo {
         caliber=2.0;
         hit=10;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.030734;
+        ACE_bulletLength=30.734;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.494};
@@ -303,7 +303,7 @@ class CfgAmmo {
         caliber=2.1;
         hit=8;
         ACE_caliber=7.214;
-        ACE_bulletLength=0.038837;
+        ACE_bulletLength=38.837;
         ACE_bulletMass=11.664;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.345};
@@ -319,7 +319,7 @@ class CfgAmmo {
         caliber=2.3;
         hit=6;
         ACE_caliber=6.172;
-        ACE_bulletLength=0.032563;
+        ACE_bulletLength=32.563;
         ACE_bulletMass=11.664;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.278};
@@ -335,7 +335,7 @@ class CfgAmmo {
         hit=17;
         typicalSpeed=900;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034366;
+        ACE_bulletLength=34.366;
         ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.268};
@@ -351,7 +351,7 @@ class CfgAmmo {
         hit=18;
         typicalSpeed=867;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.310};
@@ -367,7 +367,7 @@ class CfgAmmo {
         hit=19;
         typicalSpeed=853;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.040691;
+        ACE_bulletLength=40.691;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -381,7 +381,7 @@ class CfgAmmo {
         airFriction=-0.001023;
         typicalSpeed=820;
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -397,7 +397,7 @@ class CfgAmmo {
         hit=15;
         typicalSpeed=820;
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -416,7 +416,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //Based on the 7T2 which burns three seconds
         tracerEndTime = 3;
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -432,7 +432,7 @@ class CfgAmmo {
         hit=11;
         typicalSpeed=790;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.029286;
+        ACE_bulletLength=29.286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -448,7 +448,7 @@ class CfgAmmo {
         caliber=1.5;
         typicalSpeed=716;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -466,7 +466,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //57N231P tracer burns out to 800m
         tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -481,7 +481,7 @@ class CfgAmmo {
         typicalSpeed=390;
         hit=6;
         ACE_caliber=9.042;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -496,7 +496,7 @@ class CfgAmmo {
         airFriction=-0.001234;
         typicalSpeed=298;
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -511,7 +511,7 @@ class CfgAmmo {
         typicalSpeed=370;
         hit=6;
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -526,7 +526,7 @@ class CfgAmmo {
         typicalSpeed=425;
         hit=7;
         ACE_caliber=12.7;
-        ACE_bulletLength=0.019406;
+        ACE_bulletLength=19.406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -541,7 +541,7 @@ class CfgAmmo {
         typicalSpeed=282;
         hit=7;
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -556,7 +556,7 @@ class CfgAmmo {
         typicalSpeed=761;
         caliber=2.0;
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -570,7 +570,7 @@ class CfgAmmo {
         airFriction=-0.00106;
         typicalSpeed=880;
         ACE_caliber=9.296;
-        ACE_bulletLength=0.03429;
+        ACE_bulletLength=34.29;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -585,7 +585,7 @@ class CfgAmmo {
         airFriction=-0.000395;
         typicalSpeed=910;
         ACE_caliber=10.363;
-        ACE_bulletLength=0.054;
+        ACE_bulletLength=54.0;
         ACE_bulletMass=26.568;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -599,7 +599,7 @@ class CfgAmmo {
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
         ACE_caliber=10.566;
-        ACE_bulletLength=0.053061;
+        ACE_bulletLength=53.061;
         ACE_bulletMass=25.7904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.72};
@@ -614,7 +614,7 @@ class CfgAmmo {
         airFriction=-0.000606;
         typicalSpeed=915;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.039573;
+        ACE_bulletLength=39.573;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.322};
@@ -628,7 +628,7 @@ class CfgAmmo {
         airFriction=-0.000537;
         typicalSpeed=820;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -643,7 +643,7 @@ class CfgAmmo {
         airFriction=-0.000535;
         typicalSpeed=826;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -659,7 +659,7 @@ class CfgAmmo {
         caliber=2.8;
         typicalSpeed=826;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.038989;
+        ACE_bulletLength=38.989;
         ACE_bulletMass=16.3944;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -673,7 +673,7 @@ class CfgAmmo {
         airFriction=-0.00014;
         typicalSpeed=300;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.064516;
+        ACE_bulletLength=64.516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={1.050};
@@ -688,7 +688,7 @@ class CfgAmmo {
         airFriction=-0.0006;
         typicalSpeed=900;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -705,7 +705,7 @@ class CfgAmmo {
         hit=25;
         caliber=4.0;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -721,7 +721,7 @@ class CfgAmmo {
         typicalSpeed=860;
         caliber=3.0;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.064516;
+        ACE_bulletLength=64.516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.050};
@@ -736,7 +736,7 @@ class CfgAmmo {
         airFriction=-0.00064;
         typicalSpeed=820;
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -750,7 +750,7 @@ class CfgAmmo {
         airFriction=-0.0007182;
         typicalSpeed=250;
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -26,7 +26,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;        //M856 tracer burns out to 800m
         tracerEndTime = 1.579;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -43,7 +43,7 @@ class CfgAmmo {
         hit=11;
         typicalSpeed=836;
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -60,7 +60,7 @@ class CfgAmmo {
         hit=9;
         typicalSpeed=886;
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -77,7 +77,7 @@ class CfgAmmo {
         hit=6;
         typicalSpeed=886;
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=46;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.151};
@@ -98,7 +98,7 @@ class CfgAmmo {
         hit=7;
         typicalSpeed=880;
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -118,7 +118,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //7T3M tracer burns out to 850m
         tracerEndTime = 1.736;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -132,7 +132,7 @@ class CfgAmmo {
         airFriction=-0.000785;
         typicalSpeed=800;
         ACE_caliber=0.006706;
-        ACE_bulletLength=1.295;
+        ACE_bulletLength=0.032893;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.263};
@@ -155,7 +155,7 @@ class CfgAmmo {
         typicalSpeed=820 ;
         caliber=0.9;
         ACE_caliber=0.006706;
-        ACE_bulletLength=1.364;
+        ACE_bulletLength=0.034646;
         ACE_bulletMass=139;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -170,7 +170,7 @@ class CfgAmmo {
         typicalSpeed=860 ;
         caliber=1.1;
         ACE_caliber=0.006706;
-        ACE_bulletLength=1.426;
+        ACE_bulletLength=0.03622;
         ACE_bulletMass=140;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.317};
@@ -187,7 +187,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //Based on the British L5A1 which burns out to 1000m 
         tracerEndTime = 2.058;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -207,7 +207,7 @@ class CfgAmmo {
         hit=16;
         typicalSpeed=790;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -223,7 +223,7 @@ class CfgAmmo {
         hit=16;
         typicalSpeed=790;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.243};
@@ -239,7 +239,7 @@ class CfgAmmo {
         hit=14;
         typicalSpeed=900;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
@@ -255,7 +255,7 @@ class CfgAmmo {
         hit=11;
         typicalSpeed=930;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=127;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.377};
@@ -271,7 +271,7 @@ class CfgAmmo {
         hit=6;
         typicalSpeed=320;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.340;
+        ACE_bulletLength=0.034036;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -287,7 +287,7 @@ class CfgAmmo {
         caliber=2.0;
         hit=10;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.21;
+        ACE_bulletLength=0.030734;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.494};
@@ -303,7 +303,7 @@ class CfgAmmo {
         caliber=2.1;
         hit=8;
         ACE_caliber=0.007214;
-        ACE_bulletLength=1.529;
+        ACE_bulletLength=0.038837;
         ACE_bulletMass=180;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.345};
@@ -319,7 +319,7 @@ class CfgAmmo {
         caliber=2.3;
         hit=6;
         ACE_caliber=0.006172;
-        ACE_bulletLength=1.282;
+        ACE_bulletLength=0.032563;
         ACE_bulletMass=180;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.278};
@@ -335,7 +335,7 @@ class CfgAmmo {
         hit=17;
         typicalSpeed=900;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.353;
+        ACE_bulletLength=0.034366;
         ACE_bulletMass=190;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.268};
@@ -351,7 +351,7 @@ class CfgAmmo {
         hit=18;
         typicalSpeed=867;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.310};
@@ -367,7 +367,7 @@ class CfgAmmo {
         hit=19;
         typicalSpeed=853;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.602;
+        ACE_bulletLength=0.040691;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -381,7 +381,7 @@ class CfgAmmo {
         airFriction=-0.001023;
         typicalSpeed=820;
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -397,7 +397,7 @@ class CfgAmmo {
         hit=15;
         typicalSpeed=820;
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -416,7 +416,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //Based on the 7T2 which burns three seconds
         tracerEndTime = 3;
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -432,7 +432,7 @@ class CfgAmmo {
         hit=11;
         typicalSpeed=790;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.153;
+        ACE_bulletLength=0.029286;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -448,7 +448,7 @@ class CfgAmmo {
         caliber=1.5;
         typicalSpeed=716;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -466,7 +466,7 @@ class CfgAmmo {
         tracerStartTime = 0.073;            //57N231P tracer burns out to 800m
         tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -481,7 +481,7 @@ class CfgAmmo {
         typicalSpeed=390;
         hit=6;
         ACE_caliber=0.009042;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -496,7 +496,7 @@ class CfgAmmo {
         airFriction=-0.001234;
         typicalSpeed=298;
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -511,7 +511,7 @@ class CfgAmmo {
         typicalSpeed=370;
         hit=6;
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -526,7 +526,7 @@ class CfgAmmo {
         typicalSpeed=425;
         hit=7;
         ACE_caliber=0.0127;
-        ACE_bulletLength=0.764;
+        ACE_bulletLength=0.019406;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -541,7 +541,7 @@ class CfgAmmo {
         typicalSpeed=282;
         hit=7;
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -556,7 +556,7 @@ class CfgAmmo {
         typicalSpeed=761;
         caliber=2.0;
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -570,7 +570,7 @@ class CfgAmmo {
         airFriction=-0.00106;
         typicalSpeed=880;
         ACE_caliber=0.009296;
-        ACE_bulletLength=1.350;
+        ACE_bulletLength=0.03429;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -585,7 +585,7 @@ class CfgAmmo {
         airFriction=-0.000395;
         typicalSpeed=910;
         ACE_caliber=0.010363;
-        ACE_bulletLength=2.126;
+        ACE_bulletLength=0.054;
         ACE_bulletMass=410;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -599,7 +599,7 @@ class CfgAmmo {
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
         ACE_caliber=0.010566;
-        ACE_bulletLength=2.089;
+        ACE_bulletLength=0.053061;
         ACE_bulletMass=398;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.72};
@@ -614,7 +614,7 @@ class CfgAmmo {
         airFriction=-0.000606;
         typicalSpeed=915;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.558;
+        ACE_bulletLength=0.039573;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.322};
@@ -628,7 +628,7 @@ class CfgAmmo {
         airFriction=-0.000537;
         typicalSpeed=820;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -643,7 +643,7 @@ class CfgAmmo {
         airFriction=-0.000535;
         typicalSpeed=826;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -659,7 +659,7 @@ class CfgAmmo {
         caliber=2.8;
         typicalSpeed=826;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.535;
+        ACE_bulletLength=0.038989;
         ACE_bulletMass=253;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -673,7 +673,7 @@ class CfgAmmo {
         airFriction=-0.00014;
         typicalSpeed=300;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.540;
+        ACE_bulletLength=0.064516;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={1.050};
@@ -688,7 +688,7 @@ class CfgAmmo {
         airFriction=-0.0006;
         typicalSpeed=900;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -705,7 +705,7 @@ class CfgAmmo {
         hit=25;
         caliber=4.0;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=648;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -721,7 +721,7 @@ class CfgAmmo {
         typicalSpeed=860;
         caliber=3.0;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.540;
+        ACE_bulletLength=0.064516;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.050};
@@ -736,7 +736,7 @@ class CfgAmmo {
         airFriction=-0.00064;
         typicalSpeed=820;
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -750,7 +750,7 @@ class CfgAmmo {
         airFriction=-0.0007182;
         typicalSpeed=250;
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -34,7 +34,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class ACE_556x45_Ball_Mk262 : B_556x45_Ball {
         airFriction=-0.001125;
@@ -51,7 +51,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class ACE_556x45_Ball_Mk318 : B_556x45_Ball {
         airFriction=-0.001120;
@@ -68,7 +68,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class ACE_556x45_Ball_M995_AP : B_556x45_Ball {
         airFriction=-0.001120;
@@ -85,7 +85,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={950, 1030, 1040};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class B_556x45_Ball_Tracer_Red;
     class ACE_B_556x45_Ball_Tracer_Dim: B_556x45_Ball_Tracer_Red {
@@ -106,7 +106,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_556x45_Ball_Tracer_Green;
     class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Green {
@@ -126,7 +126,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
@@ -140,7 +140,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 788, 800, 810, 830};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26, 30};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604, 0.762};
     };
     class B_65x39_Case_yellow;
     class ACE_65x39_Caseless_Tracer_Dim : B_65x39_Case_yellow {
@@ -163,7 +163,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 790, 820, 830};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_65_Creedmor_Ball: B_65x39_Caseless {
         airFriction=-0.000651;
@@ -178,7 +178,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 820, 840, 852, 860};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_762x51_Ball : BulletBase {
         airFriction=-0.001035;
@@ -195,7 +195,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_762x51_Tracer_Yellow;
     class ACE_B_762x51_Tracer_Dim: B_762x51_Tracer_Yellow {
@@ -215,7 +215,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x51_Ball_Mk316_Mod_0 : B_762x51_Ball {
         airFriction=-0.0008525;
@@ -231,7 +231,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={775, 790, 805, 810};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x51_Ball_Mk319_Mod_0 : B_762x51_Ball {
         airFriction=-0.00103;
@@ -247,7 +247,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 910};
-        ACE_barrelLengths[]={13, 16, 20};
+        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
     };
     class ACE_762x51_Ball_M993_AP : B_762x51_Ball {
         airFriction=-0.00103;
@@ -263,7 +263,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={875, 910, 930};
-        ACE_barrelLengths[]={13, 16, 20};
+        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
     };
     class ACE_762x51_Ball_Subsonic : B_762x51_Ball {
         airFriction=-0.000535;
@@ -279,7 +279,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_30_06_M1_Ball : B_762x51_Ball {
         airFriction=-0.0009;
@@ -295,7 +295,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 785, 800, 830, 840};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_7_Remington_Magnum_Ball : B_762x51_Ball {
         airFriction=-0.0008;
@@ -311,7 +311,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={720, 780, 812, 822, 830};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_243_Winchester_Ball : B_762x51_Ball {
         airFriction=-0.00095;
@@ -327,7 +327,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={830, 875, 900, 915, 920};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball {
         airFriction=-0.000830;
@@ -343,7 +343,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class ACE_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball {
         airFriction=-0.000815;
@@ -359,7 +359,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class ACE_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball {
         airFriction=-0.00076;
@@ -375,7 +375,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 853, 884};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
@@ -389,7 +389,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x54_Ball_7N14 : B_762x51_Ball {
         airFriction=-0.001023;
@@ -405,7 +405,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_762x54_Tracer_Green;
     class ACE_762x54_Ball_7T2 : B_762x54_Tracer_Green {
@@ -424,7 +424,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x35_Ball : B_762x51_Ball {
         airFriction=-0.000821;
@@ -440,7 +440,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={620, 655, 675};
-        ACE_barrelLengths[]={9, 16, 20};
+        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
     };
     class ACE_762x39_Ball : B_762x51_Ball {
         airFriction=-0.0015168;
@@ -456,7 +456,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class ACE_762x39_Ball_57N231P : B_762x54_Tracer_Green {
         airFriction=-0.0015168;
@@ -474,7 +474,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_9x21_Ball : BulletBase {
         airFriction=-0.00125;
@@ -489,7 +489,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={440, 460, 480};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class ACE_9x18_Ball_57N181S : B_9x21_Ball {
         hit=5;
@@ -504,7 +504,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class ACE_9x19_Ball : B_9x21_Ball {
         airFriction=-0.001234;
@@ -519,7 +519,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class ACE_10x25_Ball : B_9x21_Ball {
         airFriction=-0.00168;
@@ -534,7 +534,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={4, 4.61, 9};
+        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
     };
     class ACE_765x17_Ball: B_9x21_Ball {
         airFriction=-0.001213;
@@ -549,7 +549,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class ACE_303_Ball : ACE_762x51_Ball_M118LR {
         airFriction=-0.00083;
@@ -564,7 +564,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
@@ -578,7 +578,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={850, 870, 880};
-        ACE_barrelLengths[]={20, 24.41, 26};
+        ACE_barrelLengths[]={0.508, 0.620014, 0.6604};
     };
     class B_408_Ball : BulletBase {
         timeToLive=10;
@@ -594,7 +594,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={910};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
@@ -607,7 +607,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={960};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class B_338_Ball : BulletBase {
         timeToLive=10;
@@ -622,7 +622,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={20, 26, 28};
+        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
     };
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
@@ -636,7 +636,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={790, 807, 820};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class ACE_338_Ball : B_338_Ball {
         timeToLive=10;
@@ -651,7 +651,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 820, 826, 830};
-        ACE_barrelLengths[]={20, 24, 26.5, 28};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6731, 0.7112};
     };
     class ACE_338_Ball_API526 : B_338_Ball {
         timeToLive=10;
@@ -667,7 +667,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={20, 26, 28};
+        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
     };
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
@@ -681,7 +681,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300};
-        ACE_barrelLengths[]={17.2};
+        ACE_barrelLengths[]={0.43688};
     };
     class B_127x99_Ball : BulletBase {
         timeToLive=10;
@@ -696,7 +696,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class ACE_127x99_API : BulletBase {
         timeToLive=10;
@@ -713,7 +713,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class ACE_127x99_Ball_AMAX : B_127x99_Ball {
         timeToLive=10;
@@ -729,7 +729,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={860};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class B_127x108_Ball : BulletBase {
         timeToLive=10;
@@ -744,7 +744,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
@@ -758,6 +758,6 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
 };

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -27,7 +27,7 @@ class CfgAmmo {
         tracerEndTime = 1.579;          //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -44,7 +44,7 @@ class CfgAmmo {
         typicalSpeed=836;
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -61,7 +61,7 @@ class CfgAmmo {
         typicalSpeed=886;
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -78,7 +78,7 @@ class CfgAmmo {
         typicalSpeed=886;
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=46;
+        ACE_bulletMass=2.9808;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -99,7 +99,7 @@ class CfgAmmo {
         typicalSpeed=880;
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -119,7 +119,7 @@ class CfgAmmo {
         tracerEndTime = 1.736;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -133,7 +133,7 @@ class CfgAmmo {
         typicalSpeed=800;
         ACE_caliber=0.006706;
         ACE_bulletLength=0.032893;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.263};
         ACE_velocityBoundaries[]={};
@@ -156,7 +156,7 @@ class CfgAmmo {
         caliber=0.9;
         ACE_caliber=0.006706;
         ACE_bulletLength=0.034646;
-        ACE_bulletMass=139;
+        ACE_bulletMass=9.0072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
         ACE_velocityBoundaries[]={};
@@ -171,7 +171,7 @@ class CfgAmmo {
         caliber=1.1;
         ACE_caliber=0.006706;
         ACE_bulletLength=0.03622;
-        ACE_bulletMass=140;
+        ACE_bulletMass=9.072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.317};
         ACE_velocityBoundaries[]={};
@@ -188,7 +188,7 @@ class CfgAmmo {
         tracerEndTime = 2.058;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -208,7 +208,7 @@ class CfgAmmo {
         typicalSpeed=790;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -224,7 +224,7 @@ class CfgAmmo {
         typicalSpeed=790;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -240,7 +240,7 @@ class CfgAmmo {
         typicalSpeed=900;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=130;
+        ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
         ACE_velocityBoundaries[]={};
@@ -256,7 +256,7 @@ class CfgAmmo {
         typicalSpeed=930;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=127;
+        ACE_bulletMass=8.2296;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.377};
         ACE_velocityBoundaries[]={};
@@ -272,7 +272,7 @@ class CfgAmmo {
         typicalSpeed=320;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034036;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
         ACE_velocityBoundaries[]={};
@@ -288,7 +288,7 @@ class CfgAmmo {
         hit=10;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.030734;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.494};
         ACE_velocityBoundaries[]={};
@@ -304,7 +304,7 @@ class CfgAmmo {
         hit=8;
         ACE_caliber=0.007214;
         ACE_bulletLength=0.038837;
-        ACE_bulletMass=180;
+        ACE_bulletMass=11.664;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.345};
         ACE_velocityBoundaries[]={};
@@ -320,7 +320,7 @@ class CfgAmmo {
         hit=6;
         ACE_caliber=0.006172;
         ACE_bulletLength=0.032563;
-        ACE_bulletMass=180;
+        ACE_bulletMass=11.664;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.278};
         ACE_velocityBoundaries[]={};
@@ -336,7 +336,7 @@ class CfgAmmo {
         typicalSpeed=900;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034366;
-        ACE_bulletMass=190;
+        ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.268};
         ACE_velocityBoundaries[]={};
@@ -352,7 +352,7 @@ class CfgAmmo {
         typicalSpeed=867;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.310};
         ACE_velocityBoundaries[]={};
@@ -368,7 +368,7 @@ class CfgAmmo {
         typicalSpeed=853;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.040691;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
         ACE_velocityBoundaries[]={};
@@ -382,7 +382,7 @@ class CfgAmmo {
         typicalSpeed=820;
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -398,7 +398,7 @@ class CfgAmmo {
         typicalSpeed=820;
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -417,7 +417,7 @@ class CfgAmmo {
         tracerEndTime = 3;
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -433,7 +433,7 @@ class CfgAmmo {
         typicalSpeed=790;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.029286;
-        ACE_bulletMass=125;
+        ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
         ACE_velocityBoundaries[]={792, 610, 488};
@@ -449,7 +449,7 @@ class CfgAmmo {
         typicalSpeed=716;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -467,7 +467,7 @@ class CfgAmmo {
         tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -482,7 +482,7 @@ class CfgAmmo {
         hit=6;
         ACE_caliber=0.009042;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=115;
+        ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
         ACE_velocityBoundaries[]={};
@@ -497,7 +497,7 @@ class CfgAmmo {
         typicalSpeed=298;
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -512,7 +512,7 @@ class CfgAmmo {
         hit=6;
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -527,7 +527,7 @@ class CfgAmmo {
         hit=7;
         ACE_caliber=0.0127;
         ACE_bulletLength=0.019406;
-        ACE_bulletMass=165;
+        ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
         ACE_velocityBoundaries[]={};
@@ -542,7 +542,7 @@ class CfgAmmo {
         hit=7;
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -557,7 +557,7 @@ class CfgAmmo {
         caliber=2.0;
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -571,7 +571,7 @@ class CfgAmmo {
         typicalSpeed=880;
         ACE_caliber=0.009296;
         ACE_bulletLength=0.03429;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
         ACE_velocityBoundaries[]={};
@@ -586,7 +586,7 @@ class CfgAmmo {
         typicalSpeed=910;
         ACE_caliber=0.010363;
         ACE_bulletLength=0.054;
-        ACE_bulletMass=410;
+        ACE_bulletMass=26.568;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.97};
@@ -600,7 +600,7 @@ class CfgAmmo {
         timeToLive=10;
         ACE_caliber=0.010566;
         ACE_bulletLength=0.053061;
-        ACE_bulletMass=398;
+        ACE_bulletMass=25.7904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.72};
         ACE_velocityBoundaries[]={};
@@ -615,7 +615,7 @@ class CfgAmmo {
         typicalSpeed=915;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.039573;
-        ACE_bulletMass=250;
+        ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.322};
         ACE_velocityBoundaries[]={};
@@ -629,7 +629,7 @@ class CfgAmmo {
         typicalSpeed=820;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};
@@ -644,7 +644,7 @@ class CfgAmmo {
         typicalSpeed=826;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};
@@ -660,7 +660,7 @@ class CfgAmmo {
         typicalSpeed=826;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.038989;
-        ACE_bulletMass=253;
+        ACE_bulletMass=16.3944;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
         ACE_velocityBoundaries[]={};
@@ -674,7 +674,7 @@ class CfgAmmo {
         typicalSpeed=300;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.064516;
-        ACE_bulletMass=750;
+        ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={1.050};
         ACE_velocityBoundaries[]={};
@@ -689,7 +689,7 @@ class CfgAmmo {
         typicalSpeed=900;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=647;
+        ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -706,7 +706,7 @@ class CfgAmmo {
         caliber=4.0;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=648;
+        ACE_bulletMass=41.9904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -722,7 +722,7 @@ class CfgAmmo {
         caliber=3.0;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.064516;
-        ACE_bulletMass=750;
+        ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.050};
         ACE_velocityBoundaries[]={};
@@ -737,7 +737,7 @@ class CfgAmmo {
         typicalSpeed=820;
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -751,7 +751,7 @@ class CfgAmmo {
         typicalSpeed=250;
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -25,7 +25,7 @@ class CfgAmmo {
         typicalSpeed=750;
         tracerStartTime = 0.073;        //M856 tracer burns out to 800m
         tracerEndTime = 1.579;          //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -42,7 +42,7 @@ class CfgAmmo {
         deflecting=18;
         hit=11;
         typicalSpeed=836;
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -59,7 +59,7 @@ class CfgAmmo {
         deflecting=18;
         hit=9;
         typicalSpeed=886;
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -76,7 +76,7 @@ class CfgAmmo {
         deflecting=18;
         hit=6;
         typicalSpeed=886;
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=2.9808;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -97,7 +97,7 @@ class CfgAmmo {
         deflecting=18;
         hit=7;
         typicalSpeed=880;
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -117,7 +117,7 @@ class CfgAmmo {
         typicalSpeed=883;
         tracerStartTime = 0.073;            //7T3M tracer burns out to 850m
         tracerEndTime = 1.736;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -131,7 +131,7 @@ class CfgAmmo {
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
         typicalSpeed=800;
-        ACE_caliber=0.006706;
+        ACE_caliber=6.706;
         ACE_bulletLength=0.032893;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -154,7 +154,7 @@ class CfgAmmo {
         airFriction=-0.00078;
         typicalSpeed=820 ;
         caliber=0.9;
-        ACE_caliber=0.006706;
+        ACE_caliber=6.706;
         ACE_bulletLength=0.034646;
         ACE_bulletMass=9.0072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -169,7 +169,7 @@ class CfgAmmo {
         airFriction=-0.000651;
         typicalSpeed=860 ;
         caliber=1.1;
-        ACE_caliber=0.006706;
+        ACE_caliber=6.706;
         ACE_bulletLength=0.03622;
         ACE_bulletMass=9.072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -186,7 +186,7 @@ class CfgAmmo {
         hit=9;
         tracerStartTime = 0.073;            //Based on the British L5A1 which burns out to 1000m 
         tracerEndTime = 2.058;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -206,7 +206,7 @@ class CfgAmmo {
         caliber=1.8;
         hit=16;
         typicalSpeed=790;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -222,7 +222,7 @@ class CfgAmmo {
         caliber=1.8;
         hit=16;
         typicalSpeed=790;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -238,7 +238,7 @@ class CfgAmmo {
         caliber=1.5;
         hit=14;
         typicalSpeed=900;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -254,7 +254,7 @@ class CfgAmmo {
         caliber=2.2;
         hit=11;
         typicalSpeed=930;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=8.2296;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -270,7 +270,7 @@ class CfgAmmo {
         caliber=1;
         hit=6;
         typicalSpeed=320;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -286,7 +286,7 @@ class CfgAmmo {
         typicalSpeed=800;
         caliber=2.0;
         hit=10;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.030734;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -302,7 +302,7 @@ class CfgAmmo {
         typicalSpeed=820;
         caliber=2.1;
         hit=8;
-        ACE_caliber=0.007214;
+        ACE_caliber=7.214;
         ACE_bulletLength=0.038837;
         ACE_bulletMass=11.664;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -318,7 +318,7 @@ class CfgAmmo {
         typicalSpeed=915;
         caliber=2.3;
         hit=6;
-        ACE_caliber=0.006172;
+        ACE_caliber=6.172;
         ACE_bulletLength=0.032563;
         ACE_bulletMass=11.664;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -334,7 +334,7 @@ class CfgAmmo {
         caliber=1.8;
         hit=17;
         typicalSpeed=900;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034366;
         ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -350,7 +350,7 @@ class CfgAmmo {
         caliber=1.9;
         hit=18;
         typicalSpeed=867;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -366,7 +366,7 @@ class CfgAmmo {
         caliber=2.0;
         hit=19;
         typicalSpeed=853;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.040691;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -380,7 +380,7 @@ class CfgAmmo {
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
         typicalSpeed=820;
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -396,7 +396,7 @@ class CfgAmmo {
         caliber=1.5;
         hit=15;
         typicalSpeed=820;
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -415,7 +415,7 @@ class CfgAmmo {
         typicalSpeed=800;
         tracerStartTime = 0.073;            //Based on the 7T2 which burns three seconds
         tracerEndTime = 3;
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -431,7 +431,7 @@ class CfgAmmo {
         caliber=1.5;
         hit=11;
         typicalSpeed=790;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.029286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -447,7 +447,7 @@ class CfgAmmo {
         hit=12;
         caliber=1.5;
         typicalSpeed=716;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -465,7 +465,7 @@ class CfgAmmo {
         typicalSpeed=716;
         tracerStartTime = 0.073;            //57N231P tracer burns out to 800m
         tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -480,7 +480,7 @@ class CfgAmmo {
         airFriction=-0.00125;
         typicalSpeed=390;
         hit=6;
-        ACE_caliber=0.009042;
+        ACE_caliber=9.042;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -495,7 +495,7 @@ class CfgAmmo {
         hit=5;
         airFriction=-0.001234;
         typicalSpeed=298;
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -510,7 +510,7 @@ class CfgAmmo {
         airFriction=-0.001234;
         typicalSpeed=370;
         hit=6;
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -525,7 +525,7 @@ class CfgAmmo {
         airFriction=-0.00168;
         typicalSpeed=425;
         hit=7;
-        ACE_caliber=0.0127;
+        ACE_caliber=12.7;
         ACE_bulletLength=0.019406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -540,7 +540,7 @@ class CfgAmmo {
         airFriction=-0.001213;
         typicalSpeed=282;
         hit=7;
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -555,7 +555,7 @@ class CfgAmmo {
         airFriction=-0.00083;
         typicalSpeed=761;
         caliber=2.0;
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -569,7 +569,7 @@ class CfgAmmo {
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
         typicalSpeed=880;
-        ACE_caliber=0.009296;
+        ACE_caliber=9.296;
         ACE_bulletLength=0.03429;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -584,7 +584,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.000395;
         typicalSpeed=910;
-        ACE_caliber=0.010363;
+        ACE_caliber=10.363;
         ACE_bulletLength=0.054;
         ACE_bulletMass=26.568;
         ACE_transonicStabilityCoef=1;
@@ -598,7 +598,7 @@ class CfgAmmo {
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
-        ACE_caliber=0.010566;
+        ACE_caliber=10.566;
         ACE_bulletLength=0.053061;
         ACE_bulletMass=25.7904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -613,7 +613,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.000606;
         typicalSpeed=915;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.039573;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -627,7 +627,7 @@ class CfgAmmo {
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
         typicalSpeed=820;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -642,7 +642,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.000535;
         typicalSpeed=826;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -658,7 +658,7 @@ class CfgAmmo {
         airFriction=-0.000673;
         caliber=2.8;
         typicalSpeed=826;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.038989;
         ACE_bulletMass=16.3944;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -672,7 +672,7 @@ class CfgAmmo {
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
         typicalSpeed=300;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.064516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -687,7 +687,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.0006;
         typicalSpeed=900;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -704,7 +704,7 @@ class CfgAmmo {
         typicalSpeed=900;
         hit=25;
         caliber=4.0;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -720,7 +720,7 @@ class CfgAmmo {
         airFriction=-0.000374;
         typicalSpeed=860;
         caliber=3.0;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.064516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -735,7 +735,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.00064;
         typicalSpeed=820;
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -749,7 +749,7 @@ class CfgAmmo {
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
         typicalSpeed=250;
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -34,7 +34,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class ACE_556x45_Ball_Mk262 : B_556x45_Ball {
         airFriction=-0.001125;
@@ -51,7 +51,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class ACE_556x45_Ball_Mk318 : B_556x45_Ball {
         airFriction=-0.001120;
@@ -68,7 +68,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class ACE_556x45_Ball_M995_AP : B_556x45_Ball {
         airFriction=-0.001120;
@@ -85,7 +85,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={950, 1030, 1040};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class B_556x45_Ball_Tracer_Red;
     class ACE_B_556x45_Ball_Tracer_Dim: B_556x45_Ball_Tracer_Red {
@@ -106,7 +106,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_556x45_Ball_Tracer_Green;
     class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Green {
@@ -126,7 +126,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
@@ -140,7 +140,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 788, 800, 810, 830};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604, 0.762};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4, 762.0};
     };
     class B_65x39_Case_yellow;
     class ACE_65x39_Caseless_Tracer_Dim : B_65x39_Case_yellow {
@@ -163,7 +163,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 790, 820, 830};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class ACE_65_Creedmor_Ball: B_65x39_Caseless {
         airFriction=-0.000651;
@@ -178,7 +178,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 820, 840, 852, 860};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class B_762x51_Ball : BulletBase {
         airFriction=-0.001035;
@@ -195,7 +195,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class B_762x51_Tracer_Yellow;
     class ACE_B_762x51_Tracer_Dim: B_762x51_Tracer_Yellow {
@@ -215,7 +215,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x51_Ball_Mk316_Mod_0 : B_762x51_Ball {
         airFriction=-0.0008525;
@@ -231,7 +231,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={775, 790, 805, 810};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x51_Ball_Mk319_Mod_0 : B_762x51_Ball {
         airFriction=-0.00103;
@@ -247,7 +247,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 910};
-        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
+        ACE_barrelLengths[]={330.2, 406.4, 508.0};
     };
     class ACE_762x51_Ball_M993_AP : B_762x51_Ball {
         airFriction=-0.00103;
@@ -263,7 +263,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={875, 910, 930};
-        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
+        ACE_barrelLengths[]={330.2, 406.4, 508.0};
     };
     class ACE_762x51_Ball_Subsonic : B_762x51_Ball {
         airFriction=-0.000535;
@@ -279,7 +279,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_30_06_M1_Ball : B_762x51_Ball {
         airFriction=-0.0009;
@@ -295,7 +295,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 785, 800, 830, 840};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class ACE_7_Remington_Magnum_Ball : B_762x51_Ball {
         airFriction=-0.0008;
@@ -311,7 +311,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={720, 780, 812, 822, 830};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class ACE_243_Winchester_Ball : B_762x51_Ball {
         airFriction=-0.00095;
@@ -327,7 +327,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={830, 875, 900, 915, 920};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball {
         airFriction=-0.000830;
@@ -343,7 +343,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class ACE_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball {
         airFriction=-0.000815;
@@ -359,7 +359,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class ACE_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball {
         airFriction=-0.00076;
@@ -375,7 +375,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 853, 884};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
@@ -389,7 +389,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x54_Ball_7N14 : B_762x51_Ball {
         airFriction=-0.001023;
@@ -405,7 +405,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class B_762x54_Tracer_Green;
     class ACE_762x54_Ball_7T2 : B_762x54_Tracer_Green {
@@ -424,7 +424,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x35_Ball : B_762x51_Ball {
         airFriction=-0.000821;
@@ -440,7 +440,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={620, 655, 675};
-        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
+        ACE_barrelLengths[]={228.6, 406.4, 508.0};
     };
     class ACE_762x39_Ball : B_762x51_Ball {
         airFriction=-0.0015168;
@@ -456,7 +456,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class ACE_762x39_Ball_57N231P : B_762x54_Tracer_Green {
         airFriction=-0.0015168;
@@ -474,7 +474,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_9x21_Ball : BulletBase {
         airFriction=-0.00125;
@@ -489,7 +489,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={440, 460, 480};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class ACE_9x18_Ball_57N181S : B_9x21_Ball {
         hit=5;
@@ -504,7 +504,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class ACE_9x19_Ball : B_9x21_Ball {
         airFriction=-0.001234;
@@ -519,7 +519,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class ACE_10x25_Ball : B_9x21_Ball {
         airFriction=-0.00168;
@@ -534,7 +534,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
+        ACE_barrelLengths[]={101.6, 117.094, 228.6};
     };
     class ACE_765x17_Ball: B_9x21_Ball {
         airFriction=-0.001213;
@@ -549,7 +549,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class ACE_303_Ball : ACE_762x51_Ball_M118LR {
         airFriction=-0.00083;
@@ -564,7 +564,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
@@ -578,7 +578,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={850, 870, 880};
-        ACE_barrelLengths[]={0.508, 0.620014, 0.6604};
+        ACE_barrelLengths[]={508.0, 620.014, 660.4};
     };
     class B_408_Ball : BulletBase {
         timeToLive=10;
@@ -594,7 +594,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={910};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
@@ -607,7 +607,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={960};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class B_338_Ball : BulletBase {
         timeToLive=10;
@@ -622,7 +622,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
+        ACE_barrelLengths[]={508.0, 660.4, 711.2};
     };
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
@@ -636,7 +636,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={790, 807, 820};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class ACE_338_Ball : B_338_Ball {
         timeToLive=10;
@@ -651,7 +651,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 820, 826, 830};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6731, 0.7112};
+        ACE_barrelLengths[]={508.0, 609.6, 673.1, 711.2};
     };
     class ACE_338_Ball_API526 : B_338_Ball {
         timeToLive=10;
@@ -667,7 +667,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
+        ACE_barrelLengths[]={508.0, 660.4, 711.2};
     };
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
@@ -681,7 +681,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300};
-        ACE_barrelLengths[]={0.43688};
+        ACE_barrelLengths[]={436.88};
     };
     class B_127x99_Ball : BulletBase {
         timeToLive=10;
@@ -696,7 +696,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class ACE_127x99_API : BulletBase {
         timeToLive=10;
@@ -713,7 +713,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class ACE_127x99_Ball_AMAX : B_127x99_Ball {
         timeToLive=10;
@@ -729,7 +729,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={860};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class B_127x108_Ball : BulletBase {
         timeToLive=10;
@@ -744,7 +744,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
@@ -758,6 +758,6 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
 };

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -25,7 +25,7 @@ class CfgAmmo {
         typicalSpeed=750;
         tracerStartTime = 0.073;        //M856 tracer burns out to 800m
         tracerEndTime = 1.579;          //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -42,7 +42,7 @@ class CfgAmmo {
         deflecting=18;
         hit=11;
         typicalSpeed=836;
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -59,7 +59,7 @@ class CfgAmmo {
         deflecting=18;
         hit=9;
         typicalSpeed=886;
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -76,7 +76,7 @@ class CfgAmmo {
         deflecting=18;
         hit=6;
         typicalSpeed=886;
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=46;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -97,7 +97,7 @@ class CfgAmmo {
         deflecting=18;
         hit=7;
         typicalSpeed=880;
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -117,7 +117,7 @@ class CfgAmmo {
         typicalSpeed=883;
         tracerStartTime = 0.073;            //7T3M tracer burns out to 850m
         tracerEndTime = 1.736;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -131,7 +131,7 @@ class CfgAmmo {
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
         typicalSpeed=800;
-        ACE_caliber=0.264;
+        ACE_caliber=0.006706;
         ACE_bulletLength=1.295;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -154,7 +154,7 @@ class CfgAmmo {
         airFriction=-0.00078;
         typicalSpeed=820 ;
         caliber=0.9;
-        ACE_caliber=0.264;
+        ACE_caliber=0.006706;
         ACE_bulletLength=1.364;
         ACE_bulletMass=139;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -169,7 +169,7 @@ class CfgAmmo {
         airFriction=-0.000651;
         typicalSpeed=860 ;
         caliber=1.1;
-        ACE_caliber=0.264;
+        ACE_caliber=0.006706;
         ACE_bulletLength=1.426;
         ACE_bulletMass=140;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -186,7 +186,7 @@ class CfgAmmo {
         hit=9;
         tracerStartTime = 0.073;            //Based on the British L5A1 which burns out to 1000m 
         tracerEndTime = 2.058;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -206,7 +206,7 @@ class CfgAmmo {
         caliber=1.8;
         hit=16;
         typicalSpeed=790;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -222,7 +222,7 @@ class CfgAmmo {
         caliber=1.8;
         hit=16;
         typicalSpeed=790;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -238,7 +238,7 @@ class CfgAmmo {
         caliber=1.5;
         hit=14;
         typicalSpeed=900;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -254,7 +254,7 @@ class CfgAmmo {
         caliber=2.2;
         hit=11;
         typicalSpeed=930;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=127;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -270,7 +270,7 @@ class CfgAmmo {
         caliber=1;
         hit=6;
         typicalSpeed=320;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.340;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -286,7 +286,7 @@ class CfgAmmo {
         typicalSpeed=800;
         caliber=2.0;
         hit=10;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.21;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -302,7 +302,7 @@ class CfgAmmo {
         typicalSpeed=820;
         caliber=2.1;
         hit=8;
-        ACE_caliber=0.284;
+        ACE_caliber=0.007214;
         ACE_bulletLength=1.529;
         ACE_bulletMass=180;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -318,7 +318,7 @@ class CfgAmmo {
         typicalSpeed=915;
         caliber=2.3;
         hit=6;
-        ACE_caliber=0.243;
+        ACE_caliber=0.006172;
         ACE_bulletLength=1.282;
         ACE_bulletMass=180;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -334,7 +334,7 @@ class CfgAmmo {
         caliber=1.8;
         hit=17;
         typicalSpeed=900;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.353;
         ACE_bulletMass=190;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -350,7 +350,7 @@ class CfgAmmo {
         caliber=1.9;
         hit=18;
         typicalSpeed=867;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -366,7 +366,7 @@ class CfgAmmo {
         caliber=2.0;
         hit=19;
         typicalSpeed=853;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.602;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -380,7 +380,7 @@ class CfgAmmo {
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
         typicalSpeed=820;
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -396,7 +396,7 @@ class CfgAmmo {
         caliber=1.5;
         hit=15;
         typicalSpeed=820;
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -415,7 +415,7 @@ class CfgAmmo {
         typicalSpeed=800;
         tracerStartTime = 0.073;            //Based on the 7T2 which burns three seconds
         tracerEndTime = 3;
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -431,7 +431,7 @@ class CfgAmmo {
         caliber=1.5;
         hit=11;
         typicalSpeed=790;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.153;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -447,7 +447,7 @@ class CfgAmmo {
         hit=12;
         caliber=1.5;
         typicalSpeed=716;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -465,7 +465,7 @@ class CfgAmmo {
         typicalSpeed=716;
         tracerStartTime = 0.073;            //57N231P tracer burns out to 800m
         tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -480,7 +480,7 @@ class CfgAmmo {
         airFriction=-0.00125;
         typicalSpeed=390;
         hit=6;
-        ACE_caliber=0.356;
+        ACE_caliber=0.009042;
         ACE_bulletLength=0.610;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -495,7 +495,7 @@ class CfgAmmo {
         hit=5;
         airFriction=-0.001234;
         typicalSpeed=298;
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -510,7 +510,7 @@ class CfgAmmo {
         airFriction=-0.001234;
         typicalSpeed=370;
         hit=6;
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -525,7 +525,7 @@ class CfgAmmo {
         airFriction=-0.00168;
         typicalSpeed=425;
         hit=7;
-        ACE_caliber=0.5;
+        ACE_caliber=0.0127;
         ACE_bulletLength=0.764;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -540,7 +540,7 @@ class CfgAmmo {
         airFriction=-0.001213;
         typicalSpeed=282;
         hit=7;
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -555,7 +555,7 @@ class CfgAmmo {
         airFriction=-0.00083;
         typicalSpeed=761;
         caliber=2.0;
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -569,7 +569,7 @@ class CfgAmmo {
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
         typicalSpeed=880;
-        ACE_caliber=0.366;
+        ACE_caliber=0.009296;
         ACE_bulletLength=1.350;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -584,7 +584,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.000395;
         typicalSpeed=910;
-        ACE_caliber=0.408;
+        ACE_caliber=0.010363;
         ACE_bulletLength=2.126;
         ACE_bulletMass=410;
         ACE_transonicStabilityCoef=1;
@@ -598,7 +598,7 @@ class CfgAmmo {
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
-        ACE_caliber=0.416;
+        ACE_caliber=0.010566;
         ACE_bulletLength=2.089;
         ACE_bulletMass=398;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -613,7 +613,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.000606;
         typicalSpeed=915;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.558;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -627,7 +627,7 @@ class CfgAmmo {
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
         typicalSpeed=820;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -642,7 +642,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.000535;
         typicalSpeed=826;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -658,7 +658,7 @@ class CfgAmmo {
         airFriction=-0.000673;
         caliber=2.8;
         typicalSpeed=826;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.535;
         ACE_bulletMass=253;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -672,7 +672,7 @@ class CfgAmmo {
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
         typicalSpeed=300;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.540;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -687,7 +687,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.0006;
         typicalSpeed=900;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -704,7 +704,7 @@ class CfgAmmo {
         typicalSpeed=900;
         hit=25;
         caliber=4.0;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=648;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -720,7 +720,7 @@ class CfgAmmo {
         airFriction=-0.000374;
         typicalSpeed=860;
         caliber=3.0;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.540;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -735,7 +735,7 @@ class CfgAmmo {
         timeToLive=10;
         airFriction=-0.00064;
         typicalSpeed=820;
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -749,7 +749,7 @@ class CfgAmmo {
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
         typicalSpeed=250;
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -66,7 +66,7 @@ class CfgWeapons {
         };
         initSpeed = -1.0;
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=16.0;
+        ACE_barrelLength=0.4064;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 // Shit is broken again
@@ -93,7 +93,7 @@ class CfgWeapons {
         };
         initSpeed = -1.018;
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
         class Single: Single {
             dispersion = 0.00029; // radians. Equal to 1 MOA.
             // 6.5mm is easily capable of this in a half-tuned rifle.
@@ -138,7 +138,7 @@ class CfgWeapons {
             };
         };
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
         class manual: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
         };
@@ -155,7 +155,7 @@ class CfgWeapons {
             };
         };
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18.1;
+        ACE_barrelLength=0.45974;
         class FullAuto: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
         };
@@ -242,7 +242,7 @@ class CfgWeapons {
     class hgun_P07_F: Pistol_Base_F {
         initSpeed = -0.9778;
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
@@ -254,7 +254,7 @@ class CfgWeapons {
     class hgun_Rook40_F: Pistol_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
@@ -266,7 +266,7 @@ class CfgWeapons {
     class hgun_ACPC2_F: Pistol_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
@@ -277,7 +277,7 @@ class CfgWeapons {
     class hgun_Pistol_heavy_01_F: Pistol_Base_F {
         initSpeed = -0.96;
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
@@ -288,7 +288,7 @@ class CfgWeapons {
     class hgun_Pistol_heavy_02_F: Pistol_Base_F {
         initSpeed = -0.92;
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=3;
+        ACE_barrelLength=0.0762;
         /*
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot {
@@ -301,7 +301,7 @@ class CfgWeapons {
     class hgun_PDW2000_F: pdw2000_base_F {
         initSpeed = -1.157;
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=7;
+        ACE_barrelLength=0.1778;
     };
     class arifle_Katiba_F: arifle_katiba_Base_F {
         magazines[] = {
@@ -311,7 +311,7 @@ class CfgWeapons {
         };
         initSpeed = -1.08;
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=28.7;
+        ACE_barrelLength=0.72898;
     };
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
         magazines[] = {
@@ -321,7 +321,7 @@ class CfgWeapons {
         };
         initSpeed = -1.07;
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=26.8;
+        ACE_barrelLength=0.68072;
     };
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
         magazines[] = {
@@ -331,7 +331,7 @@ class CfgWeapons {
         };
         initSpeed = -1.08;
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=28.7;
+        ACE_barrelLength=0.72898;
     };
     class arifle_MX_F: arifle_MX_Base_F {
         magazines[] = {
@@ -341,7 +341,7 @@ class CfgWeapons {
         };
         initSpeed = -0.99;
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F {
         magazines[] = {
@@ -351,12 +351,12 @@ class CfgWeapons {
         };
         initSpeed = -0.99;
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     /*
     class arifle_MX_SW_F: arifle_MX_Base_F {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=16.0;
+        ACE_barrelLength=0.4064;
     };
     */
     class arifle_MXC_F: arifle_MX_Base_F {
@@ -367,12 +367,12 @@ class CfgWeapons {
         };
         initSpeed = -0.965;
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=10.5;
+        ACE_barrelLength=0.2667;
     };
     /*
     class arifle_MXM_F: arifle_MX_Base_F {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     */
     class arifle_SDAR_F: SDAR_base_F {
@@ -389,12 +389,12 @@ class CfgWeapons {
         };
         initSpeed = -0.989;
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class SMG_02_F: SMG_02_base_F {
         initSpeed = -1.054;
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=7.7;
+        ACE_barrelLength=0.19558;
     };
     class arifle_TRG20_F: Tavor_base_F {
         magazines[] = {
@@ -409,7 +409,7 @@ class CfgWeapons {
         };
         initSpeed = -0.95;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=15;
+        ACE_barrelLength=0.381;
     };
     class arifle_TRG21_F: Tavor_base_F {
         magazines[] = {
@@ -424,7 +424,7 @@ class CfgWeapons {
         };
         initSpeed = -0.989;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.1;
+        ACE_barrelLength=0.45974;
     };
     class arifle_TRG21_GL_F: arifle_TRG21_F {
         magazines[] = {
@@ -439,12 +439,12 @@ class CfgWeapons {
         };
         initSpeed = -0.989;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.1;
+        ACE_barrelLength=0.45974;
     };
     /*
     class LMG_Zafir_F: Rifle_Long_Base_F {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18.1;
+        ACE_barrelLength=0.45974;
     };
     */
     class arifle_Mk20_F: mk20_base_F {
@@ -460,7 +460,7 @@ class CfgWeapons {
         };
         initSpeed = -0.98;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=17.4;
+        ACE_barrelLength=0.44196;
     };
     class arifle_Mk20C_F: mk20_base_F {
         magazines[] = {
@@ -475,7 +475,7 @@ class CfgWeapons {
         };
         initSpeed = -0.956;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class arifle_Mk20_GL_F: mk20_base_F {
         magazines[] = {
@@ -490,12 +490,12 @@ class CfgWeapons {
         };
         initSpeed = -0.956;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class SMG_01_F: SMG_01_Base {
         initSpeed = -1.016;
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5.5;
+        ACE_barrelLength=0.1397;
     };
     class srifle_DMR_01_F: DMR_01_base_F {
         magazines[] = {
@@ -504,7 +504,7 @@ class CfgWeapons {
         };
         initSpeed = -1.025;
         ACE_barrelTwist=0.2413;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class srifle_EBR_F: EBR_base_F {
         magazines[] = {
@@ -519,19 +519,19 @@ class CfgWeapons {
         };
         initSpeed = -0.9724;
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     /*
     class LMG_Mk200_F: Rifle_Long_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     */
     class srifle_LRR_F: LRR_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.3302;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class srifle_GM6_F: GM6_base_F {
         magazines[] = {
@@ -543,7 +543,7 @@ class CfgWeapons {
         };
         initSpeed = -1.0;
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=36.6;
+        ACE_barrelLength=0.92964;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
         magazines[] = {
@@ -556,7 +556,7 @@ class CfgWeapons {
         };
         initSpeed = -0.962;
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
         magazines[] = {
@@ -571,17 +571,17 @@ class CfgWeapons {
         };
         initSpeed = -0.9843;
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=17.72;
+        ACE_barrelLength=0.450088;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.359918;
-        ACE_barrelLength=24.41;
+        ACE_barrelLength=0.620014;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F {
         magazines[] = {
@@ -596,17 +596,17 @@ class CfgWeapons {
         };
         initSpeed = -0.9916;
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class MMG_01_hex_F: MMG_01_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.359918;
-        ACE_barrelLength=21.65;
+        ACE_barrelLength=0.54991;
     };
     class MMG_02_camo_F: MMG_02_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=0.23495;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     
     class HMG_127 : LMG_RCWS {
@@ -616,7 +616,7 @@ class CfgWeapons {
     class HMG_M2: HMG_01 {
         initSpeed = -1.0;
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=45;
+        ACE_barrelLength=1.143;
     };
     
     /* Silencers */

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -66,7 +66,7 @@ class CfgWeapons {
         };
         initSpeed = -1.0;
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 // Shit is broken again
@@ -93,7 +93,7 @@ class CfgWeapons {
         };
         initSpeed = -1.018;
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
         class Single: Single {
             dispersion = 0.00029; // radians. Equal to 1 MOA.
             // 6.5mm is easily capable of this in a half-tuned rifle.
@@ -138,7 +138,7 @@ class CfgWeapons {
             };
         };
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
         class manual: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
         };
@@ -155,7 +155,7 @@ class CfgWeapons {
             };
         };
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.45974;
+        ACE_barrelLength=459.74;
         class FullAuto: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
         };
@@ -242,7 +242,7 @@ class CfgWeapons {
     class hgun_P07_F: Pistol_Base_F {
         initSpeed = -0.9778;
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
@@ -254,7 +254,7 @@ class CfgWeapons {
     class hgun_Rook40_F: Pistol_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
@@ -266,7 +266,7 @@ class CfgWeapons {
     class hgun_ACPC2_F: Pistol_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
@@ -277,7 +277,7 @@ class CfgWeapons {
     class hgun_Pistol_heavy_01_F: Pistol_Base_F {
         initSpeed = -0.96;
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
@@ -288,7 +288,7 @@ class CfgWeapons {
     class hgun_Pistol_heavy_02_F: Pistol_Base_F {
         initSpeed = -0.92;
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.0762;
+        ACE_barrelLength=76.2;
         /*
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot {
@@ -301,7 +301,7 @@ class CfgWeapons {
     class hgun_PDW2000_F: pdw2000_base_F {
         initSpeed = -1.157;
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.1778;
+        ACE_barrelLength=177.8;
     };
     class arifle_Katiba_F: arifle_katiba_Base_F {
         magazines[] = {
@@ -311,7 +311,7 @@ class CfgWeapons {
         };
         initSpeed = -1.08;
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.72898;
+        ACE_barrelLength=728.98;
     };
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
         magazines[] = {
@@ -321,7 +321,7 @@ class CfgWeapons {
         };
         initSpeed = -1.07;
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.68072;
+        ACE_barrelLength=680.72;
     };
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
         magazines[] = {
@@ -331,7 +331,7 @@ class CfgWeapons {
         };
         initSpeed = -1.08;
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.72898;
+        ACE_barrelLength=728.98;
     };
     class arifle_MX_F: arifle_MX_Base_F {
         magazines[] = {
@@ -341,7 +341,7 @@ class CfgWeapons {
         };
         initSpeed = -0.99;
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F {
         magazines[] = {
@@ -351,12 +351,12 @@ class CfgWeapons {
         };
         initSpeed = -0.99;
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     /*
     class arifle_MX_SW_F: arifle_MX_Base_F {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     */
     class arifle_MXC_F: arifle_MX_Base_F {
@@ -367,12 +367,12 @@ class CfgWeapons {
         };
         initSpeed = -0.965;
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.2667;
+        ACE_barrelLength=266.7;
     };
     /*
     class arifle_MXM_F: arifle_MX_Base_F {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     */
     class arifle_SDAR_F: SDAR_base_F {
@@ -389,12 +389,12 @@ class CfgWeapons {
         };
         initSpeed = -0.989;
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class SMG_02_F: SMG_02_base_F {
         initSpeed = -1.054;
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.19558;
+        ACE_barrelLength=195.58;
     };
     class arifle_TRG20_F: Tavor_base_F {
         magazines[] = {
@@ -409,7 +409,7 @@ class CfgWeapons {
         };
         initSpeed = -0.95;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.381;
+        ACE_barrelLength=381.0;
     };
     class arifle_TRG21_F: Tavor_base_F {
         magazines[] = {
@@ -424,7 +424,7 @@ class CfgWeapons {
         };
         initSpeed = -0.989;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.45974;
+        ACE_barrelLength=459.74;
     };
     class arifle_TRG21_GL_F: arifle_TRG21_F {
         magazines[] = {
@@ -439,12 +439,12 @@ class CfgWeapons {
         };
         initSpeed = -0.989;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.45974;
+        ACE_barrelLength=459.74;
     };
     /*
     class LMG_Zafir_F: Rifle_Long_Base_F {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.45974;
+        ACE_barrelLength=459.74;
     };
     */
     class arifle_Mk20_F: mk20_base_F {
@@ -460,7 +460,7 @@ class CfgWeapons {
         };
         initSpeed = -0.98;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.44196;
+        ACE_barrelLength=441.96;
     };
     class arifle_Mk20C_F: mk20_base_F {
         magazines[] = {
@@ -475,7 +475,7 @@ class CfgWeapons {
         };
         initSpeed = -0.956;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class arifle_Mk20_GL_F: mk20_base_F {
         magazines[] = {
@@ -490,12 +490,12 @@ class CfgWeapons {
         };
         initSpeed = -0.956;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class SMG_01_F: SMG_01_Base {
         initSpeed = -1.016;
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1397;
+        ACE_barrelLength=139.7;
     };
     class srifle_DMR_01_F: DMR_01_base_F {
         magazines[] = {
@@ -504,7 +504,7 @@ class CfgWeapons {
         };
         initSpeed = -1.025;
         ACE_barrelTwist=241.3;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class srifle_EBR_F: EBR_base_F {
         magazines[] = {
@@ -519,19 +519,19 @@ class CfgWeapons {
         };
         initSpeed = -0.9724;
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     /*
     class LMG_Mk200_F: Rifle_Long_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     */
     class srifle_LRR_F: LRR_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=330.2;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class srifle_GM6_F: GM6_base_F {
         magazines[] = {
@@ -543,7 +543,7 @@ class CfgWeapons {
         };
         initSpeed = -1.0;
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.92964;
+        ACE_barrelLength=929.64;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
         magazines[] = {
@@ -556,7 +556,7 @@ class CfgWeapons {
         };
         initSpeed = -0.962;
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
         magazines[] = {
@@ -571,17 +571,17 @@ class CfgWeapons {
         };
         initSpeed = -0.9843;
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.450088;
+        ACE_barrelLength=450.088;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=359.918;
-        ACE_barrelLength=0.620014;
+        ACE_barrelLength=620.014;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F {
         magazines[] = {
@@ -596,17 +596,17 @@ class CfgWeapons {
         };
         initSpeed = -0.9916;
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class MMG_01_hex_F: MMG_01_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=359.918;
-        ACE_barrelLength=0.54991;
+        ACE_barrelLength=549.91;
     };
     class MMG_02_camo_F: MMG_02_base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=234.95;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     
     class HMG_127 : LMG_RCWS {
@@ -616,7 +616,7 @@ class CfgWeapons {
     class HMG_M2: HMG_01 {
         initSpeed = -1.0;
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=1.143;
+        ACE_barrelLength=1143.0;
     };
     
     /* Silencers */

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -65,7 +65,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -1.0;
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=16.0;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -92,7 +92,7 @@ class CfgWeapons {
             "ACE_30Rnd_65_Creedmor_mag"
         };
         initSpeed = -1.018;
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=18;
         class Single: Single {
             dispersion = 0.00029; // radians. Equal to 1 MOA.
@@ -137,7 +137,7 @@ class CfgWeapons {
                 compatibleItems[] += {"ACE_muzzle_mzls_H"};
             };
         };
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
         class manual: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
@@ -154,7 +154,7 @@ class CfgWeapons {
                 compatibleItems[] += {"ACE_muzzle_mzls_B"};
             };
         };
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18.1;
         class FullAuto: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
@@ -241,7 +241,7 @@ class CfgWeapons {
 
     class hgun_P07_F: Pistol_Base_F {
         initSpeed = -0.9778;
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -253,7 +253,7 @@ class CfgWeapons {
 
     class hgun_Rook40_F: Pistol_Base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.4;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -265,7 +265,7 @@ class CfgWeapons {
 
     class hgun_ACPC2_F: Pistol_Base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -276,7 +276,7 @@ class CfgWeapons {
 
     class hgun_Pistol_heavy_01_F: Pistol_Base_F {
         initSpeed = -0.96;
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -287,7 +287,7 @@ class CfgWeapons {
 
     class hgun_Pistol_heavy_02_F: Pistol_Base_F {
         initSpeed = -0.92;
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=3;
         /*
         class WeaponSlotsInfo: WeaponSlotsInfo {
@@ -300,7 +300,7 @@ class CfgWeapons {
     };
     class hgun_PDW2000_F: pdw2000_base_F {
         initSpeed = -1.157;
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=7;
     };
     class arifle_Katiba_F: arifle_katiba_Base_F {
@@ -310,7 +310,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
         initSpeed = -1.08;
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=28.7;
     };
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
@@ -320,7 +320,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
         initSpeed = -1.07;
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=26.8;
     };
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
@@ -330,7 +330,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
         initSpeed = -1.08;
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=28.7;
     };
     class arifle_MX_F: arifle_MX_Base_F {
@@ -340,7 +340,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -0.99;
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=14.5;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F {
@@ -350,12 +350,12 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -0.99;
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=14.5;
     };
     /*
     class arifle_MX_SW_F: arifle_MX_Base_F {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=16.0;
     };
     */
@@ -366,12 +366,12 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -0.965;
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=10.5;
     };
     /*
     class arifle_MXM_F: arifle_MX_Base_F {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=18;
     };
     */
@@ -388,12 +388,12 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.989;
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=18;
     };
     class SMG_02_F: SMG_02_base_F {
         initSpeed = -1.054;
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=7.7;
     };
     class arifle_TRG20_F: Tavor_base_F {
@@ -408,7 +408,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.95;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=15;
     };
     class arifle_TRG21_F: Tavor_base_F {
@@ -423,7 +423,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.989;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.1;
     };
     class arifle_TRG21_GL_F: arifle_TRG21_F {
@@ -438,12 +438,12 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.989;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.1;
     };
     /*
     class LMG_Zafir_F: Rifle_Long_Base_F {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18.1;
     };
     */
@@ -459,7 +459,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.98;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=17.4;
     };
     class arifle_Mk20C_F: mk20_base_F {
@@ -474,7 +474,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.956;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class arifle_Mk20_GL_F: mk20_base_F {
@@ -489,12 +489,12 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.956;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class SMG_01_F: SMG_01_Base {
         initSpeed = -1.016;
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5.5;
     };
     class srifle_DMR_01_F: DMR_01_base_F {
@@ -503,7 +503,7 @@ class CfgWeapons {
             "ACE_10Rnd_762x54_Tracer_mag"
         };
         initSpeed = -1.025;
-        ACE_barrelTwist=9.5;
+        ACE_barrelTwist=0.2413;
         ACE_barrelLength=24;
     };
     class srifle_EBR_F: EBR_base_F {
@@ -518,19 +518,19 @@ class CfgWeapons {
             "ACE_20Rnd_762x51_Mag_SD"
         };
         initSpeed = -0.9724;
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18;
     };
     /*
     class LMG_Mk200_F: Rifle_Long_Base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     */
     class srifle_LRR_F: LRR_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=13;
+        ACE_barrelTwist=0.3302;
         ACE_barrelLength=29;
     };
     class srifle_GM6_F: GM6_base_F {
@@ -542,7 +542,7 @@ class CfgWeapons {
             "ACE_5Rnd_127x99_AMAX_Mag"
         };
         initSpeed = -1.0;
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=36.6;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
@@ -555,7 +555,7 @@ class CfgWeapons {
             "ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag"
         };
         initSpeed = -0.962;
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=20;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
@@ -570,17 +570,17 @@ class CfgWeapons {
             "ACE_20Rnd_762x51_Mag_SD"
         };
         initSpeed = -0.9843;
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=20;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=17.72;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=14.17;
+        ACE_barrelTwist=0.359918;
         ACE_barrelLength=24.41;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F {
@@ -595,17 +595,17 @@ class CfgWeapons {
             "ACE_20Rnd_762x51_Mag_SD"
         };
         initSpeed = -0.9916;
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class MMG_01_hex_F: MMG_01_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=14.17;
+        ACE_barrelTwist=0.359918;
         ACE_barrelLength=21.65;
     };
     class MMG_02_camo_F: MMG_02_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=9.25;
+        ACE_barrelTwist=0.23495;
         ACE_barrelLength=24;
     };
     
@@ -615,7 +615,7 @@ class CfgWeapons {
     };
     class HMG_M2: HMG_01 {
         initSpeed = -1.0;
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=45;
     };
     

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -65,7 +65,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -1.0;
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4064;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -92,7 +92,7 @@ class CfgWeapons {
             "ACE_30Rnd_65_Creedmor_mag"
         };
         initSpeed = -1.018;
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4572;
         class Single: Single {
             dispersion = 0.00029; // radians. Equal to 1 MOA.
@@ -137,7 +137,7 @@ class CfgWeapons {
                 compatibleItems[] += {"ACE_muzzle_mzls_H"};
             };
         };
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
         class manual: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
@@ -154,7 +154,7 @@ class CfgWeapons {
                 compatibleItems[] += {"ACE_muzzle_mzls_B"};
             };
         };
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.45974;
         class FullAuto: Mode_FullAuto {
             dispersion = 0.00175; // radians. Equal to 6 MOA.
@@ -241,7 +241,7 @@ class CfgWeapons {
 
     class hgun_P07_F: Pistol_Base_F {
         initSpeed = -0.9778;
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.1016;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -253,7 +253,7 @@ class CfgWeapons {
 
     class hgun_Rook40_F: Pistol_Base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11176;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -265,7 +265,7 @@ class CfgWeapons {
 
     class hgun_ACPC2_F: Pistol_Base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -276,7 +276,7 @@ class CfgWeapons {
 
     class hgun_Pistol_heavy_01_F: Pistol_Base_F {
         initSpeed = -0.96;
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
@@ -287,7 +287,7 @@ class CfgWeapons {
 
     class hgun_Pistol_heavy_02_F: Pistol_Base_F {
         initSpeed = -0.92;
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.0762;
         /*
         class WeaponSlotsInfo: WeaponSlotsInfo {
@@ -300,7 +300,7 @@ class CfgWeapons {
     };
     class hgun_PDW2000_F: pdw2000_base_F {
         initSpeed = -1.157;
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.1778;
     };
     class arifle_Katiba_F: arifle_katiba_Base_F {
@@ -310,7 +310,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
         initSpeed = -1.08;
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.72898;
     };
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
@@ -320,7 +320,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
         initSpeed = -1.07;
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.68072;
     };
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
@@ -330,7 +330,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
         initSpeed = -1.08;
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.72898;
     };
     class arifle_MX_F: arifle_MX_Base_F {
@@ -340,7 +340,7 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -0.99;
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.3683;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F {
@@ -350,12 +350,12 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -0.99;
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.3683;
     };
     /*
     class arifle_MX_SW_F: arifle_MX_Base_F {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4064;
     };
     */
@@ -366,12 +366,12 @@ class CfgWeapons {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
         initSpeed = -0.965;
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.2667;
     };
     /*
     class arifle_MXM_F: arifle_MX_Base_F {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4572;
     };
     */
@@ -388,12 +388,12 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.989;
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.4572;
     };
     class SMG_02_F: SMG_02_base_F {
         initSpeed = -1.054;
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.19558;
     };
     class arifle_TRG20_F: Tavor_base_F {
@@ -408,7 +408,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.95;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.381;
     };
     class arifle_TRG21_F: Tavor_base_F {
@@ -423,7 +423,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.989;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.45974;
     };
     class arifle_TRG21_GL_F: arifle_TRG21_F {
@@ -438,12 +438,12 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.989;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.45974;
     };
     /*
     class LMG_Zafir_F: Rifle_Long_Base_F {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.45974;
     };
     */
@@ -459,7 +459,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.98;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.44196;
     };
     class arifle_Mk20C_F: mk20_base_F {
@@ -474,7 +474,7 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.956;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class arifle_Mk20_GL_F: mk20_base_F {
@@ -489,12 +489,12 @@ class CfgWeapons {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
         initSpeed = -0.956;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class SMG_01_F: SMG_01_Base {
         initSpeed = -1.016;
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1397;
     };
     class srifle_DMR_01_F: DMR_01_base_F {
@@ -503,7 +503,7 @@ class CfgWeapons {
             "ACE_10Rnd_762x54_Tracer_mag"
         };
         initSpeed = -1.025;
-        ACE_barrelTwist=0.2413;
+        ACE_barrelTwist=241.3;
         ACE_barrelLength=0.6096;
     };
     class srifle_EBR_F: EBR_base_F {
@@ -518,19 +518,19 @@ class CfgWeapons {
             "ACE_20Rnd_762x51_Mag_SD"
         };
         initSpeed = -0.9724;
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4572;
     };
     /*
     class LMG_Mk200_F: Rifle_Long_Base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     */
     class srifle_LRR_F: LRR_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.3302;
+        ACE_barrelTwist=330.2;
         ACE_barrelLength=0.7366;
     };
     class srifle_GM6_F: GM6_base_F {
@@ -542,7 +542,7 @@ class CfgWeapons {
             "ACE_5Rnd_127x99_AMAX_Mag"
         };
         initSpeed = -1.0;
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.92964;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
@@ -555,7 +555,7 @@ class CfgWeapons {
             "ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag"
         };
         initSpeed = -0.962;
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.508;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
@@ -570,17 +570,17 @@ class CfgWeapons {
             "ACE_20Rnd_762x51_Mag_SD"
         };
         initSpeed = -0.9843;
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.508;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.450088;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.359918;
+        ACE_barrelTwist=359.918;
         ACE_barrelLength=0.620014;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F {
@@ -595,17 +595,17 @@ class CfgWeapons {
             "ACE_20Rnd_762x51_Mag_SD"
         };
         initSpeed = -0.9916;
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class MMG_01_hex_F: MMG_01_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.359918;
+        ACE_barrelTwist=359.918;
         ACE_barrelLength=0.54991;
     };
     class MMG_02_camo_F: MMG_02_base_F {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.23495;
+        ACE_barrelTwist=234.95;
         ACE_barrelLength=0.6096;
     };
     
@@ -615,7 +615,7 @@ class CfgWeapons {
     };
     class HMG_M2: HMG_01 {
         initSpeed = -1.0;
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=1.143;
     };
     

--- a/addons/overheating/functions/fnc_overheat.sqf
+++ b/addons/overheating/functions/fnc_overheat.sqf
@@ -35,7 +35,6 @@ _temperature = _overheat select 0;
 _time = _overheat select 1;
 
 // Get physical parameters
-// Bullet mass is read from config in grains and converted to grams
 _bulletMass = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_BulletMass");
 if (_bulletMass == 0) then {
   // If the bullet mass is not configured, estimate it directly in grams

--- a/addons/overheating/functions/fnc_overheat.sqf
+++ b/addons/overheating/functions/fnc_overheat.sqf
@@ -36,12 +36,12 @@ _time = _overheat select 1;
 
 // Get physical parameters
 // Bullet mass is read from config in grains and converted to grams
-_bulletMass = (getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_BulletMass")) * 0.06480;
+_bulletMass = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_BulletMass");
 if (_bulletMass == 0) then {
   // If the bullet mass is not configured, estimate it directly in grams
   _bulletMass = 3.4334 + 0.5171 * (getNumber (configFile >> "CfgAmmo" >> _ammo >> "hit") + getNumber (configFile >> "CfgAmmo" >> _ammo >> "caliber"));
 };
-_energyIncrement = 0.75 * 0.0005 * 15.4323 * _bulletMass * (vectorMagnitudeSqr _velocity);
+_energyIncrement = 0.75 * 0.0005 * _bulletMass * (vectorMagnitudeSqr _velocity);
 _barrelMass = 0.50 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Calculate cooling

--- a/addons/overheating/functions/fnc_overheat.sqf
+++ b/addons/overheating/functions/fnc_overheat.sqf
@@ -41,7 +41,7 @@ if (_bulletMass == 0) then {
   // If the bullet mass is not configured, estimate it directly in grams
   _bulletMass = 3.4334 + 0.5171 * (getNumber (configFile >> "CfgAmmo" >> _ammo >> "hit") + getNumber (configFile >> "CfgAmmo" >> _ammo >> "caliber"));
 };
-_energyIncrement = 0.75 * 0.0005 * _bulletMass * (vectorMagnitudeSqr _velocity);
+_energyIncrement = 0.75 * 0.0005 * 15.4323 * _bulletMass * (vectorMagnitudeSqr _velocity);
 _barrelMass = 0.50 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Calculate cooling

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -14,7 +14,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class ACE_556x45_Ball_Mk262 : B_556x45_Ball {
         airFriction=-0.001125;
@@ -31,7 +31,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class ACE_556x45_Ball_Mk318 : B_556x45_Ball {
         airFriction=-0.001120;
@@ -48,7 +48,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class B_556x45_Ball_Tracer_Red;
     class ACE_B_556x45_Ball_Tracer_Dim: B_556x45_Ball_Tracer_Red {
@@ -69,7 +69,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_556x45_Ball_Tracer_Yellow;
     class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Yellow {
@@ -87,7 +87,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
@@ -101,7 +101,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 788, 800, 810, 830};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604, 0.762};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4, 762.0};
     };
     class B_65x39_Case_yellow;
     class ACE_65x39_Caseless_Tracer_Dim : B_65x39_Case_yellow {
@@ -124,7 +124,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 790, 820, 830};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class B_762x51_Ball : BulletBase {
         airFriction=-0.001035;
@@ -139,7 +139,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class B_762x51_Tracer_Yellow;
     class ACE_B_762x51_Tracer_Dim: B_762x51_Tracer_Yellow {
@@ -159,7 +159,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x51_Ball_Mk319_Mod_0 : B_762x51_Ball {
         airFriction=-0.00103;
@@ -175,7 +175,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 910};
-        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
+        ACE_barrelLengths[]={330.2, 406.4, 508.0};
     };
     class ACE_762x51_Ball_Subsonic : B_762x51_Ball {
         airFriction=-0.000535;
@@ -191,7 +191,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball {
         airFriction=-0.000830;
@@ -207,7 +207,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class ACE_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball {
         airFriction=-0.000815;
@@ -223,7 +223,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class ACE_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball {
         airFriction=-0.00076;
@@ -239,7 +239,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 853, 884};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
@@ -253,7 +253,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x54_Ball_7N14 : B_762x51_Ball {
         airFriction=-0.001023;
@@ -269,7 +269,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class B_762x54_Tracer_Green;
     class ACE_762x54_Ball_7T2 : B_762x54_Tracer_Green {
@@ -286,7 +286,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class ACE_762x35_Ball : B_762x51_Ball {
         airFriction=-0.000821;
@@ -302,7 +302,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={620, 655, 675};
-        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
+        ACE_barrelLengths[]={228.6, 406.4, 508.0};
     };
     class ACE_762x39_Ball : B_762x51_Ball {
         airFriction=-0.0015168;
@@ -317,7 +317,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class ACE_762x39_Ball_57N231P : B_762x51_Tracer_Yellow {
         airFriction=-0.0015168;
@@ -332,7 +332,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_9x21_Ball : BulletBase {
         airFriction=-0.00125;
@@ -347,7 +347,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={440, 460, 480};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class ACE_9x18_Ball_57N181S : B_9x21_Ball {
         hit=5;
@@ -362,7 +362,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class ACE_9x19_Ball : B_9x21_Ball {
         airFriction=-0.001234;
@@ -377,7 +377,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class ACE_10x25_Ball : B_9x21_Ball {
         airFriction=-0.00168;
@@ -392,7 +392,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
+        ACE_barrelLengths[]={101.6, 117.094, 228.6};
     };
     class ACE_765x17_Ball: B_9x21_Ball {
         airFriction=-0.001213;
@@ -407,7 +407,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class ACE_303_Ball : ACE_762x51_Ball_M118LR {
         airFriction=-0.00083;
@@ -421,7 +421,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
@@ -436,7 +436,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={850, 870, 880};
-        ACE_barrelLengths[]={0.508, 0.620014, 0.6604};
+        ACE_barrelLengths[]={508.0, 620.014, 660.4};
     };
     class B_408_Ball : BulletBase {
         timeToLive=10;
@@ -452,7 +452,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={910};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
@@ -465,7 +465,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={960};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class B_338_Ball : BulletBase {
         timeToLive=10;
@@ -480,7 +480,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
+        ACE_barrelLengths[]={508.0, 660.4, 711.2};
     };
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
@@ -494,7 +494,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={790, 807, 820};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class ACE_338_Ball : B_338_Ball {
         timeToLive=10;
@@ -510,7 +510,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 820, 826, 830};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6731, 0.7112};
+        ACE_barrelLengths[]={508.0, 609.6, 673.1, 711.2};
     };
     class ACE_338_Ball_API526 : B_338_Ball {
         timeToLive=10;
@@ -526,7 +526,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
+        ACE_barrelLengths[]={508.0, 660.4, 711.2};
     };
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
@@ -540,7 +540,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300};
-        ACE_barrelLengths[]={0.43688};
+        ACE_barrelLengths[]={436.88};
     };
     class B_127x99_Ball : BulletBase {
         timeToLive=10;
@@ -555,7 +555,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class ACE_127x99_Ball_AMAX : B_127x99_Ball {
         timeToLive=10;
@@ -570,7 +570,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={860};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class B_127x108_Ball : BulletBase {
         timeToLive=10;
@@ -585,7 +585,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
@@ -599,7 +599,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     
     class TMR_B_762x51_M118LR : B_762x51_Ball
@@ -613,7 +613,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     
     class RH_50_AE_Ball: BulletBase
@@ -627,7 +627,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 398, 420};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
     };
     class RH_454_Casull: BulletBase
     {
@@ -640,7 +640,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={450, 490, 500};
-        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
+        ACE_barrelLengths[]={101.6, 190.5, 228.6};
     };
     class RH_32ACP: BulletBase
     {
@@ -653,7 +653,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_45ACP: BulletBase
     {
@@ -666,7 +666,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_B_40SW: BulletBase
     {
@@ -679,7 +679,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
     };
     class RH_44mag_ball: BulletBase
     {
@@ -692,7 +692,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 390, 420};
-        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
+        ACE_barrelLengths[]={101.6, 190.5, 228.6};
     };
     class RH_357mag_ball: BulletBase
     {
@@ -705,7 +705,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={490, 510, 535};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
     };
     class RH_762x25: BulletBase
     {
@@ -718,7 +718,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
     };
     class RH_9x18_Ball: BulletBase
     {
@@ -731,7 +731,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class RH_B_9x19_Ball: BulletBase
     {
@@ -744,7 +744,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_B_22LR_SD: BulletBase
     {
@@ -757,7 +757,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={330, 340, 360};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
     };
     class RH_57x28mm: BulletBase
     {
@@ -770,7 +770,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={550, 625, 720};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.26289};
+        ACE_barrelLengths[]={101.6, 152.4, 262.89};
     };
     
     class RH_9x19_B_M822: BulletBase
@@ -784,7 +784,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_9x19_B_HP: BulletBase
     {
@@ -797,7 +797,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_9x19_B_HPSB: BulletBase
     {
@@ -810,7 +810,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={295, 310, 330};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_B_6x35: BulletBase
     {
@@ -823,7 +823,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={730, 750, 760};
-        ACE_barrelLengths[]={0.2032, 0.254, 0.3048};
+        ACE_barrelLengths[]={203.2, 254.0, 304.8};
     };
     class RH_556x45_B_M855A1 : B_556x45_Ball
     {
@@ -836,7 +836,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class RH_556x45_B_Mk262 : B_556x45_Ball
     {
@@ -849,7 +849,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class RH_556x45_B_Mk318 : B_556x45_Ball
     {
@@ -862,7 +862,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
@@ -875,7 +875,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={713, 785, 810, 850};
-        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
+        ACE_barrelLengths[]={304.8, 406.4, 508.0, 609.6};
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
@@ -888,7 +888,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 732, 750, 780};
-        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
+        ACE_barrelLengths[]={304.8, 406.4, 508.0, 609.6};
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
@@ -901,7 +901,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
+        ACE_barrelLengths[]={152.4, 406.4, 508.0};
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
@@ -914,7 +914,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={590, 650, 665};
-        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
+        ACE_barrelLengths[]={152.4, 406.4, 508.0};
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
@@ -927,7 +927,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
+        ACE_barrelLengths[]={228.6, 406.4, 508.0};
     };
     class RH_762x51_B_M80A1 : B_762x51_Ball
     {
@@ -940,7 +940,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class RH_762x51_B_Mk316LR : B_762x51_Ball
     {
@@ -953,7 +953,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class RH_762x51_B_Mk319 : B_762x51_Ball
     {
@@ -966,7 +966,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 920};
-        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
+        ACE_barrelLengths[]={330.2, 406.4, 508.0};
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
@@ -979,7 +979,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     
     class HLC_556NATO_SOST: BulletBase
@@ -993,7 +993,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class HLC_556NATO_SPR: BulletBase
     {
@@ -1006,7 +1006,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class HLC_556NATO_EPR: BulletBase
     {
@@ -1019,7 +1019,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class HLC_300Blackout_Ball: BulletBase
     {
@@ -1032,7 +1032,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
+        ACE_barrelLengths[]={152.4, 406.4, 508.0};
     };
     class HLC_300Blackout_SMK: BulletBase
     {
@@ -1045,7 +1045,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
+        ACE_barrelLengths[]={228.6, 406.4, 508.0};
     };
     class HLC_762x51_BTSub: BulletBase
     {
@@ -1058,7 +1058,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_762x54_ball: BulletBase
     {
@@ -1071,7 +1071,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_762x54_tracer: BulletBase
     {
@@ -1084,7 +1084,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_303Brit_B: BulletBase
     {
@@ -1097,7 +1097,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class HLC_792x57_Ball: BulletBase
     {
@@ -1110,7 +1110,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={785, 800, 815};
-        ACE_barrelLengths[]={0.508, 0.599948, 0.6604};
+        ACE_barrelLengths[]={508.0, 599.948, 660.4};
     };
     class FH_545x39_Ball: BulletBase
     {
@@ -1123,14 +1123,14 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class FH_545x39_7u1: FH_545x39_Ball
     {
         ACE_bulletMass=5.184;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_muzzleVelocities[]={260, 303, 320};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class HLC_9x19_Ball: BulletBase
     {
@@ -1143,7 +1143,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class HLC_9x19_GoldDot: HLC_9x19_Ball
     {
@@ -1164,7 +1164,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
+        ACE_barrelLengths[]={101.6, 117.094, 228.6};
     };
     class HLC_9x19_M882_SMG: HLC_9x19_Ball
     {
@@ -1177,7 +1177,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     
     class M_mas_545x39_Ball_7N6M : BulletBase
@@ -1191,7 +1191,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class M_mas_545x39_Ball_7T3M : BulletBase
     {
@@ -1204,7 +1204,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_mas_556x45_Ball_Mk262 : B_556x45_Ball
     {
@@ -1217,7 +1217,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class B_mas_9x18_Ball_57N181S : BulletBase
     {
@@ -1230,7 +1230,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class B_mas_9x21p_Ball: BulletBase
     {
@@ -1243,7 +1243,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class B_mas_9x21_Ball: BulletBase
     {
@@ -1256,7 +1256,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class B_mas_9x21d_Ball: BulletBase
     {
@@ -1269,7 +1269,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={210, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class B_mas_765x17_Ball: BulletBase
     {
@@ -1282,7 +1282,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class B_mas_762x39_Ball: BulletBase
     {
@@ -1295,7 +1295,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_mas_762x39_Ball_T: BulletBase
     {
@@ -1308,7 +1308,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_mas_762x51_Ball_M118LR : B_762x51_Ball
     {
@@ -1321,7 +1321,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class B_mas_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball
     {
@@ -1334,7 +1334,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_mas_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball
     {
@@ -1347,7 +1347,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 867, 900};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_mas_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball
     {
@@ -1360,7 +1360,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 853, 884};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };	
     class B_mas_762x54_Ball : BulletBase
     {
@@ -1373,7 +1373,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class B_mas_762x54_Ball_T : BulletBase
     {
@@ -1386,7 +1386,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class BWA3_B_762x51_Ball_LR : BulletBase
     {
@@ -1399,7 +1399,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class BWA3_B_762x51_Ball_SD : BulletBase
     {
@@ -1412,7 +1412,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={300, 340};
-        ACE_barrelLengths[]={0.4064, 0.6096};
+        ACE_barrelLengths[]={406.4, 609.6};
     };
     
     class BWA3_B_46x30_Ball : BulletBase
@@ -1426,7 +1426,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 720, 730, 740};
-        ACE_barrelLengths[]={0.1016, 0.1778, 0.2286, 0.3048};
+        ACE_barrelLengths[]={101.6, 177.8, 228.6, 304.8};
     };
     
     class Trixie_338_Ball : BulletBase
@@ -1440,7 +1440,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 826, 830};
-        ACE_barrelLengths[]={0.6096, 0.6731, 0.7112};
+        ACE_barrelLengths[]={609.6, 673.1, 711.2};
     };
     class Trixie_303_Ball : BulletBase
     {
@@ -1453,7 +1453,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     
     class rhs_ammo_556x45_Mk318_Ball : BulletBase
@@ -1467,7 +1467,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class rhs_ammo_556x45_Mk262_Ball : BulletBase
     {
@@ -1480,7 +1480,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class rhsammo_762x51_Ball : BulletBase
     {
@@ -1493,7 +1493,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_545x39_Ball : BulletBase
     {
@@ -1506,7 +1506,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class rhs_B_545x39_Ball_Tracer_Green : BulletBase
     {
@@ -1519,7 +1519,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class rhs_ammo_762x51_M118_Special_Ball : BulletBase
     {
@@ -1532,7 +1532,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_762x54_Ball : BulletBase
     {
@@ -1545,7 +1545,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_762x54_Ball_Tracer_Green : BulletBase
     {
@@ -1558,7 +1558,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_762x39_Ball : BulletBase
     {
@@ -1571,7 +1571,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class rhs_B_762x39_Tracer : BulletBase
     {
@@ -1584,7 +1584,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class rhs_ammo_762x51_M80_Ball : BulletBase
     {
@@ -1597,7 +1597,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class rhsusf_B_300winmag : BulletBase
     {
@@ -1610,7 +1610,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     
     class R3F_9x19_Ball: BulletBase
@@ -1624,7 +1624,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class R3F_556x45_Ball: BulletBase
     {
@@ -1637,7 +1637,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class R3F_762x51_Ball: BulletBase
     {
@@ -1650,7 +1650,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class R3F_762x51_Ball2: BulletBase
     {
@@ -1663,7 +1663,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class R3F_127x99_Ball: BulletBase
     {
@@ -1676,7 +1676,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class R3F_127x99_Ball2: BulletBase
     {
@@ -1689,7 +1689,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     
     class CUP_B_545x39_Ball: BulletBase
@@ -1703,7 +1703,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_545x39_Ball_Tracer_Green: BulletBase
     {
@@ -1716,7 +1716,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_545x39_Ball_Tracer_Red: BulletBase
     {
@@ -1729,7 +1729,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_545x39_Ball_Tracer_White: BulletBase
     {
@@ -1742,7 +1742,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
     {
@@ -1755,7 +1755,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_762x39_Ball: BulletBase
     {
@@ -1768,7 +1768,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_762x39_Ball_Tracer_Green: BulletBase
     {
@@ -1781,7 +1781,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_762x39mm_KLT: BulletBase
     {
@@ -1794,7 +1794,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_9x18_Ball: BulletBase
     {
@@ -1807,7 +1807,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
@@ -1820,7 +1820,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
@@ -1833,7 +1833,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
@@ -1846,7 +1846,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
@@ -1859,7 +1859,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x19_Ball: BulletBase
     {
@@ -1872,7 +1872,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class CUP_B_762x51_noTracer: BulletBase
     {
@@ -1885,7 +1885,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Red_Tracer_3RndBurst: BulletBase
     {
@@ -1898,7 +1898,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_White_Tracer_3RndBurst: BulletBase
     {
@@ -1911,7 +1911,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_303_Ball: BulletBase
     {
@@ -1924,7 +1924,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
@@ -1937,7 +1937,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
@@ -1950,7 +1950,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
@@ -1963,7 +1963,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
@@ -1976,7 +1976,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
@@ -1989,7 +1989,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
@@ -2002,7 +2002,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_9x39_SP5: BulletBase
     {
@@ -2015,7 +2015,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
@@ -2028,7 +2028,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
@@ -2041,7 +2041,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
@@ -2054,7 +2054,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
@@ -2067,7 +2067,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class B_127x107_Ball: BulletBase
     {
@@ -2080,7 +2080,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class CUP_B_9x18_SD: BulletBase
     {
@@ -2093,7 +2093,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 340};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_765x17_Ball: BulletBase
     {
@@ -2106,7 +2106,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class CUP_B_145x115_AP_Green_Tracer: BulletBase
     {
@@ -2119,7 +2119,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1000};
-        ACE_barrelLengths[]={1.3462};
+        ACE_barrelLengths[]={1346.2};
     };
     class CUP_B_127x99_Ball_White_Tracer: BulletBase
     {
@@ -2132,7 +2132,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class CUP_B_86x70_Ball_noTracer: BulletBase
     {
@@ -2145,7 +2145,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 826, 830};
-        ACE_barrelLengths[]={0.6096, 0.6731, 0.7112};
+        ACE_barrelLengths[]={609.6, 673.1, 711.2};
     };
     
     class VTN_9x18_Ball_FMJ: B_9x21_Ball
@@ -2159,7 +2159,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class VTN_9x18_Ball_SC: VTN_9x18_Ball_FMJ
     {
@@ -2172,7 +2172,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class VTN_9x18_Ball_TRC: VTN_9x18_Ball_FMJ
     {
@@ -2185,7 +2185,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class VTN_9x18_Ball_AP1: VTN_9x18_Ball_FMJ
     {
@@ -2198,7 +2198,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class VTN_9x18_Ball_AP2: VTN_9x18_Ball_FMJ
     {
@@ -2211,7 +2211,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class VTN_9x18_Ball_PRS: VTN_9x18_Ball_FMJ
     {
@@ -2224,7 +2224,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class VTN_9x19_Ball_SC: VTN_9x18_Ball_FMJ
     {
@@ -2237,7 +2237,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_9x19_Ball_TRC: VTN_9x19_Ball_SC
     {
@@ -2250,7 +2250,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_9x19_Ball_AP: VTN_9x19_Ball_SC
     {
@@ -2263,7 +2263,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_9x19_Ball_PRS: VTN_9x19_Ball_SC
     {
@@ -2276,7 +2276,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_9x39_Ball_SC: B_9x21_Ball
     {
@@ -2289,7 +2289,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_9x39_Ball_AP: VTN_9x39_Ball_SC
     {
@@ -2302,7 +2302,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_545x39_Ball_SC: B_556x45_Ball
     {
@@ -2315,7 +2315,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_545x39_Ball_TRC: VTN_545x39_Ball_SC
     {
@@ -2328,7 +2328,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_545x39_Ball_AP: VTN_545x39_Ball_TRC
     {
@@ -2341,7 +2341,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_545x39_Ball_AP2: VTN_545x39_Ball_AP
     {
@@ -2354,7 +2354,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_545x39_Ball_SS: VTN_545x39_Ball_SC
     {
@@ -2367,7 +2367,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x39_Ball_SC: B_762x51_Ball
     {
@@ -2380,7 +2380,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x39_Ball_TRC: VTN_762x39_Ball_SC
     {
@@ -2393,7 +2393,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x39_Ball_AP: VTN_762x39_Ball_TRC
     {
@@ -2406,7 +2406,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x39_Ball_INC: VTN_762x39_Ball_AP
     {
@@ -2419,7 +2419,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x39_Ball_API: VTN_762x39_Ball_INC
     {
@@ -2432,7 +2432,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x39_Ball_SS: VTN_762x39_Ball_SC
     {
@@ -2445,7 +2445,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_762x41_Ball_SS: B_762x51_Ball
     {
@@ -2458,7 +2458,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={200, 210, 220};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2032};
+        ACE_barrelLengths[]={101.6, 152.4, 203.2};
     };
     class VTN_762x54_Ball_SC: VTN_762x39_Ball_SC
     {
@@ -2471,7 +2471,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x54_Ball_TRC: VTN_762x54_Ball_SC
     {
@@ -2484,7 +2484,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x54_Ball_AP: VTN_762x54_Ball_TRC
     {
@@ -2497,7 +2497,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x54_Ball_INC: VTN_762x54_Ball_AP
     {
@@ -2510,7 +2510,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x54_Ball_API: VTN_762x54_Ball_INC
     {
@@ -2523,7 +2523,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class VTN_145x114_Ball_APT: B_127x108_Ball
     {
@@ -2536,7 +2536,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1000};
-        ACE_barrelLengths[]={1.3462};
+        ACE_barrelLengths[]={1346.2};
     };
     class VTN_6mm_BB: B_65x39_Caseless
     {
@@ -2549,7 +2549,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={100};
-        ACE_barrelLengths[]={0.381};
+        ACE_barrelLengths[]={381.0};
     };
     class VTN_9x19_Ball_FMJ: B_9x21_Ball
     {
@@ -2562,7 +2562,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_556x45_Ball_FMJ: B_556x45_Ball
     {
@@ -2575,7 +2575,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class VTN_556x45_Ball_TRC: VTN_556x45_Ball_FMJ
     {
@@ -2588,7 +2588,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class VTN_556x45_Ball_TRCN: VTN_556x45_Ball_TRC
     {
@@ -2601,7 +2601,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class VTN_556x45_Ball_SC: VTN_556x45_Ball_FMJ
     {
@@ -2614,7 +2614,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class VTN_556x45_Ball_AP: VTN_556x45_Ball_TRC
     {
@@ -2627,7 +2627,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class VTN_556x45_Ball_INC: VTN_556x45_Ball_AP
     {
@@ -2640,7 +2640,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class VTN_556x45_Ball_LR: VTN_556x45_Ball_FMJ
     {
@@ -2653,7 +2653,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class VTN_556x45_Ball_SS: B_556x45_Ball
     {
@@ -2666,7 +2666,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.254, 0.508, 0.6096};
+        ACE_barrelLengths[]={254.0, 508.0, 609.6};
     };
     class VTN_762x51_Ball_SC: B_762x51_Ball
     {
@@ -2679,7 +2679,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x51_Ball_TRC: VTN_762x51_Ball_SC
     {
@@ -2692,7 +2692,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x51_Ball_TRCN: VTN_762x51_Ball_TRC
     {
@@ -2705,7 +2705,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x51_Ball_AP: VTN_762x51_Ball_TRC
     {
@@ -2718,7 +2718,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class VTN_762x51_Ball_LR: VTN_762x51_Ball_SC
     {
@@ -2731,7 +2731,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class VTN_1143x23_Ball_FMJ: B_408_Ball
     {
@@ -2744,7 +2744,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_1143x23_Ball_HP: VTN_1143x23_Ball_FMJ
     {
@@ -2757,7 +2757,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_1143x23_Ball_JHP: VTN_1143x23_Ball_FMJ
     {
@@ -2770,7 +2770,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class VTN_762x39_Ball_FMJ: B_762x51_Ball
     {
@@ -2783,7 +2783,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class VTN_45_Pellet: B_762x51_Ball
     {
@@ -2796,6 +2796,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={100, 138, 150};
-        ACE_barrelLengths[]={0.127, 0.254, 0.4064};
+        ACE_barrelLengths[]={127.0, 254.0, 406.4};
     };
 };

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
         airFriction=-0.001265;
         hit=8;
         typicalSpeed=750;
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -22,7 +22,7 @@ class CfgAmmo
         deflecting=18;
         hit=11;
         typicalSpeed=836;
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -39,7 +39,7 @@ class CfgAmmo
         deflecting=18;
         hit=9;
         typicalSpeed=886;
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -60,7 +60,7 @@ class CfgAmmo
         deflecting=18;
         hit=7;
         typicalSpeed=880;
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -78,7 +78,7 @@ class CfgAmmo
         deflecting=18;
         hit=7;
         typicalSpeed=883;
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -92,7 +92,7 @@ class CfgAmmo
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
         typicalSpeed=800;
-        ACE_caliber=0.264;
+        ACE_caliber=0.006706;
         ACE_bulletLength=1.295;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -115,7 +115,7 @@ class CfgAmmo
     {
         airFriction=-0.00078;
         typicalSpeed=820 ;
-        ACE_caliber=0.264;
+        ACE_caliber=0.006706;
         ACE_bulletLength=1.364;
         ACE_bulletMass=139;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -130,7 +130,7 @@ class CfgAmmo
         airFriction=-0.001035;
         typicalSpeed=833;
         hit=9;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -150,7 +150,7 @@ class CfgAmmo
         caliber=1.05;
         hit=16;
         typicalSpeed=790;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -166,7 +166,7 @@ class CfgAmmo
         caliber=0.85;
         hit=14;
         typicalSpeed=890;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -182,7 +182,7 @@ class CfgAmmo
         caliber=0.5;
         hit=6;
         typicalSpeed=790;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.340;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -198,7 +198,7 @@ class CfgAmmo
         caliber=1.08;
         hit=17;
         typicalSpeed=900;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.353;
         ACE_bulletMass=190;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -214,7 +214,7 @@ class CfgAmmo
         caliber=1.12;
         hit=18;
         typicalSpeed=867;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -230,7 +230,7 @@ class CfgAmmo
         caliber=1.15;
         hit=19;
         typicalSpeed=853;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.602;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -244,7 +244,7 @@ class CfgAmmo
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
         typicalSpeed=820;
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -260,7 +260,7 @@ class CfgAmmo
         caliber=0.95;
         hit=15;
         typicalSpeed=820;
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -277,7 +277,7 @@ class CfgAmmo
         caliber=0.9;
         hit=15;
         typicalSpeed=800;
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -293,7 +293,7 @@ class CfgAmmo
         caliber=0.9;
         hit=11;
         typicalSpeed=790;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.153;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -308,7 +308,7 @@ class CfgAmmo
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -323,7 +323,7 @@ class CfgAmmo
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -338,7 +338,7 @@ class CfgAmmo
         airFriction=-0.00125;
         typicalSpeed=390;
         hit=6;
-        ACE_caliber=0.356;
+        ACE_caliber=0.009042;
         ACE_bulletLength=0.610;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -353,7 +353,7 @@ class CfgAmmo
         hit=5;
         airFriction=-0.001234;
         typicalSpeed=298;
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -368,7 +368,7 @@ class CfgAmmo
         airFriction=-0.001234;
         typicalSpeed=370;
         hit=6;
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -383,7 +383,7 @@ class CfgAmmo
         airFriction=-0.00168;
         typicalSpeed=425;
         hit=7;
-        ACE_caliber=0.5;
+        ACE_caliber=0.0127;
         ACE_bulletLength=0.764;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -398,7 +398,7 @@ class CfgAmmo
         airFriction=-0.001213;
         typicalSpeed=282;
         hit=7;
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -412,7 +412,7 @@ class CfgAmmo
     class ACE_303_Ball : ACE_762x51_Ball_M118LR {
         airFriction=-0.00083;
         typicalSpeed=761;
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -426,7 +426,7 @@ class CfgAmmo
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
         typicalSpeed=880;
-        ACE_caliber=0.366;
+        ACE_caliber=0.009296;
         ACE_bulletLength=1.350;
         ACE_bulletMass=230;
         ACE_transonicStabilityCoef=1;
@@ -442,7 +442,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.000395;
         typicalSpeed=910;
-        ACE_caliber=0.408;
+        ACE_caliber=0.010363;
         ACE_bulletLength=2.126;
         ACE_bulletMass=410;
         ACE_transonicStabilityCoef=1;
@@ -456,7 +456,7 @@ class CfgAmmo
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
-        ACE_caliber=0.416;
+        ACE_caliber=0.010566;
         ACE_bulletLength=2.089;
         ACE_bulletMass=398;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -471,7 +471,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.000606;
         typicalSpeed=915;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.558;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -485,7 +485,7 @@ class CfgAmmo
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
         typicalSpeed=820;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -501,7 +501,7 @@ class CfgAmmo
         airFriction=-0.000535;
         caliber=1.55;
         typicalSpeed=826;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -517,7 +517,7 @@ class CfgAmmo
         airFriction=-0.000673;
         caliber=2.4;
         typicalSpeed=826;
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.535;
         ACE_bulletMass=253;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -531,7 +531,7 @@ class CfgAmmo
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
         typicalSpeed=300;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.540;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -546,7 +546,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.0006;
         typicalSpeed=853;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -561,7 +561,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.000374;
         typicalSpeed=860;
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.540;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -576,7 +576,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.00064;
         typicalSpeed=820;
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -590,7 +590,7 @@ class CfgAmmo
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
         typicalSpeed=250;
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -604,7 +604,7 @@ class CfgAmmo
     
     class TMR_B_762x51_M118LR : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -618,7 +618,7 @@ class CfgAmmo
     
     class RH_50_AE_Ball: BulletBase
     {
-        ACE_caliber=0.5;
+        ACE_caliber=0.0127;
         ACE_bulletLength=1.110;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -631,7 +631,7 @@ class CfgAmmo
     };
     class RH_454_Casull: BulletBase
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.895;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -644,7 +644,7 @@ class CfgAmmo
     };
     class RH_32ACP: BulletBase
     {
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -657,7 +657,7 @@ class CfgAmmo
     };
     class RH_45ACP: BulletBase
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -670,7 +670,7 @@ class CfgAmmo
     };
     class RH_B_40SW: BulletBase
     {
-        ACE_caliber=0.4;
+        ACE_caliber=0.01016;
         ACE_bulletLength=0.447;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -683,7 +683,7 @@ class CfgAmmo
     };
     class RH_44mag_ball: BulletBase
     {
-        ACE_caliber=0.429;
+        ACE_caliber=0.010897;
         ACE_bulletLength=0.804;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -696,7 +696,7 @@ class CfgAmmo
     };
     class RH_357mag_ball: BulletBase
     {
-        ACE_caliber=0.357;
+        ACE_caliber=0.009068;
         ACE_bulletLength=0.541;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -709,7 +709,7 @@ class CfgAmmo
     };
     class RH_762x25: BulletBase
     {
-        ACE_caliber=0.310;
+        ACE_caliber=0.007874;
         ACE_bulletLength=0.5455;
         ACE_bulletMass=86;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -722,7 +722,7 @@ class CfgAmmo
     };
     class RH_9x18_Ball: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -735,7 +735,7 @@ class CfgAmmo
     };
     class RH_B_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -748,7 +748,7 @@ class CfgAmmo
     };
     class RH_B_22LR_SD: BulletBase
     {
-        ACE_caliber=0.223;
+        ACE_caliber=0.005664;
         ACE_bulletLength=0.45;
         ACE_bulletMass=38;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -761,7 +761,7 @@ class CfgAmmo
     };
     class RH_57x28mm: BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.495;
         ACE_bulletMass=28;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -775,7 +775,7 @@ class CfgAmmo
     
     class RH_9x19_B_M822: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -788,7 +788,7 @@ class CfgAmmo
     };
     class RH_9x19_B_HP: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -801,7 +801,7 @@ class CfgAmmo
     };
     class RH_9x19_B_HPSB: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.603;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -814,7 +814,7 @@ class CfgAmmo
     };
     class RH_B_6x35: BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.445;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -827,7 +827,7 @@ class CfgAmmo
     };
     class RH_556x45_B_M855A1 : B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -840,7 +840,7 @@ class CfgAmmo
     };
     class RH_556x45_B_Mk262 : B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -853,7 +853,7 @@ class CfgAmmo
     };
     class RH_556x45_B_Mk318 : B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -866,7 +866,7 @@ class CfgAmmo
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.277;
+        ACE_caliber=0.007036;
         ACE_bulletLength=0.959;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -879,7 +879,7 @@ class CfgAmmo
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.277;
+        ACE_caliber=0.007036;
         ACE_bulletLength=1.250;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -892,7 +892,7 @@ class CfgAmmo
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.118;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -905,7 +905,7 @@ class CfgAmmo
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.153;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -918,7 +918,7 @@ class CfgAmmo
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -931,7 +931,7 @@ class CfgAmmo
     };
     class RH_762x51_B_M80A1 : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -944,7 +944,7 @@ class CfgAmmo
     };
     class RH_762x51_B_Mk316LR : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -957,7 +957,7 @@ class CfgAmmo
     };
     class RH_762x51_B_Mk319 : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.074;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -970,7 +970,7 @@ class CfgAmmo
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.340;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -984,7 +984,7 @@ class CfgAmmo
     
     class HLC_556NATO_SOST: BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -997,7 +997,7 @@ class CfgAmmo
     };
     class HLC_556NATO_SPR: BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1010,7 +1010,7 @@ class CfgAmmo
     };
     class HLC_556NATO_EPR: BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -1023,7 +1023,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_Ball: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.118;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1036,7 +1036,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_SMK: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1049,7 +1049,7 @@ class CfgAmmo
     };
     class HLC_762x51_BTSub: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.340;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1062,7 +1062,7 @@ class CfgAmmo
     };
     class HLC_762x54_ball: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1075,7 +1075,7 @@ class CfgAmmo
     };
     class HLC_762x54_tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1088,7 +1088,7 @@ class CfgAmmo
     };
     class HLC_303Brit_B: BulletBase
     {
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1101,7 +1101,7 @@ class CfgAmmo
     };
     class HLC_792x57_Ball: BulletBase
     {
-        ACE_caliber=0.318;
+        ACE_caliber=0.008077;
         ACE_bulletLength=1.128;
         ACE_bulletMass=196;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1114,7 +1114,7 @@ class CfgAmmo
     };
     class FH_545x39_Ball: BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1134,7 +1134,7 @@ class CfgAmmo
     };
     class HLC_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1155,7 +1155,7 @@ class CfgAmmo
     };
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
-        ACE_caliber=0.5;
+        ACE_caliber=0.0127;
         ACE_bulletLength=0.764;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1168,7 +1168,7 @@ class CfgAmmo
     };
     class HLC_9x19_M882_SMG: HLC_9x19_Ball
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1182,7 +1182,7 @@ class CfgAmmo
     
     class M_mas_545x39_Ball_7N6M : BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1195,7 +1195,7 @@ class CfgAmmo
     };
     class M_mas_545x39_Ball_7T3M : BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1208,7 +1208,7 @@ class CfgAmmo
     };
     class B_mas_556x45_Ball_Mk262 : B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1221,7 +1221,7 @@ class CfgAmmo
     };
     class B_mas_9x18_Ball_57N181S : BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1234,7 +1234,7 @@ class CfgAmmo
     };
     class B_mas_9x21p_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1247,7 +1247,7 @@ class CfgAmmo
     };
     class B_mas_9x21_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1260,7 +1260,7 @@ class CfgAmmo
     };
     class B_mas_9x21d_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1273,7 +1273,7 @@ class CfgAmmo
     };
     class B_mas_765x17_Ball: BulletBase
     {
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1286,7 +1286,7 @@ class CfgAmmo
     };
     class B_mas_762x39_Ball: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1299,7 +1299,7 @@ class CfgAmmo
     };
     class B_mas_762x39_Ball_T: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1312,7 +1312,7 @@ class CfgAmmo
     };
     class B_mas_762x51_Ball_M118LR : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1325,7 +1325,7 @@ class CfgAmmo
     };
     class B_mas_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.353;
         ACE_bulletMass=190;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1338,7 +1338,7 @@ class CfgAmmo
     };
     class B_mas_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1351,7 +1351,7 @@ class CfgAmmo
     };
     class B_mas_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.602;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1364,7 +1364,7 @@ class CfgAmmo
     };	
     class B_mas_762x54_Ball : BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1377,7 +1377,7 @@ class CfgAmmo
     };
     class B_mas_762x54_Ball_T : BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1390,7 +1390,7 @@ class CfgAmmo
     };
     class BWA3_B_762x51_Ball_LR : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1403,7 +1403,7 @@ class CfgAmmo
     };
     class BWA3_B_762x51_Ball_SD : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1417,7 +1417,7 @@ class CfgAmmo
     
     class BWA3_B_46x30_Ball : BulletBase
     {
-        ACE_caliber=0.193;
+        ACE_caliber=0.004902;
         ACE_bulletLength=0.512;
         ACE_bulletMass=31;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1431,7 +1431,7 @@ class CfgAmmo
     
     class Trixie_338_Ball : BulletBase
     {
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1444,7 +1444,7 @@ class CfgAmmo
     };
     class Trixie_303_Ball : BulletBase
     {
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1458,7 +1458,7 @@ class CfgAmmo
     
     class rhs_ammo_556x45_Mk318_Ball : BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1471,7 +1471,7 @@ class CfgAmmo
     };
     class rhs_ammo_556x45_Mk262_Ball : BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1484,7 +1484,7 @@ class CfgAmmo
     };
     class rhsammo_762x51_Ball : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1497,7 +1497,7 @@ class CfgAmmo
     };
     class rhs_B_545x39_Ball : BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1510,7 +1510,7 @@ class CfgAmmo
     };
     class rhs_B_545x39_Ball_Tracer_Green : BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1523,7 +1523,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M118_Special_Ball : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1536,7 +1536,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_Ball : BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1549,7 +1549,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_Ball_Tracer_Green : BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1562,7 +1562,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Ball : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1575,7 +1575,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Tracer : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1588,7 +1588,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M80_Ball : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1601,7 +1601,7 @@ class CfgAmmo
     };
     class rhsusf_B_300winmag : BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1615,7 +1615,7 @@ class CfgAmmo
     
     class R3F_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1628,7 +1628,7 @@ class CfgAmmo
     };
     class R3F_556x45_Ball: BulletBase
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -1641,7 +1641,7 @@ class CfgAmmo
     };
     class R3F_762x51_Ball: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1654,7 +1654,7 @@ class CfgAmmo
     };
     class R3F_762x51_Ball2: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1667,7 +1667,7 @@ class CfgAmmo
     };
     class R3F_127x99_Ball: BulletBase
     {
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1680,7 +1680,7 @@ class CfgAmmo
     };
     class R3F_127x99_Ball2: BulletBase
     {
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1694,7 +1694,7 @@ class CfgAmmo
     
     class CUP_B_545x39_Ball: BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1707,7 +1707,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1720,7 +1720,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1733,7 +1733,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_White: BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1746,7 +1746,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1759,7 +1759,7 @@ class CfgAmmo
     };
     class CUP_B_762x39_Ball: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1772,7 +1772,7 @@ class CfgAmmo
     };
     class CUP_B_762x39_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1785,7 +1785,7 @@ class CfgAmmo
     };
     class B_762x39mm_KLT: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1798,7 +1798,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1811,7 +1811,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1824,7 +1824,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1837,7 +1837,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1850,7 +1850,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1863,7 +1863,7 @@ class CfgAmmo
     };
     class CUP_B_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1876,7 +1876,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_noTracer: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1889,7 +1889,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Red_Tracer_3RndBurst: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1902,7 +1902,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_White_Tracer_3RndBurst: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1915,7 +1915,7 @@ class CfgAmmo
     };
     class CUP_B_303_Ball: BulletBase
     {
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1928,7 +1928,7 @@ class CfgAmmo
     };
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1941,7 +1941,7 @@ class CfgAmmo
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1954,7 +1954,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1967,7 +1967,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1980,7 +1980,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1993,7 +1993,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2006,7 +2006,7 @@ class CfgAmmo
     };
     class CUP_B_9x39_SP5: BulletBase
     {
-        ACE_caliber=0.364;
+        ACE_caliber=0.009246;
         ACE_bulletLength=1.24;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2019,7 +2019,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2032,7 +2032,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2045,7 +2045,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2058,7 +2058,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2071,7 +2071,7 @@ class CfgAmmo
     };
     class B_127x107_Ball: BulletBase
     {
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2084,7 +2084,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_SD: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2097,7 +2097,7 @@ class CfgAmmo
     };
     class CUP_B_765x17_Ball: BulletBase
     {
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2110,7 +2110,7 @@ class CfgAmmo
     };
     class CUP_B_145x115_AP_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.586;
+        ACE_caliber=0.014884;
         ACE_bulletLength=2.00;
         ACE_bulletMass=1010;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2123,7 +2123,7 @@ class CfgAmmo
     };
     class CUP_B_127x99_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2136,7 +2136,7 @@ class CfgAmmo
     };
     class CUP_B_86x70_Ball_noTracer: BulletBase
     {
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2150,7 +2150,7 @@ class CfgAmmo
     
     class VTN_9x18_Ball_FMJ: B_9x21_Ball
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2163,7 +2163,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_SC: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2176,7 +2176,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_TRC: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2189,7 +2189,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_AP1: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2202,7 +2202,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_AP2: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2215,7 +2215,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_PRS: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2228,7 +2228,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_SC: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2241,7 +2241,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_TRC: VTN_9x19_Ball_SC
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2254,7 +2254,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_AP: VTN_9x19_Ball_SC
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2267,7 +2267,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_PRS: VTN_9x19_Ball_SC
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2280,7 +2280,7 @@ class CfgAmmo
     };
     class VTN_9x39_Ball_SC: B_9x21_Ball
     {
-        ACE_caliber=0.364;
+        ACE_caliber=0.009246;
         ACE_bulletLength=1.24;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2293,7 +2293,7 @@ class CfgAmmo
     };
     class VTN_9x39_Ball_AP: VTN_9x39_Ball_SC
     {
-        ACE_caliber=0.364;
+        ACE_caliber=0.009246;
         ACE_bulletLength=1.24;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2306,7 +2306,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_SC: B_556x45_Ball
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2319,7 +2319,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_TRC: VTN_545x39_Ball_SC
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2332,7 +2332,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_AP: VTN_545x39_Ball_TRC
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2345,7 +2345,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_AP2: VTN_545x39_Ball_AP
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2358,7 +2358,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_SS: VTN_545x39_Ball_SC
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2371,7 +2371,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_SC: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2384,7 +2384,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_TRC: VTN_762x39_Ball_SC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2397,7 +2397,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_AP: VTN_762x39_Ball_TRC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2410,7 +2410,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_INC: VTN_762x39_Ball_AP
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2423,7 +2423,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_API: VTN_762x39_Ball_INC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2436,7 +2436,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_SS: VTN_762x39_Ball_SC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2449,7 +2449,7 @@ class CfgAmmo
     };
     class VTN_762x41_Ball_SS: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=0.53;
         ACE_bulletMass=143;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2462,7 +2462,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_SC: VTN_762x39_Ball_SC
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2475,7 +2475,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_TRC: VTN_762x54_Ball_SC
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2488,7 +2488,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_AP: VTN_762x54_Ball_TRC
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2501,7 +2501,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_INC: VTN_762x54_Ball_AP
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2514,7 +2514,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_API: VTN_762x54_Ball_INC
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2527,7 +2527,7 @@ class CfgAmmo
     };
     class VTN_145x114_Ball_APT: B_127x108_Ball
     {
-        ACE_caliber=0.586;
+        ACE_caliber=0.014884;
         ACE_bulletLength=2.00;
         ACE_bulletMass=1010;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2540,7 +2540,7 @@ class CfgAmmo
     };
     class VTN_6mm_BB: B_65x39_Caseless
     {
-        ACE_caliber=0.24;
+        ACE_caliber=0.006096;
         ACE_bulletLength=0.24;
         ACE_bulletMass=6;
         ACE_ammoTempMuzzleVelocityShifts[]={};
@@ -2553,7 +2553,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_FMJ: B_9x21_Ball
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2566,7 +2566,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_FMJ: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2579,7 +2579,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_TRC: VTN_556x45_Ball_FMJ
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2592,7 +2592,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_TRCN: VTN_556x45_Ball_TRC
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2605,7 +2605,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_SC: VTN_556x45_Ball_FMJ
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2618,7 +2618,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_AP: VTN_556x45_Ball_TRC
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2631,7 +2631,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_INC: VTN_556x45_Ball_AP
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2644,7 +2644,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_LR: VTN_556x45_Ball_FMJ
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2657,7 +2657,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_SS: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2670,7 +2670,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_SC: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2683,7 +2683,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_TRC: VTN_762x51_Ball_SC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2696,7 +2696,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_TRCN: VTN_762x51_Ball_TRC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2709,7 +2709,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_AP: VTN_762x51_Ball_TRC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2722,7 +2722,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_LR: VTN_762x51_Ball_SC
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2735,7 +2735,7 @@ class CfgAmmo
     };
     class VTN_1143x23_Ball_FMJ: B_408_Ball
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2748,7 +2748,7 @@ class CfgAmmo
     };
     class VTN_1143x23_Ball_HP: VTN_1143x23_Ball_FMJ
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2761,7 +2761,7 @@ class CfgAmmo
     };
     class VTN_1143x23_Ball_JHP: VTN_1143x23_Ball_FMJ
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2774,7 +2774,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_FMJ: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2787,7 +2787,7 @@ class CfgAmmo
     };
     class VTN_45_Pellet: B_762x51_Ball
     {
-        ACE_caliber=0.22;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.23;
         ACE_bulletMass=3;
         ACE_ammoTempMuzzleVelocityShifts[]={};

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
         hit=8;
         typicalSpeed=750;
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -23,7 +23,7 @@ class CfgAmmo
         hit=11;
         typicalSpeed=836;
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -40,7 +40,7 @@ class CfgAmmo
         hit=9;
         typicalSpeed=886;
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -61,7 +61,7 @@ class CfgAmmo
         hit=7;
         typicalSpeed=880;
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -79,7 +79,7 @@ class CfgAmmo
         hit=7;
         typicalSpeed=883;
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -93,7 +93,7 @@ class CfgAmmo
         airFriction=-0.000785;
         typicalSpeed=800;
         ACE_caliber=6.706;
-        ACE_bulletLength=0.032893;
+        ACE_bulletLength=32.893;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.263};
@@ -116,7 +116,7 @@ class CfgAmmo
         airFriction=-0.00078;
         typicalSpeed=820 ;
         ACE_caliber=6.706;
-        ACE_bulletLength=0.034646;
+        ACE_bulletLength=34.646;
         ACE_bulletMass=9.0072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -131,7 +131,7 @@ class CfgAmmo
         typicalSpeed=833;
         hit=9;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -151,7 +151,7 @@ class CfgAmmo
         hit=16;
         typicalSpeed=790;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -167,7 +167,7 @@ class CfgAmmo
         hit=14;
         typicalSpeed=890;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
@@ -183,7 +183,7 @@ class CfgAmmo
         hit=6;
         typicalSpeed=790;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034036;
+        ACE_bulletLength=34.036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -199,7 +199,7 @@ class CfgAmmo
         hit=17;
         typicalSpeed=900;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034366;
+        ACE_bulletLength=34.366;
         ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.268};
@@ -215,7 +215,7 @@ class CfgAmmo
         hit=18;
         typicalSpeed=867;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -231,7 +231,7 @@ class CfgAmmo
         hit=19;
         typicalSpeed=853;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.040691;
+        ACE_bulletLength=40.691;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -245,7 +245,7 @@ class CfgAmmo
         airFriction=-0.001023;
         typicalSpeed=820;
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -261,7 +261,7 @@ class CfgAmmo
         hit=15;
         typicalSpeed=820;
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -278,7 +278,7 @@ class CfgAmmo
         hit=15;
         typicalSpeed=800;
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -294,7 +294,7 @@ class CfgAmmo
         hit=11;
         typicalSpeed=790;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.029286;
+        ACE_bulletLength=29.286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -309,7 +309,7 @@ class CfgAmmo
         hit=12;
         typicalSpeed=716;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -324,7 +324,7 @@ class CfgAmmo
         hit=12;
         typicalSpeed=716;
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -339,7 +339,7 @@ class CfgAmmo
         typicalSpeed=390;
         hit=6;
         ACE_caliber=9.042;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -354,7 +354,7 @@ class CfgAmmo
         airFriction=-0.001234;
         typicalSpeed=298;
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -369,7 +369,7 @@ class CfgAmmo
         typicalSpeed=370;
         hit=6;
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -384,7 +384,7 @@ class CfgAmmo
         typicalSpeed=425;
         hit=7;
         ACE_caliber=12.7;
-        ACE_bulletLength=0.019406;
+        ACE_bulletLength=19.406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -399,7 +399,7 @@ class CfgAmmo
         typicalSpeed=282;
         hit=7;
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -413,7 +413,7 @@ class CfgAmmo
         airFriction=-0.00083;
         typicalSpeed=761;
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -427,7 +427,7 @@ class CfgAmmo
         airFriction=-0.00106;
         typicalSpeed=880;
         ACE_caliber=9.296;
-        ACE_bulletLength=0.03429;
+        ACE_bulletLength=34.29;
         ACE_bulletMass=14.904;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -443,7 +443,7 @@ class CfgAmmo
         airFriction=-0.000395;
         typicalSpeed=910;
         ACE_caliber=10.363;
-        ACE_bulletLength=0.054;
+        ACE_bulletLength=54.0;
         ACE_bulletMass=26.568;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -457,7 +457,7 @@ class CfgAmmo
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
         ACE_caliber=10.566;
-        ACE_bulletLength=0.053061;
+        ACE_bulletLength=53.061;
         ACE_bulletMass=25.7904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.72};
@@ -472,7 +472,7 @@ class CfgAmmo
         airFriction=-0.000606;
         typicalSpeed=915;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.039573;
+        ACE_bulletLength=39.573;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.322};
@@ -486,7 +486,7 @@ class CfgAmmo
         airFriction=-0.000537;
         typicalSpeed=820;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -502,7 +502,7 @@ class CfgAmmo
         caliber=1.55;
         typicalSpeed=826;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -518,7 +518,7 @@ class CfgAmmo
         caliber=2.4;
         typicalSpeed=826;
         ACE_caliber=8.585;
-        ACE_bulletLength=0.038989;
+        ACE_bulletLength=38.989;
         ACE_bulletMass=16.3944;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -532,7 +532,7 @@ class CfgAmmo
         airFriction=-0.00014;
         typicalSpeed=300;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.064516;
+        ACE_bulletLength=64.516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={1.050};
@@ -547,7 +547,7 @@ class CfgAmmo
         airFriction=-0.0006;
         typicalSpeed=853;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -562,7 +562,7 @@ class CfgAmmo
         airFriction=-0.000374;
         typicalSpeed=860;
         ACE_caliber=12.954;
-        ACE_bulletLength=0.064516;
+        ACE_bulletLength=64.516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.050};
@@ -577,7 +577,7 @@ class CfgAmmo
         airFriction=-0.00064;
         typicalSpeed=820;
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -591,7 +591,7 @@ class CfgAmmo
         airFriction=-0.0007182;
         typicalSpeed=250;
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -605,7 +605,7 @@ class CfgAmmo
     class TMR_B_762x51_M118LR : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -619,7 +619,7 @@ class CfgAmmo
     class RH_50_AE_Ball: BulletBase
     {
         ACE_caliber=12.7;
-        ACE_bulletLength=0.028194;
+        ACE_bulletLength=28.194;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.228};
@@ -632,7 +632,7 @@ class CfgAmmo
     class RH_454_Casull: BulletBase
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.022733;
+        ACE_bulletLength=22.733;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.171};
@@ -645,7 +645,7 @@ class CfgAmmo
     class RH_32ACP: BulletBase
     {
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -658,7 +658,7 @@ class CfgAmmo
     class RH_45ACP: BulletBase
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -671,7 +671,7 @@ class CfgAmmo
     class RH_B_40SW: BulletBase
     {
         ACE_caliber=10.16;
-        ACE_bulletLength=0.011354;
+        ACE_bulletLength=11.354;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.105, 0.115, 0.120, 0.105};
@@ -684,7 +684,7 @@ class CfgAmmo
     class RH_44mag_ball: BulletBase
     {
         ACE_caliber=10.897;
-        ACE_bulletLength=0.020422;
+        ACE_bulletLength=20.422;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
@@ -697,7 +697,7 @@ class CfgAmmo
     class RH_357mag_ball: BulletBase
     {
         ACE_caliber=9.068;
-        ACE_bulletLength=0.013741;
+        ACE_bulletLength=13.741;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.148};
@@ -710,7 +710,7 @@ class CfgAmmo
     class RH_762x25: BulletBase
     {
         ACE_caliber=7.874;
-        ACE_bulletLength=0.013856;
+        ACE_bulletLength=13.856;
         ACE_bulletMass=5.5728;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -723,7 +723,7 @@ class CfgAmmo
     class RH_9x18_Ball: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -736,7 +736,7 @@ class CfgAmmo
     class RH_B_9x19_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -749,7 +749,7 @@ class CfgAmmo
     class RH_B_22LR_SD: BulletBase
     {
         ACE_caliber=5.664;
-        ACE_bulletLength=0.01143;
+        ACE_bulletLength=11.43;
         ACE_bulletMass=2.4624;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.111};
@@ -762,7 +762,7 @@ class CfgAmmo
     class RH_57x28mm: BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.012573;
+        ACE_bulletLength=12.573;
         ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
@@ -776,7 +776,7 @@ class CfgAmmo
     class RH_9x19_B_M822: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -789,7 +789,7 @@ class CfgAmmo
     class RH_9x19_B_HP: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -802,7 +802,7 @@ class CfgAmmo
     class RH_9x19_B_HPSB: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015316;
+        ACE_bulletLength=15.316;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.212};
@@ -815,7 +815,7 @@ class CfgAmmo
     class RH_B_6x35: BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.011303;
+        ACE_bulletLength=11.303;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.26};
@@ -828,7 +828,7 @@ class CfgAmmo
     class RH_556x45_B_M855A1 : B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.152};
@@ -841,7 +841,7 @@ class CfgAmmo
     class RH_556x45_B_Mk262 : B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -854,7 +854,7 @@ class CfgAmmo
     class RH_556x45_B_Mk318 : B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -867,7 +867,7 @@ class CfgAmmo
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=7.036;
-        ACE_bulletLength=0.024359;
+        ACE_bulletLength=24.359;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.162};
@@ -880,7 +880,7 @@ class CfgAmmo
     class RH_68x43_B_Match: B_65x39_Caseless
     {
         ACE_caliber=7.036;
-        ACE_bulletLength=0.03175;
+        ACE_bulletLength=31.75;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.253};
@@ -893,7 +893,7 @@ class CfgAmmo
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028397;
+        ACE_bulletLength=28.397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -906,7 +906,7 @@ class CfgAmmo
     class RH_762x35_B_Match: B_65x39_Caseless
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.029286;
+        ACE_bulletLength=29.286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -919,7 +919,7 @@ class CfgAmmo
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -932,7 +932,7 @@ class CfgAmmo
     class RH_762x51_B_M80A1 : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -945,7 +945,7 @@ class CfgAmmo
     class RH_762x51_B_Mk316LR : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.243};
@@ -958,7 +958,7 @@ class CfgAmmo
     class RH_762x51_B_Mk319 : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.02728;
+        ACE_bulletLength=27.28;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.277};
@@ -971,7 +971,7 @@ class CfgAmmo
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034036;
+        ACE_bulletLength=34.036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.252};
@@ -985,7 +985,7 @@ class CfgAmmo
     class HLC_556NATO_SOST: BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -998,7 +998,7 @@ class CfgAmmo
     class HLC_556NATO_SPR: BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -1011,7 +1011,7 @@ class CfgAmmo
     class HLC_556NATO_EPR: BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.152};
@@ -1024,7 +1024,7 @@ class CfgAmmo
     class HLC_300Blackout_Ball: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028397;
+        ACE_bulletLength=28.397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -1037,7 +1037,7 @@ class CfgAmmo
     class HLC_300Blackout_SMK: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -1050,7 +1050,7 @@ class CfgAmmo
     class HLC_762x51_BTSub: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034036;
+        ACE_bulletLength=34.036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -1063,7 +1063,7 @@ class CfgAmmo
     class HLC_762x54_ball: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -1076,7 +1076,7 @@ class CfgAmmo
     class HLC_762x54_tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1089,7 +1089,7 @@ class CfgAmmo
     class HLC_303Brit_B: BulletBase
     {
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -1102,7 +1102,7 @@ class CfgAmmo
     class HLC_792x57_Ball: BulletBase
     {
         ACE_caliber=8.077;
-        ACE_bulletLength=0.028651;
+        ACE_bulletLength=28.651;
         ACE_bulletMass=12.7008;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.315};
@@ -1115,7 +1115,7 @@ class CfgAmmo
     class FH_545x39_Ball: BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1135,7 +1135,7 @@ class CfgAmmo
     class HLC_9x19_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1156,7 +1156,7 @@ class CfgAmmo
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
         ACE_caliber=12.7;
-        ACE_bulletLength=0.019406;
+        ACE_bulletLength=19.406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -1169,7 +1169,7 @@ class CfgAmmo
     class HLC_9x19_M882_SMG: HLC_9x19_Ball
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1183,7 +1183,7 @@ class CfgAmmo
     class M_mas_545x39_Ball_7N6M : BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1196,7 +1196,7 @@ class CfgAmmo
     class M_mas_545x39_Ball_7T3M : BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1209,7 +1209,7 @@ class CfgAmmo
     class B_mas_556x45_Ball_Mk262 : B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -1222,7 +1222,7 @@ class CfgAmmo
     class B_mas_9x18_Ball_57N181S : BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1235,7 +1235,7 @@ class CfgAmmo
     class B_mas_9x21p_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1248,7 +1248,7 @@ class CfgAmmo
     class B_mas_9x21_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1261,7 +1261,7 @@ class CfgAmmo
     class B_mas_9x21d_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1274,7 +1274,7 @@ class CfgAmmo
     class B_mas_765x17_Ball: BulletBase
     {
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -1287,7 +1287,7 @@ class CfgAmmo
     class B_mas_762x39_Ball: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1300,7 +1300,7 @@ class CfgAmmo
     class B_mas_762x39_Ball_T: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1313,7 +1313,7 @@ class CfgAmmo
     class B_mas_762x51_Ball_M118LR : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -1326,7 +1326,7 @@ class CfgAmmo
     class B_mas_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034366;
+        ACE_bulletLength=34.366;
         ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.268};
@@ -1339,7 +1339,7 @@ class CfgAmmo
     class B_mas_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -1352,7 +1352,7 @@ class CfgAmmo
     class B_mas_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.040691;
+        ACE_bulletLength=40.691;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -1365,7 +1365,7 @@ class CfgAmmo
     class B_mas_762x54_Ball : BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -1378,7 +1378,7 @@ class CfgAmmo
     class B_mas_762x54_Ball_T : BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1391,7 +1391,7 @@ class CfgAmmo
     class BWA3_B_762x51_Ball_LR : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -1404,7 +1404,7 @@ class CfgAmmo
     class BWA3_B_762x51_Ball_SD : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.2};
@@ -1418,7 +1418,7 @@ class CfgAmmo
     class BWA3_B_46x30_Ball : BulletBase
     {
         ACE_caliber=4.902;
-        ACE_bulletLength=0.013005;
+        ACE_bulletLength=13.005;
         ACE_bulletMass=2.0088;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.1455};
@@ -1432,7 +1432,7 @@ class CfgAmmo
     class Trixie_338_Ball : BulletBase
     {
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -1445,7 +1445,7 @@ class CfgAmmo
     class Trixie_303_Ball : BulletBase
     {
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -1459,7 +1459,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk318_Ball : BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -1472,7 +1472,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk262_Ball : BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -1485,7 +1485,7 @@ class CfgAmmo
     class rhsammo_762x51_Ball : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1498,7 +1498,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball : BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1511,7 +1511,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball_Tracer_Green : BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1524,7 +1524,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M118_Special_Ball : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -1537,7 +1537,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball : BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -1550,7 +1550,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball_Tracer_Green : BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1563,7 +1563,7 @@ class CfgAmmo
     class rhs_B_762x39_Ball : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1576,7 +1576,7 @@ class CfgAmmo
     class rhs_B_762x39_Tracer : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1589,7 +1589,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M80_Ball : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1602,7 +1602,7 @@ class CfgAmmo
     class rhsusf_B_300winmag : BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -1616,7 +1616,7 @@ class CfgAmmo
     class R3F_9x19_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1629,7 +1629,7 @@ class CfgAmmo
     class R3F_556x45_Ball: BulletBase
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -1642,7 +1642,7 @@ class CfgAmmo
     class R3F_762x51_Ball: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1655,7 +1655,7 @@ class CfgAmmo
     class R3F_762x51_Ball2: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -1668,7 +1668,7 @@ class CfgAmmo
     class R3F_127x99_Ball: BulletBase
     {
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -1681,7 +1681,7 @@ class CfgAmmo
     class R3F_127x99_Ball2: BulletBase
     {
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -1695,7 +1695,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball: BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1708,7 +1708,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1721,7 +1721,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_Red: BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1734,7 +1734,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_White: BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1747,7 +1747,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1760,7 +1760,7 @@ class CfgAmmo
     class CUP_B_762x39_Ball: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1773,7 +1773,7 @@ class CfgAmmo
     class CUP_B_762x39_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1786,7 +1786,7 @@ class CfgAmmo
     class B_762x39mm_KLT: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1799,7 +1799,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1812,7 +1812,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1825,7 +1825,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1838,7 +1838,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1851,7 +1851,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1864,7 +1864,7 @@ class CfgAmmo
     class CUP_B_9x19_Ball: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1877,7 +1877,7 @@ class CfgAmmo
     class CUP_B_762x51_noTracer: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1890,7 +1890,7 @@ class CfgAmmo
     class CUP_B_762x51_Red_Tracer_3RndBurst: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1903,7 +1903,7 @@ class CfgAmmo
     class CUP_B_762x51_White_Tracer_3RndBurst: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1916,7 +1916,7 @@ class CfgAmmo
     class CUP_B_303_Ball: BulletBase
     {
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -1929,7 +1929,7 @@ class CfgAmmo
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -1942,7 +1942,7 @@ class CfgAmmo
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -1955,7 +1955,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1968,7 +1968,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1981,7 +1981,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1994,7 +1994,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -2007,7 +2007,7 @@ class CfgAmmo
     class CUP_B_9x39_SP5: BulletBase
     {
         ACE_caliber=9.246;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2020,7 +2020,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2033,7 +2033,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2046,7 +2046,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2059,7 +2059,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_White: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2072,7 +2072,7 @@ class CfgAmmo
     class B_127x107_Ball: BulletBase
     {
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -2085,7 +2085,7 @@ class CfgAmmo
     class CUP_B_9x18_SD: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2098,7 +2098,7 @@ class CfgAmmo
     class CUP_B_765x17_Ball: BulletBase
     {
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -2111,7 +2111,7 @@ class CfgAmmo
     class CUP_B_145x115_AP_Green_Tracer: BulletBase
     {
         ACE_caliber=14.884;
-        ACE_bulletLength=0.0508;
+        ACE_bulletLength=50.8;
         ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
@@ -2124,7 +2124,7 @@ class CfgAmmo
     class CUP_B_127x99_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -2137,7 +2137,7 @@ class CfgAmmo
     class CUP_B_86x70_Ball_noTracer: BulletBase
     {
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -2151,7 +2151,7 @@ class CfgAmmo
     class VTN_9x18_Ball_FMJ: B_9x21_Ball
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2164,7 +2164,7 @@ class CfgAmmo
     class VTN_9x18_Ball_SC: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2177,7 +2177,7 @@ class CfgAmmo
     class VTN_9x18_Ball_TRC: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2190,7 +2190,7 @@ class CfgAmmo
     class VTN_9x18_Ball_AP1: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2203,7 +2203,7 @@ class CfgAmmo
     class VTN_9x18_Ball_AP2: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2216,7 +2216,7 @@ class CfgAmmo
     class VTN_9x18_Ball_PRS: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2229,7 +2229,7 @@ class CfgAmmo
     class VTN_9x19_Ball_SC: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2242,7 +2242,7 @@ class CfgAmmo
     class VTN_9x19_Ball_TRC: VTN_9x19_Ball_SC
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2255,7 +2255,7 @@ class CfgAmmo
     class VTN_9x19_Ball_AP: VTN_9x19_Ball_SC
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2268,7 +2268,7 @@ class CfgAmmo
     class VTN_9x19_Ball_PRS: VTN_9x19_Ball_SC
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2281,7 +2281,7 @@ class CfgAmmo
     class VTN_9x39_Ball_SC: B_9x21_Ball
     {
         ACE_caliber=9.246;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2294,7 +2294,7 @@ class CfgAmmo
     class VTN_9x39_Ball_AP: VTN_9x39_Ball_SC
     {
         ACE_caliber=9.246;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2307,7 +2307,7 @@ class CfgAmmo
     class VTN_545x39_Ball_SC: B_556x45_Ball
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2320,7 +2320,7 @@ class CfgAmmo
     class VTN_545x39_Ball_TRC: VTN_545x39_Ball_SC
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2333,7 +2333,7 @@ class CfgAmmo
     class VTN_545x39_Ball_AP: VTN_545x39_Ball_TRC
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2346,7 +2346,7 @@ class CfgAmmo
     class VTN_545x39_Ball_AP2: VTN_545x39_Ball_AP
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2359,7 +2359,7 @@ class CfgAmmo
     class VTN_545x39_Ball_SS: VTN_545x39_Ball_SC
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.168};
@@ -2372,7 +2372,7 @@ class CfgAmmo
     class VTN_762x39_Ball_SC: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2385,7 +2385,7 @@ class CfgAmmo
     class VTN_762x39_Ball_TRC: VTN_762x39_Ball_SC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2398,7 +2398,7 @@ class CfgAmmo
     class VTN_762x39_Ball_AP: VTN_762x39_Ball_TRC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2411,7 +2411,7 @@ class CfgAmmo
     class VTN_762x39_Ball_INC: VTN_762x39_Ball_AP
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2424,7 +2424,7 @@ class CfgAmmo
     class VTN_762x39_Ball_API: VTN_762x39_Ball_INC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2437,7 +2437,7 @@ class CfgAmmo
     class VTN_762x39_Ball_SS: VTN_762x39_Ball_SC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2450,7 +2450,7 @@ class CfgAmmo
     class VTN_762x41_Ball_SS: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.013462;
+        ACE_bulletLength=13.462;
         ACE_bulletMass=9.2664;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2463,7 +2463,7 @@ class CfgAmmo
     class VTN_762x54_Ball_SC: VTN_762x39_Ball_SC
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2476,7 +2476,7 @@ class CfgAmmo
     class VTN_762x54_Ball_TRC: VTN_762x54_Ball_SC
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -2489,7 +2489,7 @@ class CfgAmmo
     class VTN_762x54_Ball_AP: VTN_762x54_Ball_TRC
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2502,7 +2502,7 @@ class CfgAmmo
     class VTN_762x54_Ball_INC: VTN_762x54_Ball_AP
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2515,7 +2515,7 @@ class CfgAmmo
     class VTN_762x54_Ball_API: VTN_762x54_Ball_INC
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2528,7 +2528,7 @@ class CfgAmmo
     class VTN_145x114_Ball_APT: B_127x108_Ball
     {
         ACE_caliber=14.884;
-        ACE_bulletLength=0.0508;
+        ACE_bulletLength=50.8;
         ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
@@ -2541,7 +2541,7 @@ class CfgAmmo
     class VTN_6mm_BB: B_65x39_Caseless
     {
         ACE_caliber=6.096;
-        ACE_bulletLength=0.006096;
+        ACE_bulletLength=6.096;
         ACE_bulletMass=0.3888;
         ACE_ammoTempMuzzleVelocityShifts[]={};
         ACE_ballisticCoefficients[]={};
@@ -2554,7 +2554,7 @@ class CfgAmmo
     class VTN_9x19_Ball_FMJ: B_9x21_Ball
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2567,7 +2567,7 @@ class CfgAmmo
     class VTN_556x45_Ball_FMJ: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2580,7 +2580,7 @@ class CfgAmmo
     class VTN_556x45_Ball_TRC: VTN_556x45_Ball_FMJ
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2593,7 +2593,7 @@ class CfgAmmo
     class VTN_556x45_Ball_TRCN: VTN_556x45_Ball_TRC
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2606,7 +2606,7 @@ class CfgAmmo
     class VTN_556x45_Ball_SC: VTN_556x45_Ball_FMJ
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2619,7 +2619,7 @@ class CfgAmmo
     class VTN_556x45_Ball_AP: VTN_556x45_Ball_TRC
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2632,7 +2632,7 @@ class CfgAmmo
     class VTN_556x45_Ball_INC: VTN_556x45_Ball_AP
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2645,7 +2645,7 @@ class CfgAmmo
     class VTN_556x45_Ball_LR: VTN_556x45_Ball_FMJ
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -2658,7 +2658,7 @@ class CfgAmmo
     class VTN_556x45_Ball_SS: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.151};
@@ -2671,7 +2671,7 @@ class CfgAmmo
     class VTN_762x51_Ball_SC: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2684,7 +2684,7 @@ class CfgAmmo
     class VTN_762x51_Ball_TRC: VTN_762x51_Ball_SC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2697,7 +2697,7 @@ class CfgAmmo
     class VTN_762x51_Ball_TRCN: VTN_762x51_Ball_TRC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2710,7 +2710,7 @@ class CfgAmmo
     class VTN_762x51_Ball_AP: VTN_762x51_Ball_TRC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2723,7 +2723,7 @@ class CfgAmmo
     class VTN_762x51_Ball_LR: VTN_762x51_Ball_SC
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -2736,7 +2736,7 @@ class CfgAmmo
     class VTN_1143x23_Ball_FMJ: B_408_Ball
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -2749,7 +2749,7 @@ class CfgAmmo
     class VTN_1143x23_Ball_HP: VTN_1143x23_Ball_FMJ
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -2762,7 +2762,7 @@ class CfgAmmo
     class VTN_1143x23_Ball_JHP: VTN_1143x23_Ball_FMJ
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -2775,7 +2775,7 @@ class CfgAmmo
     class VTN_762x39_Ball_FMJ: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2788,7 +2788,7 @@ class CfgAmmo
     class VTN_45_Pellet: B_762x51_Ball
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.005842;
+        ACE_bulletLength=5.842;
         ACE_bulletMass=0.1944;
         ACE_ammoTempMuzzleVelocityShifts[]={};
         ACE_ballisticCoefficients[]={};

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -14,7 +14,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class ACE_556x45_Ball_Mk262 : B_556x45_Ball {
         airFriction=-0.001125;
@@ -31,7 +31,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class ACE_556x45_Ball_Mk318 : B_556x45_Ball {
         airFriction=-0.001120;
@@ -48,7 +48,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class B_556x45_Ball_Tracer_Red;
     class ACE_B_556x45_Ball_Tracer_Dim: B_556x45_Ball_Tracer_Red {
@@ -69,7 +69,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_556x45_Ball_Tracer_Yellow;
     class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Yellow {
@@ -87,7 +87,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
@@ -101,7 +101,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 788, 800, 810, 830};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26, 30};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604, 0.762};
     };
     class B_65x39_Case_yellow;
     class ACE_65x39_Caseless_Tracer_Dim : B_65x39_Case_yellow {
@@ -124,7 +124,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={730, 760, 790, 820, 830};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_762x51_Ball : BulletBase {
         airFriction=-0.001035;
@@ -139,7 +139,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_762x51_Tracer_Yellow;
     class ACE_B_762x51_Tracer_Dim: B_762x51_Tracer_Yellow {
@@ -159,7 +159,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x51_Ball_Mk319_Mod_0 : B_762x51_Ball {
         airFriction=-0.00103;
@@ -175,7 +175,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 910};
-        ACE_barrelLengths[]={13, 16, 20};
+        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
     };
     class ACE_762x51_Ball_Subsonic : B_762x51_Ball {
         airFriction=-0.000535;
@@ -191,7 +191,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball {
         airFriction=-0.000830;
@@ -207,7 +207,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class ACE_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball {
         airFriction=-0.000815;
@@ -223,7 +223,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class ACE_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball {
         airFriction=-0.00076;
@@ -239,7 +239,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 853, 884};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
@@ -253,7 +253,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x54_Ball_7N14 : B_762x51_Ball {
         airFriction=-0.001023;
@@ -269,7 +269,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_762x54_Tracer_Green;
     class ACE_762x54_Ball_7T2 : B_762x54_Tracer_Green {
@@ -286,7 +286,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class ACE_762x35_Ball : B_762x51_Ball {
         airFriction=-0.000821;
@@ -302,7 +302,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={620, 655, 675};
-        ACE_barrelLengths[]={9, 16, 20};
+        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
     };
     class ACE_762x39_Ball : B_762x51_Ball {
         airFriction=-0.0015168;
@@ -317,7 +317,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class ACE_762x39_Ball_57N231P : B_762x51_Tracer_Yellow {
         airFriction=-0.0015168;
@@ -332,7 +332,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_9x21_Ball : BulletBase {
         airFriction=-0.00125;
@@ -347,7 +347,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={440, 460, 480};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class ACE_9x18_Ball_57N181S : B_9x21_Ball {
         hit=5;
@@ -362,7 +362,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class ACE_9x19_Ball : B_9x21_Ball {
         airFriction=-0.001234;
@@ -377,7 +377,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class ACE_10x25_Ball : B_9x21_Ball {
         airFriction=-0.00168;
@@ -392,7 +392,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={4, 4.61, 9};
+        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
     };
     class ACE_765x17_Ball: B_9x21_Ball {
         airFriction=-0.001213;
@@ -407,7 +407,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class ACE_303_Ball : ACE_762x51_Ball_M118LR {
         airFriction=-0.00083;
@@ -421,7 +421,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
@@ -436,7 +436,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={850, 870, 880};
-        ACE_barrelLengths[]={20, 24.41, 26};
+        ACE_barrelLengths[]={0.508, 0.620014, 0.6604};
     };
     class B_408_Ball : BulletBase {
         timeToLive=10;
@@ -452,7 +452,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={910};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
@@ -465,7 +465,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={960};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class B_338_Ball : BulletBase {
         timeToLive=10;
@@ -480,7 +480,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={20, 26, 28};
+        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
     };
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
@@ -494,7 +494,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={790, 807, 820};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class ACE_338_Ball : B_338_Ball {
         timeToLive=10;
@@ -510,7 +510,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 820, 826, 830};
-        ACE_barrelLengths[]={20, 24, 26.5, 28};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6731, 0.7112};
     };
     class ACE_338_Ball_API526 : B_338_Ball {
         timeToLive=10;
@@ -526,7 +526,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={880, 915, 925};
-        ACE_barrelLengths[]={20, 26, 28};
+        ACE_barrelLengths[]={0.508, 0.6604, 0.7112};
     };
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
@@ -540,7 +540,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300};
-        ACE_barrelLengths[]={17.2};
+        ACE_barrelLengths[]={0.43688};
     };
     class B_127x99_Ball : BulletBase {
         timeToLive=10;
@@ -555,7 +555,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class ACE_127x99_Ball_AMAX : B_127x99_Ball {
         timeToLive=10;
@@ -570,7 +570,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={860};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class B_127x108_Ball : BulletBase {
         timeToLive=10;
@@ -585,7 +585,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
@@ -599,7 +599,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     
     class TMR_B_762x51_M118LR : B_762x51_Ball
@@ -613,7 +613,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     
     class RH_50_AE_Ball: BulletBase
@@ -627,7 +627,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 398, 420};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
     };
     class RH_454_Casull: BulletBase
     {
@@ -640,7 +640,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={450, 490, 500};
-        ACE_barrelLengths[]={4, 7.5, 9};
+        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
     };
     class RH_32ACP: BulletBase
     {
@@ -653,7 +653,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_45ACP: BulletBase
     {
@@ -666,7 +666,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_B_40SW: BulletBase
     {
@@ -679,7 +679,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
     };
     class RH_44mag_ball: BulletBase
     {
@@ -692,7 +692,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 390, 420};
-        ACE_barrelLengths[]={4, 7.5, 9};
+        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
     };
     class RH_357mag_ball: BulletBase
     {
@@ -705,7 +705,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={490, 510, 535};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
     };
     class RH_762x25: BulletBase
     {
@@ -718,7 +718,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
     };
     class RH_9x18_Ball: BulletBase
     {
@@ -731,7 +731,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class RH_B_9x19_Ball: BulletBase
     {
@@ -744,7 +744,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_B_22LR_SD: BulletBase
     {
@@ -757,7 +757,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={330, 340, 360};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
     };
     class RH_57x28mm: BulletBase
     {
@@ -770,7 +770,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={550, 625, 720};
-        ACE_barrelLengths[]={4, 6, 10.35};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.26289};
     };
     
     class RH_9x19_B_M822: BulletBase
@@ -784,7 +784,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_9x19_B_HP: BulletBase
     {
@@ -797,7 +797,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_9x19_B_HPSB: BulletBase
     {
@@ -810,7 +810,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={295, 310, 330};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_B_6x35: BulletBase
     {
@@ -823,7 +823,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={730, 750, 760};
-        ACE_barrelLengths[]={8, 10, 12};
+        ACE_barrelLengths[]={0.2032, 0.254, 0.3048};
     };
     class RH_556x45_B_M855A1 : B_556x45_Ball
     {
@@ -836,7 +836,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class RH_556x45_B_Mk262 : B_556x45_Ball
     {
@@ -849,7 +849,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class RH_556x45_B_Mk318 : B_556x45_Ball
     {
@@ -862,7 +862,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
@@ -875,7 +875,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={713, 785, 810, 850};
-        ACE_barrelLengths[]={12, 16, 20, 24};
+        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
@@ -888,7 +888,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 732, 750, 780};
-        ACE_barrelLengths[]={12, 16, 20, 24};
+        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
@@ -901,7 +901,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={6, 16, 20};
+        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
@@ -914,7 +914,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={590, 650, 665};
-        ACE_barrelLengths[]={6, 16, 20};
+        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
@@ -927,7 +927,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={9, 16, 20};
+        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
     };
     class RH_762x51_B_M80A1 : B_762x51_Ball
     {
@@ -940,7 +940,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class RH_762x51_B_Mk316LR : B_762x51_Ball
     {
@@ -953,7 +953,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class RH_762x51_B_Mk319 : B_762x51_Ball
     {
@@ -966,7 +966,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 920};
-        ACE_barrelLengths[]={13, 16, 20};
+        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
@@ -979,7 +979,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     
     class HLC_556NATO_SOST: BulletBase
@@ -993,7 +993,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class HLC_556NATO_SPR: BulletBase
     {
@@ -1006,7 +1006,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class HLC_556NATO_EPR: BulletBase
     {
@@ -1019,7 +1019,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class HLC_300Blackout_Ball: BulletBase
     {
@@ -1032,7 +1032,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={6, 16, 20};
+        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
     };
     class HLC_300Blackout_SMK: BulletBase
     {
@@ -1045,7 +1045,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={9, 16, 20};
+        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
     };
     class HLC_762x51_BTSub: BulletBase
     {
@@ -1058,7 +1058,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_762x54_ball: BulletBase
     {
@@ -1071,7 +1071,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_762x54_tracer: BulletBase
     {
@@ -1084,7 +1084,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_303Brit_B: BulletBase
     {
@@ -1097,7 +1097,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class HLC_792x57_Ball: BulletBase
     {
@@ -1110,7 +1110,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={785, 800, 815};
-        ACE_barrelLengths[]={20, 23.62, 26};
+        ACE_barrelLengths[]={0.508, 0.599948, 0.6604};
     };
     class FH_545x39_Ball: BulletBase
     {
@@ -1123,14 +1123,14 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class FH_545x39_7u1: FH_545x39_Ball
     {
         ACE_bulletMass=5.184;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_muzzleVelocities[]={260, 303, 320};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class HLC_9x19_Ball: BulletBase
     {
@@ -1143,7 +1143,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class HLC_9x19_GoldDot: HLC_9x19_Ball
     {
@@ -1164,7 +1164,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={4, 4.61, 9};
+        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
     };
     class HLC_9x19_M882_SMG: HLC_9x19_Ball
     {
@@ -1177,7 +1177,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     
     class M_mas_545x39_Ball_7N6M : BulletBase
@@ -1191,7 +1191,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class M_mas_545x39_Ball_7T3M : BulletBase
     {
@@ -1204,7 +1204,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_mas_556x45_Ball_Mk262 : B_556x45_Ball
     {
@@ -1217,7 +1217,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class B_mas_9x18_Ball_57N181S : BulletBase
     {
@@ -1230,7 +1230,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class B_mas_9x21p_Ball: BulletBase
     {
@@ -1243,7 +1243,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class B_mas_9x21_Ball: BulletBase
     {
@@ -1256,7 +1256,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class B_mas_9x21d_Ball: BulletBase
     {
@@ -1269,7 +1269,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={210, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class B_mas_765x17_Ball: BulletBase
     {
@@ -1282,7 +1282,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class B_mas_762x39_Ball: BulletBase
     {
@@ -1295,7 +1295,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_mas_762x39_Ball_T: BulletBase
     {
@@ -1308,7 +1308,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_mas_762x51_Ball_M118LR : B_762x51_Ball
     {
@@ -1321,7 +1321,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_mas_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball
     {
@@ -1334,7 +1334,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_mas_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball
     {
@@ -1347,7 +1347,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 867, 900};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_mas_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball
     {
@@ -1360,7 +1360,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={800, 853, 884};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };	
     class B_mas_762x54_Ball : BulletBase
     {
@@ -1373,7 +1373,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_mas_762x54_Ball_T : BulletBase
     {
@@ -1386,7 +1386,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class BWA3_B_762x51_Ball_LR : BulletBase
     {
@@ -1399,7 +1399,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class BWA3_B_762x51_Ball_SD : BulletBase
     {
@@ -1412,7 +1412,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={300, 340};
-        ACE_barrelLengths[]={16, 24};
+        ACE_barrelLengths[]={0.4064, 0.6096};
     };
     
     class BWA3_B_46x30_Ball : BulletBase
@@ -1426,7 +1426,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 720, 730, 740};
-        ACE_barrelLengths[]={4, 7, 9, 12};
+        ACE_barrelLengths[]={0.1016, 0.1778, 0.2286, 0.3048};
     };
     
     class Trixie_338_Ball : BulletBase
@@ -1440,7 +1440,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 826, 830};
-        ACE_barrelLengths[]={24, 26.5, 28};
+        ACE_barrelLengths[]={0.6096, 0.6731, 0.7112};
     };
     class Trixie_303_Ball : BulletBase
     {
@@ -1453,7 +1453,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     
     class rhs_ammo_556x45_Mk318_Ball : BulletBase
@@ -1467,7 +1467,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class rhs_ammo_556x45_Mk262_Ball : BulletBase
     {
@@ -1480,7 +1480,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class rhsammo_762x51_Ball : BulletBase
     {
@@ -1493,7 +1493,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_545x39_Ball : BulletBase
     {
@@ -1506,7 +1506,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class rhs_B_545x39_Ball_Tracer_Green : BulletBase
     {
@@ -1519,7 +1519,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class rhs_ammo_762x51_M118_Special_Ball : BulletBase
     {
@@ -1532,7 +1532,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_762x54_Ball : BulletBase
     {
@@ -1545,7 +1545,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_762x54_Ball_Tracer_Green : BulletBase
     {
@@ -1558,7 +1558,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_762x39_Ball : BulletBase
     {
@@ -1571,7 +1571,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class rhs_B_762x39_Tracer : BulletBase
     {
@@ -1584,7 +1584,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class rhs_ammo_762x51_M80_Ball : BulletBase
     {
@@ -1597,7 +1597,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhsusf_B_300winmag : BulletBase
     {
@@ -1610,7 +1610,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     
     class R3F_9x19_Ball: BulletBase
@@ -1624,7 +1624,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class R3F_556x45_Ball: BulletBase
     {
@@ -1637,7 +1637,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class R3F_762x51_Ball: BulletBase
     {
@@ -1650,7 +1650,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class R3F_762x51_Ball2: BulletBase
     {
@@ -1663,7 +1663,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class R3F_127x99_Ball: BulletBase
     {
@@ -1676,7 +1676,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class R3F_127x99_Ball2: BulletBase
     {
@@ -1689,7 +1689,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     
     class CUP_B_545x39_Ball: BulletBase
@@ -1703,7 +1703,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_545x39_Ball_Tracer_Green: BulletBase
     {
@@ -1716,7 +1716,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_545x39_Ball_Tracer_Red: BulletBase
     {
@@ -1729,7 +1729,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_545x39_Ball_Tracer_White: BulletBase
     {
@@ -1742,7 +1742,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
     {
@@ -1755,7 +1755,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_762x39_Ball: BulletBase
     {
@@ -1768,7 +1768,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_762x39_Ball_Tracer_Green: BulletBase
     {
@@ -1781,7 +1781,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_762x39mm_KLT: BulletBase
     {
@@ -1794,7 +1794,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_9x18_Ball: BulletBase
     {
@@ -1807,7 +1807,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
@@ -1820,7 +1820,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
@@ -1833,7 +1833,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
@@ -1846,7 +1846,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
@@ -1859,7 +1859,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x19_Ball: BulletBase
     {
@@ -1872,7 +1872,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class CUP_B_762x51_noTracer: BulletBase
     {
@@ -1885,7 +1885,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Red_Tracer_3RndBurst: BulletBase
     {
@@ -1898,7 +1898,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_White_Tracer_3RndBurst: BulletBase
     {
@@ -1911,7 +1911,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_303_Ball: BulletBase
     {
@@ -1924,7 +1924,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
@@ -1937,7 +1937,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
@@ -1950,7 +1950,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
@@ -1963,7 +1963,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
@@ -1976,7 +1976,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
@@ -1989,7 +1989,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
@@ -2002,7 +2002,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_9x39_SP5: BulletBase
     {
@@ -2015,7 +2015,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
@@ -2028,7 +2028,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
@@ -2041,7 +2041,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
@@ -2054,7 +2054,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
@@ -2067,7 +2067,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class B_127x107_Ball: BulletBase
     {
@@ -2080,7 +2080,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class CUP_B_9x18_SD: BulletBase
     {
@@ -2093,7 +2093,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 340};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_765x17_Ball: BulletBase
     {
@@ -2106,7 +2106,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class CUP_B_145x115_AP_Green_Tracer: BulletBase
     {
@@ -2119,7 +2119,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1000};
-        ACE_barrelLengths[]={53};
+        ACE_barrelLengths[]={1.3462};
     };
     class CUP_B_127x99_Ball_White_Tracer: BulletBase
     {
@@ -2132,7 +2132,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class CUP_B_86x70_Ball_noTracer: BulletBase
     {
@@ -2145,7 +2145,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 826, 830};
-        ACE_barrelLengths[]={24, 26.5, 28};
+        ACE_barrelLengths[]={0.6096, 0.6731, 0.7112};
     };
     
     class VTN_9x18_Ball_FMJ: B_9x21_Ball
@@ -2159,7 +2159,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class VTN_9x18_Ball_SC: VTN_9x18_Ball_FMJ
     {
@@ -2172,7 +2172,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class VTN_9x18_Ball_TRC: VTN_9x18_Ball_FMJ
     {
@@ -2185,7 +2185,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class VTN_9x18_Ball_AP1: VTN_9x18_Ball_FMJ
     {
@@ -2198,7 +2198,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class VTN_9x18_Ball_AP2: VTN_9x18_Ball_FMJ
     {
@@ -2211,7 +2211,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class VTN_9x18_Ball_PRS: VTN_9x18_Ball_FMJ
     {
@@ -2224,7 +2224,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class VTN_9x19_Ball_SC: VTN_9x18_Ball_FMJ
     {
@@ -2237,7 +2237,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_9x19_Ball_TRC: VTN_9x19_Ball_SC
     {
@@ -2250,7 +2250,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_9x19_Ball_AP: VTN_9x19_Ball_SC
     {
@@ -2263,7 +2263,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_9x19_Ball_PRS: VTN_9x19_Ball_SC
     {
@@ -2276,7 +2276,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_9x39_Ball_SC: B_9x21_Ball
     {
@@ -2289,7 +2289,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_9x39_Ball_AP: VTN_9x39_Ball_SC
     {
@@ -2302,7 +2302,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_545x39_Ball_SC: B_556x45_Ball
     {
@@ -2315,7 +2315,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_545x39_Ball_TRC: VTN_545x39_Ball_SC
     {
@@ -2328,7 +2328,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_545x39_Ball_AP: VTN_545x39_Ball_TRC
     {
@@ -2341,7 +2341,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_545x39_Ball_AP2: VTN_545x39_Ball_AP
     {
@@ -2354,7 +2354,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_545x39_Ball_SS: VTN_545x39_Ball_SC
     {
@@ -2367,7 +2367,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x39_Ball_SC: B_762x51_Ball
     {
@@ -2380,7 +2380,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x39_Ball_TRC: VTN_762x39_Ball_SC
     {
@@ -2393,7 +2393,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x39_Ball_AP: VTN_762x39_Ball_TRC
     {
@@ -2406,7 +2406,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x39_Ball_INC: VTN_762x39_Ball_AP
     {
@@ -2419,7 +2419,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x39_Ball_API: VTN_762x39_Ball_INC
     {
@@ -2432,7 +2432,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x39_Ball_SS: VTN_762x39_Ball_SC
     {
@@ -2445,7 +2445,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_762x41_Ball_SS: B_762x51_Ball
     {
@@ -2458,7 +2458,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={200, 210, 220};
-        ACE_barrelLengths[]={4, 6, 8};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2032};
     };
     class VTN_762x54_Ball_SC: VTN_762x39_Ball_SC
     {
@@ -2471,7 +2471,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x54_Ball_TRC: VTN_762x54_Ball_SC
     {
@@ -2484,7 +2484,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x54_Ball_AP: VTN_762x54_Ball_TRC
     {
@@ -2497,7 +2497,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x54_Ball_INC: VTN_762x54_Ball_AP
     {
@@ -2510,7 +2510,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x54_Ball_API: VTN_762x54_Ball_INC
     {
@@ -2523,7 +2523,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_145x114_Ball_APT: B_127x108_Ball
     {
@@ -2536,7 +2536,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1000};
-        ACE_barrelLengths[]={53};
+        ACE_barrelLengths[]={1.3462};
     };
     class VTN_6mm_BB: B_65x39_Caseless
     {
@@ -2549,7 +2549,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={100};
-        ACE_barrelLengths[]={15};
+        ACE_barrelLengths[]={0.381};
     };
     class VTN_9x19_Ball_FMJ: B_9x21_Ball
     {
@@ -2562,7 +2562,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_556x45_Ball_FMJ: B_556x45_Ball
     {
@@ -2575,7 +2575,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class VTN_556x45_Ball_TRC: VTN_556x45_Ball_FMJ
     {
@@ -2588,7 +2588,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class VTN_556x45_Ball_TRCN: VTN_556x45_Ball_TRC
     {
@@ -2601,7 +2601,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class VTN_556x45_Ball_SC: VTN_556x45_Ball_FMJ
     {
@@ -2614,7 +2614,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class VTN_556x45_Ball_AP: VTN_556x45_Ball_TRC
     {
@@ -2627,7 +2627,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class VTN_556x45_Ball_INC: VTN_556x45_Ball_AP
     {
@@ -2640,7 +2640,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class VTN_556x45_Ball_LR: VTN_556x45_Ball_FMJ
     {
@@ -2653,7 +2653,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class VTN_556x45_Ball_SS: B_556x45_Ball
     {
@@ -2666,7 +2666,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={10, 20.0, 24.0};
+        ACE_barrelLengths[]={0.254, 0.508, 0.6096};
     };
     class VTN_762x51_Ball_SC: B_762x51_Ball
     {
@@ -2679,7 +2679,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x51_Ball_TRC: VTN_762x51_Ball_SC
     {
@@ -2692,7 +2692,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x51_Ball_TRCN: VTN_762x51_Ball_TRC
     {
@@ -2705,7 +2705,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x51_Ball_AP: VTN_762x51_Ball_TRC
     {
@@ -2718,7 +2718,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_762x51_Ball_LR: VTN_762x51_Ball_SC
     {
@@ -2731,7 +2731,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class VTN_1143x23_Ball_FMJ: B_408_Ball
     {
@@ -2744,7 +2744,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_1143x23_Ball_HP: VTN_1143x23_Ball_FMJ
     {
@@ -2757,7 +2757,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_1143x23_Ball_JHP: VTN_1143x23_Ball_FMJ
     {
@@ -2770,7 +2770,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class VTN_762x39_Ball_FMJ: B_762x51_Ball
     {
@@ -2783,7 +2783,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class VTN_45_Pellet: B_762x51_Ball
     {
@@ -2796,6 +2796,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={100, 138, 150};
-        ACE_barrelLengths[]={5, 10, 16};
+        ACE_barrelLengths[]={0.127, 0.254, 0.4064};
     };
 };

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
         hit=8;
         typicalSpeed=750;
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -23,7 +23,7 @@ class CfgAmmo
         hit=11;
         typicalSpeed=836;
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -40,7 +40,7 @@ class CfgAmmo
         hit=9;
         typicalSpeed=886;
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -61,7 +61,7 @@ class CfgAmmo
         hit=7;
         typicalSpeed=880;
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -79,7 +79,7 @@ class CfgAmmo
         hit=7;
         typicalSpeed=883;
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -93,7 +93,7 @@ class CfgAmmo
         airFriction=-0.000785;
         typicalSpeed=800;
         ACE_caliber=0.006706;
-        ACE_bulletLength=1.295;
+        ACE_bulletLength=0.032893;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.263};
@@ -116,7 +116,7 @@ class CfgAmmo
         airFriction=-0.00078;
         typicalSpeed=820 ;
         ACE_caliber=0.006706;
-        ACE_bulletLength=1.364;
+        ACE_bulletLength=0.034646;
         ACE_bulletMass=139;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -131,7 +131,7 @@ class CfgAmmo
         typicalSpeed=833;
         hit=9;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -151,7 +151,7 @@ class CfgAmmo
         hit=16;
         typicalSpeed=790;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -167,7 +167,7 @@ class CfgAmmo
         hit=14;
         typicalSpeed=890;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
@@ -183,7 +183,7 @@ class CfgAmmo
         hit=6;
         typicalSpeed=790;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.340;
+        ACE_bulletLength=0.034036;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -199,7 +199,7 @@ class CfgAmmo
         hit=17;
         typicalSpeed=900;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.353;
+        ACE_bulletLength=0.034366;
         ACE_bulletMass=190;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.268};
@@ -215,7 +215,7 @@ class CfgAmmo
         hit=18;
         typicalSpeed=867;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -231,7 +231,7 @@ class CfgAmmo
         hit=19;
         typicalSpeed=853;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.602;
+        ACE_bulletLength=0.040691;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -245,7 +245,7 @@ class CfgAmmo
         airFriction=-0.001023;
         typicalSpeed=820;
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -261,7 +261,7 @@ class CfgAmmo
         hit=15;
         typicalSpeed=820;
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -278,7 +278,7 @@ class CfgAmmo
         hit=15;
         typicalSpeed=800;
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -294,7 +294,7 @@ class CfgAmmo
         hit=11;
         typicalSpeed=790;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.153;
+        ACE_bulletLength=0.029286;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -309,7 +309,7 @@ class CfgAmmo
         hit=12;
         typicalSpeed=716;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -324,7 +324,7 @@ class CfgAmmo
         hit=12;
         typicalSpeed=716;
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -339,7 +339,7 @@ class CfgAmmo
         typicalSpeed=390;
         hit=6;
         ACE_caliber=0.009042;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -354,7 +354,7 @@ class CfgAmmo
         airFriction=-0.001234;
         typicalSpeed=298;
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -369,7 +369,7 @@ class CfgAmmo
         typicalSpeed=370;
         hit=6;
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -384,7 +384,7 @@ class CfgAmmo
         typicalSpeed=425;
         hit=7;
         ACE_caliber=0.0127;
-        ACE_bulletLength=0.764;
+        ACE_bulletLength=0.019406;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -399,7 +399,7 @@ class CfgAmmo
         typicalSpeed=282;
         hit=7;
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -413,7 +413,7 @@ class CfgAmmo
         airFriction=-0.00083;
         typicalSpeed=761;
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -427,7 +427,7 @@ class CfgAmmo
         airFriction=-0.00106;
         typicalSpeed=880;
         ACE_caliber=0.009296;
-        ACE_bulletLength=1.350;
+        ACE_bulletLength=0.03429;
         ACE_bulletMass=230;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -443,7 +443,7 @@ class CfgAmmo
         airFriction=-0.000395;
         typicalSpeed=910;
         ACE_caliber=0.010363;
-        ACE_bulletLength=2.126;
+        ACE_bulletLength=0.054;
         ACE_bulletMass=410;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -457,7 +457,7 @@ class CfgAmmo
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
         ACE_caliber=0.010566;
-        ACE_bulletLength=2.089;
+        ACE_bulletLength=0.053061;
         ACE_bulletMass=398;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.72};
@@ -472,7 +472,7 @@ class CfgAmmo
         airFriction=-0.000606;
         typicalSpeed=915;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.558;
+        ACE_bulletLength=0.039573;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.322};
@@ -486,7 +486,7 @@ class CfgAmmo
         airFriction=-0.000537;
         typicalSpeed=820;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -502,7 +502,7 @@ class CfgAmmo
         caliber=1.55;
         typicalSpeed=826;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -518,7 +518,7 @@ class CfgAmmo
         caliber=2.4;
         typicalSpeed=826;
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.535;
+        ACE_bulletLength=0.038989;
         ACE_bulletMass=253;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
@@ -532,7 +532,7 @@ class CfgAmmo
         airFriction=-0.00014;
         typicalSpeed=300;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.540;
+        ACE_bulletLength=0.064516;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={1.050};
@@ -547,7 +547,7 @@ class CfgAmmo
         airFriction=-0.0006;
         typicalSpeed=853;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -562,7 +562,7 @@ class CfgAmmo
         airFriction=-0.000374;
         typicalSpeed=860;
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.540;
+        ACE_bulletLength=0.064516;
         ACE_bulletMass=750;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.050};
@@ -577,7 +577,7 @@ class CfgAmmo
         airFriction=-0.00064;
         typicalSpeed=820;
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -591,7 +591,7 @@ class CfgAmmo
         airFriction=-0.0007182;
         typicalSpeed=250;
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -605,7 +605,7 @@ class CfgAmmo
     class TMR_B_762x51_M118LR : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -619,7 +619,7 @@ class CfgAmmo
     class RH_50_AE_Ball: BulletBase
     {
         ACE_caliber=0.0127;
-        ACE_bulletLength=1.110;
+        ACE_bulletLength=0.028194;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.228};
@@ -632,7 +632,7 @@ class CfgAmmo
     class RH_454_Casull: BulletBase
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.895;
+        ACE_bulletLength=0.022733;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.171};
@@ -645,7 +645,7 @@ class CfgAmmo
     class RH_32ACP: BulletBase
     {
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -658,7 +658,7 @@ class CfgAmmo
     class RH_45ACP: BulletBase
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -671,7 +671,7 @@ class CfgAmmo
     class RH_B_40SW: BulletBase
     {
         ACE_caliber=0.01016;
-        ACE_bulletLength=0.447;
+        ACE_bulletLength=0.011354;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.105, 0.115, 0.120, 0.105};
@@ -684,7 +684,7 @@ class CfgAmmo
     class RH_44mag_ball: BulletBase
     {
         ACE_caliber=0.010897;
-        ACE_bulletLength=0.804;
+        ACE_bulletLength=0.020422;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
@@ -697,7 +697,7 @@ class CfgAmmo
     class RH_357mag_ball: BulletBase
     {
         ACE_caliber=0.009068;
-        ACE_bulletLength=0.541;
+        ACE_bulletLength=0.013741;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.148};
@@ -710,7 +710,7 @@ class CfgAmmo
     class RH_762x25: BulletBase
     {
         ACE_caliber=0.007874;
-        ACE_bulletLength=0.5455;
+        ACE_bulletLength=0.013856;
         ACE_bulletMass=86;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -723,7 +723,7 @@ class CfgAmmo
     class RH_9x18_Ball: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -736,7 +736,7 @@ class CfgAmmo
     class RH_B_9x19_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -749,7 +749,7 @@ class CfgAmmo
     class RH_B_22LR_SD: BulletBase
     {
         ACE_caliber=0.005664;
-        ACE_bulletLength=0.45;
+        ACE_bulletLength=0.01143;
         ACE_bulletMass=38;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.111};
@@ -762,7 +762,7 @@ class CfgAmmo
     class RH_57x28mm: BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.495;
+        ACE_bulletLength=0.012573;
         ACE_bulletMass=28;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
@@ -776,7 +776,7 @@ class CfgAmmo
     class RH_9x19_B_M822: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -789,7 +789,7 @@ class CfgAmmo
     class RH_9x19_B_HP: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -802,7 +802,7 @@ class CfgAmmo
     class RH_9x19_B_HPSB: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.603;
+        ACE_bulletLength=0.015316;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.212};
@@ -815,7 +815,7 @@ class CfgAmmo
     class RH_B_6x35: BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.445;
+        ACE_bulletLength=0.011303;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.26};
@@ -828,7 +828,7 @@ class CfgAmmo
     class RH_556x45_B_M855A1 : B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.152};
@@ -841,7 +841,7 @@ class CfgAmmo
     class RH_556x45_B_Mk262 : B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -854,7 +854,7 @@ class CfgAmmo
     class RH_556x45_B_Mk318 : B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -867,7 +867,7 @@ class CfgAmmo
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=0.007036;
-        ACE_bulletLength=0.959;
+        ACE_bulletLength=0.024359;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.162};
@@ -880,7 +880,7 @@ class CfgAmmo
     class RH_68x43_B_Match: B_65x39_Caseless
     {
         ACE_caliber=0.007036;
-        ACE_bulletLength=1.250;
+        ACE_bulletLength=0.03175;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.253};
@@ -893,7 +893,7 @@ class CfgAmmo
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.118;
+        ACE_bulletLength=0.028397;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -906,7 +906,7 @@ class CfgAmmo
     class RH_762x35_B_Match: B_65x39_Caseless
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.153;
+        ACE_bulletLength=0.029286;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -919,7 +919,7 @@ class CfgAmmo
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -932,7 +932,7 @@ class CfgAmmo
     class RH_762x51_B_M80A1 : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -945,7 +945,7 @@ class CfgAmmo
     class RH_762x51_B_Mk316LR : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.243};
@@ -958,7 +958,7 @@ class CfgAmmo
     class RH_762x51_B_Mk319 : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.074;
+        ACE_bulletLength=0.02728;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.277};
@@ -971,7 +971,7 @@ class CfgAmmo
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.340;
+        ACE_bulletLength=0.034036;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.252};
@@ -985,7 +985,7 @@ class CfgAmmo
     class HLC_556NATO_SOST: BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -998,7 +998,7 @@ class CfgAmmo
     class HLC_556NATO_SPR: BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -1011,7 +1011,7 @@ class CfgAmmo
     class HLC_556NATO_EPR: BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.152};
@@ -1024,7 +1024,7 @@ class CfgAmmo
     class HLC_300Blackout_Ball: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.118;
+        ACE_bulletLength=0.028397;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -1037,7 +1037,7 @@ class CfgAmmo
     class HLC_300Blackout_SMK: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -1050,7 +1050,7 @@ class CfgAmmo
     class HLC_762x51_BTSub: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.340;
+        ACE_bulletLength=0.034036;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -1063,7 +1063,7 @@ class CfgAmmo
     class HLC_762x54_ball: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -1076,7 +1076,7 @@ class CfgAmmo
     class HLC_762x54_tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1089,7 +1089,7 @@ class CfgAmmo
     class HLC_303Brit_B: BulletBase
     {
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -1102,7 +1102,7 @@ class CfgAmmo
     class HLC_792x57_Ball: BulletBase
     {
         ACE_caliber=0.008077;
-        ACE_bulletLength=1.128;
+        ACE_bulletLength=0.028651;
         ACE_bulletMass=196;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.315};
@@ -1115,7 +1115,7 @@ class CfgAmmo
     class FH_545x39_Ball: BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1135,7 +1135,7 @@ class CfgAmmo
     class HLC_9x19_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1156,7 +1156,7 @@ class CfgAmmo
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
         ACE_caliber=0.0127;
-        ACE_bulletLength=0.764;
+        ACE_bulletLength=0.019406;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -1169,7 +1169,7 @@ class CfgAmmo
     class HLC_9x19_M882_SMG: HLC_9x19_Ball
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1183,7 +1183,7 @@ class CfgAmmo
     class M_mas_545x39_Ball_7N6M : BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1196,7 +1196,7 @@ class CfgAmmo
     class M_mas_545x39_Ball_7T3M : BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1209,7 +1209,7 @@ class CfgAmmo
     class B_mas_556x45_Ball_Mk262 : B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -1222,7 +1222,7 @@ class CfgAmmo
     class B_mas_9x18_Ball_57N181S : BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1235,7 +1235,7 @@ class CfgAmmo
     class B_mas_9x21p_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1248,7 +1248,7 @@ class CfgAmmo
     class B_mas_9x21_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1261,7 +1261,7 @@ class CfgAmmo
     class B_mas_9x21d_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1274,7 +1274,7 @@ class CfgAmmo
     class B_mas_765x17_Ball: BulletBase
     {
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -1287,7 +1287,7 @@ class CfgAmmo
     class B_mas_762x39_Ball: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1300,7 +1300,7 @@ class CfgAmmo
     class B_mas_762x39_Ball_T: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1313,7 +1313,7 @@ class CfgAmmo
     class B_mas_762x51_Ball_M118LR : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -1326,7 +1326,7 @@ class CfgAmmo
     class B_mas_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.353;
+        ACE_bulletLength=0.034366;
         ACE_bulletMass=190;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.268};
@@ -1339,7 +1339,7 @@ class CfgAmmo
     class B_mas_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -1352,7 +1352,7 @@ class CfgAmmo
     class B_mas_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.602;
+        ACE_bulletLength=0.040691;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -1365,7 +1365,7 @@ class CfgAmmo
     class B_mas_762x54_Ball : BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -1378,7 +1378,7 @@ class CfgAmmo
     class B_mas_762x54_Ball_T : BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1391,7 +1391,7 @@ class CfgAmmo
     class BWA3_B_762x51_Ball_LR : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -1404,7 +1404,7 @@ class CfgAmmo
     class BWA3_B_762x51_Ball_SD : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.2};
@@ -1418,7 +1418,7 @@ class CfgAmmo
     class BWA3_B_46x30_Ball : BulletBase
     {
         ACE_caliber=0.004902;
-        ACE_bulletLength=0.512;
+        ACE_bulletLength=0.013005;
         ACE_bulletMass=31;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.1455};
@@ -1432,7 +1432,7 @@ class CfgAmmo
     class Trixie_338_Ball : BulletBase
     {
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -1445,7 +1445,7 @@ class CfgAmmo
     class Trixie_303_Ball : BulletBase
     {
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -1459,7 +1459,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk318_Ball : BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -1472,7 +1472,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk262_Ball : BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -1485,7 +1485,7 @@ class CfgAmmo
     class rhsammo_762x51_Ball : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1498,7 +1498,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball : BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1511,7 +1511,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball_Tracer_Green : BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1524,7 +1524,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M118_Special_Ball : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -1537,7 +1537,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball : BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -1550,7 +1550,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball_Tracer_Green : BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1563,7 +1563,7 @@ class CfgAmmo
     class rhs_B_762x39_Ball : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1576,7 +1576,7 @@ class CfgAmmo
     class rhs_B_762x39_Tracer : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1589,7 +1589,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M80_Ball : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1602,7 +1602,7 @@ class CfgAmmo
     class rhsusf_B_300winmag : BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -1616,7 +1616,7 @@ class CfgAmmo
     class R3F_9x19_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1629,7 +1629,7 @@ class CfgAmmo
     class R3F_556x45_Ball: BulletBase
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -1642,7 +1642,7 @@ class CfgAmmo
     class R3F_762x51_Ball: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1655,7 +1655,7 @@ class CfgAmmo
     class R3F_762x51_Ball2: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
@@ -1668,7 +1668,7 @@ class CfgAmmo
     class R3F_127x99_Ball: BulletBase
     {
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -1681,7 +1681,7 @@ class CfgAmmo
     class R3F_127x99_Ball2: BulletBase
     {
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -1695,7 +1695,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball: BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1708,7 +1708,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1721,7 +1721,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_Red: BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1734,7 +1734,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_White: BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1747,7 +1747,7 @@ class CfgAmmo
     class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -1760,7 +1760,7 @@ class CfgAmmo
     class CUP_B_762x39_Ball: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1773,7 +1773,7 @@ class CfgAmmo
     class CUP_B_762x39_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1786,7 +1786,7 @@ class CfgAmmo
     class B_762x39mm_KLT: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -1799,7 +1799,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1812,7 +1812,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1825,7 +1825,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1838,7 +1838,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1851,7 +1851,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -1864,7 +1864,7 @@ class CfgAmmo
     class CUP_B_9x19_Ball: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -1877,7 +1877,7 @@ class CfgAmmo
     class CUP_B_762x51_noTracer: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1890,7 +1890,7 @@ class CfgAmmo
     class CUP_B_762x51_Red_Tracer_3RndBurst: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1903,7 +1903,7 @@ class CfgAmmo
     class CUP_B_762x51_White_Tracer_3RndBurst: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -1916,7 +1916,7 @@ class CfgAmmo
     class CUP_B_303_Ball: BulletBase
     {
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -1929,7 +1929,7 @@ class CfgAmmo
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -1942,7 +1942,7 @@ class CfgAmmo
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -1955,7 +1955,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1968,7 +1968,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1981,7 +1981,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -1994,7 +1994,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -2007,7 +2007,7 @@ class CfgAmmo
     class CUP_B_9x39_SP5: BulletBase
     {
         ACE_caliber=0.009246;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2020,7 +2020,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2033,7 +2033,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2046,7 +2046,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2059,7 +2059,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_White: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2072,7 +2072,7 @@ class CfgAmmo
     class B_127x107_Ball: BulletBase
     {
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -2085,7 +2085,7 @@ class CfgAmmo
     class CUP_B_9x18_SD: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2098,7 +2098,7 @@ class CfgAmmo
     class CUP_B_765x17_Ball: BulletBase
     {
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -2111,7 +2111,7 @@ class CfgAmmo
     class CUP_B_145x115_AP_Green_Tracer: BulletBase
     {
         ACE_caliber=0.014884;
-        ACE_bulletLength=2.00;
+        ACE_bulletLength=0.0508;
         ACE_bulletMass=1010;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
@@ -2124,7 +2124,7 @@ class CfgAmmo
     class CUP_B_127x99_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -2137,7 +2137,7 @@ class CfgAmmo
     class CUP_B_86x70_Ball_noTracer: BulletBase
     {
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
@@ -2151,7 +2151,7 @@ class CfgAmmo
     class VTN_9x18_Ball_FMJ: B_9x21_Ball
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2164,7 +2164,7 @@ class CfgAmmo
     class VTN_9x18_Ball_SC: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2177,7 +2177,7 @@ class CfgAmmo
     class VTN_9x18_Ball_TRC: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2190,7 +2190,7 @@ class CfgAmmo
     class VTN_9x18_Ball_AP1: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2203,7 +2203,7 @@ class CfgAmmo
     class VTN_9x18_Ball_AP2: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2216,7 +2216,7 @@ class CfgAmmo
     class VTN_9x18_Ball_PRS: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -2229,7 +2229,7 @@ class CfgAmmo
     class VTN_9x19_Ball_SC: VTN_9x18_Ball_FMJ
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2242,7 +2242,7 @@ class CfgAmmo
     class VTN_9x19_Ball_TRC: VTN_9x19_Ball_SC
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2255,7 +2255,7 @@ class CfgAmmo
     class VTN_9x19_Ball_AP: VTN_9x19_Ball_SC
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2268,7 +2268,7 @@ class CfgAmmo
     class VTN_9x19_Ball_PRS: VTN_9x19_Ball_SC
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2281,7 +2281,7 @@ class CfgAmmo
     class VTN_9x39_Ball_SC: B_9x21_Ball
     {
         ACE_caliber=0.009246;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2294,7 +2294,7 @@ class CfgAmmo
     class VTN_9x39_Ball_AP: VTN_9x39_Ball_SC
     {
         ACE_caliber=0.009246;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2307,7 +2307,7 @@ class CfgAmmo
     class VTN_545x39_Ball_SC: B_556x45_Ball
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2320,7 +2320,7 @@ class CfgAmmo
     class VTN_545x39_Ball_TRC: VTN_545x39_Ball_SC
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2333,7 +2333,7 @@ class CfgAmmo
     class VTN_545x39_Ball_AP: VTN_545x39_Ball_TRC
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2346,7 +2346,7 @@ class CfgAmmo
     class VTN_545x39_Ball_AP2: VTN_545x39_Ball_AP
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -2359,7 +2359,7 @@ class CfgAmmo
     class VTN_545x39_Ball_SS: VTN_545x39_Ball_SC
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.168};
@@ -2372,7 +2372,7 @@ class CfgAmmo
     class VTN_762x39_Ball_SC: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2385,7 +2385,7 @@ class CfgAmmo
     class VTN_762x39_Ball_TRC: VTN_762x39_Ball_SC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2398,7 +2398,7 @@ class CfgAmmo
     class VTN_762x39_Ball_AP: VTN_762x39_Ball_TRC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2411,7 +2411,7 @@ class CfgAmmo
     class VTN_762x39_Ball_INC: VTN_762x39_Ball_AP
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2424,7 +2424,7 @@ class CfgAmmo
     class VTN_762x39_Ball_API: VTN_762x39_Ball_INC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2437,7 +2437,7 @@ class CfgAmmo
     class VTN_762x39_Ball_SS: VTN_762x39_Ball_SC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2450,7 +2450,7 @@ class CfgAmmo
     class VTN_762x41_Ball_SS: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=0.53;
+        ACE_bulletLength=0.013462;
         ACE_bulletMass=143;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -2463,7 +2463,7 @@ class CfgAmmo
     class VTN_762x54_Ball_SC: VTN_762x39_Ball_SC
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2476,7 +2476,7 @@ class CfgAmmo
     class VTN_762x54_Ball_TRC: VTN_762x54_Ball_SC
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -2489,7 +2489,7 @@ class CfgAmmo
     class VTN_762x54_Ball_AP: VTN_762x54_Ball_TRC
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2502,7 +2502,7 @@ class CfgAmmo
     class VTN_762x54_Ball_INC: VTN_762x54_Ball_AP
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2515,7 +2515,7 @@ class CfgAmmo
     class VTN_762x54_Ball_API: VTN_762x54_Ball_INC
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -2528,7 +2528,7 @@ class CfgAmmo
     class VTN_145x114_Ball_APT: B_127x108_Ball
     {
         ACE_caliber=0.014884;
-        ACE_bulletLength=2.00;
+        ACE_bulletLength=0.0508;
         ACE_bulletMass=1010;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
@@ -2541,7 +2541,7 @@ class CfgAmmo
     class VTN_6mm_BB: B_65x39_Caseless
     {
         ACE_caliber=0.006096;
-        ACE_bulletLength=0.24;
+        ACE_bulletLength=0.006096;
         ACE_bulletMass=6;
         ACE_ammoTempMuzzleVelocityShifts[]={};
         ACE_ballisticCoefficients[]={};
@@ -2554,7 +2554,7 @@ class CfgAmmo
     class VTN_9x19_Ball_FMJ: B_9x21_Ball
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -2567,7 +2567,7 @@ class CfgAmmo
     class VTN_556x45_Ball_FMJ: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2580,7 +2580,7 @@ class CfgAmmo
     class VTN_556x45_Ball_TRC: VTN_556x45_Ball_FMJ
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2593,7 +2593,7 @@ class CfgAmmo
     class VTN_556x45_Ball_TRCN: VTN_556x45_Ball_TRC
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2606,7 +2606,7 @@ class CfgAmmo
     class VTN_556x45_Ball_SC: VTN_556x45_Ball_FMJ
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2619,7 +2619,7 @@ class CfgAmmo
     class VTN_556x45_Ball_AP: VTN_556x45_Ball_TRC
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2632,7 +2632,7 @@ class CfgAmmo
     class VTN_556x45_Ball_INC: VTN_556x45_Ball_AP
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -2645,7 +2645,7 @@ class CfgAmmo
     class VTN_556x45_Ball_LR: VTN_556x45_Ball_FMJ
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -2658,7 +2658,7 @@ class CfgAmmo
     class VTN_556x45_Ball_SS: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.151};
@@ -2671,7 +2671,7 @@ class CfgAmmo
     class VTN_762x51_Ball_SC: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2684,7 +2684,7 @@ class CfgAmmo
     class VTN_762x51_Ball_TRC: VTN_762x51_Ball_SC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2697,7 +2697,7 @@ class CfgAmmo
     class VTN_762x51_Ball_TRCN: VTN_762x51_Ball_TRC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2710,7 +2710,7 @@ class CfgAmmo
     class VTN_762x51_Ball_AP: VTN_762x51_Ball_TRC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -2723,7 +2723,7 @@ class CfgAmmo
     class VTN_762x51_Ball_LR: VTN_762x51_Ball_SC
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -2736,7 +2736,7 @@ class CfgAmmo
     class VTN_1143x23_Ball_FMJ: B_408_Ball
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -2749,7 +2749,7 @@ class CfgAmmo
     class VTN_1143x23_Ball_HP: VTN_1143x23_Ball_FMJ
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -2762,7 +2762,7 @@ class CfgAmmo
     class VTN_1143x23_Ball_JHP: VTN_1143x23_Ball_FMJ
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -2775,7 +2775,7 @@ class CfgAmmo
     class VTN_762x39_Ball_FMJ: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -2788,7 +2788,7 @@ class CfgAmmo
     class VTN_45_Pellet: B_762x51_Ball
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.23;
+        ACE_bulletLength=0.005842;
         ACE_bulletMass=3;
         ACE_ammoTempMuzzleVelocityShifts[]={};
         ACE_ballisticCoefficients[]={};

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -7,7 +7,7 @@ class CfgAmmo
         typicalSpeed=750;
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -24,7 +24,7 @@ class CfgAmmo
         typicalSpeed=836;
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -41,7 +41,7 @@ class CfgAmmo
         typicalSpeed=886;
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -62,7 +62,7 @@ class CfgAmmo
         typicalSpeed=880;
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -80,7 +80,7 @@ class CfgAmmo
         typicalSpeed=883;
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -94,7 +94,7 @@ class CfgAmmo
         typicalSpeed=800;
         ACE_caliber=0.006706;
         ACE_bulletLength=0.032893;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.263};
         ACE_velocityBoundaries[]={};
@@ -117,7 +117,7 @@ class CfgAmmo
         typicalSpeed=820 ;
         ACE_caliber=0.006706;
         ACE_bulletLength=0.034646;
-        ACE_bulletMass=139;
+        ACE_bulletMass=9.0072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
         ACE_velocityBoundaries[]={};
@@ -132,7 +132,7 @@ class CfgAmmo
         hit=9;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -152,7 +152,7 @@ class CfgAmmo
         typicalSpeed=790;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -168,7 +168,7 @@ class CfgAmmo
         typicalSpeed=890;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=130;
+        ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
         ACE_velocityBoundaries[]={};
@@ -184,7 +184,7 @@ class CfgAmmo
         typicalSpeed=790;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034036;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
         ACE_velocityBoundaries[]={};
@@ -200,7 +200,7 @@ class CfgAmmo
         typicalSpeed=900;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034366;
-        ACE_bulletMass=190;
+        ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.268};
         ACE_velocityBoundaries[]={};
@@ -216,7 +216,7 @@ class CfgAmmo
         typicalSpeed=867;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
         ACE_velocityBoundaries[]={};
@@ -232,7 +232,7 @@ class CfgAmmo
         typicalSpeed=853;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.040691;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
         ACE_velocityBoundaries[]={};
@@ -246,7 +246,7 @@ class CfgAmmo
         typicalSpeed=820;
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -262,7 +262,7 @@ class CfgAmmo
         typicalSpeed=820;
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -279,7 +279,7 @@ class CfgAmmo
         typicalSpeed=800;
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -295,7 +295,7 @@ class CfgAmmo
         typicalSpeed=790;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.029286;
-        ACE_bulletMass=125;
+        ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
         ACE_velocityBoundaries[]={792, 610, 488};
@@ -310,7 +310,7 @@ class CfgAmmo
         typicalSpeed=716;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -325,7 +325,7 @@ class CfgAmmo
         typicalSpeed=716;
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -340,7 +340,7 @@ class CfgAmmo
         hit=6;
         ACE_caliber=0.009042;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=115;
+        ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
         ACE_velocityBoundaries[]={};
@@ -355,7 +355,7 @@ class CfgAmmo
         typicalSpeed=298;
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -370,7 +370,7 @@ class CfgAmmo
         hit=6;
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -385,7 +385,7 @@ class CfgAmmo
         hit=7;
         ACE_caliber=0.0127;
         ACE_bulletLength=0.019406;
-        ACE_bulletMass=165;
+        ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
         ACE_velocityBoundaries[]={};
@@ -400,7 +400,7 @@ class CfgAmmo
         hit=7;
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -414,7 +414,7 @@ class CfgAmmo
         typicalSpeed=761;
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -428,7 +428,7 @@ class CfgAmmo
         typicalSpeed=880;
         ACE_caliber=0.009296;
         ACE_bulletLength=0.03429;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
@@ -444,7 +444,7 @@ class CfgAmmo
         typicalSpeed=910;
         ACE_caliber=0.010363;
         ACE_bulletLength=0.054;
-        ACE_bulletMass=410;
+        ACE_bulletMass=26.568;
         ACE_transonicStabilityCoef=1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.97};
@@ -458,7 +458,7 @@ class CfgAmmo
         timeToLive=10;
         ACE_caliber=0.010566;
         ACE_bulletLength=0.053061;
-        ACE_bulletMass=398;
+        ACE_bulletMass=25.7904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.72};
         ACE_velocityBoundaries[]={};
@@ -473,7 +473,7 @@ class CfgAmmo
         typicalSpeed=915;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.039573;
-        ACE_bulletMass=250;
+        ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.322};
         ACE_velocityBoundaries[]={};
@@ -487,7 +487,7 @@ class CfgAmmo
         typicalSpeed=820;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};
@@ -503,7 +503,7 @@ class CfgAmmo
         typicalSpeed=826;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};
@@ -519,7 +519,7 @@ class CfgAmmo
         typicalSpeed=826;
         ACE_caliber=0.008585;
         ACE_bulletLength=0.038989;
-        ACE_bulletMass=253;
+        ACE_bulletMass=16.3944;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.290};
         ACE_velocityBoundaries[]={};
@@ -533,7 +533,7 @@ class CfgAmmo
         typicalSpeed=300;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.064516;
-        ACE_bulletMass=750;
+        ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={1.050};
         ACE_velocityBoundaries[]={};
@@ -548,7 +548,7 @@ class CfgAmmo
         typicalSpeed=853;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=647;
+        ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -563,7 +563,7 @@ class CfgAmmo
         typicalSpeed=860;
         ACE_caliber=0.012954;
         ACE_bulletLength=0.064516;
-        ACE_bulletMass=750;
+        ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.050};
         ACE_velocityBoundaries[]={};
@@ -578,7 +578,7 @@ class CfgAmmo
         typicalSpeed=820;
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -592,7 +592,7 @@ class CfgAmmo
         typicalSpeed=250;
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -606,7 +606,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
         ACE_velocityBoundaries[]={853, 549, 549, 549};
@@ -620,7 +620,7 @@ class CfgAmmo
     {
         ACE_caliber=0.0127;
         ACE_bulletLength=0.028194;
-        ACE_bulletMass=325;
+        ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.228};
         ACE_velocityBoundaries[]={};
@@ -633,7 +633,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.022733;
-        ACE_bulletMass=325;
+        ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.171};
         ACE_velocityBoundaries[]={};
@@ -646,7 +646,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -659,7 +659,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -672,7 +672,7 @@ class CfgAmmo
     {
         ACE_caliber=0.01016;
         ACE_bulletLength=0.011354;
-        ACE_bulletMass=135;
+        ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.105, 0.115, 0.120, 0.105};
         ACE_velocityBoundaries[]={365, 305, 259};
@@ -685,7 +685,7 @@ class CfgAmmo
     {
         ACE_caliber=0.010897;
         ACE_bulletLength=0.020422;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
         ACE_velocityBoundaries[]={};
@@ -698,7 +698,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009068;
         ACE_bulletLength=0.013741;
-        ACE_bulletMass=125;
+        ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.148};
         ACE_velocityBoundaries[]={};
@@ -711,7 +711,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007874;
         ACE_bulletLength=0.013856;
-        ACE_bulletMass=86;
+        ACE_bulletMass=5.5728;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
         ACE_velocityBoundaries[]={};
@@ -724,7 +724,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -737,7 +737,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -750,7 +750,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005664;
         ACE_bulletLength=0.01143;
-        ACE_bulletMass=38;
+        ACE_bulletMass=2.4624;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.111};
         ACE_velocityBoundaries[]={};
@@ -763,7 +763,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.012573;
-        ACE_bulletMass=28;
+        ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
         ACE_velocityBoundaries[]={};
@@ -777,7 +777,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -790,7 +790,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -803,7 +803,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015316;
-        ACE_bulletMass=147;
+        ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.212};
         ACE_velocityBoundaries[]={};
@@ -816,7 +816,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.011303;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.26};
         ACE_velocityBoundaries[]={};
@@ -829,7 +829,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.152};
         ACE_velocityBoundaries[]={};
@@ -842,7 +842,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -855,7 +855,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -868,7 +868,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007036;
         ACE_bulletLength=0.024359;
-        ACE_bulletMass=115;
+        ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.162};
         ACE_velocityBoundaries[]={};
@@ -881,7 +881,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007036;
         ACE_bulletLength=0.03175;
-        ACE_bulletMass=135;
+        ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.253};
         ACE_velocityBoundaries[]={};
@@ -894,7 +894,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028397;
-        ACE_bulletMass=147;
+        ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
         ACE_velocityBoundaries[]={};
@@ -907,7 +907,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.029286;
-        ACE_bulletMass=125;
+        ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
         ACE_velocityBoundaries[]={792, 610, 488};
@@ -920,7 +920,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
         ACE_velocityBoundaries[]={};
@@ -933,7 +933,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -946,7 +946,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -959,7 +959,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.02728;
-        ACE_bulletMass=130;
+        ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.277};
         ACE_velocityBoundaries[]={};
@@ -972,7 +972,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034036;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.252};
         ACE_velocityBoundaries[]={};
@@ -986,7 +986,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -999,7 +999,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -1012,7 +1012,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.152};
         ACE_velocityBoundaries[]={};
@@ -1025,7 +1025,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028397;
-        ACE_bulletMass=147;
+        ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
         ACE_velocityBoundaries[]={};
@@ -1038,7 +1038,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
         ACE_velocityBoundaries[]={};
@@ -1051,7 +1051,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034036;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
         ACE_velocityBoundaries[]={};
@@ -1064,7 +1064,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -1077,7 +1077,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -1090,7 +1090,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -1103,7 +1103,7 @@ class CfgAmmo
     {
         ACE_caliber=0.008077;
         ACE_bulletLength=0.028651;
-        ACE_bulletMass=196;
+        ACE_bulletMass=12.7008;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.315};
         ACE_velocityBoundaries[]={};
@@ -1116,7 +1116,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1127,7 +1127,7 @@ class CfgAmmo
     };
     class FH_545x39_7u1: FH_545x39_Ball
     {
-        ACE_bulletMass=80;
+        ACE_bulletMass=5.184;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_muzzleVelocities[]={260, 303, 320};
         ACE_barrelLengths[]={10, 16.3, 20};
@@ -1136,7 +1136,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1157,7 +1157,7 @@ class CfgAmmo
     {
         ACE_caliber=0.0127;
         ACE_bulletLength=0.019406;
-        ACE_bulletMass=165;
+        ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
         ACE_velocityBoundaries[]={};
@@ -1170,7 +1170,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1184,7 +1184,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1197,7 +1197,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1210,7 +1210,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -1223,7 +1223,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -1236,7 +1236,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1249,7 +1249,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1262,7 +1262,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1275,7 +1275,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -1288,7 +1288,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1301,7 +1301,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1314,7 +1314,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
         ACE_velocityBoundaries[]={853, 549, 549, 549};
@@ -1327,7 +1327,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034366;
-        ACE_bulletMass=190;
+        ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.268};
         ACE_velocityBoundaries[]={};
@@ -1340,7 +1340,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
         ACE_velocityBoundaries[]={};
@@ -1353,7 +1353,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.040691;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.368};
         ACE_velocityBoundaries[]={};
@@ -1366,7 +1366,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -1379,7 +1379,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -1392,7 +1392,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
         ACE_velocityBoundaries[]={853, 549, 549, 549};
@@ -1405,7 +1405,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1419,7 +1419,7 @@ class CfgAmmo
     {
         ACE_caliber=0.004902;
         ACE_bulletLength=0.013005;
-        ACE_bulletMass=31;
+        ACE_bulletMass=2.0088;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.1455};
         ACE_velocityBoundaries[]={};
@@ -1433,7 +1433,7 @@ class CfgAmmo
     {
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};
@@ -1446,7 +1446,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -1460,7 +1460,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -1473,7 +1473,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -1486,7 +1486,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1499,7 +1499,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1512,7 +1512,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1525,7 +1525,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -1538,7 +1538,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -1551,7 +1551,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -1564,7 +1564,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1577,7 +1577,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1590,7 +1590,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1603,7 +1603,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
         ACE_velocityBoundaries[]={};
@@ -1617,7 +1617,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1630,7 +1630,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -1643,7 +1643,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1656,7 +1656,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.505, 0.496, 0.485, 0.485, 0.485};
         ACE_velocityBoundaries[]={853, 549, 549, 549};
@@ -1669,7 +1669,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=647;
+        ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -1682,7 +1682,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=647;
+        ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -1696,7 +1696,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1709,7 +1709,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1722,7 +1722,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1735,7 +1735,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1748,7 +1748,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -1761,7 +1761,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1774,7 +1774,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1787,7 +1787,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -1800,7 +1800,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -1813,7 +1813,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -1826,7 +1826,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -1839,7 +1839,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -1852,7 +1852,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -1865,7 +1865,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -1878,7 +1878,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1891,7 +1891,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1904,7 +1904,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -1917,7 +1917,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -1930,7 +1930,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -1943,7 +1943,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -1956,7 +1956,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -1969,7 +1969,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -1982,7 +1982,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -1995,7 +1995,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -2008,7 +2008,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009246;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=250;
+        ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2021,7 +2021,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2034,7 +2034,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2047,7 +2047,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2060,7 +2060,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2073,7 +2073,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -2086,7 +2086,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2099,7 +2099,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -2112,7 +2112,7 @@ class CfgAmmo
     {
         ACE_caliber=0.014884;
         ACE_bulletLength=0.0508;
-        ACE_bulletMass=1010;
+        ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
         ACE_velocityBoundaries[]={};
@@ -2125,7 +2125,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=647;
+        ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -2138,7 +2138,7 @@ class CfgAmmo
     {
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};
@@ -2152,7 +2152,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2165,7 +2165,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2178,7 +2178,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2191,7 +2191,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2204,7 +2204,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2217,7 +2217,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -2230,7 +2230,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -2243,7 +2243,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -2256,7 +2256,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -2269,7 +2269,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -2282,7 +2282,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009246;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=250;
+        ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2295,7 +2295,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009246;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=250;
+        ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2308,7 +2308,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -2321,7 +2321,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -2334,7 +2334,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -2347,7 +2347,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -2360,7 +2360,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -2373,7 +2373,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2386,7 +2386,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2399,7 +2399,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2412,7 +2412,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2425,7 +2425,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2438,7 +2438,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2451,7 +2451,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.013462;
-        ACE_bulletMass=143;
+        ACE_bulletMass=9.2664;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2464,7 +2464,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -2477,7 +2477,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -2490,7 +2490,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -2503,7 +2503,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -2516,7 +2516,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -2529,7 +2529,7 @@ class CfgAmmo
     {
         ACE_caliber=0.014884;
         ACE_bulletLength=0.0508;
-        ACE_bulletMass=1010;
+        ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
         ACE_velocityBoundaries[]={};
@@ -2542,7 +2542,7 @@ class CfgAmmo
     {
         ACE_caliber=0.006096;
         ACE_bulletLength=0.006096;
-        ACE_bulletMass=6;
+        ACE_bulletMass=0.3888;
         ACE_ammoTempMuzzleVelocityShifts[]={};
         ACE_ballisticCoefficients[]={};
         ACE_velocityBoundaries[]={};
@@ -2555,7 +2555,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -2568,7 +2568,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2581,7 +2581,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2594,7 +2594,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2607,7 +2607,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2620,7 +2620,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2633,7 +2633,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2646,7 +2646,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -2659,7 +2659,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -2672,7 +2672,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2685,7 +2685,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2698,7 +2698,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2711,7 +2711,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -2724,7 +2724,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -2737,7 +2737,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -2750,7 +2750,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -2763,7 +2763,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -2776,7 +2776,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -2789,7 +2789,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.005842;
-        ACE_bulletMass=3;
+        ACE_bulletMass=0.1944;
         ACE_ammoTempMuzzleVelocityShifts[]={};
         ACE_ballisticCoefficients[]={};
         ACE_velocityBoundaries[]={};

--- a/extras/CfgAmmoReference.hpp
+++ b/extras/CfgAmmoReference.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
         airFriction=-0.001265;
         hit=8;
         typicalSpeed=750;
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -22,7 +22,7 @@ class CfgAmmo
         deflecting=18;
         hit=11;
         typicalSpeed=836;
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -39,7 +39,7 @@ class CfgAmmo
         deflecting=18;
         hit=9;
         typicalSpeed=886;
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -60,7 +60,7 @@ class CfgAmmo
         deflecting=18;
         hit=7;
         typicalSpeed=880;
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -78,7 +78,7 @@ class CfgAmmo
         deflecting=18;
         hit=7;
         typicalSpeed=883;
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -92,7 +92,7 @@ class CfgAmmo
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.000785;
         typicalSpeed=800;
-        ACE_caliber=0.006706;
+        ACE_caliber=6.706;
         ACE_bulletLength=0.032893;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -115,7 +115,7 @@ class CfgAmmo
     {
         airFriction=-0.00078;
         typicalSpeed=820 ;
-        ACE_caliber=0.006706;
+        ACE_caliber=6.706;
         ACE_bulletLength=0.034646;
         ACE_bulletMass=9.0072;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -130,7 +130,7 @@ class CfgAmmo
         airFriction=-0.001035;
         typicalSpeed=833;
         hit=9;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -150,7 +150,7 @@ class CfgAmmo
         caliber=1.05;
         hit=16;
         typicalSpeed=790;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -166,7 +166,7 @@ class CfgAmmo
         caliber=0.85;
         hit=14;
         typicalSpeed=890;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -182,7 +182,7 @@ class CfgAmmo
         caliber=0.5;
         hit=6;
         typicalSpeed=790;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -198,7 +198,7 @@ class CfgAmmo
         caliber=1.08;
         hit=17;
         typicalSpeed=900;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034366;
         ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -214,7 +214,7 @@ class CfgAmmo
         caliber=1.12;
         hit=18;
         typicalSpeed=867;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -230,7 +230,7 @@ class CfgAmmo
         caliber=1.15;
         hit=19;
         typicalSpeed=853;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.040691;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -244,7 +244,7 @@ class CfgAmmo
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.001023;
         typicalSpeed=820;
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -260,7 +260,7 @@ class CfgAmmo
         caliber=0.95;
         hit=15;
         typicalSpeed=820;
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -277,7 +277,7 @@ class CfgAmmo
         caliber=0.9;
         hit=15;
         typicalSpeed=800;
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -293,7 +293,7 @@ class CfgAmmo
         caliber=0.9;
         hit=11;
         typicalSpeed=790;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.029286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -308,7 +308,7 @@ class CfgAmmo
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -323,7 +323,7 @@ class CfgAmmo
         airFriction=-0.0015168;
         hit=12;
         typicalSpeed=716;
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -338,7 +338,7 @@ class CfgAmmo
         airFriction=-0.00125;
         typicalSpeed=390;
         hit=6;
-        ACE_caliber=0.009042;
+        ACE_caliber=9.042;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -353,7 +353,7 @@ class CfgAmmo
         hit=5;
         airFriction=-0.001234;
         typicalSpeed=298;
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -368,7 +368,7 @@ class CfgAmmo
         airFriction=-0.001234;
         typicalSpeed=370;
         hit=6;
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -383,7 +383,7 @@ class CfgAmmo
         airFriction=-0.00168;
         typicalSpeed=425;
         hit=7;
-        ACE_caliber=0.0127;
+        ACE_caliber=12.7;
         ACE_bulletLength=0.019406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -398,7 +398,7 @@ class CfgAmmo
         airFriction=-0.001213;
         typicalSpeed=282;
         hit=7;
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -412,7 +412,7 @@ class CfgAmmo
     class ACE_303_Ball : ACE_762x51_Ball_M118LR {
         airFriction=-0.00083;
         typicalSpeed=761;
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -426,7 +426,7 @@ class CfgAmmo
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00106;
         typicalSpeed=880;
-        ACE_caliber=0.009296;
+        ACE_caliber=9.296;
         ACE_bulletLength=0.03429;
         ACE_bulletMass=14.904;
         ACE_transonicStabilityCoef=1;
@@ -442,7 +442,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.000395;
         typicalSpeed=910;
-        ACE_caliber=0.010363;
+        ACE_caliber=10.363;
         ACE_bulletLength=0.054;
         ACE_bulletMass=26.568;
         ACE_transonicStabilityCoef=1;
@@ -456,7 +456,7 @@ class CfgAmmo
     };
     class ACE_106x83mm_Ball : B_408_Ball {
         timeToLive=10;
-        ACE_caliber=0.010566;
+        ACE_caliber=10.566;
         ACE_bulletLength=0.053061;
         ACE_bulletMass=25.7904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -471,7 +471,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.000606;
         typicalSpeed=915;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.039573;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -485,7 +485,7 @@ class CfgAmmo
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.000537;
         typicalSpeed=820;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -501,7 +501,7 @@ class CfgAmmo
         airFriction=-0.000535;
         caliber=1.55;
         typicalSpeed=826;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -517,7 +517,7 @@ class CfgAmmo
         airFriction=-0.000673;
         caliber=2.4;
         typicalSpeed=826;
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.038989;
         ACE_bulletMass=16.3944;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -531,7 +531,7 @@ class CfgAmmo
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00014;
         typicalSpeed=300;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.064516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -546,7 +546,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.0006;
         typicalSpeed=853;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -561,7 +561,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.000374;
         typicalSpeed=860;
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.064516;
         ACE_bulletMass=48.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -576,7 +576,7 @@ class CfgAmmo
         timeToLive=10;
         airFriction=-0.00064;
         typicalSpeed=820;
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -590,7 +590,7 @@ class CfgAmmo
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.0007182;
         typicalSpeed=250;
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -604,7 +604,7 @@ class CfgAmmo
     
     class TMR_B_762x51_M118LR : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -618,7 +618,7 @@ class CfgAmmo
     
     class RH_50_AE_Ball: BulletBase
     {
-        ACE_caliber=0.0127;
+        ACE_caliber=12.7;
         ACE_bulletLength=0.028194;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -631,7 +631,7 @@ class CfgAmmo
     };
     class RH_454_Casull: BulletBase
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.022733;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -644,7 +644,7 @@ class CfgAmmo
     };
     class RH_32ACP: BulletBase
     {
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -657,7 +657,7 @@ class CfgAmmo
     };
     class RH_45ACP: BulletBase
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -670,7 +670,7 @@ class CfgAmmo
     };
     class RH_B_40SW: BulletBase
     {
-        ACE_caliber=0.01016;
+        ACE_caliber=10.16;
         ACE_bulletLength=0.011354;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -683,7 +683,7 @@ class CfgAmmo
     };
     class RH_44mag_ball: BulletBase
     {
-        ACE_caliber=0.010897;
+        ACE_caliber=10.897;
         ACE_bulletLength=0.020422;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -696,7 +696,7 @@ class CfgAmmo
     };
     class RH_357mag_ball: BulletBase
     {
-        ACE_caliber=0.009068;
+        ACE_caliber=9.068;
         ACE_bulletLength=0.013741;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -709,7 +709,7 @@ class CfgAmmo
     };
     class RH_762x25: BulletBase
     {
-        ACE_caliber=0.007874;
+        ACE_caliber=7.874;
         ACE_bulletLength=0.013856;
         ACE_bulletMass=5.5728;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -722,7 +722,7 @@ class CfgAmmo
     };
     class RH_9x18_Ball: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -735,7 +735,7 @@ class CfgAmmo
     };
     class RH_B_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -748,7 +748,7 @@ class CfgAmmo
     };
     class RH_B_22LR_SD: BulletBase
     {
-        ACE_caliber=0.005664;
+        ACE_caliber=5.664;
         ACE_bulletLength=0.01143;
         ACE_bulletMass=2.4624;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -761,7 +761,7 @@ class CfgAmmo
     };
     class RH_57x28mm: BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.012573;
         ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -775,7 +775,7 @@ class CfgAmmo
     
     class RH_9x19_B_M822: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -788,7 +788,7 @@ class CfgAmmo
     };
     class RH_9x19_B_HP: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -801,7 +801,7 @@ class CfgAmmo
     };
     class RH_9x19_B_HPSB: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015316;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -814,7 +814,7 @@ class CfgAmmo
     };
     class RH_B_6x35: BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.011303;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -827,7 +827,7 @@ class CfgAmmo
     };
     class RH_556x45_B_M855A1 : B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -840,7 +840,7 @@ class CfgAmmo
     };
     class RH_556x45_B_Mk262 : B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -853,7 +853,7 @@ class CfgAmmo
     };
     class RH_556x45_B_Mk318 : B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -866,7 +866,7 @@ class CfgAmmo
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.007036;
+        ACE_caliber=7.036;
         ACE_bulletLength=0.024359;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -879,7 +879,7 @@ class CfgAmmo
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.007036;
+        ACE_caliber=7.036;
         ACE_bulletLength=0.03175;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -892,7 +892,7 @@ class CfgAmmo
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -905,7 +905,7 @@ class CfgAmmo
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.029286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -918,7 +918,7 @@ class CfgAmmo
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -931,7 +931,7 @@ class CfgAmmo
     };
     class RH_762x51_B_M80A1 : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -944,7 +944,7 @@ class CfgAmmo
     };
     class RH_762x51_B_Mk316LR : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -957,7 +957,7 @@ class CfgAmmo
     };
     class RH_762x51_B_Mk319 : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.02728;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -970,7 +970,7 @@ class CfgAmmo
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -984,7 +984,7 @@ class CfgAmmo
     
     class HLC_556NATO_SOST: BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -997,7 +997,7 @@ class CfgAmmo
     };
     class HLC_556NATO_SPR: BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1010,7 +1010,7 @@ class CfgAmmo
     };
     class HLC_556NATO_EPR: BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -1023,7 +1023,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_Ball: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1036,7 +1036,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_SMK: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1049,7 +1049,7 @@ class CfgAmmo
     };
     class HLC_762x51_BTSub: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1062,7 +1062,7 @@ class CfgAmmo
     };
     class HLC_762x54_ball: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1075,7 +1075,7 @@ class CfgAmmo
     };
     class HLC_762x54_tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1088,7 +1088,7 @@ class CfgAmmo
     };
     class HLC_303Brit_B: BulletBase
     {
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1101,7 +1101,7 @@ class CfgAmmo
     };
     class HLC_792x57_Ball: BulletBase
     {
-        ACE_caliber=0.008077;
+        ACE_caliber=8.077;
         ACE_bulletLength=0.028651;
         ACE_bulletMass=12.7008;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1114,7 +1114,7 @@ class CfgAmmo
     };
     class FH_545x39_Ball: BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1134,7 +1134,7 @@ class CfgAmmo
     };
     class HLC_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1155,7 +1155,7 @@ class CfgAmmo
     };
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
-        ACE_caliber=0.0127;
+        ACE_caliber=12.7;
         ACE_bulletLength=0.019406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1168,7 +1168,7 @@ class CfgAmmo
     };
     class HLC_9x19_M882_SMG: HLC_9x19_Ball
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1182,7 +1182,7 @@ class CfgAmmo
     
     class M_mas_545x39_Ball_7N6M : BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1195,7 +1195,7 @@ class CfgAmmo
     };
     class M_mas_545x39_Ball_7T3M : BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1208,7 +1208,7 @@ class CfgAmmo
     };
     class B_mas_556x45_Ball_Mk262 : B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1221,7 +1221,7 @@ class CfgAmmo
     };
     class B_mas_9x18_Ball_57N181S : BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1234,7 +1234,7 @@ class CfgAmmo
     };
     class B_mas_9x21p_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1247,7 +1247,7 @@ class CfgAmmo
     };
     class B_mas_9x21_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1260,7 +1260,7 @@ class CfgAmmo
     };
     class B_mas_9x21d_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1273,7 +1273,7 @@ class CfgAmmo
     };
     class B_mas_765x17_Ball: BulletBase
     {
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1286,7 +1286,7 @@ class CfgAmmo
     };
     class B_mas_762x39_Ball: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1299,7 +1299,7 @@ class CfgAmmo
     };
     class B_mas_762x39_Ball_T: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1312,7 +1312,7 @@ class CfgAmmo
     };
     class B_mas_762x51_Ball_M118LR : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1325,7 +1325,7 @@ class CfgAmmo
     };
     class B_mas_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034366;
         ACE_bulletMass=12.312;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1338,7 +1338,7 @@ class CfgAmmo
     };
     class B_mas_762x67_Ball_Mk248_Mod_1 : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1351,7 +1351,7 @@ class CfgAmmo
     };
     class B_mas_762x67_Ball_Berger_Hybrid_OTM : B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.040691;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1364,7 +1364,7 @@ class CfgAmmo
     };	
     class B_mas_762x54_Ball : BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1377,7 +1377,7 @@ class CfgAmmo
     };
     class B_mas_762x54_Ball_T : BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1390,7 +1390,7 @@ class CfgAmmo
     };
     class BWA3_B_762x51_Ball_LR : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1403,7 +1403,7 @@ class CfgAmmo
     };
     class BWA3_B_762x51_Ball_SD : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1417,7 +1417,7 @@ class CfgAmmo
     
     class BWA3_B_46x30_Ball : BulletBase
     {
-        ACE_caliber=0.004902;
+        ACE_caliber=4.902;
         ACE_bulletLength=0.013005;
         ACE_bulletMass=2.0088;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1431,7 +1431,7 @@ class CfgAmmo
     
     class Trixie_338_Ball : BulletBase
     {
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1444,7 +1444,7 @@ class CfgAmmo
     };
     class Trixie_303_Ball : BulletBase
     {
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1458,7 +1458,7 @@ class CfgAmmo
     
     class rhs_ammo_556x45_Mk318_Ball : BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1471,7 +1471,7 @@ class CfgAmmo
     };
     class rhs_ammo_556x45_Mk262_Ball : BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1484,7 +1484,7 @@ class CfgAmmo
     };
     class rhsammo_762x51_Ball : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1497,7 +1497,7 @@ class CfgAmmo
     };
     class rhs_B_545x39_Ball : BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1510,7 +1510,7 @@ class CfgAmmo
     };
     class rhs_B_545x39_Ball_Tracer_Green : BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1523,7 +1523,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M118_Special_Ball : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1536,7 +1536,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_Ball : BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1549,7 +1549,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_Ball_Tracer_Green : BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1562,7 +1562,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Ball : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1575,7 +1575,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Tracer : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1588,7 +1588,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M80_Ball : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1601,7 +1601,7 @@ class CfgAmmo
     };
     class rhsusf_B_300winmag : BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1615,7 +1615,7 @@ class CfgAmmo
     
     class R3F_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1628,7 +1628,7 @@ class CfgAmmo
     };
     class R3F_556x45_Ball: BulletBase
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -1641,7 +1641,7 @@ class CfgAmmo
     };
     class R3F_762x51_Ball: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1654,7 +1654,7 @@ class CfgAmmo
     };
     class R3F_762x51_Ball2: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1667,7 +1667,7 @@ class CfgAmmo
     };
     class R3F_127x99_Ball: BulletBase
     {
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1680,7 +1680,7 @@ class CfgAmmo
     };
     class R3F_127x99_Ball2: BulletBase
     {
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1694,7 +1694,7 @@ class CfgAmmo
     
     class CUP_B_545x39_Ball: BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1707,7 +1707,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1720,7 +1720,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1733,7 +1733,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_White: BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1746,7 +1746,7 @@ class CfgAmmo
     };
     class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1759,7 +1759,7 @@ class CfgAmmo
     };
     class CUP_B_762x39_Ball: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1772,7 +1772,7 @@ class CfgAmmo
     };
     class CUP_B_762x39_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1785,7 +1785,7 @@ class CfgAmmo
     };
     class B_762x39mm_KLT: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1798,7 +1798,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1811,7 +1811,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1824,7 +1824,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1837,7 +1837,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1850,7 +1850,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1863,7 +1863,7 @@ class CfgAmmo
     };
     class CUP_B_9x19_Ball: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -1876,7 +1876,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_noTracer: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1889,7 +1889,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Red_Tracer_3RndBurst: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1902,7 +1902,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_White_Tracer_3RndBurst: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1915,7 +1915,7 @@ class CfgAmmo
     };
     class CUP_B_303_Ball: BulletBase
     {
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1928,7 +1928,7 @@ class CfgAmmo
     };
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1941,7 +1941,7 @@ class CfgAmmo
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1954,7 +1954,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1967,7 +1967,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1980,7 +1980,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -1993,7 +1993,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2006,7 +2006,7 @@ class CfgAmmo
     };
     class CUP_B_9x39_SP5: BulletBase
     {
-        ACE_caliber=0.009246;
+        ACE_caliber=9.246;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2019,7 +2019,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2032,7 +2032,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2045,7 +2045,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2058,7 +2058,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2071,7 +2071,7 @@ class CfgAmmo
     };
     class B_127x107_Ball: BulletBase
     {
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2084,7 +2084,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_SD: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2097,7 +2097,7 @@ class CfgAmmo
     };
     class CUP_B_765x17_Ball: BulletBase
     {
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2110,7 +2110,7 @@ class CfgAmmo
     };
     class CUP_B_145x115_AP_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.014884;
+        ACE_caliber=14.884;
         ACE_bulletLength=0.0508;
         ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2123,7 +2123,7 @@ class CfgAmmo
     };
     class CUP_B_127x99_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2136,7 +2136,7 @@ class CfgAmmo
     };
     class CUP_B_86x70_Ball_noTracer: BulletBase
     {
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2150,7 +2150,7 @@ class CfgAmmo
     
     class VTN_9x18_Ball_FMJ: B_9x21_Ball
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2163,7 +2163,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_SC: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2176,7 +2176,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_TRC: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2189,7 +2189,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_AP1: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2202,7 +2202,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_AP2: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2215,7 +2215,7 @@ class CfgAmmo
     };
     class VTN_9x18_Ball_PRS: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2228,7 +2228,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_SC: VTN_9x18_Ball_FMJ
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2241,7 +2241,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_TRC: VTN_9x19_Ball_SC
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2254,7 +2254,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_AP: VTN_9x19_Ball_SC
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2267,7 +2267,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_PRS: VTN_9x19_Ball_SC
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2280,7 +2280,7 @@ class CfgAmmo
     };
     class VTN_9x39_Ball_SC: B_9x21_Ball
     {
-        ACE_caliber=0.009246;
+        ACE_caliber=9.246;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2293,7 +2293,7 @@ class CfgAmmo
     };
     class VTN_9x39_Ball_AP: VTN_9x39_Ball_SC
     {
-        ACE_caliber=0.009246;
+        ACE_caliber=9.246;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2306,7 +2306,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_SC: B_556x45_Ball
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2319,7 +2319,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_TRC: VTN_545x39_Ball_SC
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2332,7 +2332,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_AP: VTN_545x39_Ball_TRC
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2345,7 +2345,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_AP2: VTN_545x39_Ball_AP
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2358,7 +2358,7 @@ class CfgAmmo
     };
     class VTN_545x39_Ball_SS: VTN_545x39_Ball_SC
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2371,7 +2371,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_SC: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2384,7 +2384,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_TRC: VTN_762x39_Ball_SC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2397,7 +2397,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_AP: VTN_762x39_Ball_TRC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2410,7 +2410,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_INC: VTN_762x39_Ball_AP
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2423,7 +2423,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_API: VTN_762x39_Ball_INC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2436,7 +2436,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_SS: VTN_762x39_Ball_SC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2449,7 +2449,7 @@ class CfgAmmo
     };
     class VTN_762x41_Ball_SS: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.013462;
         ACE_bulletMass=9.2664;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2462,7 +2462,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_SC: VTN_762x39_Ball_SC
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2475,7 +2475,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_TRC: VTN_762x54_Ball_SC
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2488,7 +2488,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_AP: VTN_762x54_Ball_TRC
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2501,7 +2501,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_INC: VTN_762x54_Ball_AP
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2514,7 +2514,7 @@ class CfgAmmo
     };
     class VTN_762x54_Ball_API: VTN_762x54_Ball_INC
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2527,7 +2527,7 @@ class CfgAmmo
     };
     class VTN_145x114_Ball_APT: B_127x108_Ball
     {
-        ACE_caliber=0.014884;
+        ACE_caliber=14.884;
         ACE_bulletLength=0.0508;
         ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2540,7 +2540,7 @@ class CfgAmmo
     };
     class VTN_6mm_BB: B_65x39_Caseless
     {
-        ACE_caliber=0.006096;
+        ACE_caliber=6.096;
         ACE_bulletLength=0.006096;
         ACE_bulletMass=0.3888;
         ACE_ammoTempMuzzleVelocityShifts[]={};
@@ -2553,7 +2553,7 @@ class CfgAmmo
     };
     class VTN_9x19_Ball_FMJ: B_9x21_Ball
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2566,7 +2566,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_FMJ: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2579,7 +2579,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_TRC: VTN_556x45_Ball_FMJ
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2592,7 +2592,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_TRCN: VTN_556x45_Ball_TRC
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2605,7 +2605,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_SC: VTN_556x45_Ball_FMJ
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2618,7 +2618,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_AP: VTN_556x45_Ball_TRC
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2631,7 +2631,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_INC: VTN_556x45_Ball_AP
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -2644,7 +2644,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_LR: VTN_556x45_Ball_FMJ
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2657,7 +2657,7 @@ class CfgAmmo
     };
     class VTN_556x45_Ball_SS: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2670,7 +2670,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_SC: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2683,7 +2683,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_TRC: VTN_762x51_Ball_SC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2696,7 +2696,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_TRCN: VTN_762x51_Ball_TRC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2709,7 +2709,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_AP: VTN_762x51_Ball_TRC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2722,7 +2722,7 @@ class CfgAmmo
     };
     class VTN_762x51_Ball_LR: VTN_762x51_Ball_SC
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2735,7 +2735,7 @@ class CfgAmmo
     };
     class VTN_1143x23_Ball_FMJ: B_408_Ball
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2748,7 +2748,7 @@ class CfgAmmo
     };
     class VTN_1143x23_Ball_HP: VTN_1143x23_Ball_FMJ
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2761,7 +2761,7 @@ class CfgAmmo
     };
     class VTN_1143x23_Ball_JHP: VTN_1143x23_Ball_FMJ
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -2774,7 +2774,7 @@ class CfgAmmo
     };
     class VTN_762x39_Ball_FMJ: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -2787,7 +2787,7 @@ class CfgAmmo
     };
     class VTN_45_Pellet: B_762x51_Ball
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.005842;
         ACE_bulletMass=0.1944;
         ACE_ammoTempMuzzleVelocityShifts[]={};

--- a/extras/CfgWeaponsReference.hpp
+++ b/extras/CfgWeaponsReference.hpp
@@ -28,1867 +28,1867 @@ class CfgWeapons
     class hgun_P07_F : Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class hgun_Rook40_F : Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class hgun_Pistol_heavy_01_F : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class hgun_Pistol_heavy_02_F : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.0762;
+        ACE_barrelLength=76.2;
     };
     class hgun_ACPC2_F : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class hgun_PDW2000_F : PDW2000_Base_F
     {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.1778;
+        ACE_barrelLength=177.8;
     };
     class arifle_Katiba_F : arifle_Katiba_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.72898;
+        ACE_barrelLength=728.98;
     };
     class arifle_Katiba_C_F : arifle_Katiba_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.68072;
+        ACE_barrelLength=680.72;
     };
     class arifle_Katiba_GL_F : arifle_Katiba_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.72898;
+        ACE_barrelLength=728.98;
     };
     class arifle_MX_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class arifle_MX_SW_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class arifle_MXC_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.2667;
+        ACE_barrelLength=266.7;
     };
     class arifle_MXM_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class arifle_SDAR_F : SDAR_base_F 
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class SMG_02_F : SMG_02_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.19558;
+        ACE_barrelLength=195.58;
     };
     class arifle_TRG20_F : Tavor_base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.381;
+        ACE_barrelLength=381.0;
     };
     class arifle_TRG21_F : Tavor_base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.45974;
+        ACE_barrelLength=459.74;
     };
     class LMG_Zafir_F : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.45974;
+        ACE_barrelLength=459.74;
     };
     class arifle_Mk20_F : Mk20_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.44196;
+        ACE_barrelLength=441.96;
     };
     class arifle_Mk20C_F : Mk20_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class arifle_Mk20_GL_F : Mk20_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class SMG_01_F : SMG_01_Base
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1397;
+        ACE_barrelLength=139.7;
     };
     class srifle_DMR_01_F : DMR_01_base_F
     {
         ACE_barrelTwist=241.3;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class srifle_EBR_F : EBR_base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class LMG_Mk200_F : Rifle_Long_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class srifle_LRR_F : LRR_base_F
     {
         ACE_barrelTwist=330.2;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class srifle_GM6_F : GM6_base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=1.09982;
+        ACE_barrelLength=1099.82;
     };
     class srifle_DMR_02_F: DMR_02_base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.6604;
+        ACE_barrelLength=660.4;
     };
     class srifle_DMR_03_F: DMR_03_base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class srifle_DMR_04_F: DMR_04_base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.450088;
+        ACE_barrelLength=450.088;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F
     {
         ACE_barrelTwist=359.918;
-        ACE_barrelLength=0.620014;
+        ACE_barrelLength=620.014;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class MMG_01_hex_F: MMG_01_base_F
     {
         ACE_barrelTwist=359.918;
-        ACE_barrelLength=0.54991;
+        ACE_barrelLength=549.91;
     };
     class MMG_02_camo_F: MMG_02_base_F
     {
         ACE_barrelTwist=234.95;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class HMG_M2 : HMG_127
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=1.143;
+        ACE_barrelLength=1143.0;
     };
     
     class RH_deagle : Pistol_Base_F
     {
         ACE_barrelTwist=482.6;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_sw659 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.188976;
+        ACE_barrelLength=188.976;
     };
     class RH_usp : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.112014;
+        ACE_barrelLength=112.014;
     };
     class RH_uspm : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_mak : Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.093472;
+        ACE_barrelLength=93.472;
     };
     class RH_m1911 : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_kimber : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_m9 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.12446;
+        ACE_barrelLength=124.46;
     };
     class RH_vz61 : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class RH_tec9 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_muzi : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_g18 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.114046;
+        ACE_barrelLength=114.046;
     };
     class RH_g17 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.114046;
+        ACE_barrelLength=114.046;
     };
     class RH_tt33 : Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.11684;
+        ACE_barrelLength=116.84;
     };
     class RH_mk2 : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class RH_p226 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class RH_g19 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class RH_gsh18 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.10414;
+        ACE_barrelLength=104.14;
     };
     class RH_mateba : Pistol_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_python : Pistol_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_bull : Pistol_Base_F
     {
         ACE_barrelTwist=609.6;
-        ACE_barrelLength=0.1651;
+        ACE_barrelLength=165.1;
     };
     class RH_ttracker : Pistol_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class RH_mp412 : Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_fnp45 : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class RH_fn57 : Pistol_Base_F
     {
         ACE_barrelTwist=231.14;
-        ACE_barrelLength=0.12192;	
+        ACE_barrelLength=121.92;	
     };
     class RH_vp70 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.11684;
+        ACE_barrelLength=116.84;
     };
     class RH_cz75 : Pistol_Base_F
     {
         ACE_barrelTwist=246.38;
-        ACE_barrelLength=0.11938;
+        ACE_barrelLength=119.38;
     };
     
     class RH_PDW : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.254;
+        ACE_barrelLength=254.0;
     };
     
     class RH_hb : Rifle_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_sbr9 : Rifle_Base_F
     {
         ACE_barrelTwist=246.38;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class RH_ar10 : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.52832;
+        ACE_barrelLength=528.32;
     };
     class RH_m4 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_M4m : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2667;
+        ACE_barrelLength=266.7;
     };
     class RH_M4sbr : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2667;
+        ACE_barrelLength=266.7;
     };
     class RH_M16a1 : Rifle_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A2 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A3 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A4 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A6 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_hk416 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_hk416c : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class RH_hk416s : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.26416;
+        ACE_barrelLength=264.16;
     };
     class RH_m27iar : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4191;
+        ACE_barrelLength=419.1;
     };
     class RH_Mk12mod1 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class RH_SAMR : Rifle_Base_F
     {
         ACE_barrelTwist=195.58;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_m110 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_mk11 : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class RH_sr25ec : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     
     class hlc_rifle_ak74 : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class hlc_rifle_aks74u : Rifle_Base_F
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.21082;
+        ACE_barrelLength=210.82;
     };
     class hlc_rifle_ak47 : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class hlc_rifle_akm : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class hlc_rifle_rpk : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.58928;
+        ACE_barrelLength=589.28;
     };
     class hlc_rifle_aek971 : Rifle_Base_F
     {
         ACE_barrelTwist=241.3;
-        ACE_barrelLength=0.4318;
+        ACE_barrelLength=431.8;
     };
     class hlc_rifle_saiga12k : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.42926;
+        ACE_barrelLength=429.26;
     };
     class hlc_ar15_base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2921;
+        ACE_barrelLength=292.1;
     };
     class hlc_rifle_bcmjack : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class hlc_rifle_Bushmaster300 : Rifle_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class hlc_rifle_SAMR : Rifle_Base_F
     {
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class hlc_rifle_honeybase : Rifle_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class hlc_rifle_SLRchopmod : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };
     class hlc_rifle_LAR : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };
     class hlc_rifle_c1A1 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.55118;
+        ACE_barrelLength=551.18;
     };
     class hlc_rifle_FAL5061 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class hlc_rifle_STG58F : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };
     class hlc_rifle_SLR : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.55118;
+        ACE_barrelLength=551.18;
     };
     class hlc_rifle_falosw : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.3302;
+        ACE_barrelLength=330.2;
     };
     class hlc_rifle_psg1 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.65024;
+        ACE_barrelLength=650.24;
     };
     class hlc_rifle_g3sg1 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.44958;
+        ACE_barrelLength=449.58;
     };
     class hlc_rifle_hk51 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.211074;
+        ACE_barrelLength=211.074;
     };
     class hlc_rifle_hk53 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.211074;
+        ACE_barrelLength=211.074;
     };
     class hlc_rifle_g3a3 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.44958;
+        ACE_barrelLength=449.58;
     };
     class hlc_M14_base : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class hlc_rifle_m14sopmod : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class hlc_lmg_M60E4 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4318;
+        ACE_barrelLength=431.8;
     };
     class hlc_lmg_m60 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     
     class hlc_smg_mp5k_PDW : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class hlc_smg_mp5a2 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
     class hlc_smg_mp5a4 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
     class hlc_smg_mp5n : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
     class hlc_smg_mp5sd5 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.14478;
+        ACE_barrelLength=144.78;
     };
     class hlc_smg_mp5sd6 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.14478;
+        ACE_barrelLength=144.78;
     };
     class hlc_smg_9mmar : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
     class hlc_smg_mp510 : Rifle_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
     class hlc_smg_mp5a3 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
             
     class hgun_mas_usp_F: Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.112014;
+        ACE_barrelLength=112.014;
     };
     class hgun_mas_m23_F: Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.149098;
+        ACE_barrelLength=149.098;
     };
     class hgun_mas_acp_F: Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127762;
+        ACE_barrelLength=127.762;
     };
     class hgun_mas_m9_F: Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.12446;
+        ACE_barrelLength=124.46;
     };
     class hgun_mas_bhp_F: Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11938;
+        ACE_barrelLength=119.38;
     };
     class hgun_mas_glock_F: Pistol_Base_F
     {
         ACE_barrelTwist=249.936;
-        ACE_barrelLength=0.113792;
+        ACE_barrelLength=113.792;
     };
     class hgun_mas_glocksf_F: Pistol_Base_F
     {
         ACE_barrelTwist=400.05;
-        ACE_barrelLength=0.11684;
+        ACE_barrelLength=116.84;
     };
     class hgun_mas_grach_F: Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class hgun_mas_mak_F: Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.093472;
+        ACE_barrelLength=93.472;
     };
     class hgun_mas_sa61_F: Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class hgun_mas_uzi_F: Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.134112;
+        ACE_barrelLength=134.112;
     };
     class arifle_mas_mk16 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.35052;
+        ACE_barrelLength=350.52;
     };
     class arifle_mas_mk16_l : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class arifle_mas_mk17 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class srifle_mas_m110 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class arifle_mas_ak_74m : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.415036;
+        ACE_barrelLength=415.036;
     };
     class arifle_mas_ak_74m_gl : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.415036;
+        ACE_barrelLength=415.036;
     };
     class srifle_mas_svd : Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class srifle_mas_m91 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class srifle_mas_ksvk : Rifle_Base_F
     {
         ACE_barrelTwist=457.2;
-        ACE_barrelLength=0.999998;
+        ACE_barrelLength=999.998;
     };
     class LMG_mas_rpk_F : Rifle_Base_F
     {
         ACE_barrelTwist=195.072;
-        ACE_barrelLength=0.58928;
+        ACE_barrelLength=589.28;
     };
     class LMG_mas_pkm_F : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.64516;
+        ACE_barrelLength=645.16;
     };
     class arifle_mas_aks74u : Rifle_Base_F
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.21082;
+        ACE_barrelLength=210.82;
     };
     class arifle_mas_bizon : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.23114;
+        ACE_barrelLength=231.14;
     };
     class arifle_mas_saiga : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.430022;
+        ACE_barrelLength=430.022;
     };
     class arifle_mas_hk416 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class arifle_mas_hk416_gl : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class arifle_mas_hk416c : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class arifle_mas_hk416_m203c : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class arifle_mas_hk417c : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.3302;
+        ACE_barrelLength=330.2;
     };
     class arifle_mas_m4 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class arifle_mas_m4c : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.26162;
+        ACE_barrelLength=261.62;
     };
     class arifle_mas_l119 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class arifle_mas_l119_gl : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class arifle_mas_l119_m203 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class arifle_mas_m16 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class arifle_mas_m16_gl : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class srifle_mas_hk417 : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.4191;
+        ACE_barrelLength=419.1;
     };
     class srifle_mas_sr25 : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class srifle_mas_ebr : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class srifle_mas_m24 : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class arifle_mas_mp5 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };
     class arifle_mas_mp5sd : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.14478;
+        ACE_barrelLength=144.78;
     };
     class srifle_mas_m107 : Rifle_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class LMG_mas_M249_F : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class LMG_mas_M249a_F : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class LMG_mas_mk48_F : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.50165;
+        ACE_barrelLength=501.65;
     };
     class LMG_mas_m240_F : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     class LMG_mas_mg3_F : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.56388;
+        ACE_barrelLength=563.88;
     };
     class arifle_mas_g3 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.44958;
+        ACE_barrelLength=449.58;
     };
     class arifle_mas_g3_m203 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.44958;
+        ACE_barrelLength=449.58;
     };
     class arifle_mas_fal : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };
     class arifle_mas_fal_m203 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };
     class arifle_mas_m1014 : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.4699;
+        ACE_barrelLength=469.9;
     };
     
     class BWA3_P8 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.10795;
+        ACE_barrelLength=107.95;
     };
     class BWA3_MP7 : Pistol_Base_F
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.18034;
+        ACE_barrelLength=180.34;
     };
     class BWA3_G36 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.48006;
+        ACE_barrelLength=480.06;
     };
     class BWA3_G36K : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class BWA3_G28_Standard : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4191;
+        ACE_barrelLength=419.1;
     };
     class BWA3_G27 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class BWA3_MG4 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.48006;
+        ACE_barrelLength=480.06;
     };
     class BWA3_MG5 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.54864;
+        ACE_barrelLength=548.64;
     };
     class BWA3_G82 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     
     class Trixie_L131A1 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class Trixie_XM8_Carbine : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class Trixie_XM8_Compact : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class Trixie_XM8_SAW : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class Trixie_XM8_SAW_NB : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class Trixie_XM8_DMR : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class Trixie_XM8_DMR_NB : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class L129A1_base : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class Trixie_Enfield : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.64008;
+        ACE_barrelLength=640.08;
     };
     class Trixie_CZ550_Rail : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.599999;
+        ACE_barrelLength=599.999;
     };
     class Trixie_FNFAL_Rail : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };
         
     class Trixie_M110 : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class Trixie_MK12 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class Trixie_LM308MWS : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class Trixie_M14DMR : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class Trixie_M14DMR_NG_Black_Short : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class Trixie_M14DMR_NG_Short : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class Trixie_M14 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class Trixie_M40A3 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class Trixie_CZ750 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.6604;
+        ACE_barrelLength=660.4;
     };
     class Trixie_M24 : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class Trixie_AWM338 : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.6858;
+        ACE_barrelLength=685.8;
     };
     class Trixie_M107 : Rifle_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class Trixie_AS50 : Rifle_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class L110A1_base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.34798;
+        ACE_barrelLength=347.98;
     };
     class Trixie_L86A2_base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.64516;
+        ACE_barrelLength=645.16;
     };
     class Trixie_l85a2_base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.51816;
+        ACE_barrelLength=518.16;
     };
     class L7A2_base : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     
     class rhs_weap_pya : Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class rhs_weap_pkp : Rifle_Long_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.65786;
+        ACE_barrelLength=657.86;
     };
     class rhs_weap_pkm : Rifle_Long_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.64516;
+        ACE_barrelLength=645.16;
     };
     class rhs_weap_rpk74m : Rifle_Long_Base_F
     {
         ACE_barrelTwist=195.072;
-        ACE_barrelLength=0.58928;
+        ACE_barrelLength=589.28;
     };
     class rhs_weap_rpk74 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=195.072;
-        ACE_barrelLength=0.58928;
+        ACE_barrelLength=589.28;
     };
     class rhs_weap_ak74m : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class rhs_weap_aks74u : Rifle_Base_F
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.21082;
+        ACE_barrelLength=210.82;
     };
     class rhs_weap_akm : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class rhs_weap_svd : Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class rhs_weap_svds : Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.56388;
+        ACE_barrelLength=563.88;
     };
     class rhs_weap_m4_Base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class rhs_weap_m16a4 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_weap_m16a4_carryhandle : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_weap_m16a4_grip : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_weap_m240B : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     class rhs_weap_m249_pip : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class rhs_weap_mk18 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.26162;
+        ACE_barrelLength=261.62;
     };
     class rhs_weap_M590_5RD : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.4699;
+        ACE_barrelLength=469.9;
     };
     class rhs_weap_M590_8RD : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_weap_sr25 : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class rhs_weap_sr25_ec : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     
     class R3F_PAMAS : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.12446;
+        ACE_barrelLength=124.46;
     };
     class R3F_Famas_F1: Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.48768;
+        ACE_barrelLength=487.68;
     };
     class R3F_Famas_surb: Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.40386;
+        ACE_barrelLength=403.86;
     };
     class R3F_Minimi: Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.34798;
+        ACE_barrelLength=347.98;
     };
     class R3F_Minimi_762: Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.50292;
+        ACE_barrelLength=502.92;
     };
     class R3F_FRF2: Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.649986;
+        ACE_barrelLength=649.986;
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.70104;
+        ACE_barrelLength=701.04;
     };
     class R3F_HK417S_HG : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.3048;
+        ACE_barrelLength=304.8;
     };
     class R3F_HK417M : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class R3F_HK417L : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class R3F_M107 : Rifle_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class R3F_HK416M : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3556;
+        ACE_barrelLength=355.6;
     };
     class R3F_MP5SD : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.14478;
+        ACE_barrelLength=144.78;
     };
     
     class CUP_hgun_Colt1911 : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class CUP_sgun_AA12 : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.4572;		
+        ACE_barrelLength=457.2;		
     };
     class CUP_arifle_AK_Base : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };	
     class CUP_arifle_AK107_Base : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class CUP_arifle_AKS_Base : Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class CUP_arifle_AKS74U : Rifle_Base_F
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.21082;
+        ACE_barrelLength=210.82;
     };
     class CUP_arifle_RPK74 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=195.072;
-        ACE_barrelLength=0.58928;
+        ACE_barrelLength=589.28;
     };			
     class CUP_srifle_AS50 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class CUP_srifle_AWM_Base : Rifle_Long_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.6858;
+        ACE_barrelLength=685.8;
     };	
     class CUP_smg_bizon : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.23114;
+        ACE_barrelLength=231.14;
     };
     class CUP_hgun_Compact : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.094996;
+        ACE_barrelLength=94.996;
     };	
     class CUP_srifle_CZ750 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.6604;
+        ACE_barrelLength=660.4;
     };	
     class CUP_arifle_CZ805_Base : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.3556;
+        ACE_barrelLength=355.6;
     };
     class CUP_arifle_CZ805_A1 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.3556;
+        ACE_barrelLength=355.6;
     };
     class CUP_arifle_CZ805_A2 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.27686;
+        ACE_barrelLength=276.86;
     };
     class CUP_srifle_DMR : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };	
     class CUP_hgun_Duty : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.094996;
+        ACE_barrelLength=94.996;
     };
     class CUP_arifle_FNFAL : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5334;
+        ACE_barrelLength=533.4;
     };	
     class CUP_arifle_G36A : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.48006;
+        ACE_barrelLength=480.06;
     };
     class CUP_arifle_G36K : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class CUP_arifle_G36C : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class CUP_arifle_MG36 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.48006;
+        ACE_barrelLength=480.06;
     };
     class CUP_hgun_Glock17 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.114046;
+        ACE_barrelLength=114.046;
     };	
     class CUP_srifle_CZ550 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.599999;
+        ACE_barrelLength=599.999;
     };	
     class CUP_srifle_ksvk : Rifle_Long_Base_F
     {
         ACE_barrelTwist=457.2;
-        ACE_barrelLength=0.999998;
+        ACE_barrelLength=999.998;
     };	
     class CUP_lmg_L7A2 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };	
     class CUP_arifle_L85A2_Base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.51816;
+        ACE_barrelLength=518.16;
     };	
     class CUP_lmg_L110A1 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.34798;
+        ACE_barrelLength=347.98;
     };	
     class CUP_srifle_LeeEnfield : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.64008;
+        ACE_barrelLength=640.08;
     };
     class CUP_hgun_M9 : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.12446;
+        ACE_barrelLength=124.46;
     };
     class CUP_srifle_M14 : Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class CUP_arifle_M16_Base : Rifle_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class CUP_arifle_M4_Base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class CUP_srifle_Mk12SPR : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class CUP_srifle_M24_des : Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };	
     class CUP_lmg_M60A4 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4318;
+        ACE_barrelLength=431.8;
     };
     class CUP_srifle_M107_Base : Rifle_Long_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.7366;
+        ACE_barrelLength=736.6;
     };
     class CUP_srifle_M110 : Rifle_Base_F
     {
         ACE_barrelTwist=279.4;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class CUP_lmg_M240 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     class CUP_lmg_M249_para : Rifle_Long_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class CUP_lmg_M249 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class CUP_sgun_M1014 : Rifle_Base_F
     {
         ACE_twistDirection=0;
         ACE_barrelTwist=0.0;
-        ACE_barrelLength=0.4699;
+        ACE_barrelLength=469.9;
     };	
     class CUP_hgun_Makarov : Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.093472;
+        ACE_barrelLength=93.472;
     };	
     class CUP_hgun_MicroUzi : Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };	
     class CUP_lmg_Mk48_Base : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.50165;
+        ACE_barrelLength=501.65;
     };	
     class CUP_smg_MP5SD6 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.14478;
+        ACE_barrelLength=144.78;
     };
     class CUP_smg_MP5A5 : Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.22606;
+        ACE_barrelLength=226.06;
     };	
     class CUP_hgun_PB6P9 : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.10414;
+        ACE_barrelLength=104.14;
     };
     class CUP_hgun_Phantom : Rifle_Base_F
     {
         ACE_barrelTwist=246.38;
-        ACE_barrelLength=0.11938;
+        ACE_barrelLength=119.38;
     };	
     class CUP_lmg_PKM : Rifle_Long_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.64516;
+        ACE_barrelLength=645.16;
     };
     class CUP_lmg_Pecheneg : Rifle_Long_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.65786;
+        ACE_barrelLength=657.86;
     };	
     class CUP_hgun_TaurusTracker455 : Pistol_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class CUP_arifle_Sa58P : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.39116;
+        ACE_barrelLength=391.16;
     };
     class CUP_arifle_Sa58V : Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.39116;
+        ACE_barrelLength=391.16;
     };
     class CUP_hgun_SA61 : Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class CUP_sgun_Saiga12K: Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.42926;
+        ACE_barrelLength=429.26;
     }	
     class CUP_arifle_Mk16_CQC : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.254;
+        ACE_barrelLength=254.0;
     };
     class CUP_arifle_Mk16_STD : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3556;
+        ACE_barrelLength=355.6;
     };
     class CUP_arifle_Mk16_SV : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };	
     class CUP_arifle_Mk17_CQC : Rifle_Base_F
     {	
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.3302;
+        ACE_barrelLength=330.2;
     };
     class CUP_arifle_Mk17_STD : Rifle_Base_F
     {	
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
     };
     class CUP_arifle_Mk20 : Rifle_Base_F
     {	
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class CUP_srifle_SVD : Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class CUP_lmg_UK59 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=0.55118;
+        ACE_barrelLength=551.18;
     };
     class CUP_DSHKM_W : MGun
     {
         ACE_barrelTwist=381.0;
-        ACE_barrelLength=1.06934;
+        ACE_barrelLength=1069.34;
     };
     class CUP_KPVT_W : MGun
     {
         ACE_barrelTwist=454.914;
-        ACE_barrelLength=1.3462;
+        ACE_barrelLength=1346.2;
     };
     class CUP_KPVB_W : MGun
     {
         ACE_barrelTwist=454.914;
-        ACE_barrelLength=1.3462;
+        ACE_barrelLength=1346.2;
     };
     class CUP_M134 : MGunCore
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class CUP_M240_veh_W : Rifle_Long_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;		 	
+        ACE_barrelLength=629.92;		 	
     };
     class CUP_PKT_W : MGun
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.722122;
+        ACE_barrelLength=722.122;
     };
     class CUP_srifle_VSSVintorez : Rifle_Base_F
     {
         ACE_barrelTwist=210.82;
-        ACE_barrelLength=0.20066;
+        ACE_barrelLength=200.66;
     };
     class CUP_arifle_XM8_Base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class CUP_arifle_XM8_Carbine : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class CUP_arifle_xm8_sharpshooter : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class CUP_arifle_xm8_SAW : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class CUP_arifle_XM8_Compact : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class CUP_arifle_XM8_Railed_Base : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     class CUP_arifle_XM8_Carbine_FG : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3175;
+        ACE_barrelLength=317.5;
     };
     
     class VTN_AK_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AK74M: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AK74M_GP25: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AK74M_GP30M: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AKS74: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AKS74N: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AKS74N_76: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AK74_76: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AKMS_aa: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.26162;
+        ACE_barrelLength=261.62;
     };
     class VTN_AKS74U_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.21082;
+        ACE_barrelLength=210.82;
     };
     class VTN_AKM_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AKMS: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AKMS_T_P: Rifle_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AK103_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_AK104_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.31496;
+        ACE_barrelLength=314.96;
     };
     class VTN_AK105_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.31496;
+        ACE_barrelLength=314.96;
     };
     class VTN_AK105_P_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.31496;
+        ACE_barrelLength=314.96;
     };
     class VTN_SVD_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class VTN_SVD_63: Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class VTN_SVD_86: Rifle_Base_F
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class VTN_SV98_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=320.04;
-        ACE_barrelLength=0.649986;
+        ACE_barrelLength=649.986;
     };
     class VTN_PKM_BAS: Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.64516;
+        ACE_barrelLength=645.16;
     };
     class VTN_PKP: Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.65786;
+        ACE_barrelLength=657.86;
     };
     class VTN_PYA: Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class VTN_PM: Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.093472;
+        ACE_barrelLength=93.472;
     };
     class VTN_PB: Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.10414;
+        ACE_barrelLength=104.14;
     };
     class VTN_GSH18: Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.10414;
+        ACE_barrelLength=104.14;
     };
     class VTN_PSS: Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.03556;
+        ACE_barrelLength=35.56;
     };
     class VTN_PKT: Rifle_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.722122;
+        ACE_barrelLength=722.122;
     };
     class VTN_KORD: Rifle_Base_F
     {
         ACE_barrelTwist=454.914;
-        ACE_barrelLength=1.3462;
+        ACE_barrelLength=1346.2;
     };
     class VTN_KPVT: Rifle_Base_F
     {
         ACE_barrelTwist=454.914;
-        ACE_barrelLength=1.3462;
+        ACE_barrelLength=1346.2;
     };
     class VTN_C_M4A1 : Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class VTN_MK18MOD0: Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.26162;
+        ACE_barrelLength=261.62;
     };
     class VTN_M16_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class VTN_FN_SAMR_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=195.58;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class VTN_M249_SAW_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class VTN_M249_PARA: Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class VTN_M240G_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     class VTN_M9: Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.12446;
+        ACE_barrelLength=124.46;
     };
     class VTN_M45A1: Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class VTN_M24: Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class VTN_M240: Rifle_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     class VTN_KO44: Rifle_Base_F
     {
         ACE_barrelTwist=241.3;
-        ACE_barrelLength=0.51308;
+        ACE_barrelLength=513.08;
     };
     class VTN_SAIGA_MK03: Rifle_Base_F
     {
         ACE_twistDirection=9.45;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
 };

--- a/extras/CfgWeaponsReference.hpp
+++ b/extras/CfgWeaponsReference.hpp
@@ -27,456 +27,456 @@ class CfgWeapons
     class MMG_02_base_F;
     class hgun_P07_F : Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.1016;
     };
     class hgun_Rook40_F : Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11176;
     };
     class hgun_Pistol_heavy_01_F : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class hgun_Pistol_heavy_02_F : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.0762;
     };
     class hgun_ACPC2_F : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class hgun_PDW2000_F : PDW2000_Base_F
     {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.1778;
     };
     class arifle_Katiba_F : arifle_Katiba_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.72898;
     };
     class arifle_Katiba_C_F : arifle_Katiba_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.68072;
     };
     class arifle_Katiba_GL_F : arifle_Katiba_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.72898;
     };
     class arifle_MX_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.3683;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.3683;
     };
     class arifle_MX_SW_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4064;
     };
     class arifle_MXC_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.2667;
     };
     class arifle_MXM_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4572;
     };
     class arifle_SDAR_F : SDAR_base_F 
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.4572;
     };
     class SMG_02_F : SMG_02_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.19558;
     };
     class arifle_TRG20_F : Tavor_base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.381;
     };
     class arifle_TRG21_F : Tavor_base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.45974;
     };
     class LMG_Zafir_F : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.45974;
     };
     class arifle_Mk20_F : Mk20_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.44196;
     };
     class arifle_Mk20C_F : Mk20_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class arifle_Mk20_GL_F : Mk20_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class SMG_01_F : SMG_01_Base
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1397;
     };
     class srifle_DMR_01_F : DMR_01_base_F
     {
-        ACE_barrelTwist=0.2413;
+        ACE_barrelTwist=241.3;
         ACE_barrelLength=0.6096;
     };
     class srifle_EBR_F : EBR_base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.6096;
     };
     class LMG_Mk200_F : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class srifle_LRR_F : LRR_base_F
     {
-        ACE_barrelTwist=0.3302;
+        ACE_barrelTwist=330.2;
         ACE_barrelLength=0.7366;
     };
     class srifle_GM6_F : GM6_base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=1.09982;
     };
     class srifle_DMR_02_F: DMR_02_base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.6604;
     };
     class srifle_DMR_03_F: DMR_03_base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.508;
     };
     class srifle_DMR_04_F: DMR_04_base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.450088;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F
     {
-        ACE_barrelTwist=0.359918;
+        ACE_barrelTwist=359.918;
         ACE_barrelLength=0.620014;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class MMG_01_hex_F: MMG_01_base_F
     {
-        ACE_barrelTwist=0.359918;
+        ACE_barrelTwist=359.918;
         ACE_barrelLength=0.54991;
     };
     class MMG_02_camo_F: MMG_02_base_F
     {
-        ACE_barrelTwist=0.23495;
+        ACE_barrelTwist=234.95;
         ACE_barrelLength=0.6096;
     };
     class HMG_M2 : HMG_127
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=1.143;
     };
     
     class RH_deagle : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4826;
+        ACE_barrelTwist=482.6;
         ACE_barrelLength=0.1524;
     };
     class RH_sw659 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.188976;
     };
     class RH_usp : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.112014;
     };
     class RH_uspm : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1524;
     };
     class RH_mak : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.093472;
     };
     class RH_m1911 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class RH_kimber : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class RH_m9 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.12446;
     };
     class RH_vz61 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class RH_tec9 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.127;
     };
     class RH_muzi : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.127;
     };
     class RH_g18 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.114046;
     };
     class RH_g17 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.114046;
     };
     class RH_tt33 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.11684;
     };
     class RH_mk2 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1016;
     };
     class RH_p226 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.11176;
     };
     class RH_g19 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.1016;
     };
     class RH_gsh18 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.10414;
     };
     class RH_mateba : Pistol_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.1524;
     };
     class RH_python : Pistol_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.1524;
     };
     class RH_bull : Pistol_Base_F
     {
-        ACE_barrelTwist=0.6096;
+        ACE_barrelTwist=609.6;
         ACE_barrelLength=0.1651;
     };
     class RH_ttracker : Pistol_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.1016;
     };
     class RH_mp412 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.1524;
     };
     class RH_fnp45 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class RH_fn57 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.23114;
+        ACE_barrelTwist=231.14;
         ACE_barrelLength=0.12192;	
     };
     class RH_vp70 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.11684;
     };
     class RH_cz75 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24638;
+        ACE_barrelTwist=246.38;
         ACE_barrelLength=0.11938;
     };
     
     class RH_PDW : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.254;
     };
     
     class RH_hb : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.1524;
     };
     class RH_sbr9 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24638;
+        ACE_barrelTwist=246.38;
         ACE_barrelLength=0.2286;
     };
     class RH_ar10 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.52832;
     };
     class RH_m4 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class RH_M4m : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2667;
     };
     class RH_M4sbr : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2667;
     };
     class RH_M16a1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.508;
     };
     class RH_M16A2 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A3 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A4 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A6 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_hk416 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class RH_hk416c : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class RH_hk416s : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.26416;
     };
     class RH_m27iar : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4191;
     };
     class RH_Mk12mod1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class RH_SAMR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.19558;
+        ACE_barrelTwist=195.58;
         ACE_barrelLength=0.508;
     };
     class RH_m110 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.508;
     };
     class RH_mk11 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class RH_sr25ec : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.508;
     };
     
     class hlc_rifle_ak74 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class hlc_rifle_aks74u : Rifle_Base_F
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.21082;
     };
     class hlc_rifle_ak47 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.41402;
     };
     class hlc_rifle_akm : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class hlc_rifle_rpk : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.58928;
     };
     class hlc_rifle_aek971 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2413;
+        ACE_barrelTwist=241.3;
         ACE_barrelLength=0.4318;
     };
     class hlc_rifle_saiga12k : Rifle_Base_F
@@ -487,274 +487,274 @@ class CfgWeapons
     };
     class hlc_ar15_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2921;
     };
     class hlc_rifle_bcmjack : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class hlc_rifle_Bushmaster300 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.4064;
     };
     class hlc_rifle_SAMR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4064;
     };
     class hlc_rifle_honeybase : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.1524;
     };
     class hlc_rifle_SLRchopmod : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };
     class hlc_rifle_LAR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };
     class hlc_rifle_c1A1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.55118;
     };
     class hlc_rifle_FAL5061 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4572;
     };
     class hlc_rifle_STG58F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };
     class hlc_rifle_SLR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.55118;
     };
     class hlc_rifle_falosw : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.3302;
     };
     class hlc_rifle_psg1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.65024;
     };
     class hlc_rifle_g3sg1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.44958;
     };
     class hlc_rifle_hk51 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.211074;
     };
     class hlc_rifle_hk53 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.211074;
     };
     class hlc_rifle_g3a3 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.44958;
     };
     class hlc_M14_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class hlc_rifle_m14sopmod : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4572;
     };
     class hlc_lmg_M60E4 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4318;
     };
     class hlc_lmg_m60 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     
     class hlc_smg_mp5k_PDW : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.1143;
     };
     class hlc_smg_mp5a2 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5a4 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5n : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5sd5 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.14478;
     };
     class hlc_smg_mp5sd6 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.14478;
     };
     class hlc_smg_9mmar : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp510 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5a3 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };
             
     class hgun_mas_usp_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.112014;
     };
     class hgun_mas_m23_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.149098;
     };
     class hgun_mas_acp_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127762;
     };
     class hgun_mas_m9_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.12446;
     };
     class hgun_mas_bhp_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11938;
     };
     class hgun_mas_glock_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.249936;
+        ACE_barrelTwist=249.936;
         ACE_barrelLength=0.113792;
     };
     class hgun_mas_glocksf_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.40005;
+        ACE_barrelTwist=400.05;
         ACE_barrelLength=0.11684;
     };
     class hgun_mas_grach_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11176;
     };
     class hgun_mas_mak_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.093472;
     };
     class hgun_mas_sa61_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class hgun_mas_uzi_F: Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.134112;
     };
     class arifle_mas_mk16 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.35052;
     };
     class arifle_mas_mk16_l : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class arifle_mas_mk17 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4064;
     };
     class srifle_mas_m110 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.508;
     };
     class arifle_mas_ak_74m : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.415036;
     };
     class arifle_mas_ak_74m_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.415036;
     };
     class srifle_mas_svd : Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class srifle_mas_m91 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.7366;
     };
     class srifle_mas_ksvk : Rifle_Base_F
     {
-        ACE_barrelTwist=0.4572;
+        ACE_barrelTwist=457.2;
         ACE_barrelLength=0.999998;
     };
     class LMG_mas_rpk_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.195072;
+        ACE_barrelTwist=195.072;
         ACE_barrelLength=0.58928;
     };
     class LMG_mas_pkm_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.64516;
     };
     class arifle_mas_aks74u : Rifle_Base_F
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.21082;
     };
     class arifle_mas_bizon : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.23114;
     };
     class arifle_mas_saiga : Rifle_Base_F
@@ -765,142 +765,142 @@ class CfgWeapons
     };
     class arifle_mas_hk416 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class arifle_mas_hk416_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class arifle_mas_hk416c : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class arifle_mas_hk416_m203c : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class arifle_mas_hk417c : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.3302;
     };
     class arifle_mas_m4 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class arifle_mas_m4c : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.26162;
     };
     class arifle_mas_l119 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class arifle_mas_l119_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class arifle_mas_l119_m203 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4064;
     };
     class arifle_mas_m16 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class arifle_mas_m16_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class srifle_mas_hk417 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.4191;
     };
     class srifle_mas_sr25 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class srifle_mas_ebr : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4572;
     };
     class srifle_mas_m24 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class arifle_mas_mp5 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };
     class arifle_mas_mp5sd : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.14478;
     };
     class srifle_mas_m107 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     class LMG_mas_M249_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.41402;
     };
     class LMG_mas_M249a_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class LMG_mas_mk48_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.50165;
     };
     class LMG_mas_m240_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     class LMG_mas_mg3_F : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.56388;
     };
     class arifle_mas_g3 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.44958;
     };
     class arifle_mas_g3_m203 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.44958;
     };
     class arifle_mas_fal : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };
     class arifle_mas_fal_m203 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };
     class arifle_mas_m1014 : Rifle_Base_F
@@ -912,275 +912,275 @@ class CfgWeapons
     
     class BWA3_P8 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.10795;
     };
     class BWA3_MP7 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.18034;
     };
     class BWA3_G36 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.48006;
     };
     class BWA3_G36K : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class BWA3_G28_Standard : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4191;
     };
     class BWA3_G27 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4064;
     };
     class BWA3_MG4 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.48006;
     };
     class BWA3_MG5 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.54864;
     };
     class BWA3_G82 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     
     class Trixie_L131A1 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.1143;
     };
     class Trixie_XM8_Carbine : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class Trixie_XM8_Compact : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class Trixie_XM8_SAW : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class Trixie_XM8_SAW_NB : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class Trixie_XM8_DMR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class Trixie_XM8_DMR_NB : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class L129A1_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.4064;
     };
     class Trixie_Enfield : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.64008;
     };
     class Trixie_CZ550_Rail : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.599999;
     };
     class Trixie_FNFAL_Rail : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };
         
     class Trixie_M110 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.508;
     };
     class Trixie_MK12 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class Trixie_LM308MWS : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.4064;
     };
     class Trixie_M14DMR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class Trixie_M14DMR_NG_Black_Short : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4572;
     };
     class Trixie_M14DMR_NG_Short : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4572;
     };
     class Trixie_M14 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class Trixie_M40A3 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.6096;
     };
     class Trixie_CZ750 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.6604;
     };
     class Trixie_M24 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class Trixie_AWM338 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.6858;
     };
     class Trixie_M107 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     class Trixie_AS50 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     class L110A1_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.34798;
     };
     class Trixie_L86A2_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.64516;
     };
     class Trixie_l85a2_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.51816;
     };
     class L7A2_base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     
     class rhs_weap_pya : Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11176;
     };
     class rhs_weap_pkp : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.65786;
     };
     class rhs_weap_pkm : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.64516;
     };
     class rhs_weap_rpk74m : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.195072;
+        ACE_barrelTwist=195.072;
         ACE_barrelLength=0.58928;
     };
     class rhs_weap_rpk74 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.195072;
+        ACE_barrelTwist=195.072;
         ACE_barrelLength=0.58928;
     };
     class rhs_weap_ak74m : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class rhs_weap_aks74u : Rifle_Base_F
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.21082;
     };
     class rhs_weap_akm : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class rhs_weap_svd : Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class rhs_weap_svds : Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.56388;
     };
     class rhs_weap_m4_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class rhs_weap_m16a4 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class rhs_weap_m16a4_carryhandle : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class rhs_weap_m16a4_grip : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class rhs_weap_m240B : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     class rhs_weap_m249_pip : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.41402;
     };
     class rhs_weap_mk18 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.26162;
     };
     class rhs_weap_M590_5RD : Rifle_Base_F
@@ -1197,89 +1197,89 @@ class CfgWeapons
     };
     class rhs_weap_sr25 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class rhs_weap_sr25_ec : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.508;
     };
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.6096;
     };
     
     class R3F_PAMAS : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.12446;
     };
     class R3F_Famas_F1: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.48768;
     };
     class R3F_Famas_surb: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.40386;
     };
     class R3F_Minimi: Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.34798;
     };
     class R3F_Minimi_762: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.50292;
     };
     class R3F_FRF2: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.649986;
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.70104;
     };
     class R3F_HK417S_HG : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.3048;
     };
     class R3F_HK417M : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.4064;
     };
     class R3F_HK417L : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.508;
     };
     class R3F_M107 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     class R3F_HK416M : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3556;
     };
     class R3F_MP5SD : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.14478;
     };
     
     class CUP_hgun_Colt1911 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class CUP_sgun_AA12 : Rifle_Base_F
@@ -1290,197 +1290,197 @@ class CfgWeapons
     };
     class CUP_arifle_AK_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.41402;
     };	
     class CUP_arifle_AK107_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class CUP_arifle_AKS_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class CUP_arifle_AKS74U : Rifle_Base_F
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.21082;
     };
     class CUP_arifle_RPK74 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.195072;
+        ACE_barrelTwist=195.072;
         ACE_barrelLength=0.58928;
     };			
     class CUP_srifle_AS50 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     class CUP_srifle_AWM_Base : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.6858;
     };	
     class CUP_smg_bizon : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.23114;
     };
     class CUP_hgun_Compact : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.094996;
     };	
     class CUP_srifle_CZ750 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.6604;
     };	
     class CUP_arifle_CZ805_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.3556;
     };
     class CUP_arifle_CZ805_A1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.3556;
     };
     class CUP_arifle_CZ805_A2 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.27686;
     };
     class CUP_srifle_DMR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };	
     class CUP_hgun_Duty : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.094996;
     };
     class CUP_arifle_FNFAL : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5334;
     };	
     class CUP_arifle_G36A : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.48006;
     };
     class CUP_arifle_G36K : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class CUP_arifle_G36C : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class CUP_arifle_MG36 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.48006;
     };
     class CUP_hgun_Glock17 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.114046;
     };	
     class CUP_srifle_CZ550 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.599999;
     };	
     class CUP_srifle_ksvk : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.4572;
+        ACE_barrelTwist=457.2;
         ACE_barrelLength=0.999998;
     };	
     class CUP_lmg_L7A2 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };	
     class CUP_arifle_L85A2_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.51816;
     };	
     class CUP_lmg_L110A1 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.34798;
     };	
     class CUP_srifle_LeeEnfield : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.64008;
     };
     class CUP_hgun_M9 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.12446;
     };
     class CUP_srifle_M14 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class CUP_arifle_M16_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.508;
     };
     class CUP_arifle_M4_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class CUP_srifle_Mk12SPR : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class CUP_srifle_M24_des : Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };	
     class CUP_lmg_M60A4 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4318;
     };
     class CUP_srifle_M107_Base : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.7366;
     };
     class CUP_srifle_M110 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.2794;
+        ACE_barrelTwist=279.4;
         ACE_barrelLength=0.508;
     };
     class CUP_lmg_M240 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     class CUP_lmg_M249_para : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.41402;
     };
     class CUP_lmg_M249 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class CUP_sgun_M1014 : Rifle_Base_F
@@ -1491,67 +1491,67 @@ class CfgWeapons
     };	
     class CUP_hgun_Makarov : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.093472;
     };	
     class CUP_hgun_MicroUzi : Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.127;
     };	
     class CUP_lmg_Mk48_Base : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.50165;
     };	
     class CUP_smg_MP5SD6 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.14478;
     };
     class CUP_smg_MP5A5 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.22606;
     };	
     class CUP_hgun_PB6P9 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.10414;
     };
     class CUP_hgun_Phantom : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24638;
+        ACE_barrelTwist=246.38;
         ACE_barrelLength=0.11938;
     };	
     class CUP_lmg_PKM : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.64516;
     };
     class CUP_lmg_Pecheneg : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.65786;
     };	
     class CUP_hgun_TaurusTracker455 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.1016;
     };
     class CUP_arifle_Sa58P : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.39116;
     };
     class CUP_arifle_Sa58V : Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.39116;
     };
     class CUP_hgun_SA61 : Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class CUP_sgun_Saiga12K: Rifle_Base_F
@@ -1562,328 +1562,328 @@ class CfgWeapons
     }	
     class CUP_arifle_Mk16_CQC : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.254;
     };
     class CUP_arifle_Mk16_STD : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3556;
     };
     class CUP_arifle_Mk16_SV : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };	
     class CUP_arifle_Mk17_CQC : Rifle_Base_F
     {	
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.3302;
     };
     class CUP_arifle_Mk17_STD : Rifle_Base_F
     {	
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4064;
     };
     class CUP_arifle_Mk20 : Rifle_Base_F
     {	
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.508;
     };
     class CUP_srifle_SVD : Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class CUP_lmg_UK59 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=0.55118;
     };
     class CUP_DSHKM_W : MGun
     {
-        ACE_barrelTwist=0.381;
+        ACE_barrelTwist=381.0;
         ACE_barrelLength=1.06934;
     };
     class CUP_KPVT_W : MGun
     {
-        ACE_barrelTwist=0.454914;
+        ACE_barrelTwist=454.914;
         ACE_barrelLength=1.3462;
     };
     class CUP_KPVB_W : MGun
     {
-        ACE_barrelTwist=0.454914;
+        ACE_barrelTwist=454.914;
         ACE_barrelLength=1.3462;
     };
     class CUP_M134 : MGunCore
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class CUP_M240_veh_W : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;		 	
     };
     class CUP_PKT_W : MGun
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.722122;
     };
     class CUP_srifle_VSSVintorez : Rifle_Base_F
     {
-        ACE_barrelTwist=0.21082;
+        ACE_barrelTwist=210.82;
         ACE_barrelLength=0.20066;
     };
     class CUP_arifle_XM8_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class CUP_arifle_XM8_Carbine : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class CUP_arifle_xm8_sharpshooter : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class CUP_arifle_xm8_SAW : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class CUP_arifle_XM8_Compact : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class CUP_arifle_XM8_Railed_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     class CUP_arifle_XM8_Carbine_FG : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3175;
     };
     
     class VTN_AK_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AK74M: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AK74M_GP25: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AK74M_GP30M: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AKS74: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AKS74N: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AKS74N_76: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AK74_76: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AKMS_aa: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.26162;
     };
     class VTN_AKS74U_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.21082;
     };
     class VTN_AKM_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AKMS: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AKMS_T_P: Rifle_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class VTN_AK103_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.41402;
     };
     class VTN_AK104_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.31496;
     };
     class VTN_AK105_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.31496;
     };
     class VTN_AK105_P_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.31496;
     };
     class VTN_SVD_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class VTN_SVD_63: Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class VTN_SVD_86: Rifle_Base_F
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class VTN_SV98_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.32004;
+        ACE_barrelTwist=320.04;
         ACE_barrelLength=0.649986;
     };
     class VTN_PKM_BAS: Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.64516;
     };
     class VTN_PKP: Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.65786;
     };
     class VTN_PYA: Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11176;
     };
     class VTN_PM: Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.093472;
     };
     class VTN_PB: Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.10414;
     };
     class VTN_GSH18: Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.10414;
     };
     class VTN_PSS: Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.03556;
     };
     class VTN_PKT: Rifle_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.722122;
     };
     class VTN_KORD: Rifle_Base_F
     {
-        ACE_barrelTwist=0.454914;
+        ACE_barrelTwist=454.914;
         ACE_barrelLength=1.3462;
     };
     class VTN_KPVT: Rifle_Base_F
     {
-        ACE_barrelTwist=0.454914;
+        ACE_barrelTwist=454.914;
         ACE_barrelLength=1.3462;
     };
     class VTN_C_M4A1 : Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class VTN_MK18MOD0: Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.26162;
     };
     class VTN_M16_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.508;
     };
     class VTN_FN_SAMR_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.19558;
+        ACE_barrelTwist=195.58;
         ACE_barrelLength=0.508;
     };
     class VTN_M249_SAW_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class VTN_M249_PARA: Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.41402;
     };
     class VTN_M240G_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     class VTN_M9: Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.12446;
     };
     class VTN_M45A1: Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class VTN_M24: Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class VTN_M240: Rifle_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     class VTN_KO44: Rifle_Base_F
     {
-        ACE_barrelTwist=0.2413;
+        ACE_barrelTwist=241.3;
         ACE_barrelLength=0.51308;
     };
     class VTN_SAIGA_MK03: Rifle_Base_F

--- a/extras/CfgWeaponsReference.hpp
+++ b/extras/CfgWeaponsReference.hpp
@@ -27,1863 +27,1863 @@ class CfgWeapons
     class MMG_02_base_F;
     class hgun_P07_F : Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4;
     };
     class hgun_Rook40_F : Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.4;
     };
     class hgun_Pistol_heavy_01_F : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class hgun_Pistol_heavy_02_F : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=3;
     };
     class hgun_ACPC2_F : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class hgun_PDW2000_F : PDW2000_Base_F
     {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=7;
     };
     class arifle_Katiba_F : arifle_Katiba_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=28.7;
     };
     class arifle_Katiba_C_F : arifle_Katiba_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=26.8;
     };
     class arifle_Katiba_GL_F : arifle_Katiba_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=28.7;
     };
     class arifle_MX_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=14.5;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=14.5;
     };
     class arifle_MX_SW_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=16.0;
     };
     class arifle_MXC_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=10.5;
     };
     class arifle_MXM_F: arifle_MX_Base_F
     {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=18;
     };
     class arifle_SDAR_F : SDAR_base_F 
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=18;
     };
     class SMG_02_F : SMG_02_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=7.7;
     };
     class arifle_TRG20_F : Tavor_base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=15;
     };
     class arifle_TRG21_F : Tavor_base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.1;
     };
     class LMG_Zafir_F : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18.1;
     };
     class arifle_Mk20_F : Mk20_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=17.4;
     };
     class arifle_Mk20C_F : Mk20_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class arifle_Mk20_GL_F : Mk20_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class SMG_01_F : SMG_01_Base
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5.5;
     };
     class srifle_DMR_01_F : DMR_01_base_F
     {
-        ACE_barrelTwist=9.5;
+        ACE_barrelTwist=0.2413;
         ACE_barrelLength=24;
     };
     class srifle_EBR_F : EBR_base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24;
     };
     class LMG_Mk200_F : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class srifle_LRR_F : LRR_base_F
     {
-        ACE_barrelTwist=13;
+        ACE_barrelTwist=0.3302;
         ACE_barrelLength=29;
     };
     class srifle_GM6_F : GM6_base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=43.3;
     };
     class srifle_DMR_02_F: DMR_02_base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=26;
     };
     class srifle_DMR_03_F: DMR_03_base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=20;
     };
     class srifle_DMR_04_F: DMR_04_base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=17.72;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F
     {
-        ACE_barrelTwist=14.17;
+        ACE_barrelTwist=0.359918;
         ACE_barrelLength=24.41;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class MMG_01_hex_F: MMG_01_base_F
     {
-        ACE_barrelTwist=14.17;
+        ACE_barrelTwist=0.359918;
         ACE_barrelLength=21.65;
     };
     class MMG_02_camo_F: MMG_02_base_F
     {
-        ACE_barrelTwist=9.25;
+        ACE_barrelTwist=0.23495;
         ACE_barrelLength=24;
     };
     class HMG_M2 : HMG_127
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=45;
     };
     
     class RH_deagle : Pistol_Base_F
     {
-        ACE_barrelTwist=19;
+        ACE_barrelTwist=0.4826;
         ACE_barrelLength=6;
     };
     class RH_sw659 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=7.44;
     };
     class RH_usp : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.41;
     };
     class RH_uspm : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=6;
     };
     class RH_mak : Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=3.68;
     };
     class RH_m1911 : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class RH_kimber : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class RH_m9 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.9;
     };
     class RH_vz61 : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class RH_tec9 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=5;
     };
     class RH_muzi : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=5;
     };
     class RH_g18 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.49;
     };
     class RH_g17 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.49;
     };
     class RH_tt33 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=4.6;
     };
     class RH_mk2 : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4;
     };
     class RH_p226 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.4;
     };
     class RH_g19 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4;
     };
     class RH_gsh18 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.1;
     };
     class RH_mateba : Pistol_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=6;
     };
     class RH_python : Pistol_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=6;
     };
     class RH_bull : Pistol_Base_F
     {
-        ACE_barrelTwist=24;
+        ACE_barrelTwist=0.6096;
         ACE_barrelLength=6.5;
     };
     class RH_ttracker : Pistol_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=4;
     };
     class RH_mp412 : Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=6;
     };
     class RH_fnp45 : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class RH_fn57 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.1;
+        ACE_barrelTwist=0.23114;
         ACE_barrelLength=4.8;	
     };
     class RH_vp70 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.6;
     };
     class RH_cz75 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.7;
+        ACE_barrelTwist=0.24638;
         ACE_barrelLength=4.7;
     };
     
     class RH_PDW : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10;
     };
     
     class RH_hb : Rifle_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=6;
     };
     class RH_sbr9 : Rifle_Base_F
     {
-        ACE_barrelTwist=9.7;
+        ACE_barrelTwist=0.24638;
         ACE_barrelLength=9;
     };
     class RH_ar10 : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=20.8;
     };
     class RH_m4 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class RH_M4m : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.5;
     };
     class RH_M4sbr : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.5;
     };
     class RH_M16a1 : Rifle_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=20;
     };
     class RH_M16A2 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A3 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A4 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A6 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_hk416 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class RH_hk416c : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9;
     };
     class RH_hk416s : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.4;
     };
     class RH_m27iar : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.5;
     };
     class RH_Mk12mod1 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class RH_SAMR : Rifle_Base_F
     {
-        ACE_barrelTwist=7.7;
+        ACE_barrelTwist=0.19558;
         ACE_barrelLength=20;
     };
     class RH_m110 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=20;
     };
     class RH_mk11 : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class RH_sr25ec : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=20;
     };
     
     class hlc_rifle_ak74 : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class hlc_rifle_aks74u : Rifle_Base_F
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=8.3;
     };
     class hlc_rifle_ak47 : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=16.3;
     };
     class hlc_rifle_akm : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class hlc_rifle_rpk : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=23.2;
     };
     class hlc_rifle_aek971 : Rifle_Base_F
     {
-        ACE_barrelTwist=9.5;
+        ACE_barrelTwist=0.2413;
         ACE_barrelLength=17;
     };
     class hlc_rifle_saiga12k : Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=16.9;
     };
     class hlc_ar15_base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=11.5;
     };
     class hlc_rifle_bcmjack : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class hlc_rifle_Bushmaster300 : Rifle_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=16;
     };
     class hlc_rifle_SAMR : Rifle_Base_F
     {
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=16;
     };
     class hlc_rifle_honeybase : Rifle_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=6;
     };
     class hlc_rifle_SLRchopmod : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };
     class hlc_rifle_LAR : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };
     class hlc_rifle_c1A1 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21.7;
     };
     class hlc_rifle_FAL5061 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18;
     };
     class hlc_rifle_STG58F : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };
     class hlc_rifle_SLR : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21.7;
     };
     class hlc_rifle_falosw : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=13;
     };
     class hlc_rifle_psg1 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=25.6;
     };
     class hlc_rifle_g3sg1 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17.7;
     };
     class hlc_rifle_hk51 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=8.31;
     };
     class hlc_rifle_hk53 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=8.31;
     };
     class hlc_rifle_g3a3 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17.7;
     };
     class hlc_M14_base : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class hlc_rifle_m14sopmod : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18;
     };
     class hlc_lmg_M60E4 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17;
     };
     class hlc_lmg_m60 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     
     class hlc_smg_mp5k_PDW : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.5;
     };
     class hlc_smg_mp5a2 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };
     class hlc_smg_mp5a4 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };
     class hlc_smg_mp5n : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };
     class hlc_smg_mp5sd5 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=5.7;
     };
     class hlc_smg_mp5sd6 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=5.7;
     };
     class hlc_smg_9mmar : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };
     class hlc_smg_mp510 : Rifle_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=8.9;
     };
     class hlc_smg_mp5a3 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };
             
     class hgun_mas_usp_F: Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.41;
     };
     class hgun_mas_m23_F: Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5.87;
     };
     class hgun_mas_acp_F: Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5.03;
     };
     class hgun_mas_m9_F: Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.9;
     };
     class hgun_mas_bhp_F: Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.7;
     };
     class hgun_mas_glock_F: Pistol_Base_F
     {
-        ACE_barrelTwist=9.84;
+        ACE_barrelTwist=0.249936;
         ACE_barrelLength=4.48;
     };
     class hgun_mas_glocksf_F: Pistol_Base_F
     {
-        ACE_barrelTwist=15.75;
+        ACE_barrelTwist=0.40005;
         ACE_barrelLength=4.60;
     };
     class hgun_mas_grach_F: Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.4;
     };
     class hgun_mas_mak_F: Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=3.68;
     };
     class hgun_mas_sa61_F: Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class hgun_mas_uzi_F: Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=5.28;
     };
     class arifle_mas_mk16 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=13.8;
     };
     class arifle_mas_mk16_l : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class arifle_mas_mk17 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=16;
     };
     class srifle_mas_m110 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=20;
     };
     class arifle_mas_ak_74m : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.34;
     };
     class arifle_mas_ak_74m_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.34;
     };
     class srifle_mas_svd : Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class srifle_mas_m91 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=29;
     };
     class srifle_mas_ksvk : Rifle_Base_F
     {
-        ACE_barrelTwist=18;
+        ACE_barrelTwist=0.4572;
         ACE_barrelLength=39.37;
     };
     class LMG_mas_rpk_F : Rifle_Base_F
     {
-        ACE_barrelTwist=7.68;
+        ACE_barrelTwist=0.195072;
         ACE_barrelLength=23.2;
     };
     class LMG_mas_pkm_F : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.4;
     };
     class arifle_mas_aks74u : Rifle_Base_F
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=8.3;
     };
     class arifle_mas_bizon : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=9.1;
     };
     class arifle_mas_saiga : Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=16.93;
     };
     class arifle_mas_hk416 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class arifle_mas_hk416_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class arifle_mas_hk416c : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9.0;
     };
     class arifle_mas_hk416_m203c : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9.0;
     };
     class arifle_mas_hk417c : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=13;
     };
     class arifle_mas_m4 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class arifle_mas_m4c : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.3;
     };
     class arifle_mas_l119 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class arifle_mas_l119_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class arifle_mas_l119_m203 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16;
     };
     class arifle_mas_m16 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class arifle_mas_m16_gl : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class srifle_mas_hk417 : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=16.5;
     };
     class srifle_mas_sr25 : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class srifle_mas_ebr : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18;
     };
     class srifle_mas_m24 : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class arifle_mas_mp5 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };
     class arifle_mas_mp5sd : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=5.7;
     };
     class srifle_mas_m107 : Rifle_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     class LMG_mas_M249_F : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.3;
     };
     class LMG_mas_M249a_F : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class LMG_mas_mk48_F : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=19.75;
     };
     class LMG_mas_m240_F : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     class LMG_mas_mg3_F : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22.2;
     };
     class arifle_mas_g3 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17.7;
     };
     class arifle_mas_g3_m203 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17.7;
     };
     class arifle_mas_fal : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };
     class arifle_mas_fal_m203 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };
     class arifle_mas_m1014 : Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=18.5;
     };
     
     class BWA3_P8 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.25;
     };
     class BWA3_MP7 : Pistol_Base_F
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=7.1;
     };
     class BWA3_G36 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.9;
     };
     class BWA3_G36K : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class BWA3_G28_Standard : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=16.5;
     };
     class BWA3_G27 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=16;
     };
     class BWA3_MG4 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.9;
     };
     class BWA3_MG5 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21.6;
     };
     class BWA3_G82 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     
     class Trixie_L131A1 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.5;
     };
     class Trixie_XM8_Carbine : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class Trixie_XM8_Compact : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9;
     };
     class Trixie_XM8_SAW : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class Trixie_XM8_SAW_NB : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class Trixie_XM8_DMR : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class Trixie_XM8_DMR_NB : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class L129A1_base : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=16;
     };
     class Trixie_Enfield : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=25.2;
     };
     class Trixie_CZ550_Rail : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=23.622;
     };
     class Trixie_FNFAL_Rail : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };
         
     class Trixie_M110 : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=20;
     };
     class Trixie_MK12 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class Trixie_LM308MWS : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=16;
     };
     class Trixie_M14DMR : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class Trixie_M14DMR_NG_Black_Short : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18;
     };
     class Trixie_M14DMR_NG_Short : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=18;
     };
     class Trixie_M14 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class Trixie_M40A3 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24;
     };
     class Trixie_CZ750 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=26;
     };
     class Trixie_M24 : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class Trixie_AWM338 : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=27;
     };
     class Trixie_M107 : Rifle_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     class Trixie_AS50 : Rifle_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     class L110A1_base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=13.7;
     };
     class Trixie_L86A2_base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=25.4;
     };
     class Trixie_l85a2_base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20.4;
     };
     class L7A2_base : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     
     class rhs_weap_pya : Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.4;
     };
     class rhs_weap_pkp : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.9;
     };
     class rhs_weap_pkm : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.4;
     };
     class rhs_weap_rpk74m : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7.68;
+        ACE_barrelTwist=0.195072;
         ACE_barrelLength=23.2;
     };
     class rhs_weap_rpk74 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7.68;
+        ACE_barrelTwist=0.195072;
         ACE_barrelLength=23.2;
     };
     class rhs_weap_ak74m : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class rhs_weap_aks74u : Rifle_Base_F
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=8.3;
     };
     class rhs_weap_akm : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class rhs_weap_svd : Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class rhs_weap_svds : Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=22.2;
     };
     class rhs_weap_m4_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class rhs_weap_m16a4 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class rhs_weap_m16a4_carryhandle : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class rhs_weap_m16a4_grip : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class rhs_weap_m240B : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     class rhs_weap_m249_pip : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.3;
     };
     class rhs_weap_mk18 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.3;
     };
     class rhs_weap_M590_5RD : Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=18.5;
     };
     class rhs_weap_M590_8RD : Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=20;
     };
     class rhs_weap_sr25 : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class rhs_weap_sr25_ec : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=20;
     };
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=24;
     };
     
     class R3F_PAMAS : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.9;
     };
     class R3F_Famas_F1: Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=19.2;
     };
     class R3F_Famas_surb: Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=15.9;
     };
     class R3F_Minimi: Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=13.7;
     };
     class R3F_Minimi_762: Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=19.8;
     };
     class R3F_FRF2: Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=25.59;
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=27.6;
     };
     class R3F_HK417S_HG : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=12;
     };
     class R3F_HK417M : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=16;
     };
     class R3F_HK417L : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=20;
     };
     class R3F_M107 : Rifle_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     class R3F_HK416M : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14;
     };
     class R3F_MP5SD : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=5.7;
     };
     
     class CUP_hgun_Colt1911 : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class CUP_sgun_AA12 : Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=18;		
     };
     class CUP_arifle_AK_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=16.3;
     };	
     class CUP_arifle_AK107_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class CUP_arifle_AKS_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class CUP_arifle_AKS74U : Rifle_Base_F
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=8.3;
     };
     class CUP_arifle_RPK74 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7.68;
+        ACE_barrelTwist=0.195072;
         ACE_barrelLength=23.2;
     };			
     class CUP_srifle_AS50 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     class CUP_srifle_AWM_Base : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=27;
     };	
     class CUP_smg_bizon : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=9.1;
     };
     class CUP_hgun_Compact : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=3.74;
     };	
     class CUP_srifle_CZ750 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=26;
     };	
     class CUP_arifle_CZ805_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=14;
     };
     class CUP_arifle_CZ805_A1 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=14;
     };
     class CUP_arifle_CZ805_A2 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=10.9;
     };
     class CUP_srifle_DMR : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };	
     class CUP_hgun_Duty : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=3.74;
     };
     class CUP_arifle_FNFAL : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=21;
     };	
     class CUP_arifle_G36A : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.9;
     };
     class CUP_arifle_G36K : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class CUP_arifle_G36C : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9;
     };
     class CUP_arifle_MG36 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18.9;
     };
     class CUP_hgun_Glock17 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.49;
     };	
     class CUP_srifle_CZ550 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=23.622;
     };	
     class CUP_srifle_ksvk : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=18;
+        ACE_barrelTwist=0.4572;
         ACE_barrelLength=39.37;
     };	
     class CUP_lmg_L7A2 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };	
     class CUP_arifle_L85A2_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20.4;
     };	
     class CUP_lmg_L110A1 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=13.7;
     };	
     class CUP_srifle_LeeEnfield : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=25.2;
     };
     class CUP_hgun_M9 : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.9;
     };
     class CUP_srifle_M14 : Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class CUP_arifle_M16_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=20;
     };
     class CUP_arifle_M4_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class CUP_srifle_Mk12SPR : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class CUP_srifle_M24_des : Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };	
     class CUP_lmg_M60A4 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17;
     };
     class CUP_srifle_M107_Base : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=29;
     };
     class CUP_srifle_M110 : Rifle_Base_F
     {
-        ACE_barrelTwist=11;
+        ACE_barrelTwist=0.2794;
         ACE_barrelLength=20;
     };
     class CUP_lmg_M240 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     class CUP_lmg_M249_para : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.3;
     };
     class CUP_lmg_M249 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class CUP_sgun_M1014 : Rifle_Base_F
     {
         ACE_twistDirection=0;
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_barrelLength=18.5;
     };	
     class CUP_hgun_Makarov : Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=3.68;
     };	
     class CUP_hgun_MicroUzi : Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=5;
     };	
     class CUP_lmg_Mk48_Base : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=19.75;
     };	
     class CUP_smg_MP5SD6 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=5.7;
     };
     class CUP_smg_MP5A5 : Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=8.9;
     };	
     class CUP_hgun_PB6P9 : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=4.1;
     };
     class CUP_hgun_Phantom : Rifle_Base_F
     {
-        ACE_barrelTwist=9.7;
+        ACE_barrelTwist=0.24638;
         ACE_barrelLength=4.7;
     };	
     class CUP_lmg_PKM : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.4;
     };
     class CUP_lmg_Pecheneg : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.9;
     };	
     class CUP_hgun_TaurusTracker455 : Pistol_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=4;
     };
     class CUP_arifle_Sa58P : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=15.4;
     };
     class CUP_arifle_Sa58V : Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=15.4;
     };
     class CUP_hgun_SA61 : Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class CUP_sgun_Saiga12K: Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=16.9;
     }	
     class CUP_arifle_Mk16_CQC : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10;
     };
     class CUP_arifle_Mk16_STD : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14;
     };
     class CUP_arifle_Mk16_SV : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };	
     class CUP_arifle_Mk17_CQC : Rifle_Base_F
     {	
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=13;
     };
     class CUP_arifle_Mk17_STD : Rifle_Base_F
     {	
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=16;
     };
     class CUP_arifle_Mk20 : Rifle_Base_F
     {	
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=20;
     };
     class CUP_srifle_SVD : Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class CUP_lmg_UK59 : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=21.7;
     };
     class CUP_DSHKM_W : MGun
     {
-        ACE_barrelTwist=15;
+        ACE_barrelTwist=0.381;
         ACE_barrelLength=42.1;
     };
     class CUP_KPVT_W : MGun
     {
-        ACE_barrelTwist=17.91;
+        ACE_barrelTwist=0.454914;
         ACE_barrelLength=53;
     };
     class CUP_KPVB_W : MGun
     {
-        ACE_barrelTwist=17.91;
+        ACE_barrelTwist=0.454914;
         ACE_barrelLength=53;
     };
     class CUP_M134 : MGunCore
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class CUP_M240_veh_W : Rifle_Long_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;		 	
     };
     class CUP_PKT_W : MGun
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=28.43;
     };
     class CUP_srifle_VSSVintorez : Rifle_Base_F
     {
-        ACE_barrelTwist=8.3;
+        ACE_barrelTwist=0.21082;
         ACE_barrelLength=7.9;
     };
     class CUP_arifle_XM8_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class CUP_arifle_XM8_Carbine : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class CUP_arifle_xm8_sharpshooter : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class CUP_arifle_xm8_SAW : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class CUP_arifle_XM8_Compact : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9;
     };
     class CUP_arifle_XM8_Railed_Base : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     class CUP_arifle_XM8_Carbine_FG : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=12.5;
     };
     
     class VTN_AK_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AK74M: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AK74M_GP25: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AK74M_GP30M: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AKS74: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AKS74N: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AKS74N_76: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AK74_76: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AKMS_aa: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=10.3;
     };
     class VTN_AKS74U_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=8.3;
     };
     class VTN_AKM_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AKMS: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AKMS_T_P: Rifle_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class VTN_AK103_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=16.3;
     };
     class VTN_AK104_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=12.4;
     };
     class VTN_AK105_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=12.4;
     };
     class VTN_AK105_P_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=12.4;
     };
     class VTN_SVD_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class VTN_SVD_63: Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class VTN_SVD_86: Rifle_Base_F
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class VTN_SV98_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=12.6;
+        ACE_barrelTwist=0.32004;
         ACE_barrelLength=25.59;
     };
     class VTN_PKM_BAS: Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.4;
     };
     class VTN_PKP: Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.9;
     };
     class VTN_PYA: Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.4;
     };
     class VTN_PM: Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=3.68;
     };
     class VTN_PB: Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=4.1;
     };
     class VTN_GSH18: Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.1;
     };
     class VTN_PSS: Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=1.4;
     };
     class VTN_PKT: Rifle_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=28.43;
     };
     class VTN_KORD: Rifle_Base_F
     {
-        ACE_barrelTwist=17.91;
+        ACE_barrelTwist=0.454914;
         ACE_barrelLength=53;
     };
     class VTN_KPVT: Rifle_Base_F
     {
-        ACE_barrelTwist=17.91;
+        ACE_barrelTwist=0.454914;
         ACE_barrelLength=53;
     };
     class VTN_C_M4A1 : Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class VTN_MK18MOD0: Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.3;
     };
     class VTN_M16_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=20;
     };
     class VTN_FN_SAMR_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=7.7;
+        ACE_barrelTwist=0.19558;
         ACE_barrelLength=20;
     };
     class VTN_M249_SAW_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class VTN_M249_PARA: Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.3;
     };
     class VTN_M240G_BASE: Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     class VTN_M9: Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.9;
     };
     class VTN_M45A1: Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class VTN_M24: Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class VTN_M240: Rifle_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     class VTN_KO44: Rifle_Base_F
     {
-        ACE_barrelTwist=9.5;
+        ACE_barrelTwist=0.2413;
         ACE_barrelLength=20.2;
     };
     class VTN_SAIGA_MK03: Rifle_Base_F

--- a/extras/CfgWeaponsReference.hpp
+++ b/extras/CfgWeaponsReference.hpp
@@ -28,1867 +28,1867 @@ class CfgWeapons
     class hgun_P07_F : Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class hgun_Rook40_F : Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class hgun_Pistol_heavy_01_F : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class hgun_Pistol_heavy_02_F : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=3;
+        ACE_barrelLength=0.0762;
     };
     class hgun_ACPC2_F : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class hgun_PDW2000_F : PDW2000_Base_F
     {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=7;
+        ACE_barrelLength=0.1778;
     };
     class arifle_Katiba_F : arifle_Katiba_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=28.7;
+        ACE_barrelLength=0.72898;
     };
     class arifle_Katiba_C_F : arifle_Katiba_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=26.8;
+        ACE_barrelLength=0.68072;
     };
     class arifle_Katiba_GL_F : arifle_Katiba_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=28.7;
+        ACE_barrelLength=0.72898;
     };
     class arifle_MX_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class arifle_MX_SW_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=16.0;
+        ACE_barrelLength=0.4064;
     };
     class arifle_MXC_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=10.5;
+        ACE_barrelLength=0.2667;
     };
     class arifle_MXM_F: arifle_MX_Base_F
     {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class arifle_SDAR_F : SDAR_base_F 
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class SMG_02_F : SMG_02_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=7.7;
+        ACE_barrelLength=0.19558;
     };
     class arifle_TRG20_F : Tavor_base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=15;
+        ACE_barrelLength=0.381;
     };
     class arifle_TRG21_F : Tavor_base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.1;
+        ACE_barrelLength=0.45974;
     };
     class LMG_Zafir_F : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18.1;
+        ACE_barrelLength=0.45974;
     };
     class arifle_Mk20_F : Mk20_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=17.4;
+        ACE_barrelLength=0.44196;
     };
     class arifle_Mk20C_F : Mk20_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class arifle_Mk20_GL_F : Mk20_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class SMG_01_F : SMG_01_Base
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5.5;
+        ACE_barrelLength=0.1397;
     };
     class srifle_DMR_01_F : DMR_01_base_F
     {
         ACE_barrelTwist=0.2413;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class srifle_EBR_F : EBR_base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class LMG_Mk200_F : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class srifle_LRR_F : LRR_base_F
     {
         ACE_barrelTwist=0.3302;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class srifle_GM6_F : GM6_base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=43.3;
+        ACE_barrelLength=1.09982;
     };
     class srifle_DMR_02_F: DMR_02_base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=26;
+        ACE_barrelLength=0.6604;
     };
     class srifle_DMR_03_F: DMR_03_base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class srifle_DMR_04_F: DMR_04_base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=17.72;
+        ACE_barrelLength=0.450088;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F
     {
         ACE_barrelTwist=0.359918;
-        ACE_barrelLength=24.41;
+        ACE_barrelLength=0.620014;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class MMG_01_hex_F: MMG_01_base_F
     {
         ACE_barrelTwist=0.359918;
-        ACE_barrelLength=21.65;
+        ACE_barrelLength=0.54991;
     };
     class MMG_02_camo_F: MMG_02_base_F
     {
         ACE_barrelTwist=0.23495;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class HMG_M2 : HMG_127
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=45;
+        ACE_barrelLength=1.143;
     };
     
     class RH_deagle : Pistol_Base_F
     {
         ACE_barrelTwist=0.4826;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_sw659 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=7.44;
+        ACE_barrelLength=0.188976;
     };
     class RH_usp : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.41;
+        ACE_barrelLength=0.112014;
     };
     class RH_uspm : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_mak : Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=3.68;
+        ACE_barrelLength=0.093472;
     };
     class RH_m1911 : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_kimber : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_m9 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.9;
+        ACE_barrelLength=0.12446;
     };
     class RH_vz61 : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class RH_tec9 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_muzi : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_g18 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.49;
+        ACE_barrelLength=0.114046;
     };
     class RH_g17 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.49;
+        ACE_barrelLength=0.114046;
     };
     class RH_tt33 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=4.6;
+        ACE_barrelLength=0.11684;
     };
     class RH_mk2 : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class RH_p226 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class RH_g19 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class RH_gsh18 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.1;
+        ACE_barrelLength=0.10414;
     };
     class RH_mateba : Pistol_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_python : Pistol_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_bull : Pistol_Base_F
     {
         ACE_barrelTwist=0.6096;
-        ACE_barrelLength=6.5;
+        ACE_barrelLength=0.1651;
     };
     class RH_ttracker : Pistol_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class RH_mp412 : Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_fnp45 : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class RH_fn57 : Pistol_Base_F
     {
         ACE_barrelTwist=0.23114;
-        ACE_barrelLength=4.8;	
+        ACE_barrelLength=0.12192;	
     };
     class RH_vp70 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.6;
+        ACE_barrelLength=0.11684;
     };
     class RH_cz75 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24638;
-        ACE_barrelLength=4.7;
+        ACE_barrelLength=0.11938;
     };
     
     class RH_PDW : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10;
+        ACE_barrelLength=0.254;
     };
     
     class RH_hb : Rifle_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_sbr9 : Rifle_Base_F
     {
         ACE_barrelTwist=0.24638;
-        ACE_barrelLength=9;
+        ACE_barrelLength=0.2286;
     };
     class RH_ar10 : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=20.8;
+        ACE_barrelLength=0.52832;
     };
     class RH_m4 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_M4m : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.5;
+        ACE_barrelLength=0.2667;
     };
     class RH_M4sbr : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.5;
+        ACE_barrelLength=0.2667;
     };
     class RH_M16a1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A2 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A3 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A4 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A6 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_hk416 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_hk416c : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9;
+        ACE_barrelLength=0.2286;
     };
     class RH_hk416s : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.4;
+        ACE_barrelLength=0.26416;
     };
     class RH_m27iar : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.5;
+        ACE_barrelLength=0.4191;
     };
     class RH_Mk12mod1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class RH_SAMR : Rifle_Base_F
     {
         ACE_barrelTwist=0.19558;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_m110 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_mk11 : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class RH_sr25ec : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     
     class hlc_rifle_ak74 : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class hlc_rifle_aks74u : Rifle_Base_F
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=8.3;
+        ACE_barrelLength=0.21082;
     };
     class hlc_rifle_ak47 : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class hlc_rifle_akm : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class hlc_rifle_rpk : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=23.2;
+        ACE_barrelLength=0.58928;
     };
     class hlc_rifle_aek971 : Rifle_Base_F
     {
         ACE_barrelTwist=0.2413;
-        ACE_barrelLength=17;
+        ACE_barrelLength=0.4318;
     };
     class hlc_rifle_saiga12k : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=16.9;
+        ACE_barrelLength=0.42926;
     };
     class hlc_ar15_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=11.5;
+        ACE_barrelLength=0.2921;
     };
     class hlc_rifle_bcmjack : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class hlc_rifle_Bushmaster300 : Rifle_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class hlc_rifle_SAMR : Rifle_Base_F
     {
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class hlc_rifle_honeybase : Rifle_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class hlc_rifle_SLRchopmod : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };
     class hlc_rifle_LAR : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };
     class hlc_rifle_c1A1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21.7;
+        ACE_barrelLength=0.55118;
     };
     class hlc_rifle_FAL5061 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class hlc_rifle_STG58F : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };
     class hlc_rifle_SLR : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21.7;
+        ACE_barrelLength=0.55118;
     };
     class hlc_rifle_falosw : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=13;
+        ACE_barrelLength=0.3302;
     };
     class hlc_rifle_psg1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=25.6;
+        ACE_barrelLength=0.65024;
     };
     class hlc_rifle_g3sg1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17.7;
+        ACE_barrelLength=0.44958;
     };
     class hlc_rifle_hk51 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=8.31;
+        ACE_barrelLength=0.211074;
     };
     class hlc_rifle_hk53 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=8.31;
+        ACE_barrelLength=0.211074;
     };
     class hlc_rifle_g3a3 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17.7;
+        ACE_barrelLength=0.44958;
     };
     class hlc_M14_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class hlc_rifle_m14sopmod : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class hlc_lmg_M60E4 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17;
+        ACE_barrelLength=0.4318;
     };
     class hlc_lmg_m60 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     
     class hlc_smg_mp5k_PDW : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class hlc_smg_mp5a2 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5a4 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5n : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5sd5 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=5.7;
+        ACE_barrelLength=0.14478;
     };
     class hlc_smg_mp5sd6 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=5.7;
+        ACE_barrelLength=0.14478;
     };
     class hlc_smg_9mmar : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp510 : Rifle_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
     class hlc_smg_mp5a3 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
             
     class hgun_mas_usp_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.41;
+        ACE_barrelLength=0.112014;
     };
     class hgun_mas_m23_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5.87;
+        ACE_barrelLength=0.149098;
     };
     class hgun_mas_acp_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5.03;
+        ACE_barrelLength=0.127762;
     };
     class hgun_mas_m9_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.9;
+        ACE_barrelLength=0.12446;
     };
     class hgun_mas_bhp_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.7;
+        ACE_barrelLength=0.11938;
     };
     class hgun_mas_glock_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.249936;
-        ACE_barrelLength=4.48;
+        ACE_barrelLength=0.113792;
     };
     class hgun_mas_glocksf_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.40005;
-        ACE_barrelLength=4.60;
+        ACE_barrelLength=0.11684;
     };
     class hgun_mas_grach_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class hgun_mas_mak_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=3.68;
+        ACE_barrelLength=0.093472;
     };
     class hgun_mas_sa61_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class hgun_mas_uzi_F: Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=5.28;
+        ACE_barrelLength=0.134112;
     };
     class arifle_mas_mk16 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=13.8;
+        ACE_barrelLength=0.35052;
     };
     class arifle_mas_mk16_l : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class arifle_mas_mk17 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class srifle_mas_m110 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class arifle_mas_ak_74m : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.34;
+        ACE_barrelLength=0.415036;
     };
     class arifle_mas_ak_74m_gl : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.34;
+        ACE_barrelLength=0.415036;
     };
     class srifle_mas_svd : Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class srifle_mas_m91 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class srifle_mas_ksvk : Rifle_Base_F
     {
         ACE_barrelTwist=0.4572;
-        ACE_barrelLength=39.37;
+        ACE_barrelLength=0.999998;
     };
     class LMG_mas_rpk_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.195072;
-        ACE_barrelLength=23.2;
+        ACE_barrelLength=0.58928;
     };
     class LMG_mas_pkm_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.4;
+        ACE_barrelLength=0.64516;
     };
     class arifle_mas_aks74u : Rifle_Base_F
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=8.3;
+        ACE_barrelLength=0.21082;
     };
     class arifle_mas_bizon : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=9.1;
+        ACE_barrelLength=0.23114;
     };
     class arifle_mas_saiga : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=16.93;
+        ACE_barrelLength=0.430022;
     };
     class arifle_mas_hk416 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class arifle_mas_hk416_gl : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class arifle_mas_hk416c : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9.0;
+        ACE_barrelLength=0.2286;
     };
     class arifle_mas_hk416_m203c : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9.0;
+        ACE_barrelLength=0.2286;
     };
     class arifle_mas_hk417c : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=13;
+        ACE_barrelLength=0.3302;
     };
     class arifle_mas_m4 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class arifle_mas_m4c : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.3;
+        ACE_barrelLength=0.26162;
     };
     class arifle_mas_l119 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class arifle_mas_l119_gl : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class arifle_mas_l119_m203 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class arifle_mas_m16 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class arifle_mas_m16_gl : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class srifle_mas_hk417 : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=16.5;
+        ACE_barrelLength=0.4191;
     };
     class srifle_mas_sr25 : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class srifle_mas_ebr : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class srifle_mas_m24 : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class arifle_mas_mp5 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };
     class arifle_mas_mp5sd : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=5.7;
+        ACE_barrelLength=0.14478;
     };
     class srifle_mas_m107 : Rifle_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class LMG_mas_M249_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class LMG_mas_M249a_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class LMG_mas_mk48_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=19.75;
+        ACE_barrelLength=0.50165;
     };
     class LMG_mas_m240_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     class LMG_mas_mg3_F : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22.2;
+        ACE_barrelLength=0.56388;
     };
     class arifle_mas_g3 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17.7;
+        ACE_barrelLength=0.44958;
     };
     class arifle_mas_g3_m203 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17.7;
+        ACE_barrelLength=0.44958;
     };
     class arifle_mas_fal : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };
     class arifle_mas_fal_m203 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };
     class arifle_mas_m1014 : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=18.5;
+        ACE_barrelLength=0.4699;
     };
     
     class BWA3_P8 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.25;
+        ACE_barrelLength=0.10795;
     };
     class BWA3_MP7 : Pistol_Base_F
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=7.1;
+        ACE_barrelLength=0.18034;
     };
     class BWA3_G36 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.9;
+        ACE_barrelLength=0.48006;
     };
     class BWA3_G36K : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class BWA3_G28_Standard : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=16.5;
+        ACE_barrelLength=0.4191;
     };
     class BWA3_G27 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class BWA3_MG4 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.9;
+        ACE_barrelLength=0.48006;
     };
     class BWA3_MG5 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21.6;
+        ACE_barrelLength=0.54864;
     };
     class BWA3_G82 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     
     class Trixie_L131A1 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class Trixie_XM8_Carbine : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class Trixie_XM8_Compact : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9;
+        ACE_barrelLength=0.2286;
     };
     class Trixie_XM8_SAW : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class Trixie_XM8_SAW_NB : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class Trixie_XM8_DMR : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class Trixie_XM8_DMR_NB : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class L129A1_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class Trixie_Enfield : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=25.2;
+        ACE_barrelLength=0.64008;
     };
     class Trixie_CZ550_Rail : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=23.622;
+        ACE_barrelLength=0.599999;
     };
     class Trixie_FNFAL_Rail : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };
         
     class Trixie_M110 : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class Trixie_MK12 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class Trixie_LM308MWS : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class Trixie_M14DMR : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class Trixie_M14DMR_NG_Black_Short : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class Trixie_M14DMR_NG_Short : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class Trixie_M14 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class Trixie_M40A3 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class Trixie_CZ750 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=26;
+        ACE_barrelLength=0.6604;
     };
     class Trixie_M24 : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class Trixie_AWM338 : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=27;
+        ACE_barrelLength=0.6858;
     };
     class Trixie_M107 : Rifle_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class Trixie_AS50 : Rifle_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class L110A1_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=13.7;
+        ACE_barrelLength=0.34798;
     };
     class Trixie_L86A2_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=25.4;
+        ACE_barrelLength=0.64516;
     };
     class Trixie_l85a2_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20.4;
+        ACE_barrelLength=0.51816;
     };
     class L7A2_base : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     
     class rhs_weap_pya : Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class rhs_weap_pkp : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.9;
+        ACE_barrelLength=0.65786;
     };
     class rhs_weap_pkm : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.4;
+        ACE_barrelLength=0.64516;
     };
     class rhs_weap_rpk74m : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.195072;
-        ACE_barrelLength=23.2;
+        ACE_barrelLength=0.58928;
     };
     class rhs_weap_rpk74 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.195072;
-        ACE_barrelLength=23.2;
+        ACE_barrelLength=0.58928;
     };
     class rhs_weap_ak74m : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class rhs_weap_aks74u : Rifle_Base_F
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=8.3;
+        ACE_barrelLength=0.21082;
     };
     class rhs_weap_akm : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class rhs_weap_svd : Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class rhs_weap_svds : Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=22.2;
+        ACE_barrelLength=0.56388;
     };
     class rhs_weap_m4_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class rhs_weap_m16a4 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_weap_m16a4_carryhandle : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_weap_m16a4_grip : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_weap_m240B : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     class rhs_weap_m249_pip : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class rhs_weap_mk18 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.3;
+        ACE_barrelLength=0.26162;
     };
     class rhs_weap_M590_5RD : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=18.5;
+        ACE_barrelLength=0.4699;
     };
     class rhs_weap_M590_8RD : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_weap_sr25 : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class rhs_weap_sr25_ec : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     
     class R3F_PAMAS : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.9;
+        ACE_barrelLength=0.12446;
     };
     class R3F_Famas_F1: Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=19.2;
+        ACE_barrelLength=0.48768;
     };
     class R3F_Famas_surb: Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=15.9;
+        ACE_barrelLength=0.40386;
     };
     class R3F_Minimi: Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=13.7;
+        ACE_barrelLength=0.34798;
     };
     class R3F_Minimi_762: Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=19.8;
+        ACE_barrelLength=0.50292;
     };
     class R3F_FRF2: Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=25.59;
+        ACE_barrelLength=0.649986;
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=27.6;
+        ACE_barrelLength=0.70104;
     };
     class R3F_HK417S_HG : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=12;
+        ACE_barrelLength=0.3048;
     };
     class R3F_HK417M : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class R3F_HK417L : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class R3F_M107 : Rifle_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class R3F_HK416M : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14;
+        ACE_barrelLength=0.3556;
     };
     class R3F_MP5SD : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=5.7;
+        ACE_barrelLength=0.14478;
     };
     
     class CUP_hgun_Colt1911 : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class CUP_sgun_AA12 : Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=18;		
+        ACE_barrelLength=0.4572;		
     };
     class CUP_arifle_AK_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };	
     class CUP_arifle_AK107_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class CUP_arifle_AKS_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class CUP_arifle_AKS74U : Rifle_Base_F
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=8.3;
+        ACE_barrelLength=0.21082;
     };
     class CUP_arifle_RPK74 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.195072;
-        ACE_barrelLength=23.2;
+        ACE_barrelLength=0.58928;
     };			
     class CUP_srifle_AS50 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class CUP_srifle_AWM_Base : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=27;
+        ACE_barrelLength=0.6858;
     };	
     class CUP_smg_bizon : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=9.1;
+        ACE_barrelLength=0.23114;
     };
     class CUP_hgun_Compact : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=3.74;
+        ACE_barrelLength=0.094996;
     };	
     class CUP_srifle_CZ750 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=26;
+        ACE_barrelLength=0.6604;
     };	
     class CUP_arifle_CZ805_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=14;
+        ACE_barrelLength=0.3556;
     };
     class CUP_arifle_CZ805_A1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=14;
+        ACE_barrelLength=0.3556;
     };
     class CUP_arifle_CZ805_A2 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=10.9;
+        ACE_barrelLength=0.27686;
     };
     class CUP_srifle_DMR : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };	
     class CUP_hgun_Duty : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=3.74;
+        ACE_barrelLength=0.094996;
     };
     class CUP_arifle_FNFAL : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=21;
+        ACE_barrelLength=0.5334;
     };	
     class CUP_arifle_G36A : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.9;
+        ACE_barrelLength=0.48006;
     };
     class CUP_arifle_G36K : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class CUP_arifle_G36C : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9;
+        ACE_barrelLength=0.2286;
     };
     class CUP_arifle_MG36 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18.9;
+        ACE_barrelLength=0.48006;
     };
     class CUP_hgun_Glock17 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.49;
+        ACE_barrelLength=0.114046;
     };	
     class CUP_srifle_CZ550 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=23.622;
+        ACE_barrelLength=0.599999;
     };	
     class CUP_srifle_ksvk : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.4572;
-        ACE_barrelLength=39.37;
+        ACE_barrelLength=0.999998;
     };	
     class CUP_lmg_L7A2 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };	
     class CUP_arifle_L85A2_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20.4;
+        ACE_barrelLength=0.51816;
     };	
     class CUP_lmg_L110A1 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=13.7;
+        ACE_barrelLength=0.34798;
     };	
     class CUP_srifle_LeeEnfield : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=25.2;
+        ACE_barrelLength=0.64008;
     };
     class CUP_hgun_M9 : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.9;
+        ACE_barrelLength=0.12446;
     };
     class CUP_srifle_M14 : Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class CUP_arifle_M16_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class CUP_arifle_M4_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class CUP_srifle_Mk12SPR : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class CUP_srifle_M24_des : Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };	
     class CUP_lmg_M60A4 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17;
+        ACE_barrelLength=0.4318;
     };
     class CUP_srifle_M107_Base : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=29;
+        ACE_barrelLength=0.7366;
     };
     class CUP_srifle_M110 : Rifle_Base_F
     {
         ACE_barrelTwist=0.2794;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class CUP_lmg_M240 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     class CUP_lmg_M249_para : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class CUP_lmg_M249 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class CUP_sgun_M1014 : Rifle_Base_F
     {
         ACE_twistDirection=0;
         ACE_barrelTwist=0.0;
-        ACE_barrelLength=18.5;
+        ACE_barrelLength=0.4699;
     };	
     class CUP_hgun_Makarov : Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=3.68;
+        ACE_barrelLength=0.093472;
     };	
     class CUP_hgun_MicroUzi : Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };	
     class CUP_lmg_Mk48_Base : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=19.75;
+        ACE_barrelLength=0.50165;
     };	
     class CUP_smg_MP5SD6 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=5.7;
+        ACE_barrelLength=0.14478;
     };
     class CUP_smg_MP5A5 : Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=8.9;
+        ACE_barrelLength=0.22606;
     };	
     class CUP_hgun_PB6P9 : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=4.1;
+        ACE_barrelLength=0.10414;
     };
     class CUP_hgun_Phantom : Rifle_Base_F
     {
         ACE_barrelTwist=0.24638;
-        ACE_barrelLength=4.7;
+        ACE_barrelLength=0.11938;
     };	
     class CUP_lmg_PKM : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.4;
+        ACE_barrelLength=0.64516;
     };
     class CUP_lmg_Pecheneg : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.9;
+        ACE_barrelLength=0.65786;
     };	
     class CUP_hgun_TaurusTracker455 : Pistol_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class CUP_arifle_Sa58P : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=15.4;
+        ACE_barrelLength=0.39116;
     };
     class CUP_arifle_Sa58V : Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=15.4;
+        ACE_barrelLength=0.39116;
     };
     class CUP_hgun_SA61 : Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class CUP_sgun_Saiga12K: Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=16.9;
+        ACE_barrelLength=0.42926;
     }	
     class CUP_arifle_Mk16_CQC : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10;
+        ACE_barrelLength=0.254;
     };
     class CUP_arifle_Mk16_STD : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14;
+        ACE_barrelLength=0.3556;
     };
     class CUP_arifle_Mk16_SV : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };	
     class CUP_arifle_Mk17_CQC : Rifle_Base_F
     {	
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=13;
+        ACE_barrelLength=0.3302;
     };
     class CUP_arifle_Mk17_STD : Rifle_Base_F
     {	
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
     };
     class CUP_arifle_Mk20 : Rifle_Base_F
     {	
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class CUP_srifle_SVD : Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class CUP_lmg_UK59 : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=21.7;
+        ACE_barrelLength=0.55118;
     };
     class CUP_DSHKM_W : MGun
     {
         ACE_barrelTwist=0.381;
-        ACE_barrelLength=42.1;
+        ACE_barrelLength=1.06934;
     };
     class CUP_KPVT_W : MGun
     {
         ACE_barrelTwist=0.454914;
-        ACE_barrelLength=53;
+        ACE_barrelLength=1.3462;
     };
     class CUP_KPVB_W : MGun
     {
         ACE_barrelTwist=0.454914;
-        ACE_barrelLength=53;
+        ACE_barrelLength=1.3462;
     };
     class CUP_M134 : MGunCore
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class CUP_M240_veh_W : Rifle_Long_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;		 	
+        ACE_barrelLength=0.62992;		 	
     };
     class CUP_PKT_W : MGun
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=28.43;
+        ACE_barrelLength=0.722122;
     };
     class CUP_srifle_VSSVintorez : Rifle_Base_F
     {
         ACE_barrelTwist=0.21082;
-        ACE_barrelLength=7.9;
+        ACE_barrelLength=0.20066;
     };
     class CUP_arifle_XM8_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class CUP_arifle_XM8_Carbine : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class CUP_arifle_xm8_sharpshooter : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class CUP_arifle_xm8_SAW : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class CUP_arifle_XM8_Compact : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9;
+        ACE_barrelLength=0.2286;
     };
     class CUP_arifle_XM8_Railed_Base : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     class CUP_arifle_XM8_Carbine_FG : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=12.5;
+        ACE_barrelLength=0.3175;
     };
     
     class VTN_AK_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AK74M: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AK74M_GP25: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AK74M_GP30M: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AKS74: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AKS74N: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AKS74N_76: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AK74_76: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AKMS_aa: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=10.3;
+        ACE_barrelLength=0.26162;
     };
     class VTN_AKS74U_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=8.3;
+        ACE_barrelLength=0.21082;
     };
     class VTN_AKM_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AKMS: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AKMS_T_P: Rifle_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AK103_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_AK104_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=12.4;
+        ACE_barrelLength=0.31496;
     };
     class VTN_AK105_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=12.4;
+        ACE_barrelLength=0.31496;
     };
     class VTN_AK105_P_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=12.4;
+        ACE_barrelLength=0.31496;
     };
     class VTN_SVD_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class VTN_SVD_63: Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class VTN_SVD_86: Rifle_Base_F
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class VTN_SV98_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.32004;
-        ACE_barrelLength=25.59;
+        ACE_barrelLength=0.649986;
     };
     class VTN_PKM_BAS: Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.4;
+        ACE_barrelLength=0.64516;
     };
     class VTN_PKP: Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.9;
+        ACE_barrelLength=0.65786;
     };
     class VTN_PYA: Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class VTN_PM: Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=3.68;
+        ACE_barrelLength=0.093472;
     };
     class VTN_PB: Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=4.1;
+        ACE_barrelLength=0.10414;
     };
     class VTN_GSH18: Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.1;
+        ACE_barrelLength=0.10414;
     };
     class VTN_PSS: Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=1.4;
+        ACE_barrelLength=0.03556;
     };
     class VTN_PKT: Rifle_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=28.43;
+        ACE_barrelLength=0.722122;
     };
     class VTN_KORD: Rifle_Base_F
     {
         ACE_barrelTwist=0.454914;
-        ACE_barrelLength=53;
+        ACE_barrelLength=1.3462;
     };
     class VTN_KPVT: Rifle_Base_F
     {
         ACE_barrelTwist=0.454914;
-        ACE_barrelLength=53;
+        ACE_barrelLength=1.3462;
     };
     class VTN_C_M4A1 : Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class VTN_MK18MOD0: Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.3;
+        ACE_barrelLength=0.26162;
     };
     class VTN_M16_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class VTN_FN_SAMR_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.19558;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class VTN_M249_SAW_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class VTN_M249_PARA: Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class VTN_M240G_BASE: Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     class VTN_M9: Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.9;
+        ACE_barrelLength=0.12446;
     };
     class VTN_M45A1: Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class VTN_M24: Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class VTN_M240: Rifle_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     class VTN_KO44: Rifle_Base_F
     {
         ACE_barrelTwist=0.2413;
-        ACE_barrelLength=20.2;
+        ACE_barrelLength=0.51308;
     };
     class VTN_SAIGA_MK03: Rifle_Base_F
     {
         ACE_twistDirection=9.45;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
 };

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball: BulletBase
 	{
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -19,7 +19,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_Green: CUP_B_545x39_Ball
 	{
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -32,7 +32,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_Red: BulletBase
 	{
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -45,7 +45,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_White: BulletBase
 	{
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -58,7 +58,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
 	{
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -71,7 +71,7 @@ class CfgAmmo
 	class CUP_B_762x39_Ball: BulletBase
 	{
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -84,7 +84,7 @@ class CfgAmmo
 	class CUP_B_762x39_Ball_Tracer_Green: BulletBase
 	{
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -97,7 +97,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -110,7 +110,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -123,7 +123,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -136,7 +136,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -149,7 +149,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -162,7 +162,7 @@ class CfgAmmo
 	class CUP_B_9x19_Ball: BulletBase
 	{
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -175,7 +175,7 @@ class CfgAmmo
 	class CUP_B_762x51_noTracer: B_762x51_Ball
 	{
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -188,7 +188,7 @@ class CfgAmmo
 	class CUP_B_303_Ball: BulletBase
 	{
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -201,7 +201,7 @@ class CfgAmmo
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -214,7 +214,7 @@ class CfgAmmo
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -227,7 +227,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -240,7 +240,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -253,7 +253,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -266,7 +266,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -279,7 +279,7 @@ class CfgAmmo
 	class CUP_B_9x39_SP5: BulletBase
 	{
         ACE_caliber=9.246;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -292,7 +292,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -305,7 +305,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -318,7 +318,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -331,7 +331,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_White: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -344,7 +344,7 @@ class CfgAmmo
 	class B_127x107_Ball: BulletBase
 	{
         ACE_caliber=12.979;
-        ACE_bulletLength=0.064008;
+        ACE_bulletLength=64.008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -357,7 +357,7 @@ class CfgAmmo
 	class CUP_B_9x18_SD: BulletBase
 	{
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -370,7 +370,7 @@ class CfgAmmo
 	class CUP_B_765x17_Ball: BulletBase
 	{
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -383,7 +383,7 @@ class CfgAmmo
 	class CUP_B_145x115_AP_Green_Tracer: BulletBase
 	{
         ACE_caliber=14.884;
-        ACE_bulletLength=0.0508;
+        ACE_bulletLength=50.8;
         ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
@@ -396,7 +396,7 @@ class CfgAmmo
 	class CUP_B_127x99_Ball_White_Tracer: B_127x99_Ball
 	{
         ACE_caliber=12.954;
-        ACE_bulletLength=0.058674;
+        ACE_bulletLength=58.674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -409,7 +409,7 @@ class CfgAmmo
 	class CUP_B_86x70_Ball_noTracer: BulletBase
 	{
         ACE_caliber=8.585;
-        ACE_bulletLength=0.04318;
+        ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -14,7 +14,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
 	class CUP_B_545x39_Ball_Tracer_Green: CUP_B_545x39_Ball
 	{
@@ -27,7 +27,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
 	class CUP_B_545x39_Ball_Tracer_Red: BulletBase
 	{
@@ -40,7 +40,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
 	class CUP_B_545x39_Ball_Tracer_White: BulletBase
 	{
@@ -53,7 +53,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
 	class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
 	{
@@ -66,7 +66,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
 	class CUP_B_762x39_Ball: BulletBase
 	{
@@ -79,7 +79,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
 	class CUP_B_762x39_Ball_Tracer_Green: BulletBase
 	{
@@ -92,7 +92,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
     class CUP_B_9x18_Ball: BulletBase
     {
@@ -105,7 +105,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
@@ -118,7 +118,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
@@ -131,7 +131,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
@@ -144,7 +144,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
@@ -157,7 +157,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
 	class CUP_B_9x19_Ball: BulletBase
 	{
@@ -170,7 +170,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
 	};
 	class CUP_B_762x51_noTracer: B_762x51_Ball
 	{
@@ -183,7 +183,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
 	};
 	class CUP_B_303_Ball: BulletBase
 	{
@@ -196,7 +196,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
 	};
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
@@ -209,7 +209,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
@@ -222,7 +222,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
@@ -235,7 +235,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
@@ -248,7 +248,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
@@ -261,7 +261,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
@@ -274,7 +274,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
 	class CUP_B_9x39_SP5: BulletBase
 	{
@@ -287,7 +287,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
 	};
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
@@ -300,7 +300,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
@@ -313,7 +313,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
@@ -326,7 +326,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
@@ -339,7 +339,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
 	class B_127x107_Ball: BulletBase
 	{
@@ -352,7 +352,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={0.72898};
+        ACE_barrelLengths[]={728.98};
 	};
 	class CUP_B_9x18_SD: BulletBase
 	{
@@ -365,7 +365,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 340};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
 	};
 	class CUP_B_765x17_Ball: BulletBase
 	{
@@ -378,7 +378,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
 	};
 	class CUP_B_145x115_AP_Green_Tracer: BulletBase
 	{
@@ -391,7 +391,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1000};
-        ACE_barrelLengths[]={1.3462};
+        ACE_barrelLengths[]={1346.2};
 	};
 	class CUP_B_127x99_Ball_White_Tracer: B_127x99_Ball
 	{
@@ -404,7 +404,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
 	};
 	class CUP_B_86x70_Ball_noTracer: BulletBase
 	{
@@ -417,6 +417,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 826, 830};
-        ACE_barrelLengths[]={0.6096, 0.6731, 0.7112};
+        ACE_barrelLengths[]={609.6, 673.1, 711.2};
 	};
 };

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -14,7 +14,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
 	class CUP_B_545x39_Ball_Tracer_Green: CUP_B_545x39_Ball
 	{
@@ -27,7 +27,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
 	class CUP_B_545x39_Ball_Tracer_Red: BulletBase
 	{
@@ -40,7 +40,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
 	class CUP_B_545x39_Ball_Tracer_White: BulletBase
 	{
@@ -53,7 +53,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
 	class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
 	{
@@ -66,7 +66,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
 	class CUP_B_762x39_Ball: BulletBase
 	{
@@ -79,7 +79,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
 	class CUP_B_762x39_Ball_Tracer_Green: BulletBase
 	{
@@ -92,7 +92,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
     class CUP_B_9x18_Ball: BulletBase
     {
@@ -105,7 +105,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
@@ -118,7 +118,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
@@ -131,7 +131,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
@@ -144,7 +144,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
@@ -157,7 +157,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
 	class CUP_B_9x19_Ball: BulletBase
 	{
@@ -170,7 +170,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
 	};
 	class CUP_B_762x51_noTracer: B_762x51_Ball
 	{
@@ -183,7 +183,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
 	};
 	class CUP_B_303_Ball: BulletBase
 	{
@@ -196,7 +196,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
 	};
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
@@ -209,7 +209,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
@@ -222,7 +222,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
@@ -235,7 +235,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
@@ -248,7 +248,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
@@ -261,7 +261,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
@@ -274,7 +274,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
 	class CUP_B_9x39_SP5: BulletBase
 	{
@@ -287,7 +287,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={280, 300, 320};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
 	};
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
@@ -300,7 +300,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
@@ -313,7 +313,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
@@ -326,7 +326,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
@@ -339,7 +339,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
 	class B_127x107_Ball: BulletBase
 	{
@@ -352,7 +352,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={28.7};
+        ACE_barrelLengths[]={0.72898};
 	};
 	class CUP_B_9x18_SD: BulletBase
 	{
@@ -365,7 +365,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 340};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
 	};
 	class CUP_B_765x17_Ball: BulletBase
 	{
@@ -378,7 +378,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
 	};
 	class CUP_B_145x115_AP_Green_Tracer: BulletBase
 	{
@@ -391,7 +391,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1000};
-        ACE_barrelLengths[]={53};
+        ACE_barrelLengths[]={1.3462};
 	};
 	class CUP_B_127x99_Ball_White_Tracer: B_127x99_Ball
 	{
@@ -404,7 +404,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={853};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
 	};
 	class CUP_B_86x70_Ball_noTracer: BulletBase
 	{
@@ -417,6 +417,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={820, 826, 830};
-        ACE_barrelLengths[]={24, 26.5, 28};
+        ACE_barrelLengths[]={0.6096, 0.6731, 0.7112};
 	};
 };

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
 	class B_127x99_Ball;
 	class CUP_B_545x39_Ball: BulletBase
 	{
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -18,7 +18,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_Green: CUP_B_545x39_Ball
 	{
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -31,7 +31,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_Red: BulletBase
 	{
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -44,7 +44,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_White: BulletBase
 	{
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -57,7 +57,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
 	{
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -70,7 +70,7 @@ class CfgAmmo
 	};
 	class CUP_B_762x39_Ball: BulletBase
 	{
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -83,7 +83,7 @@ class CfgAmmo
 	};
 	class CUP_B_762x39_Ball_Tracer_Green: BulletBase
 	{
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -96,7 +96,7 @@ class CfgAmmo
 	};
     class CUP_B_9x18_Ball: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -109,7 +109,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -122,7 +122,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -135,7 +135,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -148,7 +148,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -161,7 +161,7 @@ class CfgAmmo
     };
 	class CUP_B_9x19_Ball: BulletBase
 	{
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -174,7 +174,7 @@ class CfgAmmo
 	};
 	class CUP_B_762x51_noTracer: B_762x51_Ball
 	{
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -187,7 +187,7 @@ class CfgAmmo
 	};
 	class CUP_B_303_Ball: BulletBase
 	{
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -200,7 +200,7 @@ class CfgAmmo
 	};
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -213,7 +213,7 @@ class CfgAmmo
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -226,7 +226,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -239,7 +239,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -252,7 +252,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -265,7 +265,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -278,7 +278,7 @@ class CfgAmmo
     };
 	class CUP_B_9x39_SP5: BulletBase
 	{
-        ACE_caliber=0.364;
+        ACE_caliber=0.009246;
         ACE_bulletLength=1.24;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -291,7 +291,7 @@ class CfgAmmo
 	};
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -304,7 +304,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -317,7 +317,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -330,7 +330,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -343,7 +343,7 @@ class CfgAmmo
     };
 	class B_127x107_Ball: BulletBase
 	{
-        ACE_caliber=0.511;
+        ACE_caliber=0.012979;
         ACE_bulletLength=2.520;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -356,7 +356,7 @@ class CfgAmmo
 	};
 	class CUP_B_9x18_SD: BulletBase
 	{
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -369,7 +369,7 @@ class CfgAmmo
 	};
 	class CUP_B_765x17_Ball: BulletBase
 	{
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -382,7 +382,7 @@ class CfgAmmo
 	};
 	class CUP_B_145x115_AP_Green_Tracer: BulletBase
 	{
-        ACE_caliber=0.586;
+        ACE_caliber=0.014884;
         ACE_bulletLength=2.00;
         ACE_bulletMass=1010;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -395,7 +395,7 @@ class CfgAmmo
 	};
 	class CUP_B_127x99_Ball_White_Tracer: B_127x99_Ball
 	{
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.310;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -408,7 +408,7 @@ class CfgAmmo
 	};
 	class CUP_B_86x70_Ball_noTracer: BulletBase
 	{
-        ACE_caliber=0.338;
+        ACE_caliber=0.008585;
         ACE_bulletLength=1.70;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -7,7 +7,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -20,7 +20,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -33,7 +33,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -46,7 +46,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -59,7 +59,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -72,7 +72,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -85,7 +85,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -98,7 +98,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -111,7 +111,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -124,7 +124,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -137,7 +137,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -150,7 +150,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -163,7 +163,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -176,7 +176,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -189,7 +189,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -202,7 +202,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -215,7 +215,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -228,7 +228,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -241,7 +241,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -254,7 +254,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -267,7 +267,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -280,7 +280,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.009246;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=250;
+        ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -293,7 +293,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -306,7 +306,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -319,7 +319,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -332,7 +332,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -345,7 +345,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.012979;
         ACE_bulletLength=0.064008;
-        ACE_bulletMass=745;
+        ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
         ACE_velocityBoundaries[]={};
@@ -358,7 +358,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -371,7 +371,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -384,7 +384,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.014884;
         ACE_bulletLength=0.0508;
-        ACE_bulletMass=1010;
+        ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
         ACE_velocityBoundaries[]={};
@@ -397,7 +397,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.012954;
         ACE_bulletLength=0.058674;
-        ACE_bulletMass=647;
+        ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};
@@ -410,7 +410,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.008585;
         ACE_bulletLength=0.04318;
-        ACE_bulletMass=300;
+        ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
 	class B_127x99_Ball;
 	class CUP_B_545x39_Ball: BulletBase
 	{
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -18,7 +18,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_Green: CUP_B_545x39_Ball
 	{
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -31,7 +31,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_Red: BulletBase
 	{
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -44,7 +44,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_White: BulletBase
 	{
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -57,7 +57,7 @@ class CfgAmmo
 	};
 	class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
 	{
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -70,7 +70,7 @@ class CfgAmmo
 	};
 	class CUP_B_762x39_Ball: BulletBase
 	{
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -83,7 +83,7 @@ class CfgAmmo
 	};
 	class CUP_B_762x39_Ball_Tracer_Green: BulletBase
 	{
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -96,7 +96,7 @@ class CfgAmmo
 	};
     class CUP_B_9x18_Ball: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -109,7 +109,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -122,7 +122,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -135,7 +135,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -148,7 +148,7 @@ class CfgAmmo
     };
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -161,7 +161,7 @@ class CfgAmmo
     };
 	class CUP_B_9x19_Ball: BulletBase
 	{
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -174,7 +174,7 @@ class CfgAmmo
 	};
 	class CUP_B_762x51_noTracer: B_762x51_Ball
 	{
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -187,7 +187,7 @@ class CfgAmmo
 	};
 	class CUP_B_303_Ball: BulletBase
 	{
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -200,7 +200,7 @@ class CfgAmmo
 	};
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -213,7 +213,7 @@ class CfgAmmo
     };
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -226,7 +226,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -239,7 +239,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -252,7 +252,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -265,7 +265,7 @@ class CfgAmmo
     };
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -278,7 +278,7 @@ class CfgAmmo
     };
 	class CUP_B_9x39_SP5: BulletBase
 	{
-        ACE_caliber=0.009246;
+        ACE_caliber=9.246;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=16.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -291,7 +291,7 @@ class CfgAmmo
 	};
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -304,7 +304,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -317,7 +317,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -330,7 +330,7 @@ class CfgAmmo
     };
     class CUP_B_762x51_Tracer_White: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -343,7 +343,7 @@ class CfgAmmo
     };
 	class B_127x107_Ball: BulletBase
 	{
-        ACE_caliber=0.012979;
+        ACE_caliber=12.979;
         ACE_bulletLength=0.064008;
         ACE_bulletMass=48.276;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -356,7 +356,7 @@ class CfgAmmo
 	};
 	class CUP_B_9x18_SD: BulletBase
 	{
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -369,7 +369,7 @@ class CfgAmmo
 	};
 	class CUP_B_765x17_Ball: BulletBase
 	{
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -382,7 +382,7 @@ class CfgAmmo
 	};
 	class CUP_B_145x115_AP_Green_Tracer: BulletBase
 	{
-        ACE_caliber=0.014884;
+        ACE_caliber=14.884;
         ACE_bulletLength=0.0508;
         ACE_bulletMass=65.448;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -395,7 +395,7 @@ class CfgAmmo
 	};
 	class CUP_B_127x99_Ball_White_Tracer: B_127x99_Ball
 	{
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.058674;
         ACE_bulletMass=41.9256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -408,7 +408,7 @@ class CfgAmmo
 	};
 	class CUP_B_86x70_Ball_noTracer: BulletBase
 	{
-        ACE_caliber=0.008585;
+        ACE_caliber=8.585;
         ACE_bulletLength=0.04318;
         ACE_bulletMass=19.44;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};

--- a/optionals/compat_cup/CfgAmmo.hpp
+++ b/optionals/compat_cup/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball: BulletBase
 	{
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -19,7 +19,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_Green: CUP_B_545x39_Ball
 	{
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -32,7 +32,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_Red: BulletBase
 	{
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -45,7 +45,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_White: BulletBase
 	{
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -58,7 +58,7 @@ class CfgAmmo
 	class CUP_B_545x39_Ball_Tracer_Yellow: BulletBase
 	{
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -71,7 +71,7 @@ class CfgAmmo
 	class CUP_B_762x39_Ball: BulletBase
 	{
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -84,7 +84,7 @@ class CfgAmmo
 	class CUP_B_762x39_Ball_Tracer_Green: BulletBase
 	{
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -97,7 +97,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -110,7 +110,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Green: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -123,7 +123,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Red: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -136,7 +136,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_Tracer_Yellow: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -149,7 +149,7 @@ class CfgAmmo
     class CUP_B_9x18_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -162,7 +162,7 @@ class CfgAmmo
 	class CUP_B_9x19_Ball: BulletBase
 	{
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -175,7 +175,7 @@ class CfgAmmo
 	class CUP_B_762x51_noTracer: B_762x51_Ball
 	{
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -188,7 +188,7 @@ class CfgAmmo
 	class CUP_B_303_Ball: BulletBase
 	{
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -201,7 +201,7 @@ class CfgAmmo
     class CUP_B_127x107_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -214,7 +214,7 @@ class CfgAmmo
     class CUP_B_127x108_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -227,7 +227,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_White_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -240,7 +240,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Red_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -253,7 +253,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Green_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -266,7 +266,7 @@ class CfgAmmo
     class CUP_B_762x54_Ball_Yellow_Tracer: BulletBase
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -279,7 +279,7 @@ class CfgAmmo
 	class CUP_B_9x39_SP5: BulletBase
 	{
         ACE_caliber=0.009246;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=250;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.275};
@@ -292,7 +292,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Green: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -305,7 +305,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Red: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -318,7 +318,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_Yellow: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -331,7 +331,7 @@ class CfgAmmo
     class CUP_B_762x51_Tracer_White: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -344,7 +344,7 @@ class CfgAmmo
 	class B_127x107_Ball: BulletBase
 	{
         ACE_caliber=0.012979;
-        ACE_bulletLength=2.520;
+        ACE_bulletLength=0.064008;
         ACE_bulletMass=745;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.63};
@@ -357,7 +357,7 @@ class CfgAmmo
 	class CUP_B_9x18_SD: BulletBase
 	{
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -370,7 +370,7 @@ class CfgAmmo
 	class CUP_B_765x17_Ball: BulletBase
 	{
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -383,7 +383,7 @@ class CfgAmmo
 	class CUP_B_145x115_AP_Green_Tracer: BulletBase
 	{
         ACE_caliber=0.014884;
-        ACE_bulletLength=2.00;
+        ACE_bulletLength=0.0508;
         ACE_bulletMass=1010;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.620};
@@ -396,7 +396,7 @@ class CfgAmmo
 	class CUP_B_127x99_Ball_White_Tracer: B_127x99_Ball
 	{
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.310;
+        ACE_bulletLength=0.058674;
         ACE_bulletMass=647;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
@@ -409,7 +409,7 @@ class CfgAmmo
 	class CUP_B_86x70_Ball_noTracer: BulletBase
 	{
         ACE_caliber=0.008585;
-        ACE_bulletLength=1.70;
+        ACE_bulletLength=0.04318;
         ACE_bulletMass=300;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.381};

--- a/optionals/compat_hlc_ar15/CfgWeapons.hpp
+++ b/optionals/compat_hlc_ar15/CfgWeapons.hpp
@@ -4,62 +4,62 @@ class CfgWeapons
 	class Rifle_Base_F;
 	class hlc_ar15_base: Rifle_Base_F
 	{
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=11.5;
 	};
 	class hlc_rifle_RU556: hlc_ar15_base
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=10.3;
 	};
 	class hlc_rifle_RU5562: hlc_rifle_RU556
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=10.3;
 	};
 	class hlc_rifle_CQBR: hlc_rifle_RU556
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=10;
 	};
 	class hlc_rifle_M4: hlc_rifle_RU556
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=14.5;
 	};
 	class hlc_rifle_bcmjack: hlc_ar15_base
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=14.5;
 	};
 	class hlc_rifle_Colt727: hlc_ar15_base
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=14.5;
 	};
 	class hlc_rifle_Colt727_GL: hlc_rifle_Colt727
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=14.5;
 	};
 	class hlc_rifle_Bushmaster300: hlc_rifle_Colt727
 	{
-		ACE_barrelTwist=8;
+		ACE_barrelTwist=0.2032;
 		ACE_barrelLength=14.5;
 	};
 	class hlc_rifle_vendimus: hlc_rifle_Bushmaster300
 	{
-		ACE_barrelTwist=8;
+		ACE_barrelTwist=0.2032;
 		ACE_barrelLength=16;
 	};
 	class hlc_rifle_SAMR: hlc_rifle_RU556
 	{
-        ACE_barrelTwist=9;
+        ACE_barrelTwist=0.2286;
         ACE_barrelLength=16;
 	};
 	class hlc_rifle_honeybase: hlc_rifle_RU556
 	{
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=6;
 	};
 };

--- a/optionals/compat_hlc_ar15/CfgWeapons.hpp
+++ b/optionals/compat_hlc_ar15/CfgWeapons.hpp
@@ -4,62 +4,62 @@ class CfgWeapons
 	class Rifle_Base_F;
 	class hlc_ar15_base: Rifle_Base_F
 	{
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2921;
 	};
 	class hlc_rifle_RU556: hlc_ar15_base
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.26162;
 	};
 	class hlc_rifle_RU5562: hlc_rifle_RU556
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.26162;
 	};
 	class hlc_rifle_CQBR: hlc_rifle_RU556
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.254;
 	};
 	class hlc_rifle_M4: hlc_rifle_RU556
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_bcmjack: hlc_ar15_base
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_Colt727: hlc_ar15_base
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_Colt727_GL: hlc_rifle_Colt727
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_Bushmaster300: hlc_rifle_Colt727
 	{
-		ACE_barrelTwist=0.2032;
+		ACE_barrelTwist=203.2;
 		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_vendimus: hlc_rifle_Bushmaster300
 	{
-		ACE_barrelTwist=0.2032;
+		ACE_barrelTwist=203.2;
 		ACE_barrelLength=0.4064;
 	};
 	class hlc_rifle_SAMR: hlc_rifle_RU556
 	{
-        ACE_barrelTwist=0.2286;
+        ACE_barrelTwist=228.6;
         ACE_barrelLength=0.4064;
 	};
 	class hlc_rifle_honeybase: hlc_rifle_RU556
 	{
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.1524;
 	};
 };

--- a/optionals/compat_hlc_ar15/CfgWeapons.hpp
+++ b/optionals/compat_hlc_ar15/CfgWeapons.hpp
@@ -5,61 +5,61 @@ class CfgWeapons
 	class hlc_ar15_base: Rifle_Base_F
 	{
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2921;
+        ACE_barrelLength=292.1;
 	};
 	class hlc_rifle_RU556: hlc_ar15_base
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.26162;
+		ACE_barrelLength=261.62;
 	};
 	class hlc_rifle_RU5562: hlc_rifle_RU556
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.26162;
+		ACE_barrelLength=261.62;
 	};
 	class hlc_rifle_CQBR: hlc_rifle_RU556
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.254;
+		ACE_barrelLength=254.0;
 	};
 	class hlc_rifle_M4: hlc_rifle_RU556
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.3683;
+		ACE_barrelLength=368.3;
 	};
 	class hlc_rifle_bcmjack: hlc_ar15_base
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.3683;
+		ACE_barrelLength=368.3;
 	};
 	class hlc_rifle_Colt727: hlc_ar15_base
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.3683;
+		ACE_barrelLength=368.3;
 	};
 	class hlc_rifle_Colt727_GL: hlc_rifle_Colt727
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.3683;
+		ACE_barrelLength=368.3;
 	};
 	class hlc_rifle_Bushmaster300: hlc_rifle_Colt727
 	{
 		ACE_barrelTwist=203.2;
-		ACE_barrelLength=0.3683;
+		ACE_barrelLength=368.3;
 	};
 	class hlc_rifle_vendimus: hlc_rifle_Bushmaster300
 	{
 		ACE_barrelTwist=203.2;
-		ACE_barrelLength=0.4064;
+		ACE_barrelLength=406.4;
 	};
 	class hlc_rifle_SAMR: hlc_rifle_RU556
 	{
         ACE_barrelTwist=228.6;
-        ACE_barrelLength=0.4064;
+        ACE_barrelLength=406.4;
 	};
 	class hlc_rifle_honeybase: hlc_rifle_RU556
 	{
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
 	};
 };

--- a/optionals/compat_hlc_ar15/CfgWeapons.hpp
+++ b/optionals/compat_hlc_ar15/CfgWeapons.hpp
@@ -5,61 +5,61 @@ class CfgWeapons
 	class hlc_ar15_base: Rifle_Base_F
 	{
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=11.5;
+        ACE_barrelLength=0.2921;
 	};
 	class hlc_rifle_RU556: hlc_ar15_base
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=10.3;
+		ACE_barrelLength=0.26162;
 	};
 	class hlc_rifle_RU5562: hlc_rifle_RU556
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=10.3;
+		ACE_barrelLength=0.26162;
 	};
 	class hlc_rifle_CQBR: hlc_rifle_RU556
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=10;
+		ACE_barrelLength=0.254;
 	};
 	class hlc_rifle_M4: hlc_rifle_RU556
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=14.5;
+		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_bcmjack: hlc_ar15_base
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=14.5;
+		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_Colt727: hlc_ar15_base
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=14.5;
+		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_Colt727_GL: hlc_rifle_Colt727
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=14.5;
+		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_Bushmaster300: hlc_rifle_Colt727
 	{
 		ACE_barrelTwist=0.2032;
-		ACE_barrelLength=14.5;
+		ACE_barrelLength=0.3683;
 	};
 	class hlc_rifle_vendimus: hlc_rifle_Bushmaster300
 	{
 		ACE_barrelTwist=0.2032;
-		ACE_barrelLength=16;
+		ACE_barrelLength=0.4064;
 	};
 	class hlc_rifle_SAMR: hlc_rifle_RU556
 	{
         ACE_barrelTwist=0.2286;
-        ACE_barrelLength=16;
+        ACE_barrelLength=0.4064;
 	};
 	class hlc_rifle_honeybase: hlc_rifle_RU556
 	{
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
 	};
 };

--- a/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
+++ b/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
@@ -4,57 +4,57 @@ class CfgWeapons
 	class Rifle_Base_F;
 	class hlc_MP5_base: Rifle_Base_F
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5k_PDW: hlc_MP5_base
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.1143;
 	};
 	class hlc_smg_mp5k: hlc_smg_mp5k_PDW
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.1143;
 	};
 	class hlc_smg_mp5a2: hlc_MP5_base
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_MP5N: hlc_MP5_base
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_9mmar: hlc_smg_MP5N
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5a4: hlc_MP5_base
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp510: hlc_smg_MP5N
 	{
-		ACE_barrelTwist=0.381;
+		ACE_barrelTwist=381.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5sd5: hlc_MP5_base
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5a3: hlc_smg_mp5a2
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5sd6: hlc_smg_mp5sd5
 	{
-		ACE_barrelTwist=0.254;
+		ACE_barrelTwist=254.0;
 		ACE_barrelLength=0.2286;
     };
 };

--- a/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
+++ b/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
@@ -4,57 +4,57 @@ class CfgWeapons
 	class Rifle_Base_F;
 	class hlc_MP5_base: Rifle_Base_F
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_mp5k_PDW: hlc_MP5_base
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=4.5;
 	};
 	class hlc_smg_mp5k: hlc_smg_mp5k_PDW
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=4.5;
 	};
 	class hlc_smg_mp5a2: hlc_MP5_base
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_MP5N: hlc_MP5_base
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_9mmar: hlc_smg_MP5N
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_mp5a4: hlc_MP5_base
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_mp510: hlc_smg_MP5N
 	{
-		ACE_barrelTwist=15;
+		ACE_barrelTwist=0.381;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_mp5sd5: hlc_MP5_base
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_mp5a3: hlc_smg_mp5a2
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
 	};
 	class hlc_smg_mp5sd6: hlc_smg_mp5sd5
 	{
-		ACE_barrelTwist=10;
+		ACE_barrelTwist=0.254;
 		ACE_barrelLength=9;
     };
 };

--- a/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
+++ b/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
@@ -5,56 +5,56 @@ class CfgWeapons
 	class hlc_MP5_base: Rifle_Base_F
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_mp5k_PDW: hlc_MP5_base
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.1143;
+		ACE_barrelLength=114.3;
 	};
 	class hlc_smg_mp5k: hlc_smg_mp5k_PDW
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.1143;
+		ACE_barrelLength=114.3;
 	};
 	class hlc_smg_mp5a2: hlc_MP5_base
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_MP5N: hlc_MP5_base
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_9mmar: hlc_smg_MP5N
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_mp5a4: hlc_MP5_base
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_mp510: hlc_smg_MP5N
 	{
 		ACE_barrelTwist=381.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_mp5sd5: hlc_MP5_base
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_mp5a3: hlc_smg_mp5a2
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
 	};
 	class hlc_smg_mp5sd6: hlc_smg_mp5sd5
 	{
 		ACE_barrelTwist=254.0;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
     };
 };

--- a/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
+++ b/optionals/compat_hlc_wp_mp5/CfgWeapons.hpp
@@ -5,56 +5,56 @@ class CfgWeapons
 	class hlc_MP5_base: Rifle_Base_F
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5k_PDW: hlc_MP5_base
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=4.5;
+		ACE_barrelLength=0.1143;
 	};
 	class hlc_smg_mp5k: hlc_smg_mp5k_PDW
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=4.5;
+		ACE_barrelLength=0.1143;
 	};
 	class hlc_smg_mp5a2: hlc_MP5_base
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_MP5N: hlc_MP5_base
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_9mmar: hlc_smg_MP5N
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5a4: hlc_MP5_base
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp510: hlc_smg_MP5N
 	{
 		ACE_barrelTwist=0.381;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5sd5: hlc_MP5_base
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5a3: hlc_smg_mp5a2
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
 	};
 	class hlc_smg_mp5sd6: hlc_smg_mp5sd5
 	{
 		ACE_barrelTwist=0.254;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
     };
 };

--- a/optionals/compat_hlcmods_ak/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_ak/CfgWeapons.hpp
@@ -6,12 +6,12 @@ class CfgWeapons
     class InventoryOpticsItem_Base_F;
 	class hlc_rifle_ak74: hlc_ak_base
 	{
-		ACE_barrelTwist=7.8699999;
+		ACE_barrelTwist=0.199898;
 		ACE_barrelLength=16.299999;
 	};
 	class hlc_rifle_aku12: hlc_rifle_ak12
 	{
-		ACE_barrelTwist=6.3000002;
+		ACE_barrelTwist=0.16002;
 		ACE_barrelLength=8.3000002;
 	};
 	class hlc_rifle_RPK12: hlc_rifle_ak12
@@ -20,37 +20,37 @@ class CfgWeapons
 	};
 	class hlc_rifle_aks74u: hlc_rifle_ak74
 	{
-		ACE_barrelTwist=6.3000002;
+		ACE_barrelTwist=0.16002;
 		ACE_barrelLength=8.3000002;
 	};
 	class hlc_rifle_ak47: hlc_rifle_ak74
 	{
-		ACE_barrelTwist=9.4499998;
+		ACE_barrelTwist=0.24003;
 		ACE_barrelLength=16.299999;
 	};
 	class hlc_rifle_akm: hlc_rifle_ak47
 	{
-		ACE_barrelTwist=7.8699999;
+		ACE_barrelTwist=0.199898;
 		ACE_barrelLength=16.299999;
 	};
 	class hlc_rifle_rpk: hlc_rifle_ak47
 	{
-		ACE_barrelTwist=9.4499998;
+		ACE_barrelTwist=0.24003;
 		ACE_barrelLength=23.200001;
 	};
 	class hlc_rifle_rpk74n: hlc_rifle_rpk
 	{
-		ACE_barrelTwist=9.4499998;
+		ACE_barrelTwist=0.24003;
 		ACE_barrelLength=23.200001;
 	};
 	class hlc_rifle_aek971: hlc_rifle_ak74
 	{
-        ACE_barrelTwist=9.5;
+        ACE_barrelTwist=0.2413;
         ACE_barrelLength=17;
 	};
 	class hlc_rifle_saiga12k: hlc_rifle_ak47
 	{
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=16.9;
     };

--- a/optionals/compat_hlcmods_ak/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_ak/CfgWeapons.hpp
@@ -7,52 +7,52 @@ class CfgWeapons
 	class hlc_rifle_ak74: hlc_ak_base
 	{
 		ACE_barrelTwist=0.199898;
-		ACE_barrelLength=16.299999;
+		ACE_barrelLength=0.41402;
 	};
 	class hlc_rifle_aku12: hlc_rifle_ak12
 	{
 		ACE_barrelTwist=0.16002;
-		ACE_barrelLength=8.3000002;
+		ACE_barrelLength=0.21082;
 	};
 	class hlc_rifle_RPK12: hlc_rifle_ak12
 	{
-		ACE_barrelLength=23.200001;
+		ACE_barrelLength=0.58928;
 	};
 	class hlc_rifle_aks74u: hlc_rifle_ak74
 	{
 		ACE_barrelTwist=0.16002;
-		ACE_barrelLength=8.3000002;
+		ACE_barrelLength=0.21082;
 	};
 	class hlc_rifle_ak47: hlc_rifle_ak74
 	{
 		ACE_barrelTwist=0.24003;
-		ACE_barrelLength=16.299999;
+		ACE_barrelLength=0.41402;
 	};
 	class hlc_rifle_akm: hlc_rifle_ak47
 	{
 		ACE_barrelTwist=0.199898;
-		ACE_barrelLength=16.299999;
+		ACE_barrelLength=0.41402;
 	};
 	class hlc_rifle_rpk: hlc_rifle_ak47
 	{
 		ACE_barrelTwist=0.24003;
-		ACE_barrelLength=23.200001;
+		ACE_barrelLength=0.58928;
 	};
 	class hlc_rifle_rpk74n: hlc_rifle_rpk
 	{
 		ACE_barrelTwist=0.24003;
-		ACE_barrelLength=23.200001;
+		ACE_barrelLength=0.58928;
 	};
 	class hlc_rifle_aek971: hlc_rifle_ak74
 	{
         ACE_barrelTwist=0.2413;
-        ACE_barrelLength=17;
+        ACE_barrelLength=0.4318;
 	};
 	class hlc_rifle_saiga12k: hlc_rifle_ak47
 	{
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=16.9;
+        ACE_barrelLength=0.42926;
     };
     
     class HLC_Optic_PSO1 : optic_dms {

--- a/optionals/compat_hlcmods_ak/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_ak/CfgWeapons.hpp
@@ -7,52 +7,52 @@ class CfgWeapons
 	class hlc_rifle_ak74: hlc_ak_base
 	{
 		ACE_barrelTwist=199.898;
-		ACE_barrelLength=0.41402;
+		ACE_barrelLength=414.02;
 	};
 	class hlc_rifle_aku12: hlc_rifle_ak12
 	{
 		ACE_barrelTwist=160.02;
-		ACE_barrelLength=0.21082;
+		ACE_barrelLength=210.82;
 	};
 	class hlc_rifle_RPK12: hlc_rifle_ak12
 	{
-		ACE_barrelLength=0.58928;
+		ACE_barrelLength=589.28;
 	};
 	class hlc_rifle_aks74u: hlc_rifle_ak74
 	{
 		ACE_barrelTwist=160.02;
-		ACE_barrelLength=0.21082;
+		ACE_barrelLength=210.82;
 	};
 	class hlc_rifle_ak47: hlc_rifle_ak74
 	{
 		ACE_barrelTwist=240.03;
-		ACE_barrelLength=0.41402;
+		ACE_barrelLength=414.02;
 	};
 	class hlc_rifle_akm: hlc_rifle_ak47
 	{
 		ACE_barrelTwist=199.898;
-		ACE_barrelLength=0.41402;
+		ACE_barrelLength=414.02;
 	};
 	class hlc_rifle_rpk: hlc_rifle_ak47
 	{
 		ACE_barrelTwist=240.03;
-		ACE_barrelLength=0.58928;
+		ACE_barrelLength=589.28;
 	};
 	class hlc_rifle_rpk74n: hlc_rifle_rpk
 	{
 		ACE_barrelTwist=240.03;
-		ACE_barrelLength=0.58928;
+		ACE_barrelLength=589.28;
 	};
 	class hlc_rifle_aek971: hlc_rifle_ak74
 	{
         ACE_barrelTwist=241.3;
-        ACE_barrelLength=0.4318;
+        ACE_barrelLength=431.8;
 	};
 	class hlc_rifle_saiga12k: hlc_rifle_ak47
 	{
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.42926;
+        ACE_barrelLength=429.26;
     };
     
     class HLC_Optic_PSO1 : optic_dms {

--- a/optionals/compat_hlcmods_ak/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_ak/CfgWeapons.hpp
@@ -6,12 +6,12 @@ class CfgWeapons
     class InventoryOpticsItem_Base_F;
 	class hlc_rifle_ak74: hlc_ak_base
 	{
-		ACE_barrelTwist=0.199898;
+		ACE_barrelTwist=199.898;
 		ACE_barrelLength=0.41402;
 	};
 	class hlc_rifle_aku12: hlc_rifle_ak12
 	{
-		ACE_barrelTwist=0.16002;
+		ACE_barrelTwist=160.02;
 		ACE_barrelLength=0.21082;
 	};
 	class hlc_rifle_RPK12: hlc_rifle_ak12
@@ -20,32 +20,32 @@ class CfgWeapons
 	};
 	class hlc_rifle_aks74u: hlc_rifle_ak74
 	{
-		ACE_barrelTwist=0.16002;
+		ACE_barrelTwist=160.02;
 		ACE_barrelLength=0.21082;
 	};
 	class hlc_rifle_ak47: hlc_rifle_ak74
 	{
-		ACE_barrelTwist=0.24003;
+		ACE_barrelTwist=240.03;
 		ACE_barrelLength=0.41402;
 	};
 	class hlc_rifle_akm: hlc_rifle_ak47
 	{
-		ACE_barrelTwist=0.199898;
+		ACE_barrelTwist=199.898;
 		ACE_barrelLength=0.41402;
 	};
 	class hlc_rifle_rpk: hlc_rifle_ak47
 	{
-		ACE_barrelTwist=0.24003;
+		ACE_barrelTwist=240.03;
 		ACE_barrelLength=0.58928;
 	};
 	class hlc_rifle_rpk74n: hlc_rifle_rpk
 	{
-		ACE_barrelTwist=0.24003;
+		ACE_barrelTwist=240.03;
 		ACE_barrelLength=0.58928;
 	};
 	class hlc_rifle_aek971: hlc_rifle_ak74
 	{
-        ACE_barrelTwist=0.2413;
+        ACE_barrelTwist=241.3;
         ACE_barrelLength=0.4318;
 	};
 	class hlc_rifle_saiga12k: hlc_rifle_ak47

--- a/optionals/compat_hlcmods_aug/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_aug/CfgWeapons.hpp
@@ -6,46 +6,46 @@ class CfgWeapons
 	class hlc_rifle_aug: hlc_aug_base
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=20;
+		ACE_barrelLength=0.508;
 	};
 	class hlc_rifle_auga1carb: hlc_rifle_aug
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=16;
+		ACE_barrelLength=0.4064;
 	};
 	class hlc_rifle_aughbar: hlc_rifle_aug
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=24;
+		ACE_barrelLength=0.6096;
 	};
 	class hlc_rifle_augpara: hlc_rifle_aug
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=16.5;
+		ACE_barrelLength=0.4191;
 	};
 	class hlc_rifle_auga2: hlc_rifle_aug
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=20;
+		ACE_barrelLength=0.508;
 	};
 	class hlc_rifle_auga2para: hlc_rifle_auga2
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=16.5;
+		ACE_barrelLength=0.4191;
 	};
 	class hlc_rifle_auga2carb: hlc_rifle_auga2
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=18;
+		ACE_barrelLength=0.4572;
 	};
 	class hlc_rifle_auga2lsw: hlc_rifle_aughbar
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=24;
+		ACE_barrelLength=0.6096;
 	};
 	class hlc_rifle_auga3: hlc_rifle_aug
 	{
 		ACE_barrelTwist=0.2286;
-		ACE_barrelLength=18;
+		ACE_barrelLength=0.4572;
 	};
 };

--- a/optionals/compat_hlcmods_aug/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_aug/CfgWeapons.hpp
@@ -5,47 +5,47 @@ class CfgWeapons
 	class hlc_aug_base;
 	class hlc_rifle_aug: hlc_aug_base
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=20;
 	};
 	class hlc_rifle_auga1carb: hlc_rifle_aug
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=16;
 	};
 	class hlc_rifle_aughbar: hlc_rifle_aug
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=24;
 	};
 	class hlc_rifle_augpara: hlc_rifle_aug
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=16.5;
 	};
 	class hlc_rifle_auga2: hlc_rifle_aug
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=20;
 	};
 	class hlc_rifle_auga2para: hlc_rifle_auga2
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=16.5;
 	};
 	class hlc_rifle_auga2carb: hlc_rifle_auga2
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=18;
 	};
 	class hlc_rifle_auga2lsw: hlc_rifle_aughbar
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=24;
 	};
 	class hlc_rifle_auga3: hlc_rifle_aug
 	{
-		ACE_barrelTwist=9;
+		ACE_barrelTwist=0.2286;
 		ACE_barrelLength=18;
 	};
 };

--- a/optionals/compat_hlcmods_aug/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_aug/CfgWeapons.hpp
@@ -6,46 +6,46 @@ class CfgWeapons
 	class hlc_rifle_aug: hlc_aug_base
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.508;
+		ACE_barrelLength=508.0;
 	};
 	class hlc_rifle_auga1carb: hlc_rifle_aug
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.4064;
+		ACE_barrelLength=406.4;
 	};
 	class hlc_rifle_aughbar: hlc_rifle_aug
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.6096;
+		ACE_barrelLength=609.6;
 	};
 	class hlc_rifle_augpara: hlc_rifle_aug
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.4191;
+		ACE_barrelLength=419.1;
 	};
 	class hlc_rifle_auga2: hlc_rifle_aug
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.508;
+		ACE_barrelLength=508.0;
 	};
 	class hlc_rifle_auga2para: hlc_rifle_auga2
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.4191;
+		ACE_barrelLength=419.1;
 	};
 	class hlc_rifle_auga2carb: hlc_rifle_auga2
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.4572;
+		ACE_barrelLength=457.2;
 	};
 	class hlc_rifle_auga2lsw: hlc_rifle_aughbar
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.6096;
+		ACE_barrelLength=609.6;
 	};
 	class hlc_rifle_auga3: hlc_rifle_aug
 	{
 		ACE_barrelTwist=228.6;
-		ACE_barrelLength=0.4572;
+		ACE_barrelLength=457.2;
 	};
 };

--- a/optionals/compat_hlcmods_aug/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_aug/CfgWeapons.hpp
@@ -5,47 +5,47 @@ class CfgWeapons
 	class hlc_aug_base;
 	class hlc_rifle_aug: hlc_aug_base
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.508;
 	};
 	class hlc_rifle_auga1carb: hlc_rifle_aug
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.4064;
 	};
 	class hlc_rifle_aughbar: hlc_rifle_aug
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.6096;
 	};
 	class hlc_rifle_augpara: hlc_rifle_aug
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.4191;
 	};
 	class hlc_rifle_auga2: hlc_rifle_aug
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.508;
 	};
 	class hlc_rifle_auga2para: hlc_rifle_auga2
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.4191;
 	};
 	class hlc_rifle_auga2carb: hlc_rifle_auga2
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.4572;
 	};
 	class hlc_rifle_auga2lsw: hlc_rifle_aughbar
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.6096;
 	};
 	class hlc_rifle_auga3: hlc_rifle_aug
 	{
-		ACE_barrelTwist=0.2286;
+		ACE_barrelTwist=228.6;
 		ACE_barrelLength=0.4572;
 	};
 };

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -17,7 +17,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class HLC_556NATO_SOST: B_556x45_Ball
     {
@@ -30,7 +30,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class HLC_556NATO_SPR: B_556x45_Ball
     {
@@ -43,7 +43,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class HLC_300Blackout_Ball: B_556x45_Ball
     {
@@ -56,7 +56,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
+        ACE_barrelLengths[]={152.4, 406.4, 508.0};
     };
     class HLC_300Blackout_SMK: HLC_300Blackout_Ball
     {
@@ -69,7 +69,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
+        ACE_barrelLengths[]={228.6, 406.4, 508.0};
     };
     class HLC_762x39_Ball: HLC_300Blackout_Ball
     {
@@ -82,7 +82,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class HLC_762x39_Tracer: HLC_762x39_Ball
     {
@@ -95,7 +95,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class HLC_762x51_MK316_20in: B_762x51_Ball
     {
@@ -108,7 +108,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_762x51_BTSub: B_762x51_Ball
     {
@@ -121,7 +121,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_762x54_ball: HLC_762x51_ball
     {
@@ -134,7 +134,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_762x54_tracer: HLC_762x51_tracer
     {
@@ -147,7 +147,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class HLC_303Brit_B: B_556x45_Ball
     {
@@ -160,7 +160,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class HLC_792x57_Ball: HLC_303Brit_B
     {
@@ -173,7 +173,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={785, 800, 815};
-        ACE_barrelLengths[]={0.508, 0.599948, 0.6604};
+        ACE_barrelLengths[]={508.0, 599.948, 660.4};
     };
     class HLC_542x42_ball: HLC_303Brit_B
     {
@@ -192,14 +192,14 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class FH_545x39_7u1: FH_545x39_Ball
     {
         ACE_bulletMass=5.184;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_muzzleVelocities[]={260, 303, 320};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class HLC_57x28mm_JHP: FH_545x39_Ball
     {
@@ -212,7 +212,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={550, 625, 720};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.26289};
+        ACE_barrelLengths[]={101.6, 152.4, 262.89};
     };
     class HLC_9x19_Ball: B_556x45_Ball
     {
@@ -225,7 +225,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class HLC_9x19_M882_SMG: B_556x45_Ball
     {
@@ -238,7 +238,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class HLC_9x19_GoldDot: HLC_9x19_Ball
     {
@@ -259,7 +259,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
+        ACE_barrelLengths[]={101.6, 117.094, 228.6};
     };
     class HLC_45ACP_Ball: B_556x45_Ball
     {
@@ -272,7 +272,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class FH_44Mag: HLC_45ACP_Ball
     {
@@ -285,7 +285,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 390, 420};
-        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
+        ACE_barrelLengths[]={101.6, 190.5, 228.6};
     };
     class FH_50BMG_SLAP: B_127x99_Ball
     {
@@ -298,7 +298,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1204};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
     class FH_50BMG_Raufoss: B_127x99_Ball
     {
@@ -311,6 +311,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={817};
-        ACE_barrelLengths[]={0.7366};
+        ACE_barrelLengths[]={736.6};
     };
 };

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -9,7 +9,7 @@ class CfgAmmo
     class HLC_556NATO_EPR: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -22,7 +22,7 @@ class CfgAmmo
     class HLC_556NATO_SOST: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -35,7 +35,7 @@ class CfgAmmo
     class HLC_556NATO_SPR: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -48,7 +48,7 @@ class CfgAmmo
     class HLC_300Blackout_Ball: B_556x45_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028397;
+        ACE_bulletLength=28.397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -61,7 +61,7 @@ class CfgAmmo
     class HLC_300Blackout_SMK: HLC_300Blackout_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -74,7 +74,7 @@ class CfgAmmo
     class HLC_762x39_Ball: HLC_300Blackout_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -87,7 +87,7 @@ class CfgAmmo
     class HLC_762x39_Tracer: HLC_762x39_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -100,7 +100,7 @@ class CfgAmmo
     class HLC_762x51_MK316_20in: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.243};
@@ -113,7 +113,7 @@ class CfgAmmo
     class HLC_762x51_BTSub: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034036;
+        ACE_bulletLength=34.036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -126,7 +126,7 @@ class CfgAmmo
     class HLC_762x54_ball: HLC_762x51_ball
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -139,7 +139,7 @@ class CfgAmmo
     class HLC_762x54_tracer: HLC_762x51_tracer
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -152,7 +152,7 @@ class CfgAmmo
     class HLC_303Brit_B: B_556x45_Ball
     {
         ACE_caliber=7.899;
-        ACE_bulletLength=0.031166;
+        ACE_bulletLength=31.166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -165,7 +165,7 @@ class CfgAmmo
     class HLC_792x57_Ball: HLC_303Brit_B
     {
         ACE_caliber=8.077;
-        ACE_bulletLength=0.028651;
+        ACE_bulletLength=28.651;
         ACE_bulletMass=12.7008;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.315};
@@ -184,7 +184,7 @@ class CfgAmmo
     class FH_545x39_Ball: B_556x45_Ball
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -204,7 +204,7 @@ class CfgAmmo
     class HLC_57x28mm_JHP: FH_545x39_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.012573;
+        ACE_bulletLength=12.573;
         ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
@@ -217,7 +217,7 @@ class CfgAmmo
     class HLC_9x19_Ball: B_556x45_Ball
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -230,7 +230,7 @@ class CfgAmmo
     class HLC_9x19_M882_SMG: B_556x45_Ball
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -251,7 +251,7 @@ class CfgAmmo
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
         ACE_caliber=12.7;
-        ACE_bulletLength=0.019406;
+        ACE_bulletLength=19.406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -264,7 +264,7 @@ class CfgAmmo
     class HLC_45ACP_Ball: B_556x45_Ball
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -277,7 +277,7 @@ class CfgAmmo
     class FH_44Mag: HLC_45ACP_Ball
     {
         ACE_caliber=10.897;
-        ACE_bulletLength=0.020422;
+        ACE_bulletLength=20.422;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
@@ -290,7 +290,7 @@ class CfgAmmo
     class FH_50BMG_SLAP: B_127x99_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.03175;
+        ACE_bulletLength=31.75;
         ACE_bulletMass=22.68;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.056};
@@ -303,7 +303,7 @@ class CfgAmmo
     class FH_50BMG_Raufoss: B_127x99_Ball
     {
         ACE_caliber=12.954;
-        ACE_bulletLength=0.060452;
+        ACE_bulletLength=60.452;
         ACE_bulletMass=42.768;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -9,7 +9,7 @@ class CfgAmmo
     class HLC_556NATO_EPR: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -22,7 +22,7 @@ class CfgAmmo
     class HLC_556NATO_SOST: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -35,7 +35,7 @@ class CfgAmmo
     class HLC_556NATO_SPR: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -48,7 +48,7 @@ class CfgAmmo
     class HLC_300Blackout_Ball: B_556x45_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.118;
+        ACE_bulletLength=0.028397;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -61,7 +61,7 @@ class CfgAmmo
     class HLC_300Blackout_SMK: HLC_300Blackout_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -74,7 +74,7 @@ class CfgAmmo
     class HLC_762x39_Ball: HLC_300Blackout_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -87,7 +87,7 @@ class CfgAmmo
     class HLC_762x39_Tracer: HLC_762x39_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -100,7 +100,7 @@ class CfgAmmo
     class HLC_762x51_MK316_20in: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.243};
@@ -113,7 +113,7 @@ class CfgAmmo
     class HLC_762x51_BTSub: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.340;
+        ACE_bulletLength=0.034036;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
@@ -126,7 +126,7 @@ class CfgAmmo
     class HLC_762x54_ball: HLC_762x51_ball
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -139,7 +139,7 @@ class CfgAmmo
     class HLC_762x54_tracer: HLC_762x51_tracer
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -152,7 +152,7 @@ class CfgAmmo
     class HLC_303Brit_B: B_556x45_Ball
     {
         ACE_caliber=0.007899;
-        ACE_bulletLength=1.227;
+        ACE_bulletLength=0.031166;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
@@ -165,7 +165,7 @@ class CfgAmmo
     class HLC_792x57_Ball: HLC_303Brit_B
     {
         ACE_caliber=0.008077;
-        ACE_bulletLength=1.128;
+        ACE_bulletLength=0.028651;
         ACE_bulletMass=196;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.315};
@@ -184,7 +184,7 @@ class CfgAmmo
     class FH_545x39_Ball: B_556x45_Ball
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -204,7 +204,7 @@ class CfgAmmo
     class HLC_57x28mm_JHP: FH_545x39_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.495;
+        ACE_bulletLength=0.012573;
         ACE_bulletMass=28;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
@@ -217,7 +217,7 @@ class CfgAmmo
     class HLC_9x19_Ball: B_556x45_Ball
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -230,7 +230,7 @@ class CfgAmmo
     class HLC_9x19_M882_SMG: B_556x45_Ball
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -251,7 +251,7 @@ class CfgAmmo
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
         ACE_caliber=0.0127;
-        ACE_bulletLength=0.764;
+        ACE_bulletLength=0.019406;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
@@ -264,7 +264,7 @@ class CfgAmmo
     class HLC_45ACP_Ball: B_556x45_Ball
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -277,7 +277,7 @@ class CfgAmmo
     class FH_44Mag: HLC_45ACP_Ball
     {
         ACE_caliber=0.010897;
-        ACE_bulletLength=0.804;
+        ACE_bulletLength=0.020422;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
@@ -290,7 +290,7 @@ class CfgAmmo
     class FH_50BMG_SLAP: B_127x99_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.25;
+        ACE_bulletLength=0.03175;
         ACE_bulletMass=350;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.056};
@@ -303,7 +303,7 @@ class CfgAmmo
     class FH_50BMG_Raufoss: B_127x99_Ball
     {
         ACE_caliber=0.012954;
-        ACE_bulletLength=2.380;
+        ACE_bulletLength=0.060452;
         ACE_bulletMass=660;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -17,7 +17,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class HLC_556NATO_SOST: B_556x45_Ball
     {
@@ -30,7 +30,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class HLC_556NATO_SPR: B_556x45_Ball
     {
@@ -43,7 +43,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class HLC_300Blackout_Ball: B_556x45_Ball
     {
@@ -56,7 +56,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={6, 16, 20};
+        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
     };
     class HLC_300Blackout_SMK: HLC_300Blackout_Ball
     {
@@ -69,7 +69,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={9, 16, 20};
+        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
     };
     class HLC_762x39_Ball: HLC_300Blackout_Ball
     {
@@ -82,7 +82,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class HLC_762x39_Tracer: HLC_762x39_Ball
     {
@@ -95,7 +95,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class HLC_762x51_MK316_20in: B_762x51_Ball
     {
@@ -108,7 +108,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_762x51_BTSub: B_762x51_Ball
     {
@@ -121,7 +121,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_762x54_ball: HLC_762x51_ball
     {
@@ -134,7 +134,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_762x54_tracer: HLC_762x51_tracer
     {
@@ -147,7 +147,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class HLC_303Brit_B: B_556x45_Ball
     {
@@ -160,7 +160,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class HLC_792x57_Ball: HLC_303Brit_B
     {
@@ -173,7 +173,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={785, 800, 815};
-        ACE_barrelLengths[]={20, 23.62, 26};
+        ACE_barrelLengths[]={0.508, 0.599948, 0.6604};
     };
     class HLC_542x42_ball: HLC_303Brit_B
     {
@@ -192,14 +192,14 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class FH_545x39_7u1: FH_545x39_Ball
     {
         ACE_bulletMass=5.184;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_muzzleVelocities[]={260, 303, 320};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class HLC_57x28mm_JHP: FH_545x39_Ball
     {
@@ -212,7 +212,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={550, 625, 720};
-        ACE_barrelLengths[]={4, 6, 10.35};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.26289};
     };
     class HLC_9x19_Ball: B_556x45_Ball
     {
@@ -225,7 +225,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class HLC_9x19_M882_SMG: B_556x45_Ball
     {
@@ -238,7 +238,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class HLC_9x19_GoldDot: HLC_9x19_Ball
     {
@@ -259,7 +259,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={4, 4.61, 9};
+        ACE_barrelLengths[]={0.1016, 0.117094, 0.2286};
     };
     class HLC_45ACP_Ball: B_556x45_Ball
     {
@@ -272,7 +272,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class FH_44Mag: HLC_45ACP_Ball
     {
@@ -285,7 +285,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 390, 420};
-        ACE_barrelLengths[]={4, 7.5, 9};
+        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
     };
     class FH_50BMG_SLAP: B_127x99_Ball
     {
@@ -298,7 +298,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={1204};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
     class FH_50BMG_Raufoss: B_127x99_Ball
     {
@@ -311,6 +311,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={817};
-        ACE_barrelLengths[]={29};
+        ACE_barrelLengths[]={0.7366};
     };
 };

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -8,7 +8,7 @@ class CfgAmmo
     class HLC_762x51_ball;
     class HLC_556NATO_EPR: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -21,7 +21,7 @@ class CfgAmmo
     };
     class HLC_556NATO_SOST: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -34,7 +34,7 @@ class CfgAmmo
     };
     class HLC_556NATO_SPR: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -47,7 +47,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.118;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -60,7 +60,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_SMK: HLC_300Blackout_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -73,7 +73,7 @@ class CfgAmmo
     };
     class HLC_762x39_Ball: HLC_300Blackout_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -86,7 +86,7 @@ class CfgAmmo
     };
     class HLC_762x39_Tracer: HLC_762x39_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -99,7 +99,7 @@ class CfgAmmo
     };
     class HLC_762x51_MK316_20in: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -112,7 +112,7 @@ class CfgAmmo
     };
     class HLC_762x51_BTSub: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.340;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -125,7 +125,7 @@ class CfgAmmo
     };
     class HLC_762x54_ball: HLC_762x51_ball
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -138,7 +138,7 @@ class CfgAmmo
     };
     class HLC_762x54_tracer: HLC_762x51_tracer
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -151,7 +151,7 @@ class CfgAmmo
     };
     class HLC_303Brit_B: B_556x45_Ball
     {
-        ACE_caliber=0.311;
+        ACE_caliber=0.007899;
         ACE_bulletLength=1.227;
         ACE_bulletMass=174;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -164,7 +164,7 @@ class CfgAmmo
     };
     class HLC_792x57_Ball: HLC_303Brit_B
     {
-        ACE_caliber=0.318;
+        ACE_caliber=0.008077;
         ACE_bulletLength=1.128;
         ACE_bulletMass=196;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -183,7 +183,7 @@ class CfgAmmo
     };
     class FH_545x39_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -203,7 +203,7 @@ class CfgAmmo
     };
     class HLC_57x28mm_JHP: FH_545x39_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.495;
         ACE_bulletMass=28;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -216,7 +216,7 @@ class CfgAmmo
     };
     class HLC_9x19_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -229,7 +229,7 @@ class CfgAmmo
     };
     class HLC_9x19_M882_SMG: B_556x45_Ball
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -250,7 +250,7 @@ class CfgAmmo
     };
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
-        ACE_caliber=0.5;
+        ACE_caliber=0.0127;
         ACE_bulletLength=0.764;
         ACE_bulletMass=165;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -263,7 +263,7 @@ class CfgAmmo
     };
     class HLC_45ACP_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -276,7 +276,7 @@ class CfgAmmo
     };
     class FH_44Mag: HLC_45ACP_Ball
     {
-        ACE_caliber=0.429;
+        ACE_caliber=0.010897;
         ACE_bulletLength=0.804;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -289,7 +289,7 @@ class CfgAmmo
     };
     class FH_50BMG_SLAP: B_127x99_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.25;
         ACE_bulletMass=350;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -302,7 +302,7 @@ class CfgAmmo
     };
     class FH_50BMG_Raufoss: B_127x99_Ball
     {
-        ACE_caliber=0.510;
+        ACE_caliber=0.012954;
         ACE_bulletLength=2.380;
         ACE_bulletMass=660;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -8,7 +8,7 @@ class CfgAmmo
     class HLC_762x51_ball;
     class HLC_556NATO_EPR: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -21,7 +21,7 @@ class CfgAmmo
     };
     class HLC_556NATO_SOST: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -34,7 +34,7 @@ class CfgAmmo
     };
     class HLC_556NATO_SPR: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -47,7 +47,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -60,7 +60,7 @@ class CfgAmmo
     };
     class HLC_300Blackout_SMK: HLC_300Blackout_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -73,7 +73,7 @@ class CfgAmmo
     };
     class HLC_762x39_Ball: HLC_300Blackout_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -86,7 +86,7 @@ class CfgAmmo
     };
     class HLC_762x39_Tracer: HLC_762x39_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -99,7 +99,7 @@ class CfgAmmo
     };
     class HLC_762x51_MK316_20in: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -112,7 +112,7 @@ class CfgAmmo
     };
     class HLC_762x51_BTSub: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -125,7 +125,7 @@ class CfgAmmo
     };
     class HLC_762x54_ball: HLC_762x51_ball
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -138,7 +138,7 @@ class CfgAmmo
     };
     class HLC_762x54_tracer: HLC_762x51_tracer
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -151,7 +151,7 @@ class CfgAmmo
     };
     class HLC_303Brit_B: B_556x45_Ball
     {
-        ACE_caliber=0.007899;
+        ACE_caliber=7.899;
         ACE_bulletLength=0.031166;
         ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -164,7 +164,7 @@ class CfgAmmo
     };
     class HLC_792x57_Ball: HLC_303Brit_B
     {
-        ACE_caliber=0.008077;
+        ACE_caliber=8.077;
         ACE_bulletLength=0.028651;
         ACE_bulletMass=12.7008;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -183,7 +183,7 @@ class CfgAmmo
     };
     class FH_545x39_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -203,7 +203,7 @@ class CfgAmmo
     };
     class HLC_57x28mm_JHP: FH_545x39_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.012573;
         ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -216,7 +216,7 @@ class CfgAmmo
     };
     class HLC_9x19_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -229,7 +229,7 @@ class CfgAmmo
     };
     class HLC_9x19_M882_SMG: B_556x45_Ball
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -250,7 +250,7 @@ class CfgAmmo
     };
     class HLC_10mm_FMJ: HLC_9x19_Ball
     {
-        ACE_caliber=0.0127;
+        ACE_caliber=12.7;
         ACE_bulletLength=0.019406;
         ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -263,7 +263,7 @@ class CfgAmmo
     };
     class HLC_45ACP_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -276,7 +276,7 @@ class CfgAmmo
     };
     class FH_44Mag: HLC_45ACP_Ball
     {
-        ACE_caliber=0.010897;
+        ACE_caliber=10.897;
         ACE_bulletLength=0.020422;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -289,7 +289,7 @@ class CfgAmmo
     };
     class FH_50BMG_SLAP: B_127x99_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.03175;
         ACE_bulletMass=22.68;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -302,7 +302,7 @@ class CfgAmmo
     };
     class FH_50BMG_Raufoss: B_127x99_Ball
     {
-        ACE_caliber=0.012954;
+        ACE_caliber=12.954;
         ACE_bulletLength=0.060452;
         ACE_bulletMass=42.768;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};

--- a/optionals/compat_hlcmods_core/CfgAmmo.hpp
+++ b/optionals/compat_hlcmods_core/CfgAmmo.hpp
@@ -10,7 +10,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -23,7 +23,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -36,7 +36,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -49,7 +49,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028397;
-        ACE_bulletMass=147;
+        ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
         ACE_velocityBoundaries[]={};
@@ -62,7 +62,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
         ACE_velocityBoundaries[]={};
@@ -75,7 +75,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -88,7 +88,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -101,7 +101,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -114,7 +114,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034036;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
         ACE_velocityBoundaries[]={};
@@ -127,7 +127,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -140,7 +140,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -153,7 +153,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007899;
         ACE_bulletLength=0.031166;
-        ACE_bulletMass=174;
+        ACE_bulletMass=11.2752;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
         ACE_velocityBoundaries[]={671, 549};
@@ -166,7 +166,7 @@ class CfgAmmo
     {
         ACE_caliber=0.008077;
         ACE_bulletLength=0.028651;
-        ACE_bulletMass=196;
+        ACE_bulletMass=12.7008;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.315};
         ACE_velocityBoundaries[]={};
@@ -185,7 +185,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -196,7 +196,7 @@ class CfgAmmo
     };
     class FH_545x39_7u1: FH_545x39_Ball
     {
-        ACE_bulletMass=80;
+        ACE_bulletMass=5.184;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_muzzleVelocities[]={260, 303, 320};
         ACE_barrelLengths[]={10, 16.3, 20};
@@ -205,7 +205,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.012573;
-        ACE_bulletMass=28;
+        ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
         ACE_velocityBoundaries[]={};
@@ -218,7 +218,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -231,7 +231,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -252,7 +252,7 @@ class CfgAmmo
     {
         ACE_caliber=0.0127;
         ACE_bulletLength=0.019406;
-        ACE_bulletMass=165;
+        ACE_bulletMass=10.692;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.189};
         ACE_velocityBoundaries[]={};
@@ -265,7 +265,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -278,7 +278,7 @@ class CfgAmmo
     {
         ACE_caliber=0.010897;
         ACE_bulletLength=0.020422;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
         ACE_velocityBoundaries[]={};
@@ -291,7 +291,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.03175;
-        ACE_bulletMass=350;
+        ACE_bulletMass=22.68;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={1.056};
         ACE_velocityBoundaries[]={};
@@ -304,7 +304,7 @@ class CfgAmmo
     {
         ACE_caliber=0.012954;
         ACE_bulletLength=0.060452;
-        ACE_bulletMass=660;
+        ACE_bulletMass=42.768;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.670};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_hlcmods_fal/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_fal/CfgWeapons.hpp
@@ -4,47 +4,47 @@ class CfgWeapons
 	class hlc_fal_base;
 	class hlc_rifle_falosw: hlc_fal_base
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=13;
 	};
 	class hlc_rifle_osw_GL: hlc_rifle_falosw
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=13;
 	};
 	class hlc_rifle_SLR: hlc_fal_base
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=21.700001;
 	};
 	class hlc_rifle_STG58F: hlc_fal_base
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=21;
 	};
 	class hlc_rifle_FAL5061: hlc_fal_base
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=18;
 	};
 	class hlc_rifle_L1A1SLR: hlc_rifle_SLR
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=21.700001;
 	};
 	class hlc_rifle_c1A1: hlc_rifle_SLR
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=21.700001;
 	};
 	class hlc_rifle_LAR: hlc_rifle_FAL5061
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=21;
 	};
 	class hlc_rifle_SLRchopmod: hlc_rifle_FAL5061
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=18;
     };
 };

--- a/optionals/compat_hlcmods_fal/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_fal/CfgWeapons.hpp
@@ -4,47 +4,47 @@ class CfgWeapons
 	class hlc_fal_base;
 	class hlc_rifle_falosw: hlc_fal_base
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.3302;
 	};
 	class hlc_rifle_osw_GL: hlc_rifle_falosw
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.3302;
 	};
 	class hlc_rifle_SLR: hlc_fal_base
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.55118;
 	};
 	class hlc_rifle_STG58F: hlc_fal_base
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.5334;
 	};
 	class hlc_rifle_FAL5061: hlc_fal_base
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.4572;
 	};
 	class hlc_rifle_L1A1SLR: hlc_rifle_SLR
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.55118;
 	};
 	class hlc_rifle_c1A1: hlc_rifle_SLR
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.55118;
 	};
 	class hlc_rifle_LAR: hlc_rifle_FAL5061
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.5334;
 	};
 	class hlc_rifle_SLRchopmod: hlc_rifle_FAL5061
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.4572;
     };
 };

--- a/optionals/compat_hlcmods_fal/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_fal/CfgWeapons.hpp
@@ -5,46 +5,46 @@ class CfgWeapons
 	class hlc_rifle_falosw: hlc_fal_base
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.3302;
+		ACE_barrelLength=330.2;
 	};
 	class hlc_rifle_osw_GL: hlc_rifle_falosw
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.3302;
+		ACE_barrelLength=330.2;
 	};
 	class hlc_rifle_SLR: hlc_fal_base
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.55118;
+		ACE_barrelLength=551.18;
 	};
 	class hlc_rifle_STG58F: hlc_fal_base
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.5334;
+		ACE_barrelLength=533.4;
 	};
 	class hlc_rifle_FAL5061: hlc_fal_base
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.4572;
+		ACE_barrelLength=457.2;
 	};
 	class hlc_rifle_L1A1SLR: hlc_rifle_SLR
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.55118;
+		ACE_barrelLength=551.18;
 	};
 	class hlc_rifle_c1A1: hlc_rifle_SLR
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.55118;
+		ACE_barrelLength=551.18;
 	};
 	class hlc_rifle_LAR: hlc_rifle_FAL5061
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.5334;
+		ACE_barrelLength=533.4;
 	};
 	class hlc_rifle_SLRchopmod: hlc_rifle_FAL5061
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.4572;
+		ACE_barrelLength=457.2;
     };
 };

--- a/optionals/compat_hlcmods_fal/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_fal/CfgWeapons.hpp
@@ -5,46 +5,46 @@ class CfgWeapons
 	class hlc_rifle_falosw: hlc_fal_base
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=13;
+		ACE_barrelLength=0.3302;
 	};
 	class hlc_rifle_osw_GL: hlc_rifle_falosw
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=13;
+		ACE_barrelLength=0.3302;
 	};
 	class hlc_rifle_SLR: hlc_fal_base
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=21.700001;
+		ACE_barrelLength=0.55118;
 	};
 	class hlc_rifle_STG58F: hlc_fal_base
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=21;
+		ACE_barrelLength=0.5334;
 	};
 	class hlc_rifle_FAL5061: hlc_fal_base
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=18;
+		ACE_barrelLength=0.4572;
 	};
 	class hlc_rifle_L1A1SLR: hlc_rifle_SLR
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=21.700001;
+		ACE_barrelLength=0.55118;
 	};
 	class hlc_rifle_c1A1: hlc_rifle_SLR
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=21.700001;
+		ACE_barrelLength=0.55118;
 	};
 	class hlc_rifle_LAR: hlc_rifle_FAL5061
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=21;
+		ACE_barrelLength=0.5334;
 	};
 	class hlc_rifle_SLRchopmod: hlc_rifle_FAL5061
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=18;
+		ACE_barrelLength=0.4572;
     };
 };

--- a/optionals/compat_hlcmods_g3/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_g3/CfgWeapons.hpp
@@ -4,42 +4,42 @@ class CfgWeapons
 	class hlc_g3_base;
 	class hlc_rifle_g3sg1: hlc_g3_base
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=17.700001;
 	};
 	class hlc_rifle_psg1: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=25.6;
 	};
 	class hlc_rifle_g3a3: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=17.700001;
 	};
 	class hlc_rifle_g3a3ris: hlc_rifle_g3a3
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=17.700001;
 	};
 	class hlc_rifle_g3ka4: hlc_rifle_g3a3
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=12.4;
 	};
 	class HLC_Rifle_g3ka4_GL: hlc_rifle_g3ka4
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=12.4;
 	};
 	class hlc_rifle_hk51: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=8.3100004;
 	};
 	class hlc_rifle_hk53: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=7;
+		ACE_barrelTwist=0.1778;
 		ACE_barrelLength=8.3100004;
     };
 };

--- a/optionals/compat_hlcmods_g3/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_g3/CfgWeapons.hpp
@@ -4,42 +4,42 @@ class CfgWeapons
 	class hlc_g3_base;
 	class hlc_rifle_g3sg1: hlc_g3_base
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.44958;
 	};
 	class hlc_rifle_psg1: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.65024;
 	};
 	class hlc_rifle_g3a3: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.44958;
 	};
 	class hlc_rifle_g3a3ris: hlc_rifle_g3a3
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.44958;
 	};
 	class hlc_rifle_g3ka4: hlc_rifle_g3a3
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.31496;
 	};
 	class HLC_Rifle_g3ka4_GL: hlc_rifle_g3ka4
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.31496;
 	};
 	class hlc_rifle_hk51: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.211074;
 	};
 	class hlc_rifle_hk53: hlc_rifle_g3sg1
 	{
-		ACE_barrelTwist=0.1778;
+		ACE_barrelTwist=177.8;
 		ACE_barrelLength=0.211074;
     };
 };

--- a/optionals/compat_hlcmods_g3/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_g3/CfgWeapons.hpp
@@ -5,41 +5,41 @@ class CfgWeapons
 	class hlc_rifle_g3sg1: hlc_g3_base
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.44958;
+		ACE_barrelLength=449.58;
 	};
 	class hlc_rifle_psg1: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.65024;
+		ACE_barrelLength=650.24;
 	};
 	class hlc_rifle_g3a3: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.44958;
+		ACE_barrelLength=449.58;
 	};
 	class hlc_rifle_g3a3ris: hlc_rifle_g3a3
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.44958;
+		ACE_barrelLength=449.58;
 	};
 	class hlc_rifle_g3ka4: hlc_rifle_g3a3
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.31496;
+		ACE_barrelLength=314.96;
 	};
 	class HLC_Rifle_g3ka4_GL: hlc_rifle_g3ka4
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.31496;
+		ACE_barrelLength=314.96;
 	};
 	class hlc_rifle_hk51: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.211074;
+		ACE_barrelLength=211.074;
 	};
 	class hlc_rifle_hk53: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=177.8;
-		ACE_barrelLength=0.211074;
+		ACE_barrelLength=211.074;
     };
 };

--- a/optionals/compat_hlcmods_g3/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_g3/CfgWeapons.hpp
@@ -5,41 +5,41 @@ class CfgWeapons
 	class hlc_rifle_g3sg1: hlc_g3_base
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=17.700001;
+		ACE_barrelLength=0.44958;
 	};
 	class hlc_rifle_psg1: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=25.6;
+		ACE_barrelLength=0.65024;
 	};
 	class hlc_rifle_g3a3: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=17.700001;
+		ACE_barrelLength=0.44958;
 	};
 	class hlc_rifle_g3a3ris: hlc_rifle_g3a3
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=17.700001;
+		ACE_barrelLength=0.44958;
 	};
 	class hlc_rifle_g3ka4: hlc_rifle_g3a3
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=12.4;
+		ACE_barrelLength=0.31496;
 	};
 	class HLC_Rifle_g3ka4_GL: hlc_rifle_g3ka4
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=12.4;
+		ACE_barrelLength=0.31496;
 	};
 	class hlc_rifle_hk51: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=8.3100004;
+		ACE_barrelLength=0.211074;
 	};
 	class hlc_rifle_hk53: hlc_rifle_g3sg1
 	{
 		ACE_barrelTwist=0.1778;
-		ACE_barrelLength=8.3100004;
+		ACE_barrelLength=0.211074;
     };
 };

--- a/optionals/compat_hlcmods_m14/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m14/CfgWeapons.hpp
@@ -6,11 +6,11 @@ class CfgWeapons
 	class hlc_M14_base: Rifle_Base_F
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=22;
+		ACE_barrelLength=0.5588;
 	};
 	class hlc_rifle_m14sopmod: hlc_rifle_M14
 	{
 		ACE_barrelTwist=0.3048;
-		ACE_barrelLength=18;
+		ACE_barrelLength=0.4572;
     };
 };

--- a/optionals/compat_hlcmods_m14/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m14/CfgWeapons.hpp
@@ -5,12 +5,12 @@ class CfgWeapons
     class hlc_rifle_M14;
 	class hlc_M14_base: Rifle_Base_F
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.5588;
 	};
 	class hlc_rifle_m14sopmod: hlc_rifle_M14
 	{
-		ACE_barrelTwist=0.3048;
+		ACE_barrelTwist=304.8;
 		ACE_barrelLength=0.4572;
     };
 };

--- a/optionals/compat_hlcmods_m14/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m14/CfgWeapons.hpp
@@ -5,12 +5,12 @@ class CfgWeapons
     class hlc_rifle_M14;
 	class hlc_M14_base: Rifle_Base_F
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=22;
 	};
 	class hlc_rifle_m14sopmod: hlc_rifle_M14
 	{
-		ACE_barrelTwist=12;
+		ACE_barrelTwist=0.3048;
 		ACE_barrelLength=18;
     };
 };

--- a/optionals/compat_hlcmods_m14/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m14/CfgWeapons.hpp
@@ -6,11 +6,11 @@ class CfgWeapons
 	class hlc_M14_base: Rifle_Base_F
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.5588;
+		ACE_barrelLength=558.8;
 	};
 	class hlc_rifle_m14sopmod: hlc_rifle_M14
 	{
 		ACE_barrelTwist=304.8;
-		ACE_barrelLength=0.4572;
+		ACE_barrelLength=457.2;
     };
 };

--- a/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
@@ -4,12 +4,12 @@ class CfgWeapons
 	class hlc_M60e4_base;
 	class hlc_lmg_M60E4: hlc_M60e4_base
 	{
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.4318;
 	};
 	class hlc_lmg_m60: hlc_M60e4_base
 	{
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
 };

--- a/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
@@ -5,11 +5,11 @@ class CfgWeapons
 	class hlc_lmg_M60E4: hlc_M60e4_base
 	{
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.4318;
+        ACE_barrelLength=431.8;
 	};
 	class hlc_lmg_m60: hlc_M60e4_base
 	{
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
 };

--- a/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
@@ -4,12 +4,12 @@ class CfgWeapons
 	class hlc_M60e4_base;
 	class hlc_lmg_M60E4: hlc_M60e4_base
 	{
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=17;
 	};
 	class hlc_lmg_m60: hlc_M60e4_base
 	{
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
 };

--- a/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
+++ b/optionals/compat_hlcmods_m60e4/CfgWeapons.hpp
@@ -5,11 +5,11 @@ class CfgWeapons
 	class hlc_lmg_M60E4: hlc_M60e4_base
 	{
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=17;
+        ACE_barrelLength=0.4318;
 	};
 	class hlc_lmg_m60: hlc_M60e4_base
 	{
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
 };

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
 	class RH_50_AE_Ball: BulletBase
 	{
         ACE_caliber=0.0127;
-        ACE_bulletLength=1.110;
+        ACE_bulletLength=0.028194;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.228};
@@ -18,7 +18,7 @@ class CfgAmmo
 	class RH_454_Casull: BulletBase
 	{
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.895;
+        ACE_bulletLength=0.022733;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.171};
@@ -31,7 +31,7 @@ class CfgAmmo
 	class RH_32ACP: BulletBase
 	{
         ACE_caliber=0.007938;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -44,7 +44,7 @@ class CfgAmmo
 	class RH_45ACP: BulletBase
 	{
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -57,7 +57,7 @@ class CfgAmmo
 	class RH_B_40SW: BulletBase
 	{
         ACE_caliber=0.01016;
-        ACE_bulletLength=0.447;
+        ACE_bulletLength=0.011354;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.105, 0.115, 0.120, 0.105};
@@ -70,7 +70,7 @@ class CfgAmmo
 	class RH_44mag_ball: BulletBase
 	{
         ACE_caliber=0.010897;
-        ACE_bulletLength=0.804;
+        ACE_bulletLength=0.020422;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
@@ -83,7 +83,7 @@ class CfgAmmo
 	class RH_357mag_ball: BulletBase
 	{
         ACE_caliber=0.009068;
-        ACE_bulletLength=0.541;
+        ACE_bulletLength=0.013741;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.148};
@@ -96,7 +96,7 @@ class CfgAmmo
 	class RH_762x25: BulletBase
 	{
         ACE_caliber=0.007874;
-        ACE_bulletLength=0.5455;
+        ACE_bulletLength=0.013856;
         ACE_bulletMass=86;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -109,7 +109,7 @@ class CfgAmmo
 	class RH_9x18_Ball: BulletBase
 	{
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -122,7 +122,7 @@ class CfgAmmo
 	class RH_B_9x19_Ball: BulletBase
 	{
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -135,7 +135,7 @@ class CfgAmmo
 	class RH_B_22LR_SD: BulletBase
 	{
         ACE_caliber=0.005664;
-        ACE_bulletLength=0.45;
+        ACE_bulletLength=0.01143;
         ACE_bulletMass=38;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.111};
@@ -148,7 +148,7 @@ class CfgAmmo
 	class RH_57x28mm: BulletBase
 	{
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.495;
+        ACE_bulletLength=0.012573;
         ACE_bulletMass=28;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -13,7 +13,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 398, 420};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
 	};
 	class RH_454_Casull: BulletBase
 	{
@@ -26,7 +26,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={450, 490, 500};
-        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
+        ACE_barrelLengths[]={101.6, 190.5, 228.6};
 	};
 	class RH_32ACP: BulletBase
 	{
@@ -39,7 +39,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
 	};
 	class RH_45ACP: BulletBase
 	{
@@ -52,7 +52,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
 	};
 	class RH_B_40SW: BulletBase
 	{
@@ -65,7 +65,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
 	};
 	class RH_44mag_ball: BulletBase
 	{
@@ -78,7 +78,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 390, 420};
-        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
+        ACE_barrelLengths[]={101.6, 190.5, 228.6};
 	};
 	class RH_357mag_ball: BulletBase
 	{
@@ -91,7 +91,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={490, 510, 535};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
 	};
 	class RH_762x25: BulletBase
 	{
@@ -104,7 +104,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
 	};
 	class RH_9x18_Ball: BulletBase
 	{
@@ -117,7 +117,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
 	};
 	class RH_B_9x19_Ball: BulletBase
 	{
@@ -130,7 +130,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
 	};
 	class RH_B_22LR_SD: BulletBase
 	{
@@ -143,7 +143,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={330, 340, 360};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
+        ACE_barrelLengths[]={101.6, 152.4, 228.6};
 	};
 	class RH_57x28mm: BulletBase
 	{
@@ -156,6 +156,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={550, 625, 720};
-        ACE_barrelLengths[]={0.1016, 0.1524, 0.26289};
+        ACE_barrelLengths[]={101.6, 152.4, 262.89};
     };
 };

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
 	class RH_50_AE_Ball: BulletBase
 	{
         ACE_caliber=12.7;
-        ACE_bulletLength=0.028194;
+        ACE_bulletLength=28.194;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.228};
@@ -18,7 +18,7 @@ class CfgAmmo
 	class RH_454_Casull: BulletBase
 	{
         ACE_caliber=11.481;
-        ACE_bulletLength=0.022733;
+        ACE_bulletLength=22.733;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.171};
@@ -31,7 +31,7 @@ class CfgAmmo
 	class RH_32ACP: BulletBase
 	{
         ACE_caliber=7.938;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
@@ -44,7 +44,7 @@ class CfgAmmo
 	class RH_45ACP: BulletBase
 	{
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
@@ -57,7 +57,7 @@ class CfgAmmo
 	class RH_B_40SW: BulletBase
 	{
         ACE_caliber=10.16;
-        ACE_bulletLength=0.011354;
+        ACE_bulletLength=11.354;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.105, 0.115, 0.120, 0.105};
@@ -70,7 +70,7 @@ class CfgAmmo
 	class RH_44mag_ball: BulletBase
 	{
         ACE_caliber=10.897;
-        ACE_bulletLength=0.020422;
+        ACE_bulletLength=20.422;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
@@ -83,7 +83,7 @@ class CfgAmmo
 	class RH_357mag_ball: BulletBase
 	{
         ACE_caliber=9.068;
-        ACE_bulletLength=0.013741;
+        ACE_bulletLength=13.741;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.148};
@@ -96,7 +96,7 @@ class CfgAmmo
 	class RH_762x25: BulletBase
 	{
         ACE_caliber=7.874;
-        ACE_bulletLength=0.013856;
+        ACE_bulletLength=13.856;
         ACE_bulletMass=5.5728;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
@@ -109,7 +109,7 @@ class CfgAmmo
 	class RH_9x18_Ball: BulletBase
 	{
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
@@ -122,7 +122,7 @@ class CfgAmmo
 	class RH_B_9x19_Ball: BulletBase
 	{
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -135,7 +135,7 @@ class CfgAmmo
 	class RH_B_22LR_SD: BulletBase
 	{
         ACE_caliber=5.664;
-        ACE_bulletLength=0.01143;
+        ACE_bulletLength=11.43;
         ACE_bulletMass=2.4624;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.111};
@@ -148,7 +148,7 @@ class CfgAmmo
 	class RH_57x28mm: BulletBase
 	{
         ACE_caliber=5.69;
-        ACE_bulletLength=0.012573;
+        ACE_bulletLength=12.573;
         ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -13,7 +13,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 398, 420};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
 	};
 	class RH_454_Casull: BulletBase
 	{
@@ -26,7 +26,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={450, 490, 500};
-        ACE_barrelLengths[]={4, 7.5, 9};
+        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
 	};
 	class RH_32ACP: BulletBase
 	{
@@ -39,7 +39,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
 	};
 	class RH_45ACP: BulletBase
 	{
@@ -52,7 +52,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
 	};
 	class RH_B_40SW: BulletBase
 	{
@@ -65,7 +65,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
 	};
 	class RH_44mag_ball: BulletBase
 	{
@@ -78,7 +78,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 390, 420};
-        ACE_barrelLengths[]={4, 7.5, 9};
+        ACE_barrelLengths[]={0.1016, 0.1905, 0.2286};
 	};
 	class RH_357mag_ball: BulletBase
 	{
@@ -91,7 +91,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={490, 510, 535};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
 	};
 	class RH_762x25: BulletBase
 	{
@@ -104,7 +104,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
 	};
 	class RH_9x18_Ball: BulletBase
 	{
@@ -117,7 +117,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
 	};
 	class RH_B_9x19_Ball: BulletBase
 	{
@@ -130,7 +130,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
 	};
 	class RH_B_22LR_SD: BulletBase
 	{
@@ -143,7 +143,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={330, 340, 360};
-        ACE_barrelLengths[]={4, 6, 9};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.2286};
 	};
 	class RH_57x28mm: BulletBase
 	{
@@ -156,6 +156,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={550, 625, 720};
-        ACE_barrelLengths[]={4, 6, 10.35};
+        ACE_barrelLengths[]={0.1016, 0.1524, 0.26289};
     };
 };

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -4,7 +4,7 @@ class CfgAmmo
 	class BulletBase;
 	class RH_50_AE_Ball: BulletBase
 	{
-        ACE_caliber=0.0127;
+        ACE_caliber=12.7;
         ACE_bulletLength=0.028194;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -17,7 +17,7 @@ class CfgAmmo
 	};
 	class RH_454_Casull: BulletBase
 	{
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.022733;
         ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -30,7 +30,7 @@ class CfgAmmo
 	};
 	class RH_32ACP: BulletBase
 	{
-        ACE_caliber=0.007938;
+        ACE_caliber=7.938;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -43,7 +43,7 @@ class CfgAmmo
 	};
 	class RH_45ACP: BulletBase
 	{
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -56,7 +56,7 @@ class CfgAmmo
 	};
 	class RH_B_40SW: BulletBase
 	{
-        ACE_caliber=0.01016;
+        ACE_caliber=10.16;
         ACE_bulletLength=0.011354;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -69,7 +69,7 @@ class CfgAmmo
 	};
 	class RH_44mag_ball: BulletBase
 	{
-        ACE_caliber=0.010897;
+        ACE_caliber=10.897;
         ACE_bulletLength=0.020422;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -82,7 +82,7 @@ class CfgAmmo
 	};
 	class RH_357mag_ball: BulletBase
 	{
-        ACE_caliber=0.009068;
+        ACE_caliber=9.068;
         ACE_bulletLength=0.013741;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -95,7 +95,7 @@ class CfgAmmo
 	};
 	class RH_762x25: BulletBase
 	{
-        ACE_caliber=0.007874;
+        ACE_caliber=7.874;
         ACE_bulletLength=0.013856;
         ACE_bulletMass=5.5728;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -108,7 +108,7 @@ class CfgAmmo
 	};
 	class RH_9x18_Ball: BulletBase
 	{
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -121,7 +121,7 @@ class CfgAmmo
 	};
 	class RH_B_9x19_Ball: BulletBase
 	{
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -134,7 +134,7 @@ class CfgAmmo
 	};
 	class RH_B_22LR_SD: BulletBase
 	{
-        ACE_caliber=0.005664;
+        ACE_caliber=5.664;
         ACE_bulletLength=0.01143;
         ACE_bulletMass=2.4624;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -147,7 +147,7 @@ class CfgAmmo
 	};
 	class RH_57x28mm: BulletBase
 	{
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.012573;
         ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.0127;
         ACE_bulletLength=0.028194;
-        ACE_bulletMass=325;
+        ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.228};
         ACE_velocityBoundaries[]={};
@@ -19,7 +19,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.011481;
         ACE_bulletLength=0.022733;
-        ACE_bulletMass=325;
+        ACE_bulletMass=21.06;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.171};
         ACE_velocityBoundaries[]={};
@@ -32,7 +32,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007938;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.118};
         ACE_velocityBoundaries[]={};
@@ -45,7 +45,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};
@@ -58,7 +58,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.01016;
         ACE_bulletLength=0.011354;
-        ACE_bulletMass=135;
+        ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.105, 0.115, 0.120, 0.105};
         ACE_velocityBoundaries[]={365, 305, 259};
@@ -71,7 +71,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.010897;
         ACE_bulletLength=0.020422;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.172};
         ACE_velocityBoundaries[]={};
@@ -84,7 +84,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.009068;
         ACE_bulletLength=0.013741;
-        ACE_bulletMass=125;
+        ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.148};
         ACE_velocityBoundaries[]={};
@@ -97,7 +97,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.007874;
         ACE_bulletLength=0.013856;
-        ACE_bulletMass=86;
+        ACE_bulletMass=5.5728;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.17};
         ACE_velocityBoundaries[]={};
@@ -110,7 +110,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};
@@ -123,7 +123,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -136,7 +136,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.005664;
         ACE_bulletLength=0.01143;
-        ACE_bulletMass=38;
+        ACE_bulletMass=2.4624;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.111};
         ACE_velocityBoundaries[]={};
@@ -149,7 +149,7 @@ class CfgAmmo
 	{
         ACE_caliber=0.00569;
         ACE_bulletLength=0.012573;
-        ACE_bulletMass=28;
+        ACE_bulletMass=1.8144;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.144};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_rh_de/CfgAmmo.hpp
+++ b/optionals/compat_rh_de/CfgAmmo.hpp
@@ -4,7 +4,7 @@ class CfgAmmo
 	class BulletBase;
 	class RH_50_AE_Ball: BulletBase
 	{
-        ACE_caliber=0.5;
+        ACE_caliber=0.0127;
         ACE_bulletLength=1.110;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -17,7 +17,7 @@ class CfgAmmo
 	};
 	class RH_454_Casull: BulletBase
 	{
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.895;
         ACE_bulletMass=325;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -30,7 +30,7 @@ class CfgAmmo
 	};
 	class RH_32ACP: BulletBase
 	{
-        ACE_caliber=0.3125;
+        ACE_caliber=0.007938;
         ACE_bulletLength=0.610;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -43,7 +43,7 @@ class CfgAmmo
 	};
 	class RH_45ACP: BulletBase
 	{
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -56,7 +56,7 @@ class CfgAmmo
 	};
 	class RH_B_40SW: BulletBase
 	{
-        ACE_caliber=0.4;
+        ACE_caliber=0.01016;
         ACE_bulletLength=0.447;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -69,7 +69,7 @@ class CfgAmmo
 	};
 	class RH_44mag_ball: BulletBase
 	{
-        ACE_caliber=0.429;
+        ACE_caliber=0.010897;
         ACE_bulletLength=0.804;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -82,7 +82,7 @@ class CfgAmmo
 	};
 	class RH_357mag_ball: BulletBase
 	{
-        ACE_caliber=0.357;
+        ACE_caliber=0.009068;
         ACE_bulletLength=0.541;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -95,7 +95,7 @@ class CfgAmmo
 	};
 	class RH_762x25: BulletBase
 	{
-        ACE_caliber=0.310;
+        ACE_caliber=0.007874;
         ACE_bulletLength=0.5455;
         ACE_bulletMass=86;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -108,7 +108,7 @@ class CfgAmmo
 	};
 	class RH_9x18_Ball: BulletBase
 	{
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -121,7 +121,7 @@ class CfgAmmo
 	};
 	class RH_B_9x19_Ball: BulletBase
 	{
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -134,7 +134,7 @@ class CfgAmmo
 	};
 	class RH_B_22LR_SD: BulletBase
 	{
-        ACE_caliber=0.223;
+        ACE_caliber=0.005664;
         ACE_bulletLength=0.45;
         ACE_bulletMass=38;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -147,7 +147,7 @@ class CfgAmmo
 	};
 	class RH_57x28mm: BulletBase
 	{
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.495;
         ACE_bulletMass=28;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rh_de/CfgWeapons.hpp
+++ b/optionals/compat_rh_de/CfgWeapons.hpp
@@ -4,137 +4,137 @@ class CfgWeapons
     class RH_Pistol_Base_F;
     class RH_deagle: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4826;
+        ACE_barrelTwist=482.6;
         ACE_barrelLength=0.1524;
     };
     class RH_mateba: Pistol_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.1524;
     };
     class RH_mp412: Pistol_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.1524;
     };
     class RH_python: Pistol_Base_F
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.1524;
     };
     class RH_bull: RH_python
     {
-        ACE_barrelTwist=0.6096;
+        ACE_barrelTwist=609.6;
         ACE_barrelLength=0.1651;
     };
     class RH_ttracker: Pistol_Base_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.1016;
     };
     class RH_cz75: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24638;
+        ACE_barrelTwist=246.38;
         ACE_barrelLength=0.11938;
     };
     class RH_p226: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.11176;
     };
     class RH_sw659: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.188976;
     };
     class RH_usp: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.112014;
     };
     class RH_uspm: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1524;
     };
     class RH_kimber: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class RH_m1911: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     class RH_tt33: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.11684;
     };
     class RH_mak: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.093472;
     };
     class RH_mk2: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1016;
     };
     class RH_m9: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.12446;
     };
     class RH_g18: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.114046;
     };
     class RH_g17: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.114046;
     };
     class RH_g19: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.1016;
     };
     class RH_gsh18: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.10414;
     };
     class RH_fnp45: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class RH_fn57: RH_fnp45
     {
-        ACE_barrelTwist=0.23114;
+        ACE_barrelTwist=231.14;
         ACE_barrelLength=0.12192;
     };
     class RH_vp70: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.11684;
     };
     class RH_vz61: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.1143;
     };
     class RH_tec9: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.127;
     };
     class RH_muzi: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=0.24892;
+        ACE_barrelTwist=248.92;
         ACE_barrelLength=0.127;
     };
 };

--- a/optionals/compat_rh_de/CfgWeapons.hpp
+++ b/optionals/compat_rh_de/CfgWeapons.hpp
@@ -5,136 +5,136 @@ class CfgWeapons
     class RH_deagle: RH_Pistol_Base_F
     {
         ACE_barrelTwist=482.6;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_mateba: Pistol_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_mp412: Pistol_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_python: Pistol_Base_F
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_bull: RH_python
     {
         ACE_barrelTwist=609.6;
-        ACE_barrelLength=0.1651;
+        ACE_barrelLength=165.1;
     };
     class RH_ttracker: Pistol_Base_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class RH_cz75: RH_Pistol_Base_F
     {
         ACE_barrelTwist=246.38;
-        ACE_barrelLength=0.11938;
+        ACE_barrelLength=119.38;
     };
     class RH_p226: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class RH_sw659: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.188976;
+        ACE_barrelLength=188.976;
     };
     class RH_usp: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.112014;
+        ACE_barrelLength=112.014;
     };
     class RH_uspm: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_kimber: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_m1911: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_tt33: RH_Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.11684;
+        ACE_barrelLength=116.84;
     };
     class RH_mak: RH_Pistol_Base_F
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.093472;
+        ACE_barrelLength=93.472;
     };
     class RH_mk2: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class RH_m9: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.12446;
+        ACE_barrelLength=124.46;
     };
     class RH_g18: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.114046;
+        ACE_barrelLength=114.046;
     };
     class RH_g17: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.114046;
+        ACE_barrelLength=114.046;
     };
     class RH_g19: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.1016;
+        ACE_barrelLength=101.6;
     };
     class RH_gsh18: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.10414;
+        ACE_barrelLength=104.14;
     };
     class RH_fnp45: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class RH_fn57: RH_fnp45
     {
         ACE_barrelTwist=231.14;
-        ACE_barrelLength=0.12192;
+        ACE_barrelLength=121.92;
     };
     class RH_vp70: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.11684;
+        ACE_barrelLength=116.84;
     };
     class RH_vz61: RH_Pistol_Base_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.1143;
+        ACE_barrelLength=114.3;
     };
     class RH_tec9: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     class RH_muzi: RH_Pistol_Base_F
     {
         ACE_barrelTwist=248.92;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
 };

--- a/optionals/compat_rh_de/CfgWeapons.hpp
+++ b/optionals/compat_rh_de/CfgWeapons.hpp
@@ -5,136 +5,136 @@ class CfgWeapons
     class RH_deagle: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4826;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_mateba: Pistol_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_mp412: Pistol_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_python: Pistol_Base_F
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_bull: RH_python
     {
         ACE_barrelTwist=0.6096;
-        ACE_barrelLength=6.5;
+        ACE_barrelLength=0.1651;
     };
     class RH_ttracker: Pistol_Base_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class RH_cz75: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24638;
-        ACE_barrelLength=4.7;
+        ACE_barrelLength=0.11938;
     };
     class RH_p226: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class RH_sw659: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=7.44;
+        ACE_barrelLength=0.188976;
     };
     class RH_usp: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.41;
+        ACE_barrelLength=0.112014;
     };
     class RH_uspm: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_kimber: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_m1911: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_tt33: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=4.6;
+        ACE_barrelLength=0.11684;
     };
     class RH_mak: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=3.68;
+        ACE_barrelLength=0.093472;
     };
     class RH_mk2: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class RH_m9: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.9;
+        ACE_barrelLength=0.12446;
     };
     class RH_g18: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.49;
+        ACE_barrelLength=0.114046;
     };
     class RH_g17: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.49;
+        ACE_barrelLength=0.114046;
     };
     class RH_g19: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4;
+        ACE_barrelLength=0.1016;
     };
     class RH_gsh18: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.1;
+        ACE_barrelLength=0.10414;
     };
     class RH_fnp45: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class RH_fn57: RH_fnp45
     {
         ACE_barrelTwist=0.23114;
-        ACE_barrelLength=4.8;
+        ACE_barrelLength=0.12192;
     };
     class RH_vp70: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=4.6;
+        ACE_barrelLength=0.11684;
     };
     class RH_vz61: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=4.5;
+        ACE_barrelLength=0.1143;
     };
     class RH_tec9: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     class RH_muzi: RH_Pistol_Base_F
     {
         ACE_barrelTwist=0.24892;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
 };

--- a/optionals/compat_rh_de/CfgWeapons.hpp
+++ b/optionals/compat_rh_de/CfgWeapons.hpp
@@ -4,137 +4,137 @@ class CfgWeapons
     class RH_Pistol_Base_F;
     class RH_deagle: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=19;
+        ACE_barrelTwist=0.4826;
         ACE_barrelLength=6;
     };
     class RH_mateba: Pistol_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=6;
     };
     class RH_mp412: Pistol_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=6;
     };
     class RH_python: Pistol_Base_F
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=6;
     };
     class RH_bull: RH_python
     {
-        ACE_barrelTwist=24;
+        ACE_barrelTwist=0.6096;
         ACE_barrelLength=6.5;
     };
     class RH_ttracker: Pistol_Base_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=4;
     };
     class RH_cz75: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.7;
+        ACE_barrelTwist=0.24638;
         ACE_barrelLength=4.7;
     };
     class RH_p226: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.4;
     };
     class RH_sw659: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=7.44;
     };
     class RH_usp: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.41;
     };
     class RH_uspm: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=6;
     };
     class RH_kimber: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class RH_m1911: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     class RH_tt33: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=4.6;
     };
     class RH_mak: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=3.68;
     };
     class RH_mk2: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4;
     };
     class RH_m9: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.9;
     };
     class RH_g18: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.49;
     };
     class RH_g17: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.49;
     };
     class RH_g19: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4;
     };
     class RH_gsh18: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.1;
     };
     class RH_fnp45: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class RH_fn57: RH_fnp45
     {
-        ACE_barrelTwist=9.1;
+        ACE_barrelTwist=0.23114;
         ACE_barrelLength=4.8;
     };
     class RH_vp70: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=4.6;
     };
     class RH_vz61: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=4.5;
     };
     class RH_tec9: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=5;
     };
     class RH_muzi: RH_Pistol_Base_F
     {
-        ACE_barrelTwist=9.8;
+        ACE_barrelTwist=0.24892;
         ACE_barrelLength=5;
     };
 };

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -10,7 +10,7 @@ class CfgAmmo {
     
     class RH_9x19_B_M822: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -23,7 +23,7 @@ class CfgAmmo {
     };
     class RH_9x19_B_HP: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -36,7 +36,7 @@ class CfgAmmo {
     };
     class RH_9x19_B_HPSB: BulletBase
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015316;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -49,7 +49,7 @@ class CfgAmmo {
     };
     class RH_556x45_B_M855A1: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -62,7 +62,7 @@ class CfgAmmo {
     };
     class RH_556x45_B_Mk318: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -75,7 +75,7 @@ class CfgAmmo {
     };
     class RH_556x45_B_Mk262: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -88,7 +88,7 @@ class CfgAmmo {
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.007036;
+        ACE_caliber=7.036;
         ACE_bulletLength=0.024359;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -101,7 +101,7 @@ class CfgAmmo {
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.007036;
+        ACE_caliber=7.036;
         ACE_bulletLength=0.03175;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -114,7 +114,7 @@ class CfgAmmo {
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -127,7 +127,7 @@ class CfgAmmo {
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.029286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -140,7 +140,7 @@ class CfgAmmo {
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -153,7 +153,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_M80A1: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -166,7 +166,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_Mk316LR: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -179,7 +179,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_Mk319: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -192,7 +192,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.034036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -12,7 +12,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -25,7 +25,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=124;
+        ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
         ACE_velocityBoundaries[]={};
@@ -38,7 +38,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015316;
-        ACE_bulletMass=147;
+        ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.212};
         ACE_velocityBoundaries[]={};
@@ -51,7 +51,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
         ACE_velocityBoundaries[]={};
@@ -64,7 +64,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -77,7 +77,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -90,7 +90,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007036;
         ACE_bulletLength=0.024359;
-        ACE_bulletMass=115;
+        ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.162};
         ACE_velocityBoundaries[]={};
@@ -103,7 +103,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007036;
         ACE_bulletLength=0.03175;
-        ACE_bulletMass=135;
+        ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.253};
         ACE_velocityBoundaries[]={};
@@ -116,7 +116,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028397;
-        ACE_bulletMass=147;
+        ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
         ACE_velocityBoundaries[]={};
@@ -129,7 +129,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.029286;
-        ACE_bulletMass=125;
+        ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
         ACE_velocityBoundaries[]={792, 610, 488};
@@ -142,7 +142,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
         ACE_velocityBoundaries[]={};
@@ -155,7 +155,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -168,7 +168,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -181,7 +181,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=130;
+        ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
         ACE_velocityBoundaries[]={};
@@ -194,7 +194,7 @@ class CfgAmmo {
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.034036;
-        ACE_bulletMass=200;
+        ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -10,7 +10,7 @@ class CfgAmmo {
     
     class RH_9x19_B_M822: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -23,7 +23,7 @@ class CfgAmmo {
     };
     class RH_9x19_B_HP: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -36,7 +36,7 @@ class CfgAmmo {
     };
     class RH_9x19_B_HPSB: BulletBase
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.603;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -49,7 +49,7 @@ class CfgAmmo {
     };
     class RH_556x45_B_M855A1: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
@@ -62,7 +62,7 @@ class CfgAmmo {
     };
     class RH_556x45_B_Mk318: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -75,7 +75,7 @@ class CfgAmmo {
     };
     class RH_556x45_B_Mk262: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -88,7 +88,7 @@ class CfgAmmo {
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.277;
+        ACE_caliber=0.007036;
         ACE_bulletLength=0.959;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -101,7 +101,7 @@ class CfgAmmo {
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.277;
+        ACE_caliber=0.007036;
         ACE_bulletLength=1.250;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -114,7 +114,7 @@ class CfgAmmo {
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.118;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -127,7 +127,7 @@ class CfgAmmo {
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.153;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -140,7 +140,7 @@ class CfgAmmo {
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -153,7 +153,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_M80A1: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -166,7 +166,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_Mk316LR: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
@@ -179,7 +179,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_Mk319: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -192,7 +192,7 @@ class CfgAmmo {
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.340;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -11,7 +11,7 @@ class CfgAmmo {
     class RH_9x19_B_M822: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -24,7 +24,7 @@ class CfgAmmo {
     class RH_9x19_B_HP: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -37,7 +37,7 @@ class CfgAmmo {
     class RH_9x19_B_HPSB: BulletBase
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015316;
+        ACE_bulletLength=15.316;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.212};
@@ -50,7 +50,7 @@ class CfgAmmo {
     class RH_556x45_B_M855A1: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -63,7 +63,7 @@ class CfgAmmo {
     class RH_556x45_B_Mk318: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -76,7 +76,7 @@ class CfgAmmo {
     class RH_556x45_B_Mk262: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -89,7 +89,7 @@ class CfgAmmo {
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=7.036;
-        ACE_bulletLength=0.024359;
+        ACE_bulletLength=24.359;
         ACE_bulletMass=7.452;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.162};
@@ -102,7 +102,7 @@ class CfgAmmo {
     class RH_68x43_B_Match: B_65x39_Caseless
     {
         ACE_caliber=7.036;
-        ACE_bulletLength=0.03175;
+        ACE_bulletLength=31.75;
         ACE_bulletMass=8.748;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.253};
@@ -115,7 +115,7 @@ class CfgAmmo {
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028397;
+        ACE_bulletLength=28.397;
         ACE_bulletMass=9.5256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -128,7 +128,7 @@ class CfgAmmo {
     class RH_762x35_B_Match: B_65x39_Caseless
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.029286;
+        ACE_bulletLength=29.286;
         ACE_bulletMass=8.1;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -141,7 +141,7 @@ class CfgAmmo {
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -154,7 +154,7 @@ class CfgAmmo {
     class RH_762x51_B_M80A1: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -167,7 +167,7 @@ class CfgAmmo {
     class RH_762x51_B_Mk316LR: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.243};
@@ -180,7 +180,7 @@ class CfgAmmo {
     class RH_762x51_B_Mk319: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=8.424;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
@@ -193,7 +193,7 @@ class CfgAmmo {
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.034036;
+        ACE_bulletLength=34.036;
         ACE_bulletMass=12.96;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -19,7 +19,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_9x19_B_HP: BulletBase
     {
@@ -32,7 +32,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_9x19_B_HPSB: BulletBase
     {
@@ -45,7 +45,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={295, 310, 330};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class RH_556x45_B_M855A1: B_556x45_Ball
     {
@@ -58,7 +58,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={8.3, 9.4, 10.6, 11.8, 13.0, 14.2, 15.4, 16.5, 17.7, 18.9, 20.0, 24.0};
+        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
     };
     class RH_556x45_B_Mk318: B_556x45_Ball
     {
@@ -71,7 +71,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class RH_556x45_B_Mk262: B_556x45_Ball
     {
@@ -84,7 +84,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
@@ -97,7 +97,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={713, 785, 810, 850};
-        ACE_barrelLengths[]={12, 16, 20, 24};
+        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
@@ -110,7 +110,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 732, 750, 780};
-        ACE_barrelLengths[]={12, 16, 20, 24};
+        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
@@ -123,7 +123,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={6, 16, 20};
+        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
@@ -136,7 +136,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={572, 676, 700};
-        ACE_barrelLengths[]={6, 16, 20};
+        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
@@ -149,7 +149,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={9, 16, 20};
+        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
     };
     class RH_762x51_B_M80A1: B_762x51_Ball
     {
@@ -162,7 +162,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class RH_762x51_B_Mk316LR: B_762x51_Ball
     {
@@ -175,7 +175,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={775, 790, 805, 810};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class RH_762x51_B_Mk319: B_762x51_Ball
     {
@@ -188,7 +188,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 910};
-        ACE_barrelLengths[]={13, 16, 20};
+        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
@@ -201,6 +201,6 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
 };

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -19,7 +19,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_9x19_B_HP: BulletBase
     {
@@ -32,7 +32,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_9x19_B_HPSB: BulletBase
     {
@@ -45,7 +45,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={295, 310, 330};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class RH_556x45_B_M855A1: B_556x45_Ball
     {
@@ -58,7 +58,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={0.21082, 0.23876, 0.26924, 0.29972, 0.3302, 0.36068, 0.39116, 0.4191, 0.44958, 0.48006, 0.508, 0.6096};
+        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class RH_556x45_B_Mk318: B_556x45_Ball
     {
@@ -71,7 +71,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class RH_556x45_B_Mk262: B_556x45_Ball
     {
@@ -84,7 +84,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
@@ -97,7 +97,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={713, 785, 810, 850};
-        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
+        ACE_barrelLengths[]={304.8, 406.4, 508.0, 609.6};
     };
     class RH_68x43_B_Match: B_65x39_Caseless
     {
@@ -110,7 +110,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 732, 750, 780};
-        ACE_barrelLengths[]={0.3048, 0.4064, 0.508, 0.6096};
+        ACE_barrelLengths[]={304.8, 406.4, 508.0, 609.6};
     };	
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
@@ -123,7 +123,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={559, 609, 625};
-        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
+        ACE_barrelLengths[]={152.4, 406.4, 508.0};
     };
     class RH_762x35_B_Match: B_65x39_Caseless
     {
@@ -136,7 +136,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={572, 676, 700};
-        ACE_barrelLengths[]={0.1524, 0.4064, 0.508};
+        ACE_barrelLengths[]={152.4, 406.4, 508.0};
     };
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
@@ -149,7 +149,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={300, 320, 340};
-        ACE_barrelLengths[]={0.2286, 0.4064, 0.508};
+        ACE_barrelLengths[]={228.6, 406.4, 508.0};
     };
     class RH_762x51_B_M80A1: B_762x51_Ball
     {
@@ -162,7 +162,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class RH_762x51_B_Mk316LR: B_762x51_Ball
     {
@@ -175,7 +175,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={775, 790, 805, 810};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class RH_762x51_B_Mk319: B_762x51_Ball
     {
@@ -188,7 +188,7 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={838, 892, 910};
-        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
+        ACE_barrelLengths[]={330.2, 406.4, 508.0};
     };
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
@@ -201,6 +201,6 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={305, 325, 335, 340};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
 };

--- a/optionals/compat_rh_m4/CfgAmmo.hpp
+++ b/optionals/compat_rh_m4/CfgAmmo.hpp
@@ -11,7 +11,7 @@ class CfgAmmo {
     class RH_9x19_B_M822: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -24,7 +24,7 @@ class CfgAmmo {
     class RH_9x19_B_HP: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=124;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.165};
@@ -37,7 +37,7 @@ class CfgAmmo {
     class RH_9x19_B_HPSB: BulletBase
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.603;
+        ACE_bulletLength=0.015316;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.212};
@@ -50,7 +50,7 @@ class CfgAmmo {
     class RH_556x45_B_M855A1: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
         ACE_ballisticCoefficients[]={0.151};
@@ -63,7 +63,7 @@ class CfgAmmo {
     class RH_556x45_B_Mk318: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -76,7 +76,7 @@ class CfgAmmo {
     class RH_556x45_B_Mk262: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -89,7 +89,7 @@ class CfgAmmo {
     class RH_68x43_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=0.007036;
-        ACE_bulletLength=0.959;
+        ACE_bulletLength=0.024359;
         ACE_bulletMass=115;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.162};
@@ -102,7 +102,7 @@ class CfgAmmo {
     class RH_68x43_B_Match: B_65x39_Caseless
     {
         ACE_caliber=0.007036;
-        ACE_bulletLength=1.250;
+        ACE_bulletLength=0.03175;
         ACE_bulletMass=135;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.253};
@@ -115,7 +115,7 @@ class CfgAmmo {
     class RH_762x35_B_FMJ: B_65x39_Caseless
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.118;
+        ACE_bulletLength=0.028397;
         ACE_bulletMass=147;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.398};
@@ -128,7 +128,7 @@ class CfgAmmo {
     class RH_762x35_B_Match: B_65x39_Caseless
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.153;
+        ACE_bulletLength=0.029286;
         ACE_bulletMass=125;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
@@ -141,7 +141,7 @@ class CfgAmmo {
     class RH_762x35_B_MSB: B_65x39_Caseless
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.608};
@@ -154,7 +154,7 @@ class CfgAmmo {
     class RH_762x51_B_M80A1: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -167,7 +167,7 @@ class CfgAmmo {
     class RH_762x51_B_Mk316LR: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[]={0.243};
@@ -180,7 +180,7 @@ class CfgAmmo {
     class RH_762x51_B_Mk319: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=130;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.377};
@@ -193,7 +193,7 @@ class CfgAmmo {
     class RH_762x51_B_LFMJSB: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.340;
+        ACE_bulletLength=0.034036;
         ACE_bulletMass=200;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.235};

--- a/optionals/compat_rh_m4/CfgWeapons.hpp
+++ b/optionals/compat_rh_m4/CfgWeapons.hpp
@@ -5,126 +5,126 @@ class CfgWeapons
     class RH_ar10: Rifle_Base_F
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=20.8;
+        ACE_barrelLength=0.52832;
     };
     class RH_m110: Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_Mk11: RH_m110
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class RH_SR25EC: RH_m110
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_m4: Rifle_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_M4_ris: RH_m4
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_M4A1_ris: RH_M4_ris
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_M4m: RH_M4A1_ris
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.5;
+        ACE_barrelLength=0.2667;
     };
     class RH_M4sbr: RH_M4A1_ris
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.5;
+        ACE_barrelLength=0.2667;
     };
     class RH_hb: Rifle_Base_F
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_hb_b: RH_hb
     {
         ACE_barrelTwist=0.2032;
-        ACE_barrelLength=6;
+        ACE_barrelLength=0.1524;
     };
     class RH_sbr9: Rifle_Base_F
     {
 		ACE_barrelTwist=0.24638;
-		ACE_barrelLength=9;
+		ACE_barrelLength=0.2286;
     };
     class RH_M4A6: RH_M4A1_ris
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_M16a1: RH_m4
     {
         ACE_barrelTwist=0.3556;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A2: RH_m4
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A4 : RH_M4_ris
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A3: RH_M16A4
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A4_m: RH_M16A4
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_M16A6: RH_M16A4
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_Mk12mod1: RH_M16A4
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=18;
+        ACE_barrelLength=0.4572;
     };
     class RH_SAMR: RH_Mk12mod1
     {
         ACE_barrelTwist=0.19558;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class RH_Hk416: RH_M4A1_ris
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class RH_Hk416s: RH_M4sbr
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.4;
+        ACE_barrelLength=0.26416;
     };
     class RH_Hk416c: RH_M4sbr
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=9;
+        ACE_barrelLength=0.2286;
     };
     class RH_M27IAR: RH_Mk12mod1
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.5;
+        ACE_barrelLength=0.4191;
     };
 };

--- a/optionals/compat_rh_m4/CfgWeapons.hpp
+++ b/optionals/compat_rh_m4/CfgWeapons.hpp
@@ -5,126 +5,126 @@ class CfgWeapons
     class RH_ar10: Rifle_Base_F
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.52832;
+        ACE_barrelLength=528.32;
     };
     class RH_m110: Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_Mk11: RH_m110
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class RH_SR25EC: RH_m110
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_m4: Rifle_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_M4_ris: RH_m4
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_M4A1_ris: RH_M4_ris
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_M4m: RH_M4A1_ris
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2667;
+        ACE_barrelLength=266.7;
     };
     class RH_M4sbr: RH_M4A1_ris
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2667;
+        ACE_barrelLength=266.7;
     };
     class RH_hb: Rifle_Base_F
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_hb_b: RH_hb
     {
         ACE_barrelTwist=203.2;
-        ACE_barrelLength=0.1524;
+        ACE_barrelLength=152.4;
     };
     class RH_sbr9: Rifle_Base_F
     {
 		ACE_barrelTwist=246.38;
-		ACE_barrelLength=0.2286;
+		ACE_barrelLength=228.6;
     };
     class RH_M4A6: RH_M4A1_ris
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_M16a1: RH_m4
     {
         ACE_barrelTwist=355.6;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A2: RH_m4
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A4 : RH_M4_ris
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A3: RH_M16A4
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A4_m: RH_M16A4
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_M16A6: RH_M16A4
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_Mk12mod1: RH_M16A4
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4572;
+        ACE_barrelLength=457.2;
     };
     class RH_SAMR: RH_Mk12mod1
     {
         ACE_barrelTwist=195.58;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class RH_Hk416: RH_M4A1_ris
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class RH_Hk416s: RH_M4sbr
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.26416;
+        ACE_barrelLength=264.16;
     };
     class RH_Hk416c: RH_M4sbr
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.2286;
+        ACE_barrelLength=228.6;
     };
     class RH_M27IAR: RH_Mk12mod1
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.4191;
+        ACE_barrelLength=419.1;
     };
 };

--- a/optionals/compat_rh_m4/CfgWeapons.hpp
+++ b/optionals/compat_rh_m4/CfgWeapons.hpp
@@ -4,127 +4,127 @@ class CfgWeapons
     class Rifle_Base_F;
     class RH_ar10: Rifle_Base_F
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=20.8;
     };
     class RH_m110: Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=20;
     };
     class RH_Mk11: RH_m110
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class RH_SR25EC: RH_m110
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=20;
     };
     class RH_m4: Rifle_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class RH_M4_ris: RH_m4
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class RH_M4A1_ris: RH_M4_ris
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class RH_M4m: RH_M4A1_ris
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.5;
     };
     class RH_M4sbr: RH_M4A1_ris
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.5;
     };
     class RH_hb: Rifle_Base_F
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=6;
     };
     class RH_hb_b: RH_hb
     {
-        ACE_barrelTwist=8;
+        ACE_barrelTwist=0.2032;
         ACE_barrelLength=6;
     };
     class RH_sbr9: Rifle_Base_F
     {
-		ACE_barrelTwist=9.7;
+		ACE_barrelTwist=0.24638;
 		ACE_barrelLength=9;
     };
     class RH_M4A6: RH_M4A1_ris
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=14.5;
     };
     class RH_M16a1: RH_m4
     {
-        ACE_barrelTwist=14;
+        ACE_barrelTwist=0.3556;
         ACE_barrelLength=20;
     };
     class RH_M16A2: RH_m4
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A4 : RH_M4_ris
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A3: RH_M16A4
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A4_m: RH_M16A4
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_M16A6: RH_M16A4
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class RH_Mk12mod1: RH_M16A4
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=18;
     };
     class RH_SAMR: RH_Mk12mod1
     {
-        ACE_barrelTwist=7.7;
+        ACE_barrelTwist=0.19558;
         ACE_barrelLength=20;
     };
     class RH_Hk416: RH_M4A1_ris
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class RH_Hk416s: RH_M4sbr
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.4;
     };
     class RH_Hk416c: RH_M4sbr
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=9;
     };
     class RH_M27IAR: RH_Mk12mod1
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.5;
     };
 };

--- a/optionals/compat_rh_m4/CfgWeapons.hpp
+++ b/optionals/compat_rh_m4/CfgWeapons.hpp
@@ -4,127 +4,127 @@ class CfgWeapons
     class Rifle_Base_F;
     class RH_ar10: Rifle_Base_F
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.52832;
     };
     class RH_m110: Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.508;
     };
     class RH_Mk11: RH_m110
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class RH_SR25EC: RH_m110
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.508;
     };
     class RH_m4: Rifle_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class RH_M4_ris: RH_m4
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class RH_M4A1_ris: RH_M4_ris
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class RH_M4m: RH_M4A1_ris
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2667;
     };
     class RH_M4sbr: RH_M4A1_ris
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2667;
     };
     class RH_hb: Rifle_Base_F
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.1524;
     };
     class RH_hb_b: RH_hb
     {
-        ACE_barrelTwist=0.2032;
+        ACE_barrelTwist=203.2;
         ACE_barrelLength=0.1524;
     };
     class RH_sbr9: Rifle_Base_F
     {
-		ACE_barrelTwist=0.24638;
+		ACE_barrelTwist=246.38;
 		ACE_barrelLength=0.2286;
     };
     class RH_M4A6: RH_M4A1_ris
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.3683;
     };
     class RH_M16a1: RH_m4
     {
-        ACE_barrelTwist=0.3556;
+        ACE_barrelTwist=355.6;
         ACE_barrelLength=0.508;
     };
     class RH_M16A2: RH_m4
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A4 : RH_M4_ris
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A3: RH_M16A4
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A4_m: RH_M16A4
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_M16A6: RH_M16A4
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class RH_Mk12mod1: RH_M16A4
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4572;
     };
     class RH_SAMR: RH_Mk12mod1
     {
-        ACE_barrelTwist=0.19558;
+        ACE_barrelTwist=195.58;
         ACE_barrelLength=0.508;
     };
     class RH_Hk416: RH_M4A1_ris
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class RH_Hk416s: RH_M4sbr
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.26416;
     };
     class RH_Hk416c: RH_M4sbr
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.2286;
     };
     class RH_M27IAR: RH_Mk12mod1
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.4191;
     };
 };

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -3,7 +3,7 @@ class BulletBase;
 class RH_B_6x35: BulletBase
 {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.445;
+        ACE_bulletLength=0.011303;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.26};

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -3,7 +3,7 @@ class BulletBase;
 class RH_B_6x35: BulletBase
 {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.011303;
+        ACE_bulletLength=11.303;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.26};

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -4,7 +4,7 @@ class RH_B_6x35: BulletBase
 {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.011303;
-        ACE_bulletMass=65;
+        ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.26};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -11,5 +11,5 @@ class RH_B_6x35: BulletBase
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={730, 750, 760};
-        ACE_barrelLengths[]={0.2032, 0.254, 0.3048};
+        ACE_barrelLengths[]={203.2, 254.0, 304.8};
 };

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -2,7 +2,7 @@
 class BulletBase;
 class RH_B_6x35: BulletBase
 {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.011303;
         ACE_bulletMass=4.212;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -11,5 +11,5 @@ class RH_B_6x35: BulletBase
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={730, 750, 760};
-        ACE_barrelLengths[]={8, 10, 12};
+        ACE_barrelLengths[]={0.2032, 0.254, 0.3048};
 };

--- a/optionals/compat_rh_pdw/CfgAmmo.hpp
+++ b/optionals/compat_rh_pdw/CfgAmmo.hpp
@@ -2,7 +2,7 @@
 class BulletBase;
 class RH_B_6x35: BulletBase
 {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.445;
         ACE_bulletMass=65;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};

--- a/optionals/compat_rh_pdw/CfgWeapons.hpp
+++ b/optionals/compat_rh_pdw/CfgWeapons.hpp
@@ -5,6 +5,6 @@ class CfgWeapons
 	class RH_PDW: Rifle_Base_F
 	{
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10;
+        ACE_barrelLength=0.254;
 	};
 };

--- a/optionals/compat_rh_pdw/CfgWeapons.hpp
+++ b/optionals/compat_rh_pdw/CfgWeapons.hpp
@@ -5,6 +5,6 @@ class CfgWeapons
 	class RH_PDW: Rifle_Base_F
 	{
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.254;
+        ACE_barrelLength=254.0;
 	};
 };

--- a/optionals/compat_rh_pdw/CfgWeapons.hpp
+++ b/optionals/compat_rh_pdw/CfgWeapons.hpp
@@ -4,7 +4,7 @@ class CfgWeapons
 	class Rifle_Base_F;
 	class RH_PDW: Rifle_Base_F
 	{
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.254;
 	};
 };

--- a/optionals/compat_rh_pdw/CfgWeapons.hpp
+++ b/optionals/compat_rh_pdw/CfgWeapons.hpp
@@ -4,7 +4,7 @@ class CfgWeapons
 	class Rifle_Base_F;
 	class RH_PDW: Rifle_Base_F
 	{
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10;
 	};
 };

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
     class B_556x45_Ball;
     class rhs_B_545x39_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -18,7 +18,7 @@ class CfgAmmo
     };
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
     {
-        ACE_caliber=0.005588;
+        ACE_caliber=5.588;
         ACE_bulletLength=0.02159;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -32,7 +32,7 @@ class CfgAmmo
     class B_762x51_Ball;
     class rhs_B_762x54_Ball: B_762x51_Ball
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -45,7 +45,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -58,7 +58,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
     {
-        ACE_caliber=0.007925;
+        ACE_caliber=7.925;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -71,7 +71,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Ball: B_762x51_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -84,7 +84,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -98,7 +98,7 @@ class CfgAmmo
     class B_9x21_Ball;
     class rhs_B_9x19_7N21: B_9x21_Ball
     {
-        ACE_caliber=0.009017;
+        ACE_caliber=9.017;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=5.19696;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -111,7 +111,7 @@ class CfgAmmo
     };
     class rhs_B_9x18_57N181S: B_9x21_Ball
     {
-        ACE_caliber=0.009271;
+        ACE_caliber=9.271;
         ACE_bulletLength=0.015494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -7,7 +7,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=52.9;
+        ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -20,7 +20,7 @@ class CfgAmmo
     {
         ACE_caliber=0.005588;
         ACE_bulletLength=0.02159;
-        ACE_bulletMass=49.8;
+        ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
         ACE_velocityBoundaries[]={};
@@ -34,7 +34,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -47,7 +47,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=149;
+        ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
         ACE_velocityBoundaries[]={};
@@ -60,7 +60,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007925;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=152;
+        ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
         ACE_velocityBoundaries[]={};
@@ -73,7 +73,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=123;
+        ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -86,7 +86,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=117;
+        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -100,7 +100,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009017;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=80.2;
+        ACE_bulletMass=5.19696;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.14};
         ACE_velocityBoundaries[]={};
@@ -113,7 +113,7 @@ class CfgAmmo
     {
         ACE_caliber=0.009271;
         ACE_bulletLength=0.015494;
-        ACE_bulletMass=92.6;
+        ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -14,7 +14,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
     {
@@ -27,7 +27,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_762x51_Ball;
     class rhs_B_762x54_Ball: B_762x51_Ball
@@ -41,7 +41,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
     {
@@ -54,7 +54,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
     {
@@ -67,7 +67,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_B_762x39_Ball: B_762x51_Ball
     {
@@ -80,7 +80,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
     {
@@ -93,7 +93,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={10, 16.3, 20};
+        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
     };
     class B_9x21_Ball;
     class rhs_B_9x19_7N21: B_9x21_Ball
@@ -107,7 +107,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={445, 460, 480};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
     class rhs_B_9x18_57N181S: B_9x21_Ball
     {
@@ -120,6 +120,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={3.8, 5, 9};
+        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
     };
 };

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball: B_556x45_Ball
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -19,7 +19,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
     {
         ACE_caliber=5.588;
-        ACE_bulletLength=0.02159;
+        ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -33,7 +33,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball: B_762x51_Ball
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -46,7 +46,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -59,7 +59,7 @@ class CfgAmmo
     class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
     {
         ACE_caliber=7.925;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -72,7 +72,7 @@ class CfgAmmo
     class rhs_B_762x39_Ball: B_762x51_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -85,7 +85,7 @@ class CfgAmmo
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -99,7 +99,7 @@ class CfgAmmo
     class rhs_B_9x19_7N21: B_9x21_Ball
     {
         ACE_caliber=9.017;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=5.19696;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.14};
@@ -112,7 +112,7 @@ class CfgAmmo
     class rhs_B_9x18_57N181S: B_9x21_Ball
     {
         ACE_caliber=9.271;
-        ACE_bulletLength=0.015494;
+        ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -14,7 +14,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={780, 880, 920};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
     {
@@ -27,7 +27,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={785, 883, 925};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_762x51_Ball;
     class rhs_B_762x54_Ball: B_762x51_Ball
@@ -41,7 +41,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
     {
@@ -54,7 +54,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={680, 750, 798, 800};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
     {
@@ -67,7 +67,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_B_762x39_Ball: B_762x51_Ball
     {
@@ -80,7 +80,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
     {
@@ -93,7 +93,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={0.254, 0.41402, 0.508};
+        ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_9x21_Ball;
     class rhs_B_9x19_7N21: B_9x21_Ball
@@ -107,7 +107,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={445, 460, 480};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
     class rhs_B_9x18_57N181S: B_9x21_Ball
     {
@@ -120,6 +120,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={0.09652, 0.127, 0.2286};
+        ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
 };

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
     class B_556x45_Ball;
     class rhs_B_545x39_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -18,7 +18,7 @@ class CfgAmmo
     };
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
     {
-        ACE_caliber=0.220;
+        ACE_caliber=0.005588;
         ACE_bulletLength=0.85;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -32,7 +32,7 @@ class CfgAmmo
     class B_762x51_Ball;
     class rhs_B_762x54_Ball: B_762x51_Ball
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -45,7 +45,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -58,7 +58,7 @@ class CfgAmmo
     };
     class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
     {
-        ACE_caliber=0.312;
+        ACE_caliber=0.007925;
         ACE_bulletLength=1.14;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -71,7 +71,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Ball: B_762x51_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -84,7 +84,7 @@ class CfgAmmo
     };
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -98,7 +98,7 @@ class CfgAmmo
     class B_9x21_Ball;
     class rhs_B_9x19_7N21: B_9x21_Ball
     {
-        ACE_caliber=0.355;
+        ACE_caliber=0.009017;
         ACE_bulletLength=0.610;
         ACE_bulletMass=80.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -111,7 +111,7 @@ class CfgAmmo
     };
     class rhs_B_9x18_57N181S: B_9x21_Ball
     {
-        ACE_caliber=0.365;
+        ACE_caliber=0.009271;
         ACE_bulletLength=0.610;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball: B_556x45_Ball
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=52.9;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -19,7 +19,7 @@ class CfgAmmo
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
     {
         ACE_caliber=0.005588;
-        ACE_bulletLength=0.85;
+        ACE_bulletLength=0.02159;
         ACE_bulletMass=49.8;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.168};
@@ -33,7 +33,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball: B_762x51_Ball
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -46,7 +46,7 @@ class CfgAmmo
     class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=149;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.395};
@@ -59,7 +59,7 @@ class CfgAmmo
     class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
     {
         ACE_caliber=0.007925;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=152;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.4};
@@ -72,7 +72,7 @@ class CfgAmmo
     class rhs_B_762x39_Ball: B_762x51_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=123;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -85,7 +85,7 @@ class CfgAmmo
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=117;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
@@ -99,7 +99,7 @@ class CfgAmmo
     class rhs_B_9x19_7N21: B_9x21_Ball
     {
         ACE_caliber=0.009017;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=80.2;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.14};
@@ -112,7 +112,7 @@ class CfgAmmo
     class rhs_B_9x18_57N181S: B_9x21_Ball
     {
         ACE_caliber=0.009271;
-        ACE_bulletLength=0.610;
+        ACE_bulletLength=0.015494;
         ACE_bulletMass=92.6;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.125};

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -5,57 +5,57 @@ class CfgWeapons
     class rhs_weap_pya: hgun_Rook40_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=4.4;
+        ACE_barrelLength=0.11176;
     };
     class Pistol_Base_F;
     class rhs_weap_makarov_pmm: rhs_weap_pya
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=3.68;
+        ACE_barrelLength=0.093472;
     };
     class rhs_weap_ak74m_Base_F;
     class rhs_weap_ak74m: rhs_weap_ak74m_Base_F
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class rhs_weap_akm: rhs_weap_ak74m
     {
         ACE_barrelTwist=0.199898;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class rhs_weap_aks74;
     class rhs_weap_aks74u: rhs_weap_aks74
     {
         ACE_barrelTwist=0.16002;
-        ACE_barrelLength=8.3;
+        ACE_barrelLength=0.21082;
     };
     class rhs_weap_svd: rhs_weap_ak74m
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=24.4;
+        ACE_barrelLength=0.61976;
     };
     class rhs_weap_svdp;
     class rhs_weap_svds: rhs_weap_svdp
     {
         ACE_barrelTwist=0.23876;
-        ACE_barrelLength=22.2;
+        ACE_barrelLength=0.56388;
     };
     class rhs_pkp_base;
     class rhs_weap_pkp: rhs_pkp_base
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.9;
+        ACE_barrelLength=0.65786;
     };
     class rhs_weap_pkm: rhs_weap_pkp
     {
         ACE_barrelTwist=0.24003;
-        ACE_barrelLength=25.4;
+        ACE_barrelLength=0.64516;
     };
     class rhs_weap_rpk74m: rhs_weap_pkp
     {
         ACE_barrelTwist=0.195072;
-        ACE_barrelLength=23.2;
+        ACE_barrelLength=0.58928;
     };
     
     class rhs_acc_sniper_base;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -4,57 +4,57 @@ class CfgWeapons
     class hgun_Rook40_F;
     class rhs_weap_pya: hgun_Rook40_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.11176;
     };
     class Pistol_Base_F;
     class rhs_weap_makarov_pmm: rhs_weap_pya
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.093472;
     };
     class rhs_weap_ak74m_Base_F;
     class rhs_weap_ak74m: rhs_weap_ak74m_Base_F
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class rhs_weap_akm: rhs_weap_ak74m
     {
-        ACE_barrelTwist=0.199898;
+        ACE_barrelTwist=199.898;
         ACE_barrelLength=0.41402;
     };
     class rhs_weap_aks74;
     class rhs_weap_aks74u: rhs_weap_aks74
     {
-        ACE_barrelTwist=0.16002;
+        ACE_barrelTwist=160.02;
         ACE_barrelLength=0.21082;
     };
     class rhs_weap_svd: rhs_weap_ak74m
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.61976;
     };
     class rhs_weap_svdp;
     class rhs_weap_svds: rhs_weap_svdp
     {
-        ACE_barrelTwist=0.23876;
+        ACE_barrelTwist=238.76;
         ACE_barrelLength=0.56388;
     };
     class rhs_pkp_base;
     class rhs_weap_pkp: rhs_pkp_base
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.65786;
     };
     class rhs_weap_pkm: rhs_weap_pkp
     {
-        ACE_barrelTwist=0.24003;
+        ACE_barrelTwist=240.03;
         ACE_barrelLength=0.64516;
     };
     class rhs_weap_rpk74m: rhs_weap_pkp
     {
-        ACE_barrelTwist=0.195072;
+        ACE_barrelTwist=195.072;
         ACE_barrelLength=0.58928;
     };
     

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -5,57 +5,57 @@ class CfgWeapons
     class rhs_weap_pya: hgun_Rook40_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.11176;
+        ACE_barrelLength=111.76;
     };
     class Pistol_Base_F;
     class rhs_weap_makarov_pmm: rhs_weap_pya
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.093472;
+        ACE_barrelLength=93.472;
     };
     class rhs_weap_ak74m_Base_F;
     class rhs_weap_ak74m: rhs_weap_ak74m_Base_F
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class rhs_weap_akm: rhs_weap_ak74m
     {
         ACE_barrelTwist=199.898;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class rhs_weap_aks74;
     class rhs_weap_aks74u: rhs_weap_aks74
     {
         ACE_barrelTwist=160.02;
-        ACE_barrelLength=0.21082;
+        ACE_barrelLength=210.82;
     };
     class rhs_weap_svd: rhs_weap_ak74m
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.61976;
+        ACE_barrelLength=619.76;
     };
     class rhs_weap_svdp;
     class rhs_weap_svds: rhs_weap_svdp
     {
         ACE_barrelTwist=238.76;
-        ACE_barrelLength=0.56388;
+        ACE_barrelLength=563.88;
     };
     class rhs_pkp_base;
     class rhs_weap_pkp: rhs_pkp_base
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.65786;
+        ACE_barrelLength=657.86;
     };
     class rhs_weap_pkm: rhs_weap_pkp
     {
         ACE_barrelTwist=240.03;
-        ACE_barrelLength=0.64516;
+        ACE_barrelLength=645.16;
     };
     class rhs_weap_rpk74m: rhs_weap_pkp
     {
         ACE_barrelTwist=195.072;
-        ACE_barrelLength=0.58928;
+        ACE_barrelLength=589.28;
     };
     
     class rhs_acc_sniper_base;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -4,57 +4,57 @@ class CfgWeapons
     class hgun_Rook40_F;
     class rhs_weap_pya: hgun_Rook40_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=4.4;
     };
     class Pistol_Base_F;
     class rhs_weap_makarov_pmm: rhs_weap_pya
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=3.68;
     };
     class rhs_weap_ak74m_Base_F;
     class rhs_weap_ak74m: rhs_weap_ak74m_Base_F
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class rhs_weap_akm: rhs_weap_ak74m
     {
-        ACE_barrelTwist=7.87;
+        ACE_barrelTwist=0.199898;
         ACE_barrelLength=16.3;
     };
     class rhs_weap_aks74;
     class rhs_weap_aks74u: rhs_weap_aks74
     {
-        ACE_barrelTwist=6.3;
+        ACE_barrelTwist=0.16002;
         ACE_barrelLength=8.3;
     };
     class rhs_weap_svd: rhs_weap_ak74m
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=24.4;
     };
     class rhs_weap_svdp;
     class rhs_weap_svds: rhs_weap_svdp
     {
-        ACE_barrelTwist=9.4;
+        ACE_barrelTwist=0.23876;
         ACE_barrelLength=22.2;
     };
     class rhs_pkp_base;
     class rhs_weap_pkp: rhs_pkp_base
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.9;
     };
     class rhs_weap_pkm: rhs_weap_pkp
     {
-        ACE_barrelTwist=9.45;
+        ACE_barrelTwist=0.24003;
         ACE_barrelLength=25.4;
     };
     class rhs_weap_rpk74m: rhs_weap_pkp
     {
-        ACE_barrelTwist=7.68;
+        ACE_barrelTwist=0.195072;
         ACE_barrelLength=23.2;
     };
     

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -13,7 +13,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={20, 24, 26};
+        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
     };
     class B_556x45_Ball;
     class rhs_ammo_556x45_Mk318_Ball: B_556x45_Ball
@@ -27,7 +27,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={10, 15.5, 20};
+        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
     };
     class rhs_ammo_556x45_Mk262_Ball: B_556x45_Ball
     {
@@ -40,7 +40,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={7.5, 14.5, 18, 20};
+        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
     };
     class rhs_ammo_762x51_M80_Ball: BulletBase
     {
@@ -53,7 +53,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={10, 16, 20, 24, 26};
+        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_ammo_762x51_M118_Special_Ball: rhs_ammo_762x51_M80_Ball
     {
@@ -66,7 +66,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={16, 20, 24, 26};
+        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
     };
     class rhs_ammo_762x51_M993_Ball: rhs_ammo_762x51_M80_Ball
     {
@@ -79,7 +79,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={875, 910, 930};
-        ACE_barrelLengths[]={13, 16, 20};
+        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
     };
     class rhs_ammo_45ACP_MHP: BulletBase
     {
@@ -92,6 +92,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={4, 5, 9};
+        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
     };
 };

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -4,7 +4,7 @@ class CfgAmmo
     class BulletBase;
     class rhsusf_B_300winmag: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.037821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -18,7 +18,7 @@ class CfgAmmo
     class B_556x45_Ball;
     class rhs_ammo_556x45_Mk318_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -31,7 +31,7 @@ class CfgAmmo
     };
     class rhs_ammo_556x45_Mk262_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.00569;
+        ACE_caliber=5.69;
         ACE_bulletLength=0.023012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -44,7 +44,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M80_Ball: BulletBase
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.028956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -57,7 +57,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M118_Special_Ball: rhs_ammo_762x51_M80_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -70,7 +70,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M993_Ball: rhs_ammo_762x51_M80_Ball
     {
-        ACE_caliber=0.007823;
+        ACE_caliber=7.823;
         ACE_bulletLength=0.031496;
         ACE_bulletMass=8.2296;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -83,7 +83,7 @@ class CfgAmmo
     };
     class rhs_ammo_45ACP_MHP: BulletBase
     {
-        ACE_caliber=0.011481;
+        ACE_caliber=11.481;
         ACE_bulletLength=0.017272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -13,7 +13,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={847, 867, 877};
-        ACE_barrelLengths[]={0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_556x45_Ball;
     class rhs_ammo_556x45_Mk318_Ball: B_556x45_Ball
@@ -27,7 +27,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={780, 886, 950};
-        ACE_barrelLengths[]={0.254, 0.3937, 0.508};
+        ACE_barrelLengths[]={254.0, 393.7, 508.0};
     };
     class rhs_ammo_556x45_Mk262_Ball: B_556x45_Ball
     {
@@ -40,7 +40,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={624, 816, 832, 838};
-        ACE_barrelLengths[]={0.1905, 0.3683, 0.4572, 0.508};
+        ACE_barrelLengths[]={190.5, 368.3, 457.2, 508.0};
     };
     class rhs_ammo_762x51_M80_Ball: BulletBase
     {
@@ -53,7 +53,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={0.254, 0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class rhs_ammo_762x51_M118_Special_Ball: rhs_ammo_762x51_M80_Ball
     {
@@ -66,7 +66,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={750, 780, 790, 794};
-        ACE_barrelLengths[]={0.4064, 0.508, 0.6096, 0.6604};
+        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
     class rhs_ammo_762x51_M993_Ball: rhs_ammo_762x51_M80_Ball
     {
@@ -79,7 +79,7 @@ class CfgAmmo
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={875, 910, 930};
-        ACE_barrelLengths[]={0.3302, 0.4064, 0.508};
+        ACE_barrelLengths[]={330.2, 406.4, 508.0};
     };
     class rhs_ammo_45ACP_MHP: BulletBase
     {
@@ -92,6 +92,6 @@ class CfgAmmo
         ACE_standardAtmosphere="ASM";
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={230, 250, 285};
-        ACE_barrelLengths[]={0.1016, 0.127, 0.2286};
+        ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
 };

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
     class rhsusf_B_300winmag: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.489;
+        ACE_bulletLength=0.037821;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -19,7 +19,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk318_Ball: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -32,7 +32,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk262_Ball: B_556x45_Ball
     {
         ACE_caliber=0.00569;
-        ACE_bulletLength=0.906;
+        ACE_bulletLength=0.023012;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -45,7 +45,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M80_Ball: BulletBase
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.14;
+        ACE_bulletLength=0.028956;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -58,7 +58,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M118_Special_Ball: rhs_ammo_762x51_M80_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -71,7 +71,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M993_Ball: rhs_ammo_762x51_M80_Ball
     {
         ACE_caliber=0.007823;
-        ACE_bulletLength=1.24;
+        ACE_bulletLength=0.031496;
         ACE_bulletMass=127;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.377};
@@ -84,7 +84,7 @@ class CfgAmmo
     class rhs_ammo_45ACP_MHP: BulletBase
     {
         ACE_caliber=0.011481;
-        ACE_bulletLength=0.68;
+        ACE_bulletLength=0.017272;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -5,7 +5,7 @@ class CfgAmmo
     class rhsusf_B_300winmag: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.037821;
+        ACE_bulletLength=37.821;
         ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
@@ -19,7 +19,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk318_Ball: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
@@ -32,7 +32,7 @@ class CfgAmmo
     class rhs_ammo_556x45_Mk262_Ball: B_556x45_Ball
     {
         ACE_caliber=5.69;
-        ACE_bulletLength=0.023012;
+        ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
@@ -45,7 +45,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M80_Ball: BulletBase
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.028956;
+        ACE_bulletLength=28.956;
         ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
@@ -58,7 +58,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M118_Special_Ball: rhs_ammo_762x51_M80_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
@@ -71,7 +71,7 @@ class CfgAmmo
     class rhs_ammo_762x51_M993_Ball: rhs_ammo_762x51_M80_Ball
     {
         ACE_caliber=7.823;
-        ACE_bulletLength=0.031496;
+        ACE_bulletLength=31.496;
         ACE_bulletMass=8.2296;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.377};
@@ -84,7 +84,7 @@ class CfgAmmo
     class rhs_ammo_45ACP_MHP: BulletBase
     {
         ACE_caliber=11.481;
-        ACE_bulletLength=0.017272;
+        ACE_bulletLength=17.272;
         ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.037821;
-        ACE_bulletMass=220;
+        ACE_bulletMass=14.256;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.310};
         ACE_velocityBoundaries[]={};
@@ -20,7 +20,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=62;
+        ACE_bulletMass=4.0176;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.307};
         ACE_velocityBoundaries[]={};
@@ -33,7 +33,7 @@ class CfgAmmo
     {
         ACE_caliber=0.00569;
         ACE_bulletLength=0.023012;
-        ACE_bulletMass=77;
+        ACE_bulletMass=4.9896;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.361};
         ACE_velocityBoundaries[]={};
@@ -46,7 +46,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.028956;
-        ACE_bulletMass=146;
+        ACE_bulletMass=9.4608;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.2};
         ACE_velocityBoundaries[]={};
@@ -59,7 +59,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=175;
+        ACE_bulletMass=11.34;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.243};
         ACE_velocityBoundaries[]={};
@@ -72,7 +72,7 @@ class CfgAmmo
     {
         ACE_caliber=0.007823;
         ACE_bulletLength=0.031496;
-        ACE_bulletMass=127;
+        ACE_bulletMass=8.2296;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.377};
         ACE_velocityBoundaries[]={};
@@ -85,7 +85,7 @@ class CfgAmmo
     {
         ACE_caliber=0.011481;
         ACE_bulletLength=0.017272;
-        ACE_bulletMass=230;
+        ACE_bulletMass=14.904;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
         ACE_ballisticCoefficients[]={0.195};
         ACE_velocityBoundaries[]={};

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -4,7 +4,7 @@ class CfgAmmo
     class BulletBase;
     class rhsusf_B_300winmag: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.489;
         ACE_bulletMass=220;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -18,7 +18,7 @@ class CfgAmmo
     class B_556x45_Ball;
     class rhs_ammo_556x45_Mk318_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=62;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -31,7 +31,7 @@ class CfgAmmo
     };
     class rhs_ammo_556x45_Mk262_Ball: B_556x45_Ball
     {
-        ACE_caliber=0.224;
+        ACE_caliber=0.00569;
         ACE_bulletLength=0.906;
         ACE_bulletMass=77;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -44,7 +44,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M80_Ball: BulletBase
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.14;
         ACE_bulletMass=146;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -57,7 +57,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M118_Special_Ball: rhs_ammo_762x51_M80_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=175;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -70,7 +70,7 @@ class CfgAmmo
     };
     class rhs_ammo_762x51_M993_Ball: rhs_ammo_762x51_M80_Ball
     {
-        ACE_caliber=0.308;
+        ACE_caliber=0.007823;
         ACE_bulletLength=1.24;
         ACE_bulletMass=127;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
@@ -83,7 +83,7 @@ class CfgAmmo
     };
     class rhs_ammo_45ACP_MHP: BulletBase
     {
-        ACE_caliber=0.452;
+        ACE_caliber=0.011481;
         ACE_bulletLength=0.68;
         ACE_bulletMass=230;
         ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -6,51 +6,51 @@ class CfgWeapons
     class srifle_EBR_F;
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
-        ACE_barrelTwist=0.254;
+        ACE_barrelTwist=254.0;
         ACE_barrelLength=0.6096;
     };
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.3683;
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.26162;
     };
     class rhs_weap_m16a4: rhs_weap_m4_Base
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.508;
     };
     class rhs_M249_base;
     class rhs_weap_m249_pip: rhs_M249_base
     {
-        ACE_barrelTwist=0.1778;
+        ACE_barrelTwist=177.8;
         ACE_barrelLength=0.41402;
     };
     class weap_m240_base;
     class rhs_weap_m240B: weap_m240_base
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.62992;
     };
     class rhs_weap_m14ebrri: srifle_EBR_F
     {
-        ACE_barrelTwist=0.3048;
+        ACE_barrelTwist=304.8;
         ACE_barrelLength=0.5588;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.6096;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25
     {
-        ACE_barrelTwist=0.28575;
+        ACE_barrelTwist=285.75;
         ACE_barrelLength=0.508;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F
@@ -68,7 +68,7 @@ class CfgWeapons
     class hgun_ACPC2_F;
     class rhsusf_weap_m1911a1: hgun_ACPC2_F
     {
-        ACE_barrelTwist=0.4064;
+        ACE_barrelTwist=406.4;
         ACE_barrelLength=0.127;
     };
     

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -6,69 +6,69 @@ class CfgWeapons
     class srifle_EBR_F;
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
-        ACE_barrelTwist=10;
+        ACE_barrelTwist=0.254;
         ACE_barrelLength=24;
     };
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=14.5;
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=10.3;
     };
     class rhs_weap_m16a4: rhs_weap_m4_Base
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=20;
     };
     class rhs_M249_base;
     class rhs_weap_m249_pip: rhs_M249_base
     {
-        ACE_barrelTwist=7;
+        ACE_barrelTwist=0.1778;
         ACE_barrelLength=16.3;
     };
     class weap_m240_base;
     class rhs_weap_m240B: weap_m240_base
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=24.8;
     };
     class rhs_weap_m14ebrri: srifle_EBR_F
     {
-        ACE_barrelTwist=12;
+        ACE_barrelTwist=0.3048;
         ACE_barrelLength=22;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=24;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25
     {
-        ACE_barrelTwist=11.25;
+        ACE_barrelTwist=0.28575;
         ACE_barrelLength=20;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=18.5;
     };
     class rhs_weap_M590_8RD: rhs_weap_M590_5RD
     {
-        ACE_barrelTwist=0;
+        ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
         ACE_barrelLength=20;
     };
     class hgun_ACPC2_F;
     class rhsusf_weap_m1911a1: hgun_ACPC2_F
     {
-        ACE_barrelTwist=16;
+        ACE_barrelTwist=0.4064;
         ACE_barrelLength=5;
     };
     

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -7,69 +7,69 @@ class CfgWeapons
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
         ACE_barrelTwist=0.254;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=14.5;
+        ACE_barrelLength=0.3683;
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=10.3;
+        ACE_barrelLength=0.26162;
     };
     class rhs_weap_m16a4: rhs_weap_m4_Base
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_M249_base;
     class rhs_weap_m249_pip: rhs_M249_base
     {
         ACE_barrelTwist=0.1778;
-        ACE_barrelLength=16.3;
+        ACE_barrelLength=0.41402;
     };
     class weap_m240_base;
     class rhs_weap_m240B: weap_m240_base
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=24.8;
+        ACE_barrelLength=0.62992;
     };
     class rhs_weap_m14ebrri: srifle_EBR_F
     {
         ACE_barrelTwist=0.3048;
-        ACE_barrelLength=22;
+        ACE_barrelLength=0.5588;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=24;
+        ACE_barrelLength=0.6096;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25
     {
         ACE_barrelTwist=0.28575;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=18.5;
+        ACE_barrelLength=0.4699;
     };
     class rhs_weap_M590_8RD: rhs_weap_M590_5RD
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=20;
+        ACE_barrelLength=0.508;
     };
     class hgun_ACPC2_F;
     class rhsusf_weap_m1911a1: hgun_ACPC2_F
     {
         ACE_barrelTwist=0.4064;
-        ACE_barrelLength=5;
+        ACE_barrelLength=0.127;
     };
     
     class rhsusf_acc_sniper_base;

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -7,69 +7,69 @@ class CfgWeapons
     class rhs_weap_XM2010_Base_F: Rifle_Base_F
     {
         ACE_barrelTwist=254.0;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.3683;
+        ACE_barrelLength=368.3;
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.26162;
+        ACE_barrelLength=261.62;
     };
     class rhs_weap_m16a4: rhs_weap_m4_Base
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_M249_base;
     class rhs_weap_m249_pip: rhs_M249_base
     {
         ACE_barrelTwist=177.8;
-        ACE_barrelLength=0.41402;
+        ACE_barrelLength=414.02;
     };
     class weap_m240_base;
     class rhs_weap_m240B: weap_m240_base
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.62992;
+        ACE_barrelLength=629.92;
     };
     class rhs_weap_m14ebrri: srifle_EBR_F
     {
         ACE_barrelTwist=304.8;
-        ACE_barrelLength=0.5588;
+        ACE_barrelLength=558.8;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.6096;
+        ACE_barrelLength=609.6;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25
     {
         ACE_barrelTwist=285.75;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.4699;
+        ACE_barrelLength=469.9;
     };
     class rhs_weap_M590_8RD: rhs_weap_M590_5RD
     {
         ACE_barrelTwist=0.0;
         ACE_twistDirection=0;
-        ACE_barrelLength=0.508;
+        ACE_barrelLength=508.0;
     };
     class hgun_ACPC2_F;
     class rhsusf_weap_m1911a1: hgun_ACPC2_F
     {
         ACE_barrelTwist=406.4;
-        ACE_barrelLength=0.127;
+        ACE_barrelLength=127.0;
     };
     
     class rhsusf_acc_sniper_base;


### PR DESCRIPTION
Convert config values and the relevant lookups in advanced_ballistics.
Everything is either ~~meters~~ millimeters or grams.
The barrel length stuff is purely relative, so no multiplication there.

@ulteq should probably check if he can mash those multiplications in somewhere.