### PR TITLE
Fix treatment when weapon deployed

### DIFF
--- a/addons/medical/functions/fnc_treatment.sqf
+++ b/addons/medical/functions/fnc_treatment.sqf
@@ -181,8 +181,12 @@ if (vehicle _caller == _caller && {_callerAnim != ""}) then {
         [_caller, "", 0] call EFUNC(common,doAnimation);
     };
     
-    if (stance _caller == "STAND") then {
-        _caller setvariable [QGVAR(treatmentPrevAnimCaller), "amovpknlmstpsraswrfldnon"];
+    if ((stance _caller) == "STAND") then {
+        switch (_wpn) do {//If standing, end in a crouched animation based on their current weapon
+            case ("rfl"): {_caller setvariable [QGVAR(treatmentPrevAnimCaller), "AmovPknlMstpSrasWrflDnon"];};
+            case ("pst"): {_caller setvariable [QGVAR(treatmentPrevAnimCaller), "AmovPknlMstpSrasWpstDnon"];};
+            case ("non"): {_caller setvariable [QGVAR(treatmentPrevAnimCaller), "AmovPknlMstpSnonWnonDnon"];};
+        };
     } else {
         _caller setvariable [QGVAR(treatmentPrevAnimCaller), animationState _caller];
     };

--- a/addons/medical/functions/fnc_treatment.sqf
+++ b/addons/medical/functions/fnc_treatment.sqf
@@ -176,6 +176,11 @@ if (vehicle _caller == _caller && {_callerAnim != ""}) then {
         _caller selectWeapon (primaryWeapon _caller); // unit always has a primary weapon here
     };
 
+    if (isWeaponDeployed _caller) then {
+        TRACE_1("Weapon Deployed, breaking out first",(stance _caller));
+        [_caller, "", 0] call EFUNC(common,doAnimation);
+    };
+    
     if (stance _caller == "STAND") then {
         _caller setvariable [QGVAR(treatmentPrevAnimCaller), "amovpknlmstpsraswrfldnon"];
     } else {


### PR DESCRIPTION
Fix #2178 - Un-deploys if bipod is out

Also fixes a minor problem when healing with a pistol when standing, it would switch from pistol back to rifle and then back to pistol.  Picks ending animation based on starting weapon.