### PR TITLE
Make reserve steerable

### DIFF
--- a/addons/parachute/CfgVehicles.hpp
+++ b/addons/parachute/CfgVehicles.hpp
@@ -94,7 +94,7 @@ class CfgVehicles {
         displayName = CSTRING(ReserveParachute);
         scope = 1;
         mass = 70;
-        ParachuteClass = "NonSteerable_Parachute_F";
+        ParachuteClass = "Steerable_Parachute_F";
         ace_reserveParachute = "";
         ace_hasReserveParachute = 0;
     };


### PR DESCRIPTION
Source: http://www.globalsecurity.org/military/systems/aircraft/systems/mc-5.htm

> The system's **identical main and reserve parachutes**, which can be interchanged, are 370 square feet, seven-celled, and are manufactured from 1.1 ounce F-111 nylon ripstop fabric.

MC-5 was steerable in ACE2 and I think we are simulating it here too right? There are non-steerable and steerable reserve parachutes but MC-5 has two identical chutes.
Also this fix makes so you don't magically stop while freefalling as it is with NonSteerable_Parachute_F.
I was able to open it 20 meters above ground cause all my falling speed is gone as soon as I click open parachute. Thats BS.
This fixes that.

Also MC-5 in RL, very similiar to A3 one right?
![img](http://sofrep.com/wp-content/uploads/2015/07/RA-1.jpg)