### PR TITLE
Read settings from paramsArray (params in description.ext)

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -194,6 +194,9 @@ call FUNC(checkFiles);
 
     ACE_LOGINFO("Settings received from server.");
 
+    if (isServer) then { //read settings from paramsArray
+        [] call FUNC(readSettingsFromParamsArray);
+    };
     // Event so that ACE_Modules have their settings loaded:
     ["InitSettingsFromModules", []] call FUNC(localEvent);
 

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -139,6 +139,7 @@ PREP(playerSide);
 PREP(positionToASL);
 PREP(progressBar);
 PREP(readSettingFromModule);
+PREP(readSettingsFromParamsArray);
 PREP(receiveRequest);
 PREP(removeCanInteractWithCondition);
 PREP(removeSpecificMagazine);

--- a/addons/common/functions/fnc_readSettingsFromParamsArray.sqf
+++ b/addons/common/functions/fnc_readSettingsFromParamsArray.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: PabstMirror
+ * Read settins from paramsArray that have a ACE_setting = 1.
+ * Happens before modules but after all other configs (for force priority)
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call ace_common_fnc_readSettingsFromParamsArray
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+//paramsArray is a normal variable not a command
+local _paramsArray = missionnamespace getvariable ["paramsArray", []];
+
+TRACE_1("Reading missionConfigFile params",_paramsArray);
+
+{
+    local _config = (missionConfigFile >> "params") select _forEachIndex;
+    if ((getNumber (_config >> "ACE_setting")) > 0) then {
+        local _settingName = configName _config;
+        local _settingValue = _x;
+        local _force = (getNumber (_config >> "force")) > 0;
+        local _title = getText (_config >> "title");
+
+        TRACE_4("ace_setting",_title,_settingName,_settingValue,_force);
+
+        // Check if the variable is already defined
+        if (isNil _settingName) exitWith {
+            ACE_LOGERROR_1("readSettingsFromParamsArray - param [%1] is not an ace_setting", _settingName);
+        };
+
+        local _settingData = [_settingName] call FUNC(getSettingData);
+        _settingData params ["", "_typeName", "", "", "", "", "_isForced"];
+
+        // Check if it's already forced and quit
+        if (_isForced) exitWith {ACE_LOGWARNING_1("readSettingsFromParamsArray - param [%1] is already set and forced", _settingName);};
+
+        // The setting is not forced, so update the value
+        // Read entry and cast it to the correct type from the existing variable
+        _validValue = false;
+        _value = switch (true) do {
+            case (_typeName == "SCALAR"): {_validValue = true;};
+            case (_typeName == "BOOL"): {
+                _settingValue = _settingValue > 0;
+                _validValue = true;
+            };
+            //TODO: Handle ARRAY,COLOR,STRING??? (bool/scalar covers most important settings)
+        };
+
+        if (!_validValue) exitWith {
+            ACE_LOGWARNING_3("readSettingsFromParamsArray - param [%1] type not valid [%2] - expected type [%3]", _settingName,_settingValue,_typeName);
+        };
+
+        // Update the variable globaly and Force the setting if requested
+        [_settingName, _settingValue, _force, true] call FUNC(setSetting);
+    };
+} foreach _paramsArray;

--- a/addons/common/functions/fnc_readSettingsFromParamsArray.sqf
+++ b/addons/common/functions/fnc_readSettingsFromParamsArray.sqf
@@ -44,8 +44,8 @@ TRACE_1("Reading missionConfigFile params",_paramsArray);
 
         // The setting is not forced, so update the value
         // Read entry and cast it to the correct type from the existing variable
-        _validValue = false;
-        _value = switch (true) do {
+        local _validValue = false;
+        switch (true) do {
             case (_typeName == "SCALAR"): {_validValue = true;};
             case (_typeName == "BOOL"): {
                 _settingValue = _settingValue > 0;

--- a/addons/common/functions/fnc_readSettingsFromParamsArray.sqf
+++ b/addons/common/functions/fnc_readSettingsFromParamsArray.sqf
@@ -26,10 +26,9 @@ TRACE_1("Reading missionConfigFile params",_paramsArray);
     if ((getNumber (_config >> "ACE_setting")) > 0) then {
         local _settingName = configName _config;
         local _settingValue = _x;
-        local _force = (getNumber (_config >> "force")) > 0;
         local _title = getText (_config >> "title");
 
-        TRACE_4("ace_setting",_title,_settingName,_settingValue,_force);
+        TRACE_3("ace_setting",_title,_settingName,_settingValue);
 
         // Check if the variable is already defined
         if (isNil _settingName) exitWith {
@@ -58,7 +57,7 @@ TRACE_1("Reading missionConfigFile params",_paramsArray);
             ACE_LOGWARNING_3("readSettingsFromParamsArray - param [%1] type not valid [%2] - expected type [%3]", _settingName,_settingValue,_typeName);
         };
 
-        // Update the variable globaly and Force the setting if requested
-        [_settingName, _settingValue, _force, true] call FUNC(setSetting);
+        // Update the variable globaly and Force
+        [_settingName, _settingValue, true, true] call FUNC(setSetting);
     };
 } foreach _paramsArray;


### PR DESCRIPTION
Just an idea, not sure if we need
Allows you to make settings changeable by mission params, so one mission can be played with different settings

for now just limited to SCALAR/BOOL

e.g.
```
class Params {
    class ace_medical_level {
        title = "Medical Level";
        ACE_setting = 1;
        values[] = {1,2};
        texts[] = {"Basic", "Advanced"};
        default = 2;
    };
```