### PR TITLE
Fixing setVehicleAmmo for rearm

### DIFF
--- a/addons/rearm/XEH_postInit.sqf
+++ b/addons/rearm/XEH_postInit.sqf
@@ -2,3 +2,7 @@
 
 ["medical_onUnconscious", {_this call FUNC(handleUnconscious)}] call EFUNC(common,addEventHandler);
 ["playerVehicleChanged", {params ["_unit"]; [_unit] call FUNC(dropAmmo)}] call EFUNC(common,addEventHandler);
+
+if (isServer) then {
+    addMissionEventHandler ["HandleDisconnect", {params ["_unit"]; [_unit] call FUNC(dropAmmo)}];
+};

--- a/addons/rearm/functions/fnc_addRearmActions.sqf
+++ b/addons/rearm/functions/fnc_addRearmActions.sqf
@@ -16,7 +16,7 @@
 #include "script_component.hpp"
 
 private ["_vehicleActions", "_actions", "_action", "_vehicles", "_vehicle", "_needToAdd", "_magazineHelper", "_turretPath", "_magazines", "_magazine", "_icon", "_cnt"];
-params ["_target"];
+params [["_target", objNull, [objNull]]];
 
 _vehicles = nearestObjects [_target, ["AllVehicles"], 20];
 if (count _vehicles < 2) exitWith {false}; // Rearming needs at least 2 vehicles
@@ -31,16 +31,11 @@ _vehicleActions = [];
         _magazineHelper = [];
         {
             _turretPath = _x;
-            _magazines = [];
-            if (_turretPath isEqualTo [-1]) then {
-                _magazines = [_vehicle, _turretPath] call FUNC(getConfigMagazines);
-            } else {
-                _magazines = _vehicle magazinesTurret _turretPath;
-            };
+            _magazines = [_vehicle, _turretPath] call FUNC(getConfigMagazines);
             {
                 _magazine = _x;
-                _cnt = { _x == _magazine } count (_vehicle magazinesTurret _turretPath);
-                if ((_cnt < ([_vehicle, _turretPath, _magazine] call FUNC(getMaxMagazines))) && !(_magazine in _magazineHelper)) then {
+                _currentMagazines = { _x == _magazine } count (_vehicle magazinesTurret _turretPath);
+                if ((_currentMagazines < ([_vehicle, _turretPath, _magazine] call FUNC(getMaxMagazines))) && !(_magazine in _magazineHelper)) then {
                     _action = [_magazine,
                         getText(configFile >> "CfgMagazines" >> _magazine >> "displayName"),
                         getText(configFile >> "CfgMagazines" >> _magazine >> "picture"),

--- a/addons/rearm/functions/fnc_canRearm.sqf
+++ b/addons/rearm/functions/fnc_canRearm.sqf
@@ -17,7 +17,7 @@
 #include "script_component.hpp"
 
 private ["_dummy","_magazineClass"];
-params ["_target", "_unit"];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
 if (GVAR(level) == 0 || {isNull _unit} || {!(_unit isKindOf "CAManBase")} || {!local _unit} || {_target distance _unit > REARM_ACTION_DISTANCE} || {_target getVariable [QGVAR(disabled), false]}) exitWith {false};
 

--- a/addons/rearm/functions/fnc_canStoreAmmo.sqf
+++ b/addons/rearm/functions/fnc_canStoreAmmo.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_target", "_unit"];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
 !(isNull _unit ||
     {!(_unit isKindOf "CAManBase")} ||

--- a/addons/rearm/functions/fnc_canTakeAmmo.sqf
+++ b/addons/rearm/functions/fnc_canTakeAmmo.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_target", "_unit"];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
 !(isNull _unit ||
     {!(_unit isKindOf "CAManBase")} ||

--- a/addons/rearm/functions/fnc_createDummy.sqf
+++ b/addons/rearm/functions/fnc_createDummy.sqf
@@ -17,7 +17,7 @@
 #include "script_component.hpp"
 
 private ["_ammo", "_dummyName", "_dummy"];
-params ["_unit", "_magazineClass"];
+params [["_unit", objNull, [objNull]], ["_magazineClass", "", [""]]];
 
 _ammo = getText (configFile >> "CfgMagazines" >> _magazineClass >> "ammo");
 _dummyName = getText (configFile >> "CfgAmmo" >> _ammo >> QGVAR(dummy));

--- a/addons/rearm/functions/fnc_dropAmmo.sqf
+++ b/addons/rearm/functions/fnc_dropAmmo.sqf
@@ -18,7 +18,7 @@
 #include "script_component.hpp"
 
 private ["_dummy", "_actionID"];
-params ["_unit", ["_delete", false], ["_unholster", true]];
+params [["_unit", objNull, [objNull]], ["_delete", false, [false]], ["_unholster", true, [true]]];
 
 _dummy = _unit getVariable [QGVAR(dummy), objNull];
 if !(isNull _dummy) then {

--- a/addons/rearm/functions/fnc_getConfigMagazines.sqf
+++ b/addons/rearm/functions/fnc_getConfigMagazines.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_target", "_turretPath"];
+params [["_target", objNull, [objNull]], ["_turretPath", [], [[]]]];
 
 if (isNull _target) exitWith {[]};
 

--- a/addons/rearm/functions/fnc_getMaxMagazines.sqf
+++ b/addons/rearm/functions/fnc_getMaxMagazines.sqf
@@ -18,7 +18,7 @@
 #include "script_component.hpp"
 
 private ["_count", "_cfg"];
-params ["_target", "_turretPath", "_magazineClass"];
+params [["_target", objNull, [objNull]], ["_turretPath", [], [[]]], ["_magazineClass", "", [""]]];
 
 if (isNull _target) exitWith {0};
 

--- a/addons/rearm/functions/fnc_getNeedRearmMagazines.sqf
+++ b/addons/rearm/functions/fnc_getNeedRearmMagazines.sqf
@@ -10,7 +10,7 @@
  * Return Value <ARRAY>
  * 0: Can Rearm <BOOL>
  * 1: TurretPath <ARRAY>
- * 2: Magazine Classname <STRING>
+ * 2: Number of current magazines in turret path <NUMBER>
  *
  * Example:
  * [tank, "mag"] call ace_rearm_fnc_getNeedRearmMagazines
@@ -19,27 +19,22 @@
  */
 #include "script_component.hpp"
 
-private ["_return", "_magazines", "_cnt"];
+private ["_return", "_magazines", "_currentMagazines"];
 params ["_target", "_magazineClass"];
 
 _return = [false, [], 0];
 {
-    _magazines = [];
-    if (_x isEqualTo [-1]) then {
-        _magazines = [_target, _x] call FUNC(getConfigMagazines);
-    } else {
-        _magazines = _target magazinesTurret _x;
-    };
+    _magazines = [_target, _x] call FUNC(getConfigMagazines);
 
     if (_magazineClass in _magazines) then {
-        _cnt = {_x == _magazineClass} count (_target magazinesTurret _x);
+        _currentMagazines = {_x == _magazineClass} count (_target magazinesTurret _x);
 
         if ((_target magazineTurretAmmo [_magazineClass, _x]) < getNumber (configFile >> "CfgMagazines" >> _magazineClass >> "count")) exitWith {
-            _return = [true, _x, _cnt];
+            _return = [true, _x, _currentMagazines];
         };
 
-        if (_cnt < ([_target, _x, _magazineClass] call FUNC(getMaxMagazines))) exitWith {
-            _return = [true, _x, _cnt];
+        if (_currentMagazines < ([_target, _x, _magazineClass] call FUNC(getMaxMagazines))) exitWith {
+            _return = [true, _x, _currentMagazines];
         };
     };
 

--- a/addons/rearm/functions/fnc_grabAmmo.sqf
+++ b/addons/rearm/functions/fnc_grabAmmo.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_dummy", "_unit"];
+params [["_dummy", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
 REARM_HOLSTER_WEAPON
 [_unit, QGVAR(vehRearm), true] call EFUNC(common,setForceWalkStatus);

--- a/addons/rearm/functions/fnc_handleKilled.sqf
+++ b/addons/rearm/functions/fnc_handleKilled.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-params ["_unit"];
+params [["_unit", objNull, [objNull]]];
 
 if (!local _unit) exitWith {};
 

--- a/addons/rearm/functions/fnc_handleUnconscious.sqf
+++ b/addons/rearm/functions/fnc_handleUnconscious.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params [["_unit", objNull, [objNull], ["_isUnconscious", false, [false]]]
+params [["_unit", objNull, [objNull]], ["_isUnconscious", false, [false]]];
 
 if (!local _unit || {!_isUnconscious}) exitWith {};
 

--- a/addons/rearm/functions/fnc_handleUnconscious.sqf
+++ b/addons/rearm/functions/fnc_handleUnconscious.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_unit", "_isUnconscious"];
+params [["_unit", objNull, [objNull], ["_isUnconscious", false, [false]]]
 
 if (!local _unit || {!_isUnconscious}) exitWith {};
 

--- a/addons/rearm/functions/fnc_makeDummy.sqf
+++ b/addons/rearm/functions/fnc_makeDummy.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params ["_obj", "_dirAndUp"];
+params [["_obj", objNull, [objNull], ["_dirAndUp", [[1,0,0],[0,0,1]], [[]]]]
 
 _obj setVectorDirAndUp _dirAndUp;
 _obj allowDamage false;

--- a/addons/rearm/functions/fnc_makeDummy.sqf
+++ b/addons/rearm/functions/fnc_makeDummy.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params [["_obj", objNull, [objNull], ["_dirAndUp", [[1,0,0],[0,0,1]], [[]]]]
+params [["_obj", objNull, [objNull]], ["_dirAndUp", [[1,0,0],[0,0,1]], [[]]]];
 
 _obj setVectorDirAndUp _dirAndUp;
 _obj allowDamage false;

--- a/addons/rearm/functions/fnc_moduleRearmSettings.sqf
+++ b/addons/rearm/functions/fnc_moduleRearmSettings.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params ["_logic", "", "_activated"];
+params ["_logic", "", ["_activated", false, [false]]];
 
 if (!_activated) exitWith {};
 

--- a/addons/rearm/functions/fnc_pickUpAmmo.sqf
+++ b/addons/rearm/functions/fnc_pickUpAmmo.sqf
@@ -17,7 +17,7 @@
 #include "script_component.hpp"
 
 private ["_magazineClass"];
-params ["_target", "_unit"];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
 _dummy = _unit getVariable [QGVAR(dummy), objNull];
 if !(isNull _dummy) exitWith {};

--- a/addons/rearm/functions/fnc_rearm.sqf
+++ b/addons/rearm/functions/fnc_rearm.sqf
@@ -16,7 +16,7 @@
 #include "script_component.hpp"
 
 private ["_magazineClass", "_ammo", "_tmpCal", "_cal", "_idx", "_needRearmMags", "_magazineDisplayName"];
-params ["_unit"];
+params [["_unit", objNull, [objNull]]];
 
 _dummy = _unit getVariable [QGVAR(dummy), objNull];
 if (isNull _dummy) exitwith {false};

--- a/addons/rearm/functions/fnc_rearmEntireVehicle.sqf
+++ b/addons/rearm/functions/fnc_rearmEntireVehicle.sqf
@@ -16,8 +16,7 @@
  * Public: No
  */
 #include "script_component.hpp"
-
-params ["_target", "_unit", "_vehicle"];  // _target is for future possible finite ammo, _unit placeholder
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]], ["_vehicle", objNull, [objNull]]]; // _target is for future possible finite ammo, _unit placeholder
 
 [
     10,

--- a/addons/rearm/functions/fnc_rearmEntireVehicleSuccess.sqf
+++ b/addons/rearm/functions/fnc_rearmEntireVehicleSuccess.sqf
@@ -16,7 +16,7 @@
 #include "script_component.hpp"
 
 private ["_turretPath", "_magazines", "_magazine", "_currentMagazines", "_maxMagazines", "_maxRounds", "_currentRounds"];
-params ["_vehicle"];
+params [["_vehicle", objNull, [objNull]]];
 
 if (isServer) then {
     {

--- a/addons/rearm/functions/fnc_rearmEntireVehicleSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmEntireVehicleSuccessLocal.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
+ * 1: TurretPath <ARRAY>
  *
  * Return Value:
  * None
@@ -16,14 +17,9 @@
 #include "script_component.hpp"
 
 private ["_magazines", "_magazine", "_currentMagazines", "_maxMagazines", "_maxRounds", "_currentRounds"];
-params ["_vehicle", "_turretPath"];
+params [["_vehicle", objNull, [objNull]], ["_turretPath", [], [[]]]];
 
-_magazines = [];
-if (_turretPath isEqualTo [-1]) then {
-    _magazines = [_vehicle, _turretPath] call FUNC(getConfigMagazines);
-} else {
-    _magazines = _vehicle magazinesTurret _turretPath;
-};
+_magazines = [_vehicle, _turretPath] call FUNC(getConfigMagazines);
 {
     _magazine = _x;
     _currentMagazines = { _x == _magazine } count (_vehicle magazinesTurret _turretPath);

--- a/addons/rearm/functions/fnc_rearmSuccess.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccess.sqf
@@ -22,7 +22,7 @@
 #include "script_component.hpp"
 
 private ["_dummy", "_weaponSelect", "_turretOwnerID"];
-params ["_args"];
+params [["_args", [objNull, objNull, [], 0, "", 0], [[]]], [6]];
 _args params ["_target", "_unit", "_turretPath", "_numMagazines", "_magazineClass", "_numRounds"];
 
 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMagazine: %4\nNumRounds: %5", _target, _turretPath, _numMagazines, _magazineClass, _numRounds];

--- a/addons/rearm/functions/fnc_rearmSuccess.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccess.sqf
@@ -22,7 +22,7 @@
 #include "script_component.hpp"
 
 private ["_dummy", "_weaponSelect", "_turretOwnerID"];
-params [["_args", [objNull, objNull, [], 0, "", 0], [[]]], [6]];
+params [["_args", [objNull, objNull, [], 0, "", 0], [[]], [6]]];
 _args params ["_target", "_unit", "_turretPath", "_numMagazines", "_magazineClass", "_numRounds"];
 
 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMagazine: %4\nNumRounds: %5", _target, _turretPath, _numMagazines, _magazineClass, _numRounds];

--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -22,7 +22,7 @@
 #include "script_component.hpp"
 
 private ["_rounds", "_currentRounds", "_maxMagazines", "_currentMagazines", "_dummy", "_weaponSelect"];
-params [["_args", [objNull, objNull, [], 0, "", 0], [[]]], [6]];
+params [["_args", [objNull, objNull, [], 0, "", 0], [[]], [6]]];
 _args params ["_target", "_unit", "_turretPath", "_numMagazines", "_magazineClass", "_numRounds"];
 
 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMagazine: %4\nNumRounds: %5\nUnit: %6", _target, _turretPath, _numMagazines, _magazineClass, _numRounds, _unit];

--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -33,7 +33,8 @@ _currentRounds = 0;
 _maxMagazines = [_target, _turretPath, _magazineClass] call FUNC(getMaxMagazines);
 if (_maxMagazines == 1) then {
     _currentMagazines = { _x == _magazineClass } count (_target magazinesTurret _turretPath);
-    if (_currentMagazines == 0) then {
+    if (_currentMagazines == 0 && {!(_turretPath isEqualTo [-1])}) then {
+        // Driver gun will always retain it's magazines
         _target addMagazineTurret [_magazineClass, _turretPath];
     };
     if (GVAR(level) == 1) then {
@@ -53,7 +54,7 @@ if (_maxMagazines == 1) then {
     for "_idx" from 1 to (_maxMagazines+1) do {
         _currentRounds = _target magazineTurretAmmo [_magazineClass, _turretPath];
         if (_currentRounds > 0 || {_idx == (_maxMagazines+1)}) exitWith {
-            if (_idx == (_maxMagazines+1)) then {
+            if (_idx == (_maxMagazines+1) && {!(_turretPath isEqualTo [-1])}) then {
                 _target addMagazineTurret [_magazineClass, _turretPath];
             };
             if (GVAR(level) == 2) then {

--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -21,8 +21,8 @@
  */
 #include "script_component.hpp"
 
-private ["_rounds", "_currentRounds", "_maxMagazines", "_dummy", "_weaponSelect"];
-params ["_args"];
+private ["_rounds", "_currentRounds", "_maxMagazines", "_currentMagazines", "_dummy", "_weaponSelect"];
+params [["_args", [objNull, objNull, [], 0, "", 0], [[]]], [6]];
 _args params ["_target", "_unit", "_turretPath", "_numMagazines", "_magazineClass", "_numRounds"];
 
 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMagazine: %4\nNumRounds: %5\nUnit: %6", _target, _turretPath, _numMagazines, _magazineClass, _numRounds, _unit];
@@ -32,6 +32,10 @@ _currentRounds = 0;
 
 _maxMagazines = [_target, _turretPath, _magazineClass] call FUNC(getMaxMagazines);
 if (_maxMagazines == 1) then {
+    _currentMagazines = { _x == _magazineClass } count (_target magazinesTurret _turretPath);
+    if (_currentMagazines == 0) then {
+        _target addMagazineTurret [_magazineClass, _turretPath];
+    };
     if (GVAR(level) == 1) then {
         // Fill magazine completely
         _target setMagazineTurretAmmo [_magazineClass, _rounds, _turretPath];
@@ -46,9 +50,12 @@ if (_maxMagazines == 1) then {
             getText(configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName")], 3, _unit]] call EFUNC(common,targetEvent);
     };
 } else {
-    for "_idx" from 1 to _maxMagazines do {
+    for "_idx" from 1 to (_maxMagazines+1) do {
         _currentRounds = _target magazineTurretAmmo [_magazineClass, _turretPath];
-        if (_currentRounds > 0) exitWith {
+        if (_currentRounds > 0 || {_idx == (_maxMagazines+1)}) exitWith {
+            if (_idx == (_maxMagazines+1)) then {
+                _target addMagazineTurret [_magazineClass, _turretPath];
+            };
             if (GVAR(level) == 2) then {
                 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMaxMagazines %4\nMagazine: %5\nNumRounds: %6\nMagazine: %7", _target, _turretPath, _numMagazines, _maxMagazines, _currentRounds, _numRounds, _magazineClass];
                 // Fill only at most _numRounds

--- a/addons/rearm/functions/fnc_storeAmmo.sqf
+++ b/addons/rearm/functions/fnc_storeAmmo.sqf
@@ -17,11 +17,10 @@
 #include "script_component.hpp"
 
 private "_dummy";
-params ["_target", "_unit"];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
 _dummy = _unit getVariable [QGVAR(dummy), objNull];
 if (isNull _dummy) exitwith {};
-
 
 [
     5,

--- a/addons/rearm/functions/fnc_takeAmmo.sqf
+++ b/addons/rearm/functions/fnc_takeAmmo.sqf
@@ -21,7 +21,7 @@
 
 private ["_ammo", "_tmpCal", "_cal", "_idx"];
 
-params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]], ["_args", ["", objNull]], [[]]];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]], ["_args", ["", objNull], [[]]]];
 _args params ["_magazineClass", "_vehicle"];
 
 _ammo = getText (configFile >> "CfgMagazines" >> _magazineClass >> "ammo");

--- a/addons/rearm/functions/fnc_takeAmmo.sqf
+++ b/addons/rearm/functions/fnc_takeAmmo.sqf
@@ -21,7 +21,7 @@
 
 private ["_ammo", "_tmpCal", "_cal", "_idx"];
 
-params ["_target", "_unit", "_args"];
+params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]], ["_args", ["", objNull]], [[]]];
 _args params ["_magazineClass", "_vehicle"];
 
 _ammo = getText (configFile >> "CfgMagazines" >> _magazineClass >> "ammo");

--- a/addons/rearm/functions/fnc_takeSuccess.sqf
+++ b/addons/rearm/functions/fnc_takeSuccess.sqf
@@ -19,7 +19,7 @@
 #include "script_component.hpp"
 
 private ["_ammo", "_dummyName", "_dummy", "_actionID"];
-params ["_args"];
+params [["_args", [objNull, "", objNull]], [[]]];
 _args params ["_unit", "_magazineClass", "_target"]; // _target is for future possible finite ammo
 
 [_unit, QGVAR(vehRearm), true] call EFUNC(common,setForceWalkStatus);

--- a/addons/rearm/functions/fnc_takeSuccess.sqf
+++ b/addons/rearm/functions/fnc_takeSuccess.sqf
@@ -19,7 +19,7 @@
 #include "script_component.hpp"
 
 private ["_ammo", "_dummyName", "_dummy", "_actionID"];
-params [["_args", [objNull, "", objNull]], [[]]];
+params [["_args", [objNull, "", objNull], [[]]]];
 _args params ["_unit", "_magazineClass", "_target"]; // _target is for future possible finite ammo
 
 [_unit, QGVAR(vehRearm), true] call EFUNC(common,setForceWalkStatus);

--- a/addons/rearm/script_component.hpp
+++ b/addons/rearm/script_component.hpp
@@ -28,4 +28,4 @@
 #define REARM_UNHOLSTER_WEAPON \
     _weaponSelect = _unit getVariable QGVAR(selectedWeaponOnRearm); \
     _unit selectWeapon _weaponSelect; \
-    _unit setVariable [QGVAR(selectedWeaponOnRefuel), nil];
+    _unit setVariable [QGVAR(selectedWeaponOnRearm), nil];


### PR DESCRIPTION
Fixes the problem reported in #3242 with `setVehicleAmmo`
Also updates `params` with default values and datatypes