### PR TITLE
documentation pass 7

### DIFF
--- a/documentation/feature/attach.md
+++ b/documentation/feature/attach.md
@@ -17,14 +17,14 @@ Adds an attachable IR strobe, which is only visible using night vision devices a
 ## 2. Usage
 
 ### 2.1 Attaching to yourself
-- Use Self Interact <kbd>CTRL</kbd>+<kbd>Left Windows</kbd> (ACE3 default key bind `Self Interaction Key`).
+- Use Self Interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default).
 - Select `Equipment`.
 - Select `Attach item`.
 - Select which item you want to attach.
 - Repeat the process to detach.
 
 ### 2.2 Attaching to a vehicle
-- Interact with the vehicle <kbd>Left Windows</kbd> (ACE3 default key bind `Interact Key`).
+- Interact with the vehicle <kbd>⊞ Win</kbd> (ACE3 default).
 - Select `Attach item`.
 - Select your item and follow the instructions on the screen.
 - Repeat the process to detach.

--- a/documentation/feature/captives.md
+++ b/documentation/feature/captives.md
@@ -24,20 +24,23 @@ Allows players to surrender. It renders the unit unable to move and with the han
 
 ### 2.1 Taking a unit into captivity
 - You need `Cable Tie`.
-- Approach the unit and Interact <kbd>Left Windows</kbd> (ACE3 default key bind `Interact Key`).
+- Approach the unit and Interact <kbd>⊞ win</kbd> (ACE3 default).
 - The interaction is located around the hands in the form of a handcuffs icon.
 - Repeat to release.
 
 ### 2.2 Escorting a captive
-- Interact with the captive <kbd>Left Windows</kbd>.
+- Interact with the captive <kbd>⊞ win</kbd>.
 - Select the `Escort prisoner` option.
-- To stop escorting, use the mousewheel and select `Release` or use Self Interaction <kbd>CTRL</kbd>+<kbd>Left Windows</kbd> and select `Release`.
+- To stop escorting, use the mousewheel and select `Release` or use Self Interaction <kbd>CTRL</kbd>+<kbd>⊞ win</kbd> and select `Release`.
 
 ### 2.3 Loading and unloading a captive into/from a vehicle
 - Escort the captive.
 - Approach the vehicle you wish to load the captive unit into.
-- Interact with the vehicle <kbd>Left Windows</kbd> and select `Load captive`.
-- Interact with the vehicle to unload.
+- Interact with the vehicle <kbd>⊞ win</kbd> and select `Load captive`.
+- To unload the captive interact with the vehicle <kbd>⊞ win</kbd>
+- Select `Passengers`.
+- Select the captive.
+- Select `Unload captive`.
 
 ## 3. Dependencies
 

--- a/documentation/feature/concertina_wire.md
+++ b/documentation/feature/concertina_wire.md
@@ -1,0 +1,22 @@
+---
+layout: wiki
+title: concertina wire
+description: 
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+A concertina wire is a type of barbed wire formed in large coils that can be expanded to form obstacles, in ACE3 any vehicle making contact with it get it's tires destroyed.
+
+## 2. Usage
+
+### 2.1 Deploying the concertina wire
+- Approach the concertina coil and select <kbd>⊞ Win</kbd> (ACE3 default)
+- Select `Deploy concertina wire`.
+- Follow the instructions on screen.
+
+## 3. Dependencies
+
+`ace_apl` , `ace_interaction`

--- a/documentation/feature/dagr.md
+++ b/documentation/feature/dagr.md
@@ -1,0 +1,14 @@
+---
+layout: wiki
+title: Dagr
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds the defense Advanced GPS Receiver.
+
+## 3. Dependencies
+
+`ace_weather`

--- a/documentation/feature/dagr.md
+++ b/documentation/feature/dagr.md
@@ -7,7 +7,7 @@ parent: wiki
 
 ## 1. Overview
 
-Adds the defense Advanced GPS Receiver.
+Adds the Defense Advanced GPS Receiver.
 
 ## 3. Dependencies
 

--- a/documentation/feature/disarming.md
+++ b/documentation/feature/disarming.md
@@ -14,7 +14,7 @@ You can search the inventory and disarm captured or unconscious units.
 ## 2. Usage
 
 ### 2.1 Searching and disarming
-- Interact with the captured or unconscious unit <kbd>Left Windows</kbd> (ACE3 default key bind `Interaction Key`).
+- Interact with the captured or unconscious unit <kbd>⊞ Win</kbd> (ACE3 default key bind `Interaction Key`).
 - Select `Open inventory`.
 - Drag & Drop the items you wish to remove from the unit.
 

--- a/documentation/feature/dragging.md
+++ b/documentation/feature/dragging.md
@@ -14,9 +14,9 @@ This adds the option to drag or carry units or objects.
 
 ### 2.1 Dragging / Carrying units and objects
 - You can only drag or carry an unconscious unit.
-- Interact with the unit or object <kbd>Left Windows</kbd> (ACE3 default key bind `Interact Key`).
+- Interact with the unit or object <kbd>⊞ Win</kbd> (ACE3 default key bind `Interact Key`).
 - Select `Drag` or `Carry`.
-- To release, use the mouse wheel and select `Release` or use Self Interaction <kbd>CTRL</kbd>+<kbd>Left Windows</kbd> and select `Release`.
+- To release, use the mouse wheel and select `Release` or use Self Interaction <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> and select `Release`.
 
 ## 3. Dependencies
 

--- a/documentation/feature/explosives.md
+++ b/documentation/feature/explosives.md
@@ -20,18 +20,18 @@ Enables attaching explosives to vehicles.
 ## 2. Usage
 
 ### 2.1 Placing explosives
-- Use self interaction <kbd>CTRL</kbd>+<kbd>Left Windows</kbd> (ACE3 default key bind `Self Interaction Key`).
+- Use self interaction <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default key bind `Self Interaction Key`).
 - Select `Explosives`.
 - Choose your explosive type and follow the instructions on the screen.
 
 ### 2.2 Arming and detonating explosives
-- Interact with the explosive <kbd>Left Windows</kbd> (ACE3 default key bind `Interact Key`).
+- Interact with the explosive <kbd>⊞ Win</kbd> (ACE3 default key bind `Interact Key`).
 - Choose the arming method.
 - For clackers use Self Interaction `Explosives` &rarr; `Detonate` and choose the corresponding Firing Device.
 
 ### 2.3 Defusing explosives
 - A `Defusal Kit` is required.
-- Interact with the explosive <kbd>Left Windows</kbd>.
+- Interact with the explosive <kbd>⊞ Win</kbd>.
 - Select `Disarm`.
 - You are safe to pick it up after the action has completed.
 

--- a/documentation/feature/fonts.md
+++ b/documentation/feature/fonts.md
@@ -7,7 +7,8 @@ parent: wiki
 
 ## 1. Overview
 
-this module adds a font that will be used in the future, characters with equal widths to make it easy to structure correctly.
+This module adds a font that will be used in the future, characters with equal widths to make it easy to structure correctly. This is **NOT** present in 3.1.1 because of a bug even if it's present in the sources.
+
 
 ## 3. Dependencies
 

--- a/documentation/feature/fonts.md
+++ b/documentation/feature/fonts.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Fonts
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+### 1.1 Sub-feature 1
+Short description of sub-feature 1.
+
+### 1.2 Sub-feature 2
+Short description of sub-feature 2.
+
+## 2. Usage
+
+## 3. Dependencies
+
+`ace_something`

--- a/documentation/feature/fonts.md
+++ b/documentation/feature/fonts.md
@@ -7,14 +7,8 @@ parent: wiki
 
 ## 1. Overview
 
-### 1.1 Sub-feature 1
-Short description of sub-feature 1.
-
-### 1.2 Sub-feature 2
-Short description of sub-feature 2.
-
-## 2. Usage
+this module adds a font that will be used in the future, characters with equal widths to make it easy to structure correctly.
 
 ## 3. Dependencies
 
-`ace_something`
+`ace_main`

--- a/documentation/feature/hearing.md
+++ b/documentation/feature/hearing.md
@@ -19,7 +19,7 @@ missile launchers will be equipped with those, but remember to put them in.
 
 ### 2.1 Equipping earplugs
 - For this you need the `Earplugs` item.
-- Press the self interaction key <kbd>CTRL</kbd> + <kbd>Left Windows</kbd> (ACE3 default key bind `Self Interaction Key`).
+- Press the self interaction key <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd> (ACE3 default key bind `Self Interaction Key`).
 - Select `Equipment`.
 - Select `Earplugs in`.
 - Same method to remove them but the option is `Earplugs out`.

--- a/documentation/feature/huntIR.md
+++ b/documentation/feature/huntIR.md
@@ -8,7 +8,7 @@ parent: wiki
 ## 1. Overview
 
 ### 1.1 The HuntIR
-The **H**igh altitude **U**nit **N**avigated **T**actical **I**maging **R**ound (HuntIR) is designed to be fired from a grenade launcher, after being fired in the air the in built parachute will be deployed and the IR CMOS camera will activate, providing a video stream until it touches the ground or get shot down.
+The **H**igh altitude **U**nit **N**avigated **T**actical **I**maging **R**ound (HuntIR) is designed to be fired from a grenade launcher. After being fired in the air the in built parachute will be deployed and the IR CMOS camera will activate, providing a video stream until it touches the ground or get shot down.
 
 ## 2. Usage
 NOTE: the HuntIR round doesn't work with modded weapons without a compatibility fix made either by the ACE3 team or the mod team.
@@ -18,7 +18,7 @@ NOTE: the HuntIR round doesn't work with modded weapons without a compatibility 
 - Fire the HuntIR round as high as possible over the area you want to observe.
 - Open the `HuntIR monitor`.
   - To open the `HuntIR monitor` self interact <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd> (ACE3 default)
-  - Select `equipment`.
+  - Select `Equipment`.
   - Select `Activate HuntIR monitor`.
 - You now have control of the IR CMOS camera to close the monitor press <kbd>ESC</kbd> or <kbd>⊞ Win</kbd>
 

--- a/documentation/feature/huntIR.md
+++ b/documentation/feature/huntIR.md
@@ -1,0 +1,42 @@
+---
+layout: wiki
+title: HuntIR
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+### 1.1 The HuntIR
+The **H**igh altitude **U**nit **N**avigated **T**actical **I**maging **R**ound (HuntIR) is designed to be fired from a grenade launcher, after being fired in the air the in built parachute will be deployed and the IR CMOS camera will activate, providing a video stream until it touches the ground or get shot down.
+
+## 2. Usage
+NOTE: the HuntIR round doesn't work with modded weapons without a compatibility fix made either by the ACE3 team or the mod team.
+
+### 2.1 Using the HuntIR
+- To be able to connect to the IR CMOS camera you'll need a `HuntIR monitor`.
+- Fire the HuntIR round as high as possible over the area you want to observe.
+- Open the `HuntIR monitor`.
+  - To open the `HuntIR monitor` self interact <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd> (ACE3 default)
+  - Select `equipment`.
+  - Select `Activate HuntIR monitor`.
+- You now have control of the IR CMOS camera to close the monitor press <kbd>ESC</kbd> or <kbd>⊞ Win</kbd>
+
+### 2.2 IR CMOS camera controls
+
+Shortcut | Action
+------------ | -------------
+<kbd>A</kbd>  | Lower zoom level
+<kbd>D</kbd> | Increase zoom level
+<kbd>N</kbd> | Toggle NV and TI modes
+<kbd>S</kbd> | Next camera
+<kbd>W</kbd> | Previous camera
+<kbd>←</kbd> | Rotate camera anticlockwise
+<kbd>→</kbd>|  Rotate camera clockwise
+<kbd>↑</kbd> | Raise camera
+<kbd>↓</kbd> | Lower camera
+<kbd>R</kbd> | Reset camera
+
+## 3. Dependencies
+
+`ace_common`

--- a/documentation/feature/logistics_uavbattery.md
+++ b/documentation/feature/logistics_uavbattery.md
@@ -15,7 +15,7 @@ Adds an item `ACE_UAVBattery` that allows refuelling / recharging of the "Darter
 
 ### 2.1 Recharging the darter
 - For this you need a `UAV battery` and the UAV needs to be a quad-copter.
-- Interact with the UAV <kbd>Left Windows</kbd> (ACE3 default key bind `Interact Key`)
+- Interact with the UAV <kbd>⊞ Win</kbd> (ACE3 default key bind `Interact Key`)
 - Select `Recharge`
 
 ## 3. Dependencies

--- a/documentation/feature/logistics_wirecutter.md
+++ b/documentation/feature/logistics_wirecutter.md
@@ -16,7 +16,7 @@ Adds an item `ACE_wirecutter` that allows cutting of fences in Arma 3 and AllInA
 ### 2.1 Using the wirecutter
 - For this you need a `Wirecutter`.
 - Approach the fence you want to cut.
-- Press the interaction key <kbd>Left Windows</kbd> (ACE3 default key bind `Interaction Key`).
+- Press the interaction key <kbd>⊞ Win</kbd> (ACE3 default key bind `Interaction Key`).
 - Find the interaction point and select `Cut Fence` (the only option).
 
 ## 3. Dependencies

--- a/documentation/feature/magazinerepack.md
+++ b/documentation/feature/magazinerepack.md
@@ -15,7 +15,7 @@ Adds the ability to repack magazines of the same type.
 
 ### 2.1 Repacking
 - For this you need multiple half empty mags of the same type.
-- Press the self interaction button <kbd>CTRL</kbd> + <kbd>Left Windows</kbd> (ACE3 default key bind `Self Interaction Key`).
+- Press the self interaction button <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd> (ACE3 default key bind `Self Interaction Key`).
 - Select `Repack magazines`.
 - Select the type of magazines you want to repack.
 

--- a/documentation/feature/maptools.md
+++ b/documentation/feature/maptools.md
@@ -22,7 +22,7 @@ If you are equipped with a vanilla GPS it will be shown on the map. (You don't n
 ### 2.1 Using map tools
 - For this you need to have `Map Tools`.
 - Open the map <kbd>M</kbd> (Arma 3 default key bind `Map`).
-- Press the self interaction key <kbd>CTRL</kbd> + <kbd>Left Windows</kbd> (ACE3 default key bind `Self Interaction Key`).
+- Press the self interaction key <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd> (ACE3 default key bind `Self Interaction Key`).
 - Select `Map tools`.
 - Select the type of tools you want to use.
 - Note that you can drag the Roamer (map tool) around with <kdd> LMB </kbd> and rotate it with <kbd>CTRL</kbd> + <kbd>LMB</kbd>.

--- a/documentation/feature/mk6mortar.md
+++ b/documentation/feature/mk6mortar.md
@@ -18,7 +18,7 @@ ACE3 adds wind deflection for shells as well as a rangetable to accurately take 
 
 ### 2.2 Working with the rangetable
 - To open the table: 
-    - Self interact <kbd>CTRL</kbd> + <kbd>Left Windows</kbd>
+    - Self interact <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd>
     - Select `equipment`.
     - Select `Open 82mm Rangetable`.
 

--- a/documentation/feature/mx2a.md
+++ b/documentation/feature/mx2a.md
@@ -1,0 +1,14 @@
+---
+layout: wiki
+title: MX-2A
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds the MX-2A thermal imaging device.
+
+## 3. Dependencies
+
+`ace_apl`

--- a/documentation/feature/overheating.md
+++ b/documentation/feature/overheating.md
@@ -25,12 +25,12 @@ Adds the ability to changes barrels on machine guns to compensate for those effe
 
 ### 2.2 Swapping barrels
 - For this you need a `Spare barrel` and a compatible weapon.
-- Press self interaction <kbd>CTRL</kbd> + <kbd>Left Windows</kbd> (ACE3 default key bind `Self Interaction Key`).
+- Press self interaction <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd> (ACE3 default key bind `Self Interaction Key`).
 - Select `Equipment`.
 - Select `Swap barrel`.
 
 ### 2.3 Checking your barrel temperature
-- Press self interaction <kbd>CTRL</kbd> + <kbd>Left Windows</kbd>.
+- Press self interaction <kbd>CTRL</kbd> + <kbd>⊞ Win</kbd>.
 - Select `Equipment`.
 - Select `Check weapon temperature`. 
 

--- a/documentation/feature/reloadlaunchers.md
+++ b/documentation/feature/reloadlaunchers.md
@@ -13,7 +13,7 @@ Add the ability to reload someone else's launcher.
 ### 2. Usage
 
 ### 2.1 Reloading someone else's launcher
-- Press the interaction key <kbd>Left Windows</kbd> and aim at your buddy's launcher.
+- Press the interaction key <kbd>⊞ Win</kbd> and aim at your buddy's launcher.
 - Select `reload launcher`.
 - Select the type of ammo.
 

--- a/documentation/feature/respawn.md
+++ b/documentation/feature/respawn.md
@@ -23,7 +23,7 @@ Adds rallypoints to all 3 sides to enable teleportation from base spawn to FOB's
 ### 2.1 Using rallypoints
 - For this to work pre-emptive preparations need to be made by the mission maker.
 - Approach the rallypoint flagpole
-- Use the interaction key <kbd>Left Windows</kbd> (ACE3 default key bind `Interaction key`).
+- Use the interaction key <kbd>⊞ Win</kbd> (ACE3 default key bind `Interaction key`).
 - Select teleport to (base / rallypoint).
 
 

--- a/documentation/feature/sandbags.md
+++ b/documentation/feature/sandbags.md
@@ -1,0 +1,24 @@
+---
+layout: wiki
+title: Sandbags
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds stackable sandbags able to block bullets, shrapnel and small explosions.
+Note that those sandbags are affected by physics, a rocket will send them flying.
+
+## 2. Usage
+
+### 2.1 Placing the sandbags
+- You'll need at least one `sandbag (empty)`.
+- You need to be over a grass area / sand area to be able to fill the sandbag.
+- Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default).
+- Select `Deploy sandbag`.
+- Follow the instruction on screen.
+
+## 3. Dependencies
+
+`ace_interaction`

--- a/documentation/feature/spotting_scope.md
+++ b/documentation/feature/spotting_scope.md
@@ -1,0 +1,21 @@
+---
+layout: wiki
+title: Spotting scope
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds a deployable spotting scope.
+
+## 2. Usage
+
+### 2.1 Deploying the spotting scope
+- Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default).
+- Select `Equipment`.
+- Select `place spotting scope` (note that the scope will be at your feet).
+
+## 3. Dependencies
+
+`ace_apl` , `ace_interaction`

--- a/documentation/feature/spotting_scope.md
+++ b/documentation/feature/spotting_scope.md
@@ -14,7 +14,7 @@ Adds a deployable spotting scope.
 ### 2.1 Deploying the spotting scope
 - Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default).
 - Select `Equipment`.
-- Select `place spotting scope` (note that the scope will be at your feet).
+- Select `Place spotting scope` (note that the scope will be at your feet).
 
 ## 3. Dependencies
 

--- a/documentation/feature/tacticallader.md
+++ b/documentation/feature/tacticallader.md
@@ -1,0 +1,14 @@
+---
+layout: wiki
+title: Tactical ladder
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds a packable tactical ladder.
+
+## 3. Dependencies
+
+`ace_apl` , `ace_interaction`

--- a/documentation/feature/tacticallader.md
+++ b/documentation/feature/tacticallader.md
@@ -7,14 +7,14 @@ parent: wiki
 
 ## 1. Overview
 
-Adds a deployable ladder with adjustable heigh that you can transport on your back.
+Adds a deployable ladder with adjustable height that you can transport on your back.
 
 ## 2. Usage
 
 ### 2.1 Deploying the ladder
 - Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default).
 - Select `Deploy ladder`.
-- You can adjust it's position and heigh by interacting with it <kbd>⊞ Win</kbd> (ACE3 default) and following the instructions on screen.
+- You can adjust it's position and height by interacting with it <kbd>⊞ Win</kbd> (ACE3 default) and following the instructions on screen.
 
 ## 3. Dependencies
 

--- a/documentation/feature/tacticallader.md
+++ b/documentation/feature/tacticallader.md
@@ -7,7 +7,14 @@ parent: wiki
 
 ## 1. Overview
 
-Adds a packable tactical ladder.
+Adds a deployable ladder with adjustable heigh that you can transport on your back.
+
+## 2. Usage
+
+### 2.1 Deploying the ladder
+- Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd> (ACE3 default).
+- Select `Deploy ladder`.
+- You can adjust it's position and heigh by interacting with it <kbd>⊞ Win</kbd> (ACE3 default) and following the instructions on screen.
 
 ## 3. Dependencies
 

--- a/documentation/feature/tripod.md
+++ b/documentation/feature/tripod.md
@@ -1,0 +1,24 @@
+---
+layout: wiki
+title: Tripod
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds a packable tripod deployable on the field. It features a flat part to deploy your weapon on and adjustable legs.
+
+## 2. Usage
+
+### 2.1 deploying the tripod
+- Note that you need a `SSW kit` in your inventory.
+- Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd>.
+- Select `Equipment`
+- Select `Place SSWT kit`.
+
+To adjust or pick up the tripod just interact with it <kbd>⊞ Win</kbd> and select the desired action.
+
+## 3. Dependencies
+
+`ace_interaction`

--- a/documentation/feature/tripod.md
+++ b/documentation/feature/tripod.md
@@ -12,7 +12,7 @@ Adds a packable tripod deployable on the field. It features a flat part to deplo
 ## 2. Usage
 
 ### 2.1 deploying the tripod
-- Note that you need a `SSW kit` in your inventory.
+- Note that you need a `SSWT kit` in your inventory.
 - Self interact <kbd>CTRL</kbd>+<kbd>⊞ Win</kbd>.
 - Select `Equipment`
 - Select `Place SSWT kit`.

--- a/documentation/feature/ui.md
+++ b/documentation/feature/ui.md
@@ -1,0 +1,15 @@
+---
+layout: wiki
+title: UI
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Changes the chat contrast on the map to allow easier reading.
+
+
+## 3. Dependencies
+
+`ace_common`

--- a/documentation/feature/yardage450.md
+++ b/documentation/feature/yardage450.md
@@ -1,0 +1,22 @@
+---
+layout: wiki
+title: Yardage 450
+group: feature
+parent: wiki
+---
+
+## 1. Overview
+
+Adds the Bushnell Yardage Pro Sport 450 Laser Rangefinder.
+
+## 2. Usage
+
+### 2.1 How to use the Yardage 450
+- Bring it up like any other binocular
+- Tap <kbd>R</kbd> once to activate the device.
+- Sight the target and Hold <kbd>R</kbd> until `TARGET AQCUIRED` appears on top of the screen.
+- The range in meters should now appear at the bottom of the screen.
+
+## 3. Dependencies
+
+`ace_apl` , `ace_laser`

--- a/documentation/missionmaker/classnames.md
+++ b/documentation/missionmaker/classnames.md
@@ -77,6 +77,21 @@ classname | in game name | type   |
 --------- | --------- | ---------
 ACE_Banana | banana |  ACE_ItemCore |
 
+### Concertina_wire
+`added in 3.1.1`
+
+classname | in game name | type   |
+--------- | --------- | ---------
+ACE_ConcertinaWireCoil | Concertina Wire Coil |  ThingX |
+ACE_ConcertinaWire | Concertina Wire | deployed concertina wire |
+
+### Dagr
+`added in 3.1.1`
+
+classname | in game name | type   |
+--------- | --------- | ---------
+ACE_DAGR | DAGR | ACE_ItemCore | 
+
 ### Disposable
 `added in 3.0.0.3`
 
@@ -106,12 +121,21 @@ ACE_HandFlare_Green | M127A1 Hand Held Signal (Green) | Grenade |
 ACE_HandFlare_Yellow | M127A1 Hand Held Signal (Yellow) | Grenade |
 ACE_M84 | M84 Stun Grenade | Grenade |
 
-### hearing
+### Hearing
 `added in 3.0.0.3`
 
 classname | in game name | type   |
 --------- | --------- | ---------
 ACE_EarPlugs | Earplugs | ACE_ItemCore |
+
+### HuntIR
+`added in 3.1.1`
+
+classname | in game name | type   |
+--------- | --------- | ---------
+ACE_HuntIR_monitor | HuntIR monitor | ACE_ItemCore |
+ACE_HuntIR_M203 | HuntIR Round | Grenade shell |
+ACE_HuntIR_Box | HuntIR Transport Box | ammo box |
 
 ### Kestrel
 `added in 3.0.0.3`
@@ -187,6 +211,14 @@ classname | in game name | type   |
 --------- | --------- | ---------
 ACE_RangeTable_82mm | 82mm Rangetable | ACE_ItemCore |
 
+### M2XA
+`added in 3.1.1`
+
+classname | in game name | type   |
+--------- | --------- | ---------
+ACE_MX2A | MX-2A | Binocular |
+
+
 ### Nightvision
 `added in 3.0.0.3`
 
@@ -254,3 +286,42 @@ ACE_key_west | Vehicle Key: West | ACE_ItemCore |
 ACE_key_east | Vehicle Key: East | ACE_ItemCore |
 ACE_key_indp | Vehicle Key: Independent | ACE_ItemCore |
 ACE_key_civ | Vehicle Key: Civilian | ACE_ItemCore |
+
+### Sandbag
+`added in 3.1.1`
+
+classname | in game name | type | 
+--------- | --------- | ---------
+ACE_Sandbag_empty | Sandbag (empty) | ACE_ItemCore | 
+ACE_SandbagObject | Sandbag | ThingX | 
+
+### Spotting scope
+`added in 3.1.1`
+
+classname | in game name | type | 
+--------- | --------- | ---------
+ACE_SpottingScope | Spotting Scope | ACE_ItemCore | 
+ACE_SpottingScopeObject | Spotting Scope (placed) | StaticATWeapon | 
+
+### Tactical ladder
+`added in 3.1.1`
+
+classname | in game name | type | 
+--------- | --------- | ---------
+ACE_TacticalLadder_Pack | Telescopic Ladder | Backpack | 
+ACE_Tactical_Ladder | Telescopic Ladder (placed) | house | 
+
+### Tripod
+`added in 3.1.1`
+
+classname | in game name | type | 
+--------- | --------- | ---------
+ACE_Tripod | SSWT Kit | ACE_ItemCore | 
+ACE_TripodObject | SSWT Kit (placed) | ThingX | 
+
+### Yardage 450
+`added in 3.1.1`
+
+classname | in game name | type | 
+--------- | --------- | ---------
+ACE_Yardage450 | Yardage 450 | Binocular | 

--- a/documentation/missionmaker/modules.md
+++ b/documentation/missionmaker/modules.md
@@ -18,29 +18,39 @@ This module allows enabling and configuring advanced ballistic simulations.
 1. **Advanced Ballistics (Boolean)**<br>
 Enables advanced ballistics.<br>
 `Default value: No`
+
 2. **Enabled For Snipers (Boolean)**<br>
 Enables advanced ballistics for non local snipers (when using high power optics).<br>
 `Default value: Yes`
+
 3. **Enabled For Group Members (Boolean)**<br>
 Enables advanced ballistics for non local group members.<br>
 `Default value: No`
+
 4. **Enabled For Everyone (Boolean)**<br>
 Enables advanced ballistics for all non local players (enabling this feature may degrade performance during heavy firefights in multiplayer).<br>
 `Default value: No`
+
 5. **Disabled In FullAuto Mode (Boolean)**<br>
 Disables the advanced ballistics during full auto fire.<br>
 `Default value: No`
+
 6. **Enable Ammo Temperature Simulation (Boolean)**<br>
 Muzzle velocity varies with ammo temperature.<br>
 `Default value: Yes`
+
 7. **Enable Barrel Length Simulation (Boolean)**<br>
 Muzzle velocity varies with barrel length.<br>
 `Default value: Yes`
+
 8. **Enable Bullet Trace Effect (Boolean)**<br>
 Enables a bullet trace effect to high caliber bullets (only visible when looking through high power optics).<br>
+`default value: Yes `
+
 9. **Simulation Interval (Number)**<br>
 Defines the interval between every calculation step.<br>
 `Default value: 0.00`
+
 10. **Simulation Radius (Number)**<br>
 Defines the radius around the player (in meters) at which advanced ballistics are applied to projectiles.<br>
 `Default value: 3000`
@@ -68,7 +78,23 @@ How often the markers should be refreshed (in seconds).<br>
 Hide markers for "AI only" groups.<br>
 `Default value: No`
 
-### 1.4 Check PBOs
+### 1.4 Captives settings
+*Part of: ace_captives*
+
+Controls the settings for cable ties and surrendering.
+Very useful if you don't want your players to be able to restrict each others.
+
+**Settings:**
+
+1. **Can handcuff own side (Boolean)**<br>
+Determine if you are able to handcuff your own side or not.<br>
+`Default value: Yes`
+
+2. **Allow surrendering (Boolean)**<br>
+Determine if you are able to surrender or not when your weapon is holstered.<br>
+`Default value: Yes`
+
+### 1.5 Check PBOs
 *Part of: ace_common*
 
 If you are worried that players haven't updated ACE3 or other mods to the version you're using on the server, you can place the "Check PBOs" module on your map. You can choose one of three posible actions that are being executed when a player joins that has a wrong version of ACE3 or an other mod:
@@ -107,7 +133,7 @@ Example 3: @JSRS + @Blastcore-A3:<br>
 ```
 
 
-### 1.5 Explosive System
+### 1.6 Explosive System
 *Part of: ace_explosive*
 
 The "Explosive System" module lets you tweak the settings for the new explosive system that ACE3 introduces.
@@ -117,18 +143,19 @@ The "Explosive System" module lets you tweak the settings for the new explosive 
 1. **Require specialists? (Boolean)**<br>
 Require explosive specialists to disable explosives.<br>
 `Default value: No`
+
 2. **Punish non-specialists? (Boolean)**<br>
 Increase the time it takes to complete actions for non-specialists.<br>
 `Default value: Yes`
 
 
-### 1.6 Friendly Fire Messages
+### 1.7 Friendly Fire Messages
 *Part of: ace_respawn*
 
 The "Friendly Fire Messages" module triggers a message when a player kills a friendly or civilian unit. This module isn't needed on servers with a low difficulty setting.
 
 
-### 1.7 Hearing
+### 1.8 Hearing
 *Part of: ace_hearing*
 
 Placing this modules allows you to disable combat deafness usually triggerd by loud explosions or heavy weapons in a players proximity.
@@ -140,7 +167,7 @@ Enable combat deafness?<br>
 `Default value: Yes`
 
 
-### 1.8 Interaction System
+### 1.9 Interaction System
 *Part of: ace_interaction*
 
 This module allows you to tweak if players should be able to use team management functions (e.g. "switch group", "become leader").
@@ -151,13 +178,13 @@ This module allows you to tweak if players should be able to use team management
 Should players be allowed to use the Team Management Menu?.<br>
 `Default value: Yes`
 
-### 1.9 Make Unit Surrender
+### 1.10 Make Unit Surrender
 *Part of: ace_captives*
 
 Syncing units to that module sets them in the captive state with their arms behind their back. Usefull for e.g. hostage rescue missions. 
 
 
-### 1.10 Map
+### 1.11 Map
 *Part of: ace_map*
 
 ACE3 introdcues a bit more realism for the vanilla Arma 3 map and how it behaves. Some of these settings can be toggled by this module. 
@@ -167,18 +194,21 @@ ACE3 introdcues a bit more realism for the vanilla Arma 3 map and how it behaves
 1. **Map illumination? (Boolean)**<br>
 Calculate dynamic map illumination based on light conditions?.<br>
 `Default value: Yes`
+
 2. **Map shake? (Boolean)**<br>
 Make map shake when walking?.<br>
 `Default value: Yes`
+
 3. **Limit map zoom? (Boolean)**<br>
 Limit the amount of zoom available for the map?.<br>
 `Default value: No`
+
 4. **Show cursor coordinates? (Boolean)**<br>
 Show the grid coordinates on the mouse pointer?.<br>
 `Default value: No`
 
 
-### 1.11 MicroDAGR Map Fill
+### 1.12 MicroDAGR Map Fill
 *Part of: ace_microdagr*
 
 Controls how much data is filled on the microDAGR items. Less data restricts the map view to show less on the minimap.
@@ -190,7 +220,7 @@ How much map data is filled on MicroDAGR's.<br>
 `Default value: "Full Satellite + Buildings"`
 
 
-### 1.12 MK6 Settings
+### 1.13 MK6 Settings
 *Part of: ace_mk6mortar*
 
 ACE3 now includes the first iteration of getting a less arcady point and click mortar experience. 
@@ -201,35 +231,44 @@ Placing this modules allows you to enable the increased realism in game.
 1. **Air Resistance (Boolean)**<br>
 For Player Shots, Model Air Resistance and Wind Effects.<br>
 `Default value: Yes`
+
 2. **Allow MK6 Computer (Boolean)**<br>
 Show the Computer and Rangefinder (these **NEED** to be removed if you enable air resistance).<br>
 `Default value: No`
+
 3. **Allow MK6 Compass (Boolean)**<br>
 Show the MK6 Digital Compass.<br>
 `Default value: Yes`
 
-### 1.13 Name Tags
+### 1.14 Name Tags
 *Part of: ace_nametags*
 
 This module allows you to tweak the settings for player names tags.
 
 **Settings:**
 
-1. **Player Names View Distance (Number)**<br>
+1. **Show player names (Option)**<br>
+Let you choose when nametags appears.<br>
+`Default value: "Do Not Force"`
+
+2. **Player Names View Distance (Number)**<br>
 Distance (in meters) at which player names are shown.<br>
 `Default value: 5`
-2. **Show name tags for AI? (Option)**<br>
+
+3. **Show name tags for AI? (Option)**<br>
 Show the name and rank tags for friendly AI units, or by default allows players to choose it on their own.<br>
 `Default value: "Do Not Force"`
-3. **Show crew info? (Option)**<br>
+
+4. **Show crew info? (Option)**<br>
 Show vehicle crew info, or by default allows players to choose it on their own.<br>
 `Default value: "Do Not Force"`
-4. **Show for Vehicles? (Boolean)**<br>
+
+5. **Show for Vehicles? (Boolean)**<br>
 Show cursor NameTag for vehicle commander (only if client has name tags enabled).<br>
 `Default value: No`
 
 
-### 1.14 Rallypoint System
+### 1.15 Rallypoint System
 *Part of: ace_respawn*
 
 This module enables Mission Makers to specificly enable units to move a rallypoint. Every unit that is synced with that module is able to move a rallypoint.
@@ -242,7 +281,7 @@ This module enables Mission Makers to specificly enable units to move a rallypoi
 To enable JIP players to move rally points have a look at [ACE3 Rallypoints](./mission-tools.html#1.-ace-rallypoints).
 
 
-### 1.15 Respawn System
+### 1.16 Respawn System
 *Part of: ace_respawn*
 
 The "Respawn System" module enables players to respawn with the gear they had before dying and to remove bodies of players after a configurable interval (in seconds).
@@ -254,7 +293,7 @@ Respawn with the gear a player had just before his death.<br>
 `Default value: No`
 
 
-### 1.16 SwitchUnits System
+### 1.17 SwitchUnits System
 *Part of: ace_switchunits*
 
 The [SwitchUnits System](./mission-tools.html#2.-ace-switchunits) enables players to control certain AI units on the map. 
@@ -264,33 +303,38 @@ The [SwitchUnits System](./mission-tools.html#2.-ace-switchunits) enables player
 1. **Switch To West? (Boolean)**<br>
 Allow switching to west units?<br>
 `Default value: No`
+
 2. **Switch To East? (Boolean)**<br>
 Allow switching to east units?<br>
 `Default value: No`
+
 3. **Switch To Independent? (Boolean)**<br>
 Allow switching to independent units?<br>
 `Default value: No`
+
 4. **Switch To Civilian? (Boolean)**<br>
 Allow switching to civilian units?<br>
 `Default value: No`
+
 5. **Enable Safe Zone? (Boolean)**<br>
 Enable a safe zone around enemy units? Players can't switch to units inside of the safe zone.<br>
 `Default value: Yes`
+
 6. **Safe Zone Radius (Number)**<br>
 The safe zone around players from a different team (in meters)<br>
 `Default value: 200`
 
 
-### 1.17 Vehicle Lock
+### 1.18 Vehicle Lock
 *Part of: ace_vehiclelock*
 
 These modules allow you to lock and unlock vehicles and their inventory using a key. Players don't receive a key automatically; for key names, see [Classnames Wiki](http://ace3mod.com/wiki/missionmaker/classnames.html#vehicle-lock).
 
-#### 1.17.1 Vehicle Key Assign
+#### 1.18.1 Vehicle Key Assign
 Sync with vehicles and players. Will handout custom keys to players for every synced vehicle. Only valid for objects present at mission start.  
 Example: `[bob, car1, true] call ACE_VehicleLock_fnc_addKeyForVehicle;` - will add a key to bob and program it to work only on car1
 
-#### 1.17.2.1 Vehicle Lock Setup
+#### 1.18.2.1 Vehicle Lock Setup
 Settings for lockpick strength and initial vehicle lock state. Removes ambiguous lock states.
 
 **Settings:**
@@ -298,19 +342,21 @@ Settings for lockpick strength and initial vehicle lock state. Removes ambiguous
 1. **Lock Vehicle Inventory? (Boolean)**<br>
 Locks the inventory of locked vehicles<br>
 `Default value: No`
+
 2. **Vehicle Starting Lock State (Option)**<br>
 Set lock state for all vehicles (removes ambiguous lock states)<br>
 `Default value: "As Is"`
+
 3. **Default Lockpick Strength (Number)**<br>
 Default Time to lockpick (in seconds)<br>
 `Default value: 10`
 
-#### 1.17.2.2 Vehicle setVariables
+#### 1.18.2.2 Vehicle setVariables
 * `ACE_VehicleLock_lockSide` - SIDE: overrides a vehicle's side, allowing locking and unlocking using a different side's key. For example: Unlocking INDEP vehicles with a BLUFOR key.
 * `ACE_vehicleLock_lockpickStrength` - NUMBER: seconds, determines how long lockpicking with take, overrides the value set in the module for a specific vehicle of the mission maker's choice.
 
 
-### 1.18 View Distance Limiter
+### 1.19 View Distance Limiter
 *Part of: ace_viewdistance*
 
 This module allows disabling the ACE3 View Distance feature as well as setting a view distance limit.
@@ -320,12 +366,13 @@ This module allows disabling the ACE3 View Distance feature as well as setting a
 1. **Enable ACE viewdistance (Boolean)**<br>
 Enables ACE viewdistance<br>
 `Default value: Yes`
+
 2. **View Distance Limit (Number)**<br>
 Sets the limit for how high clients can raise their view distance (<= 10000)
 `Default value: 10000`
 
 
-### 1.19 Weather
+### 1.20 Weather
 *Part of: ace_weather*
 
 This module allows you to customize the weather settings.
@@ -344,6 +391,7 @@ Enables sever side weather propagation.<br>
     <h5>Note:</h5>
     <p>This is responsible for synchronizing weather between all clients. Disabling it is <b>not</b> recommended.</p>
 </div>
+
 2. **ACE3 Weather (Boolean)**<br>
 Overrides the default weather with ACE3 weather (map based).<br>
 `Default value: Yes`
@@ -351,21 +399,25 @@ Overrides the default weather with ACE3 weather (map based).<br>
     <h5>Note:</h5>
     <p>This can be disabled without affecting the weather propagation above. Useful if you prefer changing weather settings manually.</p>
 </div>
+
 3. **Sync Rain (Boolean)**<br>
 Synchronizes rain.<br>
 `Default value: Yes`
-3. **Sync Wind (Boolean)**<br>
+
+4. **Sync Wind (Boolean)**<br>
 Synchronizes wind.<br>
 `Default value: Yes`
-3. **Sync Misc (Boolean)**<br>
+
+5. **Sync Misc (Boolean)**<br>
 Synchronizes lightnings, rainbow, fog, ...<br>
 `Default value: Yes`
-4. **Update Interval (Number)**<br>
+
+6. **Update Interval (Number)**<br>
 Defines the interval (seconds) between weather updates.<br>
 `Default value: 60`
     
 
-### 1.20 Wind Deflection
+### 1.21 Wind Deflection
 *Part of: ace_winddeflection*
 
 This module allows you to define when wind deflection is active.
@@ -385,25 +437,53 @@ This module allows you to define when wind deflection is active.
 1. **Wind Deflection (Boolean)**<br>
 Enables wind deflection.<br>
 `Default value: Yes`
+
 2. **Vehicle Enabled (Boolean)**<br>
 Enables wind deflection for static/vehicle gunners.<br>
 `Default value: Yes`
+
 3. **Simulation Interval (Number)**<br>
 Defines the interval between every calculation step.<br>
 `Default value: 0.05`
+
 4. **Simulation Radius (Number)**<br>
 Defines the radius around the player (in meters) at which projectiles are wind deflected.<br>
 `Default value: 3000`
 
+### 1.22 Zeus Settings
+*part of: ace_zeus*
 
-### 1.21 LSD Vehicles
+This module provides control over vanilla aspects of Zeus.
+
+**Settings:**
+
+1. **Ascension Messages (Option)**<br>
+Display global popup messages when a player is assigned as Zeus<br>
+`Default value: No`
+
+2. **Zeus Eagle (Boolean)**<br>
+Spawn an eagle that follows the Zeus camera<br>
+`Default value: No`
+
+3. **Wind Sounds (Boolean)**<br>
+Play wind sounds when Zeus remote controls a unit<br>
+`Default value: No`
+
+4. **Ordnance Warning (Boolean)**<br>
+Play a radio warning when Zeus uses ordnance<br>
+`Default value: No`
+
+5. **Reveal Mines (Scalar)**<br>
+Reveal mines to allies and/or place map markers<br>
+`Default value: Disabled`
+
+### 1.23 LSD Vehicles
 *Part of: ace_core*
 
 And then there's the "LSD Vehicles" module &hellip; it does 'something' to all vehicles synced to that module.
 <div class="videoWrapper">
     <iframe src="https://www.youtube.com/embed/X3e0LTexEok" frameborder="0" allowfullscreen></iframe>
 </div>
-
 
 ## 2. ACE3 Medical
 *Part of: ace_medical*
@@ -417,37 +497,52 @@ This module allows to tweak all the medical settings used in ACE3
 1. **Medical Level (Option)**<br>
 What is the medical simulation level?<br>
 `Default value: "Basic"`
+
 2. **Medics setting (Option)**<br>
 What is the level of detail preferred for medics?<br>
 `Default value: "Normal"`
+
 3. **Enable Litter (Boolean)**<br>
 Enable litter being created upon treatment.<br>
-`Default value: "Normal"`
+`Default value: "Yes"`
+
 4. **Life time of litter objects (Number)**<br>
 How long should litter objects stay? In seconds. -1 is forever.<br>
 `Default value: 1800`
+
 5. **Enable Screams (Boolean)**<br>
 Enable screaming by injured units.<br>
 `Default value: Yes`
+
 6. **Player Damage (Number)**<br>
 What is the damage a player can take before being killed?<br>
 `Default value: 1`
+
 7. **AI Damage (Number)**<br>
 What is the damage an AI can take before being killed?<br>
 `Default value: 1`
+
 8. **AI Unconsciousness (Option)**<br>
 Allow AI to go unconscious.<br>
 `Default value: "50/50"`
-9. **Prevent instant death (Boolean)**<br>
+
+9. **Remote controlled AI (Boolean)**<br>
+Treats remote controlled units as AI not players ?
+`Default value: Yes`
+
+10. **Prevent instant death (Boolean)**<br>
 Have a unit move to unconscious instead of death.<br>
 `Default value: No`
-10. **Bleeding coefficient (Number)**<br>
+
+11. **Bleeding coefficient (Number)**<br>
 Coefficient to modify the bleeding speed.<br>
 `Default value: 1`
-11. **Pain coefficient (Number)**<br>
+
+12. **Pain coefficient (Number)**<br>
 Coefficient to modify the pain intensity.<br>
 `Default value: 1`
-12. **Pain coefficient (Boolean)**<br>
+
+13. **Sync status (Boolean)**<br>
 Keep unit status synced. Recommended on.<br>
 `Default value: Yes`
 
@@ -461,31 +556,46 @@ This module allows you to change the default Advanced Medical Settings, when [2.
 1. **Enabled for (Option)**<br>
 Select what units the advanced medical system will be enabled for.<br>
 `Default value: "Players only"`
+
 2. **Enable Advanced wounds (Boolean)**<br>
 Allow reopening of bandaged wounds?<br>
 `Default value: No`
+
 3. **Vehicle Crashes (Boolean)**<br>
 Do units take damage from a vehicle crash?<br>
 `Default value: Yes`
+
 4. **Allow PAK (Option)**<br>
 Who can use the PAK for full heal?<br>
 `Default value: "Medics only"`
+
 5. **Remove PAK on use (Boolean)**<br>
 Should PAK be removed on usage?<br>
 `Default value: Yes`
+
 6. **Locations PAK (Option)**<br>
 Where can the personal aid kit be used?<br>
 `Default value: "Vehicles & facility"`
+
 7. **Allow Surgical kit (Option)**<br>
 Who can use the surgical kit?<br>
 `Default value: "Medics only"`
+
 8. **Remove Surgical kit (Boolean)**<br>
 Should Surgical kit be removed on usage?<br>
 `Default value: Yes`
+
 9. **Locations Surgical kit (Option)**<br>
 Where can the Surgical kit be used?<br>
 `Default value: "Vehicles & facility"`
 
+10. **Bloodstains (Boolean)**<br>
+Bandaging removes bloodstains.
+`Default value: No`
+
+11. **Pain supression (Boolean)**<br>
+Pain is only temporarly supressed not removed.
+`Default value: Yes`
 
 ### 2.3 Revive Settings
 
@@ -496,9 +606,11 @@ This modules allows a mission maker to limit the amount of revives for units in 
 1. **Enable Revive (Option)**<br>
 Enable a basic revive system<br>
 `Default value: "disable"`
+
 2. **Max Revive time (Number)**<br>
 Max amount of seconds a unit can spend in revive state<br>
 `Default value: 120`
+
 3. **Max Revive lives (Number)**<br>
 Max amount of lives a unit. 0 or -1 is disabled.<br>
 `Default value: -1`
@@ -513,6 +625,7 @@ Using this module you can define which unit class is defined as a medic / doctor
 1. **List (String)**<br>
 List of unit names that will be classified as medic, separated by commas.<br>
 `Default value: ""`
+
 2. **Is Medic (Boolean)**<br>
 Medics allow for more advanced treatment in case of Advanced Medic roles enabled<br>
 `Default value: "Regular medic"`
@@ -538,6 +651,7 @@ Defines an object as a medical facility. This allows for more advanced treatment
 1. **List (String)**<br>
 List of vehicles that will be classified as medical vehicle, separated by commas.<br>
 `Default value: ""`
+
 2. **Is Medical Vehicle (Boolean)**<br>
 Whether or not the objects in the list will be a medical vehicle.<br>
 `Default value: Yes`
@@ -559,46 +673,27 @@ This module randomizes the time when the sound file is played and the position w
 1. **Sounds (String)**<br>
 Class names of the ambiance sounds played. Separated by ','. (Example: `radio_track_01, electricity_loop`).<br>
 `Default value: ""`
+
 2. **Minimal Distance (Number)**<br>
 Used for calculating a random position and sets the minimal distance between the players and the played sound file(s) (in meters)<br>
 `Default value: 400`
+
 3. **Maximum Distance (Number)**<br>
 Used for calculating a random position and sets the maximum distance between the players and the played sound file(s) (in meters)<br>
 `Default value: 900`
+
 4. **Minimal Delay (Number)**<br>
 Minimal delay (in seconds) between sounds played<br>
 `Default value: 10`
+
 5. **Maximum Delay (Number)**<br>
 Maximum delay (in seconds) between sounds played<br>
 `Default value: 10`
+
 6. **Follow Players (Boolean)**<br>
 Follow players. If set to false, loop will play sounds only nearby logic position.<br>
 `Default value: No`
+
 7. **Volume (Number)**<br>
 The volume of the sounds played<br>
 `Default value: 1`
-
-
-## 4. ACE3 Zeus
-*Part of: ace_zeus*
-
-### 4.1 Zeus Settings
-This module provides control over vanilla aspects of Zeus.
-
-**Settings:**
-
-1. **Ascension Messages (Option)**<br>
-Display global popup messages when a player is assigned as Zeus<br>
-`Default value: No`
-2. **Zeus Eagle (Boolean)**<br>
-Spawn an eagle that follows the Zeus camera<br>
-`Default value: No`
-3. **Wind Sounds (Boolean)**<br>
-Play wind sounds when Zeus remote controls a unit<br>
-`Default value: No`
-4. **Ordnance Warning (Boolean)**<br>
-Play a radio warning when Zeus uses ordnance<br>
-`Default value: No`
-5. **Reveal Mines (Scalar)**<br>
-Reveal mines to allies and/or place map markers<br>
-`Default value: Disabled`


### PR DESCRIPTION
- Updated missionmaker -> modules
- Updated missionmaker -> classnames

- Changed ```<kbd>Left windows</kbd>``` to ```<kbd>⊞ Win</kbd>```
- Added concertina wire documentation (done)
- Added Dagr documentation (placeholder)
- Added Fonts documentation (doner)
- Added HuntrIR documentation (done)
- Added M2-XA documentation (done)
- Added sandbag documentation (done)
- Added spotting scope documentation (done)
- Added tactical ladder documentation (done)
- Added Yardage 450 documentation (done)
- Added Tripod documentation (done)