### PR TITLE
Minor edits to Esc menu buttons while unconscious

### DIFF
--- a/addons/common/functions/fnc_disableUserInput.sqf
+++ b/addons/common/functions/fnc_disableUserInput.sqf
@@ -37,11 +37,12 @@ if (_state) then {
     _dlg = uiNamespace getVariable QGVAR(dlgDisableMouse);
 
     _dlg displayAddEventHandler ["KeyDown", {
-        private ["_key", "_dlg", "_ctrl", "_config", "_acc", "_index"];
+        private ["_key", "_dlgClass", "_dlg", "_abortALiVE", "_ctrl", "_config", "_acc", "_index"];
         _key = _this select 1;
 
         if (_key == 1 && {alive player}) then {
-            createDialog (["RscDisplayInterrupt", "RscDisplayMPInterrupt"] select isMultiplayer);
+            _dlgClass = ["RscDisplayInterrupt", "RscDisplayMPInterrupt"] select isMultiplayer;
+            createDialog _dlgClass;
 
             disableSerialization;
             _dlg = finddisplay 49;
@@ -54,6 +55,21 @@ if (_state) then {
                 (_dlg displayCtrl _index) ctrlEnable false;
             };
 
+            _abortALiVE = configfile >> _dlgClass >> "controls" >> "ALIVEButtonAbort";
+
+            if (isClass _abortALiVE) then {
+                (_dlg displayCtrl getNumber (_abortALiVE >> "idc")) ctrlEnable true;
+            } else {
+                _ctrl = _dlg displayCtrl 104; // "Abort" or "Save & Exit" button
+                _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize ([ARR_2('str_sure','str_msg_confirm_return_lobby_client')] select isMultiplayer),'',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; [false] call DFUNC(disableUserInput); failMission 'LOSER' }})];
+                _ctrl ctrlEnable true;
+
+                if (!isMultiplayer) then {
+                    _ctrl ctrlSetText localize "str_disp_int_abort"; // Change "Save & Exit" to "Abort"
+                    _ctrl ctrlSetTooltip localize "STR_TOOLTIP_MAIN_ABORT";
+                };
+            };
+
             _ctrl = _dlg displayCtrl 104; // "Abort" or "Save & Exit" button
             _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize ([ARR_2('str_sure','str_msg_confirm_return_lobby_client')] select isMultiplayer),'',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; [false] call DFUNC(disableUserInput); failMission 'LOSER' }})];
             _ctrl ctrlEnable true;
@@ -62,9 +78,6 @@ if (_state) then {
                 _ctrl = _dlg displayctrl 1010; // "Respawn" button
                 _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize 'str_a3_rscdisplaympinterrupt_respawnprompt','',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; player setDamage 1; [false] call DFUNC(disableUserInput) }})];
                 _ctrl ctrlEnable (call {_config = missionConfigFile >> "respawnButton"; !isNumber _config || {getNumber _config == 1}});
-            } else {
-                _ctrl ctrlSetText localize "str_disp_int_abort"; // Change "Save & Exit" to "Abort"
-                _ctrl ctrlSetTooltip localize "STR_TOOLTIP_MAIN_ABORT";
             };
         };
 

--- a/addons/common/functions/fnc_disableUserInput.sqf
+++ b/addons/common/functions/fnc_disableUserInput.sqf
@@ -54,17 +54,18 @@ if (_state) then {
                 (_dlg displayCtrl _index) ctrlEnable false;
             };
 
-            _ctrl = _dlg displayctrl 103;
-            _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(while {!isNull (uiNamespace getVariable [ARR_2(QUOTE(QGVAR(dlgDisableMouse)),displayNull)])} do {closeDialog 0}; failMission 'LOSER'; [false] call DFUNC(disableUserInput);)];
+            _ctrl = _dlg displayCtrl 104; // "Abort" or "Save & Exit" button
+            _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize ([ARR_2('str_sure','str_msg_confirm_return_lobby_client')] select isMultiplayer),'',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; [false] call DFUNC(disableUserInput); failMission 'LOSER' }})];
             _ctrl ctrlEnable true;
-            _ctrl ctrlSetText "ABORT";
-            _ctrl ctrlSetTooltip "Abort.";
 
-            _ctrl = _dlg displayctrl ([104, 1010] select isMultiplayer);
-            _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(closeDialog 0; player setDamage 1; [false] call DFUNC(disableUserInput);)];
-            _ctrl ctrlEnable (call {_config = missionConfigFile >> "respawnButton"; !isNumber _config || {getNumber _config == 1}});
-            _ctrl ctrlSetText "RESPAWN";
-            _ctrl ctrlSetTooltip "Respawn.";
+            if (isMultiplayer) then {
+                _ctrl = _dlg displayctrl 1010; // "Respawn" button
+                _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize 'str_a3_rscdisplaympinterrupt_respawnprompt','',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; player setDamage 1; [false] call DFUNC(disableUserInput) }})];
+                _ctrl ctrlEnable (call {_config = missionConfigFile >> "respawnButton"; !isNumber _config || {getNumber _config == 1}});
+            } else {
+                _ctrl ctrlSetText localize "str_disp_int_abort"; // Change "Save & Exit" to "Abort"
+                _ctrl ctrlSetTooltip localize "STR_TOOLTIP_MAIN_ABORT";
+            };
         };
 
         if (_key in actionKeys "TeamSwitch" && {teamSwitchEnabled}) then {

--- a/addons/common/functions/fnc_disableUserInput.sqf
+++ b/addons/common/functions/fnc_disableUserInput.sqf
@@ -70,10 +70,6 @@ if (_state) then {
                 };
             };
 
-            _ctrl = _dlg displayCtrl 104; // "Abort" or "Save & Exit" button
-            _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize ([ARR_2('str_sure','str_msg_confirm_return_lobby_client')] select isMultiplayer),'',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; [false] call DFUNC(disableUserInput); failMission 'LOSER' }})];
-            _ctrl ctrlEnable true;
-
             if (isMultiplayer) then {
                 _ctrl = _dlg displayctrl 1010; // "Respawn" button
                 _ctrl ctrlSetEventHandler ["buttonClick", QUOTE(0 spawn { if ([ARR_4(localize 'str_a3_rscdisplaympinterrupt_respawnprompt','',true,true)] call BIS_fnc_guiMessage) then { closeDialog 0; player setDamage 1; [false] call DFUNC(disableUserInput) }})];


### PR DESCRIPTION
* Abort functionality transferred to vanilla Abort button (idc 104), instead of overriding "Save" button (idc 103)
* Respawn button now only shows in MP, all it does is kill the player so it has no purpose in SP
* Added confirmation prompts for abort & respawn, like vanilla has
* Custom text edited to use vanilla localized strings

The reasons why I transferred Abort stuff to idc 104 are because it's the vanilla game's actual Abort button, so it makes sense for it to remain like so, and also because some vanilla missions using non-ACE revive systems disable it while being unconscious to prevent combat logging. So, it makes it easier to port those missions to ACE while maintaining cross-compatibility with vanilla. The other things are just minor improvements to user experience.