### PR TITLE
Fix Medical Triagecard Macro

### DIFF
--- a/addons/medical/ui/triagecard.hpp
+++ b/addons/medical/ui/triagecard.hpp
@@ -113,7 +113,7 @@ class GVAR(triageCard) {
             animTextureFocused = "#(argb,8,8,3)color(0,0,0,0.9)";
             animTexturePressed = "#(argb,8,8,3)color(0,0,0,0.9)";
             animTextureDefault = "#(argb,8,8,3)color(0,0,0,0.9)";
-            action = QUOTE([false] call FUNC(dropDownTriageCard); GVAR(TriageCardTarget) setvariable [ARR_3('ACE_medical_triageLevel',0,true)];);
+            action = QUOTE([false] call FUNC(dropDownTriageCard); (GVAR(TriageCardTarget)) setvariable [ARR_3('ACE_medical_triageLevel',0,true)];);
         };
         class selectTriageStatusMinor: selectTriageStatus {
             idc = 2003;
@@ -131,7 +131,7 @@ class GVAR(triageCard) {
             animTextureFocused = "#(argb,8,8,3)color(0,0.5,0,0.9)";
             animTexturePressed = "#(argb,8,8,3)color(0,0.5,0,0.9)";
             animTextureDefault = "#(argb,8,8,3)color(0,0.5,0,0.9)";
-            action = QUOTE([false] call FUNC(dropDownTriageCard); GVAR(TriageCardTarget) setvariable [ARR_3('ACE_medical_triageLevel',1,true)];);
+            action = QUOTE([false] call FUNC(dropDownTriageCard); (GVAR(TriageCardTarget)) setvariable [ARR_3('ACE_medical_triageLevel',1,true)];);
         };
         class selectTriageStatusDelayed: selectTriageStatus {
             idc = 2004;
@@ -149,7 +149,7 @@ class GVAR(triageCard) {
             animTextureFocused = "#(argb,8,8,3)color(0.77,0.51,0.08,0.9)";
             animTexturePressed = "#(argb,8,8,3)color(0.77,0.51,0.08,0.9)";
             animTextureDefault = "#(argb,8,8,3)color(0.77,0.51,0.08,0.9)";
-            action = QUOTE([false] call FUNC(dropDownTriageCard); GVAR(TriageCardTarget) setvariable [ARR_3('ACE_medical_triageLevel',2,true)];);
+            action = QUOTE([false] call FUNC(dropDownTriageCard); (GVAR(TriageCardTarget)) setvariable [ARR_3('ACE_medical_triageLevel',2,true)];);
         };
         class selectTriageStatusImmediate: selectTriageStatus {
             idc = 2005;
@@ -167,7 +167,7 @@ class GVAR(triageCard) {
             animTextureFocused = "#(argb,8,8,3)color(1,0.2,0.2,0.9)";
             animTexturePressed = "#(argb,8,8,3)color(1,0.2,0.2,0.9)";
             animTextureDefault = "#(argb,8,8,3)color(1,0.2,0.2,0.9)";
-            action = QUOTE([false] call FUNC(dropDownTriageCard); GVAR(TriageCardTarget) setvariable [ARR_3('ACE_medical_triageLevel', 3, true)];);
+            action = QUOTE([false] call FUNC(dropDownTriageCard); (GVAR(TriageCardTarget)) setvariable [ARR_3('ACE_medical_triageLevel', 3, true)];);
         };
         class selectTriageStatusDeceased: selectTriageStatus {
             idc = 2006;
@@ -185,7 +185,7 @@ class GVAR(triageCard) {
             animTextureFocused = "#(argb,8,8,3)color(0,0,0,0.9)";
             animTexturePressed = "#(argb,8,8,3)color(0,0,0,0.9)";
             animTextureDefault = "#(argb,8,8,3)color(0,0,0,0.9)";
-            action = QUOTE([false] call FUNC(dropDownTriageCard); GVAR(TriageCardTarget) setvariable [ARR_3('ACE_medical_triageLevel', 4, true)];);
+            action = QUOTE([false] call FUNC(dropDownTriageCard); (GVAR(TriageCardTarget)) setvariable [ARR_3('ACE_medical_triageLevel', 4, true)];);
         };
     };
 };


### PR DESCRIPTION
Fix #3087 

Somehow the space is removed between `GVAR(TriageCardTarget) setvariable` when pboProject evals the macros

wrapping with `()` fixes and works with both make.py and build.py builds