### PR TITLE
Remove error and don't exit if veh has no hit points

### DIFF
--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -32,8 +32,6 @@ if (_type in _initializedClasses) exitWith {};
 // get all hitpoints and selections
 (getAllHitPointsDamage _vehicle) params [["_hitPoints", []], ["_hitSelections", []]];
 
-if (_hitSelections isEqualTo []) exitWith { ACE_LOGERROR_1("No hit selections (%1)", _type); };
-
 // get hitpoints of wheels with their selections
 ([_vehicle] call FUNC(getWheelHitPointsWithSelections)) params ["_wheelHitPoints", "_wheelHitSelections"];
 


### PR DESCRIPTION
Fix #2902
B_UAV_01_F has no hitpoints and would throw error
Don't exit so "fullRepair" action still gets added