### PR TITLE
added spanish translate

### DIFF
--- a/addons/advanced_ballistics/stringtable.xml
+++ b/addons/advanced_ballistics/stringtable.xml
@@ -28,88 +28,111 @@
         <Key ID="STR_ACE_AdvancedBallistics_DisplayName">
             <English>Advanced Ballistics</English>
             <Polish>Zaawansowana balistyka</Polish>
+            <Spanish>Balística avanzada</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_enabled_DisplayName">
             <English>Advanced Ballistics</English>
             <Polish>Zaawansowana balistyka</Polish>
+            <Spanish>Balística avanzada</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_enabled_Description">
             <English>Enables advanced ballistics</English>
             <Polish>Aktywuje zaawansowaną balistykę</Polish>
+            <Spanish>Activa la balística avanzada</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulateForSnipers_DisplayName">
             <English>Enabled For Snipers</English>
+            <Spanish>Activada para francotiradores</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulateForSnipers_Description">
             <English>Enables advanced ballistics for non local snipers (when using high power optics)</English>
+            <Spanish>Activa la balística avanzada para francotiradores no locales (cuando se usa una mira telescópica)</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulateForGroupMembers_DisplayName">
             <English>Enabled For Group Members</English>
+            <Spanish>Activada para miembros de grupo</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulateForGroupMembers_Description">
             <English>Enables advanced ballistics for non local group members</English>
+            <Spanish>Activada la balística avanzada para miembros de grupo no locales</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulateForEveryone_DisplayName">
             <English>Enabled For Everyone</English>
+            <Spanish>Activada para todos</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulateForEveryone_Description">
             <English>Enables advanced ballistics for all non local players (enabling this may degrade performance during heavy firefights in multiplayer)</English>
+            <Spanish>Activada la balística avanzada para todos los jugadores no locales (activarlo puede degradar el rendimiento durante grandes tiroteos en multijugador).</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_alwaysSimulateForGroupMembers_DisplayName">
             <English>Always Enabled For Group Members</English>
             <Polish>Zawsze akt. dla czł. grupy</Polish>
+            <Spanish>Siempre activada para miembros de grupo</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_alwaysSimulateForGroupMembers_Description">
             <English>Always enables advanced ballistics when a group member fires</English>
             <Polish>Aktywuje zaawansowaną balistykę dla wszystkich członków grupy</Polish>
+            <Spanish>Activada la balística avanzada siempre cuando miembros de grupo disparan</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_disabledInFullAutoMod_DisplayName">
             <English>Disabled In FullAuto Mode</English>
             <Polish>Wył. podczas ognia auto.</Polish>
+            <Spanish>Desactivada en modo automático</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_disabledInFullAutoMod_Description">
             <English>Disables the advanced ballistics during full auto fire</English>
             <Polish>Dezaktywuje zaawansowaną balistykę podczas ognia automatycznego</Polish>
+            <Spanish>Desactivada la balística avanzada durante el fuego automático</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_DisplayName">
             <English>Enable Ammo Temperature Simulation</English>
             <Polish>Symulacja temp. amunicji</Polish>
+            <Spanish>Activar simulación de temperatura de munición</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_ammoTemperatureEnabled_Description">
             <English>Muzzle velocity varies with ammo temperature</English>
             <Polish>Prędkość wylotowa pocisku jest zależna od temperatury amunicji</Polish>
+            <Spanish>La velocidad de salida varía con la temperatura de la munición</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_DisplayName">
             <English>Enable Barrel Length Simulation</English>
             <Polish>Symulacja długości lufy</Polish>
+            <Spanish>Habilitar la simulación de longitud del cañón</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_barrelLengthInfluenceEnabled_Description">
             <English>Muzzle velocity varies with barrel length</English>
             <Polish>Prędkość wylotowa pocisku jest zależna od długości lufy</Polish>
+            <Spanish>La velocidad de salidal varía con la longitud del cañón</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_bulletTraceEnabled_DisplayName">
             <English>Enable Bullet Trace Effect</English>
             <Polish>Efekt smugi pocisku</Polish>
+            <Spanish>Activar el efecto trazador de la bala</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_bulletTraceEnabled_Description">
             <English>Enables a bullet trace effect to high caliber bullets (only visible when looking through high power optics)</English>
             <Polish>Aktywuje efekt smugi pocisku dla pocisków wysokokalibrowych (widoczne tylko podczas patrzenia przez optykę)</Polish>
+            <Spanish>Activa el efecto trazador de la balas de gran calibre (solo visible cuando se mira a través de una mira telescópica)</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulationInterval_DisplayName">
             <English>Simulation Interval</English>
             <Polish>Interwał symulacji</Polish>
+            <Spanish>Intervalo de simulación</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulationInterval_Description">
             <English>Defines the interval between every calculation step</English>
             <Polish>Określa interwał pomiędzy każdym krokiem kalkulacji</Polish>
+            <Spanish>Define el intervalo entre cada cálculo</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulationRadius_DisplayName">
             <English>Simulation Radius</English>
             <Polish>Zasięg symulacji</Polish>
+            <Spanish>Radio de simulación</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_simulationRadius_Description">
             <English>Defines the radius around the player (in meters) at which advanced ballistics are applied to projectiles</English>
             <Polish>Określa obszar naokoło gracza (w metrach), na którym zaawansowana balistyka jest aplikowana dla pocisków</Polish>
+            <Spanish>Define el radio alrededor del jugador (en metros) en el cual se aplica la balística avanzada a los proyectiles</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedBallistics_Description">
             <English></English>

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -1595,6 +1595,7 @@
         <Key ID="STR_ACE_AmmoSupplyCrate_DisplayName">
             <English>[ACE] Ammo Supply Crate</English>
             <Polish>[ACE] Skrzynka z amunicją</Polish>
+            <Spanish>[ACE] Caja de suministros de munición</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/captives/stringtable.xml
+++ b/addons/captives/stringtable.xml
@@ -196,10 +196,12 @@
         <Key ID="STR_ACE_Captives_ModuleSurrender_DisplayName">
             <English>Make Unit Surrender</English>
             <Polish>Poddaj się!</Polish>
+            <Spanish>Hacer que la unidad se rinda</Spanish>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleSurrender_Description">
             <English>Sync a unit to make them surrender.&lt;br /&gt;Source: ace_captives</English>
             <Polish>Zsynchronizuj z jednostką aby sprawić by się poddała&lt;br /&gt;Źródło: ace_captives</Polish>
+            <Spanish>Sincroniza una unidad para hacer que se rinda.&lt;br /&gt;Fuente: ace_captives</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -473,54 +473,67 @@
         <Key ID="STR_ACE_Common_CheckPBO_DisplayName">
             <English>Check PBOs</English>
             <Polish>Sprawdzaj PBO</Polish>
+            <Spanish>Comprobar PBOs</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Description">
             <English></English>
             <Polish>Sprawdzaj spójność addonów z serwerem</Polish>
+            <Spanish>Este módulo verifica la integridad de los addons con los que iniciamos el simulador</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Action_DisplayName">
             <English>Action</English>
             <Polish>Akcja</Polish>
+            <Spanish>Acción</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Action_Description">
             <English>What to do with people who do not have the right PBOs?</English>
             <Polish>Co zrobić z graczami, którzy nie mają właściwych PBO?</Polish>
+            <Spanish>¿Qué hacer con la gente que no tiene correctamente los PBOs?</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Action_WarnOnce">
             <English>Warn once</English>
             <Polish>Ostrzeż raz</Polish>
+            <Spanish>Avisar una vez</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Action_WarnPerm">
             <English>Warn (permanent)</English>
             <Polish>Ostrzeżenie (permanentne)</Polish>
+            <Spanish>Avisar (permanente)</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Action_Kick">
             <English>Kick</English>
             <Polish>Kick</Polish>
+            <Spanish>Expulsar</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_CheckAll_DisplayName">
             <English>Check all addons</English>
             <Polish>Sprawdź wsz. addony</Polish>
+            <Spanish>Comprobar todos los addons</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_CheckAll_Description">
             <English>Check all addons instead of only those of ACE?</English>
             <Polish>Sprawdzaj wszystkie addony czy tylko te z ACE?</Polish>
+            <Spanish>Comprobar todos los addons en vez de solo los del ACE</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Whitelist_DisplayName">
             <English>Whitelist</English>
             <Polish>Biała lista</Polish>
+            <Spanish>Lista blanca</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBO_Whitelist_Description">
             <English>What addons are allowed regardless?</English>
             <Polish>Jakie addony są dozwolone?</Polish>
+            <Spanish>Qué addons están permitidos igualmente</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_LSDVehicles_DisplayName">
             <English>LSD Vehicles</English>
             <Polish>Pojazdy LSD</Polish>
+            <Spanish>Vehículos LSD</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_LSDVehicles_Description">
             <English>Adds LSD effect to synchronized vehicle</English>
             <Polish>Dodaje efekt LSD pod zsynchronizowany pojazd</Polish>
+            <Spanish>Añade el efecto LSD al vehículo sincronizado</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Explosives">
         <Key ID="STR_ACE_Explosives_Menu">
@@ -508,22 +508,27 @@
         <Key ID="STR_ACE_Explosive_Module_DisplayName">
             <English>Explosive System</English>
             <Polish>System ładunków wybuchowych</Polish>
+            <Spanish>Sistema de explosivos</Spanish>
         </Key>
         <Key ID="STR_ACE_Explosive_RequireSpecialist_DisplayName">
             <English>Require specialists?</English>
             <Polish>Wymagaj specjalistów?</Polish>
+            <Spanish>¿Requiere especialista?</Spanish>
         </Key>
         <Key ID="STR_ACE_Explosive_RequireSpecialist_Description">
             <English>Require explosive specialists to disable explosives? Default: No</English>
             <Polish>Wymagać saperów do rozbrajania ładunków wybuchowych? Domyślnie: Nie</Polish>
+            <Spanish>Requiere especialista en explosivos para desactivar explosivos?. Por defecto: No</Spanish>
         </Key>
         <Key ID="STR_ACE_Explosive_PunishNonSpecialists_DisplayName">
             <English>Punish non-specialists?</English>
             <Polish>Karaj nie-specjalistów?</Polish>
+            <Spanish>¿Penalizar a los no especialistas?</Spanish>
         </Key>
         <Key ID="STR_ACE_Explosive_PunishNonSpecialists_Description">
             <English>Increase the time it takes to complete actions for non-specialists? Default: Yes</English>
             <Polish>Zwiększyć ilość wymaganego czasu do ukończenia akcji dla nie-specjalistów? Domyślnie: Tak</Polish>
+            <Spanish>Aumenta el tiempo que lleva completar acciones para los no especialstas?. Por defecto: Si</Spanish>
         </Key>
         <Key ID="STR_ACE_Explosive_Module_Description">
             <English></English>

--- a/addons/frag/stringtable.xml
+++ b/addons/frag/stringtable.xml
@@ -3,33 +3,42 @@
     <Package name="Frag">
         <Key ID="STR_ACE_frag_EnableFrag">
             <English>Fragmentation Simulation</English>
+            <Spanish>Simulación de fragmentación</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_EnableFrag_Desc">
             <English>Enable the ACE Fragmentation Simulation</English>
+            <Spanish>Activa la simulación de fragmentación ACE</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_EnableSpall">
             <English>Spalling Simulation</English>
+            <Spanish>Simulación de astillamiento</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_EnableSpall_Desc">
             <English>Enable the ACE Spalling Simulation</English>
+            <Spanish>Activa la simulación de astillamiento ACE</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_MaxTrack">
             <English>Maximum Projectiles Tracked</English>
+            <Spanish>Máximos proyectiles rastreados</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_MaxTrack_Desc">
-            <English>This setting controls the maximum amount of projectiles the fragmentation and spalling system will track at any given time. If more projectiles are fired, they will not be tracked. Lower this setting if you do not want FPS drops at high-count projectile scenarios ( >200 rounds in the air at once)</English>
+            <English>This setting controls the maximum amount of projectiles the fragmentation and spalling system will track at any given time. If more projectiles are fired, they will not be tracked. Lower this setting if you do not want FPS drops at high-count projectile scenarios ( &gt;200 rounds in the air at once)</English>
+            <Spanish>Este ajuste controla la cantidad máxima de proyectiles del sistema de fragmentación y astillamiento de los que se hará un seguimiento en cualquier momento dado. Si se disparan más proyectiles, no serán rastreados. Baja esta opción si no deseas una bajada de FPS en escenarios con muchos proyectiles (&gt;200 proyectiles en el aire a la vez)</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_MaxTrackPerFrame">
             <English>Maximum Projectiles Per Frame</English>
+            <Spanish>Máximos proyectiles por cuadro</Spanish>
         </Key>
         <Key ID="STR_ACE_frag_MaxTrackPerFrame_Desc">
             <English>The number of spall track calculations to perform in any given frame. This helps spread the FPS impact of tracking spall rounds across multiple frames, limiting its impact even further.</English>
         </Key>
         <Key ID="STR_ACE_frag_EnableDebugTrace">
             <English>(SP Only) Frag/Spall Debug Tracing</English>
+            <Spanish>(Solo SP) Seguimiento de depuración de Fragmentación/Astillamiento </Spanish>
         </Key>
         <Key ID="STR_ACE_frag_EnableDebugTrace_Desc">
             <English>(SP Only) Requires a mission/editor restart. Enables visual tracing of fragmentation and spalling rounds in SP game mode only.</English>
+            <Spanish>(Solo SP) Requiere un reinicio misión/editor. Permite el seguimiento visual de la fragmentación y astillamientos de los proyectiles en modo SP.</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/hearing/stringtable.xml
+++ b/addons/hearing/stringtable.xml
@@ -112,14 +112,17 @@
         <Key ID="STR_ACE_Hearing_Module_DisplayName">
             <English>Hearing</English>
             <Polish>Słuch</Polish>
+            <Spanish>Audición</Spanish>
         </Key>
         <Key ID="STR_ACE_Hearing_CombatDeafness_DisplayName">
             <English>Enable combat deafness?</English>
             <Polish>Wł. głuchotę bojową</Polish>
+            <Spanish>¿Habilitar sordera de combate?</Spanish>
         </Key>
         <Key ID="STR_ACE_Hearing_CombatDeafness_Description">
             <English>Enable combat deafness?</English>
             <Polish>Możliwość chwilowej utraty słuchu przy głośnych wystrzałach i jednoczesnym braku włożonych stoperów</Polish>
+            <Spanish>Habilita la sordera de combate</Spanish>
         </Key>
         <Key ID="STR_ACE_Hearing_Module_Description">
             <English></English>

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Interaction">
         <Key ID="STR_ACE_Interaction_MainAction">
@@ -796,14 +796,17 @@
         <Key ID="STR_ACE_InteractionSystem_Module_DisplayName">
             <English>Interaction System</English>
             <Polish>System interakcji</Polish>
+            <Spanish>Sistema de interacción</Spanish>
         </Key>
         <Key ID="STR_ACE_InteractionSystem_EnableTeamManagement_DisplayName">
             <English>Enable Team Management</English>
             <Polish>Wł. zarządzanie drużyną</Polish>
+            <Spanish>Habilitar gestión de equipos</Spanish>
         </Key>
         <Key ID="STR_ACE_InteractionSystem_EnableTeamManagement_Description">
             <English>Should players be allowed to use the Team Management Menu? Default: Yes</English>
             <Polish>Czy gracze mogą korzystać z menu zarządzania drużyną? Domyślnie: Tak</Polish>
+            <Spanish>¿Deben tener permitido los jugadores el uso del menu de gestión de equipos? Por defecto: Si</Spanish>
         </Key>
         <Key ID="STR_ACE_InteractionSystem_Module_Description">
             <English></English>

--- a/addons/map/stringtable.xml
+++ b/addons/map/stringtable.xml
@@ -4,38 +4,47 @@
         <Key ID="STR_ACE_Map_Module_DisplayName">
             <English>Map</English>
             <Polish>Mapa</Polish>
+            <Spanish>Mapa</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapIllumination_DisplayName">
             <English>Map illumination?</English>
             <Polish>Oświetlenie mapy</Polish>
+            <Spanish>¿Iluminación de mapa?</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapIllumination_Description">
             <English>Calculate dynamic map illumination based on light conditions?</English>
             <Polish>Oblicza dynamiczne oświetlenie mapy bazujące na warunkach oświetleniowych</Polish>
+            <Spanish>Calcula la iluminación dinámica del mapa basandose en las condiciones de luz</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapShake_DisplayName">
             <English>Map shake?</English>
             <Polish>Drżenie mapy</Polish>
+            <Spanish>¿Temblor de mapa?</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapShake_Description">
             <English>Make map shake when walking?</English>
             <Polish>Ekran mapy drży podczas ruchu</Polish>
+            <Spanish>Hace que el mapa tiemble cuando caminas</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapLimitZoom_DisplayName">
             <English>Limit map zoom?</English>
             <Polish>Ograniczony zoom</Polish>
+            <Spanish>¿Limitar el zoom de mapa?</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapLimitZoom_Description">
             <English>Limit the amount of zoom available for the map?</English>
             <Polish>Ogranicza maksymalny stopień przybliżenia mapy</Polish>
+            <Spanish>Limita la cantidad de zoom disponible para el mapa</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapShowCursorCoordinates_DisplayName">
             <English>Show cursor coordinates?</English>
             <Polish>Koordynaty pod kursorem</Polish>
+            <Spanish>¿Mostrar coordenadas de cursor?</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_MapShowCursorCoordinates_Description">
             <English>Show the grid coordinates on the mouse pointer?</English>
             <Polish>Pokazuje pod kursorem koordynaty wskazanego kwadratu mapy</Polish>
+            <Spanish>Muestra las coordenadas de la cuadricula en el puntero del ratón</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_Module_Description">
             <English></English>
@@ -44,22 +53,27 @@
         <Key ID="STR_ACE_Map_BFT_Module_DisplayName">
             <English>Blue Force Tracking</English>
             <Polish>Blue Force Tracking</Polish>
+            <Spanish>Seguimiento de fuerzas amigas</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_BFT_Interval_DisplayName">
             <English>Interval</English>
             <Polish>Interwał</Polish>
+            <Spanish>Intervalo</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_BFT_Interval_Description">
             <English>How often the markers should be refreshed (in seconds)</English>
             <Polish>Jak często markery powinny być odświeżane (w sekundach)</Polish>
+            <Spanish>Frecuencia de actualización de los marcadores (en segundos)</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_BFT_HideAiGroups_DisplayName">
             <English>Hide AI groups?</English>
             <Polish>Ukryj grupy AI</Polish>
+            <Spanish>¿Ocultar grupos de IA?</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_BFT_HideAiGroups_Description">
             <English>Hide markers for 'AI only' groups?</English>
             <Polish>Ukrywa markery dla grup złożonych tylko z AI</Polish>
+            <Spanish>Oculta las marcas de grupos 'solo IA'</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_BFT_Module_Description">
             <English></English>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -2704,298 +2704,372 @@
         <Key ID="STR_ACE_Medical_Category_DisplayName">
             <English>ACE Medical</English>
             <Polish>ACE Opcje medyczne</Polish>
+            <Spanish>Médico ACE</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_Module_DisplayName">
             <English>Medical Settings [ACE]</English>
             <Polish>Ustawienia medyczne [ACE]</Polish>
+            <Spanish>Ajustes médicos [ACE]</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_level_DisplayName">
             <English>Medical Level</English>
             <Polish>Poziom medyczny</Polish>
+            <Spanish>Nivel médico</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_level_Description">
             <English>What is the medical simulation level?</English>
             <Polish>Jaki jest poziom symulacji medycznej?</Polish>
+            <Spanish>¿Cuál es el nivel de simulación médica?</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_basic">
             <English>Basic</English>
             <Polish>Podstawowy</Polish>
+            <Spanish>Básico</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_advanced">
             <English>Advanced</English>
             <Polish>Zaawansowany</Polish>
+            <Spanish>Avanzado</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_medicSetting_DisplayName">
             <English>Medics setting</English>
             <Polish>Poziom medyków</Polish>
+            <Spanish>Configuración médica</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_medicSetting_Description">
             <English>What is the level of detail prefered for medics?</English>
             <Polish>Jaki jest poziom detali medycznych wyświetlanych dla medyków?</Polish>
+            <Spanish>¿Cuál es el nivel de detalle preferido para los médicos?</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_medicSetting_disable">
             <English>Disable medics</English>
             <Polish>Wyłącz medyków</Polish>
+            <Spanish>Desactivar médicos</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_allowLitterCreation_DisplayName">
             <English>Enable Litter</English>
             <Polish>Aktywuj odpadki</Polish>
+            <Spanish>Activar restos médicos</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_allowLitterCreation_Description">
             <English>Enable litter being created upon treatment</English>
             <Polish>Twórz odpadki medyczne podczas leczenia</Polish>
+            <Spanish>Activar los restos médicos que se crean en el tratamiento</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_litterCleanUpDelay_DisplayName">
             <English>Life time of litter objects</English>
             <Polish>Długość życia odpadków</Polish>
+            <Spanish>Tiempo de vida de los restos médicos</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_litterCleanUpDelay_Description">
             <English>How long should litter objects stay? In seconds. -1 is forever.</English>
             <Polish>Ile czasu musi upłynąć, aby odpadki zaczęły znikać? W sekundach. -1 dla nieskończoności.</Polish>
+            <Spanish>¿Por cuánto tiempo deben permanecer los restos médicos? En segundos. -1 es para siempre.</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_enableScreams_DisplayName">
             <English>Enable Screams</English>
             <Polish>Aktywuj wrzaski</Polish>
+            <Spanish>Activar gritos</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_enableScreams_Description">
             <English>Enable screaming by injuried units</English>
             <Polish>Aktywuj wrzeszczenie z bólu przez ranne jednostki</Polish>
+            <Spanish>Activar gritos para unidades heridas</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_playerDamageThreshold_DisplayName">
             <English>Player Damage</English>
             <Polish>Próg obrażeń graczy</Polish>
+            <Spanish>Daño de jugador</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_playerDamageThreshold_Description">
             <English>What is the damage a player can take before being killed?</English>
             <Polish>Jaki jest próg obrażeń, jakie gracz może otrzymać zanim zostanie zabity?</Polish>
+            <Spanish>¿Cuál es el daño que un jugador puede sufrir antes de morir?</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_AIDamageThreshold_DisplayName">
             <English>AI Damage</English>
             <Polish>Próg obrażeń AI</Polish>
+            <Spanish>Daño IA</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_AIDamageThreshold_Description">
             <English>What is the damage an AI can take before being killed?</English>
             <Polish>Jaki jest próg obrażeń, jakie AI może otrzymać zanim zostanie zabite?</Polish>
+            <Spanish>¿Cuál es el daño que la IA puede sufrir antes de morir?</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_enableUnconsciousnessAI_DisplayName">
             <English>AI Unconsciousness</English>
             <Polish>Nieprzytomność AI</Polish>
+            <Spanish>Inconsciencia IA</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_enableUnconsciousnessAI_Description">
             <English>Allow AI to go unconscious</English>
             <Polish>Czy AI może być nieprzytomne od odniesionych obrażeń?</Polish>
+            <Spanish>Permita a la IA caer inconsciente</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_disabled">
             <English>Disabled</English>
             <Polish>Wyłączone</Polish>
+            <Spanish>Activado</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_enabled">
             <English>Enabled</English>
             <Polish>Włączone</Polish>
+            <Spanish>Desactivado</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_preventInstaDeath_DisplayName">
             <English>Prevent instant death</English>
             <Polish>Wył. natychmiast. śmierć</Polish>
+            <Spanish>Prevenir muerte instantánea</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_preventInstaDeath_Description">
             <English>Have a unit move to unconscious instead of death</English>
             <Polish>Spraw, aby jednostka została przeniesiona do stanu nieprzytomności zamiast ginąć na miejscu od śmiertelnych obrażeń</Polish>
+            <Spanish>Mover una unidad a inconsciente en vez de a muerta</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_bleedingCoefficient_DisplayName">
             <English>Bleeding coefficient</English>
             <Polish>Mnożnik krwawienia</Polish>
+            <Spanish>Coeficiente de sangrado</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_bleedingCoefficient_Description">
             <English>Coefficient to modify the bleeding speed</English>
             <Polish>Mnożnik modyfikujący prędkość wykrwawiania się</Polish>
+            <Spanish>Coeficiente para modificar la velocidad de sangrado</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_painCoefficient_DisplayName">
             <English>Pain coefficient</English>
             <Polish>Mnożnik bólu</Polish>
+            <Spanish>Coeficiente de dolor</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_painCoefficient_Description">
             <English>Coefficient to modify the pain intensity</English>
             <Polish>Mnożnik modyfikujący intensywność bólu</Polish>
+            <Spanish>Coeficiente para modificar la intensidad del dolor</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_keepLocalSettingsSynced_DisplayName">
             <English>Sync status</English>
             <Polish>Synchronizuj status</Polish>
+            <Spanish>Sincronizador estado</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_keepLocalSettingsSynced_Description">
             <English>Keep unit status synced. Recommended on.</English>
             <Polish>Utrzymuj synchronizację statusu jednostek. Zalecane zostawienie tej opcji włączonej.</Polish>
+            <Spanish>Mantener el estado de la unidad sincronizado. Recomendado activado</Spanish>
         </Key>
         <Key ID="STR_ACE_MedicalSettings_Module_Description">
             <English>Provides a medical system for both players and AI.</English>
             <Polish>Moduł ten dostarcza system medyczny dla graczy oraz AI.</Polish>
+            <Spanish>Proporciona un sistema médico para  jugadores e IA.</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_Module_DisplayName">
             <English>Advanced Medical Settings [ACE]</English>
             <Polish>Zaawansowane ustawienia medyczne [ACE]</Polish>
+            <Spanish>Ajustes médicos avanzados [ACE]</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_enableFor_DisplayName">
             <English>Enabled for</English>
             <Polish>Aktywne dla</Polish>
+            <Spanish>Hablitado para</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_enableFor_Description">
             <English>Select what units the advanced medical system will be enabled for</English>
             <Polish>Wybierz dla kogo zaawansowany system medyczny będzie aktywny</Polish>
+            <Spanish>Seleccione para qué unidades será habilitado el sistema médico avanzado</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_playeronly">
             <English>Players only</English>
             <Polish>Tylko dla graczy</Polish>
+            <Spanish>Solo jugadores</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_playersandai">
             <English>Players and AI</English>
             <Polish>Gracze oraz AI</Polish>
+            <Spanish>Jugadors e IA</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_enableAdvancedWounds_DisplayName">
             <English>Enable Advanced wounds</English>
             <Polish>Akt. zaawansowane rany</Polish>
+            <Spanish>Activa heridas avanzadas</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_enableAdvancedWounds_Description">
             <English>Allow reopening of bandaged wounds?</English>
             <Polish>Pozwól na otwieranie się zabandażowanych ran?</Polish>
+            <Spanish>Permitir la reapertura de las heridas vendadas?</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_enableVehicleCrashes_DisplayName">
             <English>Vehicle Crashes</English>
             <Polish>Obrażenia od kolizji</Polish>
+            <Spanish>Accidentes de vehículos</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_enableVehicleCrashes_Description">
             <English>Do units take damage from a vehicle crash?</English>
             <Polish>Czy jednostki otrzymują obrażenia w wyniku kolizji pojazdów?</Polish>
+            <Spanish>¿Las unidades reciben daño de un accidente de tráfico?</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_PAK_DisplayName">
             <English>Allow PAK</English>
             <Polish>Ust. apteczek osobistych</Polish>
+            <Spanish>Permitir EPA</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_PAK_Description">
             <English>Who can use the PAK for full heal?</English>
             <Polish>Kto może skorzystać z apteczki osobistej w celu pełnego uleczenia?</Polish>
+            <Spanish>¿Quién puede utilizar el EPA para una cura completa?</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_anyone">
             <English>Anyone</English>
             <Polish>Wszyscy</Polish>
+            <Spanish>Nadie</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_Medic">
             <English>Medics only</English>
             <Polish>Tylko medycy</Polish>
+            <Spanish>Solo médicos</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_Special">
             <English>Doctors only</English>
             <Polish>Tylko doktorzy</Polish>
+            <Spanish>Solo doctores</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_PAK_DisplayName">
             <English>Remove PAK on use</English>
             <Polish>Usuń apteczkę po użyciu</Polish>
+            <Spanish>Eliminar EPA después del uso</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_PAK_Description">
             <English>Should PAK be removed on usage?</English>
             <Polish>Czy apteczka osobista powinna zniknąć z ekwipunku po jej użyciu?</Polish>
+            <Spanish>El EPA será eliminado después de usarlo</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_PAK_DisplayName">
             <English>Locations PAK</English>
             <Polish>Ogr. apteczek osobistych</Polish>
+            <Spanish>Ubicacions del EPA</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_PAK_Description">
             <English>Where can the personal aid kit be used?</English>
             <Polish>Gdzie można korzystać z apteczek osobistych?</Polish>
+            <Spanish>¿Dónde se puede utilizar el equipo de primeros auxilios?</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_anywhere">
             <English>Anywhere</English>
             <Polish>Wszędzie</Polish>
+            <Spanish>Donde sea</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_vehicle">
             <English>Medical vehicles</English>
             <Polish>Pojazdy medyczne</Polish>
+            <Spanish>Vehiculos médicos</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_facility">
             <English>Medical facility</English>
             <Polish>Budynki medyczne</Polish>
+            <Spanish>Centro médico</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_vehicleAndFacility">
             <English>Vehicles &amp; facility</English>
             <Polish>Pojazdy i budynki medyczne</Polish>
+            <Spanish>Vehículos y centros</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_disabled">
             <English>Disabled</English>
             <Polish>Wyłączone</Polish>
+            <Spanish>Desactivado</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_SurgicalKit_DisplayName">
             <English>Allow Surgical kit (Adv)</English>
             <Polish>Ust. zestawu chirurg.</Polish>
+            <Spanish>Permitir equipo quirúrgico (Avanzado)</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_medicSetting_SurgicalKit_Description">
             <English>Who can use the surgical kit?</English>
             <Polish>Kto może skorzystać z zestawu chirurgicznego w celu zszycia ran?</Polish>
+            <Spanish>¿Quién puede utilizar el equipo quirúrgico?</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_SurgicalKit_DisplayName">
             <English>Remove Surgical kit (Adv)</English>
             <Polish>Usuń zest. chir. po użyciu</Polish>
+            <Spanish>Eliminar equipo quirúrgico (Avanzado)</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_consumeItem_SurgicalKit_Description">
             <English>Should Surgical kit be removed on usage?</English>
             <Polish>Czy zestaw chirurgiczny powinien zniknąć z ekwipunku po jego użyciu?</Polish>
+            <Spanish>Eliminar el equipo quirúrgico después del uso</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_SurgicalKit_DisplayName">
             <English>Locations Surgical kit (Adv)</English>
             <Polish>Ogr. zestawu chirurg.</Polish>
+            <Spanish>Ubicaciones del equipo quirúrgico (Avanzado)</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_useLocation_SurgicalKit_Description">
             <English>Where can the Surgical kit be used?</English>
             <Polish>Gdzie można korzystać z zestawu chirurgicznego?</Polish>
+            <Spanish>Dónde se puede utilizar el equipo quirúrgico</Spanish>
         </Key>
         <Key ID="STR_ACE_AdvancedMedicalSettings_Module_Description">
             <English>Configure the treatment settings from ACE Medical</English>
             <Polish>Skonfiguruj zaawansowane ustawienia leczenia systemu medycznego ACE</Polish>
+            <Spanish>Configure las opciones de tratamiento del ACE Médico</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_Module_DisplayName">
             <English>Revive Settings [ACE]</English>
             <Polish>Ustawienia wskrzeszania [ACE]</Polish>
+            <Spanish>Sistema de resucitado [ACE]</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_enableRevive_DisplayName">
             <English>Enable Revive</English>
             <Polish>Aktywuj wskrzeszanie</Polish>
+            <Spanish>Habilitar resucitado</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_enableRevive_Description">
             <English>Enable a basic revive system</English>
             <Polish>Aktywuj podstawowy system wskrzeszania</Polish>
+            <Spanish>Habilitar un sistema básico de resucitado</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_maxReviveTime_DisplayName">
             <English>Max Revive time</English>
             <Polish>Maks. czas agonii</Polish>
+            <Spanish>Tiempo máximo de resucitado</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_maxReviveTime_Description">
             <English>Max amount of seconds a unit can spend in revive state</English>
             <Polish>Maksymalna długość agonii w sekundach (czas na wskrzeszenie)</Polish>
+            <Spanish>Cantidad máxima de segundos que una unidad puede gastar en estado de resucitación</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_amountOfReviveLives_DisplayName">
             <English>Max Revive lives</English>
             <Polish>Maks. ilość wskrzeszeń</Polish>
+            <Spanish>Vidas máximas de resucitado</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_amountOfReviveLives_Description">
             <English>Max amount of lives a unit. 0 or -1 is disabled.</English>
             <Polish>Maksymalna ilość wskrzeszeń. Wpisz 0 lub -1 aby wyłączyć.</Polish>
+            <Spanish>Cantidad máxima de vidas por unidad. 0 o -1 es desactivado.</Spanish>
         </Key>
         <Key ID="STR_ACE_ReviveSettings_Module_Description">
             <English>Provides a medical system for both players and AI.</English>
             <Polish>Moduł ten aktywuje podstawowy system wskrzeszania. Jednostka po otrzymaniu śmiertelnych obrażeń przechodzi do stanu agonii, która trwa określoną długość czasu. W tym czasie aby wskrzesić i jednocześnie odratować jednostkę należy opatrzeć jej rany i wykonać RKO.</Polish>
+            <Spanish>Proporciona un sistema médico para jugadores e IA.</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_Module_DisplayName">
             <English>Set Medic Class [ACE]</English>
             <Polish>Ustaw klasę medyka [ACE]</Polish>
+            <Spanish>Establecer case médica [ACE]</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_EnableList_DisplayName">
             <English>List</English>
             <Polish>Lista</Polish>
+            <Spanish>Lista</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_EnableList_Description">
             <English>List of unit names that will be classified as medic, separated by commas.</English>
             <Polish>Lista nazw jednostek, które są sklasyfikowane jako medycy, oddzielone przecinkami.</Polish>
+            <Spanish>Lista de los nombres de las unidades que se clasifican como médico, separados por comas.</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_role_DisplayName">
             <English>Is Medic</English>
             <Polish>Klasa medyczna</Polish>
+            <Spanish>Es médico</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_role_Description">
             <English></English>
@@ -3004,66 +3078,82 @@
         <Key ID="STR_ACE_AssignMedicRoles_role_none">
             <English>None</English>
             <Polish>Żadna</Polish>
+            <Spanish>Nada</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_role_medic">
             <English>Regular medic</English>
             <Polish>Zwykły medyk</Polish>
+            <Spanish>Médico regular</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_role_doctor">
             <English>Doctor (Only Advanced Medics)</English>
             <Polish>Doktor (tylko zaawansowani medycy)</Polish>
+            <Spanish>Doctor (Solo medicina avanzada)</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicRoles_Module_Description">
             <English>Assigns the ACE medic class to a unit</English>
             <Polish>Moduł ten przypisuje klasę medyka ACE do jednostek.</Polish>
+            <Spanish>Asigna la clase médico ACE a una unidad</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicVehicle_Module_DisplayName">
             <English>Set Medical Vehicle [ACE]</English>
             <Polish>Ustaw pojazd medyczny [ACE]</Polish>
+            <Spanish>Establecer vehículos médicos [ACE]</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicVehicle_EnableList_DisplayName">
             <English>List</English>
             <Polish>Lista</Polish>
+            <Spanish>Lista</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicVehicle_EnableList_Description">
             <English>List of vehicles that will be classified as medical vehicle, separated by commas.</English>
             <Polish>Lista nazw pojazdów, które są sklasyfikowane jako pojazdy medyczne, oddzielone przecinkami.</Polish>
+            <Spanish>Lista de los vehículos que se clasifican como vehículo médicos, separados por comas.</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicVehicle_enabled_DisplayName">
             <English>Is Medical Vehicle</English>
             <Polish>Jest pojazdem med.</Polish>
+            <Spanish>Es vehículo médico</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicVehicle_enabled_Description">
             <English>Whatever or not the objects in the list will be a medical vehicle.</English>
             <Polish>Czy pojazdy z tej listy są pojazdami medycznymi.</Polish>
+            <Spanish>Cualquiera de la lista o fuera de ella será un vehículo médico.</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicVehicle_Module_Description">
             <English>Assigns the ACE medic class to a unit</English>
             <Polish>Moduł ten pozwala na przypisanie danym pojazdom statusu pojazdów medycznych. Wewnątrz takiego pojazdu można wykonywać zaawansowane zabiegi medyczne.</Polish>
+            <Spanish>Asigna la clase médico ACE a una unidad</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicalFacility_Module_DisplayName">
             <English>Set Medical Facility [ACE]</English>
             <Polish>Ustaw budynek medyczny [ACE]</Polish>
+            <Spanish>Establece el centro médico [ACE]</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicalFacility_enabled_DisplayName">
             <English>Is Medical Facility</English>
             <Polish>Jest budynkiem med.</Polish>
+            <Spanish>Es centro médico</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicalFacility_enabled_Description">
             <English>Registers an object as a medical facility</English>
             <Polish>Przypisuje danemu obiektowi status budynku medycznego</Polish>
+            <Spanish>Registra un objeto como un centro médico</Spanish>
         </Key>
         <Key ID="STR_ACE_AssignMedicalFacility_Module_Description">
             <English>Defines an object as a medical facility. This allows for more advanced treatments. Can be used on buildings and vehicles.</English>
             <Polish>Moduł ten pozwala przypisać status budynku medycznego danemu obiektowi. Budynek taki pozwala na wykonywanie zaawansowanych zabiegów medycznych. Może być użyte na pojazdach i budynkach.</Polish>
+            <Spanish>Define un objeto como un centro médico. Esto permite tratamientos más avanzados. Se puede utilizar en edificios y vehículos.</Spanish>
         </Key>
         <Key ID="STR_ACE_medicalSupplyCrate">
             <English>[ACE] Medical Supply Crate (Basic)</English>
             <Polish>[ACE] Skrzynka z zapasami medycznymi (podstawowa)</Polish>
+            <Spanish>[ACE] Caja de suministros médicos (Básica)</Spanish>
         </Key>
         <Key ID="STR_ACE_medicalSupplyCrate_advanced">
             <English>[ACE] Medical Supply Crate (Advanced)</English>
             <Polish>[ACE] Skrzynka z zapasami medycznymi (zaawansowana)</Polish>
+            <Spanish>[ACE] Caja de suministros médicos (Avanzada)</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_Yes">
             <English>Yes</English>

--- a/addons/microdagr/stringtable.xml
+++ b/addons/microdagr/stringtable.xml
@@ -304,30 +304,37 @@
         <Key ID="STR_ACE_Dagr_Module_DisplayName">
             <English>MicroDAGR Map Fill</English>
             <Polish>Wypełnienie mapy MicroDAGR</Polish>
+            <Spanish>Relleno del mapa MicroDAGR</Spanish>
         </Key>
         <Key ID="STR_ACE_Dagr_MapDataAvailable_DisplayName">
             <English>MicroDAGR Map Fill</English>
             <Polish>Wypełnienie mapy MicroDAGR</Polish>
+            <Spanish>Relleno del mapa MicroDAGR</Spanish>
         </Key>
         <Key ID="STR_ACE_Dagr_MapDataAvailable_Description">
             <English>How much map data is filled on MicroDAGR's</English>
             <Polish>Jak duża część informacji mapy jest załadowana do MicroDAGR?</Polish>
+            <Spanish>Cuanta información está disponible en el mapa del MicroDAG</Spanish>
         </Key>
         <Key ID="STR_ACE_Dagr_None">
             <English>Full Satellite + Buildings</English>
             <Polish>Pełna satelitarna + budynki</Polish>
+            <Spanish>Satelite completo + Edificios</Spanish>
         </Key>
         <Key ID="STR_ACE_Dagr_Side">
             <English>Topographical + Roads</English>
             <Polish>Topograficzna + drogi</Polish>
+            <Spanish>Topografico + Carreteras</Spanish>
         </Key>
         <Key ID="STR_ACE_Dagr_Unique">
             <English>None (Cannot use map view)</English>
             <Polish>Żadna (wyłącza ekran mapy)</Polish>
+            <Spanish>Nada (No se puede el mapa)</Spanish>
         </Key>
         <Key ID="STR_ACE_Dagr_Module_Description">
             <English>Controls how much data is filled on the microDAGR items.  Less data restricts the map view to show less on the minimap.&lt;br /&gt;Source: microDAGR.pbo</English>
             <Polish>Moduł ten pozwala kontrolować jak duża ilość informacji jest załadowana do przedmiotów MicroDAGR. Mniejsza ilość danych ogranicza widok mapy pokazując mniej rzeczy na minimapie.&lt;br /&gt;Źródło: microDAGR.pbo</Polish>
+            <Spanish>Controla la cantidad de información disponible en el microDAGR. Menos datos limitan la vista del mapa a mostrar menos en el minimapa.&lt;br /&gt;Fuente: microDAGR.pbo</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/missileguidance/stringtable.xml
+++ b/addons/missileguidance/stringtable.xml
@@ -100,14 +100,17 @@
         <Key ID="STR_ACE_MissileGuidance_Off">
             <English>Off</English>
             <Polish>Wyłącz</Polish>
+            <Spanish>Desactivado</Spanish>
         </Key>
         <Key ID="STR_ACE_MissileGuidance_PlayerOnly">
             <English>Player Only</English>
             <Polish>Tylko gracz</Polish>
+            <Spanish>Solo jugador</Spanish>
         </Key>
         <Key ID="STR_ACE_MissileGuidance_PlayerAndAi">
             <English>Player and AI</English>
             <Polish>Gracz oraz AI</Polish>
+            <Spanish>Jugador e IA</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/missionmodules/stringtable.xml
+++ b/addons/missionmodules/stringtable.xml
@@ -1,73 +1,90 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Mission Modules">
         <Key ID="STR_ACE_MissionModules_Category_DisplayName">
             <English>ACE Mission Modules</English>
             <Polish>ACE Moduły misji</Polish>
+            <Spanish>Módulo de misiones ACE</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_DisplayName">
             <English>Ambiance Sounds [ACE]</English>
             <Polish>Dźwięki [ACE]</Polish>
+            <Spanish>[ACE] Sonidos ambiente</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundFiles_DisplayName">
             <English>Sounds</English>
             <Polish>Dźwięki</Polish>
+            <Spanish>Sonidos</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundFiles_Description">
             <English>Class names of the ambiance sounds to be played. Seperated by ','</English>
             <Polish>Class name-y dźwięków do odtwarzania. Oddzielone przy użyciu ','</Polish>
+            <Spanish>Class names de los sonidos ambiente que se reproducirán. Separados por ','</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDistance_DisplayName">
             <English>Minimal Distance</English>
             <Polish>Minimalny dystans</Polish>
+            <Spanish>Distancia mínima</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDistance_Description">
             <English>Used for calculating a random position and sets the minimal distance between the players and the played sound file(s)</English>
             <Polish>Używany do obliczania losowej pozycji a także ustawia minimalny dystans pomiędzy graczami a odtwarzanymi plikami dźwiękowymi</Polish>
+            <Spanish>Usado para calcular una posición aleatoria y establecer la distancia mínima entre los jugadores y los ficheros de sonido reproducidos</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDistance_DisplayName">
             <English>Maximum Distance</English>
             <Polish>Maksymalny dystans</Polish>
+            <Spanish>Distancia máxima</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDistance_Description">
             <English>Used for calculating a random position and sets the maximum distance between the players and the played sound file(s)</English>
             <Polish>Używany do obliczania losowej pozycji a także ustawia maksymalny dystans pomiędzy graczami a odtwarzanymi plikami dźwiękowymi</Polish>
+            <Spanish>Usado para calcular una posición aleatoria y establecer la distancia máxima entre los jugadores y los ficheros de sonido reproducidos</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDelay_DisplayName">
             <English>Minimal Delay</English>
             <Polish>Minimalne opóźnienie</Polish>
+            <Spanish>Retraso mínimo</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_minimalDelay_Description">
             <English>Minimal delay between sounds played</English>
             <Polish>Minimalne opóźnienie pomiędzy odtwarzanymi dźwiękami</Polish>
+            <Spanish>Retraso mínimo entre los sonidos reproducidos</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDelay_DisplayName">
             <English>Maximum Delay</English>
             <Polish>Maksymalne opóźnienie</Polish>
+            <Spanish>Retraso máximo</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_maximalDelay_Description">
             <English>Maximum delay between sounds played</English>
             <Polish>Maksymalne opóźnienie pomiędzy odtwarzanymi dźwiękami</Polish>
+            <Spanish>Retraso máximo entre los sonidos reproducidos</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_followPlayers_DisplayName">
             <English>Follow Players</English>
             <Polish>Podążaj za graczami</Polish>
+            <Spanish>Seguir jugadores</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_followPlayers_Description">
             <English>Follow players. If set to false, loop will play sounds only nearby logic position.</English>
             <Polish>Podążaj za graczami. Jeżeli ustawione na 'Nie', pętla będzie odtwarzana tylko w pobliżu pozycji logiki.</Polish>
+            <Spanish>Seguir jugadores. Si esta desabilitado (false), se reproducirán sonidos en bucle solo cerca de la posición lógica.</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundVolume_DisplayName">
             <English>Volume</English>
             <Polish>Głośność</Polish>
+            <Spanish>Volumen</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_soundVolume_Description">
             <English>The volume of the sounds played</English>
             <Polish>Głośność odtwarzanych dźwięków</Polish>
+            <Spanish>Volumen de los sonidos reproducidos</Spanish>
         </Key>
         <Key ID="STR_ACE_MissionModules_AmbianceSounds_Description">
             <English>Ambiance sounds loop (synced across MP)</English>
             <Polish>Pętla odtwarzania dzwięków (synchronizowana na MP)</Polish>
+            <Spanish>Bucle de sonidos ambiente (sincronizados en MP)</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/mk6mortar/stringtable.xml
+++ b/addons/mk6mortar/stringtable.xml
@@ -52,30 +52,37 @@
         <Key ID="STR_ACE_mk6mortar_Module_DisplayName">
             <English>MK6 Settings</English>
             <Polish>Moździerz MK6 - Ustawienia</Polish>
+            <Spanish>Ajustes MK6</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_airResistanceEnabled_DisplayName">
             <English>Air Resistance</English>
             <Polish>Opór powietrza</Polish>
+            <Spanish>Resistencia al aire</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_airResistanceEnabled_Description">
             <English>For Player Shots, Model Air Resistance and Wind Effects</English>
             <Polish>Modeluj opór powietrza oraz wpływ wiatru na tor lotu pocisku dla strzałów z moździerza MK6 przez graczy</Polish>
+            <Spanish>Para disparos del jugador, modelo de resistencia al aire y efectos de viento</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_allowComputerRangefinder_DisplayName">
             <English>Allow MK6 Computer</English>
             <Polish>Komputer MK6</Polish>
+            <Spanish>Habilitar ordenador del MK6</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_allowComputerRangefinder_Description">
             <English>Show the Computer and Rangefinder (these NEED to be removed if you enable air resistance)</English>
             <Polish>Zezwól na komputer i dalmierz (opcja ta MUSI zostać wyłączona jeżeli aktywowałeś opór powietrza)</Polish>
+            <Spanish>Muestra el ordenador y el medidor de distancia (DEBEN ser quitados si se activa la resistecia al aire)</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_allowCompass_DisplayName">
             <English>Allow MK6 Compass</English>
             <Polish>Kompas MK6</Polish>
+            <Spanish>Habilitar brujula del MK6</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_allowCompass_Description">
             <English>Show the MK6 Digital Compass</English>
             <Polish>Pokaż kompas MK6</Polish>
+            <Spanish>Muestra la brujula digital en el MK6</Spanish>
         </Key>
         <Key ID="STR_ACE_mk6mortar_Module_Description">
             <English></English>

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -112,50 +112,62 @@
         <Key ID="STR_ACE_NameTags_Module_DisplayName">
             <English>Name Tags</English>
             <Polish>Ustawienia imion</Polish>
+            <Spanish>Etiquetas de nombre</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_PlayerNamesViewDistance_DisplayName">
             <English>Player Names View Dist.</English>
             <Polish>Zasięg imion graczy</Polish>
+            <Spanish>Distancia de vision para nombres de jugadores</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_PlayerNamesViewDistance_Description">
             <English>Distance in meters at which player names are shown. Default: 5</English>
             <Polish>Dystans w metrach, na którym wyświetlane są imiona graczy. Domyślnie: 5</Polish>
+            <Spanish>Distancia en metros a la que se muestran los nombres de los jugadores. Por defecto: 5</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_showNamesForAI_DisplayName">
             <English>Show name tags for AI?</English>
             <Polish>Imiona AI</Polish>
+            <Spanish>¿Mostrar nombres para la IA?</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_showNamesForAI_Description">
             <English>Show the name and rank tags for friendly AI units? Default: Do not force</English>
             <Polish>Pokaż imiona i rangi przyjaznych jednostek AI? Domyślnie: Nie wymuszaj</Polish>
+            <Spanish>Muestra etiquetas de nombre y rango para las unidades IA amigas? Por defecto: No forzar</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_DoNotForce">
             <English>Do Not Force</English>
             <Polish>Nie wymuszaj</Polish>
+            <Spanish>No forzar</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_ForceHide">
             <English>Force Hide</English>
             <Polish>Wymuś ukrycie</Polish>
+            <Spanish>Ocultar forzado</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_ForceShow">
             <English>Force show</English>
             <Polish>Wymuś wyświetlanie</Polish>
+            <Spanish>Mostrar forzado</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_showVehicleCrewInfo_DisplayName">
             <English>Show crew info?</English>
             <Polish>Pokaż załogę</Polish>
+            <Spanish>¿Mostrar información de la tripulación?</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_showVehicleCrewInfo_Description">
             <English>Show vehicle crew info, or by default allows players to choose it on their own. Default: Do Not Force</English>
             <Polish>Pokaż informacje o obsadzie pojazdu, lub pozwól graczom ustawić tą opcje według własnego uznania. Domyślnie: Nie wymuszaj</Polish>
+            <Spanish>Muestra información de la tripulación, o por defecto permite a los jugadores elegirlo. Por defecto: No forzar</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_showCursorTagForVehicles_DisplayName">
             <English>Show for Vehicles</English>
             <Polish>Pokaż dla pojazdów</Polish>
+            <Spanish>Mostrar para vehiculos</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_showCursorTagForVehicles_Description">
             <English>Show cursor NameTag for vehicle commander (only if client has name tags enabled)Default: No</English>
             <Polish>Pokazuj imię dowódcy pojazdu nad pojazdem (tylko jeżeli klient ma włączone imiona graczy). Domyślnie: Nie</Polish>
+            <Spanish>Muestra etiquetas de nombre en el cursor para el comandante del vehiculo (solo si el cliente tiene las etiquetas de nombre activadas) Por defecto: No</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_Module_Description">
             <English></English>
@@ -164,34 +176,41 @@
         <Key ID="STR_ACE_Common_Disabled">
             <English>Disabled</English>
             <Polish>Wyłączone</Polish>
+            <Spanish>Desactivado</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_Enabled">
             <English>Enabled</English>
             <Polish>Włączone</Polish>
+            <Spanish>Activado</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_OnlyCursor">
             <English>Only Cursor</English>
             <Polish>Tylko pod kursorem</Polish>
+            <Spanish>Solo cursor</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_OnlyOnKeypress">
             <English>Only On Keypress</English>
             <Polish>Tylko po wciśnięciu klawisza</Polish>
+            <Spanish>Solo al pulsar tecla</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_OnlyCursorAndKeyPress">
             <English>Only Cursor and KeyPress</English>
             <Polish>Tylko pod kursorem i po wciśnięciu klawisza</Polish>
+            <Spanish>En cursor y al pulsar tecla</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_NameTagSettings">
             <English>Use Nametag settings</English>
             <Polish>Użyj ustawień imion</Polish>
+            <Spanish>Usar ajustes de etiquetas de nombre</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_AlwaysShowAll">
             <English>Always Show All</English>
             <Polish>Zawsze pokazuj wszystkie</Polish>
+            <Spanish>Mostrar siempre todo</Spanish>
         </Key>
         <Key ID="STR_ACE_NameTags_ShowPlayerNames_Desc">
             <English></English>
-            <Polish>Opcja ta pozwala dostosować sposób wyświetlania imion nad głowami graczy. Opcja "Tylko po wciśnięciu klawisza" wyświetla imiona tylko przytrzymania klawisza "Modyfikator" dostępnego w menu ustawień addonów -> ACE3.</Polish>
+            <Polish>Opcja ta pozwala dostosować sposób wyświetlania imion nad głowami graczy. Opcja "Tylko po wciśnięciu klawisza" wyświetla imiona tylko przytrzymania klawisza "Modyfikator" dostępnego w menu ustawień addonów -&gt; ACE3.</Polish>
         </Key>
         <Key ID="STR_ACE_NameTags_ShowSoundWaves_Desc">
             <English></English>

--- a/addons/optionsmenu/stringtable.xml
+++ b/addons/optionsmenu/stringtable.xml
@@ -244,46 +244,57 @@
         <Key ID="STR_AllowConfigExport_Module_DisplayName">
             <English>Allow Config Export [ACE]</English>
             <Polish>Pozwól na eksport ustawień [ACE]</Polish>
+            <Spanish>[ACE] Permitir exportar configuración</Spanish>
         </Key>
         <Key ID="STR_AllowConfigExport_allowconfigurationExport_DisplayName">
             <English>Allow</English>
             <Polish>Zezwól</Polish>
+            <Spanish>Permitir</Spanish>
         </Key>
         <Key ID="STR_AllowConfigExport_allowconfigurationExport_Description">
             <English>Allow export of all settings to a server config formatted.</English>
             <Polish>Zezwól na eksport wszystkich ustawień do formatu konfiguracji serwera.</Polish>
+            <Spanish>Permitir la exportación de todos los ajustes de configuración a un servidor con formato.</Spanish>
         </Key>
         <Key ID="STR_AllowConfigExport_Module_Description">
             <English>When allowed, you have access to the settings modification and export in SP. Clicking export will place the formated config on your clipboard.</English>
             <Polish>Jeżeli ustawione na zezwól, wtedy będziesz mieć dostęp do ekranu modyfikacji wszystich ustawień i zmiennych ACE, a także będziesz mieć możliwość eksportu tychże ustawień do formatu rozpoznawalnego przez userconfig serwera. Kliknięcie opcji Eksportuj skopiuje wszystkie ustawienia do schowka. Działa tylko w trybie SP.</Polish>
+            <Spanish>Cuando esta permitido, se tiene acceso a los ajustes de modificación y exportación en SP. Pulsar en exportar copiara la configuración al portapapeles.</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_Hide">
             <English>Hide</English>
             <Polish>Ukryj</Polish>
+            <Spanish>Ocultar</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_TopRightDown">
             <English>Top right, downwards</English>
             <Polish>Po prawej u góry, w dół</Polish>
+            <Spanish>Arriba a la derecha, hacia abajo</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_TopRightLeft">
             <English>Top right, to the left</English>
             <Polish>Po prawej u góry, do lewej</Polish>
+            <Spanish>Arriba a la derecha, hacia la izquierda</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_TopLeftDown">
             <English>Top left, downwards</English>
             <Polish>Po lewej u góry, w dół</Polish>
+            <Spanish>Arriba a la izquierda, hacia abajo</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_TopLeftRight">
             <English>Top left, to the right</English>
             <Polish>Po lewej u góry, do prawej</Polish>
+            <Spanish>Arriba a la izquierda, hacia la derecha</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_Top">
             <English>Top</English>
             <Polish>Góra</Polish>
+            <Spanish>Arriba</Spanish>
         </Key>
         <Key ID="STR_ACE_Common_Bottom">
             <English>Bottom</English>
             <Polish>Dół</Polish>
+            <Spanish>Abajo</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/respawn/stringtable.xml
+++ b/addons/respawn/stringtable.xml
@@ -148,22 +148,27 @@
         <Key ID="STR_ACE_Respawn_Module_DisplayName">
             <English>Respawn System</English>
             <Polish>System odrodzenia</Polish>
+            <Spanish>Sistema de reaparición</Spanish>
         </Key>
         <Key ID="STR_ACE_Respawn_SavePreDeathGear_DisplayName">
             <English>Save Gear?</English>
             <Polish>Zapisać ekwipunek?</Polish>
+            <Spanish>¿Guardar equipo?</Spanish>
         </Key>
         <Key ID="STR_ACE_Respawn_SavePreDeathGear_Description">
             <English>Respawn with the gear a soldier had just before his death?</English>
             <Polish>Odradzaj z ekwipunkiem jaki żołnierz miał tuż przed swoją śmiercią?</Polish>
+            <Spanish>Reaparece con el equipo que el soldado tenía justo antes de morir</Spanish>
         </Key>
         <Key ID="STR_ACE_Respawn_RemoveDeadBodiesDisconnected_DisplayName">
             <English>Remove bodies?</English>
             <Polish>Usuwać ciała?</Polish>
+            <Spanish>¿Eliminar cuerpos?</Spanish>
         </Key>
         <Key ID="STR_ACE_Respawn_RemoveDeadBodiesDisconnected_Description">
             <English>Remove player bodies after disconnect?</English>
             <Polish>Usuwaj ciała graczy po rozłączeniu z serwera?</Polish>
+            <Spanish>Elimina los cuerpos de los jugadores cuando se desconecten</Spanish>
         </Key>
         <Key ID="STR_ACE_Respawn_Module_Description">
             <English></English>
@@ -172,6 +177,7 @@
         <Key ID="STR_ACE_FriendlyFire_Module_DisplayName">
             <English>Friendly Fire Messages</English>
             <Polish>Wiadomości Friendly Fire</Polish>
+            <Spanish>Mensajes de fuego amigo</Spanish>
         </Key>
         <Key ID="STR_ACE_FriendlyFire_Module_Description">
             <English></English>
@@ -180,18 +186,21 @@
         <Key ID="STR_ACE_Rallypoint_Module_DisplayName">
             <English>Rallypoint System</English>
             <Polish>System punktu zbiórki</Polish>
+            <Spanish>Sistema de punto de reunión</Spanish>
         </Key>
         <Key ID="STR_ACE_Rallypoint_Module_Description">
             <English></English>
-            <Polish>Moduł ten pozwala zastosować na misji "punkt zbiórki", do którego można szybko przeteleportować się z "bazy". Wymaga postawienia odpowiednich obiektów na mapie - bazy oraz flagi. Obydwa dostępne są w kategorii Puste -> ACE Odrodzenie.</Polish>
+            <Polish>Moduł ten pozwala zastosować na misji "punkt zbiórki", do którego można szybko przeteleportować się z "bazy". Wymaga postawienia odpowiednich obiektów na mapie - bazy oraz flagi. Obydwa dostępne są w kategorii Puste -&gt; ACE Odrodzenie.</Polish>
         </Key>
         <Key ID="STR_ACE_Rallypoint_MoveRallypoint">
             <English>Move Rallypoint</English>
             <Polish>Przenieś punkt zbiórki</Polish>
+            <Spanish>Mover punto de reunión</Spanish>
         </Key>
         <Key ID="STR_ACE_Respawn_EditorCategory">
             <English>ACE Respawn</English>
             <Polish>ACE Odrodzenie</Polish>
+            <Spanish>Reaparición ACE</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/switchunits/stringtable.xml
+++ b/addons/switchunits/stringtable.xml
@@ -28,54 +28,67 @@
         <Key ID="STR_ACE_SwitchUnits_Module_DisplayName">
             <English>SwitchUnits System</English>
             <Polish>System zmiany stron</Polish>
+            <Spanish>Sistema de cambio de unidad</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToWest_DisplayName">
             <English>Switch to West?</English>
             <Polish>Zmiana na Zachód?</Polish>
+            <Spanish>¿Cambiar a Oeste?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToWest_Description">
             <English>Allow switching to west units?</English>
             <Polish>Pozwolić zmieniać graczom stronę na Zachód?</Polish>
+            <Spanish>¿Permitir cambios a unidades del Oeste?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToEast_DisplayName">
             <English>Switch to East?</English>
             <Polish>Zmiana na Wschód?</Polish>
+            <Spanish>¿Cambiar a Este?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToEast_Description">
             <English>Allow switching to east units?</English>
             <Polish>Pozwolić zmieniać graczom stronę na Wschód?</Polish>
+            <Spanish>¿Permitir cambios a unidades del Este?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToIndependent_DisplayName">
             <English>Switch to Independent?</English>
             <Polish>Zmiana na Ruch Oporu?</Polish>
+            <Spanish>¿Cambiar a Independiente?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToIndependent_Description">
             <English>Allow switching to independent units?</English>
             <Polish>Pozwolić zmieniać stronę na Ruch Oporu?</Polish>
+            <Spanish>¿Permitir cambios a unidades Independientes?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToCivilian_DisplayName">
             <English>Switch to Civilian?</English>
             <Polish>Zmiana na Cywili?</Polish>
+            <Spanish>¿Cambiar a Civil?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToCivilian_Description">
             <English>Allow switching to civilian units?</English>
             <Polish>Pozwolić zmieniać stronę na Cywili?</Polish>
+            <Spanish>¿Permitir cambios a unidades Civiles</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_EnableSafeZone_DisplayName">
             <English>Enable Safe Zone?</English>
             <Polish>Aktywuj bezp. strefę?</Polish>
+            <Spanish>¿Habilitar zona segura?</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_EnableSafeZone_Description">
             <English>Enable a safe zone around enemy units? Players can't switch to units inside of the safe zone.</English>
             <Polish>Aktywuje bezpieczną strefę wokół jednostek przeciwnika. Gracze nie mogą zmieniać strony wewnątrz tej strefy.</Polish>
+            <Spanish>Habilita una zona segura alrededor de las unidades enemigas. Los jugadores no pueden cambiar de unidad dentro de la zona segura.</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SafeZoneRadius_DisplayName">
             <English>Safe Zone Radius</English>
             <Polish>Promień bezp. strefy</Polish>
+            <Spanish>Radio de la zona segura</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SafeZoneRadius_Description">
             <English>The safe zone around players from a different team. Default: 200</English>
             <Polish>Promień bezpiecznej strefy wokół graczy z innych drużyn. Domyślnie: 200</Polish>
+            <Spanish>La zona segura alrededor de los jugadores de distintos equipos. Por defecto: 200</Spanish>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_Module_Description">
             <English></English>

--- a/addons/vehiclelock/stringtable.xml
+++ b/addons/vehiclelock/stringtable.xml
@@ -136,54 +136,67 @@
         <Key ID="STR_ACE_VehicleLock_Module_DisplayName">
             <English>Vehicle Lock Setup</English>
             <Polish>Ustawienie blokady pojazdów</Polish>
+            <Spanish>Configuración del cierre del vehiculo</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_LockVehicleInventory_DisplayName">
             <English>Lock Vehicle Inventory</English>
             <Polish>Zablokuj ekwipunek pojazdu</Polish>
+            <Spanish>Bloquear inventario del vehículo</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_LockVehicleInventory_Description">
             <English>Locks the inventory of locked vehicles</English>
             <Polish>Blokuje dostęp do ekwipunku pojazdu</Polish>
+            <Spanish>Bloquea el inventario de los vehículos cerrados</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_DisplayName">
             <English>Vehicle Starting Lock State</English>
             <Polish>Początkowy stan blok. poj.</Polish>
+            <Spanish>Estado inicial del cierre en vehículos</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_Description">
             <English>Set lock state for all vehicles (removes ambiguous lock states)</English>
             <Polish>Ustawia początkowy stan blokady dla wszystkich pojazdów (usuwa dwuznaczne stany blokady)</Polish>
+            <Spanish>Establece el estado de cierre para todos los vehículos (elimina estados de cierre ambiguos)</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_AsIs">
             <English>As Is</English>
             <Polish>Jak jest</Polish>
+            <Spanish>Está</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_Locked">
             <English>Locked</English>
             <Polish>Zablokowany</Polish>
+            <Spanish>Cerrado</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_Unlocked">
             <English>Unlocked</English>
             <Polish>Odblokowany</Polish>
+            <Spanish>Abierto</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_DefaultLockpickStrength_DisplayName">
             <English>Default Lockpick Strength</English>
             <Polish>Czas włamywania</Polish>
+            <Spanish>Durabilidad de la ganzua por defecto</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_DefaultLockpickStrength_Description">
             <English>Default Time to lockpick (in seconds). Default: 10</English>
             <Polish>Domyślny czas potrzebny na otwarcie pojazdu (w sekundach). Domyślnie: 10</Polish>
+            <Spanish>Tiempo por defecto para forzar cerradura (en segundos). Por defecto: 10</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_Module_Description">
             <English>Settings for lockpick strength and initial vehicle lock state. Removes ambiguous lock states.&lt;br /&gt;Source: vehiclelock.pbo</English>
             <Polish>Ustawienia czasu włamywania oraz domyślnego stanu blokady pojazdów. Wyłącza dwuznaczne ustawienia blokady. Moduł ten umożliwia więc np. zamknięcie pojazdów przeciwnika na klucz tak, że gracze bez odpowiedniego sprzętu (wytrycha) nie będą mogli ich używać.&lt;br /&gt;Źródło: vehiclelock.pbo</Polish>
+            <Spanish>Ajustes de la durabilidad de la ganzua y el estado inicial del cierre de los vehículos. Elimina estados de cierre ambiguos.&lt;br /&gt;Fuente: vehiclelock.pbo</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleKeyAssign_Module_DisplayName">
             <English>Vehicle Key Assign</English>
             <Polish>Przydział kluczyka do pojazdu</Polish>
+            <Spanish>Asignacion de la llave del vehículo</Spanish>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleKeyAssign_Module_Description">
             <English>Sync with vehicles and players.  Will handout custom keys to players for every synced vehicle. Only valid for objects present at mission start.&lt;br /&gt;Source: vehiclelock.pbo</English>
             <Polish>Zsynchronizuj z pojazdami i graczami. Rozda klucze dla graczy dla każdego zsynchronizowanego pojazdu. Działa tylko na pojazdy obecne na misji od samego początku (postawione w edytorze).&lt;br /&gt;Źródło: vehiclelock.pbo</Polish>
+            <Spanish>Sincronizar con vehiculos y jugadores. Distribuirá llaves personalizadas a los jugadores para todos los vehículos sincronizados. Solo valido para objetos presentes al inicio de la mision.&lt;br /&gt;Fuente: vehiclelock.pbo</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/weather/stringtable.xml
+++ b/addons/weather/stringtable.xml
@@ -16,58 +16,72 @@
         <Key ID="STR_ACE_Weather_Module_DisplayName">
             <English>Weather</English>
             <Polish>Pogoda</Polish>
+            <Spanish>Clima</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_Module_Description">
             <English>Multiplayer synchronized ACE weather module</English>
             <Polish>Synchronizowana pogoda ACE</Polish>
+            <Spanish>Modulo climático del ACE sincronizado en multijugador</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_enableServerController_DisplayName">
             <English>Weather propagation</English>
             <Polish>Zmiany pogody</Polish>
+            <Spanish>Propagación del clima</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_enableServerController_Description">
             <English>Enables server side weather propagation</English>
             <Polish>Aktywuje zmiany pogody po stronie serwera</Polish>
+            <Spanish>Permite al servidor controlar la propagación del clima</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_useACEWeather_DisplayName">
             <English>ACE Weather</English>
             <Polish>Pogoda ACE</Polish>
+            <Spanish>Clima ACE</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_useACEWeather_Description">
             <English>Overrides the default weather (editor, mission settings) with ACE weather (map based)</English>
             <Polish>Nadpisuje domyślne ustawienia pogody (edytor, wywiad) przy użyciu pogody ACE (zależna od mapy)</Polish>
+            <Spanish>Sobreescribe el sistema climático por defecto (editor, ajustes de mision) con clima del ACE (basado en el mapa)</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_syncRain_DisplayName">
             <English>Sync Rain</English>
             <Polish>Synchronizuj deszcz</Polish>
+            <Spanish>Sincronizar lluvia</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_syncRain_Description">
             <English>Synchronizes rain</English>
             <Polish>Synchronizuje deszcz</Polish>
+            <Spanish>Sincroniza la lluvia</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_syncWind_DisplayName">
             <English>Sync Wind</English>
             <Polish>Synchronizuj wiatr</Polish>
+            <Spanish>Sincronizar viento</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_syncWind_Description">
             <English>Synchronizes wind</English>
             <Polish>Synchronizuje wiatr</Polish>
+            <Spanish>Sincroniza el viento</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_syncMisc_DisplayName">
             <English>Sync Misc</English>
             <Polish>Synchronizuj różne</Polish>
+            <Spanish>Sincronizar otros</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_syncMisc_Description">
             <English>Synchronizes lightnings, rainbow, fog, ...</English>
             <Polish>Synchronizuje pioruny, tęcze, mgłę, ...</Polish>
+            <Spanish>Sincroniza relampagos, arcoiris, niebla ...</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_serverUpdateInterval_DisplayName">
             <English>Update Interval</English>
             <Polish>Interwał aktualizacji</Polish>
+            <Spanish>Intervalo de actualización</Spanish>
         </Key>
         <Key ID="STR_ACE_Weather_serverUpdateInterval_Description">
             <English>Defines the interval (seconds) between weather updates</English>
             <Polish>Określa interwał (sekundy) pomiędzy aktualizacjami pogody</Polish>
+            <Spanish>Defina el intervalo (en segundos) entre actualizacions de clima</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/winddeflection/stringtable.xml
+++ b/addons/winddeflection/stringtable.xml
@@ -65,42 +65,52 @@
             <Key ID="STR_ACE_Weather_windDeflection_DisplayName">
                 <English>Wind Deflection</English>
                 <Polish>Wpływ wiatru</Polish>
+                <Spanish>Desviación por viento</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_deflectionModule_DisplayName">
                 <English>Wind Deflection</English>
                 <Polish>Wpływ wiatru</Polish>
+                <Spanish>Desviación por viento</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_deflectionModule_Description">
                 <English>Enables wind deflection</English>
                 <Polish>Aktywuje wpływ wiatru na trajektorię lotu pocisków</Polish>
+                <Spanish>Activa la desviación por viento</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_vehicleEnabled_DisplayName">
                 <English>Vehicle Enabled</English>
                 <Polish>Włączone dla pojazdów</Polish>
+                <Spanish>Habilitada en vehículos</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_vehicleEnabled_Description">
                 <English>Enables wind deflection for static/vehicle gunners</English>
                 <Polish>Aktywuje wpływ wiatru na trajektorię lotu pocisków dla broni statycznej i na pojazdach</Polish>
+                <Spanish>Habilita la desviación por viento para artilleros estaticos/de vehículos</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_simulationInterval_DisplayName">
                 <English>Simulation Interval</English>
                 <Polish>Interwał symulacji</Polish>
+                <Spanish>Intervalo de simulación</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_simulationInterval_Description">
                 <English>Defines the interval between every calculation step</English>
                 <Polish>Określa interwał pomiędzy każdym krokiem kalkulacji</Polish>
+                <Spanish>Define el intervalo entre cada calculo</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_simulationRadius_DisplayName">
                 <English>Simulation Radius</English>
                 <Polish>Zasięg symulacji</Polish>
+                <Spanish>Radio de simulación</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_simulationRadius_Description">
                 <English>Defines the radius around the player (in meters) at which projectiles are wind deflected</English>
                 <Polish>Określa obszar naokoło gracza (w metrach), na którym pociski są znoszone przez wiatr</Polish>
+                <Spanish>Define el radio alrededor del jugador (en metros) en el cual los proyectiles son desviados por el viento</Spanish>
             </Key>
             <Key ID="STR_ACE_Weather_windDeflection_Description">
                 <English>Wind influence on projectiles trajectory</English>
                 <Polish>Wpływ wiatru na trajektorię lotu pocisków</Polish>
+                <Spanish>Influencia del viento en la trayectoria de proyectiles</Spanish>
             </Key>
         </Container>
     </Package>


### PR DESCRIPTION
added spansih translate for (advanced_ballistics, ballistics, captives,
common, explosives, frag, hearing, interaction, map, medical, microdagr,
missileguidance, missionmodules, mk6mortar, nametags, optionsmenu,
respawn, switchunits, vehiclelock, weather, winddeflection).

I used the Pull request of #1251 for complete my commit, because #1251
is outdated now.