### PR TITLE
Ace_modules - Pass synced objects to functions

### DIFF
--- a/addons/modules/XEH_postInit.sqf
+++ b/addons/modules/XEH_postInit.sqf
@@ -26,12 +26,8 @@
                 _function = missionNamespace getvariable _function;
             };
 
-            if (_isGlobal) then {
-                [_logic, [], true] call _function;
-            } else {
-                if (isServer) then {
-                    [_logic, [], true] call _function;
-                };
+            if (_isGlobal || isServer) then {
+                [_logic, (synchronizedObjects _logic), true] call _function;
             };
 
             if !(_isPersistent) then {


### PR DESCRIPTION
We switched some modules to the ace_module framework that count on syncronized objects.

Fixes LSD Vehicles (Critical Bug!!!), Rallypoint (#1699) and vehLock.

This still has the huge limitation that normal BIS framework has, in that JIP unit's still won't be synchronized, only objects present at mission start.