### PR TITLE
Added localizations for keybinding categories

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -341,6 +341,14 @@ if(isMultiplayer && { ACE_time > 0 || isNull player } ) then {
 GVAR(deviceKeyHandlingArray) = [];
 GVAR(deviceKeyCurrentIndex) = -1;
 
+// Register localizations for the Keybinding categories
+["ACE3 Equipment", localize LSTRING(ACEKeybindCategoryEquipment)] call cba_fnc_registerKeybindModPrettyName;
+["ACE3 Common", localize LSTRING(ACEKeybindCategoryCommon)] call cba_fnc_registerKeybindModPrettyName;
+["ACE3 Weapons", localize LSTRING(ACEKeybindCategoryWeapons)] call cba_fnc_registerKeybindModPrettyName;
+["ACE3 Movement", localize LSTRING(ACEKeybindCategoryMovement)] call cba_fnc_registerKeybindModPrettyName;
+["ACE3 Scope Adjustment", localize LSTRING(ACEKeybindCategoryScopeAdjustment)] call cba_fnc_registerKeybindModPrettyName;
+["ACE3 Vehicles", localize LSTRING(ACEKeybindCategoryVehicles)] call cba_fnc_registerKeybindModPrettyName;
+
 ["ACE3 Equipment", QGVAR(openDevice), (localize "STR_ACE_Common_toggleHandheldDevice"),
 {
     [] call FUNC(deviceKeyFindValidIndex);

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -600,21 +600,27 @@
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryEquipment">
             <English>ACE3 Equipment</English>
+            <Polish>ACE3 Wyposażenie</Polish>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryCommon">
             <English>ACE3 Common</English>
+            <Polish>ACE3 Ogólne</Polish>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryWeapons">
             <English>ACE3 Weapons</English>
+            <Polish>ACE3 Broń</Polish>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryMovement">
             <English>ACE3 Movement</English>
+            <Polish>ACE3 Ruch</Polish>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryScopeAdjustment">
             <English>ACE3 Scope Adjustment</English>
+            <Polish>ACE3 Regulacja optyki</Polish>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryVehicles">
             <English>ACE3 Vehicles</English>
+            <Polish>ACE3 Pojazdy</Polish>
         </Key>
     </Package>
 </Project>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -598,5 +598,23 @@
             <Polish>Następne urządzenie podręczne</Polish>
             <Czech>Procházet ruční zařízení</Czech>
         </Key>
+        <Key ID="STR_ACE_Common_ACEKeybindCategoryEquipment">
+            <English>ACE3 Eqiupment</English>
+        </Key>
+        <Key ID="STR_ACE_Common_ACEKeybindCategoryCommon">
+            <English>ACE3 Common</English>
+        </Key>
+        <Key ID="STR_ACE_Common_ACEKeybindCategoryWeapons">
+            <English>ACE3 Weapons</English>
+        </Key>
+        <Key ID="STR_ACE_Common_ACEKeybindCategoryMovement">
+            <English>ACE3 Movement</English>
+        </Key>
+        <Key ID="STR_ACE_Common_ACEKeybindCategoryScopeAdjustment">
+            <English>ACE3 Scope Adjustment</English>
+        </Key>
+        <Key ID="STR_ACE_Common_ACEKeybindCategoryVehicles">
+            <English>ACE3 Vehicles</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -599,7 +599,7 @@
             <Czech>Procházet ruční zařízení</Czech>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryEquipment">
-            <English>ACE3 Eqiupment</English>
+            <English>ACE3 Equipment</English>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryCommon">
             <English>ACE3 Common</English>


### PR DESCRIPTION
Adding keybinding localization over `CBA_fnc_registerKeybindModPrettyName`, which in the current version of CBA are still broken, but should be functioning perfectly after CBATeam/CBA_A3#105 gets merged.