### PR TITLE
Modules - Stringtabled - third try

### DIFF
--- a/addons/advanced_ballistics/CfgVehicles.hpp
+++ b/addons/advanced_ballistics/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class CfgVehicles {
     class ACE_Module;
     class GVAR(ModuleSettings): ACE_Module {
         scope = 2;
-        displayName = "Advanced Ballistics";
+        displayName = "$STR_ACE_AdvancedBallistics_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Wind_ca.paa));
         category = "ACE";
         function = QUOTE(DFUNC(initModuleSettings));
@@ -12,26 +12,26 @@ class CfgVehicles {
         author = "Ruthberg";
         class Arguments {
             class enabled {
-                displayName = "Advanced Ballistics";
-                description = "Enables advanced ballistics";
+                displayName = "$STR_ACE_AdvancedBallistics_enabled_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_enabled_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class alwaysSimulateForSnipers {
-                displayName = "Always Enabled For Snipers";
-                description = "Always enables advanced ballistics when high power optics are used";
+                displayName = "$STR_ACE_AdvancedBallistics_alwaysSimulateForSnipers_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_alwaysSimulateForSnipers_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class disabledInFullAutoMode {
-                displayName = "Disabled In FullAuto Mode";
-                description = "Disables the advanced ballistics during full auto fire";
+                displayName = "$STR_ACE_AdvancedBallistics_disabledInFullAutoMod_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_disabledInFullAutoMod_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class onlyActiveForLocalPlayers {
-                displayName = "Disabled For Non Local Players";
-                description = "Disables the advanced ballistics for bullets coming from other players (enable this if you encounter frame drops during heavy firefights in multiplayer)";
+                displayName = "$STR_ACE_AdvancedBallistics_onlyActiveForLocalPlayers_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_onlyActiveForLocalPlayers_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
@@ -44,35 +44,38 @@ class CfgVehicles {
             };
             */
             class ammoTemperatureEnabled {
-                displayName = "Enable Ammo Temperature Simulation";
-                description = "Muzzle velocity varies with ammo temperature";
+                displayName = "$STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class barrelLengthInfluenceEnabled {
-                displayName = "Enable Barrel Length Simulation";
-                description = "Muzzle velocity varies with barrel length";
+                displayName = "$STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class bulletTraceEnabled {
-                displayName = "Enable Bullet Trace Effect";
-                description = "Enables a bullet trace effect to high caliber bullets (only visible when looking through high power optics)";
+                displayName = "$STR_ACE_AdvancedBallistics_bulletTraceEnabled_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_bulletTraceEnabled_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class simulationInterval {
-                displayName = "Simulation Interval";
-                description = "Defines the interval between every calculation step";
+                displayName = "$STR_ACE_AdvancedBallistics_simulationInterval_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_simulationInterval_Description";
                 typeName = "NUMBER";
                 defaultValue = 0.0;
             };
             class simulationRadius {
-                displayName = "Simulation Radius";
-                description = "Defines the radius around the player (in meters) at which advanced ballistics are applied to projectiles";
+                displayName = "$STR_ACE_AdvancedBallistics_simulationRadius_DisplayName";
+                description = "$STR_ACE_AdvancedBallistics_simulationRadius_Description";
                 typeName = "NUMBER";
                 defaultValue = 3000;
             };
+        };
+        class ModuleDescription {
+            description = "$STR_ACE_AdvancedBallistics_Description";
         };
     };
 };

--- a/addons/advanced_ballistics/stringtable.xml
+++ b/addons/advanced_ballistics/stringtable.xml
@@ -25,5 +25,168 @@
             <Czech>Zobrazit úhloměr</Czech>
             <Portuguese>Mostrar Transferidor</Portuguese>
         </Key>
+<<<<<<< HEAD
+		<Key ID="STR_ACE_AdvancedBallistics_DisplayName">
+		    <English>Advanced Ballistics</English>
+			<Polish>Zaawansowana balistyka</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_enabled_DisplayName">
+		    <English>Advanced Ballistics</English>
+			<Polish>Zaawansowana balistyka</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_enabled_Description">
+		    <English>Enables advanced ballistics</English>
+			<Polish>Aktywuje zaawansowaną balistykę</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_alwaysSimulateForSnipers_DisplayName">
+		    <English>Always Enabled For Snipers</English>
+			<Polish>Zawsze akt. dla snajp.</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_alwaysSimulateForSnipers_Description">
+		    <English>Always enables advanced ballistics when high power optics are used</English>
+			<Polish>Aktywuje zaawansowaną balistykę zawsze, kiedy używana jest optyka</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_disabledInFullAutoMod_DisplayName">
+		    <English>Disabled In FullAuto Mode</English>
+			<Polish>Wył. podczas ognia auto.</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_disabledInFullAutoMod_Description">
+		    <English>Disables the advanced ballistics during full auto fire</English>
+			<Polish>Dezaktywuje zaawansowaną balistykę podczas ognia automatycznego</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_onlyActiveForLocalPlayers_DisplayName">
+		    <English>Disabled For Non Local Players</English>
+			<Polish>Wyłącz dla nielok. graczy</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_onlyActiveForLocalPlayers_Description">
+		    <English>Disables the advanced ballistics for bullets coming from other players (enable this if you encounter frame drops during heavy firefights in multiplayer)</English>
+			<Polish>Dezaktywuje zaawansowaną balistykę dla pocisków pochodzących od innych graczy(aktywuj tą opcję jeżeli odczuwasz spadki FPS podczas sporych strzelanin w MP)</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_DisplayName">
+		    <English>Enable Ammo Temperature Simulation</English>
+			<Polish>Symulacja temp. amunicji</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_Description">
+		    <English>Muzzle velocity varies with ammo temperature</English>
+			<Polish>Prędkość wylotowa pocisku jest zależna od temperatury amunicji</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_DisplayName">
+		    <English>Enable Barrel Length Simulation</English>
+			<Polish>Symulacja długości lufy</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_Description">
+		    <English>Muzzle velocity varies with barrel length</English>
+			<Polish>Prędkość wylotowa pocisku jest zależna od długości lufy</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_bulletTraceEnabled_DisplayName">
+		    <English>Enable Bullet Trace Effect</English>
+			<Polish>Efekt smugi pocisku</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_bulletTraceEnabled_Description">
+		    <English>Enables a bullet trace effect to high caliber bullets (only visible when looking through high power optics)</English>
+			<Polish>Aktywuje efekt smugi pocisku dla pocisków wysokokalibrowych (widoczne tylko podczas patrzenia przez optykę)</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_simulationInterval_DisplayName">
+		    <English>Simulation Interval</English>
+			<Polish>Interwał symulacji</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_simulationInterval_Description">
+		    <English>Defines the interval between every calculation step</English>
+			<Polish>Określa interwał pomiędzy każdym krokiem kalkulacji</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_simulationRadius_DisplayName">
+		    <English>Simulation Radius</English>
+			<Polish>Zasięg symulacji</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_simulationRadius_Description">
+		    <English>Defines the radius around the player (in meters) at which advanced ballistics are applied to projectiles</English>
+			<Polish>Określa obszar naokoło gracza (w metrach), na którym zaawansowana balistyka jest aplikowana dla pocisków</Polish>
+		</Key>
+		<Key ID="STR_ACE_AdvancedBallistics_Description">
+		    <English>TODO: LOCALIZE</English>
+			<Polish>TODO: LOCALIZE</Polish>
+		</Key>
+=======
+        <Key ID="STR_ACE_AdvancedBallistics_DisplayName">
+            <English>Advanced Ballistics</English>
+            <Polish>Zaawansowana balistyka</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_enabled_DisplayName">
+            <English>Advanced Ballistics</English>
+            <Polish>Zaawansowana balistyka</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_enabled_Description">
+            <English>Enables advanced ballistics</English>
+            <Polish>Aktywuje zaawansowaną balistykę</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_alwaysSimulateForSnipers_DisplayName">
+            <English>Always Enabled For Snipers</English>
+            <Polish>Zawsze akt. dla snajp.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_alwaysSimulateForSnipers_Description">
+            <English>Always enables advanced ballistics when high power optics are used</English>
+            <Polish>Aktywuje zaawansowaną balistykę zawsze, kiedy używana jest optyka</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_disabledInFullAutoMod_DisplayName">
+            <English>Disabled In FullAuto Mode</English>
+            <Polish>Wył. podczas ognia auto.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_disabledInFullAutoMod_Description">
+            <English>Disables the advanced ballistics during full auto fire</English>
+            <Polish>Dezaktywuje zaawansowaną balistykę podczas ognia automatycznego</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_onlyActiveForLocalPlayers_DisplayName">
+            <English>Disabled For Non Local Players</English>
+            <Polish>Wyłącz dla nielok. graczy</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_onlyActiveForLocalPlayers_Description">
+            <English>Disables the advanced ballistics for bullets coming from other players (enable this if you encounter frame drops during heavy firefights in multiplayer)</English>
+            <Polish>Dezaktywuje zaawansowaną balistykę dla pocisków pochodzących od innych graczy(aktywuj tą opcję jeżeli odczuwasz spadki FPS podczas sporych strzelanin w MP)</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_DisplayName">
+            <English>Enable Ammo Temperature Simulation</English>
+            <Polish>Symulacja temp. amunicji</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_Description">
+            <English>Muzzle velocity varies with ammo temperature</English>
+            <Polish>Prędkość wylotowa pocisku jest zależna od temperatury amunicji</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_DisplayName">
+            <English>Enable Barrel Length Simulation</English>
+            <Polish>Symulacja długości lufy</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_Description">
+            <English>Muzzle velocity varies with barrel length</English>
+            <Polish>Prędkość wylotowa pocisku jest zależna od długości lufy</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_bulletTraceEnabled_DisplayName">
+            <English>Enable Bullet Trace Effect</English>
+            <Polish>Efekt smugi pocisku</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_bulletTraceEnabled_Description">
+            <English>Enables a bullet trace effect to high caliber bullets (only visible when looking through high power optics)</English>
+            <Polish>Aktywuje efekt smugi pocisku dla pocisków wysokokalibrowych (widoczne tylko podczas patrzenia przez optykę)</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_simulationInterval_DisplayName">
+            <English>Simulation Interval</English>
+            <Polish>Interwał symulacji</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_simulationInterval_Description">
+            <English>Defines the interval between every calculation step</English>
+            <Polish>Określa interwał pomiędzy każdym krokiem kalkulacji</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_simulationRadius_DisplayName">
+            <English>Simulation Radius</English>
+            <Polish>Zasięg symulacji</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_simulationRadius_Description">
+            <English>Defines the radius around the player (in meters) at which advanced ballistics are applied to projectiles</English>
+            <Polish>Określa obszar naokoło gracza (w metrach), na którym zaawansowana balistyka jest aplikowana dla pocisków</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedBallistics_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala aktywować zaawansowaną balistykę biorącą przy obliczeniach trajektorii lotu pocisku pod uwagę takie rzeczy jak temperatura powietrza, ciśnienie atmosferyczne, wilgotność powietrza, siły Coriolisa i Eotvosa, grawitację a także broń z jakiej wykonywany jest strzał oraz rodzaj amunicji. Wszystko to sprowadza się na bardzo dokładne odwzorowanie balistyki.</Polish>
+        </Key>
+>>>>>>> I made mess so new pull request.
     </Package>
 </Project>

--- a/addons/ballistics/CfgVehicles.hpp
+++ b/addons/ballistics/CfgVehicles.hpp
@@ -190,7 +190,7 @@ class CfgVehicles {
     class ACE_Box_Ammo: NATO_Box_Base {
         scope = 2;
         accuracy = 1000;
-        displayName = "[ACE] Ammo Supply Crate";
+        displayName = "$STR_ACE_AmmoSupplyCrate_DisplayName";
         model = "\A3\weapons_F\AmmoBoxes\AmmoBox_F";
         author = "$STR_ACE_Common_ACETeam";
         class TransportMagazines {

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -1592,5 +1592,13 @@
             <Portuguese>Calibre: 12.7x99mm (AMAX)&lt;br/&gt;Cartuchos: 5</Portuguese>
             <Hungarian>Kaliber: 12,7x99mm (AMAX)&lt;br /&gt;Lövedékek: 5</Hungarian>
         </Key>
+        <Key ID="STR_ACE_AmmoSupplyCrate_DisplayName">
+            <English>[ACE] Ammo Supply Crate</English>
+<<<<<<< HEAD
+			<Polish>[ACE] Skrzynka z amunicją</Polish>
+=======
+            <Polish>[ACE] Skrzynka z amunicją</Polish>
+>>>>>>> I made mess so new pull request.
+        </Key>
     </Package>
 </Project>

--- a/addons/captives/CfgVehicles.hpp
+++ b/addons/captives/CfgVehicles.hpp
@@ -161,7 +161,11 @@ class CfgVehicles {
     class GVAR(ModuleSurrender): Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Make Unit Surrender";
+<<<<<<< HEAD
+        displayName = "$STR_ACE_Captives_ModuleSurrender_DisplayName"; //Make Unit Surrender
+=======
+        displayName = "$STR_ACE_Captives_ModuleSurrender_DisplayName";
+>>>>>>> I made mess so new pull request.
         function = QUOTE(DFUNC(moduleSurrender));
         scope = 2;  //show in editor
         scopeCurator = 2; //show in zeus
@@ -172,7 +176,11 @@ class CfgVehicles {
         functionPriority = 0;
         class Arguments {};
         class ModuleDescription: ModuleDescription {
-            description = "Sync a unit to make them surrender.<br/>Source: ace_captives";
+<<<<<<< HEAD
+            description = "$STR_ACE_Captives_ModuleSurrender_Description"; //Sync a unit to make them surrender.<br/>Source: ace_captives
+=======
+            description = "$STR_ACE_Captives_ModuleSurrender_Description";
+>>>>>>> I made mess so new pull request.
             sync[] = {"AnyAI"};
         };
     };

--- a/addons/captives/stringtable.xml
+++ b/addons/captives/stringtable.xml
@@ -193,5 +193,37 @@
             <Hungarian>Semmi sincs az egér alatt</Hungarian>
             <Italian>Nessuna selezione</Italian>
         </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_DisplayName">
+            <English>Make Unit Surrender</English>
+            <Polish>Poddaj się!</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_Description">
+            <English>Sync a unit to make them surrender.&lt;br /&gt;Source: ace_captives</English>
+            <Polish>Zsynchronizuj z jednostką aby sprawić by się poddała&lt;br /&gt;Źródło: ace_captives</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_DisplayName">
+            <English>Make Unit Surrender</English>
+            <Polish>Poddaj się!</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_Description">
+            <English>Sync a unit to make them surrender.&lt;br /&gt;Source: ace_captives</English>
+            <Polish>Zsynchronizuj z jednostką aby sprawić by się poddała&lt;br /&gt;Źródło: ace_captives</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_DisplayName">
+            <English>Make Unit Surrender</English>
+            <Polish>Poddaj się!</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_Description">
+            <English>Sync a unit to make them surrender.&lt;br /&gt;Source: ace_captives</English>
+            <Polish>Zsynchronizuj z jednostką aby sprawić by się poddała&lt;br /&gt;Źródło: ace_captives</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_DisplayName">
+            <English>Make Unit Surrender</English>
+            <Polish>Poddaj się!</Polish>
+        </Key>
+        <Key ID="STR_ACE_Captives_ModuleSurrender_Description">
+            <English>Sync a unit to make them surrender.&lt;br /&gt;Source: ace_captives</English>
+            <Polish>Zsynchronizuj z jednostką aby sprawić by się poddała&lt;br /&gt;Źródło: ace_captives</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -25,72 +25,72 @@ class CfgVehicles {
   // += needs a non inherited entry in that class, otherwise it simply overwrites
   //#include <DefaultItems.hpp>
 
-  class Module_F;
-  class ACE_ModuleCheckPBOs: Module_F {
+   class Logic;
+   class Module_F: Logic {
+     class ModuleDescription {};
+   };
+   class ACE_ModuleCheckPBOs: Module_F {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
-    displayName = "Check PBOs";
+    displayName = "$STR_ACE_Common_CheckPBO_DisplayName";
     function = QFUNC(moduleCheckPBOs);
     scope = 2;
     isGlobal = 1;
     icon = QUOTE(PATHTOF(UI\Icon_Module_CheckPBO_ca.paa));
     class Arguments {
       class Action {
-        displayName = "Action";
-        description = "What to do with people who do not have the right PBOs?";
+        displayName = "$STR_ACE_Common_CheckPBO_Action_DisplayName";
+        description = "$STR_ACE_Common_CheckPBO_Action_Description";
         class values {
           class WarnOnce {
             default = 1;
-            name = "Warn once";
+            name = "$STR_ACE_Common_CheckPBO_Action_WarnOnce";
             value = 0;
           };
           class Warn {
-            name = "Warn (permanent)";
+            name = "$STR_ACE_Common_CheckPBO_Action_WarnPerm";
             value = 1;
           };
           class Kick {
-            name = "Kick";
+            name = "$STR_ACE_Common_CheckPBO_Action_Kick";
             value = 2;
           };
         };
       };
       class CheckAll {
-        displayName = "Check all addons";
-        description = "Check all addons instead of only those of ACE?";
+        displayName = "$STR_ACE_Common_CheckPBO_CheckAll_DisplayName";
+        description = "$STR_ACE_Common_CheckPBO_CheckAll_Description";
         typeName = "BOOL";
-        class values {
-          class WarnOnce {
-            default = 1;
-            name = "No";
-            value = 0;
-          };
-          class Warn {
-            name = "Yes";
-            value = 1;
-          };
-        };
+        defaultValue = 0;
       };
       class Whitelist {
-        displayName = "Whitelist";
-        description = "What addons are allowed regardless?";
+        displayName = "$STR_ACE_Common_CheckPBO_Whitelist_DisplayName";
+        description = "$STR_ACE_Common_CheckPBO_Whitelist_Description";
         typeName = "STRING";
         class values {
             default = "[]";
         };
       };
     };
+    class ModuleDescription: ModuleDescription {
+        description = "$STR_ACE_Common_CheckPBO_Description";
+	};
   };
 
   class ACE_ModuleLSDVehicles: Module_F {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
-    displayName = "LSD Vehicles";
+    displayName = "$STR_ACE_Common_LSDVehicles_DisplayName";
     function = "ACE_Common_fnc_moduleLSDVehicles";
     scope = 2;
     icon = QUOTE(PATHTOF(UI\Icon_Module_LSD_ca.paa));
     isGlobal = 1;
     class Arguments {
     };
+    class ModuleDescription: ModuleDescription {
+        description = "$STR_ACE_Common_LSDVehicles_Description";
+		sync[] = {"AnyVehicle"};
+	};
   };
 
   class Box_NATO_Support_F;

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {"ACE_ItemCore","ACE_FakePrimaryWeapon", "ACE_Banana"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main"};
-        author[] = {"KoffeinFlummi"};
+        author[] = {"KoffeinFlummi","GieNkoV"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;
     };
@@ -101,7 +101,7 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = "$STR_ACE_Common_SettingFeedbackIconsName";
         description = "$STR_ACE_Common_SettingFeedbackIconsDesc";
-        values[] = {"Hide", "Top right, downwards", "Top right, to the left", "Top left, downwards", "Top left, to the right"};
+        values[] = {"$STR_ACE_Common_Hide", "$STR_ACE_Common_TopRightDown", "$STR_ACE_Common_TopRightLeft", "$STR_ACE_Common_TopLeftDown", "$STR_ACE_Common_TopLeftRight"};
     };
     class GVAR(SettingProgressBarLocation) {
         value = 0;
@@ -110,7 +110,7 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = "$STR_ACE_Common_SettingProgressbarLocationName";
         description = "$STR_ACE_Common_SettingProgressbarLocationDesc";
-        values[] = {"Top", "Bottom"};
+        values[] = {"$STR_ACE_Common_Top", "$STR_ACE_Common_Bottom"};
     };
     class GVAR(displayTextColor) {
         value[] = {0,0,0,0.1};

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -470,5 +470,117 @@
             <French>Une banane est un fruit qui, d'un point de vue botanique, fait partie du groupe des baies. Produite par plusieurs sortes de grandes plantes à fleurs herbacées du type Musa.</French>
             <Portuguese>A banana é uma fruta comestível, botanicamente uma baga, produzida por vários tipos de plantas herbáceas grandes do genero Musa.</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_DisplayName">
+<<<<<<< HEAD
+		    <English>Check PBOs</English>
+            <Polish>Sprawdzaj PBO</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Description">
+		    <English></English>
+            <Polish>Sprawdzaj spójność addonów z serwerem</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Action_DisplayName">
+		    <English>Action</English>
+            <Polish>Akcja</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Action_Description">
+		    <English>What to do with people who do not have the right PBOs?</English>
+            <Polish>Co zrobić z graczami, którzy nie mają właściwych PBO?</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Action_WarnOnce">
+		    <English>Warn once</English>
+            <Polish>Ostrzeż raz</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Action_WarnPerm">
+		    <English>Warn (permanent)</English>
+            <Polish>Ostrzeżenie (permanentne)</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Action_Kick">
+		    <English>Kick</English>
+            <Polish>Kick</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_CheckAll_DisplayName">
+		    <English>Check all addons</English>
+            <Polish>Sprawdź wszystkie addony</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_CheckAll_Description">
+		    <English>Check all addons instead of only those of ACE?</English>
+            <Polish>Sprawdzaj wszystkie addony czy tylko te z ACE?</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_CheckAll_No">
+		    <English>No</English>
+            <Polish>Tylko ACE</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_CheckAll_Yes">
+		    <English>Yes</English>
+            <Polish>Wszystkie</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Whitelist_DisplayName">
+		    <English>Whitelist</English>
+            <Polish>Biała lista</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_CheckPBO_Whitelist_Description">
+		    <English>What addons are allowed regardless?</English>
+            <Polish>Jakie addony są dozwolone?</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_LSDVehicles_DisplayName">
+		    <English>LSD Vehicles</English>
+            <Polish>Pojazdy LSD</Polish>
+		</Key>
+		<Key ID="STR_ACE_Common_LSDVehicles_Description">
+		    <English>Adds LSD effect to synchronized vehicle</English>
+=======
+            <English>Check PBOs</English>
+            <Polish>Sprawdzaj PBO</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Description">
+            <English></English>
+            <Polish>Sprawdzaj spójność addonów z serwerem</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Action_DisplayName">
+            <English>Action</English>
+            <Polish>Akcja</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Action_Description">
+            <English>What to do with people who do not have the right PBOs?</English>
+            <Polish>Co zrobić z graczami, którzy nie mają właściwych PBO?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Action_WarnOnce">
+            <English>Warn once</English>
+            <Polish>Ostrzeż raz</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Action_WarnPerm">
+            <English>Warn (permanent)</English>
+            <Polish>Ostrzeżenie (permanentne)</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Action_Kick">
+            <English>Kick</English>
+            <Polish>Kick</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_CheckAll_DisplayName">
+            <English>Check all addons</English>
+            <Polish>Sprawdź wsz. addony</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_CheckAll_Description">
+            <English>Check all addons instead of only those of ACE?</English>
+            <Polish>Sprawdzaj wszystkie addony czy tylko te z ACE?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Whitelist_DisplayName">
+            <English>Whitelist</English>
+            <Polish>Biała lista</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_CheckPBO_Whitelist_Description">
+            <English>What addons are allowed regardless?</English>
+            <Polish>Jakie addony są dozwolone?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_LSDVehicles_DisplayName">
+            <English>LSD Vehicles</English>
+            <Polish>Pojazdy LSD</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_LSDVehicles_Description">
+            <English>Adds LSD effect to synchronized vehicle</English>
+>>>>>>> I made mess so new pull request.
+            <Polish>Dodaje efekt LSD pod zsynchronizowany pojazd</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/explosives/CfgModule.hpp
+++ b/addons/explosives/CfgModule.hpp
@@ -1,44 +1,30 @@
-class Module_F;
+class Logic;
+class Module_F: Logic {
+    class ModuleDescription {};
+};
 class ACE_ModuleExplosive: Module_F {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
-    displayName = "Explosive System";
+    displayName = "$STR_ACE_Explosive_Module_DisplayName";
     function = QUOTE(FUNC(module));
     scope = 2;
     isGlobal = 1;
     icon = PATHTOF(UI\Icon_Module_Explosives_ca.paa);
     class Arguments {
         class RequireSpecialist {
-            displayName = "Require specialists?";
-            description = "Require explosive specialists to disable explosives? Default: No";
+            displayName = "$STR_ACE_Explosive_RequireSpecialist_DisplayName";
+            description = "$STR_ACE_Explosive_RequireSpecialist_Description";
             typeName = "BOOL";
-            class values {
-                class Yes {
-                    name = "Yes";
-                    value = 1;
-                };
-                class No {
-                    default = 1;
-                    name = "No";
-                    value = 0;
-                };
-            };
+            defaultValue = 0;
         };
         class PunishNonSpecialists {
-            displayName = "Punish non-specialists?";
-            description = "Increase the time it takes to complete actions for non-specialists? Default: Yes";
+            displayName = "$STR_ACE_Explosive_PunishNonSpecialists_DisplayName";
+            description = "$STR_ACE_Explosive_PunishNonSpecialists_Description";
             typeName = "BOOL";
-            class values {
-                class Yes {
-                    default = 1;
-                    name = "Yes";
-                    value = 1;
-                };
-                class No {
-                    name = "No";
-                    value = 0;
-                };
-            };
+            defaultValue = 1;
         };
+    };
+	class ModuleDescription: ModuleDescription {
+            description = "$STR_ACE_Explosive_Module_Description";
     };
 };

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -505,5 +505,29 @@
             <Italian>Raccogli</Italian>
             <Portuguese>Pegar</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Explosive_Module_DisplayName">
+            <English>Explosive System</English>
+            <Polish>System ładunków wybuchowych</Polish>
+        </Key>
+        <Key ID="STR_ACE_Explosive_RequireSpecialist_DisplayName">
+            <English>Require specialists?</English>
+            <Polish>Wymagaj specjalistów?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Explosive_RequireSpecialist_Description">
+            <English>Require explosive specialists to disable explosives? Default: No</English>
+            <Polish>Wymagać saperów do rozbrajania ładunków wybuchowych? Domyślnie: Nie</Polish>
+        </Key>
+        <Key ID="STR_ACE_Explosive_PunishNonSpecialists_DisplayName">
+            <English>Punish non-specialists?</English>
+            <Polish>Karaj nie-specjalistów?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Explosive_PunishNonSpecialists_Description">
+            <English>Increase the time it takes to complete actions for non-specialists? Default: Yes</English>
+            <Polish>Zwiększyć ilość wymaganego czasu do ukończenia akcji dla nie-specjalistów? Domyślnie: Tak</Polish>
+        </Key>
+        <Key ID="STR_ACE_Explosive_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala dostosować opcje związane z ładunkami wybuchowymi, ich podkładaniem oraz rozbrajaniem.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/hearing/CfgVehicles.hpp
+++ b/addons/hearing/CfgVehicles.hpp
@@ -98,21 +98,21 @@ class CfgVehicles {
     class ACE_ModuleHearing: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Hearing";
+        displayName = "$STR_ACE_Hearing_Module_DisplayName";
         function = QFUNC(moduleHearing);
         scope = 2;
         isGlobal = 1;
         icon = PATHTOF(UI\Icon_Module_Hearing_ca.paa);
         class Arguments {
             class EnableCombatDeafness {
-                displayName = "Enable combat deafness?";
-                description = "Enable combat deafness?";
+                displayName = "$STR_ACE_Hearing_CombatDeafness_DisplayName";
+                description = "$STR_ACE_Hearing_CombatDeafness_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes { name = "Yes"; value = 1; default = 1; };
-                    class No { name = "No"; value = 0; };
-                };
+                defaultValue = 1;
             };
+        };
+		class ModuleDescription {
+            description = "$STR_ACE_Hearing_Module_Description";
         };
     };
 };

--- a/addons/hearing/stringtable.xml
+++ b/addons/hearing/stringtable.xml
@@ -109,5 +109,21 @@
             <Italian>Disabilita i fischi nelle orecchie</Italian>
             <Portuguese>Desabilitar zumbido de ouvidos</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Hearing_Module_DisplayName">
+            <English>Hearing</English>
+            <Polish>Słuch</Polish>
+        </Key>
+        <Key ID="STR_ACE_Hearing_CombatDeafness_DisplayName">
+            <English>Enable combat deafness?</English>
+            <Polish>Wł. głuchotę bojową</Polish>
+        </Key>
+        <Key ID="STR_ACE_Hearing_CombatDeafness_Description">
+            <English>Enable combat deafness?</English>
+            <Polish>Możliwość chwilowej utraty słuchu przy głośnych wystrzałach i jednoczesnym braku włożonych stoperów</Polish>
+        </Key>
+        <Key ID="STR_ACE_Hearing_Module_Description">
+            <English></English>
+            <Polish>Głuchota bojowa pojawia się w momentach, kiedy stoimy w pobliżu broni wielkokalibrowej bez ochrony słuchu, lub np. podczas ostrzału artyleryjskiego. Moduł ten pozwala na włączenie lub wyłączenie tego efektu.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -4,21 +4,21 @@ class CfgVehicles {
   class ACE_ModuleInteraction: Module_F {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
-    displayName = "Interaction System";
+    displayName = "$STR_ACE_InteractionSystem_Module_DisplayName";
     function = "ACE_Interaction_fnc_moduleInteraction";
     scope = 2;
     isGlobal = 1;
     icon = PATHTOF(UI\Icon_Module_Interaction_ca.paa);
     class Arguments {
       class EnableTeamManagement {
-        displayName = "Enable Team Management";
-        description = "Should players be allowed to use the Team Management Menu? Default: Yes";
+        displayName = "$STR_ACE_InteractionSystem_EnableTeamManagement_DisplayName";
+        description = "$STR_ACE_InteractionSystem_EnableTeamManagement_Description";
         typeName = "BOOL";
-        class values {
-          class Yes { default = 1; name = "Yes"; value = 1;};
-          class No { name = "No"; value = 0; };
-        };
+        defaultValue = 1;
       };
+    };
+	class ModuleDescription {
+      description = "$STR_ACE_InteractionSystem_Module_Description";
     };
   };
 

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -522,7 +522,7 @@
             <German>Rot</German>
             <Spanish>Rojo</Spanish>
             <French>Rouge</French>
-            <Polish>Czerwony</Polish>
+            <Polish>Czerwonych</Polish>
             <Czech>Červený</Czech>
             <Russian>Красный</Russian>
             <Portuguese>Vermelha</Portuguese>
@@ -534,7 +534,7 @@
             <German>Grün</German>
             <Spanish>Verde</Spanish>
             <French>Vert</French>
-            <Polish>Zielony</Polish>
+            <Polish>Zielonych</Polish>
             <Czech>Zelený</Czech>
             <Russian>Зеленый</Russian>
             <Portuguese>Verde</Portuguese>
@@ -546,7 +546,7 @@
             <German>Blau</German>
             <Spanish>Azul</Spanish>
             <French>Bleu</French>
-            <Polish>Niebieski</Polish>
+            <Polish>Niebieskich</Polish>
             <Czech>Modrý</Czech>
             <Russian>Синий</Russian>
             <Portuguese>Azul</Portuguese>
@@ -558,7 +558,7 @@
             <German>Gelb</German>
             <Spanish>Amarillo</Spanish>
             <French>Jaune</French>
-            <Polish>Żółty</Polish>
+            <Polish>Żółtych</Polish>
             <Czech>Žlutý</Czech>
             <Russian>Жёлтый</Russian>
             <Portuguese>Amarela</Portuguese>
@@ -666,7 +666,7 @@
             <German>Du bist Gruppe %1 beigetreten</German>
             <Spanish>Te has unido al equipo %1</Spanish>
             <French>Tu as rejoint l'équipe %1</French>
-            <Polish>Dołączyłeś do drużyny %1</Polish>
+            <Polish>Dołączyłeś do %1</Polish>
             <Czech>Připojil ses do %1 týmu</Czech>
             <Russian>Вы присоединились к группе %1</Russian>
             <Portuguese>Você uniu-se à Equipe %1</Portuguese>
@@ -792,6 +792,22 @@
             <Hungarian>Utasok</Hungarian>
             <Italian>Passeggeri</Italian>
             <Portuguese>Passageiros</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_InteractionSystem_Module_DisplayName">
+            <English>Interaction System</English>
+            <Polish>System interakcji</Polish>
+        </Key>
+        <Key ID="STR_ACE_InteractionSystem_EnableTeamManagement_DisplayName">
+            <English>Enable Team Management</English>
+            <Polish>Wł. zarządzanie drużyną</Polish>
+        </Key>
+        <Key ID="STR_ACE_InteractionSystem_EnableTeamManagement_Description">
+            <English>Should players be allowed to use the Team Management Menu? Default: Yes</English>
+            <Polish>Czy gracze mogą korzystać z menu zarządzania drużyną? Domyślnie: Tak</Polish>
+        </Key>
+        <Key ID="STR_ACE_InteractionSystem_Module_Description">
+            <English></English>
+            <Polish>Na zarządzanie drużyną składa się: przydział kolorów dla członków drużyny, przejmowanie dowodzenia, dołączanie/opuszczanie drużyn.</Polish>
         </Key>
     </Package>
 </Project>

--- a/addons/map/CfgVehicles.hpp
+++ b/addons/map/CfgVehicles.hpp
@@ -3,74 +3,66 @@ class CfgVehicles {
     class ACE_ModuleMap: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Map";
+        displayName = "$STR_ACE_Map_Module_DisplayName";
         function = QFUNC(moduleMap);
         scope = 2;
         isGlobal = 1;
         icon = PATHTOF(UI\Icon_Module_Map_ca.paa);
         class Arguments {
             class MapIllumination {
-                displayName = "Map illumination?";
-                description = "Calculate dynamic map illumination based on light conditions?";
+                displayName = "$STR_ACE_Map_MapIllumination_DisplayName";
+                description = "$STR_ACE_Map_MapIllumination_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes { name = "Yes"; value = 1; default = 1; };
-                    class No { name = "No"; value = 0; };
-                };
+                defaultValue = 1;
             };
             class MapShake {
-                displayName = "Map shake?";
-                description = "Make map shake when walking?";
+                displayName = "$STR_ACE_Map_MapShake_DisplayName";
+                description = "$STR_ACE_Map_MapShake_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes { name = "Yes"; value = 1; default = 1;};
-                    class No { name = "No"; value = 0; };
-                };
+                defaultValue = 1;
             };
             class MapLimitZoom {
-                displayName = "Limit map zoom?";
-                description = "Limit the amount of zoom available for the map?";
+                displayName = "$STR_ACE_Map_MapLimitZoom_DisplayName";
+                description = "$STR_ACE_Map_MapLimitZoom_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes { name = "Yes"; value = 1; };
-                    class No { name = "No"; value = 0; default = 1;};
-                };
+                defaultValue = 0;
             };
             class MapShowCursorCoordinates {
-                displayName = "Show cursor coordinates?";
-                description = "Show the grid coordinates on the mouse pointer?";
+                displayName = "$STR_ACE_Map_MapShowCursorCoordinates_DisplayName";
+                description = "$STR_ACE_Map_MapShowCursorCoordinates_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes { name = "Yes"; value = 1; };
-                    class No { name = "No"; value = 0; default = 1;};
-                };
+                defaultValue = 0;
             };
+        };
+		class ModuleDescription {
+            description = "$STR_ACE_Map_Module_Description";
         };
     };
 
     class ACE_ModuleBlueForceTracking: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Blue Force Tracking";
+        displayName = "$STR_ACE_Map_BFT_Module_DisplayName";
         function = QFUNC(blueForceTrackingModule);
         scope = 2;
         isGlobal = 1;
         icon = PATHTOF(UI\Icon_Module_BFTracking_ca.paa);
         class Arguments {
             class Interval {
-                displayName = "Interval";
-                description = "How often the markers should be refreshed (in seconds)";
+                displayName = "$STR_ACE_Map_BFT_Interval_DisplayName";
+                description = "$STR_ACE_Map_BFT_Interval_Description";
+				typeName = "NUMBER";
                 defaultValue = 1;
             };
             class HideAiGroups {
-                displayName = "Hide AI groups?";
-                description = "Hide markers for 'AI only' groups?";
+                displayName = "$STR_ACE_Map_BFT_HideAiGroups_DisplayName";
+                description = "$STR_ACE_Map_BFT_HideAiGroups_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes { name = "Yes"; value = 1; };
-                    class No { name = "No"; value = 0; default = 1; };
-                };
+                defaultValue = 0;
             };
+        };
+		class ModuleDescription {
+            description = "$STR_ACE_Map_BFT_Module_Description";
         };
     };
 };

--- a/addons/map/stringtable.xml
+++ b/addons/map/stringtable.xml
@@ -1,6 +1,137 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
-  <Package name="Map">
-
-  </Package>
+    <Package name="Map">
+        <Key ID="STR_ACE_Map_Module_DisplayName">
+            <English>Map</English>
+            <Polish>Mapa</Polish>
+        </Key>
+<<<<<<< HEAD
+		<Key ID="STR_ACE_Map_MapIllumination_DisplayName">
+            <English>Map illumination?</English>
+            <Polish>Oświetlenie mapy</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapIllumination_Description">
+            <English>Calculate dynamic map illumination based on light conditions?</English>
+            <Polish>Oblicza dynamiczne oświetlenie mapy bazujące na warunkach oświetleniowych</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_Yes">
+            <English>Yes</English>
+            <Polish>Tak</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_No">
+            <English>No</English>
+            <Polish>Nie</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapShake_DisplayName">
+            <English>Map shake?</English>
+            <Polish>Drżenie mapy</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapShake_Description">
+            <English>Make map shake when walking?</English>
+            <Polish>Ekran mapy drży podczas ruchu</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapLimitZoom_DisplayName">
+            <English>Limit map zoom?</English>
+            <Polish>Ograniczony zoom</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapLimitZoom_Description">
+            <English>Limit the amount of zoom available for the map?</English>
+            <Polish>Ogranicza maksymalny stopień przybliżenia mapy</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapShowCursorCoordinates_DisplayName">
+            <English>Show cursor coordinates?</English>
+            <Polish>Koordynaty pod kursorem</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_MapShowCursorCoordinates_Description">
+            <English>Show the grid coordinates on the mouse pointer?</English>
+            <Polish>Pokazuje pod kursorem koordynaty wskazanego kwadratu mapy</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala dostosować opcje widoku ekranu mapy.</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_BFT_Module_DisplayName">
+            <English>Blue Force Tracking</English>
+            <Polish>Blue Force Tracking</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_BFT_Interval_DisplayName">
+            <English>Interval</English>
+            <Polish>Interwał</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_BFT_Interval_Description">
+            <English>How often the markers should be refreshed (in seconds)</English>
+            <Polish>Jak często markery powinny być odświeżane (w sekundach)</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_BFT_HideAiGroups_DisplayName">
+            <English>Hide AI groups?</English>
+            <Polish>Ukryj grupy AI</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_BFT_HideAiGroups_Description">
+            <English>Hide markers for 'AI only' groups?</English>
+            <Polish>Ukrywa markery dla grup złożonych tylko z AI</Polish>
+        </Key>
+		<Key ID="STR_ACE_Map_BFT_Module_Description">
+=======
+        <Key ID="STR_ACE_Map_MapIllumination_DisplayName">
+            <English>Map illumination?</English>
+            <Polish>Oświetlenie mapy</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapIllumination_Description">
+            <English>Calculate dynamic map illumination based on light conditions?</English>
+            <Polish>Oblicza dynamiczne oświetlenie mapy bazujące na warunkach oświetleniowych</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapShake_DisplayName">
+            <English>Map shake?</English>
+            <Polish>Drżenie mapy</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapShake_Description">
+            <English>Make map shake when walking?</English>
+            <Polish>Ekran mapy drży podczas ruchu</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapLimitZoom_DisplayName">
+            <English>Limit map zoom?</English>
+            <Polish>Ograniczony zoom</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapLimitZoom_Description">
+            <English>Limit the amount of zoom available for the map?</English>
+            <Polish>Ogranicza maksymalny stopień przybliżenia mapy</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapShowCursorCoordinates_DisplayName">
+            <English>Show cursor coordinates?</English>
+            <Polish>Koordynaty pod kursorem</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_MapShowCursorCoordinates_Description">
+            <English>Show the grid coordinates on the mouse pointer?</English>
+            <Polish>Pokazuje pod kursorem koordynaty wskazanego kwadratu mapy</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala dostosować opcje widoku ekranu mapy.</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_Module_DisplayName">
+            <English>Blue Force Tracking</English>
+            <Polish>Blue Force Tracking</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_Interval_DisplayName">
+            <English>Interval</English>
+            <Polish>Interwał</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_Interval_Description">
+            <English>How often the markers should be refreshed (in seconds)</English>
+            <Polish>Jak często markery powinny być odświeżane (w sekundach)</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_HideAiGroups_DisplayName">
+            <English>Hide AI groups?</English>
+            <Polish>Ukryj grupy AI</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_HideAiGroups_Description">
+            <English>Hide markers for 'AI only' groups?</English>
+            <Polish>Ukrywa markery dla grup złożonych tylko z AI</Polish>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_Module_Description">
+>>>>>>> I made mess so new pull request.
+            <English></English>
+            <Polish>Pozwala śledzić na mapie pozycje sojuszniczych jednostek za pomocą markerów BFT.</Polish>
+        </Key>
+    </Package>
 </Project>

--- a/addons/medical/CfgFactionClasses.hpp
+++ b/addons/medical/CfgFactionClasses.hpp
@@ -1,6 +1,6 @@
 class CfgFactionClasses {
     class NO_CATEGORY;
     class ADDON: NO_CATEGORY {
-        displayName = "ACE Medical";
+        displayName = "$STR_ACE_Medical_Category_DisplayName";
     };
 };

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -12,7 +12,7 @@ class CfgVehicles {
     // TODO localization for all the modules
     class ACE_moduleMedicalSettings: ACE_Module {
         scope = 2;
-        displayName = "Medical Settings [ACE]";
+        displayName = "$STR_ACE_MedicalSettings_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Medical_ca.paa));
         category = "ACE_medical";
         function = QUOTE(DFUNC(moduleMedicalSettings));
@@ -22,78 +22,78 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class level {
-                displayName = "Medical Level";
-                description = "What is the medical simulation level?";
+                displayName = "$STR_ACE_MedicalSettings_level_DisplayName";
+                description = "$STR_ACE_MedicalSettings_level_Description";
                 typeName = "NUMBER";
                 class values {
                     class normal {
-                        name = "Basic";
+                        name = "$STR_ACE_MedicalSettings_basic";
                         value = 1;
                         default = 1;
                     };
                     class full  {
-                        name = "Advanced";
+                        name = "$STR_ACE_MedicalSettings_advanced";
                         value = 2;
                     };
                 };
             };
             class medicSetting {
-                displayName = "Medics setting";
-                description = "What is the level of detail prefered for medics?";
+                displayName = "$STR_ACE_MedicalSettings_medicSetting_DisplayName";
+                description = "$STR_ACE_MedicalSettings_medicSetting_Description";
                 typeName = "NUMBER";
                 class values {
                     class disable {
-                        name = "Disable medics";
+                        name = "$STR_ACE_MedicalSettings_medicSetting_disable";
                         value = 0;
                     };
                     class normal {
-                        name = "Normal";
+                        name = "$STR_ACE_MedicalSettings_basic";
                         value = 1;
                         default = 1;
                     };
                     class full  {
-                        name = "Advanced";
+                        name = "$STR_ACE_MedicalSettings_advanced";
                         value = 2;
                     };
                 };
             };
             class allowLitterCreation {
-                displayName = "Enable Litter";
-                description = "Enable litter being created upon treatment";
+                displayName = "$STR_ACE_MedicalSettings_allowLitterCreation_DisplayName";
+                description = "$STR_ACE_MedicalSettings_allowLitterCreation_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class litterCleanUpDelay {
-                displayName = "Life time of litter objects";
-                description = "How long should litter objects stay? In seconds. -1 is forever.";
+                displayName = "$STR_ACE_MedicalSettings_litterCleanUpDelay_DisplayName";
+                description = "$STR_ACE_MedicalSettings_litterCleanUpDelay_Description";
                 typeName = "NUMBER";
                 defaultValue = 1800;
             };
             class enableScreams {
-                displayName = "Enable Screams";
-                description = "Enable screaming by injuried units";
+                displayName = "$STR_ACE_MedicalSettings_enableScreams_DisplayName";
+                description = "$STR_ACE_MedicalSettings_enableScreams_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class playerDamageThreshold {
-                displayName = "Player Damage";
-                description = "What is the damage a player can take before being killed?";
+                displayName = "$STR_ACE_MedicalSettings_playerDamageThreshold_DisplayName";
+                description = "$STR_ACE_MedicalSettings_playerDamageThreshold_Description";
                 typeName = "NUMBER";
                 defaultValue = 1;
             };
             class AIDamageThreshold {
-                displayName = "AI Damage";
-                description = "What is the damage an AI can take before being killed?";
+                displayName = "$STR_ACE_MedicalSettings_AIDamageThreshold_DisplayName";
+                description = "$STR_ACE_MedicalSettings_AIDamageThreshold_Description";
                 typeName = "NUMBER";
                 defaultValue = 1;
             };
             class enableUnconsciousnessAI {
-                displayName = "AI Unconsciousness";
-                description = "Allow AI to go unconscious";
+                displayName = "$STR_ACE_MedicalSettings_enableUnconsciousnessAI_DisplayName";
+                description = "$STR_ACE_MedicalSettings_enableUnconsciousnessAI_Description";
                 typeName = "NUMBER";
                 class values {
                     class disable {
-                        name = "Disabled";
+                        name = "$STR_ACE_Medical_disabled";
                         value = 0;
                     };
                     class normal {
@@ -102,45 +102,45 @@ class CfgVehicles {
                         default = 1;
                     };
                     class full {
-                        name = "Enabled";
+                        name = "$STR_ACE_Medical_enabled";
                         value = 2;
                     };
                 };
             };
             class preventInstaDeath {
-                displayName = "Prevent instant death";
-                description = "Have a unit move to unconscious instead of death";
+                displayName = "$STR_ACE_MedicalSettings_preventInstaDeath_DisplayName";
+                description = "$STR_ACE_MedicalSettings_preventInstaDeath_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class bleedingCoefficient {
-                displayName = "Bleeding coefficient";
-                description = "Coefficient to modify the bleeding speed";
+                displayName = "$STR_ACE_MedicalSettings_bleedingCoefficient_DisplayName";
+                description = "$STR_ACE_MedicalSettings_bleedingCoefficient_Description";
                 typeName = "NUMBER";
                 defaultValue = 1;
             };
             class painCoefficient {
-                displayName = "Pain coefficient";
-                description = "Coefficient to modify the pain intensity";
+                displayName = "$STR_ACE_MedicalSettings_painCoefficient_DisplayName";
+                description = "$STR_ACE_MedicalSettings_painCoefficient_Description";
                 typeName = "NUMBER";
                 defaultValue = 1;
             };
             class keepLocalSettingsSynced {
-                displayName = "Sync status";
-                description = "Keep unit status synced. Recommended on.";
+                displayName = "$STR_ACE_MedicalSettings_keepLocalSettingsSynced_DisplayName";
+                description = "$STR_ACE_MedicalSettings_keepLocalSettingsSynced_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
         };
         class ModuleDescription {
-            description = "Provides a medical system for both players and AI.";
+            description = "$STR_ACE_MedicalSettings_Module_Description";
             sync[] = {};
         };
     };
 
     class ACE_moduleAdvancedMedicalSettings: ACE_Module {
         scope = 2;
-        displayName = "Advanced Medical Settings [ACE]";
+        displayName = "$STR_ACE_AdvancedMedicalSettings_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Medical_ca.paa));
         category = "ACE_medical";
         function = QUOTE(FUNC(moduleAdvancedMedicalSettings));
@@ -151,80 +151,77 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class enableFor {
-                displayName = "Enabled for";
-                description = "Select what units the advanced medical system will be enabled for";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_enableFor_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_enableFor_Description";
                 typeName = "NUMBER";
                 class values {
                     class playableUnits {
-                        name = "Players only.";
+                        name = "$STR_ACE_Medical_playeronly";
                         value = 0;
                         default = 1;
                     };
                     class playableUnitsAndAI {
-                        name = "Players and AI";
+                        name = "$STR_ACE_Medical_playersandai";
                         value = 1;
                     };
                 };
             };
             class enableAdvancedWounds {
-                displayName = "Enable Advanced wounds";
-                description = "Allow reopening of bandaged wounds?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_enableAdvancedWounds_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_enableAdvancedWounds_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class enableVehicleCrashes {
-                displayName = "Vehicle Crashes";
-                description = "Do units take damage from a vehicle crash?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_enableVehicleCrashes_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_enableVehicleCrashes_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class medicSetting_PAK {
-                displayName = "Allow PAK";
-                description = "Who can use the PAK for full heal?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_medicSetting_PAK_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_medicSetting_PAK_Description";
                 typeName = "NUMBER";
                 class values {
-                    class anyone { name = "Anyone"; value = 0; };
-                    class Medic { name = "Medics only"; value = 1; default = 1; };
-                    class Special { name = "Doctors only"; value = 2; };
+                    class anyone { name = "$STR_ACE_AdvancedMedicalSettings_anyone"; value = 0; };
+                    class Medic { name = "$STR_ACE_AdvancedMedicalSettings_Medic"; value = 1; default = 1; };
+                    class Special { name = "$STR_ACE_AdvancedMedicalSettings_Special"; value = 2; };
                 };
             };
             class consumeItem_PAK {
-                displayName = "Remove PAK on use";
-                description = "Should PAK be removed on usage?";
-                typeName = "NUMBER";
-                class values {
-                    class keep { name = "No"; value = 0; };
-                    class remove { name = "Yes"; value = 1; default = 1; };
-                };
+                displayName = "$STR_ACE_AdvancedMedicalSettings_consumeItem_PAK_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_consumeItem_PAK_Description";
+                typeName = "BOOL";
+                defaultValue = 1;
             };
             class useLocation_PAK {
-                displayName = "Locations PAK";
-                description = "Where can the personal aid kit be used?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_useLocation_PAK_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_useLocation_PAK_Description";
                 typeName = "NUMBER";
                 class values {
-                    class anywhere { name = "Anywhere"; value = 0; };
-                    class vehicle { name = "Medical Vehicles"; value = 1; };
-                    class facility { name = "Medical facility"; value = 2; };
-                    class vehicleAndFacility { name = "Vehicles & facility"; value = 3; default = 1; };
-                    class disabled { name = "Disabled"; value = 4;};
+                    class anywhere { name = "$STR_ACE_AdvancedMedicalSettings_anywhere"; value = 0; };
+                    class vehicle { name = "$STR_ACE_AdvancedMedicalSettings_vehicle"; value = 1; };
+                    class facility { name = "$STR_ACE_AdvancedMedicalSettings_facility"; value = 2; };
+                    class vehicleAndFacility { name = "$STR_ACE_AdvancedMedicalSettings_vehicleAndFacility"; value = 3; default = 1; };
+                    class disabled { name = "$STR_ACE_AdvancedMedicalSettings_disabled"; value = 4;};
                 };
             };
             class medicSetting_SurgicalKit: medicSetting_PAK {
-                displayName = "Allow Surgical kit (Adv)";
-                description = "Who can use the surgical kit?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_medicSetting_SurgicalKit_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_medicSetting_SurgicalKit_Description";
             };
             class consumeItem_SurgicalKit: consumeItem_PAK {
-                displayName = "Remove Surgical kit (Adv)";
-                description = "Should Surgical kit be removed on usage?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_consumeItem_SurgicalKit_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_consumeItem_SurgicalKit_Description";
             };
             class useLocation_SurgicalKit: useLocation_PAK {
-                displayName = "Locations Surgical kit (Adv)";
-                description = "Where can the Surgical kit be used?";
+                displayName = "$STR_ACE_AdvancedMedicalSettings_useLocation_SurgicalKit_DisplayName";
+                description = "$STR_ACE_AdvancedMedicalSettings_useLocation_SurgicalKit_Description";
             };
 
         };
         class ModuleDescription {
-            description = "Configure the treatment settings from ACE Medical";
+            description = "$STR_ACE_AdvancedMedicalSettings_Module_Description";
             sync[] = {};
         };
     };
@@ -232,7 +229,7 @@ class CfgVehicles {
 
     class ACE_moduleReviveSettings: ACE_Module {
         scope = 2;
-        displayName = "Revive Settings [ACE]";
+        displayName = "$STR_ACE_ReviveSettings_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Medical_ca.paa));
         category = "ACE_medical";
         function = QUOTE(DFUNC(moduleReviveSettings));
@@ -242,37 +239,37 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class enableRevive {
-                displayName = "Enable Revive";
-                description = "Enable a basic revive system";
+                displayName = "$STR_ACE_ReviveSettings_enableRevive_DisplayName";
+                description = "$STR_ACE_ReviveSettings_enableRevive_Description";
                 typeName = "NUMBER";
                 defaultValue = 0;
                 class values {
-                    class disable { name = "Disabled"; value = 0; default = 1;};
-                    class playerOnly { name = "Player only"; value = 1; };
-                    class playerAndAI { name = "Player & AI"; value = 2; };
+                    class disable { name = "$STR_ACE_Medical_disabled"; value = 0; default = 1;};
+                    class playerOnly { name = "$STR_ACE_Medical_playeronly"; value = 1; };
+                    class playerAndAI { name = "$STR_ACE_Medical_playersandai"; value = 2; };
                 };
             };
             class maxReviveTime {
-                displayName = "Max Revive time";
-                description = "Max amount of seconds a unit can spend in revive state";
+                displayName = "$STR_ACE_ReviveSettings_maxReviveTime_DisplayName";
+                description = "$STR_ACE_ReviveSettings_maxReviveTime_Description";
                 typeName = "NUMBER";
                 defaultValue = 120;
             };
             class amountOfReviveLives {
-                displayName = "Max Revive lives";
-                description = "Max amount of lives a unit. 0 or -1 is disabled.";
+                displayName = "$STR_ACE_ReviveSettings_amountOfReviveLives_DisplayName";
+                description = "$STR_ACE_ReviveSettings_amountOfReviveLives_Description";
                 typeName = "NUMBER";
                 defaultValue = -1;
             };
         };
         class ModuleDescription {
-            description = "Provides a medical system for both players and AI.";
+            description = "$STR_ACE_ReviveSettings_Module_Description";
             sync[] = {};
         };
     };
     class ACE_moduleAssignMedicRoles: Module_F {
         scope = 2;
-        displayName = "Set Medic Class [ACE]";
+        displayName = "$STR_ACE_AssignMedicRoles_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Medical_ca.paa));
         category = "ACE_medical";
         function = QUOTE(FUNC(moduleAssignMedicRoles));
@@ -283,41 +280,41 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class EnableList {
-                displayName = "List";
-                description = "List of unit names that will be classified as medic, separated by commas.";
+                displayName = "$STR_ACE_AssignMedicRoles_EnableList_DisplayName";
+                description = "$STR_ACE_AssignMedicRoles_EnableList_Description";
                 defaultValue = "";
                 typeName = "STRING";
             };
             class role {
-                displayName = "Is Medic";
-                description = "Medics allow for more advanced treatment in case of Advanced Medic roles enabled";
+                displayName = "$STR_ACE_AssignMedicRoles_role_DisplayName";
+                description = "$STR_ACE_AssignMedicRoles_role_Description";
                 typeName = "NUMBER";
                 class values {
                     class none {
-                        name = "None";
+                        name = "$STR_ACE_AssignMedicRoles_role_none";
                         value = 0;
                     };
                     class medic {
-                        name = "Regular medic";
+                        name = "$STR_ACE_AssignMedicRoles_role_medic";
                         value = 1;
                         default = 1;
                     };
                     class doctor {
-                        name = "Doctor (Only Advanced Medics)";
+                        name = "$STR_ACE_AssignMedicRoles_role_doctor";
                         value = 2;
                     };
                 };
             };
         };
         class ModuleDescription {
-            description = "Assigns the ACE medic class to a unit";
+            description = "$STR_ACE_AssignMedicRoles_Module_Description";
             sync[] = {};
         };
     };
 
     class ACE_moduleAssignMedicVehicle: Module_F {
         scope = 2;
-        displayName = "Set Medical Vehicle [ACE]";
+        displayName = "$STR_ACE_AssignMedicVehicle_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Medical_ca.paa));
         category = "ACE_medical";
         function = QUOTE(FUNC(moduleAssignMedicalVehicle));
@@ -328,36 +325,26 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class EnableList {
-                displayName = "List";
-                description = "List of vehicles that will be classified as medical vehicle, separated by commas.";
+                displayName = "$STR_ACE_AssignMedicVehicle_EnableList_DisplayName";
+                description = "$STR_ACE_AssignMedicVehicle_EnableList_Description";
                 defaultValue = "";
                 typeName = "STRING";
             };
             class enabled {
-                displayName = "Is Medical Vehicle";
-                description = "Whatever or not the objects in the list will be a medical vehicle.";
-                typeName = "NUMBER";
-                class values {
-                    class none {
-                        name = "No";
-                        value = 0;
-                    };
-                    class medic {
-                        name = "Yes";
-                        value = 1;
-                        default = 1;
-                    };
-                };
+                displayName = "$STR_ACE_AssignMedicVehicle_enabled_DisplayName";
+                description = "$STR_ACE_AssignMedicVehicle_enabled_Description";
+                typeName = "BOOL";
+                defaultValue = 1;
             };
         };
         class ModuleDescription {
-            description = "Assigns the ACE medic class to a unit";
+            description = "$STR_ACE_AssignMedicVehicle_Module_Description";
             sync[] = {};
         };
     };
     class ACE_moduleAssignMedicalFacility: Module_F {
         scope = 2;
-        displayName = "Set Medical Facility [ACE]";
+        displayName = "$STR_ACE_AssignMedicalFacility_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Medical_ca.paa));
         category = "ACE_medical";
         function = QUOTE(FUNC(moduleAssignMedicalFacility));
@@ -368,13 +355,13 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class enabled {
-                displayName = "Is Medical Facility";
-                description = "Registers an object as a medical facility for CMS";
+                displayName = "$STR_ACE_AssignMedicalFacility_enabled_DisplayName";
+                description = "$STR_ACE_AssignMedicalFacility_enabled_Description";
                 typeName = "BOOL";
             };
         };
         class ModuleDescription {
-            description = "Defines an object as a medical facility for CMS. This allows for more advanced treatments. Can be used on buildings and vehicles. ";
+            description = "$STR_ACE_AssignMedicalFacility_Module_Description";
             sync[] = {};
         };
     };
@@ -897,7 +884,7 @@ class CfgVehicles {
     class ACE_medicalSupplyCrate: NATO_Box_Base {
         scope = 2;
         accuracy = 1000;
-        displayName = "[ACE] Medical Supply Crate (Basic)";
+        displayName = "$STR_ACE_medicalSupplyCrate";
         model = PATHTOF(data\ace_medcrate.p3d);
         author = "$STR_ACE_Common_ACETeam";
         class TransportItems {
@@ -932,7 +919,7 @@ class CfgVehicles {
         };
     };
     class ACE_medicalSupplyCrate_advanced: ACE_medicalSupplyCrate {
-        displayName = "[ACE] Medical Supply Crate (Advanced)";
+        displayName = "$STR_ACE_medicalSupplyCrate_advanced";
         class TransportItems {
             class ACE_fieldDressing {
                 name = "ACE_fieldDressing";

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_tourniquet", "ACE_morphine", "ACE_atropine", "ACE_epinephrine", "ACE_plasmaIV", "ACE_plasmaIV_500", "ACE_plasmaIV_250", "ACE_bloodIV", "ACE_bloodIV_500", "ACE_bloodIV_250", "ACE_salineIV", "ACE_salineIV_500", "ACE_salineIV_250", "ACE_quikclot", "ACE_personalAidKit", "ACE_surgicalKit", "ACE_bodyBag"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction","ace_modules", "ace_apl"};
-        author[] = {"Glowbal", "KoffienFlummi"};
+        author[] = {"Glowbal", "KoffeinFlummi"};
         authorUrl = "";
         VERSION_CONFIG;
     };

--- a/addons/medical/functions/fnc_actionCheckPulseLocal.sqf
+++ b/addons/medical/functions/fnc_actionCheckPulseLocal.sqf
@@ -24,7 +24,7 @@ if (!alive _unit) then {
     _heartRate = 0;
 };
 _heartRateOutput = "STR_ACE_Medical_Check_Pulse_Output_5";
-_logOutPut = "No heart rate";
+_logOutPut = localize "STR_ACE_Medical_Check_Pulse_None";
 
 if (_heartRate > 1.0) then {
     if ([_caller] call FUNC(isMedic)) then {

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -632,7 +632,7 @@
             <Polish>Natychmiastowy</Polish>
             <French>Urgence Immédiate</French>
             <German>Sofort</German>
-            <Czech>Okamžitý</Czech>
+            <Czech>Okamžiý</Czech>
             <Hungarian>Azonnali</Hungarian>
             <Italian>Immediata</Italian>
             <Portuguese>Imediato</Portuguese>
@@ -1290,7 +1290,7 @@
             <French>Trousse chirurgicale</French>
             <Russian>Хирургический набор</Russian>
             <Spanish>Kit quirúrgico</Spanish>
-            <Polish>Zestaw do szycia ran</Polish>
+            <Polish>Zestaw chirurgiczny</Polish>
             <German>Operationsset</German>
             <Hungarian>Sebészeti készlet</Hungarian>
             <Italian>Kit chirurgico</Italian>
@@ -1584,6 +1584,10 @@
             <Hungarian>%1 ellenőrizte a szívverés-számot: %2</Hungarian>
             <Czech>%1 zkontroloval srdeční tep: %2</Czech>
             <Portuguese>%1 verificou a frequência cardíaca: %2</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_Medical_Check_Pulse_None">
+            <English>None</English>
+            <Polish>Brak</Polish>
         </Key>
         <Key ID="STR_ACE_Medical_Check_Pulse_Weak">
             <English>Weak</English>
@@ -2701,5 +2705,373 @@
             <Russian>Снятие жгута ...</Russian>
             <Italian>Togliendo il laccio emostatico ...</Italian>
         </Key>
+        <Key ID="STR_ACE_Medical_Category_DisplayName">
+            <English>ACE Medical</English>
+            <Polish>ACE Opcje medyczne</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_Module_DisplayName">
+            <English>Medical Settings [ACE]</English>
+            <Polish>Ustawienia medyczne [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_level_DisplayName">
+            <English>Medical Level</English>
+            <Polish>Poziom medyczny</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_level_Description">
+            <English>What is the medical simulation level?</English>
+            <Polish>Jaki jest poziom symulacji medycznej?</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_basic">
+            <English>Basic</English>
+            <Polish>Podstawowy</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_advanced">
+            <English>Advanced</English>
+            <Polish>Zaawansowany</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_medicSetting_DisplayName">
+            <English>Medics setting</English>
+            <Polish>Poziom medyków</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_medicSetting_Description">
+            <English>What is the level of detail prefered for medics?</English>
+            <Polish>Jaki jest poziom detali medycznych wyświetlanych dla medyków?</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_medicSetting_disable">
+            <English>Disable medics</English>
+            <Polish>Wyłącz medyków</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_allowLitterCreation_DisplayName">
+            <English>Enable Litter</English>
+            <Polish>Aktywuj odpadki</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_allowLitterCreation_Description">
+            <English>Enable litter being created upon treatment</English>
+            <Polish>Twórz odpadki medyczne podczas leczenia</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_litterCleanUpDelay_DisplayName">
+            <English>Life time of litter objects</English>
+            <Polish>Długość życia odpadków</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_litterCleanUpDelay_Description">
+            <English>How long should litter objects stay? In seconds. -1 is forever.</English>
+            <Polish>Ile czasu musi upłynąć, aby odpadki zaczęły znikać? W sekundach. -1 dla nieskończoności.</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_enableScreams_DisplayName">
+            <English>Enable Screams</English>
+            <Polish>Aktywuj wrzaski</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_enableScreams_Description">
+            <English>Enable screaming by injuried units</English>
+            <Polish>Aktywuj wrzeszczenie z bólu przez ranne jednostki</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_playerDamageThreshold_DisplayName">
+            <English>Player Damage</English>
+            <Polish>Próg obrażeń graczy</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_playerDamageThreshold_Description">
+            <English>What is the damage a player can take before being killed?</English>
+            <Polish>Jaki jest próg obrażeń, jakie gracz może otrzymać zanim zostanie zabity?</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_AIDamageThreshold_DisplayName">
+            <English>AI Damage</English>
+            <Polish>Próg obrażeń AI</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_AIDamageThreshold_Description">
+            <English>What is the damage an AI can take before being killed?</English>
+            <Polish>Jaki jest próg obrażeń, jakie AI może otrzymać zanim zostanie zabite?</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_enableUnconsciousnessAI_DisplayName">
+            <English>AI Unconsciousness</English>
+            <Polish>Nieprzytomność AI</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_enableUnconsciousnessAI_Description">
+            <English>Allow AI to go unconscious</English>
+            <Polish>Czy AI może być nieprzytomne od odniesionych obrażeń?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Medical_disabled">
+            <English>Disabled</English>
+            <Polish>Wyłączone</Polish>
+        </Key>
+        <Key ID="STR_ACE_Medical_enabled">
+            <English>Enabled</English>
+            <Polish>Włączone</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_preventInstaDeath_DisplayName">
+            <English>Prevent instant death</English>
+            <Polish>Wył. natychmiast. śmierć</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_preventInstaDeath_Description">
+            <English>Have a unit move to unconscious instead of death</English>
+            <Polish>Spraw, aby jednostka została przeniesiona do stanu nieprzytomności zamiast ginąć na miejscu od śmiertelnych obrażeń</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_bleedingCoefficient_DisplayName">
+            <English>Bleeding coefficient</English>
+            <Polish>Mnożnik krwawienia</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_bleedingCoefficient_Description">
+            <English>Coefficient to modify the bleeding speed</English>
+            <Polish>Mnożnik modyfikujący prędkość wykrwawiania się</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_painCoefficient_DisplayName">
+            <English>Pain coefficient</English>
+            <Polish>Mnożnik bólu</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_painCoefficient_Description">
+            <English>Coefficient to modify the pain intensity</English>
+            <Polish>Mnożnik modyfikujący intensywność bólu</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_keepLocalSettingsSynced_DisplayName">
+            <English>Sync status</English>
+            <Polish>Synchronizuj status</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_keepLocalSettingsSynced_Description">
+            <English>Keep unit status synced. Recommended on.</English>
+            <Polish>Utrzymuj synchronizację statusu jednostek. Zalecane zostawienie tej opcji włączonej.</Polish>
+        </Key>
+        <Key ID="STR_ACE_MedicalSettings_Module_Description">
+            <English>Provides a medical system for both players and AI.</English>
+            <Polish>Moduł ten dostarcza system medyczny dla graczy oraz AI.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_Module_DisplayName">
+            <English>Advanced Medical Settings [ACE]</English>
+            <Polish>Zaawansowane ustawienia medyczne [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_enableFor_DisplayName">
+            <English>Enabled for</English>
+            <Polish>Aktywne dla</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_enableFor_Description">
+            <English>Select what units the advanced medical system will be enabled for</English>
+            <Polish>Wybierz dla kogo zaawansowany system medyczny będzie aktywny</Polish>
+        </Key>
+        <Key ID="STR_ACE_Medical_playeronly">
+            <English>Players only</English>
+            <Polish>Tylko dla graczy</Polish>
+        </Key>
+        <Key ID="STR_ACE_Medical_playersandai">
+            <English>Players and AI</English>
+            <Polish>Gracze oraz AI</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_enableAdvancedWounds_DisplayName">
+            <English>Enable Advanced wounds</English>
+            <Polish>Akt. zaawansowane rany</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_enableAdvancedWounds_Description">
+            <English>Allow reopening of bandaged wounds?</English>
+            <Polish>Pozwól na otwieranie się zabandażowanych ran?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_enableVehicleCrashes_DisplayName">
+            <English>Vehicle Crashes</English>
+            <Polish>Obrażenia od kolizji</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_enableVehicleCrashes_Description">
+            <English>Do units take damage from a vehicle crash?</English>
+            <Polish>Czy jednostki otrzymują obrażenia w wyniku kolizji pojazdów?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_PAK_DisplayName">
+            <English>Allow PAK</English>
+            <Polish>Ust. apteczek osobistych</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_PAK_Description">
+            <English>Who can use the PAK for full heal?</English>
+            <Polish>Kto może skorzystać z apteczki osobistej w celu pełnego uleczenia?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_anyone">
+            <English>Anyone</English>
+            <Polish>Wszyscy</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_Medic">
+            <English>Medics only</English>
+            <Polish>Tylko medycy</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_Special">
+            <English>Doctors only</English>
+            <Polish>Tylko doktorzy</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_PAK_DisplayName">
+            <English>Remove PAK on use</English>
+            <Polish>Usuń apteczkę po użyciu</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_PAK_Description">
+            <English>Should PAK be removed on usage?</English>
+            <Polish>Czy apteczka osobista powinna zniknąć z ekwipunku po jej użyciu?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_PAK_DisplayName">
+            <English>Locations PAK</English>
+            <Polish>Ogr. apteczek osobistych</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_PAK_Description">
+            <English>Where can the personal aid kit be used?</English>
+            <Polish>Gdzie można korzystać z apteczek osobistych?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_anywhere">
+            <English>Anywhere</English>
+            <Polish>Wszędzie</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_vehicle">
+            <English>Medical vehicles</English>
+            <Polish>Pojazdy medyczne</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_facility">
+            <English>Medical facility</English>
+            <Polish>Budynki medyczne</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_vehicleAndFacility">
+            <English>Vehicles &amp; facility</English>
+            <Polish>Pojazdy i budynki medyczne</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_disabled">
+            <English>Disabled</English>
+            <Polish>Wyłączone</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_SurgicalKit_DisplayName">
+            <English>Allow Surgical kit (Adv)</English>
+            <Polish>Ust. zestawu chirurg.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_SurgicalKit_Description">
+            <English>Who can use the surgical kit?</English>
+            <Polish>Kto może skorzystać z zestawu chirurgicznego w celu zszycia ran?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_SurgicalKit_DisplayName">
+            <English>Remove Surgical kit (Adv)</English>
+            <Polish>Usuń zest. chir. po użyciu</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_SurgicalKit_Description">
+            <English>Should Surgical kit be removed on usage?</English>
+            <Polish>Czy zestaw chirurgiczny powinien zniknąć z ekwipunku po jego użyciu?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_SurgicalKit_DisplayName">
+            <English>Locations Surgical kit (Adv)</English>
+            <Polish>Ogr. zestawu chirurg.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_SurgicalKit_Description">
+            <English>Where can the Surgical kit be used?</English>
+            <Polish>Gdzie można korzystać z zestawu chirurgicznego?</Polish>
+        </Key>
+        <Key ID="STR_ACE_AdvancedMedicalSettings_Module_Description">
+            <English>Configure the treatment settings from ACE Medical</English>
+            <Polish>Skonfiguruj zaawansowane ustawienia leczenia systemu medycznego ACE</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_Module_DisplayName">
+            <English>Revive Settings [ACE]</English>
+            <Polish>Ustawienia wskrzeszania [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_enableRevive_DisplayName">
+            <English>Enable Revive</English>
+            <Polish>Aktywuj wskrzeszanie</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_enableRevive_Description">
+            <English>Enable a basic revive system</English>
+            <Polish>Aktywuj podstawowy system wskrzeszania</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_maxReviveTime_DisplayName">
+            <English>Max Revive time</English>
+            <Polish>Maks. czas agonii</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_maxReviveTime_Description">
+            <English>Max amount of seconds a unit can spend in revive state</English>
+            <Polish>Maksymalna długość agonii w sekundach (czas na wskrzeszenie)</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_amountOfReviveLives_DisplayName">
+            <English>Max Revive lives</English>
+            <Polish>Maks. ilość wskrzeszeń</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_amountOfReviveLives_Description">
+            <English>Max amount of lives a unit. 0 or -1 is disabled.</English>
+            <Polish>Maksymalna ilość wskrzeszeń. Wpisz 0 lub -1 aby wyłączyć.</Polish>
+        </Key>
+        <Key ID="STR_ACE_ReviveSettings_Module_Description">
+            <English>Provides a medical system for both players and AI.</English>
+            <Polish>Moduł ten aktywuje podstawowy system wskrzeszania. Jednostka po otrzymaniu śmiertelnych obrażeń przechodzi do stanu agonii, która trwa określoną długość czasu. W tym czasie aby wskrzesić i jednocześnie odratować jednostkę należy opatrzeć jej rany i wykonać RKO.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_Module_DisplayName">
+            <English>Set Medic Class [ACE]</English>
+            <Polish>Ustaw klasę medyka [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_EnableList_DisplayName">
+            <English>List</English>
+            <Polish>Lista</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_EnableList_Description">
+            <English>List of unit names that will be classified as medic, separated by commas.</English>
+            <Polish>Lista nazw jednostek, które są sklasyfikowane jako medycy, oddzielone przecinkami.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_role_DisplayName">
+            <English>Is Medic</English>
+            <Polish>Klasa medyczna</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_role_Description">
+            <English></English>
+            <Polish></Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_role_none">
+            <English>None</English>
+            <Polish>Żadna</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_role_medic">
+            <English>Regular medic</English>
+            <Polish>Zwykły medyk</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_role_doctor">
+            <English>Doctor (Only Advanced Medics)</English>
+            <Polish>Doktor (tylko zaawansowani medycy)</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicRoles_Module_Description">
+            <English>Assigns the ACE medic class to a unit</English>
+            <Polish>Moduł ten przypisuje klasę medyka ACE do jednostek.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicVehicle_Module_DisplayName">
+            <English>Set Medical Vehicle [ACE]</English>
+            <Polish>Ustaw pojazd medyczny [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicVehicle_EnableList_DisplayName">
+            <English>List</English>
+            <Polish>Lista</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicVehicle_EnableList_Description">
+            <English>List of vehicles that will be classified as medical vehicle, separated by commas.</English>
+            <Polish>Lista nazw pojazdów, które są sklasyfikowane jako pojazdy medyczne, oddzielone przecinkami.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicVehicle_enabled_DisplayName">
+            <English>Is Medical Vehicle</English>
+            <Polish>Jest pojazdem med.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicVehicle_enabled_Description">
+            <English>Whatever or not the objects in the list will be a medical vehicle.</English>
+            <Polish>Czy pojazdy z tej listy są pojazdami medycznymi.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicVehicle_Module_Description">
+            <English>Assigns the ACE medic class to a unit</English>
+            <Polish>Moduł ten pozwala na przypisanie danym pojazdom statusu pojazdów medycznych. Wewnątrz takiego pojazdu można wykonywać zaawansowane zabiegi medyczne.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicalFacility_Module_DisplayName">
+            <English>Set Medical Facility [ACE]</English>
+            <Polish>Ustaw budynek medyczny [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicalFacility_enabled_DisplayName">
+            <English>Is Medical Facility</English>
+            <Polish>Jest budynkiem med.</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicalFacility_enabled_Description">
+            <English>Registers an object as a medical facility</English>
+            <Polish>Przypisuje danemu obiektowi status budynku medycznego</Polish>
+        </Key>
+        <Key ID="STR_ACE_AssignMedicalFacility_Module_Description">
+            <English>Defines an object as a medical facility. This allows for more advanced treatments. Can be used on buildings and vehicles.</English>
+            <Polish>Moduł ten pozwala przypisać status budynku medycznego danemu obiektowi. Budynek taki pozwala na wykonywanie zaawansowanych zabiegów medycznych. Może być użyte na pojazdach i budynkach.</Polish>
+        </Key>
+        <Key ID="STR_ACE_medicalSupplyCrate">
+            <English>[ACE] Medical Supply Crate (Basic)</English>
+            <Polish>[ACE] Skrzynka z zapasami medycznymi (podstawowa)</Polish>
+        </Key>
+        <Key ID="STR_ACE_medicalSupplyCrate_advanced">
+            <English>[ACE] Medical Supply Crate (Advanced)</English>
+            <Polish>[ACE] Skrzynka z zapasami medycznymi (zaawansowana)</Polish>
+        </Key>
     </Package>
 </Project>
+<<<<<<< HEAD
+=======
+    
+>>>>>>> TABS

--- a/addons/microdagr/CfgVehicles.hpp
+++ b/addons/microdagr/CfgVehicles.hpp
@@ -44,7 +44,7 @@ class CfgVehicles {
     class GVAR(dagrModule): Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "MicroDAGR Map Fill";
+        displayName = "$STR_ACE_Dagr_Module_DisplayName";
         function = QFUNC(moduleMapFill);
         scope = 2;
         isGlobal = 1;
@@ -52,18 +52,18 @@ class CfgVehicles {
         functionPriority = 0;
         class Arguments {
             class MapDataAvailable {
-                displayName = "MicroDAGR Map Fill"; // Argument label
-                description = "How much map data is filled on MicroDAGR's "; // Tooltip description
-                typeName = "NUMBER"; // Value type, can be "NUMBER", "STRING" or "BOOL"
+                displayName = "$STR_ACE_Dagr_MapDataAvailable_DisplayName";
+                description = "$STR_ACE_Dagr_MapDataAvailable_Description";
+                typeName = "NUMBER";
                 class values {
-                    class None {name = "Full Satellite + Buildings"; value = MAP_DETAIL_SAT; default = 1;};
-                    class Side {name = "Topographical + Roads"; value = MAP_DETAIL_TOPOROADS;};
-                    class Unique {name = "None (Cannot use map view)"; value = MAP_DETAIL_NONE;};
+                    class None {name = "$STR_ACE_Dagr_None"; value = MAP_DETAIL_SAT; default = 1;};
+                    class Side {name = "$STR_ACE_Dagr_Side"; value = MAP_DETAIL_TOPOROADS;};
+                    class Unique {name = "$STR_ACE_Dagr_Unique"; value = MAP_DETAIL_NONE;};
                 };
             };
         };
         class ModuleDescription: ModuleDescription {
-            description = "Controls how much data is filled on the microDAGR items.  Less data restricts the map view to show less on the minimap.<br/>Source: microDAGR.pbo";
+            description = "$STR_ACE_Dagr_Module_Description";
         };
     };
     

--- a/addons/microdagr/stringtable.xml
+++ b/addons/microdagr/stringtable.xml
@@ -301,5 +301,33 @@
             <Italian>Chiudi MicroDAGR</Italian>
             <Portuguese>Fechar MicroDAGR</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Dagr_Module_DisplayName">
+            <English>MicroDAGR Map Fill</English>
+            <Polish>Wypełnienie mapy MicroDAGR</Polish>
+        </Key>
+        <Key ID="STR_ACE_Dagr_MapDataAvailable_DisplayName">
+            <English>MicroDAGR Map Fill</English>
+            <Polish>Wypełnienie mapy MicroDAGR</Polish>
+        </Key>
+        <Key ID="STR_ACE_Dagr_MapDataAvailable_Description">
+            <English>How much map data is filled on MicroDAGR's</English>
+            <Polish>Jak duża część informacji mapy jest załadowana do MicroDAGR?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Dagr_None">
+            <English>Full Satellite + Buildings</English>
+            <Polish>Pełna satelitarna + budynki</Polish>
+        </Key>
+        <Key ID="STR_ACE_Dagr_Side">
+            <English>Topographical + Roads</English>
+            <Polish>Topograficzna + drogi</Polish>
+        </Key>
+        <Key ID="STR_ACE_Dagr_Unique">
+            <English>None (Cannot use map view)</English>
+            <Polish>Żadna (wyłącza ekran mapy)</Polish>
+        </Key>
+        <Key ID="STR_ACE_Dagr_Module_Description">
+            <English>Controls how much data is filled on the microDAGR items.  Less data restricts the map view to show less on the minimap.&lt;br /&gt;Source: microDAGR.pbo</English>
+            <Polish>Moduł ten pozwala kontrolować jak duża ilość informacji jest załadowana do przedmiotów MicroDAGR. Mniejsza ilość danych ogranicza widok mapy pokazując mniej rzeczy na minimapie.&lt;br /&gt;Źródło: microDAGR.pbo</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/missileguidance/ACE_Settings.hpp
+++ b/addons/missileguidance/ACE_Settings.hpp
@@ -5,6 +5,6 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = "$STR_ACE_MissileGuidance";
         description = "$STR_ACE_MissileGuidance_Desc";
-        values[] = {"Off", "Player Only", "Player and AI"};
+        values[] = {"$STR_ACE_MissileGuidance_Off", "$STR_ACE_MissileGuidance_PlayerOnly", "$STR_ACE_MissileGuidance_PlayerAndAi"};
     };
 };

--- a/addons/missileguidance/stringtable.xml
+++ b/addons/missileguidance/stringtable.xml
@@ -97,5 +97,17 @@
             <Hungarian>Hellfire II AGM-114K lézer-irányított rakéta</Hungarian>
             <Russian>Управляемая ракета лазерного наведения Hellfire II AGM-114K</Russian>
         </Key>
+        <Key ID="STR_ACE_MissileGuidance_Off">
+            <English>Off</English>
+            <Polish>Wyłącz</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissileGuidance_PlayerOnly">
+            <English>Player Only</English>
+            <Polish>Tylko gracz</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissileGuidance_PlayerAndAi">
+            <English>Player and AI</English>
+            <Polish>Gracz oraz AI</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/missionmodules/CfgFactionClasses.hpp
+++ b/addons/missionmodules/CfgFactionClasses.hpp
@@ -1,6 +1,6 @@
 class CfgFactionClasses {
     class NO_CATEGORY;
     class ACE_missionModules: NO_CATEGORY {
-        displayName = "ACE Mission Modules";
+        displayName = "$STR_ACE_MissionModules_Category_DisplayName";
     };
 };

--- a/addons/missionmodules/CfgVehicles.hpp
+++ b/addons/missionmodules/CfgVehicles.hpp
@@ -8,7 +8,7 @@ class CfgVehicles {
     // TODO make a curator variant for this
     class ACE_moduleAmbianceSound: Module_F {
         scope = 2;
-        displayName = "Ambiance Sounds [ACE]";
+        displayName = "$STR_ACE_MissionModules_AmbianceSounds_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Ambient_Sounds_ca.paa));
         category = "ACE_missionModules";
         function = QUOTE(FUNC(moduleAmbianceSound));
@@ -18,50 +18,75 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments    {
             class soundFiles {
+<<<<<<< HEAD
                 displayName = "Sounds";
                 description = "Class names of the ambiance sounds to be played. Seperated by ','";
+=======
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_soundFiles_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_soundFiles_Description";
+>>>>>>> I made mess so new pull request.
                 typeName = "STRING";
                 defaultValue = "";
             };
             class minimalDistance {
+<<<<<<< HEAD
                 displayName = "Minimal Distance";
                 description = "Used for calculating a random position and sets the minimal distance between the players and the played sound file(s)";
+=======
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_minimalDistance_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_minimalDistance_Description";
+>>>>>>> I made mess so new pull request.
                 typeName = "NUMBER";
                 defaultValue = 400;
             };
             class maximalDistance {
+<<<<<<< HEAD
                 displayName = "Maximum Distance";
                 description = "Used for calculating a random position and sets the maximum distance between the players and the played sound file(s)";
+=======
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_maximalDistance_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_maximalDistance_Description";
+>>>>>>> I made mess so new pull request.
                 typeName = "NUMBER";
                 defaultValue = 900;
             };
             class minimalDelay {
+<<<<<<< HEAD
                 displayName = "Minimal Delay";
                 description = "Minimal delay between sounds played";
+=======
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_minimalDelay_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_minimalDelay_Description";
+>>>>>>> I made mess so new pull request.
                 typeName = "NUMBER";
                 defaultValue = 10;
             };
             class maximalDelay {
+<<<<<<< HEAD
                 displayName = "Maximum Delay";
                 description = "Maximum delay between sounds played";
+=======
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_maximalDelay_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_maximalDelay_Description";
+>>>>>>> I made mess so new pull request.
                 typeName = "NUMBER";
                 defaultValue = 170;
             };
             class followPlayers {
-                displayName = "Follow Players";
-                description = "Follow players. If set to false, loop will play sounds only nearby logic position.";
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_followPlayers_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_followPlayers_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class soundVolume {
-                displayName = "Volume";
-                description = "The volume of the sounds played";
+                displayName = "$STR_ACE_MissionModules_AmbianceSounds_soundVolume_DisplayName";
+                description = "$STR_ACE_MissionModules_AmbianceSounds_soundVolume_Description";
                 typeName = "NUMBER";
                 defaultValue = 1;
             };
         };
         class ModuleDescription {
-            description = "Ambiance sounds loop (synced across MP)";
+            description = "$STR_ACE_MissionModules_AmbianceSounds_Description";
             sync[] = {};
         };
     };

--- a/addons/missionmodules/stringtable.xml
+++ b/addons/missionmodules/stringtable.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACE">
+<<<<<<< HEAD
+    <Package name="Mission Modules">
+<<<<<<< HEAD
+
+=======
+=======
+    <Package name="Mission_Modules">
+>>>>>>> TABS
+        <Key ID="STR_ACE_MissionModules_Category_DisplayName">
+            <English>ACE Mission Modules</English>
+            <Polish>ACE Moduły misji</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_DisplayName">
+            <English>Ambiance Sounds [ACE]</English>
+            <Polish>Dźwięki [ACE]</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundFiles_DisplayName">
+            <English>Sounds</English>
+            <Polish>Dźwięki</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundFiles_Description">
+            <English>Classnames of the ambiance sounds played. Seperated by ','. </English>
+            <Polish>Classname-y dźwięków do odtwarzania. Oddzielone przy użyciu ','.</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDistance_DisplayName">
+            <English>Minimal Distance</English>
+            <Polish>Minimalny dystans</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDistance_Description">
+            <English>Minimal Distance</English>
+            <Polish>Minimalny dystans</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDistance_DisplayName">
+            <English>Maximal Distance</English>
+            <Polish>Maksymalny dystans</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDistance_Description">
+            <English>Maximal Distance</English>
+            <Polish>Maksymalny dystans</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDelay_DisplayName">
+            <English>Minimal Delay</English>
+            <Polish>Minimalne opóźnienie</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDelay_Description">
+            <English>Minimal Delay between sounds played</English>
+            <Polish>Minimalne opóźnienie pomiędzy odtwarzanymi dźwiękami</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDelay_DisplayName">
+            <English>Maximal Delay</English>
+            <Polish>Maksymalne opóźnienie</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDelay_Description">
+            <English>Maximal Delay between sounds played</English>
+            <Polish>Maksymalne opóźnienie pomiędzy odtwarzanymi dźwiękami</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_followPlayers_DisplayName">
+            <English>Follow Players</English>
+            <Polish>Podążaj za graczami</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_followPlayers_Description">
+            <English>Follow players. If set to false, loop will play sounds only nearby logic position.</English>
+            <Polish>Podążaj za graczami. Jeżeli ustawione na 'Nie', pętla będzie odtwarzana tylko w pobliżu pozycji logiki.</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundVolume_DisplayName">
+            <English>Volume</English>
+            <Polish>Głośność</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundVolume_Description">
+            <English>The volume of the sounds played</English>
+            <Polish>Głośność odtwarzanych dźwięków</Polish>
+        </Key>
+        <Key ID="STR_ACE_MissionModules_AmbianceSounds_Description">
+            <English>Ambiance sounds loop (synced across MP)</English>
+            <Polish>Pętla odtwarzania dzwięków (synchronizowana na MP)</Polish>
+        </Key>
+>>>>>>> I made mess so new pull request.
+    </Package>
+</Project>

--- a/addons/mk6mortar/CfgVehicles.hpp
+++ b/addons/mk6mortar/CfgVehicles.hpp
@@ -50,7 +50,7 @@ class CfgVehicles {
     class GVAR(module): Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "MK6 Settings";
+        displayName = "$STR_ACE_mk6mortar_Module_DisplayName";
         function = QFUNC(moduleInit);
         scope = 2;
         isGlobal = 0;
@@ -58,26 +58,26 @@ class CfgVehicles {
         functionPriority = 0;
         class Arguments {
             class airResistanceEnabled {
-                displayName = "Air Resistance";
-                description = "For Player Shots, Model Air Resistance and Wind Effects";
+                displayName = "$STR_ACE_mk6mortar_airResistanceEnabled_DisplayName";
+                description = "$STR_ACE_mk6mortar_airResistanceEnabled_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class allowComputerRangefinder {
-                displayName = "Allow MK6 Computer";
-                description = "Show the Computer and Rangefinder (these NEED to be removed if you enable air resistance)";
+                displayName = "$STR_ACE_mk6mortar_allowComputerRangefinder_DisplayName";
+                description = "$STR_ACE_mk6mortar_allowComputerRangefinder_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class allowCompass {
-                displayName = "Allow MK6 Compass";
-                description = "Show the MK6 Digital Compass";
+                displayName = "$STR_ACE_mk6mortar_allowCompass_DisplayName";
+                description = "$STR_ACE_mk6mortar_allowCompass_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
         };
         class ModuleDescription: ModuleDescription {
-            description = "";
+            description = "$STR_ACE_mk6mortar_Module_Description";
         };
     };
 };

--- a/addons/mk6mortar/stringtable.xml
+++ b/addons/mk6mortar/stringtable.xml
@@ -49,5 +49,37 @@
             <Czech>Nabít</Czech>
             <Italian>Carica</Italian>
         </Key>
+        <Key ID="STR_ACE_mk6mortar_Module_DisplayName">
+            <English>MK6 Settings</English>
+            <Polish>Moździerz MK6 - Ustawienia</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_airResistanceEnabled_DisplayName">
+            <English>Air Resistance</English>
+            <Polish>Opór powietrza</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_airResistanceEnabled_Description">
+            <English>For Player Shots, Model Air Resistance and Wind Effects</English>
+            <Polish>Modeluj opór powietrza oraz wpływ wiatru na tor lotu pocisku dla strzałów z moździerza MK6 przez graczy</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_allowComputerRangefinder_DisplayName">
+            <English>Allow MK6 Computer</English>
+            <Polish>Komputer MK6</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_allowComputerRangefinder_Description">
+            <English>Show the Computer and Rangefinder (these NEED to be removed if you enable air resistance)</English>
+            <Polish>Zezwól na komputer i dalmierz (opcja ta MUSI zostać wyłączona jeżeli aktywowałeś opór powietrza)</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_allowCompass_DisplayName">
+            <English>Allow MK6 Compass</English>
+            <Polish>Kompas MK6</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_allowCompass_Description">
+            <English>Show the MK6 Digital Compass</English>
+            <Polish>Pokaż kompas MK6</Polish>
+        </Key>
+        <Key ID="STR_ACE_mk6mortar_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala dostosować ustawienia moździerza MK6.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/nametags/CfgVehicles.hpp
+++ b/addons/nametags/CfgVehicles.hpp
@@ -1,69 +1,72 @@
 class CfgVehicles {
-    class Module_F;
+    class Logic;
+    class Module_F: Logic {
+        class ModuleDescription {};
+    };
     class ACE_ModuleNameTags : Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Name Tags";
+        displayName = "$STR_ACE_NameTags_Module_DisplayName";
         function = QFUNC(moduleNameTags);
         scope = 2;
         isGlobal = 1;
         icon = QUOTE(PATHTOF(UI\Icon_Module_NameTags_ca.paa));
         class Arguments {
             class PlayerNamesViewDistance {
-                displayName = "Player Names View Dist.";
-                description = "Distance in meters at which player names are shown. Default: 5";
+                displayName = "$STR_ACE_NameTags_PlayerNamesViewDistance_DisplayName";
+                description = "$STR_ACE_NameTags_PlayerNamesViewDistance_Description";
                 typeName = "NUMBER";
                 defaultValue = 5;
             };
             class showNamesForAI {
-                displayName = "Show name tags for AI?";
-                description = "Show the name and rank tags for friendly AI units? Default: Do not force";
+                displayName = "$STR_ACE_NameTags_showNamesForAI_DisplayName";
+                description = "$STR_ACE_NameTags_showNamesForAI_Description";
                 typeName = "NUMBER";
                 class values {
                     class DoNotForce {
                         default = 1;
-                        name = "Do Not Force";
+                        name = "$STR_ACE_NameTags_DoNotForce";
                         value = -1;
                     };
                     class ForceHide {
-                        name = "Force Hide";
+                        name = "$STR_ACE_NameTags_ForceHide";
                         value = 0;
                     };
                     class ForceShow {
-                        name = "Force show";
+                        name = "$STR_ACE_NameTags_ForceShow";
                         value = 1;
                     };
                 };
             };
             class showVehicleCrewInfo {
-                displayName = "Show crew info?";
-                description = "Show vehicle crew info, or by default allows players to choose it on their own. Default: Do Not Force";
+                displayName = "$STR_ACE_NameTags_showVehicleCrewInfo_DisplayName";
+                description = "$STR_ACE_NameTags_showVehicleCrewInfo_Description";
                 typeName = "NUMBER";
                 class values {
                     class DoNotForce {
                         default = 1;
-                        name = "Do Not Force";
+                        name = "$STR_ACE_NameTags_DoNotForce";
                         value = -1;
                     };
                     class ForceHide {
-                        name = "Force Hide";
+                        name = "$STR_ACE_NameTags_ForceHide";
                         value = 0;
                     };
                     class ForceShow {
-                        name = "Force Show";
+                        name = "$STR_ACE_NameTags_ForceShow";
                         value = 1;
                     };
                 };
             };
             class showCursorTagForVehicles {
-                displayName = "Show for Vehicles";
-                description = "Show cursor NameTag for vehicle commander (only if client has name tags enabled)Default: No";
+                displayName = "$STR_ACE_NameTags_showCursorTagForVehicles_DisplayName";
+                description = "$STR_ACE_NameTags_showCursorTagForVehicles_Description";
                 typeName = "BOOL";
-                class values {
-                    class Yes {name = "Yes"; value = 1;};
-                    class No {default = 1; name = "No"; value = 0;};
-                };
+                defaultValue = 0;
             };
+        };
+		class ModuleDescription: ModuleDescription {
+            description = "$STR_ACE_NameTags_Module_Description";
         };
     };
 };

--- a/addons/nametags/config.cpp
+++ b/addons/nametags/config.cpp
@@ -27,7 +27,8 @@ class ACE_Settings {
         typeName = "SCALAR";
         isClientSettable = 1;
         displayName = "$STR_ACE_NameTags_ShowPlayerNames";
-        values[] = {"Disabled", "Enabled", "Only Cursor", "Only On Keypress", "Only Cursor and KeyPress"};
+		description = "$STR_ACE_NameTags_ShowPlayerNames_Desc";
+        values[] = {"$STR_ACE_Common_Disabled", "$STR_ACE_Common_Enabled", "$STR_ACE_Common_OnlyCursor", "$STR_ACE_Common_OnlyOnKeypress", "$STR_ACE_Common_OnlyCursorAndKeyPress"};
     };
     class GVAR(showPlayerRanks) {
         value = 1;
@@ -57,7 +58,8 @@ class ACE_Settings {
         typeName = "SCALAR";
         isClientSettable = 1;
         displayName = "$STR_ACE_NameTags_ShowSoundWaves";
-        values[] = {"Disabled", "Use Nametag settings", "Always Show All"};
+		description = "$STR_ACE_NameTags_ShowSoundWaves_Desc";
+        values[] = {"$STR_ACE_Common_Disabled", "$STR_ACE_Common_NameTagSettings", "$STR_ACE_Common_AlwaysShowAll"};
     };
     class GVAR(PlayerNamesViewDistance) {
         value = 5;

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -109,5 +109,93 @@
             <Italian>Colore dei nomi non appartenenti al gruppo</Italian>
             <Portuguese>Cor padrão do nome (unidades fora do grupo)</Portuguese>
         </Key>
+        <Key ID="STR_ACE_NameTags_Module_DisplayName">
+            <English>Name Tags</English>
+            <Polish>Ustawienia imion</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_PlayerNamesViewDistance_DisplayName">
+            <English>Player Names View Dist.</English>
+            <Polish>Zasięg imion graczy</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_PlayerNamesViewDistance_Description">
+            <English>Distance in meters at which player names are shown. Default: 5</English>
+            <Polish>Dystans w metrach, na którym wyświetlane są imiona graczy. Domyślnie: 5</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_showNamesForAI_DisplayName">
+            <English>Show name tags for AI?</English>
+            <Polish>Imiona AI</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_showNamesForAI_Description">
+            <English>Show the name and rank tags for friendly AI units? Default: Do not force</English>
+            <Polish>Pokaż imiona i rangi przyjaznych jednostek AI? Domyślnie: Nie wymuszaj</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_DoNotForce">
+            <English>Do Not Force</English>
+            <Polish>Nie wymuszaj</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_ForceHide">
+            <English>Force Hide</English>
+            <Polish>Wymuś ukrycie</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_ForceShow">
+            <English>Force show</English>
+            <Polish>Wymuś wyświetlanie</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_showVehicleCrewInfo_DisplayName">
+            <English>Show crew info?</English>
+            <Polish>Pokaż załogę</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_showVehicleCrewInfo_Description">
+            <English>Show vehicle crew info, or by default allows players to choose it on their own. Default: Do Not Force</English>
+            <Polish>Pokaż informacje o obsadzie pojazdu, lub pozwól graczom ustawić tą opcje według własnego uznania. Domyślnie: Nie wymuszaj</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_showCursorTagForVehicles_DisplayName">
+            <English>Show for Vehicles</English>
+            <Polish>Pokaż dla pojazdów</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_showCursorTagForVehicles_Description">
+            <English>Show cursor NameTag for vehicle commander (only if client has name tags enabled)Default: No</English>
+            <Polish>Pokazuj imię dowódcy pojazdu nad pojazdem (tylko jeżeli klient ma włączone imiona graczy). Domyślnie: Nie</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala dostosować ustawienia i zasięg wyświetlania imion.</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_Disabled">
+            <English>Disabled</English>
+            <Polish>Wyłączone</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_Enabled">
+            <English>Enabled</English>
+            <Polish>Włączone</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_OnlyCursor">
+            <English>Only Cursor</English>
+            <Polish>Tylko pod kursorem</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_OnlyOnKeypress">
+            <English>Only On Keypress</English>
+            <Polish>Tylko po wciśnięciu klawisza</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_OnlyCursorAndKeyPress">
+            <English>Only Cursor and KeyPress</English>
+            <Polish>Tylko pod kursorem i po wciśnięciu klawisza</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_NameTagSettings">
+            <English>Use Nametag settings</English>
+            <Polish>Użyj ustawień imion</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_AlwaysShowAll">
+            <English>Always Show All</English>
+            <Polish>Zawsze pokazuj wszystkie</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_ShowPlayerNames_Desc">
+            <English></English>
+            <Polish>Opcja ta pozwala dostosować sposób wyświetlania imion nad głowami graczy. Opcja "Tylko po wciśnięciu klawisza" wyświetla imiona tylko przytrzymania klawisza "Modyfikator" dostępnego w menu ustawień addonów -> ACE3.</Polish>
+        </Key>
+        <Key ID="STR_ACE_NameTags_ShowSoundWaves_Desc">
+            <English></English>
+            <Polish>Opcja ta pozwala dostosować sposób wyświetlania efektu fal dźwiękowych nad głowami mówiących graczy, wyświetlanych po przytrzymaniu klawisza PTT. Opcja ta współpracuje z TFAR oraz ACRE2.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/optionsmenu/CfgVehicles.hpp
+++ b/addons/optionsmenu/CfgVehicles.hpp
@@ -1,9 +1,8 @@
 class CfgVehicles {
     class ACE_Module;
-    // TODO localization for all the modules
     class ACE_moduleAllowConfigExport: ACE_Module {
         scope = 2;
-        displayName = "Allow Config Export [ACE]";
+        displayName = "$STR_AllowConfigExport_Module_DisplayName";
         //icon = "";
         category = "ACE";
         function = QUOTE(DFUNC(moduleAllowConfigExport));
@@ -13,16 +12,15 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class allowconfigurationExport {
-                displayName = "Allow";
-                description = "Allow export of all settings to a server config formatted.";
+                displayName = "$STR_AllowConfigExport_allowconfigurationExport_DisplayName";
+                description = "$STR_AllowConfigExport_allowconfigurationExport_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
         };
         class ModuleDescription {
-            description = "When allowed, you have access to the settings modification and export in SP. Clicking export will place the formated config on your clipboard.";
+            description = "$STR_AllowConfigExport_Module_Description";
             sync[] = {};
         };
     };
-
 };

--- a/addons/optionsmenu/stringtable.xml
+++ b/addons/optionsmenu/stringtable.xml
@@ -241,5 +241,49 @@
             <Portuguese>Escalar o menu de opções</Portuguese>
             <Italian>Proporzioni della interfaccia utente</Italian>
         </Key>
+        <Key ID="STR_AllowConfigExport_Module_DisplayName">
+            <English>Allow Config Export [ACE]</English>
+            <Polish>Pozwól na eksport ustawień [ACE]</Polish>
+        </Key>
+        <Key ID="STR_AllowConfigExport_allowconfigurationExport_DisplayName">
+            <English>Allow</English>
+            <Polish>Zezwól</Polish>
+        </Key>
+        <Key ID="STR_AllowConfigExport_allowconfigurationExport_Description">
+            <English>Allow export of all settings to a server config formatted.</English>
+            <Polish>Zezwól na eksport wszystkich ustawień do formatu konfiguracji serwera.</Polish>
+        </Key>
+        <Key ID="STR_AllowConfigExport_Module_Description">
+            <English>When allowed, you have access to the settings modification and export in SP. Clicking export will place the formated config on your clipboard.</English>
+            <Polish>Jeżeli ustawione na zezwól, wtedy będziesz mieć dostęp do ekranu modyfikacji wszystich ustawień i zmiennych ACE, a także będziesz mieć możliwość eksportu tychże ustawień do formatu rozpoznawalnego przez userconfig serwera. Kliknięcie opcji Eksportuj skopiuje wszystkie ustawienia do schowka. Działa tylko w trybie SP.</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_Hide">
+            <English>Hide</English>
+            <Polish>Ukryj</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_TopRightDown">
+            <English>Top right, downwards</English>
+            <Polish>Po prawej u góry, w dół</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_TopRightLeft">
+            <English>Top right, to the left</English>
+            <Polish>Po prawej u góry, do lewej</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_TopLeftDown">
+            <English>Top left, downwards</English>
+            <Polish>Po lewej u góry, w dół</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_TopLeftRight">
+            <English>Top left, to the right</English>
+            <Polish>Po lewej u góry, do prawej</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_Top">
+            <English>Top</English>
+            <Polish>Góra</Polish>
+        </Key>
+        <Key ID="STR_ACE_Common_Bottom">
+            <English>Bottom</English>
+            <Polish>Dół</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/respawn/CfgVehicleClasses.hpp
+++ b/addons/respawn/CfgVehicleClasses.hpp
@@ -1,5 +1,5 @@
 class CfgVehicleClasses {
     class GVAR(Rallypoints) {
-        displayName = "ACE Respawn";
+        displayName = "$STR_ACE_Respawn_EditorCategory";
     };
 };

--- a/addons/respawn/CfgVehicles.hpp
+++ b/addons/respawn/CfgVehicles.hpp
@@ -1,9 +1,12 @@
 class CfgVehicles {
-    class Module_F;
+    class Logic;
+    class Module_F: Logic {
+        class ModuleDescription {};
+    };
     class ACE_ModuleRespawn: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Respawn System";
+        displayName = "$STR_ACE_Respawn_Module_DisplayName";
         function = QFUNC(module);
         scope = 2;
         isGlobal = 1;
@@ -11,43 +14,52 @@ class CfgVehicles {
 
         class Arguments {
             class SavePreDeathGear {
-                displayName = "Save Gear?";
-                description = "Respawn with the gear a soldier had just before his death?";
+                displayName = "$STR_ACE_Respawn_SavePreDeathGear_DisplayName";
+                description = "$STR_ACE_Respawn_SavePreDeathGear_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
 
             class RemoveDeadBodiesDisconnected {
-                displayName = "Remove bodies?";
-                description = "Remove player bodies after disconnect?";
+                displayName = "$STR_ACE_Respawn_RemoveDeadBodiesDisconnected_DisplayName";
+                description = "$STR_ACE_Respawn_RemoveDeadBodiesDisconnected_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
+        };
+		class ModuleDescription: ModuleDescription {
+            description = "$STR_ACE_Respawn_Module_Description";
         };
     };
 
     class ACE_ModuleFriendlyFire: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Friendly Fire Messages";
+        displayName = "$STR_ACE_FriendlyFire_Module_DisplayName";
         function = QFUNC(moduleFriendlyFire);
         scope = 2;
         isGlobal = 1;
         icon = QUOTE(PATHTOF(UI\Icon_Module_FriendlyFire_ca.paa));
 
         class Arguments {};
+		class ModuleDescription: ModuleDescription {
+            description = "$STR_ACE_FriendlyFire_Module_Description";
+        };
     };
 
     class ACE_ModuleRallypoint: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Rallypoint System";
+        displayName = "$STR_ACE_Rallypoint_Module_DisplayName";
         function = QFUNC(moduleRallypoint);
         scope = 2;
         isGlobal = 1;
         icon = QUOTE(PATHTOF(UI\Icon_Module_Rallypoint_ca.paa));
 
         class Arguments {};
+		class ModuleDescription: ModuleDescription {
+            description = "$STR_ACE_Rallypoint_Module_Description";
+        };
     };
 
     // team leader
@@ -55,7 +67,7 @@ class CfgVehicles {
     class CAManBase : Man {
         class ACE_SelfActions {
             class ACE_MoveRallypoint {
-                displayName = "Move Rallypoint";
+                displayName = "$STR_ACE_Rallypoint_MoveRallypoint";
                 condition = QUOTE([ARR_2(_player, side group _player)] call FUNC(canMoveRallypoint));
                 statement = QUOTE([ARR_2(_player, side group _player)] call FUNC(moveRallypoint));
                 showDisabled = 0;

--- a/addons/respawn/stringtable.xml
+++ b/addons/respawn/stringtable.xml
@@ -145,5 +145,53 @@
             <Czech>Rallypoint Nezávislý</Czech>
             <Portuguese>Ponto de encontro Independente</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Respawn_Module_DisplayName">
+            <English>Respawn System</English>
+            <Polish>System odrodzenia</Polish>
+        </Key>
+        <Key ID="STR_ACE_Respawn_SavePreDeathGear_DisplayName">
+            <English>Save Gear?</English>
+            <Polish>Zapisać ekwipunek?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Respawn_SavePreDeathGear_Description">
+            <English>Respawn with the gear a soldier had just before his death?</English>
+            <Polish>Odradzaj z ekwipunkiem jaki żołnierz miał tuż przed swoją śmiercią?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Respawn_RemoveDeadBodiesDisconnected_DisplayName">
+            <English>Remove bodies?</English>
+            <Polish>Usuwać ciała?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Respawn_RemoveDeadBodiesDisconnected_Description">
+            <English>Remove player bodies after disconnect?</English>
+            <Polish>Usuwaj ciała graczy po rozłączeniu z serwera?</Polish>
+        </Key>
+        <Key ID="STR_ACE_Respawn_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala dostosować ustawienia odrodzenia (respawnu).</Polish>
+        </Key>
+        <Key ID="STR_ACE_FriendlyFire_Module_DisplayName">
+            <English>Friendly Fire Messages</English>
+            <Polish>Wiadomości Friendly Fire</Polish>
+        </Key>
+        <Key ID="STR_ACE_FriendlyFire_Module_Description">
+            <English></English>
+            <Polish>Użycie tego modułu na misji spowoduje wyświetlenie wiadomości na czacie w przypadku, kiedy zostanie popełniony friendly fire - wyświetlona zostanie wtedy wiadomość kto kogo zabił.</Polish>
+        </Key>
+        <Key ID="STR_ACE_Rallypoint_Module_DisplayName">
+            <English>Rallypoint System</English>
+            <Polish>System punktu zbiórki</Polish>
+        </Key>
+        <Key ID="STR_ACE_Rallypoint_Module_Description">
+            <English></English>
+            <Polish>Moduł ten pozwala zastosować na misji "punkt zbiórki", do którego można szybko przeteleportować się z "bazy". Wymaga postawienia odpowiednich obiektów na mapie - bazy oraz flagi. Obydwa dostępne są w kategorii Puste -> ACE Odrodzenie.</Polish>
+        </Key>
+        <Key ID="STR_ACE_Rallypoint_MoveRallypoint">
+            <English>Move Rallypoint</English>
+            <Polish>Przenieś punkt zbiórki</Polish>
+        </Key>
+        <Key ID="STR_ACE_Respawn_EditorCategory">
+            <English>ACE Respawn</English>
+            <Polish>ACE Odrodzenie</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/switchunits/CfgVehicles.hpp
+++ b/addons/switchunits/CfgVehicles.hpp
@@ -3,63 +3,51 @@ class CfgVehicles {
   class ACE_ModuleSwitchUnits: Module_F {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
-    displayName = "SwitchUnits System";
+    displayName = "$STR_ACE_SwitchUnits_Module_DisplayName";
     function = FUNC(module);
     scope = 2;
     isGlobal = 1;
     icon = QUOTE(PATHTOF(UI\Icon_Module_SwitchUnits_ca.paa));
     class Arguments {
       class SwitchToWest {
-        displayName = "Switch to West?";
-        description = "Allow switching to west units?";
+        displayName = "$STR_ACE_SwitchUnits_SwitchToWest_DisplayName";
+        description = "$STR_ACE_SwitchUnits_SwitchToWest_Description";
         typeName = "BOOL";
-        class values {
-          class Yes {name = "Yes"; value = 1;};
-          class No {default = 1; name = "No"; value = 0;};
-        };
+        defaultValue = 0;
       };
       class SwitchToEast {
-        displayName = "Switch to East?";
-        description = "Allow switching to east units?";
+        displayName = "$STR_ACE_SwitchUnits_SwitchToEast_DisplayName";
+        description = "$STR_ACE_SwitchUnits_SwitchToEast_Description";
         typeName = "BOOL";
-        class values {
-          class Yes {name = "Yes"; value = 1;};
-          class No {default = 1; name = "No"; value = 0;};
-        };
+        defaultValue = 0;
       };
       class SwitchToIndependent {
-        displayName = "Switch to Independent?";
-        description = "Allow switching to independent units?";
+        displayName = "$STR_ACE_SwitchUnits_SwitchToIndependent_DisplayName";
+        description = "$STR_ACE_SwitchUnits_SwitchToIndependent_Description";
         typeName = "BOOL";
-        class values {
-          class Yes {name = "Yes"; value = 1;};
-          class No {default = 1; name = "No"; value = 0;};
-        };
+        defaultValue = 0;
       };
       class SwitchToCivilian {
-        displayName = "Switch to Civilian?";
-        description = "Allow switching to civilian units?";
+        displayName = "$STR_ACE_SwitchUnits_SwitchToCivilian_DisplayName";
+        description = "$STR_ACE_SwitchUnits_SwitchToCivilian_Description";
         typeName = "BOOL";
-        class values {
-          class Yes {name = "Yes"; value = 1;};
-          class No {default = 1; name = "No"; value = 0;};
-        };
+        defaultValue = 0;
       };
       class EnableSafeZone {
-        displayName = "Enable Safe Zone?";
-        description = "Enable a safe zone around enemy units? Players can't switch to units inside of the safe zone.";
+        displayName = "$STR_ACE_SwitchUnits_EnableSafeZone_DisplayName";
+        description = "$STR_ACE_SwitchUnits_EnableSafeZone_Description";
         typeName = "BOOL";
-        class values {
-          class Yes {default = 1; name = "Yes"; value = 1;};
-          class No {name = "No"; value = 0;};
-        };
+        defaultValue = 1;
       };
       class SafeZoneRadius {
-        displayName = "Safe Zone Radius";
-        description = "The safe zone around players from a different team. Default: 200";
+        displayName = "$STR_ACE_SwitchUnits_SafeZoneRadius_DisplayName";
+        description = "$STR_ACE_SwitchUnits_SafeZoneRadius_Description";
         typeName = "NUMBER";
         defaultValue = 100;
       };
+    };
+	class ModuleDescription {
+            description = "$STR_ACE_SwitchUnits_Module_Description";
     };
   };
 };

--- a/addons/switchunits/stringtable.xml
+++ b/addons/switchunits/stringtable.xml
@@ -25,5 +25,136 @@
             <Italian>Questa unità è troppo vicina al nemico.</Italian>
             <Portuguese>Essa unidade  está muito perta do inimigo.</Portuguese>
         </Key>
+<<<<<<< HEAD
+<<<<<<< HEAD
+		<Key ID="STR_ACE_SwitchUnits_Yes">
+            <English>Yes</English>
+            <Polish>Tak</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_No">
+            <English>No</English>
+            <Polish>Nie</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_Module_DisplayName">
+            <English>SwitchUnits System</English>
+            <Polish>System zmiany stron</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToWest_DisplayName">
+            <English>Switch to West?</English>
+            <Polish>Zmiana na Zachód?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToWest_Description">
+            <English>Allow switching to west units?</English>
+            <Polish>Pozwolić zmieniać graczom stronę na Zachód?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToEast_DisplayName">
+            <English>Switch to East?</English>
+            <Polish>Zmiana na Wschód?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToEast_Description">
+            <English>Allow switching to east units?</English>
+            <Polish>Pozwolić zmieniać graczom stronę na Wschód?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToIndependent_DisplayName">
+            <English>Switch to Independent?</English>
+            <Polish>Zmiana na Ruch Oporu?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToIndependent_Description">
+            <English>Allow switching to independent units?</English>
+            <Polish>Pozwolić zmieniać stronę na Ruch Oporu?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToCivilian_DisplayName">
+            <English>Switch to Civilian?</English>
+            <Polish>Zmiana na Cywili?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SwitchToCivilian_Description">
+            <English>Allow switching to civilian units?</English>
+            <Polish>Pozwolić zmieniać stronę na Cywili?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_EnableSafeZone_DisplayName">
+            <English>Enable Safe Zone?</English>
+            <Polish>Aktywuj bezp. strefę?</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_EnableSafeZone_Description">
+            <English>Enable a safe zone around enemy units? Players can't switch to units inside of the safe zone.</English>
+            <Polish>Aktywuje bezpieczną strefę wokół jednostek przeciwnika. Gracze nie mogą zmieniać strony wewnątrz tej strefy.</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SafeZoneRadius_DisplayName">
+            <English>Safe Zone Radius</English>
+            <Polish>Promień bezp. strefy</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_SafeZoneRadius_Description">
+            <English>The safe zone around players from a different team. Default: 200</English>
+            <Polish>Promień bezpiecznej strefy wokół graczy z innych drużyn. Domyślnie: 200</Polish>
+        </Key>
+		<Key ID="STR_ACE_SwitchUnits_Module_Description">
+=======
+        <Key ID="STR_ACE_SwitchUnits_Yes">
+            <English>Yes</English>
+            <Polish>Tak</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_No">
+            <English>No</English>
+            <Polish>Nie</Polish>
+        </Key>
+=======
+>>>>>>> Yes/No to BOOL
+        <Key ID="STR_ACE_SwitchUnits_Module_DisplayName">
+            <English>SwitchUnits System</English>
+            <Polish>System zmiany stron</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToWest_DisplayName">
+            <English>Switch to West?</English>
+            <Polish>Zmiana na Zachód?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToWest_Description">
+            <English>Allow switching to west units?</English>
+            <Polish>Pozwolić zmieniać graczom stronę na Zachód?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToEast_DisplayName">
+            <English>Switch to East?</English>
+            <Polish>Zmiana na Wschód?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToEast_Description">
+            <English>Allow switching to east units?</English>
+            <Polish>Pozwolić zmieniać graczom stronę na Wschód?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToIndependent_DisplayName">
+            <English>Switch to Independent?</English>
+            <Polish>Zmiana na Ruch Oporu?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToIndependent_Description">
+            <English>Allow switching to independent units?</English>
+            <Polish>Pozwolić zmieniać stronę na Ruch Oporu?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToCivilian_DisplayName">
+            <English>Switch to Civilian?</English>
+            <Polish>Zmiana na Cywili?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SwitchToCivilian_Description">
+            <English>Allow switching to civilian units?</English>
+            <Polish>Pozwolić zmieniać stronę na Cywili?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_EnableSafeZone_DisplayName">
+            <English>Enable Safe Zone?</English>
+            <Polish>Aktywuj bezp. strefę?</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_EnableSafeZone_Description">
+            <English>Enable a safe zone around enemy units? Players can't switch to units inside of the safe zone.</English>
+            <Polish>Aktywuje bezpieczną strefę wokół jednostek przeciwnika. Gracze nie mogą zmieniać strony wewnątrz tej strefy.</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SafeZoneRadius_DisplayName">
+            <English>Safe Zone Radius</English>
+            <Polish>Promień bezp. strefy</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_SafeZoneRadius_Description">
+            <English>The safe zone around players from a different team. Default: 200</English>
+            <Polish>Promień bezpiecznej strefy wokół graczy z innych drużyn. Domyślnie: 200</Polish>
+        </Key>
+        <Key ID="STR_ACE_SwitchUnits_Module_Description">
+>>>>>>> I made mess so new pull request.
+            <English></English>
+            <Polish></Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/vehiclelock/CfgVehicles.hpp
+++ b/addons/vehiclelock/CfgVehicles.hpp
@@ -69,7 +69,7 @@ class CfgVehicles {
     class ACE_VehicleLock_ModuleSetup: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Vehicle Lock Setup";
+        displayName = "$STR_ACE_VehicleLock_Module_DisplayName";
         function = QFUNC(moduleInit);
         scope = 2;
         isGlobal = 0;
@@ -77,37 +77,37 @@ class CfgVehicles {
         functionPriority = 0;
         class Arguments {
             class LockVehicleInventory {
-                displayName = "Lock Vehicle Inventory";
-                description = "Locks the inventory of locked vehicles";
+                displayName = "$STR_ACE_VehicleLock_LockVehicleInventory_DisplayName";
+                description = "$STR_ACE_VehicleLock_LockVehicleInventory_Description";
                 typeName = "BOOL";
                 defaultValue = 0;
             };
             class VehicleStartingLockState {
-                displayName = "Vehicle Starting Lock State"; // Argument label
-                description = "Set lock state for all vehicles (removes ambiguous lock states)"; // Tooltip description
-                typeName = "NUMBER"; // Value type, can be "NUMBER", "STRING" or "BOOL"
+                displayName = "$STR_ACE_VehicleLock_VehicleStartingLockState_DisplayName";
+                description = "$STR_ACE_VehicleLock_VehicleStartingLockState_Description";
+                typeName = "NUMBER";
                 class values {
-                    class None {name = "As Is"; value = 0; default = 1;};
-                    class Side {name = "Locked"; value = 1;};
-                    class Unique {name = "Unlocked"; value = 2;};
+                    class None {name = "$STR_ACE_VehicleLock_VehicleStartingLockState_AsIs"; value = 0; default = 1;};
+                    class Side {name = "$STR_ACE_VehicleLock_VehicleStartingLockState_Locked"; value = 1;};
+                    class Unique {name = "$STR_ACE_VehicleLock_VehicleStartingLockState_Unlocked"; value = 2;};
                 };
             };
             class DefaultLockpickStrength {
-                displayName = "Default Lockpick Strength";
-                description = "Default Time to lockpick (in seconds). Default: 10";
-                typeName = "NUMBER"; // Value type, can be "NUMBER", "STRING" or "BOOL"
-                defaultValue = "10"; // Default text filled in the input box
+                displayName = "$STR_ACE_VehicleLock_DefaultLockpickStrength_DisplayName";
+                description = "$STR_ACE_VehicleLock_DefaultLockpickStrength_Description";
+                typeName = "NUMBER";
+                defaultValue = "10";
             };
         };
         class ModuleDescription: ModuleDescription {
-            description = "Settings for lockpick strength and initial vehicle lock state. Removes ambiguous lock states.<br/>Source: vehiclelock.pbo";
+            description = "$STR_ACE_VehicleLock_Module_Description";
         };
     };
 
     class ACE_VehicleLock_ModuleSyncedAssign: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
-        displayName = "Vehicle Key Assign";
+        displayName = "$STR_ACE_VehicleLock_VehicleKeyAssign_Module_DisplayName";
         function = QFUNC(moduleSync);
         scope = 2;
         isGlobal = 0;
@@ -115,7 +115,7 @@ class CfgVehicles {
         functionPriority = 0;
         class Arguments {};
         class ModuleDescription: ModuleDescription {
-            description = "Sync with vehicles and players.  Will handout custom keys to players for every synced vehicle. Only valid for objects present at mission start.<br/>Source: vehiclelock.pbo";
+            description = "$STR_ACE_VehicleLock_VehicleKeyAssign_Module_Description";
             sync[] = {"AnyPlayer", "AnyVehicle"};
         };
     };

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
     weapons[] = {};
     requiredVersion = REQUIRED_VERSION;
     requiredAddons[] = {"ace_interaction"};
-    author[] = {"PabstMirror"};
+    author[] = {"PabstMirror", "GieNkoV"};
     authorUrl = "https://github.com/acemod/ACE3";
     VERSION_CONFIG;
   };

--- a/addons/vehiclelock/stringtable.xml
+++ b/addons/vehiclelock/stringtable.xml
@@ -133,5 +133,57 @@
             <Italian>Una chaive che apr ela maggior parte dei veicoli civili</Italian>
             <Portuguese>Uma chave que abre a maioria dos veículos civis.</Portuguese>
         </Key>
+        <Key ID="STR_ACE_VehicleLock_Module_DisplayName">
+            <English>Vehicle Lock Setup</English>
+            <Polish>Ustawienie blokady pojazdów</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_LockVehicleInventory_DisplayName">
+            <English>Lock Vehicle Inventory</English>
+            <Polish>Zablokuj ekwipunek pojazdu</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_LockVehicleInventory_Description">
+            <English>Locks the inventory of locked vehicles</English>
+            <Polish>Blokuje dostęp do ekwipunku pojazdu</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_DisplayName">
+            <English>Vehicle Starting Lock State</English>
+            <Polish>Początkowy stan blok. poj.</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_Description">
+            <English>Set lock state for all vehicles (removes ambiguous lock states)</English>
+            <Polish>Ustawia początkowy stan blokady dla wszystkich pojazdów (usuwa dwuznaczne stany blokady)</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_AsIs">
+            <English>As Is</English>
+            <Polish>Jak jest</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_Locked">
+            <English>Locked</English>
+            <Polish>Zablokowany</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_Unlocked">
+            <English>Unlocked</English>
+            <Polish>Odblokowany</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_DefaultLockpickStrength_DisplayName">
+            <English>Default Lockpick Strength</English>
+            <Polish>Czas włamywania</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_DefaultLockpickStrength_Description">
+            <English>Default Time to lockpick (in seconds). Default: 10</English>
+            <Polish>Domyślny czas potrzebny na otwarcie pojazdu (w sekundach). Domyślnie: 10</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_Module_Description">
+            <English>Settings for lockpick strength and initial vehicle lock state. Removes ambiguous lock states.&lt;br /&gt;Source: vehiclelock.pbo</English>
+            <Polish>Ustawienia czasu włamywania oraz domyślnego stanu blokady pojazdów. Wyłącza dwuznaczne ustawienia blokady. Moduł ten umożliwia więc np. zamknięcie pojazdów przeciwnika na klucz tak, że gracze bez odpowiedniego sprzętu (wytrycha) nie będą mogli ich używać.&lt;br /&gt;Źródło: vehiclelock.pbo</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleKeyAssign_Module_DisplayName">
+            <English>Vehicle Key Assign</English>
+            <Polish>Przydział kluczyka do pojazdu</Polish>
+        </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleKeyAssign_Module_Description">
+            <English>Sync with vehicles and players.  Will handout custom keys to players for every synced vehicle. Only valid for objects present at mission start.&lt;br /&gt;Source: vehiclelock.pbo</English>
+            <Polish>Zsynchronizuj z pojazdami i graczami. Rozda klucze dla graczy dla każdego zsynchronizowanego pojazdu. Działa tylko na pojazdy obecne na misji od samego początku (postawione w edytorze).&lt;br /&gt;Źródło: vehiclelock.pbo</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/weather/CfgVehicles.hpp
+++ b/addons/weather/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class CfgVehicles {
     class ACE_Module;
     class GVAR(ModuleSettings): ACE_Module {
         scope = 2;
-        displayName = "Weather";
+        displayName = "$STR_ACE_Weather_Module_DisplayName";
         icon = QUOTE(PATHTOF(UI\Icon_Module_Wind_ca.paa));
         category = "ACE";
         function = QUOTE(DFUNC(initModuleSettings));
@@ -12,41 +12,44 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class enableServerController {
-                displayName = "Weather propagation";
-                description = "Enables sever side weather propagation";
+                displayName = "$STR_ACE_Weather_enableServerController_DisplayName";
+                description = "$STR_ACE_Weather_enableServerController_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class useACEWeather {
-                displayName = "ACE Weather";
-                description = "Overrides the default weather (editor, mission settings) with ACE weather (map based)";
+                displayName = "$STR_ACE_Weather_useACEWeather_DisplayName";
+                description = "$STR_ACE_Weather_useACEWeather_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class syncRain {
-                displayName = "Sync Rain";
-                description = "Synchronizes rain";
+                displayName = "$STR_ACE_Weather_syncRain_DisplayName";
+                description = "$STR_ACE_Weather_syncRain_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class syncWind {
-                displayName = "Sync Wind";
-                description = "Synchronizes wind";
+                displayName = "$STR_ACE_Weather_syncWind_DisplayName";
+                description = "$STR_ACE_Weather_syncWind_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class syncMisc {
-                displayName = "Sync Misc";
-                description = "Synchronizes lightnings, rainbow, fog, ...";
+                displayName = "$STR_ACE_Weather_syncMisc_DisplayName";
+                description = "$STR_ACE_Weather_syncMisc_Description";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class serverUpdateInterval {
-                displayName = "Update Interval";
-                description = "Defines the interval (seconds) between weather updates";
+                displayName = "$STR_ACE_Weather_serverUpdateInterval_DisplayName";
+                description = "$STR_ACE_Weather_serverUpdateInterval_Description";
                 typeName = "NUMBER";
                 defaultValue = 60;
             };
+        };
+        class ModuleDescription {
+            description = "$STR_ACE_Weather_Module_Description";
         };
     };
 };

--- a/addons/weather/stringtable.xml
+++ b/addons/weather/stringtable.xml
@@ -13,5 +13,65 @@
             <Czech>Zobrazit informace o větru</Czech>
             <Portuguese>Mostrar informação do vento</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Weather_Module_DisplayName">
+            <English>Weather</English>
+            <Polish>Pogoda</Polish>
+        </Key>
+<<<<<<< HEAD
+		<Key ID="STR_ACE_Weather_Module_Description">
+=======
+        <Key ID="STR_ACE_Weather_Module_Description">
+>>>>>>> I made mess so new pull request.
+            <English>Multiplayer synchronized ACE weather module</English>
+            <Polish>Synchronizowana pogoda ACE</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_enableServerController_DisplayName">
+            <English>Weather propagation</English>
+            <Polish>Zmiany pogody</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_enableServerController_Description">
+            <English>Enables server side weather propagation</English>
+            <Polish>Aktywuje zmiany pogody po stronie serwera</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_useACEWeather_DisplayName">
+            <English>ACE Weather</English>
+            <Polish>Pogoda ACE</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_useACEWeather_Description">
+            <English>Overrides the default weather (editor, mission settings) with ACE weather (map based)</English>
+            <Polish>Nadpisuje domyślne ustawienia pogody (edytor, wywiad) przy użyciu pogody ACE (zależna od mapy)</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_syncRain_DisplayName">
+            <English>Sync Rain</English>
+            <Polish>Synchronizuj deszcz</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_syncRain_Description">
+            <English>Synchronizes rain</English>
+            <Polish>Synchronizuje deszcz</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_syncWind_DisplayName">
+            <English>Sync Wind</English>
+            <Polish>Synchronizuj wiatr</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_syncWind_Description">
+            <English>Synchronizes wind</English>
+            <Polish>Synchronizuje wiatr</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_syncMisc_DisplayName">
+            <English>Sync Misc</English>
+            <Polish>Synchronizuj różne</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_syncMisc_Description">
+            <English>Synchronizes lightnings, rainbow, fog, ...</English>
+            <Polish>Synchronizuje pioruny, tęcze, mgłę, ...</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_serverUpdateInterval_DisplayName">
+            <English>Update Interval</English>
+            <Polish>Interwał aktualizacji</Polish>
+        </Key>
+        <Key ID="STR_ACE_Weather_serverUpdateInterval_Description">
+            <English>Defines the interval (seconds) between weather updates</English>
+            <Polish>Określa interwał (sekundy) pomiędzy aktualizacjami pogody</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/winddeflection/CfgVehicles.hpp
+++ b/addons/winddeflection/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class CfgVehicles {
     class ACE_Module;
     class GVAR(ModuleSettings): ACE_Module {
         scope = 2;
-        displayName = "Wind Deflection";
+        displayName = "$STR_ACE_WEATHER_WINDDEFLECTION_DISPLAYNAME"; //WIND DEFLECTION
         icon = QUOTE(PATHTOF(UI\Icon_Module_Wind_ca.paa));
         category = "ACE";
         function = QUOTE(DFUNC(initModuleSettings));
@@ -12,29 +12,32 @@ class CfgVehicles {
         author = "$STR_ACE_Common_ACETeam";
         class Arguments {
             class enabled {
-                displayName = "Wind Deflection";
-                description = "Enables wind deflection";
+                displayName = "$STR_ACE_WEATHER_DEFLECTIONMODULE_DISPLAYNAME";
+                description = "$STR_ACE_WEATHER_DEFLECTIONMODULE_DESCRIPTION";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class vehicleEnabled {
-                displayName = "Vehicle Enabled";
-                description = "Enables wind deflection for static/vehicle gunners";
+                displayName = "$STR_ACE_WEATHER_VEHICLEENABLED_DISPLAYNAME";
+                description = "$STR_ACE_WEATHER_VEHICLEENABLED_DESCRIPTION";
                 typeName = "BOOL";
                 defaultValue = 1;
             };
             class simulationInterval {
-                displayName = "Simulation Interval";
-                description = "Defines the interval between every calculation step";
+                displayName = "$STR_ACE_WEATHER_SIMULATIONINTERVAL_DISPLAYNAME";
+                description = "$STR_ACE_WEATHER_SIMULATIONINTERVAL_DESCRIPTION";
                 typeName = "NUMBER";
                 defaultValue = 0.05;
             };
             class simulationRadius {
-                displayName = "Simulation Radius";
-                description = "Defines the radius around the player (in meters) at which projectiles are wind deflected";
+                displayName = "$STR_ACE_WEATHER_SIMULATIONRADIUS_DISPLAYNAME";
+                description = "$STR_ACE_WEATHER_SIMULATIONRADIUS_DESCRIPTION";
                 typeName = "NUMBER";
                 defaultValue = 3000;
             };
         };
+		class ModuleDescription {
+			description = "$STR_ACE_WEATHER_WINDDEFLECTION_DESCRIPTION";
+		};
     };
 };

--- a/addons/winddeflection/stringtable.xml
+++ b/addons/winddeflection/stringtable.xml
@@ -62,6 +62,53 @@
                 <Italian>Umidità: %1%</Italian>
                 <Portuguese>Humidade: %1%</Portuguese>
             </Key>
+            <Key ID="STR_ACE_WEATHER_WINDDEFLECTION_DISPLAYNAME">
+                <English>Wind Deflection</English>
+                <Polish>Wpływ wiatru</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_DEFLECTIONMODULE_DISPLAYNAME">
+                <English>Wind Deflection</English>
+                <Polish>Wpływ wiatru</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_DEFLECTIONMODULE_DESCRIPTION">
+                <English>Enables wind deflection</English>
+                <Polish>Aktywuje wpływ wiatru na trajektorię lotu pocisków</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_VEHICLEENABLED_DISPLAYNAME">
+                <English>Vehicle Enabled</English>
+                <Polish>Włączone dla pojazdów</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_VEHICLEENABLED_DESCRIPTION">
+                <English>Enables wind deflection for static/vehicle gunners</English>
+                <Polish>Aktywuje wpływ wiatru na trajektorię lotu pocisków dla broni statycznej i na pojazdach</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_SIMULATIONINTERVAL_DISPLAYNAME">
+                <English>Simulation Interval</English>
+                <Polish>Interwał symulacji</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_SIMULATIONINTERVAL_DESCRIPTION">
+                <English>Defines the interval between every calculation step</English>
+                <Polish>Określa interwał pomiędzy każdym krokiem kalkulacji</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_SIMULATIONRADIUS_DISPLAYNAME">
+                <English>Simulation Radius</English>
+                <Polish>Zasięg symulacji</Polish>
+            </Key>
+            <Key ID="STR_ACE_WEATHER_SIMULATIONRADIUS_DESCRIPTION">
+                <English>Defines the radius around the player (in meters) at which projectiles are wind deflected</English>
+                <Polish>Określa obszar naokoło gracza (w metrach), na którym pociski są znoszone przez wiatr</Polish>
+            </Key>
+<<<<<<< HEAD
+			<Key ID="STR_ACE_WEATHER_WINDDEFLECTION_DESCRIPTION">
+				<English>Wind influence on projectiles trajectory</English>
+				<Polish>Wpływ wiatru na trajectorię lotu pocisków</Polish>
+			</Key>
+=======
+            <Key ID="STR_ACE_WEATHER_WINDDEFLECTION_DESCRIPTION">
+                <English>Wind influence on projectiles trajectory</English>
+                <Polish>Wpływ wiatru na trajektorię lotu pocisków</Polish>
+            </Key>
+>>>>>>> I made mess so new pull request.
         </Container>
     </Package>
 </Project>


### PR DESCRIPTION
Done:

* Advanced Ballistics module
* Ballistics - ammo crate
* Captives module
* Common module
* 2 Vehiclelock modules
* Weather module
* Winddeflection module
* Hearing module
* Interaction module
* Map and BFT modules
* SwitchUnits module
* Ambiance Sounds - module, category
* Medical - all 6 modules, 2 chests, editor category, fixes to CMS leftovers in descriptions
* MK6 Settings - module
* Name Tags - module
* Rallypoint System - module + move rallypoint action
* Respawn System - module + editor category
* Friendly Fire Messages - module
* Explosive System - module
* Allow Config Export [ACE] - module
* MicroDAGR Map Fill - module

Also:
* Added module descriptions to all modules (where they were missing)
* Fixed #976
* Missing translations inside options menu and that were: missileguidance, common, nametags
* Changed options like:

> class CheckAll {
        displayName = "$STR_ACE_Common_CheckPBO_CheckAll_DisplayName";
        description = "$STR_ACE_Common_CheckPBO_CheckAll_Description";
         typeName = "BOOL";
         class values {
           class WarnOnce {
             default = 1;
            name = "$STR_ACE_Common_CheckPBO_CheckAll_No";
             value = 0;
           };
           class Warn {
            name = "$STR_ACE_Common_CheckPBO_CheckAll_Yes";
             value = 1;
           };
         };

to

> class CheckAll {
        displayName = "$STR_ACE_Common_CheckPBO_CheckAll_DisplayName";
        description = "$STR_ACE_Common_CheckPBO_CheckAll_Description";
         typeName = "BOOL";
         defaultValue = 0;
>         };

So it's shorter that way. @bux578 was writing about doing that and I did that for him.

Left:
* Nothing, I kindly ask for a merge