### PR TITLE
Finalize port of all extensions for cross-platform builds

### DIFF
--- a/extensions/advanced_ballistics/AdvancedBallistics.cpp
+++ b/extensions/advanced_ballistics/AdvancedBallistics.cpp
@@ -82,7 +82,7 @@ double calculateRoughnessLength(double posX, double posY) {
             return 1.6;
         }
 
-        return roughness_lengths[2 + min(nearBuildings, 6)];
+        return roughness_lengths[2 + std::min(nearBuildings, 6)];
     }
 
     return 0.0024;
@@ -230,7 +230,7 @@ double calculateRetard(int DragFunction, double DragCoefficient, double Velocity
 
 extern "C"
 {
-    __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+   EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
 }
 
 void __stdcall RVExtension(char *output, int outputSize, const char *function)

--- a/extensions/break_line/ace_break_line.cpp
+++ b/extensions/break_line/ace_break_line.cpp
@@ -20,7 +20,7 @@
 #define MAXCHARACTERS 14
 
 extern "C" {
-    __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+    EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
 };
 
 std::vector<std::string> splitString(const std::string & input) {

--- a/extensions/clipboard/ace_clipboard.cpp
+++ b/extensions/clipboard/ace_clipboard.cpp
@@ -14,7 +14,7 @@
 #include <string>
 
 extern "C" {
-    __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+    EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
 };
 
 std::string gClipboardData;

--- a/extensions/common/p3d/animation.cpp
+++ b/extensions/common/p3d/animation.cpp
@@ -2,7 +2,6 @@
 
 #include "p3d/animation.hpp"
 #include "read_helpers.hpp"
-#include "..\simulation\object.hpp"
 
 namespace ace {
     namespace p3d {

--- a/extensions/common/p3d/compressed.cpp
+++ b/extensions/common/p3d/compressed.cpp
@@ -1,5 +1,7 @@
 #include "compressed.hpp"
 
+#include <memory>
+
 #include <limits.h>
 #include <stddef.h>
 #include <limits.h>
@@ -41,11 +43,7 @@ namespace ace {
             if (in.eof()) {
                 in.clear();
             }
-#if _MSC_VER == 1800
-            _data = std::make_shared<uint8_t[]>(expected_size + (expected_size % 8));
-#else
-            _data = std::make_unique<uint8_t[]>(expected_size + (expected_size % 8));
-#endif
+            _data = std::unique_ptr<uint8_t[]>(new uint8_t[expected_size + (expected_size % 8)]);
 
             result = _mikero_lzo1x_decompress_safe(buffer, _data.get(), expected_size);
             if (result < 0) {

--- a/extensions/common/p3d/compressed.hpp
+++ b/extensions/common/p3d/compressed.hpp
@@ -37,34 +37,34 @@ namespace ace {
             compressed() { }
             compressed(std::istream &stream_, bool compressed_ = false, bool fill_ = false, uint32_t version = 68) 
             {
-                stream_.read((char *)&size, sizeof(uint32_t));
+                stream_.read((char *)&this->size, sizeof(uint32_t));
                  
                // if(version <)
                 if(fill_)
-                    READ_BOOL(fill);
+                    READ_BOOL(this->fill);
 
-                assert(size < 4095 * 10);
-                if (size > 0) {
-                    if (fill) {
+                assert(this->size < 4095 * 10);
+                if (this->size > 0) {
+                    if (this->fill) {
                         T val;
                         stream_.read((char *)&val, sizeof(T));
-                        for (int x = 0; x < size; x++) {
-                            data.push_back(val);
+                        for (int x = 0; x < this->size; x++) {
+                            this->data.push_back(val);
                         }
                     }  else {
                         if (version >= 64 && compressed_) {
-                            READ_BOOL(flag);
+                            READ_BOOL(this->flag);
                         }
-                        if ( (size * sizeof(T) >= 1024 && compressed_  && version < 64) || (flag && compressed_)) {
-                            int32_t result = _decompress_safe(stream_, size * sizeof(T));
+                        if ( (this->size * sizeof(T) >= 1024 && compressed_  && version < 64) || (this->flag && compressed_)) {
+                            int32_t result = this->_decompress_safe(stream_, this->size * sizeof(T));
                             assert(result > 0);
-                            T * ptr = (T *)(_data.get());
-                            data.assign(ptr, ptr + size );
+                            T * ptr = (T *)(this->_data.get());
+                            this->data.assign(ptr, ptr + this->size );
                         } else {
-                            for (int x = 0; x < size; x++) { 
+                            for (int x = 0; x < this->size; x++) { 
                                 T val;
                                 stream_.read((char *)&val, sizeof(T));
-                                data.push_back(val);
+                                this->data.push_back(val);
                             }
                         }
                     }

--- a/extensions/common/pbo/archive.cpp
+++ b/extensions/common/pbo/archive.cpp
@@ -16,7 +16,7 @@ namespace ace {
             std::streampos _save = stream_.tellg();
             file_offset = begin_data_offset + entry->offset;
           
-            use_size = max(entry->size, entry->storage_size);
+            use_size = std::max(entry->size, entry->storage_size);
             output->data = new uint8_t[use_size];
 
             bytes_read = 0;

--- a/extensions/common/pbo/search.cpp
+++ b/extensions/common/pbo/search.cpp
@@ -1,3 +1,5 @@
+#ifdef _WIN32
+
 #include "search.hpp"
 #include <sstream>
 #include <iterator>
@@ -299,3 +301,5 @@ namespace ace {
         }
     }
 }
+
+#endif

--- a/extensions/common/pbo/search.hpp
+++ b/extensions/common/pbo/search.hpp
@@ -1,3 +1,5 @@
+#ifdef _WIN32
+
 #pragma once
 
 #include "shared.hpp"
@@ -25,3 +27,5 @@ namespace ace {
         typedef std::shared_ptr<search> search_p;
     }
 }
+
+#endif

--- a/extensions/common/shared.hpp
+++ b/extensions/common/shared.hpp
@@ -3,6 +3,8 @@
 #include "targetver.h"
 #include <assert.h>
 #include <stdio.h>
+#include <math.h>
+
 #include <string>
 #include <vector>
 #include <list>
@@ -23,8 +25,11 @@
 #define EXTENSION_RETURN() return;
 #endif
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #define sleep(x) Sleep(x)
+#else
+#define _strdup strdup
+#define strtok_s strtok_r
 #endif
 
 namespace ace {
@@ -39,6 +44,11 @@ namespace ace {
 
     std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems);
     std::vector<std::string> split(const std::string &s, char delim);
+
+    template<typename T, typename... Args>
+    std::unique_ptr<T> make_unique(Args&&... args) {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
 
     // trim from start
     static inline std::string &ltrim(std::string &s) {
@@ -74,4 +84,23 @@ namespace ace {
 #define ACE_ASSERT assert()
 #else
 #define ACE_ASSERT ace::runtime_assert()
+#endif
+
+#ifndef _WIN32
+#define __stdcall 
+#endif
+
+#if defined(_MSC_VER)
+    //  Microsoft 
+    #define EXPORT __declspec(dllexport)
+    #define IMPORT __declspec(dllimport)
+#elif defined(_GCC)
+    //  GCC
+    #define EXPORT __attribute__((visibility("default")))
+    #define IMPORT
+#else
+    //  do nothing and hope for the best?
+    #define EXPORT
+    #define IMPORT
+    #pragma warning Unknown dynamic link import/export semantics.
 #endif

--- a/extensions/common/simplepipe_win32.cpp
+++ b/extensions/common/simplepipe_win32.cpp
@@ -1,3 +1,5 @@
+#ifdef _WIN32
+
 #include "simplepipe_win32.hpp"
 #include <Sddl.h>
 #include <AccCtrl.h>
@@ -177,3 +179,5 @@ namespace ace {
       return &buf_[0];
     }
 }
+
+#endif

--- a/extensions/common/simplepipe_win32.hpp
+++ b/extensions/common/simplepipe_win32.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef _WIN32
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -55,3 +57,4 @@ namespace ace {
     };
 }
 
+#endif

--- a/extensions/common/simulation/object.cpp
+++ b/extensions/common/simulation/object.cpp
@@ -1,8 +1,8 @@
 #include "object.hpp"
-#include "p3d\parser.hpp"
+#include "p3d/parser.hpp"
 
 
-#include "glm\gtc\matrix_transform.hpp"
+#include "glm/gtc/matrix_transform.hpp"
 
 ace::simulation::vertex::vertex(vertex_table & _table, ace::vector3<float> _vertex, uint32_t _id) : table(_table), vertex_id(_id)
 {

--- a/extensions/common/simulation/object.hpp
+++ b/extensions/common/simulation/object.hpp
@@ -8,10 +8,10 @@
 
 #define GLM_PRECISION_HIGHP_FLOAT
 
-#include "p3d\model.hpp"
-#include "glm\glm.hpp"
-#include "glm\vec3.hpp"
-#include "glm\mat4x4.hpp"
+#include "p3d/model.hpp"
+#include "glm/glm.hpp"
+#include "glm/vec3.hpp"
+#include "glm/mat4x4.hpp"
 
 
 namespace ace {

--- a/extensions/common/vector.hpp
+++ b/extensions/common/vector.hpp
@@ -5,7 +5,17 @@
 #include "LinearMath\btVector3.h"
 #endif
 */
+
 #include "shared.hpp"
+
+#ifndef _WIN32
+
+#define sinf(x) sin(x)
+#define cosf(x) cos(x)
+#define acosf(x) acos(x)
+
+#endif
+
 namespace ace {
 
     template <typename T> T acos(T n) { return -1; }

--- a/extensions/fcs/ace_fcs.cpp
+++ b/extensions/fcs/ace_fcs.cpp
@@ -26,7 +26,7 @@
 #define RADIANS(X) (X / (180 / M_PI))
 
 extern "C" {
-    __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+    EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
 };
 
 std::vector<std::string> splitString(std::string input) {


### PR DESCRIPTION
Since the tool chain was already set up for cross-platform builds, and most code was already done for it, I finished it.

This adds the few extra platform-dependent macros and some GCC syntaxian changes for cross platform builds. These extensions will all now run on linux. 

This closes #1266 and refs #1256