### PR TITLE
Correcting RHS class inheritence from my previous PR

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_afrf3/CfgMagazines.hpp
@@ -8,7 +8,7 @@ class cfgMagazines {
     class rhs_mag_127x108mm_50: VehicleMagazine {
         ace_isbelt = 1;
     };
-    class rhs_mag_127x108mm_150: rhs_mag_127x108mm_50 {        
+    class rhs_mag_127x108mm_150: rhs_mag_127x108mm_50 {
         ace_isbelt = 0;
     };
     class rhs_mag_127x108mm_1470 : rhs_mag_127x108mm_50 {

--- a/optionals/compat_rhs_afrf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_afrf3/CfgMagazines.hpp
@@ -5,13 +5,13 @@ class cfgMagazines {
     class rhs_100Rnd_762x54mmR: rhs_30Rnd_545x39_AK {
         ace_isbelt = 1;
     };
-    class rhs_100Rnd_762x54mmR_green: rhs_100Rnd_762x54mmR {
+    class rhs_mag_127x108mm_50: VehicleMagazine {
         ace_isbelt = 1;
     };
-    class rhs_mag_127x108mm_50 : VehicleMagazine {
-        ace_isbelt = 1;
+    class rhs_mag_127x108mm_150: rhs_mag_127x108mm_50 {        
+        ace_isbelt = 0;
     };
-    class rhs_mag_127x108mm_150 : rhs_mag_127x108mm_50 {        
+    class rhs_mag_127x108mm_1470 : rhs_mag_127x108mm_50 {
         ace_isbelt = 0;
     };
 };

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -10,16 +10,7 @@ class cfgMagazines {
     class rhsusf_100Rnd_556x45_M200_soft_pouch: rhs_mag_30Rnd_556x45_M200_Stanag {
         ace_isbelt = 1;
     };
-    class rhsusf_200Rnd_556x45_soft_pouch: rhsusf_100Rnd_556x45_soft_pouch {
-        ace_isbelt = 1;
-    };
-    class rhsusf_100Rnd_762x51: CA_Magazine {
-        ace_isbelt = 1;
-    };
-    class rhsusf_100Rnd_762x51_m80a1epr: rhsusf_100Rnd_762x51 {
-        ace_isbelt = 1;
-    };
-    class rhsusf_100Rnd_762x51_m993: rhsusf_100Rnd_762x51 {
+    class rhsusf_50Rnd_762x51: CA_Magazine {
         ace_isbelt = 1;
     };
     class rhs_mag_100rnd_127x99_mag: VehicleMagazine {


### PR DESCRIPTION
I had submitted pull request #1745 .. I noticed a mistake in what I had submitted.

The magazine class name for the 100rnd 7.62 boxes was inheriting as it was in RHS USF 0.3.7, not as it currently is in 0.3.8. Additionally I'm cleaning up some classes that probably didn't need to be individually defined 