### PR TITLE
Medical Vitals Fixes

### DIFF
--- a/addons/medical/functions/fnc_addToInjuredCollection.sqf
+++ b/addons/medical/functions/fnc_addToInjuredCollection.sqf
@@ -29,7 +29,7 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
     [{
         private ["_unit", "_interval"];
         _unit = (_this select 0) select 0;
-        _interval = time - (_this select 0) select 1;
+        _interval = time - ((_this select 0) select 1);
         (_this select 0) set [1, time];
         
         if (!alive _unit || !local _unit) then {

--- a/addons/medical/functions/fnc_addToInjuredCollection.sqf
+++ b/addons/medical/functions/fnc_addToInjuredCollection.sqf
@@ -29,7 +29,7 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
     [{
         private ["_unit", "_lastTime"];
         _unit = (_this select 0) select 0;
-        _interval = time - ((_this select 0) select 1);
+        _interval = time - (_this select 0) select 1;
         (_this select 0) set [1, time];
         
         if (!alive _unit || !local _unit) then {

--- a/addons/medical/functions/fnc_addToInjuredCollection.sqf
+++ b/addons/medical/functions/fnc_addToInjuredCollection.sqf
@@ -27,8 +27,11 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
     _unit setvariable [QGVAR(addedToUnitLoop), true, true];
 
     [{
-        private "_unit";
+        private ["_unit", "_lastTime"];
         _unit = (_this select 0) select 0;
+        _interval = time - ((_this select 0) select 1);
+        (_this select 0) set [1, time];
+        
         if (!alive _unit || !local _unit) then {
            [_this select 1] call CBA_fnc_removePerFrameHandler;
            if (!local _unit) then {
@@ -39,7 +42,7 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
                 _unit setvariable [QGVAR(bloodVolume), _unit getvariable [QGVAR(bloodVolume), 100], true];
            };
         } else {
-            [_unit] call FUNC(handleUnitVitals);
+            [_unit, _interval] call FUNC(handleUnitVitals);
 
             private "_pain";
             _pain = _unit getvariable [QGVAR(pain), 0];
@@ -51,5 +54,5 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
                 [_unit, _pain] call FUNC(playInjuredSound);
             };
         };
-    }, 1, [_unit]] call CBA_fnc_addPerFrameHandler;
+    }, 1, [_unit, time]] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/medical/functions/fnc_addToInjuredCollection.sqf
+++ b/addons/medical/functions/fnc_addToInjuredCollection.sqf
@@ -27,7 +27,7 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
     _unit setvariable [QGVAR(addedToUnitLoop), true, true];
 
     [{
-        private ["_unit", "_lastTime"];
+        private ["_unit", "_interval"];
         _unit = (_this select 0) select 0;
         _interval = time - (_this select 0) select 1;
         (_this select 0) set [1, time];

--- a/addons/medical/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical/functions/fnc_handleUnitVitals.sqf
@@ -13,11 +13,14 @@
 
 #include "script_component.hpp"
 
-private ["_unit", "_heartRate","_bloodPressure","_bloodVolume","_painStatus", "_lastTimeValuesSynced", "_syncValues", "_airwayStatus", "_blood", "_bloodPressureH", "_bloodPressureL", "_interval"];
+private ["_unit", "_heartRate","_bloodPressure","_bloodVolume","_painStatus", "_lastTimeValuesSynced", "_syncValues", "_airwayStatus", "_blood", "_bloodPressureH", "_bloodPressureL", "_interval", "_lastMomentVitalsHandled"];
 _unit = _this select 0;
 
-_interval = time - (_unit getVariable [QGVAR(lastMomentVitalsHandled), 0]);
+_lastMomentVitalsHandled = _unit getVariable [QGVAR(lastMomentVitalsHandled), -1];
 _unit setVariable [QGVAR(lastMomentVitalsHandled), time];
+
+//If QGVAR(lastMomentVitalsHandled) is undefined then assume 1 second interval:
+_interval = if (_lastMomentVitalsHandled == -1) then {1} else {time - _lastMomentVitalsHandled};
 
 if (_interval == 0) exitWith {};
 

--- a/addons/medical/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical/functions/fnc_handleUnitVitals.sqf
@@ -13,14 +13,9 @@
 
 #include "script_component.hpp"
 
-private ["_unit", "_heartRate","_bloodPressure","_bloodVolume","_painStatus", "_lastTimeValuesSynced", "_syncValues", "_airwayStatus", "_blood", "_bloodPressureH", "_bloodPressureL", "_interval", "_lastMomentVitalsHandled"];
+private ["_unit", "_heartRate","_bloodPressure","_bloodVolume","_painStatus", "_lastTimeValuesSynced", "_syncValues", "_airwayStatus", "_blood", "_bloodPressureH", "_bloodPressureL", "_interval"];
 _unit = _this select 0;
-
-_lastMomentVitalsHandled = _unit getVariable [QGVAR(lastMomentVitalsHandled), -1];
-_unit setVariable [QGVAR(lastMomentVitalsHandled), time];
-
-//If QGVAR(lastMomentVitalsHandled) is undefined then assume 1 second interval:
-_interval = if (_lastMomentVitalsHandled == -1) then {1} else {time - _lastMomentVitalsHandled};
+_interval = _this select 1;
 
 if (_interval == 0) exitWith {};
 

--- a/addons/medical/functions/fnc_treatment_success.sqf
+++ b/addons/medical/functions/fnc_treatment_success.sqf
@@ -55,3 +55,8 @@ if (isNil _callback) then {
 _args call _callback;
 
 _args call FUNC(createLitter);
+
+//If we're not already tracking vitals, start:
+if (!(_target getvariable [QGVAR(addedToUnitLoop),false])) then {
+    [_target] call FUNC(addToInjuredCollection);
+};


### PR DESCRIPTION
Fixes two related problems with medical:

In handleUnitVitals, _interval is calculated by:
`_interval = time - (_unit getVariable [QGVAR(lastMomentVitalsHandled), 0]);`
so on first run it could be >100000; so all the effects multiplied by interval time will be wrong.  If a player has injected a morphine, the first time handleUnitVitals is run it will stop their heart:

example (inject morphine, wait a minute, shoot in foot):
```
_interval 78.128
(([_unit] call FUNC(getHeartRateChange)) * _interval) = -61.9465
_interval 1.009
(([_unit] call FUNC(getHeartRateChange)) * _interval) = 0
_interval 1.084
(([_unit] call FUNC(getHeartRateChange)) * _interval) = 0
```

Both medical levels are effected by this, but it's a bigger problem on advanced.

The other, minor problem is that handleUnitVital only starts being called after taking damage.  If a player takes medication prior to battle (I think) it should start effecting their vitals right away.  This starts tracking after any treatment success. 