### PR TITLE
runOnHover can now be CODE & SurgicalKits

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -69,7 +69,12 @@ _recurseFnc = {
             _showDisabled = (getNumber (_entryCfg >> "showDisabled")) > 0;
             _enableInside = (getNumber (_entryCfg >> "enableInside")) > 0;
             _canCollapse = (getNumber (_entryCfg >> "canCollapse")) > 0;
-            _runOnHover = (getNumber (_entryCfg >> "runOnHover")) > 0;
+            _runOnHover = false;
+            if (isText (_entryCfg >> "runOnHover")) then {
+                _runOnHover = compile getText (_entryCfg >> "runOnHover");
+            } else {
+                _runOnHover = (getNumber (_entryCfg >> "runOnHover")) > 0;
+            };
 
             _condition = compile _condition;
             _children = [_entryCfg] call _recurseFnc;

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -53,7 +53,12 @@ _recurseFnc = {
             _showDisabled = (getNumber (_entryCfg >> "showDisabled")) > 0;
             _enableInside = (getNumber (_entryCfg >> "enableInside")) > 0;
             _canCollapse = (getNumber (_entryCfg >> "canCollapse")) > 0;
-            _runOnHover = (getNumber (_entryCfg >> "runOnHover")) > 0;
+            _runOnHover = true;
+            if (isText (_entryCfg >> "runOnHover")) then {
+                _runOnHover = compile getText (_entryCfg >> "runOnHover");
+            } else {
+                _runOnHover = (getNumber (_entryCfg >> "runOnHover")) > 0;
+            };
 
             _condition = compile _condition;
             _children = [_entryCfg] call _recurseFnc;

--- a/addons/interact_menu/functions/fnc_render.sqf
+++ b/addons/interact_menu/functions/fnc_render.sqf
@@ -89,7 +89,17 @@ if (GVAR(openedMenuType) >= 0) then {
 
             // Execute the current action if it's run on hover
             private "_runOnHover";
-            _runOnHover = ((GVAR(selectedAction) select 0) select 9) select 3;
+            _tmp = ((GVAR(selectedAction) select 0) select 9) select 3;
+            _runOnHover = true;
+            if ((typeName _tmp) == "CODE" ) then {
+                _runOnHover = call _tmp;
+            } else {
+                if ((typeName _tmp) == "BOOL" ) then {
+                    _runOnHover = _tmp;
+                } else {
+                    _runOnHover = _tmp > 0;
+                };
+            };
             if (_runOnHover) then {
                 this = GVAR(selectedTarget);
                 _player = ACE_Player;


### PR DESCRIPTION
1)
Expanded render, compileMenu, compileMenuSelfAction so runOnHover can be CODE
e.g. runOnHover = QUOTE([] call DFUNC(myRunOnHoverCheck););
This allows more dynamic menus.

2)
- added SurgicalKit action to other body parts
- fixed vanilla damage in bandageLocal
- added ACE messge to CPRLocal informing about sucess
- added surgicalKit and surgicalKitLocal functions
- fixed some german translations
- added surgicalKit functions to preInit