### PR TITLE
#1704 - Add missing AnimationSources

### DIFF
--- a/addons/ballistics/CfgVehicles.hpp
+++ b/addons/ballistics/CfgVehicles.hpp
@@ -225,5 +225,27 @@ class CfgVehicles {
             MACRO_ADDMAGAZINE(ACE_5Rnd_127x99_API_Mag,4);
             MACRO_ADDMAGAZINE(ACE_5Rnd_127x99_AMAX_Mag,4);
         };
+        class AnimationSources {
+            class Ammo_source {
+                source = "user";
+                animPeriod = 1;
+                initPhase = 0;
+            };
+            class AmmoOrd_source {
+                source = "user";
+                animPeriod = 1;
+                initPhase = 1;
+            };
+            class Grenades_source {
+                source = "user";
+                animPeriod = 1;
+                initPhase = 1;
+            };
+            class Support_source {
+                source = "user";
+                animPeriod = 1;
+                initPhase = 1;
+            };
+        };
     };
 };


### PR DESCRIPTION
#1704 Ammo box missing AnimationSources

Also fixes the overlapping text on the side, as it seems like the animations control what's written on the box.