### PR TITLE
ASDG- Fail gracefully if attachments not compatible

### DIFF
--- a/addons/laserpointer/XEH_postInit.sqf
+++ b/addons/laserpointer/XEH_postInit.sqf
@@ -4,6 +4,12 @@
 // fixes laser when being captured. Needed, because the selectionpsoition of the right hand is used
 ["SetHandcuffed", {if (_this select 1) then {(_this select 0) action ["GunLightOff", _this select 0]};}] call EFUNC(common,addEventHandler);
 
+//If user has ASDG JR without the compat patch, then ace's' laser pointers won't be compatible with anything
+if ((isClass (configFile >> "CfgPatches" >> "asdg_jointrails")) && {!(isClass (configFile >> "CfgPatches" >> "ace_asdg_comp"))}) then {
+    diag_log text format ["[ACE_laserpointer] - ASDG Joint Rails but no ace_asdg_comp"];
+};
+
+
 if !(hasInterface) exitWith {};
 
 GVAR(nearUnits) = [];

--- a/addons/laserpointer/functions/fnc_switchLaserLightMode.sqf
+++ b/addons/laserpointer/functions/fnc_switchLaserLightMode.sqf
@@ -1,7 +1,7 @@
 // by commy2
 #include "script_component.hpp"
 
-private ["_unit", "_weapon"];
+private ["_unit", "_weapon", "_error"];
 
 _unit = _this select 0;
 _weapon = _this select 1;
@@ -44,21 +44,41 @@ private ["_description", "_picture"];
 
 _description = getText (configFile >> "CfgWeapons" >> _nextPointer >> "ACE_modeDescription");
 _picture = getText (configFile >> "CfgWeapons" >> _nextPointer >> "picture");
+_error = false;
 
 switch (_currentWeaponType) do {
-	case 1: {
-		_unit removePrimaryWeaponItem _pointer;
-		_unit addPrimaryWeaponItem _nextPointer;
-	};
-	case 2: {
-		_unit removeSecondaryWeaponItem _pointer;
-		_unit addSecondaryWeaponItem _nextPointer;
-	};
-	case 3: {
-		_unit removeHandgunItem _pointer;
-		_unit addHandgunItem _nextPointer;
-	};
+    case 1: {
+        _unit removePrimaryWeaponItem _pointer;
+        _unit addPrimaryWeaponItem _nextPointer;
+        if (((primaryWeaponItems _unit) select 1) != _nextPointer) then {
+            ERROR("NextPointer not compatible");
+            _unit addPrimaryWeaponItem _pointer;
+            _error = true;
+        };
+    };
+    case 2: {
+        _unit removeSecondaryWeaponItem _pointer;
+        _unit addSecondaryWeaponItem _nextPointer;
+        if (((secondaryWeaponItems _unit) select 1) != _nextPointer) then {
+            ERROR("NextPointer not compatible");
+            _unit addSecondaryWeaponItem _pointer;
+            _error = true;
+        };
+    };
+    case 3: {
+        _unit removeHandgunItem _pointer;
+        _unit addHandgunItem _nextPointer;
+        if (((handgunItems _unit) select 1) != _nextPointer) then {
+            ERROR("NextPointer not compatible");
+            _unit addHandgunItem _pointer;
+            _error = true;
+        };
+    };
 };
 
-[_description, _picture] call EFUNC(common,displayTextPicture);
+if (!_error) then {
+    [_description, _picture] call EFUNC(common,displayTextPicture);
+} else {
+    diag_log text format ["Failed to add %1 to %2 - reverting to %3", _nextPointer, _weapon, _pointer];
+};
 playSound "ACE_Sound_Click";

--- a/optionals/compat_asdg/config.cpp
+++ b/optionals/compat_asdg/config.cpp
@@ -17,6 +17,7 @@ class asdg_FrontSideRail: asdg_SlotInfo {
     class compatibleItems {
         ACE_acc_pointer_red = 1;
         ACE_acc_pointer_green = 1;
+        ACE_acc_pointer_green_IR = 1;
     };
 };
 


### PR DESCRIPTION
To reproduce: run @ASDG without the ace_asdg_comp - hit ctrl-L, laser pointer is gone.

ASDG messes with `PointerSlot` and compatible items.
If a user has ASDG installed without our compatibilty patch, then it seems like none of our ACE_x attachements will work on weapons.

With laser pointers, on switch we delete the current and then add the new laser.  If that new laser isn't compatible then it won't get added and the user will have nothing.

This dumps several error messages in the RPT and if the `ACE_nextModeClass` doesn't get added then it reverts back to the current so nothing is lost.