### PR TITLE
- Fix gun smoke on AMV

### DIFF
--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -530,6 +530,10 @@ class CfgWeapons {
         displayName = "MAG 58";
     };
 
+    class ACE_LMG_coax_APC_Wheeled_01: LMG_coax {
+        displayName = "MAG 58";
+    };
+    
     class ACE_LMG_coax_APC_Tracked_03: LMG_coax {
         displayName = "L94A1";
     };

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -525,16 +525,14 @@ class CfgWeapons {
     class LMG_coax: LMG_RCWS {
         displayName = "PKT";
     };
-
-    class ACE_LMG_coax_MBT_01: LMG_coax {
+    // class ACE_LMG_coax_PKT_mem2: LMG_coax {};
+    class ACE_LMG_coax_MAG58_mem2: LMG_coax {
         displayName = "MAG 58";
     };
-
-    class ACE_LMG_coax_APC_Wheeled_01: LMG_coax {
+    class ACE_LMG_coax_MAG58_mem3: LMG_coax {
         displayName = "MAG 58";
     };
-    
-    class ACE_LMG_coax_APC_Tracked_03: LMG_coax {
+    class ACE_LMG_coax_L94A1_mem3: LMG_coax {
         displayName = "L94A1";
     };
 

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -281,7 +281,7 @@ class CfgVehicles {
     class B_APC_Wheeled_01_cannon_F: B_APC_Wheeled_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_40mm_CTWS","ACE_LMG_coax_MBT_01"};
+                weapons[] = {"autocannon_40mm_CTWS", "ACE_LMG_coax_APC_Wheeled_01"};
                 magazines[] = {"60Rnd_40mm_GPR_Tracer_Red_shells","40Rnd_40mm_APFSDS_Tracer_Red_shells","2000Rnd_762x51_Belt_Green"};
             };
         };

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -91,7 +91,7 @@ class CfgVehicles {
     class O_APC_Tracked_02_cannon_F: O_APC_Tracked_02_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_MBT_01","missiles_titan"};
+                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_PKT_mem2","missiles_titan"};
                 magazines[] = {"140Rnd_30mm_MP_shells_Tracer_Green","60Rnd_30mm_APFSDS_shells_Tracer_Green","2000Rnd_762x51_Belt_Green","2Rnd_GAT_missiles"};
             };
         };
@@ -101,7 +101,7 @@ class CfgVehicles {
         fuelCapacity = 660 * FUEL_FACTOR;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_30mm","ACE_LMG_coax_APC_Tracked_03"};
+                weapons[] = {"autocannon_30mm","ACE_LMG_coax_L94A1_mem3"};
                 magazines[] = {"140Rnd_30mm_MP_shells_Tracer_Yellow","60Rnd_30mm_APFSDS_shells_Tracer_Yellow","1000Rnd_762x51_Belt_Yellow","1000Rnd_762x51_Belt_Yellow"};
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -114,7 +114,7 @@ class CfgVehicles {
         fuelCapacity = 550 * FUEL_FACTOR;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"cannon_120mm_long","ACE_LMG_coax_MBT_01"};
+                weapons[] = {"cannon_120mm_long","ACE_LMG_coax_MAG58_mem3"};
                 magazines[] = {"28Rnd_120mm_APFSDS_shells_Tracer_Yellow","14Rnd_120mm_HE_shells_Tracer_Yellow","2000Rnd_762x51_Belt_Yellow","2000Rnd_762x51_Belt_Yellow"};
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -127,7 +127,7 @@ class CfgVehicles {
         fuelCapacity = 500 * FUEL_FACTOR;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"cannon_120mm","ACE_LMG_coax_MBT_01"};
+                weapons[] = {"cannon_120mm","ACE_LMG_coax_MAG58_mem2"};
                 magazines[] = {"32Rnd_120mm_APFSDS_shells_Tracer_Red","16Rnd_120mm_HE_shells_Tracer_Red","2000Rnd_762x51_Belt_Green","2000Rnd_762x51_Belt_Green"};
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -281,7 +281,7 @@ class CfgVehicles {
     class B_APC_Wheeled_01_cannon_F: B_APC_Wheeled_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_40mm_CTWS", "ACE_LMG_coax_APC_Wheeled_01"};
+                weapons[] = {"autocannon_40mm_CTWS", "ACE_LMG_coax_MAG58_mem2"};
                 magazines[] = {"60Rnd_40mm_GPR_Tracer_Red_shells","40Rnd_40mm_APFSDS_Tracer_Red_shells","2000Rnd_762x51_Belt_Green"};
             };
         };
@@ -301,7 +301,7 @@ class CfgVehicles {
     class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"cannon_105mm","ACE_LMG_coax_MBT_01"};
+                weapons[] = {"cannon_105mm","ACE_LMG_coax_MAG58_mem2"};
                 magazines[] = {"40Rnd_105mm_APFSDS_T_Red","20Rnd_105mm_HEAT_MP_T_Red","2000Rnd_762x51_Belt_Green","2000Rnd_762x51_Belt_Green"};
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -326,7 +326,7 @@ class CfgVehicles {
     class I_APC_Wheeled_03_cannon_F: I_APC_Wheeled_03_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_MBT_01","missiles_titan"};
+                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_MAG58_mem2","missiles_titan"};
                 magazines[] = {"140Rnd_30mm_MP_shells_Tracer_Yellow","60Rnd_30mm_APFSDS_shells_Tracer_Yellow","2000Rnd_762x51_Belt_Yellow","2Rnd_GAT_missiles"};
             };
         };

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -281,7 +281,7 @@ class CfgVehicles {
     class B_APC_Wheeled_01_cannon_F: B_APC_Wheeled_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_40mm_CTWS", "ACE_LMG_coax_MAG58_mem2"};
+                weapons[] = {"autocannon_40mm_CTWS","ACE_LMG_coax_MAG58_mem2"};
                 magazines[] = {"60Rnd_40mm_GPR_Tracer_Red_shells","40Rnd_40mm_APFSDS_Tracer_Red_shells","2000Rnd_762x51_Belt_Green"};
             };
         };

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -5,8 +5,18 @@ class CfgWeapons {
     class LMG_RCWS: MGun {};
 
     class LMG_coax;
-    class ACE_LMG_coax_MBT_01: LMG_coax {};
-    class ACE_LMG_coax_APC_Wheeled_01: LMG_coax {
+    class ACE_LMG_coax_L94A1_mem3: LMG_coax {};
+    class ACE_LMG_coax_PKT_mem2: LMG_coax {
+        class GunParticles {
+            class effect1 {
+                positionName = "usti hlavne2";
+                directionName = "konec hlavne2";
+                effectName = "MachineGunCloud";
+            };
+        };
+    };
+    class ACE_LMG_coax_MAG58_mem3: LMG_coax {};
+    class ACE_LMG_coax_MAG58_mem2: LMG_coax {
         class GunParticles {
             class effect1 {
                 positionName = "usti hlavne2";

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -6,7 +6,15 @@ class CfgWeapons {
 
     class LMG_coax;
     class ACE_LMG_coax_MBT_01: LMG_coax {};
-    class ACE_LMG_coax_APC_Tracked_03: LMG_coax {};
+    class ACE_LMG_coax_APC_Wheeled_01: LMG_coax {
+        class GunParticles {
+            class effect1 {
+                positionName = "usti hlavne2";
+                directionName = "konec hlavne2";
+                effectName = "MachineGunCloud";
+            };
+        };
+    };
 
     class LMG_Minigun: LMG_RCWS {
         magazines[] = {"1000Rnd_65x39_Belt","1000Rnd_65x39_Belt_Green","1000Rnd_65x39_Belt_Tracer_Green","1000Rnd_65x39_Belt_Tracer_Red","1000Rnd_65x39_Belt_Tracer_Yellow","1000Rnd_65x39_Belt_Yellow","2000Rnd_65x39_Belt","2000Rnd_65x39_Belt_Green","2000Rnd_65x39_Belt_Tracer_Green","2000Rnd_65x39_Belt_Tracer_Green_Splash","2000Rnd_65x39_Belt_Tracer_Red","2000Rnd_65x39_Belt_Tracer_Yellow","2000Rnd_65x39_Belt_Tracer_Yellow_Splash","2000Rnd_65x39_Belt_Yellow","2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","200Rnd_65x39_Belt","200Rnd_65x39_Belt_Tracer_Green","200Rnd_65x39_Belt_Tracer_Red","200Rnd_65x39_Belt_Tracer_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt"};


### PR DESCRIPTION
Fix #2701

weapon LMG_coax  uses `usti hlavne3`, 
AMV's default weapon and model expect `...2`