### PR TITLE
remove Original entries

### DIFF
--- a/addons/rearm/stringtable.xml
+++ b/addons/rearm/stringtable.xml
@@ -86,7 +86,6 @@
             <Polish>Przezbrojono %1 pocisków %2 na %3</Polish>
         </Key>
         <Key ID="STR_ACE_Rearm_Mag_SmokeLauncherMag">
-            <Original>Smoke Screen</Original>
             <English>Smoke Screen</English>
             <Czech>Kouřová clona</Czech>
             <French>Écran de fumée</French>
@@ -98,7 +97,6 @@
             <Spanish>Pantalla de humo</Spanish>
         </Key>
         <Key ID="STR_ACE_Rearm_Mag_60Rnd_CMFlareMagazine">
-            <Original>Flares</Original>
             <English>Flares</English>
             <Czech>Světlice</Czech>
             <French>Fusées</French>


### PR DESCRIPTION
This PR removes two "Original" entries from stringtables so this:
![problem](http://i.imgur.com/QMhOBvw.jpg)
Becomes this:
![noproblem](http://i.imgur.com/ds1DXlS.jpg)
Making it easier to edit stringtables with Tabler :)