### PR TITLE
Fix disarming

### DIFF
--- a/addons/disarming/functions/fnc_disarmDropItems.sqf
+++ b/addons/disarming/functions/fnc_disarmDropItems.sqf
@@ -79,7 +79,7 @@ _holderMagazinesStart = magazinesAmmoCargo _holder;
 
 {
     EXPLODE_2_PVT(_x,_xClassname,_xAmmo);
-    if ((_xClassname in _listOfItemsToRemove) && {!(_xClassname in UNIQUE_MAGAZINES)}) then {
+    if ((_xClassname in _listOfItemsToRemove) && {(getNumber (configFile >> "CfgMagazines" >> _xClassname >> "ACE_isUnique")) == 0}) then {
         _holder addMagazineAmmoCargo [_xClassname, 1, _xAmmo];
         _target removeMagazine _xClassname;
     };
@@ -89,7 +89,7 @@ _targetMagazinesEnd = magazinesAmmo _target;
 _holderMagazinesEnd = magazinesAmmoCargo _holder;
 
 //Verify Mags dropped from unit:
-if ( ({((_x select 0) in _listOfItemsToRemove) && {!((_x select 0) in UNIQUE_MAGAZINES)}} count _targetMagazinesEnd) != 0) exitWith {
+if (({((_x select 0) in _listOfItemsToRemove) && {(getNumber (configFile >> "CfgMagazines" >> (_x select 0) >> "ACE_isUnique")) == 0}} count _targetMagazinesEnd) != 0) exitWith {
     _holder setVariable [QGVAR(holderInUse), false];
     [_caller, _target, "Debug: Didn't Remove Magazines"] call FUNC(eventTargetFinish);
 };

--- a/addons/disarming/functions/fnc_disarmDropItems.sqf
+++ b/addons/disarming/functions/fnc_disarmDropItems.sqf
@@ -102,7 +102,7 @@ if (!([_targetMagazinesStart, _targetMagazinesEnd, _holderMagazinesStart, _holde
 
 //Remove Items, Assigned Items and NVG
 _holderItemsStart = getitemCargo _holder;
-_targetItemsStart = (assignedItems _target) + (items _target);
+_targetItemsStart = (assignedItems _target) + (items _target) - (weapons _target);
 if ((headgear _target) != "") then {_targetItemsStart pushBack (headgear _target);};
 if ((goggles _target) != "") then {_targetItemsStart pushBack (goggles _target);};
 
@@ -132,7 +132,7 @@ _addToCrateCount = [];
 } forEach _addToCrateClassnames;
 
 _holderItemsEnd = getitemCargo _holder;
-_targetItemsEnd = (assignedItems _target) + (items _target);
+_targetItemsEnd = (assignedItems _target) + (items _target) - (weapons _target);
 if ((headgear _target) != "") then {_targetItemsEnd pushBack (headgear _target);};
 if ((goggles _target) != "") then {_targetItemsEnd pushBack (goggles _target);};
 
@@ -144,6 +144,16 @@ if (((count _targetItemsStart) - (count _targetItemsEnd)) != ([_addToCrateCount]
 if ((([_holderItemsEnd select 1] call _fncSumArray) - ([_holderItemsStart select 1] call _fncSumArray)) != ([_addToCrateCount] call _fncSumArray)) exitWith {
     _holder setVariable [QGVAR(holderInUse), false];
     [_caller, _target, "Debug: Items Not Added to Holder"] call FUNC(eventTargetFinish);
+};
+
+//Script drop uniforms/vest if empty
+if (((uniform _target) != "") && {(uniform _target) in _listOfItemsToRemove} && {(uniformItems _target) isEqualTo []}) then {
+    _holder addItemCargoGlobal [(uniform _target), 1];
+    removeUniform _target;
+};
+if (((vest _target) != "") && {(vest _target) in _listOfItemsToRemove} && {(vestItems _target) isEqualTo []}) then {
+    _holder addItemCargoGlobal [(vest _target), 1];
+    removeVest _target;
 };
 
 

--- a/addons/disarming/functions/fnc_getAllGearUnit.sqf
+++ b/addons/disarming/functions/fnc_getAllGearUnit.sqf
@@ -19,7 +19,7 @@ PARAMS_1(_target);
 
 private ["_allItems", "_classnamesCount", "_index", "_uniqueClassnames"];
 
-_allItems = ((weapons _target) + (magazines _target) + (items _target) + (assignedItems _target));
+_allItems = (((items _target) + (assignedItems _target)) - (weapons _target)) + (weapons _target) + (magazines _target);
 
 if ((backpack _target) != "") then {
     _allItems pushBack (backpack _target);

--- a/addons/disarming/functions/fnc_showItemsInListbox.sqf
+++ b/addons/disarming/functions/fnc_showItemsInListbox.sqf
@@ -28,7 +28,7 @@ private ["_classname", "_count", "_displayName", "_picture"];
     _classname = _x;
     _count = (_itemsCountArray select 1) select _forEachIndex;
 
-    if (_classname != DUMMY_ITEM) then { //Don't show the dummy potato
+    if ((_classname != DUMMY_ITEM) && {_classname != "ACE_FakePrimaryWeapon"}) then { //Don't show the dummy potato or fake weapon
 
         switch (true) do {
         case (isClass (configFile >> "CfgWeapons" >> _classname)): {
@@ -53,8 +53,8 @@ private ["_classname", "_count", "_displayName", "_picture"];
         };
 
         _listBoxCtrl lbAdd format ["%1", _displayName];
-        _listBoxCtrl lbSetData [_forEachIndex, _classname];
-        _listBoxCtrl lbSetPicture [_forEachIndex, _picture];
-        _listBoxCtrl lbSetTextRight [_forEachIndex, str _count];
+        _listBoxCtrl lbSetData [((lbSize _listBoxCtrl) - 1), _classname];
+        _listBoxCtrl lbSetPicture [((lbSize _listBoxCtrl) - 1), _picture];
+        _listBoxCtrl lbSetTextRight [((lbSize _listBoxCtrl) - 1), str _count];
     };
 } forEach (_itemsCountArray select 0);

--- a/addons/disarming/script_component.hpp
+++ b/addons/disarming/script_component.hpp
@@ -13,4 +13,3 @@
 
 #define DISARM_CONTAINER "GroundWeaponHolder"
 #define DUMMY_ITEM "ACE_DebugPotato"
-#define UNIQUE_MAGAZINES ["ACE_key_customKeyMagazine"]

--- a/addons/vehiclelock/CfgMagazines.hpp
+++ b/addons/vehiclelock/CfgMagazines.hpp
@@ -6,5 +6,6 @@ class CfgMagazines {
         descriptionShort = "$STR_ACE_Vehicle_Item_Custom_Description";
         count = 1;
         mass = 0;
+        ACE_isUnique = 1;
     };
 };


### PR DESCRIPTION
Fix #1081

Binocular types items show up as both an `item`/ `assignedItem` and `weapons`.  It was trying to drop them the wrong way.

Also adds `ACE_isUnique` flag for magazines (so they get dropped via action and preserve `magazinesDetail`) which we'll need for BFT or other mods using `magazinesDetail`.