### PR TITLE
Fix ace_map changes to compass display object

### DIFF
--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -125,13 +125,6 @@ class RscDisplayDiary {
             };
         };
     };
-    // scale up the compass
-    class objects {
-        class Compass: RscObject {
-            scale = 0.7;
-            zoomDuration = 0;
-        };
-    };
 };
 
 // BRIEFING SCREEN
@@ -149,13 +142,6 @@ class RscDisplayGetReady: RscDisplayMainMap {
             #include "MapControls.hpp"
         };
     };
-    // scale up the compass
-    class objects {
-        class Compass: RscObject {
-            scale = 0.7;
-            zoomDuration = 0;
-        };
-    };
 };
 class RscDisplayClientGetReady: RscDisplayGetReady {
     // get rid of the "center to player position" - button (as it works even on elite)
@@ -164,26 +150,12 @@ class RscDisplayClientGetReady: RscDisplayGetReady {
             #include "MapControls.hpp"
         };
     };
-    // scale up the compass
-    class objects {
-        class Compass: RscObject {
-            scale = 0.7;
-            zoomDuration = 0;
-        };
-    };
 };
 class RscDisplayServerGetReady: RscDisplayGetReady {
     // get rid of the "center to player position" - button (as it works even on elite)
     class controls {
         class TopRight: RscControlsGroup {
             #include "MapControls.hpp"
-        };
-    };
-    // scale up the compass
-    class objects {
-        class Compass: RscObject {
-            scale = 0.7;
-            zoomDuration = 0;
         };
     };
 };


### PR DESCRIPTION
1. RscDisplayDiary doesn't even have a compass object that needs to be changed
2. The briefing displays (RscDisplayGetReady, RscDisplayClientGetReady, RscDisplayServerGetReady) were all inheriting from base class RscDisplayMainMap and re-defined the compass object subclasses was overriding that subclass inheritance chain (producing missing idc errors in the .rpt).