### PR TITLE
fix autoriflemen spawning with 0x frag grenade bug

### DIFF
--- a/addons/overheating/CfgWeapons.hpp
+++ b/addons/overheating/CfgWeapons.hpp
@@ -9,7 +9,7 @@ class CfgWeapons {
         picture = QUOTE(PATHTOF(UI\spare_barrel_ca.paa));
         scope = 2;
         class ItemInfo: InventoryItem_Base_F {
-            mass = 50;
+            mass = 30;
         };
     };
 


### PR DESCRIPTION
This fixes the issue with unselectable grenades when spawning as autorifleman of every faction (except for FIA?).
Reason is that grenades can be added to the throw muzzle by config, even though there is not enough space in the inventory. This fix was in AGM, but probably got lost during porting...
The spare barrel still weights 1.36kg. Considering it's "usefulness" this seems more approriate anyway.