### PR TITLE
Single PFEH for waitAndExecute - using sort

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -286,6 +286,7 @@ PREP(_handleRequestSyncedEvent);
 PREP(_handleRequestAllSyncedEvents);
 
 GVAR(syncedEvents) = HASH_CREATE;
+GVAR(waitAndExecArray) = [];
 
 // @TODO: Generic local-managed global-synced objects (createVehicleLocal)
 

--- a/addons/common/functions/fnc_waitAndExecute.sqf
+++ b/addons/common/functions/fnc_waitAndExecute.sqf
@@ -7,30 +7,31 @@
  * 0: Code to execute (Code)
  * 1: Parameters to run the code with (Array)
  * 2: Delay in seconds before executing the code (Number)
- * 3: Interval of ACE_time in which the execution is evaluated, 0 means every frame (Number)
  *
  * Return value:
- * PFH handler ID
+ * None
+ *
+ * Example:
+ * [{(_this select 0) setVelocity [0,0,200];}, [player], 10] call ace_common_fnc_waitAndExecute
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
-PARAMS_4(_func,_params,_delay,_interval);
+PARAMS_3(_func,_params,_delay);
 
-[
-    {
-        EXPLODE_2_PVT(_this,_params,_pfhId);
-        EXPLODE_2_PVT(_params,_delayedExecParams,_startTime);
-        EXPLODE_3_PVT(_delayedExecParams,_func,_funcParams,_delay);
+GVAR(waitAndExecArray) pushBack [(ACE_time + _delay), _func, _params];
+GVAR(waitAndExecArray) sort true;
 
-        // Exit if the ACE_time was not reached yet
-        if (ACE_time < _startTime + _delay) exitWith {};
-
-        // Remove the PFH
-        [_pfhId] call cba_fnc_removePerFrameHandler;
-
-        // Execute the function
-        _funcParams call _func;
-    },
-    _interval,
-    [_this, ACE_time]
-] call CBA_fnc_addPerFrameHandler
+if ((count GVAR(waitAndExecArray)) == 1) then {
+    [{
+        while {((count GVAR(waitAndExecArray)) > 0) && {((GVAR(waitAndExecArray) select 0) select 0) <= ACE_Time}} do {
+            private ["_entry"];
+            _entry = GVAR(waitAndExecArray) deleteAt 0;
+            (_entry select 2) call (_entry select 1);
+        };
+        if ((count GVAR(waitAndExecArray)) == 0) then {
+            [(_this select 1)] call cba_fnc_removePerFrameHandler;
+        };
+    }, 0, []] call CBA_fnc_addPerFrameHandler;
+};


### PR DESCRIPTION
This is an alternative to glob's #360 (issue  #301).
Uses the native `sort` command, so it should be simple and fast.

Might get some performance gains out of this (at least on servers):
At start we do a waitAndExecute on each local unit.
With about ~200 local units at start:
`count cba_common_perFrameHandlerArray` = 237 (~23 that aren't nil)

CBA runs something like:
```
{
    _handlerData = _x;
    if (!isNil "_handlerData") then {
        doStuff = true;
    };
} forEach cba_common_perFrameHandlerArray
```
With a huge array that is eating 0.7 ms each frame for the entire game.