### PR TITLE
Explosive enhancements

### DIFF
--- a/addons/explosives/CfgAmmo.hpp
+++ b/addons/explosives/CfgAmmo.hpp
@@ -21,7 +21,6 @@ class CfgAmmo {
 
     class DirectionalBombCore: TimeBombCore;
     class DirectionalBombBase: DirectionalBombCore;
-    class APERSTripMine_Wire_Ammo: DirectionalBombBase;
 
     class SLAMDirectionalMine_Wire_Ammo: DirectionalBombBase;
 
@@ -31,10 +30,15 @@ class CfgAmmo {
     class DirectionalBombBase;
     class ClaymoreDirectionalMine_Remote_Ammo: DirectionalBombBase {
         ACE_Explosive = "ClaymoreDirectionalMine_Remote_Ammo_Scripted";
+        GVAR(defuseObjectPosition[]) = {0, 0, 0.038};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
     //class ClaymoreDirectionalMine_Remote_Ammo_Scripted: ClaymoreDirectionalMine_Remote_Ammo;
+
+    class APERSTripMine_Wire_Ammo: DirectionalBombBase {
+        GVAR(defuseObjectPosition[]) = {-1.415, 0, 0.12};
+    };
 
     class SLAMDirectionalMine_Wire_Ammo: DirectionalBombBase {
         indirectHitRange = 20;
@@ -55,6 +59,7 @@ class CfgAmmo {
     class PipeBombBase;
     class DemoCharge_Remote_Ammo: PipeBombBase {
         ACE_Explosive = "DemoCharge_Remote_Ammo_Scripted";
+        GVAR(defuseObjectPosition[]) = {0.07,0,0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
         hit = 500;
@@ -63,17 +68,18 @@ class CfgAmmo {
     };
     class SatchelCharge_Remote_Ammo: PipeBombBase {
         ACE_Explosive = "SatchelCharge_Remote_Ammo_Scripted";
+        GVAR(defuseObjectPosition[]) = {0.1,0.1,0.05};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
-    
+
     /*class DemoCharge_Remote_Ammo_Scripted: DemoCharge_Remote_Ammo;
     class SatchelCharge_Remote_Ammo_Scripted: SatchelCharge_Remote_Ammo;*/
-    
+
     class IEDUrbanBig_Remote_Ammo: PipeBombBase {
         triggerWhenDestroyed = 1;
         ACE_explodeOnDefuse = 0.02;
-        soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};        
+        soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};
     };
     class IEDUrbanBig_Command_Ammo: IEDUrbanBig_Remote_Ammo {
         mineTrigger = "RemoteTrigger";
@@ -81,19 +87,19 @@ class CfgAmmo {
     class IEDUrbanBig_Range_Ammo: IEDUrbanBig_Remote_Ammo {
         mineTrigger = "RangeTrigger";
     };
-    
+
     class IEDUrbanSmall_Remote_Ammo: PipeBombBase {
         triggerWhenDestroyed = 1;
         ACE_explodeOnDefuse = 0.02;
         soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};
-    };    
-    class IEDUrbanSmall_Command_Ammo: IEDUrbanSmall_Remote_Ammo {   
+    };
+    class IEDUrbanSmall_Command_Ammo: IEDUrbanSmall_Remote_Ammo {
         mineTrigger = "RemoteTrigger";
     };
     class IEDUrbanSmall_Range_Ammo: IEDUrbanSmall_Remote_Ammo {
         mineTrigger = "RangeTrigger";
     };
-    
+
     class IEDLandBig_Remote_Ammo: PipeBombBase {
         triggerWhenDestroyed = 1;
         ACE_explodeOnDefuse = 0.02;
@@ -105,7 +111,7 @@ class CfgAmmo {
     class IEDLandBig_Range_Ammo: IEDLandBig_Remote_Ammo {
         mineTrigger = "RangeTrigger";
     };
-    
+
     class IEDLandSmall_Remote_Ammo: PipeBombBase {
         triggerWhenDestroyed = 1;
         ACE_explodeOnDefuse = 0.02;

--- a/addons/explosives/CfgAmmo.hpp
+++ b/addons/explosives/CfgAmmo.hpp
@@ -59,7 +59,7 @@ class CfgAmmo {
     class PipeBombBase;
     class DemoCharge_Remote_Ammo: PipeBombBase {
         ACE_Explosive = "DemoCharge_Remote_Ammo_Scripted";
-        GVAR(defuseObjectPosition[]) = {0.07,0,0.055};
+        GVAR(defuseObjectPosition[]) = {0.07, 0, 0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
         hit = 500;
@@ -68,7 +68,7 @@ class CfgAmmo {
     };
     class SatchelCharge_Remote_Ammo: PipeBombBase {
         ACE_Explosive = "SatchelCharge_Remote_Ammo_Scripted";
-        GVAR(defuseObjectPosition[]) = {0.1,0.1,0.05};
+        GVAR(defuseObjectPosition[]) = {0.1, 0.1, 0.05};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -141,14 +141,11 @@ class CfgVehicles {
     class ACE_Explosives_Place_APERSTripwireMine:ACE_Explosives_Place {
         displayName = "APERS Tripwire Mine";
         model = "\A3\Weapons_F\explosives\mine_AP_tripwire";
-
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 position = "[1.415,0,0.12]";
             };
         };
-
-
     };
 
     class ACE_Explosives_Place_ATMine:ACE_Explosives_Place {

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -62,7 +62,7 @@ class CfgVehicles {
         class ACE_Actions {
             class ACE_MainActions {
                 selection = "";
-                distance = 5;
+                distance = 1;
                 condition = "true";
                 class ACE_Defuse {
                     displayName = CSTRING(Defuse);
@@ -73,7 +73,7 @@ class CfgVehicles {
                     icon = PATHTOF(UI\Defuse_ca.paa);
                     priority = 0.8;
                     hotkey = "F";
-                    distance = 5;
+                    distance = 1;
                 };
             };
         };
@@ -92,12 +92,12 @@ class CfgVehicles {
         class ACE_Actions {
             class ACE_MainActions {
                 selection = "";
-                distance = 5;
+                distance = 1;
                 condition = "true";
                 class ACE_SetTrigger {
                     selection = "";
                     displayName = CSTRING(TriggerMenu);
-                    distance = 4;
+                    distance = 1;
                     condition = "true";
                     statement = "";
                     insertChildren = QUOTE([ARR_3(_target getVariable QUOTE(QGVAR(class)),_target,_player)] call FUNC(addTriggerActions););
@@ -109,7 +109,7 @@ class CfgVehicles {
                 class ACE_PickUp {
                     selection = "";
                     displayName = CSTRING(Pickup);
-                    distance = 4;
+                    distance = 1;
                     condition = "true";
                     statement = QUOTE([ARR_2(_player,_target getVariable QUOTE(QGVAR(class)))] call EFUNC(common,addToInventory);deleteVehicle _target;);
                     showDisabled = 0;
@@ -124,6 +124,11 @@ class CfgVehicles {
     class ACE_Explosives_Place_DemoCharge:ACE_Explosives_Place {
         displayName = "Demo Charge";
         model = "\A3\Weapons_F\explosives\c4_charge_small_d";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[-0.07,0,0.055]";
+            };
+        };
     };
     class ACE_Explosives_Place_APERSBoundingMine:ACE_Explosives_Place {
         displayName = "APERS Bounding Mine";
@@ -136,6 +141,14 @@ class CfgVehicles {
     class ACE_Explosives_Place_APERSTripwireMine:ACE_Explosives_Place {
         displayName = "APERS Tripwire Mine";
         model = "\A3\Weapons_F\explosives\mine_AP_tripwire";
+
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[1.415,0,0.12]";
+            };
+        };
+
+
     };
 
     class ACE_Explosives_Place_ATMine:ACE_Explosives_Place {
@@ -146,11 +159,21 @@ class CfgVehicles {
     class ACE_Explosives_Place_Claymore:ACE_Explosives_Place {
         displayName = "Claymore";
         model = "\A3\Weapons_F\explosives\mine_AP_miniclaymore";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0,0,0.038]";
+            };
+        };
     };
 
     class ACE_Explosives_Place_SatchelCharge:ACE_Explosives_Place {
         displayName = "Satchel Charge";
         model = "\A3\Weapons_F\Explosives\satchel";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[-0.1,-0.1,0.05]";
+            };
+        };
     };
 
     class ACE_Explosives_Place_SLAM:ACE_Explosives_Place {

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -89,7 +89,6 @@ class CfgVehicles {
         scope = 2;
         scopeCurator = 1;
         vehicleClass = "Cargo";
-        ACE_offset[] = {0,0,0};
         class ACE_Actions {
             class ACE_MainActions {
                 selection = "";
@@ -137,7 +136,6 @@ class CfgVehicles {
     class ACE_Explosives_Place_APERSTripwireMine:ACE_Explosives_Place {
         displayName = "APERS Tripwire Mine";
         model = "\A3\Weapons_F\explosives\mine_AP_tripwire";
-        ACE_offset[] = {1,0,0};
     };
 
     class ACE_Explosives_Place_ATMine:ACE_Explosives_Place {

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -45,7 +45,17 @@ if (!("ACE_DefusalKit" in (items ACE_player))) exitWith {};
                 if (((_x distance ACE_player) < 15) && {!(_x in _minesHelped)}) then {
                     TRACE_2("Making Defuse Helper",(_x),(typeOf _x));
                     _defuseHelper = "ACE_DefuseObject" createVehicleLocal (getPos _x);
-                    _defuseHelper attachTo [_x, [0,0,0]];
+
+                    private _config = configFile >> "CfgAmmo" >> typeOf _x;
+
+                    private _defuseObjectPosition = getArray (_config >> QGVAR(defuseObjectPosition));
+                    if (_defuseObjectPosition isEqualTo []) then {
+                        _defuseObjectPosition = [0,0,0];
+                    };
+
+                    TRACE_1("DefuseObjectPosition",(_defuseObjectPosition));
+
+                    _defuseHelper attachTo [_x, _defuseObjectPosition];
                     _defuseHelper setVariable [QGVAR(Explosive),_x];
                     _addedDefuseHelpers pushBack _defuseHelper;
                     _minesHelped pushBack _x;


### PR DESCRIPTION
When merged this pull request will
* remove the invalid `ACE_offset` config entry (which was ported from AGM but was never used)
* reduce the interaction distance from 5 to 1, so as an EOD you really have to get close to the explosives to arm or defuse them
* move interaction points for some explosives to more logical positions
* add a config setting where to attach the defuse helper object (same place as the interaction point in most cases, but could be different for other (e.g. modded) explosives)

![2015-12-30_00001](https://cloud.githubusercontent.com/assets/1235520/12048048/e85138ae-aed5-11e5-9ab8-786c81be3d1a.jpg)
![2015-12-30_00002](https://cloud.githubusercontent.com/assets/1235520/12048049/eb60b768-aed5-11e5-8623-0c8ebb7548e9.jpg)
![2015-12-30_00003](https://cloud.githubusercontent.com/assets/1235520/12048051/ed977a30-aed5-11e5-80c1-b06697fd3fd8.jpg)
![2015-12-30_00004](https://cloud.githubusercontent.com/assets/1235520/12048052/f05aab0c-aed5-11e5-9303-3115395ed9e7.jpg)


Pinging the [maintainers](https://github.com/acemod/ACE3/blob/master/addons/explosives/README.md#maintainers) @esteldunedain and @CorruptedHeart 


