### PR TITLE
Overpresure - Misc fixes

### DIFF
--- a/addons/overpressure/functions/fnc_fireLauncherBackblast.sqf
+++ b/addons/overpressure/functions/fnc_fireLauncherBackblast.sqf
@@ -41,10 +41,10 @@ _var params["_backblastAngle","_backblastRange","_backblastDamage"];
 
 // Damage to others
 private "_affected";
-_affected = getPos _projectile nearEntities ["CAManBase", _backblastRange];
+_affected = (ASLtoAGL _position) nearEntities ["CAManBase", _backblastRange];
 
 // Let each client handle their own affected units
-["overpressure", _affected, [_firer, _position, _direction, _weapon]] call EFUNC(common,targetEvent);
+["overpressure", _affected, [_firer, _position, _direction, _weapon, _magazine, _ammo]] call EFUNC(common,targetEvent);
 
 // Damage to the firer
 private "_distance";

--- a/addons/overpressure/functions/fnc_fireLauncherBackblast.sqf
+++ b/addons/overpressure/functions/fnc_fireLauncherBackblast.sqf
@@ -48,7 +48,7 @@ _affected = (ASLtoAGL _position) nearEntities ["CAManBase", _backblastRange];
 
 // Damage to the firer
 private "_distance";
-_distance = [_position, _direction, _backblastRange] call FUNC(getDistance);
+_distance = [_position, _direction, _backblastRange, _firer] call FUNC(getDistance);
 
 TRACE_1("Distance",_distance);
 

--- a/addons/overpressure/functions/fnc_fireOverpressureZone.sqf
+++ b/addons/overpressure/functions/fnc_fireOverpressureZone.sqf
@@ -40,7 +40,7 @@ _var params["_dangerZoneAngle","_dangerZoneRange","_dangerZoneDamage"];
 
 // Damage to others
 private "_affected";
-_affected = getPos _projectile nearEntities ["CAManBase", _dangerZoneRange];
+_affected = (ASLtoAGL _position) nearEntities ["CAManBase", _dangerZoneRange];
 
 // Let each client handle their own affected units
 ["overpressure", _affected, [_firer, _position, _direction, _weapon, _magazine, _ammo]] call EFUNC(common,targetEvent);

--- a/addons/overpressure/functions/fnc_getDistance.sqf
+++ b/addons/overpressure/functions/fnc_getDistance.sqf
@@ -13,7 +13,8 @@
  */
 #include "script_component.hpp"
 
-EXPLODE_3_PVT(_this,_posASL,_direction,_maxDistance);
+params ["_posASL", "_direction", "_maxDistance"];
+TRACE_3("params",_posASL,_direction,_maxDistance);
 
 private ["_distance", "_interval", "_line", "_intersections", "_terrainIntersect", "_lastTerrainIntersect"];
 
@@ -42,20 +43,21 @@ while {
     };
 
     _distance = _distance + ([1, -1] select (_intersections > 0 || _terrainIntersect)) * _interval;
-
     if (_distance > _maxDistance) exitWith {_distance = 999};
 };
+
+TRACE_4("while done",_distance,_maxDistance,_terrainIntersect,_lastTerrainIntersect);
 
 if (_distance > _maxDistance) exitWith {_distance};
 
 // If the intersection was with the terrain, check slope
-if (_terrainIntersect || _lastTerrainIntersect) exitWith {
+if (_terrainIntersect || _lastTerrainIntersect) then {
     private ["_slope","_angle"];
     _slope = surfaceNormal (_posASL vectorAdd (_direction vectorMultiply _distance));
     // Calculate the angle between the terrain and the back blast direction
     _angle = 90 - acos (- (_slope vectorDotProduct _direction));
 
-    //systemChat format ["Angle: %1", _angle];
+    TRACE_3("Terrain Intersect",_slope,_direction,_angle);
     // Angles is below 25º, no backblast at all
     if (_angle < 25) exitWith {_distance = 999};
     // Angles is below 45º the distance is increased according to the difference

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -30,12 +30,6 @@ _var params["_overpressureAngle","_overpressureRange","_overpressureDamage"];
 
 TRACE_4("Parameters:",_overpressureAngle,_overpressureRange,_overpressureDamage,_weapon);
 
-private "_pos";
-_pos = _posASL;
-if (!surfaceIsWater _pos) then {
-    _pos = ASLtoATL _pos;
-};
-
 {
     if (local _x && {_x != _firer} && {vehicle _x == _x}) then {
         private ["_targetPositionASL", "_relativePosition", "_axisDistance", "_distance", "_angle", "_line", "_line2"];
@@ -68,4 +62,4 @@ if (!surfaceIsWater _pos) then {
             };
         };
     };
-} forEach (_pos nearEntities ["CAManBase", _overpressureRange]);
+} forEach ((ASLtoAGL _posASL) nearEntities ["CAManBase", _overpressureRange]);


### PR DESCRIPTION
- Fix passing magazine/ammo to overpressure event
- Use AGL for nearEntities
- Fix getDistance returning nil

Use `lineIntersectsSurfaces` which should be faster and will fix issue #2747