### PR TITLE
Added steps I had to do for windows to make ace3

### DIFF
--- a/documentation/development/setting-up-the-development-environment.md
+++ b/documentation/development/setting-up-the-development-environment.md
@@ -18,7 +18,7 @@ This page describes how you can setup your development environment for ACE3, all
 - Run ArmA 3 and Arma 3 Tools directly from steam once to install registry entries (and again after every update)
 - Python 3.x, available [here](http://www.python.org)
 - The following Mikero Tools (available [here](https://dev.withsix.com/projects/mikero-pbodll/files)): DePBO, DeOgg, Rapify, MakePBO, PBOProject
-- A properly setup PATH variable (containing Python ,the Mikero tools and Github if you are using it)
+- A properly setup PATH variable (containing Python ,the Mikero tools and git)
 
 
 ## 2. Why so complicated?

--- a/documentation/development/setting-up-the-development-environment.md
+++ b/documentation/development/setting-up-the-development-environment.md
@@ -17,8 +17,8 @@ This page describes how you can setup your development environment for ACE3, all
 - A properly setup P-drive
 - Run ArmA 3 and Arma 3 Tools directly from steam once to install registry entries (and again after every update)
 - Python 3.x, available [here](http://www.python.org)
-- The following Mikero Tools (available [here](https://dev.withsix.com/projects/mikero-pbodll/files)): DePBO, Rapify, MakePBO, PBOProject
-- A properly setup PATH variable (containing Python and the Mikero tools)
+- The following Mikero Tools (available [here](https://dev.withsix.com/projects/mikero-pbodll/files)): DePBO, DeOgg, Rapify, MakePBO, PBOProject
+- A properly setup PATH variable (containing Python ,the Mikero tools and Github if you are using it)
 
 
 ## 2. Why so complicated?


### PR DESCRIPTION
Just a little addition to the setup which I had to perform to get the make.py to run.
* First problem was the PATH variable for git.exe was missing
* Then the make.py was complaining about DeOgg missing

The setup.py went through without a problem and I don't know why I had to add the path to git.exe (in AppData/Local/GitHub/PortableGit_{GUID}/cmd and ../bin), I did clone it (with the Git Shell since the application broke anyway).