### PR TITLE
Allow moving map while shake effect active

### DIFF
--- a/addons/map/XEH_postInitClient.sqf
+++ b/addons/map/XEH_postInitClient.sqf
@@ -18,7 +18,30 @@ call FUNC(determineZoom);
     GVAR(lastStillTime) = ACE_time;
     GVAR(isShaking) = false;
 
+    //Allow panning the lastStillPosition while mapShake is active
+    GVAR(rightMouseButtonLastPos) = [];
     ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["Draw", {[] call FUNC(updateMapEffects);}];
+    ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseMoving", {
+        if (GVAR(isShaking) && {(count GVAR(rightMouseButtonLastPos)) == 2}) then {
+            private["_lastPos", "_newPos"];
+            _lastPos = (_this select 0) ctrlMapScreenToWorld GVAR(rightMouseButtonLastPos);
+            _newPos = (_this select 0) ctrlMapScreenToWorld (_this select [1,2]);
+            GVAR(lastStillPosition) set [0, (GVAR(lastStillPosition) select 0) + (_lastPos select 0) - (_newPos select 0)];
+            GVAR(lastStillPosition) set [1, (GVAR(lastStillPosition) select 1) + (_lastPos select 1) - (_newPos select 1)];
+            GVAR(rightMouseButtonLastPos) = _this select [1,2];
+            TRACE_3("Mouse Move",_lastPos,_newPos,GVAR(rightMouseButtonLastPos));
+        };
+    }];
+    ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseButtonDown", {
+        if ((_this select 1) == 1) then {
+            GVAR(rightMouseButtonLastPos) = _this select [2,2];
+        };
+    }];
+    ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseButtonUp", {
+        if ((_this select 1) == 1) then {
+            GVAR(rightMouseButtonLastPos) = [];
+        };
+    }];
 };
 
 ["SettingsInitialized", {


### PR DESCRIPTION
#1736 (Map can't be scrolled through or zoomed while player is moving)

Allow panning the lastStillPosition while mapShake is active.
Map doesn't stop shaking, just changes the "origin" that it shakes around.

I would be fine moving this to an option (like 3 settings for shake (off, on /w panning, and current-mode).