### PR TITLE
Correct mention of diag_mergeConfigFile

### DIFF
--- a/documentation/development/setting-up-the-development-environment.md
+++ b/documentation/development/setting-up-the-development-environment.md
@@ -107,6 +107,6 @@ class CfgSettings {
 
 Files must exist in the built PBOs for filepatching to work. If you create a new file you must rebuild the PBO or Arma will not find it in your file paths.
 
-Configs are not patched during run time, only at load time. You do not have have to rebuild a PBO to make config changes, just restart Arma. You can get around this though if you are on the dev branch of Arma 3 and running the diagnostic exe. That includes `diag_mergeConfig` which takes a full system path (as in `p:\z\ace\addons\my_module\config.cpp`) and allows you selectivly reload config files.
+Configs are not patched during run time, only at load time. You do not have have to rebuild a PBO to make config changes, just restart Arma. You can get around this though if you are on the dev branch of Arma 3 and running the [diagnostic exe](https://community.bistudio.com/wiki/Arma_3_Diagnostics_Exe). That includes `diag_mergeConfigFile` which takes a full system path (as in `diag_mergeConfigFile  ["p:\z\ace\addons\my_module\config.cpp"]`) and allows you to selectively reload config files.
 
 If you need to add/remove files, then you'll need to run build.py again without the game running, and restart. That is all that is required to add new files to then further use in testing.


### PR DESCRIPTION
* Replaced `diag_mergeConfig` with `diag_mergeConfigFile` and improved its example
* Linked to BIKI on how to use the diagnostic exe