### PR TITLE
added the addons folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site/
 _theme_packages/
 _drafts/
+addons/
 
 Thumbs.db
 .DS_Store


### PR DESCRIPTION
**THIS IS FOR gh-pages ONLY**
Removes the need to delete the folder every time you checkout from master (or any branch tracking it)