### PR TITLE
Clean up explosive interaction menu

### DIFF
--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -10,17 +10,8 @@ class CfgVehicles {
                 showDisabled = 1;
                 priority = 4;
                 icon = PATHTOF(UI\Explosives_Menu_ca.paa);
+                insertChildren = QUOTE([_player] call FUNC(addTransmitterActions););
                 //Sub-menu items
-                class ACE_Detonate {
-                    displayName = CSTRING(Detonate);
-                    condition = QUOTE([_player] call FUNC(canDetonate));
-                    statement = "";
-                    insertChildren = QUOTE([_player] call FUNC(addTransmitterActions););
-                    exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting"};
-                    showDisabled = 1;
-                    icon = PATHTOF(UI\Explosives_Menu_ca.paa);
-                    priority = 2;
-                };
                 class ACE_Place {
                     displayName = CSTRING(Place);
                     condition = QUOTE((vehicle _player == _player) and {[_player] call FUNC(hasExplosives)});

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -14,28 +14,28 @@
             <Russian>Взрывчатка</Russian>
         </Key>
         <Key ID="STR_ACE_Explosives_Place">
-            <English>Place &gt;&gt;</English>
-            <German>Platzieren &gt;&gt;</German>
-            <Spanish>Colocar &gt;&gt;</Spanish>
-            <Polish>Umieść &gt;&gt;</Polish>
-            <French>Placer &gt;&gt;</French>
-            <Czech>Položit &gt;&gt;</Czech>
-            <Italian>Piazza &gt;&gt;</Italian>
-            <Hungarian>Elhelyezés &gt;&gt;</Hungarian>
-            <Portuguese>Colocar &gt;&gt;</Portuguese>
-            <Russian>Установить &gt;&gt;</Russian>
+            <English>Place</English>
+            <German>Platzieren</German>
+            <Spanish>Colocar</Spanish>
+            <Polish>Umieść</Polish>
+            <French>Placer</French>
+            <Czech>Položit</Czech>
+            <Italian>Piazza</Italian>
+            <Hungarian>Elhelyezés</Hungarian>
+            <Portuguese>Colocar</Portuguese>
+            <Russian>Установить</Russian>
         </Key>
         <Key ID="STR_ACE_Explosives_Detonate">
-            <English>Detonate &gt;&gt;</English>
-            <German>Zünden &gt;&gt;</German>
-            <Spanish>Detonar &gt;&gt;</Spanish>
-            <Polish>Detonuj &gt;&gt;</Polish>
-            <French>Mise à feu &gt;&gt;</French>
-            <Czech>Odpálit &gt;&gt;</Czech>
-            <Italian>Detona &gt;&gt;</Italian>
-            <Hungarian>Robbantás &gt;&gt;</Hungarian>
-            <Portuguese>Detonar &gt;&gt;</Portuguese>
-            <Russian>Подрыв &gt;&gt;</Russian>
+            <English>Detonate</English>
+            <German>Zünden</German>
+            <Spanish>Detonar</Spanish>
+            <Polish>Detonuj</Polish>
+            <French>Mise à feu</French>
+            <Czech>Odpálit</Czech>
+            <Italian>Detona</Italian>
+            <Hungarian>Robbantás</Hungarian>
+            <Portuguese>Detonar</Portuguese>
+            <Russian>Подрыв</Russian>
         </Key>
         <Key ID="STR_ACE_Explosives_DetonateCode">
             <English>Explosive code: %1</English>


### PR DESCRIPTION
Move detonate actions from "Detonate" layer to "Explosives" layer and remove inconsistent ">>" from explosive actions.
Reasoning is that the amount of detonators that someone can reasonably be expected to carry isn't large enough to warrant an extra layer to the interaction menu.