### PR TITLE
MapTools - Handle Bad Aspect Ratio

### DIFF
--- a/addons/maptools/functions/fnc_updateMapToolMarkers.sqf
+++ b/addons/maptools/functions/fnc_updateMapToolMarkers.sqf
@@ -18,7 +18,7 @@
 
 params ["_theMap"];
 
-private ["_rotatingTexture", "_textureWidth", "_scale", "_xPos", "_yPos"];
+private ["_rotatingTexture", "_textureWidth", "_scaleX", "_scaleY", "_xPos", "_yPos"];
 
 // Show/Hide draw buttons
 if ([] call FUNC(canDraw)) then {
@@ -43,16 +43,18 @@ if (GVAR(mapTool_Shown) == 1) then {
 };
 
 // Update scale of both parts
-_scale = _textureWidth * CONSTANT_SCALE * (call FUNC(calculateMapScale));
+getResolution params ["_resWidth", "_resHeight", "", "", "_aspectRatio"];
+_scaleX = 32 * _textureWidth * CONSTANT_SCALE * (call FUNC(calculateMapScale));
+_scaleY = _scaleX * ((_resWidth / _resHeight) / _aspectRatio); //handle bad aspect ratios
 
 // Position of the fixed part
 _xPos = GVAR(mapTool_pos) select 0;
 _yPos = (GVAR(mapTool_pos) select 1) + _textureWidth * CENTER_OFFSET_Y_PERC;
 
-_theMap drawIcon [QUOTE(PATHTOF(data\mapToolFixed.paa)), [1,1,1,1], [_xPos,_yPos], (32 * _scale), (32 * _scale), 0, "", 0];
+_theMap drawIcon [QUOTE(PATHTOF(data\mapToolFixed.paa)), [1,1,1,1], [_xPos,_yPos], _scaleX, _scaleY, 0, "", 0];
 
 // Position and rotation of the rotating part
 _xPos = (GVAR(mapTool_pos) select 0) + sin(GVAR(mapTool_angle)) * _textureWidth * CENTER_OFFSET_Y_PERC;
 _yPos = (GVAR(mapTool_pos) select 1) + cos(GVAR(mapTool_angle)) * _textureWidth * CENTER_OFFSET_Y_PERC;
 
-_theMap drawIcon [_rotatingTexture, [1,1,1,1], [_xPos,_yPos], (32 * _scale), (32 * _scale), GVAR(mapTool_angle), "", 0];
+_theMap drawIcon [_rotatingTexture, [1,1,1,1], [_xPos,_yPos], _scaleX, _scaleY, GVAR(mapTool_angle), "", 0];


### PR DESCRIPTION
If you have your aspect ratio set wrong map tools will draw incorrectly (dot wobbles inside crosshairs):

![2015-08-31_00002](https://cloud.githubusercontent.com/assets/9376747/9595931/09a7157a-5033-11e5-9e23-9f6a074179e3.jpg)

It really is more of a user problem, but we can handle it.