### PR TITLE
Explosive events, fix #3104

### DIFF
--- a/addons/explosives/functions/fnc_defuseExplosive.sqf
+++ b/addons/explosives/functions/fnc_defuseExplosive.sqf
@@ -22,6 +22,8 @@ TRACE_2("params",_unit,_explosive);
 if (GVAR(ExplodeOnDefuse) && {(random 1.0) < (getNumber (ConfigFile >> "CfgAmmo" >> typeOf _explosive >> "ACE_explodeOnDefuse"))}) exitWith {
     TRACE_1("exploding on defuse",_explosive);
     [_unit, -1, [_explosive, 1], true] call FUNC(detonateExplosive);
+    [QGVAR(explodeOnDefuse), [_explosive, _unit]] call EFUNC(common,globalEvent);
 };
 
 _unit action ["Deactivate", _unit, _explosive];
+[QGVAR(defuse), [_explosive, _unit]] call EFUNC(common,globalEvent);

--- a/addons/explosives/functions/fnc_placeExplosive.sqf
+++ b/addons/explosives/functions/fnc_placeExplosive.sqf
@@ -94,7 +94,7 @@ if (isText(_triggerConfig >> "onPlace") && {[_unit,_explosive,_magazineClass,_tr
 
 _pitch = getNumber (_magazineTrigger >> "pitch");
 
-//Globaly set the position angle:
-[QGVAR(place), [_explosive, _dir, _pitch]] call EFUNC(common,globalEvent);
+//Globaly set the position and angle:
+[QGVAR(place), [_explosive, _dir, _pitch, _unit]] call EFUNC(common,globalEvent);
 
 _explosive


### PR DESCRIPTION
When merged this pull request will:
* add 2 new events: `defuse` and `explodeOnDefuse`
* add `_unit` to place event

Can be tested with:

```sqf
["ace_explosives_place", {
    hint format ["Placed:\nexpl: %1\nunit: %2", _this select 0, _this select 3];
}] call ace_common_fnc_addEventHandler;

["ace_explosives_defuse", {
    hint format ["Defused:\nexpl: %1\nunit: %2", _this select 0, _this select 1];
}] call ace_common_fnc_addEventHandler;

["ace_explosives_explodeOnDefuse", {
    hint format ["ExplodedOnDefuse:\nexpl: %1\nunit: %2", _this select 0, _this select 1];
}] call ace_common_fnc_addEventHandler;
```