### PR TITLE
fix custom cameras (for intros) being broken with ACE, fix #2248

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -284,22 +284,13 @@ GVAR(OldVisibleMap) = false;
 }, 0, []] call CBA_fnc_addPerFrameHandler;
 
 
-// PFH to raise camera created event. Only works on these cams by BI.
-#define ALL_CAMERAS [ \
-    missionNamespace getVariable ["BIS_DEBUG_CAM", objNull], \
-    missionNamespace getVariable ["BIS_fnc_camera_cam", objNull], \
-    uiNamespace getVariable ["BIS_fnc_arsenal_cam", objNull], \
-    uiNamespace getVariable ["BIS_fnc_animViewer_cam", objNull], \
-    missionNamespace getVariable ["BIS_fnc_establishingShot_fakeUAV", objNull] \
-]
-
 GVAR(OldIsCamera) = false;
 
 [{
 
     // "activeCameraChanged" event
     private ["_isCamera"];
-    _isCamera = {!isNull _x} count ALL_CAMERAS > 0;
+    _isCamera = call FUNC(isfeatureCameraActive);
     if !(_isCamera isEqualTo GVAR(OldIsCamera)) then {
         // Raise ACE event locally
         GVAR(OldIsCamera) = _isCamera;

--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -3,26 +3,22 @@
 
 if (!hasInterface) exitWith {};
 
-#define ALL_CAMERAS [ \
-    missionNamespace getVariable ["BIS_DEBUG_CAM", objNull], \
-    missionNamespace getVariable ["BIS_fnc_camera_cam", objNull], \
-    uiNamespace getVariable ["BIS_fnc_arsenal_cam", objNull], \
-    uiNamespace getVariable ["BIS_fnc_animViewer_cam", objNull], \
-    missionNamespace getVariable ["BIS_fnc_establishingShot_fakeUAV", objNull], \
-    missionNamespace getVariable ["ACE_CustomCamera", objNull] \
-]
+GVAR(camera) = objNull;
 
 0 = 0 spawn {
     waituntil {!isNull ACE_player};
-    waituntil {sleep 0.5; {!isNull _x} count ALL_CAMERAS == 0};
+    waituntil {sleep 0.5; !(call EFUNC(common,isfeatureCameraActive)) && isNull (missionNamespace getVariable ["ACE_CustomCamera", objNull])};
+
+    GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
+    camDestroy GVAR(camera);
 
     // PiP technique by BadBenson
-    GVAR(camera) = "camera" camCreate positioncameratoworld [0,0,0];
+    GVAR(camera) = "camera" camCreate positionCameraToWorld [0,0,0];
     GVAR(camera) camSetFov 0.7;
     GVAR(camera) camSetTarget ACE_player;
     GVAR(camera) camCommit 1;
 
-    "ace_optics_rendertarget0" setPiPEffect [2, 1.0, 1.0, 1.0, 0.0, [0.0, 1.0, 0.0, 0.25], [1.0, 0.0, 1.0, 1.0], [0.199, 0.587, 0.114, 0.0]];
+    "ace_optics_rendertarget0" setPiPEffect [0];
     GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
 };
 
@@ -33,18 +29,19 @@ if (!hasInterface) exitWith {};
     };
 }] call EFUNC(common,addEventHandler);
 
-// camera has to be re-created every ACE_time another camera is created. Otherwise r2t is either black or transparent. @todo Add popular custom cameras to the event in ACE_common.
+// camera has to be re-created every time another camera is created. Otherwise r2t is either black or transparent. @todo Add popular custom cameras to the event in ACE_common.
 ["activeCameraChanged", {
     if !(_this select 1) then {
-        deleteVehicle GVAR(camera);
+        GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
+        camDestroy GVAR(camera);
 
         // PiP technique by BadBenson
-        GVAR(camera) = "camera" camCreate positioncameratoworld [0,0,0];
+        GVAR(camera) = "camera" camCreate positionCameraToWorld [0,0,0];
         GVAR(camera) camSetFov 0.7;
         GVAR(camera) camSetTarget ACE_player;
         GVAR(camera) camCommit 1;
 
-        "ace_optics_rendertarget0" setPiPEffect [2, 1.0, 1.0, 1.0, 0.0, [0.0, 1.0, 0.0, 0.25], [1.0, 0.0, 1.0, 1.0], [0.199, 0.587, 0.114, 0.0]];
+        "ace_optics_rendertarget0" setPiPEffect [0];
         GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
     };
 }] call EFUNC(common,addEventHandler);

--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -3,8 +3,18 @@
 
 if (!hasInterface) exitWith {};
 
+#define ALL_CAMERAS [ \
+    missionNamespace getVariable ["BIS_DEBUG_CAM", objNull], \
+    missionNamespace getVariable ["BIS_fnc_camera_cam", objNull], \
+    uiNamespace getVariable ["BIS_fnc_arsenal_cam", objNull], \
+    uiNamespace getVariable ["BIS_fnc_animViewer_cam", objNull], \
+    missionNamespace getVariable ["BIS_fnc_establishingShot_fakeUAV", objNull], \
+    missionNamespace getVariable ["ACE_CustomCamera", objNull] \
+]
+
 0 = 0 spawn {
     waituntil {!isNull ACE_player};
+    waituntil {sleep 0.5; {!isNull _x} count ALL_CAMERAS == 0};
 
     // PiP technique by BadBenson
     GVAR(camera) = "camera" camCreate positioncameratoworld [0,0,0];

--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -7,7 +7,7 @@ GVAR(camera) = objNull;
 
 0 = 0 spawn {
     waituntil {!isNull ACE_player};
-    waituntil {sleep 0.5; !(call EFUNC(common,isfeatureCameraActive)) && isNull (missionNamespace getVariable ["ACE_CustomCamera", objNull])};
+    waituntil {sleep 1; {_x != GVAR(camera)} count allMissionObjects "camera" == 0};
 
     GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
     camDestroy GVAR(camera);

--- a/addons/optics/functions/fnc_onDrawScope2D.sqf
+++ b/addons/optics/functions/fnc_onDrawScope2D.sqf
@@ -22,8 +22,8 @@ _optic = (primaryWeaponItems ACE_player) select 2;
 _isPIP = (getText (configFile >> "CfgWeapons" >> _optic >> "ItemInfo" >> "modelOptics")) == QUOTE(PATHTOF(models\ace_optics_pip.p3d));
 
 if (_isPIP) then {
-    GVAR(camera) setposATL positioncameratoworld [0,0,0.4];
-    GVAR(camera) camPrepareTarget positioncameratoworld [0,0,50];
+    GVAR(camera) setPosATL positionCameraToWorld [0,0,0.4];
+    GVAR(camera) camPrepareTarget positionCameraToWorld [0,0,50];
     GVAR(camera) camCommitPrepared 0;
 
     // @todo, check if that needs to be done at all


### PR DESCRIPTION
~~The camera for the pip opctics break intros with cameras. This is because the camera effect "internal" breaks whenever a new camCreate command is used.
Unfortunately there is no command that returns all cameras. The only solution for this problem I can come up with (without adding random sleeps and hoping for the best) is for mission makers to use a predifned variable name for their cameras.~~

```
~_camera = "camera" camCreate [0,0,0];~
~_camera cameraEffect ["internal", "back"];~
```

~becomes:~

```
~ACE_CustomCamera = "camera" camCreate [0,0,0];~
~ACE_CustomCamera cameraEffect ["internal", "back"];~
```

~~We probably should add this to the wiki if this PR gets merged.
Also fixes the camera being broken when entering the VA for the first time.~~

Completely solved this by using the wonderfull new command:
```
allMissionObjects "camera"
```