### PR TITLE
AB - Handle subsonic ammo when configs not defined

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_calculateBarrelLengthVelocityShift.sqf
+++ b/addons/advanced_ballistics/functions/fnc_calculateBarrelLengthVelocityShift.sqf
@@ -22,6 +22,7 @@ private ["_muzzleVelocityTableCount", "_barrelLengthTableCount", "_lowerDataInde
     "_upperDataIndex", "_lowerBarrelLength", "_upperBarrelLength", "_lowerMuzzleVelocity",
     "_upperMuzzleVelocity", "_interpolationRatio"];
 params ["_barrelLength", "_muzzleVelocityTable", "_barrelLengthTable", "_muzzleVelocity"];
+TRACE_4("params",_barrelLength,_muzzleVelocityTable,_barrelLengthTable,_muzzleVelocity);
 
 // If barrel length is not defined, then there is no point in calculating muzzle velocity
 if (_barrelLength == 0) exitWith { 0 };

--- a/addons/advanced_ballistics/functions/fnc_readAmmoDataFromConfig.sqf
+++ b/addons/advanced_ballistics/functions/fnc_readAmmoDataFromConfig.sqf
@@ -24,6 +24,7 @@
  */
 #include "script_component.hpp"
 
+TRACE_1("Reading Ammo Config",_this);
 private ["_ammo", "_airFriction", "_caliber", "_bulletLength", "_bulletMass", "_transonicStabilityCoef", "_dragModel", "_ballisticCoefficients", "_velocityBoundaries", "_atmosphereModel", "_ammoTempMuzzleVelocityShifts", "_muzzleVelocityTable", "_barrelLengthTable", "_result"];
 _ammoConfig = configFile >> "CfgAmmo" >> _this;
 
@@ -48,6 +49,42 @@ if (_atmosphereModel isEqualTo "") then {
 _ammoTempMuzzleVelocityShifts = getArray(_ammoConfig >> "ACE_ammoTempMuzzleVelocityShifts");
 _muzzleVelocityTable = getArray(_ammoConfig >> "ACE_muzzleVelocities");
 _barrelLengthTable = getArray(_ammoConfig >> "ACE_barrelLengths");
+
+//Handle subsonic ammo that would have a huge muzzle velocity shift (when ballistic configs not explicitly defined)
+private _typicalSpeed = getNumber (_ammoConfig >> "typicalSpeed");
+if ((_typicalSpeed > 0) && {_typicalSpeed < 360}) then {
+    private _inheritedBarrelConfig = (!(_muzzleVelocityTable isEqualTo [])) && {(configProperties [_ammoConfig, "(configName _x) == 'ACE_muzzleVelocities'", false]) isEqualTo []};
+    private _inheritedTempConfig = (!(_ammoTempMuzzleVelocityShifts isEqualTo [])) && {(configProperties [_ammoConfig, "(configName _x) == 'ACE_ammoTempMuzzleVelocityShifts'", false]) isEqualTo []};
+    TRACE_3("subsonic",_typicalSpeed,_inheritedBarrelConfig,_inheritedTempConfig);
+    if (_inheritedBarrelConfig || _inheritedTempConfig) then {
+        private _parentConfig = inheritsFrom _ammoConfig;
+        private _parentSpeed = getNumber (_parentConfig >> "typicalSpeed");
+        ACE_LOGWARNING_4("Subsonic Ammo %1 (%2 m/s) missing `ACE_muzzleVelocities` or `ACE_ammoTempMuzzleVelocityShifts` configs, attempting to use parent %3 (%4m/s)",_this,_typicalSpeed,configName _parentConfig, _parentSpeed);
+        if (_parentSpeed <= 0) exitWith {//Handle weird or null parent
+            _muzzleVelocityTable = [];
+            _ammoTempMuzzleVelocityShifts = [];
+        };
+        private _linearMuliplier = _typicalSpeed / _parentSpeed;
+        if (_inheritedBarrelConfig) then {
+            if (!((configProperties [_parentConfig, "(configName _x) == 'ACE_muzzleVelocities'", false]) isEqualTo [])) then {
+                TRACE_2("Parent Has Defined Barrel MV",_linearMuliplier,_muzzleVelocityTable);
+                { _muzzleVelocityTable set [_forEachIndex, (_x * _linearMuliplier)]; } forEach _muzzleVelocityTable;
+            } else {
+                TRACE_2("Parent DOES NOT Have Defined Barrel MV",_linearMuliplier,_muzzleVelocityTable);
+                _muzzleVelocityTable = [];
+            };
+        };
+        if (_inheritedTempConfig) then {
+            if (!((configProperties [_parentConfig, "(configName _x) == 'ACE_ammoTempMuzzleVelocityShifts'", false]) isEqualTo [])) then {
+                TRACE_2("Parent Has Defined Ammo Temp Shifts",_linearMuliplier,_muzzleVelocityTable);
+                { _ammoTempMuzzleVelocityShifts set [_forEachIndex, (_x * _linearMuliplier)]; } forEach _ammoTempMuzzleVelocityShifts;
+            } else {
+                TRACE_2("Parent DOES NOT Have Defined Ammo Temp Shifts",_linearMuliplier,_muzzleVelocityTable);
+                _ammoTempMuzzleVelocityShifts = [];
+            };
+        };
+    };
+};
 
 _result = [_airFriction, _caliber, _bulletLength, _bulletMass, _transonicStabilityCoef, _dragModel, _ballisticCoefficients, _velocityBoundaries, _atmosphereModel, _ammoTempMuzzleVelocityShifts, _muzzleVelocityTable, _barrelLengthTable];
 

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -14,6 +14,12 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={780, 880, 920};
         ACE_barrelLengths[]={254.0, 414.02, 508.0};
     };
+    class rhs_B_545x39_7U1_Ball: rhs_B_545x39_Ball {
+        //Subsonic - ToDo need full config for this bullet
+        ACE_ammoTempMuzzleVelocityShifts[]={-8.85,-8.49,-7.61667,-6.70667,-5.66,-4.26667,-2.54667,-0.51,1.98667,5.05667,8.73}; //Just Scaled Down Normal?
+        ACE_muzzleVelocities[] = {303};
+        ACE_barrelLengths[] = {200};
+    };
     class rhs_B_545x39_Ball_Tracer_Green: rhs_B_545x39_Ball {
         ACE_caliber=5.588;
         ACE_bulletLength=21.59;
@@ -74,6 +80,12 @@ class CfgAmmo {
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={650, 716, 750};
         ACE_barrelLengths[]={254.0, 414.02, 508.0};
+    };
+    class rhs_B_762x39_U_Ball: rhs_B_762x39_Ball {
+        //Subsonic - ToDo need full config for this bullet
+        ACE_ammoTempMuzzleVelocityShifts[]={-8.85,-8.49,-7.61667,-6.70667,-5.66,-4.26667,-2.54667,-0.51,1.98667,5.05667,8.73}; //Just Scaled Down Normal?
+        ACE_muzzleVelocities[] = {295};
+        ACE_barrelLengths[] = {414};
     };
     class rhs_B_762x39_Tracer: rhs_B_762x39_Ball {
         ACE_caliber=7.823;


### PR DESCRIPTION
Fix #3062
- Add basic AB configs for subsonic Russian bullets.
- When building ab ammo cache, if round is subsonic and does not have AB
configured attempt to use the parent's config, scaled down to the subsonic's round
speed.


Without this, AB would use the parents muzzle velocity which broke the sights
and more importantly it causes the silent bullet to still have normal speed/damage.

Linear scaling probably isn't going to be perfect, but it should be much closer than using the unmodified parent config; this will also put a warning in rpt (only once per game because this is all cached).