### PR TITLE
Frag - Handel Deleted Rounds

### DIFF
--- a/addons/frag/functions/fnc_fired.sqf
+++ b/addons/frag/functions/fnc_fired.sqf
@@ -50,7 +50,7 @@ if(_doFragTrack && alive _round) then {
     GVAR(trackedObjects) pushBack _round;
     _spallTrack = [];
     _spallTrackID = [];
-    [DFUNC(trackFragRound), 0, [_round, (getPosASL _round), (velocity _round), _type, time, _gun, _doSpall, _spallTrack, _spallTrackID]] call cba_fnc_addPerFrameHandler;
+    [DFUNC(trackFragRound), 0, [_round, (getPosASL _round), (velocity _round), _type, diag_frameno, _gun, _doSpall, _spallTrack, _spallTrackID]] call cba_fnc_addPerFrameHandler;
     if(_doSpall) then {
         [_round, 2, _spallTrack, _spallTrackID] call FUNC(spallTrack);
     };

--- a/addons/frag/functions/fnc_trackFragRound.sqf
+++ b/addons/frag/functions/fnc_trackFragRound.sqf
@@ -1,19 +1,19 @@
 //fnc_trackFragRound.sqf
 #include "script_component.hpp"
-private ["_params", "_round", "_lastPos", "_lastVel", "_type", "_time", "_doSpall", "_spallTrack", "_foundObjectHPIds", "_skip", "_explosive", "_indirectRange", "_force", "_fragPower"];
+private ["_params", "_round", "_lastPos", "_lastVel", "_type", "_firedFrame", "_doSpall", "_spallTrack", "_foundObjectHPIds", "_skip", "_explosive", "_indirectRange", "_force", "_fragPower"];
 _params = _this select 0;
 _round = _params select 0;
 _lastPos = _params select 1;
 _lastVel = _params select 2;
 _type = _params select 3;
-_time = _params select 4;
+_firedFrame = _params select 4;
 _doSpall = _params select 6;
 _spallTrack = _params select 7;
 _foundObjectHPIds = _params select 8;
 
 if (!alive _round) then {
     [_this select 1] call cba_fnc_removePerFrameHandler;
-    if(_time != time && {_round in GVAR(trackedObjects)} && {!(_round in GVAR(blackList))}) then {
+    if(((diag_frameno - _firedFrame) > 1) && {_round in GVAR(trackedObjects)} && {!(_round in GVAR(blackList))}) then {
         GVAR(trackedObjects) = GVAR(trackedObjects) - [_round];
         _skip = getNumber (configFile >> "CfgAmmo" >> _type >> QGVAR(skip));
         if(_skip == 0) then {
@@ -43,7 +43,7 @@ if (!alive _round) then {
             GVAR(blackList) = GVAR(blackList) - [_round];
         };
     };
-    
+
     _params set[1, (getPosASL _round)];
     _params set[2, (velocity _round)];
     if(_doSpall) then {


### PR DESCRIPTION
This should take care of #820.

Changes
`_time != time`
to 
`((diag_frameno - _firedFrame) > 1)`

I think the delete happens on the frame the grenade was fired and the PFEH runs the next frame.
So if the explosive was deleted within a frame, don't do the frag.