### PR TITLE
Optionalized Cargo Loaded Hint

### DIFF
--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -6,6 +6,7 @@
  * 0: Item Classname <STRING>
  * 1: Vehicle <OBJECT>
  * 2: Amount <NUMBER> (default: 1)
+ * 3: Show Hint <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -18,7 +19,7 @@
 #include "script_component.hpp"
 
 private ["_position", "_item", "_i"];
-params ["_itemClass", "_vehicle", ["_amount", 1]];
+params ["_itemClass", "_vehicle", ["_amount", 1], ["_showHint", false, [false]] ];
 TRACE_3("params",_itemClass,_vehicle,_amount);
 
 _position = getPos _vehicle;
@@ -29,7 +30,7 @@ for "_i" from 1 to _amount do {
     _item = createVehicle [_itemClass, _position, [], 0, "CAN_COLLIDE"];
 
     // Load item or delete it if no space left
-    if !([_item, _vehicle, false] call FUNC(loadItem)) exitWith {
+    if !([_item, _vehicle, _showHint] call FUNC(loadItem)) exitWith {
         TRACE_1("no room to load item - deleting",_item);
         deleteVehicle _item;
     };

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -29,12 +29,12 @@ for "_i" from 1 to _amount do {
     _item = createVehicle [_itemClass, _position, [], 0, "CAN_COLLIDE"];
 
     // Load item or delete it if no space left
-    if !([_item, _vehicle] call FUNC(loadItem)) exitWith {
+    if !([_item, _vehicle, false] call FUNC(loadItem)) exitWith {
         TRACE_1("no room to load item - deleting",_item);
         deleteVehicle _item;
     };
     TRACE_1("Item Loaded",_item);
-    
+
     // Invoke listenable event
     ["cargoAddedByClass", [_itemClass, _vehicle, _amount]] call EFUNC(common,globalEvent);
 };

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -5,6 +5,7 @@
  * Arguments:
  * 0: Object <OBJECT>
  * 1: Vehicle <OBJECT>
+ * 2: Show Hint <BOOL> (default: true)
  *
  * Return value:
  * Object loaded <BOOL>
@@ -18,7 +19,7 @@
 
 private ["_loaded", "_space", "_itemSize"];
 
-params ["_item", "_vehicle"];
+params ["_item", "_vehicle", ["_showHint", true, [true]] ];
 TRACE_2("params",_item,_vehicle);
 
 if !([_item, _vehicle] call FUNC(canLoadItemIn)) exitWith {
@@ -46,7 +47,9 @@ private ["_itemName", "_vehicleName"];
 _itemName = getText (configFile >> "CfgVehicles" >> typeOf _item >> "displayName");
 _vehicleName = getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName");
 
-["displayTextStructured", [[localize LSTRING(LoadedItem), _itemName, _vehicleName], 3.0]] call EFUNC(common,localEvent);
+if (_showHint) then {
+    ["displayTextStructured", [[localize LSTRING(LoadedItem), _itemName, _vehicleName], 3.0]] call EFUNC(common,localEvent);
+};
 
 // Invoke listenable event
 ["cargoLoaded", [_item, _vehicle]] call EFUNC(common,globalEvent);


### PR DESCRIPTION
And disabled it when called through `addCargoItem`, for example `addSpareParts`, which happens on vehicle init, would show the hint, even if the vehicle would be spawned during the mission.