### PR TITLE
reset interaction menu time variables on save game load

### DIFF
--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -67,6 +67,13 @@ GVAR(expanded) = false;
 
 GVAR(startHoverTime) = ACE_diagTime;
 GVAR(expandedTime) = ACE_diagTime;
+
+// reset on mission load
+addMissionEventHandler ["Loaded", {
+    GVAR(startHoverTime) = 0;
+    GVAR(expandedTime) = 0;
+}];
+
 GVAR(iconCtrls) = [];
 GVAR(iconCount) = 0;
 


### PR DESCRIPTION
ref: #1098

I have to set them to 0, because `ACE_diagTime` is still the value from the previous session and `execNextFrame` fails, because it relies on `GVAR(nextFrameNo)` (from common) which isn't refreshed either.