### PR TITLE
Frag - only run addPfhRound on ammo that will frag

### DIFF
--- a/addons/common/CfgLocationTypes.hpp
+++ b/addons/common/CfgLocationTypes.hpp
@@ -1,0 +1,16 @@
+//Create a location type that won't be drawn on the map
+//Ref: https://community.bistudio.com/wiki/Location
+
+class CfgLocationTypes {
+    class ACE_HashLocation {
+        color[] = {0,0,0,0};
+        drawStyle = "bananas";
+        font = "PuristaMedium";
+        importance = 5;
+        name = "HashLocation";
+        shadow = 0;
+        size = 0;
+        textSize = 0.0;
+        texture = "";
+    };
+};

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -14,6 +14,7 @@ class CfgPatches {
 
 #include "CfgEventHandlers.hpp"
 
+#include "CfgLocationTypes.hpp"
 #include "CfgSounds.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/frag/XEH_postInit.sqf
+++ b/addons/frag/XEH_postInit.sqf
@@ -12,5 +12,5 @@ if(isServer) then {
 [FUNC(masterPFH), 0, []] call CBA_fnc_addPerFrameHandler;
 
 //Cache for ammo type configs
-GVAR(cacheRoundsTypesToTrack) = createLocation ["NameVillage", [-10000,-10000,-10000], 0, 0];
+GVAR(cacheRoundsTypesToTrack) = createLocation ["ACE_HashLocation", [-10000,-10000,-10000], 0, 0];
 GVAR(cacheRoundsTypesToTrack) setText QGVAR(cacheRoundsTypesToTrack);

--- a/addons/frag/XEH_postInit.sqf
+++ b/addons/frag/XEH_postInit.sqf
@@ -10,3 +10,7 @@ if(isServer) then {
 };
 
 [FUNC(masterPFH), 0, []] call CBA_fnc_addPerFrameHandler;
+
+//Cache for ammo type configs
+GVAR(cacheRoundsTypesToTrack) = createLocation ["NameVillage", [-10000,-10000,-10000], 0, 0];
+GVAR(cacheRoundsTypesToTrack) setText QGVAR(cacheRoundsTypesToTrack);

--- a/addons/frag/functions/fnc_fired.sqf
+++ b/addons/frag/functions/fnc_fired.sqf
@@ -1,8 +1,56 @@
+/*
+ * Author: nou, jaynus, PabstMirror
+ * Called from FiredBIS event on AllVehicles
+ * If spall is not enabled (default), then cache and only track those that will actually trigger fragmentation.
+ *
+ * Arguments:
+ * 0: gun - Object the event handler is assigned to <OBJECT>
+ * 4: type - Ammo used <STRING>
+ * 6: round - Object of the projectile that was shot <OBJECT>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [clientFiredBIS-XEH] call ace_frag_fnc_fired
+ *
+ * Public: No
+ */
+// #define DEBUG_ENABLED_FRAG
 #include "script_component.hpp"
-private["_gun", "_type", "_round"];
 
-_gun = _this select 0;
-_type = _this select 4;
-_round = _this select 6;
+params ["_gun", "", "", "", "_type", "", "_round"];
 
-[_gun, _type, _round] call FUNC(addPfhRound);
+private _shouldAdd = GVAR(cacheRoundsTypesToTrack) getVariable _type;
+if (isNil "_shouldAdd") then {
+    TRACE_1("no cache for round",_type);
+
+    if (!EGVAR(common,settingsInitFinished)) exitWith {
+        //Just incase fired event happens before settings init, don't want to set cache wrong if spall setting changes
+        TRACE_1("Settings not init yet - exit without setting cache",_type);
+        _shouldAdd = false;
+    };
+
+    if (GVAR(SpallEnabled)) exitWith {
+        //Always want to run whenever spall is enabled?
+        _shouldAdd = true;
+        TRACE_2("SettingCache[spallEnabled]",_type,_shouldAdd);
+        GVAR(cacheRoundsTypesToTrack) setVariable [_type, _shouldAdd];
+    };
+
+    //Read configs and test if it would actually cause a frag, using same logic as FUNC(pfhRound)
+    private _skip = getNumber (configFile >> "CfgAmmo" >> _type >> QGVAR(skip));
+    private _explosive = getNumber (configFile >> "CfgAmmo" >> _type >> "explosive");
+    private _indirectRange = getNumber (configFile >> "CfgAmmo" >> _type >> "indirectHitRange");
+    private _force = getNumber (configFile >> "CfgAmmo" >> _type >> QGVAR(force));
+    private _fragPower = getNumber(configFile >> "CfgAmmo" >> _type >> "indirecthit")*(sqrt((getNumber (configFile >> "CfgAmmo" >> _type >> "indirectHitRange"))));
+
+    _shouldAdd = (_skip == 0) && {(_force == 1) || {_explosive > 0.5 && {_indirectRange >= 4.5} && {_fragPower >= 35}}};
+    TRACE_6("SettingCache[willFrag?]",_skip,_explosive,_indirectRange,_force,_fragPower,_shouldAdd);
+    GVAR(cacheRoundsTypesToTrack) setVariable [_type, _shouldAdd];
+};
+
+if (_shouldAdd) then {
+    TRACE_3("Running Frag Tracking",_gun,_type,_round);
+    [_gun, _type, _round] call FUNC(addPfhRound);
+};


### PR DESCRIPTION
If spall is not enabled (default) then calculate which ammo types will
actually cause a frag event, cache and then only track those.

before: `(#2): 0.0883651ms  - CODE: {_this call ace_frag_fnc_fired}`
after: `(#2): 0.0179289ms  - CODE: {_this call ace_frag_fnc_fired}`

More importantly this skips running frag simulation (tracking bullet position in a PFEH) for rounds that will never trigger a frag event.