### PR TITLE
ACE_time variables for accurate purposeful time use

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -312,6 +312,15 @@ if (hasInterface) then {
     }, 0, []] call cba_fnc_addPerFrameHandler;
 };
 
+// Time handling
+ACE_time = diag_tickTime;
+ACE_realTime = diag_tickTime;
+ACE_virtualTime = diag_tickTime;
+ACE_gameTime = time;
+
+PREP(timePFH);
+[FUNC(timePFH), 0, []] call cba_fnc_addPerFrameHandler;
+
 // Init toHex
 [0] call FUNC(toHex);
 

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -316,7 +316,7 @@ if (hasInterface) then {
 ACE_time = diag_tickTime;
 ACE_realTime = diag_tickTime;
 ACE_virtualTime = diag_tickTime;
-ACE_tickTime = diag_tickTime;
+ACE_diagTime = diag_tickTime;
 ACE_gameTime = time;
 
 PREP(timePFH);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -316,6 +316,7 @@ if (hasInterface) then {
 ACE_time = diag_tickTime;
 ACE_realTime = diag_tickTime;
 ACE_virtualTime = diag_tickTime;
+ACE_tickTime = diag_tickTime;
 ACE_gameTime = time;
 
 PREP(timePFH);

--- a/addons/common/functions/fnc_timePFH.sqf
+++ b/addons/common/functions/fnc_timePFH.sqf
@@ -7,9 +7,9 @@ _lastRealTime = ACE_realTime;
 _lastGameTime = ACE_gameTime;
 
 ACE_gameTime = time;
-ACE_realTime = diag_tickTime;
+ACE_tickTime = diag_tickTime;
 
-_delta = ACE_realTime - _lastRealTime;
+_delta = ACE_tickTime - _lastRealTime;
 if(ACE_gameTime <= _lastGameTime) then {
     ACE_paused = true;
     // Game is paused or not running
@@ -18,7 +18,8 @@ if(ACE_gameTime <= _lastGameTime) then {
 } else {
     ACE_paused = false;
     // Time is updating
+    ACE_realTime = ACE_realTime + _delta;
     ACE_virtualTime = ACE_virtualTime + (_delta * accTime);
-    ACE_time = ACE_time + _delta;
+    ACE_time = ACE_virtualTime;
 };
 

--- a/addons/common/functions/fnc_timePFH.sqf
+++ b/addons/common/functions/fnc_timePFH.sqf
@@ -3,24 +3,22 @@
 
 private["_lastTime", "_lastRealTime", "_lastVirtualTime", "_lastGameTime", "_delta"];
 
-_lastTime = ACE_time;
 _lastRealTime = ACE_realTime;
-_lastVirtualTime = ACE_virtualTime;
 _lastGameTime = ACE_gameTime;
-_lastPausedTime = ACE_pausedTime;
-_lastVirtualPausedTime = ACE_virtualPausedTime;
 
 ACE_gameTime = time;
 ACE_realTime = diag_tickTime;
 
 _delta = ACE_realTime - _lastRealTime;
 if(time <= _lastGameTime) then {
+    ACE_paused = true;
     // Game is paused or not running
     ACE_pausedTime = ACE_pausedTime + _delta;
     ACE_virtualPausedTime = ACE_pausedTime + (_delta * accTime);
 } else {
+    ACE_paused = false;
     // Time is updating
-    ACE_virtualTime = _lastVirtualTime + (_delta * accTime);
-    ACE_time = ACE_realTime + _delta;
+    ACE_virtualTime = ACE_virtualTime + (_delta * accTime);
+    ACE_time = ACE_time + _delta;
 };
 

--- a/addons/common/functions/fnc_timePFH.sqf
+++ b/addons/common/functions/fnc_timePFH.sqf
@@ -7,9 +7,9 @@ _lastRealTime = ACE_realTime;
 _lastGameTime = ACE_gameTime;
 
 ACE_gameTime = time;
-ACE_tickTime = diag_tickTime;
+ACE_diagTime = diag_tickTime;
 
-_delta = ACE_tickTime - _lastRealTime;
+_delta = ACE_diagTime - _lastRealTime;
 if(ACE_gameTime <= _lastGameTime) then {
     ACE_paused = true;
     // Game is paused or not running

--- a/addons/common/functions/fnc_timePFH.sqf
+++ b/addons/common/functions/fnc_timePFH.sqf
@@ -1,0 +1,26 @@
+//#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+private["_lastTime", "_lastRealTime", "_lastVirtualTime", "_lastGameTime", "_delta"];
+
+_lastTime = ACE_time;
+_lastRealTime = ACE_realTime;
+_lastVirtualTime = ACE_virtualTime;
+_lastGameTime = ACE_gameTime;
+_lastPausedTime = ACE_pausedTime;
+_lastVirtualPausedTime = ACE_virtualPausedTime;
+
+ACE_gameTime = time;
+ACE_realTime = diag_tickTime;
+
+_delta = ACE_realTime - _lastRealTime;
+if(time <= _lastGameTime) then {
+    // Game is paused or not running
+    ACE_pausedTime = ACE_pausedTime + _delta;
+    ACE_virtualPausedTime = ACE_pausedTime + (_delta * accTime);
+} else {
+    // Time is updating
+    ACE_virtualTime = _lastVirtualTime + (_delta * accTime);
+    ACE_time = ACE_realTime + _delta;
+};
+

--- a/addons/common/functions/fnc_timePFH.sqf
+++ b/addons/common/functions/fnc_timePFH.sqf
@@ -10,7 +10,7 @@ ACE_gameTime = time;
 ACE_realTime = diag_tickTime;
 
 _delta = ACE_realTime - _lastRealTime;
-if(time <= _lastGameTime) then {
+if(ACE_gameTime <= _lastGameTime) then {
     ACE_paused = true;
     // Game is paused or not running
     ACE_pausedTime = ACE_pausedTime + _delta;

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -83,7 +83,7 @@
 #define HASHLIST_PUSH(hashList, value)            ([hashList, value, __FILE__, __LINE__] call EFUNC(common,hashListPush))
 
 // Time functions for accuracy per frame
-#define ACE_tickTime (ACE_tickTime + (diag_tickTime - ACE_tickTime))
+#define ACE_tickTime (ACE_diagTime + (diag_tickTime - ACE_diagTime))
 
 
 #include "script_debug.hpp"

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -82,4 +82,8 @@
 #define HASHLIST_SET(hashList, index, value)    ([hashList, index, value, __FILE__, __LINE__] call EFUNC(common,hashListSet))
 #define HASHLIST_PUSH(hashList, value)            ([hashList, value, __FILE__, __LINE__] call EFUNC(common,hashListPush))
 
+// Time functions for accuracy per frame
+#define ACE_tickTime (ACE_tickTime + (diag_tickTime - ACE_tickTime))
+
+
 #include "script_debug.hpp"

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -83,7 +83,7 @@
 #define HASHLIST_PUSH(hashList, value)            ([hashList, value, __FILE__, __LINE__] call EFUNC(common,hashListPush))
 
 // Time functions for accuracy per frame
-#define ACE_tickTime (ACE_diagTime + (diag_tickTime - ACE_diagTime))
+#define ACE_tickTime (ACE_time + (diag_tickTime - ACE_diagTime))
 
 
 #include "script_debug.hpp"


### PR DESCRIPTION
There was discussion recently about the fact we use 'time' everywhere in our PFH's so they detect game pausing and support saved games.

However, time is unreliable on slow machines (< 20fps) - so we *should* be using diag_tickTime for PFH functionality.

This provides the following global variables for a hybrid approach of this:
ACE_time = diag_tickTime accuracy, except it does not advance when the game is paused. It will also obviously save and continue forward in a saved game, so supports them as well.
ACE_realTime = diag_tickTime
ACE_gameTime = time
ACE_virtualTime = diag_tickTime accuracy, except taking accTime into account.
ACE_virtualGameTime = time, except takes accTime into account.
ACE_virtualPausedTime = the amount of diag_tickTime time that was paused, except accTime is taken into account. WHO THE FUCK WOULD NEED THIS!? I'm sure someone will.
ACE_pausedTime = the amount of time the game has been paused in total. 

ACE_paused = true/false, whether the game is currently paused.

These would have a seperate PR, which would *replace all uses of time with ACE_time!!!!!!!*

Completes #1091