### PR TITLE
Fixed CheckPBO Kick

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -11,7 +11,6 @@ PREP(addCanInteractWithCondition);
 PREP(addLineToDebugDraw);
 PREP(addSetting);
 PREP(addToInventory);
-PREP(adminKick);
 PREP(ambientBrightness);
 PREP(applyForceWalkStatus);
 PREP(ASLToPosition);

--- a/addons/common/functions/fnc_adminKick.sqf
+++ b/addons/common/functions/fnc_adminKick.sqf
@@ -1,8 +1,0 @@
-// by commy2
-#include "script_component.hpp"
-
-private "_name";
-
-_name = name (_this select 0);
-
-[_name, "{if (serverCommandAvailable '#kick') then {serverCommand format['#kick %1', _this]}}"] call FUNC(execRemoteFnc);

--- a/addons/common/functions/fnc_checkPBOs.sqf
+++ b/addons/common/functions/fnc_checkPBOs.sqf
@@ -67,24 +67,26 @@ if (!isServer) then {
             //[_error, "{systemChat _this}"] call FUNC(execRemoteFnc);
             diag_log text _error;
 
-            _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
+            if (_mode < 2) then {
+                _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
 
-            _rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
-            _rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
+                _rscLayer = "ACE_RscErrorHint" call BIS_fnc_rscLayer;
+                _rscLayer cutRsc ["ACE_RscErrorHint", "PLAIN", 0, true];
 
-            disableSerialization;
-            _ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
-            _ctrlHint ctrlSetStructuredText _text;
+                disableSerialization;
+                _ctrlHint = uiNamespace getVariable "ACE_ctrlErrorHint";
+                _ctrlHint ctrlSetStructuredText _text;
 
-            if (_mode == 0) then {
-                sleep 10;
-                _rscLayer cutFadeOut 0.2;
+                if (_mode == 0) then {
+                    sleep 10;
+                    _rscLayer cutFadeOut 0.2;
+                };
             };
 
             if (_mode == 2) then {
-                sleep 10;
-                waitUntil {alive player};
-                [player] call FUNC(adminKick);
+                waitUntil {alive player}; // To be able to show list if using checkAll
+                _text = composeText [parseText format ["<t align='center'>%1</t>", _text]];
+                ["[ACE] ERROR", _text, {findDisplay 46 closeDisplay 0}] call FUNC(errorMessage);
             };
         };
     };


### PR DESCRIPTION
- Removed function `adminKick` as it is now redundant
- Used close display 46 in combination with `errorMessage` function
- Actual error message is what it is until a rewrite of CheckPBOs comes, meaning no displaying of what mods in the error pop-up as that is displayed in chat from a separate script - hence why waitUntil is also needed