### PR TITLE
Titan inheritance fix

### DIFF
--- a/addons/javelin/CfgMagazines.hpp
+++ b/addons/javelin/CfgMagazines.hpp
@@ -1,0 +1,18 @@
+class CfgMagazines {
+    //Static Titan Magazine
+    class 5Rnd_GAT_missiles;
+    class 1Rnd_GAT_missiles: 5Rnd_GAT_missiles {
+        ammo = "ACE_Javelin_FGM148_static"; //from misssileGuidance, was "M_Titan_AT_static"
+    };
+
+    //Handheld Titan "AT" Magazine (Locking - "Anti-Tank")
+    class Titan_AA;
+    class Titan_AT: Titan_AA {
+        ammo = "ACE_Javelin_FGM148"; //from misssileGuidance, was "M_Titan_AT"
+    };
+    
+    //Handheld Titan "AP" Magazine (SACLOS? "Anti-personal")
+    // class Titan_AP: Titan_AA {
+        //???
+    // };
+};

--- a/addons/javelin/config.cpp
+++ b/addons/javelin/config.cpp
@@ -15,3 +15,4 @@ class CfgPatches {
 #include "CfgSounds.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
+#include "CfgMagazines.hpp"

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -35,8 +35,17 @@ _soundTime = _args select 4;
 _randomLockInterval = _args select 5;
 _fireDisabledEH = _args select 6;
 
-_configs = configProperties [configFile >> "CfgWeapons" >> (currentWeapon (vehicle ACE_player)), QUOTE(configName _x == QUOTE(QGVAR(enabled))), false];
-if (((count _configs) < 1) || {(getNumber (_configs select 0)) != 1}) exitWith {
+private["_ammo", "_magazineConfig", "_weaponConfig"];
+_weaponConfig = configProperties [configFile >> "CfgWeapons" >> (currentWeapon _currentShooter), QUOTE(configName _x == QUOTE(QGVAR(enabled))), false];
+_magazineConfig = if ((currentMagazine _currentShooter) != "") then {
+    _ammo = getText (configFile >> "CfgMagazines" >> (currentMagazine _currentShooter) >> "ammo");
+    configProperties [(configFile >> "CfgAmmo" >> _ammo), "(configName _x) == 'ace_missileguidance'", false];
+} else {
+    []
+};
+
+//Only enable if both weapon and currentMagazine are enabled (bandaid to allow firing the "AP" missle)
+if (((count _weaponConfig) < 1) || {(getNumber (_weaponConfig select 0)) != 1} || {(count _magazineConfig) < 1} || {(getNumber ((_magazineConfig select 0) >> "enabled")) != 1}) exitWith {
     __JavelinIGUITargeting ctrlShow false;
     __JavelinIGUITargetingGate ctrlShow false;
     __JavelinIGUITargetingLines ctrlShow false;

--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -94,47 +94,59 @@ class CfgAmmo {
     };
     
     // Titan
-    class M_Titan_AT : MissileBase {
+    class M_Titan_AT : MissileBase {};
+
+    class ACE_Javelin_FGM148: M_Titan_AT {
         irLock = 0;
         laserLock = 0;
         airLock = 0;
 
         // Turn off arma crosshair-guidance
         manualControl = 0;
-        
+
         hit = 1400;         // default: 800
         indirectHit = 20;
         indirectHitRange = 2;
         // ACE uses these values
         //trackOversteer = 1;
         //trackLead = 0;
-       
+
+        initTime = 2;
+
         // Begin ACE guidance Configs
         class ADDON {
             enabled = 1;
-            
+
             minDeflection = 0.00005;      // Minium flap deflection for guidance
             maxDeflection = 0.025;       // Maximum flap deflection for guidance
             incDeflection = 0.00005;      // The incrmeent in which deflection adjusts.
-            
+
             canVanillaLock = 0;
-            
+
             // Guidance type for munitions
             defaultSeekerType = "Optic";
-            seekerTypes[] = { "Optic" };   
-            
+            seekerTypes[] = { "Optic" };
+
             defaultSeekerLockMode = "LOBL";
             seekerLockModes[] = { "LOBL" };
-            
+
             seekerAngle = 180;           // Angle in front of the missile which can be searched
             seekerAccuracy = 1;         // seeker accuracy multiplier
-            
+
             seekerMinRange = 0;
             seekerMaxRange = 2500;      // Range from the missile which the seeker can visually search
-            
+
             // Attack profile type selection
             defaultAttackProfile = "JAV_TOP";
             attackProfiles[] = { "JAV_TOP", "JAV_DIR" };
+        };
+    };
+    class ACE_Javelin_FGM148_static: ACE_Javelin_FGM148 {
+        //Take config changes from (M_Titan_AT_static: M_Titan_AT)
+        initTime = 0.25;  //"How long (in seconds) the projectile waits before starting it's engine.", - but doesn't seem to do anything
+        effectsMissileInit = "RocketBackEffectsStaticRPG";
+        class ADDON: ADDON {
+            enabled = 1;
         };
     };
 };


### PR DESCRIPTION
Adds custom CfgAmmo's for the Titan and Static-Ttitan.
This should fix A3 vehicles and mods that use `M_Titan_AT` (fix #1175)
Also fixes Static Titans which are broken right now as they use `M_Titan_AT_static` which doesn't have missile guidance enabled.

Also checks the loaded magazine on the javelin code (tab locking and the trigger hold).
This will allow firing of the "AP" (wire-guided) ammo without lock.

I know this isn't what we want in the long run, but for now this should make all these weapon systems usable.