### PR TITLE
RHS Weapon HuntIR Compatibility

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -37,6 +37,7 @@ Aleksey EpMAK Yermakov <epmak777@gmail.com>
 Alganthe <alganthe@live.fr>
 Anthariel <Contact@storm-simulation.com>
 Asgar Serran <piechottaf@web.de>
+Bamse <bamsis@gmail.com>
 Bla1337
 BlackPixxel
 BlackQwar
@@ -101,4 +102,3 @@ Valentin Torikian <valentin.torikian@gmail.com>
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
 zGuba
-Bamse <bamsis@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -101,3 +101,4 @@ Valentin Torikian <valentin.torikian@gmail.com>
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
 zGuba
+Bamse <bamsis@gmail.com>

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -15,7 +15,7 @@ class CfgWeapons
     class rhs_weap_m4_Base: arifle_MX_Base_F {
         ACE_barrelTwist=177.8;
         ACE_barrelLength=368.3;
-		class  M203_GL : UGL_F {
+		class M203_GL : UGL_F {
 			magazines[] = {
 				"rhs_mag_M441_HE",
 				"rhs_mag_M433_HEDP",
@@ -61,7 +61,7 @@ class CfgWeapons
 				"ACE_HuntIR_M203"
 			};
 		};
-		class  M320_GL : M203_GL {
+		class M320_GL : M203_GL {
 			magazines[] = {
 				"rhs_mag_M441_HE",
 				"rhs_mag_M433_HEDP",

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -6,7 +6,7 @@ class CfgWeapons
     class srifle_EBR_F;
     class launch_O_Titan_F;
     class UGL_F;
-	
+
     class rhs_weap_XM2010_Base_F: Rifle_Base_F {
         ACE_barrelTwist=254.0;
         ACE_barrelLength=609.6;
@@ -15,98 +15,98 @@ class CfgWeapons
     class rhs_weap_m4_Base: arifle_MX_Base_F {
         ACE_barrelTwist=177.8;
         ACE_barrelLength=368.3;
-		class M203_GL : UGL_F {
-			magazines[] = {
-				"rhs_mag_M441_HE",
-				"rhs_mag_M433_HEDP",
-				"rhs_mag_M4009",
-				"rhs_mag_m576",
-				"rhs_mag_M585_white",
-				"rhs_mag_M661_green",
-				"rhs_mag_M662_red",
-				"rhs_mag_M713_red",
-				"rhs_mag_M714_white",
-				"rhs_mag_M715_green",
-				"rhs_mag_M716_yellow",
+        class M203_GL : UGL_F {
+            magazines[] = {
+                "rhs_mag_M441_HE",
+                "rhs_mag_M433_HEDP",
+                "rhs_mag_M4009",
+                "rhs_mag_m576",
+                "rhs_mag_M585_white",
+                "rhs_mag_M661_green",
+                "rhs_mag_M662_red",
+                "rhs_mag_M713_red",
+                "rhs_mag_M714_white",
+                "rhs_mag_M715_green",
+                "rhs_mag_M716_yellow",
 
-				//bis compatibility
-				"1Rnd_HE_Grenade_shell",
-				"UGL_FlareWhite_F",
-				"UGL_FlareGreen_F",
-				"UGL_FlareRed_F",
-				"UGL_FlareYellow_F",
-				"UGL_FlareCIR_F",
-				"1Rnd_Smoke_Grenade_shell",
-				"1Rnd_SmokeRed_Grenade_shell",
-				"1Rnd_SmokeGreen_Grenade_shell",
-				"1Rnd_SmokeYellow_Grenade_shell",
-				"1Rnd_SmokePurple_Grenade_shell",
-				"1Rnd_SmokeBlue_Grenade_shell",
-				"1Rnd_SmokeOrange_Grenade_shell",
-				"3Rnd_HE_Grenade_shell",
-				"3Rnd_UGL_FlareWhite_F",
-				"3Rnd_UGL_FlareGreen_F",
-				"3Rnd_UGL_FlareRed_F",
-				"3Rnd_UGL_FlareYellow_F",
-				"3Rnd_UGL_FlareCIR_F",
-				"3Rnd_Smoke_Grenade_shell",
-				"3Rnd_SmokeRed_Grenade_shell",
-				"3Rnd_SmokeGreen_Grenade_shell",
-				"3Rnd_SmokeYellow_Grenade_shell",
-				"3Rnd_SmokePurple_Grenade_shell",
-				"3Rnd_SmokeBlue_Grenade_shell",
-				"3Rnd_SmokeOrange_Grenade_shell",
-				
-				//ACE3 Compatibility
-				"ACE_HuntIR_M203"
-			};
-		};
-		class M320_GL : M203_GL {
-			magazines[] = {
-				"rhs_mag_M441_HE",
-				"rhs_mag_M433_HEDP",
-				"rhs_mag_M4009",
-				"rhs_mag_m576",
-				"rhs_mag_M585_white",
-				"rhs_mag_M661_green",
-				"rhs_mag_M662_red",
-				"rhs_mag_M713_red",
-				"rhs_mag_M714_white",
-				"rhs_mag_M715_green",
-				"rhs_mag_M716_yellow",
+                //bis compatibility
+                "1Rnd_HE_Grenade_shell",
+                "UGL_FlareWhite_F",
+                "UGL_FlareGreen_F",
+                "UGL_FlareRed_F",
+                "UGL_FlareYellow_F",
+                "UGL_FlareCIR_F",
+                "1Rnd_Smoke_Grenade_shell",
+                "1Rnd_SmokeRed_Grenade_shell",
+                "1Rnd_SmokeGreen_Grenade_shell",
+                "1Rnd_SmokeYellow_Grenade_shell",
+                "1Rnd_SmokePurple_Grenade_shell",
+                "1Rnd_SmokeBlue_Grenade_shell",
+                "1Rnd_SmokeOrange_Grenade_shell",
+                "3Rnd_HE_Grenade_shell",
+                "3Rnd_UGL_FlareWhite_F",
+                "3Rnd_UGL_FlareGreen_F",
+                "3Rnd_UGL_FlareRed_F",
+                "3Rnd_UGL_FlareYellow_F",
+                "3Rnd_UGL_FlareCIR_F",
+                "3Rnd_Smoke_Grenade_shell",
+                "3Rnd_SmokeRed_Grenade_shell",
+                "3Rnd_SmokeGreen_Grenade_shell",
+                "3Rnd_SmokeYellow_Grenade_shell",
+                "3Rnd_SmokePurple_Grenade_shell",
+                "3Rnd_SmokeBlue_Grenade_shell",
+                "3Rnd_SmokeOrange_Grenade_shell",
+                
+                //ACE3 Compatibility
+                "ACE_HuntIR_M203"
+            };
+        };
+        class M320_GL : M203_GL {
+            magazines[] = {
+                "rhs_mag_M441_HE",
+                "rhs_mag_M433_HEDP",
+                "rhs_mag_M4009",
+                "rhs_mag_m576",
+                "rhs_mag_M585_white",
+                "rhs_mag_M661_green",
+                "rhs_mag_M662_red",
+                "rhs_mag_M713_red",
+                "rhs_mag_M714_white",
+                "rhs_mag_M715_green",
+                "rhs_mag_M716_yellow",
 
-				//bis compatibility
-				"1Rnd_HE_Grenade_shell",
-				"UGL_FlareWhite_F",
-				"UGL_FlareGreen_F",
-				"UGL_FlareRed_F",
-				"UGL_FlareYellow_F",
-				"UGL_FlareCIR_F",
-				"1Rnd_Smoke_Grenade_shell",
-				"1Rnd_SmokeRed_Grenade_shell",
-				"1Rnd_SmokeGreen_Grenade_shell",
-				"1Rnd_SmokeYellow_Grenade_shell",
-				"1Rnd_SmokePurple_Grenade_shell",
-				"1Rnd_SmokeBlue_Grenade_shell",
-				"1Rnd_SmokeOrange_Grenade_shell",
-				"3Rnd_HE_Grenade_shell",
-				"3Rnd_UGL_FlareWhite_F",
-				"3Rnd_UGL_FlareGreen_F",
-				"3Rnd_UGL_FlareRed_F",
-				"3Rnd_UGL_FlareYellow_F",
-				"3Rnd_UGL_FlareCIR_F",
-				"3Rnd_Smoke_Grenade_shell",
-				"3Rnd_SmokeRed_Grenade_shell",
-				"3Rnd_SmokeGreen_Grenade_shell",
-				"3Rnd_SmokeYellow_Grenade_shell",
-				"3Rnd_SmokePurple_Grenade_shell",
-				"3Rnd_SmokeBlue_Grenade_shell",
-				"3Rnd_SmokeOrange_Grenade_shell",
-				
-				//ACE3 Compatibility
-				"ACE_HuntIR_M203"
-			};
-		};
+                //bis compatibility
+                "1Rnd_HE_Grenade_shell",
+                "UGL_FlareWhite_F",
+                "UGL_FlareGreen_F",
+                "UGL_FlareRed_F",
+                "UGL_FlareYellow_F",
+                "UGL_FlareCIR_F",
+                "1Rnd_Smoke_Grenade_shell",
+                "1Rnd_SmokeRed_Grenade_shell",
+                "1Rnd_SmokeGreen_Grenade_shell",
+                "1Rnd_SmokeYellow_Grenade_shell",
+                "1Rnd_SmokePurple_Grenade_shell",
+                "1Rnd_SmokeBlue_Grenade_shell",
+                "1Rnd_SmokeOrange_Grenade_shell",
+                "3Rnd_HE_Grenade_shell",
+                "3Rnd_UGL_FlareWhite_F",
+                "3Rnd_UGL_FlareGreen_F",
+                "3Rnd_UGL_FlareRed_F",
+                "3Rnd_UGL_FlareYellow_F",
+                "3Rnd_UGL_FlareCIR_F",
+                "3Rnd_Smoke_Grenade_shell",
+                "3Rnd_SmokeRed_Grenade_shell",
+                "3Rnd_SmokeGreen_Grenade_shell",
+                "3Rnd_SmokeYellow_Grenade_shell",
+                "3Rnd_SmokePurple_Grenade_shell",
+                "3Rnd_SmokeBlue_Grenade_shell",
+                "3Rnd_SmokeOrange_Grenade_shell",
+                
+                //ACE3 Compatibility
+                "ACE_HuntIR_M203"
+            };
+        };
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1 {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -5,7 +5,8 @@ class CfgWeapons
     class Rifle_Base_F;
     class srifle_EBR_F;
     class launch_O_Titan_F;
-    
+    class UGL_F;
+	
     class rhs_weap_XM2010_Base_F: Rifle_Base_F {
         ACE_barrelTwist=254.0;
         ACE_barrelLength=609.6;
@@ -14,6 +15,98 @@ class CfgWeapons
     class rhs_weap_m4_Base: arifle_MX_Base_F {
         ACE_barrelTwist=177.8;
         ACE_barrelLength=368.3;
+		class  M203_GL : UGL_F {
+			magazines[] = {
+				"rhs_mag_M441_HE",
+				"rhs_mag_M433_HEDP",
+				"rhs_mag_M4009",
+				"rhs_mag_m576",
+				"rhs_mag_M585_white",
+				"rhs_mag_M661_green",
+				"rhs_mag_M662_red",
+				"rhs_mag_M713_red",
+				"rhs_mag_M714_white",
+				"rhs_mag_M715_green",
+				"rhs_mag_M716_yellow",
+
+				//bis compatibility
+				"1Rnd_HE_Grenade_shell",
+				"UGL_FlareWhite_F",
+				"UGL_FlareGreen_F",
+				"UGL_FlareRed_F",
+				"UGL_FlareYellow_F",
+				"UGL_FlareCIR_F",
+				"1Rnd_Smoke_Grenade_shell",
+				"1Rnd_SmokeRed_Grenade_shell",
+				"1Rnd_SmokeGreen_Grenade_shell",
+				"1Rnd_SmokeYellow_Grenade_shell",
+				"1Rnd_SmokePurple_Grenade_shell",
+				"1Rnd_SmokeBlue_Grenade_shell",
+				"1Rnd_SmokeOrange_Grenade_shell",
+				"3Rnd_HE_Grenade_shell",
+				"3Rnd_UGL_FlareWhite_F",
+				"3Rnd_UGL_FlareGreen_F",
+				"3Rnd_UGL_FlareRed_F",
+				"3Rnd_UGL_FlareYellow_F",
+				"3Rnd_UGL_FlareCIR_F",
+				"3Rnd_Smoke_Grenade_shell",
+				"3Rnd_SmokeRed_Grenade_shell",
+				"3Rnd_SmokeGreen_Grenade_shell",
+				"3Rnd_SmokeYellow_Grenade_shell",
+				"3Rnd_SmokePurple_Grenade_shell",
+				"3Rnd_SmokeBlue_Grenade_shell",
+				"3Rnd_SmokeOrange_Grenade_shell",
+				
+				//ACE3 Compatibility
+				"ACE_HuntIR_M203"
+			};
+		};
+		class  M320_GL : M203_GL {
+			magazines[] = {
+				"rhs_mag_M441_HE",
+				"rhs_mag_M433_HEDP",
+				"rhs_mag_M4009",
+				"rhs_mag_m576",
+				"rhs_mag_M585_white",
+				"rhs_mag_M661_green",
+				"rhs_mag_M662_red",
+				"rhs_mag_M713_red",
+				"rhs_mag_M714_white",
+				"rhs_mag_M715_green",
+				"rhs_mag_M716_yellow",
+
+				//bis compatibility
+				"1Rnd_HE_Grenade_shell",
+				"UGL_FlareWhite_F",
+				"UGL_FlareGreen_F",
+				"UGL_FlareRed_F",
+				"UGL_FlareYellow_F",
+				"UGL_FlareCIR_F",
+				"1Rnd_Smoke_Grenade_shell",
+				"1Rnd_SmokeRed_Grenade_shell",
+				"1Rnd_SmokeGreen_Grenade_shell",
+				"1Rnd_SmokeYellow_Grenade_shell",
+				"1Rnd_SmokePurple_Grenade_shell",
+				"1Rnd_SmokeBlue_Grenade_shell",
+				"1Rnd_SmokeOrange_Grenade_shell",
+				"3Rnd_HE_Grenade_shell",
+				"3Rnd_UGL_FlareWhite_F",
+				"3Rnd_UGL_FlareGreen_F",
+				"3Rnd_UGL_FlareRed_F",
+				"3Rnd_UGL_FlareYellow_F",
+				"3Rnd_UGL_FlareCIR_F",
+				"3Rnd_Smoke_Grenade_shell",
+				"3Rnd_SmokeRed_Grenade_shell",
+				"3Rnd_SmokeGreen_Grenade_shell",
+				"3Rnd_SmokeYellow_Grenade_shell",
+				"3Rnd_SmokePurple_Grenade_shell",
+				"3Rnd_SmokeBlue_Grenade_shell",
+				"3Rnd_SmokeOrange_Grenade_shell",
+				
+				//ACE3 Compatibility
+				"ACE_HuntIR_M203"
+			};
+		};
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1 {


### PR DESCRIPTION
Added HuntIR as magazine to all RHS AR15s that has a M203 or M320 attached (class rhs_weap_m4_Base).
I've added full magazine list to the M320-class instead of using the += operator due to possible PBO:er version issues when/if binarizing configs. If no binarization is done I'm happy to replace the M320-class  with:
class M320_GL : M203_GL {magazines[] += {};};

Tested and working in my compatibility-mod; http://www.armaholic.com/page.php?id=28963