### PR TITLE
Docs: cleanup & maintenance

### DIFF
--- a/wiki/development/branching-and-release.md
+++ b/wiki/development/branching-and-release.md
@@ -7,19 +7,17 @@ parent: wiki
 order: 5
 ---
 
-
 ## 1 Versioning
-
-For ACE3 we use an versioning strategy based on <a href="http://semver.org/">Semver</a>. This means our version numbering is structured `MAJOR.MINOR.PATCH.BUILD`. 
+For ACE3 we use an versioning strategy based on <a href="http://semver.org/">Semver</a>. This means our version numbering has the following structure:
+- **`MAJOR.MINOR.PATCH.BUILD`**  
 
 Because this modification is for Arma and backwards compatability is not always possible, our `MAJOR.MINOR.PATCH.BUILD` rules are slightly different. We increment the:
 
-    MAJOR version when we switch to a new arma version (ie Arma 4 or standalone expansion),
-    MINOR version when we add new features or large amount of bug fixes.
-    PATCH version when a release only contains bug fixes.
+    MAJOR version when we switch to a new arma version (i.e. Arma 4 or standalone expansion);
+    MINOR version when we add new features or large amount of bug fixes;
+    PATCH version when a release contains only bug fixes.
 
 ## 2 Branching and releases
-
 We have a release scheduled every 2 weeks on a Tuesday. On the Friday before release, the project management will decide whether or not this scheduled release will continue. When continuing  with the release, the current `master branch` will be merged into the `release branch`. The release branch will not contain any direct commits and no other branches will be merged into this branch. The exception being `hotfixes`, which are branched off `Release` and merged back into `Release` and `Master`. 
 
 `Hotfixes` are fixes for critical bugs that prevent stable gameplay with the currently available version of ACE3.
@@ -27,11 +25,9 @@ We have a release scheduled every 2 weeks on a Tuesday. On the Friday before rel
 During this release process between the Friday and Tuesday, the day of release, work can continue on as normal on the `Master branch`. This includes new features, bug fixes that won't make it for release or other work. These will not be merged into the `Release branch` until the next release cycle, normally 2 weeks later.
 
 ### 2.1 Branching
-
 * New features, bug fixes that are not a hotfix or other work will always be branched off `master` or another branch but never a `hotfix` or the `Release branch`. 
-* Hotfixes are always branched off the `Release branch`
+* Hotfixes are always branched off the `Release branch`.
 * The release branch is never merged or deleted. Only master or hotfixes are allowed to merge into the `Release branch`. 
 
 ### 2.2 Diagram
-
 <a href="{{ site.baseurl }}/img/wiki/development/release_and_branching.jpg"><img src="{{ site.baseurl }}/img/wiki/development/release_and_branching.jpg" alt="Release and branching flowchart" /></a>

--- a/wiki/development/merging-pull-requests.md
+++ b/wiki/development/merging-pull-requests.md
@@ -9,14 +9,13 @@ order: 5
 
 Who's responsible for merging pull requests.
 
-All authors must add themselves to the AUTHORS.txt file **with a valid email adress**.
+All authors must add themselves to the AUTHORS.txt file **with a valid email address**.
 
 
-#### Changes To Existing Addons
-
+#### Changes to Existing Addons
 The people responsible for merging changes to existing addons are the maintainers listed in the README.md file of the respective addon folder.
 
-If the changes consists of trivial changes, such as spelling or indentation fixes:
+If the changes consist of trivial updates, such as spelling or indentation fixes:
 
 ```diff
      valueA = 12;
@@ -25,13 +24,12 @@ If the changes consists of trivial changes, such as spelling or indentation fixe
 +    valueC = 2;
 ```
 
-... the PR can be merged right away by one of the maintainers.
+...then the PR can be merged right away by one of the maintainers.
 
 Non-trivial pull requests remain open for a minimum of 48 hours, to give all other contributors time to comment on potential issues, and are then merged by a maintainer, should no issues arise.
 
 
 #### New Addons / Other Changes
-
 If a pull request adds a new addon, or changes something else, like the README, everyone has 72 hours to comment on the changes. After that, one of the team leads ([NouberNou](https://github.com/NouberNou), [KoffeinFlummi](https://github.com/KoffeinFlummi), [Glowbal](https://github.com/Glowbal)) will merge it.
 
 Trivial changes such as spelling fixes can be merged immediately by any contributor.

--- a/wiki/user/information-center.md
+++ b/wiki/user/information-center.md
@@ -9,46 +9,43 @@ parent: wiki
 
 Downloaded ACE3 and have no idea where to start? This page serves as a starting point to help new players and mission makers understand what's available to them.
 
+**Q:** Don't know where to begin your ACE3 journey?</br>
+**A:** [**Check out ACE3 features**](http://ace3mod.com/wiki/feature/)
 
-- You don't know where to begin your ACE3 journey? [**Check out ACE3 features**](http://ace3mod.com/wiki/feature/)
+**Q:** Are you a mission maker but don't know yet what ACE3 has to offer?</br>
+**A:** [**We have a wiki section just for you**](http://ace3mod.com/wiki/missionmaker/)
 
-
-- You are a mission maker but you don't know what ACE3 has to offer? [**We have some documentation for you**](http://ace3mod.com/wiki/missionmaker/)
-
-
-- Are you searching for ACE3 classnames ? [**Here they are**](http://ace3mod.com/wiki/missionmaker/classnames.html)
-
+**Q:** Looking for information on ACE3 class names?</br>
+**A:** [**Here they are**](http://ace3mod.com/wiki/missionmaker/class-names.html)
 
 ## 1. FAQ
 ### 1.1 Features
-**Q:** Where is X feature? </br>
-**A:** When it's done.</br>
+**Q:** Where is X feature?</br>
+**A:** When it's done.
 
 **Q:** Feature X was in ACE2/AGM/CSE where is it?</br>
-**A:** It's going to be ported at some point.</br>
+**A:** It's going to be ported at some point.
 
 **Q:** Why was my feature request closed on GitHub?</br>
-**A:** Feature requests should initially be added to issue #414 for easy tracking.[HERE](https://github.com/acemod/ACE3/issues/414/)
+**A:** Feature requests should initially be added to issue #414 for easy tracking ([HERE](https://github.com/acemod/ACE3/issues/414/)).
 
-**Q:** I want to disable feature X how do I do it?</br>
-**A:** Simply delete the PBO.(note that some features depends on others, check dependencies before deleting anything).</br>
+**Q:** I want to disable feature X, how do I do that?</br>
+**A:** Simply remove the associated module (delete its PBO). Note, however, that some features might depend on others; make sure to check dependencies before disabling anything.
 
 ### 1.2 Issues
-
 **Q:** Laser locking is broken, when are you going to fix it?</br>
-**A:** Fun fact, it isn't, you need to come from the direction of the laser, (laser is pointing to the east, you come from the west) and you drop the GBU, it will then guide itself to the target. The reasoning behind that is that the vehicle or building laser designated would obstruct the laser and the GBU would then be unable to lock on it. </br>
+**A:** Fun fact, it isn't, you need to come from the direction of the laser, (laser is pointing to the east, you come from the west) and you drop the GBU, it will then guide itself to the target. The reasoning behind that is that the vehicle or building laser designated would obstruct the laser and the GBU would then be unable to lock on it.
 
-**Q:** I am having dll errors.</br>
+**Q:** Experiencing DLL errors.</br>
 **A:** Start the game once with the Arma 3 Launcher, close it, then start the game with your usual launcher (ArmA3Sync, Play withSix, etc &hellip;).</br>
-The simple explanation is that the BattlEye process wasn't ended properly and is unable to start again properly, launching it with the Arma 3 Launcher is the only known solution to fix it.</br>
+>The simple explanation is that the BattlEye process wasn't ended properly and is unable to start again properly, launching it with the Arma 3 Launcher is the only known solution to fix it.
 
-**Q:** ACE3 fonts is outdated.</br>
+**Q:** ACE3 fonts are outdated.</br>
 **A:** This happens because you have file patching enabled, restart your game without the `-FilePatching` param.
 
 ### 1.3 Compatibility
-
 **Q:** (mod) doesn't have some ACE3 features.</br>
-**A:** ACE3 isn't and can't be responsible for compatibility with every (mod), due it's size other (mod) authors are strongly encouraged to provide that from their side. Compatibility PBO's currently in ACE3 are there to kick-start and provide examples for (mod) authors.</br>
+**A:** ACE3 isn't and can't be responsible for compatibility with every (mod), due it's size other (mod) authors are strongly encouraged to provide that from their side. Compatibility PBO's currently in ACE3 are there to kick-start and provide examples for (mod) authors.
 
 **Q:** ACE3 causes issues in (mod).</br>
-**A:** If you've found an issue with ACE3 please make sure that ACE3 is really the cause of the problem. To do this try to reproduce the issue with using only `@CBA_A3` and `@ace` on a newly created mission. ACE3 isn't and can't be responsible for all mod conflicts, due it's size other mod authors are strongly encouraged to provide that from their side.</br>
+**A:** If you've found an issue with ACE3 please make sure that ACE3 is really the cause of the problem. To do this try to reproduce the issue with using only `@CBA_A3` and `@ace` on a newly created mission. ACE3 isn't and can't be responsible for all mod conflicts, due it's size other mod authors are strongly encouraged to provide that from their side.

--- a/wiki/user/information-center.md
+++ b/wiki/user/information-center.md
@@ -9,43 +9,43 @@ parent: wiki
 
 Downloaded ACE3 and have no idea where to start? This page serves as a starting point to help new players and mission makers understand what's available to them.
 
-**Q:** Don't know where to begin your ACE3 journey?</br>
+**Q:** Don't know where to begin your ACE3 journey?  
 **A:** [**Check out ACE3 features**](http://ace3mod.com/wiki/feature/)
 
-**Q:** Are you a mission maker but don't know yet what ACE3 has to offer?</br>
+**Q:** Are you a mission maker but don't know yet what ACE3 has to offer?  
 **A:** [**We have a wiki section just for you**](http://ace3mod.com/wiki/missionmaker/)
 
-**Q:** Looking for information on ACE3 class names?</br>
+**Q:** Looking for information on ACE3 class names?  
 **A:** [**Here they are**](http://ace3mod.com/wiki/missionmaker/class-names.html)
 
 ## 1. FAQ
 ### 1.1 Features
-**Q:** Where is X feature?</br>
-**A:** When it's done.
+**Q:** Where is X feature?  
+**A:** When it's done!
 
-**Q:** Feature X was in ACE2/AGM/CSE where is it?</br>
+**Q:** Feature X was in ACE2/AGM/CSE where is it?  
 **A:** It's going to be ported at some point.
 
-**Q:** Why was my feature request closed on GitHub?</br>
+**Q:** Why was my feature request closed on GitHub?  
 **A:** Feature requests should initially be added to issue #414 for easy tracking ([HERE](https://github.com/acemod/ACE3/issues/414/)).
 
-**Q:** I want to disable feature X, how do I do that?</br>
+**Q:** I want to disable feature X, how do I do that?  
 **A:** Simply remove the associated module (delete its PBO). Note, however, that some features might depend on others; make sure to check dependencies before disabling anything.
 
 ### 1.2 Issues
-**Q:** Laser locking is broken, when are you going to fix it?</br>
+**Q:** Laser locking is broken, when are you going to fix it?  
 **A:** Fun fact, it isn't, you need to come from the direction of the laser, (laser is pointing to the east, you come from the west) and you drop the GBU, it will then guide itself to the target. The reasoning behind that is that the vehicle or building laser designated would obstruct the laser and the GBU would then be unable to lock on it.
 
-**Q:** Experiencing DLL errors.</br>
-**A:** Start the game once with the Arma 3 Launcher, close it, then start the game with your usual launcher (ArmA3Sync, Play withSix, etc &hellip;).</br>
+**Q:** Experiencing DLL errors.  
+**A:** Start the game once with the Arma 3 Launcher, close it, then start the game with your usual launcher (ArmA3Sync, Play withSix, etc &hellip;).  
 >The simple explanation is that the BattlEye process wasn't ended properly and is unable to start again properly, launching it with the Arma 3 Launcher is the only known solution to fix it.
 
-**Q:** ACE3 fonts are outdated.</br>
+**Q:** ACE3 fonts are outdated.  
 **A:** This happens because you have file patching enabled, restart your game without the `-FilePatching` param.
 
 ### 1.3 Compatibility
-**Q:** (mod) doesn't have some ACE3 features.</br>
+**Q:** (mod) doesn't have some ACE3 features.  
 **A:** ACE3 isn't and can't be responsible for compatibility with every (mod), due it's size other (mod) authors are strongly encouraged to provide that from their side. Compatibility PBO's currently in ACE3 are there to kick-start and provide examples for (mod) authors.
 
-**Q:** ACE3 causes issues in (mod).</br>
+**Q:** ACE3 causes issues in (mod).  
 **A:** If you've found an issue with ACE3 please make sure that ACE3 is really the cause of the problem. To do this try to reproduce the issue with using only `@CBA_A3` and `@ace` on a newly created mission. ACE3 isn't and can't be responsible for all mod conflicts, due it's size other mod authors are strongly encouraged to provide that from their side.


### PR DESCRIPTION
The "Class names" page has changed to being written as two separate words (hyphenated in the URL).

Also, formatted the preamble questionnaire to resemble the FAQ lists that follow it.