### PR TITLE
add event for placing units in body bags

### DIFF
--- a/addons/medical/functions/fnc_actionPlaceInBodyBag.sqf
+++ b/addons/medical/functions/fnc_actionPlaceInBodyBag.sqf
@@ -28,9 +28,11 @@ _spinePos = _target modelToWorldVisual (_target selectionPosition "Spine3");
 _dirVect = _headPos vectorFromTo _spinePos;
 _direction = _dirVect call CBA_fnc_vectDir;
 
-deleteVehicle _target;
-
 _bodyBag = createVehicle ["ACE_bodyBagObject", _position, [], 0, "CAN_COLLIDE"];
+
+["placedInBodyBag", [_target, _bodyBag]] call EFUNC(common,globalEvent);
+
+deleteVehicle _target;
 
 // prevent body bag from flipping
 _bodyBag setPosASL _position;


### PR DESCRIPTION
ref: #3021

`["placedInBodyBag", {systemChat str _this}] call ace_common_fnc_addEventhandler`

0: dead body
1: body bag object

executed on all machines