### PR TITLE
Display basicMed wounds for AI in mixed mode

### DIFF
--- a/addons/medical/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical/functions/fnc_displayPatientInformation.sqf
@@ -54,7 +54,7 @@ if (_show) then {
         _allInjuryTexts = [];
         _genericMessages = [];
 
-        if (GVAR(level) >= 2) then {
+        if (GVAR(level) >= 2 && {([_unit] call FUNC(hasMedicalEnabled))}) then {
             _partText = [LSTRING(Head), LSTRING(Torso), LSTRING(LeftArm) ,LSTRING(RightArm) ,LSTRING(LeftLeg), LSTRING(RightLeg)] select _selectionN;
             _genericMessages pushback [localize _partText, [1, 1, 1, 1]];
         };
@@ -87,7 +87,7 @@ if (_show) then {
 
         _damaged = [false, false, false, false, false, false];
         _selectionBloodLoss = [0,0,0,0,0,0];
-        if (GVAR(level) >= 2) then {
+        if (GVAR(level) >= 2 && {([_target] call FUNC(hasMedicalEnabled))}) then {
             _openWounds = _target getvariable [QGVAR(openWounds), []];
             private "_amountOf";
             {

--- a/addons/medical/functions/fnc_modifyMedicalAction.sqf
+++ b/addons/medical/functions/fnc_modifyMedicalAction.sqf
@@ -19,7 +19,7 @@
 
 params ["_target", "_player", "_selectionN", "_actionData"];
 
-if (GVAR(level) < 2) exitwith {
+if (GVAR(level) < 2 || {!([_target] call FUNC(hasMedicalEnabled))}) exitwith {
     private ["_pointDamage"];
     _pointDamage = (_target getvariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]]) select _selectionN;
 

--- a/addons/medical_menu/functions/fnc_updateUIInfo.sqf
+++ b/addons/medical_menu/functions/fnc_updateUIInfo.sqf
@@ -62,7 +62,7 @@ _damaged = [false, false, false, false, false, false];
 _selectionBloodLoss = [0, 0, 0, 0, 0, 0];
 
 _allInjuryTexts = [];
-if (EGVAR(medical,level) >= 2) then {
+if ((EGVAR(medical,level) >= 2) && {([_target] call EFUNC(medical,hasMedicalEnabled))}) then {
     _openWounds = _target getVariable [QEGVAR(medical,openWounds), []];
     private "_amountOf";
     {


### PR DESCRIPTION
Fix #2772

With GVAR(level) = 2, but advanced not enabled for AI, the AI won't get any `GVAR(openWounds)`.

This will use the "basic" method of showing wound info if the unit doesn't `hasMedicalEnabled`