### PR TITLE
UserSetting to swap optic modes

### DIFF
--- a/addons/optics/CfgWeapons.hpp
+++ b/addons/optics/CfgWeapons.hpp
@@ -253,6 +253,7 @@ class CfgWeapons {
     };
 
     class optic_LRPS: ItemCore {
+        GVAR(switchableTo)[] = {"optic_LRPS", "ACE_optic_LRPS_2D", "ACE_optic_LRPS_PIP"};
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class Snip;
@@ -261,6 +262,8 @@ class CfgWeapons {
     };
 
     class ACE_optic_LRPS_2D: optic_LRPS {
+        GVAR(switchableTo)[] = {"optic_LRPS", "ACE_optic_LRPS_2D", "ACE_optic_LRPS_PIP"};
+        
         GVAR(BodyDay) = QUOTE(PATHTOF(reticles\sos-body_ca.paa));
         GVAR(BodyNight) = QUOTE(PATHTOF(reticles\sos-bodyNight_ca.paa));
         GVAR(ReticleDay) = QUOTE(PATHTOF(reticles\sos-reticleMLR_ca.paa));
@@ -288,6 +291,8 @@ class CfgWeapons {
     };
 
     class ACE_optic_LRPS_PIP: ACE_optic_LRPS_2D {
+        GVAR(switchableTo)[] = {"optic_LRPS", "ACE_optic_LRPS_2D", "ACE_optic_LRPS_PIP"};
+        
         author = "$STR_ACE_Common_ACETeam";
         _generalMacro = "ACE_optic_LRPS_PIP";
         //scopeArsenal = 1;

--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -38,3 +38,25 @@ if (!hasInterface) exitWith {};
         GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
     };
 }] call EFUNC(common,addEventHandler);
+
+DFUNC(updateOptics) = {
+    if ((isNull ACE_player) || {!alive ACE_player} || {GVAR(prefferedOpticType) == 0}) exitWith {};
+
+    _currentScope = (primaryWeaponItems ACE_player) select 2;
+    if (_currentScope == "") exitWith {};
+
+    _configs = configProperties [configFile >> "CfgWeapons" >> _currentScope, QUOTE(configName _x == QUOTE(QGVAR(switchableTo))), false];
+    if ((count _configs) != 1) exitWith {};
+    _switchableToArray = getArray (_configs select 0);
+
+    if ((GVAR(prefferedOpticType) - 1) > (count _switchableToArray)) exitWith {};
+    _preferedScope = _switchableToArray select (GVAR(prefferedOpticType) - 1);
+
+    if ((_currentScope == _preferedScope) || {_preferedScope == ""}) exitWith {};
+
+    ACE_player removePrimaryWeaponItem _currentScope;
+    ACE_player addPrimaryWeaponItem _preferedScope;
+};
+
+["playerInventoryChanged", DFUNC(updateOptics)] call EFUNC(common,addEventHandler);
+["SettingChanged", {if ((_this select 0) == QGVAR(prefferedOpticType)) then {[] call FUNC(updateOptics)};}] call EFUNC(common,addEventhandler);

--- a/addons/optics/config.cpp
+++ b/addons/optics/config.cpp
@@ -32,3 +32,14 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 
 #include "CfgPreloadTextures.hpp"
+
+class ACE_Settings {
+    class GVAR(prefferedOpticType) {
+        value = 0;
+        typeName = "SCALAR";
+        isClientSettable = 1;
+        displayName = "Prefered Optic Type";
+        description = "For those optics that support switching";
+        values[] = {"Don't change", "3d (vanilla)", "2d", "PIP"};
+    };
+};


### PR DESCRIPTION
@commy2 

for feature request:
>Instead of having both PIP and 2D scopes, the 2D scope should have optional PIP functionality, which you can turn on or off in the ACE settings menu. There's no need to have both.

Just an rough draft of an idea I had to allow the user to switch between optics in the same "family"; similar to how laser_pointers switching works.