### PR TITLE
check for outdated pbo files

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -64,8 +64,6 @@ if (_currentVersion != _previousVersion) then {
     profileNamespace setVariable ["ACE_VersionNumberString", _currentVersion];
 };
 
-0 spawn COMPILE_FILE(scripts\Version\checkVersionNumber);
-
 // ACE events
 "ACEg" addPublicVariableEventHandler { _this call FUNC(_handleNetEvent); };
 "ACEc" addPublicVariableEventHandler { _this call FUNC(_handleNetEvent); };

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -84,6 +84,7 @@ if(!isServer) then {
 ["SEH_s", FUNC(_handleRequestSyncedEvent)] call FUNC(addEventHandler);
 [FUNC(syncedEventPFH), 0.5, []] call cba_fnc_addPerFrameHandler;
 
+call FUNC(checkFiles);
 
 /***************************************************************/
 /***************************************************************/
@@ -250,14 +251,3 @@ if(isMultiplayer && { time > 0 || isNull player } ) then {
         };
     }, 0, []] call cba_fnc_addPerFrameHandler;
 };
-
-// check dlls
-{
-    if (_x callExtension "version" == "") then {
-        private "_errorMsg";
-        _errorMsg = format ["Extension %1.dll not installed.", _x];
-
-        diag_log text format ["[ACE] ERROR: %1", _errorMsg];
-        ["[ACE] ERROR", _errorMsg, {findDisplay 46 closeDisplay 0}] call FUNC(errorMessage);
-    };
-} forEach getArray (configFile >> "ACE_Extensions" >> "extensions");

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -21,6 +21,7 @@ PREP(canInteract);
 PREP(canInteractWith);
 PREP(canUseWeapon);
 PREP(changeProjectileDirection);
+PREP(checkFiles);
 PREP(checkPBOs);
 PREP(claim);
 PREP(closeDialogIfTargetMoves);

--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -1,0 +1,59 @@
+/*
+ * Author: commy2
+ *
+ * Compares version numbers of PBOs and DLLs.
+ *
+ * Argument:
+ * 0: Mode (Number)
+ *
+ * Return value:
+ * None.
+ */
+#include "script_component.hpp"
+
+///////////////
+// check addons
+///////////////
+private "_version";
+_version = getText (configFile >> "CfgPatches" >> "ace_main" >> "versionStr");
+
+diag_log text format ["[ACE]: ACE is version %1", _version]; ///////////////////////////////////////////////////////////////////////////
+
+private ["_addons", "_index"];
+
+_addons = activatedAddons;
+
+// speed up search. all ace pbos are loaded after ace_main.
+_index = _addons find "ace_main";
+reverse _addons; 
+_addons resize (count _addons - _index);
+_addons = [_addons, {_this find "ace_" == 0}] call FUNC(filter);
+
+{
+    if (getText (configFile >> "CfgPatches" >> _x >> "versionStr") != _version) then {
+        private "_errorMsg";
+        _errorMsg = format ["File %1.pbo is outdated.", _x];
+
+        diag_log text format ["[ACE] ERROR: %1", _errorMsg];
+
+        if (hasInterface) then {
+            ["[ACE] ERROR", _errorMsg, {findDisplay 46 closeDisplay 0}] call FUNC(errorMessage);
+        };
+    };
+} forEach _addons;
+
+///////////////
+// check dlls
+///////////////
+{
+    if (_x callExtension "version" == "") then {
+        private "_errorMsg";
+        _errorMsg = format ["Extension %1.dll not installed.", _x];
+
+        diag_log text format ["[ACE] ERROR: %1", _errorMsg];
+
+        if (hasInterface) then {
+            ["[ACE] ERROR", _errorMsg, {findDisplay 46 closeDisplay 0}] call FUNC(errorMessage);
+        };
+    };
+} forEach getArray (configFile >> "ACE_Extensions" >> "extensions");

--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -17,7 +17,7 @@
 private "_version";
 _version = getText (configFile >> "CfgPatches" >> "ace_main" >> "versionStr");
 
-diag_log text format ["[ACE]: ACE is version %1", _version]; ///////////////////////////////////////////////////////////////////////////
+diag_log text format ["[ACE]: ACE is version %1", _version];
 
 private ["_addons", "_index"];
 

--- a/addons/common/functions/fnc_checkPBOs.sqf
+++ b/addons/common/functions/fnc_checkPBOs.sqf
@@ -25,11 +25,11 @@ _checkAll = _this select 1;
 _whitelist = _this select 2;
 
 if (isNil "_checkAll") then {
-  _checkAll = false;
+    _checkAll = false;
 };
 
 if (isNil "_whitelist") then {
-  _whitelist = "[]";
+    _whitelist = "[]";
 };
 
 _logic = "Logic" createVehicleLocal [0,0,0];

--- a/addons/common/functions/fnc_errorMessage.sqf
+++ b/addons/common/functions/fnc_errorMessage.sqf
@@ -15,6 +15,21 @@
 disableSerialization;
 endLoadingScreen;
 
+
+// no message without player possible
+if (!hasInterface) exitWith {};
+
+// wait for display
+if (isNull (call BIS_fnc_displayMission)) exitWith {
+    [{
+        if (isNull (call BIS_fnc_displayMission)) exitWith {};
+
+        (_this select 0) call FUNC(errorMessage);
+        [_this select 1] call CBA_fnc_removePerFrameHandler;
+
+    }, 1, _this] call CBA_fnc_addPerFrameHandler;
+};
+
 private ["_textHeader", "_textMessage", "_onOK", "_onCancel"];
 
 _textHeader = _this select 0;

--- a/addons/common/functions/fnc_moduleCheckPBOs.sqf
+++ b/addons/common/functions/fnc_moduleCheckPBOs.sqf
@@ -22,7 +22,7 @@ _checkAll = _logic getVariable ["CheckAll", false];
 _whitelist = call compile (_logic getVariable ["Whitelist", "[]"]);
 
 if (isNil "_whitelist") then {
-	_whitelist = [];
+    _whitelist = [];
 };
 
 _whitelist = [_whitelist, {toLower _this}] call FUNC(map);
@@ -31,67 +31,67 @@ ACE_Version_CheckAll = _checkAll;
 ACE_Version_Whitelist = _whitelist;
 
 if (!isServer) then {
-	[_mode, _checkAll, _whitelist] spawn {
-		_mode = _this select 0;
-		_checkAll = _this select 1;
-		_whitelist = _this select 2;
+    [_mode, _checkAll, _whitelist] spawn {
+        _mode = _this select 0;
+        _checkAll = _this select 1;
+        _whitelist = _this select 2;
 
-		waitUntil {
-			sleep 1;
-			!isNil "ACE_Version_ClientErrors"
-		};
+        waitUntil {
+            sleep 1;
+            !isNil "ACE_Version_ClientErrors"
+        };
 
-		_missingAddon = ACE_Version_ClientErrors select 0;
-		_missingAddonServer = ACE_Version_ClientErrors select 1;
-		_oldVersionClient = ACE_Version_ClientErrors select 2;
-		_oldVersionServer = ACE_Version_ClientErrors select 3;
+        _missingAddon = ACE_Version_ClientErrors select 0;
+        _missingAddonServer = ACE_Version_ClientErrors select 1;
+        _oldVersionClient = ACE_Version_ClientErrors select 2;
+        _oldVersionServer = ACE_Version_ClientErrors select 3;
 
-		// Display error message.
-		if (_missingAddon || {_missingAddonServer} || {_oldVersionClient} || {_oldVersionServer}) then {
-			_text = "[ACE] Version mismatch:<br/><br/>";
-			_error = format ["ACE version mismatch: %1: ", profileName];
+        // Display error message.
+        if (_missingAddon || {_missingAddonServer} || {_oldVersionClient} || {_oldVersionServer}) then {
+            _text = "[ACE] Version mismatch:<br/><br/>";
+            _error = format ["ACE version mismatch: %1: ", profileName];
 
-			if (_missingAddon) then {
-				_text = _text + "Detected missing addon on client<br/>";
-				_error = _error + "Missing file(s); ";
-			};
-			if (_missingAddonServer) then {
-				_text = _text + "Detected missing addon on server<br/>";
-				_error = _error + "Additional file(s); ";
-			};
-			if (_oldVersionClient) then {
-				_text = _text + "Detected old client version<br/>";
-				_error = _error + "Older version; ";
-			};
-			if (_oldVersionServer) then {
-				_text = _text + "Detected old server version<br/>";
-				_error = _error + "Newer version; ";
-			};
+            if (_missingAddon) then {
+                _text = _text + "Detected missing addon on client<br/>";
+                _error = _error + "Missing file(s); ";
+            };
+            if (_missingAddonServer) then {
+                _text = _text + "Detected missing addon on server<br/>";
+                _error = _error + "Additional file(s); ";
+            };
+            if (_oldVersionClient) then {
+                _text = _text + "Detected old client version<br/>";
+                _error = _error + "Older version; ";
+            };
+            if (_oldVersionServer) then {
+                _text = _text + "Detected old server version<br/>";
+                _error = _error + "Newer version; ";
+            };
 
-			//[_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
-			diag_log text _error;
+            //[_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
+            diag_log text _error;
 
-			_text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
+            _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
 
-			_rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
-			_rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
+            _rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
+            _rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
 
-			disableSerialization;
-			_ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
-			_ctrlHint ctrlSetStructuredText _text;
+            disableSerialization;
+            _ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
+            _ctrlHint ctrlSetStructuredText _text;
 
-			if (_mode == 0) then {
-				sleep 10;
-				_rscLayer cutFadeOut 0.2;
-			};
+            if (_mode == 0) then {
+                sleep 10;
+                _rscLayer cutFadeOut 0.2;
+            };
 
-			if (_mode == 2) then {
-				sleep 10;
-				waitUntil {alive player};
-				[player] call FUNC(adminKick);
-			};
-		};
-	};
+            if (_mode == 2) then {
+                sleep 10;
+                waitUntil {alive player};
+                [player] call FUNC(adminKick);
+            };
+        };
+    };
 };
 
 diag_log text format ["[ACE]: Check-PBOs Module Initialized. Mode: %1.", _mode];

--- a/addons/common/functions/fnc_moduleCheckPBOs.sqf
+++ b/addons/common/functions/fnc_moduleCheckPBOs.sqf
@@ -22,7 +22,7 @@ _checkAll = _logic getVariable ["CheckAll", false];
 _whitelist = call compile (_logic getVariable ["Whitelist", "[]"]);
 
 if (isNil "_whitelist") then {
-  _whitelist = [];
+	_whitelist = [];
 };
 
 _whitelist = [_whitelist, {toLower _this}] call FUNC(map);
@@ -31,67 +31,71 @@ ACE_Version_CheckAll = _checkAll;
 ACE_Version_Whitelist = _whitelist;
 
 if (!isServer) then {
-  [_mode, _checkAll, _whitelist] spawn {
-    _mode = _this select 0;
-    _checkAll = _this select 1;
-    _whitelist = _this select 2;
+	[_mode, _checkAll, _whitelist] spawn {
+		_mode = _this select 0;
+		_checkAll = _this select 1;
+		_whitelist = _this select 2;
 
-    waitUntil {
-      sleep 1;
-      !isNil "ACE_Version_ClientErrors"
-    };
+		waitUntil {
+			sleep 1;
+			!isNil "ACE_Version_ClientErrors"
+		};
 
-    _missingAddon = ACE_Version_ClientErrors select 0;
-    _missingAddonServer = ACE_Version_ClientErrors select 1;
-    _oldVersionClient = ACE_Version_ClientErrors select 2;
-    _oldVersionServer = ACE_Version_ClientErrors select 3;
+		_missingAddon = ACE_Version_ClientErrors select 0;
+		_missingAddonServer = ACE_Version_ClientErrors select 1;
+		_oldVersionClient = ACE_Version_ClientErrors select 2;
+		_oldVersionServer = ACE_Version_ClientErrors select 3;
 
-    // Display error message.
-    if (_missingAddon || {_missingAddonServer} || {_oldVersionClient} || {_oldVersionServer}) then {
-      _text = "[ACE] Version mismatch:<br/><br/>";
-      _error = format ["ACE version mismatch: %1: ", profileName];
+		// Display error message.
+		if (_missingAddon || {_missingAddonServer} || {_oldVersionClient} || {_oldVersionServer}) then {
+			_text = "[ACE] Version mismatch:<br/><br/>";
+			_error = format ["ACE version mismatch: %1: ", profileName];
 
-      if (_missingAddon) then {
-        _text = _text + "Detected missing addon on client<br/>";
-        _error = _error + "Missing file(s); ";
-      };
-      if (_missingAddonServer) then {
-        _text = _text + "Detected missing addon on server<br/>";
-        _error = _error + "Additional file(s); ";
-      };
-      if (_oldVersionClient) then {
-        _text = _text + "Detected old client version<br/>";
-        _error = _error + "Older version; ";
-      };
-      if (_oldVersionServer) then {
-        _text = _text + "Detected old server version<br/>";
-        _error = _error + "Newer version; ";
-      };
+			if (_missingAddon) then {
+				_text = _text + "Detected missing addon on client<br/>";
+				_error = _error + "Missing file(s); ";
+			};
+			if (_missingAddonServer) then {
+				_text = _text + "Detected missing addon on server<br/>";
+				_error = _error + "Additional file(s); ";
+			};
+			if (_oldVersionClient) then {
+				_text = _text + "Detected old client version<br/>";
+				_error = _error + "Older version; ";
+			};
+			if (_oldVersionServer) then {
+				_text = _text + "Detected old server version<br/>";
+				_error = _error + "Newer version; ";
+			};
 
-      //[_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
-      diag_log text _error;
+			//[_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
+			diag_log text _error;
 
-      _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
+			_text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
 
-      _rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
-      _rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
+			_rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
+			_rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
 
-      disableSerialization;
-      _ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
-      _ctrlHint ctrlSetStructuredText _text;
+			disableSerialization;
+			_ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
+			_ctrlHint ctrlSetStructuredText _text;
 
-      if (_mode == 0) then {
-        sleep 10;
-        _rscLayer cutFadeOut 0.2;
-      };
+			if (_mode == 0) then {
+				sleep 10;
+				_rscLayer cutFadeOut 0.2;
+			};
 
-      if (_mode == 2) then {
-        sleep 10;
-        waitUntil {alive player};
-        [player] call FUNC(adminKick);
-      };
-    };
-  };
+			if (_mode == 2) then {
+				sleep 10;
+				waitUntil {alive player};
+				[player] call FUNC(adminKick);
+			};
+		};
+	};
 };
 
 diag_log text format ["[ACE]: Check-PBOs Module Initialized. Mode: %1.", _mode];
+
+if (_checkAll) then {
+    0 spawn COMPILE_FILE(scripts\Version\checkVersionNumber);
+};

--- a/addons/common/scripts/Version/checkVersionNumber.sqf
+++ b/addons/common/scripts/Version/checkVersionNumber.sqf
@@ -1,193 +1,156 @@
 // by commy2
 #include "script_component.hpp"
 
-sleep 1;  //wait for module
-
 _files = [];
 
-if (missionNamespace getVariable ["ACE_Version_CheckAll", false]) then {
-  {
-    if (toLower _x find "a3_" != 0 && {!(toLower _x in (missionNamespace getVariable ["ACE_Version_Whitelist", []]))}) then {
-      _files pushBack _x;
+{
+    if (_x find "a3_" != 0 && {_x find "ace_" != 0} && {!(toLower _x in (missionNamespace getVariable ["ACE_Version_Whitelist", []]))}) then {
+        _files pushBack _x;
     };
-  } forEach activatedAddons;
-} else {
-  {
-    if (toLower _x find "ace_" == 0) then {
-      _files pushBack _x;
-    };
-  } forEach activatedAddons;
-};
-
-_versionMain = parseNumber getText (configFile >> "CfgPatches" >> QUOTE(ADDON) >> "version");
+} forEach activatedAddons;
 
 _versions = [];
 {
-  _version = parseNumber getText (configFile >> "CfgPatches" >> _x >> "version");
-  _versions set [_forEachIndex, _version];
+    _version = parseNumber getText (configFile >> "CfgPatches" >> _x >> "version");
+    _versions set [_forEachIndex, _version];
 } forEach _files;
 
-_versionFull = getText (configFile >> "CfgPatches" >> QUOTE(ADDON) >> "versionStr");
-diag_log text format ["[ACE] Full Version Number: %1", _versionFull];
-
 if (isServer) then {
-  diag_log text format ["[ACE] Server: ACE_Common is Version %1.", _versionMain];
-
-  {
-    if (toLower _x find "ace_" == 0) then {//
-      _version = _versions select _forEachIndex;
-      if (_version != _versionMain) then {
-        diag_log text format ["[ACE] Server: %1 is Version %2.", _x, _version];
-      };
-    };
-  } forEach _files;
-
-  ACE_Version_ServerVersions = [_files, _versions];
-  publicVariable "ACE_Version_ServerVersions";
+    ACE_Version_ServerVersions = [_files, _versions];
+    publicVariable "ACE_Version_ServerVersions";
 } else {
-  diag_log text format ["[ACE] Client: ACE_Common is Version %1.", _versionMain];
-
-  {
-    if (toLower _x find "ace_" == 0) then {//
-      _version = _versions select _forEachIndex;
-      if (_version != _versionMain) then {
-        diag_log text format ["[ACE] Client: %1 is Version %2.", _x, _version];
-      };
-    };
-  } forEach _files;
-
-  ACE_Version_ClientVersions = [_files, _versions];
+    ACE_Version_ClientVersions = [_files, _versions];
 };
 
 // Begin client version check
 if (!isServer) then {
-  // Wait for server to send the servers files and version numbers
-  waitUntil {
-    sleep 1;
-    !isNil "ACE_Version_ClientVersions" && {!isNil "ACE_Version_ServerVersions"}
-  };
-
-  _client = profileName;
-
-  _files = ACE_Version_ClientVersions select 0;
-  _versions = ACE_Version_ClientVersions select 1;
-
-  _serverFiles = ACE_Version_ServerVersions select 0;
-  _serverVersions = ACE_Version_ServerVersions select 1;
-
-  // Compare client and server files and versions
-  _missingAddons = [];
-  _oldVersionsClient = [];
-  _oldVersionsServer = [];
-  {
-    _serverVersion = _serverVersions select _forEachIndex;
-
-    _index = _files find _x;
-    if (_index == -1) then {
-        if (_x != "ace_serverconfig") then {_missingAddons pushBack _x;};
-    } else {
-
-      _clientVersion = _versions select _index;
-
-      if (_clientVersion < _serverVersion) then {
-        _oldVersionsClient pushBack [_x, _clientVersion, _serverVersion];
-      };
-
-      if (_clientVersion > _serverVersion) then {
-        _oldVersionsServer pushBack [_x, _clientVersion, _serverVersion];
-      };
+    // Wait for server to send the servers files and version numbers
+    waitUntil {
+        sleep 1;
+        !isNil "ACE_Version_ClientVersions" && {!isNil "ACE_Version_ServerVersions"}
     };
-  } forEach _serverFiles;
 
-  // find client files which the server doesn't have
-  _missingAddonsServer = [];
-  {
-    _index = _serverFiles find _x;
-    if (_index == -1) then {
-      _missingAddonsServer pushBack _x;
-    }
-  } forEach _files;
+    _client = profileName;
 
-  // display and log error messages
-  _fnc_cutComma = {
-    _string = _this;
-    _string = toArray _string;
+    _files = ACE_Version_ClientVersions select 0;
+    _versions = ACE_Version_ClientVersions select 1;
 
-    _count = count _string;
-    _string set [_count - 2, toArray "." select 0];
-    _string set [_count - 1, -1];
-    _string = _string - [-1];
+    _serverFiles = ACE_Version_ServerVersions select 0;
+    _serverVersions = ACE_Version_ServerVersions select 1;
 
-    toString _string;
-  };
-
-  _missingAddon = false;
-  if (count _missingAddons > 0) then {
-    _missingAddon = true;
-
-    _error = format ["[ACE] %1: ERROR missing addon(s): ", _client];
+    // Compare client and server files and versions
+    _missingAddons = [];
+    _oldVersionsClient = [];
+    _oldVersionsServer = [];
     {
-      _error = _error + format ["%1, ", _x];
+        _serverVersion = _serverVersions select _forEachIndex;
 
-      if (_forEachIndex > 9) exitWith {};//
-    } forEach _missingAddons;
+        _index = _files find _x;
+        if (_index == -1) then {
+                if (_x != "ace_serverconfig") then {_missingAddons pushBack _x;};
+        } else {
 
-    _error = _error call _fnc_cutComma;
+            _clientVersion = _versions select _index;
 
-    diag_log text _error;
-    [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
-  };
+            if (_clientVersion < _serverVersion) then {
+                _oldVersionsClient pushBack [_x, _clientVersion, _serverVersion];
+            };
 
-  _missingAddonServer = false;
-  if (count _missingAddonsServer > 0) then {
-    _missingAddonServer = true;
+            if (_clientVersion > _serverVersion) then {
+                _oldVersionsServer pushBack [_x, _clientVersion, _serverVersion];
+            };
+        };
+    } forEach _serverFiles;
 
-    _error = format ["[ACE] %1: ERROR missing server addon(s): ", _client];
+    // find client files which the server doesn't have
+    _missingAddonsServer = [];
     {
-      _error = _error + format ["%1, ", _x];
+        _index = _serverFiles find _x;
+        if (_index == -1) then {
+            _missingAddonsServer pushBack _x;
+        }
+    } forEach _files;
 
-      if (_forEachIndex > 9) exitWith {};//
-    } forEach _missingAddonsServer;
+    // display and log error messages
+    _fnc_cutComma = {
+        _string = _this;
+        _string = toArray _string;
 
-    _error = _error call _fnc_cutComma;
+        _count = count _string;
+        _string set [_count - 2, toArray "." select 0];
+        _string set [_count - 1, -1];
+        _string = _string - [-1];
 
-    diag_log text _error;
-    [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
-  };
+        toString _string;
+    };
 
-  _oldVersionClient = false;
-  if (count _oldVersionsClient > 0) then {
-    _oldVersionClient = true;
+    _missingAddon = false;
+    if (count _missingAddons > 0) then {
+        _missingAddon = true;
 
-    _error = format ["[ACE] %1: ERROR outdated addon(s): ", _client];
-    {
-      _error = _error + format ["%1 (client: %2, server: %3), ", _x select 0, _x select 1, _x select 2];
+        _error = format ["[ACE] %1: ERROR missing addon(s): ", _client];
+        {
+            _error = _error + format ["%1, ", _x];
 
-      if (_forEachIndex > 9) exitWith {};//
-    } forEach _oldVersionsClient;
+            if (_forEachIndex > 9) exitWith {};//
+        } forEach _missingAddons;
 
-    _error = _error call _fnc_cutComma;
+        _error = _error call _fnc_cutComma;
 
-    diag_log text _error;
-    [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
-  };
+        diag_log text _error;
+        [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
+    };
 
-  _oldVersionServer = false;
-  if (count _oldVersionsServer > 0) then {
-    _oldVersionServer = true;
+    _missingAddonServer = false;
+    if (count _missingAddonsServer > 0) then {
+        _missingAddonServer = true;
 
-    _error = format ["[ACE] %1: ERROR outdated server addon(s): ", _client];
-    {
-      _error = _error + format ["%1 (client: %2, server: %3), ", _x select 0, _x select 1, _x select 2];
+        _error = format ["[ACE] %1: ERROR missing server addon(s): ", _client];
+        {
+            _error = _error + format ["%1, ", _x];
 
-      if (_forEachIndex > 9) exitWith {};//
-    } forEach _oldVersionsServer;
+            if (_forEachIndex > 9) exitWith {};//
+        } forEach _missingAddonsServer;
 
-    _error = _error call _fnc_cutComma;
+        _error = _error call _fnc_cutComma;
 
-    diag_log text _error;
-    [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
-  };
+        diag_log text _error;
+        [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
+    };
 
-  ACE_Version_ClientErrors = [_missingAddon, _missingAddonServer, _oldVersionClient, _oldVersionServer];
+    _oldVersionClient = false;
+    if (count _oldVersionsClient > 0) then {
+        _oldVersionClient = true;
+
+        _error = format ["[ACE] %1: ERROR outdated addon(s): ", _client];
+        {
+            _error = _error + format ["%1 (client: %2, server: %3), ", _x select 0, _x select 1, _x select 2];
+
+            if (_forEachIndex > 9) exitWith {};//
+        } forEach _oldVersionsClient;
+
+        _error = _error call _fnc_cutComma;
+
+        diag_log text _error;
+        [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
+    };
+
+    _oldVersionServer = false;
+    if (count _oldVersionsServer > 0) then {
+        _oldVersionServer = true;
+
+        _error = format ["[ACE] %1: ERROR outdated server addon(s): ", _client];
+        {
+            _error = _error + format ["%1 (client: %2, server: %3), ", _x select 0, _x select 1, _x select 2];
+
+            if (_forEachIndex > 9) exitWith {};//
+        } forEach _oldVersionsServer;
+
+        _error = _error call _fnc_cutComma;
+
+        diag_log text _error;
+        [_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
+    };
+
+    ACE_Version_ClientErrors = [_missingAddon, _missingAddonServer, _oldVersionClient, _oldVersionServer];
 };

--- a/addons/laser_selfdesignate/config.cpp
+++ b/addons/laser_selfdesignate/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_laser"};
-        version = VERSION;
+        VERSION_CONFIG;
     };
 };
 


### PR DESCRIPTION
- logs full version of ace once
- checks if .dlls are present
- checks if all ace.pbos are up to date
- in MP checks if server and client version match up
- otherwise -> RPT log, message box that ends mission
- this is independant from the checkPBO module, which is now for third party addons only.

________________
this checks all pbos taged as ace on mission start. Popup + RPT error when a file with another version number is detected.

This is meant for all those who simply overwrite their folders and then end up with invalid, outdated and/or conflicting stuff.