### PR TITLE
Minor improvement to medical class assignment modules

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -72,6 +72,7 @@ Raspu86
 Riccardo Petricca <petriccarcc@gmail.com>
 Robert Boklahánics <bokirobi@gmail.com>
 ramius86 <pasini86@hotmail.com>
+SilentSpike <SilentSpike100@gmail.com>
 simon84 <badguy360th@gmail.com>
 Sniperwolf572 <tenga6@gmail.com>
 Tachi <zaveruha007@gmail.com>

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -7,6 +7,11 @@ class CfgVehicles {
     class Module_F: Logic {
         class ArgumentsBaseUnits {
         };
+        class ModuleDescription {
+            class AnyPerson;
+            class AnyStaticObject;
+            class AnyVehicle;
+        };
     };
     class ACE_Module;
     // TODO localization for all the modules
@@ -309,9 +314,14 @@ class CfgVehicles {
                 };
             };
         };
-        class ModuleDescription {
-            description = "Assigns the ACE medic class to a unit";
-            sync[] = {};
+        class ModuleDescription: ModuleDescription {
+            description = "Assigns the ACE medic class to all synchronized/listed units";
+            sync[] = {"AnyPerson"};
+
+            class AnyPerson: AnyPerson {
+                description = "Unit to be assigned as a medic";
+                optional = 1;
+            };
         };
     };
 
@@ -329,13 +339,13 @@ class CfgVehicles {
         class Arguments {
             class EnableList {
                 displayName = "List";
-                description = "List of vehicles that will be classified as medical vehicle, separated by commas.";
+                description = "List of vehicles to be classified as medical vehicles, separated by commas.";
                 defaultValue = "";
                 typeName = "STRING";
             };
             class enabled {
                 displayName = "Is Medical Vehicle";
-                description = "Whatever or not the objects in the list will be a medical vehicle.";
+                description = "Whether or not the objects in the list will be medical vehicles.";
                 typeName = "NUMBER";
                 class values {
                     class none {
@@ -350,9 +360,14 @@ class CfgVehicles {
                 };
             };
         };
-        class ModuleDescription {
-            description = "Assigns the ACE medic class to a unit";
-            sync[] = {};
+        class ModuleDescription: ModuleDescription {
+            description = "Assigns the ACE medic class to all synchronized/listed vehicles";
+            sync[] = {"AnyVehicle"};
+
+            class AnyVehicle: AnyVehicle {
+                description = "Vehicle to be assigned as a medical vehicle";
+                optional = 1;
+            };
         };
     };
     class ACE_moduleAssignMedicalFacility: Module_F {
@@ -375,7 +390,7 @@ class CfgVehicles {
         };
         class ModuleDescription {
             description = "Defines an object as a medical facility for CMS. This allows for more advanced treatments. Can be used on buildings and vehicles. ";
-            sync[] = {};
+            sync[] = {"AnyStaticObject","AnyVehicle"};
         };
     };
 

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -388,7 +388,7 @@ class CfgVehicles {
                 typeName = "BOOL";
             };
         };
-        class ModuleDescription {
+        class ModuleDescription: ModuleDescription {
             description = "Defines an object as a medical facility for CMS. This allows for more advanced treatments. Can be used on buildings and vehicles. ";
             sync[] = {"AnyStaticObject","AnyVehicle"};
         };

--- a/addons/medical/functions/fnc_moduleAssignMedicRoles.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicRoles.sqf
@@ -15,7 +15,7 @@
 
 #include "script_component.hpp"
 
-private ["_logic","_setting","_objects", "_list", "_splittedList", "_nilCheckPassedList", "_parsedList"];
+private ["_logic","_list","_splittedList","_nilCheckPassedList","_objects","_setting"];
 _logic = [_this,0,objNull,[objNull]] call BIS_fnc_param;
 
 if (!isNull _logic) then {
@@ -35,20 +35,9 @@ if (!isNull _logic) then {
     }foreach _splittedList;
 
     _list = "[" + _nilCheckPassedList + "]";
-    _parsedList = [] call compile _list;
-    _setting = _logic getvariable ["role",0];
-    _objects = synchronizedObjects _logic;
-    if (!(_objects isEqualTo []) && _parsedList isEqualTo []) then {
-        {
-            if (!isnil "_x") then {
-                   if (typeName _x == typeName objNull) then {
-                    if (local _x) then {
-                        _x setvariable [QGVAR(medicClass), _setting, true];
-                    };
-                };
-            };
-        }foreach _objects;
-    };
+    _objects = [] call compile _list;
+    _setting = _logic getvariable ["enabled", false];
+    _objects append (synchronizedObjects _logic);
     {
         if (!isnil "_x") then {
                if (typeName _x == typeName objNull) then {
@@ -57,7 +46,7 @@ if (!isNull _logic) then {
                 };
             };
         };
-    }foreach _parsedList;
- };
+    }foreach _objects;
+};
 
 true

--- a/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
@@ -13,10 +13,9 @@
  * Public: No
  */
 
-
 #include "script_component.hpp"
 
-private ["_logic","_setting","_objects", "_list", "_splittedList", "_nilCheckPassedList", "_parsedList"];
+private ["_logic","_list","_splittedList","_nilCheckPassedList","_objects","_setting"];
 _logic = [_this,0,objNull,[objNull]] call BIS_fnc_param;
 
 if (!isNull _logic) then {
@@ -36,20 +35,9 @@ if (!isNull _logic) then {
     }foreach _splittedList;
 
     _list = "[" + _nilCheckPassedList + "]";
-    _parsedList = [] call compile _list;
+    _objects = [] call compile _list;
     _setting = _logic getvariable ["enabled", false];
-    _objects = synchronizedObjects _logic;
-    if (!(_objects isEqualTo []) && _parsedList isEqualTo []) then {
-        {
-            if (!isnil "_x") then {
-                   if (typeName _x == typeName objNull) then {
-                    if (local _x) then {
-                        _x setvariable [QGVAR(medicClass), _setting, true];
-                    };
-                };
-            };
-        }foreach _objects;
-    };
+    _objects append (synchronizedObjects _logic);
     {
         if (!isnil "_x") then {
                if (typeName _x == typeName objNull) then {
@@ -58,7 +46,7 @@ if (!isNull _logic) then {
                 };
             };
         };
-    }foreach _parsedList;
- };
+    }foreach _objects;
+};
 
 true;


### PR DESCRIPTION
I noticed the `moduleAssignMedicVehicle` and `moduleAssignMedicRoles` functions worked for synchronized objects, but only if a list of objects was **not** provided to the module as an argument. This seems like a pointless restriction to me so I changed them to use both synchronized objects and the list of objects.

While I was at it I added editor synchronization details to the module descriptions and edited the module text descriptions to reflect my changes (and fix a typo).