### PR TITLE
Fix Handgrenade DisplayNameShort

### DIFF
--- a/addons/realisticnames/CfgMagazines.hpp
+++ b/addons/realisticnames/CfgMagazines.hpp
@@ -394,6 +394,7 @@ class CfgMagazines {
     // hand grenades
     class HandGrenade: CA_Magazine {
         displayName = CSTRING(HandGrenade_Name);
+        displayNameShort = "M67";
     };
     class SmokeShell: HandGrenade {
         displayName = CSTRING(SmokeShell_Name);


### PR DESCRIPTION
Display name says M67, but DNS says RGO.
This is a fix for the above.