### PR TITLE
CBA zeus integration

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -449,6 +449,7 @@ if (!isNil QGVAR(PreInit_playerChanged_PFHID)) then {
     {_unit != _target && {vehicle _unit == vehicle _target}}
 }] call FUNC(addCanInteractWithCondition);
 
+["isNotInZeus", {isNull curatorCamera}] call FUNC(addCanInteractWithCondition);
 
 //////////////////////////////////////////////////
 // Set up PlayerJIP eventhandler

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -77,37 +77,6 @@ GVAR(ParsedTextCached) = [];
     if (GVAR(menuBackground)==2) then {(uiNamespace getVariable [QGVAR(menuBackground), displayNull]) closeDisplay 0;};
 }] call EFUNC(common,addEventHandler);
 
-// Let key work with zeus open (not perfect, contains workaround to prevent other CBA keybindings)
-["zeusDisplayChanged",{
-    if (_this select 1) then {
-        (finddisplay 312) displayAddEventHandler ["KeyUp", {
-            _key = ["ACE3 Common","ace_interact_menu_InteractKey"] call CBA_fnc_getKeybind;
-            _key = _key select 5;
-            _dik = _key select 0;
-            _mods = _key select 1;
-
-            if ((_this select 1) == _dik) then {
-                if ((_this select [2,3]) isEqualTo _mods) then {
-                    [_this,'keyup'] call CBA_events_fnc_keyHandler
-                };
-            };
-        }];
-        (finddisplay 312) displayAddEventHandler ["KeyDown", {
-            _key = ["ACE3 Common","ace_interact_menu_InteractKey"] call CBA_fnc_getKeybind;
-            _key = _key select 5;
-            _dik = _key select 0;
-            _mods = _key select 1;
-
-            if ((_this select 1) == _dik) then {
-                if ((_this select [2,3]) isEqualTo _mods) then {
-                    [_this,'keydown'] call CBA_events_fnc_keyHandler
-                };
-            };
-        }];
-    };
-}] call EFUNC(common,addEventHandler);
-
-
 //Debug to help end users identify mods that break CBA's XEH
 [{
     private ["_badClassnames"];


### PR DESCRIPTION
Close #2937

CBA now adds keyDown EH to zeus interface, so #1951 (CTRL+V from climb blocking paste in zeus) is back.

 - Adds "isNotInZeus" to caninteractWith conditions.
 - Removed code to forward interaction keybind to CBA  as this is handled by CBA
 - Use `CBA_curatorOpened/Closed` events from CBA to trigger ACE's zeus event (trivial savings from removing constant checking in PFEH).

@commy2 - tested with this code and it seems to handle scripted closing fine.
```
[] spawn {sleep 2; systemChat "scipted closing zeus"; (findDisplay 312) closeDisplay 1};
```