### PR TITLE
Add action to detonate all explosives on a detonator

### DIFF
--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -28,6 +28,7 @@ PREP(canDefuse);
 PREP(canDetonate);
 PREP(defuseExplosive);
 PREP(detonateExplosive);
+PREP(detonateExplosiveAll);
 PREP(dialPhone);
 PREP(dialingPhone);
 

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -43,10 +43,10 @@ _explosivesList = [];
                         {(_this select 2) call FUNC(detonateExplosive);},
                         {true},
                         {},
-                        [ACE_player,_range,_x]
+                        [_unit,_range,_x]
                     ] call EFUNC(interact_menu,createAction),
                     [],
-                    ACE_Player
+                    _unit
                 ];
         };
     };
@@ -62,10 +62,10 @@ if (count _explosivesList > 0) then {
             {(_this select 2) call FUNC(detonateExplosiveAll);},
             {true},
             {},
-            [ACE_player,_range,_explosivesList]
+            [_unit,_range,_explosivesList]
         ] call EFUNC(interact_menu,createAction),
         [],
-        ACE_Player
+        _unit
     ];
 };
 

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -57,7 +57,7 @@ if (count _explosivesList > 0) then {
     _children pushBack [
         [
             "Explosive_All",
-            "Detonate All", 
+            localize LSTRING(DetonateAll), 
             getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
             {(_this select 2) call FUNC(detonateExplosiveAll);},
             {true},

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -19,17 +19,20 @@
 params ["_unit", "_detonator"];
 TRACE_2("params",_unit,_detonator);
 
-private ["_result", "_item", "_children", "_range", "_required"];
+private ["_result", "_item", "_children", "_range", "_required","_explosivesList"];
 
 _range = getNumber (ConfigFile >> "CfgWeapons" >> _detonator >> "ACE_Range");
 
 _result = [_unit] call FUNC(getPlacedExplosives);
 _children = [];
+_explosivesList = [];
 {
     if (!isNull(_x select 0)) then {
         _required = getArray (ConfigFile >> "ACE_Triggers" >> (_x select 4) >> "requires");
         if (_detonator in _required) then {
             _item = ConfigFile >> "CfgMagazines" >> (_x select 3);
+
+            _explosivesList pushBack _x;
 
             _children pushBack
                 [
@@ -48,5 +51,22 @@ _children = [];
         };
     };
 } forEach _result;
+
+// Add action to detonate all explosives tied to the detonator
+if (count _explosivesList > 0) then {
+    _children pushBack [
+        [
+            "Explosive_All",
+            "Detonate All", 
+            getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
+            {(_this select 2) call FUNC(detonateExplosiveAll);},
+            {true},
+            {},
+            [ACE_player,_range,_explosivesList]
+        ] call EFUNC(interact_menu,createAction),
+        [],
+        ACE_Player
+    ];
+};
 
 _children

--- a/addons/explosives/functions/fnc_addTransmitterActions.sqf
+++ b/addons/explosives/functions/fnc_addTransmitterActions.sqf
@@ -33,10 +33,10 @@ _children = [];
                 {},
                 {true},
                 {(_this select 2) call FUNC(addDetonateActions);},
-                [ACE_player,_x]
+                [_unit,_x]
             ] call EFUNC(interact_menu,createAction),
             [],
-            ACE_Player
+            _unit
         ];
 } forEach _detonators;
 

--- a/addons/explosives/functions/fnc_detonateExplosiveAll.sqf
+++ b/addons/explosives/functions/fnc_detonateExplosiveAll.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: VKing
+ * Causes the unit to detonate all passed explosives.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Range (-1 to ignore) <NUMBER>
+ * 2: Explosives to detonate <ARRAY>
+ *     0: Explosive <OBJECT>
+ *     1: Fuse time <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, -1, "Command"] call ACE_Explosives_fnc_detonateExplosive;
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit", "_range", "_explosivesList"];
+TRACE_3("Params",_unit,_range,_explosivesList);
+
+{
+    [_unit,_range,_x] call FUNC(detonateExplosive);
+} forEach _explosivesList;

--- a/addons/explosives/functions/fnc_detonateExplosiveAll.sqf
+++ b/addons/explosives/functions/fnc_detonateExplosiveAll.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * [player, -1, "Command"] call ACE_Explosives_fnc_detonateExplosive;
+ * [player, -1, [[c4,0.5]]] call ACE_Explosives_fnc_detonateExplosiveAll;
  *
  * Public: No
  */

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -37,6 +37,12 @@
             <Portuguese>Detonar &gt;&gt;</Portuguese>
             <Russian>Подрыв &gt;&gt;</Russian>
         </Key>
+        <Key ID="STR_ACE_Explosives_DetonateAll">
+            <English>Detonate All</English>
+            <German>Zünden Alles</German>
+            <Spanish>Detonar Todo</Spanish>
+            <Russian>Подрыв Все</Russian>
+        </Key>
         <Key ID="STR_ACE_Explosives_DetonateCode">
             <English>Explosive code: %1</English>
             <German>Sprengstoffcode: %1</German>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -41,7 +41,7 @@
             <English>Detonate All</English>
             <German>Zünden Alles</German>
             <Spanish>Detonar Todo</Spanish>
-            <Russian>Подрыв Все</Russian>
+            <Russian>Подрыв всех</Russian>
         </Key>
         <Key ID="STR_ACE_Explosives_DetonateCode">
             <English>Explosive code: %1</English>


### PR DESCRIPTION
This PR will add an action to the detonator menu to detonate all explosives associated with it.
Example can be seen [here](http://i.imgur.com/oGUEKTl.jpg?1)

This fixes #2108 and will probably deprecate #1219.