### PR TITLE
EnableTeamManagement setting for joinGroup

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -91,7 +91,7 @@ class CfgVehicles {
 
                 class ACE_JoinGroup {
                     displayName = CSTRING(JoinGroup);
-                    condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinGroup));
+                    condition = QUOTE(GVAR(EnableTeamManagement) && {[ARR_2(_player,_target)] call DFUNC(canJoinGroup)});
                     statement = QUOTE([_player] joinSilent group _target);
                     showDisabled = 0;
                     priority = 2.6;


### PR DESCRIPTION
#2024

I'm pretty sure joinGroup should be disabled if EnableTeamManagement is false.
Unless we want separate settings for fireteam team management (different colors) and a setting for joining/leaving groups.