### PR TITLE
Update bandage effectiveness on wiki

### DIFF
--- a/wiki/feature/medical-system.md
+++ b/wiki/feature/medical-system.md
@@ -190,11 +190,11 @@ In order to stop the bleeding, all bleeding injuries on every body part requires
 
 Bandage | Abrasions | Avulsions | Contusions | Crush wounds | Cut wounds | Lacerations | Velocity wounds | Puncture wounds|
 ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ------- |
-Basic | `highest` | lowest | `highest` | low | very low | medium | lowest | low
-Bandage (packing) | `highest` | `highest` | `highest` | low | lowest | lowest | `highest` | lowest
-Bandage (elastic) | `highest` | lowest | `highest` | `highest` | `highest` | `highest` | low | high
-QuikClot | medium | high | medium | medium | medium | medium | high | high
-
+Basic (FieldDressing) | highest | low | highest | medium | low | high | low | medium
+Bandage (packing) | highest | highest | highest | medium | lowest | low | highest | low
+Bandage (elastic) | highest | low | highest | highest | highest | highest | medium | highest
+QuikClot | high | lowest | high | high | high | high | high | medium
+ 
 ##### 2.2.1.10 Tourniquet
 
 - Can only be applied on limbs.


### PR DESCRIPTION
Fixes some thing like quickclot on Avulsions is listed as `high` but `effectiveness = 0.2;`

Generated via the following code (Thanks to @aaco)

```
private _wounds = "true" configClasses (configfile >> "ACE_Medical_Advanced" >> "Injuries" >> "wounds");
{
    private _config = _x;
    _treatmentsDiaryBuilder = format ["%1", configName (_config)];
    {
        private _wound = configName _x;
        private _woundName = getText (_x >> "name");
        private _effectivenessNumber = getNumber (_config >> _wound >> "effectiveness");
        private _effectivenessText = switch true do {
        case (_effectivenessNumber >= 0.85): { "highest" };
        case (_effectivenessNumber >= 0.65): { "high" };
        case (_effectivenessNumber >= 0.45): { "medium" };
        case (_effectivenessNumber >= 0.25): { "low" };
            default { "lowest" };
        };
        _treatmentsDiaryBuilder = _treatmentsDiaryBuilder + format [" | %1", _effectivenessText];
        nil
    } count _wounds;
    diag_log text _treatmentsDiaryBuilder;
    nil
} count ("true" configClasses (configfile >> "ACE_Medical_Advanced" >> "Treatment" >> "Bandaging"));
```