### PR TITLE
Setting init delay functions

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -150,6 +150,14 @@ call FUNC(checkFiles);
     //Event that settings are safe to use:
     ["SettingsInitialized", []] call FUNC(localEvent);
 
+    //Set init finished and run all delayed functions:
+    GVAR(settingsInitFinished) = true;
+    diag_log text format ["%1 delayed functions", (count GVAR(runAtSettingsInitialized))];
+    {
+        _x params ["_args", "_code"];
+        _args call _code;
+    } forEach GVAR(runAtSettingsInitialized);
+    
 }, 0, [false]] call CBA_fnc_addPerFrameHandler;
 
 
@@ -326,7 +334,7 @@ GVAR(OldIsCamera) = false;
 if (didJip) then {
     // We are jipping! Get ready and wait, and throw the event
     [{
-        if(!(isNull player)) then {
+        if((!(isNull player)) && GVAR(settingsInitFinished)) then {
             ["PlayerJip", [player] ] call FUNC(localEvent);
             [(_this select 1)] call cba_fnc_removePerFrameHandler;
         };

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -157,6 +157,7 @@ call FUNC(checkFiles);
         _x params ["_func", "_params"];
         _params call _func;
     } forEach GVAR(runAtSettingsInitialized);
+    GVAR(runAtSettingsInitialized) = nil; //cleanup
     
 }, 0, [false]] call CBA_fnc_addPerFrameHandler;
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -152,10 +152,10 @@ call FUNC(checkFiles);
 
     //Set init finished and run all delayed functions:
     GVAR(settingsInitFinished) = true;
-    diag_log text format ["%1 delayed functions", (count GVAR(runAtSettingsInitialized))];
+    diag_log text format ["[ACE] %1 delayed functions running", (count GVAR(runAtSettingsInitialized))];
     {
-        _x params ["_args", "_code"];
-        _args call _code;
+        _x params ["_func", "_params"];
+        _params call _func;
     } forEach GVAR(runAtSettingsInitialized);
     
 }, 0, [false]] call CBA_fnc_addPerFrameHandler;

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -157,6 +157,7 @@ PREP(requestCallback);
 PREP(resetAllDefaults);
 PREP(restoreVariablesJIP);
 PREP(revertKeyCodeLocalized);
+PREP(runAfterSettingsInit);
 PREP(sanitizeString);
 PREP(sendRequest);
 PREP(serverLog);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -303,6 +303,9 @@ GVAR(nextFrameNo) = diag_frameno;
 GVAR(nextFrameBufferA) = [];
 GVAR(nextFrameBufferB) = [];
 
+GVAR(settingsInitFinished) = false;
+GVAR(runAtSettingsInitialized) = [];
+
 // @TODO: Generic local-managed global-synced objects (createVehicleLocal)
 
 //Debug

--- a/addons/common/functions/fnc_runAfterSettingsInit.sqf
+++ b/addons/common/functions/fnc_runAfterSettingsInit.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: PabstMirror
+ * Executes code after setting are initilized.
+ *
+ * Argument:
+ * 0: Code to execute <CODE>
+ * 1: Parameters to run the code with <ANY>
+ *
+ * Return value:
+ * None
+ *
+ * Example:
+ * [{if (GVAR(setting) then {x} else {y};}, []] call ace_common_fnc_runAfterSettingsInit
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_func", "_params"];
+
+if (GVAR(settingsInitFinished)) then {
+    //Setting Already Finished, Direct Run the code
+    _params call _func;
+} else {
+    //Waiting on settings, throw it on the delayed run array
+    GVAR(runAtSettingsInitialized) pushBack [_func, _params];
+};


### PR DESCRIPTION
From https://github.com/acemod/ACE3/issues/1842#issuecomment-120689590

Adds a way to run a function w/ parameters after settings are initialized.

We really need something like this for when we run code on objects that depends on settings, as the order isn't guaranteed in dedicated MP.

For example: @ViperMaul @Glowbal - the new medical FUNC(init) can run before settings are init
https://github.com/acemod/ACE3/blob/medical-adjustments/addons/medical/functions/fnc_init.sqf

@jonpas did something very similar in https://github.com/acemod/ACE3/pull/2187/files#diff-75f4a28dd014c00256df94dd2f6e929fR28

Helper function, otherwise you can just do something like:
```
if (!EGVAR(common,settingsInitFinished)) exitWith {
    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(init), _this];
};
```