### PR TITLE
NightVision adjustment - use CSE's gamma

### DIFF
--- a/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
+++ b/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
@@ -22,12 +22,12 @@ PARAMS_2(_player,_changeInBrightness);
 
 _brightness = _player getVariable [QGVAR(NVGBrightness), 0];
 
-_brightness = ((round (10 * _brightness + _changeInBrightness) / 10) min 1) max -1;
+_brightness = ((round (10 * _brightness + _changeInBrightness) / 10) min 0.5) max -0.5;
 
 _player setVariable [QGVAR(NVGBrightness), _brightness, false];
 
-GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, 1, _brightness / 4, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
+GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (_brightness + 1), 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
 GVAR(ppEffectNVGBrightness) ppEffectCommit 0;
 
-[format [(localize "STR_ACE_NightVision_NVGBrightness"), (_brightness * 100)]] call EFUNC(common,displayTextStructured);
+[format [(localize "STR_ACE_NightVision_NVGBrightness"), (_brightness * 10)]] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";


### PR DESCRIPTION
#1374

Shots taken at -5, 0 and +5 adjustment:
Current:
![old](https://cloud.githubusercontent.com/assets/9376747/7892282/cea9da84-0618-11e5-9277-61c269e7d0ca.jpg)
New:
![new](https://cloud.githubusercontent.com/assets/9376747/7892290/d9226756-0618-11e5-86a6-1263baea8e52.jpg)