### PR TITLE
Deadman switch - trigger explosives in inventory

### DIFF
--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -51,22 +51,103 @@ _explosivesList = [];
         };
     };
 } forEach _result;
-
-// Add action to detonate all explosives tied to the detonator
-if (count _explosivesList > 0) then {
-    _children pushBack [
+if (_detonator != "ACE_DeadManSwitch") then {
+    // Add action to detonate all explosives tied to the detonator
+    if (count _explosivesList > 0) then {
+        _children pushBack [
         [
             "Explosive_All",
-            localize LSTRING(DetonateAll), 
+            localize LSTRING(DetonateAll),
             getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
             {(_this select 2) call FUNC(detonateExplosiveAll);},
             {true},
             {},
             [_unit,_range,_explosivesList]
-        ] call EFUNC(interact_menu,createAction),
-        [],
-        _unit
+            ] call EFUNC(interact_menu,createAction),
+            [],
+            _unit
+        ];
+    };
+} else {
+    //Add action to detonate all explosives (including the inventory explosive):
+    _children pushBack [
+    [
+    "Explosive_All_Deadman",
+    localize LSTRING(DetonateAll),
+    getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
+    {[_player] call FUNC(onIncapacitated)},
+    {true}
+    ] call EFUNC(interact_menu,createAction),
+    [],
+    _unit
     ];
+
+    //Adds actions for the explosives you can connect to the deadman switch.
+    private _connectedInventoryExplosive = _unit getVariable [QGVAR(deadmanInvExplosive), ""];
+    if ((_connectedInventoryExplosive != "") && {!(_connectedInventoryExplosive in (magazines _unit))}) then {
+        TRACE_1("set, but missing in inventory",_connectedInventoryExplosive);
+        _unit setVariable [QGVAR(deadmanInvExplosive), "", true];
+    };
+
+    _connectedInventoryExplosive = _unit getVariable [QGVAR(deadmanInvExplosive), ""];
+    if (_connectedInventoryExplosive != "") then {
+        //Add the disconect action
+        private _magConfig = configFile >> "CfgMagazines" >> _connectedInventoryExplosive;
+        private _name = if ((getText (_magConfig >> "displayNameShort")) != "") then {
+            getText (_magConfig >> "displayNameShort")
+        } else {
+            getText(_magConfig >> "displayName")
+        };
+        private _picture = getText (_magConfig >> "picture");
+
+        _children pushBack [
+        ([
+        "Deadman_disconnect",
+        format ["%1 %2", localize "str_disp_disconnect", _name],
+        _picture,
+        {
+            params ["_player"];
+            TRACE_1("clear",_player);
+            _player setVariable [QGVAR(deadmanInvExplosive), "", true];
+        },
+        {true}
+        ] call EFUNC(interact_menu,createAction)), [], _unit];
+
+    } else {
+        //Add all magazines that would work with the deadman switch
+        private _procressedMags = [];
+        {
+            private _mag = _x;
+            if (!(_mag in _procressedMags)) then {
+                _procressedMags pushBack _x;
+                private _magConfig = configFile >> "CfgMagazines" >> _mag;
+                private _supportedTriggers = getArray (_magConfig >> "ACE_Triggers" >> "SupportedTriggers");
+                if (({_x == "DeadmanSwitch"} count _supportedTriggers) == 1) then { //case insensitive search
+                    private _name = if ((getText (_magConfig >> "displayNameShort")) != "") then {
+                        getText (_magConfig >> "displayNameShort")
+                    } else {
+                        getText(_magConfig >> "displayName")
+                    };
+                    private _picture = getText (_magConfig >> "picture");
+
+                    _children pushBack [
+                    ([
+                    format ["Deadman_exp_%1", _mag],
+                    format [localize LSTRING(connectInventoryExplosiveToDeadman), _name],
+                    _picture,
+                    {
+                        params ["_player", "", "_mag"];
+                        TRACE_2("set new",_player,_mag);
+                        _player setVariable [QGVAR(deadmanInvExplosive), _mag, true];
+                    },
+                    {(_this select 2) in (magazines _player)},
+                    {},
+                    (_mag)
+                    ] call EFUNC(interact_menu,createAction)), [], _unit];
+                };
+            };
+        } forEach (magazines _unit);
+    };
 };
 
 _children

--- a/addons/explosives/functions/fnc_onIncapacitated.sqf
+++ b/addons/explosives/functions/fnc_onIncapacitated.sqf
@@ -25,3 +25,24 @@ _deadman = [_unit, "DeadManSwitch"] call FUNC(getPlacedExplosives);
 {
     [_unit, -1, _x, true] call FUNC(detonateExplosive);
 } forEach _deadman;
+
+//Handle deadman connected to explosive in inventory
+private _connectedInventoryExplosive = _unit getVariable [QGVAR(deadmanInvExplosive), ""];
+if (_connectedInventoryExplosive != "") then {
+    if (!(_connectedInventoryExplosive in (magazines _unit))) exitWith {};
+
+    //Remove mag and reset variable
+    _unit removeMagazine _connectedInventoryExplosive;
+    _unit setVariable [QGVAR(deadmanInvExplosive), "", true];
+
+    private _ammo = getText (configFile >> "CfgMagazines" >> _connectedInventoryExplosive >> "ammo");
+    TRACE_2("deadman inventory",_connectedInventoryExplosive,_ammo);
+    private _magazineTrigger = configFile >> "CfgMagazines" >> _connectedInventoryExplosive >> "ACE_Triggers" >> "DeadmanSwitch";
+    if (isText (_magazineTrigger >> "ammo")) then {
+        _ammo = getText (_magazineTrigger >> "ammo");
+    };
+
+    private _explosive = createVehicle [_ammo, (getPos _unit), [], 0, "NONE"];
+    _explosive setPosASL (getPosASL _unit);
+    [_unit, -1, [_explosive, -1]] call FUNC(detonateExplosive); //Explode, ignoring range, with a random 0-1 second delay
+};

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -689,8 +689,8 @@
         <Key ID="STR_ACE_Explosives_connectInventoryExplosiveToDeadman">
             <English>Connect to %1</English>
             <Spanish>Conectar a %1</Spanish>
-            <Russian>Подключиться к  %1</Russian>
-            <German>Verbinde zu %1</German>
+            <Russian>Подключиться к %1</Russian>
+            <German>Verbinde mit %1</German>
             <Czech>Připojit k %1</Czech>
             <Polish>Podłącz do %1</Polish>
             <French>Connecter %1</French>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -686,5 +686,17 @@
             <!-- <Russian>Малое СВУ (зарытое)</Russian> -->
             <!-- <Spanish>IED pequeño (Enterrado)</Spanish> -->
         </Key>
+        <Key ID="STR_ACE_Explosives_connectInventoryExplosiveToDeadman">
+            <English>Connect to %1</English>
+            <Spanish>Conectar a %1</Spanish>
+            <Russian>Подключиться к  %1</Russian>
+            <German>Verbinde zu %1</German>
+            <Czech>Připojit k %1</Czech>
+            <Polish>Podłącz do %1</Polish>
+            <French>Connecter %1</French>
+            <Hungarian>Csatlakozás %1</Hungarian>
+            <Italian>Collega a  %1</Italian>
+            <Portuguese>Conectar à %1</Portuguese>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Allows connecting explosives in inventory that work with the dead man switch (Satchel/Demo/IED but not mines).  Will trigger when killed/incapacitated or manually tirggered.

AKA "Suicide vest".