### PR TITLE
Hearing stuff

### DIFF
--- a/addons/hearing/CfgEventHandlers.hpp
+++ b/addons/hearing/CfgEventHandlers.hpp
@@ -29,7 +29,7 @@ class Extended_FiredNear_EventHandlers {
 class Extended_Explosion_EventHandlers {
     class CAManBase {
         class GVAR(ExplosionNear) {
-            clientExplosion = QUOTE( if (GVAR(enableCombatDeafness) && {_this select 0 == ACE_player}) then {_this call FUNC(explosionNear)}; );
+            clientExplosion = QUOTE(_this call FUNC(explosionNear););
         };
     };
 };

--- a/addons/hearing/functions/fnc_explosionNear.sqf
+++ b/addons/hearing/functions/fnc_explosionNear.sqf
@@ -21,8 +21,12 @@ if ((!GVAR(enableCombatDeafness)) && GVAR(DisableEarRinging)) exitWith {};
 
 params ["_unit", "_damage"];
 
+if (_unit != ACE_player) exitWith {};
+
+TRACE_2("explosion near player",_unit,_damage);
+
 private ["_strength"];
-_strength = 0 max _damage;
+_strength = (0 max _damage) * 30;
 if (_strength < 0.01) exitWith {};
 
-[{_this call FUNC(earRinging)}, [_unit, _strength], 0.2, 0] call EFUNC(common,waitAndExecute);
+[{_this call FUNC(earRinging)}, [_unit, _strength], 0.2] call EFUNC(common,waitAndExecute);

--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -7,8 +7,8 @@
  * 1: Firer: Object - Object which fires a weapon near the unit <OBJECT>
  * 2: Distance - Distance in meters between the unit and firer <NUMBER>
  * 3: weapon - Fired weapon <STRING>
- * 4: muzzle - Muzzle that was used <STRING>
- * 5: mod - Current mode of the fired weapon <STRING>
+ * 4: muzzle - Muzzle that was used (not used) <STRING>
+ * 5: mode - Current mode of the fired weapon (not used) <STRING>
  * 6: ammo - Ammo used <STRING>
  *
  * Return Value:
@@ -16,6 +16,7 @@
  *
  * Example:
  * [clientFiredNearEvent] call ace_hearing_fnc_firedNear
+ * [player, player, 10, "arifle_MX_ACO_pointer_F", "arifle_MX_ACO_pointer_F", "single", "B_65x39_Caseless"] call ace_hearing_fnc_firedNear
  *
  * Public: No
  */
@@ -24,14 +25,14 @@
 //Only run if deafness or ear ringing is enabled:
 if ((!GVAR(enableCombatDeafness)) && GVAR(DisableEarRinging)) exitWith {};
 
-params ["_object", "_firer", "_distance", "_weapon", "_muzzle", "_mode", "_ammo"];
+params ["_object", "_firer", "_distance", "_weapon", "", "", "_ammo"];
 
 //Only run if firedNear object is player or player's vehicle:
 if ((ACE_player != _object) && {(vehicle ACE_player) != _object}) exitWith {};
 if (_weapon in ["Throw", "Put"]) exitWith {};
 if (_distance > 50) exitWith {};
 
-private ["_silencer", "_audibleFireCoef", "_loudness", "_strength", "_vehAttenuation", "_magazine", "_muzzles", "_weaponMagazines", "_muzzleMagazines", "_ammoType", "_initSpeed", "_ammoConfig", "_caliber", "_parentClasses"];
+private ["_silencer", "_audibleFireCoef", "_loudness", "_strength", "_vehAttenuation", "_magazine", "_muzzles", "_weaponMagazines", "_muzzleMagazines", "_ammoType", "_initSpeed", "_ammoConfig", "_caliber"];
 
 _vehAttenuation = if ((ACE_player == (vehicle ACE_player)) || {isTurnedOut ACE_player}) then {1} else {GVAR(playerVehAttenuation)};
 
@@ -78,21 +79,20 @@ if (_magazine == "") exitWith {};
 
 _initSpeed = getNumber(configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
 _ammoConfig = (configFile >> "CfgAmmo" >> _ammo);
-_parentClasses = [_ammoConfig, true] call BIS_fnc_returnParents;
 _caliber = getNumber(_ammoConfig >> "ACE_caliber");
 _caliber = call {
-    if ("ShellBase" in _parentClasses) exitWith { 80 };
-    if ("RocketBase" in _parentClasses) exitWith { 200 };
-    if ("MissileBase" in _parentClasses) exitWith { 600 };
-    if ("SubmunitionBase" in _parentClasses) exitWith { 80 };
+    if (_ammo isKindOf ["ShellBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
+    if (_ammo isKindOf ["RocketBase", (configFile >> "CfgAmmo")]) exitWith { 200 };
+    if (_ammo isKindOf ["MissileBase", (configFile >> "CfgAmmo")]) exitWith { 600 };
+    if (_ammo isKindOf ["SubmunitionBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
     if (_caliber <= 0) then { 6.5 } else { _caliber };
 };
 _loudness = (_caliber ^ 1.25 / 10) * (_initspeed / 1000) * _audibleFireCoef / 5;
 _strength = _vehAttenuation * (_loudness - (_loudness / 50 * _distance)); // linear drop off
 
-//systemChat format["%1 : %2 : %3", _strength, _initSpeed, _parentClasses];
+//systemChat format["%1 : %2", _strength, _initSpeed];
 //systemChat format["%1 : %2 : %3", _weapon, _magazine, _initSpeed];
 
 if (_strength < 0.01) exitWith {};
 
-[{_this call FUNC(earRinging)}, [ACE_player, _strength], 0.2, 0] call EFUNC(common,waitAndExecute);
+[{_this call FUNC(earRinging)}, [ACE_player, _strength], 0.2] call EFUNC(common,waitAndExecute);

--- a/addons/hearing/functions/fnc_moduleHearing.sqf
+++ b/addons/hearing/functions/fnc_moduleHearing.sqf
@@ -9,9 +9,8 @@
  * None
  */
 #include "script_component.hpp"
-params ["_logic", "_units", "_activated"];
 
-if !(_activated) exitWith {};
+params ["_logic"];
 
 [_logic, QGVAR(enableCombatDeafness), "EnableCombatDeafness"] call EFUNC(common,readSettingFromModule);
 


### PR DESCRIPTION
Fix 	#1988  - the "hearing damage" switched from a 0-1 scale to 0-20.
It's still not perfect because we can only get an event when taking direct explosive damage,

Also got some nice performance improvements with new `isKindOf` command in firedNear
0.230 ms vs 0.081 ms