### PR TITLE
Add shebang line to specify python version to SQF validator

### DIFF
--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 import fnmatch
 import os
@@ -149,11 +150,11 @@ def main():
     args = parser.parse_args()
 
     # Allow running from root directory as well as from inside the tools directory
-    rootDir = "../addons"
+    rootDir = "..\\addons"
     if (os.path.exists("addons")):
         rootDir = "addons"
 
-    for root, dirnames, filenames in os.walk(rootDir + '/' + args.module):
+    for root, dirnames, filenames in os.walk(rootDir + '\\' + args.module):
       for filename in fnmatch.filter(filenames, '*.sqf'):
         sqf_list.append(os.path.join(root, filename))
 


### PR DESCRIPTION
So it can be used without specifying python version from command line.