### PR TITLE
fix inverted isTurnedOut for map lighting

### DIFF
--- a/addons/map/functions/fnc_determineMapLight.sqf
+++ b/addons/map/functions/fnc_determineMapLight.sqf
@@ -73,7 +73,7 @@ _vehicle = vehicle _unit;
 // Do not obscure the map if the player is on a enclosed vehicle (assume internal illumination)
 if (_vehicle != _unit) then {
     // Player is in a vehicle
-    if (isTurnedOut _unit && { _vehicle isKindOf "Tank" || { ( _vehicle isKindOf "Helicopter" || _vehicle isKindOf "Plane" ) && { (driver _vehicle) == _unit || { (gunner _vehicle) == _unit } } } || {_vehicle isKindOf "Wheeled_APC"}}) then {
+    if (!isTurnedOut _unit && { _vehicle isKindOf "Tank" || { ( _vehicle isKindOf "Helicopter" || _vehicle isKindOf "Plane" ) && { (driver _vehicle) == _unit || { (gunner _vehicle) == _unit } } } || {_vehicle isKindOf "Wheeled_APC"}}) then {
         _isEnclosed = true;
     };
 };


### PR DESCRIPTION
A simple oneliner for what seems to be an obvious typo.

According to the comment, the idea is to provide unobscured map when
inside an enclosed vehicle (`!isTurnedOut`).
