### PR TITLE
scripted approach to hand flares, fix #1079

### DIFF
--- a/addons/grenades/CfgAmmo.hpp
+++ b/addons/grenades/CfgAmmo.hpp
@@ -28,66 +28,66 @@ class CfgAmmo {
     };
 
     class ACE_F_Hand_White: F_20mm_White {
-        grenadeBurningSound[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        grenadeFireSound[] = {"SmokeShellSoundHit1",0.25,"SmokeShellSoundHit2",0.25,"SmokeShellSoundHit3",0.5};
-        soundTrigger[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        SmokeShellSoundHit1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_1",1.25893,1,100};
-        SmokeShellSoundHit2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_2",1.25893,1,100};
-        SmokeShellSoundHit3[] = {"A3\Sounds_F\weapons\smokeshell\smoke_3",1.25893,1,100};
-        SmokeShellSoundLoop1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop1",0.125893,1,70};
-        SmokeShellSoundLoop2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop2",0.125893,1,70};
         timeToLive = 60;
     };
 
     class F_20mm_Red;
     class ACE_F_Hand_Red: F_20mm_Red {
-        grenadeBurningSound[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        grenadeFireSound[] = {"SmokeShellSoundHit1",0.25,"SmokeShellSoundHit2",0.25,"SmokeShellSoundHit3",0.5};
-        soundTrigger[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        SmokeShellSoundHit1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_1",1.25893,1,100};
-        SmokeShellSoundHit2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_2",1.25893,1,100};
-        SmokeShellSoundHit3[] = {"A3\Sounds_F\weapons\smokeshell\smoke_3",1.25893,1,100};
-        SmokeShellSoundLoop1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop1",0.125893,1,70};
-        SmokeShellSoundLoop2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop2",0.125893,1,70};
         timeToLive = 60;
     };
 
     class F_20mm_Green;
     class ACE_F_Hand_Green: F_20mm_Green {
-        grenadeBurningSound[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        grenadeFireSound[] = {"SmokeShellSoundHit1",0.25,"SmokeShellSoundHit2",0.25,"SmokeShellSoundHit3",0.5};
-        soundTrigger[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        SmokeShellSoundHit1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_1",1.25893,1,100};
-        SmokeShellSoundHit2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_2",1.25893,1,100};
-        SmokeShellSoundHit3[] = {"A3\Sounds_F\weapons\smokeshell\smoke_3",1.25893,1,100};
-        SmokeShellSoundLoop1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop1",0.125893,1,70};
-        SmokeShellSoundLoop2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop2",0.125893,1,70};
         timeToLive = 60;
     };
 
     class F_20mm_Yellow;
     class ACE_F_Hand_Yellow: F_20mm_Yellow {
-        grenadeBurningSound[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        grenadeFireSound[] = {"SmokeShellSoundHit1",0.25,"SmokeShellSoundHit2",0.25,"SmokeShellSoundHit3",0.5};
-        soundTrigger[] = {"SmokeShellSoundLoop1",0.5,"SmokeShellSoundLoop2",0.5};
-        SmokeShellSoundHit1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_1",1.25893,1,100};
-        SmokeShellSoundHit2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_2",1.25893,1,100};
-        SmokeShellSoundHit3[] = {"A3\Sounds_F\weapons\smokeshell\smoke_3",1.25893,1,100};
-        SmokeShellSoundLoop1[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop1",0.125893,1,70};
-        SmokeShellSoundLoop2[] = {"A3\Sounds_F\weapons\smokeshell\smoke_loop2",0.125893,1,70};
         timeToLive = 60;
     };
 
     class SmokeShell;
+    class ACE_G_Handflare_White: SmokeShell {
+        GVAR(flare) = 1;
+        GVAR(color)[] = {0.5,0.5,0.5,0.5};
+        model = "\A3\weapons_f\ammo\flare_white";
+        dangerRadiusHit = -1;
+        suppressionRadiusHit = -1;
+        typicalSpeed = 22;
+        cost = 100;
+        deflecting = 30;
+        explosionTime = 3;
+        timeToLive = 60;
+        grenadeFireSound[] = {};
+        grenadeBurningSound[] = {};
+        aiAmmoUsageFlags = "4 + 2";
+        smokeColor[] = {0,0,0,0};
+        effectsSmoke = "ACE_HandFlareEffect";
+        whistleDist = 0;
+    };
+    class ACE_G_Handflare_Red: ACE_G_Handflare_White {
+        GVAR(color)[] = {0.5,0.25,0.25,0.5};
+        model = "\A3\weapons_f\ammo\flare_red";
+    };
+    class ACE_G_Handflare_Green: ACE_G_Handflare_White {
+        GVAR(color)[] = {0.25,0.5,0.25,0.5};
+        model = "\A3\weapons_f\ammo\flare_green";
+    };
+    class ACE_G_Handflare_Yellow: ACE_G_Handflare_White {
+        GVAR(color)[] = {0.5,0.5,0.25,0.5};
+        model = "\A3\weapons_f\ammo\flare_yellow";
+    };
+
     class ACE_G_M84: SmokeShell {
+        GVAR(flashbang) = 1;
         model = PATHTOF(models\ACE_m84_thrown.p3d);
         dangerRadiusHit = -1;
         suppressionRadiusHit = 20;
         typicalSpeed = 22;
         cost = 40;
         deflecting = 15;
+        explosionTime = 2.3;
         timeToLive = 6;
-        fuseDistance = 2.3;
         grenadeFireSound[] = {};
         grenadeBurningSound[] = {};
         aiAmmoUsageFlags = "0";

--- a/addons/grenades/CfgMagazines.hpp
+++ b/addons/grenades/CfgMagazines.hpp
@@ -1,3 +1,4 @@
+
 class CfgMagazines {
     class HandGrenade;
     class ACE_HandFlare_Base: HandGrenade {
@@ -8,55 +9,60 @@ class CfgMagazines {
         mass = 4;
         initSpeed = 22;
     };
+
     class ACE_HandFlare_White: ACE_HandFlare_Base {
         author = ECSTRING(common,ACETeam);
         scope = 2;
-        ammo = "ACE_F_Hand_White";
         displayname = CSTRING(M127A1_White_Name);
         descriptionshort = CSTRING(M127A1_White_Description);
         displayNameShort = CSTRING(M127A1_White_NameShort);
         model = "\A3\weapons_f\ammo\flare_white";
         picture = "\A3\Weapons_F\Data\UI\gear_flare_white_ca.paa";
+        ammo = "ACE_G_Handflare_White";
     };
+
     class ACE_HandFlare_Red: ACE_HandFlare_Base {
         author = ECSTRING(common,ACETeam);
         scope = 2;
-        ammo = "ACE_F_Hand_Red";
         displayname = CSTRING(M127A1_Red_Name);
         descriptionshort = CSTRING(M127A1_Red_Description);
         displayNameShort = CSTRING(M127A1_Red_NameShort);
         model = "\A3\weapons_f\ammo\flare_red";
         picture = "\A3\Weapons_F\Data\UI\gear_flare_red_ca.paa";
+        ammo = "ACE_G_Handflare_Red";
     };
+
     class ACE_HandFlare_Green: ACE_HandFlare_Base {
         author = ECSTRING(common,ACETeam);
         scope = 2;
-        ammo = "ACE_F_Hand_Green";
         displayname = CSTRING(M127A1_Green_Name);
         descriptionshort = CSTRING(M127A1_Green_Description);
         displayNameShort = CSTRING(M127A1_Green_NameShort);
         model = "\A3\weapons_f\ammo\flare_green";
         picture = "\A3\Weapons_F\Data\UI\gear_flare_green_ca.paa";
+        ammo = "ACE_G_Handflare_Green";
     };
+
     class ACE_HandFlare_Yellow: ACE_HandFlare_Base {
         author = ECSTRING(common,ACETeam);
         scope = 2;
-        ammo = "ACE_F_Hand_Yellow";
         displayname = CSTRING(M127A1_Yellow_Name);
         descriptionshort = CSTRING(M127A1_Yellow_Description);
         displayNameShort = CSTRING(M127A1_Yellow_NameShort);
         model = "\A3\weapons_f\ammo\flare_yellow";
         picture = "\A3\Weapons_F\Data\UI\gear_flare_yellow_ca.paa";
+        ammo = "ACE_G_Handflare_Yellow";
     };
+
     class ACE_M84: HandGrenade {
         author = ECSTRING(common,ACETeam);
-        ammo = "ACE_G_M84";
         displayname = CSTRING(M84_Name);
         descriptionshort = CSTRING(M84_Description);
         displayNameShort = "M84";
-        mass = 4;
         model = PATHTOF(models\ACE_m84.p3d);
         picture = PATHTOF(UI\ACE_m84_x_ca.paa);
+        ammo = "ACE_G_M84";
+        mass = 4;
     };
 
     class 3Rnd_UGL_FlareGreen_F;
@@ -65,6 +71,7 @@ class CfgMagazines {
         ammo = "F_40mm_Green";
         initSpeed = 120;
     };
+
     class 6Rnd_RedSignal_F: 6Rnd_GreenSignal_F {
         author = ECSTRING(common,ACETeam);
         ammo = "F_40mm_Red";

--- a/addons/grenades/Effects.hpp
+++ b/addons/grenades/Effects.hpp
@@ -2,3 +2,7 @@
 class ACE_M84FlashbangEffect {
     // empty
 };
+
+class ACE_HandFlareEffect {
+    // empty
+};

--- a/addons/grenades/XEH_preInit.sqf
+++ b/addons/grenades/XEH_preInit.sqf
@@ -2,6 +2,7 @@
 
 ADDON = false;
 
+PREP(flare);
 PREP(flashbangExplosionEH);
 PREP(flashbangThrownFuze);
 PREP(nextMode);

--- a/addons/grenades/functions/fnc_flare.sqf
+++ b/addons/grenades/functions/fnc_flare.sqf
@@ -1,4 +1,21 @@
-// by commy2
+/*
+ * Author: commy2
+ * Makes flare shine.
+ *
+ * Arguments:
+ * 0: The flare <OBJECT>
+ * 1: Color of flare <ARRAY>
+ * 2: Intensity of flare <NUMBER>
+ * 3: Flare lifetime <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_nade, [0.5,0.5,0.5], 0.5, 60] call ace_grenades_fnc_flare
+ *
+ * Public: No
+ */
 #include "script_component.hpp"
 
 params ["_projectile", "_color", "_intensity", "_timeToLive"];

--- a/addons/grenades/functions/fnc_flare.sqf
+++ b/addons/grenades/functions/fnc_flare.sqf
@@ -1,0 +1,23 @@
+// by commy2
+#include "script_component.hpp"
+
+params ["_projectile", "_color", "_intensity", "_timeToLive"];
+
+private "_light";
+_light = "#lightpoint" createVehicleLocal position _projectile;
+
+_light setLightColor _color;
+_light setLightAmbient _color;
+_light setLightIntensity _intensity;
+_light setLightBrightness 0.8;
+
+_light setLightUseFlare true;
+_light setLightFlareSize 3.0;
+_light setLightFlareMaxDistance 1000;
+
+_light setLightDayLight true;
+
+_light lightAttachObject [_projectile, [0,0,0]];
+//_light attachTo [_projectile, [0,0,0]];
+
+[{deleteVehicle _this}, _light, _timeToLive, 1] call EFUNC(common,waitAndExecute);

--- a/addons/grenades/functions/fnc_throwGrenade.sqf
+++ b/addons/grenades/functions/fnc_throwGrenade.sqf
@@ -25,6 +25,11 @@ params ["_unit", "_weapon", "", "", "_ammo", "", "_projectile"];
 
 if (_weapon != "Throw") exitWith {};
 
+// http://feedback.arma3.com/view.php?id=12340
+if (isNull _projectile) then {
+    _projectile = nearestObject [_unit, _ammo];
+};
+
 // handle speial grenades
 if (local _unit) then {
     if (getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(flashbang)) == 1) then {
@@ -33,18 +38,18 @@ if (local _unit) then {
 
         [FUNC(flashbangThrownFuze), [_projectile], _fuzeTime, 0] call EFUNC(common,waitAndExecute);
     };
+};
 
-    if (getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(flare)) == 1) then {
-        private ["_fuzeTime", "_timeToLive", "_color", "_intensity"];
+if (getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(flare)) == 1) then {
+    private ["_fuzeTime", "_timeToLive", "_color", "_intensity"];
 
-        _fuzeTime = getNumber (configFile >> "CfgAmmo" >> _ammo >> "explosionTime");
-        _timeToLive = getNumber (configFile >> "CfgAmmo" >> _ammo >> "timeToLive");
-        _color = getArray (configFile >> "CfgAmmo" >> _ammo >> QGVAR(color));
-        _intensity = _color select 3;
-        _color resize 3;
+    _fuzeTime = getNumber (configFile >> "CfgAmmo" >> _ammo >> "explosionTime");
+    _timeToLive = getNumber (configFile >> "CfgAmmo" >> _ammo >> "timeToLive");
+    _color = getArray (configFile >> "CfgAmmo" >> _ammo >> QGVAR(color));
+    _intensity = _color select 3;
+    _color resize 3;
 
-        [FUNC(flare), [_projectile, _color, _intensity, _timeToLive], _fuzeTime, 0] call EFUNC(common,waitAndExecute);
-    };
+    [FUNC(flare), [_projectile, _color, _intensity, _timeToLive], _fuzeTime, 0] call EFUNC(common,waitAndExecute);
 };
 
 // handle throw modes

--- a/addons/grenades/functions/fnc_throwGrenade.sqf
+++ b/addons/grenades/functions/fnc_throwGrenade.sqf
@@ -30,7 +30,7 @@ if (isNull _projectile) then {
     _projectile = nearestObject [_unit, _ammo];
 };
 
-// handle speial grenades
+// handle special grenades
 if (local _unit) then {
     if (getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(flashbang)) == 1) then {
         private "_fuzeTime";


### PR DESCRIPTION
This is the only way I know of to fix the flickering flares #1079 

benefits:
- hand flares can bounce like normal grenades
- they have impact sounds
- no flickering
- more options to adjust light

disadvantages:
- it's scripted
- it's not config