### PR TITLE
DAGR overlay auto hide

### DIFF
--- a/addons/dagr/XEH_postInit.sqf
+++ b/addons/dagr/XEH_postInit.sqf
@@ -2,7 +2,10 @@
 
 #include "initKeybinds.sqf"
 
+GVAR(outputPFH) = -1;
+
 GVAR(run) = false;
+GVAR(hidden) = true;
 GVAR(menuRun) = false;
 GVAR(useDegrees) = true;
 GVAR(updateInterval) = 0.5;

--- a/addons/dagr/functions/fnc_outputData.sqf
+++ b/addons/dagr/functions/fnc_outputData.sqf
@@ -27,11 +27,14 @@
 
 __background ctrlSetText QUOTE(PATHTOF(UI\dagr_gps.paa));
 
-[{
+if (GVAR(outputPFH) != -1) exitWith {};
+
+GVAR(outputPFH) = [{
     private ["_pos", "_mapSize", "_gridConfig", "_offsetX", "_offsetY", "_stepX", "_stepY", "_xgrid", "_ygrid", "_xcoord", "_ycoord", "_speed", "_dagrHeading", "_dagrGrid", "_dagrElevation", "_dagrSpeed", "_dagrTime", "_elevation"];
     
     // Abort Condition
     if !(GVAR(run) && [ACE_player, "ACE_DAGR"] call EFUNC(common,hasItem)) exitWith {
+        GVAR(outputPFH) = -1;
         135471 cutText ["", "PLAIN"];
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/dagr/functions/fnc_outputWP.sqf
+++ b/addons/dagr/functions/fnc_outputWP.sqf
@@ -27,11 +27,14 @@
 
 __background ctrlSetText QUOTE(PATHTOF(UI\dagr_wp.paa));
 
-[{
+if (GVAR(outputPFH) != -1) exitWith {};
+
+GVAR(outputPFH) = [{
     private ["_pos", "_mapSize", "_gridConfig", "_offsetX", "_offsetY", "_stepX", "_stepY", "_xGrid", "_yGrid", "_xCoord", "_yCoord", "_dagrHeading", "_dagrGrid", "_bearing", "_MYpos", "_WPpos", "_dagrDistance", "_distance"];
     
     // Abort Condition
     if !(GVAR(run) && [ACE_player, "ACE_DAGR"] call EFUNC(common,hasItem)) exitWith {
+        GVAR(outputPFH) = -1;
         135471 cutText ["", "PLAIN"];
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/dagr/functions/fnc_toggleOverlay.sqf
+++ b/addons/dagr/functions/fnc_toggleOverlay.sqf
@@ -14,27 +14,37 @@
  */
 #include "script_component.hpp"
 
-if (cameraView == "GUNNER") exitWith {};
-
 GVAR(run) = !GVAR(run);
 
 if (GVAR(run)) then {
-    switch (toUpper GVAR(displaySelection)) do {
-        case "WP" : {
-            call FUNC(outputWP);
-        };
-        case "VECTOR" : {
-            call FUNC(outputVector);
-        };
-        case "DATA" : {
-            call FUNC(outputData);
-        };
-    };
+    GVAR(hidden) = true;
     [{
         EXPLODE_1_PVT(_this select 0,_vehicle);
-        if (!GVAR(run) || (!alive ACE_player) || (cameraView == "GUNNER") || (vehicle ACE_player != _vehicle)) exitWith {
+        if (!GVAR(run) || (!alive ACE_player) || (vehicle ACE_player != _vehicle)) exitWith {
+            GVAR(run) = false;
             135471 cutText ["", "PLAIN"];
             [_this select 1] call CBA_fnc_removePerFrameHandler;
+        };
+        if (cameraView == "GUNNER") then {
+            if (!GVAR(hidden)) then {
+                GVAR(hidden) = true;
+                135471 cutText ["", "PLAIN"];
+            };
+        } else {
+            if (GVAR(hidden)) then {
+                GVAR(hidden) = false;
+                switch (toUpper GVAR(displaySelection)) do {
+                    case "WP" : {
+                        call FUNC(outputWP);
+                    };
+                    case "VECTOR" : {
+                        call FUNC(outputVector);
+                    };
+                    case "DATA" : {
+                        call FUNC(outputData);
+                    };
+                };
+            };
         };
     }, 0.1, [vehicle ACE_player]] call CBA_fnc_addPerFrameHandler;
 };


### PR DESCRIPTION
Thanks @SzwedzikPL for bringing this issue up. :+1: 

* Properly resets GVAR(run) when the main PFH aborts
* Prevents having duplicate PFHs
* Auto hides the DAGR overlay when you go into gunner view