### PR TITLE
Remove outdated references to AGM in documentation

### DIFF
--- a/documentation/feature/ai.md
+++ b/documentation/feature/ai.md
@@ -15,9 +15,9 @@ AIs will now use the automatic mode of their weapons on short distances, instead
 ## Longer engagement ranges
 The maximum engagement ranges are increased: AI will fire in bursts with variable length on high ranges of 500 - 700 meters, depending on their weapon and optic.
 ## No deadzones in CQB
-Some weapons had minimum engagement ranges. If you were as close as 2 meters to an AAF soldier, he wouldn't open fire, because the AI couldn't find any valid fire mode for their weapon. AGM removes this behaviour mostly notable in CQB by adding a valid firing mode.
+Some weapons had minimum engagement ranges. If you were as close as 2 meters to an AAF soldier, he wouldn't open fire, because the AI couldn't find any valid fire mode for their weapon. ACE removes this behaviour mostly notable in CQB by adding a valid firing mode.
 ## No scripting
-All changes of AGM AI are config based to ensure full compatibility with advanced AI modifications like ASR AI.
+All AI changes are config based to ensure full compatibility with advanced AI modifications like ASR AI.
 
 # Usage
 Short overview of how to use the feature, e.g. menu options, key bindings, 

--- a/documentation/feature/ballistics.md
+++ b/documentation/feature/ballistics.md
@@ -10,7 +10,7 @@ Changes include adjusted muzzle velocity, air friction and dispersion based on r
 ## Body armour nerf
 Nerfs protection values of vests, CSAT uniforms and various campaign only gear to more realistic levels comparable to Arma 2 levels.
 ## Realistic silencers and sub-sonic ammunition
-Silencers no longer decrease the muzzle velocity and are generally less effective when used with normal ammunition. They now only remove the muzzle blast and flash. To prevent the crack caused by super sonic projectiles, AGM introduces sub sonic ammunition. This is also fully compatible with AI. Sub sonic ammunition is available for the calibers 5.56mm, 6.5mm and 7.62mm.
+Silencers no longer decrease the muzzle velocity and are generally less effective when used with normal ammunition. They now only remove the muzzle blast and flash. To prevent the crack caused by super sonic projectiles, ACE introduces sub sonic ammunition. This is also fully compatible with AI. Sub sonic ammunition is available for the calibers 5.56mm, 6.5mm and 7.62mm.
 ## Armour piercing ammunition
 Armour piercing rounds have higher penetration values against light armoured targets or other obstacles on the battlefield. Their drawback is a slighly decreased man-stopping power. AP rounds are available for the calibers 5.56mm, 6.5mm and 7.62mm.
 ## IR-Dim tracer ammunition

--- a/documentation/feature/movement.md
+++ b/documentation/feature/movement.md
@@ -12,7 +12,7 @@ Walking slowly with the weapon lowered now has a less silly looking animation.
 ## Fatigue adjustments
 Soldiers get fatigued slower, but regain their stamina slower aswell. Fatigued soldiers have a faster walking speed and no longer turn into snails.
 ## Weight display
-Adds a weight of the current loadout display in the inventory to estimate the fatigue gain while moving in combat. Can be adjusted to display lb. instead of kg in the AGM Options Menu.
+Adds a weight of the current loadout display in the inventory to estimate the fatigue gain while moving in combat. Can be adjusted to display lb. instead of kg in the ACE Options Menu.
 ## Optics view in all stances
 The player can now use the sights of rifles and pistols in all prone stances.
 

--- a/documentation/feature/nametags.md
+++ b/documentation/feature/nametags.md
@@ -6,7 +6,7 @@ parent: wiki
 ---
 # Overview
 ## Nametag and rank display
-Adds nametags and soldier ranks to friendly players in multiplayer. This can be adjusted in the AGM Options Menu to not display the rank, display all nametags of nearby soldiers instead of those who are looked directly at, to require a button press to show the nametags or to disable them altogether.
+Adds nametags and soldier ranks to friendly players in multiplayer. This can be adjusted in the ACE Options Menu to not display the rank, display all nametags of nearby soldiers instead of those who are looked directly at, to require a button press to show the nametags or to disable them altogether.
 
 # Usage
 Short overview of how to use the feature, e.g. menu options, key bindings, 

--- a/documentation/feature/nightvision.md
+++ b/documentation/feature/nightvision.md
@@ -12,7 +12,7 @@ represents Generation 3) and a wide view NVG.
 ## Blending effects
 Adds a blending effect depending on ammunition type when firing while using a 
 night vision device. Especially tracer rounds are bright, but you can use the
- IR-dim tracers from AGM_Ballistics to reduce tis effect.
+ IR-dim tracers from the Ballistics module to reduce tis effect.
 ## Brightness adjustment
 Enables the user to manually adjust NVG brightness.
 


### PR DESCRIPTION
Remove outdated instances of "AGM" in documenation. Thanks to @alganthe for catching this :smile: 