### PR TITLE
Prevent CBA keybindings in zeus interface

### DIFF
--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -80,18 +80,26 @@ addMissionEventHandler ["Draw3D", DFUNC(render)];
     if (_this select 1) then {
         (finddisplay 312) displayAddEventHandler ["KeyUp", {
             _key = ["ACE3 Common","ace_interact_menu_InteractKey"] call CBA_fnc_getKeybind;
-            _key = (_key select 5) select 0;
+            _key = _key select 5;
+            _dik = _key select 0;
+            _mods = _key select 1;
 
-            if ((_this select 1) == _key) then {
-                [_this,'keyup'] call CBA_events_fnc_keyHandler
+            if ((_this select 1) == _dik) then {
+                if ((_this select [2,3]) isEqualTo _mods) then {
+                    [_this,'keyup'] call CBA_events_fnc_keyHandler
+                };
             };
         }];
         (finddisplay 312) displayAddEventHandler ["KeyDown", {
             _key = ["ACE3 Common","ace_interact_menu_InteractKey"] call CBA_fnc_getKeybind;
-            _key = (_key select 5) select 0;
+            _key = _key select 5;
+            _dik = _key select 0;
+            _mods = _key select 1;
 
-            if ((_this select 1) == _key) then {
-                [_this,'keydown'] call CBA_events_fnc_keyHandler
+            if ((_this select 1) == _dik) then {
+                if ((_this select [2,3]) isEqualTo _mods) then {
+                    [_this,'keydown'] call CBA_events_fnc_keyHandler
+                };
             };
         }];
     };

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -75,10 +75,24 @@ addMissionEventHandler ["Draw3D", DFUNC(render)];
     if (GVAR(menuBackground)==2) then {(uiNamespace getVariable [QGVAR(menuBackground), displayNull]) closeDisplay 0;};
 }] call EFUNC(common,addEventHandler);
 
-// Let key work with zeus open (not perfect, enables all added hotkeys in zeus interface rather than only menu)
+// Let key work with zeus open (not perfect, contains workaround to prevent other CBA keybindings)
 ["zeusDisplayChanged",{
     if (_this select 1) then {
-        (finddisplay 312) displayAddEventHandler ["KeyUp", {[_this,'keyup'] call CBA_events_fnc_keyHandler}];
-        (finddisplay 312) displayAddEventHandler ["KeyDown", {[_this,'keydown'] call CBA_events_fnc_keyHandler}];
+        (finddisplay 312) displayAddEventHandler ["KeyUp", {
+            _key = ["ACE3 Common","ace_interact_menu_InteractKey"] call CBA_fnc_getKeybind;
+            _key = (_key select 5) select 0;
+
+            if ((_this select 1) == _key) then {
+                [_this,'keyup'] call CBA_events_fnc_keyHandler
+            };
+        }];
+        (finddisplay 312) displayAddEventHandler ["KeyDown", {
+            _key = ["ACE3 Common","ace_interact_menu_InteractKey"] call CBA_fnc_getKeybind;
+            _key = (_key select 5) select 0;
+
+            if ((_this select 1) == _key) then {
+                [_this,'keydown'] call CBA_events_fnc_keyHandler
+            };
+        }];
     };
 }] call EFUNC(common,addEventHandler);


### PR DESCRIPTION
Checks if the key pressed matches the zeus menu keybind and only fires the code to handle CBA keybinds if true. Should fix the majority of weirdness with keybinds in zeus. However, not perfect as shared keybinds with different modifiers will still fire and it's really an un-ideal workaround.

Fixes #1951