### PR TITLE
Fix medical menu not closing on range, litter dir

### DIFF
--- a/addons/medical/functions/fnc_handleCreateLitter.sqf
+++ b/addons/medical/functions/fnc_handleCreateLitter.sqf
@@ -16,7 +16,7 @@
 
 if(!hasInterface) exitWith { false };
 
-params ["_litterClass", "_position", "_unit"];
+params ["_litterClass", "_position", "_direction"];
 private["_litterObject", "_maxLitterCount"];
 //IGNORE_PRIVATE_WARNING(_values);
 

--- a/addons/medical_menu/functions/fnc_onMenuOpen.sqf
+++ b/addons/medical_menu/functions/fnc_onMenuOpen.sqf
@@ -77,11 +77,11 @@ GVAR(MenuPFHID) = [{
     [GVAR(LatestDisplayOptionMenu)] call FUNC(handleUI_DisplayOptions);
 
     //Check that it's valid to stay open:
-    if !(([ACE_player, _target, ["isNotInside"]] call EFUNC(common,canInteractWith)) && {[ACE_player, _target] call FUNC(canOpenMenu)}) then {
+    if !(([ACE_player, GVAR(INTERACTION_TARGET), ["isNotInside"]] call EFUNC(common,canInteractWith)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call FUNC(canOpenMenu)}) then {
         closeDialog 314412;
         //If we failed because of distance check, show UI message:
         if ((ACE_player distance GVAR(INTERACTION_TARGET)) > GVAR(maxRange)) then {
-            ["displayTextStructured", [ACE_player], [[ELSTRING(medical,DistanceToFar), [GVAR(INTERACTION_TARGET)] call EFUNC(common,getName)], 1.75, ACE_player]] call EFUNC(common,targetEvent);
+            ["displayTextStructured", [[ELSTRING(medical,DistanceToFar), [GVAR(INTERACTION_TARGET)] call EFUNC(common,getName)], 2, ACE_player]] call EFUNC(common,localEvent);
         };
     };
 


### PR DESCRIPTION
- Medical Menu didn't close when target moved out of range
- Litter was always created in the same direction