### PR TITLE
Reset make.py Cache on new build version

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -975,6 +975,18 @@ See the make.cfg file for additional build options.
         print ("No cache found.")
         cache = {}
 
+    # Check the ace build version (from main) with cached version - Forces a full rebuild when version changes
+    aceVersion = get_project_version()
+    cacheVersion = "None";
+    if 'cacheVersion' in cache:
+        cacheVersion = cache['cacheVersion']
+
+    if (aceVersion != cacheVersion):
+        cache = {}
+        print("Reseting Cache {0} to New Version {1}".format(cacheVersion, aceVersion))
+        cache['cacheVersion'] = aceVersion
+
+
     if not os.path.isdir(os.path.join(release_dir, project, "addons")):
         try:
             os.makedirs(os.path.join(release_dir, project, "addons"))


### PR DESCRIPTION
Replace #3028 (that was on release branch)

Close #1127
If the version (from main) changes, reset cache
Same effect as "force"