### PR TITLE
Fix some spectator errors

### DIFF
--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -10,4 +10,4 @@
 }] call EFUNC(common,addEventHandler);
 
 // Should prevent unending spectator on mission end
-addMissionEventHandler ["Ended",{ [false] call FUNC(setSpectator) }];
+addMissionEventHandler ["Ended",{ [QGVAR(EndMission)] call FUNC(interrupt) }];

--- a/addons/spectator/XEH_preInit.sqf
+++ b/addons/spectator/XEH_preInit.sqf
@@ -25,6 +25,9 @@ PREP(updateSpectatableSides);
 PREP(updateUnits);
 PREP(updateVisionModes);
 
+// Reset the stored display
+SETUVAR(GVAR(interface),displayNull);
+
 // Permanent variables
 GVAR(availableModes) = [0,1,2];
 GVAR(availableSides) = [west,east,resistance,civilian];

--- a/addons/spectator/functions/fnc_handleInterface.sqf
+++ b/addons/spectator/functions/fnc_handleInterface.sqf
@@ -22,6 +22,7 @@ params ["_mode",["_args",[]]];
 switch (toLower _mode) do {
     case "onload": {
         _args params ["_display"];
+        SETUVAR(GVAR(interface),_display);
 
         // Always show interface and hide map upon opening
         [_display,nil,nil,!GVAR(showInterface),GVAR(showMap)] call FUNC(toggleInterface);
@@ -451,13 +452,13 @@ switch (toLower _mode) do {
 
         // PFH to re-open display when menu closes
         [{
-            if !(isNull (findDisplay 49)) exitWith {};
+            if !(isNull (_this select 0)) exitWith {};
 
             // If still a spectator then re-enter the interface
             [QGVAR(escape),false] call FUNC(interrupt);
 
             [_this select 1] call CBA_fnc_removePerFrameHandler;
-        },0] call CBA_fnc_addPerFrameHandler;
+        },0,_dlg] call CBA_fnc_addPerFrameHandler;
     };
     case "zeus": {
         openCuratorInterface;

--- a/addons/spectator/functions/fnc_interrupt.sqf
+++ b/addons/spectator/functions/fnc_interrupt.sqf
@@ -29,16 +29,16 @@ if (_interrupt) then {
 };
 
 if (GVAR(interrupts) isEqualTo []) then {
-    if (isNull (findDisplay 12249)) then {
-        createDialog QGVAR(interface);
+    if (isNull (GETUVAR(GVAR(interface),displayNull))) then {
+        (findDisplay 46) createDisplay QGVAR(interface);
         [] call FUNC(transitionCamera);
     };
 } else {
-    if !(isNull (findDisplay 12249)) then {
+    if !(isNull (GETUVAR(GVAR(interface),displayNull))) then {
         while {dialog} do {
             closeDialog 0;
         };
 
-        (findDisplay 12249) closeDisplay 0;
+        (GETUVAR(GVAR(interface),displayNull)) closeDisplay 0;
     };
 };

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -24,7 +24,7 @@
 params [["_set",true,[true]], ["_force",true,[true]]];
 
 // Only clients can be spectators
-if (!hasInterface) exitWith {};
+if !(hasInterface) exitWith {};
 
 // Exit if no change
 if (_set isEqualTo GVAR(isSet)) exitWith {};
@@ -76,12 +76,13 @@ if (_set) then {
     };
 
     [{
+        disableSerialization;
         // Create the display
-        (findDisplay 46) createDisplay QGVAR(interface);
+        _display = (findDisplay 46) createDisplay QGVAR(interface);
 
         // If not forced, make esc end spectator
         if (_this) then {
-            (findDisplay 12249) displayAddEventHandler ["KeyDown", {
+            _display displayAddEventHandler ["KeyDown", {
                 if (_this select 1 == 1) then {
                     [false] call ace_spectator_fnc_setSpectator;
                     true
@@ -101,9 +102,9 @@ if (_set) then {
     while {dialog} do {
         closeDialog 0;
     };
-
+    
     // Kill the display
-    (findDisplay 12249) closeDisplay 0;
+    (GETUVAR(GVAR(interface),displayNull)) closeDisplay 0;
 
     // Terminate camera
     GVAR(freeCamera) cameraEffect ["terminate", "back"];

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -102,7 +102,7 @@ if (_set) then {
     while {dialog} do {
         closeDialog 0;
     };
-    
+
     // Kill the display
     (GETUVAR(GVAR(interface),displayNull)) closeDisplay 0;
 
@@ -131,7 +131,6 @@ if (_set) then {
     //Kill these PFEH handlers now because the PFEH can run before the `onunload` event is handled
     GVAR(camHandler) = nil;
     GVAR(compHandler) = nil;
-    GVAR(iconHandler) = nil;
     GVAR(toolHandler) = nil;
 
     // Cleanup display variables


### PR DESCRIPTION
<ul>
<li>Storing the display in a <code>uiNamespace</code> variable allows me to explicitly close the right display and hopefully fix the interface staying open upon mission end.<br/><br/>
@Commy2's theory is that perhaps when the main display <code>46</code> is killed upon mission end, <code>findDisplay</code> can't find the spectator display to close it because the game thinks it doesn't exist.</li>
<br/>
<li>That was also a minor oversight introduced in the fix for #2989, the icon handler is a mission event handler that isn't self terminating so the index needs to be preserved until after it is removed via <code>removeMissionEventHandler</code>. It is safe to let the <code>onUnload</code> event take care of that (and preferable so that icons disappear while temporarily closed).</li>
</ul>