### PR TITLE
RHS Compat fix for RU Sprut turret

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -104,7 +104,29 @@ class cfgVehicles {
                     };
                 };
             };
+        };
+    };
+    class rhs_bmd4_vdv: rhs_a3spruttank_base {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {};
+                };
+            };
             class GPMGTurret1: NewTurret {
+                ace_fcs_Enabled = 0;
+            };
+        };
+    };
+    class rhs_bmd4m_vdv: rhs_bmd4_vdv {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {};
+                };
+            };
+            class GPMGTurret1: GPMGTurret1 {};
+            class GPMGTurret2: GPMGTurret1 {
                 ace_fcs_Enabled = 0;
             };
         };

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -77,8 +77,12 @@ class cfgVehicles {
     class APC_Tracked_02_base_F;
     class rhsusf_m113_tank_base : APC_Tracked_02_base_F {
         EGVAR(refuel,fuelCapacity) = 360;
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                ace_fcs_Enabled = 0;
+            };
+        };
     };
-
     class APC_Tracked_03_base_F;
     class RHS_M2A2_Base : APC_Tracked_03_base_F {
         EGVAR(refuel,fuelCapacity) = 746;


### PR DESCRIPTION
This is a fix for the issue mentioned [here](https://forums.bistudio.com/topic/181341-ace3-a-collaborative-merger-between-agm-cse-and-ace/page-116#entry2950880) in the ACE thread.

Additionally the other commit disables ACE FCS on the M113 family... turned out gunner without a laser range finder and all that.