### PR TITLE
Remove manual team synching

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -98,7 +98,6 @@
 ["setFuel", {(_this select 0) setFuel (_this select 1)}] call FUNC(addEventhandler);
 ["setSpeaker", {(_this select 0) setSpeaker (_this select 1)}] call FUNC(addEventhandler);
 ["selectLeader", {(_this select 0) selectLeader (_this select 1)}] call FUNC(addEventHandler);
-["assignTeam", {(_this select 0) assignTeam (_this select 1)}] call FUNC(addEventHandler);
 ["setVelocity", {(_this select 0) setVelocity (_this select 1)}] call FUNC(addEventHandler);
 
 if (isServer) then {

--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -37,14 +37,6 @@ GVAR(isOpeningDoor) = false;
     ["displayTextStructured", _message] call EFUNC(common,targetEvent);
 }] call EFUNC(common,addEventHandler);
 
-// restore global fire teams for JIP
-private "_team";
-{
-    _team = _x getVariable [QGVAR(assignedFireTeam), ""];
-    if (_team != "") then {_x assignTeam _team};
-    false
-} count allUnits;
-
 // add keybinds
 ["ACE3 Common", QGVAR(openDoor), localize LSTRING(OpenDoor), {
     // Conditions: canInteract

--- a/addons/interaction/functions/fnc_joinTeam.sqf
+++ b/addons/interaction/functions/fnc_joinTeam.sqf
@@ -18,11 +18,7 @@
 
 params ["_unit", "_team"];
 
-// make sure correct team is set on JIP
-_unit setVariable [QGVAR(assignedFireTeam), _team, true];
-
-// join fire team on every machine in that group
-["assignTeam", units group _unit, [_unit, _team]] call EFUNC(common,targetEvent);
+["CBA_teamColorChanged", [_unit, _team]] call CBA_fnc_globalEvent;
 
 // display message
 if (_unit == ACE_player) then {

--- a/addons/nametags/XEH_postInit.sqf
+++ b/addons/nametags/XEH_postInit.sqf
@@ -22,42 +22,6 @@ GVAR(showNamesTime) = -10;
 {false},
 [29, [false, false, false]], false] call cba_fnc_addKeybind; //LeftControl Key
 
-// Monitor the assigned teams, and propegate them appropriately for the player
-// This allows for assigned team colors to match across the entire group
-[{
-    private["_leader", "_playerIsLeader", "_unitTeam"];
-    if (!(isNull ACE_player) && { alive ACE_player } ) then {
-        _leader = leader (group ACE_player);
-        _playerIsLeader = false;
-        
-        if(alive _leader) then {
-            if(_leader == ACE_player) then {
-                _playerIsLeader = true;
-            };
-        };
-        
-        if (_playerIsLeader) then {
-            {
-                if(alive _x) then {
-                    _unitTeam = _x getVariable [QGVAR(teamAssignment),"MAIN"];
-                    if (_unitTeam != assignedTeam _x) then {
-                        _x setVariable [QGVAR(teamAssignment), assignedTeam _x,true];
-                    };
-                };
-            } forEach units (group ACE_player);
-        } else {
-            {
-                if(alive _x) then {
-                    _unitTeam = _x getVariable [QGVAR(teamAssignment),"MAIN"];
-                    if (_unitTeam != assignedTeam _x) then {
-                        _x assignTeam _unitTeam;
-                    };
-                };
-            } forEach units (group ACE_player);
-        };
-    };
-}, 5, []] call CBA_fnc_addPerFrameHandler;
-
 // Wait until the colors are defined before starting to draw the nametags
 ["SettingsInitialized", {
     // Draw handle


### PR DESCRIPTION
This PR removes all occurences of assignTeam since this will be handled by the next version of CBA, see CBATeam/CBA_A3#185. The call of the ACE event has also been replaced with the CBA event.