### PR TITLE
Fix make.py undefined variable and regex

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -697,11 +697,9 @@ def version_stamp_pboprefix(module,commitID):
         f.close()
 
         if configtext:
-            patchestext = re.search(r"version.*?=.*?$", configtext, re.DOTALL)
-            if patchestext:
+            if re.search(r"version=(.*?)$", configtext, re.DOTALL):
                 if configtext:
-                    patchestext = re.search(r"(version.*?=)(.*?)$", configtext, re.DOTALL).group(1)
-                    configtext = re.sub(r"version(.*?)=(.*?)$", "version = {}\n".format(commitID), configtext, flags=re.DOTALL)
+                    configtext = re.sub(r"version=(.*?)$", "version={}\n".format(commitID), configtext, flags=re.DOTALL)
                     f = open(configpath, "w")
                     f.write(configtext)
                     f.close()
@@ -975,17 +973,16 @@ See the make.cfg file for additional build options.
         print ("No cache found.")
         cache = {}
 
-    # Check the ace build version (from main) with cached version - Forces a full rebuild when version changes
-    aceVersion = get_project_version()
+    # Check the build version (from main) with cached version - forces a full rebuild when version changes
+    project_version = get_project_version()
     cacheVersion = "None";
     if 'cacheVersion' in cache:
         cacheVersion = cache['cacheVersion']
 
-    if (aceVersion != cacheVersion):
+    if (project_version != cacheVersion):
         cache = {}
-        print("Reseting Cache {0} to New Version {1}".format(cacheVersion, aceVersion))
-        cache['cacheVersion'] = aceVersion
-
+        print("Reseting Cache {0} to New Version {1}".format(cacheVersion, project_version))
+        cache['cacheVersion'] = project_version
 
     if not os.path.isdir(os.path.join(release_dir, project, "addons")):
         try:
@@ -1010,6 +1007,9 @@ See the make.cfg file for additional build options.
         # Set version
         set_version_in_files();
         print("Version in files has been changed, make sure you commit and push the updates!")
+
+    amountOfBuildsFailed = 0
+    namesOfBuildsFailed = []
 
     try:
         # Temporarily copy optionals_root for building. They will be removed later.
@@ -1094,9 +1094,6 @@ See the make.cfg file for additional build options.
                     except:
                         print_error("\nFailed to delete {}".format(os.path.join(obsolete_check_path,file)))
                         pass
-
-        amountOfBuildsFailed = 0
-        namesOfBuildsFailed = []
 
         # For each module, prep files and then build.
         print_blue("\nBuilding...")


### PR DESCRIPTION
When merged this pull request will:
- Fix possible undefined variable error when make.py exits before builds (`amountOfBuildsFailed` and `namesOfBuildsFailed` were getting initialized inside the if statement, but used outside)
- Rename `aceVersion` to `project_version` for consistency
- Update version check regex from CBA (could throw errors in edge-case PBO names)