### PR TITLE
Fix and enhancement of two common functions

### DIFF
--- a/addons/common/functions/fnc_disableUserInput.sqf
+++ b/addons/common/functions/fnc_disableUserInput.sqf
@@ -84,7 +84,7 @@ if (_state) then {
             openMap true;
         };
 
-        if (serverCommandAvailable "#missions" || {player getVariable ["ACE_isUnconscious", false] && {(call FUNC(player)) getVariable [QEGVAR(medical,AllowChatWhileUnconscious), missionNamespace getVariable [QEGVAR(medical,AllowChatWhileUnconscious), false]]}}) then {
+        if (isServer || {serverCommandAvailable "#kick"} || {player getVariable ["ACE_isUnconscious", false] && {(call FUNC(player)) getVariable [QEGVAR(medical,AllowChatWhileUnconscious), missionNamespace getVariable [QEGVAR(medical,AllowChatWhileUnconscious), false]]}}) then {
             if (!(_key in (actionKeys "DefaultAction" + actionKeys "Throw")) && {_key in (actionKeys "Chat" + actionKeys "PrevChannel" + actionKeys "NextChannel")}) then {
                 _key = 0;
             };

--- a/addons/common/functions/fnc_isFeatureCameraActive.sqf
+++ b/addons/common/functions/fnc_isFeatureCameraActive.sqf
@@ -1,31 +1,35 @@
 /*
  * Author: Sniperwolf572
+ * Checks if one of the following common feature cameras is active:
  *
- * Checks if one of the following BI feature cameras are active:
- *
- * - Classic camera (BIS_fnc_cameraOld)
- * - Splendid camera (BIS_fnc_camera)
+ * - Curator
+ * - ACE Spectator
  * - Arsenal camera (BIS_fnc_arsenal)
- * - Animation viewer (BIS_fnc_animViewer)
  * - Establishing shot (BIS_fnc_establishingShot)
+ * - Splendid camera (BIS_fnc_camera)
+ * - Animation viewer (BIS_fnc_animViewer)
+ * - Classic camera (BIS_fnc_cameraOld)
  *
  * Arguments:
- * None
+ * 0: None <NIL>
  *
- * Return value:
- * Is BI feature camera active (bool)
+ * Return Value:
+ * A feature camera is active <BOOL>
  *
  * Example:
- * call ace_common_fnc_isFeatureCameraActive;
+ * [] call ace_common_fnc_isFeatureCameraActive
  *
+ * Public: No
  */
 
 #include "script_component.hpp"
 
-(
-    !isNull (missionNamespace getVariable ["BIS_DEBUG_CAM", objNull]) || // Classic camera
-    {!isNull (missionNamespace getVariable ["BIS_fnc_camera_cam", objNull])} || // Splendid camera
-    {!isNull (uiNamespace getVariable ["BIS_fnc_arsenal_cam", objNull])} || // Arsenal camera
-    {!isNull (uiNamespace getVariable ["BIS_fnc_animViewer_cam", objNull])} || // Animation viewer camera
-    {!isNull (missionNamespace getVariable ["BIS_fnc_establishingShot_fakeUAV", objNull])} // Establishing shot camera   
+!(
+    isNull curatorCamera && // Curator
+    {isNull (GETMVAR(EGVAR(spectator,camera),objNull))} && // ACE Spectator
+    {isNull (GETUVAR(BIS_fnc_arsenal_cam, objNull))} && // Arsenal camera
+    {isNull (GETMVAR(BIS_fnc_establishingShot_fakeUAV, objNull))} && // Establishing shot camera
+    {isNull (GETMVAR(BIS_fnc_camera_cam, objNull))} && // Splendid camera
+    {isNull (GETUVAR(BIS_fnc_animViewer_cam, objNull))} && // Animation viewer camera
+    {isNull (GETMVAR(BIS_DEBUG_CAM, objNull))} // Classic camera
 )


### PR DESCRIPTION
- The `disableUserInput` function allows for use of chat if user has admin access, however it didn't account for the host of listen servers (where `serverCommandAvailable` returns false).
- Expanding the `isFeatureCameraActive` function to support the curator camera and the upcoming ace_spectator camera. Also optimized the lazy evaluation and updated the function header.