### PR TITLE
Fix vanilla damage effects

### DIFF
--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -80,9 +80,11 @@ if (GVAR(level) < 2) then {
     } else {
         _damageReturn = _damageReturn min 0.89;
     };
+
 };
 [_unit] call FUNC(addToInjuredCollection);
 
+_unit setHit [_selection, _damageReturn];
 
 if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitWith {
     if (vehicle _unit != _unit and {damage (vehicle _unit) >= 1}) then {
@@ -98,8 +100,8 @@ if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitW
 
     if (_damageReturn >= 0.9 && {_selection in ["", "head", "body"]}) exitWith {
         if (_unit getvariable ["ACE_isUnconscious", false]) exitwith {
-            [_unit] call FUNC(setDead);
-            0.89
+            if ([_unit] call FUNC(setDead)) exitwith {1};
+            0;
         };
         if (_delayedUnconsicous) then {
             [{
@@ -110,9 +112,9 @@ if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitW
                 [_this select 0, true] call FUNC(setUnconscious);
             }, [_unit]] call EFUNC(common,execNextFrame);
         };
-        0.89
+        0;
     };
-    _damageReturn min 0.89;
+    0;
 };
 
 if (((_unit getVariable [QGVAR(enableRevive), GVAR(enableRevive)]) > 0) && {_damageReturn >= 0.9} && {_selection in ["", "head", "body"]}) exitWith {
@@ -120,8 +122,10 @@ if (((_unit getVariable [QGVAR(enableRevive), GVAR(enableRevive)]) > 0) && {_dam
         [_unit] call EFUNC(common,unloadPerson);
     };
     [_unit] call FUNC(setDead);
-
-    0.89
+    0;
 };
 
-_damageReturn
+if (_damageReturn < 1) exitwith {
+    0;
+};
+1;

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -84,8 +84,6 @@ if (GVAR(level) < 2) then {
 };
 [_unit] call FUNC(addToInjuredCollection);
 
-_unit setHit [_selection, _damageReturn];
-
 if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitWith {
     if (vehicle _unit != _unit and {damage (vehicle _unit) >= 1}) then {
         [_unit] call EFUNC(common,unloadPerson);
@@ -100,8 +98,8 @@ if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitW
 
     if (_damageReturn >= 0.9 && {_selection in ["", "head", "body"]}) exitWith {
         if (_unit getvariable ["ACE_isUnconscious", false]) exitwith {
-            if ([_unit] call FUNC(setDead)) exitwith {1};
-            0;
+            [_unit] call FUNC(setDead);
+            0.89;
         };
         if (_delayedUnconsicous) then {
             [{
@@ -112,9 +110,9 @@ if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitW
                 [_this select 0, true] call FUNC(setUnconscious);
             }, [_unit]] call EFUNC(common,execNextFrame);
         };
-        0;
+        0.89;
     };
-    0;
+    0.89;
 };
 
 if (((_unit getVariable [QGVAR(enableRevive), GVAR(enableRevive)]) > 0) && {_damageReturn >= 0.9} && {_selection in ["", "head", "body"]}) exitWith {
@@ -122,10 +120,7 @@ if (((_unit getVariable [QGVAR(enableRevive), GVAR(enableRevive)]) > 0) && {_dam
         [_unit] call EFUNC(common,unloadPerson);
     };
     [_unit] call FUNC(setDead);
-    0;
+    0.89;
 };
 
-if (_damageReturn < 1) exitwith {
-    0;
-};
-1;
+_damageReturn;

--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -39,8 +39,6 @@ _damageBodyParts = _unit getvariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
 _damageBodyParts set [_part, (_damageBodyParts select _part) + _newDamage];
 _unit setvariable [QGVAR(bodyPartStatus), _damageBodyParts, true];
 
-[_unit] call FUNC(handleDamage_advancedSetDamage);
-
 _typeOfDamage = [_typeOfProjectile] call FUNC(getTypeOfDamage);
 [_unit, _selectionName, _newDamage, _typeOfProjectile, _typeOfDamage] call FUNC(handleDamage_assignWounds);
 

--- a/addons/medical/functions/fnc_handleDamage_caching.sqf
+++ b/addons/medical/functions/fnc_handleDamage_caching.sqf
@@ -81,12 +81,17 @@ if (diag_frameno > (_unit getVariable [QGVAR(frameNo_damageCaching), -3]) + 2) t
         _args = _this select 0;
 
         if (diag_frameno > (_args select 1) + 2) then {
+            (_args select 0) setDamage 0;
+
             _cache_params = (_args select 0) getVariable [QGVAR(cachedHandleDamageParams), []];
             _cache_damages = (_args select 0) getVariable QGVAR(cachedDamages);
             {
                 _params = _x + [_cache_damages select _foreachIndex];
                 _params call FUNC(handleDamage_advanced);
             }foreach _cache_params;
+
+            [(_args select 0)] call FUNC(handleDamage_advancedSetDamage);
+
             [(_this select 1)] call cba_fnc_removePerFrameHandler;
         };
     }, 0, [_unit, diag_frameno] ] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Vanilla plays damage effects when `damage unit` returns > 0. 

The damage is increased when using return values in the `handleDamage` eventhandler. Returning 0 on the eventhandler appears to be breaking the current implementation of handleDamage in both basic and advanced (all units become invulnerable). 

Solution for advanced only at the moment is to reset damage in the caching and apply proper hitpoint damage after we are done processing the handleDamage calls. As an added side bonus this also seems to be fixing the flashing hitpoint textures.