### PR TITLE
Add new zeus addObjects setting to settings module

### DIFF
--- a/addons/zeus/ACE_Settings.hpp
+++ b/addons/zeus/ACE_Settings.hpp
@@ -21,9 +21,7 @@ class ACE_Settings {
         values[] = {"$STR_A3_OPTIONS_DISABLED", CSTRING(revealMines_partial), CSTRING(revealMines_full)};
     };
     class GVAR(autoAddObjects) {
-        displayName = CSTRING(AddObjectsToCurator);
-        description = CSTRING(AddObjectsToCurator_desc);
-        value = 0;
         typeName = "BOOL";
+        value = 0;
     };
 };

--- a/addons/zeus/ACE_Settings.hpp
+++ b/addons/zeus/ACE_Settings.hpp
@@ -23,5 +23,7 @@ class ACE_Settings {
     class GVAR(autoAddObjects) {
         typeName = "BOOL";
         value = 0;
+        displayName = CSTRING(AddObjectsToCurator);
+        description = CSTRING(AddObjectsToCurator_desc);
     };
 };

--- a/addons/zeus/CfgVehicles.hpp
+++ b/addons/zeus/CfgVehicles.hpp
@@ -70,6 +70,12 @@ class CfgVehicles {
                     };
                 };
             };
+            class GVAR(autoAddObjects) {
+                displayName = CSTRING(AddObjectsToCurator);
+                description = CSTRING(AddObjectsToCurator_desc);
+                typeName = "BOOL";
+                defaultValue = 0;
+            };
         };
         class ModuleDescription {
             description = CSTRING(Settings_Description);


### PR DESCRIPTION
The module part in CfgVehicles.hpp was missing and thus the option to turn it  on / off wasn't here.