### PR TITLE
HitReactions - Don't do when mounted, add setting

### DIFF
--- a/addons/hitreactions/ACE_Settings.hpp
+++ b/addons/hitreactions/ACE_Settings.hpp
@@ -1,0 +1,7 @@
+class ACE_Settings {
+    class GVAR(minDamageToTrigger) {
+        //Minimum mamage needed to trigger falling down while moving. Set to -1 to disable completely.
+        typeName = "SCALAR";
+        value = 0.1;
+    };
+};

--- a/addons/hitreactions/config.cpp
+++ b/addons/hitreactions/config.cpp
@@ -12,4 +12,5 @@ class CfgPatches {
     };
 };
 
+#include "ACE_Settings.hpp"
 #include "CfgEventHandlers.hpp"

--- a/addons/hitreactions/functions/fnc_fallDown.sqf
+++ b/addons/hitreactions/functions/fnc_fallDown.sqf
@@ -10,6 +10,9 @@ _damage = _this select 2;
 // don't fall on collision damage
 if (_unit == _firer) exitWith {};
 
+//Exit if system disabled:
+if (GVAR(minDamageToTrigger) == -1) exitWith {};
+
 // cam shake for player
 if (_unit == ACE_player) then {
     addCamShake [3, 5, _damage + random 10];
@@ -27,12 +30,15 @@ if (_vehicle isKindOf "StaticWeapon") exitwith {
 };
 
 // don't fall after minor damage
-if (_damage < 0.1) exitWith {};
+if (_damage < GVAR(minDamageToTrigger)) exitWith {};
 
 // play sound
 if (!isNil QUOTE(EFUNC(medical,playInjuredSound))) then {
     [_unit] call EFUNC(medical,playInjuredSound);
 };
+
+//Don't do animations if in a vehicle (looks weird and animations never reset):
+if (_vehicle != _unit) exitWith {};
 
 // this checks most things, so it doesn't mess with being inside vehicles or while dragging etc.
 if !([_unit, _vehicle] call EFUNC(common,canInteractWith)) exitWith {};


### PR DESCRIPTION
Disables hit reactions when mounted.

Right now they can happen from FFV seats.
But it looks silly and never resets to normal seated position.
![image](https://cloud.githubusercontent.com/assets/9376747/7903977/fa52e6b8-07b1-11e5-823b-39d819da8850.png)

Also adds setting for minimum damage to trigger, and can disable by setting to -1.
