### PR TITLE
Prevent Cargo opening if vehicle is locked

### DIFF
--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -41,7 +41,7 @@ if (getNumber (configFile >> "CfgVehicles" >> _type >> QGVAR(hasCargo)) != 1) ex
 private ["_text", "_condition", "_statement", "_icon", "_action"];
 _condition = {
     params ["_target", "_player"];
-    GVAR(enable) && {[_player, _target, []] call EFUNC(common,canInteractWith)}
+    GVAR(enable) && {locked _target < 2} && {[_player, _target, []] call EFUNC(common,canInteractWith)}
 };
 _text = localize LSTRING(openMenu);
 _statement = {GVAR(interactionVehicle) = _target; createDialog QGVAR(menu);};


### PR DESCRIPTION
I think it makes sense, if a vehicle is locked you probably can't get into the trunk either. Automatically compatible with `vehiclelock` as well obviously.