### PR TITLE
Fix healHitPointAfterAdvBandage - Issue #2498.

### DIFF
--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -102,7 +102,7 @@ if (GVAR(healHitPointAfterAdvBandage)) then {
     private["_currentWounds", "_headWounds", "_bodyWounds", "_legsWounds", "_armWounds"];
 
     // Get the list of the wounds the target is currently suffering from.
-    _currentWounds = GETVAR(_target, openWounds, []);
+    _currentWounds = _target getvariable [QGVAR(openWounds), []];
 
     // Tally of unbandaged wounds to each body part.
     _headWounds = 0;

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -115,9 +115,9 @@ if (GVAR(healHitPointAfterAdvBandage)) then {
         _x params ["", "", "_bodyPart", "_numOpenWounds", "_bloodLoss"];
 
         // Use switch/case for early termination if wounded limb is found before all six are checked.
-        // Multiplying wounds by blood loss will either increment the wound count by
-        // some number (only care if greater than zero) or it will return zero indicating
-        // the body part is still undamaged.
+        // Number of wounds multiplied by blood loss will return zero for a fully
+        // bandaged body part, not incrementing the wound counter; or it will return
+        // some other number which will increment the wound counter. 
         switch (_bodyPart) do {
             // Head
             case 0: {

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -102,7 +102,7 @@ if (GVAR(healHitPointAfterAdvBandage)) then {
     private["_currentWounds", "_headWounds", "_bodyWounds", "_legsWounds", "_armWounds"];
 
     // Get the list of the wounds the target is currently suffering from.
-    _currentWounds = _target getvariable [QGVAR(openWounds), []];
+    _currentWounds = _target getVariable [QGVAR(openWounds), []];
 
     // Tally of unbandaged wounds to each body part.
     _headWounds = 0;
@@ -143,7 +143,7 @@ if (GVAR(healHitPointAfterAdvBandage)) then {
         if (_bodyPart == 5 && {(_numOpenWounds * _bloodLoss) > 0}) then {
             _legsWounds = _legsWounds + 1;
         };
-    } foreach _currentWounds;
+    } forEach _currentWounds;
 
     // Any body part that has no wounds is healed to full health
     if (_headWounds == 0) then {

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -98,13 +98,12 @@ if (_impact > 0 && {GVAR(enableAdvancedWounds)}) then {
 // so that the body part functions normally and blood is removed from the uniform.
 // Arma combines left and right arms into a single body part (HitHands), same with left and right legs (HitLegs).
 // Arms are actually hands.
-if (GVAR(healHitPointAfterAdvBandage)) then
-{
+if (GVAR(healHitPointAfterAdvBandage)) then {
     private["_currentWounds", "_headWounds", "_bodyWounds", "_legsWounds", "_armWounds"];
 
     // Get the list of the wounds the target is currently suffering from.
-    _currentWounds = _target getvariable [QGVAR(openWounds), []];
-
+    _currentWounds = GETVAR(_target, openWounds, []);
+    
     // Tally of unbandaged wounds to each body part.
     _headWounds = 0;
     _bodyWounds = 0;
@@ -115,19 +114,53 @@ if (GVAR(healHitPointAfterAdvBandage)) then
     {
         _x params ["", "", "_bodyPart", "_numOpenWounds", "_bloodLoss"];
 
-        if (_bodyPart == 0 && {(_numOpenWounds * _bloodLoss) > 0}) then { _headWounds = _headWounds + 1; }; // Head
-        if (_bodyPart == 1 && {(_numOpenWounds * _bloodLoss) > 0}) then { _bodyWounds = _bodyWounds + 1; }; // Body
-        if (_bodyPart == 2 && {(_numOpenWounds * _bloodLoss) > 0}) then { _armWounds  = _armWounds  + 1; }; // Left Arm
-        if (_bodyPart == 3 && {(_numOpenWounds * _bloodLoss) > 0}) then { _armWounds  = _armWounds  + 1; }; // Right Arm
-        if (_bodyPart == 4 && {(_numOpenWounds * _bloodLoss) > 0}) then { _legsWounds = _legsWounds + 1; }; // Left Leg
-        if (_bodyPart == 5 && {(_numOpenWounds * _bloodLoss) > 0}) then { _legsWounds = _legsWounds + 1; }; // Right Leg
+        // Head
+        if (_bodyPart == 0 && {(_numOpenWounds * _bloodLoss) > 0}) then {
+            _headWounds = _headWounds + 1;
+        };
+
+        // Body
+        if (_bodyPart == 1 && {(_numOpenWounds * _bloodLoss) > 0}) then {
+            _bodyWounds = _bodyWounds + 1;
+        };
+
+        // Left Arm
+        if (_bodyPart == 2 && {(_numOpenWounds * _bloodLoss) > 0}) then {
+            _armWounds = _armWounds  + 1;
+        };
+
+        // Right Arm
+        if (_bodyPart == 3 && {(_numOpenWounds * _bloodLoss) > 0}) then {
+            _armWounds = _armWounds  + 1;
+        };
+
+         // Left Leg
+        if (_bodyPart == 4 && {(_numOpenWounds * _bloodLoss) > 0}) then {
+            _legsWounds = _legsWounds + 1;
+        };
+
+         // Right Leg
+        if (_bodyPart == 5 && {(_numOpenWounds * _bloodLoss) > 0}) then {
+            _legsWounds = _legsWounds + 1;
+        };
     } foreach _currentWounds;
 
     // Any body part that has no wounds is healed to full health
-    if (_headWounds == 0) then { _target setHitPointDamage ["hitHead", 0.0];  };
-    if (_bodyWounds == 0) then { _target setHitPointDamage ["hitBody", 0.0];  };
-    if (_armWounds  == 0) then { _target setHitPointDamage ["hitHands", 0.0]; };
-    if (_legsWounds == 0) then { _target setHitPointDamage ["hitLegs", 0.0];  };
+    if (_headWounds == 0) then {
+        _target setHitPointDamage ["hitHead",  0.0];
+    };
+
+    if (_bodyWounds == 0) then {
+        _target setHitPointDamage ["hitBody",  0.0];
+    };
+
+    if (_armWounds == 0) then {
+        _target setHitPointDamage ["hitHands", 0.0];
+    };
+
+    if (_legsWounds == 0) then {
+        _target setHitPointDamage ["hitLegs",  0.0];
+    };
 };
 
 true;

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -114,34 +114,40 @@ if (GVAR(healHitPointAfterAdvBandage)) then {
     {
         _x params ["", "", "_bodyPart", "_numOpenWounds", "_bloodLoss"];
 
-        // Head
-        if (_bodyPart == 0 && {(_numOpenWounds * _bloodLoss) > 0}) then {
-            _headWounds = _headWounds + 1;
-        };
+        // Use switch/case for early termination if wounded limb is found before all six are checked.
+        // Multiplying wounds by blood loss will either increment the wound count by
+        // some number (only care if greater than zero) or it will return zero indicating
+        // the body part is still undamaged.
+        switch (_bodyPart) do {
+            // Head
+            case 0: {
+                _headWounds = _headWounds + (_numOpenWounds * _bloodLoss);
+            };
 
-        // Body
-        if (_bodyPart == 1 && {(_numOpenWounds * _bloodLoss) > 0}) then {
-            _bodyWounds = _bodyWounds + 1;
-        };
+            // Body
+            case 1: {
+                _bodyWounds = _bodyWounds + (_numOpenWounds * _bloodLoss);
+            };
 
-        // Left Arm
-        if (_bodyPart == 2 && {(_numOpenWounds * _bloodLoss) > 0}) then {
-            _armWounds = _armWounds  + 1;
-        };
+            // Left Arm
+            case 2: {
+                _armWounds = _armWounds + (_numOpenWounds * _bloodLoss);
+            };
 
-        // Right Arm
-        if (_bodyPart == 3 && {(_numOpenWounds * _bloodLoss) > 0}) then {
-            _armWounds = _armWounds  + 1;
-        };
+            // Right Arm
+            case 3: {
+                _armWounds = _armWounds + (_numOpenWounds * _bloodLoss);
+            };
 
-         // Left Leg
-        if (_bodyPart == 4 && {(_numOpenWounds * _bloodLoss) > 0}) then {
-            _legsWounds = _legsWounds + 1;
-        };
+            // Left Leg
+            case 4: {
+                _legsWounds = _legsWounds + (_numOpenWounds * _bloodLoss);
+            };
 
-         // Right Leg
-        if (_bodyPart == 5 && {(_numOpenWounds * _bloodLoss) > 0}) then {
-            _legsWounds = _legsWounds + 1;
+            // Right Leg
+            case 5: {
+                _legsWounds = _legsWounds + (_numOpenWounds * _bloodLoss);
+            };
         };
     } forEach _currentWounds;
 

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -113,14 +113,14 @@ if (GVAR(healHitPointAfterAdvBandage)) then
 
     // Loop through all current wounds and add up the number of unbandaged wounds on each body part.
     {
-        _x params ["", "", "_bodyPart", "_numOpenWounds"];
+        _x params ["", "", "_bodyPart", "_numOpenWounds", "_bloodLoss"];
 
-        if (_bodyPart == 0 && {_numOpenWounds > 0}) then { _headWounds = _headWounds + 1; }; // Head
-        if (_bodyPart == 1 && {_numOpenWounds > 0}) then { _bodyWounds = _bodyWounds + 1; }; // Body
-        if (_bodyPart == 2 && {_numOpenWounds > 0}) then { _armWounds  = _armWounds  + 1; }; // Left Arm
-        if (_bodyPart == 3 && {_numOpenWounds > 0}) then { _armWounds  = _armWounds  + 1; }; // Right Arm
-        if (_bodyPart == 4 && {_numOpenWounds > 0}) then { _legsWounds = _legsWounds + 1; }; // Left Leg
-        if (_bodyPart == 5 && {_numOpenWounds > 0}) then { _legsWounds = _legsWounds + 1; }; // Right Leg
+        if (_bodyPart == 0 && {(_numOpenWounds * _bloodLoss) > 0}) then { _headWounds = _headWounds + 1; }; // Head
+        if (_bodyPart == 1 && {(_numOpenWounds * _bloodLoss) > 0}) then { _bodyWounds = _bodyWounds + 1; }; // Body
+        if (_bodyPart == 2 && {(_numOpenWounds * _bloodLoss) > 0}) then { _armWounds  = _armWounds  + 1; }; // Left Arm
+        if (_bodyPart == 3 && {(_numOpenWounds * _bloodLoss) > 0}) then { _armWounds  = _armWounds  + 1; }; // Right Arm
+        if (_bodyPart == 4 && {(_numOpenWounds * _bloodLoss) > 0}) then { _legsWounds = _legsWounds + 1; }; // Left Leg
+        if (_bodyPart == 5 && {(_numOpenWounds * _bloodLoss) > 0}) then { _legsWounds = _legsWounds + 1; }; // Right Leg
     } foreach _currentWounds;
 
     // Any body part that has no wounds is healed to full health


### PR DESCRIPTION
[Issue: Adv. Medical Heal hitpoints doesn't work #2498.](https://github.com/acemod/ACE3/issues/2498)

With "ace_medical_healHitPointAfterAdvBandage" enabled fully bandaging wounded body parts were not healing those body parts in the Arma engine. ACE's interface would show body parts fully bandaged and undamaged but the player's uniform would remain bloody and the effected parts would remain non-functional (E.g.: Even though ACE thinks your legs are healed, Arma doesn't and you can't run. Your pants are also full of blood).

This fix checks to see if an ACE body part is fully bandaged and then heals the respective Arma body part while keeping in mind that Arma does not have separate body parts for left & right arms and legs. 