### PR TITLE
Delay initialization of modules until settings are properly setup

### DIFF
--- a/addons/advanced_ballistics/config.cpp
+++ b/addons/advanced_ballistics/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_ballistics", "ace_weather", "ace_modules"};
+        requiredAddons[] = {"ace_ballistics", "ace_weather"};
         author[] = {"Ruthberg"};
         authorUrl = "https://github.com/ulteq";
         VERSION_CONFIG;

--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -25,11 +25,8 @@ class CfgVehicles {
   // += needs a non inherited entry in that class, otherwise it simply overwrites
   //#include <DefaultItems.hpp>
 
-   class Logic;
-   class Module_F: Logic {
-     class ModuleDescription {};
-   };
-   class ACE_ModuleCheckPBOs: Module_F {
+   class ACE_Module;
+   class ACE_ModuleCheckPBOs: ACE_Module {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
     displayName = "$STR_ACE_Common_CheckPBO_DisplayName";
@@ -72,12 +69,12 @@ class CfgVehicles {
         };
       };
     };
-    class ModuleDescription: ModuleDescription {
+    class ModuleDescription {
         description = "$STR_ACE_Common_CheckPBO_Description";
     };
   };
 
-  class ACE_ModuleLSDVehicles: Module_F {
+  class ACE_ModuleLSDVehicles: ACE_Module {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
     displayName = "$STR_ACE_Common_LSDVehicles_DisplayName";
@@ -87,7 +84,7 @@ class CfgVehicles {
     isGlobal = 1;
     class Arguments {
     };
-    class ModuleDescription: ModuleDescription {
+    class ModuleDescription {
         description = "$STR_ACE_Common_LSDVehicles_Description";
         sync[] = {"AnyVehicle"};
     };

--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -24,8 +24,11 @@ class CfgVehicles {
 
   // += needs a non inherited entry in that class, otherwise it simply overwrites
   //#include <DefaultItems.hpp>
-
-   class ACE_Module;
+    class Logic;
+    class Module_F: Logic {
+        class ModuleDescription;
+    };
+    class ACE_Module: Module_F {};
    class ACE_ModuleCheckPBOs: ACE_Module {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
@@ -69,7 +72,7 @@ class CfgVehicles {
         };
       };
     };
-    class ModuleDescription {
+    class ModuleDescription: ModuleDescription {
         description = "$STR_ACE_Common_CheckPBO_Description";
     };
   };
@@ -84,7 +87,7 @@ class CfgVehicles {
     isGlobal = 1;
     class Arguments {
     };
-    class ModuleDescription {
+    class ModuleDescription: ModuleDescription {
         description = "$STR_ACE_Common_LSDVehicles_Description";
         sync[] = {"AnyVehicle"};
     };

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -264,6 +264,9 @@ GVAR(commonPostInited) = true;
 
     diag_log text format["[ACE] Settings received from server"];
 
+    // Event so that ACE_Modules have their settings loaded:
+    ["InitSettingsFromModules", []] call FUNC(localEvent);
+
     // Load user settings from profile
     if (hasInterface) then {
         call FUNC(loadSettingsFromProfile);

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {"ACE_Box_Misc", "ACE_bananaItem"};
         weapons[] = {"ACE_ItemCore","ACE_FakePrimaryWeapon", "ACE_Banana"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_main"};
+        requiredAddons[] = {"ace_main","ace_modules"};
         author[] = {"KoffeinFlummi"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;

--- a/addons/explosives/CfgModule.hpp
+++ b/addons/explosives/CfgModule.hpp
@@ -1,8 +1,5 @@
-class Logic;
-class Module_F: Logic {
-    class ModuleDescription {};
-};
-class ACE_ModuleExplosive: Module_F {
+class ACE_Module;
+class ACE_ModuleExplosive: ACE_Module {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
     displayName = "$STR_ACE_Explosive_Module_DisplayName";

--- a/addons/explosives/CfgModule.hpp
+++ b/addons/explosives/CfgModule.hpp
@@ -21,7 +21,7 @@ class ACE_ModuleExplosive: ACE_Module {
             defaultValue = 1;
         };
     };
-    class ModuleDescription: ModuleDescription {
+    class ModuleDescription {
         description = "$STR_ACE_Explosive_Module_Description";
     };
 };

--- a/addons/hearing/CfgVehicles.hpp
+++ b/addons/hearing/CfgVehicles.hpp
@@ -94,8 +94,8 @@ class CfgVehicles {
     };
 
 
-    class Module_F;
-    class ACE_ModuleHearing: Module_F {
+    class ACE_Module;
+    class ACE_ModuleHearing: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_Hearing_Module_DisplayName";

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles {
 
-  class Module_F;
-  class ACE_ModuleInteraction: Module_F {
+  class ACE_Module;
+  class ACE_ModuleInteraction: ACE_Module {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
     displayName = "$STR_ACE_InteractionSystem_Module_DisplayName";

--- a/addons/map/CfgVehicles.hpp
+++ b/addons/map/CfgVehicles.hpp
@@ -1,6 +1,7 @@
 class CfgVehicles {
-    class Module_F;
-    class ACE_ModuleMap: Module_F {
+
+    class ACE_Module;
+    class ACE_ModuleMap: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_Map_Module_DisplayName";
@@ -39,6 +40,7 @@ class CfgVehicles {
         };
     };
 
+    class Module_F;
     class ACE_ModuleBlueForceTracking: Module_F {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {"ACE_medicalSupplyCrate", "ACE_medicalSupplyCrate_advanced", "ACE_fieldDressingItem", "ACE_packingBandageItem", "ACE_elasticBandageItem", "ACE_tourniquetItem", "ACE_morphineItem", "ACE_atropineItem", "ACE_epinephrineItem", "ACE_plasmaIVItem", "ACE_bloodIVItem", "ACE_salineIVItem", "ACE_quikclotItem", "ACE_personalAidKitItem", "ACE_surgicalKitItem", "ACE_bodyBagItem", "ACE_bodyBagObject"};
         weapons[] = {"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_tourniquet", "ACE_morphine", "ACE_atropine", "ACE_epinephrine", "ACE_plasmaIV", "ACE_plasmaIV_500", "ACE_plasmaIV_250", "ACE_bloodIV", "ACE_bloodIV_500", "ACE_bloodIV_250", "ACE_salineIV", "ACE_salineIV_500", "ACE_salineIV_250", "ACE_quikclot", "ACE_personalAidKit", "ACE_surgicalKit", "ACE_bodyBag"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interaction","ace_modules", "ace_apl"};
+        requiredAddons[] = {"ace_interaction", "ace_apl"};
         author[] = {"Glowbal", "KoffeinFlummi"};
         authorUrl = "";
         VERSION_CONFIG;

--- a/addons/microdagr/CfgVehicles.hpp
+++ b/addons/microdagr/CfgVehicles.hpp
@@ -36,12 +36,8 @@ class CfgVehicles {
         };
     };
 
-    class Logic;
-    class Module_F: Logic {
-        class ArgumentsBaseUnits {};
-        class ModuleDescription {};
-    };
-    class GVAR(dagrModule): Module_F {
+    class ACE_Module;
+    class GVAR(dagrModule): ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_Dagr_Module_DisplayName";
@@ -62,7 +58,7 @@ class CfgVehicles {
                 };
             };
         };
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_Dagr_Module_Description";
         };
     };

--- a/addons/mk6mortar/CfgVehicles.hpp
+++ b/addons/mk6mortar/CfgVehicles.hpp
@@ -43,11 +43,8 @@ class CfgVehicles {
         };
     };
 
-    class Logic;
-    class Module_F: Logic {
-        class ModuleDescription {};
-    };
-    class GVAR(module): Module_F {
+    class ACE_Module;
+    class GVAR(module): ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_mk6mortar_Module_DisplayName";
@@ -76,7 +73,7 @@ class CfgVehicles {
                 defaultValue = 1;
             };
         };
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_mk6mortar_Module_Description";
         };
     };

--- a/addons/modules/XEH_postInit.sqf
+++ b/addons/modules/XEH_postInit.sqf
@@ -1,44 +1,46 @@
 
 #include "script_component.hpp"
 
-// TODO This is a basic and limited implementation that mimics some of the functionality from the A3 module framework, but not all of it.
-// We have to execute this in the postInit XEH because on object init, the parameters of the modules are not yet available. They are if we execute it at the start of postInit execution.
-{
-    [_x] call {
-        private ["_logic", "_logicType", "_config", "_isGlobal", "_isDisposable", "_isPersistent","_function"];
-        _logic = _this select 0;
-        _logicType = typeof _logic;
-        _logic hideobject true;
+["InitSettingsFromModules", {
+    // TODO This is a basic and limited implementation that mimics some of the functionality from the A3 module framework, but not all of it.
+    // We have to execute this in the postInit XEH because on object init, the parameters of the modules are not yet available. They are if we execute it at the start of postInit execution.
+    {
+        [_x] call {
+            private ["_logic", "_logicType", "_config", "_isGlobal", "_isDisposable", "_isPersistent","_function"];
+            _logic = _this select 0;
+            _logicType = typeof _logic;
+            _logic hideobject true;
 
-        if (_logic getvariable [QGVAR(initalized), false]) exitwith {};
-        _config = (configFile >> "CfgVehicles" >> _logicType);
-        if !(isClass _config) exitwith {};
+            if (_logic getvariable [QGVAR(initalized), false]) exitwith {};
+            _config = (configFile >> "CfgVehicles" >> _logicType);
+            if !(isClass _config) exitwith {};
 
-        // isGlobal = 1;
-        _isGlobal = getNumber (_config >> "isGlobal") > 0;
-        _isDisposable = getNumber (_config >> "isDisposable") > 0;
-        _isPersistent = getNumber (_config >> "isPersistent") > 0 || getnumber (_config >> "isGlobal") > 1;
-        _function = getText (_config >> "function");
-        if (isnil _function) then {
-            _function = compile _function;
-        } else {
-            _function = missionNamespace getvariable _function;
-        };
+            // isGlobal = 1;
+            _isGlobal = getNumber (_config >> "isGlobal") > 0;
+            _isDisposable = getNumber (_config >> "isDisposable") > 0;
+            _isPersistent = getNumber (_config >> "isPersistent") > 0 || getnumber (_config >> "isGlobal") > 1;
+            _function = getText (_config >> "function");
+            if (isnil _function) then {
+                _function = compile _function;
+            } else {
+                _function = missionNamespace getvariable _function;
+            };
 
-        if (_isGlobal) then {
-            [_logic, [], true] call _function;
-        } else {
-            if (isServer) then {
+            if (_isGlobal) then {
                 [_logic, [], true] call _function;
+            } else {
+                if (isServer) then {
+                    [_logic, [], true] call _function;
+                };
+            };
+
+            if !(_isPersistent) then {
+                _logic setvariable [QGVAR(initalized), true];
+            };
+
+            if (_isDisposable) then {
+                deleteVehicle _logic;
             };
         };
-
-        if !(_isPersistent) then {
-            _logic setvariable [QGVAR(initalized), true];
-        };
-
-        if (_isDisposable) then {
-            deleteVehicle _logic;
-        };
-    };
-}foreach GVAR(moduleInitCollection);
+    }foreach GVAR(moduleInitCollection);
+}] call FUNC(addEventhandler);

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common"};
+        requiredAddons[] = {};
         author[] = {"Glowbal"};
         authorUrl = "";
         VERSION_CONFIG;

--- a/addons/nametags/CfgVehicles.hpp
+++ b/addons/nametags/CfgVehicles.hpp
@@ -1,9 +1,6 @@
 class CfgVehicles {
-    class Logic;
-    class Module_F: Logic {
-        class ModuleDescription {};
-    };
-    class ACE_ModuleNameTags : Module_F {
+    class ACE_Module;
+    class ACE_ModuleNameTags: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_NameTags_Module_DisplayName";
@@ -65,7 +62,7 @@ class CfgVehicles {
                 defaultValue = 0;
             };
         };
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_NameTags_Module_Description";
         };
     };

--- a/addons/respawn/CfgVehicles.hpp
+++ b/addons/respawn/CfgVehicles.hpp
@@ -1,9 +1,6 @@
 class CfgVehicles {
-    class Logic;
-    class Module_F: Logic {
-        class ModuleDescription {};
-    };
-    class ACE_ModuleRespawn: Module_F {
+    class ACE_Module;
+    class ACE_ModuleRespawn: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_Respawn_Module_DisplayName";
@@ -27,12 +24,12 @@ class CfgVehicles {
                 defaultValue = 1;
             };
         };
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_Respawn_Module_Description";
         };
     };
 
-    class ACE_ModuleFriendlyFire: Module_F {
+    class ACE_ModuleFriendlyFire: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_FriendlyFire_Module_DisplayName";
@@ -42,12 +39,12 @@ class CfgVehicles {
         icon = QUOTE(PATHTOF(UI\Icon_Module_FriendlyFire_ca.paa));
 
         class Arguments {};
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_FriendlyFire_Module_Description";
         };
     };
 
-    class ACE_ModuleRallypoint: Module_F {
+    class ACE_ModuleRallypoint: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_Rallypoint_Module_DisplayName";
@@ -57,7 +54,7 @@ class CfgVehicles {
         icon = QUOTE(PATHTOF(UI\Icon_Module_Rallypoint_ca.paa));
 
         class Arguments {};
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_Rallypoint_Module_Description";
         };
     };

--- a/addons/switchunits/CfgVehicles.hpp
+++ b/addons/switchunits/CfgVehicles.hpp
@@ -1,6 +1,6 @@
 class CfgVehicles {
-  class Module_F;
-  class ACE_ModuleSwitchUnits: Module_F {
+  class ACE_Module;
+  class ACE_ModuleSwitchUnits: ACE_Module {
     author = "$STR_ACE_Common_ACETeam";
     category = "ACE";
     displayName = "$STR_ACE_SwitchUnits_Module_DisplayName";

--- a/addons/vehiclelock/CfgVehicles.hpp
+++ b/addons/vehiclelock/CfgVehicles.hpp
@@ -62,7 +62,11 @@ class CfgVehicles {
         MACRO_LOCK_ACTIONS
     };
 
-    class ACE_Module;
+    class Logic;
+    class Module_F: Logic {
+        class ModuleDescription;
+    };
+    class ACE_Module: Module_F {};
     class ACE_VehicleLock_ModuleSetup: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
@@ -111,7 +115,7 @@ class CfgVehicles {
         icon = QUOTE(PATHTOF(UI\Icon_Module_VehicleKey_ca.paa));
         functionPriority = 0;
         class Arguments {};
-        class ModuleDescription {
+        class ModuleDescription: ModuleDescription {
             description = "$STR_ACE_VehicleLock_VehicleKeyAssign_Module_Description";
             sync[] = {"AnyPlayer", "AnyVehicle"};
         };

--- a/addons/vehiclelock/CfgVehicles.hpp
+++ b/addons/vehiclelock/CfgVehicles.hpp
@@ -62,11 +62,8 @@ class CfgVehicles {
         MACRO_LOCK_ACTIONS
     };
 
-    class Logic;
-    class Module_F: Logic {
-        class ModuleDescription {};
-    };
-    class ACE_VehicleLock_ModuleSetup: Module_F {
+    class ACE_Module;
+    class ACE_VehicleLock_ModuleSetup: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_VehicleLock_Module_DisplayName";
@@ -99,12 +96,12 @@ class CfgVehicles {
                 defaultValue = "10";
             };
         };
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_VehicleLock_Module_Description";
         };
     };
 
-    class ACE_VehicleLock_ModuleSyncedAssign: Module_F {
+    class ACE_VehicleLock_ModuleSyncedAssign: ACE_Module {
         author = "$STR_ACE_Common_ACETeam";
         category = "ACE";
         displayName = "$STR_ACE_VehicleLock_VehicleKeyAssign_Module_DisplayName";
@@ -114,7 +111,7 @@ class CfgVehicles {
         icon = QUOTE(PATHTOF(UI\Icon_Module_VehicleKey_ca.paa));
         functionPriority = 0;
         class Arguments {};
-        class ModuleDescription: ModuleDescription {
+        class ModuleDescription {
             description = "$STR_ACE_VehicleLock_VehicleKeyAssign_Module_Description";
             sync[] = {"AnyPlayer", "AnyVehicle"};
         };

--- a/addons/weather/config.cpp
+++ b/addons/weather/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "ace_modules"};
+        requiredAddons[] = {"ace_common"};
         author[] = {"q1184", "Rocko", "esteldunedain", "Ruthberg"};
         VERSION_CONFIG;
     };

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common","ace_modules"};
+        requiredAddons[] = {"ace_common"};
         author[] = {"SilentSpike"};
         authorUrl = "https://github.com/SilentSpike";
         VERSION_CONFIG;


### PR DESCRIPTION
As part of the reliable settings framework, we need to ensure that settings are not read from modules before the settings lists have arrived from the server.

So this PR does the following:
- Change all modules on ACE using settings to type ACE_Module, so we can guarantee that they wait for settings before initing.
- Command the ACE_Modules to init only once the settings from the server have arrived.
- Make ACE_Common require ACE_Modules, so we can use that functionality everywhere.