### PR TITLE
Overpressure cleanup and fix distance check

### DIFF
--- a/addons/overpressure/CfgEventHandlers.hpp
+++ b/addons/overpressure/CfgEventHandlers.hpp
@@ -14,7 +14,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_FiredBIS_EventHandlers {
     class CAManBase {
         class ADDON {
-            clientFiredBIS = QUOTE(_this call FUNC(firedEHBB););
+            clientFiredBIS = QUOTE(if (local (_this select 0)) then {_this call FUNC(firedEHBB);};);
         };
     };
 

--- a/addons/overpressure/CfgEventHandlers.hpp
+++ b/addons/overpressure/CfgEventHandlers.hpp
@@ -14,7 +14,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_FiredBIS_EventHandlers {
     class CAManBase {
         class ADDON {
-            firedBIS = QUOTE(if (local (_this select 0)) then {_this call FUNC(firedEHBB);};);
+            clientFiredBIS = QUOTE(_this call FUNC(firedEHBB););
         };
     };
 

--- a/addons/overpressure/CfgWeapons.hpp
+++ b/addons/overpressure/CfgWeapons.hpp
@@ -49,6 +49,20 @@ class CfgWeapons {
         GVAR(damage) = 0.85;
     };
 
+    class cannon_125mm: CannonCore {
+        GVAR(priority) = 1;
+        GVAR(angle) = 90;
+        GVAR(range) = 50;
+        GVAR(damage) = 0.85;
+    };
+
+    class cannon_105mm: CannonCore {
+        GVAR(priority) = 1;
+        GVAR(angle) = 90;
+        GVAR(range) = 50;
+        GVAR(damage) = 0.85;
+    };
+
     class mortar_155mm_AMOS: CannonCore {
         GVAR(priority) = 1;
         GVAR(angle) = 90;

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -51,7 +51,7 @@ private _return = [
 ];
 
 private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
-missionNameSpace setVariable [format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine], _return];
+missionNameSpace setVariable [_varName, _return];
 TRACE_2("Return",_varName,_return);
 
 _return

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -49,9 +49,9 @@ private _return = [
     (getNumber (_config >> QGVAR(range))),
     (getNumber (_config >> QGVAR(damage)))
 ];
-TRACE_2("Return",_varName,_return);
 
 private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
 missionNameSpace setVariable [format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine], _return];
+TRACE_2("Return",_varName,_return);
 
 _return

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: joko // Jonas
- *
- * Handle fire of local launchers
+ * Cache the shot data for a given weapon/mag/ammo combination.
+ * Will use the config that has the highest priority.
  *
  * Argument:
  * 0: Weapon <STRING>
@@ -9,68 +9,49 @@
  * 2: Ammo <STRING>
  *
  * Return value:
- * Array:
+ * Shot Config <ARRAY>:
  *  0: Angle <Number>
  *  1: Range <Number>
  *  2: Damage <Number>
  *
+ * Example: 
+ * ["cannon_125mm","Sh_125mm_APFSDS_T_Green","24Rnd_125mm_APFSDS_T_Green"] call ace_overpressure_fnc_cacheOverPressureValues
+ *
+ * Public: No
  */
- #include "script_component.hpp"
+#include "script_component.hpp"
 
 params ["_weapon", "_ammo", "_magazine"];
 TRACE_3("Parameter",_weapon,_magazine,_ammo);
 
-private ["_array", "_type", "_return", "_config" /*, "_priority"*/];
-
 // get Priority Array from Config
-_array = [
+private _array = [
     getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(priority)),
     getNumber (configFile >> "CfgMagazines" >> _magazine >> QGVAR(priority)),
     getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(priority))
 ];
 
-TRACE_1("Proiroity Array",_array);
+(_array call CBA_fnc_findMax) params ["", ["_indexOfMaxPriority", 0, [0]]];
 
-/* for CBA Upadte 2.1
-_priority = _array call CBA_fnc_findMax;
-_type = if (isNil "_priority") then {
-    0
-} else {
-    _priority select 1
-};
-*/
+TRACE_2("Priority Array",_array,_indexOfMaxPriority);
 
-// obsolete as CBA Update 2.1 start
-_array params ["_max"];
-
-// set Default type
-_type = 0;
-// get Highest Entry out the the Priority Array
-{
-    if (_max < _x) then {
-        _max = _x;
-        _type = _forEachIndex;
-    };
-} forEach _array;
-// obsolete end
-
-TRACE_2("Highest Value",_max,_type);
 // create the Config entry Point
-_config = [
+private _config = [
     (configFile >> "CfgWeapons" >> _weapon),
     (configFile >> "CfgMagazines" >> _magazine),
     (configFile >> "CfgAmmo" >> _ammo)
-] select _type;
+] select _indexOfMaxPriority;
 TRACE_1("ConfigPath",_config);
 
 // get the Variables out of the Configes and create a array with then
-_return = [
+private _return = [
     (getNumber (_config >> QGVAR(angle))),
     (getNumber (_config >> QGVAR(range))),
     (getNumber (_config >> QGVAR(damage)))
 ];
-TRACE_1("Return",_return);
-_varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
+TRACE_2("Return",_varName,_return);
+
+private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
 missionNameSpace setVariable [format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine], _return];
 
 _return

--- a/addons/overpressure/functions/fnc_fireLauncherBackblast.sqf
+++ b/addons/overpressure/functions/fnc_fireLauncherBackblast.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: commy2 and esteldunedain
- *
  * Handle fire of local launchers
+ * Called from firedEHBB, only for ace_player with shot that will cause damage
  *
  * Arguments:
  * 0: Unit that fired <OBJECT>
@@ -14,51 +14,46 @@
  *
  * Return value:
  * None
+ *
+ * Example: 
+ * [player, "launch_RPG32_F", "launch_RPG32_F", "Single", "R_PG32V_F", "RPG32_F", projectile] call ace_overpressure_fnc_fireLauncherBackblast;
+ *
+ * Public: No
  */
-
 #include "script_component.hpp"
 
-params ["_firer", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
+params ["_firer", "_weapon", "_muzzle", "", "_ammo", "_magazine", "_projectile"];
+TRACE_6("params",_firer,_weapon,_muzzle,_ammo,_magazine,_projectile);
 
-// Prevent AI from causing backblast damage
-if !([_firer] call EFUNC(common,isPlayer)) exitWith {};
+private _position = getPosASL _projectile;
+private _direction = [0, 0, 0] vectorDiff (vectorDir _projectile);
 
-private ["_position", "_direction"];
-
-_position = getPosASL _projectile;
-_direction = [0, 0, 0] vectorDiff (vectorDir _projectile);
-
-private ["_var","_varName","_backblastAngle", "_backblastRange", "_backblastDamage"];
 // Bake variable name and check if the variable exists, call the caching function otherwise
-_varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
-_var = if (isNil _varName) then {
+private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
+private _var = if (isNil _varName) then {
     [_weapon, _ammo, _magazine] call FUNC(cacheOverPressureValues);
 } else {
     missionNameSpace getVariable _varName;
 };
 _var params["_backblastAngle","_backblastRange","_backblastDamage"];
-
+TRACE_3("cache",_backblastAngle,_backblastRange,_backblastDamage);
 
 // Damage to others
-private "_affected";
-_affected = (ASLtoAGL _position) nearEntities ["CAManBase", _backblastRange];
+private _affected = (ASLtoAGL _position) nearEntities ["CAManBase", _backblastRange];
 
 // Let each client handle their own affected units
 ["overpressure", _affected, [_firer, _position, _direction, _weapon, _magazine, _ammo]] call EFUNC(common,targetEvent);
 
 // Damage to the firer
-private "_distance";
-_distance = 2 * ([_position, _direction, _backblastRange, _firer] call FUNC(getDistance));
+private _distance = 2 * ([_position, _direction, _backblastRange, _firer] call FUNC(getDistance));
 
 TRACE_1("Distance",_distance);
 
 if (_distance < _backblastRange) then {
-    private ["_alpha", "_beta", "_damage"];
+    private _alpha = sqrt (1 - _distance / _backblastRange);
+    private _beta = sqrt 0.5;
 
-    _alpha = sqrt (1 - _distance / _backblastRange);
-    _beta = sqrt 0.5;
-
-    _damage = _alpha * _beta * _backblastDamage;
+    private _damage = _alpha * _beta * _backblastDamage;
     [_damage * 100] call BIS_fnc_bloodEffect;
 
     if (isClass (configFile >> "CfgPatches" >> "ACE_Medical") && {([_firer] call EFUNC(medical,hasMedicalEnabled))}) then {
@@ -75,8 +70,7 @@ if (_distance < _backblastRange) then {
         [1,1,0,1]
     ] call EFUNC(common,addLineToDebugDraw);
 
-    private "_ref";
-    _ref = _direction call EFUNC(common,createOrthonormalReference);
+    private _ref = _direction call EFUNC(common,createOrthonormalReference);
     [   _position,
         _position vectorAdd (_direction vectorMultiply _backblastRange) vectorAdd ((_ref select 1) vectorMultiply _backblastRange * tan _backblastAngle),
         [1,1,0,1]

--- a/addons/overpressure/functions/fnc_fireOverpressureZone.sqf
+++ b/addons/overpressure/functions/fnc_fireOverpressureZone.sqf
@@ -1,10 +1,10 @@
 /*
  * Author: commy2 and esteldunedain
- *
  * Handle fire of local vehicle weapons creating overpressure zones
+ * Called from firedEHOP, only for local vehicles
  *
  * Arguments:
- * 0: Unit that fired <OBJECT>
+ * 0: Vehicle that fired <OBJECT>
  * 1: Weapon fired <STRING>
  * 2: Muzzle <STRING>
  * 3: Mode <STRING>
@@ -14,33 +14,35 @@
  *
  * Return value:
  * None
+ *
+ * Example:
+ * [tank, "cannon_125mm", "cannon_125mm", "player", "Sh_125mm_APFSDS_T_Green", "24Rnd_125mm_APFSDS_T_Green", projectile] call ace_overpressure_fnc_fireOverpressureZone
+ *
+ * Public: No
  */
-//#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-params ["_firer", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-// Prevent AI from causing overpressure damage
-if !([gunner _firer] call EFUNC(common,isPlayer)) exitWith {};  //@todo non-maingun turrets?
+params ["_firer", "_weapon", "_muzzle", "", "_ammo", "_magazine", "_projectile"];
+TRACE_6("params",_firer,_weapon,_muzzle,_ammo,_magazine,_projectile);
 
-private ["_position", "_direction"];
+// Prevent AI from causing overpressure damage (NOTE: Vehicle is local, but turret gunner may not be)
+if !([gunner _firer] call EFUNC(common,isPlayer)) exitWith {};
 
-_position = getPosASL _projectile;
-_direction = vectorDir _projectile;
-
-private ["_var", "_varName", "_dangerZoneAngle", "_dangerZoneRange", "_dangerZoneDamage"];
+private _position = getPosASL _projectile;
+private _direction = vectorDir _projectile;
 
 // Bake variable name and check if the variable exists, call the caching function otherwise
-_varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
-_var = if (isNil _varName) then {
+private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
+private _var = if (isNil _varName) then {
     [_weapon, _ammo, _magazine] call FUNC(cacheOverPressureValues);
 } else {
     missionNameSpace getVariable _varName;
 };
 _var params["_dangerZoneAngle","_dangerZoneRange","_dangerZoneDamage"];
+TRACE_3("cache",_dangerZoneAngle,_dangerZoneRange,_dangerZoneDamage);
 
 // Damage to others
-private "_affected";
-_affected = (ASLtoAGL _position) nearEntities ["CAManBase", _dangerZoneRange];
+private _affected = (ASLtoAGL _position) nearEntities ["CAManBase", _dangerZoneRange];
 
 // Let each client handle their own affected units
 ["overpressure", _affected, [_firer, _position, _direction, _weapon, _magazine, _ammo]] call EFUNC(common,targetEvent);
@@ -52,8 +54,7 @@ _affected = (ASLtoAGL _position) nearEntities ["CAManBase", _dangerZoneRange];
         [1,0,0,1]
     ] call EFUNC(common,addLineToDebugDraw);
 
-    private "_ref";
-    _ref = _direction call EFUNC(common,createOrthonormalReference);
+    private _ref = _direction call EFUNC(common,createOrthonormalReference);
     [   _position,
         _position vectorAdd (_direction vectorMultiply _dangerZoneRange) vectorAdd ((_ref select 1) vectorMultiply _dangerZoneRange * tan _dangerZoneAngle),
         [1,1,0,1]

--- a/addons/overpressure/functions/fnc_firedEHBB.sqf
+++ b/addons/overpressure/functions/fnc_firedEHBB.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: joko // Jonas
- *
  * Handle fire of local launchers
  *
  * Arguments:
@@ -14,14 +13,22 @@
  *
  * Return value:
  * None
+ *
+ * Example: 
+ * [player, "launch_RPG32_F", "launch_RPG32_F", "Single", "R_PG32V_F", "RPG32_F", projectile] call ace_overpressure_fnc_firedEHBB;
+ *
+ * Public: No
  */
 #include "script_component.hpp"
-private ["_damage","_varName"];
-params ["", "_weapon", "", "", "_ammo", "_magazine", ""];
+
+params ["_firer", "_weapon", "", "", "_ammo", "_magazine", ""];
+
+// Prevent AI from causing backblast damage (fast exit to only run for local players)
+if (_firer != ACE_player) exitWith {};
 
 // Bake variable name and check if the variable exists, call the caching function otherwise
-_varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
-_damage = if (isNil _varName) then {
+private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
+private _damage = if (isNil _varName) then {
     ([_weapon, _ammo, _magazine] call FUNC(cacheOverPressureValues)) select 2;
 } else {
     (missionNameSpace getVariable _varName) select 2;

--- a/addons/overpressure/functions/fnc_firedEHOP.sqf
+++ b/addons/overpressure/functions/fnc_firedEHOP.sqf
@@ -1,10 +1,9 @@
 /*
  * Author: joko // Jonas
- *
- * Handle fire of Other Weapons
+ * Handle fire of Vehicle Weapons
  *
  * Arguments:
- * 0: Unit that fired <OBJECT>
+ * 0: Vehicle that fired (XEH will filter only local) <OBJECT>
  * 1: Weapon fired <STRING>
  * 2: Muzzle <STRING>
  * 3: Mode <STRING>
@@ -14,14 +13,19 @@
  *
  * Return value:
  * None
+ *
+ * Example:
+ * [tank, "cannon_125mm", "cannon_125mm", "player", "Sh_125mm_APFSDS_T_Green", "24Rnd_125mm_APFSDS_T_Green", projectile] call ace_overpressure_fnc_firedEHOP
+ *
+ * Public: No
  */
 #include "script_component.hpp"
-private ["_damage","_varName"];
+
 params ["", "_weapon", "", "", "_ammo", "_magazine", ""];
 
 // Bake variable name and check if the variable exists, call the caching function otherwise
-_varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
-_damage = if (isNil _varName) then {
+private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
+private _damage = if (isNil _varName) then {
     ([_weapon, _ammo, _magazine] call FUNC(cacheOverPressureValues)) select 2;
 } else {
     (missionNameSpace getVariable _varName) select 2;

--- a/addons/overpressure/functions/fnc_getDistance.sqf
+++ b/addons/overpressure/functions/fnc_getDistance.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2 and esteldunedain
- *
  * Calculate the distance to the first intersection of a line
  *
  * Arguments:
@@ -15,11 +14,12 @@
  * Example:
  * [[1823.41,5729.05,6.66627], [-0.953255,0.109689,-0.281554], 15, ace_player] call ace_overpressure_fnc_getDistance
  *
+ * Public: No
  */
 #include "script_component.hpp"
 
 params ["_posASL", "_direction", "_maxDistance", "_shooter"];
-TRACE_3("params",_posASL,_direction,_maxDistance);
+TRACE_4("params",_posASL,_direction,_maxDistance, _shooter);
 
 private _intersections = lineIntersectsSurfaces [_posASL, _posASL vectorAdd (_direction vectorMultiply _maxDistance), _shooter, objNull, true, 99];
 
@@ -29,9 +29,10 @@ private _distance = 999;
 
 {
     _x params ["_intersectPosASL", "_surfaceNormal", "_intersectObject"];
-
-    //Hit something solid that can reflect - (Static covers Building)
-    if ((isNull _intersectObject) || {(_intersectObject isKindOf "Static") || {_intersectObject isKindOf "AllVehicles"}}) exitWith {
+    TRACE_3("Intersect",_intersectPosASL,_surfaceNormal,_intersectObject);
+    
+    //Hit something solid that can reflect - (Static covers Building)  [Need to manually filter out _shoot for FFV shots]
+    if ((isNull _intersectObject) || {(_intersectObject != _shooter) && {(_intersectObject isKindOf "Static") || {_intersectObject isKindOf "AllVehicles"}}}) exitWith {
         _distance = _posASL vectorDistance _intersectPosASL;
         TRACE_3("hit solid object",_distance,_intersectObject,typeOf _intersectObject);
 

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -1,56 +1,56 @@
 /*
  * Author: commy2 and esteldunedain
- *
  * Calculate and apply backblast damage to potentially affected local units
+ * Handles the "overpressure" event.
  *
  * Argument:
  * 0: Unit that fired <OBJECT>
  * 1: Pos ASL of the projectile <ARRAY>
- * 2: Direction of the projectile <ARRAY>
+ * 2: Direction of the projectile (reversed for launcher backblast) <ARRAY>
  * 3: Weapon fired <STRING>
  * 4: Magazine <STRING>
  * 5: Ammo <STRING>
  *
  * Return value:
  * None
+ *
+ * Example:
+ * [tank, [1727.57,5786.15,7.24899], [-0.982474,-0.185998,-0.0122501], "cannon_125mm", "24Rnd_125mm_APFSDS_T_Green", "Sh_125mm_APFSDS_T_Green"] call ace_overpressure_fnc_overpressureDamage
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
-private ["_var","_overpressureAngle", "_overpressureRange", "_overpressureDamage"];
 params ["_firer", "_posASL", "_direction", "_weapon", "_magazine", "_ammo"];
 
 // Bake variable name and check if the variable exists, call the caching function otherwise
-_varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
-_var = if (isNil _varName) then {
+private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];
+private _var = if (isNil _varName) then {
     [_weapon, _ammo, _magazine] call FUNC(cacheOverPressureValues);
 } else {
     missionNameSpace getVariable _varName;
 };
 _var params["_overpressureAngle","_overpressureRange","_overpressureDamage"];
-
-TRACE_4("Parameters:",_overpressureAngle,_overpressureRange,_overpressureDamage,_weapon);
+TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
 
 {
     if (local _x && {_x != _firer} && {vehicle _x == _x}) then {
-        private ["_targetPositionASL", "_relativePosition", "_axisDistance", "_distance", "_angle", "_line", "_line2"];
+        private _targetPositionASL = eyePos _x;
+        private _relativePosition = _targetPositionASL vectorDiff _posASL;
+        private _axisDistance = _relativePosition vectorDotProduct _direction;
+        private _distance = vectorMagnitude _relativePosition;
+        private _angle = acos (_axisDistance / _distance);
 
-        _targetPositionASL = eyePos _x;
-        _relativePosition = _targetPositionASL vectorDiff _posASL;
-        _axisDistance = _relativePosition vectorDotProduct _direction;
-        _distance = vectorMagnitude _relativePosition;
-        _angle = acos (_axisDistance / _distance);
-
-        _line = [_posASL, _targetPositionASL, _firer, _x];
-        _line2 = [_posASL, _targetPositionASL];
+        private _line = [_posASL, _targetPositionASL, _firer, _x];
+        private _line2 = [_posASL, _targetPositionASL];
         TRACE_4("Affected:",_x,_axisDistance,_distance,_angle);
 
         if (_angle < _overpressureAngle && {_distance < _overpressureRange} && {!lineIntersects _line} && {!terrainIntersectASL _line2}) then {
-            private ["_alpha", "_beta", "_damage"];
 
-            _alpha = sqrt (1 - _distance / _overpressureRange);
-            _beta = sqrt (1 - _angle / _overpressureAngle);
+            private _alpha = sqrt (1 - _distance / _overpressureRange);
+            private _beta = sqrt (1 - _angle / _overpressureAngle);
 
-            _damage = _alpha * _beta * _overpressureDamage;
+            private _damage = _alpha * _beta * _overpressureDamage;
 
             // If the target is the ACE_player
             if (_x == ACE_player) then {[_damage * 100] call BIS_fnc_bloodEffect};
@@ -60,6 +60,14 @@ TRACE_4("Parameters:",_overpressureAngle,_overpressureRange,_overpressureDamage,
             } else {
                 _x setDamage (damage _x + _damage);
             };
+
+            #ifdef DEBUG_MODE_FULL
+            //Shows damage lines in green
+            [   _posASL,
+            _targetPositionASL,
+            [0,1,0,1]
+            ] call EFUNC(common,addLineToDebugDraw);
+            #endif
         };
     };
 } forEach ((ASLtoAGL _posASL) nearEntities ["CAManBase", _overpressureRange]);

--- a/addons/overpressure/script_component.hpp
+++ b/addons/overpressure/script_component.hpp
@@ -1,6 +1,8 @@
 #define COMPONENT overpressure
 #include "\z\ace\addons\main\script_mod.hpp"
 
+// #define DEBUG_MODE_FULL
+
 #ifdef DEBUG_ENABLED_OVERPRESSURE
     #define DEBUG_MODE_FULL
 #endif


### PR DESCRIPTION
 - Cleanup, headers, modern privates
 - Fix #3156 (`lineIntersectsSurfaces` did not filter ffv shooter)
 - Added both a3 tank weapons, I am unsure why there were not already added.