### PR TITLE
getHitpoints and fixFloating cleanup & enhancement

### DIFF
--- a/addons/common/functions/fnc_fixFloating.sqf
+++ b/addons/common/functions/fnc_fixFloating.sqf
@@ -19,14 +19,21 @@ _object = _this;
 if (!local _object) exitWith {};
 
 // save and restore hitpoints, see below why
-private ["_hitPoints", "_hitPointDamages"];
+private ["_hitPointsAndSelections", "_hitPointDamages", "_hitSelectionDamages"];
 
-_hitPoints = [_object] call FUNC(getHitpoints);
-_hitPointDamages = [_hitPoints, {_object getHitPointDamage _this}] call FUNC(map);
+_hitPointsAndSelections = [_object, true] call FUNC(getHitpoints);
+_hitPointsAndSelections params ["_hitpoints", "_hitselections"];
+
+_hitPointDamages = [_hitpoints, {_object getHitPointDamage _this}] call FUNC(map);
+_hitSelectionDamages = [_hitselections, {_object getHit _this}] call FUNC(map);
 
 // this prevents physx objects from floating when near other physx objects with allowDamage false
-_object setDamage damage _object;
+//_object setDamage damage _object;
 
 {
-    _object setHitPointDamage [_x, _hitPointDamages select _forEachIndex];
-} forEach _hitPoints;
+	_object setHitPointDamage [_x, _hitPointDamages select _forEachIndex];
+} forEach _hitpoints;
+
+{
+	_object setHit [_x, _hitSelectionDamages select _forEachIndex];
+} forEach _hitselections;

--- a/addons/common/functions/fnc_getHitPoints.sqf
+++ b/addons/common/functions/fnc_getHitPoints.sqf
@@ -21,7 +21,9 @@ _allHitpointsAndSelections = getAllHitPointsDamage _vehicle;
 _allHitpointsAndSelections params ["_allHitpoints", "_allHitselections"];
 
 {
-    if(!(_x in _hitpoints) && (_x != "")) then {_hitpoints pushback _x;};
+    if(!(_x in _hitpoints) && (_x != "")) then {
+        _hitpoints pushback _x;
+    };
     nil
 } count _allHitpoints;
 
@@ -30,7 +32,10 @@ if(_includeHitSelections) then {
 
     _hitselections = [];
     {
-        if(!(_x in _hitselections) && (_x != "")) then {_hitselections pushback _x;};nil
+        if(!(_x in _hitselections) && (_x != "")) then {
+            _hitselections pushback _x;
+        };
+        nil
     } count _allHitselections;
 
     [_hitpoints, _hitselections]

--- a/addons/common/functions/fnc_getHitPoints.sqf
+++ b/addons/common/functions/fnc_getHitPoints.sqf
@@ -11,46 +11,29 @@
  */
 #include "script_component.hpp"
 
-private ["_config", "_hitpoints", "_i"];
+params ["_vehicle", ["_includeHitSelections", false]];
 
-PARAMS_1(_vehicle);
-
-_config = configFile >> "CfgVehicles" >> typeOf _vehicle;
+private ["_hitpoints", "_allHitpointsAndSelections"];
 
 _hitpoints = [];
 
-// get all classes that can contain hitpoints
-private "_hitpointClasses";
-_hitpointClasses = [_config >> "HitPoints"];
+_allHitpointsAndSelections = getAllHitPointsDamage _vehicle;
+_allHitpointsAndSelections params ["_allHitpoints", "_allHitselections"];
+
 {
-    private "_class";
-    _class = ([_config, _x] call FUNC(getTurretConfigPath)) >> "HitPoints";
+    if(!(_x in _hitpoints) && (_x != "")) then {_hitpoints pushback _x;};
+    nil
+} count _allHitpoints;
 
-    if (isClass _class) then {
-        _hitpointClasses pushBack _class;
-    };
+if(_includeHitSelections) then {
+    private "_hitselections";
 
-} forEach allTurrets _vehicle;
+    _hitselections = [];
+    {
+        if(!(_x in _hitselections) && (_x != "")) then {_hitselections pushback _x;};nil
+    } count _allHitselections;
 
-// iterate through all classes with hitpoints and their parents
-{
-    private "_class";
-    _class = _x;
-
-    while {isClass _class} do {
-
-        for "_i" from 0 to (count _class - 1) do {
-            private "_entry";
-            _entry = configName (_class select _i);
-
-            if (!(_entry in _hitpoints) && {!isNil {_vehicle getHitPointDamage _entry}}) then {
-                _hitpoints pushBack _entry;
-            };
-        };
-
-        _class = inheritsFrom _class;
-    };
-
-} forEach _hitpointClasses;
-
-_hitpoints
+    [_hitpoints, _hitselections]
+} else {
+    _hitpoints
+};


### PR DESCRIPTION
Fix for https://github.com/acemod/ACE3/issues/2259

Added support for hit selections in getHitpoints
Little cleanup & use of `getAllHitPointsDamage`

I dont know why but after `_object setDamage damage _object` `setHit` doesnt work. If someone knows how to fix that i will be grateful :)