### PR TITLE
Fixed incorrect string path in nametags

### DIFF
--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -11,7 +11,7 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = CSTRING(ShowPlayerNames);
         description = CSTRING(ShowPlayerNames_Desc);
-        values[] = {ECSTRING(common,Disabled), CSTRING(Enabled), CSTRING(OnlyCursor), CSTRING(OnlyKeypress), CSTRING(OnlyCursorAndKeypress)};
+        values[] = {ECSTRING(common,Disabled), ECSTRING(common,Enabled), CSTRING(OnlyCursor), CSTRING(OnlyKeypress), CSTRING(OnlyCursorAndKeypress)};
     };
     class GVAR(showPlayerRanks) {
         value = 1;


### PR DESCRIPTION
Fixes #2076 - The missing one was actually "Enabled".
@gienkov you should get the error `String $STR_ace_nametags_Enabled not found` before.