### PR TITLE
AddAction basic param checking

### DIFF
--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -19,7 +19,9 @@
  */
 #include "script_component.hpp"
 
-params ["_objectType", "_typeNum", "_parentPath", "_action"];
+if (!params [["_objectType", "", [""]], ["_typeNum", 0, [0]], ["_parentPath", [], [[]]], ["_action", [], [[]], 11]]) exitWith {
+    ERROR("Bad Params");
+};
 
 // Ensure the config menu was compiled first
 if (_typeNum == 0) then {

--- a/addons/interact_menu/functions/fnc_addActionToObject.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToObject.sqf
@@ -19,7 +19,9 @@
  */
 #include "script_component.hpp"
 
-params ["_object", "_typeNum", "_parentPath", "_action"];
+if (!params [["_object", objNull, [objNull]], ["_typeNum", 0, [0]], ["_parentPath", [], [[]]], ["_action", [], [[]], 11]]) exitWith {
+    ERROR("Bad Params");
+};
 
 private ["_varName","_actionList"];
 _varName = [QGVAR(actions),QGVAR(selfActions)] select _typeNum;


### PR DESCRIPTION
From @alganthe 

doing `[cursorTarget, 0, ["ACE_TapShoulderRight"], XX] call ace_interact_menu_fnc_addActionToObject;` will cause hard lockup if `XX` is undefined.

Params is very fast and I think it's worth it as these can be publicly used functions.