### PR TITLE
Fix PostRepairDamage and toolkit consumtion setting

### DIFF
--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -34,10 +34,11 @@ class ACE_Repair {
             displayName = CSTRING(Repairing); // let's make empty string an auto generated string
             displayNameProgress = CSTRING(RepairingHitPoint);
             condition = QUOTE(call FUNC(canMiscRepair));
-            requiredEngineer = 0;
+            requiredEngineer = QGVAR(engineerSetting_Repair);
             repairingTime = 15;
             callbackSuccess = QUOTE(call FUNC(doRepair));
             items[] = {"ToolKit"};
+            itemConsumed = QGVAR(consumeItem_ToolKit);
             claimObjects[] = {};
         };
         class RepairTrack: MiscRepair {
@@ -47,6 +48,7 @@ class ACE_Repair {
             callbackSuccess = QUOTE(call FUNC(doRepairTrack));
             requiredEngineer = QGVAR(engineerSetting_Wheel);
             claimObjects[] = {{"ACE_Track"}};
+            itemConsumed = 0;
         };
         class RemoveTrack: MiscRepair {
             displayName = CSTRING(RemoveTrack);
@@ -54,6 +56,7 @@ class ACE_Repair {
             condition = QUOTE(call FUNC(canRemove));
             callbackSuccess = QUOTE(call FUNC(doRemoveTrack));
             requiredEngineer = QGVAR(engineerSetting_Wheel);
+            itemConsumed = 0;
         };
         class ReplaceTrack: RemoveTrack {
             displayName = CSTRING(ReplaceTrack);
@@ -71,6 +74,7 @@ class ACE_Repair {
             repairingTime = 30;
             condition = "damage _target > 0";
             callbackSuccess = QUOTE(call FUNC(doFullRepair));
+            itemConsumed = 0;
         };
     };
 };

--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -74,7 +74,7 @@ class ACE_Repair {
             repairingTime = 30;
             condition = "damage _target > 0";
             callbackSuccess = QUOTE(call FUNC(doFullRepair));
-            itemConsumed = 0;
+            itemConsumed = QGVAR(consumeItem_ToolKit);
         };
     };
 };

--- a/addons/repair/ACE_Settings.hpp
+++ b/addons/repair/ACE_Settings.hpp
@@ -41,7 +41,7 @@ class ACE_Settings {
         displayName = CSTRING(consumeItem_ToolKit_name);
         description = CSTRING(consumeItem_ToolKit_description);
         typeName = "SCALAR";
-        value = 1;
+        value = 0;
         values[] = {ECSTRING(common,No), ECSTRING(common,Yes)};
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };

--- a/addons/repair/functions/fnc_getPostRepairDamage.sqf
+++ b/addons/repair/functions/fnc_getPostRepairDamage.sqf
@@ -17,10 +17,15 @@
 
 params ["_unit"];
 TRACE_1("params",_unit);
-// TODO when near repair station, full repair?
 
+//If in facility or near vehicle then complete repair of hitpoint:
 if (([_unit] call FUNC(isInRepairFacility) || {[_unit] call FUNC(isNearRepairVehicle)})) exitWith {0};
 
-if ([_unit, GVAR(engineerSetting_Repair) + 1] call FUNC(isEngineer)) exitWith {GVAR(repairDamageThreshold_Engineer)};
-if ([_unit, GVAR(engineerSetting_Repair)] call FUNC(isEngineer)) exitWith {GVAR(repairDamageThreshold)};
-0.3;
+private _class = _unit getVariable ["ACE_IsEngineer", getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "engineer")];
+//If specialist or more qualified than min, then use engineer threshold:
+if ((_class isEqualTo 2) || {[_unit, GVAR(engineerSetting_Repair) + 1] call FUNC(isEngineer)}) exitWith {
+    (GVAR(repairDamageThreshold_Engineer) min GVAR(repairDamageThreshold))
+};
+
+//Return default threshold:
+GVAR(repairDamageThreshold)

--- a/addons/repair/functions/fnc_isEngineer.sqf
+++ b/addons/repair/functions/fnc_isEngineer.sqf
@@ -26,4 +26,4 @@ _class = _unit getVariable ["ACE_IsEngineer", getNumber (configFile >> "CfgVehic
 // We cannot move this function to common because we require the GVAR(engineerSetting_Repair), which only makes sense to include in the repair module.
 if (_class isEqualType false) then {_class = [0, 1] select _class};
 
-_class >= (_engineerN min GVAR(engineerSetting_Repair));
+_class >= _engineerN;

--- a/addons/repair/functions/fnc_repair.sqf
+++ b/addons/repair/functions/fnc_repair.sqf
@@ -128,7 +128,7 @@ _consumeItems = if (isNumber (_config >> "itemConsumed")) then {
 
 _usersOfItems = [];
 if (_consumeItems > 0) then {
-    _usersOfItems = ([_caller, _target, _items] call FUNC(useItems)) select 1;
+    _usersOfItems = ([_caller, _items] call FUNC(useItems)) select 1;
 };
 
 // Parse the config for the progress callback


### PR DESCRIPTION
Fix #2982

Now respects `GVAR(consumeItem_ToolKit)` setting. I made the `ace_setting` default off so as not to change expected behavior (module is default off).

For Release Branch