### PR TITLE
Medical tweaks

### DIFF
--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -159,7 +159,7 @@ GVAR(lastHeartBeatSound) = ACE_time;
         _heartRate = 60 + 40 * _pain;
     };
     if (_heartRate <= 0) exitwith {};
-    _interval = 60 / (_heartRate min 50);
+    _interval = 60 / (_heartRate min 40);
 
     if ((ACE_player getVariable ["ACE_isUnconscious", false])) then {
         if (GVAR(painEffectType) == 1) then {
@@ -173,7 +173,7 @@ GVAR(lastHeartBeatSound) = ACE_time;
 
             // Pain effect, no pain effect in zeus camera
             if (isNull curatorCamera) then {
-                _strength = (_pain - (ACE_player getvariable [QGVAR(painSuppress), 0])) max 0;
+                _strength = ((_pain - (ACE_player getvariable [QGVAR(painSuppress), 0])) max 0) min 1;
                 _strength = _strength * (ACE_player getVariable [QGVAR(painCoefficient), GVAR(painCoefficient)]);
                 if (GVAR(painEffectType) == 1) then {
                     GVAR(effectPainCC) ppEffectEnable false;

--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -20,7 +20,7 @@
 #include "script_component.hpp"
 
 private ["_typeOfProjectile", "_part", "_damageBodyParts", "_hitPoints"];
-params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfProjectile", "_newDamage"];
+params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfProjectile", "_hitPointNumber", "_newDamage"];
 
 _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitwith {};

--- a/addons/medical/functions/fnc_handleDamage_basic.sqf
+++ b/addons/medical/functions/fnc_handleDamage_basic.sqf
@@ -36,7 +36,7 @@ TRACE_4("ACE_DEBUG: HandleDamage BASIC",_unit, _damageBodyParts,_cache_params,_c
         if (alive _unit && {!(_unit getvariable ["ACE_isUnconscious", false])}) then {
             // If it reaches this, we can assume that the hit did not kill this unit, as this function is called 3 frames after the damage has been passed.
             if ([_unit, _part, if (_part > 1) then {_newDamage * 1.3} else {_newDamage * 2}] call FUNC(determineIfFatal)) then {
-                [_unit, true, 0.5+random(3)] call FUNC(setUnconscious);
+                [_unit, true, 0.5+random(10)] call FUNC(setUnconscious);
             };
         };
         _pain = _unit getVariable [QGVAR(pain), 0];

--- a/addons/medical/functions/fnc_handleDamage_caching.sqf
+++ b/addons/medical/functions/fnc_handleDamage_caching.sqf
@@ -76,7 +76,7 @@ if (diag_frameno > (_unit getVariable [QGVAR(frameNo_damageCaching), -3]) + 2) t
         private ["_args", "_params"];
         params ["_args", "_idPFH"];
         _args params ["_unit", "_frameno"];
-        if (diag_frameno > _frameno + 2) then {
+        if (diag_frameno >= _frameno + 2) then {
             _unit setDamage 0;
 
             if (GVAR(level) < 2 || {!([_unit] call FUNC(hasMedicalEnabled))}) then {

--- a/addons/medical/functions/fnc_treatmentBasic_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bandageLocal.sqf
@@ -28,7 +28,7 @@ if ((_damageBodyParts select _part) > 0) then {
     _damageOnPart = (_damageBodyParts select _part);
     // Temp quick fix to change in behaviour of basic medical bandaging
     if (_damageOnPart - BANDAGEHEAL > 0) then {
-        _damageOnPart = _damageOnPart * BANDAGEHEAL;
+        _damageOnPart = _damageOnPart - (_damageOnPart * BANDAGEHEAL);
     } else {
         _damageOnPart = _damageOnPart - BANDAGEHEAL;
     };

--- a/addons/medical/functions/fnc_treatmentBasic_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bandageLocal.sqf
@@ -25,7 +25,14 @@ _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitwith {false};
 
 if ((_damageBodyParts select _part) > 0) then {
-    _damageBodyParts set [_part, ((_damageBodyParts select _part) - BANDAGEHEAL) max 0];
+    _damageOnPart = (_damageBodyParts select _part);
+    // Temp quick fix to change in behaviour of basic medical bandaging
+    if (_damageOnPart - BANDAGEHEAL > 0) then {
+        _damageOnPart = _damageOnPart * BANDAGEHEAL;
+    } else {
+        _damageOnPart = _damageOnPart - BANDAGEHEAL;
+    };
+    _damageBodyParts set [_part, _damageOnPart max 0];
     _target setvariable [QGVAR(bodyPartStatus), _damageBodyParts, true];
     TRACE_2("ACE_DEBUG: Treatment BASIC Bandage Broadcast value here",_unit, _target getvariable QGVAR(bodyPartStatus));
 };


### PR DESCRIPTION
Some minor tweaks to medical based upon user feedback from RC testing.

- [x] Tweaked visual effects for pain. Lowered flashing, max strength of 1
- [x] Increase duration of knock down upon damage for basic medical
- [x] Missing damage execution
- [x] Increase chance of fatal injury when the damage is above given damage threshold
