### PR TITLE
Bandage and tourniquet on adv. medical change proposal

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -118,7 +118,7 @@ class ACE_Medical_Actions {
             // What is the level of medical skill required for this treatment action? 0 = all soldiers, 1 = medic, 2 = doctor
             requiredMedic = 0;
             // The time it takes for a treatment action to complete. Time is in seconds.
-            treatmentTime = 5;
+            treatmentTime = 8;
             // Item required for the action. Leave empty for no item required.
             items[] = {"ACE_fieldDressing"};
             condition = "";
@@ -156,7 +156,7 @@ class ACE_Medical_Actions {
             displayNameProgress = CSTRING(Applying_Tourniquet);
             allowedSelections[] = {"hand_l", "hand_r", "leg_l", "leg_r", "body"};
             items[] = {"ACE_tourniquet"};
-            treatmentTime = 6;
+            treatmentTime = 4;
             callbackSuccess = QUOTE(DFUNC(treatmentTourniquet));
             condition = QUOTE(!([ARR_2(_this select 1, _this select 2)] call FUNC(hasTourniquetAppliedTo)));
             litter[] = {};


### PR DESCRIPTION
Make bandaging longer as it is not very fast process.
Make putting on tourniquet faster cause it's should be easy to put one on limb, so it's actually useful now and with above change (putting it on before was longer than bandagin).