### PR TITLE
Fix ace_scopes capturing native adjustment keys for the PSO scope. 

### DIFF
--- a/addons/scopes/functions/fnc_adjustScope.sqf
+++ b/addons/scopes/functions/fnc_adjustScope.sqf
@@ -44,7 +44,8 @@ _maxVertical = getArray (_opticConfig >> "ACE_ScopeAdjust_Vertical");
 _maxHorizontal = getArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal");
 
 if ((count _maxHorizontal < 2) || (count _maxVertical < 2)) exitWith {false};
-if ((_verticalIncrement == 0) && (_horizontalIncrement == 0)) exitWith {false};
+if ((_verticalIncrement == 0) && (_turretAndDirection in [ELEVATION_UP, ELEVATION_DOWN])) exitWith {false};
+if ((_horizontalIncrement == 0) && (_turretAndDirection in [WINDAGE_UP, WINDAGE_DOWN])) exitWith {false};
 
 _zeroing   = _adjustment select _weaponIndex;
 _zeroing params ["_elevation", "_windage", "_zero"];

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -51,13 +51,13 @@ class CfgWeapons {
     class rhs_acc_pso1m2: rhs_acc_sniper_base {
         ACE_ScopeAdjust_Vertical[] = { 0, 0 };
         ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
-        ACE_ScopeAdjust_VerticalIncrement = 0.0;
+        ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };
     class rhs_acc_pso1m21: rhs_acc_sniper_base {
         ACE_ScopeAdjust_Vertical[] = { 0, 0 };
         ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
-        ACE_ScopeAdjust_VerticalIncrement = 0.0;
+        ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };
 


### PR DESCRIPTION
This was first and foremost a data problem. Due to the way `ace_scopes_fnc_adjustScope` is coded,  `ACE_ScopeAdjust_VerticalIncrement` needs to be none zero to quit when adjusting isn't possible.

~~It would also be possible to make changes to that function to prevent this from happening when zero is provided. Should I do that too?~~ I just did, so it's possible to set increment to zero to disable adjusting in that direction without capturing keys.

Close #3238