### PR TITLE
Inherited ACE_Actions class compile improvements

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -30,8 +30,8 @@ _recurseFnc = {
     EXPLODE_1_PVT(_this,_actionsCfg);
     _actions = [];
 
-    for "_i" from 0 to (count _actionsCfg) - 1 do {
-        _entryCfg = _actionsCfg select _i;
+    {
+        _entryCfg = _x;
         if(isClass _entryCfg) then {
             _displayName = getText (_entryCfg >> "displayName");
             _distance = getNumber (_entryCfg >> "distance");
@@ -90,7 +90,7 @@ _recurseFnc = {
                     ];
             _actions pushBack _entry;
         };
-    };
+    } forEach ([_actionsCfg, 0, true, true] call BIS_fnc_returnChildren);
     _actions
 };
 

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -31,8 +31,8 @@ _recurseFnc = {
     EXPLODE_1_PVT(_this,_actionsCfg);
     _actions = [];
 
-    for "_i" from 0 to (count _actionsCfg) - 1 do {
-        _entryCfg = _actionsCfg select _i;
+    {
+        _entryCfg = _x;
         if(isClass _entryCfg) then {
             _displayName = getText (_entryCfg >> "displayName");
 
@@ -74,7 +74,7 @@ _recurseFnc = {
                     ];
             _actions pushBack _entry;
         };
-    };
+    } forEach ([_actionsCfg, 0, true, true] call BIS_fnc_returnChildren);
     _actions
 };
 


### PR DESCRIPTION
Compile actions & self actions menu with BIS_fnc_returnChildren function which returns inherited ACE_Actions class with ACE_MainActions subclass.
For example:
```
class CfgVehicles {
	class StaticWeapon;
	class StaticMGWeapon: StaticWeapon {
		class ACE_Actions;
	};
	class rhs_nsv_tripod_base: StaticMGWeapon
	{
		class ACE_SelfActions: ACE_SelfActions {
			class HMG_LoadAmmo {
				displayName = "Load Ammo";
				distance = 2;
				condition = "true";
				icon = "\x\hmg\addons\staticLoad\Resources\icon_reload.paa";
				selection = "otocHlaven";
				insertChildren = "_this call HMG_StaticLoad_fnc_StaticCreateChildActions";
			};
			class ACE_MainActions;
		};
	};
};
```
Now, with this code you can create additional menu for rhs_nsv_tripod_base class (and child classes) only without ACE_MainActions class loss.