### PR TITLE
Missle Guidance / Javelin Fixes

### DIFF
--- a/addons/javelin/XEH_pre_init.sqf
+++ b/addons/javelin/XEH_pre_init.sqf
@@ -9,5 +9,6 @@ PREP(showFireMode);
 PREP(onFired);
 PREP(onOpticLoad);
 PREP(onOpticDraw);
+PREP(onOpticUnload);
 
 GVAR(isLockKeyDown) = false;

--- a/addons/javelin/XEH_pre_init.sqf
+++ b/addons/javelin/XEH_pre_init.sqf
@@ -12,3 +12,4 @@ PREP(onOpticDraw);
 PREP(onOpticUnload);
 
 GVAR(isLockKeyDown) = false;
+GVAR(pfehID) = -1;

--- a/addons/javelin/functions/fnc_onFired.sqf
+++ b/addons/javelin/functions/fnc_onFired.sqf
@@ -1,21 +1,17 @@
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-PARAMS_7(_shooter,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile);
+PARAMS_2(_shooter,_weapon);
 
-// Bail on not missile
-if( _shooter != ACE_player) exitWith { false }; 
+// Bail on not missile or javelin PFEH not running
+if ((_shooter != ACE_player) || {(GVAR(pfehID) == -1)}) exitWith { false };
+
+private ["_configs"];
 
 _configs = configProperties [configFile >> "CfgWeapons" >> _weapon, QUOTE(configName _x == QUOTE(QGVAR(enabled))), false];
 if (((count _configs) < 1) || {(getNumber (_configs select 0)) != 1}) exitWith {};
 
-_pfh_handle = uiNamespace getVariable ["ACE_RscOptics_javelin_PFH", nil];
-if(!isNil "_pfh_handle") then {
-    //[_pfh_handle] call cba_fnc_removePerFrameHandler;
-    //uiNamespace setVariable["ACE_RscOptics_javelin_PFH", nil];
-    
-    __JavelinIGUITargeting ctrlShow false;
-    __JavelinIGUITargetingGate ctrlShow false;
-    __JavelinIGUITargetingLines ctrlShow false;
-    __JavelinIGUITargetingConstraints ctrlShow false;
-};
+__JavelinIGUITargeting ctrlShow false;
+__JavelinIGUITargetingGate ctrlShow false;
+__JavelinIGUITargetingLines ctrlShow false;
+__JavelinIGUITargetingConstraints ctrlShow false;

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -56,7 +56,7 @@ if (((count _weaponConfig) < 1) || {(getNumber (_weaponConfig select 0)) != 1}) 
     };
 
     [(_this select 1)] call cba_fnc_removePerFrameHandler;
-    uiNamespace setVariable["ACE_RscOptics_javelin_PFH", nil];
+    GVAR(pfehID) = -1;
 };
 
 // Find a target within the optic range

--- a/addons/javelin/functions/fnc_onOpticLoad.sqf
+++ b/addons/javelin/functions/fnc_onOpticLoad.sqf
@@ -18,6 +18,10 @@ __JavelinIGUITargetingConstrains ctrlShow false;
 __JavelinIGUITargetingGate ctrlShow false;
 __JavelinIGUITargetingLines ctrlShow false;
 
+if(GVAR(pfehID) != -1) then {
+    [] call FUNC(onOpticUnload); // Unload optic if it was already loaded
+};
+
 uiNameSpace setVariable [QGVAR(arguments), 
     [
         ACE_diagTime,         // Last runtime
@@ -30,11 +34,4 @@ uiNameSpace setVariable [QGVAR(arguments),
     ]
 ];
 
-
-
-_pfh_handle = uiNamespace getVariable ["ACE_RscOptics_javelin_PFH", nil];
-if(!isNil "_pfh_handle") then {
-    [] call FUNC(onOpticUnload); // Unload optic if it was already loaded
-};
-_pfh_handle = [FUNC(onOpticDraw), 0, []] call CBA_fnc_addPerFrameHandler;
-uiNamespace setVariable["ACE_RscOptics_javelin_PFH", _pfh_handle];
+GVAR(pfehID) = [FUNC(onOpticDraw), 0, []] call CBA_fnc_addPerFrameHandler;

--- a/addons/javelin/functions/fnc_onOpticUnload.sqf
+++ b/addons/javelin/functions/fnc_onOpticUnload.sqf
@@ -1,14 +1,13 @@
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 TRACE_1("enter", _this);
-private["_args", "_disableFireEH", "_pfh"];
+private["_args", "_disableFireEH"];
 
-uiNameSpace setVariable ['ACE_RscOptics_javelin',nil];
+// uiNameSpace setVariable ['ACE_RscOptics_javelin',nil];
 
-_pfh = uiNamespace getVariable["ACE_RscOptics_javelin_PFH", nil ];
-if(!isNil "_pfh") then {
-    [_pfh] call CBA_fnc_removePerFrameHandler;
-    uiNameSpace setVariable ['ACE_RscOptics_javelin_PFH',nil];
+if(GVAR(pfehID) != -1) then {
+    [GVAR(pfehID)] call CBA_fnc_removePerFrameHandler;
+    GVAR(pfehID) = -1;
 };
 
 _args = uiNamespace getVariable[QGVAR(arguments), nil ];

--- a/addons/missileguidance/functions/fnc_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_onFired.sqf
@@ -1,19 +1,20 @@
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
+PARAMS_7(_shooter,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile);
+
 // Bail if guidance is disabled
 // Bail on locality of the projectile, it should be local to us
 if(GVAR(enabled) < 1 || {!local _projectile} ) exitWith { false };
 
+//Bail if shooter isn't player AND system not enabled for AI:
 if( !isPlayer _shooter && { GVAR(enabled) < 2 } ) exitWith { false };
-
-private["_config", "_configs", "_enabled", "_target", "_seekerType", "_attackProfile"];
-private["_args", "_canUseLock", "_guidingUnit", "_launchPos", "_lockMode", "_targetPos", "_vanillaTarget"];
-
-PARAMS_7(_shooter,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile);
 
 // Bail on not missile
 if(! (_ammo isKindOf "MissileBase") ) exitWith { false }; 
+
+private["_config", "_configs", "_enabled", "_target", "_seekerType", "_attackProfile"];
+private["_args", "_canUseLock", "_guidingUnit", "_launchPos", "_lockMode", "_targetPos", "_vanillaTarget"];
 
 //Verify ammo has explicity added guidance config (ignore inheritances)
 _configs = configProperties [(configFile >> "CfgAmmo" >> _ammo), QUOTE(configName _x == QUOTE(QUOTE(ADDON))), false];


### PR DESCRIPTION
Javelin - Fixed onOpticUnload, and switched from suing uiNameSpace to store the PFEH.  It was persistent through mission restart and could do some weird things.

Missile Guidance - Moved `PARAMS_7` above were variables are used.
