### PR TITLE
Custom Hitpoint Repair Positions Framework

### DIFF
--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -334,4 +334,9 @@ class CfgVehicles {
         GVAR(canRepair) = 1;
         transportRepair = 0;
     };
+
+    class Quadbike_01_base_F;
+    class B_Quadbike_01_F: Quadbike_01_base_F {
+        GVAR(hitpointPositions[]) = {"HitEngine", "0, 0.5, -0.7", "HitFuel", "0, 0, -0.5"};
+    };
 };

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -337,6 +337,6 @@ class CfgVehicles {
 
     class Quadbike_01_base_F;
     class B_Quadbike_01_F: Quadbike_01_base_F {
-        GVAR(hitpointPositions[]) = {"HitEngine", "0, 0.5, -0.7", "HitFuel", "0, 0, -0.5"};
+        GVAR(hitpointPositions[]) = { {"HitEngine", {0, 0.5, -0.7}}, {"HitFuel", {0, 0, -0.5}} };
     };
 };

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -72,7 +72,7 @@ if (_type in _initializedClasses) exitWith {};
 
     } else {
         // exit if the hitpoint is in the blacklist, e.g. glasses
--       if (_x in IGNORED_HITPOINTS) exitWith {};
+        if (_x in IGNORED_HITPOINTS) exitWith {};
 
         // exit if the hitpoint is virtual
         if (isText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _x >> "depends")) exitWith {};

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -71,6 +71,9 @@ if (_type in _initializedClasses) exitWith {};
         [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
 
     } else {
+        // exit if the hitpoint is in the blacklist, e.g. glasses
+-       if (_x in IGNORED_HITPOINTS) exitWith {};
+
         // exit if the hitpoint is virtual
         if (isText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _x >> "depends")) exitWith {};
 

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -27,17 +27,13 @@ _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 
 // do nothing if the class is already initialized
 if (_type in _initializedClasses) exitWith {};
-// get all hitpoints
-private "_hitPoints";
-_hitPoints = [_vehicle] call EFUNC(common,getHitPointsWithSelections) select 0;
+
+// get all hitpoints and selections
+([_vehicle] call EFUNC(common,getHitPointsWithSelections)) params ["_hitPoints", "_hitPointsSelections"];
 
 // get hitpoints of wheels with their selections
-private ["_wheelHitPointsWithSelections", "_wheelHitPoints", "_wheelHitPointSelections"];
+([_vehicle] call FUNC(getWheelHitPointsWithSelections)) params ["_wheelHitPoints", "_wheelHitPointSelections"];
 
-_wheelHitPointsWithSelections = [_vehicle] call FUNC(getWheelHitPointsWithSelections);
-
-_wheelHitPoints = _wheelHitPointsWithSelections select 0;
-_wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
 
 // add repair events to this vehicle class
 {
@@ -96,7 +92,7 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
         };
 
         _icon = "A3\ui_f\data\igui\cfg\actions\repair_ca.paa";
-        _selection = "";
+        _selection = _vehicle selectionPosition (_hitPointsSelections select (_hitPoints find _x));
         _condition = {[_this select 1, _this select 0, _this select 2 select 0, _this select 2 select 1] call DFUNC(canRepair)};
         _statement = {[_this select 1, _this select 0, _this select 2 select 0, _this select 2 select 1] call DFUNC(repair)};
 
@@ -112,7 +108,11 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
         } else {
             private "_action";
             _action = [_name, _text, _icon, _statement, _condition, {}, [_x, "MiscRepair"], _selection, 4] call EFUNC(interact_menu,createAction);
-            [_type, 0, ["ACE_MainActions", QGVAR(Repair)], _action] call EFUNC(interact_menu,addActionToClass);
+            if (_selection isEqualTo [0, 0, 0]) then {
+                [_type, 0, ["ACE_MainActions", QGVAR(Repair)], _action] call EFUNC(interact_menu,addActionToClass);
+            } else {
+                [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
+            }
         };
     };
 } forEach _hitPoints;

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -129,11 +129,12 @@ if (_type in _initializedClasses) exitWith {};
         } else {
             private "_action";
             _action = [_name, _text, _icon, _statement, _condition, {}, [_x, "MiscRepair"], _selection, 4] call EFUNC(interact_menu,createAction);
-            [   _type,
-                0,
-                if (_selection isEqualTo [0, 0 ,0]) then { ["ACE_MainActions", QGVAR(Repair)] } else { [] }, // Put inside main actions if no other position was found above
-                _action
-            ] call EFUNC(interact_menu,addActionToClass);
+            // Put inside main actions if no other position was found above
+            if (_selection isEqualTo [0, 0, 0]) then {
+                [_type, 0, ["ACE_MainActions", QGVAR(Repair)], _action] call EFUNC(interact_menu,addActionToClass);
+            } else {
+                [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
+            };
         };
     };
 } forEach _hitPoints;

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -108,11 +108,11 @@ if (_type in _initializedClasses) exitWith {};
         } else {
             private "_action";
             _action = [_name, _text, _icon, _statement, _condition, {}, [_x, "MiscRepair"], _selection, 4] call EFUNC(interact_menu,createAction);
-            if (_selection isEqualTo [0, 0, 0]) then {
-                [_type, 0, ["ACE_MainActions", QGVAR(Repair)], _action] call EFUNC(interact_menu,addActionToClass);
-            } else {
-                [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
-            }
+            [   _type,
+                0,
+                if (_selection isEqualTo [0, 0 ,0]) then { ["ACE_MainActions", QGVAR(Repair)] } else { [] },
+                _action
+            ] call EFUNC(interact_menu,addActionToClass);
         };
     };
 } forEach _hitPoints;

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -12,4 +12,4 @@
 #include "\z\ace\addons\main\script_macros.hpp"
 
 #define IGNORED_HITPOINTS ["HitGlass1","HitGlass2","HitGlass3","HitGlass4","HitGlass5","HitGlass6","HitGlass7","HitGlass8","HitGlass9","HitGlass10","HitGlass11","HitGlass12","HitGlass13","HitGlass14","HitGlass15","HitRGlass","HitLGlass"]
--// #define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"];
+// #define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"];

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -11,5 +11,6 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
+
 #define IGNORED_HITPOINTS ["HitGlass1","HitGlass2","HitGlass3","HitGlass4","HitGlass5","HitGlass6","HitGlass7","HitGlass8","HitGlass9","HitGlass10","HitGlass11","HitGlass12","HitGlass13","HitGlass14","HitGlass15","HitRGlass","HitLGlass"]
 // #define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"];

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -10,3 +10,6 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+
+#define IGNORED_HITPOINTS ["HitGlass1","HitGlass2","HitGlass3","HitGlass4","HitGlass5","HitGlass6","HitGlass7","HitGlass8","HitGlass9","HitGlass10","HitGlass11","HitGlass12","HitGlass13","HitGlass14","HitGlass15","HitRGlass","HitLGlass"]
+-// #define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"];

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -10,7 +10,3 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
-
-
-#define IGNORED_HITPOINTS ["HitGlass1","HitGlass2","HitGlass3","HitGlass4","HitGlass5","HitGlass6","HitGlass7","HitGlass8","HitGlass9","HitGlass10","HitGlass11","HitGlass12","HitGlass13","HitGlass14","HitGlass15","HitRGlass","HitLGlass"]
-// #define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"];


### PR DESCRIPTION
**Overview:**
Adds a framework for custom hitpoint positions/selection names to be used as position to render the repair action of the specified hitpoint. Most default selections (except Winch) have position of `[0,0,0]` which obviously doesn't work, the check if it's on that location was added to prevent being over the base interaction menu (if it is on zero location, it will be grouped into the base interaction menu as before).

**Config entries:**
`GVAR(hitpointPositions[]) = { {"HitPointName", {position}} };`
Example:
`GVAR(hitpointPositions[]) = { {"HitEngine", {0, 1, -1}}, {"HitFuel", {0, 0, -0.5}} };`
(It is impossible to use array in a config array, so I decided to parse the string into an array.)

Instead of a position it can also be a selection name:
`GVAR(hitpointPositions[]) = { {"HitEngine", "engineSelection"} };`


**Side-note:**
~~`IGNORED_HITPOINTS` was also removed, since all it did was prevent glasses from being repaired (and it can be freaking nasty to drive/fly with a broken window).~~ I will be adding framework for grouping hitpoints (so you fix another hitpoint when you fix one, but doesn't show in the menu) in another PR.

**API Suggestion:**
I suggest a check of `[0,0,0]` position is made in public API for adding the actions to interaction menu, the only thing it does is cover the base interaction point.