### PR TITLE
_site folder added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 release/*
+_site/*
 *.cache
 *.pbo
 texHeaders.bin


### PR DESCRIPTION
**THIS IS FOR ANY BRANCH TRACKING MASTER AND MASTER ONLY**

Removes the need to delete the folder when switching from gh-pages or
any branch tracking it into a branch tracking master or master.