### PR TITLE
Fix FCS not taking weapon initSpeed into account in some circumstances

### DIFF
--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -116,8 +116,9 @@ private _FCSElevation = [];
 {
     private _magazine = _x;
     private _ammo = getText (configFile >> "CfgMagazines" >> _magazine >> "ammo");
+    private _bulletSimulation = getText (configFile >> "CfgAmmo" >> _ammo >> "simulation");
 
-    if !(getText (configFile >> "CfgAmmo" >> _ammo >> "simulation") == "shotMissile") then {
+    if !(_bulletSimulation == "shotMissile") then {
         private _maxElev     = getNumber (_turretConfig >> "maxElev");
         private _initSpeed   = getNumber (configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
         private _airFriction = getNumber (configFile >> "CfgAmmo" >> _ammo >> "airFriction");
@@ -142,7 +143,8 @@ private _FCSElevation = [];
                 _weaponMagazinesCheck pushBack (toLower _x);
             } forEach _weaponMagazines;
 
-            if (toLower _magazine in _weaponMagazinesCheck) exitWith {
+            // Another BIS fix: ShotBullet simulation uses weapon initSpeed, others ignore it
+            if (toLower _magazine in _weaponMagazinesCheck && {_bulletSimulation == "shotBullet"}) exitWith {
                 _initSpeedCoef = getNumber(configFile >> "CfgWeapons" >> _weapon >> "initSpeed");
 
                 if (_initSpeedCoef < 0) then {

--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -137,12 +137,13 @@ private _FCSElevation = [];
             } count _muzzles;
 
             // Fix the `in` operator being case sensitive and BI fucking up the spelling of their own classnames
-            _magazine = toLower _magazine;
+            private _magazineCheck = toLower _magazine;
+            private _weaponMagazinesCheck = [];
             {
-                _weaponMagazines set [_forEachIndex, toLower _x];
+                _weaponMagazinesCheck pushBack (toLower _x);
             } forEach _weaponMagazines;
 
-            if (_magazine in _weaponMagazines) exitWith {
+            if (_magazineCheck in _weaponMagazinesCheck) exitWith {
                 _initSpeedCoef = getNumber(configFile >> "CfgWeapons" >> _weapon >> "initSpeed");
 
                 if (_initSpeedCoef < 0) then {

--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -137,13 +137,12 @@ private _FCSElevation = [];
             } count _muzzles;
 
             // Fix the `in` operator being case sensitive and BI fucking up the spelling of their own classnames
-            private _magazineCheck = toLower _magazine;
             private _weaponMagazinesCheck = [];
             {
                 _weaponMagazinesCheck pushBack (toLower _x);
             } forEach _weaponMagazines;
 
-            if (_magazineCheck in _weaponMagazinesCheck) exitWith {
+            if (toLower _magazine in _weaponMagazinesCheck) exitWith {
                 _initSpeedCoef = getNumber(configFile >> "CfgWeapons" >> _weapon >> "initSpeed");
 
                 if (_initSpeedCoef < 0) then {

--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -136,6 +136,12 @@ private _FCSElevation = [];
                 false
             } count _muzzles;
 
+            // Fix the `in` operator being case sensitive and BI fucking up the spelling of their own classnames
+            _magazine = toLower _magazine;
+            {
+                _weaponMagazines set [_forEachIndex, toLower _x];
+            } forEach _weaponMagazines;
+
             if (_magazine in _weaponMagazines) exitWith {
                 _initSpeedCoef = getNumber(configFile >> "CfgWeapons" >> _weapon >> "initSpeed");
 


### PR DESCRIPTION
Since the `in` operator is case sensitive, the FCS code sometimes doesn't enter the part where it checks if the weapon's `initSpeed` is different from 0.

This is BI's fault for not consistently capitalizing their magazine names.