### PR TITLE
Allow fixing jam when in FFV slot

### DIFF
--- a/addons/overheating/XEH_postInit.sqf
+++ b/addons/overheating/XEH_postInit.sqf
@@ -7,7 +7,7 @@ if (!hasInterface) exitWith {};
 ["ACE3 Weapons", QGVAR(unjamWeapon), localize LSTRING(UnjamWeapon),
 {
     // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, objNull, ["isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
     // Conditions: specific
     if !([ACE_player] call EFUNC(common,canUseWeapon) &&
     {currentWeapon ACE_player in (ACE_player getVariable [QGVAR(jammedWeapons), []])}


### PR DESCRIPTION
>But anyway you can't clear a weapon jam while turned out of a vehicle
>Like when using fire from vehicle in a commander hatch

The `EFUNC(common,canUseWeapon)` already limits this keybind to FFV / turned out animations states, so this should be safe.

Without this, there is no way to clear a jam.  (Shift+R) just reloads and does't fix the jam.