### PR TITLE
Show Options on Intro/Outro in Missions

### DIFF
--- a/addons/optionsmenu/gui/pauseMenu.hpp
+++ b/addons/optionsmenu/gui/pauseMenu.hpp
@@ -95,6 +95,11 @@ class RscDisplayInterruptEditor3D: RscStandardDisplay {
         class ACE_Open_settingsMenu_Btn : ACE_Open_SettingsMenu_BtnBase {};
     };
 };
+class RscDisplayMovieInterrupt: RscStandardDisplay {
+    class controls {
+        class ACE_Open_settingsMenu_Btn : ACE_Open_SettingsMenu_BtnBase {};
+    };
+};
 class RscDisplayMain: RscStandardDisplay {
     //Hide the button if there is no world (-world=empty)
     //Seems odd to use onMouseMoving, but I don't want to overload onLoad


### PR DESCRIPTION
Fix #1812

I don't know much about how intro/outro works, 
but this seems to add the options menu button to them and nothing caught on fire.