### PR TITLE
delay setUnconscious until the settings are inited

### DIFF
--- a/addons/medical/functions/fnc_setUnconscious.sqf
+++ b/addons/medical/functions/fnc_setUnconscious.sqf
@@ -21,6 +21,11 @@
 
 #define DEFAULT_DELAY (round(random(10)+5))
 
+// only run this after the settings are initialized
+if !(EGVAR(common,settingsInitFinished)) exitWith {
+    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(setUnconscious), _this];
+};
+
 private ["_animState", "_originalPos", "_startingTime", "_isDead"];
 params ["_unit", ["_set", true], ["_minWaitingTime", DEFAULT_DELAY], ["_force", false]];
 


### PR DESCRIPTION
Fixes #148

Confirmed working

5 AIs with
`[this, true] call ace_medical_fnc_setUnconscious`
in init box

No medic modle: 3 die and 2 are unconscious
With module and "AI Unconsciousness" set to "Enabled": All 5 unconscious