### PR TITLE
Restart specatator display if player in unitList

### DIFF
--- a/addons/spectator/functions/fnc_stageSpectator.sqf
+++ b/addons/spectator/functions/fnc_stageSpectator.sqf
@@ -66,3 +66,13 @@ if !(_set isEqualTo (GETVAR(_unit,GVAR(isStaged),false))) then {
 
     ["spectatorStaged",[_set]] call EFUNC(common,localEvent);
 };
+
+//BandAid for #2677 - if player in unitList weird before being staged, weird things can happen
+if ((player in GVAR(unitList)) || {ACE_player in GVAR(unitList)}) then {
+    [] call FUNC(updateUnits);  //update list now
+    if (!(isNull (findDisplay 12249))) then {//If display is open now, close it and restart
+        ACE_LOGWARNING("Player in unitList, call ace_spectator_fnc_stageSpectator before ace_spectator_fnc_setSpectator");
+        ["fixWeirdList", true] call FUNC(interrupt);
+        [{["fixWeirdList", false] call FUNC(interrupt);}, []] call EFUNC(common,execNextFrame);
+    };
+};


### PR DESCRIPTION
Possible fix for #2677

I think the core problem is that voiperr's demo mission does setSpectator before calling stage.
SetSpectator updates the unitList that has the player in it.

This PR is really just a bandAid that restarts the display when they are called out of order.