### PR TITLE
Javelin - Fix zeus RC after switchCamera

### DIFF
--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -67,7 +67,7 @@ if ((velocity ACE_player) distance [0,0,0] > 0.5 && {cameraView == "GUNNER"} && 
     ACE_player switchCamera "INTERNAL";
     if (player != ACE_player) then {
         TRACE_2("Zeus, manually reseting RC after switchCamera",player,ACE_player);
-        player remotecontrol ACE_player;
+        player remoteControl ACE_player;
     };
 };
 

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -65,6 +65,10 @@ _newTarget = objNull;
 // Bail on fast movement
 if ((velocity ACE_player) distance [0,0,0] > 0.5 && {cameraView == "GUNNER"} && {cameraOn == ACE_player}) exitWith {    // keep it steady.
     ACE_player switchCamera "INTERNAL";
+    if (player != ACE_player) then {
+        TRACE_2("Zeus, manually reseting RC after switchCamera",player,ACE_player);
+        player remotecontrol ACE_player;
+    };
 };
 
 // Refresh the firemode


### PR DESCRIPTION
Fix #3175

`switchCamera` seems to break zeus RC of untis, resets control with `remotecontrol`