### PR TITLE
Fixed: Safe mode Italian translation

### DIFF
--- a/addons/safemode/stringtable.xml
+++ b/addons/safemode/stringtable.xml
@@ -34,7 +34,7 @@
             <Hungarian>Biztonsági kapcsoló helyretolása</Hungarian>
             <Russian>Поставить на предохранитель</Russian>
             <French>Sécurité mise</French>
-            <Italian>Metti la sicura</Italian>
+            <Italian>Sicura inserita</Italian>
             <Portuguese>Colocar Segurança</Portuguese>
         </Key>
         <Key ID="STR_ACE_SafeMode_TookOffSafety">


### PR DESCRIPTION
Safety message was wrong: it was indicating the action, not the status.