### PR TITLE
Kill Spectator PFEH when exiting spectator

### DIFF
--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -127,6 +127,12 @@ if (_set) then {
     GVAR(unitCamera) = nil;
     GVAR(targetCamera) = nil;
 
+    //Kill these PFEH handlers now because the PFEH can run before the `onunload` event is handled
+    GVAR(camHandler) = nil;
+    GVAR(compHandler) = nil;
+    GVAR(iconHandler) = nil;
+    GVAR(toolHandler) = nil;
+
     // Cleanup display variables
     GVAR(ctrlKey) = nil;
     GVAR(heldKeys) = nil;


### PR DESCRIPTION
Should fix #2989

There is a race condition between these 4 PFEH and the "onUnload" event
in handleInterface.
If the PFEHs run first they will use nil variables and throw a script
error.
This sets them to nil immediately when exiting spectator

@SilentSpike - I'm not 100% sure this is the right way to fix, but it seems to work.

Debug of the race condition:
```
handleCamera Frame:35839 (normal)
end spectator Frame:35840
handleCamera Frame:35840 (throws error)
Error in expression ... File z\ace\addons\spectator\functions\fnc_handleCamera.sqf, line 35
Killing CamHandler in handleInterface: onunload Frame:35840
handleCamera Frame:35841 (exits cleanly)
```