### PR TITLE
Medical - Fix Unconscious Condition

### DIFF
--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -252,7 +252,7 @@ if (USE_WOUND_EVENT_SYNC) then {
 
 [
     {(((_this select 0) getvariable [QGVAR(bloodVolume), 100]) < 65)},
-    {(((_this select 0) getvariable [QGVAR(pain), 0] - ((_this select 0) getvariable [QGVAR(painSuppress), 0])) > 0.9)},
+    {(((_this select 0) getvariable [QGVAR(pain), 0]) - ((_this select 0) getvariable [QGVAR(painSuppress), 0])) > 0.9},
     {(([_this select 0] call FUNC(getBloodLoss)) > 0.25)},
     {((_this select 0) getvariable [QGVAR(inReviveState), false])},
     {((_this select 0) getvariable [QGVAR(inCardiacArrest), false])},


### PR DESCRIPTION
RPT Spamed with:

```
13:24:18 Error in expression < 0) getvariable ["ace_medical_pain", 0] - ((_this select 0) getvariable ["ace_me>
13:24:18   Error position: <- ((_this select 0) getvariable ["ace_me>
13:24:18   Error Generic error in expression
13:24:18 File z\ace\addons\medical\XEH_postInit.sqf, line 255
```