### PR TITLE
Delay one frame when selecting explosives

### DIFF
--- a/addons/explosives/functions/fnc_addExplosiveActions.sqf
+++ b/addons/explosives/functions/fnc_addExplosiveActions.sqf
@@ -45,7 +45,7 @@ _children = [];
                 format ["Explosive_%1", _forEachIndex],
                 format [_name + " (%1)", _itemCount select _forEachIndex],
                 getText(_x >> "picture"),
-                {_this call FUNC(setupExplosive);},
+                {[{_this call FUNC(setupExplosive)}, _this] call EFUNC(common,execNextFrame)},
                 {true},
                 {},
                 (configName _x)


### PR DESCRIPTION
Fix #2537

I think we have to delay one frame because the interaction menu could still be partially open and the same mouse click used to select will trigger the setupExplosive click detector.