### PR TITLE
Scopes: Don't show adjustment or play click sound if the adjustment doesn't happen

### DIFF
--- a/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
+++ b/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
@@ -32,6 +32,7 @@ if (isNil "_adjustment") then {
 };
 
 _adjustmentDifference = (_adjustment select _weaponIndex) vectorDiff [_elevation, _windage, _zero];
+if (_adjustmentDifference isEqualTo [0,0,0]) exitWith {false};  // Don't coninue if no adjustment is made
 
 _adjustment set [_weaponIndex, [_elevation, _windage, _zero]];
 [_unit, QGVAR(Adjustment), _adjustment, 0.5] call EFUNC(common,setVariablePublic);


### PR DESCRIPTION
Fixing an issue discussed in #3171, where, even if the scope is not set to allow adjustment in a particular axis, the click sound will still play and the adjustment turret will still be displayed.