### PR TITLE
RHS Compat Enhancement for Weapons and Grenades  

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -1,10 +1,8 @@
 
-class CfgAmmo
-{
+class CfgAmmo {
     class BulletBase;
     class B_556x45_Ball;
-    class rhs_B_545x39_Ball: B_556x45_Ball
-    {
+    class rhs_B_545x39_Ball: B_556x45_Ball {
         ACE_caliber=5.588;
         ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
@@ -16,8 +14,7 @@ class CfgAmmo
         ACE_muzzleVelocities[]={780, 880, 920};
         ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
-    class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball
-    {
+    class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball {
         ACE_caliber=5.588;
         ACE_bulletLength=21.59;
         ACE_bulletMass=3.22704;
@@ -30,8 +27,7 @@ class CfgAmmo
         ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_762x51_Ball;
-    class rhs_B_762x54_Ball: B_762x51_Ball
-    {
+    class rhs_B_762x54_Ball: B_762x51_Ball {
         ACE_caliber=7.925;
         ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
@@ -43,8 +39,7 @@ class CfgAmmo
         ACE_muzzleVelocities[]={700, 800, 820, 833};
         ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
-    class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball
-    {
+    class rhs_B_762x54_Ball_Tracer_Green: B_762x51_Ball {
         ACE_caliber=7.925;
         ACE_bulletLength=28.956;
         ACE_bulletMass=9.6552;
@@ -56,8 +51,7 @@ class CfgAmmo
         ACE_muzzleVelocities[]={680, 750, 798, 800};
         ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
-    class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball
-    {
+    class rhs_B_762x54_7N1_Ball: rhs_B_762x54_Ball {
         ACE_caliber=7.925;
         ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
@@ -69,8 +63,7 @@ class CfgAmmo
         ACE_muzzleVelocities[]={700, 800, 820, 833};
         ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
-    class rhs_B_762x39_Ball: B_762x51_Ball
-    {
+    class rhs_B_762x39_Ball: B_762x51_Ball {
         ACE_caliber=7.823;
         ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
@@ -82,8 +75,7 @@ class CfgAmmo
         ACE_muzzleVelocities[]={650, 716, 750};
         ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
-    class rhs_B_762x39_Tracer: rhs_B_762x39_Ball
-    {
+    class rhs_B_762x39_Tracer: rhs_B_762x39_Ball {
         ACE_caliber=7.823;
         ACE_bulletLength=28.956;
         ACE_bulletMass=7.5816;
@@ -96,8 +88,7 @@ class CfgAmmo
         ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
     class B_9x21_Ball;
-    class rhs_B_9x19_7N21: B_9x21_Ball
-    {
+    class rhs_B_9x19_7N21: B_9x21_Ball {
         ACE_caliber=9.017;
         ACE_bulletLength=15.494;
         ACE_bulletMass=5.19696;
@@ -109,8 +100,7 @@ class CfgAmmo
         ACE_muzzleVelocities[]={445, 460, 480};
         ACE_barrelLengths[]={101.6, 127.0, 228.6};
     };
-    class rhs_B_9x18_57N181S: B_9x21_Ball
-    {
+    class rhs_B_9x18_57N181S: B_9x21_Ball {
         ACE_caliber=9.271;
         ACE_bulletLength=15.494;
         ACE_bulletMass=6.00048;
@@ -129,7 +119,7 @@ class CfgAmmo
     
     class GrenadeHand;
     class rhs_ammo_rgd5: GrenadeHand {
-	    ace_frag_enabled = 1;
+        ace_frag_enabled = 1;
         ace_frag_metal = 200;
         ace_frag_charge = 110;
         ace_frag_gurney_c = 2440;
@@ -139,7 +129,7 @@ class CfgAmmo
         ace_frag_force = 1;
     };
     class rhs_ammo_rgn_base: rhs_ammo_rgd5 {
-	    ace_frag_enabled = 1;
+        ace_frag_enabled = 1;
         ace_frag_metal = 193;
         ace_frag_charge = 97;
         ace_frag_gurney_c = 2800;

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -126,4 +126,66 @@ class CfgAmmo
     class rhs_ammo_127x108mm_x5: SubmunitionBase {
         ACE_rearm_caliber=13;
     };
+    
+    class GrenadeHand;
+    class rhs_ammo_rgd5: GrenadeHand {
+	    ace_frag_enabled = 1;
+        ace_frag_metal = 200;
+        ace_frag_charge = 110;
+        ace_frag_gurney_c = 2440;
+        ace_frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_small_HD"};
+        ace_frag_skip = 0;
+        ace_frag_force = 1;
+    };
+    class rhs_ammo_rgn_base: rhs_ammo_rgd5 {
+	    ace_frag_enabled = 1;
+        ace_frag_metal = 193;
+        ace_frag_charge = 97;
+        ace_frag_gurney_c = 2800;
+        ace_frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
+        ace_frag_skip = 0;
+        ace_frag_force = 1;
+    };
+    class rhs_ammo_rgn: rhs_ammo_rgn_base {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_ammo_rgn_sub: rhs_ammo_rgn_base {};
+    class rhs_ammo_rgn_exp: rhs_ammo_rgn_base {};
+    class rhs_ammo_fakel: GrenadeHand {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_ammo_fakels: rhs_ammo_fakel {};
+    class rhs_ammo_zarya2: rhs_ammo_fakels {};
+    class rhs_ammo_plamyam: rhs_ammo_fakels {};
+	
+    class RocketBase;
+    class R_PG32V_F: RocketBase {};
+    class rhs_rpg26_rocket: R_PG32V_F {};
+    class rhs_rpg7v2_pg7vl: rhs_rpg26_rocket {};
+    class rhs_rpg7v2_og7v: rhs_rpg7v2_pg7vl {
+        ace_frag_enabled = 1;
+        ace_frag_metal = 400;
+        ace_frag_charge = 210;
+        ace_frag_gurney_c = 2800;
+        ace_frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_medium_HD"};
+        ace_frag_skip = 0;
+        ace_frag_force = 1;
+    };
+    class rhs_rpg7v2_tbg7v: rhs_rpg7v2_pg7vl {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_rshg2_rocket: rhs_rpg7v2_tbg7v {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
 };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -1,61 +1,50 @@
 
-class CfgWeapons
-{
+class CfgWeapons {
     class hgun_Rook40_F;
-    class rhs_weap_pya: hgun_Rook40_F
-    {
-        ACE_barrelTwist=254.0;
-        ACE_barrelLength=111.76;
+    class rhs_weap_pya: hgun_Rook40_F {
+        ACE_barrelTwist = 254.0;
+        ACE_barrelLength = 111.76;
     };
     class Pistol_Base_F;
-    class rhs_weap_makarov_pmm: rhs_weap_pya
-    {
-        ACE_barrelTwist=240.03;
-        ACE_barrelLength=93.472;
+    class rhs_weap_makarov_pmm: rhs_weap_pya {
+        ACE_barrelTwist = 240.03;
+        ACE_barrelLength = 93.472;
     };
     class rhs_weap_ak74m_Base_F;
-    class rhs_weap_ak74m: rhs_weap_ak74m_Base_F
-    {
-        ACE_barrelTwist=199.898;
-        ACE_barrelLength=414.02;
+    class rhs_weap_ak74m: rhs_weap_ak74m_Base_F {
+        ACE_barrelTwist = 199.898;
+        ACE_barrelLength = 414.02;
     };
-    class rhs_weap_akm: rhs_weap_ak74m
-    {
-        ACE_barrelTwist=199.898;
-        ACE_barrelLength=414.02;
+    class rhs_weap_akm: rhs_weap_ak74m {
+        ACE_barrelTwist = 199.898;
+        ACE_barrelLength = 414.02;
     };
     class rhs_weap_aks74;
-    class rhs_weap_aks74u: rhs_weap_aks74
-    {
-        ACE_barrelTwist=160.02;
-        ACE_barrelLength=210.82;
+    class rhs_weap_aks74u: rhs_weap_aks74 {
+        ACE_barrelTwist = 160.02;
+        ACE_barrelLength = 210.82;
     };
-    class rhs_weap_svd: rhs_weap_ak74m
-    {
-        ACE_barrelTwist=238.76;
-        ACE_barrelLength=619.76;
+    class rhs_weap_svd: rhs_weap_ak74m {
+        ACE_barrelTwist = 238.76;
+        ACE_barrelLength = 619.76;
     };
     class rhs_weap_svdp;
-    class rhs_weap_svds: rhs_weap_svdp
-    {
-        ACE_barrelTwist=238.76;
-        ACE_barrelLength=563.88;
+    class rhs_weap_svds: rhs_weap_svdp {
+        ACE_barrelTwist = 238.76;
+        ACE_barrelLength = 563.88;
     };
     class rhs_pkp_base;
-    class rhs_weap_pkp: rhs_pkp_base
-    {
-        ACE_barrelTwist=240.03;
-        ACE_barrelLength=657.86;
+    class rhs_weap_pkp: rhs_pkp_base {
+        ACE_barrelTwist = 240.03;
+        ACE_barrelLength = 657.86;
     };
-    class rhs_weap_pkm: rhs_weap_pkp
-    {
-        ACE_barrelTwist=240.03;
-        ACE_barrelLength=645.16;
+    class rhs_weap_pkm: rhs_weap_pkp {
+        ACE_barrelTwist = 240.03;
+        ACE_barrelLength = 645.16;
     };
-    class rhs_weap_rpk74m: rhs_weap_pkp
-    {
-        ACE_barrelTwist=195.072;
-        ACE_barrelLength=589.28;
+    class rhs_weap_rpk74m: rhs_weap_pkp {
+        ACE_barrelTwist = 195.072;
+        ACE_barrelLength = 589.28;
     };
 
     class rhs_acc_sniper_base;

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -93,6 +93,7 @@ class CfgAmmo
         irLock = 0;
         laserLock = 0;
         airLock = 0;
+  
 
         // Begin ACE guidance Configs
         class ace_missileguidance {
@@ -121,5 +122,49 @@ class CfgAmmo
             defaultAttackProfile = "JAV_TOP";
             attackProfiles[] = { "JAV_TOP", "JAV_DIR" };
         };
+    };
+    
+    class GrenadeHand;
+    class rhs_ammo_mk3a2: GrenadeHand {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_ammo_m84: GrenadeHand {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_ammo_m7a3_cs: GrenadeHand {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_ammo_m69: GrenadeHand {
+        ace_frag_enabled = 0;
+        ace_frag_skip = 1;
+        ace_frag_force = 0;
+    };
+    class rhs_ammo_m67: GrenadeHand {
+        ace_frag_enabled = 1;
+        ace_frag_metal = 213;
+        ace_frag_charge = 185;
+        ace_frag_gurney_c = 2700;
+        ace_frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_medium_HD"};
+        ace_frag_skip = 0;
+        ace_frag_force = 1;
+    };
+    class RocketBase;
+    class rhs_ammo_M136_rocket: RocketBase {};
+    class rhs_ammo_M136_hedp_rocket: rhs_ammo_M136_rocket {
+        ace_frag_enabled = 1;
+        ace_frag_metal = 330;
+        ace_frag_charge = 280;
+        ace_frag_gurney_c = 2800;
+        ace_frag_gurney_k = "3/5";
+        ace_frag_classes[] = {"ACE_frag_medium_HD"};
+        ace_frag_skip = 0;
+        ace_frag_force = 1;
     };
 };

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -93,7 +93,6 @@ class CfgAmmo
         irLock = 0;
         laserLock = 0;
         airLock = 0;
-  
 
         // Begin ACE guidance Configs
         class ace_missileguidance {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -8,13 +8,13 @@ class CfgWeapons
     class UGL_F;
 
     class rhs_weap_XM2010_Base_F: Rifle_Base_F {
-        ACE_barrelTwist=254.0;
-        ACE_barrelLength=609.6;
+        ACE_barrelTwist = 254.0;
+        ACE_barrelLength = 609.6;
     };
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F {
-        ACE_barrelTwist=177.8;
-        ACE_barrelLength=368.3;
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 368.3;
         ACE_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
         ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
         ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
@@ -113,8 +113,8 @@ class CfgWeapons
     };
     class rhs_weap_m4a1;
     class rhs_weap_mk18: rhs_weap_m4a1 {
-        ACE_barrelTwist=177.8;
-        ACE_barrelLength=261.62;
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 261.62;
         ACE_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
         ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
         ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
@@ -127,7 +127,7 @@ class CfgWeapons
     class rhs_weap_lmg_minimi_railed : rhs_weap_lmg_minimipara {
         ACE_barrelLength = 465.0;
         ACE_barrelTwist = 177.8;
-		ACE_Overheating_allowSwapBarrel = 1;
+        ACE_Overheating_allowSwapBarrel = 1;
         ACE_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
         ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
         ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
@@ -137,37 +137,37 @@ class CfgWeapons
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 629.92;
         ACE_Overheating_allowSwapBarrel = 1;
-        ACE_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+        ACE_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.004};
         ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
         ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
     };
     class rhs_weap_m14ebrri: srifle_EBR_F {
-        ACE_barrelTwist=304.8;
-        ACE_barrelLength=558.8;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 558.8;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri {
-        ACE_barrelTwist=285.75;
-        ACE_barrelLength=609.6;
+        ACE_barrelTwist = 285.75;
+        ACE_barrelLength = 609.6;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25 {
-        ACE_barrelTwist=285.75;
-        ACE_barrelLength=508.0;
+        ACE_barrelTwist = 285.75;
+        ACE_barrelLength = 508.0;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F {
-        ACE_barrelTwist=0.0;
-        ACE_twistDirection=0;
-        ACE_barrelLength=469.9;
+        ACE_barrelTwist = 0.0;
+        ACE_twistDirection = 0;
+        ACE_barrelLength = 469.9;
     };
     class rhs_weap_M590_8RD: rhs_weap_M590_5RD {
-        ACE_barrelTwist=0.0;
-        ACE_twistDirection=0;
-        ACE_barrelLength=508.0;
+        ACE_barrelTwist = 0.0;
+        ACE_twistDirection = 0;
+        ACE_barrelLength = 508.0;
     };
 
     class hgun_ACPC2_F;
     class rhsusf_weap_m1911a1: hgun_ACPC2_F {
-        ACE_barrelTwist=406.4;
-        ACE_barrelLength=127.0;
+        ACE_barrelTwist = 406.4;
+        ACE_barrelLength = 127.0;
     };
 
     class rhsusf_acc_sniper_base;

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -15,6 +15,9 @@ class CfgWeapons
     class rhs_weap_m4_Base: arifle_MX_Base_F {
         ACE_barrelTwist=177.8;
         ACE_barrelLength=368.3;
+        ACE_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
+        ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+        ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
         class M203_GL : UGL_F {
             magazines[] = {
                 "rhs_mag_M441_HE",
@@ -112,15 +115,31 @@ class CfgWeapons
     class rhs_weap_mk18: rhs_weap_m4a1 {
         ACE_barrelTwist=177.8;
         ACE_barrelLength=261.62;
+        ACE_Overheating_Dispersion[] = {0, 0.001, 0.002, 0.004};
+        ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+        ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
     };
     class rhs_weap_m16a4: rhs_weap_m4_Base {
-        ACE_barrelTwist=177.8;
-        ACE_barrelLength=508.0;
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 508.0;
     };
+	class rhs_weap_lmg_minimipara;	
+    class rhs_weap_lmg_minimi_railed : rhs_weap_lmg_minimipara {
+        ACE_barrelLength = 465.0;
+        ACE_barrelTwist = 177.8;
+		ACE_Overheating_allowSwapBarrel = 1;
+        ACE_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+        ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+        ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
+	};
     class rhs_weap_m240_base;
     class rhs_weap_m240B: rhs_weap_m240_base {
-        ACE_barrelTwist=304.8;
-        ACE_barrelLength=629.92;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 629.92;
+        ACE_Overheating_allowSwapBarrel = 1;
+        ACE_Overheating_Dispersion[] = {0, -0.001, 0.001, 0.003};
+        ACE_Overheating_SlowdownFactor[] = {1, 1, 1, 0.9};
+        ACE_Overheating_JamChance[] = {0, 0.0003, 0.0015, 0.0075};
     };
     class rhs_weap_m14ebrri: srifle_EBR_F {
         ACE_barrelTwist=304.8;


### PR DESCRIPTION
The RHS M249 and M240 now have the overheating and change barrel, plus
the M4 and M16 branch should have overheating applied to them. The ammo
class should have all of the hand grenade fixes in there. 