### PR TITLE
Trivial variable name fix for moduleAssignMedicalVehicle function

### DIFF
--- a/addons/medical/functions/fnc_isInMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_isInMedicalVehicle.sqf
@@ -21,4 +21,4 @@ _vehicle = vehicle _unit;
 if (_unit == _vehicle) exitWith {false};
 if (_unit in [driver _vehicle, gunner _vehicle, commander _vehicle]) exitWith {false};
 
-_vehicle getVariable [QGVAR(isMedic), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant") == 1]
+_vehicle getVariable [QGVAR(medicClass), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant") == 1]

--- a/addons/medical/functions/fnc_isMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_isMedicalVehicle.sqf
@@ -15,4 +15,4 @@
 private ["_vehicle"];
 _vehicle = _this select 0;
 
-_vehicle getVariable [QGVAR(isMedic), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant") == 1]
+_vehicle getVariable [QGVAR(medicClass), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant") == 1]

--- a/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
@@ -44,7 +44,7 @@ if (!isNull _logic) then {
             if (!isnil "_x") then {
                    if (typeName _x == typeName objNull) then {
                     if (local _x) then {
-                        _x setvariable [QGVAR(medicClass), _setting, true];
+                        _x setvariable [QGVAR(isMedic), _setting, true];
                     };
                 };
             };
@@ -54,7 +54,7 @@ if (!isNull _logic) then {
         if (!isnil "_x") then {
                if (typeName _x == typeName objNull) then {
                 if (local _x) then {
-                    _x setvariable [QGVAR(medicClass), _setting, true];
+                    _x setvariable [QGVAR(isMedic), _setting, true];
                 };
             };
         };

--- a/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
@@ -44,7 +44,7 @@ if (!isNull _logic) then {
             if (!isnil "_x") then {
                    if (typeName _x == typeName objNull) then {
                     if (local _x) then {
-                        _x setvariable [QGVAR(isMedic), _setting, true];
+                        _x setvariable [QGVAR(medicClass), _setting, true];
                     };
                 };
             };
@@ -54,7 +54,7 @@ if (!isNull _logic) then {
         if (!isnil "_x") then {
                if (typeName _x == typeName objNull) then {
                 if (local _x) then {
-                    _x setvariable [QGVAR(isMedic), _setting, true];
+                    _x setvariable [QGVAR(medicClass), _setting, true];
                 };
             };
         };

--- a/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
@@ -37,7 +37,7 @@ if (!isNull _logic) then {
 
     _list = "[" + _nilCheckPassedList + "]";
     _parsedList = [] call compile _list;
-    _setting = _logic getvariable ["enabled", false];
+    _setting = _logic getvariable ["enabled", 0];
     _objects = synchronizedObjects _logic;
     if (!(_objects isEqualTo []) && _parsedList isEqualTo []) then {
         {


### PR DESCRIPTION
The rest of the medical vehicle functions are using variable `ace_medical_isMedic` rather than `ace_medical_medicClass` so I changed this one to match.

Probably just an oversight in copy-pasting as the function is very similar to the `moduleAssignMedicRoles` function.