### PR TITLE
Fixed small UAV carrying allot of cargo.

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -171,6 +171,13 @@ class CfgVehicles {
         GVAR(hasCargo) = 0;
     };
 
+    // autonomus
+    class Helicopter_Base_F;
+    class UAV_01_base_F: Helicopter_Base_F {
+        GVAR(space) = 0;
+        GVAR(hasCargo) = 0;
+    };
+    
     // boats
     class Ship;
     class Ship_F: Ship {


### PR DESCRIPTION
I've fixed small UAV carrying allot of cargo.

The following parameters were active:
```ace_cargo_hasCargo = 1;```
```ace_cargo_space = 8;```

This is due to the fact that the UAV inheritance the class ```Helicopter```