### PR TITLE
Fix Changes in Wind Deflection s in AB

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -53,7 +53,9 @@ if (!GVAR(simulateForEveryone) && !(local _unit)) then {
 if (GVAR(disabledInFullAutoMode) && getNumber(configFile >> "CfgWeapons" >> _weapon >> _mode >> "autoFire") == 1) then { _abort = true; };
 
 if (_abort || !(GVAR(extensionAvailable))) exitWith {
-    [_bullet, getNumber(configFile >> "CfgAmmo" >> _ammo >> "airFriction")] call EFUNC(winddeflection,updateTrajectoryPFH);
+    if (missionNamespace getVariable [QEGVAR(windDeflection,enabled), false]) then {
+        EGVAR(windDeflection,trackedBullets) pushBack [_bullet, getNumber(configFile >> "cfgAmmo" >> _ammo >> "airFriction")];
+    };
 };
 
 _AmmoCacheEntry = uiNamespace getVariable format[QGVAR(%1), _ammo];


### PR DESCRIPTION
Fix #1962

PR #1886 changed EFUNC(winddeflection,updateTrajectoryPFH) to be called once and bullets added to the array.

I missed that AB called that function to hand-off bullets.