### PR TITLE
Wirecutters - Update Fence Configs, Use faster getModelInfo

### DIFF
--- a/addons/logistics_wirecutter/CfgVehicles.hpp
+++ b/addons/logistics_wirecutter/CfgVehicles.hpp
@@ -11,16 +11,16 @@ class CfgVehicles {
 
     class Land_Net_Fence_4m_F: Wall_F { GVAR(isFence) = 1; };
     class Land_Net_Fence_8m_F: Wall_F { GVAR(isFence) = 1; };
-    class Land_Net_FenceD_8m_F: Wall_F { GVAR(isFence) = 1; };
     class Land_New_WiredFence_5m_F: Wall_F { GVAR(isFence) = 1; };
-    class Land_New_WiredFence_10m_Dam_F: Wall_F { GVAR(isFence) = 1; };
     class Land_New_WiredFence_10m_F: Wall_F { GVAR(isFence) = 1; };
-    class Land_Pipe_fence_4m_F: Wall_F { GVAR(isFence) = 1; };
-    class Land_Pipe_fence_4mNoLC_F: Wall_F { GVAR(isFence) = 1; };
     class Land_SportGround_fence_F: Wall_F { GVAR(isFence) = 1; };
     class Land_Wired_Fence_4m_F: Wall_F { GVAR(isFence) = 1; };
-    class Land_Wired_Fence_4mD_F: Wall_F { GVAR(isFence) = 1; };
     class Land_Wired_Fence_8m_F: Wall_F { GVAR(isFence) = 1; };
-    class Land_Wired_Fence_8mD_F: Wall_F { GVAR(isFence) = 1; };
+    class Land_SportGround_fence_noLC_F: Wall_F { GVAR(isFence) = 1; };
+    class Land_Mil_WiredFence_F: Wall_F { GVAR(isFence) = 1; };
+    class Land_IndFnc_Corner_F: Wall_F { GVAR(isFence) = 1; };
+    class Land_IndFnc_9_F: Wall_F { GVAR(isFence) = 1; };
+    class Land_IndFnc_3_Hole_F: Wall_F { GVAR(isFence) = 1; };
+    class Land_IndFnc_3_F: Wall_F { GVAR(isFence) = 1; };
     class Land_Razorwire_F: NonStrategic { GVAR(isFence) = 1; };
 };

--- a/addons/logistics_wirecutter/functions/fnc_interactEH.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_interactEH.sqf
@@ -56,7 +56,7 @@ TRACE_1("Starting wire-cut action PFEH",_interactionType);
                     if ([_x] call FUNC(isFence)) then {
                         _fencesHelped pushBack _x;
                         _helper = "ACE_LogicDummy" createVehicleLocal (getpos _x);
-                        _action = [QGVAR(helperCutFence), (localize LSTRING(CutFence)), QUOTE(PATHTOF(ui\wirecutter_ca.paa)), _fncStatement, _fncCondition, {}, _x, [0,0,0], 5] call EFUNC(interact_menu,createAction);
+                        _action = [QGVAR(helperCutFence), (localize LSTRING(CutFence)), QUOTE(PATHTOF(ui\wirecutter_ca.paa)), _fncStatement, _fncCondition, {}, _x, {[0,0,0]}, 5.5] call EFUNC(interact_menu,createAction);
                         [_helper, 0, [],_action] call EFUNC(interact_menu,addActionToObject);
                         _helper setPosASL ((getPosASL _x) vectorAdd [0,0,1.25]);
                         _addedHelpers pushBack _helper;

--- a/addons/logistics_wirecutter/functions/fnc_isFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_isFence.sqf
@@ -19,23 +19,14 @@
 params ["_object"];
 TRACE_1("params",_object);
 
-private ["_typeOf", "_returnValue"];
+local _typeOf = typeOf _object;
 
-_typeOf = typeOf _object;
-_returnValue = false;
-
-if (_typeOf != "") then {
+local _returnValue = if (_typeOf != "") then {
     //If the fence has configEntry we can check it directly
-    _returnValue = (1 == (getNumber (configFile >> "CfgVehicles" >> _typeOf >> QGVAR(isFence))));
+    (1 == (getNumber (configFile >> "CfgVehicles" >> _typeOf >> QGVAR(isFence))));
 } else {
-    //TODO: 1.50 use getModelInfo
-    _typeOf = toLower (str _object);  //something like "123201: wall_indfnc_9.p3d"
-    {
-        if ((_typeOf find _x) != -1) exitWith {
-            _returnValue = true;
-        };
-        nil
-    } count FENCE_P3DS;
+    //Check the p3d name against list (in script_component.hpp)
+    ((getModelInfo _object) select 0) in FENCE_P3DS;
 };
 
 _returnValue


### PR DESCRIPTION
Update isFence configs, was missing some (industrial and razor) and had some that didn't make any sense (damaged fences and pipes)

Use 1.50's `getModelInfo` which seems to be about 3x faster than doing string old string find.