### PR TITLE
#1871 - Don't do ctrlText(set) on RscControlsGroup

### DIFF
--- a/addons/vector/functions/fnc_illuminate.sqf
+++ b/addons/vector/functions/fnc_illuminate.sqf
@@ -7,35 +7,36 @@ disableSerialization;
 _dlgVector = GETUVAR(ACE_dlgVector,displayNull);
 
 if (_this select 0) then {
-
     {
-        private ["_string", "_index"];
+        if (ctrlIDC _x != 170) then {
+            private ["_string", "_index"];
 
-        _string = ctrlText _x;
-        _index = _string find ".paa";
+            _string = ctrlText _x;
+            _index = _string find ".paa";
 
-        if (_index != -1 && {_string find "_illum.paa" == -1}) then {
-            _string = toArray _string;
-            _string resize _index;
+            if (_index != -1 && {_string find "_illum.paa" == -1}) then {
+                _string = toArray _string;
+                _string resize _index;
 
-            _x ctrlSetText format ["%1_illum.paa", toString _string];
+                _x ctrlSetText format ["%1_illum.paa", toString _string];
+            };
         };
     } forEach allControls _dlgVector;
-
 } else {
-
     {
-        private ["_string", "_index"];
+        if (ctrlIDC _x != 170) then {
+            private ["_string", "_index"];
 
-        _string = ctrlText _x;
-        _index = _string find "_illum.paa";
+            _string = ctrlText _x;
+            _index = _string find "_illum.paa";
 
-        if (_index != -1) then {
-            _string = toArray _string;
-            _string resize _index;
+            if (_index != -1) then {
+                _string = toArray _string;
+                _string resize _index;
 
-            _x ctrlSetText format ["%1.paa", toString _string];
+                _x ctrlSetText format ["%1.paa", toString _string];
+            };
+
         };
     } forEach allControls _dlgVector;
-
 };


### PR DESCRIPTION
#1871

Doing `ctrlText` or `ctrlSetText` on a `RscControlsGroup` spams the rpt with 
```
control[ACE_ScriptedDisplayControlsGroup]: Unexpected control type [15]
```

We do both each frame so I believe it is the source of the frame lag when using the vector.