### PR TITLE
Add support for non local Zeus RC in common-isPlayer

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -69,6 +69,7 @@ if (isServer) then {
                     ACE_LOGINFO_3("[%1] DC - Was Zeus [%2] while controlling unit [%3] - manually clearing `bis_fnc_moduleRemoteControl_owner`", [_x] call FUNC(getName), _dcPlayer, _x);
                     _x setVariable ["bis_fnc_moduleRemoteControl_owner", nil, true];
                 };
+                nil
             } count (curatorEditableObjects  _zeusLogic);
         };
     }];

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -57,6 +57,23 @@
 // Eventhandlers
 //////////////////////////////////////////////////
 
+//Add a fix for BIS's zeus remoteControl module not reseting variables on DC when RC a unit
+//This variable is used for isPlayer checks
+if (isServer) then {
+    addMissionEventHandler ["HandleDisconnect", {
+        params ["_dcPlayer"];
+        private _zeusLogic = getAssignedCuratorLogic _dcPlayer;
+        if ((!isNil "_zeusLogic") && {!isNull _zeusLogic}) then {
+            {
+                if ((_x getvariable ["bis_fnc_moduleRemoteControl_owner", objnull]) isEqualTo _dcPlayer) exitWith {
+                    ACE_LOGINFO_3("[%1] DC - Was Zeus [%2] while controlling unit [%3] - manually clearing `bis_fnc_moduleRemoteControl_owner`", [_x] call FUNC(getName), _dcPlayer, _x);
+                    _x setVariable ["bis_fnc_moduleRemoteControl_owner", nil, true];
+                };
+            } count (curatorEditableObjects  _zeusLogic);
+        };
+    }];
+};
+
 // Listens for global "SettingChanged" events, to update the force status locally
 ["SettingChanged", {
     params ["_name", "_value", "_force"];

--- a/addons/common/functions/fnc_isPlayer.sqf
+++ b/addons/common/functions/fnc_isPlayer.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: bux578, commy2, akalegman
  * Checks if a unit is a player / curator controlled unit.
- * Currently returns false for non-local remote controlled zeus units. (Remotes from another zeus machine)
+ * This now includes both local and non-local remote controlled zeus units. (Remotes from another zeus machine)
  *
  * Arguments:
  * 0: unit to be checked <OBJECT>
@@ -10,10 +10,13 @@
  * Return Value:
  * Is unit a player? <BOOL>
  *
+ * Example:
+ * [cursorTarget, false] call ace_common_fnc_isPlayer;
+ *
  * Public: Yes
  */
 #include "script_component.hpp"
 
 params ["_unit", ["_excludeRemoteControlled", false]];
 
-isPlayer _unit || (!_excludeRemoteControlled && {_unit == call FUNC(player)}) // return
+(isPlayer _unit) || {(!_excludeRemoteControlled) && {!isNull (_unit getVariable ["bis_fnc_moduleRemoteControl_owner", objNull])}}


### PR DESCRIPTION
Adds support for non-local zeus remote controlled units in isPlayer.
So this command will now work consistantly on any machine.

Uses a BIS setVar from the zeus module, had to add a disconnect handler to clear variable.
Slightly faster as well.

I think this is important for consistent behavior, for example wind deflection does:
`if (!([_unit] call EFUNC(common,isPlayer))) exitWith {false};`
Right now only the zeus would run the code, so the bullet's path won't appear consistent with it's effects.