### PR TITLE
Remove enable optics in adjusted prone stances

### DIFF
--- a/addons/movement/CfgMoves.hpp
+++ b/addons/movement/CfgMoves.hpp
@@ -114,31 +114,6 @@ class CfgMovesMaleSdr: CfgMovesBasic {
             leftHandIKCurve[] = {};
         };
 
-        // enable optics in prone left and right stance
-        class AidlPpneMstpSrasWrflDnon_G0S;
-        class AadjPpneMstpSrasWrflDleft: AidlPpneMstpSrasWrflDnon_G0S {
-            enableOptics = 1;
-        };
-        class AadjPpneMstpSrasWrflDright: AidlPpneMstpSrasWrflDnon_G0S {
-            enableOptics = 1;
-        };
-        class AadjPpneMstpSrasWrflDup;
-        class AadjPpneMstpSrasWrflDdown: AadjPpneMstpSrasWrflDup {
-            enableOptics = 1;
-        };
-
-        class AidlPpneMstpSrasWpstDnon_G0S;
-        class AadjPpneMstpSrasWpstDleft: AidlPpneMstpSrasWpstDnon_G0S {
-            enableOptics = 2;
-        };
-        class AadjPpneMstpSrasWpstDright: AidlPpneMstpSrasWpstDnon_G0S {
-            enableOptics = 2;
-        };
-        class AadjPpneMstpSrasWpstDup;
-        class AadjPpneMstpSrasWpstDdown: AadjPpneMstpSrasWpstDup {
-            enableOptics = 2;
-        };
-
         // climb animation
         class AmovPercMstpSnonWnonDnon: StandBase {
             ConnectTo[] += {"ACE_Climb",0.02};

--- a/addons/movement/CfgMoves.hpp
+++ b/addons/movement/CfgMoves.hpp
@@ -114,6 +114,16 @@ class CfgMovesMaleSdr: CfgMovesBasic {
             leftHandIKCurve[] = {};
         };
 
+        // enable optics in prone down stance
+        class AadjPpneMstpSrasWrflDup;
+        class AadjPpneMstpSrasWrflDdown: AadjPpneMstpSrasWrflDup {
+            enableOptics = 1;
+        };
+        class AadjPpneMstpSrasWpstDup;
+        class AadjPpneMstpSrasWpstDdown: AadjPpneMstpSrasWpstDup {
+            enableOptics = 2;
+        };
+
         // climb animation
         class AmovPercMstpSnonWnonDnon: StandBase {
             ConnectTo[] += {"ACE_Climb",0.02};


### PR DESCRIPTION
From https://forums.bistudio.com/topic/140837-development-branch-changelog/?p=2922316:
> Fixed: Couldn't use sights in adjusted prone stance

If someone could confirm that on dev-branch that would be great, either way this PR removes that fix from ACE3, please set milestone to Backlog for now until it is in vanilla (stable branch).