### PR TITLE
Proper CPR cycle time

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -264,7 +264,7 @@ class ACE_Medical_Actions {
             displayNameProgress = CSTRING(Actions_PerformingCPR);
             treatmentLocations[] = {"All"};
             requiredMedic = 0;
-            treatmentTime = 22 + (random 2);
+            treatmentTime = "22 + (random 2)";
             items[] = {};
             condition = "((_this select 1) getvariable ['ACE_medical_inCardiacArrest', false])";
             callbackSuccess = QUOTE(DFUNC(treatmentAdvanced_CPR));

--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -264,7 +264,7 @@ class ACE_Medical_Actions {
             displayNameProgress = CSTRING(Actions_PerformingCPR);
             treatmentLocations[] = {"All"};
             requiredMedic = 0;
-            treatmentTime = 15;
+            treatmentTime = 22 + (random 2);
             items[] = {};
             condition = "((_this select 1) getvariable ['ACE_medical_inCardiacArrest', false])";
             callbackSuccess = QUOTE(DFUNC(treatmentAdvanced_CPR));


### PR DESCRIPTION
Source: http://www.ncbi.nlm.nih.gov/pubmed/19491691
- ```The time required to perform five cycles of CPR was 115+/-5 s```

So one cycle should last about 23 +/- 1 second.
- ```The time needed to deliver the **first two** rescue breaths was between 12 and 15 s```

And you do about 100 compressions per minute, so about 2 per second, so you need about 15 seconds to do 30 compressions.