### PR TITLE
Document module dependencies

### DIFF
--- a/addons/medical/functions/fnc_isMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_isMedicalVehicle.sqf
@@ -15,4 +15,4 @@
 private ["_vehicle"];
 _vehicle = _this select 0;
 
-_vehicle getVariable [QGVAR(medicClass), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant") == 1]
+(_vehicle getVariable [QGVAR(medicClass), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant")]) > 0

--- a/documentation/feature/advanced_ballistics.md
+++ b/documentation/feature/advanced_ballistics.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_ballistics`, `ace_weather`, `ace_modules`

--- a/documentation/feature/ai.md
+++ b/documentation/feature/ai.md
@@ -15,9 +15,9 @@ AIs will now use the automatic mode of their weapons on short distances, instead
 ## Longer engagement ranges
 The maximum engagement ranges are increased: AI will fire in bursts with variable length on high ranges of 500 - 700 meters, depending on their weapon and optic.
 ## No deadzones in CQB
-Some weapons had minimum engagement ranges. If you were as close as 2 meters to an AAF soldier, he wouldn't open fire, because the AI couldn't find any valid fire mode for their weapon. AGM removes this behaviour mostly notable in CQB by adding a valid firing mode.
+Some weapons had minimum engagement ranges. If you were as close as 2 meters to an AAF soldier, he wouldn't open fire, because the AI couldn't find any valid fire mode for their weapon. ACE removes this behaviour mostly notable in CQB by adding a valid firing mode.
 ## No scripting
-All changes of AGM AI are config based to ensure full compatibility with advanced AI modifications like ASR AI.
+All AI changes are config based to ensure full compatibility with advanced AI modifications like ASR AI.
 
 # Usage
 Short overview of how to use the feature, e.g. menu options, key bindings, 

--- a/documentation/feature/ai.md
+++ b/documentation/feature/ai.md
@@ -24,4 +24,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/aircraft.md
+++ b/documentation/feature/aircraft.md
@@ -22,4 +22,4 @@ Adds a laser marker to the copilot seat of the Wildcat.
 Adds a HUD to the AH-9 based on the comanches HUD.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/apl.md
+++ b/documentation/feature/apl.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_main`

--- a/documentation/feature/atragmx.md
+++ b/documentation/feature/atragmx.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`, `ace_weather`

--- a/documentation/feature/attach.md
+++ b/documentation/feature/attach.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/backpacks.md
+++ b/documentation/feature/backpacks.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/ballistics.md
+++ b/documentation/feature/ballistics.md
@@ -25,4 +25,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/ballistics.md
+++ b/documentation/feature/ballistics.md
@@ -10,7 +10,7 @@ Changes include adjusted muzzle velocity, air friction and dispersion based on r
 ## Body armour nerf
 Nerfs protection values of vests, CSAT uniforms and various campaign only gear to more realistic levels comparable to Arma 2 levels.
 ## Realistic silencers and sub-sonic ammunition
-Silencers no longer decrease the muzzle velocity and are generally less effective when used with normal ammunition. They now only remove the muzzle blast and flash. To prevent the crack caused by super sonic projectiles, AGM introduces sub sonic ammunition. This is also fully compatible with AI. Sub sonic ammunition is available for the calibers 5.56mm, 6.5mm and 7.62mm.
+Silencers no longer decrease the muzzle velocity and are generally less effective when used with normal ammunition. They now only remove the muzzle blast and flash. To prevent the crack caused by super sonic projectiles, ACE introduces sub sonic ammunition. This is also fully compatible with AI. Sub sonic ammunition is available for the calibers 5.56mm, 6.5mm and 7.62mm.
 ## Armour piercing ammunition
 Armour piercing rounds have higher penetration values against light armoured targets or other obstacles on the battlefield. Their drawback is a slighly decreased man-stopping power. AP rounds are available for the calibers 5.56mm, 6.5mm and 7.62mm.
 ## IR-Dim tracer ammunition

--- a/documentation/feature/captives.md
+++ b/documentation/feature/captives.md
@@ -17,4 +17,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/common.md
+++ b/documentation/feature/common.md
@@ -1,0 +1,13 @@
+---
+layout: wiki
+title: Common
+group: feature
+parent: wiki
+---
+# Overview
+Module that provides common features required by many other modules.
+
+# Dependencies
+`ace_main`
+
+Note: The Common module is required by many other modules. Disabling it is not recommended.

--- a/documentation/feature/difficulties.md
+++ b/documentation/feature/difficulties.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/disarming.md
+++ b/documentation/feature/disarming.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/disposable.md
+++ b/documentation/feature/disposable.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/dragging.md
+++ b/documentation/feature/dragging.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/explosives.md
+++ b/documentation/feature/explosives.md
@@ -17,4 +17,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/fcs.md
+++ b/documentation/feature/fcs.md
@@ -18,4 +18,4 @@ To engage moving targets, place the crosshair on the enemy vehicle and press and
 To use manual lasing, place the crosshair on the object to range and press and hold tab.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/flashsuppressors.md
+++ b/documentation/feature/flashsuppressors.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/frag.md
+++ b/documentation/feature/frag.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/gforces.md
+++ b/documentation/feature/gforces.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/goggles.md
+++ b/documentation/feature/goggles.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/grenades.md
+++ b/documentation/feature/grenades.md
@@ -17,4 +17,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/hearing.md
+++ b/documentation/feature/hearing.md
@@ -16,4 +16,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/hitreactions.md
+++ b/documentation/feature/hitreactions.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/interact_menu.md
+++ b/documentation/feature/interact_menu.md
@@ -15,4 +15,6 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`
+
+Note: The Interact Menu module is required by many other modules. Disabling it is not recommended.

--- a/documentation/feature/interaction.md
+++ b/documentation/feature/interaction.md
@@ -15,4 +15,6 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interact_menu`
+
+Note: The Interaction module is required by many other modules. Disabling it is not recommended.

--- a/documentation/feature/inventory.md
+++ b/documentation/feature/inventory.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/javelin.md
+++ b/documentation/feature/javelin.md
@@ -25,4 +25,4 @@ Steps to lock titan/Javelin:
 CTRL+TAB is default key to change firemode (configurable as a key)
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_main`, `ace_common`, `ace_missileguidance`

--- a/documentation/feature/kestrel4500.md
+++ b/documentation/feature/kestrel4500.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`, `ace_weather`

--- a/documentation/feature/laser.md
+++ b/documentation/feature/laser.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/laser_selfdesignate.md
+++ b/documentation/feature/laser_selfdesignate.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_laser`

--- a/documentation/feature/laserpointer.md
+++ b/documentation/feature/laserpointer.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/logistics_uavbattery.md
+++ b/documentation/feature/logistics_uavbattery.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/logistics_wirecutter.md
+++ b/documentation/feature/logistics_wirecutter.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/magazinerepack.md
+++ b/documentation/feature/magazinerepack.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/main.md
+++ b/documentation/feature/main.md
@@ -10,4 +10,4 @@ Main module which acts as the ACE core module.
 # Dependencies
 Arma 3 and CBA
 
-Note: Note: The Common module is required by all other modules. Do not disable it!
+Note: Note: The Main module is required by all other modules. Do not disable it!

--- a/documentation/feature/main.md
+++ b/documentation/feature/main.md
@@ -1,0 +1,13 @@
+---
+layout: wiki
+title: Main
+group: feature
+parent: wiki
+---
+# Overview
+Main module which acts as the ACE core module.
+
+# Dependencies
+Arma 3 and CBA
+
+Note: Note: The Common module is required by all other modules. Do not disable it!

--- a/documentation/feature/map.md
+++ b/documentation/feature/map.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/maptools.md
+++ b/documentation/feature/maptools.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/markers.md
+++ b/documentation/feature/markers.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/medical-system.md
+++ b/documentation/feature/medical-system.md
@@ -68,3 +68,6 @@ Morphine is used to alleviate large amounts of pain. Has an effect similar to He
 Epinephrine is used to increase heart rate and blood pressure and alleviate unconsciousness. Epinephrine is a synthetic form of Adrenaline, which is naturally produced in the body. It can also be applied to counter-act the effects of Atropine. Be careful though, as it may only be given once.
 
 _Epinephrine must never be given to a casualty with a high heart rate or blood pressure._
+
+# Dependencies
+`ace_interaction`, `ace_modules`, `ace_apl`

--- a/documentation/feature/microdagr.md
+++ b/documentation/feature/microdagr.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/missileguidance.md
+++ b/documentation/feature/missileguidance.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_laser`

--- a/documentation/feature/missionmodules.md
+++ b/documentation/feature/missionmodules.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/mk6mortar.md
+++ b/documentation/feature/mk6mortar.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/movement.md
+++ b/documentation/feature/movement.md
@@ -21,4 +21,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/movement.md
+++ b/documentation/feature/movement.md
@@ -12,7 +12,7 @@ Walking slowly with the weapon lowered now has a less silly looking animation.
 ## Fatigue adjustments
 Soldiers get fatigued slower, but regain their stamina slower aswell. Fatigued soldiers have a faster walking speed and no longer turn into snails.
 ## Weight display
-Adds a weight of the current loadout display in the inventory to estimate the fatigue gain while moving in combat. Can be adjusted to display lb. instead of kg in the AGM Options Menu.
+Adds a weight of the current loadout display in the inventory to estimate the fatigue gain while moving in combat. Can be adjusted to display lb. instead of kg in the ACE Options Menu.
 ## Optics view in all stances
 The player can now use the sights of rifles and pistols in all prone stances.
 

--- a/documentation/feature/nametags.md
+++ b/documentation/feature/nametags.md
@@ -6,7 +6,7 @@ parent: wiki
 ---
 # Overview
 ## Nametag and rank display
-Adds nametags and soldier ranks to friendly players in multiplayer. This can be adjusted in the AGM Options Menu to not display the rank, display all nametags of nearby soldiers instead of those who are looked directly at, to require a button press to show the nametags or to disable them altogether.
+Adds nametags and soldier ranks to friendly players in multiplayer. This can be adjusted in the ACE Options Menu to not display the rank, display all nametags of nearby soldiers instead of those who are looked directly at, to require a button press to show the nametags or to disable them altogether.
 
 # Usage
 Short overview of how to use the feature, e.g. menu options, key bindings, 

--- a/documentation/feature/nametags.md
+++ b/documentation/feature/nametags.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/nightvision.md
+++ b/documentation/feature/nightvision.md
@@ -12,7 +12,7 @@ represents Generation 3) and a wide view NVG.
 ## Blending effects
 Adds a blending effect depending on ammunition type when firing while using a 
 night vision device. Especially tracer rounds are bright, but you can use the
- IR-dim tracers from AGM_Ballistics to reduce tis effect.
+ IR-dim tracers from the Ballistics module to reduce tis effect.
 ## Brightness adjustment
 Enables the user to manually adjust NVG brightness.
 

--- a/documentation/feature/nightvision.md
+++ b/documentation/feature/nightvision.md
@@ -20,4 +20,4 @@ Enables the user to manually adjust NVG brightness.
 Use Alt+PageUp and Alt+PageDown to adjust NVG brightness.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/noidle.md
+++ b/documentation/feature/noidle.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/noradio.md
+++ b/documentation/feature/noradio.md
@@ -14,4 +14,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/norearm.md
+++ b/documentation/feature/norearm.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/optics.md
+++ b/documentation/feature/optics.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/optionsmenu.md
+++ b/documentation/feature/optionsmenu.md
@@ -15,4 +15,6 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`
+
+Note: The Options Menu module is utilized by many other modules. Disabling it is not recommended.

--- a/documentation/feature/overheating.md
+++ b/documentation/feature/overheating.md
@@ -24,4 +24,4 @@ To clear a jammed weapon, press Shift+R.
 *needs documentation on swapping barrels*
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/overpressure.md
+++ b/documentation/feature/overpressure.md
@@ -1,6 +1,6 @@
 ---
 layout: wiki
-title: Weather
+title: Overpressure
 group: feature
 parent: wiki
 ---
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-`ace_common`, `ace_modules`
+`ace_common`

--- a/documentation/feature/parachute.md
+++ b/documentation/feature/parachute.md
@@ -19,4 +19,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/protection.md
+++ b/documentation/feature/protection.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/ragdolls.md
+++ b/documentation/feature/ragdolls.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/realisticnames.md
+++ b/documentation/feature/realisticnames.md
@@ -14,4 +14,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/recoil.md
+++ b/documentation/feature/recoil.md
@@ -17,4 +17,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/reload.md
+++ b/documentation/feature/reload.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/reloadlaunchers.md
+++ b/documentation/feature/reloadlaunchers.md
@@ -15,5 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
-r
+`ace_interaction`

--- a/documentation/feature/respawn.md
+++ b/documentation/feature/respawn.md
@@ -17,4 +17,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/safemode.md
+++ b/documentation/feature/safemode.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/scopes.md
+++ b/documentation/feature/scopes.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/smallarms.md
+++ b/documentation/feature/smallarms.md
@@ -17,4 +17,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/switchunits.md
+++ b/documentation/feature/switchunits.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/testmissions.md
+++ b/documentation/feature/testmissions.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/thermals.md
+++ b/documentation/feature/thermals.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/vector.md
+++ b/documentation/feature/vector.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/vehiclelock.md
+++ b/documentation/feature/vehiclelock.md
@@ -15,4 +15,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_interaction`

--- a/documentation/feature/vehicles.md
+++ b/documentation/feature/vehicles.md
@@ -29,4 +29,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/weaponselect.md
+++ b/documentation/feature/weaponselect.md
@@ -21,4 +21,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_common`

--- a/documentation/feature/windeflection.md
+++ b/documentation/feature/windeflection.md
@@ -13,4 +13,4 @@ Short overview of how to use the feature, e.g. menu options, key bindings,
 instructions. May not apply to all modules.
 
 # Dependencies
-List of modules that must be present for this module to work.
+`ace_weather`


### PR DESCRIPTION
* Add module dependencies to feature docs (macro'ed copy and paste job from each modules config.cpp). 

* Adds a note to the documentation on Main, Common, Options Menu, Interact Menu and Interaction recommending against disabling those modules.

* Add a missing placeholder doc for the Overpressure module.

This helps users who want to maintain a custom distribution of ACE3 by helping them determine which modules are safe to disable.

Depends on #1152.