### PR TITLE
Make finger enabled by default

### DIFF
--- a/addons/finger/ACE_Settings.hpp
+++ b/addons/finger/ACE_Settings.hpp
@@ -1,6 +1,6 @@
 class ACE_Settings {
     class GVAR(enabled) {
-        value = 0;
+        value = 1;
         typeName = "BOOL";
         displayName = CSTRING(enabled_displayName);
     };


### PR DESCRIPTION
Why it's disabled in first place?