### PR TITLE
Switch scopes to use firedBIS

### DIFF
--- a/addons/scopes/CfgEventHandlers.hpp
+++ b/addons/scopes/CfgEventHandlers.hpp
@@ -10,10 +10,10 @@ class Extended_PostInit_EventHandlers {
     };
 };
 
-class Extended_Fired_EventHandlers {
+class Extended_FiredBIS_EventHandlers {
     class CAManBase {
         class ADDON {
-            fired = QUOTE(_this call FUNC(firedEH););
+            firedBIS = QUOTE(_this call FUNC(firedEH););
         };
     };
 };

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -3,12 +3,13 @@
  * Adjusts the flight path of the bullet according to the zeroing
  *
  * Argument:
- * 0: Unit <OBJECT>
- * 1: Weapon <STRING>
- * 3: Muzzle <STRING>
- * 4: Magazine <STRING>
- * 5: Ammo <STRING>
- * 6: Projectile <OBJECT>
+ * 0: unit - Object the event handler is assigned to <OBJECT>
+ * 1: weapon - Fired weapon <STRING>
+ * 2: muzzle - Muzzle that was used <STRING>
+ * 3: mode - Current mode of the fired weapon <STRING>
+ * 4: ammo - Ammo used <STRING>
+ * 5: magazine - magazine name which was used <STRING>
+ * 6: projectile - Object of the projectile that was shot <OBJECT>
  *
  * Return value:
  * None
@@ -20,23 +21,25 @@
 private ["_unit", "_adjustment", "_weapon", "_projectile", "_weaponIndex", "_zeroing", "_adjustment"];
 
 _unit = _this select 0;
+_weapon = _this select 1;
+_projectile = _this select 6;
 
 // Exit if the unit doesn't have any adjusment variable
-_adjustment = _unit getVariable QGVAR(Adjustment);
-if (isNil "_adjustment") exitWith {};
+_adjustment = _unit getVariable [QGVAR(Adjustment), []];
+if (_adjustment isEqualTo []) exitWith {};
 
 // Exit if the unit isn't a player
 if !([_unit] call EFUNC(common,isPlayer)) exitWith {};
-
-_weapon = _this select 1;
-_projectile = _this select 5;
 
 _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
 if (_weaponIndex < 0) exitWith {};
 
 _zeroing = _adjustment select _weaponIndex;
 
+//Exit if adjusment is zero:
+if (_zeroing isEqualTo [0,0,0]) exitWith {};
+
 // Convert zeroing from mils to degrees
-_zeroing = [_zeroing, {_this * 0.05625}] call EFUNC(common,map);
+_zeroing = _zeroing vectorMultiply 0.05625;
 
 [_projectile, (_zeroing select 1), (_zeroing select 0) + (_zeroing select 2), 0] call EFUNC(common,changeProjectileDirection);


### PR DESCRIPTION
firedBIS (last one to switch)
also skips call to `EFUNC(common,changeProjectileDirection)` if there are no adjustment (will be true for most bullets, grenades,)