### PR TITLE
fix spectator view if called instantly

### DIFF
--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -72,8 +72,10 @@ if (_set) then {
         closeDialog 0;
     };
 
-    // Create the display
-    (findDisplay 46) createDisplay QGVAR(interface);
+    [{
+        // Create the display
+        (findDisplay 46) createDisplay QGVAR(interface);
+    }, []] call EFUNC(common,execNextFrame);
 
     // Cache and disable nametag settings
     if (["ace_nametags"] call EFUNC(common,isModLoaded)) then {


### PR DESCRIPTION
If you call setSpectator directly from init.sqf you'll be put into some
weird limbo mode with borders and spectator not working. This should fix
it