### PR TITLE
Rally point object names

### DIFF
--- a/addons/respawn/CfgAddons.hpp
+++ b/addons/respawn/CfgAddons.hpp
@@ -1,5 +1,5 @@
 class CfgAddons {
     class GVAR(Rallypoints) {
-        list[] = { "ACE_Rallypoint_West", "ACE_Rallypoint_East", "ACE_Rallypoint_Independent", "ACE_RallypointExit_West", "ACE_RallypointExit_East", "ACE_RallypointExit_Independent" };
+        list[] = {"ACE_Rallypoint_West", "ACE_Rallypoint_East", "ACE_Rallypoint_Independent", "ACE_Rallypoint_West_Base", "ACE_Rallypoint_East_Base", "ACE_Rallypoint_Independent_Base"};
     };
 };

--- a/addons/respawn/config.cpp
+++ b/addons/respawn/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
     class ADDON {
         units[] = {};
-        weapons[] = { "ACE_Rallypoint_West", "ACE_Rallypoint_East", "ACE_Rallypoint_Independent", "ACE_RallypointExit_West", "ACE_RallypointExit_East", "ACE_RallypointExit_Independent" };
+        weapons[] = {"ACE_Rallypoint_West", "ACE_Rallypoint_East", "ACE_Rallypoint_Independent", "ACE_Rallypoint_West_Base", "ACE_Rallypoint_East_Base", "ACE_Rallypoint_Independent_Base"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "ace_common" };
         author[] = { "bux578", "commy2" };

--- a/addons/respawn/functions/fnc_moveRallypoint.sqf
+++ b/addons/respawn/functions/fnc_moveRallypoint.sqf
@@ -26,9 +26,11 @@ private ["_rallypoint", "_position"];
 _rallypoint = [
   objNull,
   missionNamespace getVariable ["ACE_Rallypoint_West", objNull],
-  missionNamespace getVariable ["ACE_RallypointExit_East", objNull],
-  missionNamespace getVariable ["ACE_RallypointExit_Independent", objNull]
+  missionNamespace getVariable ["ACE_Rallypoint_East", objNull],
+  missionNamespace getVariable ["ACE_Rallypoint_Independent", objNull]
 ] select ([west, east, independent] find _side) + 1;
+
+TRACE_3("moving rally",_unit, _rallypoint, (typeOf _rallypoint));
 
 if (isNull _rallypoint) exitWith {};
 


### PR DESCRIPTION
#1699 (partial fix)

Looks like at some point 
`ACE_RallypointExit_East` became `ACE_Rallypoint_East`
but wasn't switched everywhere