### PR TITLE
Add missing FUNC to FCS key (Rangefinders)

### DIFF
--- a/addons/fcs/functions/fnc_keyDown.sqf
+++ b/addons/fcs/functions/fnc_keyDown.sqf
@@ -16,7 +16,7 @@
 params ["_vehicle", "_turret"];
 
 private _distance = call FUNC(getRange);
-call (updateRangeHUD);
+call FUNC(updateRangeHUD);
 
 if !(!GVAR(enabled) && FUNC(canUseFCS)) exitWith {};
 

--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -17,7 +17,7 @@ params ["_vehicle", "_turret", "_distance", ["_showHint", false], ["_playSound",
 
 private _turretConfig = [configFile >> "CfgVehicles" >> typeOf _vehicle, _turret] call EFUNC(common,getTurretConfigPath);
 
-call (updateRangeHUD);
+call FUNC(updateRangeHUD);
 
 if (isNil "_distance") then {
     _distance = call FUNC(getRange);


### PR DESCRIPTION
Fix #3160

This should match behaviour in pre-3.4.2