### PR TITLE
Create missing documentation placeholders

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -94,3 +94,4 @@ Bla1337
 nikolauska <nikolauska1@gmail.com>
 adam3adam <br.ada@seznam.cz>
 Professor <lukas.trneny@wo.cz> 
+Dharma Bellamkonda <dharma.bellamkonda@gmail.com>

--- a/documentation/feature/advanced_ballistics.md
+++ b/documentation/feature/advanced_ballistics.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Advanced Ballistics
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/ai.md
+++ b/documentation/feature/ai.md
@@ -1,0 +1,27 @@
+---
+layout: wiki
+title: AI (Artifical Intelligence)
+group: feature
+order: 5
+parent: wiki
+---
+
+# Overview
+## Adjusted AI skill values
+The idea here is to reduce the AI's godlike aiming capabilties while retaining it's high intelligence. The AI should be smart enough to move through a town, but also be 'human' in their reaction time and aim.
+Note: All these values can still be adjusted via scripts, these arrays just change what 0 & 1 are for setSkill.
+## Firing in burst mode
+AIs will now use the automatic mode of their weapons on short distances, instead of always relying on firing single shots in quick succession.
+## Longer engagement ranges
+The maximum engagement ranges are increased: AI will fire in bursts with variable length on high ranges of 500 - 700 meters, depending on their weapon and optic.
+## No deadzones in CQB
+Some weapons had minimum engagement ranges. If you were as close as 2 meters to an AAF soldier, he wouldn't open fire, because the AI couldn't find any valid fire mode for their weapon. AGM removes this behaviour mostly notable in CQB by adding a valid firing mode.
+## No scripting
+All changes of AGM AI are config based to ensure full compatibility with advanced AI modifications like ASR AI.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/aircraft.md
+++ b/documentation/feature/aircraft.md
@@ -1,0 +1,25 @@
+---
+layout: wiki
+title: Aircraft
+group: feature
+order: 5
+parent: wiki
+---
+# Overview
+## Adjusted flight behaviour
+Changes the flight behaviour of various aircraft.
+## Various adjustments to A2A, A2G and G2A munitions
+- needs documentaion -
+## Missile lock warnings
+Adds missile-lock warning systems to helicopters and planes based on the various real life capabilities.
+## Semi-automatic flare mode
+Adds the semi-automatic flare mode known from Arma 2. The key to switch the mode still exists in Arma 3's key settings, but is unused.
+### Ejecting from pilot and copilot seats
+Pilots and copilots of all helicopters can now eject.
+## Laser marker for wildcat
+Adds a laser marker to the copilot seat of the Wildcat.
+## HUD for AH-9
+Adds a HUD to the AH-9 based on the comanches HUD.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/apl.md
+++ b/documentation/feature/apl.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: APL
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/atragmx.md
+++ b/documentation/feature/atragmx.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: ATragMX
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/attach.md
+++ b/documentation/feature/attach.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Attach
+group: feature
+parent: wiki
+---
+# Overview
+## Attach items to uniform
+Enables player to attach IR grenades and chemlights to themselves.
+## IR Strobe
+Adds an attachable IR strobe, which is only visible using night vision devices and offers better visibility than IR grenades.re 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/backpacks.md
+++ b/documentation/feature/backpacks.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Backpacks
+group: feature
+parent: wiki
+---
+# Overview
+## Lock backpack
+Adds the ability to lock backpacks. Locked backpacks can't be accessed by others.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/ballistics.md
+++ b/documentation/feature/ballistics.md
@@ -1,0 +1,28 @@
+---
+layout: wiki
+title: Ballistics
+group: feature
+parent: wiki
+---
+# Overview
+## Realistic rifle ammunition
+Changes include adjusted muzzle velocity, air friction and dispersion based on real life values.
+## Body armour nerf
+Nerfs protection values of vests, CSAT uniforms and various campaign only gear to more realistic levels comparable to Arma 2 levels.
+## Realistic silencers and sub-sonic ammunition
+Silencers no longer decrease the muzzle velocity and are generally less effective when used with normal ammunition. They now only remove the muzzle blast and flash. To prevent the crack caused by super sonic projectiles, AGM introduces sub sonic ammunition. This is also fully compatible with AI. Sub sonic ammunition is available for the calibers 5.56mm, 6.5mm and 7.62mm.
+## Armour piercing ammunition
+Armour piercing rounds have higher penetration values against light armoured targets or other obstacles on the battlefield. Their drawback is a slighly decreased man-stopping power. AP rounds are available for the calibers 5.56mm, 6.5mm and 7.62mm.
+## IR-Dim tracer ammunition
+IR-Dim ammunition is similar to tracer rounds, but their tracers are only visible using night vision devices.
+## M118 Long range ammunition
+The M14 EBR now uses ammunition with decreased muzzle velocity and air friction to improve precission on long ranges.
+## Flash suppressors
+Flash suppressors are similar to sound suppressors and prevent the muzzle flash reducing visibilty without decreasing combat effectiveness. Flash suppressors are available for the calibers 5.56mm, 6.5mm, 7.62mm, .45 ACP and 9mm.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/captives.md
+++ b/documentation/feature/captives.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Captives
+group: feature
+parent: wiki
+---
+# Overview
+## Take captives
+Introduces a captivity system for taking and moving prisoners.
+## Load and unload captives into / from vehicles
+- needs documentaion -
+## Frisk captives
+- needs documentaion -
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/difficulties.md
+++ b/documentation/feature/difficulties.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Difficulties
+group: feature
+parent: wiki
+---
+# Overview
+## Elite mode adjustments
+Adjusts the default settings for the hardest difficulty to more closely resemble A2 settings. (No crosshair, stat screen, death messages...)
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/disarming.md
+++ b/documentation/feature/disarming.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Disarming
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/disposable.md
+++ b/documentation/feature/disposable.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Disposable
+group: feature
+parent: wiki
+---
+# Overview
+## NLAW disposable anti tank weapon
+Makes the NLAW disposable and provides the tools for other addons to do the same.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/dragging.md
+++ b/documentation/feature/dragging.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Dragging
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/explosives.md
+++ b/documentation/feature/explosives.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Explosives
+group: feature
+parent: wiki
+---
+# Overview
+## Advanced explosives placement
+Enables more precise placement of explosives.
+## More trigger types
+Offers different trigger types, like clackers and dead man switches.
+## Attack explosives to vehicles
+Enables attaching explosives to vehicles.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/fcs.md
+++ b/documentation/feature/fcs.md
@@ -1,0 +1,21 @@
+---
+layout: wiki
+title: FCS (Fire Control System)
+group: feature
+parent: wiki
+---
+# Overview
+## Fire control system
+Offers a custom fire control system for tanks and helicopters. It enables engaging stationary and moving targets. 
+## Manual lasing targets
+Changes the default rangefinders, including those in vehicles, to require manual lasing.
+## Air burst ammunition
+Anti air cannons can now use airburst ammunition. It will explode on the FCS' zeroed in range.
+
+# Usage
+To engage moving targets, place the crosshair on the enemy vehicle and press and hold tab. Follow the moving target with your crosshair for about 2 seconds and release tab. The optic will now be adjusted sideways to ensure a hit.
+
+To use manual lasing, place the crosshair on the object to range and press and hold tab.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/flashsuppressors.md
+++ b/documentation/feature/flashsuppressors.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Flash Suppressors
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/frag.md
+++ b/documentation/feature/frag.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Frag
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/gforces.md
+++ b/documentation/feature/gforces.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: G-Forces
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/goggles.md
+++ b/documentation/feature/goggles.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Goggles
+group: feature
+parent: wiki
+---
+# Overview
+## Visual Effects for eyewear
+Adds color tint to sunglasses and other eyewear. Causes raindrops to appear on 
+the screen in rain. Causes dirt to appear on the screen when dirt is kicked up
+nearby (e.g. explsions, rotor wash, bullet impacts).
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/grenades.md
+++ b/documentation/feature/grenades.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Grenades
+group: feature
+parent: wiki
+---
+# Overview
+## Throw modes
+Provides different modes for throwing grenades (high throw, precision throw and drop mode).
+## Hand flares
+Adds throwable hand flares in the colors white, red, green and yellow. Additionally buffs existing flares.
+## M84 stun grenade
+Adds stun grenade. This will also affect AI.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/hearing.md
+++ b/documentation/feature/hearing.md
@@ -1,0 +1,19 @@
+---
+layout: wiki
+title: Hearing
+group: feature
+parent: wiki
+---
+# Overview
+## Hearing damage simulation
+Introduces hearing damage caused by nearby explosions and large-caliber weapons.
+## Earplugs
+Adds ear plugs to mitigate that effect. Soldiers with high caliber weapons or 
+missile launchers will be equipped with those, but remember to put them in.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/hitreactions.md
+++ b/documentation/feature/hitreactions.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Hit Reactions
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/interact_menu.md
+++ b/documentation/feature/interact_menu.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Interact Menu
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/interaction.md
+++ b/documentation/feature/interaction.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Interaction
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/inventory.md
+++ b/documentation/feature/inventory.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Inventory
+group: feature
+parent: wiki
+---
+# Overview
+## Resized inventory UI
+Makes the inventory dialog bigger and increases the number of items that can be seen in the list at once.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/javelin.md
+++ b/documentation/feature/javelin.md
@@ -1,13 +1,18 @@
 ---
 layout: wiki
-title: Javelin/Titan Locking and Firing
+title: Javelin
 group: feature
-order: 5
 parent: wiki
 ---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
 
-## 1. Overview
-Blah blah blah
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
 
 Steps to lock titan/Javelin:
 
@@ -17,5 +22,7 @@ Steps to lock titan/Javelin:
 4. Hold TAB over a target, it will start beeping and the constraint boxes will appear
 5. Once the beeping changes to LOCK tone, and the lock crosshairs appear, click fire without releasing tab
 
-
 CTRL+TAB is default key to change firemode (configurable as a key)
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/kestrel4500.md
+++ b/documentation/feature/kestrel4500.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Kestrel 4500
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/laser.md
+++ b/documentation/feature/laser.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Laser
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/laser_selfdesignate.md
+++ b/documentation/feature/laser_selfdesignate.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Laser Self-Designate
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/laserpointer.md
+++ b/documentation/feature/laserpointer.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Laser Pointer
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/logistics_uavbattery.md
+++ b/documentation/feature/logistics_uavbattery.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Logistics - UAV Battery
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/logistics_wirecutter.md
+++ b/documentation/feature/logistics_wirecutter.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Logistics - Wirecutter
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/magazinerepack.md
+++ b/documentation/feature/magazinerepack.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Magazine Repack
+group: feature
+parent: wiki
+---
+# Overview
+## Repacking magazines
+Adds ability to repack magazines of the same type. An optional module provides 
+options to adjust the repacking time of single rounds and whole magazines to 
+the mission maker.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/map.md
+++ b/documentation/feature/map.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Map
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/maptools.md
+++ b/documentation/feature/maptools.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Map Tools
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/markers.md
+++ b/documentation/feature/markers.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Markers
+group: feature
+parent: wiki
+---
+# Overview
+## Improved marker placement
+Expands the "Insert Marker" menu and allows to rotate map markers. Shows the currently selected channel to prevent misplacement.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/microdagr.md
+++ b/documentation/feature/microdagr.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: MicroDAGR
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/missileguidance.md
+++ b/documentation/feature/missileguidance.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Missile Guidance
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/missionmodules.md
+++ b/documentation/feature/missionmodules.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Mission Modules
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/mk6mortar.md
+++ b/documentation/feature/mk6mortar.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Mk6 Mortar
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/movement.md
+++ b/documentation/feature/movement.md
@@ -1,0 +1,24 @@
+---
+layout: wiki
+title: Movement
+group: feature
+parent: wiki
+---
+# Overview
+## Jumping
+Adds the ability to jump when pressing the vault key while moving. (V - key)
+## Minor animation tweaks
+Walking slowly with the weapon lowered now has a less silly looking animation.
+## Fatigue adjustments
+Soldiers get fatigued slower, but regain their stamina slower aswell. Fatigued soldiers have a faster walking speed and no longer turn into snails.
+## Weight display
+Adds a weight of the current loadout display in the inventory to estimate the fatigue gain while moving in combat. Can be adjusted to display lb. instead of kg in the AGM Options Menu.
+## Optics view in all stances
+The player can now use the sights of rifles and pistols in all prone stances.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/nametags.md
+++ b/documentation/feature/nametags.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Nametags
+group: feature
+parent: wiki
+---
+# Overview
+## Nametag and rank display
+Adds nametags and soldier ranks to friendly players in multiplayer. This can be adjusted in the AGM Options Menu to not display the rank, display all nametags of nearby soldiers instead of those who are looked directly at, to require a button press to show the nametags or to disable them altogether.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/nightvision.md
+++ b/documentation/feature/nightvision.md
@@ -1,0 +1,23 @@
+---
+layout: wiki
+title: Nightvision
+group: feature
+parent: wiki
+---
+# Overview
+## Multiple Generation NVGs
+Adds different night vision devices with varying image quality and field of 
+view. New Classnames for Generations 1, 2, and 4 NVGs (default ArmA3 NVGs 
+represents Generation 3) and a wide view NVG.
+## Blending effects
+Adds a blending effect depending on ammunition type when firing while using a 
+night vision device. Especially tracer rounds are bright, but you can use the
+ IR-dim tracers from AGM_Ballistics to reduce tis effect.
+## Brightness adjustment
+Enables the user to manually adjust NVG brightness.
+
+# Usage
+Use Alt+PageUp and Alt+PageDown to adjust NVG brightness.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/noidle.md
+++ b/documentation/feature/noidle.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: No Idle
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/noradio.md
+++ b/documentation/feature/noradio.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: No Radio
+group: feature
+parent: wiki
+---
+# Overview
+## Silent avatar
+Mutes the player's automatic callouts ("Enemy man, 100 meters, front!").
+Does not mute AI callouts.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/norearm.md
+++ b/documentation/feature/norearm.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: No Rearm
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/optics.md
+++ b/documentation/feature/optics.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Optics
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/optionsmenu.md
+++ b/documentation/feature/optionsmenu.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Options Menu
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/ovepressure.md
+++ b/documentation/feature/ovepressure.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Overpressure
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/overheating.md
+++ b/documentation/feature/overheating.md
@@ -1,0 +1,27 @@
+---
+layout: wiki
+title: Overheating
+group: feature
+parent: wiki
+---
+# Overview
+## Weapon Jamming
+Adds a propability to jam a weapon when firing. Jams can be cleared by 
+reloading or by using the clear jam-key.
+## Temperature simulation
+Introduces weapon temperature simulation depending on weapon and bullet
+mass. Hot weapons are more prone to jamming. Depending on weapon type 
+the accuracy and in extreme cases the muzzle velocity might be reduced 
+on high temperatues. Adds smoke puff and heat refraction effects to 
+indicate this.
+## Spare barrels
+Adds the ability to changes barrels on machine guns to compensate for those 
+effects.
+
+# Usage
+To clear a jammed weapon, press Shift+R.
+
+*needs documentation on swapping barrels*
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/parachute.md
+++ b/documentation/feature/parachute.md
@@ -1,0 +1,22 @@
+---
+layout: wiki
+title: Parachute
+group: feature
+parent: wiki
+---
+# Overview
+## Altimeter
+Removes the altitude and descend speed UI elements when free-falling and 
+parachuting on higher difficulties and instead adds an altimeter watch type
+item.
+## Non-steerable parachute
+Adds a non-steerable parachute variant for jet pilots.
+## Landing animation
+Smoothens parachute landing animation.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/protection.md
+++ b/documentation/feature/protection.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Protection
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/ragdolls.md
+++ b/documentation/feature/ragdolls.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Ragdolls
+group: feature
+parent: wiki
+---
+# Overview
+## Adjusted Ragdolls
+Changes the ragdolls to react more to the force of shots and explosions.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/realisticnames.md
+++ b/documentation/feature/realisticnames.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: Realistic Names
+group: feature
+parent: wiki
+---
+# Overview
+## Real names
+Changes the names of vehicles, magazines, weapons, grenades, explosive charges 
+and mines to their respective real-world counterparts whenever possible.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/recoil.md
+++ b/documentation/feature/recoil.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Recoil
+group: feature
+parent: wiki
+---
+# Overview
+## Recoil adjustment
+Overhauls the recoil system reducing upwards recoil.
+## Advanced cam shake
+Introducing camshake when firing on foot or as vehicle gunner depending on stance and weapon type.
+## Burst dispersion
+Firing in longer burst (> 3 rounds per burst) slightly reduces the accuracy. Firing machine guns in bursts is now useful.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/reload.md
+++ b/documentation/feature/reload.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Reload
+group: feature
+parent: wiki
+---
+# Overview
+## Ammo count
+Hides the actual round count of magazines and removes the icon when the current magazine is emptied. The player can instead check the magazine weight, but that gives only estimated values for magazines with more than 10 rounds.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/reloadlaunchers.md
+++ b/documentation/feature/reloadlaunchers.md
@@ -1,0 +1,19 @@
+---
+layout: wiki
+title: Reload Launchers
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.
+r

--- a/documentation/feature/respawn.md
+++ b/documentation/feature/respawn.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Respawn
+group: feature
+parent: wiki
+---
+# Overview
+## Respawn with same gear
+Requires the Respawn Gear module to be placed. Respawned soldiers now have their loadout when killed.
+## Friendly Fire messages
+Shows friendly fire warnings in system chat if the module is placed. Works even in higher difficulties where kill messages are normally disabled.
+## Rallypoints
+Adds rallypoints to all 3 sides to enable teleportation from base spawn to FOBs. Requires some setup from the mission maker.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/safemode.md
+++ b/documentation/feature/safemode.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Safe Mode
+group: feature
+parent: wiki
+---
+# Overview
+## Safety
+You can now use the safety mode of any weapon. Switching weapon modes takes the safety off.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/scopes.md
+++ b/documentation/feature/scopes.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Scopes
+group: feature
+parent: wiki
+---
+# Overview
+## Sniper Scope Adjustment
+Enables snipers to adjust their scopes horizontally and vertically in mils.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/smallarms.md
+++ b/documentation/feature/smallarms.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Small Arms
+group: feature
+parent: wiki
+---
+# Overview
+## Magazine Names
+Unifies the name formatting of magazines similar to Arma 2 standards.
+## No tracers in non-tracer mags
+Assault rifles no longer have tracer rounds in their non-tracer magazines. This doesn't effect the additional tracers in the last rounds of machine gun magazines.
+## Real magazine round counts
+All pistol and sub machine gun magazines now have adjusted capacaties to match their real life counterparts.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/switchunits.md
+++ b/documentation/feature/switchunits.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Switch Units
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/testmissions.md
+++ b/documentation/feature/testmissions.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Test Missions
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/thermals.md
+++ b/documentation/feature/thermals.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Thermals
+group: feature
+parent: wiki
+---
+# Overview
+## Body Warmth
+Adjusts the thermal properties of humans making them less like torches.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/vector.md
+++ b/documentation/feature/vector.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Vector
+group: feature
+parent: wiki
+---
+# Overview
+## Vector IV Rangefinder
+Adds the Vector IV rangefinder, including all real-life usage modes (distance between two points, angle between two points etc.)
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/vehiclelock.md
+++ b/documentation/feature/vehiclelock.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Vehicle Lock
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/vehicles.md
+++ b/documentation/feature/vehicles.md
@@ -1,0 +1,32 @@
+---
+layout: wiki
+title: Vehicles
+group: feature
+parent: wiki
+---
+# Overview
+## Speedlimiter
+Adds ability to limit the max. speed of any vehicle.
+## Engine start delay
+The engine has to be started before the vehicle can move. Starting the engine takes aprox. 1 to 2 seconds.
+## Fuel capacity
+The range of all vehicle gets signifigantly reduced to reflect ranges of their real life counterparts. Scaled down to match the relative short distances in Arma. A full vehicle on mission start should still most likely never need a refueling during a mission.
+## Main gun muzzles
+APCs and Tanks now share a muzzle for all ammunition types of their main guns. This prevents an exploit that skips the reloading time of a round or clip while changing the ammunition type. Also makes it possible to switch between ammunition types using the scroll wheel like in Arma 2.
+## Boat machine gun tracers
+NATO and AAF armed boats now use their respective tracer colours like any vehicle when they fire their rear gun. (Red for BluFor, yellow for Indep)
+## Improved smoke launcher of Fennek (Strider)
+Reduced smoke shell count and launch angle of the AAF Fennek to match the models smoke launcher.
+## Stabilized optic of Fennek (Strider)
+Stabilizes the commander's view in the Fennek (Strider).
+## Vehicle mounted machine guns ROF
+The rate of fire of vehicle mounted miniguns and machine guns is adjusted to match real life values.
+## 120mm gun and mortar behavior
+MBT main guns and mortars can no longer lock on enemies. The AT rounds of both now have raised cost values to encourage the AI to not use those rounds against foot soldiers over their machine guns or HE rounds.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/weaponselect.md
+++ b/documentation/feature/weaponselect.md
@@ -7,13 +7,13 @@ parent: wiki
 # Overview
 ## Weapon select
 The number key can be used to quickly switch between weapons. (1 key - pistol, 2 key - rifle, 3 key - grenade launcher, 4 key - rocket launcher, 5 key - binocular)
-Holster weapon
+## Holster weapon
 Adds the ability to holster a weapon on the back. (0 key)
-Engine select
+## Engine select
 Quickly turn engine on and off (1 key - turn off, 2 key - turn on)
-Weapon select
+## Weapon select
 Quickly switch between vehicle weapons (1-3 key)
-Grenade select
+## Grenade select
 To prevent accidents a grenade has to be selected before it can be thrown. Toggles between explosive and non-explosive grenades. When spamming the throw key, the player won't automatically switch to frag grenades when all smokes are used up. Also shows an indicator to quickly see how many grenades are left when selecting and after throwing (6 key - switch between frag grenades, 7 key - switch between other grenades)
 
 # Usage

--- a/documentation/feature/weaponselect.md
+++ b/documentation/feature/weaponselect.md
@@ -1,0 +1,24 @@
+---
+layout: wiki
+title: Weapon Select
+group: feature
+parent: wiki
+---
+# Overview
+## Weapon select
+The number key can be used to quickly switch between weapons. (1 key - pistol, 2 key - rifle, 3 key - grenade launcher, 4 key - rocket launcher, 5 key - binocular)
+Holster weapon
+Adds the ability to holster a weapon on the back. (0 key)
+Engine select
+Quickly turn engine on and off (1 key - turn off, 2 key - turn on)
+Weapon select
+Quickly switch between vehicle weapons (1-3 key)
+Grenade select
+To prevent accidents a grenade has to be selected before it can be thrown. Toggles between explosive and non-explosive grenades. When spamming the throw key, the player won't automatically switch to frag grenades when all smokes are used up. Also shows an indicator to quickly see how many grenades are left when selecting and after throwing (6 key - switch between frag grenades, 7 key - switch between other grenades)
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/weather.md
+++ b/documentation/feature/weather.md
@@ -1,0 +1,18 @@
+---
+layout: wiki
+title: Weather
+group: feature
+parent: wiki
+---
+# Overview
+## Sub-feature 1
+Short description of sub-feature 1.
+## Sub-feature 2
+Short description of sub-feature 2.
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.

--- a/documentation/feature/windeflection.md
+++ b/documentation/feature/windeflection.md
@@ -1,0 +1,16 @@
+---
+layout: wiki
+title: Wind Deflection
+group: feature
+parent: wiki
+---
+# Overview
+## Wind Deflection
+Adds ballistic influences of wind, air density and temperature
+
+# Usage
+Short overview of how to use the feature, e.g. menu options, key bindings, 
+instructions. May not apply to all modules.
+
+# Dependencies
+List of modules that must be present for this module to work.


### PR DESCRIPTION
Creates placeholder documentation for modules which did not previously
have any. If a module had the same name and apparent purpose as a module
from AGM, AGM's documentation was imported into the placeholder.

These documentation are useful to users for explaining what ACE3
changes. They are also useful to community admins who want to create a
custom distribution of ACE3 and need to know which modules to disable.

The documentation needs to be significantly fleshed out before it's
ready for public consumption, but this should be a helpful start.

I decided to get this started because I maintained a custom version of AGM for my community and wanted to do the same with ACE3, but without module documentation it's hard to know what modules to disable. Moving forward, I'd like to work with the maintainers of each module to get basic documentation for as many modules as possible.