### PR TITLE
BFT_Devices Updated

### DIFF
--- a/addons/bft/XEH_postInit.sqf
+++ b/addons/bft/XEH_postInit.sqf
@@ -170,7 +170,7 @@ if(!isServer) then {
     if (GVAR(updateAvailableDevicesPositions)) then {
         {
             if (time - (_x select 8) >= (_x select 9)) then {
-                systemChat format["updating a device position: %1", _x];
+                //systemChat format["updating a device position: %1", _x];
                 _x set [8, time];
                 _x set [4, getPosASL (_x select 10)];
             };

--- a/addons/bft_devices/ACE_BFT.hpp
+++ b/addons/bft_devices/ACE_BFT.hpp
@@ -1,6 +1,6 @@
 class ACE_BFT {
     class Devices {
-        // Infantry
+        // Personal Devices
         class DK10_b {
             deviceSide = "NATO";
             refreshRate = 5;
@@ -8,6 +8,25 @@ class ACE_BFT {
             defaultInformation[] = {"Inf", 0, "", 0};
 
             GVAR(dialogName) = QGVAR(DK10_dlg);
+
+            class InterfaceSettings {
+                dlgIfPosition[] = {};
+                mode = "DESKTOP";
+                showIconText = "true";
+                mapWorldPos[] = {};
+                mapScaleDsp = 2;
+                mapScaleDlg = 2;
+                class mapTypes {
+                    SAT = IDC_SCREEN;
+                    TOPO = IDC_SCREEN_TOPO;
+                };
+                mapType = "SAT";
+                uavCam = "";
+                hCam = "";
+                mapTools = "true";
+                nightMode = 2;
+                brightness = 0.9;
+            };
         };
         class DK10_o: DK10_b {
             deviceSide = "EAST";
@@ -16,9 +35,33 @@ class ACE_BFT {
             deviceSide = "IND";
         };
 
-        class GD300_b: DK10_b {
+        class GD300_b {
+            deviceSide = "NATO";
+            refreshRate = 5;
+            reportingModes[] = {"FBCB2"};
+            defaultInformation[] = {"Inf", 0, "", 0};
+
             GVAR(displayName) = QGVAR(GD300_dsp);
             GVAR(dialogName) = QGVAR(GD300_dlg);
+
+            class InterfaceSettings {
+                dlgIfPosition[] = {};
+                dspIfPosition = "false";
+                mode = "BFT";
+                showIconText = "true";
+                mapWorldPos[] = {};
+                mapScaleDsp = 0.4;
+                mapScaleDlg = 0.4;
+                class mapTypes {
+                    SAT = IDC_SCREEN;
+                    TOPO = IDC_SCREEN_TOPO;
+                };
+                mapType = "SAT";
+                showMenu = "false";
+                mapTools = "true";
+                nightMode = 2;
+                brightness = 0.9;
+            };
         };
         class GD300_o: GD300_b {
             deviceSide = "EAST";
@@ -27,11 +70,61 @@ class ACE_BFT {
             deviceSide = "IND";
         };
 
+        class MicroDAGR_b {
+            deviceSide = "NATO";
+            refreshRate = 5;
+            reportingModes[] = {"GroupOnly"};
+            defaultInformation[] = {"Inf", 0, "", 0};
+
+            GVAR(displayName) = QGVAR(GD300_dsp);
+            GVAR(dialogName) = QGVAR(GD300_dlg);
+
+            class InterfaceSettings {
+                dlgIfPosition[] = {};
+                dspIfPosition = "false";
+                mapWorldPos[] = {};
+                showIconText = "true";
+                mapScaleDsp = 0.4;
+                mapScaleDlg = 0.4;
+                class mapTypes {
+                    SAT = IDC_SCREEN;
+                    TOPO = IDC_SCREEN_TOPO;
+                };
+                mapType = "SAT";
+                mapTools = "true";
+                nightMode = 2;
+                brightness = 0.9;
+            };
+        };
+        class MicroDAGR_o: MicroDAGR_b {
+            deviceSide = "EAST";
+        };
+        class MicroDAGR_i: MicroDAGR_b {
+            deviceSide = "IND";
+        };
+
         // Motorized
-        class JV5_Mot_b: DK10_b {
+        class JV5_Mot_b {
+            deviceSide = "NATO";
+            refreshRate = 5;
+            reportingModes[] = {"FBCB2"};
             defaultInformation[] = {"Motorized", 0, "", 0};
 
             GVAR(dialogName) = QGVAR(JV5_dlg);
+
+            class InterfaceSettings {
+                dlgIfPosition[] = {};
+                mapWorldPos[] = {};
+                showIconText = "true";
+                mapScaleDsp = 2;
+                mapScaleDlg = 2;
+                class mapTypes {
+                    SAT = IDC_SCREEN;
+                    TOPO = IDC_SCREEN_TOPO;
+                };
+                mapType = "SAT";
+                mapTools = "true";
+            };
         };
         class JV5_Mot_o: JV5_Mot_b {
             deviceSide = "EAST";
@@ -60,6 +153,25 @@ class ACE_BFT {
 
             GVAR(displayName) = QGVAR(TAD_dsp);
             GVAR(dialogName) = QGVAR(TAD_dlg);
+
+            class InterfaceSettings {
+                dlgIfPosition[] = {};
+                dspIfPosition = "false";
+                mapWorldPos[] = {};
+                showIconText = "true";
+                mapScaleDsp = 2;
+                mapScaleDlg = 2;
+                mapScaleMin = 1;
+                class mapTypes {
+                    SAT = IDC_SCREEN;
+                    TOPO = IDC_SCREEN_TOPO;
+                    BLK = IDC_SCREEN_BLACK;
+                };
+                mapType = "SAT";
+                mapTools = "true";
+                nightMode = 0;
+                brightness = 0.8;
+            };
         };
         class TAD_Heli_o: TAD_Heli_b {
             deviceSide = "EAST";

--- a/addons/bft_devices/ACE_BFT.hpp
+++ b/addons/bft_devices/ACE_BFT.hpp
@@ -190,5 +190,30 @@ class ACE_BFT {
         class TAD_Plane_i: TAD_Plane_b {
             deviceSide = "IND";
         };
+
+        // UAV
+        class UAV_b {
+            deviceSide = "NATO";
+            reportingModes[] = {"UAV"};
+            refreshRate = 1;
+            defaultInformation[] = {"UAV", 0, "", 0};
+        };
+        class UAV_o: UAV_b {
+            deviceSide = "EAST";
+        };
+        class UAV_i: UAV_b {
+            deviceSide = "IND";
+        };
+
+        // UGV
+        class UGV_b: UAV_b {
+            refreshRate = 5;
+        };
+        class UGV_o: UGV_b {
+            deviceSide = "EAST";
+        };
+        class UGV_i: UGV_b {
+            deviceSide = "IND";
+        };
     };
 };

--- a/addons/bft_devices/CfgVehicles.hpp
+++ b/addons/bft_devices/CfgVehicles.hpp
@@ -167,4 +167,61 @@ class CfgVehicles {
     class Plane_Fighter_03_base_F: Plane_Base_F {
         EGVAR(bft,vehicleDevices)[] = {"TAD_Plane_i"};
     };
+
+    // UAVs
+    class UAV_01_base_F;
+    class B_UAV_01_F: UAV_01_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_b"};
+    };
+    class O_UAV_01_F: UAV_01_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_o"};
+    };
+    class I_UAV_01_F: UAV_01_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_i"};
+    };
+
+    class UAV_02_base_F;
+    class B_UAV_02_F: UAV_02_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_b"};
+    };
+    class O_UAV_02_F: UAV_02_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_o"};
+    };
+    class I_UAV_02_F: UAV_02_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_i"};
+    };
+
+    class UAV_02_CAS_base_F;
+    class B_UAV_02_CAS_F : UAV_02_CAS_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_b"};
+    };
+    class O_UAV_02_CAS_F : UAV_02_CAS_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_o"};
+    };
+    class I_UAV_02_CAS_F : UAV_02_CAS_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UAV_i"};
+    };
+
+    // UGVs
+    class UGV_01_base_F;
+    class B_UGV_01_F : UGV_01_base_F{
+        EGVAR(bft,vehicleDevices)[] = {"UGV_b"};
+    };
+    class O_UGV_01_F : UGV_01_base_F{
+        EGVAR(bft,vehicleDevices)[] = {"UGV_o"};
+    };
+    class I_UGV_01_F : UGV_01_base_F{
+        EGVAR(bft,vehicleDevices)[] = {"UGV_i"};
+    };
+
+    class UGV_01_rcws_base_F;
+    class B_UGV_01_rcws_F : UGV_01_rcws_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UGV_b"};
+    };
+    class O_UGV_01_rcws_F : UGV_01_rcws_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UGV_o"};
+    };
+    class I_UGV_01_rcws_F : UGV_01_rcws_base_F {
+        EGVAR(bft,vehicleDevices)[] = {"UGV_i"};
+    };
 };

--- a/addons/bft_devices/CfgVehicles.hpp
+++ b/addons/bft_devices/CfgVehicles.hpp
@@ -1,4 +1,60 @@
 class CfgVehicles {
+    class Man;
+    class CAManBase: Man {
+        class ACE_SelfActions {
+            class ACE_Equipment {
+                class GVAR(BFT) {
+                    displayName = "BFT";
+                    condition = QUOTE(!(([ACE_player] call EFUNC(bft,getOwnedDevices) isEqualTo [])) || !(([vehicle ACE_player] call EFUNC(bft,getOwnedDevices) isEqualTo [])));
+                    statement = "";
+                    showDisabled = 0;
+                    priority = 2;
+                    icon = PATHTOF(UI\inventory\DK10_icon.paa);
+                    exceptions[] = {"notOnMap", "isNotInside"};
+
+                    class openDisplay {
+                        displayName = "Open Overlay";
+                        condition = QUOTE(I_CLOSED);
+                        statement = QUOTE(0 call FUNC(onIfToggleKey));
+                        showDisabled = 0;
+                        priority = 2;
+                        icon = PATHTOF(UI\inventory\DK10_icon.paa);
+                        exceptions[] = {"notOnMap", "isNotInside"};
+                    };
+
+                    class closeDisplay {
+                        displayName = "Close Overlay";
+                        condition = QUOTE(I_OPEN && {!I_GET_ISDIALOG});
+                        statement = QUOTE([] call FUNC(ifClose));
+                        showDisabled = 0;
+                        priority = 2;
+                        icon = PATHTOF(UI\inventory\DK10_icon.paa);
+                        exceptions[] = {"notOnMap", "isNotInside"};
+                    };
+
+                    class openDialog {
+                        displayName = "Open Interactive Mode";
+                        condition = QUOTE(I_CLOSED);
+                        statement = QUOTE(1 call FUNC(onIfToggleKey));
+                        showDisabled = 0;
+                        priority = 2;
+                        icon = PATHTOF(UI\inventory\DK10_icon.paa);
+                        exceptions[] = {"notOnMap", "isNotInside"};
+                    };
+
+                    class toggleDisplayPosition {
+                        displayName = "Toggle Overlay Position (left/right)";
+                        condition = QUOTE(I_OPEN && {!I_GET_ISDIALOG});
+                        statement = QUOTE([] call FUNC(onIfTogglePositionKey));
+                        showDisabled = 0;
+                        priority = 2;
+                        icon = PATHTOF(UI\inventory\DK10_icon.paa);
+                        exceptions[] = {"notOnMap", "isNotInside"};
+                    };
+                };
+            };
+        };
+    };
     // Boxes
     class Box_NATO_Support_F;
     class ACE_Box_BFT_b: Box_NATO_Support_F {

--- a/addons/bft_devices/UI/defines/shared_controls.hpp
+++ b/addons/bft_devices/UI/defines/shared_controls.hpp
@@ -201,7 +201,7 @@ class GVAR(RscEdit) {
         0,
         0,
         0,
-        1
+        0
     };
     colorText[] = {
         0.95,

--- a/addons/bft_devices/XEH_clientInit.sqf
+++ b/addons/bft_devices/XEH_clientInit.sqf
@@ -69,119 +69,15 @@ GVAR(notificationCache) = [];
 GVAR(UAVlist) = [];
 GVAR(Hcamlist) = [];
 
-// Define interfaces that share the same property group
-GVAR(displayPropertyGroups) = HASH_CREATE;
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(DK10_dlg),"DK10");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(GD300_dlg),"GD300");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(GD300_dsp),"GD300");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(JV5_dlg),"JV5");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(TAD_dsp),"TAD");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(TAD_dlg),"TAD");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(MicroDAGR_dsp),"MicroDAGR");
-HASH_SET(GVAR(displayPropertyGroups),QGVAR(MicroDAGR_dlg),"MicroDAGR");
-
 // Define default settings for interface property groups
 GVAR(settings) = HASH_CREATE;
 
-private ["_tempHash", "_tempMapHash"];
+private ["_tempHash"];
 // COMMON settings
 _tempHash = HASH_CREATE;
 HASH_SET(_tempHash,"mode","BFT");
 HASH_SET(_tempHash,"mapScaleMin",0.1);
 HASH_SET(_tempHash,"mapScaleMax",2 ^ round(sqrt(GVAR(worldSize) / 1024)));
 HASH_SET(GVAR(settings),"COMMON",_tempHash);
-
-// DK10 settings
-_tempHash = HASH_CREATE;
-HASH_SET(_tempHash,"dlgIfPosition",[]);
-HASH_SET(_tempHash,"mode","DESKTOP");
-HASH_SET(_tempHash,"showIconText",true);
-HASH_SET(_tempHash,"mapWorldPos",[]);
-HASH_SET(_tempHash,"mapScaleDsp",2);
-HASH_SET(_tempHash,"mapScaleDlg",2);
-_tempMapHash = HASH_CREATE;
-HASH_SET(_tempMapHash,"SAT",IDC_SCREEN);
-HASH_SET(_tempMapHash,"TOPO",IDC_SCREEN_TOPO);
-HASH_SET(_tempHash,"mapTypes",_tempMapHash);
-HASH_SET(_tempHash,"mapType","SAT");
-HASH_SET(_tempHash,"uavCam","");
-HASH_SET(_tempHash,"hCam","");
-HASH_SET(_tempHash,"mapTools",true);
-HASH_SET(_tempHash,"nightMode",2);
-HASH_SET(_tempHash,"brightness",0.9);
-HASH_SET(GVAR(settings),"DK10",_tempHash);
-
-// GD300 settings
-_tempHash = HASH_CREATE;
-HASH_SET(_tempHash,"dlgIfPosition",[]);
-HASH_SET(_tempHash,"dspIfPosition",false);
-HASH_SET(_tempHash,"mode","BFT");
-HASH_SET(_tempHash,"showIconText",true);
-HASH_SET(_tempHash,"mapWorldPos",[]);
-HASH_SET(_tempHash,"mapScaleDsp",0.4);
-HASH_SET(_tempHash,"mapScaleDlg",0.4);
-_tempMapHash = HASH_CREATE;
-HASH_SET(_tempMapHash,"SAT",IDC_SCREEN);
-HASH_SET(_tempMapHash,"TOPO",IDC_SCREEN_TOPO);
-HASH_SET(_tempHash,"mapTypes",_tempMapHash);
-HASH_SET(_tempHash,"mapType","SAT");
-HASH_SET(_tempHash,"showMenu",false);
-HASH_SET(_tempHash,"mapTools",true);
-HASH_SET(_tempHash,"nightMode",2);
-HASH_SET(_tempHash,"brightness",0.9);
-HASH_SET(GVAR(settings),"GD300",_tempHash);
-
-// JV5 settings
-_tempHash = HASH_CREATE;
-HASH_SET(_tempHash,"dlgIfPosition",[]);
-HASH_SET(_tempHash,"mapWorldPos",[]);
-HASH_SET(_tempHash,"showIconText",true);
-HASH_SET(_tempHash,"mapScaleDsp",2);
-HASH_SET(_tempHash,"mapScaleDlg",2);
-_tempMapHash = HASH_CREATE;
-HASH_SET(_tempMapHash,"SAT",IDC_SCREEN);
-HASH_SET(_tempMapHash,"TOPO",IDC_SCREEN_TOPO);
-HASH_SET(_tempHash,"mapTypes",_tempMapHash);
-HASH_SET(_tempHash,"mapType","SAT");
-HASH_SET(_tempHash,"mapTools",true);
-HASH_SET(GVAR(settings),"JV5",_tempHash);
-
-// TAD settings
-_tempHash = HASH_CREATE;
-HASH_SET(_tempHash,"dlgIfPosition",[]);
-HASH_SET(_tempHash,"dspIfPosition",false);
-HASH_SET(_tempHash,"mapWorldPos",[]);
-HASH_SET(_tempHash,"showIconText",true);
-HASH_SET(_tempHash,"mapScaleDsp",2);
-HASH_SET(_tempHash,"mapScaleDlg",2);
-HASH_SET(_tempHash,"mapScaleMin",1);
-_tempMapHash = HASH_CREATE;
-HASH_SET(_tempMapHash,"SAT",IDC_SCREEN);
-HASH_SET(_tempMapHash,"TOPO",IDC_SCREEN_TOPO);
-HASH_SET(_tempMapHash,"BLK",IDC_SCREEN_BLACK);
-HASH_SET(_tempHash,"mapTypes",_tempMapHash);
-HASH_SET(_tempHash,"mapType","SAT");
-HASH_SET(_tempHash,"mapTools",true);
-HASH_SET(_tempHash,"nightMode",0);
-HASH_SET(_tempHash,"brightness",0.8);
-HASH_SET(GVAR(settings),"TAD",_tempHash);
-
-// MicroDAGR settings
-_tempHash = HASH_CREATE;
-HASH_SET(_tempHash,"dlgIfPosition",[]);
-HASH_SET(_tempHash,"dspIfPosition",false);
-HASH_SET(_tempHash,"mapWorldPos",[]);
-HASH_SET(_tempHash,"showIconText",true);
-HASH_SET(_tempHash,"mapScaleDsp",0.4);
-HASH_SET(_tempHash,"mapScaleDlg",0.4);
-_tempMapHash = HASH_CREATE;
-HASH_SET(_tempMapHash,"SAT",IDC_SCREEN);
-HASH_SET(_tempMapHash,"TOPO",IDC_SCREEN_TOPO);
-HASH_SET(_tempHash,"mapTypes",_tempMapHash);
-HASH_SET(_tempHash,"mapType","SAT");
-HASH_SET(_tempHash,"mapTools",true);
-HASH_SET(_tempHash,"nightMode",2);
-HASH_SET(_tempHash,"brightness",0.9);
-HASH_SET(GVAR(settings),"MicroDAGR",_tempHash);
 
 #include "initKeybinds.sqf"

--- a/addons/bft_devices/XEH_clientInit.sqf
+++ b/addons/bft_devices/XEH_clientInit.sqf
@@ -12,16 +12,24 @@ GVAR(rscLayerMailNotification) = [QGVAR(mailNotification)] call BIS_fnc_rscLayer
 /*
 Figure out the scaling factor based on the current map (island) being played
 */
-call {
-    private ["_ctrlMap","_mapPos1","_mapPos2","_mapSize"];
+GVAR(worldSize) = call {
+    private ["_ctrlMap","_mapPos1","_mapPos2"];
+    disableSerialization;
     _ctrlMap = finddisplay 12 displayctrl 51;
-    _mapPos1 = _ctrlMap ctrlmapscreentoworld [0,0];
-    _mapPos2 = _ctrlMap ctrlmapscreentoworld [1,0];
-    _mapPos1 set [2,0];  _mapPos2 set [2,0];
-    _mapSize = round ((_mapPos1 vectordistance _mapPos2) / ctrlmapscale _ctrlMap);
-    GVAR(worldSize) = _mapSize;
-    GVAR(mapScaleFactor) = _mapSize / 2666.65;
+    if !(isNull _ctrlMap) then {
+    	_mapPos1 = _ctrlMap ctrlmapscreentoworld [0,0];
+    	_mapPos2 = _ctrlMap ctrlmapscreentoworld [1,0];
+    	_mapPos1 set [2,0];  _mapPos2 set [2,0];
+    	round ((_mapPos1 vectordistance _mapPos2) / ctrlmapscale _ctrlMap)
+    } else {
+    	// this will most likely only happen when we are loading a world while in ArmA main menu
+    	// meaning we don't have to return the real value; 8192 is the default worldSize for Stratis and VR
+    	8192
+	};
 };
+
+// still need to figure out if this is really required and how I actually got to this number (too long ago!)
+GVAR(mapScaleFactor) = GVAR(worldSize) / 2666.65;
 
 // ifOpenStart will be set to true while interface is starting and prevent further open attempts
 GVAR(ifOpenStart) = false;

--- a/addons/bft_devices/XEH_preInit.sqf
+++ b/addons/bft_devices/XEH_preInit.sqf
@@ -46,5 +46,6 @@ PREP(toggleMapTools);
 PREP(toggleMapType);
 PREP(toggleNightMode);
 PREP(updateTextAndIconSize);
+PREP(updateUAVList);
 
 ADDON = true;

--- a/addons/bft_devices/XEH_preInit.sqf
+++ b/addons/bft_devices/XEH_preInit.sqf
@@ -17,6 +17,7 @@ PREP(deleteUavCam);
 PREP(dirTo);
 PREP(distance2D);
 PREP(getBackgroundPosition);
+PREP(getDeviceAppData);
 PREP(getSettings);
 PREP(ifClose);
 PREP(ifOnDrawBFT);

--- a/addons/bft_devices/config.cpp
+++ b/addons/bft_devices/config.cpp
@@ -16,11 +16,13 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgVehicles.hpp"
-#include "ACE_BFT.hpp"
+
 
 // General UI defines and controls
 #include "UI\defines\shared_defines.hpp"
 #include "UI\defines\shared_controls.hpp"
+
+#include "ACE_BFT.hpp"
 
 // Defines
 #include "UI\defines\DK10_defines.hpp"

--- a/addons/bft_devices/functions/fnc_addNotification.sqf
+++ b/addons/bft_devices/functions/fnc_addNotification.sqf
@@ -7,22 +7,24 @@
  * Arguments:
  *   0: App ID <STRING>
  *   1: Notification <STRING>
+ *   2: Decay time in seconds <INTEGER>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   [_appID,"This is a notification"] call ace_bft_devices_addNotification;
+ *   [_appID,"This is a notification",5] call ace_bft_devices_addNotification;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_appID","_notification","_time","_done"];
+private ["_appID","_notification","_time","_done","_decayTime"];
 
 _appID = _this select 0;
 _notification = _this select 1;
+_decayTime = _this select 2;
 _time = call FUNC(currentTime);
 _done = false;
 
@@ -30,14 +32,14 @@ _done = false;
 {
     // if we find one, override it and increase the counter
     if ((_x select 0) isEqualTo _appID) exitWith {
-        GVAR(notificationCache) set [_forEachIndex,[_appID,_time,_notification,(_x select 3) + 1]];
+        GVAR(notificationCache) set [_forEachIndex,[_appID,_time,_notification,_decayTime,(_x select 4) + 1]];
         _done = true;
     };
 } forEach GVAR(notificationCache);
 
 // if we haven't added the notification to the cache above, do it now
 if !(_done) then {
-    GVAR(notificationCache) pushBack [_appID,_time,_notification];
+    GVAR(notificationCache) pushBack [_appID,_time,_notification,_decayTime,1];
 };
 
 [] call FUNC(processNotifications);

--- a/addons/bft_devices/functions/fnc_centerMapOnPlayerPosition.sqf
+++ b/addons/bft_devices/functions/fnc_centerMapOnPlayerPosition.sqf
@@ -5,13 +5,13 @@
  *   Center BFT Map on current player position
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_fnc_centerMapOnPlayerPosition;
+ *   ["deviceID"] call ace_bft_devices_fnc_centerMapOnPlayerPosition;
  *
  * Public: No
  */

--- a/addons/bft_devices/functions/fnc_createUavCam.sqf
+++ b/addons/bft_devices/functions/fnc_createUavCam.sqf
@@ -1,5 +1,108 @@
-// not yet ported
+/*
+ * Author: Gundy
+ *
+ * Description:
+ *   Set up UAV camera and display on supplied render target
+ *   Modified to include lessons learned from KK's excellent tutorial: http://killzonekid.com/arma-scripting-tutorials-uav-r2t-and-pip/
+ *
+ * Arguments:
+ *   0: Device ID <STRING>
+ *   1: List of arrays with seats with render targets <ARRAY>
+ *       0: Seat <INTEGER>
+ *           0 = DRIVER
+ *           1 = GUNNER
+ *       1: Name of render target <STRING>
+ *
+ * Return Value:
+ *   If UAV cam could be set up or not <BOOL>
+ *
+ * Example:
+ *   ["deviceID",[[0,"rendertarget8"],[1,"rendertarget9"]]] call ace_bft_devices_fnc_createUavCam;
+ *
+ * Public: No
+ */
 
 #include "script_component.hpp"
 
-true
+private ["_renderTarget","_deviceID","_seat","_uav","_uavCams","_seatName","_camPosMemPt","_camDirMemPt","_cam","_uavDeviceData"];
+
+_uav = objNull;
+_deviceID = _this select 0;
+
+// see if given UAV name is still in the list of valid UAVs
+{
+    if (_deviceID == (_x select 0)) exitWith {
+        // get the owner of the device (aka the UAV)
+        _uavDeviceData = _x select 1;
+        _uav = D_GET_OWNER(_uavDeviceData);
+    };
+} count GVAR(UAVlist);
+
+// remove exisitng UAV cameras
+[] call FUNC(deleteUAVcam);
+
+// exit if requested UAV could not be found
+if (isNull _uav) exitWith {false};
+
+// exit if requested UAV is not alive
+if (!alive _uav) exitWith {false};
+
+_uavCams = _this select 1;
+{
+    _seat = _x select 0;
+    _renderTarget = _x select 1;
+    // check existing cameras
+    _cam = objNull;
+    _camPosMemPt = "";
+    _camDirMemPt = "";
+    
+    _seatName = call {
+        if (_seat == 0) exitWith {"Driver"};
+        if (_seat == 1) exitWith {"Gunner"};
+        ""
+    };
+    if (_seatName != "") then {
+        // retrieve memory point names from vehicle config
+        _camPosMemPt = getText (configFile >> "CfgVehicles" >> typeOf _uav >> "uavCamera" + _seatName + "Pos");
+        _camDirMemPt = getText (configFile >> "CfgVehicles" >> typeOf _uav >> "uavCamera" + _seatName + "Dir");
+    };
+    // If memory points could be retrieved, create camera
+    if ((_camPosMemPt != "") && (_camDirMemPt != "")) then {
+        _cam = "camera" camCreate [0,0,0];
+        _cam attachTo [_uav,[0,0,0],_camPosMemPt];
+        // set up cam on render target
+        _cam cameraEffect ["INTERNAL","BACK",_renderTarget];
+        call {
+            if (_seat == 1) exitWith {
+                _renderTarget setPiPEffect [2]; // IR mode
+                _cam camSetFov 0.1; // set zoom
+            };
+            _cam camSetFov 0.5; // set default zoom
+        };
+        0 = GVAR(UAVcams) pushBack [_uav,_renderTarget,_cam,_camPosMemPt,_camDirMemPt];
+    };
+} count _uavCams;
+
+// set up event handler
+if !(GVAR(UAVcams) isEqualTo []) exitWith {
+    if (isNil QGVAR(UAVEventHandle)) then {
+        GVAR(UAVEventHandle) = addMissionEventHandler ["Draw3D",{
+            {
+                if !(isNil "_x") then {
+                    _uav = _x select 0;
+                    _cam = _x select 2;
+                    if (alive _uav) then {
+                        _dir = (_uav selectionPosition (_x select 3)) vectorFromTo (_uav selectionPosition (_x select 4));
+                        _cam setVectorDirAndUp [_dir,_dir vectorCrossProduct [-(_dir select 1), _dir select 0, 0]];
+                    } else {
+                        [_cam] call FUNC(deleteUAVcam);
+                    };
+                };
+            } count GVAR(UAVcams);
+        }];
+    };
+    GVAR(actUav) = _uav;
+    true
+};
+
+false

--- a/addons/bft_devices/functions/fnc_decBrightness.sqf
+++ b/addons/bft_devices/functions/fnc_decBrightness.sqf
@@ -5,26 +5,26 @@
  *   Decrease interface brightness
  *
  * Arguments:
- *   0: Name of uiNamespace display / dialog variable <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_decTextSize;
+ *   ["deviceID"] call ace_bft_devices_decBrightness;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_brightness", "_displayName"];
+private ["_brightness", "_deviceID"];
 
-_displayName = _this select 0;
-_brightness = [_displayName,"brightness"] call FUNC(getSettings);
+_deviceID = _this select 0;
+_brightness = [_deviceID,"brightness"] call FUNC(getSettings);
 _brightness = _brightness - 0.1;
 // make sure brightness is not larger than 0.5
 if (_brightness < 0.5) then {_brightness = 0.5};
-[_displayName,[["brightness",_brightness]]] call FUNC(setSettings);
+[_deviceID,[["brightness",_brightness]]] call FUNC(setSettings);
 
 true

--- a/addons/bft_devices/functions/fnc_deleteUavCam.sqf
+++ b/addons/bft_devices/functions/fnc_deleteUavCam.sqf
@@ -1,5 +1,48 @@
-// not yet ported
+/*
+ * Author: Gundy
+ *
+ * Description:
+ *   Delete UAV camera
+ *
+ * Arguments:
+ *   Optional:
+ *      0: Camera to delete <OBJECT>
+ *
+ * Return Value:
+ *   TRUE <BOOL>
+ *
+ * Example:
+ *   // delete all UAV cameras
+ *   [] call ace_bft_devices_fnc__fnc_deleteUAVcam;
+ *      
+ *   // delete a specific UAV camera
+ *   [_cam] call ace_bft_devices_fnc__fnc_deleteUAVcam;
+ *
+ * Public: No
+ */
 
 #include "script_component.hpp"
+
+private ["_cam","_camToDelete","_i"];
+
+_camToDelete = if (count _this == 1) then {_this select 0} else {objNull};
+
+// remove cameras
+for "_i" from (count GVAR(UAVcams) -1) to 0 step -1 do {
+    _cam = GVAR(UAVcams) select _i select 2;
+    if (isNull _camToDelete || {_cam == _camToDelete}) then {
+        0 = GVAR(UAVcams) deleteAt _i;
+        _cam cameraEffect ["TERMINATE","BACK"];
+        camDestroy _cam;
+    };
+};
+
+// remove camera direction update event handler if no more cams are present
+if (count GVAR(UAVcams) == 0) then {
+    if (!isNil QGVAR(UAVEventHandle)) then {
+        removeMissionEventHandler ["Draw3D",GVAR(UAVEventHandle)];
+        GVAR(UAVEventHandle) = nil;
+    };
+};
 
 true

--- a/addons/bft_devices/functions/fnc_getBackgroundPosition.sqf
+++ b/addons/bft_devices/functions/fnc_getBackgroundPosition.sqf
@@ -26,7 +26,7 @@ private ["_displayName","_display","_isDialog","_backgroundCtrl","_backgroundCla
 
 _displayName = _this select 0;
 _display = uiNamespace getVariable _displayName;
-_isDialog = [_displayName] call FUNC(isDialog);
+_isDialog = I_GET_ISDIALOG;
 
 // get both classes "controls" and "controlsBackground" if they exist
 _displayConfigContainers = if (_isDialog) then {

--- a/addons/bft_devices/functions/fnc_getDeviceAppData.sqf
+++ b/addons/bft_devices/functions/fnc_getDeviceAppData.sqf
@@ -1,0 +1,63 @@
+/*
+ * Author: Gundy
+ *
+ * Description:
+ *   Read InterfaceSettings for device from config
+ *
+ * Arguments:
+ *   0: Device ID <STRING>
+ *
+ * Return Value:
+ *   HASH of InterfaceSettings config class <ARRAY>
+ *
+ * Example:
+ *   ["deviceID"] call ace_bft_getDeviceAppData;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+
+private ["_deviceID","_deviceData","_deviceType","_deviceConfigPath","_configHash"];
+
+_deviceID = _this select 0;
+_deviceData = [_deviceID] call EFUNC(bft,getDeviceData);
+_deviceType = D_GET_DEVICETYPE(_deviceData);
+
+_deviceConfigPath =  configFile >> "ACE_BFT" >> "Devices" >> _deviceType >> "InterfaceSettings";
+
+_configToHash = {
+    private ["_config","_configProperties","_configHash","_key","_value","_tempValue"];
+    
+    _config = _this select 0;
+    
+    _configProperties = configProperties [_config];
+    _configHash = HASH_CREATE;
+    {
+        _key = configName _x;
+        
+        _value = call {
+            if (isClass _x) exitWith {
+                [_x] call _configToHash
+            };
+            if (isNumber _x) exitWith {getNumber _x};
+            if (isText _x) exitWith {
+                _tempValue = getText _x;
+                call {
+                    if (_tempValue == "true") exitWith {true};
+                    if (_tempValue == "false") exitWith {false};
+                    _tempValue
+                };
+            };
+            if (isArray _x) exitWith {getArray _x};
+            nil
+        };
+        if !(isNil "_value") then {
+            HASH_SET(_configHash,_key,_value);
+        };
+    } forEach _configProperties;
+    
+    _configHash
+};
+
+[_deviceConfigPath] call _configToHash;

--- a/addons/bft_devices/functions/fnc_ifClose.sqf
+++ b/addons/bft_devices/functions/fnc_ifClose.sqf
@@ -28,7 +28,7 @@ if !(I_CLOSED) then {
     if !(isNull _display) then {
         _display closeDisplay 0;
         // only call ifOnUnload for displays (dialogs call ifOnUnload themselves when they close)
-        if !([_displayName] call FUNC(isDialog)) then {
+        if !(I_GET_ISDIALOG) then {
             [] call FUNC(ifOnUnload);
         };
     };

--- a/addons/bft_devices/functions/fnc_ifOnDrawBFT.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnDrawBFT.sqf
@@ -32,8 +32,7 @@ _vehicle = vehicle ACE_player;
 _position = getPosASL _vehicle;
 _heading = direction _vehicle;
 
-// temporary bodge
-_isDialog = [I_GET_NAME] call FUNC(isDialog);
+_isDialog = I_GET_ISDIALOG;
 
 if (_isDialog) then {
     GVAR(mapWorldPos) = [_ctrlScreen] call FUNC(ctrlMapCenter);

--- a/addons/bft_devices/functions/fnc_ifOnKeyDown.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnKeyDown.sqf
@@ -24,46 +24,47 @@
 
 #include "\a3\editor_f\Data\Scripts\dikCodes.h"
 
-private["_display","_dikCode","_shiftKey","_ctrlKey","_altKey","_displayName","_mapTypes","_currentMapType","_currentMapTypeIndex","_ctrlScreen","_markerIndex"];
+private["_display","_dikCode","_shiftKey","_ctrlKey","_altKey","_displayName","_deviceID","_mapTypes","_currentMapType","_currentMapTypeIndex","_ctrlScreen","_markerIndex"];
 
 _display = _this select 0;
 _displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
 _dikCode = _this select 1;
 _shiftKey = _this select 2;
 _ctrlKey = _this select 3;
 _altKey = _this select 4;
 
 if (_dikCode == DIK_F1 && {_displayName in [QGVAR(DK10_dlg),QGVAR(GD300_dlg)]}) exitWith {
-    [_displayName,[["mode","BFT"]]] call FUNC(setSettings);
+    [_deviceID,[["mode","BFT"]]] call FUNC(setSettings);
     true
 };
 if (_dikCode == DIK_F2 && {_displayName in [QGVAR(DK10_dlg)]}) exitWith {
-    [_displayName,[["mode","UAV"]]] call FUNC(setSettings);
+    [_deviceID,[["mode","UAV"]]] call FUNC(setSettings);
     true
 };
 if (_dikCode == DIK_F3 && {_displayName in [QGVAR(DK10_dlg)]}) exitWith {
-    [_displayName,[["mode","HCAM"]]] call FUNC(setSettings);
+    [_deviceID,[["mode","HCAM"]]] call FUNC(setSettings);
     true
 };
 if (_dikCode == DIK_F4 && {_displayName in [QGVAR(DK10_dlg),QGVAR(GD300_dlg)]}) exitWith {
-    [_displayName,[["mode","MESSAGE"]]] call FUNC(setSettings);
+    [_deviceID,[["mode","MESSAGE"]]] call FUNC(setSettings);
     true
 };
 if (_dikCode == DIK_F5 && {_displayName in [QGVAR(DK10_dlg),QGVAR(GD300_dlg),QGVAR(TAD_dlg),QGVAR(MicroDAGR_dlg),QGVAR(JV5_dlg)]}) exitWith {
-    [_displayName] call FUNC(toggleMapTools);
+    [_deviceID] call FUNC(toggleMapTools);
     true
 };
 if (_dikCode == DIK_F6 && {_displayName in [QGVAR(DK10_dlg),QGVAR(GD300_dlg),QGVAR(TAD_dlg),QGVAR(MicroDAGR_dlg),QGVAR(JV5_dlg)]}) exitWith {
-    [_displayName] call FUNC(toggleMapType);
+    [_deviceID] call FUNC(toggleMapType);
     true
 };
 if (_dikCode == DIK_F7 && {_displayName in [QGVAR(DK10_dlg),QGVAR(GD300_dlg),QGVAR(TAD_dlg),QGVAR(MicroDAGR_dlg),QGVAR(JV5_dlg)]}) exitWith {
-    [_displayName] call FUNC(centerMapOnPlayerPosition);
+    [_deviceID] call FUNC(centerMapOnPlayerPosition);
     true
 };
 if (_dikCode == DIK_DELETE && {GVAR(cursorOnMap)}) exitWith {
-    _mapTypes = [_displayName,"mapTypes"] call FUNC(getSettings);
-    _currentMapType = [_displayName,"mapType"] call FUNC(getSettings);
+    _mapTypes = [_deviceID,"mapTypes"] call FUNC(getSettings);
+    _currentMapType = [_deviceID,"mapType"] call FUNC(getSettings);
     _currentMapTypeIndex = (_mapTypes select 0) find _currentMapType;
     _ctrlScreen = _display displayCtrl ((_mapTypes select 1) select _currentMapTypeIndex);
     /*_markerIndex = [_ctrlScreen,GVAR(mapCursorPos)] call FUNC(findUserMarker);

--- a/addons/bft_devices/functions/fnc_ifOnLBSelChanged.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnLBSelChanged.sqf
@@ -24,7 +24,7 @@ private [];
 
 #include "script_component.hpp"
 
-private ["_control", "_display", "_displayName", "_function", "_selectedIndex"];
+private ["_control", "_display", "_deviceID", "_function", "_selectedIndex"];
 
 // ignore function call if the interface has not finished setup
 if (GVAR(ifOpenStart) || I_CLOSED) exitWith {true};
@@ -32,18 +32,18 @@ if (GVAR(ifOpenStart) || I_CLOSED) exitWith {true};
 _function = _this select 0;
 _control = _this select 1 select 0;
 _display = ctrlParent _control;
-_displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
 _selectedIndex = _this select 1 select 1;
 
 switch (_function) do {
     case "UAVlist": {
         if (_selectedIndex != -1) then {
-            [_displayName,[['uavCam',_control lbData _selectedIndex]]] call FUNC(setSettings);
+            [_deviceID,[['uavCam',_control lbData _selectedIndex]]] call FUNC(setSettings);
         };
     };
     case "HCAMlist": {
         if (_selectedIndex != -1) then {
-            [_displayName,[['uavCam',_control lbData _selectedIndex]]] call FUNC(setSettings);
+            [_deviceID,[['uavCam',_control lbData _selectedIndex]]] call FUNC(setSettings);
         };
     };
 };

--- a/addons/bft_devices/functions/fnc_ifOnLoad.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnLoad.sqf
@@ -18,16 +18,17 @@
 
 #include "script_component.hpp"
 
-private ["_displayName","_mapTypes"];
+private ["_displayName","_deviceID","_mapTypes"];
 
 _displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
 
 uiNamespace setVariable [_displayName,_this select 0];
 
 [] call FUNC(ifUpdate);
 
-// set up bft_drawing
-_mapTypes = [_displayName,"mapTypes"] call FUNC(getSettings);
+// setup bft_drawing
+_mapTypes = [_deviceID,"mapTypes"] call FUNC(getSettings);
 {
 	0 = [(_this select 0) displayCtrl _x] call EFUNC(bft_drawing,doBFTDraw);
 } count (_mapTypes select 1);
@@ -36,7 +37,7 @@ _mapTypes = [_displayName,"mapTypes"] call FUNC(getSettings);
 [true,["MFD","FBCB2"]] call EFUNC(bft,updateRegisteredModes);
 
 // send "bft_deviceOpened" event
-["bft_deviceOpened",[I_GET_DEVICE]] call EFUNC(common,localEvent);
+["bft_deviceOpened",[_deviceID]] call EFUNC(common,localEvent);
 
 GVAR(ifOpenStart) = false;
 

--- a/addons/bft_devices/functions/fnc_ifOnLoad.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnLoad.sqf
@@ -34,7 +34,7 @@ _mapTypes = [_deviceID,"mapTypes"] call FUNC(getSettings);
 } count (_mapTypes select 1);
 
 // register reporting modes
-[true,["MFD","FBCB2"]] call EFUNC(bft,updateRegisteredModes);
+[true,["MFD","FBCB2","UAV"]] call EFUNC(bft,updateRegisteredModes);
 
 // send "bft_deviceOpened" event
 ["bft_deviceOpened",[_deviceID]] call EFUNC(common,localEvent);

--- a/addons/bft_devices/functions/fnc_ifOnMouseButtonUp.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnMouseButtonUp.sqf
@@ -24,7 +24,7 @@ private [];
 
 #include "script_component.hpp"
 
-private ["_control", "_display", "_displayName", "_function", "_mouseButton"];
+private ["_control","_display","_deviceID","_function","_mouseButton"];
 
 // ignore function call if the interface has not finished setup
 if (GVAR(ifOpenStart) || I_CLOSED) exitWith {true};
@@ -33,7 +33,7 @@ _function = _this select 0;
 _control = _this select 1 select 0;
 _mouseButton = _this select 1 select 1;
 _display = ctrlParent _control;
-_displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
 
 switch (_function) do {
     case "close": {
@@ -42,16 +42,16 @@ switch (_function) do {
     case "btnACT": {
     };
     case "centerMapOnPlayerPosition": {
-        [_displayName] call FUNC(centerMapOnPlayerPosition);
+        [_deviceID] call FUNC(centerMapOnPlayerPosition);
     };
     case "toggleMapType": {
-        [_displayName] call FUNC(toggleMapType);
+        [_deviceID] call FUNC(toggleMapType);
     };
     case "toggleMapTools": {
-        [_displayName] call FUNC(toggleMapTools);
+        [_deviceID] call FUNC(toggleMapTools);
     };
     case "toggleIconText": {
-        [_displayName] call FUNC(toggleIconText);
+        [_deviceID] call FUNC(toggleIconText);
     };
     case "incTextSize": {
         [] call FUNC(incTextSize);
@@ -60,32 +60,32 @@ switch (_function) do {
         [] call FUNC(decTextSize);
     };
     case "incBrightness": {
-        [_displayName] call FUNC(incBrightness);
+        [_deviceID] call FUNC(incBrightness);
     };
     case "decBrightness": {
-        [_displayName] call FUNC(decBrightness);
+        [_deviceID] call FUNC(decBrightness);
     };
     case "modeBFT": {
-        [_displayName,[['mode','BFT']]] call FUNC(setSettings);
+        [_deviceID,[['mode','BFT']]] call FUNC(setSettings);
     };
     case "modeUAV": {
-        [_displayName,[['mode','UAV']]] call FUNC(setSettings);
+        [_deviceID,[['mode','UAV']]] call FUNC(setSettings);
     };
     case "modeHCAM": {
-        [_displayName,[['mode','HCAM']]] call FUNC(setSettings);
+        [_deviceID,[['mode','HCAM']]] call FUNC(setSettings);
     };
     case "modeMESSAGE": {
-        [_displayName,[['mode','MESSAGE']]] call FUNC(setSettings);
+        [_deviceID,[['mode','MESSAGE']]] call FUNC(setSettings);
     };
     case "modeCOMPOSE": {
-        [_displayName,[['mode','COMPOSE']]] call FUNC(setSettings);
+        [_deviceID,[['mode','COMPOSE']]] call FUNC(setSettings);
     };
     case "modeDESKTOP": {
-        [_displayName,[['mode','DESKTOP']]] call FUNC(setSettings);
+        [_deviceID,[['mode','DESKTOP']]] call FUNC(setSettings);
     };
     case "toggleNightModeOrClose": {
         if (_mouseButton == 0) then {
-            [_displayName] call FUNC(toggleNightMode);
+            [_deviceID] call FUNC(toggleNightMode);
         } else {
             if (_mouseButton == 1) then {
                 [] call FUNC(ifClose);
@@ -93,10 +93,10 @@ switch (_function) do {
         };
     };
     case "toggleMapMenu": {
-        [_displayName] call FUNC(toggleMapMenu);
+        [_deviceID] call FUNC(toggleMapMenu);
     };
     case "toggleInterfaceMode": {
-        [_displayName] call FUNC(toggleInterfaceMode);
+        [] call FUNC(toggleInterfaceMode);
     };
 };
 

--- a/addons/bft_devices/functions/fnc_ifOnUnload.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnUnload.sqf
@@ -22,7 +22,7 @@ private ["_displayName","_mapScale","_ifType","_player","_playerKilledEhId","_ve
 
 // remove helmet and UAV cameras
 //[] call FUNC(deleteHelmetCam);
-//[] call FUNC(deleteUAVcam);
+[] call FUNC(deleteUAVcam);
 
 if !(I_CLOSED) then {
     // [_deviceID,_ifType,_displayName,_player,_playerKilledEhId,_vehicle,_vehicleGetOutEhId]

--- a/addons/bft_devices/functions/fnc_ifOnUnload.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnUnload.sqf
@@ -79,12 +79,20 @@ if !(I_CLOSED) then {
             };
             
             // Save mapWorldPos, mapScaleDlg and background offset of current dialog so it can be restored later
-            [_displayName,[["mapWorldPos",GVAR(mapWorldPos)],["mapScaleDlg",_mapScale],["dlgIfPosition",_backgroundOffset]],false] call FUNC(setSettings);
+            [_deviceID,[["mapWorldPos",GVAR(mapWorldPos)],["mapScaleDlg",_mapScale],["dlgIfPosition",_backgroundOffset]],false] call FUNC(setSettings);
         };
     };
     
+    _deviceData = [_deviceID] call EFUNC(bft,getDeviceData);
+    _deviceOwner = D_GET_OWNER(_deviceData);
+
+    // if the device is a personal device, save settings to device appData store
+    if (_deviceOwner isKindOf "ParachuteBase" || _deviceOwner isKindOf "CAManBase") then {
+        [_deviceID,[-1,HASH_GET(GVAR(settings),_deviceID)]] call EFUNC(bft,handleUpdateDeviceAppData);
+    };
+    
     // send "bft_deviceClosed" event
-    ["bft_deviceClosed",[I_GET_DEVICE]] call EFUNC(common,localEvent);
+    ["bft_deviceClosed",[_deviceID]] call EFUNC(common,localEvent);
     
     uiNamespace setVariable [_displayName, displayNull];
     GVAR(ifOpen) = nil;

--- a/addons/bft_devices/functions/fnc_ifOnUnload.sqf
+++ b/addons/bft_devices/functions/fnc_ifOnUnload.sqf
@@ -18,7 +18,7 @@
 
 #include "script_component.hpp"
 
-private ["_displayName","_mapScale","_ifType","_player","_playerKilledEhId","_vehicle","_vehicleGetOutEhId","_draw3dEhId","_aceUnconciousEhId","_acePlayerInventoryChangedEhId","_acePlayerChangedEhId","_backgroundPosition","_backgroundPositionX","_backgroundPositionY","_backgroundConfigPositionX","_backgroundConfigPositionY","_xOffset","_yOffset","_backgroundOffset","_aceUpdateDeviceOwnerEhId","_deviceID"];
+private ["_displayName","_mapScale","_ifType","_player","_playerKilledEhId","_vehicle","_vehicleGetOutEhId","_draw3dEhId","_aceUnconciousEhId","_acePlayerInventoryChangedEhId","_acePlayerChangedEhId","_backgroundPosition","_backgroundPositionX","_backgroundPositionY","_backgroundConfigPositionX","_backgroundConfigPositionY","_xOffset","_yOffset","_backgroundOffset","_aceUpdateDeviceOwnerEhId","_deviceID","_isDialog"];
 
 // remove helmet and UAV cameras
 //[] call FUNC(deleteHelmetCam);
@@ -29,14 +29,15 @@ if !(I_CLOSED) then {
     _deviceID = I_GET_DEVICE;
     _ifType = I_GET_TYPE;
     _displayName = I_GET_NAME;
-    _player = GVAR(ifOpen) select 3;
-    _playerKilledEhId = GVAR(ifOpen) select 4;
-    _vehicle = GVAR(ifOpen) select 5;
-    _vehicleGetOutEhId = GVAR(ifOpen) select 6;
-    _draw3dEhId = GVAR(ifOpen) select 7;
-    _aceUnconciousEhId = GVAR(ifOpen) select 8;
-    _aceUpdateDeviceOwnerEhId = GVAR(ifOpen) select 9;
-    _acePlayerChangedEhId = GVAR(ifOpen) select 10;
+    _isDialog = I_GET_ISDIALOG;
+    _player = GVAR(ifOpen) select 4;
+    _playerKilledEhId = GVAR(ifOpen) select 5;
+    _vehicle = GVAR(ifOpen) select 6;
+    _vehicleGetOutEhId = GVAR(ifOpen) select 7;
+    _draw3dEhId = GVAR(ifOpen) select 8;
+    _aceUnconciousEhId = GVAR(ifOpen) select 9;
+    _aceUpdateDeviceOwnerEhId = GVAR(ifOpen) select 10;
+    _acePlayerChangedEhId = GVAR(ifOpen) select 11;
     
     if (!isNil "_playerKilledEhId") then {_player removeEventHandler ["killed",_playerKilledEhId]};
     if (!isNil "_vehicleGetOutEhId") then {_vehicle removeEventHandler ["GetOut",_vehicleGetOutEhId]};
@@ -53,7 +54,7 @@ if !(I_CLOSED) then {
     
     // don't call this part if we are closing down before setup has finished
     if (!GVAR(ifOpenStart)) then {
-        if ([_displayName] call FUNC(isDialog)) then {
+        if (_isDialog) then {
             // convert mapscale to km
             _mapScale = GVAR(mapScale) * GVAR(mapScaleFactor) / 0.86 * (safezoneH * 0.8);
             

--- a/addons/bft_devices/functions/fnc_ifOpen.sqf
+++ b/addons/bft_devices/functions/fnc_ifOpen.sqf
@@ -6,29 +6,32 @@
  *       
  *   This function will define iffOpen, using the following format:
  *       Parameter 0: Device ID <STRING>
- *       Parameter 1: Interface type, 0 = Main, 1 = Secondary, 2 = Tertiary
- *       Parameter 2: Name of uiNameSpace variable for display / dialog (i.e. "ace_bft_devices_TAD_dlg")
- *       Parameter 3: Unit we registered the killed eventhandler for
- *       Parameter 4: ID of registered eventhandler for killed event
- *       Parameter 5: Vehicle we registered the GetOut eventhandler for (even if no EH is registered)
- *       Parameter 6: ID of registered eventhandler for GetOut event (nil if no EH is registered)
- *       Parameter 7: ID of registered eventhandler for Draw3D event (nil if no EH is registered)
- *       Parameter 8: ID of registered eventhandler ACE_medical medical_onUnconscious event (nil if no EH is registered)
- *       Parameter 9: ID of registered eventhandler ACE bft_updateDeviceOwner event (nil if no EH is registered)
- *       Parameter 10: ID of registered eventhandler ACE playerChanged event (nil if no EH is registered)
+ *       Parameter 1: Interface type, 0 = Main, 1 = Secondary, 2 = Tertiary <INTEGER>
+ *       Parameter 2: Name of uiNameSpace variable for display / dialog (i.e. "ace_bft_devices_TAD_dlg") <TRING>
+ *       Parameter 3: isDialog (true if dialog, false if display) <BOOL>
+ *       Parameter 4: Unit we registered the killed eventhandler for <OBJECT>
+ *       Parameter 5: ID of registered eventhandler for killed event <INTEGER>
+ *       Parameter 6: Vehicle we registered the GetOut eventhandler for (even if no EH is registered) <OBJECT>
+ *       Parameter 7: ID of registered eventhandler for GetOut event (nil if no EH is registered) <INTEGER>
+ *       Parameter 8: ID of registered eventhandler for Draw3D event (nil if no EH is registered) <INTEGER>
+ *       Parameter 9: ID of registered eventhandler ACE_medical medical_onUnconscious event (nil if no EH is registered) <INTEGER>
+ *       Parameter 10: ID of registered eventhandler ACE bft_updateDeviceOwner event (nil if no EH is registered) <INTEGER>
+ *       Parameter 11: ID of registered eventhandler ACE playerChanged event (nil if no EH is registered) <INTEGER>
  *
  * Arguments:
- *   0: Interface type, 0 = Main, 1 = Secondary <INTEGER>
- *   1: Name of uiNameSpace variable for display / dialog (i.e. "ace_bft_devices_TAD_dlg") <STRING>
- *   2: Unit to register killed eventhandler for <OBJECT>
- *   3: Vehicle to register GetOut eventhandler for <OBJECT>
+ *   0: Device ID <STRING>
+ *   1: Interface type, 0 = Main, 1 = Secondary, 3 = Tertiary <INTEGER>
+ *   2: Name of uiNameSpace variable for display / dialog (i.e. "ace_bft_devices_TAD_dlg") <STRING>
+ *   3: isDialog <BOOL>
+ *   4: Unit to register killed EH for <OBJECT>
+ *   5: Vehicle to register getOut EH for <OBJECT>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
  *   // open TAD display as primary interface type
- *   [0,"ace_bft_devices_TAD_dsp",player,vehicle player] call ace_bft_devices_ifOpen;
+ *   [[vehicle ACE_player] call ace_bft_fnc_getOwnedDevices,0,"ace_bft_devices_TAD_dsp",false] call ace_bft_devices_ifOpen;
  *
  * Public: No
  */
@@ -47,17 +50,17 @@ GVAR(ifOpenStart) = true;
 _deviceID = _this select 0;
 _interfaceType = _this select 1;
 _displayName = _this select 2;
-_player = _this select 3;
-_vehicle = _this select 4;
+_isDialog = _this select 3;
+_player = _this select 4;
+_vehicle = _this select 5;
 _inVehicle = (_vehicle != _player);
-
-_isDialog = [_displayName] call FUNC(isDialog);
 
 // start setting up event-handlers
 GVAR(ifOpen) = [
     _deviceID,
     _interfaceType,
     _displayName,
+    _isDialog,
     _player,
     _player addEventHandler ["killed",{[] call FUNC(ifClose)}],
     _vehicle,
@@ -70,7 +73,7 @@ GVAR(ifOpen) = [
 
 // Only register the GetOut event handler for vehicle displays
 if (_inVehicle && (_isDialog || _displayName in [QGVAR(TAD_dsp)])) then {
-    GVAR(ifOpen) set [6,
+    GVAR(ifOpen) set [7,
         _vehicle addEventHandler ["GetOut",{if (_this select 2 == ACE_player) then {[] call FUNC(ifClose)}}]
     ];
 };
@@ -78,7 +81,7 @@ if (_inVehicle && (_isDialog || _displayName in [QGVAR(TAD_dsp)])) then {
 // Set up event handler to update display header / footer
 // Also set up vehicle icon
 if (_displayName in [QGVAR(TAD_dsp),QGVAR(TAD_dlg)]) then {
-    GVAR(ifOpen) set [7,
+    GVAR(ifOpen) set [8,
         addMissionEventHandler ["Draw3D",{
             _display = I_GET_DISPLAY;
             _veh = vehicle ACE_player;
@@ -103,7 +106,7 @@ if (_displayName in [QGVAR(TAD_dsp),QGVAR(TAD_dlg)]) then {
         "\A3\ui_f\data\map\VehicleIcons\iconmanvirtual_ca.paa"
     };
 } else {
-    GVAR(ifOpen) set [7,
+    GVAR(ifOpen) set [8,
         addMissionEventHandler ["Draw3D",{
             _display = I_GET_DISPLAY;
             _veh = vehicle ACE_player;
@@ -123,7 +126,7 @@ if (_displayName in [QGVAR(TAD_dsp),QGVAR(TAD_dlg)]) then {
 };
 
 // Register with ACE_medical medical_onUnconscious event
-GVAR(ifOpen) set [8,
+GVAR(ifOpen) set [9,
     ["medical_onUnconscious",{
         if (_this select 0 == ACE_player && _this select 1) then {
             [] call FUNC(ifClose);
@@ -132,7 +135,7 @@ GVAR(ifOpen) set [8,
 ];
 
 // Register with ACE bft_updateDeviceOwner event
-GVAR(ifOpen) set [9,
+GVAR(ifOpen) set [10,
     ["bft_updateDeviceOwner",{
         // if the device ID matches the one currently open and we aren't the owner anymore, close the interface
         if ((_this select 0 == I_GET_DEVICE) && (_this select 1 != ACE_player)) then {
@@ -142,7 +145,7 @@ GVAR(ifOpen) set [9,
 ];
 
 // Register with ACE playerChanged event
-GVAR(ifOpen) set [10,
+GVAR(ifOpen) set [11,
     ["playerChanged",{
         _this call FUNC(onPlayerChanged);
     }] call EFUNC(common,addEventHandler)

--- a/addons/bft_devices/functions/fnc_ifOpen.sqf
+++ b/addons/bft_devices/functions/fnc_ifOpen.sqf
@@ -151,6 +151,19 @@ GVAR(ifOpen) set [11,
     }] call EFUNC(common,addEventHandler)
 ];
 
+// get device owner
+_deviceData = [_deviceID] call EFUNC(bft,getDeviceData);
+_deviceOwner = D_GET_OWNER(_deviceData);
+
+// if the device is a personal device, get settings from device appData store
+if (_deviceOwner isKindOf "ParachuteBase" || _deviceOwner isKindOf "CAManBase") then {
+    _deviceAppData = D_GET_APP_DATA(_deviceData);
+    if !(_deviceAppData isEqualTo []) then {
+        // write settings to local cache
+        HASH_SET(GVAR(settings),_deviceID,_deviceAppData);
+    };
+};
+
 // start the interface
 if (_isDialog) then {
     // Check if map and / or another dialog is open and close them

--- a/addons/bft_devices/functions/fnc_ifOpen.sqf
+++ b/addons/bft_devices/functions/fnc_ifOpen.sqf
@@ -31,7 +31,7 @@
  *
  * Example:
  *   // open TAD display as primary interface type
- *   [[vehicle ACE_player] call ace_bft_fnc_getOwnedDevices,0,"ace_bft_devices_TAD_dsp",false] call ace_bft_devices_ifOpen;
+ *   ["deviceID",0,"ace_bft_devices_TAD_dsp",false] call ace_bft_devices_ifOpen;
  *
  * Public: No
  */

--- a/addons/bft_devices/functions/fnc_ifUpdate.sqf
+++ b/addons/bft_devices/functions/fnc_ifUpdate.sqf
@@ -572,9 +572,6 @@ if ((!isNil "_targetMapScale") || (!isNil "_targetMapWorldPos")) then {
     while {!(ctrlMapAnimDone _targetMapCtrl)} do {};
 };
 
-// move mouse cursor to the center of the screen if its a dialog
-if (_interfaceInit && _isDialog) then {setMousePosition [0.5,0.5];};
-
 // now hide the "Loading" control since we are done
 if (!isNull _loadingCtrl) then {
     // move mouse cursor to the center of the screen if its a dialog

--- a/addons/bft_devices/functions/fnc_ifUpdate.sqf
+++ b/addons/bft_devices/functions/fnc_ifUpdate.sqf
@@ -33,7 +33,7 @@ _loadingCtrl = _display displayCtrl IDC_LOADINGTXT;
 _targetMapCtrl = controlNull;
 _targetMapScale = nil;
 _targetMapWorldPos = nil;
-_isDialog = [_displayName] call FUNC(isDialog);
+_isDialog = I_GET_ISDIALOG;
 
 if (count _this == 1) then {
     _settings = _this select 0;

--- a/addons/bft_devices/functions/fnc_incBrightness.sqf
+++ b/addons/bft_devices/functions/fnc_incBrightness.sqf
@@ -5,26 +5,26 @@
  *   Increases interface brightness
  *
  * Arguments:
- *   0: Name of uiNamespace display / dialog variable <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_incTextSize;
+ *   ["deviceID"] call ace_bft_devices_incBrightness;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_brightness", "_displayName"];
+private ["_brightness", "_deviceID"];
 
-_displayName = _this select 0;
-_brightness = [_displayName,"brightness"] call FUNC(getSettings);
+_deviceID = _this select 0;
+_brightness = [_deviceID,"brightness"] call FUNC(getSettings);
 _brightness = _brightness + 0.1;
 // make sure brightness is not larger than 1
 if (_brightness > 1) then {_brightness = 1};
-[_displayName,[["brightness",_brightness]]] call FUNC(setSettings);
+[_deviceID,[["brightness",_brightness]]] call FUNC(setSettings);
 
 true

--- a/addons/bft_devices/functions/fnc_onIfToggleKey.sqf
+++ b/addons/bft_devices/functions/fnc_onIfToggleKey.sqf
@@ -18,7 +18,7 @@
 
 #include "script_component.hpp"
 
-private ["_handled","_previousInterface","_playerDevices","_vehicleDevices","_playerDeviceId","_vehicleDeviceId","_playerDeviceData","_vehicleDeviceData","_playerDeviceClassName","_vehicleDeviceClassName","_playerDeviceDisplayName","_playerDeviceDialogName","_vehicleDeviceDisplayName","_vehicleDeviceDialogName","_selectedInterface","_interfaceName","_deviceID"];
+private ["_handled","_previousInterface","_playerDevices","_vehicleDevices","_playerDeviceId","_vehicleDeviceId","_playerDeviceData","_vehicleDeviceData","_playerDeviceClassName","_vehicleDeviceClassName","_playerDeviceDisplayName","_playerDeviceDialogName","_vehicleDeviceDisplayName","_vehicleDeviceDialogName","_selectedInterface","_interfaceName","_deviceID","_isDialog"];
 
 _handled = false;
 
@@ -90,26 +90,26 @@ _vehicleDeviceDialogName = if (_vehicleDeviceClassName != "") then {
 _selectedInterface = switch (_this) do {
     case 0: {
         // display first, vehicle device first
-        if (_vehicleDeviceDisplayName != "") exitWith {[_vehicleDeviceDisplayName,_vehicleDeviceId]};
-        if (_playerDeviceDisplayName != "") exitWith {[_playerDeviceDisplayName,_playerDeviceId]};
-        if (_vehicleDeviceDialogName != "") exitWith {[_vehicleDeviceDialogName,_vehicleDeviceId]};
-        if (_playerDeviceDialogName != "") exitWith {[_playerDeviceDialogName,_playerDeviceId]};
+        if (_vehicleDeviceDisplayName != "") exitWith {[_vehicleDeviceDisplayName,_vehicleDeviceId,false]};
+        if (_playerDeviceDisplayName != "") exitWith {[_playerDeviceDisplayName,_playerDeviceId,false]};
+        if (_vehicleDeviceDialogName != "") exitWith {[_vehicleDeviceDialogName,_vehicleDeviceId,true]};
+        if (_playerDeviceDialogName != "") exitWith {[_playerDeviceDialogName,_playerDeviceId,true]};
         []
     };
     case 1: {
         // dialog first, vehicle device first
-        if (_vehicleDeviceDialogName != "") exitWith {[_vehicleDeviceDialogName,_vehicleDeviceId]};
-        if (_playerDeviceDialogName != "") exitWith {[_playerDeviceDialogName,_playerDeviceId]};
-        if (_vehicleDeviceDisplayName != "") exitWith {[_vehicleDeviceDisplayName,_vehicleDeviceId]};
-        if (_playerDeviceDisplayName != "") exitWith {[_playerDeviceDisplayName,_playerDeviceId]};
+        if (_vehicleDeviceDialogName != "") exitWith {[_vehicleDeviceDialogName,_vehicleDeviceId,true]};
+        if (_playerDeviceDialogName != "") exitWith {[_playerDeviceDialogName,_playerDeviceId,true]};
+        if (_vehicleDeviceDisplayName != "") exitWith {[_vehicleDeviceDisplayName,_vehicleDeviceId,false]};
+        if (_playerDeviceDisplayName != "") exitWith {[_playerDeviceDisplayName,_playerDeviceId,false]};
         []
     };
     case 2: {
         // dialog first, player device first
-        if (_playerDeviceDialogName != "") exitWith {[_playerDeviceDialogName,_playerDeviceId]};
-        if (_vehicleDeviceDialogName != "") exitWith {[_vehicleDeviceDialogName,_vehicleDeviceId]};
-        if (_playerDeviceDisplayName != "") exitWith {[_playerDeviceDisplayName,_playerDeviceId]};
-        if (_vehicleDeviceDisplayName != "") exitWith {[_vehicleDeviceDisplayName,_vehicleDeviceId]};
+        if (_playerDeviceDialogName != "") exitWith {[_playerDeviceDialogName,_playerDeviceId,true]};
+        if (_vehicleDeviceDialogName != "") exitWith {[_vehicleDeviceDialogName,_vehicleDeviceId,true]};
+        if (_playerDeviceDisplayName != "") exitWith {[_playerDeviceDisplayName,_playerDeviceId,false]};
+        if (_vehicleDeviceDisplayName != "") exitWith {[_vehicleDeviceDisplayName,_vehicleDeviceId,false]};
         []
     };
     default {[]};
@@ -117,6 +117,7 @@ _selectedInterface = switch (_this) do {
 
 _interfaceName = _selectedInterface select 0;
 _deviceID = _selectedInterface select 1;
+_isDialog = _selectedInterface select 2;
 
 if (_interfaceName != "" && _interfaceName != _previousInterface) then {
     // queue the start up of the interface as we might still have one closing down
@@ -125,7 +126,7 @@ if (_interfaceName != "" && _interfaceName != _previousInterface) then {
             [_this select 1] call CBA_fnc_removePerFrameHandler;
             ((_this select 0) + [ACE_player, vehicle ACE_player]) call FUNC(ifOpen);
         };
-    },0,[_deviceID,_this,_interfaceName]] call CBA_fnc_addPerFrameHandler;
+    },0,[_deviceID,_this,_interfaceName,_isDialog]] call CBA_fnc_addPerFrameHandler;
 };
 
 true

--- a/addons/bft_devices/functions/fnc_onIfTogglePositionKey.sqf
+++ b/addons/bft_devices/functions/fnc_onIfTogglePositionKey.sqf
@@ -25,7 +25,7 @@ if (I_CLOSED) exitWith {false};
 
 _displayName = I_GET_NAME;
 
-if ([_displayName] call FUNC(isDialog)) then {
+if (I_GET_ISDIALOG) then {
     // reset position to default
     [_displayName,[["dlgIfPosition",[]]],true,true] call FUNC(setSettings);
 } else {

--- a/addons/bft_devices/functions/fnc_onIfTogglePositionKey.sqf
+++ b/addons/bft_devices/functions/fnc_onIfTogglePositionKey.sqf
@@ -18,20 +18,20 @@
 
 #include "script_component.hpp"
 
-private ["_displayName"];
+private ["_deviceID"];
 
 // bail if there is no interface open
 if (I_CLOSED) exitWith {false};
 
-_displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
 
 if (I_GET_ISDIALOG) then {
     // reset position to default
-    [_displayName,[["dlgIfPosition",[]]],true,true] call FUNC(setSettings);
+    [_deviceID,[["dlgIfPosition",[]]],true,true] call FUNC(setSettings);
 } else {
-    _dspIfPosition = [_displayName,"dspIfPosition"] call FUNC(getSettings);
+    _dspIfPosition = [_deviceID,"dspIfPosition"] call FUNC(getSettings);
     // toggle position
-    [_displayName,[["dspIfPosition",!_dspIfPosition]]] call FUNC(setSettings);
+    [_deviceID,[["dspIfPosition",!_dspIfPosition]]] call FUNC(setSettings);
 };
 
 true

--- a/addons/bft_devices/functions/fnc_onIfZoomKey.sqf
+++ b/addons/bft_devices/functions/fnc_onIfZoomKey.sqf
@@ -18,33 +18,33 @@
 
 #include "script_component.hpp"
 
-private ["_displayName","_mapScale","_mapScaleMin","_mapScaleMax"];
+private ["_deviceID","_mapScale","_mapScaleMin","_mapScaleMax"];
 
 // bail if there is no interface open, or it is still being started
 if (GVAR(ifOpenStart) || (I_CLOSED)) exitWith {false};
 
-_displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
 // bail if this is a dialog
 if (I_GET_ISDIALOG) exitWith {false};
 
 
 switch (_this) do {
     case 0: { // Zoom In
-        _mapScale = ([_displayName,"mapScaleDsp"] call FUNC(getSettings)) / 2;
-        _mapScaleMin = [_displayName,"mapScaleMin"] call FUNC(getSettings);
+        _mapScale = ([_deviceID,"mapScaleDsp"] call FUNC(getSettings)) / 2;
+        _mapScaleMin = [_deviceID,"mapScaleMin"] call FUNC(getSettings);
         if (_mapScale < _mapScaleMin) then {
             _mapScale = _mapScaleMin;
         };
-        _mapScale = [_displayName,[["mapScaleDsp",_mapScale]]] call FUNC(setSettings);
+        _mapScale = [_deviceID,[["mapScaleDsp",_mapScale]]] call FUNC(setSettings);
         true
     };
     case 1: { // Zoom Out
-        _mapScale = ([_displayName,"mapScaleDsp"] call FUNC(getSettings)) * 2;
-        _mapScaleMax = [_displayName,"mapScaleMax"] call FUNC(getSettings);
+        _mapScale = ([_deviceID,"mapScaleDsp"] call FUNC(getSettings)) * 2;
+        _mapScaleMax = [_deviceID,"mapScaleMax"] call FUNC(getSettings);
         if (_mapScale > _mapScaleMax) then {
             _mapScale = _mapScaleMax;
         };
-        _mapScale = [_displayName,[["mapScaleDsp",_mapScale]]] call FUNC(setSettings);
+        _mapScale = [_deviceID,[["mapScaleDsp",_mapScale]]] call FUNC(setSettings);
         true
     };
     

--- a/addons/bft_devices/functions/fnc_onIfZoomKey.sqf
+++ b/addons/bft_devices/functions/fnc_onIfZoomKey.sqf
@@ -25,7 +25,7 @@ if (GVAR(ifOpenStart) || (I_CLOSED)) exitWith {false};
 
 _displayName = I_GET_NAME;
 // bail if this is a dialog
-if ([_displayName] call FUNC(isDialog)) exitWith {false};
+if (I_GET_ISDIALOG) exitWith {false};
 
 
 switch (_this) do {

--- a/addons/bft_devices/functions/fnc_processNotifications.sqf
+++ b/addons/bft_devices/functions/fnc_processNotifications.sqf
@@ -20,7 +20,9 @@
 
 #include "\z\ace\addons\bft_devices\UI\defines\shared_defines.hpp"
 
-private ["_displayName","_display","_ctrl","_currentTime","_text","_notification"];
+private ["_displayName","_display","_ctrl","_currentTime","_text","_notification","_decayTime","_counter"];
+
+disableSerialization;
 
 // make sure there is no PFH already, the interface is open and notifications are available
 if (isNil QGVAR(processNotificationsPFH) && !(I_CLOSED) && count GVAR(notificationCache) != 0) then {
@@ -38,17 +40,18 @@ if (isNil QGVAR(processNotificationsPFH) && !(I_CLOSED) && count GVAR(notificati
                 if (count GVAR(notificationCache) != 0) then {
                     // grab and delete the oldest notification
                     _notification = GVAR(notificationCache) deleteAt 0;
-                    
+                    _decayTime = _notification select 3;
+                    _counter = _notification select 4;
                     _currentTime = [] call FUNC(currentTime);
                     // see if notification was issued in the same minute, if so, omit showing the time
-                    if (_currentTime isEqualTo (_notification select 1)) then {
-                        _text = format ["%1",_notification select 2];
+                    _text = if (_currentTime isEqualTo (_notification select 1)) then {
+                        _notification select 2
                     } else {
-                        _text = format ["%1: %2",_notification select 1,_notification select 2];
+                        format ["%1: %2",_notification select 1,_notification select 2]
                     };
                     // if the counter on the notification is greater than 1, append the counter to the notification text
-                    if ((_notification select 3) > 1) then {
-                        _text = format ["%1 (x%2)",_text,_notification select 3];
+                    if (_counter > 1) then {
+                        _text = format ["%1 (x%2)",_text,_counter];
                     };
                     
                     // show the notification
@@ -66,7 +69,7 @@ if (isNil QGVAR(processNotificationsPFH) && !(I_CLOSED) && count GVAR(notificati
                     
                     // make the control fade out
                     _ctrl ctrlSetFade 1;
-                    _ctrl ctrlCommit 5;
+                    _ctrl ctrlCommit _decayTime;
                 } else {
                     [_this select 1] call CBA_fnc_removePerFrameHandler;
                     _ctrl ctrlShow false;

--- a/addons/bft_devices/functions/fnc_setInterfacePosition.sqf
+++ b/addons/bft_devices/functions/fnc_setInterfacePosition.sqf
@@ -27,7 +27,7 @@ _displayName = _this select 0;
 _xOffset = _this select 1 select 0;
 _yOffset = _this select 1 select 1;
 _display = uiNamespace getVariable _displayName;
-_isDialog = [_displayName] call FUNC(isDialog);
+_isDialog = I_GET_ISDIALOG;
 
 // get both classes "controls" and "controlsBackground" if they exist
 _displayConfigContainers = if (_isDialog) then {

--- a/addons/bft_devices/functions/fnc_setInterfacePosition.sqf
+++ b/addons/bft_devices/functions/fnc_setInterfacePosition.sqf
@@ -21,6 +21,8 @@
 
 private ["_displayName","_xOffset","_yOffset","_display","_isDialog","_backgroundCtrl","_backgroundClassName","_displayConfigContainers","_displayConfigClasses","_idc","_ctrl","_ctrlPosition"];
 
+disableSerialization;
+
 _displayName = _this select 0;
 _xOffset = _this select 1 select 0;
 _yOffset = _this select 1 select 1;

--- a/addons/bft_devices/functions/fnc_toggleIconText.sqf
+++ b/addons/bft_devices/functions/fnc_toggleIconText.sqf
@@ -5,23 +5,23 @@
  *   Toggle text next to BFT icons
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_fnc_toggleIconText;
+ *   ["deviceID"] call ace_bft_devices_fnc_toggleIconText;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_displayName"];
+private ["_deviceID"];
 
-_displayName = _this select 0;
+_deviceID = _this select 0;
 if (GVAR(showBFTtext)) then {GVAR(showBFTtext) = false} else {GVAR(showBFTtext) = true};
-[_displayName,[["showIconText",GVAR(showBFTtext)]]] call FUNC(setSettings);
+[_deviceID,[["showIconText",GVAR(showBFTtext)]]] call FUNC(setSettings);
 
 true

--- a/addons/bft_devices/functions/fnc_toggleInterfaceMode.sqf
+++ b/addons/bft_devices/functions/fnc_toggleInterfaceMode.sqf
@@ -5,23 +5,26 @@
  *   Toggle interface mode
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   NONE
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   _drawMapTools = ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_toggleInterfaceMode;
+ *   [] call ace_bft_devices_toggleInterfaceMode;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_displayName","_mode"];
+private ["_displayName","_deviceID","_mode"];
 
-_displayName = _this select 0;
-_mode = [_displayName,"mode"] call FUNC(getSettings);
+if (I_CLOSED) exitWith {true};
+
+_displayName = I_GET_NAME;
+_deviceID = I_GET_DEVICE;
+_mode = [_deviceID,"mode"] call FUNC(getSettings);
 
 call {
     if (_displayName == QGVAR(GD300_dlg)) exitWith {
@@ -31,6 +34,6 @@ call {
         };
     };
 };
-[_displayName,[["mode",_mode]]] call FUNC(setSettings);
+[_deviceID,[["mode",_mode]]] call FUNC(setSettings);
 
 true

--- a/addons/bft_devices/functions/fnc_toggleMapMenu.sqf
+++ b/addons/bft_devices/functions/fnc_toggleMapMenu.sqf
@@ -5,24 +5,24 @@
  *   Toggle map menu on / off
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   _drawMapTools = ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_toggleMapMenu;
+ *   ["deviceID"] call ace_bft_devices_toggleMapMenu;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_displayName","_showMenu"];
+private ["_deviceID","_showMenu"];
 
-_displayName = _this select 0;
-_showMenu = [_displayName,"showMenu"] call FUNC(getSettings);
+_deviceID = _this select 0;
+_showMenu = [_deviceID,"showMenu"] call FUNC(getSettings);
 _showMenu = !_showMenu;
-[_displayName,[["showMenu",_showMenu]]] call FUNC(setSettings);
+[_deviceID,[["showMenu",_showMenu]]] call FUNC(setSettings);
 
 true

--- a/addons/bft_devices/functions/fnc_toggleMapTools.sqf
+++ b/addons/bft_devices/functions/fnc_toggleMapTools.sqf
@@ -5,23 +5,23 @@
  *   Toggle drawing of map tools
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   Draw map tools <BOOL>
  *
  * Example:
- *   _drawMapTools = ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_toggleMapTools;
+ *   _drawMapTools = ["deviceID"] call ace_bft_devices_toggleMapTools;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_displayName","_newMapTools"];
+private ["_deviceID","_newMapTools"];
 
-_displayName = _this select 0;
-_newMapTools = !([_displayName,"mapTools"] call FUNC(getSettings));
-[_displayName,[["mapTools",_newMapTools]]] call FUNC(setSettings);
+_deviceID = _this select 0;
+_newMapTools = !([_deviceID,"mapTools"] call FUNC(getSettings));
+[_deviceID,[["mapTools",_newMapTools]]] call FUNC(setSettings);
 
 _newMapTools

--- a/addons/bft_devices/functions/fnc_toggleMapType.sqf
+++ b/addons/bft_devices/functions/fnc_toggleMapType.sqf
@@ -5,29 +5,29 @@
  *   Toggle mapType to the next one in the list of available map types
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_fnc_toggleMapType;
+ *   ["deviceID"] call ace_bft_devices_fnc_toggleMapType;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_displayName","_mapTypes","_currentMapType","_currentMapTypeIndex"];
+private ["_deviceID","_mapTypes","_currentMapType","_currentMapTypeIndex"];
 
-_displayName = _this select 0;
-_mapTypes = [_displayName,"mapTypes"] call FUNC(getSettings);
-_currentMapType = [_displayName,"mapType"] call FUNC(getSettings);
+_deviceID = _this select 0;
+_mapTypes = [_deviceID,"mapTypes"] call FUNC(getSettings);
+_currentMapType = [_deviceID,"mapType"] call FUNC(getSettings);
 _currentMapTypeIndex = (_mapTypes select 0) find _currentMapType;
 if (_currentMapTypeIndex == count (_mapTypes select 0) - 1) then {
-    [_displayName,[["mapType",_mapTypes select 0 select 0]]] call FUNC(setSettings);
+    [_deviceID,[["mapType",_mapTypes select 0 select 0]]] call FUNC(setSettings);
 } else {
-    [_displayName,[["mapType",(_mapTypes select 0) select (_currentMapTypeIndex + 1)]]] call FUNC(setSettings);
+    [_deviceID,[["mapType",(_mapTypes select 0) select (_currentMapTypeIndex + 1)]]] call FUNC(setSettings);
 };
 
 true

--- a/addons/bft_devices/functions/fnc_toggleNightMode.sqf
+++ b/addons/bft_devices/functions/fnc_toggleNightMode.sqf
@@ -5,27 +5,27 @@
  *   Toggle night mode
  *
  * Arguments:
- *   0: Name of uiNamespace variable for interface <STRING>
+ *   0: Device ID <STRING>
  *
  * Return Value:
  *   TRUE <BOOL>
  *
  * Example:
- *   ["ace_bft_devices_TAD_dlg"] call ace_bft_devices_fnc_toggleNightMode;
+ *   ["deviceID"] call ace_bft_devices_fnc_toggleNightMode;
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_displayName","_nightMode"];
+private ["_deviceID","_nightMode"];
 
-_displayName = _this select 0;
-_nightMode = [_displayName,"nightMode"] call FUNC(getSettings);
+_deviceID = _this select 0;
+_nightMode = [_deviceID,"nightMode"] call FUNC(getSettings);
 
 if (_nightMode != 2) then {
     if (_nightMode == 0) then {_nightMode = 1} else {_nightMode = 0};
-    [_displayName,[["nightMode",_nightMode]]] call FUNC(setSettings);
+    [_deviceID,[["nightMode",_nightMode]]] call FUNC(setSettings);
 };
 
 true

--- a/addons/bft_devices/functions/fnc_updateUAVList.sqf
+++ b/addons/bft_devices/functions/fnc_updateUAVList.sqf
@@ -1,0 +1,45 @@
+/*
+ * Author: Gundy
+ *
+ * Description:
+ *   Temporary function to get a list of UAVs that have a device configured and are match the encryption key
+ *
+ * Arguments:
+ *   NONE
+ *
+ * Return Value:
+ *   TRUE <BOOL>
+ *
+ * Example:
+ *   [] call ace_bft_devices_updateUAVList;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+
+// bail if no interface is open
+if (I_CLOSED) exitWith {};
+
+// get encryption keys for currently open device
+_deviceData = [I_GET_DEVICE] call EFUNC(bft,getDeviceData);
+_deviceEncryption = D_GET_ENCRYPTION(_deviceData);
+
+GVAR(UAVlist) = [];
+
+// interate through all UAVs and create a list containing [deviceID,[deviceData]]
+{
+    // check if UAV has a device
+    _uavDevices = [_x] call EFUNC(bft,getOwnedDevices);
+    if !(_uavDevices isEqualTo []) then {
+        _uavDevice = _uavDevices select 0;
+        _uavDeviceData = [_uavDevice] call EFUNC(bft,getDeviceData);
+        // check if UAV has matching encryption key
+        _uavEncryption = D_GET_ENCRYPTION(_uavDeviceData);
+        if ([_deviceEncryption,_uavEncryption] call EFUNC(BFT,encryptionKeyMatch)) then {
+            0 = GVAR(UAVlist) pushBack [_uavDevice,_uavDeviceData];
+        };
+    };
+} count allUnitsUav;
+
+true

--- a/addons/bft_devices/ifOpen_macros.hpp
+++ b/addons/bft_devices/ifOpen_macros.hpp
@@ -1,6 +1,15 @@
-#define I_CLOSED isNil QGVAR(ifOpen)
+// if interface is open <BOOL>
+#define I_OPEN (!isNil 'GVAR(ifOpen)')
+// if interface is closed <BOOL>
+#define I_CLOSED (isNil 'GVAR(ifOpen)')
 
+// device ID <STRING>
 #define I_GET_DEVICE (GVAR(ifOpen) select 0)
+// 0 = primary, 1 = secondary, 3 = tertiary <INTEGER>
 #define I_GET_TYPE (GVAR(ifOpen) select 1)
+// uiNamespace variable name of interface <STRING>
 #define I_GET_NAME (GVAR(ifOpen) select 2)
+// if interface is a dialog <BOOL>
+#define I_GET_ISDIALOG (GVAR(ifOpen) select 3)
+// display of interface <OBJECT>
 #define I_GET_DISPLAY (uiNamespace getVariable I_GET_NAME)


### PR DESCRIPTION
* Tweaked notification system and added decayTime per notification
* Making sure the map control used for worldSize calculation can actually be resolved. This section was previously throwing an error when game was loading a world while in the main menu.
* Save weather or not the interface is a dialog in ifOpen and grab it from there, instead of using a function that relies on the dialog interface name ending in "dlg".
* First stab at adding self-interaction menu items, heavy WIP
* Disable chatty debug on position update (in BFT module)
* Fixed message composition and display elements having a black background after ArmA3 1.46 update
* Moved interface settings to device config to use interface settings associated with deviceID rather than interface type. Settings are stored with the device if it is a personal device and read from it when opened. If the device is on a vehicle, the settings will be kept locally only.
* Added temporary function to generate a list of UAVs and UGVs
* Added device config to UAVs and UGVs
* Ported cTab functions for creating and deleting UAV cameras