### PR TITLE
Revert the medical clean up for medical-adjustments

### DIFF
--- a/addons/medical/XEH_init.sqf
+++ b/addons/medical/XEH_init.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
-params ["_unit"];
+private ["_unit"];
+_unit = _this select 0;
 
 _unit addEventHandler ["HandleDamage", {_this call FUNC(handleDamage)}];
 

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -11,9 +11,10 @@ GVAR(heartBeatSounds_Slow) = ["ACE_heartbeat_slow_1", "ACE_heartbeat_slow_2"];
 ["interactMenuClosed", {[objNull, false] call FUNC(displayPatientInformation); }] call EFUNC(common,addEventHandler);
 
 ["medical_onUnconscious", {
-    params ["_unit", "_status"];
-    if (local _unit) then {
-        if (_status) then {
+    if (local (_this select 0)) then {
+        private ["_unit"];
+        _unit = _this select 0;
+        if (_this select 1) then {
             _unit setVariable ["tf_globalVolume", 0.4];
             _unit setVariable ["tf_voiceVolume", 0, true];
             _unit setVariable ["tf_unable_to_use_radio", true, true];
@@ -34,8 +35,10 @@ GVAR(heartBeatSounds_Slow) = ["ACE_heartbeat_slow_1", "ACE_heartbeat_slow_2"];
 
 // Initialize all effects
 _fnc_createEffect = {
-    private "_effect";
-    params ["_type", "_layer", "_default"];
+    private ["_type", "_layer", "_default", "_effect"];
+    _type = _this select 0;
+    _layer = _this select 1;
+    _default = _this select 2;
 
     _effect = ppEffectCreate [_type, _layer];
     _effect ppEffectForceInNVG true;

--- a/addons/medical/XEH_respawn.sqf
+++ b/addons/medical/XEH_respawn.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 
-params ["_unit"];
+private ["_unit"];
+
+_unit = _this select 0;
 
 // reset all variables. @todo GROUP respawn?
 [_unit] call FUNC(init);

--- a/addons/medical/functions/fnc_actionCheckResponse.sqf
+++ b/addons/medical/functions/fnc_actionCheckResponse.sqf
@@ -7,17 +7,23 @@
  * 1: The patient <OBJECT>
  *
  * Return Value:
- * None
+ * NONE
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_output"];
-params ["_caller", "_target"];
+private ["_caller","_target", "_output"];
+_caller = _this select 0;
+_target = _this select 1;
 
-_output = [LSTRING(Check_Response_Unresponsive), LSTRING(Check_Response_Responsive)] select ([_target] call EFUNC(common,isAwake));
+_output = "";
+if ([_target] call EFUNC(common,isAwake)) then {
+    _output = LSTRING(Check_Response_Responsive);
+} else {
+    _output = LSTRING(Check_Response_Unresponsive);
+};
 
 ["displayTextStructured", [_caller], [[_output, [_target] call EFUNC(common,getName)], 2, _caller]] call EFUNC(common,targetEvent);
 

--- a/addons/medical/functions/fnc_actionDiagnose.sqf
+++ b/addons/medical/functions/fnc_actionDiagnose.sqf
@@ -7,15 +7,16 @@
 * 1: The patient <OBJECT>
 *
 * Return Value:
-* None
+* NONE
 *
 * Public: No
 */
 
 #include "script_component.hpp"
 
-private "_genericMessages";
-params ["_caller", "_target"];
+private ["_caller", "_target", "_genericMessages"];
+_caller = _this select 0;
+_target = _this select 1;
 
 _genericMessages = [LSTRING(diagnoseMessage)];
 

--- a/addons/medical/functions/fnc_actionPlaceInBodyBag.sqf
+++ b/addons/medical/functions/fnc_actionPlaceInBodyBag.sqf
@@ -14,8 +14,9 @@
 
 #include "script_component.hpp"
 
+PARAMS_2(_caller,_target);
+
 private ["_position", "_headPos", "_spinePos", "_dirVect", "_direction", "_bodyBag"];
-params ["_caller", "_target"];
 
 if (alive _target) then {
     [_target, true] call FUNC(setDead);

--- a/addons/medical/functions/fnc_actionUnloadUnit.sqf
+++ b/addons/medical/functions/fnc_actionUnloadUnit.sqf
@@ -5,17 +5,20 @@
  * Arguments:
  * 0: The medic <OBJECT>
  * 1: The patient <OBJECT>
- * 2: Drag after unload <BOOL> (default: false)
+ * 2: Drag after unload <BOOL> <OPTIONAL>
  *
  * Return Value:
- * None
+ * NONE
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_caller", "_target", ["_drag", false]];
+private ["_caller", "_target", "_drag"];
+_caller = _this select 0;
+_target = _this select 1;
+_drag = if (count _this > 2) then {_this select 2} else {false};
 
 // cannot unload a unit not in a vehicle.
 if (vehicle _target == _target) exitwith {};

--- a/addons/medical/functions/fnc_addHeartRateAdjustment.sqf
+++ b/addons/medical/functions/fnc_addHeartRateAdjustment.sqf
@@ -9,15 +9,18 @@
  * 3: callback <CODE>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-
-params [["_unit", objNull, [objNull]], ["_value", 0, [0]], ["_time", 1, [0]], ["_callBack", {}, [{}]]];
+private ["_unit", "_value", "_time", "_adjustment", "_callBack"];
+_unit = [_this, 0, objNull, [objNull]] call BIS_fnc_Param;
+_value = [_this, 1, 0, [0]] call BIS_fnc_Param;
+_time = [_this, 2, 1, [0]] call BIS_fnc_Param;
+_callBack = [_this, 3, {}, [{}]] call BIS_fnc_Param;
 
 _adjustment = _unit getvariable [QGVAR(heartRateAdjustments), []];
 _adjustment pushback [_value, _time, _callBack];

--- a/addons/medical/functions/fnc_addToInjuredCollection.sqf
+++ b/addons/medical/functions/fnc_addToInjuredCollection.sqf
@@ -6,14 +6,16 @@
  * 0: The Unit <OBJECT>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-params ["_unit", ["_force", false]];
+private ["_unit", "_force"];
+_unit = _this select 0;
+_force = if (count _this > 1) then {_this select 1} else {false};
 
 if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
 
@@ -25,13 +27,13 @@ if ([_unit] call FUNC(hasMedicalEnabled) || _force) then {
     _unit setvariable [QGVAR(addedToUnitLoop), true, true];
 
     [{
-        params ["_args", "_idPFH"];
-        _args params ["_unit", "_interval"];
-        _interval = ACE_time - _interval;
+        private ["_unit", "_interval"];
+        _unit = (_this select 0) select 0;
+        _interval = ACE_time - ((_this select 0) select 1);
         (_this select 0) set [1, ACE_time];
-
+        
         if (!alive _unit || !local _unit) then {
-           [_idPFH] call CBA_fnc_removePerFrameHandler;
+           [_this select 1] call CBA_fnc_removePerFrameHandler;
            if (!local _unit) then {
                 if (GVAR(level) >= 2) then {
                     _unit setvariable [QGVAR(heartRate), _unit getvariable [QGVAR(heartRate), 80], true];

--- a/addons/medical/functions/fnc_addToTriageCard.sqf
+++ b/addons/medical/functions/fnc_addToTriageCard.sqf
@@ -7,15 +7,16 @@
  * 1: The new item classname <STRING>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-private ["_log", "_inList", "_amount"];
-params ["_unit", "_newItem"];
+private ["_unit", "_newItem", "_log", "_inList", "_amount"];
+_unit = _this select 0;
+_newItem = _this select 1;
 
 if (!local _unit) exitwith {
     [_this, QUOTE(DFUNC(addToTriageList)), _unit] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */
@@ -35,7 +36,7 @@ _amount = 1;
         _amount = (_info select 1);
         _inList = true;
     };
-} foreach _log;
+}foreach _log;
 
 if (!_inList) then {
     _log pushback [_newItem, 1, ACE_time];

--- a/addons/medical/functions/fnc_addUnconsciousCondition.sqf
+++ b/addons/medical/functions/fnc_addUnconsciousCondition.sqf
@@ -3,13 +3,14 @@
  * Adds new condition for the unconscious state. Conditions are not actively checked for units unless unit is in unconscious state.
  *
  * Arguments:
- * 0-N: Code, should return a boolean <CODE>
+ * 0: Code, should return a boolean <CODE>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: Yes
  */
+
 #include "script_component.hpp"
 
 if (isnil QGVAR(unconsciousConditions)) then {
@@ -20,5 +21,5 @@ if (typeName _this == typeName []) then {
         if (typeName _x == typeName {}) then {
             GVAR(unconsciousConditions) pushback _x;
         };
-    } foreach _this;
+    }foreach _this;
 };

--- a/addons/medical/functions/fnc_addUnloadPatientActions.sqf
+++ b/addons/medical/functions/fnc_addUnloadPatientActions.sqf
@@ -13,7 +13,8 @@
  * Public: No
  */
 #include "script_component.hpp"
-params ["_vehicle", "_player", "_parameters"];
+
+EXPLODE_3_PVT(_this,_vehicle,_player,_parameters);
 
 private ["_actions", "_unit"];
 _actions = [];

--- a/addons/medical/functions/fnc_adjustPainLevel.sqf
+++ b/addons/medical/functions/fnc_adjustPainLevel.sqf
@@ -18,7 +18,7 @@
 
 private ["_pain"];
 
-params ["_unit", "_addedPain"];
+PARAMS_2(_unit,_addedPain);
 
 //Only run on local units:
 if (!local _unit) exitWith {ERROR("unit is not local");};

--- a/addons/medical/functions/fnc_canAccessMedicalEquipment.sqf
+++ b/addons/medical/functions/fnc_canAccessMedicalEquipment.sqf
@@ -14,8 +14,9 @@
 
 #include "script_component.hpp"
 
-private ["_accessLevel", "_return"];
-params ["_caller", "_targ"];
+private ["_target", "_caller", "_accessLevel", "_return"];
+_caller = _this select 0;
+_target = _this select 1;
 
 _accessLevel = _target getvariable [QGVAR(allowSharedEquipmentAccess), -1];
 

--- a/addons/medical/functions/fnc_canTreatCached.sqf
+++ b/addons/medical/functions/fnc_canTreatCached.sqf
@@ -17,7 +17,6 @@
 #include "script_component.hpp"
 
 #define MAX_DURATION_CACHE 2
-params ["", "_target", "_selection", "_classname"];
 
 // parameters, function, namespace, uid
-[_this, DFUNC(canTreat), _target, format [QGVAR(canTreat_%1_%2), _selection, _classname], MAX_DURATION_CACHE, "clearConditionCaches"] call EFUNC(common,cachedCall);
+[_this, DFUNC(canTreat), _this select 1, format[QGVAR(canTreat_%1_%2), _this select 2, _this select 3], MAX_DURATION_CACHE, "clearConditionCaches"] call EFUNC(common,cachedCall);

--- a/addons/medical/functions/fnc_copyDeadBody.sqf
+++ b/addons/medical/functions/fnc_copyDeadBody.sqf
@@ -7,15 +7,16 @@
  * 1: The caller <OBJECT>
  *
  * Return Value:
- * Returns the copy of the unit. If no copy could be made, returns the oldBody <OBJECT>
+ * OBJECT Returns the copy of the unit. If no copy could be made, returns the oldBody
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_newUnit", "_class", "_group", "_position", "_side", "_name"];
-params ["_oldBody", "_caller"];
+private ["_oldBody","_newUnit","_class","_group","_position","_side", "_caller", "_name"];
+_oldBody = _this select 0;
+_caller = _this select 1;
 
 if (alive _oldBody) exitwith {_oldBody}; // we only want to do this for dead bodies
 

--- a/addons/medical/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical/functions/fnc_determineIfFatal.sqf
@@ -1,21 +1,19 @@
-/*
- * Author: Glowbal
- * Determine If Fatal
+/**
+ * fn_determineIfFatal.sqf
+ * @Descr: N/A
+ * @Author: Glowbal
  *
- * Arguments:
- * 0: Unit <OBJECT>
- * 1: Part <NUMBER>
- * 2: with Damage <NUMBER> (default: 0)
- *
- * Return Value:
- * None
- *
- * Public: No
+ * @Arguments: []
+ * @Return:
+ * @PublicAPI: false
  */
+
 #include "script_component.hpp"
 
-private ["_damageThreshold", "_damageBodyPart"];
-params ["_unit", "_part", ["_withDamage", 0]];
+private ["_unit","_part","_damageThreshold", "_withDamage", "_damageBodyPart"];
+_unit = _this select 0;
+_part = _this select 1;
+_withDamage = if (count _this > 2) then { _this select 2} else {0};
 
 if (!alive _unit) exitwith {true};
 if (_part < 0 || _part > 5) exitwith {false};

--- a/addons/medical/functions/fnc_displayTriageCard.sqf
+++ b/addons/medical/functions/fnc_displayTriageCard.sqf
@@ -4,18 +4,18 @@
  *
  * Arguments:
  * 0: The unit <OBJECT>
- * 1: Show <BOOL> (default: true)
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-private ["_amount", "_item", "_log", "_message", "_triageCardTexts", "_triageStatus"];
-params ["_target", ["_show", true]];
+private ["_target", "_show", "_amount", "_item", "_log", "_message", "_triageCardTexts", "_triageStatus"];
+_target = _this select 0;
+_show = if (count _this > 1) then {_this select 1} else {true};
 
 GVAR(TriageCardTarget) = if (_show) then {_target} else {ObjNull};
 
@@ -25,16 +25,15 @@ if (_show) then {
 
     [{
         private ["_target", "_display", "_alphaLevel", "_alphaLevel", "_lbCtrl"];
-        params ["_args", "_idPFH"];
-        _args params ["_target"];
+        _target = (_this select 0) select 0;
         if (GVAR(TriageCardTarget) != _target) exitwith {
-            [_idPFH] call CBA_fnc_removePerFrameHandler;
+            [_this select 1] call CBA_fnc_removePerFrameHandler;
         };
 
         disableSerialization;
         _display = uiNamespace getvariable QGVAR(triageCard);
         if (isnil "_display") exitwith {
-            [_idPFH] call CBA_fnc_removePerFrameHandler;
+            [_this select 1] call CBA_fnc_removePerFrameHandler;
         };
 
         _triageCardTexts = [];
@@ -45,7 +44,8 @@ if (_show) then {
 
         _log = _target getvariable [QGVAR(triageCard), []];
         {
-            _x params ["_item", "_amount"];
+            _item = _x select 0;
+            _amount = _x select 1;
             _message = _item;
             if (isClass(configFile >> "CfgWeapons" >> _item)) then {
                 _message = getText(configFile >> "CfgWeapons" >> _item >> "DisplayName");
@@ -55,21 +55,18 @@ if (_show) then {
                 };
             };
             _triageCardTexts pushback format["%1x - %2", _amount, _message];
-        } foreach _log;
+        }foreach _log;
 
         if (count _triageCardTexts == 0) then {
             _lbCtrl lbAdd (localize LSTRING(TriageCard_NoEntry));
         };
         {
             _lbCtrl lbAdd _x;
-        } foreach _triageCardTexts;
+        }foreach _triageCardTexts;
 
         _triageStatus = [_target] call FUNC(getTriageStatus);
-
-        _triageStatus params ["_text", "_color"];
-
-        (_display displayCtrl 2000) ctrlSetText _text;
-        (_display displayCtrl 2000) ctrlSetBackgroundColor _color;
+        (_display displayCtrl 2000) ctrlSetText (_triageStatus select 0);
+        (_display displayCtrl 2000) ctrlSetBackgroundColor (_triageStatus select 2);
 
     }, 0, [_target]] call CBA_fnc_addPerFrameHandler;
 

--- a/addons/medical/functions/fnc_dropDownTriageCard.sqf
+++ b/addons/medical/functions/fnc_dropDownTriageCard.sqf
@@ -3,18 +3,18 @@
  * Display triage card for a unit
  *
  * Arguments:
- * 0: Show <BOOL>
+ * 0: The unit <OBJECT>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-private ["_ctrl", "_display", "_idc", "_pos"];
-params ["_show"];
+private ["_show", "_ctrl", "_display", "_idc", "_pos"];
+_show = _this select 0;
 disableSerialization;
 
 _display = uiNamespace getvariable QGVAR(triageCard);

--- a/addons/medical/functions/fnc_getBloodLoss.sqf
+++ b/addons/medical/functions/fnc_getBloodLoss.sqf
@@ -15,9 +15,10 @@
 
 #define BLOODLOSSRATE_BASIC 0.2
 
-private ["_totalBloodLoss","_tourniquets","_openWounds", "_cardiacOutput", "_internalWounds"];
+private ["_unit", "_totalBloodLoss","_tourniquets","_openWounds", "_cardiacOutput", "_internalWounds"];
 // TODO Only use this calculation if medium or higher, otherwise use vanilla calculations (for basic medical).
-params ["_unit"];
+
+_unit = _this select 0;
 _totalBloodLoss = 0;
 
 // Advanced medical bloodloss handling
@@ -33,12 +34,12 @@ if (GVAR(level) >= 2) then {
 
             // (((BLOODLOSS_SMALL_WOUNDS * (_x select 0))) + ((BLOODLOSS_MEDIUM_WOUNDS * (_x select 1))) + ((BLOODLOSS_LARGE_WOUNDS * (_x select 2))) * (_cardiacOutput / DEFAULT_CARDIAC_OUTPUT));
         };
-    } foreach _openWounds;
+    }foreach _openWounds;
 
     _internalWounds = _unit getvariable [QGVAR(internalWounds), []];
     {
         _totalBloodLoss = _totalBloodLoss + ((_x select 4) * (_x select 3));
-    } foreach _internalWounds;
+    }foreach _internalWounds;
 
     // cap the blood loss to be no greater as the current cardiac output
     //(_totalBloodLoss min _cardiacOutput);

--- a/addons/medical/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/medical/functions/fnc_getBloodVolumeChange.sqf
@@ -28,8 +28,10 @@
 */
 #define BLOOD_CHANGE_PER_SECOND        0.0595
 
-private ["_bloodVolume", "_bloodVolumeChange", "_ivVolume"];
-params ["_unit"];
+
+
+private ["_unit","_bloodVolume","_bloodVolumeChange", "_ivVolume"];
+_unit = _this select 0;
 
 _bloodVolume = _unit getvariable [QGVAR(bloodVolume), 100];
 _bloodVolumeChange = -([_unit] call FUNC(getBloodLoss));
@@ -41,13 +43,13 @@ if (_bloodVolume < 100.0) then {
             _ivVolume = (_unit getvariable [_x, 0]) + IV_CHANGE_PER_SECOND;
             _unit setvariable [_x,_ivVolume];
         };
-    } foreach GVAR(IVBags);
+    }foreach GVAR(IVBags);
 } else {
     {
         if ((_unit getvariable [_x, 0]) > 0) then {
             _unit setvariable [_x, 0]; // lets get rid of exessive IV volume
         };
-    } foreach GVAR(IVBags);
+    }foreach GVAR(IVBags);
 };
 
 _bloodVolumeChange;

--- a/addons/medical/functions/fnc_getCardiacOutput.sqf
+++ b/addons/medical/functions/fnc_getCardiacOutput.sqf
@@ -22,6 +22,7 @@
 // to limit the amount of complex calculations necessary, we take a set modifier to calculate Stroke Volume.
 #define MODIFIER_CARDIAC_OUTPUT     19.04761
 
-params ["_unit"];
+private "_unit";
+_unit = _this select 0;
 
 ((_unit getvariable [QGVAR(bloodVolume), 100])/MODIFIER_CARDIAC_OUTPUT) + ((_unit getvariable [QGVAR(heartRate), 80])/80-1);

--- a/addons/medical/functions/fnc_getHeartRateChange.sqf
+++ b/addons/medical/functions/fnc_getHeartRateChange.sqf
@@ -15,9 +15,8 @@
 
 #define HEART_RATE_MODIFIER 0.02
 
-private ["_heartRate", "_hrIncrease", "_bloodLoss", "_time", "_values", "_adjustment", "_change", "_callBack", "_bloodVolume"];
-params ["_unit"];
-
+private ["_unit", "_heartRate", "_hrIncrease", "_bloodLoss", "_time", "_values", "_adjustment", "_change", "_callBack", "_bloodVolume"];
+_unit = _this select 0;
 _hrIncrease = 0;
 if (!(_unit getvariable [QGVAR(inCardiacArrest),false])) then {
     _heartRate = _unit getvariable [QGVAR(heartRate), 80];
@@ -25,8 +24,10 @@ if (!(_unit getvariable [QGVAR(inCardiacArrest),false])) then {
 
     _adjustment = _unit getvariable [QGVAR(heartRateAdjustments), []];
     {
-        _x params ["_values", "_time", "_callBack"];
+        _values = (_x select 0);
         if (abs _values > 0) then {
+            _time = (_x select 1);
+            _callBack = _x select 2;
             if (_time <= 0) then {
                 _time = 1;
             };
@@ -46,7 +47,7 @@ if (!(_unit getvariable [QGVAR(inCardiacArrest),false])) then {
             [_unit] call _callBack;
         };
 
-    } foreach _adjustment;
+    }foreach _adjustment;
     _adjustment = _adjustment - [ObjNull];
     _unit setvariable [QGVAR(heartRateAdjustments), _adjustment];
 

--- a/addons/medical/functions/fnc_getTriageStatus.sqf
+++ b/addons/medical/functions/fnc_getTriageStatus.sqf
@@ -6,9 +6,7 @@
  * 0: The unit <OBJECT>
  *
  * Return Value:
- * 0: Name <STRING>
- * 1: Status ID <NUMBER>
- * 2: Color <ARRAY <NUMBER>>
+ * Triage status from the unit. Name, statusID, color <ARRAY <STRING><NUMBER><ARRAY>>
  *
  * Public: Yes
  */
@@ -16,7 +14,7 @@
 #include "script_component.hpp"
 
 private ["_unit","_return","_status"];
-params ["_unit"];
+_unit = _this select 0;
 _status = _unit getvariable [QGVAR(triageLevel), -1];
 _return = switch (_status) do {
     case 1: {[localize LSTRING(Triage_Status_Minor), 1, [0, 0.5, 0, 0.9]]};
@@ -25,4 +23,4 @@ _return = switch (_status) do {
     case 4: {[localize LSTRING(Triage_Status_Deceased), 4, [0, 0, 0, 0.9]]};
     default {[localize LSTRING(Triage_Status_None), 0, [0, 0, 0, 0.9]]};
 };
-_return
+_return;

--- a/addons/medical/functions/fnc_getUnconsciousCondition.sqf
+++ b/addons/medical/functions/fnc_getUnconsciousCondition.sqf
@@ -14,7 +14,7 @@
 #include "script_component.hpp"
 
 private ["_unit","_return"];
-params ["_unit"];
+_unit = _this select 0;
 
 if (isnil QGVAR(unconsciousConditions)) then {
     GVAR(unconsciousConditions) = [];
@@ -25,6 +25,6 @@ _return = false;
     if (typeName _x == typeName {} && {([_unit] call _x)}) exitwith {
        _return = true;
     };
-} foreach GVAR(unconsciousConditions);
+}foreach GVAR(unconsciousConditions);
 
-_return
+_return;

--- a/addons/medical/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical/functions/fnc_handleBandageOpening.sqf
@@ -18,8 +18,13 @@
 
 #include "script_component.hpp"
 
-private ["_className", "_reopeningChance", "_reopeningMinDelay", "_reopeningMaxDelay", "_config", "_woundTreatmentConfig", "_bandagedWounds", "_exist", "_injuryId", "_existingInjury", "_delay", "_openWounds", "_selectedInjury", "_bandagedInjury"];
-params ["_target", "_impact", "_part", "_injuryIndex", "_injury", "_bandage"];
+private ["_target", "_impact", "_part", "_injuryIndex", "_injury", "_bandage", "_classID", "_className", "_reopeningChance", "_reopeningMinDelay", "_reopeningMaxDelay", "_config", "_woundTreatmentConfig", "_bandagedWounds", "_exist", "_injuryId", "_existingInjury", "_delay", "_openWounds", "_selectedInjury", "_bandagedInjury"];
+_target = _this select 0;
+_impact = _this select 1;
+_part = _this select 2;
+_injuryIndex = _this select 3;
+_injury = _this select 4;
+_bandage = _this select 5;
 
 _classID = _injury select 1;
 _className = GVAR(woundClassNames) select _classID;
@@ -52,8 +57,8 @@ if (isClass (_config >> _className)) then {
 };
 
 _bandagedWounds = _target getvariable [QGVAR(bandagedWounds), []];
-_injuryType = _injury select 1;
 _exist = false;
+_injuryType = _injury select 1;
 _bandagedInjury = [];
 {
     if ((_x select 1) == _injuryType && (_x select 2) == (_injury select 2)) exitwith {
@@ -64,7 +69,7 @@ _bandagedInjury = [];
 
         _bandagedInjury = _existingInjury;
     };
-} foreach _bandagedWounds;
+}foreach _bandagedWounds;
 
 if !(_exist) then {
     // [ID, classID, bodypart, percentage treated, bloodloss rate]
@@ -78,8 +83,12 @@ _target setvariable [QGVAR(bandagedWounds), _bandagedWounds, true];
 if (random(1) <= _reopeningChance) then {
     _delay = _reopeningMinDelay + random(_reopeningMaxDelay - _reopeningMinDelay);
     [{
-        private ["_bandage", "_openWounds", "_selectedInjury","_bandagedWounds","_exist"];
-        params ["_target", "_impact", "_part", "_injuryIndex", "_injury"];
+        private ["_target", "_impact", "_part", "_injuryIndex", "_bandage", "_injury", "_openWounds", "_selectedInjury","_bandagedWounds","_exist"];
+        _target = _this select 0;
+        _impact = _this select 1;
+        _part = _this select 2;
+        _injuryIndex = _this select 3;
+        _injury = _this select 4;
 
         //if (alive _target) then {
             _openWounds = _target getvariable [QGVAR(openWounds), []];
@@ -99,7 +108,7 @@ if (random(1) <= _reopeningChance) then {
                         _existingInjury set [3, ((_existingInjury select 3) - _impact) max 0];
                         _bandagedWounds set [_foreachIndex, _existingInjury];
                     };
-                } foreach _bandagedWounds;
+                }foreach _bandagedWounds;
 
                 if (_exist) then {
                     _target setvariable [QGVAR(bandagedWounds), _bandagedWounds, true];

--- a/addons/medical/functions/fnc_handleCreateLitter.sqf
+++ b/addons/medical/functions/fnc_handleCreateLitter.sqf
@@ -1,22 +1,9 @@
-/*
- * Author: Glowbal
- * handle Litter Create
- *
- * Arguments:
- * 0: Litter Class <STRING>
- * 1: Position <ARRAY>
- * 2: Unit <OBJECT>
- *
- * Return Value:
- * None
- *
- * Public: No
- */
+//#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 if(!hasInterface) exitWith { false };
 
-params ["_litterClass", "_position", "_unit"];
+PARAMS_3(_litterClass,_position,_direction);
 private["_litterObject", "_maxLitterCount"];
 //IGNORE_PRIVATE_WARNING(_values);
 
@@ -29,9 +16,9 @@ _litterObject = _litterClass createVehicleLocal _position;
 _litterObject setDir _direction;
 _litterObject setPosATL _position;
 // Move the litter next frame to get rid of HORRIBLE spacing, fixes #1112
-[{ params ["_object", "_pos"]; _object setPosATL _pos; }, [_litterObject, _position]] call EFUNC(common,execNextFrame);
-
-_maxLitterCount = getArray (configFile >> "ACE_Settings" >> QGVAR(litterSimulationDetail) >> "_values") select GVAR(litterSimulationDetail);
+[{ (_this select 0) setPosATL (_this select 1); }, [_litterObject, _position]] call EFUNC(common,execNextFrame);
+    
+_maxLitterCount = getArray (configFile >> "ACE_Settings" >> QGVAR(litterSimulationDetail) >> "_values") select GVAR(litterSimulationDetail); 
 if((count GVAR(allCreatedLitter)) > _maxLitterCount ) then {
     // gank the first litter object, and spawn ours.
     private["_oldLitter"];
@@ -47,11 +34,10 @@ if(!GVAR(litterPFHRunning) && {GVAR(litterCleanUpDelay) > 0}) then {
     GVAR(litterPFHRunning) = true;
     [{
         {
-            _x params ["_time", "_objects"];
-            if (ACE_time - _time >= GVAR(litterCleanUpDelay)) then {
+            if (ACE_time - (_x select 0) >= GVAR(litterCleanUpDelay)) then {
                 {
                     deleteVehicle _x;
-                } forEach _objects;
+                } forEach (_x select 1);
                 GVAR(allCreatedLitter) set[_foreachIndex, objNull];
             };
         } forEach GVAR(allCreatedLitter);
@@ -60,6 +46,8 @@ if(!GVAR(litterPFHRunning) && {GVAR(litterCleanUpDelay) > 0}) then {
         if ( (count GVAR(allCreatedLitter)) == 0) exitwith {
             [(_this select 1)] call CBA_fnc_removePerFrameHandler;
             GVAR(litterPFHRunning) = false;
-        };
+        }; 
     }, 30, []] call CBA_fnc_addPerFrameHandler;
 };
+
+true

--- a/addons/medical/functions/fnc_handleDamage_advancedSetDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advancedSetDamage.sqf
@@ -6,23 +6,23 @@
  * 0: Unit for which the hitpoint damage will be sorted out <OBJECT>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_unit"];
+PARAMS_1(_unit);
 
 if (!local _unit) exitwith {};
 
-private "_bodyStatus";
+private ["_bodyStatus", "_headDamage", "_torsoDamage", "_handsDamage", "_legsDamage"];
 
 // ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"]
 _bodyStatus = _unit getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
 
-_bodyStatus params ["_headDamage", "_torsoDamage", "_handsDamageR", "_handsDamageL", "_legsDamageR", "_legsDamageL"];
+EXPLODE_6_PVT(_bodyStatus,_headDamage,_torsoDamage,_handsDamageR,_handsDamageL,_legsDamageR,_legsDamageL);
 
 _unit setHitPointDamage ["hitHead", _headDamage min 0.95];
 _unit setHitPointDamage ["hitBody", _torsoDamage min 0.95];

--- a/addons/medical/functions/fnc_handleDamage_airway.sqf
+++ b/addons/medical/functions/fnc_handleDamage_airway.sqf
@@ -10,15 +10,19 @@
  * 4: Type of the damage done <STRING>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private "_bodyPartn";
-params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfDamage"];
+private ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfDamage", "_bodyPartn"];
+_unit = _this select 0;
+_selectionName = _this select 1;
+_amountOfDamage = _this select 2;
+_sourceOfDamage = _this select 3;
+_typeOfDamage = _this select 4;
 _bodyPartn = [_selectionName] call FUNC(selectionNameToNumber);
 
 if (_bodyPartn > 1) exitwith {};

--- a/addons/medical/functions/fnc_handleDamage_fractures.sqf
+++ b/addons/medical/functions/fnc_handleDamage_fractures.sqf
@@ -17,8 +17,12 @@
 
 #include "script_component.hpp"
 
-private ["_bodyPartn", "_fractures", "_fractureType"];
-params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfDamage"];
+private ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfDamage", "_bodyPartn", "_fractures", "_fractureType"];
+_unit = _this select 0;
+_selectionName = _this select 1;
+_amountOfDamage = _this select 2;
+_sourceOfDamage = _this select 3;
+_typeOfDamage = _this select 4;
 _bodyPartn = [_selectionName] call FUNC(selectionNameToNumber);
 
 _fractureType = 1;

--- a/addons/medical/functions/fnc_handleDamage_internalInjuries.sqf
+++ b/addons/medical/functions/fnc_handleDamage_internalInjuries.sqf
@@ -10,15 +10,19 @@
  * 4: Type of the damage done <STRING>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private "_bodyPartn";
-params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfDamage"];
+private ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfDamage", "_bodyPartn"];
+_unit = _this select 0;
+_selectionName = _this select 1;
+_amountOfDamage = _this select 2;
+_sourceOfDamage = _this select 3;
+_typeOfDamage = _this select 4;
 _bodyPartn = [_selectionName] call FUNC(selectionNameToNumber);
 
 // TODO implement internal injuries

--- a/addons/medical/functions/fnc_handleDamage_wounds.sqf
+++ b/addons/medical/functions/fnc_handleDamage_wounds.sqf
@@ -10,15 +10,19 @@
  * 4: Type of the damage done <STRING>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_bodyPartn", "_injuryTypeInfo", "_allInjuriesForDamageType", "_allPossibleInjuries", "_highestPossibleDamage", "_highestPossibleSpot", "_minDamage", "_openWounds", "_woundID", "_toAddInjury", "_painToAdd", "_bloodLoss", "_bodyPartNToAdd", "_classType", "_damageLevels", "_foundIndex", "_i", "_injury", "_maxDamage", "_pain", "_painLevel", "_selections", "_toAddClassID", "_woundsCreated"];
-params ["_unit", "_selectionName", "_damage", "_typeOfProjectile", "_typeOfDamage"];
+private ["_unit", "_selectionName", "_damage", "_typeOfProjectile", "_typeOfDamage", "_bodyPartn", "_injuryTypeInfo", "_allInjuriesForDamageType", "_allPossibleInjuries", "_highestPossibleDamage", "_highestPossibleSpot", "_minDamage", "_openWounds", "_woundID", "_toAddInjury", "_painToAdd", "_bloodLoss", "_bodyPartNToAdd", "_classType", "_damageLevels", "_foundIndex", "_i", "_injury", "_maxDamage", "_pain", "_painLevel", "_selections", "_toAddClassID", "_woundsCreated"];
+_unit = _this select 0;
+_selectionName = _this select 1;
+_damage = _this select 2;
+_typeOfProjectile = _this select 3;
+_typeOfDamage = _this select 4;
 
 // Administration for open wounds and ids
 _openWounds = _unit getvariable[QGVAR(openWounds), []];
@@ -39,7 +43,7 @@ _foundIndex = -1;
         if (_x select 1 == _toAddClassID && {_x select 2 == _bodyPartNToAdd}) exitwith {
             _foundIndex = _foreachIndex;
         };
-    } foreach _openWounds;
+    }foreach _openWounds;
 
     if (_foundIndex < 0) then {
         // Since it is a new injury, we will have to add it to the open wounds array to store it
@@ -49,7 +53,7 @@ _foundIndex = -1;
         _injury = _openWounds select _foundIndex;
         _injury set [3, (_injury select 3) + 1];
     };
-} foreach _woundsCreated;
+}foreach _woundsCreated;
 
 _unit setvariable [QGVAR(openWounds), _openWounds, true];
 

--- a/addons/medical/functions/fnc_handleDamage_woundsOld.sqf
+++ b/addons/medical/functions/fnc_handleDamage_woundsOld.sqf
@@ -17,8 +17,12 @@
 
 #include "script_component.hpp"
 
-private ["_bodyPartn", "_injuryTypeInfo", "_allInjuriesForDamageType", "_allPossibleInjuries", "_highestPossibleDamage", "_highestPossibleSpot", "_minDamage", "_openWounds", "_woundID", "_toAddInjury", "_painToAdd", "_bloodLoss", "_bodyPartNToAdd", "_classType", "_damageLevels", "_foundIndex", "_i", "_injury", "_maxDamage", "_pain", "_painLevel", "_selections", "_toAddClassID", "_woundsCreated"];
-params ["_unit", "_selectionName", "_damage", "_typeOfProjectile", "_typeOfDamage"];
+private ["_unit", "_selectionName", "_damage", "_typeOfProjectile", "_typeOfDamage", "_bodyPartn", "_injuryTypeInfo", "_allInjuriesForDamageType", "_allPossibleInjuries", "_highestPossibleDamage", "_highestPossibleSpot", "_minDamage", "_openWounds", "_woundID", "_toAddInjury", "_painToAdd", "_bloodLoss", "_bodyPartNToAdd", "_classType", "_damageLevels", "_foundIndex", "_i", "_injury", "_maxDamage", "_pain", "_painLevel", "_selections", "_toAddClassID", "_woundsCreated"];
+_unit = _this select 0;
+_selectionName = _this select 1;
+_damage = _this select 2;
+_typeOfProjectile = _this select 3;
+_typeOfDamage = _this select 4;
 
 // Convert the selectionName to a number and ensure it is a valid selection.
 _bodyPartn = [_selectionName] call FUNC(selectionNameToNumber);
@@ -66,7 +70,7 @@ _allPossibleInjuries = [];
             _allPossibleInjuries pushback _x;
         };
     };
-} foreach _allInjuriesForDamageType;
+}foreach _allInjuriesForDamageType;
 
 // No possible wounds available for this damage type or damage amount.
 if (_highestPossibleSpot < 0) exitwith {};
@@ -94,7 +98,7 @@ _woundsCreated = [];
                     if (_x select 1 == _toAddClassID && {_x select 2 == _bodyPartNToAdd}) exitwith {
                         _foundIndex = _foreachIndex;
                     };
-                } foreach _openWounds;
+                }foreach _openWounds;
             };
 
             _injury = [];
@@ -119,7 +123,7 @@ _woundsCreated = [];
             _painToAdd = _painToAdd + (_toAddInjury select 3);
         };
     };
-} foreach (_injuryTypeInfo select 0); // foreach damage thresholds
+}foreach (_injuryTypeInfo select 0); // foreach damage thresholds
 
 _unit setvariable [QGVAR(openWounds), _openWounds, !USE_WOUND_EVENT_SYNC];
 

--- a/addons/medical/functions/fnc_handleKilled.sqf
+++ b/addons/medical/functions/fnc_handleKilled.sqf
@@ -13,8 +13,8 @@
 
 #include "script_component.hpp"
 
-private "_openWounds";
-params ["_unit"];
+private["_unit", "_openWounds"];
+_unit = _this select 0;
 if (!local _unit) exitwith {};
 
 _unit setvariable [QGVAR(pain), 0];

--- a/addons/medical/functions/fnc_handleLocal.sqf
+++ b/addons/medical/functions/fnc_handleLocal.sqf
@@ -15,7 +15,9 @@
 
 #include "script_component.hpp"
 
-params ["_unit", "_local"];
+private["_unit", "_local"];
+_unit = _this select 0;
+_local = _this  select 1;
 if (_local) then {
     if (_unit getvariable[QGVAR(addedToUnitLoop),false]) then {
         [_unit, true] call FUNC(addToInjuredCollection);

--- a/addons/medical/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical/functions/fnc_handleUnitVitals.sqf
@@ -13,8 +13,9 @@
 
 #include "script_component.hpp"
 
-private ["_heartRate","_bloodPressure","_bloodVolume","_painStatus", "_lastTimeValuesSynced", "_syncValues", "_airwayStatus", "_blood"];
-params ["_unit", "_interval"];
+private ["_unit", "_heartRate","_bloodPressure","_bloodVolume","_painStatus", "_lastTimeValuesSynced", "_syncValues", "_airwayStatus", "_blood", "_bloodPressureH", "_bloodPressureL", "_interval"];
+_unit = _this select 0;
+_interval = _this select 1;
 
 if (_interval == 0) exitWith {};
 
@@ -139,7 +140,8 @@ if (GVAR(level) >= 2) then {
 
     // Check vitals for medical status
     // TODO check for in revive state instead of variable
-    _bloodPressure params ["_bloodPressureL", "_bloodPressureH"];
+    _bloodPressureL = _bloodPressure select 0;
+    _bloodPressureH = _bloodPressure select 1;
 
     if (!(_unit getvariable [QGVAR(inCardiacArrest),false])) then {
         if (_heartRate < 10 || _bloodPressureH < 30 || _bloodVolume < 20) then {
@@ -178,6 +180,6 @@ if (GVAR(level) >= 2) then {
             if !(isnil "_value") then {
                 _unit setvariable [_x,(_unit getvariable [_x, 0]), true];
             };
-        } foreach GVAR(IVBags);
+        }foreach GVAR(IVBags);
     };
 };

--- a/addons/medical/functions/fnc_hasItem.sqf
+++ b/addons/medical/functions/fnc_hasItem.sqf
@@ -16,17 +16,19 @@
 #include "script_component.hpp"
 
 private ["_medic", "_patient", "_item", "_return", "_crew"];
-params ["_medic", "_patient", "_item"];
+_medic = _this select 0;
+_patient = _this select 1;
+_item = _this select 2;
 
 if (isnil QGVAR(setting_allowSharedEquipment)) then {
     GVAR(setting_allowSharedEquipment) = true;
 };
 if (GVAR(setting_allowSharedEquipment) && {[_patient, _item] call EFUNC(common,hasItem)}) exitwith {
-    true
+    true;
 };
 
 if ([_medic, _item] call EFUNC(common,hasItem)) exitwith {
-    true
+    true;
 };
 
 _return = false;
@@ -36,7 +38,7 @@ if ((vehicle _medic != _medic) && {[vehicle _medic] call FUNC(isMedicalVehicle)}
         if ([_medic, _x] call FUNC(canAccessMedicalEquipment) && {([_x, _item] call EFUNC(common,hasItem))}) exitwith {
             _return = true;
         };
-    } foreach _crew;
+    }foreach _crew;
 };
 
-_return
+_return;

--- a/addons/medical/functions/fnc_hasItems.sqf
+++ b/addons/medical/functions/fnc_hasItems.sqf
@@ -16,7 +16,9 @@
 #include "script_component.hpp"
 
 private ["_medic", "_patient", "_items", "_return"];
-params ["_medic", "_patient", "_items"];
+_medic = _this select 0;
+_patient = _this select 1;
+_items = _this select 2;
 
 _return = true;
 {
@@ -29,4 +31,4 @@ _return = true;
     };
 }foreach _items;
 
-_return
+_return;

--- a/addons/medical/functions/fnc_hasMedicalEnabled.sqf
+++ b/addons/medical/functions/fnc_hasMedicalEnabled.sqf
@@ -1,27 +1,21 @@
-
-/*
- * Author: Glowbal
- * Check if unit has CMS enabled
+/**
+ * fn_hasMedicalEnabled.sqf
+ * @Descr: Check if unit has CMS enabled.
+ * @Author: Glowbal
  *
- * Arguments:
- * 0: unit <OBJECT>
- *
- * Return Value:
- * enabled <BOOL>
- *
- * Example:
- * [Unit] call ace_medical_fnc_hasMedicalEnabled
- *
- * Public: No
+ * @Arguments: [unit OBJECT]
+ * @Return: BOOL
+ * @PublicAPI: true
  */
+
 #include "script_component.hpp"
 
-private "_medicalEnabled";
-params ["_unit"];
+private ["_unit", "_medicalEnabled"];
+_unit = _this select 0;
 
 _medicalEnabled = _unit getvariable QGVAR(enableMedical);
 if (isnil "_medicalEnabled") exitwith {
-    (((GVAR(enableFor) == 0 && (isPlayer _unit || (_unit getvariable [QEGVAR(common,isDeadPlayer), false])))) || (GVAR(enableFor) == 1) || GVAR(level) == 1)
+    (((GVAR(enableFor) == 0 && (isPlayer _unit || (_unit getvariable [QEGVAR(common,isDeadPlayer), false])))) || (GVAR(enableFor) == 1) || GVAR(level) == 1);
 };
 
-_medicalEnabled
+_medicalEnabled;

--- a/addons/medical/functions/fnc_hasTourniquetAppliedTo.sqf
+++ b/addons/medical/functions/fnc_hasTourniquetAppliedTo.sqf
@@ -14,6 +14,8 @@
 
 #include "script_component.hpp"
 
-params ["_target", "_selectionName"];
+private ["_target", "_selectionName"];
+_target = _this select 0;
+_selectionName = _this select 1;
 
 (((_target getvariable [QGVAR(tourniquets), [0,0,0,0,0,0]]) select ([_selectionName] call FUNC(selectionNameToNumber))) > 0);

--- a/addons/medical/functions/fnc_isBeingCarried.sqf
+++ b/addons/medical/functions/fnc_isBeingCarried.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-params ["_target"];
+PARAMS_1(_target);
 
 private "_owner";
 

--- a/addons/medical/functions/fnc_isBeingDragged.sqf
+++ b/addons/medical/functions/fnc_isBeingDragged.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-params ["_target"];
+PARAMS_1(_target);
 
 private "_owner";
 

--- a/addons/medical/functions/fnc_isInMedicalFacility.sqf
+++ b/addons/medical/functions/fnc_isInMedicalFacility.sqf
@@ -13,8 +13,8 @@
 
 #include "script_component.hpp"
 
-private ["_eyePos", "_objects", "_isInBuilding", "_medicalFacility"];
-params ["_unit"];
+private ["_unit","_eyePos","_objects","_isInBuilding","_medicalFacility"];
+_unit = _this select 0;
 
 _eyePos = eyePos _unit;
 _isInBuilding = false;
@@ -42,13 +42,13 @@ _objects = (lineIntersectsWith [_unit modelToWorldVisual [0, 0, (_eyePos select 
     if (((typeOf _x) in _medicalFacility) || (_x getVariable [QGVAR(isMedicalFacility),false])) exitwith {
         _isInBuilding = true;
     };
-} foreach _objects;
+}foreach _objects;
 if (!_isInBuilding) then {
     _objects = position _unit nearObjects 7.5;
     {
         if (((typeOf _x) in _medicalFacility) || (_x getVariable [QGVAR(isMedicalFacility),false])) exitwith {
             _isInBuilding = true;
         };
-    } foreach _objects;
+    }foreach _objects;
 };
 _isInBuilding;

--- a/addons/medical/functions/fnc_isInMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_isInMedicalVehicle.sqf
@@ -13,8 +13,9 @@
 
 #include "script_component.hpp"
 
-private ["_vehicle"];
-params ["_unit"];
+private ["_unit", "_vehicle"];
+
+_unit = _this select 0;
 _vehicle = vehicle _unit;
 
 if (_unit == _vehicle) exitWith {false};

--- a/addons/medical/functions/fnc_isInStableCondition.sqf
+++ b/addons/medical/functions/fnc_isInStableCondition.sqf
@@ -13,8 +13,8 @@
 
 #include "script_component.hpp"
 
-private ["_openWounds", "_openWounds"];
-params ["_unit"];
+private ["_unit"];
+_unit = _this select 0;
 
 if (GVAR(level) <= 1) exitwith {
     ([_unit] call FUNC(getBloodloss)) == 0;
@@ -25,6 +25,6 @@ _openWounds = _unit getvariable [QGVAR(openWounds), []];
 {
     // total bleeding ratio * percentage of injury left
     _totalBloodLoss = _totalBloodLoss + ((_x select 4) * (_x select 3));
-} foreach _openWounds;
+}foreach _openWounds;
 
 (_totalBloodLoss == 0);

--- a/addons/medical/functions/fnc_isMedic.sqf
+++ b/addons/medical/functions/fnc_isMedic.sqf
@@ -4,7 +4,7 @@
  *
  * Arguments:
  * 0: The Unit <OBJECT>
- * 1: Class <NUMBER> (default: 1)
+ * 1: Class <NUMBER> <OPTIONAL>
  *
  * ReturnValue:
  * Is in of medic class <BOOL>
@@ -15,7 +15,8 @@
 #include "script_component.hpp"
 
 private ["_unit", "_class", "_medicN"];
-params ["_unit", ["_medicN", 1]];
+_unit = _this select 0;
+_medicN = if (count _this > 1) then {_this select 1} else {1};
 
 _class = _unit getVariable [QGVAR(medicClass),
     getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "attendant")];

--- a/addons/medical/functions/fnc_isMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_isMedicalVehicle.sqf
@@ -12,6 +12,7 @@
  */
 #include "script_component.hpp"
 
-params ["_vehicle"];
+private ["_vehicle"];
+_vehicle = _this select 0;
 
 (_vehicle getVariable [QGVAR(medicClass), getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "attendant")]) > 0

--- a/addons/medical/functions/fnc_itemCheck.sqf
+++ b/addons/medical/functions/fnc_itemCheck.sqf
@@ -6,14 +6,15 @@
  * 0: The unit <OBJECT>
  *
  * ReturnValue:
- * None
+ * nil
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-params ["_unit"];
+private ["_unit"];
+_unit = _this select 0;
 
 while {({_x == "FirstAidKit"} count items _unit) > 0} do {
     _unit removeItem "FirstAidKit";

--- a/addons/medical/functions/fnc_modifyMedicalAction.sqf
+++ b/addons/medical/functions/fnc_modifyMedicalAction.sqf
@@ -10,15 +10,14 @@
  * 3: The action to modify <OBJECT>
  *
  * ReturnValue:
- * None
+ * nil
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_target", "_player", "_selectionN", "_actionData"];
-
+EXPLODE_4_PVT(_this,_target,_player,_selectionN,_actionData);
 if (GVAR(level) < 2) exitwith {
     private ["_pointDamage"];
     _pointDamage = _target getHitPointDamage (["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"] select _selectionN);
@@ -34,8 +33,8 @@ if (GVAR(level) < 2) exitwith {
 private ["_openWounds", "_amountOf"];
 _openWounds = _target getvariable [QGVAR(openWounds), []];
 {
-    _x params ["", "", "_selectionX", "_amountOf", "_x4"];
-    if (_amountOf > 0 && {(_selectionN == _selectionX)} && {_x4 > 0}) exitwith {
+    _amountOf = _x select 3;
+    if (_amountOf > 0 && {(_selectionN == (_x select 2))} && {(_x select 4) > 0}) exitwith {
         _actionData set [2, QUOTE(PATHTOF(UI\icons\medical_crossRed.paa))];
     };
 } foreach _openWounds;

--- a/addons/medical/functions/fnc_moduleAdvancedMedicalSettings.sqf
+++ b/addons/medical/functions/fnc_moduleAdvancedMedicalSettings.sqf
@@ -8,14 +8,17 @@
  * 2: activated <BOOL>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_logic", "_units", "_activated"];
+private ["_logic", "_units", "_activated"];
+_logic = _this select 0;
+_units = _this select 1;
+_activated = _this select 2;
 
 if !(_activated) exitWith {};
 

--- a/addons/medical/functions/fnc_moduleAssignMedicRoles.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicRoles.sqf
@@ -8,15 +8,15 @@
  * 2: activated <BOOL>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_setting", "_objects", "_list", "_splittedList", "_nilCheckPassedList", "_parsedList"];
-params [["_logic", objNull, [objNull]]];
+private ["_logic","_setting","_objects", "_list", "_splittedList", "_nilCheckPassedList", "_parsedList"];
+_logic = [_this,0,objNull,[objNull]] call BIS_fnc_param;
 
 if (!isNull _logic) then {
     _list = _logic getvariable ["EnableList",""];
@@ -32,7 +32,7 @@ if (!isNull _logic) then {
                 _nilCheckPassedList = _nilCheckPassedList + ","+ _x;
             };
         };
-    } foreach _splittedList;
+    }foreach _splittedList;
 
     _list = "[" + _nilCheckPassedList + "]";
     _parsedList = [] call compile _list;
@@ -47,7 +47,7 @@ if (!isNull _logic) then {
                     };
                 };
             };
-        } foreach _objects;
+        }foreach _objects;
     };
     {
         if (!isnil "_x") then {
@@ -57,5 +57,7 @@ if (!isNull _logic) then {
                 };
             };
         };
-    } foreach _parsedList;
+    }foreach _parsedList;
  };
+
+true

--- a/addons/medical/functions/fnc_moduleAssignMedicalFacility.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicalFacility.sqf
@@ -8,15 +8,15 @@
  * 2: activated <BOOL>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_setting", "_objects"];
-params [["_logic", objNull, [objNull]]];
+private ["_logic","_setting","_objects"];
+_logic = [_this,0,objNull,[objNull]] call BIS_fnc_param;
 if (!isNull _logic) then {
     _setting = _logic getvariable ["class",0];
     _objects = synchronizedObjects _logic;
@@ -24,7 +24,7 @@ if (!isNull _logic) then {
         if (local _x) then {
             _x setvariable[QGVAR(isMedicalFacility), true, true];
         };
-    } foreach _objects;
+    }foreach _objects;
 };
 
 true;

--- a/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
+++ b/addons/medical/functions/fnc_moduleAssignMedicalVehicle.sqf
@@ -8,7 +8,7 @@
  * 2: activated <BOOL>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
@@ -16,8 +16,8 @@
 
 #include "script_component.hpp"
 
-private ["_setting", "_objects", "_list", "_splittedList", "_nilCheckPassedList", "_parsedList"];
-params [["_logic", objNull, [objNull]]];
+private ["_logic","_setting","_objects", "_list", "_splittedList", "_nilCheckPassedList", "_parsedList"];
+_logic = [_this,0,objNull,[objNull]] call BIS_fnc_param;
 
 if (!isNull _logic) then {
     _list = _logic getvariable ["EnableList",""];
@@ -33,7 +33,7 @@ if (!isNull _logic) then {
                 _nilCheckPassedList = _nilCheckPassedList + ","+ _x;
             };
         };
-    } foreach _splittedList;
+    }foreach _splittedList;
 
     _list = "[" + _nilCheckPassedList + "]";
     _parsedList = [] call compile _list;
@@ -48,7 +48,7 @@ if (!isNull _logic) then {
                     };
                 };
             };
-        } foreach _objects;
+        }foreach _objects;
     };
     {
         if (!isnil "_x") then {
@@ -58,5 +58,7 @@ if (!isNull _logic) then {
                 };
             };
         };
-    } foreach _parsedList;
+    }foreach _parsedList;
  };
+
+true;

--- a/addons/medical/functions/fnc_moduleMedicalSettings.sqf
+++ b/addons/medical/functions/fnc_moduleMedicalSettings.sqf
@@ -8,14 +8,17 @@
  * 2: activated <BOOL>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_logic", "_units", "_activated"];
+private ["_logic", "_units", "_activated"];
+_logic = _this select 0;
+_units = _this select 1;
+_activated = _this select 2;
 
 if !(_activated) exitWith {};
 

--- a/addons/medical/functions/fnc_moduleReviveSettings.sqf
+++ b/addons/medical/functions/fnc_moduleReviveSettings.sqf
@@ -8,14 +8,17 @@
  * 2: activated <BOOL>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_logic", "_units", "_activated"];
+private ["_logic", "_units", "_activated"];
+_logic = _this select 0;
+_units = _this select 1;
+_activated = _this select 2;
 
 if !(_activated) exitWith {};
 

--- a/addons/medical/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical/functions/fnc_onMedicationUsage.sqf
@@ -11,21 +11,28 @@
  * 5: Incompatable medication <ARRAY<STRING>>
  *
  * Return Value:
- * None
+ * NONE
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-private ["_foundEntry", "_allUsedMedication","_allMedsFromClassname", "_usedMeds", "_hasOverDosed", "_med", "_limit", "_decreaseAmount", "_viscosityAdjustment", "_medicationConfig", "_onOverDose"];
-params ["_target", "_className", "_variable", "_maxDosage", "_timeInSystem", "_incompatabileMeds", "_viscosityChange", "_painReduce"];
+private ["_target", "_className", "_variable", "_maxDosage", "_timeInSystem", "_incompatabileMeds", "_foundEntry", "_allUsedMedication","_allMedsFromClassname", "_usedMeds", "_hasOverDosed", "_med", "_limit", "_classNamesUsed", "_decreaseAmount", "_viscosityChange", "_viscosityAdjustment", "_medicationConfig", "_onOverDose", "_painReduce"];
+_target = _this select 0;
+_className = _this select 1;
+_variable = _this select 2;
+_maxDosage = _this select 3;
+_timeInSystem = _this select 4;
+_incompatabileMeds = _this select 5;
+_viscosityChange = _this select 6;
+_painReduce = _this select 7;
 
 _foundEntry = false;
 _allUsedMedication = _target getvariable [QGVAR(allUsedMedication), []];
 {
-    _x params ["_variableX", "_allMedsFromClassname"];
-    if (_variableX== _variable) exitwith {
+    if (_x select 0 == _variable) exitwith {
+        _allMedsFromClassname = _x select 1;
         if !(_className in _allMedsFromClassname) then {
             _allMedsFromClassname pushback _className;
             _x set [1, _allMedsFromClassname];
@@ -49,14 +56,15 @@ if (_usedMeds >= floor (_maxDosage + round(random(2))) && _maxDosage >= 1 && GVA
 
 _hasOverDosed = 0;
 {
-    _x params ["_med", "_limit"];
+    _med = _x select 0;
+    _limit = _x select 1;
     {
-        _x params ["", "_classNamesUsed"];
+        _classNamesUsed = _x select 1;
         if ({_x == _med} count _classNamesUsed > _limit) then {
             _hasOverDosed = _hasOverDosed + 1;
         };
-    } foreach _allUsedMedication;
-} foreach _incompatabileMeds;
+    }foreach _allUsedMedication;
+}foreach _incompatabileMeds;
 
 if (_hasOverDosed > 0 && GVAR(enableOverdosing)) then {
     _medicationConfig = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Medication");
@@ -77,8 +85,16 @@ _decreaseAmount = 1 / _timeInSystem;
 _viscosityAdjustment = _viscosityChange / _timeInSystem;
 
 [{
-    params ["_args", "_idPFH"];
-    _args params ["_target", "_timeInSystem", "_variable", "_amountDecreased","_decreaseAmount", "_usedMeds", "_viscosityAdjustment", "_painReduce"];
+    private ["_args", "_target", "_timeInSystem", "_variable", "_amountDecreased","_decreaseAmount", "_usedMeds", "_viscosityAdjustment", "_painReduce"];
+    _args = _this select 0;
+    _target = _args select 0;
+    _timeInSystem = _args select 1;
+    _variable = _args select 2;
+    _amountDecreased = _args select 3;
+    _decreaseAmount = _args select 4;
+    _viscosityAdjustment = _args select 5;
+    _painReduce = _args select 6;
+
     _usedMeds = _target getvariable [_variable, 0];
     _usedMeds = _usedMeds - _decreaseAmount;
     _target setvariable [_variable, _usedMeds];
@@ -90,7 +106,7 @@ _viscosityAdjustment = _viscosityChange / _timeInSystem;
     _target setvariable [QGVAR(painSuppress), ((_target getvariable [QGVAR(painSuppress), 0]) - _painReduce) max 0];
 
     if (_amountDecreased >= 1 || (_usedMeds <= 0) || !alive _target) then {
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        [(_this select 1)] call cba_fnc_removePerFrameHandler;
     };
     _args set [3, _amountDecreased];
 }, 1, [_target, _timeInSystem, _variable, 0, _decreaseAmount, _viscosityAdjustment, _painReduce / _timeInSystem] ] call CBA_fnc_addPerFrameHandler;

--- a/addons/medical/functions/fnc_onPropagateWound.sqf
+++ b/addons/medical/functions/fnc_onPropagateWound.sqf
@@ -7,7 +7,7 @@
  * 1: injury <ARRAY>
  *
  * Return Value:
- * None
+ * None <NIL>
  *
  * Public: No
  */
@@ -15,7 +15,8 @@
 #include "script_component.hpp"
 
 private ["_unit", "_injury", "_openWounds", "_injuryID", "_exists"];
-params ["_unit", "_injury"];
+_unit = _this select 0;
+_injury = _this select 1;
 
 if (!local _unit) then {
     _openWounds = _unit getvariable[QGVAR(openWounds), []];
@@ -27,7 +28,7 @@ if (!local _unit) then {
             _exists = true;
             _openWounds set [_foreachIndex, _injury];
         };
-    } foreach _openWounds;
+    }foreach _openWounds;
 
     if (!_exists) then {
         _openWounds pushback _injury;

--- a/addons/medical/functions/fnc_onWoundUpdateRequest.sqf
+++ b/addons/medical/functions/fnc_onWoundUpdateRequest.sqf
@@ -7,18 +7,19 @@
  * 1: Origin object <OBJECT>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 private ["_unit", "_openWounds", "_originOfrequest"];
-params ["_unit", "_originOfrequest"];
+_unit = _this select 0;
+_originOfrequest = _this select 1;
 
 if (local _unit && !(local _originOfrequest)) then {
     _openWounds = _unit getvariable [QGVAR(openWounds), []];
     {
         ["medical_propagateWound", [_originOfrequest], [_unit, _x]] call EFUNC(common,targetEvent);
-    } foreach _openWounds;
+    }foreach _openWounds;
 };

--- a/addons/medical/functions/fnc_parseConfigForInjuries.sqf
+++ b/addons/medical/functions/fnc_parseConfigForInjuries.sqf
@@ -3,12 +3,13 @@
  * Parse the ACE_Medical_Advanced config for all injury types.
  *
  * Arguments:
- * None
+ *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: No
  */
+
 #include "script_component.hpp"
 
 private ["_injuriesRootConfig", "_woundsConfig", "_allWoundClasses", "_amountOf", "_entry","_classType", "_selections", "_bloodLoss", "_pain","_minDamage","_causes", "_damageTypesConfig", "_thresholds", "_typeThresholds", "_selectionSpecific", "_selectionSpecificType", "_classDisplayName", "_subClassDisplayName", "_maxDamage", "_subClassmaxDamage", "_defaultMinLethalDamage", "_minLethalDamage", "_allFoundDamageTypes", "_classID", "_configDamageTypes", "_i", "_parseForSubClassWounds", "_subClass", "_subClassConfig", "_subClassbloodLoss", "_subClasscauses", "_subClassminDamage", "_subClasspain", "_subClassselections", "_subClasstype", "_type", "_varName", "_woundTypes"];
@@ -109,7 +110,7 @@ _selectionSpecific = getNumber(_damageTypesConfig >> "selectionSpecific");
         if (_type in (_x select 5)) then {
             _woundTypes pushback _x;
         };
-    } foreach _allWoundClasses;
+    }foreach _allWoundClasses;
     _typeThresholds = _thresholds;
     _selectionSpecificType = _selectionSpecific;
     if (isClass(_damageTypesConfig >> _x)) then {
@@ -129,11 +130,11 @@ _selectionSpecific = getNumber(_damageTypesConfig >> "selectionSpecific");
             _minDamageThresholds = _minDamageThresholds + ":";
             _amountThresholds = _amountThresholds + ":";
         };
-    } foreach _typeThresholds;
+    }foreach _typeThresholds;
 
     "ace_medical" callExtension format ["addDamageType,%1,%2,%3,%4,%5", _type, GVAR(minLethalDamages) select _foreachIndex, _minDamageThresholds, _amountThresholds, _selectionSpecificType];
 
-} foreach _allFoundDamageTypes;
+}foreach _allFoundDamageTypes;
 
 
 // Extension loading
@@ -141,30 +142,34 @@ _selectionSpecific = getNumber(_damageTypesConfig >> "selectionSpecific");
 {
     private ["_classID", "_className", "_allowedSelections", "_bloodLoss", "_pain", "_minDamage", "_maxDamage", "_causes", "_classDisplayName", "_extensionInput", "_selections", "_causesArray"];
     // add shit to addInjuryType
-    _x params ["_classID", "_selections", "_bloodLoss", "_pain", "_damage", "_causesArray", "_classDisplayName"];
-    _damage params ["_minDamage", "_maxDamage"];
+    _classID = _x select 0;
     _className = GVAR(woundClassNames) select _forEachIndex;
     _allowedSelections = "";
 
+    _selections = _x select 1;
     {
         _allowedSelections = _allowedSelections + _x;
         if (_forEachIndex < (count _selections) - 1) then {
             _allowedSelections = _allowedSelections + ":";
         };
-    } foreach _selections;
+    }foreach _selections;
 
+    _bloodLoss = _x select 2;
+    _pain = _x select 3;
+    _minDamage = (_x select 4) select 0;
+    _maxDamage = (_x select 4) select 1;
     _causes = "";
-
+    _causesArray = (_x select 5);
     {
         _causes = _causes + _x;
         if (_forEachIndex < (count _causesArray) - 1) then {
             _causes = _causes + ":";
         };
-    } foreach _causesArray;
+    }foreach _causesArray;
     _classDisplayName = _x select 6;
 
     "ace_medical" callExtension format["addInjuryType,%1,%2,%3,%4,%5,%6,%7,%8,%9", _classID, _className, _allowedSelections, _bloodLoss, _pain, _minDamage, _maxDamage, _causes, _classDisplayName];
 
-} foreach _allWoundClasses;
+}foreach _allWoundClasses;
 
 "ace_medical" callExtension "ConfigComplete";

--- a/addons/medical/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical/functions/fnc_playInjuredSound.sqf
@@ -6,10 +6,9 @@
  *
  * Arguments:
  * 0: The Unit <OBJECT>
- * 1: Amount of Pain <NUMBER>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: No
  */
@@ -17,7 +16,8 @@
 #include "script_component.hpp"
 
 private ["_unit","_availableSounds_A","_availableSounds_B","_availableSounds_C","_sound", "_pain"];
-params ["_unit", "_pain"];
+_unit = _this select 0;
+_pain = _this select 1;
 if (!local _unit || !GVAR(enableScreams)) exitwith{};
 
 // Lock if the unit is already playing a sound.

--- a/addons/medical/functions/fnc_requestWoundSync.sqf
+++ b/addons/medical/functions/fnc_requestWoundSync.sqf
@@ -7,14 +7,16 @@
  * 1: object belonging to the caller <OBJECT>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-params [ "_target", "_caller"];
+private [ "_target", "_caller"];
+_target = _this select 0;
+_caller = _this select 1;
 
 if (local _target || GVAR(level) < 2) exitwith {}; // if the target is local, we already got the most update to date information
 if (_target getvariable [QGVAR(isWoundSynced), false]) exitwith {};

--- a/addons/medical/functions/fnc_setCardiacArrest.sqf
+++ b/addons/medical/functions/fnc_setCardiacArrest.sqf
@@ -7,15 +7,15 @@
  * 0: The unit that will be put in cardiac arrest state <OBJECT>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: yes
  */
 
 #include "script_component.hpp"
 
-private "_timeInCardiacArrest";
-params ["_unit"];
+private ["_unit", "_timeInCardiacArrest"];
+_unit = _this select 0;
 
 if (_unit getvariable [QGVAR(inCardiacArrest),false]) exitwith {};
 _unit setvariable [QGVAR(inCardiacArrest), true,true];
@@ -28,17 +28,20 @@ _timeInCardiacArrest = 120 + round(random(600));
 
 [{
     private ["_args","_unit","_startTime","_timeInCardiacArrest","_heartRate"];
-    params ["_args", "_idPFH"];
-    _args params ["_unit", "_startTime", "_timeInCardiacArrest"];
+    _args = _this select 0;
+    _unit = _args select 0;
+    _startTime = _args select 1;
+    _timeInCardiacArrest = _args select 2;
 
     _heartRate = _unit getvariable [QGVAR(heartRate), 80];
     if (_heartRate > 0 || !alive _unit) exitwith {
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        [(_this select 1)] call cba_fnc_removePerFrameHandler;
         _unit setvariable [QGVAR(inCardiacArrest), nil,true];
     };
     if (ACE_time - _startTime >= _timeInCardiacArrest) exitwith {
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        [(_this select 1)] call cba_fnc_removePerFrameHandler;
         _unit setvariable [QGVAR(inCardiacArrest), nil,true];
         [_unit] call FUNC(setDead);
     };
 }, 1, [_unit, ACE_time, _timeInCardiacArrest] ] call CBA_fnc_addPerFrameHandler;
+

--- a/addons/medical/functions/fnc_setDead.sqf
+++ b/addons/medical/functions/fnc_setDead.sqf
@@ -6,7 +6,7 @@
  * 0: The unit that will be killed <OBJECT>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: yes
  */
@@ -14,7 +14,11 @@
 #include "script_component.hpp"
 
 private ["_unit", "_force", "_reviveVal", "_lifesLeft"];
-params ["_unit", ["_force", false]];
+_unit = _this select 0;
+_force = false;
+if (count _this >= 2) then {
+    _force = _this select 1;
+};
 
 if (!alive _unit) exitwith{true};
 if (!local _unit) exitwith {
@@ -40,13 +44,13 @@ if (((_reviveVal == 1 && {[_unit] call EFUNC(common,isPlayer)} || _reviveVal == 
     [_unit, true] call FUNC(setUnconscious);
 
     [{
-        private "_startTime";
-        params ["_args", "_idPFH"];
-        _args params ["_unit"];
+        private ["_args","_unit","_startTime"];
+        _args = _this select 0;
+        _unit = _args select 0;
         _startTime = _unit getvariable [QGVAR(reviveStartTime), 0];
 
         if (GVAR(maxReviveTime) > 0 && {ACE_time - _startTime > GVAR(maxReviveTime)}) exitwith {
-            [_idPFH] call CBA_fnc_removePerFrameHandler;
+            [(_this select 1)] call cba_fnc_removePerFrameHandler;
             _unit setvariable [QGVAR(inReviveState), nil, true];
             _unit setvariable [QGVAR(reviveStartTime), nil];
             [_unit, true] call FUNC(setDead);
@@ -60,7 +64,7 @@ if (((_reviveVal == 1 && {[_unit] call EFUNC(common,isPlayer)} || _reviveVal == 
             };
 
             _unit setvariable [QGVAR(reviveStartTime), nil];
-            [_idPFH] call CBA_fnc_removePerFrameHandler;
+            [(_this select 1)] call cba_fnc_removePerFrameHandler;
         };
         if (GVAR(level) >= 2) then {
             if (_unit getvariable [QGVAR(heartRate), 60] > 0) then {

--- a/addons/medical/functions/fnc_setHitPointDamage.sqf
+++ b/addons/medical/functions/fnc_setHitPointDamage.sqf
@@ -7,10 +7,10 @@
  * 0: Unit <OBJECT>
  * 1: HitPoint <STRING>
  * 2: Damage <NUMBER>
- * 3: Disable overall damage adjustment <BOOL> (default: false)
+ * 3: Disable overall damage adjustment (optional) <BOOL>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: Yes
  */
@@ -22,7 +22,10 @@
 #define ARMDAMAGETRESHOLD2 1.7
 
 private ["_unit", "_selection", "_damage", "_selections", "_damages", "_damageOld", "_damageSumOld", "_damageNew", "_damageSumNew", "_damageFinal", "_armdamage", "_legdamage"];
-params ["_unit", "_selection", "_damage", ["_disabled", false]];
+
+_unit = _this select 0;
+_selection = _this select 1;
+_damage = _this select 2;
 
 // Unit isn't local, give function to machine where it is.
 if !(local _unit) exitWith {
@@ -30,7 +33,7 @@ if !(local _unit) exitWith {
 };
 
 // Check if overall damage adjustment is disabled
-if (_disabled) exitWith {
+if (count _this > 3 && {_this select 3}) exitWith {
     _unit setHitPointDamage [_selection, _damage];
 };
 

--- a/addons/medical/functions/fnc_setUnconscious.sqf
+++ b/addons/medical/functions/fnc_setUnconscious.sqf
@@ -4,9 +4,9 @@
  *
  * Arguments:
  * 0: The unit that will be put in an unconscious state <OBJECT>
- * 1: Set unconsciouns <BOOL> (default: true)
- * 2: Minimum unconscious ACE_time <NUMBER> (default: (round(random(10)+5)))
- * 3: Force AI Unconscious (skip random death chance) <BOOL> (default: false)
+ * 1: Set unconsciouns <BOOL> <OPTIONAL>
+ * 2: Minimum unconscious ACE_time <NUMBER> <OPTIONAL>
+ * 3: Force AI Unconscious (skip random death chance) <BOOL> <OPTIONAL>
  *
  * ReturnValue:
  * nil
@@ -19,10 +19,13 @@
 
 #include "script_component.hpp"
 
-#define DEFAULT_DELAY (round(random(10)+5))
+#define DEFAULT_DELAY   (round(random(10)+5))
 
-private ["_animState", "_originalPos", "_startingTime", "_isDead"];
-params ["_unit", ["_set", true], ["_minWaitingTime", DEFAULT_DELAY], ["_force", false]];
+private ["_unit", "_set", "_animState", "_originalPos", "_startingTime","_minWaitingTime", "_force", "_isDead"];
+_unit = _this select 0;
+_set = if (count _this > 1) then {_this select 1} else {true};
+_minWaitingTime = if (count _this > 2) then {_this select 2} else {DEFAULT_DELAY};
+_force = if (count _this > 3) then {_this select 3} else {false};
 
 // No change, fuck off. (why is there no xor?)
 if (_set isEqualTo (_unit getVariable ["ACE_isUnconscious", false])) exitWith {};
@@ -94,7 +97,8 @@ if (GVAR(moveUnitsFromGroupOnUnconscious)) then {
 _anim = [_unit] call EFUNC(common,getDeathAnim);
 [_unit, _anim, 1, true] call EFUNC(common,doAnimation);
 [{
-    params ["_unit", "_anim"];
+    _unit = _this select 0;
+    _anim = _this select 1;
     if ((_unit getVariable "ACE_isUnconscious") and (animationState _unit != _anim)) then {
         [_unit, _anim, 2, true] call EFUNC(common,doAnimation);
     };

--- a/addons/medical/functions/fnc_treatment.sqf
+++ b/addons/medical/functions/fnc_treatment.sqf
@@ -16,8 +16,11 @@
 
 #include "script_component.hpp"
 
-private ["_config", "_medicRequired", "_items", "_locations", "_return", "_callbackProgress", "_treatmentTime", "_callerAnim", "_patientAnim", "_iconDisplayed", "_return", "_usersOfItems", "_consumeItems", "_condition", "_displayText", "_wpn", "_treatmentTimeConfig", "_patientStateCondition", "_allowedSelections"];
-params ["_caller", "_target", "_selectionName", "_className"];
+private ["_caller", "_target", "_selectionName", "_className", "_config", "_medicRequired", "_items", "_locations", "_return", "_callbackProgress", "_treatmentTime", "_callerAnim", "_patientAnim", "_iconDisplayed", "_return", "_usersOfItems", "_consumeItems", "_condition", "_displayText", "_wpn", "_treatmentTimeConfig", "_patientStateCondition", "_allowedSelections"];
+_caller = _this select 0;
+_target = _this select 1;
+_selectionName = _this select 2;
+_className = _this select 3;
 
 // If the cursorMenu is open, the loading bar will fail. If we execute the function one frame later, it will work fine
 if (uiNamespace getVariable [QEGVAR(interact_menu,cursorMenuOpened),false]) exitwith {
@@ -104,7 +107,7 @@ if ("All" in _locations) then {
                 };
             };
         };
-    } foreach _locations;
+    }foreach _locations;
 };
 
 if !(_return) exitwith {false};
@@ -177,7 +180,7 @@ if (vehicle _caller == _caller && {_callerAnim != ""}) then {
         TRACE_1("Weapon Deployed, breaking out first",(stance _caller));
         [_caller, "", 0] call EFUNC(common,doAnimation);
     };
-
+    
     if ((stance _caller) == "STAND") then {
         switch (_wpn) do {//If standing, end in a crouched animation based on their current weapon
             case ("rfl"): {_caller setvariable [QGVAR(treatmentPrevAnimCaller), "AmovPknlMstpSrasWrflDnon"];};

--- a/addons/medical/functions/fnc_treatmentAdvanced_CPR.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_CPR.sqf
@@ -16,7 +16,12 @@
 
 #include "script_component.hpp"
 
-params ["_caller", "_target", "_selectionName", "_className", "_items"];
+private ["_caller", "_target", "_selectionName", "_className", "_items"];
+_caller = _this select 0;
+_target = _this select 1;
+_selectionName = _this select 2;
+_className = _this select 3;
+_items = _this select 4;
 
 if (alive _target && {(_target getvariable [QGVAR(inCardiacArrest), false] || _target getvariable [QGVAR(inReviveState), false])}) then {
     [[_caller, _target], QUOTE(DFUNC(treatmentAdvanced_CPRLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */

--- a/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
@@ -14,8 +14,9 @@
 
 #include "script_component.hpp"
 
-private "_reviveStartTime";
-param ["_caller","_target"];
+private ["_caller","_target", "_reviveStartTime"];
+_caller = _this select 0;
+_target = _this select 1;
 
 if (_target getvariable [QGVAR(inReviveState), false]) then {
     _reviveStartTime = _target getvariable [QGVAR(reviveStartTime),0];

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHeal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHeal.sqf
@@ -10,7 +10,12 @@
 
 #include "script_component.hpp"
 
-params ["_target", "_caller", "_selectionName", "_className", "_items"];
+private ["_target", "_caller", "_selectionName", "_className", "_items"];
+_caller = _this select 0;
+_target = _this select 1;
+_selectionName = _this select 2;
+_className = _this select 3;
+_items = _this select 4;
 
 // TODO replace by event system
 [[_caller, _target], QUOTE(DFUNC(treatmentAdvanced_fullHealLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf
@@ -10,8 +10,9 @@
 
 #include "script_component.hpp"
 
-private "_allUsedMedication";
-params ["_caller", "_target"];
+private ["_target", "_caller", "_allUsedMedication"];
+_caller = _this select 0;
+_target = _this select 1;
 
 if (alive _target) exitwith {
 
@@ -63,7 +64,7 @@ if (alive _target) exitwith {
     _allUsedMedication = _target getVariable [QGVAR(allUsedMedication), []];
     {
        _target setvariable [_x select 0, nil];
-    } foreach _allUsedMedication;
+    }foreach _allUsedMedication;
 
     // Resetting damage
     _target setDamage 0;

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
@@ -15,12 +15,12 @@
  */
 #include "script_component.hpp"
 
-private "_totalDamage";
-
+private ["_target", "_totalDamage"];
+_target = _this;
 _totalDamage = 0;
 
 {
     _totalDamage = _totalDamage + _x;
-} forEach (_this getVariable [QGVAR(bodyPartStatus), []]);
+} forEach (_target getVariable [QGVAR(bodyPartStatus), []]);
 
 (10 max (_totalDamage * 10) min 120)

--- a/addons/medical/functions/fnc_treatmentAdvanced_medication.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_medication.sqf
@@ -17,7 +17,12 @@
 
 #include "script_component.hpp"
 
-params ["_caller", "_target", "_selectionName", "_className", "_items"];
+private ["_caller", "_target", "_selectionName", "_className", "_items"];
+_caller = _this select 0;
+_target = _this select 1;
+_selectionName = _this select 2;
+_className = _this select 3;
+_items = _this select 4;
 
 [[_target, _className], QUOTE(DFUNC(treatmentAdvanced_medicationLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */
 
@@ -27,7 +32,7 @@ params ["_caller", "_target", "_selectionName", "_className", "_items"];
         [_target, "activity", LSTRING(Activity_usedItem), [[_caller] call EFUNC(common,getName), getText (configFile >> "CfgWeapons" >> _x >> "displayName")]] call FUNC(addToLog);
         [_target, "activity_view", LSTRING(Activity_usedItem), [[_caller] call EFUNC(common,getName), getText (configFile >> "CfgWeapons" >> _x >> "displayName")]] call FUNC(addToLog);
     };
-} foreach _items;
+}foreach _items;
 
 
 true;

--- a/addons/medical/functions/fnc_treatmentAdvanced_medicationLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_medicationLocal.sqf
@@ -15,8 +15,9 @@
 
 #include "script_component.hpp"
 
-private ["_currentInSystem", "_medicationConfig", "_painReduce", "_hrIncreaseLow", "_hrIncreaseNorm", "_hrIncreaseHigh", "_maxDose", "_inCompatableMedication", "_timeInSystem", "_heartRate", "_pain", "_resistance", "_hrCallback", "_varName", "_viscosityChange"];
-params ["_target", "_className"];
+private ["_target", "_className", "_currentInSystem", "_medicationConfig", "_painReduce", "_hrIncreaseLow", "_hrIncreaseNorm", "_hrIncreaseHigh", "_maxDose", "_inCompatableMedication", "_timeInSystem", "_heartRate", "_pain", "_resistance", "_hrCallback", "_varName", "_viscosityChange"];
+_target = _this select 0;
+_className = _this select 1;
 
 // We have added a new dose of this medication to our system, so let's increase it
 _varName = format[QGVAR(%1_inSystem), _className];

--- a/addons/medical/functions/fnc_treatmentAdvanced_surgicalKit_onProgress.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_surgicalKit_onProgress.sqf
@@ -1,30 +1,23 @@
 /*
  * Author: BaerMitUmlaut
- * Handles treatment via surgical kit per frame
- *
- * Arguments:
- * 0: Arguments <ARRAY>
- *  0: Caller <OBJECT>
- *  1: Target <OBJECT>
- * 1: Elapsed Time <NUMBER>
- * 2: Total Time <NUMBER>
- *
- * Return Value:
- * Succesful treatment started <BOOL>
+ * Handles treatment via surgical kit per frame.
  *
  * Public: No
  */
+
 #include "script_component.hpp"
 
-
-private "_bandagedWounds";
-params ["_args", "_elapsedTime", "_totalTime"];
-_args params ["_caller", "_target"];
+private ["_args", "_target", "_caller", "_elapsedTime", "_totalTime", "_bandagedWounds"];
+_args = _this select 0;
+_caller = _args select 0;
+_target = _args select 1;
+_elapsedTime = _this select 1;
+_totalTime = _this select 2;
 
 _bandagedWounds = _target getVariable [QGVAR(bandagedWounds), []];
 
 //In case two people stitch up one patient and the last wound has already been closed we can stop already
-if (count _bandagedWounds == 0) exitWith { false };
+if (count _bandagedWounds == 0) exitWith {false};
 
 //Has enough time elapsed that we can close another wound?
 if ((_totalTime - _elapsedTime) <= (((count _bandagedWounds) - 1) * 5)) then {

--- a/addons/medical/functions/fnc_treatmentBasic_bandage.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bandage.sqf
@@ -9,7 +9,7 @@
  * 3: Treatment classname <STRING>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
@@ -17,8 +17,11 @@
 #include "script_component.hpp"
 #define BANDAGEHEAL 0.8
 
-private ["_hitSelections", "_hitPoints", "_point", "_damage"];
-params ["_caller", "_target", "_selection", "_className"];
+private ["_caller", "_target","_selection","_className","_target","_hitSelections","_hitPoints","_point", "_damage"];
+_caller = _this select 0;
+_target = _this select 1;
+_selection = _this select 2;
+_className = _this select 3;
 
 if (_selection == "all") then {
     _target setDamage ((damage _target - BANDAGEHEAL) max 0);

--- a/addons/medical/functions/fnc_treatmentBasic_bloodbag.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bloodbag.sqf
@@ -9,13 +9,16 @@
  * 3: Treatment classname <STRING>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_caller", "_target", "_treatmentClassname"];
+private ["_caller", "_target", "_treatmentClassname"];
+_caller = _this select 0;
+_target = _this select 1;
+_treatmentClassname = _this select 3;
 
 [[_target, _treatmentClassname], QUOTE(DFUNC(treatmentBasic_bloodbagLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */

--- a/addons/medical/functions/fnc_treatmentBasic_bloodbagLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bloodbagLocal.sqf
@@ -15,7 +15,7 @@
 #include "script_component.hpp"
 #define BLOODBAGHEAL 70
 
-params ["_target", "_treatmentClassname"];
+PARAMS_2(_target,_treatmentClassname);
 
 private ["_blood", "_bloodAdded"];
 

--- a/addons/medical/functions/fnc_treatmentBasic_epipen.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_epipen.sqf
@@ -9,13 +9,17 @@
  * 3: Treatment classname <STRING>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
+
 #include "script_component.hpp"
 
-params ["_caller", "_target","_className"];
+private ["_caller", "_target","_className"];
+_caller = _this select 0;
+_target = _this select 1;
+_className = _this select 3;
 
 [_target, false] call FUNC(setUnconscious);
 

--- a/addons/medical/functions/fnc_treatmentBasic_morphine.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_morphine.sqf
@@ -9,7 +9,7 @@
  * 3: Treatment classname <STRING>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
@@ -17,6 +17,8 @@
 #include "script_component.hpp"
 #define MORPHINEHEAL 0.4
 
-params ["_caller", "_target"];
+private ["_caller", "_target"];
+_caller = _this select 0;
+_target = _this select 1;
 
 [[_target], QUOTE(DFUNC(treatmentBasic_morphineLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */

--- a/addons/medical/functions/fnc_treatmentBasic_morphineLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_morphineLocal.sqf
@@ -7,7 +7,7 @@
  * 1: The patient <OBJECT>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
@@ -15,8 +15,8 @@
 #include "script_component.hpp"
 #define MORPHINEHEAL 0.4
 
-private ["_morphine", "_pain"];
-params ["_target"];
+private ["_target", "_morphine", "_pain"];
+_target = _this select 0;
 
 // reduce pain, pain sensitivity
 _morphine = ((_target getVariable [QGVAR(morphine), 0]) + MORPHINEHEAL) min 1;

--- a/addons/medical/functions/fnc_treatmentIV.sqf
+++ b/addons/medical/functions/fnc_treatmentIV.sqf
@@ -8,23 +8,26 @@
  * 2: SelectionName <STRING>
  * 3: Treatment classname <STRING>
  *
+ *
  * Return Value:
- * Succesful treatment started <BOOL>
+ * <BOOL>
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-private "_removeItem";
-params ["_caller", "_target", "_selectionName", "_className", "_items"];
+private ["_caller", "_target", "_selectionName", "_className", "_items", "_removeItem"];
+_caller = _this select 0;
+_target = _this select 1;
+_selectionName = _this select 2;
+_className = _this select 3;
+_items = _this select 4;
 
-if (count _items == 0) exitwith {false};
+if (count _items == 0) exitwith {};
 
 _removeItem = _items select 0;
 [[_target, _className], QUOTE(DFUNC(treatmentIVLocal)), _target] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */
 [_target, _removeItem] call FUNC(addToTriageCard);
 [_target, "activity", LSTRING(Activity_gaveIV), [[_caller] call EFUNC(common,getName)]] call FUNC(addToLog);
 [_target, "activity_view", LSTRING(Activity_gaveIV), [[_caller] call EFUNC(common,getName)]] call FUNC(addToLog); // TODO expand message
-
-true

--- a/addons/medical/functions/fnc_treatmentIVLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentIVLocal.sqf
@@ -8,15 +8,16 @@
  *
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-private ["_config", "_volumeAdded", "_typeOf", "_varName", "_bloodVolume"];
-params ["_target", "_treatmentClassname"];
+private ["_target", "_treatmentClassname", "_config", "_volumeAdded", "_typeOf", "_varName", "_bloodVolume"];
+_target = _this select 0;
+_treatmentClassname = _this select 1;
 
 _bloodVolume = _target getvariable [QGVAR(bloodVolume), 100];
 if (_bloodVolume >= 100) exitwith {};

--- a/addons/medical/functions/fnc_treatmentTourniquet.sqf
+++ b/addons/medical/functions/fnc_treatmentTourniquet.sqf
@@ -10,7 +10,7 @@
  *
  *
  * Return Value:
- * Succesful treatment started <BOOL>
+ * <BOOL>
  *
  * Public: No
  */
@@ -24,7 +24,7 @@ _selectionName = _this select 2;
 _className = _this select 3;
 _items = _this select 4;
 
-if (count _items == 0) exitwith {false};
+if (count _items == 0) exitwith {};
 
 _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part == 0 || _part == 1) exitwith {
@@ -47,4 +47,4 @@ _removeItem = _items select 0;
 [_target, "activity_view", LSTRING(Activity_appliedTourniquet), [[_caller] call EFUNC(common,getName)]] call FUNC(addToLog); // TODO expand message
 
 
-true
+true;

--- a/addons/medical/functions/fnc_treatmentTourniquetLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentTourniquetLocal.sqf
@@ -7,14 +7,16 @@
  * 1: Item used classname <STRING>
  *
  * Return Value:
- * None
+ * nil
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-private ["_tourniquetItem", "_part", "_applyingTo"];
-params ["_target", "_tourniquets", "_selectionName"];
+private ["_target", "_tourniquetItem", "_part", "_tourniquets", "_applyingTo", "_selectionName"];
+_target = _this select 0;
+_tourniquetItem = _this select 1;
+_selectionName = _this select 2;
 
 [_target] call FUNC(addToInjuredCollection);
 
@@ -27,21 +29,24 @@ _tourniquets set[_part, _applyingTo];
 _target setvariable [QGVAR(tourniquets), _tourniquets, true];
 
 [{
-    params ["_args", "_idPFH"];
-    _args params ["_target", "_applyingTo", "_part", "_time"];
-
+    private ["_args","_target","_applyingTo","_part", "_tourniquets", "_time"];
+    _args = _this select 0;
+    _target = _args select 0;
+    _applyingTo = _args select 1;
+    _part = _args select 2;
+    _time = _args select 3;
     if (!alive _target) exitwith {
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        [(_this select 1)] call cba_fnc_removePerFrameHandler;
     };
 
     _tourniquets = _target getvariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
     if !((_tourniquets select _part) == _applyingTo) exitwith {
         // Tourniquet has been removed
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        [(_this select 1)] call cba_fnc_removePerFrameHandler;
     };
     if (ACE_time - _time > 120) then {
         _target setvariable [QGVAR(pain), (_target getvariable [QGVAR(pain), 0]) + 0.005];
     };
 }, 5, [_target, _applyingTo, _part, ACE_time] ] call CBA_fnc_addPerFrameHandler;
 
-true
+true;

--- a/addons/medical/functions/fnc_unconsciousPFH.sqf
+++ b/addons/medical/functions/fnc_unconsciousPFH.sqf
@@ -13,15 +13,21 @@
  * 1: PFEH ID <NUMBER>
  *
  * ReturnValue:
- * None
+ * nil
  *
  * Public: yes
  */
+
 #include "script_component.hpp"
 
 private ["_unit", "_minWaitingTime", "_slotInfo", "_hasMovedOut", "_parachuteCheck", "_args", "_originalPos", "_startingTime", "_awakeInVehicleAnimation", "_oldVehicleAnimation", "_vehicle"];
-params ["_args", "_idPFH"];
-_args params ["_unit", "_originalPos", "_startingTime", "_minWaitingTime", "_hasMovedOut", "_parachuteCheck"];
+_args = _this select 0;
+_unit = _args select 0;
+_originalPos = _args select 1;
+_startingTime = _args select 2;
+_minWaitingTime = _args select 3;
+_hasMovedOut = _args select 4;
+_parachuteCheck = _args select 5;
 
 if (!alive _unit) exitwith {
     if ("ACE_FakePrimaryWeapon" in (weapons _unit)) then {
@@ -39,7 +45,7 @@ if (!alive _unit) exitwith {
     [_unit, "isUnconscious"] call EFUNC(common,unmuteUnit);
     ["medical_onUnconscious", [_unit, false]] call EFUNC(common,globalEvent);
 
-    [_idPFH] call CBA_fnc_removePerFrameHandler;
+    [(_this select 1)] call cba_fnc_removePerFrameHandler;
 };
 
 // In case the unit is no longer in an unconscious state, we are going to check if we can already reset the animation
@@ -51,7 +57,7 @@ if !(_unit getvariable ["ACE_isUnconscious",false]) exitwith {
             TRACE_1("Removing fake weapon [on wakeup]",_unit);
             _unit removeWeapon "ACE_FakePrimaryWeapon";
         };
-
+    
         if (vehicle _unit == _unit) then {
             if (animationState _unit == "AinjPpneMstpSnonWrflDnon") then {
                 [_unit,"AinjPpneMstpSnonWrflDnon_rolltofront", 2] call EFUNC(common,doAnimation);
@@ -93,7 +99,7 @@ if !(_unit getvariable ["ACE_isUnconscious",false]) exitwith {
 
         ["medical_onUnconscious", [_unit, false]] call EFUNC(common,globalEvent);
         // EXIT PFH
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        [(_this select 1)] call cba_fnc_removePerFrameHandler;
     };
     if (!_hasMovedOut) then {
         // Reset the unit back to the previous captive state.
@@ -126,7 +132,7 @@ if (_parachuteCheck) then {
 if (!local _unit) exitwith {
     _args set [3, _minWaitingTime - (ACE_time - _startingTime)];
     _unit setvariable [QGVAR(unconsciousArguments), _args, true];
-    [_idPFH] call CBA_fnc_removePerFrameHandler;
+    [(_this select 1)] call cba_fnc_removePerFrameHandler;
 };
 
 // Ensure we are waiting at least a minimum period before checking if we can wake up the unit again, allows for temp knock outs

--- a/addons/medical/functions/fnc_useItem.sqf
+++ b/addons/medical/functions/fnc_useItem.sqf
@@ -8,16 +8,17 @@
  * 2: Item <STRING>
  *
  * ReturnValue:
- * 0: success <BOOL>
- * 1: Unit <OBJECT>
+ * <NIL>
  *
  * Public: Yes
  */
 
 #include "script_component.hpp"
 
-private ["_return","_crew"];
-params ["_medic", "_patient", "_item"];
+private ["_medic", "_patient", "_item", "_return","_crew"];
+_medic = _this select 0;
+_patient = _this select 1;
+_item = _this select 2;
 
 if (isnil QGVAR(setting_allowSharedEquipment)) then {
     GVAR(setting_allowSharedEquipment) = true;
@@ -41,7 +42,7 @@ if ([vehicle _medic] call FUNC(isMedicalVehicle) && {vehicle _medic != _medic}) 
             _return = [true, _x];
             [[_x, _item], QUOTE(EFUNC(common,useItem)), _x] call EFUNC(common,execRemoteFnc); /* TODO Replace by event system */
         };
-    } foreach _crew;
+    }foreach _crew;
 };
 
-_return
+_return;

--- a/addons/medical/functions/fnc_useItems.sqf
+++ b/addons/medical/functions/fnc_useItems.sqf
@@ -8,7 +8,7 @@
  * 2: Items <ARRAY<STRING>>
  *
  * ReturnValue:
- * None
+ * <NIL>
  *
  * Public: Yes
  */
@@ -16,7 +16,9 @@
 #include "script_component.hpp"
 
 private ["_medic", "_patient", "_items", "_itemUsedInfo", "_itemsUsedBy"];
-params ["_medic", "_patient", "_items"];
+_medic = _this select 0;
+_patient = _this select 1;
+_items = _this select 2;
 
 _itemsUsedBy = [];
 {
@@ -25,7 +27,7 @@ _itemsUsedBy = [];
         {
             _itemUsedInfo = [_medic, _patient, _x] call FUNC(useItem);
             if (_itemUsedInfo select 0) exitwith { _itemsUsedBy pushback [(_itemUsedInfo select 1), _x]};
-        } foreach _x;
+        }foreach _x;
     };
 
     // handle required item
@@ -33,6 +35,6 @@ _itemsUsedBy = [];
         _itemUsedInfo = [_medic, _patient, _x] call FUNC(useItem);
         if (_itemUsedInfo select 0) exitwith { _itemsUsedBy pushback [(_itemUsedInfo select 1), _x]};
     };
-} foreach _items;
+}foreach _items;
 
 [count _items == count _itemsUsedBy, _itemsUsedBy];

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -3726,10 +3726,5 @@
             <English>Distance to %1 has become to far for treatment</English>
             <Polish>%1 odszedł zbyt daleko, nie można kontynuować leczenia</Polish>
         </Key>
-        <Key ID="STR_ACE_Medical_CanNotLoaded">
-            <English>This person (%1) is awake and cannot be loaded</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_noTourniquetOnBodyPart">
-            <English>There is no tourniquet on this body part!</English>
     </Package>
 </Project>


### PR DESCRIPTION
The clean up PR introduced a lot of issues and is the largest difference between master and the `medical-adjustments` branch. We could revert the changes made with this clean up PR and redo it in smaller pieces for 3.4.

This revert respects the other changes and fixes we have done. Thoughts @commy2 and @ViperMaul ?