### PR TITLE
Use Function Caching in CBA

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -84,7 +84,7 @@
 #ifdef DISABLE_COMPILE_CACHE
     #define PREP(fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QUOTE(PATHTOF(functions\DOUBLES(fnc,fncName).sqf))
 #else
-    #define PREP(fncName) DFUNC(fncName) = QUOTE(PATHTOF(functions\DOUBLES(fnc,fncName).sqf)) call SLX_XEH_COMPILE
+    #define PREP(fncName) [QUOTE(PATHTOF(functions\DOUBLES(fnc,fncName).sqf)), QFUNC(fncName)] call SLX_XEH_COMPILE_NEW
 #endif
 
 #define PREP_MODULE(folder) [] call compile preprocessFileLineNumbers QUOTE(PATHTOF(folder\__PREP__.sqf))


### PR DESCRIPTION
`SLX_XEH_COMPILE` doesn't cache anymore, it had been updated to a new version that takes new params.

Pretty trivial, but important to know about or the file patching won't do what you think it will. 
ACE devs need to use put this in a mission description.ext
```
class CfgSettings {
    class CBA {
        class Caching {
            compile = 0;
        };
    };
};
```
OR 
Add `#define DISABLE_COMPILE_CACHE` to the module's script component 
(or top of main/script_macros.hpp)
You NEED to use this method if you recompile functions mid-mission as the others use `compileFinal`

OR
Just add `cba_cache_disable.pbo` from optionals

PreInit goes from ~4.5 seconds to less than 0.3 (cuts mission SP Editor restart time in half)