### PR TITLE
Fixed Capitalized folders on include paths

### DIFF
--- a/addons/ai/script_component.hpp
+++ b/addons/ai/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT ai
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_AI
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_AI
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/attach/$PBOPREFIX$
+++ b/addons/attach/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ace\Addons\attach
+z\ace\addons\attach

--- a/addons/attach/script_component.hpp
+++ b/addons/attach/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT attach
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_ATTACH
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_ATTACH
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/disposable/script_component.hpp
+++ b/addons/disposable/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT disposable
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_ATTACH
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_ATTACH
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/fcs/functions/script_component.hpp
+++ b/addons/fcs/functions/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT fcs
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_FCS
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_FCS
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/fcs/script_component.hpp
+++ b/addons/fcs/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT fcs
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_FCS
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_FCS
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/frag/script_component.hpp
+++ b/addons/frag/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT frag
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 //#define DEBUG_ENABLED_FRAG
 
@@ -11,6 +11,6 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_FRAG
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 #define ACE_TRACE_DRAW_INC    1

--- a/addons/gforces/script_component.hpp
+++ b/addons/gforces/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT gforces
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_GFORCES
     #define DEBUG_MODE_FULL
@@ -9,7 +9,7 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_GFORCES
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 #define AVERAGEDURATION 6
 #define INTERVAL 0.20

--- a/addons/hearing/script_component.hpp
+++ b/addons/hearing/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT hearing
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_HEARING
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_HEARING
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/interaction/script_component.hpp
+++ b/addons/interaction/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT interaction
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_INTERACTION
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_INTERACTION
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/inventory/script_component.hpp
+++ b/addons/inventory/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT inventory
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_INVENTORY
   #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
   #define DEBUG_SETTINGS DEBUG_SETTINGS_INVENTORY
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/javelin/script_component.hpp
+++ b/addons/javelin/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT javelin
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_JAVELIN
     #define DEBUG_MODE_FULL
@@ -9,7 +9,7 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_JAVELIN
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 #define ACE_JAV_FIREMODE_DIR 1
 #define ACE_JAV_FIREMODE_TOP 2

--- a/addons/laser/script_component.hpp
+++ b/addons/laser/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT laser
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_LASER
     #define DEBUG_MODE_FULL
@@ -9,7 +9,7 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_LASER
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 
 #define FIREMODE_DIRECT_LOAL 1

--- a/addons/laser_selfdesignate/$PBOPREFIX$
+++ b/addons/laser_selfdesignate/$PBOPREFIX$
@@ -1,1 +1,1 @@
-sz\ace\addons\laser_selfdesignate
+z\ace\addons\laser_selfdesignate

--- a/addons/laser_selfdesignate/$PBOPREFIX$
+++ b/addons/laser_selfdesignate/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ace\Addons\laser_selfdesignate
+sz\ace\addons\laser_selfdesignate

--- a/addons/laser_selfdesignate/functions/script_component.hpp
+++ b/addons/laser_selfdesignate/functions/script_component.hpp
@@ -1,1 +1,1 @@
-#include "\z\ace\Addons\laser_selfdesignate\script_component.hpp"
+#include "\z\ace\addons\laser_selfdesignate\script_component.hpp"

--- a/addons/laser_selfdesignate/script_component.hpp
+++ b/addons/laser_selfdesignate/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT laser_selfdesignate
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_LASER_SELFDESIGNATE
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_LASER_SELFDESIGNATE
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/map/$PBOPREFIX$
+++ b/addons/map/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ace\Addons\map
+z\ace\addons\map

--- a/addons/map/script_component.hpp
+++ b/addons/map/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT map
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_MAP
     #define DEBUG_MODE_FULL
@@ -9,7 +9,7 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_MAP
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 
 #define MARKERNAME_MAPTOOL_FIXED "ACE_MapToolFixed"

--- a/addons/maptools/$PBOPREFIX$
+++ b/addons/maptools/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ace\Addons\maptools
+z\ace\addons\maptools

--- a/addons/maptools/script_component.hpp
+++ b/addons/maptools/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT maptools
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_MAPTOOLS
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_MAPTOOLS
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/missileguidance/script_component.hpp
+++ b/addons/missileguidance/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT missileguidance
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_MISSILEGUIDANCE
     #define DEBUG_MODE_FULL
@@ -9,6 +9,6 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_MISSILEGUIDANCE
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 #define FIREMODE_DIRECT_LOAL 1

--- a/addons/mk6mortar/$PBOPREFIX$
+++ b/addons/mk6mortar/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ace\Addons\mk6mortar
+z\ace\addons\mk6mortar

--- a/addons/mk6mortar/script_component.hpp
+++ b/addons/mk6mortar/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT mk6mortar
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_MK6MORTAR
     #define DEBUG_MODE_FULL
@@ -9,6 +9,6 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_MK6MORTAR
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
 
 #define MK6_82mm_AIR_FRICTION -0.0001

--- a/addons/overheating/script_component.hpp
+++ b/addons/overheating/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT overheating
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_OVERHEATING
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_OVERHEATING
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/overpressure/script_component.hpp
+++ b/addons/overpressure/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT overpressure
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_OVERPRESSURE
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_ENABLED_OVERPRESSURE
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/ragdolls/script_component.hpp
+++ b/addons/ragdolls/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT ragdolls
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_RAGDOLLS
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_RAGDOLLS
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/realisticnames/script_component.hpp
+++ b/addons/realisticnames/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT realisticnames
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_REALISTICNAMES
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_REALISTICNAMES
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/safemode/script_component.hpp
+++ b/addons/safemode/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT safemode
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_SAFEMODE
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_SAFEMODE
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/testmissions/$PBOPREFIX$
+++ b/addons/testmissions/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ace\Addons\testmissions
+z\ace\addons\testmissions

--- a/addons/testmissions/script_component.hpp
+++ b/addons/testmissions/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT testmissions
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_TESTMISSIONS
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_ENABLED_TESTMISSIONS
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/addons/thermals/script_component.hpp
+++ b/addons/thermals/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT thermals
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_THERMALS
     #define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_THERMALS
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/optionals/server/script_component.hpp
+++ b/optionals/server/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT server
-#include "\z\ace\Addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
 
 #ifdef DEBUG_ENABLED_SERVER
 	#define DEBUG_MODE_FULL
@@ -9,4 +9,4 @@
 	#define DEBUG_SETTINGS DEBUG_SETTINGS_SERVER
 #endif
 
-#include "\z\ace\Addons\main\script_macros.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
Crash on linux dedicated servers with this error:

```
Include file z\ace\Addons\main\script_mod.hpp not found.
```