### PR TITLE
Medical - Don't play *_medic anims at end

### DIFF
--- a/addons/medical/functions/fnc_treatment_failure.sqf
+++ b/addons/medical/functions/fnc_treatment_failure.sqf
@@ -17,7 +17,7 @@
 
 #include "script_component.hpp"
 
-private ["_args", "_caller", "_target","_selectionName","_className","_config","_callback", "_usersOfItems", "_weaponSelect"];
+private ["_args", "_caller", "_target","_selectionName","_className","_config","_callback", "_usersOfItems", "_weaponSelect", "_lastAnim"];
 
 _args = _this select 0;
 _caller = _args select 0;
@@ -30,7 +30,17 @@ if (primaryWeapon _caller == "ACE_FakePrimaryWeapon") then {
     _caller removeWeapon "ACE_FakePrimaryWeapon";
 };
 if (vehicle _caller == _caller) then {
-    [_caller, _caller getvariable [QGVAR(treatmentPrevAnimCaller), ""], 1] call EFUNC(common,doAnimation);
+    _lastAnim = _caller getvariable [QGVAR(treatmentPrevAnimCaller), ""];
+    //Don't play another medic animation (when player is rapidily treating)
+    TRACE_2("Reseting to old animation", animationState player, _lastAnim);
+    switch (true) do {
+        case (_lastAnim == "AinvPknlMstpSlayWrflDnon_medic"): {_lastAnim = "AmovPknlMstpSrasWrflDnon"};
+        case (_lastAnim == "AinvPpneMstpSlayWrflDnon_medic"): {_lastAnim = "AmovPpneMstpSrasWrflDnon"};
+        case (_lastAnim == "AinvPknlMstpSlayWnonDnon_medic"): {_lastAnim = "AmovPknlMstpSnonWnonDnon"};
+        case (_lastAnim == "AinvPpneMstpSlayWpstDnon_medic"): {_lastAnim = "AinvPpneMstpSlayWpstDnon"};
+        case (_lastAnim == "AinvPknlMstpSlayWpstDnon_medic"): {_lastAnim = "AmovPknlMstpSrasWpstDnon"};
+    };
+    [_caller, _lastAnim, 1] call EFUNC(common,doAnimation);
 };
 _caller setvariable [QGVAR(treatmentPrevAnimCaller), nil];
 

--- a/addons/medical/functions/fnc_treatment_success.sqf
+++ b/addons/medical/functions/fnc_treatment_success.sqf
@@ -17,7 +17,7 @@
 
 #include "script_component.hpp"
 
-private ["_args", "_caller", "_target","_selectionName","_className","_config","_callback", "_weaponSelect"];
+private ["_args", "_caller", "_target","_selectionName","_className","_config","_callback", "_weaponSelect", "_lastAnim"];
 _args = _this select 0;
 _caller = _args select 0;
 _target = _args select 1;
@@ -28,7 +28,17 @@ if (primaryWeapon _caller == "ACE_FakePrimaryWeapon") then {
     _caller removeWeapon "ACE_FakePrimaryWeapon";
 };
 if (vehicle _caller == _caller) then {
-    [_caller, _caller getvariable [QGVAR(treatmentPrevAnimCaller), ""], 1] call EFUNC(common,doAnimation);
+    _lastAnim = _caller getvariable [QGVAR(treatmentPrevAnimCaller), ""];
+    //Don't play another medic animation (when player is rapidily treating)
+    TRACE_2("Reseting to old animation", animationState player, _lastAnim);
+    switch (true) do {
+        case (_lastAnim == "AinvPknlMstpSlayWrflDnon_medic"): {_lastAnim = "AmovPknlMstpSrasWrflDnon"};
+        case (_lastAnim == "AinvPpneMstpSlayWrflDnon_medic"): {_lastAnim = "AmovPpneMstpSrasWrflDnon"};
+        case (_lastAnim == "AinvPknlMstpSlayWnonDnon_medic"): {_lastAnim = "AmovPknlMstpSnonWnonDnon"};
+        case (_lastAnim == "AinvPpneMstpSlayWpstDnon_medic"): {_lastAnim = "AinvPpneMstpSlayWpstDnon"};
+        case (_lastAnim == "AinvPknlMstpSlayWpstDnon_medic"): {_lastAnim = "AmovPknlMstpSrasWpstDnon"};
+    };
+    [_caller, _lastAnim, 1] call EFUNC(common,doAnimation);
 };
 _caller setvariable [QGVAR(treatmentPrevAnimCaller), nil];
 


### PR DESCRIPTION
User reported that when unarmed, rapidly bandaging themselves they got animation locked into a "holding an invisible gun" in a crouched pose.

Debugging, it seems to be that we're still playing `ainvpknlmstpslaywrfldnon_medic` when we start the 2nd treatment, so that gets saved and replayed again at the end.  And without a fakegun, this seems to lock up the player.

```
12.97 - adding fake weapon
12.97 - saving anim amovpknlmstpsraswrfldnon
18.053 - rem weap
18.053 - playing anim amovpknlmstpsraswrfldnon
//Starting 2nd heal
20.617 - adding fake weapon
20.617 - saving anim ainvpknlmstpslaywrfldnon_medic
25.697 - rem weap
25.697 - playing anim ainvpknlmstpslaywrfldnon_medic
```

