### PR TITLE
Added the correct preprocessor macro for parse_imagepath

### DIFF
--- a/extensions/parse_imagepath/ace_parse_imagepath.cpp
+++ b/extensions/parse_imagepath/ace_parse_imagepath.cpp
@@ -17,7 +17,7 @@
 #include <string>
 
 extern "C" {
-    __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+    EXPORT void __stdcall RVExtension(char *output, int outputSize, const char *function);
 }
 
 std::string getImagePathFromStructuredText(const std::string & input) {


### PR DESCRIPTION
Added the correct preprocessor macro for parse_imagepath, so that the source can now be compiled on Linux.