### PR TITLE
Fix for the viewDistance module

### DIFF
--- a/addons/viewdistance/ACE_Settings.hpp
+++ b/addons/viewdistance/ACE_Settings.hpp
@@ -8,24 +8,24 @@ class ACE_Settings {
     class GVAR(viewDistanceOnFoot) {
         typeName = "SCALAR";
         isClientSettable = 1;
-        value = 11; // index, NOT value // Can set it to client's actual viewdistance in the init function once ACE_Settings supports numbers (if ever).
-        values[] = {"1500","2000","2500","3000","3500","4000","5000","6000","7000","8000","9000","10000"}; // Values also need to be changed in functions/fnc_returnValue.sqf
+        value = 0; // index, NOT value // Can set it to client's actual viewdistance in the init function once ACE_Settings supports numbers (if ever).
+        values[] = {"Video settings","500","1000","1500","2000","2500","3000","3500","4000","5000","6000","7000","8000","9000","10000"}; // Values also need to be changed in functions/fnc_returnValue.sqf
         displayName = "Client View Distance (On Foot)";
         description = "Changes in game view distance when the player is on foot.";
     };
     class GVAR(viewDistanceLandVehicle) {
         typeName = "SCALAR";
         isClientSettable = 1;
-        value = 11; // index, NOT value
-        values[] = {"1500","2000","2500","3000","3500","4000","5000","6000","7000","8000","9000","10000"}; // Values also need to be changed in functions/fnc_returnValue.sqf
+        value = 0; // index, NOT value
+        values[] = {"Video settings","500","1000","1500","2000","2500","3000","3500","4000","5000","6000","7000","8000","9000","10000"}; // Values also need to be changed in functions/fnc_returnValue.sqf
         displayName = "Client View Distance (Land Vehicle)";
         description = "Changes in game view distance when the player is in a land vehicle.";
     };
     class GVAR(viewDistanceAirVehicle) {
         typeName = "SCALAR";
         isClientSettable = 1;
-        value = 11; // index, NOT value
-        values[] = {"1500","2000","2500","3000","3500","4000","5000","6000","7000","8000","9000","10000"}; // Values also need to be changed in functions/fnc_returnValue.sqf
+        value = 0; // index, NOT value
+        values[] = {"Video settings","500","1000","1500","2000","2500","3000","3500","4000","5000","6000","7000","8000","9000","10000"}; // Values also need to be changed in functions/fnc_returnValue.sqf
         displayName = "Client View Distance (Air Vehicle)";
         description = "Changes in game view distance when the player is in an air vehicle.";
     };

--- a/addons/viewdistance/functions/fnc_changeViewDistance.sqf
+++ b/addons/viewdistance/functions/fnc_changeViewDistance.sqf
@@ -26,21 +26,21 @@ _new_view_distance = [_index_requested] call FUNC(returnValue); // changes the s
 _object_view_distance_coeff = [GVAR(objectViewDistanceCoeff)] call FUNC(returnObjectCoeff); // changes the setting index into a coefficient.
 _view_distance_limit = GVAR(limitViewDistance); // Grab the limit
 
+setViewDistance (_new_view_distance min _view_distance_limit);
+
+if (_object_view_distance_coeff > 0) then {
+    setObjectViewDistance (_object_view_distance_coeff * viewDistance);
+};
+
 if (_show_prompt) then {
     _text = if (_new_view_distance <= _view_distance_limit) then {
-            format ["<t align='center'>View Distance: %1m",str(_new_view_distance)];
+            format ["<t align='center'>View Distance: %1m", str(viewDistance)];
         } else {
-            format ["<t align='center'>That option is invalid! The limit is %1m",str(_view_distance_limit)];
+            format ["<t align='center'>That option is invalid! The limit is %1m", str(viewDistance)];
         };
 
     if (GVAR(objectViewDistanceCoeff) > 0) then {
         _text = _text + format ["<br/><t align='center'>Object View Distance is %1%2</t>",str(_object_view_distance_coeff * 100),"%"];
     };
     [parseText _text,2] call EFUNC(common,displayTextStructured);
-};
-
-setViewDistance (_new_view_distance min _view_distance_limit);
-
-if (_object_view_distance_coeff > 0) then {
-    setObjectViewDistance (_object_view_distance_coeff * _new_view_distance);
 };

--- a/addons/viewdistance/functions/fnc_returnValue.sqf
+++ b/addons/viewdistance/functions/fnc_returnValue.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: Winter
  * Returns the view distance value according to the given index
- * 
+ *
  *
  * Arguments:
  * 0: View Distance Index <SCALAR>
@@ -22,18 +22,21 @@ PARAMS_1(_index);
 private ["_return"];
 
 _return = switch (_index) do {
-    case 0:   {1500};
-    case 1:   {2000};
-    case 2:   {2500};
-    case 3:   {3000};
-    case 4:   {3500};
-    case 5:   {4000};
-    case 6:   {5000};
-    case 7:   {6000};
-    case 8:   {7000};
-    case 9:   {8000};
-    case 10:  {9000};
-    case 11:  {10000};
+    case 0:   {-1};
+    case 1:   {500};
+    case 2:   {1000};
+    case 3:   {1500};
+    case 4:   {2000};
+    case 5:   {2500};
+    case 6:   {3000};
+    case 7:   {3500};
+    case 8:   {4000};
+    case 9:   {5000};
+    case 10:  {6000};
+    case 11:  {7000};
+    case 12:  {8000};
+    case 13:  {9000};
+    case 14:  {10000};
     default   {1000};
 };
 


### PR DESCRIPTION
Apparently it's not safe to set a large view distance by default, as this overrides Arma video settings instead of using the lowest of both. Now view distance is defaulted to video settings, which renders the pbo inert by default. However, users can still leverage the settings to customize the view distance by vehicle type

To improve granularity, I added additional settings for view distances of 500m and 1000m 