### PR TITLE
Fix Kestrel Y position on large interface

### DIFF
--- a/addons/kestrel4500/RscTitles.hpp
+++ b/addons/kestrel4500/RscTitles.hpp
@@ -56,6 +56,7 @@ class Kestrel4500_Display {
     controlsBackground[]={};
     objects[]={};
     class controls {
+        #define DIALOG_SAFE_Y(num) QUOTE((safeZoneY + num) min (safeZoneY + safeZoneH - 1.024*4/3 + num))
         class BACKGROUND {
             moving=1;
             type=0;
@@ -64,7 +65,7 @@ class Kestrel4500_Display {
             idc=74000;
             style=48;
             x=safezoneX;
-            y=safezoneY;
+            y = DIALOG_SAFE_Y(0);
             w=1.024;
             h=1.024*4/3;
             colorBackground[]={1,1,1,1};
@@ -74,7 +75,7 @@ class Kestrel4500_Display {
         class POWER: Kestrel4500_RscButton {
             idc=-1;
             x=safezoneX+0.385;
-            y=safezoneY+1.125;
+            y = DIALOG_SAFE_Y(1.125);
             w=0.042;
             h=0.042*4/3;
             action=QUOTE(7 call FUNC(buttonPressed));
@@ -83,7 +84,7 @@ class Kestrel4500_Display {
         class ENTER: POWER {
             idc=-1;
             x=safezoneX+0.46;
-            y=safezoneY+1.0;
+            y = DIALOG_SAFE_Y(1.0);
             w=0.1;
             action=QUOTE(0 call FUNC(buttonPressed));
             onMouseButtonDown = "playSound 'kestrel4500_center_button_click'";
@@ -91,7 +92,7 @@ class Kestrel4500_Display {
         class TOP: Kestrel4500_RscButton {
             idc=-1;
             x=safezoneX+0.46;
-            y=safezoneY+0.93;
+            y = DIALOG_SAFE_Y(0.93);
             w=0.1;
             h=0.03;
             action=QUOTE(1 call FUNC(buttonPressed));
@@ -99,14 +100,14 @@ class Kestrel4500_Display {
         };
         class BOTTOM: TOP {
             idc=-1;
-            y=safezoneY+1.1;
+            y = DIALOG_SAFE_Y(1.1);
             action=QUOTE(2 call FUNC(buttonPressed));
             onMouseButtonDown = "playSound 'kestrel4500_bottom_button_click'";
         };
         class LEFT: Kestrel4500_RscButton {
             idc=-1;
             x=safezoneX+0.4;
-            y=safezoneY+0.97;
+            y = DIALOG_SAFE_Y(0.97);
             w=0.046;
             h=0.11;
             action=QUOTE(3 call FUNC(buttonPressed));
@@ -121,7 +122,7 @@ class Kestrel4500_Display {
         class MEMORY: Kestrel4500_RscButton {
             idc=-1;
             x=safezoneX+0.395;
-            y=safezoneY+0.87;
+            y = DIALOG_SAFE_Y(0.87);
             w=0.05;
             h=0.045*4/3;
             action=QUOTE(5 call FUNC(buttonPressed));
@@ -131,39 +132,39 @@ class Kestrel4500_Display {
             x=safezoneX+0.585;
             action=QUOTE(6 call FUNC(buttonPressed));
         };
-        
+
         class TEXT_TOP: Kestrel4500_RscText {
             idc=74100;
             x=safezoneX+0.40;
-            y=safezoneY+0.58;
+            y = DIALOG_SAFE_Y(0.58);
             w=0.22;
             h=0.04;
             text="";
         };
         class TEXT_CENTER_BIG: TEXT_TOP {
             idc=74200;
-            y=safezoneY+0.61;
+            y = DIALOG_SAFE_Y(0.61);
             h=0.10;
             SizeEx=0.06;
         };
         class TEXT_CENTER: TEXT_TOP {
             idc=74201;
-            y=safezoneY+0.64;
+            y = DIALOG_SAFE_Y(0.64);
         };
         class TEXT_CENTER_LINE_1_LEFT: TEXT_TOP {
             idc=74300;
-            y=safezoneY+0.60;
+            y = DIALOG_SAFE_Y(0.60);
             style=ST_LEFT;
             h=0.10;
             SizeEx=0.05;
         };
         class TEXT_CENTER_LINE2_LEFT: TEXT_CENTER_LINE_1_LEFT {
             idc=74301;
-            y=safezoneY+0.64;
+            y = DIALOG_SAFE_Y(0.64);
         };
         class TEXT_CENTER_LINE_3_LEFT: TEXT_CENTER_LINE2_LEFT {
             idc=74302;
-            y=safezoneY+0.68;
+            y = DIALOG_SAFE_Y(0.68);
         };
         class TEXT_CENTER_LINE_1_RIGHT: TEXT_CENTER_LINE_1_LEFT {
             idc=74303;
@@ -179,42 +180,42 @@ class Kestrel4500_Display {
         };
         class TEXT_INFO_LINE_1: TEXT_TOP {
             idc=74400;
-            y=safezoneY+0.68;
+            y = DIALOG_SAFE_Y(0.68);
         };
         class TEXT_INFO_LINE_2: TEXT_TOP {
             idc=74401;
-            y=safezoneY+0.72;
+            y = DIALOG_SAFE_Y(0.72);
         };
         class TEXT_BOTTOM_BIG: TEXT_TOP {
             idc=74500;
-            y=safezoneY+0.67;
+            y = DIALOG_SAFE_Y(0.67);
             h=0.10;
             SizeEx=0.06;
         };
         class TEXT_CENTER_LINE_1: TEXT_TOP {
             idc=74600;
-            y=safezoneY+0.58;
+            y = DIALOG_SAFE_Y(0.58);
             SizeEx=0.03;
         };
         class TEXT_CENTER_LINE_2: TEXT_CENTER_LINE_1 {
             idc=74601;
-            y=safezoneY+0.61;
+            y = DIALOG_SAFE_Y(0.61);
         };
         class TEXT_CENTER_LINE_3: TEXT_CENTER_LINE_1 {
             idc=74602;
-            y=safezoneY+0.64;
+            y = DIALOG_SAFE_Y(0.64);
         };
         class TEXT_CENTER_LINE_4: TEXT_CENTER_LINE_1 {
             idc=74603;
-            y=safezoneY+0.67;
+            y = DIALOG_SAFE_Y(0.67);
         };
         class TEXT_CENTER_LINE_5: TEXT_CENTER_LINE_1 {
             idc=74604;
-            y=safezoneY+0.70;
+            y = DIALOG_SAFE_Y(0.70);
         };
         class TEXT_CENTER_LINE_6: TEXT_CENTER_LINE_1 {
             idc=74605;
-            y=safezoneY+0.73;
+            y = DIALOG_SAFE_Y(0.73);
         };
     };
 };
@@ -228,6 +229,7 @@ class RscTitles {
         fadeIn="false";
         fadeOut="false";
         class controls {
+            #define DISPLAY_SAFE_Y(num) QUOTE((safeZoneY + 0.7 + num) min (safeZoneY + safeZoneH - 1.024*4/3*0.75 + num))
             class RscKestrel4500 {
                 idc=75000;
                 moving=0;
@@ -236,7 +238,7 @@ class RscTitles {
                 SizeEX=0.025*0.75;
                 style=48;
                 x=safezoneX+0.14;
-                y=safezoneY+0.7;
+                y = DISPLAY_SAFE_Y(0);
                 w=0.512*0.75;
                 h=1.024*4/3*0.75;
                 colorBackground[]={1,1,1,1};
@@ -246,7 +248,7 @@ class RscTitles {
             class RscTextTop: Kestrel4500_RscText {
                 idc=75100;
                 x=safezoneX-0.05+0.40*0.75;
-                y=safezoneY+0.7+0.58*0.75;
+                y = DISPLAY_SAFE_Y(0.58*0.75);
                 w=0.22*0.75;
                 h=0.04*0.75;
                 SizeEx=0.04*0.75;
@@ -254,18 +256,18 @@ class RscTitles {
             };
             class RscTextCenterBig: RscTextTop {
                 idc=75200;
-                y=safezoneY+0.7+0.61*0.75;
+                y = DISPLAY_SAFE_Y(0.61*0.75);
                 h=0.10*0.75;
                 SizeEx=0.06*0.75;
                 text="";
             };
             class RscTextCenter: RscTextTop {
                 idc=75201;
-                y=safezoneY+0.7+0.64*0.75;
+                y = DISPLAY_SAFE_Y(0.64*0.75);
             };
             class RscTextCenterLine1Left: RscTextTop {
                 idc=75300;
-                y=safezoneY+0.7+0.60*0.75;
+                y = DISPLAY_SAFE_Y(0.60*0.75);
                 style=ST_LEFT;
                 h=0.10*0.75;
                 SizeEx=0.05*0.75;
@@ -273,12 +275,12 @@ class RscTitles {
             };
             class RscTextCenterLine2Left: RscTextCenterLine1Left {
                 idc=75301;
-                y=safezoneY+0.7+0.64*0.75;
+                y = DISPLAY_SAFE_Y(0.64*0.75);
                 text="";
             };
             class RscTextCenterLine3Left: RscTextCenterLine2Left {
                 idc=75302;
-                y=safezoneY+0.7+0.68*0.75;
+                y = DISPLAY_SAFE_Y(0.68*0.75);
                 text="";
             };
             class RscTextCenterLine1Right: RscTextCenterLine1Left {
@@ -295,49 +297,49 @@ class RscTitles {
             };
             class RscTextInfoLine1: RscTextTop {
                 idc=75400;
-                y=safezoneY+0.7+0.68*0.75;
+                y = DISPLAY_SAFE_Y(0.68*0.75);
                 text="";
             };
             class RscTextInfoLine2: RscTextTop {
                 idc=75401;
-                y=safezoneY+0.7+0.72*0.75;
+                y = DISPLAY_SAFE_Y(0.72*0.75);
                 text="";
             };
             class RscTextBottomBig: RscTextTop {
                 idc=75500;
-                y=safezoneY+0.7+0.67*0.75;
+                y = DISPLAY_SAFE_Y(0.67*0.75);
                 h=0.10*0.75;
                 SizeEx=0.06*0.75;
                 text="";
             };
             class RscTextCenterLine1: RscTextTop {
                 idc=75600;
-                y=safezoneY+0.7+0.58*0.75;
+                y = DISPLAY_SAFE_Y(0.58*0.75);
                 SizeEx=0.03*0.75;
             };
             class RscTextCenterLine2: RscTextCenterLine1 {
                 idc=75601;
-                y=safezoneY+0.7+0.61*0.75;
+                y = DISPLAY_SAFE_Y(0.61*0.75);
             };
             class RscTextCenterLine3: RscTextCenterLine1 {
                 idc=75602;
-                y=safezoneY+0.7+0.64*0.75;
+                y = DISPLAY_SAFE_Y(0.64*0.75);
             };
             class RscTextCenterLine4: RscTextCenterLine1 {
                 idc=75603;
-                y=safezoneY+0.7+0.67*0.75;
+                y = DISPLAY_SAFE_Y(0.67*0.75);
             };
             class RscTextCenterLine5: RscTextCenterLine1 {
                 idc=75604;
-                y=safezoneY+0.7+0.70*0.75;
+                y = DISPLAY_SAFE_Y(0.70*0.75);
             };
             class RscTextCenterLine6: RscTextCenterLine1 {
                 idc=75605;
-                y=safezoneY+0.7+0.73*0.75;
+                y = DISPLAY_SAFE_Y(0.73*0.75);
             };
         };
     };
-    
+
     class RscKestrel4500_Preload {
         idd = -1;
         movingEnable = 0;


### PR DESCRIPTION
#1655
On large interface size, the kestrel would go off the bottom of the screen.

Now takes the min of either original value or a new value that guaranties the bottom is viewable.

e.g:  4x3, extra large interface is fully usable:
![2015-07-22_00001](https://cloud.githubusercontent.com/assets/9376747/8819144/ebaf556c-300e-11e5-8470-b72b497f6415.jpg)
