### PR TITLE
Bad xeh check

### DIFF
--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -114,7 +114,7 @@ addMissionEventHandler ["Draw3D", DFUNC(render)];
         if ((isNil (format [QGVAR(Act_%1), typeOf _x])) || {isNil (format [QGVAR(SelfAct_%1), typeOf _x])}) then {
             if (!((typeOf _x) in _badClassnames)) then {
                 _badClassnames pushBack (typeOf _x);
-                ACE_LOGERROR_3("Compile checks bad for (classname: %1)(addon: %2) %1", (typeOf _x), (unitAddons (typeOf _x)), _x);
+                ACE_LOGERROR_3("Compile checks bad for (classname: %1)(addon: %2) %3", (typeOf _x), (unitAddons (typeOf _x)), _x);
             };
         };
     } forEach (allUnits + vehicles);

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -104,3 +104,25 @@ addMissionEventHandler ["Draw3D", DFUNC(render)];
         }];
     };
 }] call EFUNC(common,addEventHandler);
+
+
+//Debug to help end users identify mods that break CBA's XEH
+["SettingsInitialized", {
+    private ["_badClassnames"];
+    _badClassnames = [];
+    {
+        if ((isNil (format [QGVAR(Act_%1), typeOf _x])) || {isNil (format [QGVAR(SelfAct_%1), typeOf _x])}) then {
+            if (!((typeOf _x) in _badClassnames)) then {
+                _badClassnames pushBack (typeOf _x);
+                ACE_LOGERROR_3("Compile checks bad for (classname: %1)(addon: %2) %1", (typeOf _x), (unitAddons (typeOf _x)), _x);
+            };
+        };
+    } forEach (allUnits + vehicles);
+    if ((count _badClassnames) == 0) then {
+        ACE_LOGINFO("All compile checks passed");
+    } else {
+        ACE_LOGERROR_1("%1 Classnames failed compile check!!! (bad XEH / missing cba_enable_auto_xeh.pbo)", (count _badClassnames));
+        ["ACE Interaction failed to compile for some units (try adding cba_enable_auto_xeh.pbo)"] call BIS_fnc_error;
+    };
+}] call EFUNC(common,addEventHandler);
+

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -117,7 +117,7 @@ addMissionEventHandler ["Draw3D", DFUNC(render)];
                 ACE_LOGERROR_3("Compile checks bad for (classname: %1)(addon: %2) %3", (typeOf _x), (unitAddons (typeOf _x)), _x);
             };
         };
-    } forEach (allUnits + vehicles);
+    } forEach (allUnits + allDeadMen + vehicles);
     if ((count _badClassnames) == 0) then {
         ACE_LOGINFO("All compile checks passed");
     } else {


### PR DESCRIPTION
Ref #2437 (not our fault so it's not a fix)

At mission start checks for interaction menu compiles on all units and vehicles and spits out a message to users that there is a problem.

Designed to help users identify when mods break XEH (with RHS update I see this happening even more).
May help with #1171