### PR TITLE
Fix incorrect damage value return when prevent death is enabled

### DIFF
--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -112,7 +112,7 @@ if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitW
         };
         0.89;
     };
-    0.89;
+    _damageReturn min 0.89;
 };
 
 if (((_unit getVariable [QGVAR(enableRevive), GVAR(enableRevive)]) > 0) && {_damageReturn >= 0.9} && {_selection in ["", "head", "body"]}) exitWith {


### PR DESCRIPTION
fix #1946 

Suggested as a patch/hotfix.