### PR TITLE
setStructuralDamage function

### DIFF
--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -68,6 +68,7 @@ PREP(selectionNameToNumber);
 PREP(setCardiacArrest);
 PREP(setDead);
 PREP(setHitPointDamage);
+PREP(setStructuralDamage);
 PREP(setUnconscious);
 PREP(treatment);
 PREP(treatment_failure);

--- a/addons/medical/functions/fnc_copyDeadBody.sqf
+++ b/addons/medical/functions/fnc_copyDeadBody.sqf
@@ -79,5 +79,5 @@ _newUnit setvariable ["ACE_isUnconscious", true, true];
 _newUnit setvariable [QGVAR(disableInteraction), true, true];
 _oldBody setvariable [QGVAR(disableInteraction), true, true];
 
-_newUnit setDamage 0.89;
+[_newUnit, 0.89] call FUNC(setStructuralDamage);
 _newUnit;

--- a/addons/medical/functions/fnc_setDead.sqf
+++ b/addons/medical/functions/fnc_setDead.sqf
@@ -82,5 +82,5 @@ if (isPLayer _unit) then {
 
 ["medical_onSetDead", [_unit]] call EFUNC(common,localEvent);
 
-_unit setdamage 1;
+[_unit, 1] call FUNC(setStructuralDamage);
 true;

--- a/addons/medical/functions/fnc_setStructuralDamage.sqf
+++ b/addons/medical/functions/fnc_setStructuralDamage.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: commy2
+ * Set the structural damage of a soldier without changing the individual hitpoints. Unit has to be local. Not safe to use with vehicles!
+ *
+ * Arguments:
+ * 0: The unit <OBJECT>
+ *
+ * ReturnValue:
+ * <NIL>
+ *
+ * Public: no?
+ */
+
+params ["_unit", "_damage"];
+
+if (!local _unit) exitWith {};
+
+private "_allHitPoints";
+_allHitPoints = getAllHitPointsDamage _unit select 2;
+
+_unit setDamage _damage;
+
+{
+    _unit setHitIndex [_forEachIndex, _x];
+} forEach _allHitPoints;


### PR DESCRIPTION
Killing a soldier by shooting him in the chest causes the whole body to get bloody. This is because `setDamage 1` is called in fnc_setDead. I wrote a function that can manipulate the structural damage without changing the hitpoints to prevent this.
Possibly needs to be used in more places. I have no idea when setDamage is intended (e.g. `setDamage 0` for a complete heal) and where it's not.
Uses the new hit index system. Pretty neat.

Plz review Glowbal.