### PR TITLE
Litter distribution fix and "floating litter over water" fix (medical)

### DIFF
--- a/addons/medical/functions/fnc_createLitter.sqf
+++ b/addons/medical/functions/fnc_createLitter.sqf
@@ -38,12 +38,18 @@ _litter = getArray (_config >> "litter");
 
 _createLitter = {
     private["_position", "_litterClass", "_direction"];
-    _position = getPos (_this select 0);
+    
+    // @TODO: handle carriers over water
+    // For now, don't spawn litter if we are over water to avoid floating litter
+    if(surfaceIsWater (getPos (_this select 0))) exitWith { false };
+    
+    _position = getPosATL (_this select 0);
+    _position = [_position select 0, _position select 1, 0];
     _litterClass = _this select 1;
     if (random(1) >= 0.5) then {
-        _position = [(_position select 0) + random 2, (_position select 1) + random 2, _position select 2];
+        _position = [(_position select 0) + random 1, (_position select 1) + random 1, _position select 2];
     } else {
-       _position =  [(_position select 0) - random 2, (_position select 1) - random 2, _position select 2];
+       _position =  [(_position select 0) - random 1, (_position select 1) - random 1, _position select 2];
     };
     _direction = (random 360);
 

--- a/addons/medical/functions/fnc_handleCreateLitter.sqf
+++ b/addons/medical/functions/fnc_handleCreateLitter.sqf
@@ -14,7 +14,10 @@ if (isNil QGVAR(allCreatedLitter)) then {
 
 _litterObject = _litterClass createVehicleLocal _position;
 _litterObject setDir _direction;
-
+_litterObject setPosATL _position;
+// Move the litter next frame to get rid of HORRIBLE spacing, fixes #1112
+[{ (_this select 0) setPosATL (_this select 1); }, [_litterObject, _position], 0, 0] call EFUNC(common,waitAndExecute);
+    
 _maxLitterCount = getArray (configFile >> "ACE_Settings" >> QGVAR(litterSimulationDetail) >> "_values") select GVAR(litterSimulationDetail); 
 if((count GVAR(allCreatedLitter)) > _maxLitterCount ) then {
     // gank the first litter object, and spawn ours.

--- a/addons/medical/functions/fnc_handleCreateLitter.sqf
+++ b/addons/medical/functions/fnc_handleCreateLitter.sqf
@@ -16,7 +16,7 @@ _litterObject = _litterClass createVehicleLocal _position;
 _litterObject setDir _direction;
 _litterObject setPosATL _position;
 // Move the litter next frame to get rid of HORRIBLE spacing, fixes #1112
-[{ (_this select 0) setPosATL (_this select 1); }, [_litterObject, _position], 0, 0] call EFUNC(common,waitAndExecute);
+[{ (_this select 0) setPosATL (_this select 1); }, [_litterObject, _position]] call EFUNC(common,execNextFrame);
     
 _maxLitterCount = getArray (configFile >> "ACE_Settings" >> QGVAR(litterSimulationDetail) >> "_values") select GVAR(litterSimulationDetail); 
 if((count GVAR(allCreatedLitter)) > _maxLitterCount ) then {


### PR DESCRIPTION
Fixed: Litter spawning at huge radius because createVehicleLocal was moving it on initial spawn. Added a single move on spawn, plus another on the next frame to cover collision issues.

Fixed: Litter spawned over water on carriers or other wierd places caused floating magical litter.

 Fixes #1112