### PR TITLE
HuntIR - Handle Dead Projectile

### DIFF
--- a/addons/huntir/functions/fnc_handleFired.sqf
+++ b/addons/huntir/functions/fnc_handleFired.sqf
@@ -25,6 +25,12 @@ if (_ammo != "F_HuntIR") exitWith {};
 
 [{
     PARAMS_1(_projectile);
+ 
+    //If null (deleted or hit water) exit:
+    if (isNull _projectile) exitWith {};
+    //If it's not spinning (hit ground), bail:
+    if ((vectorMagnitude (velocity _projectile)) < 0.1) exitWith {};
+
     "ACE_HuntIR_Propell" createVehicle (getPosATL _projectile);
     [{
         PARAMS_1(_position);

--- a/addons/huntir/script_component.hpp
+++ b/addons/huntir/script_component.hpp
@@ -1,6 +1,8 @@
 #define COMPONENT huntir
 #include "\z\ace\addons\main\script_mod.hpp"
 
+// #define DEBUG_MODE_FULL
+
 #ifdef DEBUG_ENABLED_HUNTIR
     #define DEBUG_MODE_FULL
 #endif


### PR DESCRIPTION
Fix #1843

5 seconds after firing the HuntIR, a secondary explosions launches the camera 50 meters up.
This prevents that from happening if the shell is null or dead on the ground.