### PR TITLE
Removed pedantic errors and redefinition of M_PI variable

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -20,7 +20,7 @@ option(USE_STATIC_LINKING "USE_STATIC_LINKING" ON)
 
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-	SET(CMAKE_CXX_FLAGS "-std=c++11 -march=i686 -m32 -O2 -s -fPIC -fpermissive")
+	SET(CMAKE_CXX_FLAGS "-std=c++11 -pedantic -pedantic-errors -march=i686 -m32 -O2 -s -fPIC -fpermissive")
 	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 	set(CMAKE_SHARED_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/extensions/advanced_ballistics/AdvancedBallistics.cpp
+++ b/extensions/advanced_ballistics/AdvancedBallistics.cpp
@@ -5,7 +5,6 @@
 #include <unordered_map>
 #include <random>
 
-#define M_PI 3.14159265358979323846f
 #define GRAVITY 9.80665f
 #define ABSOLUTE_ZERO_IN_CELSIUS -273.15f
 #define KELVIN(t) (t - ABSOLUTE_ZERO_IN_CELSIUS)

--- a/extensions/break_line/ace_break_line.cpp
+++ b/extensions/break_line/ace_break_line.cpp
@@ -21,7 +21,7 @@
 
 extern "C" {
     EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
-};
+}
 
 std::vector<std::string> splitString(const std::string & input) {
     std::istringstream ss(input);

--- a/extensions/clipboard/ace_clipboard.cpp
+++ b/extensions/clipboard/ace_clipboard.cpp
@@ -15,7 +15,7 @@
 
 extern "C" {
     EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
-};
+}
 
 std::string gClipboardData;
 

--- a/extensions/common/p3d/animation.cpp
+++ b/extensions/common/p3d/animation.cpp
@@ -67,5 +67,5 @@ namespace ace {
         
                 animation::~animation() {
         }
-    };
-};
+    }
+}

--- a/extensions/common/p3d/animation.hpp
+++ b/extensions/common/p3d/animation.hpp
@@ -65,5 +65,5 @@ namespace ace {
             //ace::vector3<float> axis_dir;
         };
         typedef std::shared_ptr<animation> animation_p;
-    };
-};
+    }
+}

--- a/extensions/common/p3d/model.hpp
+++ b/extensions/common/p3d/model.hpp
@@ -53,5 +53,5 @@ namespace ace {
 
         };
         typedef std::shared_ptr<model> model_p;
-    };
-};
+    }
+}

--- a/extensions/common/p3d/model_info.hpp
+++ b/extensions/common/p3d/model_info.hpp
@@ -70,5 +70,5 @@ namespace ace {
         };
         typedef std::shared_ptr<model_info> model_info_p;
 
-    };
-};
+    }
+}

--- a/extensions/common/p3d/parser.hpp
+++ b/extensions/common/p3d/parser.hpp
@@ -13,5 +13,5 @@ namespace ace {
 
             model_p load(const std::string &);
         };
-    };
-};
+    }
+}

--- a/extensions/common/p3d/skeleton.hpp
+++ b/extensions/common/p3d/skeleton.hpp
@@ -32,5 +32,5 @@ namespace ace {
             std::vector<bone_p> all_bones;
         };
         typedef std::shared_ptr<skeleton> skeleton_p;
-    };
-};
+    }
+}

--- a/extensions/common/transform_matrix.hpp
+++ b/extensions/common/transform_matrix.hpp
@@ -31,4 +31,4 @@ namespace ace {
     };
 
     typedef transform_matrix_base<float> transform_matrix;
-};
+}

--- a/extensions/common/vector.hpp
+++ b/extensions/common/vector.hpp
@@ -168,4 +168,4 @@ namespace ace {
         T _x;
         T _y;
     };
-};
+}

--- a/extensions/fcs/ace_fcs.cpp
+++ b/extensions/fcs/ace_fcs.cpp
@@ -27,7 +27,7 @@
 
 extern "C" {
     EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
-};
+}
 
 std::vector<std::string> splitString(std::string input) {
     std::istringstream ss(input);

--- a/extensions/medical/medical.cpp
+++ b/extensions/medical/medical.cpp
@@ -14,7 +14,7 @@
 
 extern "C" {
     EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
-};
+}
 
 std::vector<std::string> parseExtensionInput(const std::string& input)
 {

--- a/extensions/parse_imagepath/ace_parse_imagepath.cpp
+++ b/extensions/parse_imagepath/ace_parse_imagepath.cpp
@@ -18,7 +18,7 @@
 
 extern "C" {
     __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
-};
+}
 
 std::string getImagePathFromStructuredText(const std::string & input) {
 	std::string returnValue = "";


### PR DESCRIPTION
This pull requests mainly does:

* Pedantic errors are added as compiling flags in GNU C++ compiler.
* Removed redefinition of M_PI in "extensions/advanced_ballistics/AdvancedBallistics.cpp" (defined already in "shared.hpp")
* Removed pedantic errors. Mainly extra ';' in definition on namespaces and "extern C" lines.