### PR TITLE
Added "medical_onSetDead" local event in fnc_setDead.sqf

### DIFF
--- a/addons/medical/functions/fnc_setDead.sqf
+++ b/addons/medical/functions/fnc_setDead.sqf
@@ -75,7 +75,7 @@ if (isPLayer _unit) then {
     _unit setvariable ["isDeadPlayer", true, true];
 };
 
-["medical_onSetDead", _unit] call EFUNC(common,localEvent);
+["medical_onSetDead", [_unit]] call EFUNC(common,localEvent);
 
 _unit setdamage 1;
 true;

--- a/addons/medical/functions/fnc_setDead.sqf
+++ b/addons/medical/functions/fnc_setDead.sqf
@@ -74,5 +74,8 @@ _unit setvariable ["ACE_isDead", true, true];
 if (isPLayer _unit) then {
     _unit setvariable ["isDeadPlayer", true, true];
 };
+
+["medical_onSetDead", _unit] call EFUNC(common,localEvent);
+
 _unit setdamage 1;
 true;


### PR DESCRIPTION
I am currently in the process of porting a mission to ACE3, and it contains a scoreboard system which requires capture of the "source" and "projectile" parameters passed to the <a href="https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#HandleDamage" target="_blank">`HandleDamage`</a> event, either when the player falls unconscious or  right before being considered dead, in order to give appropriate credit. For the "unconscious" part, I am able to recover those values within the `medical_onUnconscious` event, but there is no equivalent for the "dead" part.

Since most ACE-handled deaths are triggered via `fnc_setDead` within `medical`'s `fnc_handleDamage` scripts, adding a `medical_onSetDead` event at this location allows extraction of aforementioned parameters, which is enough to make the scoreboard work properly.