### PR TITLE
Repeat CPR until success

### DIFF
--- a/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
@@ -29,6 +29,10 @@ if ((random 1) >= 0.6) then {
     _target setvariable [QGVAR(inCardiacArrest), nil,true];
     _target setvariable [QGVAR(heartRate), 40];
     _target setvariable [QGVAR(bloodPressure), [50,70]];
+}
+else
+{
+    [ARR_4(_caller, _target, 'body', 'CPR')] call DFUNC(treatment);
 };
 
 [_target, "activity", LSTRING(Activity_CPR), [[_caller] call EFUNC(common,getName)]] call FUNC(addToLog);

--- a/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
@@ -29,9 +29,7 @@ if ((random 1) >= 0.6) then {
     _target setvariable [QGVAR(inCardiacArrest), nil,true];
     _target setvariable [QGVAR(heartRate), 40];
     _target setvariable [QGVAR(bloodPressure), [50,70]];
-}
-else
-{
+} else {
     [ARR_4(_caller, _target, 'body', 'CPR')] call DFUNC(treatment);
 };
 


### PR DESCRIPTION
This will basically run CPR action again as you would select it from interaction menu. It will be ran if CPR statement chance fails.
I did this because in RL you would repeat CPR cycles over and over until success, right now you have to select it again and it may be cumbersome for some.

Failed once:
https://youtu.be/9k70o4F8amc