### PR TITLE
fix removeWhiteSpace function name in ambiance sound module

### DIFF
--- a/addons/missionmodules/functions/fnc_moduleAmbianceSound.sqf
+++ b/addons/missionmodules/functions/fnc_moduleAmbianceSound.sqf
@@ -26,39 +26,39 @@ _activated = [_this,2,true,[true]] call BIS_fnc_param;
 // We only play this on the locality of the logic, since the sounds are broadcasted across the network
 if (_activated && local _logic) then {
     _ambianceSounds = [];
-    _unparsedSounds = _logic getvariable ["soundFiles", ""];
-    _minimalDistance = (_logic getvariable ["minimalDistance", 400]) max 1;
-    _maximalDistance = (_logic getvariable ["maximalDistance", 10]) max _minimalDistance;
-    _minDelayBetweensounds = (_logic getvariable ["minimalDelay", 10]) max 1;
-    _maxDelayBetweenSounds = (_logic getvariable ["maximalDelay", 170]) max _minDelayBetweensounds;
-    _volume = (_logic getvariable ["soundVolume", 30]) max 1;
-    _followPlayers = _logic getvariable ["followPlayers", false];
+    _unparsedSounds = _logic getVariable ["soundFiles", ""];
+    _minimalDistance = (_logic getVariable ["minimalDistance", 400]) max 1;
+    _maximalDistance = (_logic getVariable ["maximalDistance", 10]) max _minimalDistance;
+    _minDelayBetweensounds = (_logic getVariable ["minimalDelay", 10]) max 1;
+    _maxDelayBetweenSounds = (_logic getVariable ["maximalDelay", 170]) max _minDelayBetweensounds;
+    _volume = (_logic getVariable ["soundVolume", 30]) max 1;
+    _followPlayers = _logic getVariable ["followPlayers", false];
 
     _splittedList = [_unparsedSounds, ","] call BIS_fnc_splitString;
 
     _nilCheckPassedList = "";
     {
-        _x = [_x] call EFUNC(common,string_removeWhiteSpace);
-        _splittedList set [_foreachIndex, _x];
-    }foreach _splittedList;
+        _x = [_x] call EFUNC(common,stringRemoveWhiteSpace);
+        _splittedList set [_forEachIndex, _x];
+    }forEach _splittedList;
 
     _soundPath = [(str missionConfigFile), 0, -15] call BIS_fnc_trimString;
     {
-        if (isclass (missionConfigFile >> "CfgSounds" >> _x)) then {
-            _ambianceSounds pushback (_soundPath + (getArray(missionConfigFile >> "CfgSounds" >> _x >> "sound") select 0));
+        if (isClass (missionConfigFile >> "CfgSounds" >> _x)) then {
+            _ambianceSounds pushBack (_soundPath + (getArray(missionConfigFile >> "CfgSounds" >> _x >> "sound") select 0));
         } else {
-            if (isclass (configFile >> "CfgSounds" >> _x)) then {
-                _ambianceSounds pushback ((getArray(configFile >> "CfgSounds" >> _x >> "sound") select 0));
+            if (isClass (configFile >> "CfgSounds" >> _x)) then {
+                _ambianceSounds pushBack ((getArray(configFile >> "CfgSounds" >> _x >> "sound") select 0));
             };
         };
-    }foreach _splittedList;
+    }forEach _splittedList;
 
-    if (count _ambianceSounds == 0) exitwith {};
+    if (count _ambianceSounds == 0) exitWith {};
     {
         if !([".", _x, true] call BIS_fnc_inString) then {
-            _ambianceSounds set [_foreachIndex, _x + ".wss"];
+            _ambianceSounds set [_forEachIndex, _x + ".wss"];
         };
-    }foreach _ambianceSounds;
+    }forEach _ambianceSounds;
 
     [{
         private ["_args", "_logic", "_ambianceSounds", "_minimalDistance", "_maximalDistance", "_minDelayBetweensounds", "_maxDelayBetweenSounds", "_volume", "_followPlayers","_lastTimePlayed", "_newPos"];
@@ -68,7 +68,7 @@ if (_activated && local _logic) then {
         _maxDelayBetweenSounds = _args select 5;
         _lastTimePlayed = _args select 8;
 
-        if (!alive _logic) exitwith {
+        if (!alive _logic) exitWith {
             [(_this select 1)] call cba_fnc_removePerFrameHandler;
         };
 


### PR DESCRIPTION
used `string_removeWhiteSpace` but had to be `stringRemoveWhiteSpace`
due to 612fa69c1c4cf7ed8b81c5086dc90877d0eda400