### PR TITLE
Medical Menu stringtable.xml space invalidating xml structure

### DIFF
--- a/addons/medical_menu/stringtable.xml
+++ b/addons/medical_menu/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Project name="Combat Space Enhancement">
     <Package name="Combat Medical System">
         <Container name="UI">
@@ -388,4 +388,4 @@
             </Key>
         </Container>
     </Package>
-</Project> 
+</Project>


### PR DESCRIPTION
The space in the XML metadata leads to XML parser issues.