### PR TITLE
Optics - Don't modify camera for ThreeDen Editor

### DIFF
--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -6,6 +6,12 @@ if (!hasInterface) exitWith {};
 GVAR(camera) = objNull;
 
 0 = 0 spawn {
+    // Workarround for the ThreeDen Editor Camera
+    //ToDo: verify if command will exist in 1.56 release
+    if (((productVersion select 2) >= 155) && {is3DEN}) exitWith {
+        ACE_LOGINFO("Eden detected: disabling Optics PIP Camera");
+    };
+    
     waituntil {!isNull ACE_player};
     waituntil {sleep 1; {_x != GVAR(camera)} count allMissionObjects "camera" == 0 && {isNull curatorCamera}};
 

--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -7,8 +7,7 @@ GVAR(camera) = objNull;
 
 0 = 0 spawn {
     // Workarround for the ThreeDen Editor Camera
-    //ToDo: verify if command will exist in 1.56 release
-    if (((productVersion select 2) >= 155) && {is3DEN}) exitWith {
+    if ((!isNil {is3DEN}) && {is3DEN}) exitWith {
         ACE_LOGINFO("Eden detected: disabling Optics PIP Camera");
     };
     


### PR DESCRIPTION
Fix broken ThreeDen Camera when returning to editor from preview.
PIP will still work in preview.
Will have to take a look at 1.56 RC to see if command exists and eventually cleanup.