### PR TITLE
Repair Hitpoint Groups Framework

### DIFF
--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -31,7 +31,7 @@ class ACE_Repair {
         class MiscRepair: ReplaceWheel {
             displayName = CSTRING(Repairing); // let's make empty string an auto generated string
             displayNameProgress = CSTRING(RepairingHitPoint);
-            condition = QUOTE((_target getHitPointDamage _hitPoint) > ([_caller] call FUNC(getPostRepairDamage)));
+            condition = QUOTE(call FUNC(canMiscRepair));
             requiredEngineer = 0;
             repairingTime = 15;
             callbackSuccess = QUOTE(call FUNC(doRepair));

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -287,7 +287,7 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_04_base_F: Helicopter_Base_H {
-        GVAR(hitpointGroup[]) = {"Glass_1_hitpoint", "Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"};
+        GVAR(hitpointGroups[]) = { {"HitEngine", {"HitEngine1", "HitEngine2"}}, {"Glass_1_hitpoint", {"Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"}} };
     };
     class O_Heli_Transport_04_repair_F: Heli_Transport_04_base_F {
         GVAR(canRepair) = 1;
@@ -308,7 +308,7 @@ class CfgVehicles {
 
     class Car_F;
     class Offroad_01_base_F: Car_F {
-        GVAR(hitpointGroup[]) = {"HitGlass1", "HitGlass2"};
+        GVAR(hitpointGroups[]) = { {"HitGlass1", {"HitGlass2"}} };
     };
     class Offroad_01_repair_base_F: Offroad_01_base_F {
         GVAR(canRepair) = 1;
@@ -316,7 +316,7 @@ class CfgVehicles {
     };
 
     class MRAP_01_base_F: Car_F {
-        GVAR(hitpointGroup[]) = {"HitGlass1", "HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6"};
+        GVAR(hitpointGroups[]) = { {"HitGlass1", {"HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6"}} };
     };
 
     class B_Truck_01_mover_F;

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -285,7 +285,10 @@ class CfgVehicles {
         transportRepair = 0;
     };
 
-    class Heli_Transport_04_base_F;
+    class Helicopter_Base_H;
+    class Heli_Transport_04_base_F: Helicopter_Base_H {
+        GVAR(hitpointGroup[]) = {"Glass_1_hitpoint", "Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"};
+    };
     class O_Heli_Transport_04_repair_F: Heli_Transport_04_base_F {
         GVAR(canRepair) = 1;
         transportRepair = 0;
@@ -303,10 +306,17 @@ class CfgVehicles {
         transportRepair = 0;
     };
 
-    class Offroad_01_base_F;
+    class Car_F;
+    class Offroad_01_base_F: Car_F {
+        GVAR(hitpointGroup[]) = {"HitGlass1", "HitGlass2"};
+    };
     class Offroad_01_repair_base_F: Offroad_01_base_F {
         GVAR(canRepair) = 1;
         transportRepair = 0;
+    };
+
+    class MRAP_01_base_F: Car_F {
+        GVAR(hitpointGroup[]) = {"HitGlass1", "HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6"};
     };
 
     class B_Truck_01_mover_F;

--- a/addons/repair/XEH_preInit.sqf
+++ b/addons/repair/XEH_preInit.sqf
@@ -3,6 +3,7 @@
 ADDON = false;
 
 PREP(addRepairActions);
+PREP(canMiscRepair);
 PREP(canRemove);
 PREP(canRepair);
 PREP(canRepairTrack);

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -75,11 +75,27 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
         [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
 
     } else {
-        private "_hitpointGroup";
-        // Exit if the hitpoint is in group and not main group hitpoint (which gets added as group repair action)
-        _hitpointGroup = configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointGroup);
-        _hitpointGroup = if (isArray _hitpointGroup) then {getArray _hitpointGroup} else {[]};
-        if (count _hitpointGroup > 0 && {_x in _hitpointGroup} && {_x != _hitpointGroup select 0}) exitWith {};
+        private ["_hitpointGroupConfig", "_inHitpointSubGroup", "_currentHitpoint"];
+
+        // Get hitpoint groups if available
+        _hitpointGroupConfig = configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointGroups);
+        _inHitpointSubGroup = false;
+        if (isArray _hitpointGroupConfig) then {
+            // Loop through hitpoint groups
+            _currentHitpoint = _x;
+            {
+                // Loop through sub-group
+                {
+                    // Current hitpoint is in a sub-group, set it so
+                    if (_x == _currentHitpoint) exitWith {
+                        _inHitpointSubGroup = true;
+                    };
+                } forEach (_x select 1);
+            } forEach (getArray _hitpointGroupConfig);
+        };
+
+        // Exit if current hitpoint is not a group leader (only they get actions)
+        if (_inHitpointSubGroup) exitWith {};
 
         // exit if the hitpoint is virtual
         if (isText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _x >> "depends")) exitWith {};

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -81,12 +81,10 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
         _hitpointGroupConfig = configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointGroups);
         _inHitpointSubGroup = false;
         if (isArray _hitpointGroupConfig) then {
-            // Loop through hitpoint groups
+            // Set variable if current hitpoint is in a sub-group (to be excluded from adding action)
             _currentHitpoint = _x;
             {
-                // Loop through sub-group
                 {
-                    // Current hitpoint is in a sub-group, set it so
                     if (_x == _currentHitpoint) exitWith {
                         _inHitpointSubGroup = true;
                     };
@@ -94,7 +92,7 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
             } forEach (getArray _hitpointGroupConfig);
         };
 
-        // Exit if current hitpoint is not a group leader (only they get actions)
+        // Exit if current hitpoint is in sub-group (only main hitpoints get actions)
         if (_inHitpointSubGroup) exitWith {};
 
         // exit if the hitpoint is virtual

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -75,8 +75,11 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
         [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
 
     } else {
-        // exit if the hitpoint is in the blacklist, e.g. glasses
-        if (_x in IGNORED_HITPOINTS) exitWith {};
+        private "_hitpointGroup";
+        // Exit if the hitpoint is in group and not main group hitpoint (which gets added as group repair action)
+        _hitpointGroup = configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointGroup);
+        _hitpointGroup = if (isArray _hitpointGroup) then {getArray _hitpointGroup} else {[]};
+        if (count _hitpointGroup > 0 && {_x in _hitpointGroup} && {_x != _hitpointGroup select 0}) exitWith {};
 
         // exit if the hitpoint is virtual
         if (isText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _x >> "depends")) exitWith {};

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -14,7 +14,6 @@
  * Public: No
  */
 #include "script_component.hpp"
-#define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"]
 
 params ["_vehicle"];
 TRACE_1("params", _vehicle);
@@ -75,6 +74,9 @@ _wheelHitPointSelections = _wheelHitPointsWithSelections select 1;
         [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
 
     } else {
+        // exit if the hitpoint is in the blacklist, e.g. glasses
+        if (_x in IGNORED_HITPOINTS) exitWith {};
+
         private ["_hitpointGroupConfig", "_inHitpointSubGroup", "_currentHitpoint"];
 
         // Get hitpoint groups if available

--- a/addons/repair/functions/fnc_canMiscRepair.sqf
+++ b/addons/repair/functions/fnc_canMiscRepair.sqf
@@ -21,7 +21,7 @@ private ["_hitpointGroupConfig", "_hitpointGroup", "_postRepairDamage", "_return
 params ["_caller", "_target", "_hitPoint"];
 
 // Get hitpoint groups if available
-_hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroup);
+_hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroups);
 _hitpointGroup = [];
 if (isArray _hitpointGroupConfig) then {
     // Loop through hitpoint groups
@@ -46,5 +46,9 @@ _return = false;
         _return = true;
     };
 } forEach _hitpointGroup;
+
+if (typeOf _target == "B_MRAP_01_F") then {
+    diag_log format ["%1 - %2", _hitPoint, _hitpointGroup];
+};
 
 _return

--- a/addons/repair/functions/fnc_canMiscRepair.sqf
+++ b/addons/repair/functions/fnc_canMiscRepair.sqf
@@ -1,0 +1,40 @@
+/*
+ * Author: Jonpas
+ * Check if misc repair action can be done, called from callbackSuccess.
+ *
+ * Arguments:
+ * 0: Unit that does the repairing <OBJECT>
+ * 1: Vehicle to repair <OBJECT>
+ * 2: Selected hitpoint <STRING>
+ *
+ * Return Value:
+ * Can Misc Repair <BOOL>
+ *
+ * Example:
+ * [unit, vehicle, "hitpoint", "classname"] call ace_repair_fnc_canMiscRepair
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+private ["_hitpointGroup", "_postRepairDamage", "_return"];
+params ["_caller", "_target", "_hitPoint"];
+
+// Check hitpoint group
+_hitpointGroup = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroup);
+_hitpointGroup = if (isArray _hitpointGroup) then {getArray _hitpointGroup} else {[]};
+
+if !(_hitPoint in _hitpointGroup) then {
+    _hitpointGroup pushBack _hitPoint;
+};
+
+_postRepairDamage = [_caller] call FUNC(getPostRepairDamage);
+
+_return = false;
+{
+    if ((_target getHitPointDamage _x) > _postRepairDamage) exitWith {
+        _return = true;
+    };
+} forEach _hitpointGroup;
+
+_return

--- a/addons/repair/functions/fnc_canMiscRepair.sqf
+++ b/addons/repair/functions/fnc_canMiscRepair.sqf
@@ -17,19 +17,29 @@
  */
 #include "script_component.hpp"
 
-private ["_hitpointGroup", "_postRepairDamage", "_return"];
+private ["_hitpointGroupConfig", "_hitpointGroup", "_postRepairDamage", "_return"];
 params ["_caller", "_target", "_hitPoint"];
 
-// Check hitpoint group
-_hitpointGroup = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroup);
-_hitpointGroup = if (isArray _hitpointGroup) then {getArray _hitpointGroup} else {[]};
-
-if !(_hitPoint in _hitpointGroup) then {
-    _hitpointGroup pushBack _hitPoint;
+// Get hitpoint groups if available
+_hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroup);
+_hitpointGroup = [];
+if (isArray _hitpointGroupConfig) then {
+    // Loop through hitpoint groups
+    {
+        // Exit using found hitpoint group if this hitpoint is leader of any
+        if (_x select 0 == _hitPoint) exitWith {
+            _hitpointGroup = _x select 1;
+        };
+    } forEach (getArray _hitpointGroupConfig);
 };
 
+// Add current hitpoint to the group
+_hitpointGroup pushBack _hitPoint;
+
+// Get post repair damage
 _postRepairDamage = [_caller] call FUNC(getPostRepairDamage);
 
+// Return true if damage can be repaired on any hitpoint in the group, else false
 _return = false;
 {
     if ((_target getHitPointDamage _x) > _postRepairDamage) exitWith {

--- a/addons/repair/functions/fnc_canMiscRepair.sqf
+++ b/addons/repair/functions/fnc_canMiscRepair.sqf
@@ -24,7 +24,7 @@ params ["_caller", "_target", "_hitPoint"];
 _hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroups);
 _hitpointGroup = [];
 if (isArray _hitpointGroupConfig) then {
-    // Loop through hitpoint groups
+    // Retrieve hitpoint subgroup if current hitpoint is main hitpoint of a group
     {
         // Exit using found hitpoint group if this hitpoint is leader of any
         if (_x select 0 == _hitPoint) exitWith {

--- a/addons/repair/functions/fnc_doRepair.sqf
+++ b/addons/repair/functions/fnc_doRepair.sqf
@@ -35,14 +35,12 @@ _hitPointDamage = _hitPointDamage max ([_unit] call FUNC(getPostRepairDamage));
 _hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(hitpointGroups);
 _hitpointGroup = [];
 if (isArray _hitpointGroupConfig) then {
-    // Loop through hitpoint groups
+    // Retrieve group if current hitpoint is leader of any
     {
-        // Exit using found hitpoint group if this hitpoint is leader of any
         if (_x select 0 == _hitPoint) exitWith {
             ([_vehicle] call EFUNC(common,getHitPointsWithSelections)) params ["_hitpoints"];
-            // Loop through the found group
+            // Set all sub-group hitpoints' damage to 0, if a hitpoint is invalid print RPT error
             {
-                // If hitpoint is valid set damage to 0, else print RPT error
                 if (_x in _hitpoints) then {
                     ["setVehicleHitPointDamage", _vehicle, [_vehicle, _x, 0]] call EFUNC(common,targetEvent);
                 } else {

--- a/addons/repair/functions/fnc_doRepair.sqf
+++ b/addons/repair/functions/fnc_doRepair.sqf
@@ -32,7 +32,7 @@ _hitPointDamage = _hitPointDamage max ([_unit] call FUNC(getPostRepairDamage));
 ["setVehicleHitPointDamage", _vehicle, [_vehicle, _hitPoint, _hitPointDamage]] call EFUNC(common,targetEvent);
 
 // Get hitpoint groups if available
-_hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(hitpointGroup);
+_hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(hitpointGroups);
 _hitpointGroup = [];
 if (isArray _hitpointGroupConfig) then {
     // Loop through hitpoint groups

--- a/addons/repair/functions/fnc_doRepair.sqf
+++ b/addons/repair/functions/fnc_doRepair.sqf
@@ -17,11 +17,11 @@
  */
 #include "script_component.hpp"
 
+private ["_hitPointDamage", "_text", "_hitpointGroup"];
 params ["_unit", "_vehicle", "_hitPoint"];
 TRACE_3("params",_unit,_vehicle,_hitPoint);
 
 // get current hitpoint damage
-private "_hitPointDamage";
 _hitPointDamage = _vehicle getHitPointDamage _hitPoint;
 
 _hitPointDamage = _hitPointDamage - 0.5;
@@ -31,9 +31,23 @@ _hitPointDamage = _hitPointDamage max ([_unit] call FUNC(getPostRepairDamage));
 // raise event to set the new hitpoint damage
 ["setVehicleHitPointDamage", _vehicle, [_vehicle, _hitPoint, _hitPointDamage]] call EFUNC(common,targetEvent);
 
+// Repair the rest in the group (don't need to worry about specific damage as it's not checked)
+_hitpointGroup = configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(hitpointGroup);
+_hitpointGroup = if (isArray _hitpointGroup) then {getArray _hitpointGroup} else {[]};
+if (count _hitpointGroup > 0) then {
+    ([_vehicle] call EFUNC(common,getHitPointsWithSelections)) params ["_hitpoints"];
+    _hitpointGroup deleteAt 0; // Remove main group hitpoint
+    {
+        if (_x in _hitpoints) then {
+            _vehicle setHitPointDamage [_x, 0];
+        } else {
+            diag_log text format ["[ACE] ERROR: Invalid hitpoint %1 in hitpointGroup of %2", _x, _vehicle];
+        };
+    } forEach _hitpointGroup;
+};
+
 // display text message if enabled
 if (GVAR(DisplayTextOnRepair)) then {
-    private "_text";
     _text = format ["STR_ACE_Repair_%1", _hitPoint];
 
     if (isLocalized _text) then {

--- a/addons/repair/functions/fnc_doRepair.sqf
+++ b/addons/repair/functions/fnc_doRepair.sqf
@@ -31,7 +31,7 @@ _hitPointDamage = _hitPointDamage max ([_unit] call FUNC(getPostRepairDamage));
 // raise event to set the new hitpoint damage
 ["setVehicleHitPointDamage", _vehicle, [_vehicle, _hitPoint, _hitPointDamage]] call EFUNC(common,targetEvent);
 
-// Repair the rest in the group (don't need to worry about specific damage as it's not checked)
+// Repair the rest in the group (no specific damage, main hitpoint is enough)
 _hitpointGroup = configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(hitpointGroup);
 _hitpointGroup = if (isArray _hitpointGroup) then {getArray _hitpointGroup} else {[]};
 if (count _hitpointGroup > 0) then {

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -10,3 +10,7 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+
+
+#define IGNORED_HITPOINTS ["HitGlass1", "HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6", "HitGlass7", "HitGlass8", "HitGlass9", "HitGlass10", "HitGlass11", "HitGlass12", "HitGlass13", "HitGlass14", "HitGlass15", "HitRGlass", "HitLGlass", "Glass_1_hitpoint", "Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"]
+#define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"]

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -10,7 +10,3 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
-
-
-#define IGNORED_HITPOINTS ["HitGlass1","HitGlass2","HitGlass3","HitGlass4","HitGlass5","HitGlass6","HitGlass7","HitGlass8","HitGlass9","HitGlass10","HitGlass11","HitGlass12","HitGlass13","HitGlass14","HitGlass15","HitRGlass","HitLGlass"]
-// #define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"];


### PR DESCRIPTION
**Overview:**
Adds a framework to allow grouping of multiple hitpoints into one by config. This means only the first hitpoint in the config array gets the repair action, all the rest in that group get repaired simultaneously when the main one gets repaired. They repair to full even if the main repair is only partial, this should have no issues though.

**Config entries:**
`GVAR(hitpointGroups[]) = { {"hitpointName1", {"hitpointName2"}} };`
Example:
`GVAR(hitpointGroups[]) = { {"HitGlass1", {"HitGlass2"}} };`
(`HitGlass1` is the one which gets the action here and `HitGlass2` is grouped under it.)

**To-do:**
- [x] Add support when one of the grouped hitpoints is damaged but not the main
- [x] Add support for multiple groups on one vehicle
- [x] Fix check group damage returning true even if current hitpoint not in a group
- [x] Decide on `IGNORED_HITPOINTS` -> config framework in separate PR