### PR TITLE
Fix ace_settings

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -254,6 +254,7 @@ GVAR(commonPostInited) = true;
 [{
     // If post inits are not ready then wait
     if !(SLX_XEH_MACHINE select 8) exitWith {};
+
     // If settings are not initialized then wait
     if (isNil QGVAR(settings)) exitWith {
         diag_log text format["[ACE] Waiting on settings from server"];
@@ -261,11 +262,16 @@ GVAR(commonPostInited) = true;
 
     [(_this select 1)] call cba_fnc_removePerFrameHandler;
 
+    diag_log text format["[ACE] Settings received from server"];
+
+    // Load user settings from profile
+    if (hasInterface) then {
+        call FUNC(loadSettingsFromProfile);
+        call FUNC(loadSettingsLocalizedText);
+    };
+
     diag_log text format["[ACE] Settings initialized"];
-    
-    //Load from profile and localize settings:
-    ["ServerSettingsReceived", []] call FUNC(localEvent);
-    
+
     //Event that settings are safe to use:
     ["SettingsInitialized", []] call FUNC(localEvent);
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -255,11 +255,18 @@ GVAR(commonPostInited) = true;
     // If post inits are not ready then wait
     if !(SLX_XEH_MACHINE select 8) exitWith {};
     // If settings are not initialized then wait
-    if !(GVAR(SettingsInitialized)) exitWith {};
+    if (isNil QGVAR(settings)) exitWith {
+        diag_log text format["[ACE] Waiting on settings from server"];
+    };
 
     [(_this select 1)] call cba_fnc_removePerFrameHandler;
 
     diag_log text format["[ACE] Settings initialized"];
+    
+    //Load from profile and localize settings:
+    ["ServerSettingsReceived", []] call FUNC(localEvent);
+    
+    //Event that settings are safe to use:
     ["SettingsInitialized", []] call FUNC(localEvent);
 
 }, 0, []] call cba_fnc_addPerFrameHandler;

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -294,23 +294,9 @@ GVAR(waitAndExecArray) = [];
 //Debug
 ACE_COUNTERS = [];
 
-// Wait for server settings to arrive
-GVAR(SettingsInitialized) = false;
-["ServerSettingsReceived", {
-    diag_log text format["[ACE] Settings received from server"];
-    // Load user settings from profile
-    if (hasInterface) then {
-        call FUNC(loadSettingsFromProfile);
-        call FUNC(loadSettingsLocalizedText);
-    };
-    GVAR(SettingsInitialized) = true;
-}] call FUNC(addEventhandler);
-
 // Load settings on the server and broadcast them
 if (isServer) then {
     call FUNC(loadSettingsOnServer);
-    // Raise a local event for other modules to listen too
-    ["ServerSettingsReceived", []] call FUNC(localEvent);
 };
 
 ACE_player = player;


### PR DESCRIPTION
Problem with #1214 
this should also solve issue #1273

Clients don't localize and they don't load settings from profile.

I think the problem is we never raise the `ServerSettingsReceived` on clients and GVAR(SettingsInitialized) never changes to true, so that PFEH at bottom of postInit runs forever.

Server language english
Client screenshot in spanish:

![untitled](https://cloud.githubusercontent.com/assets/9376747/7895229/9ba72dd4-0646-11e5-84c7-590d6bdbc96c.jpg)