### PR TITLE
Fixed error pop-up invalid configured hitpoints

### DIFF
--- a/addons/common/functions/fnc_getHitPointsWithSelections.sqf
+++ b/addons/common/functions/fnc_getHitPointsWithSelections.sqf
@@ -41,14 +41,15 @@ _hitpointClasses = [_config >> "HitPoints"];
     while {isClass _class} do {
 
         for "_i" from 0 to (count _class - 1) do {
-            private ["_entry", "_selection"];
+            if (isClass (_class select _i)) then {
+                private ["_entry", "_selection"];
+                _entry = configName (_class select _i);
+                _selection = getText (_class select _i >> "name");
 
-            _entry = configName (_class select _i);
-            _selection = getText (_class select _i >> "name");
-
-            if (!(_selection in _selections) && {!isNil {_vehicle getHit _selection}}) then {
-                _hitpoints pushBack _entry;
-                _selections pushBack _selection;
+                if (!(_selection in _selections) && {!isNil {_vehicle getHit _selection}}) then {
+                    _hitpoints pushBack _entry;
+                    _selections pushBack _selection;
+                };
             };
         };
 


### PR DESCRIPTION
Fixed error pop-up kicking you out of game in case a third party vehicle has incorrect configured hitpoints/selections.

This is necessary for the vehicle repair module, that makes use of `getHitPointsWithSelections`. Some custom party modifications have incorrectly configured their vehicle hitpoints and as a result you will get kicked out of the game. 

This validation check ensures this doesn't happen anymore.