### PR TITLE
change order of BloodPressure readout, fix #2400

### DIFF
--- a/addons/medical/functions/fnc_actionCheckBloodPressureLocal.sqf
+++ b/addons/medical/functions/fnc_actionCheckBloodPressureLocal.sqf
@@ -22,7 +22,7 @@ _bloodPressure = if (!alive _target) then {
 } else {
     [_target] call FUNC(getBloodPressure)
 };
-_bloodPressure params ["_bloodPressureHigh", "_bloodPressureLow"];
+_bloodPressure params [ "_bloodPressureLow", "_bloodPressureHigh"];
 _output = "";
 _logOutPut = "";
 if ([_caller] call FUNC(isMedic)) then {


### PR DESCRIPTION
Fixes #2400

fnc_getBloodPressure returns:
`[_bloodPressureLow max 0, _bloodPressureHigh max 0]`