### PR TITLE
Fix Script Error when treating with bincos

### DIFF
--- a/addons/medical/functions/fnc_treatment.sqf
+++ b/addons/medical/functions/fnc_treatment.sqf
@@ -156,7 +156,7 @@ if (currentWeapon _caller == secondaryWeapon _caller) then {
     _caller selectWeapon (primaryWeapon _caller);
 };
 
-_wpn = ["non", "rfl", "pst"] select (["", primaryWeapon _caller, handgunWeapon _caller] find (currentWeapon _caller));
+_wpn = ["non", "rfl", "pst"] select (1 + ([primaryWeapon _caller, handgunWeapon _caller] find (currentWeapon _caller)));
 _callerAnim = [_callerAnim, "[wpn]", _wpn] call CBA_fnc_replace;
 if (vehicle _caller == _caller && {_callerAnim != ""}) then {
     if (primaryWeapon _caller == "") then {


### PR DESCRIPTION
To reproduce: Equip Binoculars, Treat self:
```
21:53:32 Error in expression <ller);
};

_wpn = ["non", "rfl", "pst"] select (["", primaryWeapon _caller, hand>
21:53:32   Error position: <select (["", primaryWeapon _caller, hand>
21:53:32   Error Zero divisor
21:53:32 File z\ace\addons\medical\functions\fnc_treatment.sqf, line 145
```

Animation seems to look ok as far as I can tell.