### PR TITLE
Prevent Tactical Ladder interaction if unit on ladder

### DIFF
--- a/addons/tacticalladder/CfgVehicles.hpp
+++ b/addons/tacticalladder/CfgVehicles.hpp
@@ -68,7 +68,7 @@ class CfgVehicles {
             class ACE_MainActions {
                 selection = "roadway";
                 distance = 5;
-                condition = "true";
+                condition = QUOTE(_target call FUNC(isLadderEmpty));
 
                 class ACE_PickUp {
                     selection = "";

--- a/addons/tacticalladder/XEH_preInit.sqf
+++ b/addons/tacticalladder/XEH_preInit.sqf
@@ -10,6 +10,7 @@ PREP(handleInteractMenuOpened);
 PREP(handlePlayerChanged);
 PREP(handleScrollWheel);
 PREP(handleUnconscious);
+PREP(isLadderEmpty);
 PREP(pickupTL);
 PREP(positionTL);
 

--- a/addons/tacticalladder/functions/fnc_handleScrollWheel.sqf
+++ b/addons/tacticalladder/functions/fnc_handleScrollWheel.sqf
@@ -40,9 +40,9 @@ if (GETMVAR(ACE_Modifier,0) == 0) then {
         };
     };
 } else {
-    // Tilting
-    GVAR(currentAngle) = 0 max (GVAR(currentAngle) + _scroll) min 30;
-    GVAR(ladder) animate ["rotate", GVAR(currentAngle)];
+    // Tilting (disabled due to sinking, interaction point offset and unsuitable animation)
+    //GVAR(currentAngle) = 0 max (GVAR(currentAngle) + _scroll) min 30;
+    //GVAR(ladder) animate ["rotate", GVAR(currentAngle)];
 };
 
 true

--- a/addons/tacticalladder/functions/fnc_isLadderEmpty.sqf
+++ b/addons/tacticalladder/functions/fnc_isLadderEmpty.sqf
@@ -1,0 +1,31 @@
+/*
+ * Author: Jonpas
+ * Checks if Tactical Ladder is empty (no one climbing it).
+ *
+ * Arguments:
+ * 0: Ladder <OBJECT>
+ *
+ * Return Value:
+ * Can Be Picked Up <BOOL>
+ *
+ * Example:
+ * [ladder] call ace_tacticalladder_fnc_isLadderEmpty;
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_ladder"];
+
+private _unitsNearLadder = nearestObjects [_ladder, ["CAManBase"], 4];
+TRACE_1("Near Ladder",_unitsNearLadder);
+
+private _ladderEmpty = true;
+{
+    if (getNumber (configFile >> "CfgMovesMaleSdr" >> "States" >> animationState _x >> "ACE_isLadder") == 1) exitWith {
+        _ladderEmpty = false;
+        TRACE_1("On Ladder",_x);
+    };
+} forEach _unitsNearLadder;
+
+_ladderEmpty

--- a/addons/tacticalladder/functions/fnc_positionTL.sqf
+++ b/addons/tacticalladder/functions/fnc_positionTL.sqf
@@ -42,7 +42,8 @@ GVAR(currentStep) = 3;
 GVAR(currentAngle) = 0;
 
 // add mouse buttons and hints
-[localize LSTRING(Deploy), localize LSTRING(Drop), localize LSTRING(Adjust)] call EFUNC(interaction,showMouseHint);
+//private _adjustText = format ["%1, +%2", localize LSTRING(Adjust), localize LSTRING(AdjustTilt)]; // Tilting disabled due to sinking, interaction point offset and unsuitable animation
+[localize LSTRING(Deploy), localize LSTRING(Drop), /*_adjustText*/ localize LSTRING(Adjust)] call EFUNC(interaction,showMouseHint);
 
 _unit setVariable [QGVAR(Deploy), [
     _unit, "DefaultAction",

--- a/addons/tacticalladder/stringtable.xml
+++ b/addons/tacticalladder/stringtable.xml
@@ -38,12 +38,20 @@
             <Portuguese>Derrubar escada</Portuguese>
         </Key>
         <Key ID="STR_ACE_TacticalLadder_Adjust">
-            <English>Extend, +Ctrl tilt</English>
-            <German>Ausfahren, +Strg kippen</German>
-            <Polish>Rozłóż, +Ctrl nachyl</Polish>
-            <Portuguese>Extender, +Ctrl tilt</Portuguese>
-            <Russian>Разложить, +Ctrl наклонить</Russian>
-            <Czech>Prodloužit, +Ctrl naklonit</Czech>
+            <English>Extend</English>
+            <German>Ausfahren</German>
+            <Polish>Rozłóż</Polish>
+            <Portuguese>Extender</Portuguese>
+            <Russian>Разложить</Russian>
+            <Czech>Prodloužit</Czech>
+        </Key>
+        <Key ID="STR_ACE_TacticalLadder_AdjustTilt">
+            <English>Ctrl tilt</English>
+            <German>Strg kippen</German>
+            <Polish>Ctrl nachyl</Polish>
+            <Portuguese>Ctrl tilt</Portuguese>
+            <Russian>Ctrl наклонить</Russian>
+            <Czech>Ctrl naklonit</Czech>
         </Key>
         <Key ID="STR_ACE_TacticalLadder_Position">
             <English>Position ladder</English>


### PR DESCRIPTION
Fixes #3077 

Somewhat hacky workaround, but it works quite reliably. Also disabled tilting because it's broken in many ways (unsuitable animation, ladder sinks into the ground, interaction point is completely offset) and with that also split the string for adjusting mouse hint.