### PR TITLE
Explosives - Local defuse objects

### DIFF
--- a/addons/explosives/XEH_postInit.sqf
+++ b/addons/explosives/XEH_postInit.sqf
@@ -15,47 +15,10 @@
  */
 #include "script_component.hpp"
 
-//Event system to add the defuse object to all explosive devices (defuse is local)
-GVAR(explosivesHelped) = [];
-GVAR(defuseOjbects) = [];
-
-["explosive_placed", {
-    PARAMS_1(_explosive);
-    if (_explosive in GVAR(explosivesHelped)) exitWith {};
-    private ["_defuseHelper"];
-    _defuseHelper = "ACE_DefuseObject" createVehicleLocal (getPos _explosive);
-    _defuseHelper attachTo [_explosive, [0,0,0]];
-    _defuseHelper setVariable [QGVAR(Explosive),_explosive];
-    TRACE_3("Added local defuse to helper",_explosive,(typeOf _explosive),_defuseHelper);
-    GVAR(explosivesHelped) pushBack _explosive;
-    GVAR(defuseOjbects) pushBack _defuseHelper;
-}] call EFUNC(common,addEventHandler);
-
-//Start up a PFEH that scans all mines/explosives without defuseObjects attached and adds them
-//Handles Editor Placed / Zeus / Scripted / JIP
-[{
-    private ["_modeAdd"];
-    _modeAdd = (_this select 0) select 0;
-    if (_modeAdd) then {
-        TRACE_2("Adding Helpers",(count allMines),(count GVAR(explosivesHelped)));
-        {
-            TRACE_2("Explosive without helper",_explosive,(typeOf _explosive));
-            ["explosive_placed", [_x]] call EFUNC(common,localEvent);
-        } forEach (allMines - GVAR(explosivesHelped));
-    } else {
-        TRACE_2("Cleaning Helpers",(count allMines),(count GVAR(explosivesHelped)));
-        {
-            if (isNull _x) then {
-                deleteVehicle (GVAR(defuseObjects) select _forEachIndex);
-            };
-        } forEach GVAR(explosivesHelped);
-        GVAR(explosivesHelped) = GVAR(explosivesHelped) - [objNull];
-        GVAR(defuseOjbects) = GVAR(defuseOjbects) - [objNull];
-    };
-    (_this select 0) set [0, !_modeAdd];
-}, 5, [true]] call CBA_fnc_addPerFrameHandler;
-
 if !(hasInterface) exitWith {};
+
+["interactMenuOpened", {_this call FUNC(interactEH)}] call EFUNC(common,addEventHandler);
+
 GVAR(PlacedCount) = 0;
 GVAR(Setup) = objNull;
 GVAR(pfeh_running) = false;

--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -36,6 +36,8 @@ PREP(handleScrollWheel);
 PREP(hasExplosives);
 PREP(hasPlacedExplosives);
 
+PREP(interactEH);
+
 PREP(getDetonators);
 PREP(getPlacedExplosives);
 PREP(getSpeedDialExplosive);

--- a/addons/explosives/functions/fnc_defuseExplosive.sqf
+++ b/addons/explosives/functions/fnc_defuseExplosive.sqf
@@ -21,10 +21,4 @@ if (getNumber (ConfigFile >> "CfgAmmo" >> typeof _explosive >> "ACE_explodeOnDef
     [_unit, -1, [_explosive, 1], true] call FUNC(detonateExplosive);
 };
 
-{
-    detach _x;
-    deleteVehicle _x;
-    false
-} count (attachedObjects (_explosive));
-
 _unit action ["Deactivate", _unit, _explosive];

--- a/addons/explosives/functions/fnc_detonateExplosive.sqf
+++ b/addons/explosives/functions/fnc_detonateExplosive.sqf
@@ -26,12 +26,6 @@ _result = true;
 
 if (!_ignoreRange && {(_unit distance (_item select 0)) > _range}) exitWith {false};
 
-_helpers = attachedObjects (_item select 0);
-{
-    detach _x;
-    deleteVehicle _x;  
-} forEach _helpers;
-
 if (getNumber (ConfigFile >> "CfgAmmo" >> typeof (_item select 0) >> "TriggerWhenDestroyed") == 0) then {
     private ["_exp", "_previousExp"];
     _previousExp = _item select 0;

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -1,0 +1,56 @@
+/*
+ * Author: PabstMirror
+ * When interact_menu starts rendering (from "interact_keyDown" event)
+ * Add defuse helpers to all nearby mines
+ *
+ * Arguments:
+ * Interact Menu Type (0 - world, 1 - self) <NUMBER>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [0] call ace_explosives_fnc_interactEH
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+PARAMS_1(_interactionType);
+
+//Ignore self-interaction menu
+if (_interactionType != 0) exitWith {};
+//Ignore while mounted:
+if ((vehicle ACE_player) != ACE_player) exitWith {};
+//Ignore if we don't have defuse kit
+if (!("ACE_DefusalKit" in (items ACE_player))) exitWith {};
+
+[{
+    PARAMS_2(_args,_pfID);
+    EXPLODE_3_PVT(_args,_setPosition,_addedDefuseHelpers,_minesHelped);
+
+    if (!EGVAR(interact_menu,keyDown)) then {
+        TRACE_1("Cleaning Defuse Helpers",(count _addedDefuseHelpers));
+        {deleteVehicle _x;} forEach _addedDefuseHelpers;
+        [_pfID] call CBA_fnc_removePerFrameHandler;
+    } else {
+        private ["_defuseHelper"];
+        // Prevent Rare Error when ending mission with interact key down:
+        if (isNull ace_player) exitWith {};
+
+        //If player moved >5 meters from last pos, then rescan
+        if (((getPosASL ace_player) distance _setPosition) > 5) then {
+            {
+                if (((_x distance ACE_player) < 15) && {!(_x in _minesHelped)}) then {
+                    TRACE_2("Making Defuse Helper",(_x),(typeOf _x));
+                    _defuseHelper = "ACE_DefuseObject" createVehicleLocal (getPos _x);
+                    _defuseHelper attachTo [_x, [0,0,0]];
+                    _defuseHelper setVariable [QGVAR(Explosive),_x];
+                    _addedDefuseHelpers pushBack _defuseHelper;
+                    _minesHelped pushBack _x;
+                };
+            } forEach allMines;
+            _args set [0, (getPosASL ace_player)];
+        };
+    };
+}, 0.5, [((getPosASL ace_player) vectorAdd [-100,0,0]), [], []]] call CBA_fnc_addPerFrameHandler;

--- a/addons/explosives/functions/fnc_placeExplosive.sqf
+++ b/addons/explosives/functions/fnc_placeExplosive.sqf
@@ -51,17 +51,11 @@ if (isText(_magazineTrigger >> "ammo")) then {
     _ammo = getText (_magazineTrigger >> "ammo");
 };
 _triggerSpecificVars pushBack _triggerConfig;
-private ["_defuseHelper"];
-_defuseHelper = createVehicle ["ACE_DefuseObject", _pos, [], 0, "NONE"];
-_defuseHelper setPosATL _pos;
 
 _explosive = createVehicle [_ammo, _pos, [], 0, "NONE"];
-_defuseHelper attachTo [_explosive, [0,0,0], ""];
-_defuseHelper setVariable [QGVAR(Explosive),_explosive,true];
-
-_expPos = getPosATL _explosive;
-_defuseHelper setPosATL (((getPosATL _defuseHelper) vectorAdd (_pos vectorDiff _expPos)));
 _explosive setPosATL _pos;
+
+["explosive_placed", [_explosive]] call EFUNC(common,globalEvent);
 
 if (!isNull _attachedTo) then {
     TRACE_1("Attaching Live Explosive",_attachedTo);

--- a/addons/explosives/functions/fnc_placeExplosive.sqf
+++ b/addons/explosives/functions/fnc_placeExplosive.sqf
@@ -55,8 +55,6 @@ _triggerSpecificVars pushBack _triggerConfig;
 _explosive = createVehicle [_ammo, _pos, [], 0, "NONE"];
 _explosive setPosATL _pos;
 
-["explosive_placed", [_explosive]] call EFUNC(common,globalEvent);
-
 if (!isNull _attachedTo) then {
     TRACE_1("Attaching Live Explosive",_attachedTo);
     _explosive attachTo [_attachedTo];

--- a/addons/explosives/functions/fnc_place_Approve.sqf
+++ b/addons/explosives/functions/fnc_place_Approve.sqf
@@ -37,7 +37,7 @@ if (_dir > 180) then {
 } else {
     _dir = 180 + _dir;
 };
-_setup setVariable [QGVAR(Direction), _dir];
+_setup setVariable [QGVAR(Direction), _dir, true];
 _player setVariable [QGVAR(PlantingExplosive), true];
 [{_this setVariable [QGVAR(PlantingExplosive), false]}, _player, 1.5, 0.5] call EFUNC(common,waitAndExecute);
 _setup addEventHandler ["EpeContactStart", FUNC(onLanded)];


### PR DESCRIPTION
#1381 (MP Explosive Defusal Issue)

See the debug console from that issue and:

![2015-05-28_00001](https://cloud.githubusercontent.com/assets/9376747/7866793/4aeb3134-0537-11e5-8d7d-c24b187a453f.jpg)

Different clients see different positions on the defuse object.  I don't have a good explanation for this besides the fact that we're attaching to a real object to a CfgAmmo which has some locality issues.

This switches to creating the defuse objects locally, only on clients and only when needed.

With the old system, if someone puts down a 100x minefield site, we'd have 100 extra objects each with a global setVariable.