### PR TITLE
Fixed Release action blending with base interaction point

### DIFF
--- a/addons/dragging/functions/fnc_setCarryable.sqf
+++ b/addons/dragging/functions/fnc_setCarryable.sqf
@@ -53,4 +53,4 @@ _carryAction = [QGVAR(carry), localize LSTRING(Carry), "", {[_player, _target] c
 _dropAction = [QGVAR(drop_carry), localize LSTRING(Drop), "", {[_player, _target] call FUNC(dropObject_carry)}, {[_player, _target] call FUNC(canDrop_carry)}] call EFUNC(interact_menu,createAction);
 
 [_type, 0, ["ACE_MainActions"], _carryAction] call EFUNC(interact_menu,addActionToClass);
-[_type, 0, [], _dropAction] call EFUNC(interact_menu,addActionToClass);
+[_type, 0, ["ACE_MainActions"], _dropAction] call EFUNC(interact_menu,addActionToClass);

--- a/addons/dragging/functions/fnc_setDraggable.sqf
+++ b/addons/dragging/functions/fnc_setDraggable.sqf
@@ -53,4 +53,4 @@ _dragAction = [QGVAR(drag), localize LSTRING(Drag), "", {[_player, _target] call
 _dropAction = [QGVAR(drop), localize LSTRING(Drop), "", {[_player, _target] call FUNC(dropObject)}, {[_player, _target] call FUNC(canDrop)}] call EFUNC(interact_menu,createAction);
 
 [_type, 0, ["ACE_MainActions"], _dragAction] call EFUNC(interact_menu,addActionToClass);
-[_type, 0, [], _dropAction] call EFUNC(interact_menu,addActionToClass);
+[_type, 0, ["ACE_MainActions"], _dropAction] call EFUNC(interact_menu,addActionToClass);


### PR DESCRIPTION
This moves `Release` interaction menu action inside `Interactions`, otherwise they were on top of each other, blending together (well technically `Release` was over `Interactions`).

With this you can now also drag/carry and load into vehicle directly without the need of releasing the object first (animation resets due to the dragging/carrying PFH).