### PR TITLE
Headgear influence on hearing

### DIFF
--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -12,4 +12,39 @@ class CfgWeapons {
             mass = 1;
         };
     };
+
+    class H_HelmetB;
+    class H_HelmetCrew_B: H_HelmetB {
+        GVAR(protection) = 1;
+        GVAR(lowerVolume) = 0.80;
+    };
+    class H_HelmetCrew_0: H_HelmetCrew_B {};
+    class H_HelmetCrew_I: H_HelmetCrew_B {};
+
+    class H_CrewHelmetHeli_B: H_HelmetB {
+        GVAR(protection) = 0.75;
+        GVAR(lowerVolume) = 0.70;
+    };
+    class H_CrewHelmetHeli_O: H_CrewHelmetHeli_B {};
+    class H_CrewHelmetHeli_I: H_CrewHelmetHeli_B {};
+
+    class H_PilotHelmetHeli_B: H_HelmetB {
+        GVAR(protection) = 0.75;
+        GVAR(lowerVolume) = 0.70;
+    };
+    class H_PilotHelmetHeli_O: H_PilotHelmetHeli_B {};
+    class H_PilotHelmetHeli_I: H_PilotHelmetHeli_B {};
+
+    class H_PilotHelmetFighter_B: H_HelmetB {
+        GVAR(protection) = 1;
+        GVAR(lowerVolume) = 0.80;
+    };
+    class H_PilotHelmetFighter_O: H_PilotHelmetFighter_B {};
+    class H_PilotHelmetFighter_I: H_PilotHelmetFighter_B {};
+
+    class H_Cap_headphones: H_HelmetB {
+        GVAR(protection) = 0.5;
+        GVAR(lowerVolume) = 0.60;
+    };
+    class H_Cap_marshal: H_Cap_headphones {};
 };

--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {"ACE_EarPlugs"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interaction"};
+        requiredAddons[] = {"ace_interaction", "A3_Characters_F", "A3_Characters_F_Kart"};
         author[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2", "Rocko", "Rommel", "Ruthberg"};
         authorUrl = "https://github.com/KoffeinFlummi/";
         VERSION_CONFIG;

--- a/addons/hearing/functions/fnc_earRinging.sqf
+++ b/addons/hearing/functions/fnc_earRinging.sqf
@@ -27,6 +27,15 @@ if (_unit getVariable ["ACE_hasEarPlugsin", false]) then {
     _strength = _strength / 4;
 };
 
+//headgear hearing protection
+if(headgear _unit != "") then {
+    private ["_protection"];
+    _protection = (getNumber (configFile >> "CfgWeapons" >> (headgear _unit) >> QGVAR(protection))) min 1;
+    if(_protection > 0) then {
+        _strength = _strength * (1 - _protection);
+    };
+};
+
 _unit setVariable [QGVAR(dv), (_unit getVariable [QGVAR(dv), 0]) + _strength];
 
 if (GVAR(earRingingPFH) != -1) exitWith {};
@@ -35,7 +44,7 @@ GVAR(earRingingPFH) = [{
     EXPLODE_1_PVT(_this select 0,_unit);
     private ["_prior"];
     _prior = (_unit getvariable [QGVAR(dv), 0]) min 20;
-    
+
     if (!alive _unit || _prior <= 0) exitWith {
         _unit setVariable [QGVAR(dv), 0];
         _unit setVariable [QGVAR(prior), 0];
@@ -47,7 +56,7 @@ GVAR(earRingingPFH) = [{
         GVAR(earRingingPFH) = -1;
         [_this select 1] call cba_fnc_removePerFrameHandler;
     };
-    
+
     if (((_unit getvariable [QGVAR(dv), 0]) - (_unit getvariable [QGVAR(prior), 0])) > 2) then {
         if (ACE_time > GVAR(time3)) then {
             GVAR(beep2) = false;
@@ -58,16 +67,16 @@ GVAR(earRingingPFH) = [{
             GVAR(time3) = ACE_time + 5;
         };
     };
-    
+
     _unit setvariable [QGVAR(prior), _prior];
     GVAR(volume) = (1 -  (_prior / 20)) max 0;
-        
+
     if (_prior > 19.75) then {
         _unit setvariable [QGVAR(deaf), true];
     } else {
         _unit setvariable [QGVAR(deaf), false];
     };
-    
+
     if ((_unit getvariable [QGVAR(deaf), false]) && {ACE_time > GVAR(time4)}) then {
         playSound "ACE_Combat_Deafness";
         GVAR(beep2) = true;
@@ -77,7 +86,7 @@ GVAR(earRingingPFH) = [{
 
     // Hearing takes longer to return to normal after it hits rock bottom
     _unit setvariable [QGVAR(dv), _prior - (0.5 * (GVAR(volume) max 0.1))];
-        
+
     if (_prior > 10) then {
         //check if the ringing is already being played
         if (ACE_time > GVAR(time2)) then {

--- a/addons/hearing/functions/fnc_updateVolume.sqf
+++ b/addons/hearing/functions/fnc_updateVolume.sqf
@@ -46,6 +46,15 @@ if ([ACE_player] call FUNC(hasEarPlugsIn)) then {
     _volume = _volume min GVAR(EarplugsVolume);
 };
 
+// Headgear can reduce hearing
+if(headgear ACE_player != "") then {
+    private ["_lowerVolume"];
+    _lowerVolume = (getNumber (configFile >> "CfgWeapons" >> (headgear ACE_player) >> QGVAR(lowerVolume))) min 1;
+    if(_lowerVolume > 0) then {
+        _volume = _volume min (1 - _lowerVolume);
+    };
+};
+
 // Reduce volume if player is unconscious
 if (ACE_player getVariable ["ACE_isUnconscious", false]) then {
     _volume = _volume min GVAR(UnconsciousnessVolume);

--- a/documentation/development/ace3-config-entries.md
+++ b/documentation/development/ace3-config-entries.md
@@ -63,6 +63,8 @@ ace_barrelLength
 ace_laserpointer
 ace_nextmodeclass
 ace_modedescription
+ace_hearing_protection
+ace_hearing_lowerVolume
 ```
 
 

--- a/documentation/feature/hearing.md
+++ b/documentation/feature/hearing.md
@@ -11,9 +11,12 @@ parent: wiki
 ### 1.1 Hearing damage simulation
 Introduces hearing damage caused by nearby explosions and large-caliber weapons.
 
-### 1.2  Earplugs
+### 1.2 Earplugs
 Adds earplugs to mitigate that effect. Soldiers with high caliber weapons or 
 missile launchers will be equipped with those, but remember to put them in.
+
+### 1.3 Helmets
+Some types of helmets can mitigate hearing damage also (ie. crewman helmet, pilot helmet etc.).
 
 ## 2. Usage
 


### PR DESCRIPTION
Headgear can lower player volume and mitigate hearing damage.
Config vars:
protection: % of hearing protection, 1 = 100% protection (no hearing damage)
lowerVolume: % of volume to lower, 0.8 = 80% lowered (player volume will be 20% of normal volume)