### PR TITLE
Fixed NameTags Settings defaults

### DIFF
--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -21,13 +21,13 @@ class ACE_Settings {
     };
     class GVAR(showVehicleCrewInfo) {
         value = 1;
-        typeName = "BOOL";
+        typeName = "SCALAR";
         isClientSettable = 1;
         displayName = CSTRING(ShowVehicleCrewInfo);
     };
     class GVAR(showNamesForAI) {
         value = 0;
-        typeName = "BOOL";
+        typeName = "SCALAR";
         isClientSettable = 1;
         displayName = CSTRING(ShowNamesForAI);
     };

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -24,12 +24,14 @@ class ACE_Settings {
         typeName = "SCALAR";
         isClientSettable = 1;
         displayName = CSTRING(ShowVehicleCrewInfo);
+        values[] = {CSTRING(DoNotForce), CSTRING(ForceHide), CSTRING(ForceShow)};
     };
     class GVAR(showNamesForAI) {
         value = 0;
         typeName = "SCALAR";
         isClientSettable = 1;
         displayName = CSTRING(ShowNamesForAI);
+        values[] = {CSTRING(DoNotForce), CSTRING(ForceHide), CSTRING(ForceShow)};
     };
     class GVAR(showCursorTagForVehicles) {
         value = 0;


### PR DESCRIPTION
Fixed:

```
Error in expression <= false;
_failed = false;
};
if (_value == 1) then {
_value = true;
_failed = fa>
Error position: <== 1) then {
_value = true;
_failed = fa>
Error ==: Type Bool, expected Number,String,Not a Number,Object,Side,Group,Text,Config entry,Display (dialog),Control,Network Object,Team member,Task,Location
File z\ace\addons\common\functions\fnc_setSetting.sqf, line 32
```