### PR TITLE
Goggles - Cache Surface Dust

### DIFF
--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -47,6 +47,8 @@ GVAR(DustHandler) = -1;
 GVAR(RainDrops) = objNull;
 GVAR(RainActive) = false;
 GVAR(RainLastLevel) = 0;
+GVAR(surfaceCache) = "";
+GVAR(surfaceCacheIsDust) = false;
 
 FUNC(CheckGlasses) = {
     if (GVAR(Current) != (goggles ace_player)) then {

--- a/addons/goggles/functions/fnc_dustHandler.sqf
+++ b/addons/goggles/functions/fnc_dustHandler.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 #include "script_component.hpp"
-private ["_bullets", "_position", "_surface", "_found", "_weapon", "_cloudType", "_unit"];
+private ["_bullets", "_position", "_surface", "_weapon", "_cloudType", "_unit"];
 EXPLODE_2_PVT(_this,_unit,_weapon);
 if (_unit != ace_player) exitWith {true};
 _cloudType = "";
@@ -39,12 +39,14 @@ if (surfaceIsWater _position) exitWith {};
 if ((_position select 2) > 0.2) exitWith {};
 
 _surface = surfaceType _position;
-_surface = ([_surface, "#"] call CBA_fnc_split) select 1;
-_found = false;
 
-_found = getNumber (ConfigFile >> "CfgSurfaces" >> _surface >> "dust") >= 0.1;
+if (_surface != GVAR(surfaceCache)) then {
+    GVAR(surfaceCache) = _surface;
+    _surface = ([_surface, "#"] call CBA_fnc_split) select 1;
+    GVAR(surfaceCacheIsDust) = getNumber (ConfigFile >> "CfgSurfaces" >> _surface >> "dust") >= 0.1;
+};
 
-if (!_found) exitWith {};
+if (!GVAR(surfaceCacheIsDust)) exitWith {};
 
 _bullets = GETDUSTT(DBULLETS);
 


### PR DESCRIPTION
Minor performance gain on google effects when player is shooting prone (code is called for every shot):

Test code: `[player, "arifle_MX_pointer_F"] call  ace_goggles_fnc_dustHandler`

Before:
standing: 0.0172974 ms
prone: 0.193288 ms

After:
standing: 0.0166992 ms
prone: 0.0830994 ms