### PR TITLE
Changes for CBA 2.3

### DIFF
--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -32,7 +32,6 @@ class CfgVehicles {
     // ammo boxes
     class ThingX;
     class ReammoBox_F: ThingX {
-        XEH_ENABLED;
         GVAR(canCarry) = 0;
         GVAR(carryPosition[]) = {0,1,1};
         GVAR(carryDirection) = 0;

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -76,28 +76,3 @@ GVAR(ParsedTextCached) = [];
     if (GVAR(menuBackground)==1) then {[QGVAR(menuBackground), false] call EFUNC(common,blurScreen);};
     if (GVAR(menuBackground)==2) then {(uiNamespace getVariable [QGVAR(menuBackground), displayNull]) closeDisplay 0;};
 }] call EFUNC(common,addEventHandler);
-
-//Debug to help end users identify mods that break CBA's XEH
-[{
-    private _badClassnames = [];
-    {
-        //Only check Land objects (WeaponHolderSimulated show up in `vehicles` for some reason)
-        if ((_x isKindOf "Land") && {(isNil (format [QGVAR(Act_%1), typeOf _x])) || {isNil (format [QGVAR(SelfAct_%1), typeOf _x])}}) then {
-            if (!((typeOf _x) in _badClassnames)) then {
-                _badClassnames pushBack (typeOf _x);
-                ACE_LOGERROR_3("Compile checks bad for (classname: %1)(addon: %2) %3", (typeOf _x), (unitAddons (typeOf _x)), _x);
-            };
-        };
-    } forEach (allUnits + allDeadMen + vehicles);
-    if ((count _badClassnames) == 0) then {
-        ACE_LOGINFO("All compile checks passed");
-    } else {
-        ACE_LOGERROR_1("%1 Classnames failed compile check!!! (bad XEH / missing cba_enable_auto_xeh.pbo)", (count _badClassnames));
-
-        //Only show visual error if they are actually missing the pbo:
-        #define SUPMON configFile>>"CfgSettings">>"CBA">>"XEH">>"supportMonitor"
-        if ((!isNumber(SUPMON)) || {getNumber(SUPMON) != 1}) then {
-            ["ACE Interaction failed to compile for some units (try adding cba_enable_auto_xeh.pbo)"] call BIS_fnc_error;
-        };
-    };
-}, [], 5] call EFUNC(common,waitAndExecute);  //ensure CBASupMon has time to run first


### PR DESCRIPTION
Minor changes for CBA 2.3

Fix `Updating base class CBA_Extended_EventHandlers->, by z\ace\addons\dragging\config.cpp/CfgVehicles/ReammoBox_F/EventHandlers/CBA_Extended_EventHandlers/ `

And the interaction_menu debug isn't necessary anymore as XEH should be be guaranteed.
