### PR TITLE
Simplify Map Light Interactions

### DIFF
--- a/addons/map/CfgVehicles.hpp
+++ b/addons/map/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
             class ACE_MapFlashlight {
                 displayName = CSTRING(Action_Flashlights);
                 icon = QUOTE(\a3\ui_f\data\IGUI\Cfg\VehicleToggles\lightsiconon_ca.paa);
-                condition = QUOTE(GVAR(mapIllumination) && visibleMap && (count ([ACE_player] call FUNC(getUnitFlashlights)) > 0));
+                condition = QUOTE(GVAR(mapIllumination) && visibleMap && {count ([ACE_player] call FUNC(getUnitFlashlights)) > 0});
                 statement = "true";
                 exceptions[] = {"isNotDragging", "notOnMap", "isNotInside", "isNotSitting"};
                 insertChildren = QUOTE(_this call DFUNC(compileFlashlightMenu));

--- a/addons/map/functions/fnc_compileFlashlightMenu.sqf
+++ b/addons/map/functions/fnc_compileFlashlightMenu.sqf
@@ -30,7 +30,6 @@ _flashlights = [_player] call FUNC(getUnitFlashlights);
     _cfg = (configFile >> "CfgWeapons" >> _x);
     _displayName = getText (_cfg >> "displayName");
     _icon = getText (_cfg >> "picture");
-    _statement = {};
     
     _statement = if (GVAR(flashlightInUse) == _x) then {
         _displayName = format [localize LSTRING(turnLightOff), _displayName];

--- a/addons/map/functions/fnc_compileFlashlightMenu.sqf
+++ b/addons/map/functions/fnc_compileFlashlightMenu.sqf
@@ -18,47 +18,30 @@
 
 #include "script_component.hpp"
 
-params ["_vehicle", "_player", "_parameters"];
+params ["", "_player"];
+
+private["_action", "_actions", "_cfg", "_displayName", "_flashlights", "_icon", "_statement"];
 
 _actions = [];
 _flashlights = [_player] call FUNC(getUnitFlashlights);
 
 //add all carried flashlight menus and on/off submenu actions
 {
-    private ["_cfg", "_displayName"," _icon", "_children", "_parentAction"];
     _cfg = (configFile >> "CfgWeapons" >> _x);
     _displayName = getText (_cfg >> "displayName");
     _icon = getText (_cfg >> "picture");
-
-    _children = {
-        private ["_onAction", "_offAction"];
-        params ["_vehicle", "_player", "_flashlight"];
-
-        _onAction = [
-            (_flashlight + "_On"),
-            "On",
-            "",
-            {[_this select 2] call FUNC(switchFlashlight)},
-            {GVAR(flashlightInUse) != (_this select 2)},
-            {},
-            _flashlight
-        ] call EFUNC(interact_menu,createAction);
-
-        _offAction = [
-            (_flashlight + "_Off"),
-            "Off",
-            "",
-            {[""] call FUNC(switchFlashlight)},
-            {GVAR(flashlightInUse) == (_this select 2)},
-            {},
-            _flashlight
-        ] call EFUNC(interact_menu,createAction);
-
-        [[_onAction, [], _player], [_offAction, [], _player]]
+    _statement = {};
+    
+    _statement = if (GVAR(flashlightInUse) == _x) then {
+        _displayName = format [localize LSTRING(turnLightOff), _displayName];
+        {[""] call FUNC(switchFlashlight)}
+    } else {
+        _displayName = format [localize LSTRING(turnLightOn), _displayName];
+        {[_this select 2] call FUNC(switchFlashlight)}
     };
 
-    _parentAction = [_x, _displayName, _icon, {true}, {true}, _children, _x] call EFUNC(interact_menu,createAction);
-    _actions pushBack [_parentAction, [], _player];
+    _action = [_x, _displayName, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+    _actions pushBack [_action, [], _player];
 } forEach _flashlights;
 
 _actions

--- a/addons/map/stringtable.xml
+++ b/addons/map/stringtable.xml
@@ -256,5 +256,29 @@
             <Czech>Snížit jas</Czech>
             <Spanish>Reducir brillo</Spanish>
         </Key>
+        <Key ID="STR_ACE_Map_turnLightOn">
+            <English>Turn On %1</English>
+            <German>%1 Aktivieren</German>
+            <Spanish>Encender %1</Spanish>
+            <Polish>Włącz %1</Polish>
+            <French>Allumer %1</French>
+            <Czech>Zapnout %1</Czech>
+            <Italian>Accendi %1</Italian>
+            <Hungarian>%1 Bekapcsolása</Hungarian>
+            <Portuguese>Ativar %1</Portuguese>
+            <Russian>Активировать %1</Russian>
+        </Key>
+        <Key ID="STR_ACE_Map_turnLightOff">
+            <English>Turn Off %1</English>
+            <German>%1 Deaktivieren</German>
+            <Spanish>Apagar %1</Spanish>
+            <Polish>Wyłącz %1</Polish>
+            <French>Éteindre %1</French>
+            <Czech>Vypnout %1</Czech>
+            <Italian>Spegni %1</Italian>
+            <Hungarian>%1 Kikapcsolása</Hungarian>
+            <Portuguese>Desativar %1</Portuguese>
+            <Russian>Деактивировать %1</Russian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Currently each flashlight has 2 mutually exclusive child actions
This just shortens the depth of the action tree and puts the toggle action on the flashlight itself. 
(The 4th level can be hard to reach on some interface sizes)

@voiperr - If you were planning on adding other actions besides on/off or have any other objections to this please let me know.

before
![a](https://cloud.githubusercontent.com/assets/9376747/10495428/69bd99aa-7281-11e5-8c22-2e18206629fa.jpg)

after
![bb](https://cloud.githubusercontent.com/assets/9376747/10495431/6c4bd0f6-7281-11e5-9e68-262300f6d766.jpg)