### PR TITLE
Compile Self Menu, set "Default Params" to array instead of code

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -71,7 +71,7 @@ _recurseFnc = {
                             _statement,
                             _condition,
                             _insertChildren,
-                            {},
+                            [],
                             [0,0,0],
                             10, //distace
                             [_showDisabled,_enableInside,_canCollapse,_runOnHover, true],


### PR DESCRIPTION
This is for the `6: Action parameters <ANY> (Optional)`

Compile self uses `{}`
compile external uses `[]` which I think makes more sense

ref #2228