### PR TITLE
Medical - Better handle odd selection/hitpoint names

### DIFF
--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_unit", "_selection", "_damage", "_shooter", "_projectile"];
+params ["_unit", "_selection", "_damage", "_shooter", "_projectile", "_hitPointIndex"];
 TRACE_5("ACE_DEBUG: HandleDamage Called",_unit, _selection, _damage, _shooter, _projectile);
 
 // bug, apparently can fire for remote units in special cases
@@ -43,7 +43,7 @@ if (_selection == "legs") exitWith {_unit getHit "legs"};
 // This will convert new selection names into selection names that the medical system understands
 // TODO This should be cleaned up when we revisit the medical system at a later stage
 // and instead we should deal with the new hitpoints directly
-_selection = [_selection] call FUNC(translateSelections);
+_selection = [_unit, _selection, _hitPointIndex] call FUNC(translateSelections);
 _this set [1, _selection]; // ensure that the parameters are set correctly
 
 // If the damage is being weird, we just tell it to fuck off. Ignore: "hands", "legs", "?"

--- a/addons/medical/functions/fnc_translateSelections.sqf
+++ b/addons/medical/functions/fnc_translateSelections.sqf
@@ -24,13 +24,13 @@
 #define TORSO_SELECTIONS ["pelvis", "spine1", "spine2", "spine3", "body"]
 #define TORSO_HITPOINTS ["hitpelvis", "hitabdomen", "hitdiaphragm", "hitchest", "hitbody"]
 #define L_ARM_SELECTIONS ["hand_l"]
-#define L_ARM_HITPOINTS ["HitLeftArm", "hand_l"]
+#define L_ARM_HITPOINTS ["hitleftarm", "hand_l"]
 #define R_ARM_SELECTIONS ["hand_r"]
-#define R_ARM_HITPOINTS ["HitRightArm", "hand_r"]
+#define R_ARM_HITPOINTS ["hitrightarm", "hand_r"]
 #define L_LEG_SELECTIONS ["leg_l"]
-#define L_LEG_HITPOINTS ["HitLeftLeg", "leg_l"]
+#define L_LEG_HITPOINTS ["hitleftleg", "leg_l"]
 #define R_LEG_SELECTIONS ["leg_r"]
-#define R_LEG_HITPOINTS ["HitRightLeg", "leg_r"]
+#define R_LEG_HITPOINTS ["hitrightleg", "leg_r"]
 
 params ["_unit", "_selection", "_hitPointIndex"];
 

--- a/addons/medical/functions/fnc_translateSelections.sqf
+++ b/addons/medical/functions/fnc_translateSelections.sqf
@@ -4,34 +4,60 @@
  * Aims to deal with the new hitpoint system introduced in Arma3 v1.50 and later.
  *
  * Arguments:
- * 0: selection name <STRING>
+ * 0: Unit <OBJECT>
+ * 1: selection name <STRING>
+ * 2: HitPoint Index <SCALAR>
  *
  * Return Value:
  * translated selection name <STRING>
  *
  * Example:
- * ["pelvis"] call ace_medical_fnc_translateSelections
+ * [bob, "pelvis", 4] call ace_medical_fnc_translateSelections
  * Returns "body"
  *
  * Public: No
  */
+#include "script_component.hpp"
 
 #define HEAD_SELECTIONS ["face_hub", "neck", "head"]
+#define HEAD_HITPOINTS ["hitface", "hitneck", "hithead"]
 #define TORSO_SELECTIONS ["pelvis", "spine1", "spine2", "spine3", "body"]
+#define TORSO_HITPOINTS ["hitpelvis", "hitabdomen", "hitdiaphragm", "hitchest", "hitbody"]
 #define L_ARM_SELECTIONS ["hand_l"]
+#define L_ARM_HITPOINTS ["HitLeftArm", "hand_l"]
 #define R_ARM_SELECTIONS ["hand_r"]
+#define R_ARM_HITPOINTS ["HitRightArm", "hand_r"]
 #define L_LEG_SELECTIONS ["leg_l"]
+#define L_LEG_HITPOINTS ["HitLeftLeg", "leg_l"]
 #define R_LEG_SELECTIONS ["leg_r"]
+#define R_LEG_HITPOINTS ["HitRightLeg", "leg_r"]
 
-params ["_selection"];
+params ["_unit", "_selection", "_hitPointIndex"];
 
-if (_selection in HEAD_SELECTIONS) exitwith {"head"};
-if (_selection in TORSO_SELECTIONS) exitwith {"body"};
+if (_selection == "") exitWith {""};
+if (_selection in HEAD_SELECTIONS) exitWith {"head"};
+if (_selection in TORSO_SELECTIONS) exitWith {"body"};
 
 // Not necessary unless we get more hitpoints variants in an next arma update
 /*if (_selection in L_ARM_SELECTIONS) exitwith {"hand_l"};
 if (_selection in R_ARM_SELECTIONS) exitwith {"hand_r"};
 if (_selection in L_LEG_SELECTIONS) exitwith {"leg_l"};
 if (_selection in R_LEG_SELECTIONS) exitwith {"leg_r"};*/
+
+//Backup method to detect weird selections/hitpoints
+if ((_selection == "?") || {!(_selection in GVAR(SELECTIONS))}) exitWith {
+    if (_hitPointIndex < 0) exitWith {_selection};
+    local _hitPoint = toLower configName ((configProperties [(configFile >> "CfgVehicles" >> (typeOf _unit) >> "HitPoints")]) select _hitPointIndex);
+    TRACE_4("Weird sel/hit", _unit, _selection, _hitPointIndex, _hitPoint);
+
+    if (_hitPoint in HEAD_HITPOINTS) exitWith {"head"};
+    if (_hitPoint in TORSO_HITPOINTS) exitWith {"body"};
+    if (_hitPoint in L_ARM_HITPOINTS) exitWith {"hand_l"};
+    if (_hitPoint in R_ARM_HITPOINTS) exitWith {"hand_r"};
+    if (_hitPoint in L_LEG_HITPOINTS) exitWith {"leg_l"};
+    if (_hitPoint in R_LEG_HITPOINTS) exitWith {"leg_r"};
+
+    _selection
+};
 
 _selection;


### PR DESCRIPTION
Adds a backup method to get the correct selection if the model/uniform is weird.

fix #2768 - VR people have weird hitpoint selection names:
```
class HitHead: HitHead {
    name = "hitHead";
```

Seems to fix odd RHS uniforms (eg, this guy could not take damage from headshots):
```
bob = group player createUnit ["B_soldier_F", Position player, [], 0, "FORM"];
bob addUniform "rhs_uniform_cu_ucp";
```