### PR TITLE
Send string to serverLog instead of strucText

### DIFF
--- a/addons/common/functions/fnc_serverLog.sqf
+++ b/addons/common/functions/fnc_serverLog.sqf
@@ -1,19 +1,24 @@
 /*
  * Author: esteldunedain
- * ?
+ * Log a RPT messaged on just the server
  *
  * Arguments:
- * ?
+ * 0: Text to display <STRING>
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * ["x happened"] call ace_common_fnc_serverLog;
  *
  * Public: no
  */
 #include "script_component.hpp"
 
+params [["_msg", "", [""]]];
+
 if (isServer) then {
-    diag_log _this;
+    diag_log text _msg;
 } else {
     [_this, QFUNC(serverLog), 1] call FUNC(execRemoteFnc);
 };

--- a/addons/maptools/functions/fnc_handleMouseButton.sqf
+++ b/addons/maptools/functions/fnc_handleMouseButton.sqf
@@ -44,7 +44,7 @@ if (_dir != 1) then {
             deleteMarkerLocal (GVAR(drawing_tempLineMarker) select 0);
             ["drawing_addLineMarker", GVAR(drawing_tempLineMarker)] call EFUNC(common,globalEvent);
             // Log who drew on the briefing screen
-            (text format ["[ACE] Server: Player %1 drew on the briefing screen", profileName]) call EFUNC(common,serverLog);
+            [ACE_INFOFORMAT_1("Player %1 drew on the briefing screen", profileName)] call EFUNC(common,serverLog);
         } else {
             GVAR(drawing_tempLineMarker) call FUNC(updateLineMarker);
             GVAR(drawing_lineMarkers) pushBack (+GVAR(drawing_tempLineMarker));


### PR DESCRIPTION
Trivial Fix for
`Performance warning: SimpleSerialization::Read
'ace_common_remoteFnc' is using type of ,'TEXT' which is not optimized
by simple serialization, falling back to generic serialization, use
generic type or ask for optimizations for these types`