### PR TITLE
Bandaid to prevent interact menu init from being interrupted

### DIFF
--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -70,4 +70,9 @@ GVAR(collectedActionPoints) = [];
 GVAR(foundActions) = [];
 GVAR(lastTimeSearchedActions) = -1000;
 
+
+// Init CAManBase menus
+["CAManBase"] call FUNC(compileMenu);
+["CAManBase"] call FUNC(compileMenuSelfAction);
+
 ADDON = true;

--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -14,10 +14,12 @@
 
 EXPLODE_1_PVT(_this,_target);
 
-private ["_objectType","_actionsVarName"];
+private ["_objectType","_actionsVarName","_isMan"];
 _objectType = _target;
+_isMan = false;
 if (typeName _target == "OBJECT") then {
     _objectType = typeOf _target;
+    _isMan = _target isKindOf "CAManBase";
 };
 _actionsVarName = format [QGVAR(Act_%1), _objectType];
 
@@ -94,10 +96,16 @@ _recurseFnc = {
     _actions
 };
 
-private "_actionsCfg";
+private ["_actionsCfg","_actions"];
 _actionsCfg = configFile >> "CfgVehicles" >> _objectType >> "ACE_Actions";
 
-missionNamespace setVariable [_actionsVarName, [_actionsCfg] call _recurseFnc];
+// If the classname inherits from CAManBase, just copy it's menu without recompiling a new one
+_actions = if (_isMan) then {
+    + (missionNamespace getVariable QGVAR(Act_CAManBase))
+} else {
+    [_actionsCfg] call _recurseFnc
+};
+missionNamespace setVariable [_actionsVarName, _actions];
 
 /*
 [

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -14,10 +14,12 @@
 
 EXPLODE_1_PVT(_this,_target);
 
-private ["_objectType","_actionsVarName", "_canCollapse", "_children", "_enableInside", "_entry", "_entryCfg", "_i", "_insertChildren", "_modifierFunction", "_runOnHover"];
+private ["_objectType","_actionsVarName","_isMan"];
 _objectType = _target;
+_isMan = false;
 if (typeName _target == "OBJECT") then {
     _objectType = typeOf _target;
+    _isMan = _target isKindOf "CAManBase";
 };
 _actionsVarName = format [QGVAR(SelfAct_%1), _objectType];
 
@@ -78,7 +80,7 @@ _recurseFnc = {
     _actions
 };
 
-private "_actionsCfg";
+private ["_actionsCfg","_actions"];
 _actionsCfg = configFile >> "CfgVehicles" >> _objectType >> "ACE_SelfActions";
 
 private ["_baseDisplayName", "_baseIcon"];
@@ -100,26 +102,31 @@ if (_objectType isKindOf "CAManBase") then {
     };
 };
 
-// Create a master action to base on self action
-_actions = [
+// If the classname inherits from CAManBase, just copy it's menu without recompiling a new one
+_actions = if (_isMan) then {
+    + (missionNamespace getVariable QGVAR(SelfAct_CAManBase))
+} else {
+    // Create a master action to base on self action
     [
         [
-            "ACE_SelfActions",
-            _baseDisplayName,
-            _baseIcon,
-            {
-                // Dummy statement so it's not collapsed when there's no available actions
-                true
-            },
-            {[ACE_player, _target, ["isNotInside","isNotDragging", "isNotCarrying", "isNotSwimming", "notOnMap", "isNotEscorting", "isNotSurrendering"]] call EFUNC(common,canInteractWith)},
-            {},
-            {},
-            "Spine3",
-            10,
-            [false,true,false]
-        ],
-        [_actionsCfg] call _recurseFnc
+            [
+                "ACE_SelfActions",
+                _baseDisplayName,
+                _baseIcon,
+                {
+                    // Dummy statement so it's not collapsed when there's no available actions
+                    true
+                },
+                {[ACE_player, _target, ["isNotInside","isNotDragging", "isNotCarrying", "isNotSwimming", "notOnMap", "isNotEscorting", "isNotSurrendering"]] call EFUNC(common,canInteractWith)},
+                {},
+                {},
+                "Spine3",
+                10,
+                [false,true,false]
+            ],
+            [_actionsCfg] call _recurseFnc
+        ]
     ]
-];
+};
 
 missionNamespace setVariable [_actionsVarName, _actions];


### PR DESCRIPTION
Bandaid for #1281, until we properly solve unreliable init handlers.

1- Menus for CAManBase are precomputed on preInit

2- Class action menus for all men are supposed to be equal to those of CAManBase

Note: we loose the capability of defining actions for specific classes from config (which we don't do on ACE annyway)
