### PR TITLE
Define custom repair points for a few vehicles

### DIFF
--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -355,10 +355,24 @@ class CfgVehicles {
         transportRepair = 0;
     };
 
+    class Heli_Transport_02_base_F;
+    class I_Heli_Transport_02_F: Heli_Transport_02_base_F {
+        GVAR(hitpointPositions[]) = {{"HitVRotor", {-1,-9.4,1.8}}, {"HitHRotor", {0,1.8,1.3}}};
+    };
+
+    class Helicopter_Base_F;
+    class Heli_light_03_base_F: Helicopter_Base_F {
+        GVAR(hitpointPositions[]) = {{"HitVRotor", {-0.5,-5.55,1.2}}, {"HitHRotor", {0,1.8,1.5}}};
+    };
+
     class B_APC_Tracked_01_base_F;
     class B_APC_Tracked_01_CRV_F: B_APC_Tracked_01_base_F {
         GVAR(canRepair) = 1;
         transportRepair = 0;
+    };
+
+    class B_APC_Tracked_01_AA_F: B_APC_Tracked_01_base_F {
+        GVAR(hitpointPositions[]) = {{"HitTurret", {0,-2,0}}};
     };
 
     class Car_F;


### PR DESCRIPTION
Some helicopters have the main rotor point on the tip of a single blade which can be problematic depending on the orientation of the helicopter so those have been moved to the center (to match others). The tail rotor is also in the complete wrong position for some.

Also the turret of `B_APC_Tracked_01_AA_F` was unreachable. It should be noted that there are two turret hitpoints with the same name so they are both moved to the new position (the second was overlapping with a different hitpoint anyway though).