### PR TITLE
Update fnc_addEarPlugs.sqf

### DIFF
--- a/addons/hearing/functions/fnc_addEarPlugs.sqf
+++ b/addons/hearing/functions/fnc_addEarPlugs.sqf
@@ -15,6 +15,8 @@
  */
 #include "script_component.hpp"
 
+if (!GVAR(enableCombatDeafness)) exitWith {};
+
 private ["_unit", "_launcher"];
 
 _unit = _this select 0;


### PR DESCRIPTION
Do not automatically add earplugs to units if combat deafness is disabled.