### PR TITLE
Remove undefined laser selfdesignate macro

### DIFF
--- a/addons/laser_selfdesignate/XEH_post_init.sqf
+++ b/addons/laser_selfdesignate/XEH_post_init.sqf
@@ -1,3 +1,2 @@
 #include "script_component.hpp"
-NO_DEDICATED;
 


### PR DESCRIPTION
This is never defined. It's treated as undefined variable and errors in unsheduled environment.