### PR TITLE
#2349 - Don't disable locking for base RocketPods

### DIFF
--- a/addons/laser_selfdesignate/CfgWeapons.hpp
+++ b/addons/laser_selfdesignate/CfgWeapons.hpp
@@ -2,7 +2,7 @@ class CfgWeapons {
     // Disable locking unless newb mode
     class LauncherCore;
     class RocketPods: LauncherCore {
-        canLock = 1;
+        // canLock = 1;
     };
 
     class missiles_DAGR: RocketPods {

--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -6,7 +6,7 @@ enum {
 class CfgAmmo {
     class MissileBase;
     
-    class M_PG_AT : MissileBase {
+    class M_PG_AT: MissileBase {
         model = "\A3\Weapons_F\Ammo\Rocket_01_fly_F";
         proxyShape = "\A3\Weapons_F\Ammo\Rocket_01_F";
 
@@ -68,15 +68,18 @@ class CfgAmmo {
         };
     };
     
-    class ACE_Hydra70_DAGR : M_PG_AT {
+    class ACE_Hydra70_DAGR: M_PG_AT {
         displayName = CSTRING(Hydra70_DAGR);
         displayNameShort = CSTRING(Hydra70_DAGR_Short);
         
         description = CSTRING(Hydra70_DAGR_Desc);
         descriptionShort = CSTRING(Hydra70_DAGR_Desc);
+        
+        //Explicity add guidance config
+        class ADDON: ADDON {};
     };
     
-    class ACE_Hellfire_AGM114K : ACE_Hydra70_DAGR {
+    class ACE_Hellfire_AGM114K: ACE_Hydra70_DAGR {
         displayName = CSTRING(Hellfire_AGM114K);
         displayNameShort = CSTRING(Hellfire_AGM114K_Short);
         
@@ -91,10 +94,13 @@ class CfgAmmo {
         indirectHit = 71;
         indirectHitRange = 4.5;
         effectsMissile = "missile2";
+        
+        //Explicity add guidance config
+        class ADDON: ADDON {};
     };
     
     // Titan
-    class M_Titan_AT : MissileBase {};
+    class M_Titan_AT: MissileBase {};
 
     class ACE_Javelin_FGM148: M_Titan_AT {
         irLock = 0;
@@ -145,8 +151,8 @@ class CfgAmmo {
         //Take config changes from (M_Titan_AT_static: M_Titan_AT)
         initTime = 0.25;  //"How long (in seconds) the projectile waits before starting it's engine.", - but doesn't seem to do anything
         effectsMissileInit = "RocketBackEffectsStaticRPG";
-        class ADDON: ADDON {
-            enabled = 1;
-        };
+
+        //Explicity add guidance config
+        class ADDON: ADDON {};
     };
 };

--- a/addons/missileguidance/CfgWeapons.hpp
+++ b/addons/missileguidance/CfgWeapons.hpp
@@ -4,7 +4,7 @@ class CfgWeapons {
     class LauncherCore;
     
     class RocketPods: LauncherCore {
-        canLock = 1;
+        // canLock = 1;
     };
     class missiles_DAGR : RocketPods {
         canLock = 1;


### PR DESCRIPTION
redo #2434 for master

Fix #2349 #1363 #1898

As far as I can tell, this is what missleguidance will be enabled for:

Name | Ammo  | Magazine | Weapon
------------- | ------------- | ------------- | -------------
DAGR | M_PG_AT | 24Rnd_PG_missiles | missiles_DAGR
Hydra70 | ACE_Hydra70_DAGR | 6Rnd_ACE_Hydra70_DAGR | missiles_DAGR
Hellfire (ComancheTest?) | ACE_Hellfire_AGM114K | 6Rnd_ACE_Hellfire_AGM114K | missiles_DAGR
Javelin Man | ACE_Javelin_FGM148 | Titan_AT | launch_Titan_short_base
Javelin Static | ACE_Javelin_FGM148_static | 1Rnd_GAT_missiles | missiles_titan_static

But right now we're setting `canLock` for the base **RocketPods** which breaks stuff like the `missiles_SCALPEL` (9K121 Vikhr) which the Greyhawk/AAF CAS use. Also the GBU.

I think we just want to mess with `canLock` on weapons where we have a guidence system in place (missiles_DAGR and both javelins)