### PR TITLE
Update README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@
         <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
-        <img src="http://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
+        <img src="https://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
-        <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
+        <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
     </a>
     <a href="https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/?p=2859670">
         <img src="https://img.shields.io/badge/BIF-Thread-lightgrey.svg" alt="BIF Thread">
     </a>
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
-        <img src="http://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
+        <img src="https://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
     </a>
     <a href="http://slackin.ace3mod.com/">
         <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
     </a>
     <a href="https://travis-ci.org/acemod/ACE3">
-        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 Build Status">
+        <img src="https://img.shields.io/travis/acemod/ACE3.svg" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Requires the latest version of <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Visit us on <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
         <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
-        <img src="http://img.shields.io/badge/Download-62.0_MB-green.svg" alt="ACE3 Download">
+        <img src="http://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
         <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
         <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
     </a>
     <a href="https://travis-ci.org/acemod/ACE3">
-        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 CI Status (master branch)">
+        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Requires the latest version of <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Visit us on <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
         <img src="http://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
     </a>
-    <a href="http://slackin.koffeinflummi.de">
-        <img src="http://slackin.koffeinflummi.de/badge.svg" alt="ACE3 Slack">
+    <a href="http://slackin.ace3mod.com/">
+        <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
+    </a>
+    <a href="https://travis-ci.org/acemod/ACE3">
+        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 CI Status (master branch)">
     </a>
 </p>
 <p align="center"><sup><strong>Requires the latest version of <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Visit us on <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -17,8 +17,11 @@
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
         <img src="http://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
     </a>
-    <a href="http://slackin.koffeinflummi.de">
-        <img src="http://slackin.koffeinflummi.de/badge.svg" alt="ACE3 Slack">
+    <a href="http://slackin.ace3mod.com/">
+        <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
+    </a>
+    <a href="https://travis-ci.org/acemod/ACE3">
+        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 CI Status (master branch)">
     </a>
 </p>
 <p align="center"><sup><strong>Benötigt die aktuellste Version von <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Besucht uns auf <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -5,7 +5,7 @@
     <a href="https://github.com/acemod/ACE3/releases">
         <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
+    <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
         <img src="https://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -21,7 +21,7 @@
         <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
     </a>
     <a href="https://travis-ci.org/acemod/ACE3">
-        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 CI Status (master branch)">
+        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Benötigt die aktuellste Version von <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Besucht uns auf <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -6,22 +6,22 @@
         <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
-        <img src="http://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
+        <img src="https://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
-        <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
+        <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">
     </a>
     <a href="https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/?p=2859670">
         <img src="https://img.shields.io/badge/BIF-Thread-lightgrey.svg" alt="BIF Thread">
     </a>
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
-        <img src="http://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
+        <img src="https://img.shields.io/badge/License-GPLv2-red.svg" alt="ACE3 License">
     </a>
     <a href="http://slackin.ace3mod.com/">
         <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
     </a>
     <a href="https://travis-ci.org/acemod/ACE3">
-        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 Build Status">
+        <img src="https://img.shields.io/travis/acemod/ACE3.svg" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Benötigt die aktuellste Version von <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Besucht uns auf <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -3,10 +3,10 @@
 </p>
 <p align="center">
     <a href="https://github.com/acemod/ACE3/releases">
-        <img src="https://img.shields.io/badge/Version-3.2.1-blue.svg" alt="ACE3 Version">
+        <img src="https://img.shields.io/badge/Version-3.3.2-blue.svg" alt="ACE3 Version">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
-        <img src="http://img.shields.io/badge/Download-56.5_MB-green.svg" alt="ACE3 Download">
+        <img src="http://img.shields.io/badge/Download-65.7_MB-green.svg" alt="ACE3 Download">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
         <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Issues" alt="ACE3 Issues">

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -21,7 +21,7 @@
         <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
     </a>
     <a href="https://travis-ci.org/acemod/ACE3">
-        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 CI Status (master branch)">
+        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Wymaga najnowszej wersji <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Odwiedź nas na <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -3,10 +3,10 @@
 </p>
 <p align="center">
     <a href="https://github.com/acemod/ACE3/releases">
-        <img src="https://img.shields.io/badge/Wersja-3.2.1-blue.svg" alt="ACE3 Wersja">
+        <img src="https://img.shields.io/badge/Wersja-3.3.2-blue.svg" alt="ACE3 Wersja">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
-        <img src="http://img.shields.io/badge/Pobierz-56.5_MB-green.svg" alt="ACE3 Pobierz">
+        <img src="http://img.shields.io/badge/Pobierz-65.7_MB-green.svg" alt="ACE3 Pobierz">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
         <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Zagadnienia" alt="ACE3 Zagadnienia">

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -6,22 +6,22 @@
         <img src="https://img.shields.io/badge/Wersja-3.3.2-blue.svg" alt="ACE3 Wersja">
     </a>
     <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
-        <img src="http://img.shields.io/badge/Pobierz-65.7_MB-green.svg" alt="ACE3 Pobierz">
+        <img src="https://img.shields.io/badge/Pobierz-65.7_MB-green.svg" alt="ACE3 Pobierz">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">
-        <img src="http://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Zagadnienia" alt="ACE3 Zagadnienia">
+        <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Zagadnienia" alt="ACE3 Zagadnienia">
     </a>
     <a href="https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/?p=2859670">
         <img src="https://img.shields.io/badge/Temat-BIF-lightgrey.svg" alt="Temat BIF">
     </a>
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
-        <img src="http://img.shields.io/badge/Licencja-GPLv2-red.svg" alt="ACE3 Licencja">
+        <img src="https://img.shields.io/badge/Licencja-GPLv2-red.svg" alt="ACE3 Licencja">
     </a>
     <a href="http://slackin.ace3mod.com/">
         <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
     </a>
     <a href="https://travis-ci.org/acemod/ACE3">
-        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 Build Status">
+        <img src="https://img.shields.io/travis/acemod/ACE3.svg" alt="ACE3 Build Status">
     </a>
 </p>
 <p align="center"><sup><strong>Wymaga najnowszej wersji <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Odwiedź nas na <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -5,7 +5,7 @@
     <a href="https://github.com/acemod/ACE3/releases">
         <img src="https://img.shields.io/badge/Wersja-3.3.2-blue.svg" alt="ACE3 Wersja">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.2.1/ace3_3.2.1.zip">
+    <a href="https://github.com/acemod/ACE3/releases/download/v3.3.2/ace3_3.3.2.zip">
         <img src="https://img.shields.io/badge/Pobierz-65.7_MB-green.svg" alt="ACE3 Pobierz">
     </a>
     <a href="https://github.com/acemod/ACE3/issues">

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -17,8 +17,11 @@
     <a href="https://github.com/acemod/ACE3/blob/master/LICENSE">
         <img src="http://img.shields.io/badge/Licencja-GPLv2-red.svg" alt="ACE3 Licencja">
     </a>
-    <a href="http://slackin.koffeinflummi.de">
-        <img src="http://slackin.koffeinflummi.de/badge.svg" alt="ACE3 Slack">
+    <a href="http://slackin.ace3mod.com/">
+        <img src="http://slackin.ace3mod.com/badge.svg" alt="ACE3 Slack">
+    </a>
+    <a href="https://travis-ci.org/acemod/ACE3">
+        <img src="https://travis-ci.org/acemod/ACE3.svg?branch=master" alt="ACE3 CI Status (master branch)">
     </a>
 </p>
 <p align="center"><sup><strong>Wymaga najnowszej wersji <a href="https://github.com/CBATeam/CBA_A3/releases">CBA A3</a>. Odwiedź nas na <a href="https://www.facebook.com/ACE3Mod">Facebook</a> | <a href="https://www.youtube.com/c/ACE3Mod">YouTube</a> | <a href="https://twitter.com/ACE3Mod">Twitter</a> | <a href="http://www.reddit.com/r/arma/search?q=ACE&restrict_sr=on&sort=new&t=all">Reddit</a></strong></sup></p>


### PR DESCRIPTION
- Fixed Slackin badge links (were still pointing to koffeinflummi.de)
- Added Travis CI build status (master branch) badge
- Updated version in non-English files
- Updated download size

The Travis CI build status badge is at the end now, might be better to move it elsewhere, feel free to give suggestions.