### PR TITLE
Cargo Events

### DIFF
--- a/addons/cargo/CfgEventHandlers.hpp
+++ b/addons/cargo/CfgEventHandlers.hpp
@@ -4,6 +4,12 @@ class Extended_PreInit_EventHandlers {
     };
 };
 
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};
+
 class Extended_Killed_EventHandlers {
     class All {
         init = QUOTE(call FUNC(handleDestroyed));

--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -2,3 +2,4 @@
 
 ["LoadItem", {_this call FUNC(loadItem)}] call EFUNC(common,addEventHandler);
 ["UnloadItem", {_this call FUNC(unloadItem)}] call EFUNC(common,addEventHandler);
+["AddCargoItem", {_this call FUNC(addCargoItem)}] call EFUNC(common,addEventHandler);

--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -1,5 +1,5 @@
 #include "script_component.hpp"
 
-["LoadItem", {_this call FUNC(loadItem)}] call EFUNC(common,addEventHandler);
-["UnloadItem", {_this call FUNC(unloadItem)}] call EFUNC(common,addEventHandler);
-["AddCargoItem", {_this call FUNC(addCargoItem)}] call EFUNC(common,addEventHandler);
+["LoadCargo", {_this call FUNC(loadItem)}] call EFUNC(common,addEventHandler);
+["UnloadCargo", {_this call FUNC(unloadItem)}] call EFUNC(common,addEventHandler);
+["AddCargoByClass", {_this call FUNC(addCargoItem)}] call EFUNC(common,addEventHandler);

--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -1,0 +1,4 @@
+#include "script_component.hpp"
+
+["LoadItem", {_this call FUNC(loadItem)}] call EFUNC(common,addEventHandler);
+["UnloadItem", {_this call FUNC(unloadItem)}] call EFUNC(common,addEventHandler);

--- a/addons/cargo/XEH_preInit.sqf
+++ b/addons/cargo/XEH_preInit.sqf
@@ -2,6 +2,7 @@
 
 ADDON = false;
 
+PREP(addCargoItem);
 PREP(canLoad);
 PREP(canLoadItemIn);
 PREP(canUnloadItem);

--- a/addons/cargo/XEH_preInit.sqf
+++ b/addons/cargo/XEH_preInit.sqf
@@ -21,8 +21,4 @@ PREP(validateCargoSpace);
 
 GVAR(initializedItemClasses) = [];
 
-if (isServer) then {
-    ["cargo_hideItem", {params ["_object", "_status"]; _object hideObjectGlobal _status;}] call EFUNC(common,addEventHandler);
-};
-
 ADDON = true;

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -27,7 +27,12 @@ _position set [2, (_position select 2) + 7.5];
 
 for "_i" from 1 to _amount do {
     _item = createVehicle [_itemClass, _position, [], 0, "CAN_COLLIDE"];
+
+    // Load item or delete it if no space left
     if !([_item, _vehicle] call FUNC(loadItem)) exitWith {
         deleteVehicle _item;
     };
+
+    // Invoke listenable event
+    ["cargo_itemAdded", [_itemClass, _vehicle, _amount]] call EFUNC(common,globalEvent);
 };

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * ["item", vehicle] call ace_cargo_fnc_addItem
+ * ["item", vehicle] call ace_cargo_fnc_addCargoItem
  *
  * Public: No
  */
@@ -34,5 +34,5 @@ for "_i" from 1 to _amount do {
     };
 
     // Invoke listenable event
-    ["cargo_itemAdded", [_itemClass, _vehicle, _amount]] call EFUNC(common,globalEvent);
+    ["cargoAddedByClass", [_itemClass, _vehicle, _amount]] call EFUNC(common,globalEvent);
 };

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -1,0 +1,33 @@
+/*
+ * Author: Glowbal, Jonpas
+ * Adds a cargo item to the vehicle.
+ *
+ * Arguments:
+ * 0: Item Classname <STRING>
+ * 1: Vehicle <OBJECT>
+ * 2: Amount <NUMBER> (default: 1)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["item", vehicle] call ace_cargo_fnc_addItem
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+private ["_position", "_item", "_i"];
+params ["_itemClass", "_vehicle", ["_amount", 1]];
+TRACE_3("params",_itemClass,_vehicle,_amount);
+
+_position = getPos _vehicle;
+_position set [1, (_position select 1) + 1];
+_position set [2, (_position select 2) + 7.5];
+
+for "_i" from 1 to _amount do {
+    _item = createVehicle [_itemClass, _position, [], 0, "CAN_COLLIDE"];
+    if !([_item, _vehicle] call FUNC(loadItem)) exitWith {
+        deleteVehicle _item;
+    };
+};

--- a/addons/cargo/functions/fnc_getSizeItem.sqf
+++ b/addons/cargo/functions/fnc_getSizeItem.sqf
@@ -19,7 +19,7 @@ private "_config";
 
 params ["_item"];
 
-_config = (configFile >> "CfgVehicles" >> typeof _item >> QGVAR(size));
+_config = (configFile >> "CfgVehicles" >> typeOf _item >> QGVAR(size));
 
 if (isNumber (_config)) exitWith {
     _item getVariable [QGVAR(size), getNumber (_config)]

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -25,20 +25,8 @@ _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 if (isServer) then {
     {
         if (isClass _x) then {
-            private ["_className", "_amount","_position","_object"];
-            _className = getText (_x >> "type");
-            _amount = getNumber (_x >> "amount");
-            _position = getPos _vehicle;
-            _position set [1, (_position select 1) + 1];
-            _position set [2, (_position select 2) + 7.5];
-            for "_i" from 1 to _amount do {
-                _object = createVehicle [_className, _position, [], 0, "CAN_COLLIDE"];
-                if !([_object, _vehicle] call FUNC(loadItem)) exitWith {
-                    deleteVehicle _object;
-                };
-            };
+            [getText (_x >> "type"), _vehicle, getNumber (_x >> "amount")] call FUNC(addItem);
         };
-        nil
     } count ("true" configClasses (configFile >> "CfgVehicles" >> _type >> "ACE_Cargo" >> "Cargo"));
 };
 

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: Glowbal
- * Initializes vehicle, adds open caro menu action if available.
+ * Initializes vehicle, adds open cargo menu action if available.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
@@ -25,7 +25,7 @@ _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 if (isServer) then {
     {
         if (isClass _x) then {
-            [getText (_x >> "type"), _vehicle, getNumber (_x >> "amount")] call FUNC(addItem);
+            ["AddCargoItem", [getText (_x >> "type"), _vehicle, getNumber (_x >> "amount")]] call EFUNC(common,localEvent);
         };
     } count ("true" configClasses (configFile >> "CfgVehicles" >> _type >> "ACE_Cargo" >> "Cargo"));
 };

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -25,7 +25,7 @@ _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 if (isServer) then {
     {
         if (isClass _x) then {
-            ["AddCargoItem", [getText (_x >> "type"), _vehicle, getNumber (_x >> "amount")]] call EFUNC(common,localEvent);
+            ["AddCargoByClass", [getText (_x >> "type"), _vehicle, getNumber (_x >> "amount")]] call EFUNC(common,localEvent);
         };
     } count ("true" configClasses (configFile >> "CfgVehicles" >> _type >> "ACE_Cargo" >> "Cargo"));
 };

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -34,4 +34,7 @@ detach _item;
 _item attachTo [_vehicle,[0,0,100]];
 ["hideObjectGlobal", [_item, true]] call EFUNC(common,serverEvent);
 
+// Invoke listenable event
+["cargo_itemLoaded", [_item, _vehicle]] call EFUNC(common,globalEvent);
+
 true

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -35,6 +35,6 @@ _item attachTo [_vehicle,[0,0,100]];
 ["hideObjectGlobal", [_item, true]] call EFUNC(common,serverEvent);
 
 // Invoke listenable event
-["cargo_itemLoaded", [_item, _vehicle]] call EFUNC(common,globalEvent);
+["cargoLoaded", [_item, _vehicle]] call EFUNC(common,globalEvent);
 
 true

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -32,6 +32,6 @@ _vehicle setVariable [QGVAR(space), _space - _itemSize, true];
 
 detach _item;
 _item attachTo [_vehicle,[0,0,100]];
-["cargo_hideItem", [_item, true]] call EFUNC(common,serverEvent);
+["hideObjectGlobal", [_item, true]] call EFUNC(common,serverEvent);
 
 true

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -62,4 +62,7 @@ _item setPosASL (_emptyPos call EFUNC(common,PositiontoASL));
 
 // TOOO maybe drag/carry the unloaded item?
 
+// Invoke listenable event
+["cargo_itemUnloaded", [_item, _vehicle]] call EFUNC(common,globalEvent);
+
 true

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -63,6 +63,6 @@ _item setPosASL (_emptyPos call EFUNC(common,PositiontoASL));
 // TOOO maybe drag/carry the unloaded item?
 
 // Invoke listenable event
-["cargo_itemUnloaded", [_item, _vehicle]] call EFUNC(common,globalEvent);
+["cargoUnloaded", [_item, _vehicle]] call EFUNC(common,globalEvent);
 
 true

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -58,7 +58,7 @@ _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
 detach _item;
 _item setPosASL (_emptyPos call EFUNC(common,PositiontoASL));
-["cargo_hideItem", [_item, false]] call EFUNC(common,serverEvent);
+["hideObjectGlobal", [_item, false]] call EFUNC(common,serverEvent);
 
 // TOOO maybe drag/carry the unloaded item?
 


### PR DESCRIPTION
Replaced `cargo_hideUnit` event with already existing `hideObjectGlobal` from common.

Added new events to cargo:

Type | Event Name | Passed parameter(s) `_this` | Locality
------ | --------------- | ------------------------------------ | ---------
Listenable | "cargoLoaded" | [_item, _vehicle] | Global
Listenable | "cargoUnloaded" | [_item, _vehicle] | Global
Listenable | "cargoAddedByClass" | [_item, _vehicle, _amount] | Global
Callable | "LoadObject" | [_item, _vehicle] | Local
Callable | "UnloadObject" | [_item, _vehicle] | Local
Callable | "AddCargoByClass" | [_item, _vehicle, _amount (default: 1)] | Local