### PR TITLE
Add category optionsmenu #852

### DIFF
--- a/addons/common/functions/fnc_setSettingFromConfig.sqf
+++ b/addons/common/functions/fnc_setSettingFromConfig.sqf
@@ -65,7 +65,8 @@ if (isNil _name) then {
         localizedDescription,
         possibleValues,
         isForced,
-        defaultValue
+        defaultValue,
+        category
     ];*/
     _settingData = [
         _name,
@@ -75,7 +76,8 @@ if (isNil _name) then {
         getText (_optionEntry >> "description"),
         getArray (_optionEntry >> "values"),
         getNumber (_optionEntry >> "force") > 0,
-        _value
+        _value,
+        getText (_optionEntry >> "category")
     ];
 
     //Strings in the values array won't be localized from the config, so just do that now:

--- a/addons/interact_menu/ACE_Settings.hpp
+++ b/addons/interact_menu/ACE_Settings.hpp
@@ -3,14 +3,14 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(AlwaysUseCursorSelfInteraction);
     };
     class GVAR(cursorKeepCentered) {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(cursorKeepCentered);
         description = CSTRING(cursorKeepCenteredDescription);
     };
@@ -18,48 +18,49 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(AlwaysUseCursorInteraction);
     };
     class GVAR(UseListMenu) {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(UseListMenu);
     };
     class GVAR(colorTextMax) {
         value[] = {1, 1, 1, 1};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorTextMax);
     };
     class GVAR(colorTextMin) {
         value[] = {1, 1, 1, 0.25};
         typeName = "COLOR";
         isClientSettable = 1;
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorTextMin);
     };
     class GVAR(colorShadowMax) {
         value[] = {0, 0, 0, 1};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorShadowMax);
     };
     class GVAR(colorShadowMin) {
         value[] = {0, 0, 0, 0.25};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorShadowMin);
     };
     class GVAR(textSize) {
         value = 2;
         typeName = "SCALAR";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(textSize);
         values[] = {"$str_very_small", "$str_small", "$str_medium", "$str_large", "$str_very_large"};
     };
@@ -67,7 +68,7 @@ class ACE_Settings {
         value = 2;
         typeName = "SCALAR";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(shadowSetting);
         description = CSTRING(shadowSettingDescription);
         values[] = {"$STR_A3_OPTIONS_DISABLED", "$STR_A3_OPTIONS_ENABLED", CSTRING(shadowOutline)};
@@ -76,14 +77,14 @@ class ACE_Settings {
         value = 1;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(ActionOnKeyRelease);
     };
     class GVAR(menuBackground) {
         value = 0;
         typeName = "SCALAR";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(background);
         values[] = {"$STR_A3_OPTIONS_DISABLED", CSTRING(backgroundBlur), CSTRING(backgroundBlack)};
     };
@@ -91,7 +92,7 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = "Interaction Menu";
+        category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(addBuildingActions);
         description = CSTRING(addBuildingActionsDescription);
     };

--- a/addons/interact_menu/ACE_Settings.hpp
+++ b/addons/interact_menu/ACE_Settings.hpp
@@ -3,12 +3,14 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(AlwaysUseCursorSelfInteraction);
     };
     class GVAR(cursorKeepCentered) {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(cursorKeepCentered);
         description = CSTRING(cursorKeepCenteredDescription);
     };
@@ -16,18 +18,21 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(AlwaysUseCursorInteraction);
     };
     class GVAR(UseListMenu) {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(UseListMenu);
     };
     class GVAR(colorTextMax) {
         value[] = {1, 1, 1, 1};
         typeName = "COLOR";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(ColorTextMax);
     };
     class GVAR(colorTextMin) {
@@ -40,18 +45,21 @@ class ACE_Settings {
         value[] = {0, 0, 0, 1};
         typeName = "COLOR";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(ColorShadowMax);
     };
     class GVAR(colorShadowMin) {
         value[] = {0, 0, 0, 0.25};
         typeName = "COLOR";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(ColorShadowMin);
     };
     class GVAR(textSize) {
         value = 2;
         typeName = "SCALAR";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(textSize);
         values[] = {"$str_very_small", "$str_small", "$str_medium", "$str_large", "$str_very_large"};
     };
@@ -59,6 +67,7 @@ class ACE_Settings {
         value = 2;
         typeName = "SCALAR";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(shadowSetting);
         description = CSTRING(shadowSettingDescription);
         values[] = {"$STR_A3_OPTIONS_DISABLED", "$STR_A3_OPTIONS_ENABLED", CSTRING(shadowOutline)};
@@ -67,12 +76,14 @@ class ACE_Settings {
         value = 1;
         typeName = "BOOL";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(ActionOnKeyRelease);
     };
     class GVAR(menuBackground) {
         value = 0;
         typeName = "SCALAR";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(background);
         values[] = {"$STR_A3_OPTIONS_DISABLED", CSTRING(backgroundBlur), CSTRING(backgroundBlack)};
     };
@@ -80,6 +91,7 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
+        category = "Interaction Menu";
         displayName = CSTRING(addBuildingActions);
         description = CSTRING(addBuildingActionsDescription);
     };

--- a/addons/interact_menu/ACE_Settings.hpp
+++ b/addons/interact_menu/ACE_Settings.hpp
@@ -3,14 +3,14 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(AlwaysUseCursorSelfInteraction);
     };
     class GVAR(cursorKeepCentered) {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(cursorKeepCentered);
         description = CSTRING(cursorKeepCenteredDescription);
     };
@@ -18,49 +18,49 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(AlwaysUseCursorInteraction);
     };
     class GVAR(UseListMenu) {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(UseListMenu);
     };
     class GVAR(colorTextMax) {
         value[] = {1, 1, 1, 1};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorTextMax);
     };
     class GVAR(colorTextMin) {
         value[] = {1, 1, 1, 0.25};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorTextMin);
     };
     class GVAR(colorShadowMax) {
         value[] = {0, 0, 0, 1};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorShadowMax);
     };
     class GVAR(colorShadowMin) {
         value[] = {0, 0, 0, 0.25};
         typeName = "COLOR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(ColorShadowMin);
     };
     class GVAR(textSize) {
         value = 2;
         typeName = "SCALAR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(textSize);
         values[] = {"$str_very_small", "$str_small", "$str_medium", "$str_large", "$str_very_large"};
     };
@@ -68,7 +68,7 @@ class ACE_Settings {
         value = 2;
         typeName = "SCALAR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(shadowSetting);
         description = CSTRING(shadowSettingDescription);
         values[] = {"$STR_A3_OPTIONS_DISABLED", "$STR_A3_OPTIONS_ENABLED", CSTRING(shadowOutline)};
@@ -77,14 +77,14 @@ class ACE_Settings {
         value = 1;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(ActionOnKeyRelease);
     };
     class GVAR(menuBackground) {
         value = 0;
         typeName = "SCALAR";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(background);
         values[] = {"$STR_A3_OPTIONS_DISABLED", CSTRING(backgroundBlur), CSTRING(backgroundBlack)};
     };
@@ -92,7 +92,7 @@ class ACE_Settings {
         value = 0;
         typeName = "BOOL";
         isClientSettable = 1;
-        category = CSTRING(Category_InteractionMenu);
+        category = LSTRING(Category_InteractionMenu);
         displayName = CSTRING(addBuildingActions);
         description = CSTRING(addBuildingActionsDescription);
     };

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -267,7 +267,7 @@
             <Czech>Přidá možnost interakce pro otevření dvěří a umistňovat žebříky na budovy. (Poznámka: Použití této možnosti snižuje výkon při otevírání pomocí interakčního menu, zejména ve velkých městech.) </Czech>
             <Spanish>Añade las acciones de interacción para la apertura de puertas y montaje de escaleras en los edificios. (Nota: Hay un coste de rendimiento al abrir el menú de interacción, especialmente en las ciudades)</Spanish>
         </Key>
-        <Key ID="STR_ACE_Medical_Category_InteractionMenu">
+        <Key ID="STR_ACE_Interact_Menu_Category_InteractionMenu">
             <English>Interaction Menu</English>
         </Key>
     </Package>

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -267,5 +267,8 @@
             <Czech>Přidá možnost interakce pro otevření dvěří a umistňovat žebříky na budovy. (Poznámka: Použití této možnosti snižuje výkon při otevírání pomocí interakčního menu, zejména ve velkých městech.) </Czech>
             <Spanish>Añade las acciones de interacción para la apertura de puertas y montaje de escaleras en los edificios. (Nota: Hay un coste de rendimiento al abrir el menú de interacción, especialmente en las ciudades)</Spanish>
         </Key>
+        <Key ID="STR_ACE_Medical_Category_InteractionMenu">
+            <English>Interaction Menu</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -269,6 +269,7 @@
         </Key>
         <Key ID="STR_ACE_Interact_Menu_Category_InteractionMenu">
             <English>Interaction Menu</English>
+            <Polish>Menu interakcji</Polish>
         </Key>
     </Package>
 </Project>

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -1,116 +1,116 @@
 class ACE_Settings {
     class GVAR(level) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "Basic", "Advanced"};
     };
     class GVAR(medicSetting) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "Normal", "Advanced"};
     };
     class GVAR(enableFor) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         value = 0;
         typeName = "SCALAR";
         values[] = {"Players only", "Players and AI"};
     };
     class GVAR(enableOverdosing) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(bleedingCoefficient) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(painCoefficient) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(enableAirway) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableFractures) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableAdvancedWounds) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableVehicleCrashes) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(enableScreams) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(playerDamageThreshold) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(AIDamageThreshold) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(enableUnconsciousnessAI) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "50/50", "Enabled"};
     };
     class GVAR(remoteControlledAI) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(preventInstaDeath) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(enableRevive) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
         values[] = {"Disabled", "Players only", "Players and AI"};
     };
     class GVAR(maxReviveTime) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 120;
     };
     class GVAR(amountOfReviveLives) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = -1;
     };
     class GVAR(allowDeadBodyMovement) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(allowLitterCreation) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(litterSimulationDetail) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(litterSimulationDetail);
         description = CSTRING(litterSimulationDetail_Desc);
         typeName = "SCALAR";
@@ -122,48 +122,48 @@ class ACE_Settings {
         isClientSettable = 1;
     };
     class GVAR(litterCleanUpDelay) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
     };
     class GVAR(medicSetting_PAK) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
         values[] = {"Anyone", "Medics only", "Doctors only"};
     };
     class GVAR(medicSetting_SurgicalKit) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
         values[] = {"Anyone", "Medics only", "Doctors only"};
     };
     class GVAR(consumeItem_PAK) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
         values[] = {"No", "Yes"};
     };
     class GVAR(consumeItem_SurgicalKit) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
         values[] = {"No", "Yes"};
     };
     class GVAR(useLocation_PAK) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 3;
         values[] = {"Anywhere", "Medical vehicles", "Medical facility", "vehicle & facility", "Disabled"};
     };
     class GVAR(useLocation_SurgicalKit) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 2;
         values[] = {"Anywhere", "Medical vehicles", "Medical facility", "vehicle & facility", "Disabled"};
     };
     class GVAR(useCondition_PAK) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(AdvancedMedicalSettings_useCondition_PAK_DisplayName);
         description = CSTRING(AdvancedMedicalSettings_useCondition_PAK_Description);
         typeName = "SCALAR";
@@ -171,7 +171,7 @@ class ACE_Settings {
         values[] = {"Anytime", "Stable"};
     };
     class GVAR(useCondition_SurgicalKit) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(AdvancedMedicalSettings_useCondition_SurgicalKit_DisplayName);
         description = CSTRING(AdvancedMedicalSettings_useCondition_SurgicalKit_Description);
         typeName = "SCALAR";
@@ -179,24 +179,24 @@ class ACE_Settings {
         values[] = {"Anytime", "Stable"};
     };
     class GVAR(keepLocalSettingsSynced) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(healHitPointAfterAdvBandage) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(healHitPointAfterAdvBandage);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(painIsOnlySuppressed) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(painIsOnlySuppressed);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(painEffectType) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(painEffectType);
         typeName = "SCALAR";
         value = 0;
@@ -204,18 +204,18 @@ class ACE_Settings {
         isClientSettable = 1;
     };
     class GVAR(allowUnconsciousAnimationOnTreatment) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(moveUnitsFromGroupOnUnconscious) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
 
     class GVAR(menuTypeStyle) {
-        category = CSTRING(Category_Medical);
+        category = LSTRING(Category_Medical);
         displayName = CSTRING(menuTypeDisplay);
         description = CSTRING(menuTypeDescription);
         typeName = "SCALAR";

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -1,94 +1,116 @@
 class ACE_Settings {
     class GVAR(level) {
+        category = "medical";
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "Basic", "Advanced"};
     };
     class GVAR(medicSetting) {
+        category = "medical";
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "Normal", "Advanced"};
     };
     class GVAR(enableFor) {
+        category = "medical";
         value = 0;
         typeName = "SCALAR";
         values[] = {"Players only", "Players and AI"};
     };
     class GVAR(enableOverdosing) {
+        category = "medical";
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(bleedingCoefficient) {
+        category = "medical";
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(painCoefficient) {
+        category = "medical";
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(enableAirway) {
+        category = "medical";
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableFractures) {
+        category = "medical";
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableAdvancedWounds) {
+        category = "medical";
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableVehicleCrashes) {
+        category = "medical";
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(enableScreams) {
+        category = "medical";
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(playerDamageThreshold) {
+        category = "medical";
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(AIDamageThreshold) {
+        category = "medical";
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(enableUnconsciousnessAI) {
+        category = "medical";
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "50/50", "Enabled"};
     };
     class GVAR(remoteControlledAI) {
+        category = "medical";
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(preventInstaDeath) {
+        category = "medical";
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(enableRevive) {
+        category = "medical";
         typeName = "SCALAR";
         value = 0;
         values[] = {"Disabled", "Players only", "Players and AI"};
     };
     class GVAR(maxReviveTime) {
+        category = "medical";
         typeName = "SCALAR";
         value = 120;
     };
     class GVAR(amountOfReviveLives) {
+        category = "medical";
         typeName = "SCALAR";
         value = -1;
     };
     class GVAR(allowDeadBodyMovement) {
+        category = "medical";
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(allowLitterCreation) {
+        category = "medical";
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(litterSimulationDetail) {
+        category = "medical";
         displayName = CSTRING(litterSimulationDetail);
         description = CSTRING(litterSimulationDetail_Desc);
         typeName = "SCALAR";
@@ -100,40 +122,48 @@ class ACE_Settings {
         isClientSettable = 1;
     };
     class GVAR(litterCleanUpDelay) {
+        category = "medical";
         typeName = "SCALAR";
         value = 0;
     };
     class GVAR(medicSetting_PAK) {
+        category = "medical";
         typeName = "SCALAR";
         value = 1;
         values[] = {"Anyone", "Medics only", "Doctors only"};
     };
     class GVAR(medicSetting_SurgicalKit) {
+        category = "medical";
         typeName = "SCALAR";
         value = 1;
         values[] = {"Anyone", "Medics only", "Doctors only"};
     };
     class GVAR(consumeItem_PAK) {
+        category = "medical";
         typeName = "SCALAR";
         value = 0;
         values[] = {"No", "Yes"};
     };
     class GVAR(consumeItem_SurgicalKit) {
+        category = "medical";
         typeName = "SCALAR";
         value = 0;
         values[] = {"No", "Yes"};
     };
     class GVAR(useLocation_PAK) {
+        category = "medical";
         typeName = "SCALAR";
         value = 3;
         values[] = {"Anywhere", "Medical vehicles", "Medical facility", "vehicle & facility", "Disabled"};
     };
     class GVAR(useLocation_SurgicalKit) {
+        category = "medical";
         typeName = "SCALAR";
         value = 2;
         values[] = {"Anywhere", "Medical vehicles", "Medical facility", "vehicle & facility", "Disabled"};
     };
     class GVAR(useCondition_PAK) {
+        category = "medical";
         displayName = CSTRING(AdvancedMedicalSettings_useCondition_PAK_DisplayName);
         description = CSTRING(AdvancedMedicalSettings_useCondition_PAK_Description);
         typeName = "SCALAR";
@@ -141,6 +171,7 @@ class ACE_Settings {
         values[] = {"Anytime", "Stable"};
     };
     class GVAR(useCondition_SurgicalKit) {
+        category = "medical";
         displayName = CSTRING(AdvancedMedicalSettings_useCondition_SurgicalKit_DisplayName);
         description = CSTRING(AdvancedMedicalSettings_useCondition_SurgicalKit_Description);
         typeName = "SCALAR";
@@ -148,20 +179,24 @@ class ACE_Settings {
         values[] = {"Anytime", "Stable"};
     };
     class GVAR(keepLocalSettingsSynced) {
+        category = "medical";
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(healHitPointAfterAdvBandage) {
+        category = "medical";
         displayName = CSTRING(healHitPointAfterAdvBandage);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(painIsOnlySuppressed) {
+        category = "medical";
         displayName = CSTRING(painIsOnlySuppressed);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(painEffectType) {
+        category = "medical";
         displayName = CSTRING(painEffectType);
         typeName = "SCALAR";
         value = 0;
@@ -169,15 +204,18 @@ class ACE_Settings {
         isClientSettable = 1;
     };
     class GVAR(allowUnconsciousAnimationOnTreatment) {
+        category = "medical";
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(moveUnitsFromGroupOnUnconscious) {
+        category = "medical";
         typeName = "BOOL";
         value = 0;
     };
 
     class GVAR(menuTypeStyle) {
+        category = "medical";
         displayName = CSTRING(menuTypeDisplay);
         description = CSTRING(menuTypeDescription);
         typeName = "SCALAR";

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -1,116 +1,116 @@
 class ACE_Settings {
     class GVAR(level) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "Basic", "Advanced"};
     };
     class GVAR(medicSetting) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "Normal", "Advanced"};
     };
     class GVAR(enableFor) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         value = 0;
         typeName = "SCALAR";
         values[] = {"Players only", "Players and AI"};
     };
     class GVAR(enableOverdosing) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(bleedingCoefficient) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(painCoefficient) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(enableAirway) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableFractures) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableAdvancedWounds) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = false;
     };
     class GVAR(enableVehicleCrashes) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(enableScreams) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(playerDamageThreshold) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(AIDamageThreshold) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
     };
     class GVAR(enableUnconsciousnessAI) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         value = 1;
         typeName = "SCALAR";
         values[] = {"Disabled", "50/50", "Enabled"};
     };
     class GVAR(remoteControlledAI) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(preventInstaDeath) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(enableRevive) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
         values[] = {"Disabled", "Players only", "Players and AI"};
     };
     class GVAR(maxReviveTime) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 120;
     };
     class GVAR(amountOfReviveLives) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = -1;
     };
     class GVAR(allowDeadBodyMovement) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(allowLitterCreation) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(litterSimulationDetail) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(litterSimulationDetail);
         description = CSTRING(litterSimulationDetail_Desc);
         typeName = "SCALAR";
@@ -122,48 +122,48 @@ class ACE_Settings {
         isClientSettable = 1;
     };
     class GVAR(litterCleanUpDelay) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
     };
     class GVAR(medicSetting_PAK) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
         values[] = {"Anyone", "Medics only", "Doctors only"};
     };
     class GVAR(medicSetting_SurgicalKit) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 1;
         values[] = {"Anyone", "Medics only", "Doctors only"};
     };
     class GVAR(consumeItem_PAK) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
         values[] = {"No", "Yes"};
     };
     class GVAR(consumeItem_SurgicalKit) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 0;
         values[] = {"No", "Yes"};
     };
     class GVAR(useLocation_PAK) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 3;
         values[] = {"Anywhere", "Medical vehicles", "Medical facility", "vehicle & facility", "Disabled"};
     };
     class GVAR(useLocation_SurgicalKit) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "SCALAR";
         value = 2;
         values[] = {"Anywhere", "Medical vehicles", "Medical facility", "vehicle & facility", "Disabled"};
     };
     class GVAR(useCondition_PAK) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(AdvancedMedicalSettings_useCondition_PAK_DisplayName);
         description = CSTRING(AdvancedMedicalSettings_useCondition_PAK_Description);
         typeName = "SCALAR";
@@ -171,7 +171,7 @@ class ACE_Settings {
         values[] = {"Anytime", "Stable"};
     };
     class GVAR(useCondition_SurgicalKit) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(AdvancedMedicalSettings_useCondition_SurgicalKit_DisplayName);
         description = CSTRING(AdvancedMedicalSettings_useCondition_SurgicalKit_Description);
         typeName = "SCALAR";
@@ -179,24 +179,24 @@ class ACE_Settings {
         values[] = {"Anytime", "Stable"};
     };
     class GVAR(keepLocalSettingsSynced) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(healHitPointAfterAdvBandage) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(healHitPointAfterAdvBandage);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(painIsOnlySuppressed) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(painIsOnlySuppressed);
         typeName = "BOOL";
         value = 1;
     };
     class GVAR(painEffectType) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(painEffectType);
         typeName = "SCALAR";
         value = 0;
@@ -204,18 +204,18 @@ class ACE_Settings {
         isClientSettable = 1;
     };
     class GVAR(allowUnconsciousAnimationOnTreatment) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
     class GVAR(moveUnitsFromGroupOnUnconscious) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         typeName = "BOOL";
         value = 0;
     };
 
     class GVAR(menuTypeStyle) {
-        category = "medical";
+        category = CSTRING(Category_Medical);
         displayName = CSTRING(menuTypeDisplay);
         description = CSTRING(menuTypeDescription);
         typeName = "SCALAR";

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -3648,5 +3648,17 @@
             <Spanish>Estable</Spanish>
             <Polish>Po stabilizacji</Polish>
         </Key>
+        <Key ID="STR_ACE_Medical_Category_Medical">
+            <English>Medical</English>
+            <Czech>Zdravotní</Czech>
+            <French>Médical</French>
+            <German>Sanitäter</German>
+            <Italian>Medico</Italian>
+            <Polish>Medyczne</Polish>
+            <Portuguese>Médico</Portuguese>
+            <Russian>Медик</Russian>
+            <Spanish>Médico</Spanish>
+            <Hungarian>Orvosi</Hungarian>
+        </Key>
     </Package>
 </Project>

--- a/addons/optionsmenu/CfgEventHandlers.hpp
+++ b/addons/optionsmenu/CfgEventHandlers.hpp
@@ -1,5 +1,10 @@
 class Extended_PreInit_EventHandlers {
-  class ADDON {
-    init = QUOTE(call COMPILE_FILE(XEH_preInit));
-  };
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
 };

--- a/addons/optionsmenu/XEH_postInit.sqf
+++ b/addons/optionsmenu/XEH_postInit.sqf
@@ -1,0 +1,11 @@
+
+#include "script_component.hpp"
+
+["SettingsInitialized", {
+    {
+        if !(_x select 8 in GVAR(categories)) then {
+            GVAR(categories) pushback (_x select 8);
+            diag_log format["Category: %1", _x];
+        };
+    }foreach EGVAR(common,settings);
+}] call EFUNC(common,addEventHandler);

--- a/addons/optionsmenu/XEH_postInit.sqf
+++ b/addons/optionsmenu/XEH_postInit.sqf
@@ -6,7 +6,6 @@
     {
         if !(_x select 8 in GVAR(categories)) then {
             GVAR(categories) pushback (_x select 8);
-            diag_log format["Category: %1", _x];
         };
     }foreach EGVAR(common,settings);
 }] call EFUNC(common,addEventHandler);

--- a/addons/optionsmenu/XEH_preInit.sqf
+++ b/addons/optionsmenu/XEH_preInit.sqf
@@ -17,10 +17,12 @@ PREP(settingsMenuUpdateKeyView);
 PREP(settingsMenuUpdateList);
 PREP(serverSettingsMenuUpdateKeyView);
 PREP(serverSettingsMenuUpdateList);
+PREP(onServerCategorySelectChanged);
 PREP(updateSetting);
 PREP(exportSettings);
 PREP(toggleIncludeClientSettings);
 PREP(moduleAllowConfigExport);
+PREP(stringEscape);
 
 GVAR(clientSideOptions) = [];
 GVAR(clientSideColors) = [];

--- a/addons/optionsmenu/XEH_preInit.sqf
+++ b/addons/optionsmenu/XEH_preInit.sqf
@@ -10,6 +10,7 @@ PREP(onSliderPosChanged);
 PREP(onServerSaveInputField);
 PREP(onServerSettingsMenuOpen);
 PREP(onServerListBoxShowSelectionChanged);
+PREP(onCategorySelectChanged);
 PREP(resetSettings);
 PREP(serverResetSettings);
 PREP(settingsMenuUpdateKeyView);
@@ -29,5 +30,7 @@ GVAR(ClientSettingsExportIncluded) = false;
 GVAR(serverSideOptions) = [];
 GVAR(serverSideColors) = [];
 GVAR(serverSideValues) = [];
+GVAR(categories) = [];
+GVAR(currentCategorySelection) = 0;
 
 ADDON = true;

--- a/addons/optionsmenu/functions/fnc_exportSettings.sqf
+++ b/addons/optionsmenu/functions/fnc_exportSettings.sqf
@@ -41,7 +41,6 @@ private ["_compiledConfig", "_name", "_typeName", "_isClientSetable", "_localize
     if (GVAR(ClientSettingsExportIncluded) || !_isClientSetable) then {
         _value = missionNamespace getvariable [_name, _defaultValue];
         if (_typeName == "STRING") then {
-            _value = [_value, '"', "'"] call CBA_fnc_replace; // TODO improve the quotation replacement
             _value = format['"%1"', _value];
         };
         if (_typeName == "BOOL") then {

--- a/addons/optionsmenu/functions/fnc_exportSettings.sqf
+++ b/addons/optionsmenu/functions/fnc_exportSettings.sqf
@@ -40,7 +40,8 @@ private ["_compiledConfig", "_name", "_typeName", "_isClientSetable", "_localize
 
     if (GVAR(ClientSettingsExportIncluded) || !_isClientSetable) then {
         _value = missionNamespace getvariable [_name, _defaultValue];
-        if (_typeName == "STRING") then { // I dont think we have string values, but just in case
+        if (_typeName == "STRING") then {
+            _value = [_value, '"', "'"] call CBA_fnc_replace; // TODO improve the quotation replacement
             _value = format['"%1"', _value];
         };
         if (_typeName == "BOOL") then {

--- a/addons/optionsmenu/functions/fnc_onCategorySelectChanged.sqf
+++ b/addons/optionsmenu/functions/fnc_onCategorySelectChanged.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: Glowbal
+ * Changes which category is selected
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call ACE_optionsmenu_fnc_onCategorySelectChanged
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+
+private ["_settingsMenu"];
+
+disableSerialization;
+_settingsMenu = uiNamespace getVariable 'ACE_settingsMenu';
+
+_ctrlComboBox = (_settingsMenu displayCtrl 14);
+GVAR(currentCategorySelection) = lbCurSel _ctrlComboBox;
+
+[false] call ACE_optionsmenu_fnc_settingsMenuUpdateList;

--- a/addons/optionsmenu/functions/fnc_onCategorySelectChanged.sqf
+++ b/addons/optionsmenu/functions/fnc_onCategorySelectChanged.sqf
@@ -24,4 +24,4 @@ _settingsMenu = uiNamespace getVariable 'ACE_settingsMenu';
 _ctrlComboBox = (_settingsMenu displayCtrl 14);
 GVAR(currentCategorySelection) = lbCurSel _ctrlComboBox;
 
-[false] call ACE_optionsmenu_fnc_settingsMenuUpdateList;
+[false] call FUNC(settingsMenuUpdateList);

--- a/addons/optionsmenu/functions/fnc_onServerCategorySelectChanged.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerCategorySelectChanged.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: Glowbal
+ * Changes which category is selected
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call ACE_optionsmenu_fnc_onCategorySelectChanged
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+
+private ["_settingsMenu"];
+
+disableSerialization;
+_settingsMenu = uiNamespace getVariable 'ACE_settingsMenu';
+
+_ctrlComboBox = (_settingsMenu displayCtrl 14);
+GVAR(currentCategorySelection) = lbCurSel _ctrlComboBox;
+
+[false] call FUNC(serverSettingsMenuUpdateList);

--- a/addons/optionsmenu/functions/fnc_onServerCategorySelectChanged.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerCategorySelectChanged.sqf
@@ -16,8 +16,11 @@
 
 #include "script_component.hpp"
 
-GVAR(currentCategorySelection) = lbCurSel 14;
+private ["_settingsMenu", "_ctrlComboBox"];
+disableSerialization;
+_settingsMenu = uiNamespace getVariable 'ACE_serverSettingsMenu';
 
-systemChat format["Current selection: %1", GVAR(currentCategorySelection)];
+_ctrlComboBox = (_settingsMenu displayCtrl 14);
+GVAR(currentCategorySelection) = lbCurSel _ctrlComboBox;
 
 [false] call FUNC(serverSettingsMenuUpdateList);

--- a/addons/optionsmenu/functions/fnc_onServerCategorySelectChanged.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerCategorySelectChanged.sqf
@@ -16,12 +16,8 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu"];
+GVAR(currentCategorySelection) = lbCurSel 14;
 
-disableSerialization;
-_settingsMenu = uiNamespace getVariable 'ACE_settingsMenu';
-
-_ctrlComboBox = (_settingsMenu displayCtrl 14);
-GVAR(currentCategorySelection) = lbCurSel _ctrlComboBox;
+systemChat format["Current selection: %1", GVAR(currentCategorySelection)];
 
 [false] call FUNC(serverSettingsMenuUpdateList);

--- a/addons/optionsmenu/functions/fnc_onServerSaveInputField.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerSaveInputField.sqf
@@ -29,7 +29,10 @@ switch (GVAR(optionMenu_openTab)) do {
                 _settingName = _setting select 0;
 
                 _convertedValue = switch (toUpper (_setting select 1)) do {
-                case "STRING": {format ['"%1"', _inputText]};
+                case "STRING": {
+                    ctrlSetText [414, _inputText call FUNC(stringEscape)];
+                    format ['%1', _inputText call FUNC(stringEscape)];
+                };
                 case "ARRAY": {format [call compile "[%1]", _inputText]};
                 case "SCALAR": {parseNumber _inputText;};
                     default {throw "Error"};

--- a/addons/optionsmenu/functions/fnc_onServerSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerSettingsMenuOpen.sqf
@@ -61,16 +61,19 @@ _menu = uiNamespace getvariable "ACE_serverSettingsMenu";
 (_menu displayCtrl 1003) ctrlEnable false;
 
 if (GVAR(ClientSettingsExportIncluded)) then {
-    (_settingsMenu displayCtrl 1102) ctrlSetText localize (LSTRING(exClientSettings));
+    (_settingsMenu displayCtrl 1102) ctrlSetText localize (CSTRING(exClientSettings));
 } else {
-    (_settingsMenu displayCtrl 1102) ctrlSetText localize (LSTRING(inClientSettings));
+    (_settingsMenu displayCtrl 1102) ctrlSetText localize (CSTRING(inClientSettings));
 };
 
+
+lbClear (_menu displayCtrl 14);
 {
     if (_x == "") then {
         _x = localize "STR_ACE_OptionsMenu_category_all";
     };
-    (_menu displayCtrl 14) lbAdd if (isLocalized _x) then {localize _x} else {_x};
+    if (isLocalized _x) then {_x = localize _x};
+    (_menu displayCtrl 14) lbAdd _x;
 } forEach GVAR(categories);
 
-(_menu displayCtrl 14) lbSetCurSel 0; //All Catagoies
+(_menu displayCtrl 14) lbSetCurSel GVAR(currentCategorySelection); //All Catagoies

--- a/addons/optionsmenu/functions/fnc_onServerSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onServerSettingsMenuOpen.sqf
@@ -65,3 +65,12 @@ if (GVAR(ClientSettingsExportIncluded)) then {
 } else {
     (_settingsMenu displayCtrl 1102) ctrlSetText localize (LSTRING(inClientSettings));
 };
+
+{
+    if (_x == "") then {
+        _x = localize "STR_ACE_OptionsMenu_category_all";
+    };
+    (_menu displayCtrl 14) lbAdd if (isLocalized _x) then {localize _x} else {_x};
+} forEach GVAR(categories);
+
+(_menu displayCtrl 14) lbSetCurSel 0; //All Catagoies

--- a/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
@@ -53,13 +53,15 @@ if (GVAR(serverConfigGeneration) == 0) then {
     (_menu displayCtrl 1102) ctrlShow false;
 };
 
+lbClear (_menu displayCtrl 14);
 {
     if (_x == "") then {
         _x = localize "STR_ACE_OptionsMenu_category_all";
     };
-    (_menu displayCtrl 14) lbAdd if (isLocalized _x) then {localize _x} else {_x};
+    if (isLocalized _x) then {_x = localize _x};
+    (_menu displayCtrl 14) lbAdd _x;
 } forEach GVAR(categories);
 
-(_menu displayCtrl 14) lbSetCurSel 0; //All Catagoies
+(_menu displayCtrl 14) lbSetCurSel GVAR(currentCategorySelection); //All Catagoies
 
 

--- a/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
@@ -52,3 +52,10 @@ if (GVAR(serverConfigGeneration) == 0) then {
     (_menu displayCtrl 1102) ctrlEnable false;
     (_menu displayCtrl 1102) ctrlShow false;
 };
+
+{
+    if (_x == "") then {
+        _x = "All Categories";
+    };
+    (_menu displayCtrl 14) lbAdd _x;
+} forEach GVAR(categories);

--- a/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
+++ b/addons/optionsmenu/functions/fnc_onSettingsMenuOpen.sqf
@@ -55,9 +55,9 @@ if (GVAR(serverConfigGeneration) == 0) then {
 
 {
     if (_x == "") then {
-        _x = "All Categories";
+        _x = localize "STR_ACE_OptionsMenu_category_all";
     };
-    (_menu displayCtrl 14) lbAdd _x;
+    (_menu displayCtrl 14) lbAdd if (isLocalized _x) then {localize _x} else {_x};
 } forEach GVAR(categories);
 
 (_menu displayCtrl 14) lbSetCurSel 0; //All Catagoies

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateKeyView.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateKeyView.sqf
@@ -52,7 +52,7 @@ if (count _collection > 0) then {
     switch (GVAR(optionMenu_openTab)) do {
         case (MENU_TAB_SERVER_OPTIONS): {
             _possibleValues = _setting select 5;
-            _settingsValue = _setting select 8;
+            _settingsValue = _setting select 9;
             // Created disable/enable options for bools
             if ((_setting select 1) == "BOOL") then {
                 lbClear 400;
@@ -66,14 +66,14 @@ if (count _collection > 0) then {
             (_settingsMenu displayCtrl 400) lbSetCurSel _settingsValue;
         };
         case (MENU_TAB_SERVER_COLORS): {
-            _currentColor = _setting select 8;
+            _currentColor = _setting select 9;
             {
                 sliderSetPosition [_x, (255 * (_currentColor select _forEachIndex))];
             } forEach [410, 411, 412, 413];
         };
         case (MENU_TAB_SERVER_VALUES): {
             // TODO implement
-            _settingsValue = _setting select 8;
+            _settingsValue = _setting select 9;
 
             // Created disable/enable options for bools
             _expectedType = switch (_setting select 1) do {

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateKeyView.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateKeyView.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu", "_ctrlList", "_collection", "_settingIndex", "_setting", "_entryName", "_localizedName", "_localizedDescription", "_possibleValues", "_settingsValue", "_currentColor", "_expectedType"];
+private ["_settingsMenu", "_ctrlList", "_collection", "_settingIndex", "_setting", "_entryName", "_localizedName", "_localizedDescription", "_possibleValues", "_settingsValue", "_currentColor", "_expectedType", "_filteredCollection", "_selectedCategory"];
 disableSerialization;
 
 _settingsMenu = uiNamespace getVariable 'ACE_serverSettingsMenu';
@@ -29,16 +29,24 @@ _collection = switch (GVAR(optionMenu_openTab)) do {
     default {[]};
 };
 
-if (count _collection > 0) then {
+_selectedCategory = GVAR(categories) select GVAR(currentCategorySelection);
+_filteredCollection = [];
+{
+    if (_selectedCategory == "" || {_selectedCategory == (_x select 8)}) then {
+        _filteredCollection pushBack _x;
+    };
+} forEach _collection;
+
+if (count _filteredCollection > 0) then {
     _settingIndex =  (lbCurSel _ctrlList);
-    if (_settingIndex > (count _collection)) then {
-        _settingIndex = count _collection  - 1;
+    if (_settingIndex > (count _filteredCollection)) then {
+        _settingIndex = count _filteredCollection  - 1;
     };
 
     if (_settingIndex < 0) then {
         _settingIndex = 0;
     };
-    _setting = _collection select _settingIndex;
+    _setting = _filteredCollection select _settingIndex;
 
     _entryName = _setting select 0;
     _localizedName = _setting select 3;

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
@@ -27,8 +27,6 @@ lbclear _ctrlList;
 
 _selectedCategory = GVAR(categories) select GVAR(currentCategorySelection);
 
-systemChat format["_selectedCategory: %1", _selectedCategory];
-
 
 switch (GVAR(optionMenu_openTab)) do {
     case (MENU_TAB_SERVER_OPTIONS): {

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
@@ -33,7 +33,7 @@ switch (GVAR(optionMenu_openTab)) do {
                 _ctrlList lbadd (_x select 0);
             };
 
-            _settingsValue = _x select 8;
+            _settingsValue = _x select 9;
 
             // Created disable/enable options for bools
             _settingsText = if ((_x select 1) == "BOOL") then {
@@ -47,7 +47,7 @@ switch (GVAR(optionMenu_openTab)) do {
     };
     case (MENU_TAB_SERVER_COLORS): {
         {
-            _color = +(_x select 8);
+            _color = +(_x select 9);
             {
                 _color set [_forEachIndex, ((round (_x * 100))/100)];
             } forEach _color;
@@ -58,7 +58,7 @@ switch (GVAR(optionMenu_openTab)) do {
                 _ctrlList lbadd (_x select 0);
             };
             _ctrlList lbadd (_settingsColor);
-            _ctrlList lnbSetColor [[_forEachIndex, 1], (_x select 8)];
+            _ctrlList lnbSetColor [[_forEachIndex, 1], (_x select 9)];
         }foreach GVAR(serverSideColors);
     };
     case (MENU_TAB_SERVER_VALUES): {
@@ -68,7 +68,7 @@ switch (GVAR(optionMenu_openTab)) do {
             } else {
                 _ctrlList lbadd (_x select 0);
             };
-            _settingsValue = _x select 8;
+            _settingsValue = _x select 9;
             if (typeName _settingsValue != "STRINg") then {
                 _settingsValue = format["%1", _settingsValue];
             };

--- a/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_serverSettingsMenuUpdateList.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView", "_settingsValue"];
+private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView", "_settingsValue", "_selectedCategory"];
 DEFAULT_PARAM(0,_updateKeyView,true);
 
 disableSerialization;
@@ -24,55 +24,67 @@ _settingsMenu = uiNamespace getVariable 'ACE_serverSettingsMenu';
 _ctrlList = _settingsMenu displayCtrl 200;
 
 lbclear _ctrlList;
+
+_selectedCategory = GVAR(categories) select GVAR(currentCategorySelection);
+
+systemChat format["_selectedCategory: %1", _selectedCategory];
+
+
 switch (GVAR(optionMenu_openTab)) do {
     case (MENU_TAB_SERVER_OPTIONS): {
         {
-            if ((_x select 3) != "") then {
-                _ctrlList lbadd (_x select 3);
-            } else {
-                _ctrlList lbadd (_x select 0);
+            if (_selectedCategory == "" || _selectedCategory == (_X select 8)) then {
+                if ((_x select 3) != "") then {
+                    _ctrlList lbadd (_x select 3);
+                } else {
+                    _ctrlList lbadd (_x select 0);
+                };
+
+                _settingsValue = _x select 9;
+
+                // Created disable/enable options for bools
+                _settingsText = if ((_x select 1) == "BOOL") then {
+                    [(localize LSTRING(Disabled)), (localize LSTRING(Enabled))] select _settingsValue;
+                } else {
+                    (_x select 5) select _settingsValue;
+                };
+
+                _ctrlList lbadd (_settingsText);
             };
-
-            _settingsValue = _x select 9;
-
-            // Created disable/enable options for bools
-            _settingsText = if ((_x select 1) == "BOOL") then {
-                [(localize LSTRING(Disabled)), (localize LSTRING(Enabled))] select _settingsValue;
-            } else {
-                (_x select 5) select _settingsValue;
-            };
-
-            _ctrlList lbadd (_settingsText);
         }foreach GVAR(serverSideOptions);
     };
     case (MENU_TAB_SERVER_COLORS): {
         {
-            _color = +(_x select 9);
-            {
-                _color set [_forEachIndex, ((round (_x * 100))/100)];
-            } forEach _color;
-            _settingsColor = str _color;
-            if ((_x select 3) != "") then {
-                _ctrlList lbadd (_x select 3);
-            } else {
-                _ctrlList lbadd (_x select 0);
+            if (_selectedCategory == "" || _selectedCategory == (_X select 8)) then {
+                _color = +(_x select 9);
+                {
+                    _color set [_forEachIndex, ((round (_x * 100))/100)];
+                } forEach _color;
+                _settingsColor = str _color;
+                if ((_x select 3) != "") then {
+                    _ctrlList lbadd (_x select 3);
+                } else {
+                    _ctrlList lbadd (_x select 0);
+                };
+                _ctrlList lbadd (_settingsColor);
+                _ctrlList lnbSetColor [[_forEachIndex, 1], (_x select 9)];
             };
-            _ctrlList lbadd (_settingsColor);
-            _ctrlList lnbSetColor [[_forEachIndex, 1], (_x select 9)];
         }foreach GVAR(serverSideColors);
     };
     case (MENU_TAB_SERVER_VALUES): {
         {
-            if ((_x select 3) != "") then {
-                _ctrlList lbadd (_x select 3);
-            } else {
-                _ctrlList lbadd (_x select 0);
+            if (_selectedCategory == "" || _selectedCategory == (_X select 8)) then {
+                if ((_x select 3) != "") then {
+                    _ctrlList lbadd (_x select 3);
+                } else {
+                    _ctrlList lbadd (_x select 0);
+                };
+                _settingsValue = _x select 9;
+                if (typeName _settingsValue != "STRINg") then {
+                    _settingsValue = format["%1", _settingsValue];
+                };
+                _ctrlList lbadd (_settingsValue);
             };
-            _settingsValue = _x select 9;
-            if (typeName _settingsValue != "STRINg") then {
-                _settingsValue = format["%1", _settingsValue];
-            };
-            _ctrlList lbadd (_settingsValue);
         }foreach GVAR(serverSideValues);
     };
 };

--- a/addons/optionsmenu/functions/fnc_settingsMenuUpdateKeyView.sqf
+++ b/addons/optionsmenu/functions/fnc_settingsMenuUpdateKeyView.sqf
@@ -37,7 +37,18 @@ if (count _collection > 0) then {
     if (_settingIndex < 0) then {
         _settingIndex = 0;
     };
+    diag_log format["_collection: %1", _collection];
     _setting = _collection select _settingIndex;
+
+    _selectedCategory = GVAR(categories) select GVAR(currentCategorySelection);
+    if !(_selectedCategory == "All Categories" || _selectedCategory == (_setting select 8)) exitwith {
+        systemChat format["INCORRECT CATEGORY: %1 != %2", _selectedCategory, _setting];
+        diag_log format["INCORRECT CATEGORY: %1 != %2", _selectedCategory, _setting];
+        lbClear 400;
+        (_settingsMenu displayCtrl 250) ctrlSetText "No settings available";
+        (_settingsMenu displayCtrl 251) ctrlSetText "No settings available";
+        (_settingsMenu displayCtrl 300) ctrlSetText "No settings available";
+    };
 
     _entryName = _setting select 0;
     _localizedName = _setting select 3;
@@ -51,7 +62,7 @@ if (count _collection > 0) then {
     switch (GVAR(optionMenu_openTab)) do {
         case (MENU_TAB_OPTIONS): {
             _possibleValues = _setting select 5;
-            _settingsValue = _setting select 8;
+            _settingsValue = _setting select 9;
 
             // Created disable/enable options for bools
             if ((_setting select 1) == "BOOL") then {
@@ -66,7 +77,7 @@ if (count _collection > 0) then {
             (_settingsMenu displayCtrl 400) lbSetCurSel _settingsValue;
         };
         case (MENU_TAB_COLORS): {
-            _currentColor = _setting select 8;
+            _currentColor = _setting select 9;
             {
                 sliderSetPosition [_x, (255 * (_currentColor select _forEachIndex))];
             } forEach [410, 411, 412, 413];

--- a/addons/optionsmenu/functions/fnc_settingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_settingsMenuUpdateList.sqf
@@ -25,33 +25,37 @@ _ctrlList = _settingsMenu displayCtrl 200;
 
 lbclear _ctrlList;
 
+_selectedCategory = GVAR(categories) select GVAR(currentCategorySelection);
+
 switch (GVAR(optionMenu_openTab)) do {
     case (MENU_TAB_OPTIONS): {
         {
-            _ctrlList lbadd (_x select 3);
+            if (_selectedCategory == "All Categories" || _selectedCategory == (_X select 8)) then {
+                _ctrlList lbadd (_x select 3);
+                _settingsValue = _x select 9;
 
-            _settingsValue = _x select 8;
-
-            // Created disable/enable options for bools
-            _settingsText = if ((_x select 1) == "BOOL") then {
-                [(localize LSTRING(Disabled)), (localize LSTRING(Enabled))] select _settingsValue;
-            } else {
-                (_x select 5) select _settingsValue;
+                // Created disable/enable options for bools
+                _settingsText = if ((_x select 1) == "BOOL") then {
+                    [(localize LSTRING(Disabled)), (localize LSTRING(Enabled))] select _settingsValue;
+                } else {
+                    (_x select 5) select _settingsValue;
+                };
+                _ctrlList lbadd (_settingsText);
             };
-
-            _ctrlList lbadd (_settingsText);
         }foreach GVAR(clientSideOptions);
     };
     case (MENU_TAB_COLORS): {
-    {
-            _color = +(_x select 8);
-            {
-                _color set [_forEachIndex, ((round (_x * 100))/100)];
-            } forEach _color;
-            _settingsColor = str _color;
-            _ctrlList lbadd (_x select 3);
-            _ctrlList lbadd (_settingsColor);
-            _ctrlList lnbSetColor [[_forEachIndex, 1], (_x select 8)];
+        {
+            if (_selectedCategory == "All Categories" || _selectedCategory == (_X select 8)) then {
+                _color = +(_x select 9);
+                {
+                    _color set [_forEachIndex, ((round (_x * 100))/100)];
+                } forEach _color;
+                _settingsColor = str _color;
+                _ctrlList lbadd (_x select 3);
+                _ctrlList lbadd (_settingsColor);
+                _ctrlList lnbSetColor [[_forEachIndex, 1], (_x select 9)];
+            };
         }foreach GVAR(clientSideColors);
     };
 };

--- a/addons/optionsmenu/functions/fnc_settingsMenuUpdateList.sqf
+++ b/addons/optionsmenu/functions/fnc_settingsMenuUpdateList.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView", "_settingsValue"];
+private ["_settingsMenu", "_ctrlList", "_settingsText", "_color", "_settingsColor", "_updateKeyView", "_settingsValue", "_selectedCategory"];
 DEFAULT_PARAM(0,_updateKeyView,true);
 
 disableSerialization;

--- a/addons/optionsmenu/functions/fnc_stringEscape.sqf
+++ b/addons/optionsmenu/functions/fnc_stringEscape.sqf
@@ -1,0 +1,59 @@
+/*
+ * Author: Glowbal
+ * Parse the string for quotation marks, so it can be used for config export.
+ *
+ * Arguments:
+ * 0: string <STRING>
+ *
+ * Return Value:
+ * parsed string <STRING>
+ *
+ * Example:
+ * [] call ACE_optionsmenu_fnc_stringEscape
+ *
+ * Public: No
+ */
+
+private ["_str", "_array", "_maxIndex"];
+_str = _this;
+
+_isEven = {
+    params ["_array", "_index"];
+    private [ "_count"];
+    _count = 0;
+    {
+        if (_forEachIndex <= _index && {_x == 39}) then {
+            _count = _count + 1;
+        };
+    }foreach _array;
+
+    _count %2 == 0;
+};
+
+// reg: 34
+// single: 39
+_array = toArray _str;
+{
+    if (_x == 34) then {
+        _array set [_foreachIndex, 39];
+    };
+}foreach _array;
+
+_maxIndex = count _array;
+for "_i" from 0 to _maxIndex /* step +1 */ do {
+    if (((_i + 1) < _maxIndex - 1) && {_array select _i == 39 && (_array select (_i + 1)) == 39}) then {
+        if ([_array, _i] call _isEven) then {
+            _array deleteAt _i;
+            _i = _i - 1;
+            _maxIndex = _maxIndex - 1;
+        };
+    };
+};
+
+{
+    if (_x == 34) then {
+        _array set [_foreachIndex, 39];
+    };
+}foreach _array;
+
+toString _array;

--- a/addons/optionsmenu/functions/fnc_updateSetting.sqf
+++ b/addons/optionsmenu/functions/fnc_updateSetting.sqf
@@ -34,7 +34,7 @@ switch (_type) do {
 
           if !((_x select 9) isEqualTo _newValue) then {
             _changed = true;
-            _x set [8, _newValue];
+            _x set [9, _newValue];
           } ;
 
         };
@@ -44,7 +44,7 @@ switch (_type) do {
       {
         if (((_x select 0) == _name) && {!((_x select 9) isEqualTo _newValue)}) then {
           _changed = true;
-          _x set [8, _newValue];
+          _x set [9, _newValue];
         };
       } foreach GVAR(clientSideColors);
   };
@@ -58,7 +58,7 @@ switch (_type) do {
 
           if !((_x select 9) isEqualTo _newValue) then {
             _changed = true;
-            _x set [8, _newValue];
+            _x set [9, _newValue];
           } ;
 
         };
@@ -68,7 +68,7 @@ switch (_type) do {
       {
         if (((_x select 0) == _name) && {!((_x select 9) isEqualTo _newValue)}) then {
           _changed = true;
-          _x set [8, _newValue];
+          _x set [9, _newValue];
         };
       } foreach GVAR(serverSideColors);
   };
@@ -76,7 +76,7 @@ switch (_type) do {
       {
         if (((_x select 0) == _name) && {!((_x select 9) isEqualTo _newValue)}) then {
           _changed = true;
-          _x set [8, _newValue];
+          _x set [9, _newValue];
         };
       } foreach GVAR(serverSideValues);
   };

--- a/addons/optionsmenu/functions/fnc_updateSetting.sqf
+++ b/addons/optionsmenu/functions/fnc_updateSetting.sqf
@@ -32,7 +32,7 @@ switch (_type) do {
             _newValue = [false, true] select _newValue;
           };
 
-          if !((_x select 8) isEqualTo _newValue) then {
+          if !((_x select 9) isEqualTo _newValue) then {
             _changed = true;
             _x set [8, _newValue];
           } ;
@@ -42,7 +42,7 @@ switch (_type) do {
   };
   case (MENU_TAB_COLORS): {
       {
-        if (((_x select 0) == _name) && {!((_x select 8) isEqualTo _newValue)}) then {
+        if (((_x select 0) == _name) && {!((_x select 9) isEqualTo _newValue)}) then {
           _changed = true;
           _x set [8, _newValue];
         };
@@ -56,7 +56,7 @@ switch (_type) do {
             _newValue = [false, true] select _newValue;
           };
 
-          if !((_x select 8) isEqualTo _newValue) then {
+          if !((_x select 9) isEqualTo _newValue) then {
             _changed = true;
             _x set [8, _newValue];
           } ;
@@ -66,7 +66,7 @@ switch (_type) do {
   };
   case (MENU_TAB_SERVER_COLORS): {
       {
-        if (((_x select 0) == _name) && {!((_x select 8) isEqualTo _newValue)}) then {
+        if (((_x select 0) == _name) && {!((_x select 9) isEqualTo _newValue)}) then {
           _changed = true;
           _x set [8, _newValue];
         };
@@ -74,7 +74,7 @@ switch (_type) do {
   };
   case (MENU_TAB_SERVER_VALUES): {
       {
-        if (((_x select 0) == _name) && {!((_x select 8) isEqualTo _newValue)}) then {
+        if (((_x select 0) == _name) && {!((_x select 9) isEqualTo _newValue)}) then {
           _changed = true;
           _x set [8, _newValue];
         };

--- a/addons/optionsmenu/gui/settingsMenu.hpp
+++ b/addons/optionsmenu/gui/settingsMenu.hpp
@@ -77,9 +77,19 @@ class ACE_settingsMenu {
             idc = 13;
             x = X_PART(2);
             y = Y_PART(3.4);
-            w = W_PART(30);
+            w = W_PART(15);
             h = H_PART(1);
             text = "";
+        };
+        class categorySelection: ACE_gui_comboBoxBase {
+            idc = 14;
+            x = X_PART(15);
+            y = Y_PART(3.4);
+            w = W_PART(9);
+            h = H_PART(1);
+            text = "";
+            onLBSelChanged = QUOTE( call FUNC(onCategorySelectChanged));
+            SizeEx = H_PART(0.9);
         };
         class selectionAction_1: ACE_gui_buttonBase {
             idc = 1000;

--- a/addons/optionsmenu/gui/settingsMenu.hpp
+++ b/addons/optionsmenu/gui/settingsMenu.hpp
@@ -1,9 +1,3 @@
-class ACE_settingsMenu {
-    idd = 145246;
-    movingEnable = false;
-    onLoad = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', _this select 0)]; [] call FUNC(onSettingsMenuOpen););
-    onUnload = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', nil)]; saveProfileNamespace;);
-
 #define SIZEX (((safezoneW / safezoneH) min 1.2))
 #define SIZEY (SIZEX / 1.2)
 #define X_ORIGINAL(num) (num * (SIZEX / 40) + (safezoneX + (safezoneW - SIZEX)/2))
@@ -20,6 +14,12 @@ class ACE_settingsMenu {
 #define Y_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), Y_ORIGINAL(num), Y_MAKEITBIGGA(num))])
 #define W_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), W_ORIGINAL(num), W_MAKEITBIGGA(num))])
 #define H_PART(num) QUOTE(linearConversion [ARR_5(0, 2, (missionNamespace getVariable [ARR_2(QUOTE(QGVAR(optionMenuDisplaySize)), 0)]), H_ORIGINAL(num), H_MAKEITBIGGA(num))])
+
+class ACE_settingsMenu {
+    idd = 145246;
+    movingEnable = false;
+    onLoad = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', _this select 0)]; [] call FUNC(onSettingsMenuOpen););
+    onUnload = QUOTE(uiNamespace setVariable [ARR_2('ACE_settingsMenu', nil)]; saveProfileNamespace;);
 
     class controlsBackground {
         class HeaderBackground: ACE_gui_backgroundBase {
@@ -83,7 +83,7 @@ class ACE_settingsMenu {
         };
         class categorySelection: ACE_gui_comboBoxBase {
             idc = 14;
-            x = X_PART(15);
+            x = X_PART(14);
             y = Y_PART(3.4);
             w = W_PART(9);
             h = H_PART(1);
@@ -300,6 +300,16 @@ class ACE_serverSettingsMenu: ACE_settingsMenu {
             w = W_PART(30);
             h = H_PART(1);
             text = "";
+        };
+        class categorySelection: ACE_gui_comboBoxBase {
+            idc = 14;
+            x = X_PART(14);
+            y = Y_PART(3.4);
+            w = W_PART(9);
+            h = H_PART(1);
+            text = "";
+            onLBSelChanged = QUOTE( call FUNC(onServerCategorySelectChanged));
+            SizeEx = H_PART(0.9);
         };
         class selectionAction_1: ACE_gui_buttonBase {
             idc = 1000;

--- a/addons/optionsmenu/stringtable.xml
+++ b/addons/optionsmenu/stringtable.xml
@@ -367,5 +367,8 @@
             <Polish>Pokazuj wiadomości ACE w menu głównym</Polish>
             <Czech>Zobrazit novinky v hlavním menu</Czech>
         </Key>
+        <Key ID="STR_ACE_OptionsMenu_category_all">
+            <English>All Categories</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/optionsmenu/stringtable.xml
+++ b/addons/optionsmenu/stringtable.xml
@@ -345,10 +345,10 @@
             <German>Protokolliert Debug-Informationen im RPT und speichert sie in der Zwischenablage.</German>
             <Portuguese>Envia informação de depuração para RPT e área de transferência.</Portuguese>
         </Key>
-		<Key ID="STR_ACE_OptionsMenu_headBugFix">
+        <Key ID="STR_ACE_OptionsMenu_headBugFix">
             <English>Headbug Fix</English>
         </Key>
-		<Key ID="STR_ACE_OptionsMenu_headBugFixTooltip">
+        <Key ID="STR_ACE_OptionsMenu_headBugFixTooltip">
             <English>Resets your animation state.</English>
         </Key>
         <Key ID="STR_ACE_OptionsMenu_aceNews">
@@ -369,6 +369,7 @@
         </Key>
         <Key ID="STR_ACE_OptionsMenu_category_all">
             <English>All Categories</English>
+            <Polish>Wszystkie kategorie</Polish>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
* Adds a category selection to the options menu, both client and config export variants.
* Two of the larger modules with settings received categories with this PR. All others still require adding them.
* All categories are localized for clients. 

Adding a new category is done through adding the following attribute to a settings entry:
```c++
category = "STR_ACE_Module_Category";
```
Obviously replace module by whatever module the setting belongs to and add the string to the stringtable entry with necessary translations. No other requirements.
