### PR TITLE
Add canInteractWith checks for cargo

### DIFF
--- a/addons/cargo/functions/fnc_canLoad.sqf
+++ b/addons/cargo/functions/fnc_canLoad.sqf
@@ -18,6 +18,8 @@
 
 params ["_player", "_object"];
 
+if (!([_player, _object, []] call EFUNC(common,canInteractWith))) exitWith {false};
+
 private ["_nearestVehicle"];
 _nearestVehicle = [_player] call FUNC(findNearestVehicle);
 

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -39,7 +39,10 @@ SETMVAR(GVAR(initializedClasses),_initializedClasses);
 if (getNumber (configFile >> "CfgVehicles" >> _type >> QGVAR(hasCargo)) != 1) exitWith {};
 
 private ["_text", "_condition", "_statement", "_icon", "_action"];
-_condition = {GVAR(enable)};
+_condition = {
+    params ["_target", "_player"];
+    GVAR(enable) && {[_player, _target, []] call EFUNC(common,canInteractWith)}
+};
 _text = localize LSTRING(openMenu);
 _statement = {GVAR(interactionVehicle) = _target; createDialog QGVAR(menu);};
 _icon = "";


### PR DESCRIPTION
Should fix #2281 
Will probably make #2185 unnecessary 

CreateAction doesn't add the canInteractWith check, so that's why both actions are showing at the same time when they should be mutually exclusive.
Should also solve stuff like people loading objects that others are carrying. 