### PR TITLE
One PFEH for execNextFrame and waitAndExec

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -3,6 +3,27 @@
 
 //IGNORE_PRIVATE_WARNING("_handleNetEvent", "_handleRequestAllSyncedEvents", "_handleRequestSyncedEvent", "_handleSyncedEvent");
 
+//Singe PFEH to handle execNextFrame and waitAndExec:
+[{
+    private ["_entry"];
+    
+    //Handle the waitAndExec array:
+    while {((count GVAR(waitAndExecArray)) > 0) && {((GVAR(waitAndExecArray) select 0) select 0) <= ACE_Time}} do {
+        _entry = GVAR(waitAndExecArray) deleteAt 0;
+        (_entry select 2) call (_entry select 1);
+    };
+
+    //Handle the execNextFrame array:
+    {
+        (_x select 0) call (_x select 1);
+    } forEach GVAR(nextFrameBufferA);
+    //Swap double-buffer:
+    GVAR(nextFrameBufferA) = GVAR(nextFrameBufferB);
+    GVAR(nextFrameBufferB) = [];
+    GVAR(nextFrameNo) = diag_frameno + 1;
+}, 0, []] call CBA_fnc_addPerFrameHandler;
+
+
 // Listens for global "SettingChanged" events, to update the force status locally
 ["SettingChanged", {
     PARAMS_2(_name,_value);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -287,7 +287,12 @@ PREP(_handleRequestSyncedEvent);
 PREP(_handleRequestAllSyncedEvents);
 
 GVAR(syncedEvents) = HASH_CREATE;
+
+//GVARS for execNextFrame and waitAndExec
 GVAR(waitAndExecArray) = [];
+GVAR(nextFrameNo) = diag_frameno;
+GVAR(nextFrameBufferA) = [];
+GVAR(nextFrameBufferB) = [];
 
 // @TODO: Generic local-managed global-synced objects (createVehicleLocal)
 

--- a/addons/common/functions/fnc_execNextFrame.sqf
+++ b/addons/common/functions/fnc_execNextFrame.sqf
@@ -14,21 +14,8 @@
 
 PARAMS_2(_func,_params);
 
-[
-    {
-        EXPLODE_2_PVT(_this,_params,_pfhId);
-        EXPLODE_2_PVT(_params,_delayedExecParams,_startFrame);
-        EXPLODE_2_PVT(_delayedExecParams,_func,_funcParams);
-
-        // Exit if we are still on the same frame
-        if (diag_frameno == _startFrame) exitWith {};
-
-        // Remove the PFH
-        [_pfhId] call cba_fnc_removePerFrameHandler;
-
-        // Execute the function
-        _funcParams call _func;
-    },
-    0,
-    [_this, diag_frameno]
-] call CBA_fnc_addPerFrameHandler
+if (diag_frameno != GVAR(nextFrameNo)) then {
+    GVAR(nextFrameBufferA) pushBack [_params, _func];
+} else {
+    GVAR(nextFrameBufferB) pushBack [_params, _func];
+};

--- a/addons/common/functions/fnc_waitAndExecute.sqf
+++ b/addons/common/functions/fnc_waitAndExecute.sqf
@@ -22,16 +22,3 @@ PARAMS_3(_func,_params,_delay);
 
 GVAR(waitAndExecArray) pushBack [(ACE_time + _delay), _func, _params];
 GVAR(waitAndExecArray) sort true;
-
-if ((count GVAR(waitAndExecArray)) == 1) then {
-    [{
-        while {((count GVAR(waitAndExecArray)) > 0) && {((GVAR(waitAndExecArray) select 0) select 0) <= ACE_Time}} do {
-            private ["_entry"];
-            _entry = GVAR(waitAndExecArray) deleteAt 0;
-            (_entry select 2) call (_entry select 1);
-        };
-        if ((count GVAR(waitAndExecArray)) == 0) then {
-            [(_this select 1)] call cba_fnc_removePerFrameHandler;
-        };
-    }, 0, []] call CBA_fnc_addPerFrameHandler;
-};


### PR DESCRIPTION
For each waitAndExec we create a new `CBA_fnc_addPerFrameHandler` and remove it.
They do have some overhead for stuff like handles that we really don't need.
```
x1 = [{systemChat "x"}, 0, []] call CBA_fnc_addPerFrameHandler; 
[x1] call cba_fnc_removePerFrameHandler;
```
is ~0.3 ms.  There also is an array that permanently grows each time we add: 
`count cba_common_pfhhandles` was about 3500 after an hour.

This just creates one single permanent pfeh that handles both execNextFrame and waitAndExec.  It's pretty lightweight and I'm think having it up all the time should be faster than constantly adding and removing.