### PR TITLE
Increase "load in bodybag" action time to 15s

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -335,7 +335,7 @@ class ACE_Medical_Actions {
             category = "advanced";
             treatmentLocations[] = {"All"};
             requiredMedic = 0;
-            treatmentTime = 2;
+            treatmentTime = 15;
             items[] = {"ACE_bodyBag"};
             condition = "!alive (_this select 1);";
             callbackSuccess = QUOTE(DFUNC(actionPlaceInBodyBag));


### PR DESCRIPTION
Around 15 seconds seems optimal (for dead bodies that are left in **one** piece).