### PR TITLE
Update FCS display after distance adjust

### DIFF
--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -210,3 +210,11 @@ if(_playSound) then {
 if(_showHint) then {
     [format ["%1: %2", localize LSTRING(ZeroedTo), _distance]] call EFUNC(common,displayTextStructured);
 };
+
+//Update the hud's distance display to the new value or "----" if out of range
+//(10m fudge because of EFUNC(common,getTargetDistance))
+if ((_distance + 10) >= (getNumber (_turretConfig >> QGVAR(MaxDistance)))) then {
+    ((uiNamespace getVariable ["ACE_dlgRangefinder", displayNull]) displayCtrl 1713151) ctrlSetText "----";
+} else {
+    ((uiNamespace getVariable ["ACE_dlgRangefinder", displayNull]) displayCtrl 1713151) ctrlSetText ([_distance, 4, 0] call CBA_fnc_formatNumber);
+};

--- a/addons/fcs/functions/script_component.hpp
+++ b/addons/fcs/functions/script_component.hpp
@@ -1,12 +1,1 @@
-#define COMPONENT fcs
-#include "\z\ace\addons\main\script_mod.hpp"
-
-#ifdef DEBUG_ENABLED_FCS
-    #define DEBUG_MODE_FULL
-#endif
-
-#ifdef DEBUG_SETTINGS_FCS
-    #define DEBUG_SETTINGS DEBUG_SETTINGS_FCS
-#endif
-
-#include "\z\ace\addons\main\script_macros.hpp"
+#include "\z\ace\addons\fcs\script_component.hpp"


### PR DESCRIPTION
Fix #2750

KeyUp can take a specific distance as 3rd arg when using pageUp/Down.
The hud's distance was only set in getRange with the rangefinder's raw text