### PR TITLE
Add CanInteractWith checks for repair

### DIFF
--- a/addons/repair/functions/fnc_canMiscRepair.sqf
+++ b/addons/repair/functions/fnc_canMiscRepair.sqf
@@ -20,6 +20,8 @@
 private ["_hitpointGroupConfig", "_hitpointGroup", "_postRepairDamage", "_return"];
 params ["_caller", "_target", "_hitPoint"];
 
+if !([_unit, _target, ["isNotDragging", "isNotCarrying", "isNotOnLadder"]] call EFUNC(common,canInteractWith)) exitWith {false};
+
 // Get hitpoint groups if available
 _hitpointGroupConfig = configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hitpointGroups);
 _hitpointGroup = [];

--- a/addons/repair/functions/fnc_canRemove.sqf
+++ b/addons/repair/functions/fnc_canRemove.sqf
@@ -20,4 +20,6 @@
 params ["_unit", "_target", "_hitPoint"];
 TRACE_3("params",_unit,_target,_hitPoint);
 
+if !([_unit, _target, ["isNotDragging", "isNotCarrying", "isNotOnLadder"]] call EFUNC(common,canInteractWith)) exitWith {false};
+
 alive _target && {_target getHitPointDamage _hitPoint < 1}

--- a/addons/repair/functions/fnc_canRepairTrack.sqf
+++ b/addons/repair/functions/fnc_canRepairTrack.sqf
@@ -21,6 +21,8 @@ params ["_unit", "_target", "_hitPoint", ["_wheel",false]];
 TRACE_4("params",_unit,_target,_hitPoint,_wheel);
 // TODO [_unit, _wheel] call EFUNC(common,claim); on start of action
 
+if !([_unit, _target, ["isNotDragging", "isNotCarrying", "isNotOnLadder"]] call EFUNC(common,canInteractWith)) exitWith {false};
+
 if (typeName _wheel == "OBJECT") then {
     // not near interpret as objNull
     if !(_wheel in nearestObjects [_unit, ["ACE_Track"], 5]) then {

--- a/addons/repair/functions/fnc_canReplaceTrack.sqf
+++ b/addons/repair/functions/fnc_canReplaceTrack.sqf
@@ -22,6 +22,8 @@ params ["_unit", "_target", "_hitPoint", ["_track", false]];
 TRACE_4("params",_unit,_target,_hitPoint,_track);
 // TODO [_unit, _track] call EFUNC(common,claim); on start of action
 
+if !([_unit, _target, ["isNotDragging", "isNotCarrying", "isNotOnLadder"]] call EFUNC(common,canInteractWith)) exitWith {false};
+
 if (typeName _track == "OBJECT") then {
     // not near interpret as objNull
     if !(_track in nearestObjects [_unit, ["ACE_Track"], 5]) then {

--- a/addons/repair/functions/fnc_canReplaceWheel.sqf
+++ b/addons/repair/functions/fnc_canReplaceWheel.sqf
@@ -23,7 +23,7 @@ TRACE_4("params",_unit,_target,_hitPoint,_wheel);
 // TODO [_unit, _wheel] call EFUNC(common,claim); on start of action
 //if !([_unit, _target, _hitpoint, "ReplaceWheel"] call FUNC(canRepair)) exitwith {false};
 
-//if !([_unit, _target, []] call EFUNC(common,canInteractWith)) exitWith {false};
+if !([_unit, _target, ["isNotDragging", "isNotCarrying", "isNotOnLadder"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
 //if !([_unit, GVAR(engineerSetting_Wheel)] call FUNC(isEngineer)) exitWith {false};
 


### PR DESCRIPTION
#2525

There is no canInterctWith check for repair actions, so right now you can remove wheels when underwater or handcuffed.

Does it make sense to do repairs underwater, if so we will want to add an exception for that??