### PR TITLE
Remove VehicleLock Items from Virtual Arsenal

### DIFF
--- a/addons/vehiclelock/CfgMagazines.hpp
+++ b/addons/vehiclelock/CfgMagazines.hpp
@@ -1,6 +1,7 @@
 class CfgMagazines {
     class CA_Magazine;
     class ACE_key_customKeyMagazine: CA_Magazine {
+        scopeArsenal = 0;
         picture = QUOTE(PATHTOF(ui\keyBlack.paa));
         displayName = "ACE Vehicle Key";   //!!!CANNOT be localized!!!: because it is used as part of the magazineDetail string
         descriptionShort = CSTRING(Item_Custom_Description);

--- a/addons/vehiclelock/CfgMagazines.hpp
+++ b/addons/vehiclelock/CfgMagazines.hpp
@@ -1,7 +1,6 @@
 class CfgMagazines {
     class CA_Magazine;
     class ACE_key_customKeyMagazine: CA_Magazine {
-        scopeArsenal = 0;
         picture = QUOTE(PATHTOF(ui\keyBlack.paa));
         displayName = "ACE Vehicle Key";   //!!!CANNOT be localized!!!: because it is used as part of the magazineDetail string
         descriptionShort = CSTRING(Item_Custom_Description);

--- a/addons/vehiclelock/CfgWeapons.hpp
+++ b/addons/vehiclelock/CfgWeapons.hpp
@@ -3,6 +3,7 @@ class CfgWeapons {
     class ACE_ItemCore;
 
     class ACE_key_master: ACE_ItemCore {
+        scopeArsenal = 0;
         author = ECSTRING(common,ACETeam);
         displayName = "Vehicle Key: Master";
         descriptionShort = CSTRING(Item_Master_Description);


### PR DESCRIPTION
Close #3215

Removes all the keys from the VA so they are not obtainable from magic VA boxes in missions.