### PR TITLE
remove BI blood overlay

### DIFF
--- a/addons/medical/XEH_PREP.hpp
+++ b/addons/medical/XEH_PREP.hpp
@@ -73,6 +73,7 @@ PREP(setDead);
 PREP(setHitPointDamage);
 PREP(setStructuralDamage);
 PREP(setUnconscious);
+PREP(showBloodEffect);
 PREP(translateSelections);
 PREP(treatment);
 PREP(treatment_failure);

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -22,5 +22,6 @@ class CfgPatches {
 #include "CfgEden.hpp"
 #include "ACE_Medical_Treatments.hpp"
 #include "ACE_Settings.hpp"
+#include "UI\CfgInGameUI.hpp"
 #include "UI\RscTitles.hpp"
 #include "UI\triagecard.hpp"

--- a/addons/medical/functions/fnc_showBloodEffect.sqf
+++ b/addons/medical/functions/fnc_showBloodEffect.sqf
@@ -1,0 +1,158 @@
+/*
+ * Author: KoffeinFlummi, Glowbal
+ * Does the blood screen effect, just like BIS_fnc_bloodeffect, but in non-sheduled environment.
+ *
+ * Arguments:
+ * 0: Effect multiplier <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params ["_bloodRemaining"];
+
+disableSerialization;
+
+// get already existing controls, or create them
+private ["_fxBloodControls", "_bloodCtrl1", "_bloodCtrl2", "_bloodCtrl3"];
+
+_fxBloodControls = GETUVAR(GVAR(FXBloodControls),[]);
+
+if (count _fxBloodControls != 3) then {
+    _bloodCtrl1 = findDisplay 46 ctrlCreate ["RscPicture", -1];
+    _bloodCtrl2 = findDisplay 46 ctrlCreate ["RscPicture", -1];
+    _bloodCtrl3 = findDisplay 46 ctrlCreate ["RscPicture", -1];
+
+    // set their textures, screen position etc.
+    _bloodCtrl1 ctrlSetText "A3\Ui_f\data\igui\rsctitles\HealthTextures\blood_lower_ca.paa";
+    _bloodCtrl2 ctrlSetText "A3\Ui_f\data\igui\rsctitles\HealthTextures\blood_middle_ca.paa";
+    _bloodCtrl3 ctrlSetText "A3\Ui_f\data\igui\rsctitles\HealthTextures\blood_upper_ca.paa";
+
+    // positions are from config
+    private "_ctrlPosition";
+    _ctrlPosition = [
+        ((0 * safezoneW) + safezoneX) + ((safezoneW - (2.125 * safezoneW * 3/4)) / 2),
+        (-0.0625 * safezoneH) + safezoneY,
+        2.125 * safezoneW * 3/4,
+        1.125 * safezoneH
+    ];
+
+    _bloodCtrl1 ctrlSetPosition _ctrlPosition;
+    _bloodCtrl2 ctrlSetPosition _ctrlPosition;
+    _bloodCtrl3 ctrlSetPosition _ctrlPosition;
+
+    _fxBloodControls = [_bloodCtrl1, _bloodCtrl2, _bloodCtrl3];
+    SETUVAR(GVAR(FXBloodControls),_fxBloodControls);
+} else {
+    _bloodCtrl1 = _fxBloodControls select 0;
+    _bloodCtrl2 = _fxBloodControls select 1;
+    _bloodCtrl3 = _fxBloodControls select 2;
+};
+
+// reset everything
+_bloodCtrl1 ctrlSetFade 1;
+_bloodCtrl2 ctrlSetFade 1;
+_bloodCtrl3 ctrlSetFade 1;
+
+_bloodCtrl1 ctrlCommit 0;
+_bloodCtrl2 ctrlCommit 0;
+_bloodCtrl3 ctrlCommit 0;
+
+if (_bloodRemaining < 5) exitWith {
+    // nothing
+};
+
+if (_bloodRemaining < 25) exitWith {
+    _bloodCtrl1 ctrlSetFade 0.2;
+    _bloodCtrl1 ctrlCommit 0.2;
+
+    [{
+        (_this select 0) ctrlSetFade 1;
+        (_this select 0) ctrlCommit 0.8;
+    }, _fxBloodControls, 0.7] call EFUNC(common,waitAndExecute);
+};
+
+if (_bloodRemaining < 40) exitWith {
+    _bloodCtrl1 ctrlSetFade 0.2;
+    _bloodCtrl2 ctrlSetFade 0.85;
+    _bloodCtrl1 ctrlCommit 0.2;
+    _bloodCtrl2 ctrlCommit 0.2;
+
+    [{
+        (_this select 0) ctrlSetFade 1;
+        (_this select 1) ctrlSetFade 1;
+        (_this select 1) ctrlCommit 1;
+    }, _fxBloodControls, 0.7] call EFUNC(common,waitAndExecute);
+
+    [{
+        (_this select 0) ctrlCommit 0.8;
+    }, _fxBloodControls, 1.2] call EFUNC(common,waitAndExecute);
+};
+
+if (_bloodRemaining < 55) exitWith {
+    _bloodCtrl1 ctrlSetFade 0.2;
+    _bloodCtrl2 ctrlSetFade 0.7;
+    _bloodCtrl1 ctrlCommit 0.2;
+    _bloodCtrl2 ctrlCommit 0.2;
+
+    [{
+        (_this select 0) ctrlSetFade 1;
+        (_this select 1) ctrlSetFade 1;
+        (_this select 2) ctrlSetFade 1;
+        (_this select 1) ctrlCommit 1;
+    }, _fxBloodControls, 0.7] call EFUNC(common,waitAndExecute);
+
+    [{
+        (_this select 0) ctrlCommit 0.8;
+    }, _fxBloodControls, 1.2] call EFUNC(common,waitAndExecute);
+};
+
+if (_bloodRemaining < 70) exitWith {
+    _bloodCtrl1 ctrlSetFade 0.2;
+    _bloodCtrl2 ctrlSetFade 0.7;
+    _bloodCtrl3 ctrlSetFade 0.85;
+    _bloodCtrl1 ctrlCommit 0.2;
+    _bloodCtrl2 ctrlCommit 0.2;
+    _bloodCtrl3 ctrlCommit 0.2;
+
+    [{
+        (_this select 0) ctrlSetFade 1;
+        (_this select 1) ctrlSetFade 1;
+        (_this select 2) ctrlSetFade 1;
+        (_this select 2) ctrlCommit 1.5;
+    }, _fxBloodControls, 0.7] call EFUNC(common,waitAndExecute);
+
+    [{
+        (_this select 1) ctrlCommit 1;
+    }, _fxBloodControls, 1.7] call EFUNC(common,waitAndExecute);
+
+    [{
+        (_this select 0) ctrlCommit 0.8;
+    }, _fxBloodControls, 2.2] call EFUNC(common,waitAndExecute);
+};
+
+//default
+_bloodCtrl1 ctrlSetFade 0.2;
+_bloodCtrl2 ctrlSetFade 0.7;
+_bloodCtrl3 ctrlSetFade 0.7;
+_bloodCtrl1 ctrlCommit 0.2;
+_bloodCtrl2 ctrlCommit 0.2;
+_bloodCtrl3 ctrlCommit 0.2;
+
+[{
+    (_this select 0) ctrlSetFade 1;
+    (_this select 1) ctrlSetFade 1;
+    (_this select 2) ctrlSetFade 1;
+    (_this select 2) ctrlCommit 1.5;
+}, _fxBloodControls, 0.7] call EFUNC(common,waitAndExecute);
+
+[{
+    (_this select 1) ctrlCommit 1;
+}, _fxBloodControls, 1.7] call EFUNC(common,waitAndExecute);
+
+[{
+    (_this select 0) ctrlCommit 0.8;
+}, _fxBloodControls, 2.2] call EFUNC(common,waitAndExecute);

--- a/addons/medical/ui/CfgInGameUI.hpp
+++ b/addons/medical/ui/CfgInGameUI.hpp
@@ -1,0 +1,6 @@
+
+class CfgInGameUI {
+    class PeripheralVision {
+        bloodTexture = ""; //"A3\ui_f\data\igui\cfg\PeripheralVision\bloodTexture_ca.paa";
+    };
+};

--- a/addons/medical/ui/RscTitles.hpp
+++ b/addons/medical/ui/RscTitles.hpp
@@ -110,4 +110,20 @@ class Rsctitles {
         };
     };
   };
+
+    // disables blood texture overlay
+    class RscHealthTextures {
+        class controls {
+            class Flame_1;
+            class Blood_1: Flame_1 {
+                text = ""; //"A3\Ui_f\data\igui\rsctitles\HealthTextures\blood_lower_ca.paa";
+            };
+            class Blood_2: Flame_1 {
+                text = ""; //"A3\Ui_f\data\igui\rsctitles\HealthTextures\blood_middle_ca.paa";
+            };
+            class Blood_3: Flame_1 {
+                text = ""; //"A3\Ui_f\data\igui\rsctitles\HealthTextures\blood_upper_ca.paa";
+            };
+        };
+    };
 };


### PR DESCRIPTION
On the medical-adjustments branch the wound visuals on the uniform are flickering when shooting someone, because some hitpoints are reset for one frame.
I was told that this was added to prevent some BI effects when getting hit by a bullet.
No idea which effects exactly, but if it's only the blood fx, then this PR does it by config and not by scripting which is the prefered way imo.