### PR TITLE
Wind deflection single pfeh

### DIFF
--- a/addons/winddeflection/CfgEventHandlers.hpp
+++ b/addons/winddeflection/CfgEventHandlers.hpp
@@ -3,7 +3,11 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
-
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};
 class Extended_FiredBIS_EventHandlers {
     class AllVehicles {
         class ADDON {

--- a/addons/winddeflection/XEH_postInit.sqf
+++ b/addons/winddeflection/XEH_postInit.sqf
@@ -1,0 +1,13 @@
+#include "script_component.hpp"
+
+if !(hasInterface) exitWith {};
+
+GVAR(trackedBullets) = [];
+
+["SettingsInitialized", {
+    //If not enabled, dont't add PFEH
+    if (!GVAR(enabled)) exitWith {};
+
+    [] call FUNC(updateTrajectoryPFH);
+
+}] call EFUNC(common,addEventHandler);

--- a/addons/winddeflection/functions/fnc_handleFired.sqf
+++ b/addons/winddeflection/functions/fnc_handleFired.sqf
@@ -34,6 +34,6 @@ if (!((_bullet isKindOf "BulletBase") || (_bullet isKindOf "GrenadeBase"))) exit
 if (_unit distance ACE_player > GVAR(simulationRadius)) exitWith {false};
 if (!([_unit] call EFUNC(common,isPlayer))) exitWith {false};
 
-[_bullet, getNumber(configFile >> "cfgAmmo" >> (_this select 4) >> "airFriction")] call FUNC(updateTrajectoryPFH);
+GVAR(trackedBullets) pushBack [_bullet, getNumber(configFile >> "cfgAmmo" >> (_this select 4) >> "airFriction")];
 
 true;

--- a/addons/winddeflection/functions/fnc_updateTrajectoryPFH.sqf
+++ b/addons/winddeflection/functions/fnc_updateTrajectoryPFH.sqf
@@ -13,12 +13,11 @@
  *
  * Public: No
  */
-#define ENABLE_PERFORMANCE_COUNTERS
+// #define ENABLE_PERFORMANCE_COUNTERS
 #include "script_component.hpp"
 
 [{
-    BEGIN_COUNTER(pfeh);
-
+    // BEGIN_COUNTER(pfeh);
     private["_accel", "_accelRef", "_bulletSpeed", "_bulletVelocity", "_deleted", "_deltaT", "_drag", "_dragRef", "_isWind", "_lastTime", "_trueSpeed", "_trueVelocity"];
 
     _lastTime = (_this select 0) select 0;
@@ -53,7 +52,5 @@
         };
 
     } forEach GVAR(trackedBullets);
-
-    END_COUNTER(pfeh);
-
+    // END_COUNTER(pfeh);
 }, GVAR(simulationInterval), [ACE_time]] call CBA_fnc_addPerFrameHandler;

--- a/addons/winddeflection/functions/fnc_updateTrajectoryPFH.sqf
+++ b/addons/winddeflection/functions/fnc_updateTrajectoryPFH.sqf
@@ -13,38 +13,47 @@
  *
  * Public: No
  */
+#define ENABLE_PERFORMANCE_COUNTERS
 #include "script_component.hpp"
 
 [{
-    private ["_args", "_bullet", "_airFriction", "_time", "_deltaT", "_bulletVelocity", "_bulletSpeed", "_trueVelocity", "_trueSpeed", "_dragRef", "_drag", "_accelRef", "_accel"];
+    BEGIN_COUNTER(pfeh);
 
-    _args = _this select 0;
-    _bullet = _args select 0;
-    _airFriction = _args select 1;
-    _time = _args select 2;
-    
-    _bulletVelocity = velocity _bullet;
-    _bulletSpeed = vectorMagnitude _bulletVelocity;
-    
-    if (!alive _bullet || ((_bullet isKindOf "BulletBase") && _bulletSpeed < 100)) exitwith {
-        [_this select 1] call cba_fnc_removePerFrameHandler;
-    };
-    
-    _deltaT = ACE_time - _time;
-    _args set[2, ACE_time];
-    
-    if (vectorMagnitude ACE_wind > 0) then {
-        _trueVelocity = _bulletVelocity vectorDiff ACE_wind;
-        _trueSpeed = vectorMagnitude _trueVelocity;
+    private["_accel", "_accelRef", "_bulletSpeed", "_bulletVelocity", "_deleted", "_deltaT", "_drag", "_dragRef", "_isWind", "_lastTime", "_trueSpeed", "_trueVelocity"];
 
-        _dragRef = _deltaT * _airFriction * _bulletSpeed * _bulletSpeed;
-        _accelRef = (vectorNormalized _bulletVelocity) vectorMultiply (_dragRef);
-        _bulletVelocity = _bulletVelocity vectorDiff _accelRef;
+    _lastTime = (_this select 0) select 0;
+    _deltaT = ACE_time - _lastTime;
+    (_this select 0) set [0, ACE_time];
+    _deleted = 0;
+    _isWind = (vectorMagnitude ACE_wind > 0);
 
-        _drag = _deltaT * _airFriction * _trueSpeed;
-        _accel = _trueVelocity vectorMultiply (_drag);
-        _bulletVelocity = _bulletVelocity vectorAdd _accel;
-    };
-    _bullet setVelocity _bulletVelocity;
-    
-}, GVAR(simulationInterval), [_this select 0, _this select 1, ACE_time]] call CBA_fnc_addPerFrameHandler;
+    {
+        _x params ["_bullet", "_airFriction"];
+
+        _bulletVelocity = velocity _bullet;
+        _bulletSpeed = vectorMagnitude _bulletVelocity;
+
+        if ((!alive _bullet) || {(_bullet isKindOf "BulletBase") && {_bulletSpeed < 100}}) then {
+            GVAR(trackedBullets) deleteAt (_forEachIndex - _deleted);
+            _deleted = _deleted + 1;
+        } else {
+            if (_isWind) then {
+                _trueVelocity = _bulletVelocity vectorDiff ACE_wind;
+                _trueSpeed = vectorMagnitude _trueVelocity;
+
+                _dragRef = _deltaT * _airFriction * _bulletSpeed * _bulletSpeed;
+                _accelRef = (vectorNormalized _bulletVelocity) vectorMultiply (_dragRef);
+                _bulletVelocity = _bulletVelocity vectorDiff _accelRef;
+
+                _drag = _deltaT * _airFriction * _trueSpeed;
+                _accel = _trueVelocity vectorMultiply (_drag);
+                _bulletVelocity = _bulletVelocity vectorAdd _accel;
+            };
+            _bullet setVelocity _bulletVelocity;
+        };
+
+    } forEach GVAR(trackedBullets);
+
+    END_COUNTER(pfeh);
+
+}, GVAR(simulationInterval), [ACE_time]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Switches fnc_updateTrajectoryPFH to be a master PFEH, bullets get added to an internal array instead of creating/deleting a new cba PFEH each time.

I believe this solves a big performance problem where the `count cba_common_perFrameHandlerArray` can grow too large.

In actual session I saw it hit >2000.  Most entries are nil, but it sill takes time to process them, which happens each frame.  (2000 is about 5.5ms each frame),

In a stress test mission with about 50 ai + disabling the isPlayer check in handleFired so all AI bullets are tracked.  Unscientific results because AI are unpredictable, but I get a huge performance difference:

![image](https://cloud.githubusercontent.com/assets/9376747/8821397/eb5048d8-3022-11e5-84c1-4426b061f353.png)
VS
![image](https://cloud.githubusercontent.com/assets/9376747/8821408/ff87d276-3022-11e5-926f-b0caa4083642.png)

With PFEH debug enabled:
```
ace_windDeflection_pfeh_counter: Average: 0.812859s / 2257 = 0.36015ms
```