### PR TITLE
Add assignedTeam color propagation to nametags from the leader

### DIFF
--- a/addons/nametags/XEH_postInit.sqf
+++ b/addons/nametags/XEH_postInit.sqf
@@ -22,6 +22,41 @@ GVAR(ShowNamesTime) = -10;
 {false},
 [29, [false, false, false]], false] call cba_fnc_addKeybind; //LeftControl Key
 
+// Monitor the assigned teams, and propegate them appropriately for the player
+// This allows for assigned team colors to match across the entire group
+[{
+    private["_leader", "_playerIsLeader", "_unitTeam"];
+    if (alive ACE_player) then {
+        _leader = leader (group ACE_player);
+        _playerIsLeader = false;
+        
+        if(alive _leader) then {
+            if(_leader == ACE_player) then {
+                _playerIsLeader = true;
+            };
+        };
+        
+        if (_playerIsLeader) then {
+            {
+                if(alive _x) then {
+                    _unitTeam = _x getVariable [QGVAR(teamAssignment),"MAIN"];
+                    if (_unitTeam != assignedTeam _x) then {
+                        _x setVariable [QGVAR(teamAssignment), assignedTeam _x,true];
+                    };
+                };
+            } forEach units (group ACE_player);
+        } else {
+            {
+                if(alive _x) then {
+                    _unitTeam = _x getVariable [QGVAR(teamAssignment),"MAIN"];
+                    if (_unitTeam != assignedTeam _x) then {
+                        _x assignTeam _unitTeam;
+                    };
+                };
+            } forEach units (group ACE_player);
+        };
+    };
+}, 5, []] call CBA_fnc_addPerFrameHandler;
 
 // Draw handle
 addMissionEventHandler ["Draw3D", {_this call FUNC(onDraw3d);}];

--- a/addons/nametags/XEH_postInit.sqf
+++ b/addons/nametags/XEH_postInit.sqf
@@ -26,7 +26,7 @@ GVAR(ShowNamesTime) = -10;
 // This allows for assigned team colors to match across the entire group
 [{
     private["_leader", "_playerIsLeader", "_unitTeam"];
-    if (alive ACE_player) then {
+    if (!(isNull ACE_player) && { alive ACE_player } ) then {
         _leader = leader (group ACE_player);
         _playerIsLeader = false;
         


### PR DESCRIPTION
Vanilla A3 does NOT propegate the assignedTeams between clients; so if a group leader assigns teams, they do not get reflected on all clients and the colors are not uniform; they are local. 

This monitors the assigned teams on the leader and sets them on the player objects, giving the entire squad uniform colors for fireteams. This also persists across respawns, and only changes the color for the nametag when the unit itself changes. 

This means everyone can be identified by their nametag color assigned by the group leader.