### PR TITLE
Add method to deal with new hitpoints

### DIFF
--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -70,6 +70,7 @@ PREP(setDead);
 PREP(setHitPointDamage);
 PREP(setStructuralDamage);
 PREP(setUnconscious);
+PREP(translateSelections);
 PREP(treatment);
 PREP(treatment_failure);
 PREP(treatment_success);

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -39,6 +39,13 @@ TRACE_3("ACE_DEBUG: HandleDamage",_selection,_damage,_unit);
 if (_selection == "hands") exitWith {_unit getHit "hands"};
 if (_selection == "legs") exitWith {_unit getHit "legs"};
 
+// Deal with the new hitpoint and selection names introduced with Arma v1.50 and later.
+// This will convert new selection names into selection names that the medical system understands
+// TODO This should be cleaned up when we revisit the medical system at a later stage
+// and instead we should deal with the new hitpoints directly
+_selection = [_selection] call FUNC(translateSelections);
+_this set [1, _selection]; // ensure that the parameters are set correctly
+
 // If the damage is being weird, we just tell it to fuck off. Ignore: "hands", "legs", "?"
 if (_selection != "" && {!(_selection in GVAR(SELECTIONS))}) exitWith {0}; //@todo "neck", "pelvis", "spine1", "spine2", "spine3"
 

--- a/addons/medical/functions/fnc_translateSelections.sqf
+++ b/addons/medical/functions/fnc_translateSelections.sqf
@@ -1,0 +1,37 @@
+/*
+ * Author: Glowbal
+ * Translate selection names into medical usable hit selection names.
+ * Aims to deal with the new hitpoint system introduced in Arma3 v1.50 and later.
+ *
+ * Arguments:
+ * 0: selection name <STRING>
+ *
+ * Return Value:
+ * translated selection name <STRING>
+ *
+ * Example:
+ * ["pelvis"] call ace_medical_fnc_translateSelections
+ * Returns "body"
+ *
+ * Public: No
+ */
+
+#define HEAD_SELECTIONS ["face_hub", "neck", "head"]
+#define TORSO_SELECTIONS ["pelvis", "spine1", "spine2", "spine3", "body"]
+#define L_ARM_SELECTIONS ["hand_l"]
+#define R_ARM_SELECTIONS ["hand_r"]
+#define L_LEG_SELECTIONS ["leg_l"]
+#define R_LEG_SELECTIONS ["leg_r"]
+
+params ["_selection"];
+
+if (_selection in HEAD_SELECTIONS) exitwith {"head"};
+if (_selection in TORSO_SELECTIONS) exitwith {"body"};
+
+// Not necessary unless we get more hitpoints variants in an next arma update
+/*if (_selection in L_ARM_SELECTIONS) exitwith {"hand_l"};
+if (_selection in R_ARM_SELECTIONS) exitwith {"hand_r"};
+if (_selection in L_LEG_SELECTIONS) exitwith {"leg_l"};
+if (_selection in R_LEG_SELECTIONS) exitwith {"leg_r"};*/
+
+_selection;


### PR DESCRIPTION
This addition tries to deal with the new hitpoints introduced in Arma3 v1.50 and above. It converts new selection names to by the current medical system usable selection names.

This is only a temporarily patch, while we are still working on a larger overhaul to account both the new hitpoints and any potential new features / polishing.