### PR TITLE
Fix gunner goggles

### DIFF
--- a/addons/goggles/functions/fnc_checkGoggles.sqf
+++ b/addons/goggles/functions/fnc_checkGoggles.sqf
@@ -18,7 +18,7 @@
 if (!alive ace_player) exitWith {};
 if (true) then {
     // Detect if curator interface is open and disable effects
-    if (!isNull(findDisplay 312)) exitWith {
+    if !(isNull curatorCamera) exitWith {
         if (GVAR(EffectsActive)) then {
             call FUNC(removeGlassesEffect);
         };

--- a/addons/goggles/functions/fnc_isGogglesVisible.sqf
+++ b/addons/goggles/functions/fnc_isGogglesVisible.sqf
@@ -15,14 +15,16 @@
  */
 #include "script_component.hpp"
 
-PARAMS_1(_unit);
-
+params ["_unit"];
 private ["_currentGlasses", "_result", "_position", "_visible"];
 
 _currentGlasses = goggles _unit;
 _result = false;
 
-if ((vehicle _unit) != _unit) exitWith {(cameraView != "GUNNER")};
+if ((vehicle _unit) != _unit) exitWith {
+    (cameraView != "GUNNER") ||
+    {[_unit] call EFUNC(common,canUseWeapon)}
+};
 
 if (_currentGlasses != "") then {
     _position =(getPosASLW _unit);

--- a/addons/goggles/functions/fnc_isGogglesVisible.sqf
+++ b/addons/goggles/functions/fnc_isGogglesVisible.sqf
@@ -21,13 +21,8 @@ private ["_currentGlasses", "_result", "_position", "_visible"];
 _currentGlasses = goggles _unit;
 _result = false;
 
-if ((vehicle _unit) != _unit) exitWith {
-    (cameraView != "GUNNER") ||
-    {[_unit] call EFUNC(common,canUseWeapon)}
-};
-
 if (_currentGlasses != "") then {
-    _position =(getPosASLW _unit);
+    _position = getPosASLW _unit;
     if (surfaceIsWater _position && {((_position select 2) < 0.25)}) exitWith {
         _result = ([_currentGlasses] call FUNC(isDivingGoggles));
     };


### PR DESCRIPTION
Fixes #1721 and #1342

Originally I introduced a canUseWeapon check to fix the FFV seats. Then when it came to considering the second issue I think it makes sense to just remove any special treatment for gunners anyway:
  - It simplifies the code and offers a slight performance benefit (that function is used by a PFH)
  - If you intend to be a vehicle gunner, you probably shouldn't be wearing unsuitable glasses anyway. Besides it's not the end of the world if you do, you can still see after all.
  - It makes things more consistent
    - Overlay already persists when using a UAV
    - Would be inconsistent for the weirdly configured commander seats/co-pilot seats
    - All the other effects checked by that function will now still take place when in a vehicle (if the vehicle goes underwater/etc.)
  - We will be introducing a client setting for the goggles overlay so nobody is forced to use it by default.