### PR TITLE
A few items for RHS compatibility (ACE reload and reloadablelaunchers, disabling ACE FCS)

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_afrf3/CfgMagazines.hpp
@@ -1,0 +1,17 @@
+class cfgMagazines {
+    class VehicleMagazine;
+    class rhs_30Rnd_545x39_AK;
+
+    class rhs_100Rnd_762x54mmR: rhs_30Rnd_545x39_AK {
+        ace_isbelt = 1;
+    };
+    class rhs_100Rnd_762x54mmR_green: rhs_100Rnd_762x54mmR {
+        ace_isbelt = 1;
+    };
+    class rhs_mag_127x108mm_50 : VehicleMagazine {
+        ace_isbelt = 1;
+    };
+    class rhs_mag_127x108mm_150 : rhs_mag_127x108mm_50 {        
+        ace_isbelt = 0;
+    };
+};

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -1,0 +1,156 @@
+class cfgVehicles {
+    class LandVehicle;
+    class Tank: LandVehicle {
+        class NewTurret;
+    };
+    class Tank_F: Tank {
+        class Turrets {
+            class MainTurret: NewTurret {
+                class Turrets {
+                    class CommanderOptics;
+                };
+            };
+        };
+    };
+    class Car;
+    class Car_F: Car {
+        class ViewPilot;
+        class NewTurret;
+    };
+    class Wheeled_APC_F: Car_F {
+        class NewTurret;
+        class Turrets {
+            class MainTurret: NewTurret
+            {
+                class ViewOptics;
+            };
+        };
+        class CommanderOptics;
+    };
+    class rhs_bmd_base: Tank_F {
+        class Turrets: Turrets {
+            class CommanderOptics: NewTurret {
+                ace_fcs_Enabled = 0;
+            };
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+            };
+            class GPMGTurret1: NewTurret {
+                ace_fcs_Enabled = 0;
+            };
+        };
+    };
+    class rhs_bmp1tank_base: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+            };
+            class Com_BMP1: NewTurret {
+                ace_fcs_Enabled = 0;
+            };
+        };
+    };
+    class rhs_bmp_base: rhs_bmp1tank_base {};
+    class rhs_bmp1_vdv: rhs_bmp_base {};
+    class rhs_bmp2e_vdv : rhs_bmp1_vdv {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Turrets: Turrets {
+                    class CommanderOptics : CommanderOptics {
+                        ace_fcs_Enabled = 0;            
+                    };
+                };
+            };
+        };
+    };
+    class rhs_bmp3tank_base: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                };
+            };
+            class GPMGTurret1: NewTurret {
+                ace_fcs_Enabled = 0;
+            };
+        };
+    };
+    class rhs_btr_base: Wheeled_APC_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret  {
+                ace_fcs_Enabled = 0;
+            };
+            class CommanderOptics: CommanderOptics {
+                ace_fcs_Enabled = 0;
+            };
+        };
+    };
+    class rhs_a3spruttank_base: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics
+                    {
+                        ace_fcs_Enabled = 0;
+                    };
+                };
+            };
+            class GPMGTurret1: NewTurret {
+                ace_fcs_Enabled = 0;
+            };
+        };
+    };
+    class rhs_a3t72tank_base: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                    class CommanderMG: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                };
+            };
+        };
+    };
+    class rhs_t72bd_tv: rhs_a3t72tank_base {};
+    class rhs_t90_tv: rhs_t72bd_tv {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                };
+            };
+        };
+    };
+    class rhs_tank_base: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                    class CommanderMG: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                };
+            };
+        };
+    };
+
+    class rhs_infantry_msv_base;
+    class rhs_pilot_base : rhs_infantry_msv_base
+    {
+        ace_gforcecoef = 0.55;
+    };
+};

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -65,4 +65,8 @@ class CfgWeapons
         ACE_ScopeAdjust_VerticalIncrement = 0.0;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };
+    class Launcher_Base_F;
+    class rhs_weap_rpg7: Launcher_Base_F {
+        ace_reloadlaunchers_enabled = 1;
+    };
 };

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -12,4 +12,6 @@ class CfgPatches {
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -1,0 +1,31 @@
+class cfgMagazines {
+    class CA_Magazine;
+    class VehicleMagazine;
+    class rhs_mag_30Rnd_556x45_M855A1_Stanag;
+    class rhs_mag_30Rnd_556x45_M200_Stanag;
+
+    class rhsusf_100Rnd_556x45_soft_pouch: rhs_mag_30Rnd_556x45_M855A1_Stanag {
+        ace_isbelt = 1;
+    };
+    class rhsusf_100Rnd_556x45_M200_soft_pouch: rhs_mag_30Rnd_556x45_M200_Stanag {
+        ace_isbelt = 1;
+    };
+    class rhsusf_200Rnd_556x45_soft_pouch: rhsusf_100Rnd_556x45_soft_pouch {
+        ace_isbelt = 1;
+    };
+    class rhsusf_100Rnd_762x51: CA_Magazine {
+        ace_isbelt = 1;
+    };
+    class rhsusf_100Rnd_762x51_m80a1epr: rhsusf_100Rnd_762x51 {
+        ace_isbelt = 1;
+    };
+    class rhsusf_100Rnd_762x51_m993: rhsusf_100Rnd_762x51 {
+        ace_isbelt = 1;
+    };
+    class rhs_mag_100rnd_127x99_mag: VehicleMagazine {
+        ace_isbelt = 1;
+    };
+    class RHS_48Rnd_40mm_MK19: VehicleMagazine {
+        ace_isbelt = 1;
+    };
+};

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -1,0 +1,32 @@
+class cfgVehicles {
+    class LandVehicle;
+    class Tank: LandVehicle {
+        class NewTurret;
+    };
+    class Tank_F: Tank {
+        class Turrets {
+            class MainTurret: NewTurret {
+                class Turrets {
+                    class CommanderOptics;
+                };
+            };
+        };
+    };
+
+    class MBT_01_base_F: Tank_F {};
+    class rhsusf_m1a1tank_base: MBT_01_base_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                    class Loader: CommanderOptics {
+                        ace_fcs_Enabled = 0;
+                    };
+                };
+            };
+        };
+    };
+};

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -12,4 +12,6 @@ class CfgPatches {
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"


### PR DESCRIPTION
As mentioned in the title, this PR does ~~three~~ four things:

- It adds ACE reload functionality for belted weapons like the PKM or 249 using ace_reload.

- It allows the RPG-7 to be buddy reloaded using ace_reloadablelaunchers

- It disables ace_fcs on RHS vehicles to avoid conflicts with their hardcoded vehicle FCS.

- Sets g-force resistance to the RHS RU pilot.

I think formattings correct - spaces instead of tabs, etc.