### PR TITLE
setup.py fix

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -37,8 +37,8 @@ def main():
     try:
         reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
         key = winreg.OpenKey(reg,
-                r"SOFTWARE\Wow6432Node\bohemia interactive\arma 3")
-        armapath = winreg.EnumValue(key,1)[1]
+                r"SOFTWARE\Wow6432Node\Bohemia Interactive Studio\ArmA 3")
+        armapath = winreg.EnumValue(key,0)[1]
     except:
         print("Failed to determine Arma 3 Path.")
         return 1


### PR DESCRIPTION
as of 1.44 the winreg key is now under:
Wow6432Node\Bohemia Interactive Studio\ArmA 3 key n°0 instead of 1