### PR TITLE
CreateLitter / syncEvents performance fixes

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -118,8 +118,9 @@ if(!isServer) then {
 };
 ["SEH", FUNC(_handleSyncedEvent)] call FUNC(addEventHandler);
 ["SEH_s", FUNC(_handleRequestSyncedEvent)] call FUNC(addEventHandler);
-[FUNC(syncedEventPFH), 0.5, []] call CBA_fnc_addPerFrameHandler;
-
+if (isServer) then {
+    [FUNC(syncedEventPFH), 0.5, []] call CBA_fnc_addPerFrameHandler;
+};
 call FUNC(checkFiles);
 
 

--- a/addons/medical/functions/fnc_handleCreateLitter.sqf
+++ b/addons/medical/functions/fnc_handleCreateLitter.sqf
@@ -31,6 +31,7 @@ if((count GVAR(allCreatedLitter)) > _maxLitterCount ) then {
 GVAR(allCreatedLitter) pushBack [ACE_time, [_litterObject]];
 
 if(!GVAR(litterPFHRunning) && {GVAR(litterCleanUpDelay) > 0}) then {
+    GVAR(litterPFHRunning) = true;
     [{
         {
             if (ACE_time - (_x select 0) >= GVAR(litterCleanUpDelay)) then {


### PR DESCRIPTION
* Common: Top of fnc_syncedEventPFH.sqf is `if(!isServer) exitWith { false };` - so there is no reason to install that PFEH anywhere but the server.

* Medical: GVAR(litterPFHRunning) was never set true, so it installed an additional PFEH for each litter created.