### PR TITLE
Docs: README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The mod is **built modularly**, so almost any included PBO can be easily removed
 
 ### Guides & how-tos
 If you installed ACE3 but have trouble understanding how it all works, or where to start, read this first:
+- [Installation guide](http://ace3mod.com/wiki/user/installation-guide.html)
 - [Information center](http://ace3mod.com/wiki/user/information-center.html)
 
 #### Contributing

--- a/README.md
+++ b/README.md
@@ -6,19 +6,22 @@
         <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
-        <img src="http://img.shields.io/badge/Download-62.0_MB-green.svg" alt="ACE3 Download">
+        <img src="https://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
-        <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
+        <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
     </a>
     <a href="https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/?p=2859670">
         <img src="https://img.shields.io/badge/BIF-Thread-lightgrey.svg" alt="BIF Thread">
     </a>
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
-        <img src="http://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
+        <img src="https://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
     </a>
-    <a href="http://slackin.koffeinflummi.de">
-        <img src="http://slackin.koffeinflummi.de/badge.svg" alt="ACE3 Slack">
+    <a href="http://slackin.ace3mod.com/">
+        <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
+    </a>
+    <a href="https://travis-ci.org/acemod/ACE3">
+        <img src="https://img.shields.io/travis/acemod/ACE3.svg?label=Build" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Requires the latest version of <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Visit us on <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>
@@ -66,7 +69,7 @@ The mod is **built modularly**, so almost any included PBO can be easily removed
 
 ### Guides & how-tos
 If you installed ACE3 but have trouble understanding how it all works, or where to start, read this first:
-- [Getting started](http://ace3mod.com/wiki/user/getting-started.html)
+- [Information center](http://ace3mod.com/wiki/user/information-center.html)
 
 #### Contributing
 You can help out with the ongoing development by looking for potential bugs in our code base, or by contributing new features. To contribute something to ACE3, simply fork this repository and submit your pull requests for review by other collaborators. Remember to add yourself to the author array of any PBO you will be editing and the [`AUTHORS.txt`](https://github.com/acemod/ACE3/blob/master/AUTHORS.txt) file; including a valid email address.

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -3,23 +3,26 @@
 </p>
 <p align="center">
     <a href="https://github.com/acemod/ACE3/releases">
-        <img src="https://img.shields.io/badge/Version-3.2.1-blue.svg" alt="ACE3 Version">
+        <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
-        <img src="http://img.shields.io/badge/Download-56.5_MB-green.svg" alt="ACE3 Download">
+    <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
+        <img src="https://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
-        <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
+        <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
     </a>
     <a href="https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/?p=2859670">
         <img src="https://img.shields.io/badge/BIF-Thread-lightgrey.svg" alt="BIF Thread">
     </a>
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
-        <img src="http://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
+        <img src="https://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
     </a>
-    <a href="http://slackin.koffeinflummi.de">
-        <img src="http://slackin.koffeinflummi.de/badge.svg" alt="ACE3 Slack">
-    </a>
+    <a href="http://slackin.ace3mod.com/">
+        <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
+     </a>
+    <a href="https://travis-ci.org/acemod/ACE3">
+        <img src="https://img.shields.io/travis/acemod/ACE3.svg?label=Build" alt="ACE3 Build Status">
+     </a>
 </p>
 <p align="center"><sup><strong>Benötigt die aktuellste Version von <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Besucht uns auf <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>
 
@@ -27,7 +30,7 @@
 
 Da die MOD vollkommen als **open-source** Projekt gestaltet ist, steht es jedem frei Änderungen vorzuschlagen, oder seine eigene, modifizierte Version zu erstellen, solange diese ebenfalls der Öffentlichkeit zugänglich ist und mit GNU General Public License übereinstimmt. (Weitere Informationen ist der Lizenzdatei in diesem Projekt entnehmbar)
 
-Die Mod ist **modular gestaltet** — beinahe jede PBO kann entfernt werden, sodass jede Gemeinschaft ihre eigene Version der Mod unterhalten kann. Dies kann zum Beispiel einige Funktionalitäten ausschließen, da das Feature nicht gewünscht ist, oder es mit einer anderen MOD in Konflikt gerät etc. .Ebenfalls können viele Einstellungen vom Missionsersteller vorgenommen werden (u.a. am medizinischem System), sodass eine individuelle Erfahrung gewährleistet wird.
+Die Mod ist **modular gestaltet** – beinahe jede PBO kann entfernt werden, sodass jede Gemeinschaft ihre eigene Version der Mod unterhalten kann. Dies kann zum Beispiel einige Funktionalitäten ausschließen, da das Feature nicht gewünscht ist, oder es mit einer anderen MOD in Konflikt gerät etc. .Ebenfalls können viele Einstellungen vom Missionsersteller vorgenommen werden (u.a. am medizinischem System), sodass eine individuelle Erfahrung gewährleistet wird.
 
 ### Features
 - Verbessertes medizinisches System
@@ -42,15 +45,15 @@ Die Mod ist **modular gestaltet** — beinahe jede PBO kann entfernt werden, sod
 
 #### Anleitungen
 Du hast ACE3 installiert, hast aber keine Ahnung was und wie alles funktioniert und wo sich was befindet?
-- [Erste Schritte](http://ace3mod.com/wiki/user/getting-started.html).
+- [Information center](http://ace3mod.com/wiki/user/information-center.html)
 
 #### Mitwirken
 Wenn du bei der Entwicklung der MOD mithelfen möchtest, so kannst du dies tun, indem du nach Fehlern Ausschau hältst, oder neue Funktionen vorschlägst. Um etwas beizutragen, "Forke" einfach dieses Archiv (bzw. repository) und erstelle deine "Pull-Request", welche von anderen Entwicklern und Beiträgern überprüft wird. Bitte trage dich dabei in [`AUTHORS.txt`](https://github.com/acemod/ACE3/blob/master/AUTHORS.txt) mit deinem Nutzernamen und einer gütligen Email-Adresse ein.  
 
-Um einen Fehler oder ein Feature zu melden bzw. ein bereits Bestehendes zu ändern - nutze unseren [Issue Tracker](https://github.com/acemod/ACE3/issues). Besuche auch:
+Um einen Fehler oder ein Feature zu melden bzw. ein bereits Bestehendes zu ändern – nutze unseren [Issue Tracker](https://github.com/acemod/ACE3/issues). Besuche auch:
 - [Wie kann ich ein Problem melden](http://ace3mod.com/wiki/user/how-to-report-an-issue.html)
 - [Wie kann ich ein Feature Request erstellen](http://ace3mod.com/wiki/user/how-to-make-a-feature-request.html)
 
 #### Testen & MOD erstellen
-Wenn du die neusten Entwicklungen erleben und uns dabei helfen möchtest bestehende Fehler zu entdecken, lade dir einfach die "Master Branch" herunter. Entweder nutzt du [Git](https://help.github.com/articles/fetching-a-remote/) - wenn die Schritte bekannt sind - oder du lädst es dir direkt über [diesen Link](https://github.com/acemod/ACE3/archive/master.zip) herunter.  
+Wenn du die neusten Entwicklungen erleben und uns dabei helfen möchtest bestehende Fehler zu entdecken, lade dir einfach die "Master Branch" herunter. Entweder nutzt du [Git](https://help.github.com/articles/fetching-a-remote/) – wenn die Schritte bekannt sind – oder du lädst es dir direkt über [diesen Link](https://github.com/acemod/ACE3/archive/master.zip) herunter.  
 Wie du deine eigene Entwicklungsumgebung und eine Testversion von ACE3 erstellst folge [dieser Anleitung](https://github.com/acemod/ACE3/blob/master/documentation/development/setting-up-the-development-environment.md).

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -3,22 +3,25 @@
 </p>
 <p align="center">
     <a href="https://github.com/acemod/ACE3/releases">
-        <img src="https://img.shields.io/badge/Wersja-3.2.1-blue.svg" alt="ACE3 Wersja">
+        <img src="https://img.shields.io/badge/Wersja-3.3.2-blue.svg" alt="ACE3 Wersja">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
-        <img src="http://img.shields.io/badge/Pobierz-56.5_MB-green.svg" alt="ACE3 Pobierz">
+    <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
+        <img src="https://img.shields.io/badge/Pobierz-65.7_MB-green.svg" alt="ACE3 Pobierz">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
-        <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Zagadnienia" alt="ACE3 Zagadnienia">
+        <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Zagadnienia" alt="ACE3 Zagadnienia">
     </a>
     <a href="https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/?p=2859670">
         <img src="https://img.shields.io/badge/Temat-BIF-lightgrey.svg" alt="Temat BIF">
     </a>
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
-        <img src="http://img.shields.io/badge/Licencja-GPLv2-red.svg" alt="ACE3 Licencja">
+        <img src="https://img.shields.io/badge/Licencja-GPLv2-red.svg" alt="ACE3 Licencja">
     </a>
-    <a href="http://slackin.koffeinflummi.de">
-        <img src="http://slackin.koffeinflummi.de/badge.svg" alt="ACE3 Slack">
+    <a href="http://slackin.ace3mod.com/">
+        <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
+    </a>
+    <a href="https://travis-ci.org/acemod/ACE3">
+        <img src="https://img.shields.io/travis/acemod/ACE3.svg?label=Build" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Wymaga najnowszej wersji <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Odwiedź nas na <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>
@@ -39,7 +42,7 @@ Modyfikacja ta jest **budowana modułowo**, dzięki temu prawie każdy dostarczo
 - Balistyka oparta na warunkach pogodowych i wietrze
 - Możliwość brania jeńców
 - Rozszerzony system ładunków wybuchowych, włączając w to użycie różnego rodzaju zapalników
-- Ulepszenia mapy - stawianie markerów i przybory mapy
+- Ulepszenia mapy – stawianie markerów i przybory mapy
 - Zaawansowane naprowadzanie rakiet i wskazywanie laserem
 
 #### Dodatkowe cechy
@@ -66,10 +69,10 @@ Modyfikacja ta jest **budowana modułowo**, dzięki temu prawie każdy dostarczo
 
 ### Poradniki i instrukcje
 Jeżeli zainstalowałeś ACE3 lecz masz problem ze zrozumieniem jak to wszystko działa, lub gdzie zacząć, zacznij od przeczytania tego:
-- [Wprowadzenie](http://ace3mod.com/wiki/user/getting-started.html)
+- [Information center](http://ace3mod.com/wiki/user/information-center.html)
 
 #### Współpraca
-Możesz pomóc w rozwoju addonu szukając potencjalnych bugów w naszym kodzie, lub zgłaszając nowe funkcje. Aby wnieść swój wkład do ACE3, po prostu zforkuj to repozytorium na swoje konto GitHub i zgłoś swoje pull requesty do przeglądu przez innych współpracowników. Pamiętaj, aby dodać siebie do listy autorów każdego PBO jakie edytujesz oraz do pliku ['AUTHORS.txt'](https://github.com/acemod/ACE3/blob/master/AUTHORS.txt) dodając także swój adres e-mail.
+Możesz pomóc w rozwoju addonu szukając potencjalnych bugów w naszym kodzie, lub zgłaszając nowe funkcje. Aby wnieść swój wkład do ACE3, po prostu zforkuj to repozytorium na swoje konto GitHub i zgłoś swoje pull requesty do przeglądu przez innych współpracowników. Pamiętaj, aby dodać siebie do listy autorów każdego PBO jakie edytujesz oraz do pliku [`AUTHORS.txt`](https://github.com/acemod/ACE3/blob/master/AUTHORS.txt) dodając także swój adres email.
 
 Używaj naszego [Issue Tracker-a](https://github.com/acemod/ACE3/issues) aby zgłaszać bugi, proponować nowe funkcje lub sugerować zmiany do aktualnie istniejących. Zobacz także:
 - [Jak zgłosić bug-a](http://ace3mod.com/wiki/user/how-to-report-an-issue.html)


### PR DESCRIPTION
The page previously titled as "Getting started" was renamed to "Information center", in the process changing its physical location within the site hierarchy and breaking the old link as a result.