### PR TITLE
Fix dragging moving object to random location

### DIFF
--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -20,6 +20,10 @@ params ["_unit", "_target"];
 
 if !([_unit, _target, []] call EFUNC(common,canInteractWith)) exitWith {false};
 
+//#2644 - Units with injured legs cannot bear the extra weight of carrying an object
+//The fireman carry animation does not slow down for injured legs, so you could carry and run
+if ((_unit getHitPointDamage "HitLegs") >= 0.5) exitWith {false};
+
 // a static weapon has to be empty for dragging (ignore UAV AI)
 if (((typeOf _target) isKindOf "StaticWeapon") && {{(getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) != "UAVPilot"} count crew _target > 0}) exitWith {false};
 

--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Check if unit can carry the object. Doesn't check weight.
  *
  * Arguments:
@@ -9,6 +8,9 @@
  *
  * Return Value:
  * Can the unit carry the object? <BOOL>
+ *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_canCarry;
  *
  * Public: No
  */

--- a/addons/dragging/functions/fnc_canDrag.sqf
+++ b/addons/dragging/functions/fnc_canDrag.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Check if unit can drag the object. Doesn't check weight.
  *
  * Arguments:
@@ -10,14 +9,14 @@
  * Return Value:
  * Can the unit drag the object? <BOOL>
  *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_canDrag;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
-private ["_unit", "_target"];
-
-_unit = _this select 0;
-_target = _this select 1;
+params ["_unit", "_target"];
 
 if !([_unit, _target, []] call EFUNC(common,canInteractWith)) exitWith {false};
 

--- a/addons/dragging/functions/fnc_canDrop.sqf
+++ b/addons/dragging/functions/fnc_canDrop.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Check if unit can drop the object.
  *
  * Arguments:
@@ -9,6 +8,9 @@
  *
  * Return Value:
  * Can the unit drop the object? <BOOL>
+ *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_canDrop;
  *
  * Public: No
  */

--- a/addons/dragging/functions/fnc_canDrop_carry.sqf
+++ b/addons/dragging/functions/fnc_canDrop_carry.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Check if unit can drop the carried object.
  *
  * Arguments:
@@ -9,6 +8,9 @@
  *
  * Return Value:
  * Can the unit drop the object? <BOOL>
+ *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_canDrop_carry;
  *
  * Public: No
  */

--- a/addons/dragging/functions/fnc_carryObject.sqf
+++ b/addons/dragging/functions/fnc_carryObject.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Carry an object.
  *
  * Arguments:
@@ -10,17 +9,20 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_carryObject;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_unit", "_target"];
+TRACE_2("params",_unit,_target);
 
 // get attachTo offset and direction.
-private ["_position", "_direction", "_UAVCrew"];
 
-_position = _target getVariable [QGVAR(carryPosition), [0, 0, 0]];
-_direction = _target getVariable [QGVAR(carryDirection), 0];
+private _position = _target getVariable [QGVAR(carryPosition), [0, 0, 0]];
+private _direction = _target getVariable [QGVAR(carryDirection), 0];
 
 // handle objects vs persons
 if (_target isKindOf "CAManBase") then {
@@ -34,8 +36,7 @@ if (_target isKindOf "CAManBase") then {
 } else {
 
     // add height offset of model
-    private "_offset";
-    _offset = (_target modelToWorldVisual [0, 0, 0] select 2) - (_unit modelToWorldVisual [0, 0, 0] select 2);
+    private _offset = (_target modelToWorldVisual [0, 0, 0] select 2) - (_unit modelToWorldVisual [0, 0, 0] select 2);
 
     _position = _position vectorAdd [0, 0, _offset];
 
@@ -65,7 +66,7 @@ _unit setVariable [QGVAR(ReleaseActionID), [
 GVAR(currentHeightChange) = 0;
 
 // prevent UAVs from firing
-_UAVCrew = _target call EFUNC(common,getVehicleUAVCrew);
+private _UAVCrew = _target call EFUNC(common,getVehicleUAVCrew);
 
 if !(_UAVCrew isEqualTo []) then {
     {_target deleteVehicleCrew _x} count _UAVCrew;

--- a/addons/dragging/functions/fnc_carryObject.sqf
+++ b/addons/dragging/functions/fnc_carryObject.sqf
@@ -57,10 +57,14 @@ _unit setVariable [QGVAR(ReleaseActionID), [
 ] call EFUNC(common,addActionEventHandler)];
 
 // show mouse hint
-[localize LSTRING(Drop), "", localize LSTRING(LowerRaise)] call EFUNC(interaction,showMouseHint);
+if (_target isKindOf "CAManBase") then {
+    [localize LSTRING(Drop), "", ""] call EFUNC(interaction,showMouseHint);
+} else {
+    [localize LSTRING(Drop), "", localize LSTRING(LowerRaise)] call EFUNC(interaction,showMouseHint);
+};
 
 // check everything
-[FUNC(carryObjectPFH), 0.5, [_unit, _target]] call CBA_fnc_addPerFrameHandler;
+[FUNC(carryObjectPFH), 0.5, [_unit, _target, ACE_time]] call CBA_fnc_addPerFrameHandler;
 
 // reset current dragging height.
 GVAR(currentHeightChange) = 0;

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -6,6 +6,7 @@
  * 0: ARGS <ARRAY>
  *  0: Unit <OBJECT>
  *  1: Target <OBJECT>
+ *  2: Start time <NUMBER>
  * 1: PFEH Id <NUMBER>
  *
  * Return Value:
@@ -23,7 +24,7 @@
 #endif
 
 params ["_args", "_idPFH"];
-_args params ["_unit","_target"];
+_args params ["_unit","_target", "_startTime"];
 
 if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {
     TRACE_2("carry false",_unit,_target);
@@ -33,6 +34,11 @@ if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {
 // drop if the crate is destroyed OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
     TRACE_2("dead/distance",_unit,_target);
+    if ((_unit distance _target > 10) && {(ACE_time - _startTime) < 1}) exitWith {
+        //attachTo seems to have some kind of network delay and target can return an odd position durring the first few frames, 
+        //so wait a full second to exit if out of range (this is critical as we would otherwise detach and set it's pos to weird pos)
+        TRACE_3("ignoring bad distance at start",_unit distance _target,_startTime,ACE_time);
+    };
     [_unit, _target] call FUNC(dropObject_carry);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -1,13 +1,18 @@
 /*
  * Author: commy2
- *
  * PFH for Carry Object
  *
  * Arguments:
- * ?
+ * 0: ARGS <ARRAY>
+ *  0: Unit <OBJECT>
+ *  1: Target <OBJECT>
+ * 1: PFEH Id <NUMBER>
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * [[player, target], 20] call ace_dragging_fnc_carryObjectPFH;
  *
  * Public: No
  */
@@ -21,11 +26,13 @@ params ["_args", "_idPFH"];
 _args params ["_unit","_target"];
 
 if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {
+    TRACE_2("carry false",_unit,_target);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
 // drop if the crate is destroyed OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
+    TRACE_2("dead/distance",_unit,_target);
     [_unit, _target] call FUNC(dropObject_carry);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };

--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -25,10 +25,13 @@ private _direction = _target getVariable [QGVAR(dragDirection), 0];
 
 // add height offset of model
 private _offset = (_target modelToWorldVisual [0, 0, 0] select 2) - (_unit modelToWorldVisual [0, 0, 0] select 2);
-
+if (_target isKindOf "CAManBase") then {
+    _offset = 0;
+};
 _position = _position vectorAdd [0, 0, _offset];
 
 // attach object
+TRACE_3("attaching",_position,_offset,_direction);
 _target attachTo [_unit, _position];
 ["setDir", _target, [_target, _direction]] call EFUNC(common,targetEvent);
 
@@ -50,7 +53,7 @@ _unit setVariable [QGVAR(ReleaseActionID), [
 [localize LSTRING(Drop), ""] call EFUNC(interaction,showMouseHint);
 
 // check everything
-[FUNC(dragObjectPFH), 0.5, [_unit, _target]] call CBA_fnc_addPerFrameHandler;
+[FUNC(dragObjectPFH), 0.5, [_unit, _target, ACE_time]] call CBA_fnc_addPerFrameHandler;
 
 // reset current dragging height.
 GVAR(currentHeightChange) = 0;

--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Drag an object. Called from ace_dragging_fnc_startDrag
  *
  * Arguments:
@@ -10,20 +9,22 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_dragObject;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_unit", "_target"];
-
-private ["_position", "_direction", "_offset", "_UAVCrew"];
+TRACE_2("params",_unit,_target);
 
 // get attachTo offset and direction.
-_position = _target getVariable [QGVAR(dragPosition), [0, 0, 0]];
-_direction = _target getVariable [QGVAR(dragDirection), 0];
+private _position = _target getVariable [QGVAR(dragPosition), [0, 0, 0]];
+private _direction = _target getVariable [QGVAR(dragDirection), 0];
 
 // add height offset of model
-_offset = (_target modelToWorldVisual [0, 0, 0] select 2) - (_unit modelToWorldVisual [0, 0, 0] select 2);
+private _offset = (_target modelToWorldVisual [0, 0, 0] select 2) - (_unit modelToWorldVisual [0, 0, 0] select 2);
 
 _position = _position vectorAdd [0, 0, _offset];
 
@@ -55,7 +56,7 @@ _unit setVariable [QGVAR(ReleaseActionID), [
 GVAR(currentHeightChange) = 0;
 
 // prevent UAVs from firing
-_UAVCrew = _target call EFUNC(common,getVehicleUAVCrew);
+private _UAVCrew = _target call EFUNC(common,getVehicleUAVCrew);
 
 if !(_UAVCrew isEqualTo []) then {
     {_target deleteVehicleCrew _x} count _UAVCrew;

--- a/addons/dragging/functions/fnc_dragObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_dragObjectPFH.sqf
@@ -6,6 +6,7 @@
  * 0: ARGS <ARRAY>
  *  0: Unit <OBJECT>
  *  1: Target <OBJECT>
+ *  2: Start time <NUMBER>
  * 1: PFEH Id <NUMBER>
  *
  * Return Value:
@@ -23,7 +24,7 @@
 #endif
 
 params ["_args", "_idPFH"];
-_args params ["_unit", "_target"];
+_args params ["_unit","_target", "_startTime"];
 
 if !(_unit getVariable [QGVAR(isDragging), false]) exitWith {
     TRACE_2("drag false",_unit,_target);
@@ -33,6 +34,11 @@ if !(_unit getVariable [QGVAR(isDragging), false]) exitWith {
 // drop if the crate is destroyed OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
     TRACE_2("dead/distance",_unit,_target);
+    if ((_unit distance _target > 10) && {(ACE_time - _startTime) < 1}) exitWith {
+        //attachTo seems to have some kind of network delay and target can return an odd position durring the first few frames, 
+        //so wait a full second to exit if out of range (this is critical as we would otherwise detach and set it's pos to weird pos)
+        TRACE_3("ignoring bad distance at start",_unit distance _target,_startTime,ACE_time);
+    };
     [_unit, _target] call FUNC(dropObject);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };

--- a/addons/dragging/functions/fnc_dragObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_dragObjectPFH.sqf
@@ -1,13 +1,18 @@
 /*
  * Author: commy2
- *
  * PFH for Drag Object
  *
  * Arguments:
- * ?
+ * 0: ARGS <ARRAY>
+ *  0: Unit <OBJECT>
+ *  1: Target <OBJECT>
+ * 1: PFEH Id <NUMBER>
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * [[player, target], 20] call ace_dragging_fnc_dragObjectPFH;
  *
  * Public: No
  */
@@ -21,11 +26,13 @@ params ["_args", "_idPFH"];
 _args params ["_unit", "_target"];
 
 if !(_unit getVariable [QGVAR(isDragging), false]) exitWith {
+    TRACE_2("drag false",_unit,_target);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
 // drop if the crate is destroyed OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
+    TRACE_2("dead/distance",_unit,_target);
     [_unit, _target] call FUNC(dropObject);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };

--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Drop a dragged object.
  *
  * Arguments:
@@ -10,17 +9,20 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_dropObject;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_unit", "_target"];
+TRACE_2("params",_unit,_target);
 
 // remove drop action
 [_unit, "DefaultAction", _unit getVariable [QGVAR(ReleaseActionID), -1]] call EFUNC(common,removeActionEventHandler);
 
-private "_inBuilding";
-_inBuilding = [_unit] call FUNC(isObjectOnObject);
+private _inBuilding = [_unit] call FUNC(isObjectOnObject);
 
 if !(_unit getVariable ["ACE_isUnconscious", false]) then {
     // play release animation
@@ -47,6 +49,7 @@ _unit removeWeapon "ACE_FakePrimaryWeapon";
 // prevent object from flipping inside buildings
 if (_inBuilding) then {
     _target setPosASL (getPosASL _target vectorAdd [0, 0, 0.05]);
+    TRACE_2("setPos",getPosASL _unit,getPosASL _target);
 };
 
 // hide mouse hint

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Drop a carried object.
  *
  * Arguments:
@@ -10,17 +9,20 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_dropObject_carry;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_unit", "_target"];
+TRACE_2("params",_unit,_target);
 
 // remove drop action
 [_unit, "DefaultAction", _unit getVariable [QGVAR(ReleaseActionID), -1]] call EFUNC(common,removeActionEventHandler);
 
-private "_inBuilding";
-_inBuilding = [_unit] call FUNC(isObjectOnObject);
+private _inBuilding = [_unit] call FUNC(isObjectOnObject);
 
 // prevent collision damage
 ["fixCollision", _unit] call EFUNC(common,localEvent);

--- a/addons/dragging/functions/fnc_getWeight.sqf
+++ b/addons/dragging/functions/fnc_getWeight.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: L-H, edited by commy2, rewritten by joko // Jonas
- *
  * Returns the weight of a crate.
  *
  * Arguments:
@@ -10,20 +9,20 @@
  * Total Weight <NUMBER>
  *
  * Example:
- * _weight = Crate1 call ace_dragging_fnc_getweight;
+ * [Crate1] call ace_dragging_fnc_getweight;
  *
  * Public: No
 */
 #include "script_component.hpp"
 
-private "_totalWeight";
 params ["_object"];
+
 // Initialize the total weight.
-_totalWeight = 0;
+private _totalWeight = 0;
 
 // Cycle through all item types with their assigned config paths.
 {
-    _x params["_items","_getConfigCode"];
+    _x params ["_items", "_getConfigCode"];
     _items params ["_item", "_count"];
     // Cycle through all items and read their mass out of the config.
     {

--- a/addons/dragging/functions/fnc_handleAnimChanged.sqf
+++ b/addons/dragging/functions/fnc_handleAnimChanged.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Handle the animaion for a Unit for Dragging Module
  *
  * Arguments:
@@ -17,35 +16,28 @@
 */
 #include "script_component.hpp"
 
-private ["_unit", "_anim"];
-
-_unit = _this select 0;
-_anim = _this select 1;
+params ["_unit", "_anim"];
 
 if (_unit getVariable [QGVAR(isDragging), false]) then {
 
     // drop dragged object when not in valid animation
     if !(_anim in DRAG_ANIMATIONS) then {
-        private "_draggedObject";
-        _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
+        private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
 
         if (!isNull _draggedObject) then {
             [_unit, _draggedObject] call FUNC(dropObject);
         };
     };
-
 };
 
 if (_unit getVariable [QGVAR(isCarrying), false]) then {
 
     // drop carried object when not standing; also some exceptions when picking up crate
     if (stance _unit != "STAND" && {_anim != "amovpercmstpsnonwnondnon"}) then {
-        private "_carriedObject";
-        _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
+        private _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
 
         if (!isNull _carriedObject) then {
             [_unit, _carriedObject] call FUNC(dropObject_carry);
         };
     };
-
 };

--- a/addons/dragging/functions/fnc_handleKilled.sqf
+++ b/addons/dragging/functions/fnc_handleKilled.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Handle death of the dragger
  *
  * Arguments:
@@ -17,17 +16,16 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_1("params",_unit);
 
 if (_unit getVariable [QGVAR(isDragging), false]) then {
-    private "_draggedObject";
-    _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
+    private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
 
     [_unit, _draggedObject] call FUNC(dropObject);
 };
 
 if (_unit getVariable [QGVAR(isCarrying), false]) then {
-    private "_carriedObject";
-    _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
+    private _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
 
     [_unit, _carriedObject] call FUNC(dropObject_carry);
 };

--- a/addons/dragging/functions/fnc_handlePlayerChanged.sqf
+++ b/addons/dragging/functions/fnc_handlePlayerChanged.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Handle player changes.
  *
  * Arguments:
@@ -11,13 +10,14 @@
  * None
  *
  * Example:
- * [_unitNew, _unitOld] call ace_dragging_fnc_handlePlayerChanged;
+ * [_newPlayer, _oldPlayer] call ace_dragging_fnc_handlePlayerChanged;
  *
  * Public: No
 */
 #include "script_component.hpp"
 
 params ["_newPlayer", "_oldPlayer"];
+TRACE_2("params",_newPlayer,_oldPlayer);
 
 {
     if (_x getVariable [QGVAR(isDragging), false]) then {

--- a/addons/dragging/functions/fnc_handlePlayerWeaponChanged.sqf
+++ b/addons/dragging/functions/fnc_handlePlayerWeaponChanged.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Handle the Weapon Changed Event
  *
  * Arguments:
@@ -11,20 +10,20 @@
  * None
  *
  * Example:
- * [_unit, _currentWeapon] call ace_dragging_fnc_handlePlayerWeaponChanged;
+ * [_unit, "gun"] call ace_dragging_fnc_handlePlayerWeaponChanged;
  *
  * Public: No
 */
 #include "script_component.hpp"
 
 params ["_unit", "_weapon"];
+TRACE_2("params",_unit,_weapon);
 
 if (_unit getVariable [QGVAR(isDragging), false]) then {
 
     // drop dragged object when selecting a non-primary weapon
     if (_weapon != primaryWeapon _unit) then {
-        private "_draggedObject";
-        _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
+        private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
 
         [_unit, _draggedObject] call FUNC(dropObject);
     };
@@ -33,8 +32,7 @@ if (_unit getVariable [QGVAR(isDragging), false]) then {
 
 if (_unit getVariable [QGVAR(isCarrying), false]) then {
 
-    private "_carriedObject";
-    _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
+    private _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
 
     if (_carriedObject isKindOf "CAManBase") then {
 

--- a/addons/dragging/functions/fnc_handleScrollWheel.sqf
+++ b/addons/dragging/functions/fnc_handleScrollWheel.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: L-H, commy2
- *
  * Handles raising and lowering the dragged weapon to be able to place it on top of objects.
  *
  * Arguments:
@@ -9,15 +8,16 @@
  * Return Value:
  * Handled or not. <BOOL>
  *
+ * Example:
+ * [0.1] call ace_dragging_fnc_handleScrollWheel;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_scrollAmount"];
 
-private ["_unit", "_carriedItem", "_position", "_maxHeight"];
-
-_unit = ACE_player;
+private _unit = ACE_player;
 
 // EH is always assigned. Exit and don't overwrite input if not carrying
 if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {false};
@@ -25,13 +25,13 @@ if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {false};
 // move carried item 15 cm per scroll interval
 _scrollAmount = _scrollAmount * 0.15;
 
-_carriedItem = _unit getVariable [QGVAR(carriedObject), objNull];
+private _carriedItem = _unit getVariable [QGVAR(carriedObject), objNull];
 
 //disabled for persons
 if (_carriedItem isKindOf "CAManBase") exitWith {false};
 
-_position = getPosATL _carriedItem;
-_maxHeight = (_unit modelToWorldVisual [0,0,0]) select 2;
+private _position = getPosATL _carriedItem;
+private _maxHeight = (_unit modelToWorldVisual [0,0,0]) select 2;
 
 _position set [2, ((_position select 2) + _scrollAmount min (_maxHeight + 1.5)) max _maxHeight];
 

--- a/addons/dragging/functions/fnc_handleUnconscious.sqf
+++ b/addons/dragging/functions/fnc_handleUnconscious.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Handle the Unconscious of a Unit while Dragging
  *
  * Arguments:
@@ -16,15 +15,13 @@
 */
 #include "script_component.hpp"
 
-private ["_player", "_draggedObject", "_carriedObject"];
-
 params ["_unit"];
 
-_player = ACE_player;
+private _player = ACE_player;
 
 if (_player getVariable [QGVAR(isDragging), false]) then {
 
-    _draggedObject = _player getVariable [QGVAR(draggedObject), objNull];
+    private _draggedObject = _player getVariable [QGVAR(draggedObject), objNull];
 
     // handle falling unconscious
     if (_unit == _player) then {
@@ -40,7 +37,7 @@ if (_player getVariable [QGVAR(isDragging), false]) then {
 
 if (_player getVariable [QGVAR(isCarrying), false]) then {
 
-    _carriedObject = _player getVariable [QGVAR(carriedObject), objNull];
+    private _carriedObject = _player getVariable [QGVAR(carriedObject), objNull];
 
     // handle falling unconscious
     if (_unit == _player) then {

--- a/addons/dragging/functions/fnc_initObject.sqf
+++ b/addons/dragging/functions/fnc_initObject.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Initialize variables for drag or carryable objects. Called from init EH.
  *
  * Argument:
@@ -9,26 +8,27 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [box] call ace_dragging_fnc_initObject;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
-private ["_position", "_direction", "_config"];
-
 params ["_object"];
 
-_config = configFile >> "CfgVehicles" >> typeOf _object;
+private _config = configFile >> "CfgVehicles" >> typeOf _object;
 
 if (getNumber (_config >> QGVAR(canDrag)) == 1) then {
-    _position = getArray (_config >> QGVAR(dragPosition));
-    _direction = getNumber (_config >> QGVAR(dragDirection));
+    private _position = getArray (_config >> QGVAR(dragPosition));
+    private _direction = getNumber (_config >> QGVAR(dragDirection));
 
     [_object, true, _position, _direction] call FUNC(setDraggable);
 };
 
 if (getNumber (_config >> QGVAR(canCarry)) == 1) then {
-    _position = getArray (_config >> QGVAR(carryPosition));
-    _direction = getNumber (_config >> QGVAR(carryDirection));
+    private _position = getArray (_config >> QGVAR(carryPosition));
+    private _direction = getNumber (_config >> QGVAR(carryDirection));
 
     [_object, true, _position, _direction] call FUNC(setCarryable);
 };

--- a/addons/dragging/functions/fnc_initPerson.sqf
+++ b/addons/dragging/functions/fnc_initPerson.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Initialize variables for drag or carryable persons. Called from init EH.
  *
  * Argument:
@@ -8,6 +7,9 @@
  *
  * Return value:
  * None
+ *
+ * Example:
+ * [player] call ace_dragging_fnc_initPerson;
  *
  * Public: No
  */

--- a/addons/dragging/functions/fnc_isObjectOnObject.sqf
+++ b/addons/dragging/functions/fnc_isObjectOnObject.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Check if Object is Overlapping
  *
  * Argument:
@@ -8,6 +7,9 @@
  *
  * Return value:
  * <BOOL>
+ *
+ * Example;
+ * [player] call ace_dragging_fnc_isObjectOnObject
  *
  * Public: No
  */

--- a/addons/dragging/functions/fnc_setCarryable.sqf
+++ b/addons/dragging/functions/fnc_setCarryable.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Enable the object to be carried.
  *
  * Argument:
@@ -12,11 +11,12 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [object, true, [0,1,1], 0] call ace_dragging_fnc_setCarryable;
+ *
  * Public: Yes
  */
 #include "script_component.hpp"
-
-private ["_carryAction", "_dropAction", "_type", "_initializedClasses"];
 
 params ["_object", "_enableCarry", "_position", "_direction"];
 
@@ -34,8 +34,8 @@ _object setVariable [QGVAR(carryPosition), _position];
 _object setVariable [QGVAR(carryDirection), _direction];
 
 // add action to class if it is not already present
-_type = typeOf _object;
-_initializedClasses = GETGVAR(initializedClasses_carry,[]);
+private _type = typeOf _object;
+private _initializedClasses = GETGVAR(initializedClasses_carry,[]);
 
 // do nothing if the class is already initialized
 if (_type in _initializedClasses) exitWith {};
@@ -43,8 +43,8 @@ if (_type in _initializedClasses) exitWith {};
 _initializedClasses pushBack _type;
 GVAR(initializedClasses_carry) = _initializedClasses;
 
-_carryAction = [QGVAR(carry), localize LSTRING(Carry), "", {[_player, _target] call FUNC(startCarry)}, {[_player, _target] call FUNC(canCarry)}] call EFUNC(interact_menu,createAction);
-_dropAction = [QGVAR(drop_carry), localize LSTRING(Drop), "", {[_player, _target] call FUNC(dropObject_carry)}, {[_player, _target] call FUNC(canDrop_carry)}] call EFUNC(interact_menu,createAction);
+private _carryAction = [QGVAR(carry), localize LSTRING(Carry), "", {[_player, _target] call FUNC(startCarry)}, {[_player, _target] call FUNC(canCarry)}] call EFUNC(interact_menu,createAction);
+private _dropAction = [QGVAR(drop_carry), localize LSTRING(Drop), "", {[_player, _target] call FUNC(dropObject_carry)}, {[_player, _target] call FUNC(canDrop_carry)}] call EFUNC(interact_menu,createAction);
 
 [_type, 0, ["ACE_MainActions"], _carryAction] call EFUNC(interact_menu,addActionToClass);
 [_type, 0, [], _dropAction] call EFUNC(interact_menu,addActionToClass);

--- a/addons/dragging/functions/fnc_setDraggable.sqf
+++ b/addons/dragging/functions/fnc_setDraggable.sqf
@@ -1,22 +1,23 @@
 /*
  * Author: commy2
- *
  * Enable the object to be dragged.
  *
  * Argument:
- * 0: Any object (Object)
- * 1: true to enable dragging, false to disable (Bool)
+ * 0: Any object <OBJECT>
+ * 1: true to enable dragging, false to disable <BOOL>
  * 2: Position offset for attachTo command (Array, optinal; default: [0,0,0])
  * 3: Direction in degree to rotate the object after attachTo (Number, optional; default: 0)
  *
  * Return value:
  * None
  *
+ * Example:
+ * [object, true, [0,0,0], 0] call ace_dragging_fnc_setDraggable;
+ *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-private ["_dragAction", "_dropAction", "_type", "_initializedClasses"];
 //IGNORE_PRIVATE_WARNING("_player", "_target");
 params ["_object", "_enableDrag", "_position", "_direction"];
 
@@ -34,8 +35,8 @@ _object setVariable [QGVAR(dragPosition), _position];
 _object setVariable [QGVAR(dragDirection), _direction];
 
 // add action to class if it is not already present
-_type = typeOf _object;
-_initializedClasses = GETGVAR(initializedClasses,[]);
+private _type = typeOf _object;
+private _initializedClasses = GETGVAR(initializedClasses,[]);
 
 // do nothing if the class is already initialized
 if (_type in _initializedClasses) exitWith {};
@@ -43,8 +44,8 @@ if (_type in _initializedClasses) exitWith {};
 _initializedClasses pushBack _type;
 GVAR(initializedClasses) = _initializedClasses;
 
-_dragAction = [QGVAR(drag), localize LSTRING(Drag), "", {[_player, _target] call FUNC(startDrag)}, {[_player, _target] call FUNC(canDrag)}] call EFUNC(interact_menu,createAction);
-_dropAction = [QGVAR(drop), localize LSTRING(Drop), "", {[_player, _target] call FUNC(dropObject)}, {[_player, _target] call FUNC(canDrop)}] call EFUNC(interact_menu,createAction);
+private _dragAction = [QGVAR(drag), localize LSTRING(Drag), "", {[_player, _target] call FUNC(startDrag)}, {[_player, _target] call FUNC(canDrag)}] call EFUNC(interact_menu,createAction);
+private _dropAction = [QGVAR(drop), localize LSTRING(Drop), "", {[_player, _target] call FUNC(dropObject)}, {[_player, _target] call FUNC(canDrop)}] call EFUNC(interact_menu,createAction);
 
 [_type, 0, ["ACE_MainActions"], _dragAction] call EFUNC(interact_menu,addActionToClass);
 [_type, 0, [], _dropAction] call EFUNC(interact_menu,addActionToClass);

--- a/addons/dragging/functions/fnc_startCarry.sqf
+++ b/addons/dragging/functions/fnc_startCarry.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Start the carrying process.
  *
  * Arguments:
@@ -10,22 +9,24 @@
  * Return Value:
  * None
  *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_startCarry;
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
-private ["_weight", "_timer"];
-
 params ["_unit", "_target"];
+TRACE_2("params",_unit,_target);
 
 // check weight
-_weight = [_target] call FUNC(getWeight);
+private _weight = [_target] call FUNC(getWeight);
 
 if (_weight > missionNamespace getVariable ["ACE_maxWeightCarry", 1E11]) exitWith {
     [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
 };
 
-_timer = ACE_time + 5;
+private _timer = ACE_time + 5;
 
 // handle objects vs persons
 if (_target isKindOf "CAManBase") then {

--- a/addons/dragging/functions/fnc_startCarryPFH.sqf
+++ b/addons/dragging/functions/fnc_startCarryPFH.sqf
@@ -1,13 +1,19 @@
 /*
  * Author: commy2
- *
  * Carry PFH
  *
  * Arguments:
- * ?
+ * 0: ARGS <ARRAY>
+ *  0: Unit <OBJECT>
+ *  1: Target <OBJECT>
+ *  2: Timeout <NUMBER>
+ * 1: PFEH Id <NUMBER>
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * [[player, target, 100], 20] call ace_dragging_fnc_startCarryPFH;
  *
  * Public: No
  */
@@ -22,11 +28,13 @@ _args params ["_unit", "_target", "_timeOut"];
 
 // handle aborting carry
 if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {
+    TRACE_4("carry false",_unit,_target,_timeOut,ACE_time);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
 // same as dragObjectPFH, checks if object is deleted or dead OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
+    TRACE_4("dead/distance",_unit,_target,_timeOut,ACE_time);
     [_unit, _target] call FUNC(dropObject);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
@@ -34,25 +42,26 @@ if (!alive _target || {_unit distance _target > 10}) then {
 // handle persons vs objects
 if (_target isKindOf "CAManBase") then {
     if (ACE_time > _timeOut) exitWith {
+        TRACE_4("Start carry person",_unit,_target,_timeOut,ACE_time);
         [_unit, _target] call FUNC(carryObject);
 
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 } else {
     if (ACE_time > _timeOut) exitWith {
+        TRACE_4("timeout",_unit,_target,_timeOut,ACE_time);
         [_idPFH] call CBA_fnc_removePerFrameHandler;
 
         // drop if in timeout
-        private "_draggedObject";
-        _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
+        private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
         [_unit, _draggedObject] call FUNC(dropObject);
     };
 
     // wait for the unit to stand up
     if (stance _unit == "STAND") exitWith {
+        TRACE_4("Start carry object",_unit,_target,_timeOut,ACE_time);
         [_unit, _target] call FUNC(carryObject);
 
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
-
 };

--- a/addons/dragging/functions/fnc_startDrag.sqf
+++ b/addons/dragging/functions/fnc_startDrag.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Start the dragging process.
  *
  * Argument:
@@ -9,14 +8,19 @@
  *
  * Return value:
  * None
+ *
+ * Example:
+ * [player, cursorTarget] call ace_dragging_fnc_startDrag;
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
 params ["_unit", "_target"];
+TRACE_2("params",_unit,_target);
 
 // check weight
-private "_weight";
-_weight = [_target] call FUNC(getWeight);
+private _weight = [_target] call FUNC(getWeight);
 
 if (_weight > missionNamespace getVariable ["ACE_maxWeightDrag", 1E11]) exitWith {
     [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);

--- a/addons/dragging/functions/fnc_startDragPFH.sqf
+++ b/addons/dragging/functions/fnc_startDragPFH.sqf
@@ -1,13 +1,19 @@
 /*
  * Author: commy2
- *
  * Drag PFH
  *
  * Arguments:
- * ?
+ * 0: ARGS <ARRAY>
+ *  0: Unit <OBJECT>
+ *  1: Target <OBJECT>
+ *  2: Timeout <NUMBER>
+ * 1: PFEH Id <NUMBER>
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * [[player, target, 100], 20] call ace_dragging_fnc_startDragPFH;
  *
  * Public: No
  */
@@ -22,27 +28,30 @@ _args params ["_unit", "_target", "_timeOut"];
 
 // handle aborting drag
 if !(_unit getVariable [QGVAR(isDragging), false]) exitWith {
+    TRACE_4("drag false",_unit,_target,_timeOut,ACE_time);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
 // same as dragObjectPFH, checks if object is deleted or dead OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
+    TRACE_4("dead/distance",_unit,_target,_timeOut,ACE_time);
     [_unit, _target] call FUNC(dropObject);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
 // timeout. Do nothing. Quit. ACE_time, because anim length is linked to ingame time.
 if (ACE_time > _timeOut) exitWith {
+    TRACE_4("timeout",_unit,_target,_timeOut,ACE_time);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 
     // drop if in timeout
-    private "_draggedObject";
-    _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
+    private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
     [_unit, _draggedObject] call FUNC(dropObject);
 };
 
 // unit is ready to start dragging
 if (animationState _unit in DRAG_ANIMATIONS) exitWith {
+    TRACE_4("Start Dragging",_unit,_target,_timeOut,ACE_time);
     [_unit, _target] call FUNC(dragObject);
 
     [_idPFH] call CBA_fnc_removePerFrameHandler;


### PR DESCRIPTION
 - modern privates / params / headers
 - functional changes in https://github.com/acemod/ACE3/commit/3f1d6ffeb73eb174331dad0585385f7a6a78a5a9

Fixes a critical bug we've seen a few times where a person or object being dragged will be teleported to a random location often in the middle of the ocean (which is not good if that person is unconscious :smile:).

Problem seems to be that `attachTo` has effects on getPos and distance for a few frames.

debug from ace_dragging_fnc_dragObject
```
attachTo [2709.28,6047.91,2.31902] @ 1946.34
tick [-2532.71,1995.72,4.07294] @ 1946.36
tick [-2532.71,1995.73,4.07294] @ 1946.38
tick [-2532.71,1995.73,4.07294] @ 1946.39
tick [-2532.71,1995.74,4.07294] @ 1946.41
tick [-2532.7,1995.74,4.07293] @ 1946.43
tick [2709.3,6047.94,2.31901] @ 1946.44
tick [2709.3,6047.95,2.31901] @ 1946.46
```

The same frame as `attachTo`, getPos is stable, then for a few frames it's some weird random location then it settles back to where it should be. dragObjectPFH could fail the distance check and permently set the object to that random position.

Only happens in mp, reproducible ~20% of all attempts done on a pier over water.

Also hides the scroll wheel action hint when carrying man.
