### PR TITLE
Function to detonate explosives via script

### DIFF
--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -28,7 +28,6 @@ PREP(canDefuse);
 PREP(canDetonate);
 PREP(defuseExplosive);
 PREP(detonateExplosive);
-PREP(detonateExplosiveTrigger);
 PREP(dialPhone);
 PREP(dialingPhone);
 
@@ -53,6 +52,7 @@ PREP(openTimerSetUI);
 PREP(placeExplosive);
 PREP(removeFromSpeedDial);
 
+PREP(scriptedExplosive);
 PREP(selectTrigger);
 PREP(setupExplosive);
 PREP(setPosition);

--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -28,6 +28,7 @@ PREP(canDefuse);
 PREP(canDetonate);
 PREP(defuseExplosive);
 PREP(detonateExplosive);
+PREP(detonateExplosiveTrigger);
 PREP(dialPhone);
 PREP(dialingPhone);
 

--- a/addons/explosives/functions/fnc_detonateExplosiveTrigger.sqf
+++ b/addons/explosives/functions/fnc_detonateExplosiveTrigger.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: VKing
+ * Detonate explosives via script, for use in triggers or mission scripts to
+ * detonate editor-placed explosives.
+ *
+ * Arguments:
+ * 0: Explosives objects to detonate <ARRAY>
+ * 1: Fuze delay (for each explosive; use negative number for random time up to value) <NUMBER> <OPTIONAL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [[charge1, charge2, charge3], -1] call ACE_Explosives_fnc_detonateExplosiveTrigger;
+ * [[claymore1, claymore2]] call ACE_Explosives_fnc_detonateExplosiveTrigger;
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params ["_explosiveArr",["_fuzeTime",0]];
+
+private _detTime;
+{
+    _detTime = if (_fuzeTime < 0) then {random abs _fuzeTime} else {_fuzeTime};
+    [objNull, -1, [_x, _detTime]] call FUNC(detonateExplosive);
+} forEach _explosiveArr;

--- a/addons/explosives/functions/fnc_scriptedExplosive.sqf
+++ b/addons/explosives/functions/fnc_scriptedExplosive.sqf
@@ -11,8 +11,8 @@
  * None
  *
  * Example:
- * [[charge1, charge2, charge3], -1] call ACE_Explosives_fnc_detonateExplosiveTrigger;
- * [[claymore1, claymore2]] call ACE_Explosives_fnc_detonateExplosiveTrigger;
+ * [[charge1, charge2, charge3], -1] call ACE_Explosives_fnc_scriptedExplosive;
+ * [[claymore1, claymore2]] call ACE_Explosives_fnc_scriptedExplosive;
  *
  * Public: Yes
  */


### PR DESCRIPTION
This function is designed to wrap `ace_explosives_fnc_detonateExplosive` for use in triggers or scripts, to detonate explosives placed down in the editor.