### PR TITLE
Move littler syncedEH install to after settingInit

### DIFF
--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -246,6 +246,9 @@ GVAR(lastHeartBeatSound) = ACE_time;
 };
 
 ["SettingsInitialized", {
+    // Networked litter (need to wait for GVAR(litterCleanUpDelay) to be set)
+    [QGVAR(createLitter), FUNC(handleCreateLitter), GVAR(litterCleanUpDelay)] call EFUNC(common,addSyncedEventHandler);
+
     if (GVAR(level) == 2) exitWith {
         [
             {(((_this select 0) getVariable [QGVAR(bloodVolume), 100]) < 65)},
@@ -275,9 +278,6 @@ GVAR(lastHeartBeatSound) = ACE_time;
 ["playerInventoryChanged", {
     [ACE_player] call FUNC(itemCheck);
 }] call EFUNC(common,addEventHandler);
-
-// Networked litter
-[QGVAR(createLitter), FUNC(handleCreateLitter), GVAR(litterCleanUpDelay)] call EFUNC(common,addSyncedEventHandler);
 
 if (hasInterface) then {
     ["PlayerJip", {


### PR DESCRIPTION
Need to call this after settingInitalized for `GVAR(litterCleanUpDelay)` to be set correctly from module settings.  

From closed PR #2758 (not sure why I fixed it there)