### PR TITLE
Add all wound types to bandage treatment configs

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -254,7 +254,7 @@ class ACE_Medical_Actions {
             animationCaller = "AinvPknlMstpSnonWnonDnon_medic1";
         };
         class SalineIV_500: SalineIV {
-         displayName = CSTRING(Actions_Saline4_500);
+            displayName = CSTRING(Actions_Saline4_500);
             items[] = {"ACE_salineIV_500"};
         };
         class SalineIV_250: SalineIV {
@@ -670,7 +670,7 @@ class ACE_Medical_Advanced {
     };
     class Treatment {
         class Bandaging {
-           class FieldDressing {
+            class FieldDressing {
                 // How effect is the bandage for treating one wounds type injury
                 effectiveness = 1;
                 // What is the chance and delays (in seconds) of the treated default injury reopening
@@ -683,198 +683,296 @@ class ACE_Medical_Advanced {
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class AbrasionMinor: Abrasion {};
+                class AbrasionMedium: Abrasion {};
+                class AbrasionLarge: Abrasion {};
                 class Avulsions: Abrasion {
                     effectiveness = 0.3;
                     reopeningChance = 0.5;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 200;
                 };
+                class AvulsionsMinor: Avulsions {};
+                class AvulsionsMedium: Avulsions {};
+                class AvulsionsLarge: Avulsions {};
                 class Contusion: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class ContusionMinor: Contusion {};
+                class ContusionMedium: Contusion {};
+                class ContusionLarge: Contusion {};
                 class CrushWound: Abrasion {
                     effectiveness = 0.6;
                     reopeningChance = 0.2;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 200;
                 };
+                class CrushWoundMinor: CrushWound {};
+                class CrushWoundMedium: CrushWound {};
+                class CrushWoundLarge: CrushWound {};
                 class Cut: Abrasion {
                     effectiveness = 0.4;
                     reopeningChance = 0.5;
                     reopeningMinDelay = 220;
                     reopeningMaxDelay = 260;
                 };
+                class CutMinor: Cut {};
+                class CutMedium: Cut {};
+                class CutLarge: Cut {};
+
                 class Laceration: Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0.3;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 260;
                 };
+                class LacerationMinor: Laceration {};
+                class LacerationMedium: Laceration {};
+                class LacerationLarge: Laceration {};
+
                 class velocityWound: Abrasion {
                     effectiveness = 0.3;
                     reopeningChance = 0.8;
                     reopeningMinDelay = 20;
                     reopeningMaxDelay = 300;
                 };
+                class velocityWoundMinor: velocityWound {};
+                class velocityWoundMedium: velocityWound {};
+                class velocityWoundLarge: velocityWound {};
                 class punctureWound: Abrasion {
                     effectiveness = 0.5;
                     reopeningChance = 0.8;
                     reopeningMinDelay = 20;
                     reopeningMaxDelay = 300;
                 };
+                class punctureWoundMinor: punctureWound {};
+                class punctureWoundMedium: punctureWound {};
+                class punctureWoundLarge: punctureWound {};
             };
             class PackingBandage: fieldDressing {
-                 class Abrasion {
+                class Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class AbrasionMinor: Abrasion {};
+                class AbrasionMedium: Abrasion {};
+                class AbrasionLarge: Abrasion {};
                 class Avulsions: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0.3;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 200;
                 };
+                class AvulsionsMinor: Avulsions {};
+                class AvulsionsMedium: Avulsions {};
+                class AvulsionsLarge: Avulsions {};
                 class Contusion: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class ContusionMinor: Contusion {};
+                class ContusionMedium: Contusion {};
+                class ContusionLarge: Contusion {};
                 class CrushWound: Abrasion {
                     effectiveness = 0.6;
                     reopeningChance = 0.2;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 200;
                 };
+                class CrushWoundMinor: CrushWound {};
+                class CrushWoundMedium: CrushWound {};
+                class CrushWoundLarge: CrushWound {};
                 class Cut: Abrasion {
                     effectiveness = 0.2;
                     reopeningChance = 0.6;
                     reopeningMinDelay = 30;
                     reopeningMaxDelay = 260;
                 };
+                class CutMinor: Cut {};
+                class CutMedium: Cut {};
+                class CutLarge: Cut {};
                 class Laceration: Abrasion {
                     effectiveness = 0.3;
                     reopeningChance = 0.3;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 260;
                 };
+                class LacerationMinor: Laceration {};
+                class LacerationMedium: Laceration {};
+                class LacerationLarge: Laceration {};
                 class velocityWound: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0.5;
                     reopeningMinDelay = 20;
                     reopeningMaxDelay = 300;
                 };
+                class velocityWoundMinor: velocityWound {};
+                class velocityWoundMedium: velocityWound {};
+                class velocityWoundLarge: velocityWound {};
                 class punctureWound: Abrasion {
                     effectiveness = 0.3;
                     reopeningChance = 0.5;
                     reopeningMinDelay = 20;
                     reopeningMaxDelay = 300;
                 };
+                class punctureWoundMinor: punctureWound {};
+                class punctureWoundMedium: punctureWound {};
+                class punctureWoundLarge: punctureWound {};
             };
             class ElasticBandage: fieldDressing {
-                 class Abrasion {
+                class Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class AbrasionMinor: Abrasion {};
+                class AbrasionMedium: Abrasion {};
+                class AbrasionLarge: Abrasion {};
                 class Avulsions: Abrasion {
                     effectiveness = 0.3;
                     reopeningChance = 0.4;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 200;
                 };
+                class AvulsionsMinor: Avulsions {};
+                class AvulsionsMedium: Avulsions {};
+                class AvulsionsLarge: Avulsions {};
                 class Contusion: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class ContusionMinor: Contusion {};
+                class ContusionMedium: Contusion {};
+                class ContusionLarge: Contusion {};
                 class CrushWound: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class CrushWoundMinor: CrushWound {};
+                class CrushWoundMedium: CrushWound {};
+                class CrushWoundLarge: CrushWound {};
                 class Cut: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0.2;
                     reopeningMinDelay = 10;
                     reopeningMaxDelay = 400;
                 };
+                class CutMinor: Cut {};
+                class CutMedium: Cut {};
+                class CutLarge: Cut {};
                 class Laceration: Abrasion {
                     effectiveness = 1;
                     reopeningChance = 0.3;
                     reopeningMinDelay = 120;
                     reopeningMaxDelay = 260;
                 };
+                class LacerationMinor: Laceration {};
+                class LacerationMedium: Laceration {};
+                class LacerationLarge: Laceration {};
                 class velocityWound: Abrasion {
                     effectiveness = 0.5;
                     reopeningChance = 0.5;
                     reopeningMinDelay = 20;
                     reopeningMaxDelay = 300;
                 };
+                class velocityWoundMinor: velocityWound {};
+                class velocityWoundMedium: velocityWound {};
+                class velocityWoundLarge: velocityWound {};
                 class punctureWound: Abrasion {
                     effectiveness = 0.85;
                     reopeningChance = 0.5;
                     reopeningMinDelay = 20;
                     reopeningMaxDelay = 300;
                 };
+                class punctureWoundMinor: punctureWound {};
+                class punctureWoundMedium: punctureWound {};
+                class punctureWoundLarge: punctureWound {};
             };
             class QuikClot: fieldDressing {
-                 class Abrasion {
+                class Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class AbrasionMinor: Abrasion {};
+                class AbrasionMedium: Abrasion {};
+                class AbrasionLarge: Abrasion {};
                 class Avulsions: Abrasion {
                     effectiveness = 0.2;
                     reopeningChance = 0.1;
                     reopeningMinDelay = 300;
                     reopeningMaxDelay = 350;
                 };
+                class AvulsionsMinor: Avulsions {};
+                class AvulsionsMedium: Avulsions {};
+                class AvulsionsLarge: Avulsions {};
                 class Contusion: Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class ContusionMinor: Contusion {};
+                class ContusionMedium: Contusion {};
+                class ContusionLarge: Contusion {};
                 class CrushWound: Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class CrushWoundMinor: CrushWound {};
+                class CrushWoundMedium: CrushWound {};
+                class CrushWoundLarge: CrushWound {};
                 class Cut: Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0.2;
                     reopeningMinDelay = 100;
                     reopeningMaxDelay = 400;
                 };
+                class CutMinor: Cut {};
+                class CutMedium: Cut {};
+                class CutLarge: Cut {};
                 class Laceration: Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0;
                     reopeningMinDelay = 0;
                     reopeningMaxDelay = 0;
                 };
+                class LacerationMinor: Laceration {};
+                class LacerationMedium: Laceration {};
+                class LacerationLarge: Laceration {};
                 class velocityWound: Abrasion {
                     effectiveness = 0.7;
                     reopeningChance = 0.1;
                     reopeningMinDelay = 200;
                     reopeningMaxDelay = 300;
                 };
+                class velocityWoundMinor: velocityWound {};
+                class velocityWoundMedium: velocityWound {};
+                class velocityWoundLarge: velocityWound {};
                 class punctureWound: Abrasion {
                     effectiveness = 0.5;
                     reopeningChance = 0.1;
                     reopeningMinDelay = 200;
                     reopeningMaxDelay = 300;
                 };
+                class punctureWoundMinor: punctureWound {};
+                class punctureWoundMedium: punctureWound {};
+                class punctureWoundLarge: punctureWound {};
             };
 
         };

--- a/addons/medical/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical/functions/fnc_handleBandageOpening.sqf
@@ -40,21 +40,6 @@ if (isClass (_config >> _bandage)) then {
     ACE_LOGWARNING_2("No config for bandage [%1] config base [%2]", _bandage, _config);
 };
 
-if (!isClass (_config >> _className)) then {
-    TRACE_1("Could Not Find Wound Type, trying base class - not minor/major/large", _className);
-    switch (true) do {
-        case ((_className select [((count _className) - (count "Minor")) max 0]) == "Minor"): {
-            _className = _className select [0, ((count _className) - (count "Minor"))];
-        };
-        case ((_className select [((count _className) - (count "Medium")) max 0]) == "Medium"): {
-            _className = _className select [0, ((count _className) - (count "Medium"))];
-        };
-        case ((_className select [((count _className) - (count "Large")) max 0]) == "Large"): {
-            _className = _className select [0, ((count _className) - (count "Large"))];
-        };
-    };
-    TRACE_1("Changed to",_className);
-};
 if (isClass (_config >> _className)) then {
     _woundTreatmentConfig = (_config >> _className);
     if (isNumber (_woundTreatmentConfig >> "reopeningChance")) then {

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -48,13 +48,31 @@ _exit = false;
 
         // Select the classname from the wound classname storage
         _className = GVAR(woundClassNames) select _classID;
+
         // Check if this wound type has attributes specified for the used bandage
+        if (!isClass (_config >> _className)) then {
+            TRACE_1("Could Not Find Wound Type, trying base class - not minor/major/large", _className);
+            switch (true) do {
+                case ((_className select [((count _className) - (count "Minor")) max 0]) == "Minor"): {
+                    _className = _className select [0, ((count _className) - (count "Minor"))];
+                    };
+                case ((_className select [((count _className) - (count "Medium")) max 0]) == "Medium"): {
+                    _className = _className select [0, ((count _className) - (count "Medium"))];
+                    };
+                case ((_className select [((count _className) - (count "Large")) max 0]) == "Large"): {
+                    _className = _className select [0, ((count _className) - (count "Large"))];
+                };
+            };
+            TRACE_1("Changed to",_className);
+        };
         if (isClass (_config >> _className)) then {
             // Collect the effectiveness from the used bandage for this wound type
             _woundTreatmentConfig = (_config >> _className);
             if (isNumber (_woundTreatmentConfig >> "effectiveness")) then {
                 _woundEffectivenss = getNumber (_woundTreatmentConfig >> "effectiveness");
             };
+        } else {
+            ACE_LOGWARNING_2("No config for wound type [%1] config base [%2]", _className, _config);
         };
 
         TRACE_2("Wound classes: ", _specificClass, _classID);

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -50,21 +50,6 @@ _exit = false;
         _className = GVAR(woundClassNames) select _classID;
 
         // Check if this wound type has attributes specified for the used bandage
-        if (!isClass (_config >> _className)) then {
-            TRACE_1("Could Not Find Wound Type, trying base class - not minor/major/large", _className);
-            switch (true) do {
-                case ((_className select [((count _className) - (count "Minor")) max 0]) == "Minor"): {
-                    _className = _className select [0, ((count _className) - (count "Minor"))];
-                    };
-                case ((_className select [((count _className) - (count "Medium")) max 0]) == "Medium"): {
-                    _className = _className select [0, ((count _className) - (count "Medium"))];
-                    };
-                case ((_className select [((count _className) - (count "Large")) max 0]) == "Large"): {
-                    _className = _className select [0, ((count _className) - (count "Large"))];
-                };
-            };
-            TRACE_1("Changed to",_className);
-        };
         if (isClass (_config >> _className)) then {
             // Collect the effectiveness from the used bandage for this wound type
             _woundTreatmentConfig = (_config >> _className);


### PR DESCRIPTION
Should fix #2878

Gets the correct wound for the bandage treatment config
Used for selecting most effective bandage and reopening
_className was something like "velocityWoundMedium"
but configs only had base class "velocityWound"

Debug Output:
```
fnc_treatmentAdvanced_bandageLocal.sqf:44","OPENWOUND: :  _target=q1_1,  _x=[1,4,1,1,0.02]"]
fnc_treatmentAdvanced_bandageLocal.sqf:54","Could Not Find Wound Type trying base class - not minor/major/large:  _className=AvulsionsMedium"]
fnc_treatmentAdvanced_bandageLocal.sqf:66","Changed to: _className=Avulsions"]
fnc_treatmentAdvanced_bandageLocal.sqf:78","Wound classes: :  _specificClass=-1,  _classID=4"]
fnc_handleBandageOpening.sqf:44","Could Not Find Wound Type trying base class - not minor/major/large:  _className=AvulsionsMedium"]
fnc_handleBandageOpening.sqf:56","Changed to: _className=Avulsions"]
fnc_handleBandageOpening.sqf:72","configs: _bandage=PackingBandage, _className=Avulsions, _reopeningChance=0.3, _reopeningMinDelay=120, _reopeningMaxDelay=200"]
fnc_handleBandageOpening.sqf:97",": _reopeningChance=0.3"]
```

Another possible solution would be to add all ~21 wound classes to each bandage in `ACE_Medical_Treatments.hpp` and have the subclasses inherit?