### PR TITLE
Add Hearing Protection to Helmets with Peltor Headsets

### DIFF
--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -47,5 +47,16 @@ class CfgWeapons {
         GVAR(lowerVolume) = 0.60;
     };
     class H_Cap_marshal: H_Cap_headphones {};
-};
 
+    class H_HelmetB_light: H_HelmetB {
+        GVAR(protection) = 0.8;
+        GVAR(lowerVolume) = 0.20;
+    };
+
+    class H_HelmetB_plain_mcamo;
+    class H_HelmetSpecB: H_HelmetB_plain_mcamo {
+        GVAR(protection) = 0.8;
+        GVAR(lowerVolume) = 0.20;
+    };
+
+};


### PR DESCRIPTION
`"H_HelmetSpecB"` and `"H_HelmetB_light"` (and their variations) have visible Peltor Headsets on the 3d model. Those are electronical and will block/damp sounds that are too loud as soon as the sound appears but won't dampen environment sounds like earplugs would.

![image](https://cloud.githubusercontent.com/assets/1235520/9541127/745f19ba-4d65-11e5-970c-5eb80140ca00.png)
