### PR TITLE
Changed absolute make.py paths to read from variables

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -413,11 +413,11 @@ def cleanup_optionals(mod):
             print("Cleaning {}".format(destination))
 
             try:
-                file_name = pbo_name_prefix + dir_name + ".pbo"
+                file_name = "{}{}.pbo".format(pbo_name_prefix,dir_name)
                 src_file_path = os.path.join(release_dir, project, "addons", file_name)
                 dst_file_path = os.path.join(release_dir, project, "optionals", file_name)
 
-                sigFile_name = file_name +"."+ key_name + ".bisign"
+                sigFile_name = "{}.{}.bisign".format(file_name,key_name)
                 src_sig_path = os.path.join(release_dir, project, "addons", sigFile_name)
                 dst_sig_path = os.path.join(release_dir, project, "optionals", sigFile_name)
 
@@ -428,7 +428,7 @@ def cleanup_optionals(mod):
                     #print("Preserving {}".format(sigFile_name))
                     os.renames(src_sig_path,dst_sig_path)
             except FileExistsError:
-                print_error(file_name + " already exists")
+                print_error("{} already exists".format(file_name))
                 continue
             shutil.rmtree(destination)
 
@@ -572,7 +572,7 @@ def get_ace_version():
         input("Press Enter to continue...")
         print("Resuming build...")
 
-    print_yellow(pbo_name_prefix.rstrip("_").upper() + " VERSION set to " + versionStamp)
+    print_yellow("{} VERSION set to {}".format(project.lstrip("@").upper(),versionStamp))
     ACE_VERSION = versionStamp
     return ACE_VERSION
 
@@ -959,13 +959,13 @@ See the make.cfg file for additional build options.
 
                 # Use biKeyNameAbrev to attempt to minimize problems from this BI Bug REFERENCE: http://feedback.arma3.com/view.php?id=22133
                 biKeyNameAbrev = key_name.split("-")[0]
-                shutil.copyfile(os.path.join(private_key_path, key_name + ".bikey"), os.path.join(module_root, release_dir, project, "keys", biKeyNameAbrev + ".bikey"))
+                shutil.copyfile(os.path.join(private_key_path, key_name + ".bikey"), os.path.join(module_root, release_dir, project, "keys", "{}.bikey".format(biKeyNameAbrev)))
 
             except:
                 print_error("Could not copy key to release directory.")
                 raise
 
-            key = os.path.join(private_key_path, key_name + ".biprivatekey")
+            key = os.path.join(private_key_path, "{}.biprivatekey".format(key_name))
 
         # Remove any obsolete files.
         print_blue("\nChecking for obsolete files...")
@@ -975,7 +975,7 @@ See the make.cfg file for additional build options.
                 if check_for_obsolete_pbos(module_root, file):
                     fileName = os.path.splitext(file)[0]
                     print_yellow("Removing obsolete file => {}".format(file))
-                    purge(obsolete_check_path,fileName+"\..",fileName+".*")
+                    purge(obsolete_check_path, "{}\..".format(fileName), "{}.*".format(fileName))
 
         obsolete_check_path = os.path.join(module_root, release_dir, project)
         for file in os.listdir(obsolete_check_path):
@@ -1006,12 +1006,12 @@ See the make.cfg file for additional build options.
             new_sha = get_directory_hash(os.path.join(module_root, module))
 
             # Is the pbo or sig file missing?
-            missing = not os.path.isfile(os.path.join(release_dir, project, "addons", pbo_name_prefix + module + ".pbo"))
-            sigFile = pbo_name_prefix + module + ".pbo." + key_name + ".bisign"
+            missing = not os.path.isfile(os.path.join(release_dir, project, "addons", "{}{}.pbo".format(pbo_name_prefix,module)))
+            sigFile = "{}{}.pbo.{}.bisign".format(pbo_name_prefix,module,key_name)
             sigMissing = not os.path.isfile(os.path.join(release_dir, project, "addons", sigFile))
 
             if missing:
-                print_yellow("Missing PBO file " + pbo_name_prefix + module + ".pbo. Building...")
+                print_yellow("Missing PBO file {}{}.pbo. Building...".format(pbo_name_prefix,module))
 
             # Check if it needs rebuilt
             # print ("Hash:", new_sha)
@@ -1021,7 +1021,7 @@ See the make.cfg file for additional build options.
                     if sigMissing:
                         if key:
                             print("Missing Signature key {}".format(sigFile))
-                            build_signature_file(os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo"))
+                            build_signature_file(os.path.join(module_root, release_dir, project, "addons", "{}{}.pbo".format(pbo_name_prefix,module)))
                     # Skip everything else
                     continue
 
@@ -1046,13 +1046,13 @@ See the make.cfg file for additional build options.
 
             try:
                 # Remove the old pbo, key, and log
-                old = os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix+module) + "*"
+                old = os.path.join(module_root, release_dir, project, "addons", "{}{}".format(pbo_name_prefix,module)) + "*"
                 files = glob.glob(old)
                 for f in files:
                     os.remove(f)
 
                 if pbo_name_prefix:
-                    old = os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix+module) + "*"
+                    old = os.path.join(module_root, release_dir, project, "addons", "{}{}".format(pbo_name_prefix,module)) + "*"
                     files = glob.glob(old)
                     for f in files:
                         os.remove(f)
@@ -1110,17 +1110,17 @@ See the make.cfg file for additional build options.
                         # Prettyprefix rename the PBO if requested.
                         if pbo_name_prefix:
                             try:
-                                os.rename(os.path.join(module_root, release_dir, project, "addons", module+".pbo"), os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix+module+".pbo"))
+                                os.rename(os.path.join(module_root, release_dir, project, "addons", "{}.pbo".format(module)), os.path.join(module_root, release_dir, project, "addons", "{}{}.pbo".format(pbo_name_prefix,module)))
                             except:
                                 raise
                                 print_error("Could not rename built PBO with prefix.")
                         # Sign result
-                        if (key and not "ace_{}.pbo".format(module) in signature_blacklist):
+                        if (key and not "{}{}.pbo".format(pbo_name_prefix,module) in signature_blacklist):
                             print("Signing with {}.".format(key))
                             if pbo_name_prefix:
-                                ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo")])
+                                ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "addons", "{}{}.pbo".format(pbo_name_prefix,module))])
                             else:
-                                ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "addons", module + ".pbo")])
+                                ret = subprocess.call([dssignfile, key, os.path.join(module_root, release_dir, project, "addons", "{}.pbo".format(module))])
 
                             if ret == 0:
                                 build_successful = True
@@ -1179,7 +1179,7 @@ See the make.cfg file for additional build options.
                     # Prettyprefix rename the PBO if requested.
                     if pbo_name_prefix:
                         try:
-                            os.rename(os.path.join(make_root, release_dir, project, "addons", module+".pbo"), os.path.join(make_root, release_dir, project, "addons", pbo_name_prefix+module+".pbo"))
+                            os.rename(os.path.join(make_root, release_dir, project, "addons", "{}.pbo".format(module)), os.path.join(make_root, release_dir, project, "addons", "{}{}.pbo".format(pbo_name_prefix,module)))
                         except:
                             raise
                             print_error("Could not rename built PBO with prefix.")
@@ -1188,12 +1188,12 @@ See the make.cfg file for additional build options.
                         # Sign result
 
                         #print_yellow("Sig_fileName: ace_{}.pbo".format(module))
-                        if (key and not (pbo_name_prefix + module + ".pbo") in signature_blacklist) :
+                        if (key and not "{}{}.pbo".format(pbo_name_prefix,module) in signature_blacklist) :
                             print("Signing with {}.".format(key))
                             if pbo_name_prefix:
-                                ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo")])
+                                ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons","{}{}.pbo".format(pbo_name_prefix,module))])
                             else:
-                                ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons", module + ".pbo")])
+                                ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons", "{}.pbo".format(module))])
 
                             if ret == 0:
                                 build_successful = True

--- a/tools/make.py
+++ b/tools/make.py
@@ -55,6 +55,7 @@ if sys.platform == "win32":
     import winreg
 
 ######## GLOBALS #########
+project = "@ace"
 ACE_VERSION = "3.0.0"
 arma3tools_path = ""
 work_drive = ""
@@ -69,6 +70,7 @@ dssignfile = ""
 prefix = "ace"
 pbo_name_prefix = "ace_"
 signature_blacklist = ["ace_server.pbo"]
+importantFiles = ["mod.cpp", "README.md", "AUTHORS.txt", "LICENSE", "logo_ace3_ca.paa"]
 
 ###############################################################################
 # http://akiscode.com/articles/sha-1directoryhash.shtml
@@ -310,12 +312,6 @@ def print_yellow(msg):
 def copy_important_files(source_dir,destination_dir):
 
     originalDir = os.getcwd()
-    importantFiles = ["mod.cpp",
-    "README.md",
-    "AUTHORS.txt",
-    "LICENSE",
-    "logo_ace3_ca.paa"
-    ]
 
     #copy importantFiles
     try:
@@ -358,21 +354,21 @@ def copy_optionals_for_building(mod,pbos):
     try:
 
         #special server.pbo processing
-        files = glob.glob(os.path.join(release_dir, "@ace","optionals","*.pbo"))
+        files = glob.glob(os.path.join(release_dir, project, "optionals", "*.pbo"))
         for file in files:
             file_name = os.path.basename(file)
             #print ("Adding the following file: {}".format(file_name))
             pbos.append(file_name)
-            pbo_path = os.path.join(release_dir, "@ace","optionals",file_name)
+            pbo_path = os.path.join(release_dir, project, "optionals", file_name)
             sigFile_name = file_name +"."+ key_name + ".bisign"
-            sig_path = os.path.join(release_dir, "@ace","optionals",sigFile_name)
+            sig_path = os.path.join(release_dir, project, "optionals", sigFile_name)
             if (os.path.isfile(pbo_path)):
                 print("Moving {} for processing.".format(pbo_path))
-                shutil.move(pbo_path, os.path.join(release_dir,"@ace","addons",file_name))
+                shutil.move(pbo_path, os.path.join(release_dir, project, "addons", file_name))
 
             if (os.path.isfile(sig_path)):
                 #print("Moving {} for processing.".format(sig_path))
-                shutil.move(sig_path, os.path.join(release_dir,"@ace","addons",sigFile_name))
+                shutil.move(sig_path, os.path.join(release_dir, project, "addons", sigFile_name))
     except:
         print_error("Error in moving")
         raise
@@ -386,9 +382,9 @@ def copy_optionals_for_building(mod,pbos):
             #userconfig requires special handling since it is not a PBO source folder.
             #CfgConvert fails to build server.pbo if userconfig is not found in P:\
             if (dir_name == "userconfig"):
-                if (os.path.exists(os.path.join(release_dir, "@ace","optionals",dir_name))):
-                    shutil.rmtree(os.path.join(release_dir, "@ace","optionals",dir_name), True)
-                shutil.copytree(os.path.join(optionals_root,dir_name), os.path.join(release_dir, "@ace","optionals",dir_name))
+                if (os.path.exists(os.path.join(release_dir, project, "optionals", dir_name))):
+                    shutil.rmtree(os.path.join(release_dir, project, "optionals", dir_name), True)
+                shutil.copytree(os.path.join(optionals_root,dir_name), os.path.join(release_dir, project, "optionals", dir_name))
                 destination = os.path.join(work_drive,dir_name)
             else:
                 destination = os.path.join(module_root,dir_name)
@@ -417,13 +413,13 @@ def cleanup_optionals(mod):
             print("Cleaning {}".format(destination))
 
             try:
-                file_name = "ace_{}.pbo".format(dir_name)
-                src_file_path = os.path.join(release_dir, "@ace","addons",file_name)
-                dst_file_path = os.path.join(release_dir, "@ace","optionals",file_name)
+                file_name = pbo_name_prefix + dir_name + ".pbo"
+                src_file_path = os.path.join(release_dir, project, "addons", file_name)
+                dst_file_path = os.path.join(release_dir, project, "optionals", file_name)
 
                 sigFile_name = file_name +"."+ key_name + ".bisign"
-                src_sig_path = os.path.join(release_dir, "@ace","addons",sigFile_name)
-                dst_sig_path = os.path.join(release_dir, "@ace","optionals",sigFile_name)
+                src_sig_path = os.path.join(release_dir, project, "addons", sigFile_name)
+                dst_sig_path = os.path.join(release_dir, project, "optionals", sigFile_name)
 
                 if (os.path.isfile(src_file_path)):
                     #print("Preserving {}".format(file_name))
@@ -465,7 +461,7 @@ def build_signature_file(file_name):
 
 
 def check_for_obsolete_pbos(addonspath, file):
-    module = file[4:-4]
+    module = file[len(pbo_name_prefix):-4]
     if not os.path.exists(os.path.join(addonspath, module)):
         return True
     return False
@@ -576,7 +572,7 @@ def get_ace_version():
         input("Press Enter to continue...")
         print("Resuming build...")
 
-    print_yellow("ACE VERSION set to {}".format(versionStamp))
+    print_yellow(pbo_name_prefix.rstrip("_").upper() + " VERSION set to " + versionStamp)
     ACE_VERSION = versionStamp
     return ACE_VERSION
 
@@ -1010,12 +1006,12 @@ See the make.cfg file for additional build options.
             new_sha = get_directory_hash(os.path.join(module_root, module))
 
             # Is the pbo or sig file missing?
-            missing = not os.path.isfile(os.path.join(release_dir, project, "addons", "ace_{}.pbo".format(module)))
-            sigFile = pbo_name_prefix+module + ".pbo." + key_name + ".bisign"
-            sigMissing = not os.path.isfile(os.path.join(release_dir, project, "addons", sigFile ))
+            missing = not os.path.isfile(os.path.join(release_dir, project, "addons", pbo_name_prefix + module + ".pbo"))
+            sigFile = pbo_name_prefix + module + ".pbo." + key_name + ".bisign"
+            sigMissing = not os.path.isfile(os.path.join(release_dir, project, "addons", sigFile))
 
             if missing:
-                print_yellow("Missing PBO file ace_{}.pbo".format(module) + ". Building...")
+                print_yellow("Missing PBO file " + pbo_name_prefix + module + ".pbo. Building...")
 
             # Check if it needs rebuilt
             # print ("Hash:", new_sha)
@@ -1192,7 +1188,7 @@ See the make.cfg file for additional build options.
                         # Sign result
 
                         #print_yellow("Sig_fileName: ace_{}.pbo".format(module))
-                        if (key and not "ace_{}.pbo".format(module) in signature_blacklist) :
+                        if (key and not (pbo_name_prefix + module + ".pbo") in signature_blacklist) :
                             print("Signing with {}.".format(key))
                             if pbo_name_prefix:
                                 ret = subprocess.call([dssignfile, key, os.path.join(make_root, release_dir, project, "addons", pbo_name_prefix + module + ".pbo")])
@@ -1229,7 +1225,7 @@ See the make.cfg file for additional build options.
         
 
     finally:
-        copy_important_files(module_root_parent,os.path.join(release_dir, "@ace"))
+        copy_important_files(module_root_parent,os.path.join(release_dir, project))
         cleanup_optionals(optionals_modules)
 
     # Done building all modules!


### PR DESCRIPTION
I felt like I should dive into Python a bit and did that, could prove useful if used for other projects.

- All absolute names have been changed to read from variables, for that `project = "@ace"` has also been copied to non-cfg definitions
- `importantFiles` moved to beginning for easier editing, I can't seem to figure out how to read a list from cfg...
- Also changed "ACE VERSION" to read "ACE" part from `pbo_prefix_name` minues underscore and capitalize, goes for different project names
- Changed prefix elimination in check modules to count prefix length and use that rather than hard-coded 4 chars

This is nothing big, obviously project name would have to be changed at the beginning still in some cases as far as I am aware.