### PR TITLE
Headdirection based wind indication

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -107,3 +107,4 @@ VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
 zGuba
 Drill <drill87@gmail.com>
+MikeMatrix <m.braun92@gmail.com>

--- a/addons/weather/functions/fnc_displayWindInfo.sqf
+++ b/addons/weather/functions/fnc_displayWindInfo.sqf
@@ -47,7 +47,7 @@ GVAR(WindInfo) = true;
     };
     
     if (_windSpeed > 0.2) then {
-        _playerDir = getDir ACE_player;
+        _playerDir = (ACE_player call CBA_fnc_headDir) select 0;
         _windDir = (ACE_wind select 0) atan2 (ACE_wind select 1);
         _windIndex = round(((_playerDir - _windDir + 360) % 360) / 30);
         _windIndex = _windIndex % 12;


### PR DESCRIPTION
Replaced direction detection with ```CBA_fnc_headDir``` to calculate the indicator direction off of the head direction instead of the player direction.

This solves #1892.