### PR TITLE
Slightly reduce the distance for which the LOS check is skipped. 

### DIFF
--- a/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
@@ -41,8 +41,8 @@ if ((GVAR(openedMenuType) == 0) && {vehicle ACE_player == ACE_player} && {isNull
 
         if (_distanceToBasePoint > _distance) exitWith {true};
 
-        if ((_distanceToBasePoint > 1.5) && {!(_params select 4)}) exitWith {
-            // If distance to action is greater than 1.5 m and check isn't disabled in params, check LOS
+        if ((_distanceToBasePoint > 1.2) && {!(_params select 4)}) exitWith {
+            // If distance to action is greater than 1.2 m and check isn't disabled in params, check LOS
             lineIntersects [AGLtoASL _headPos, AGLtoASL _pos, _object, ACE_player]
         };
         false


### PR DESCRIPTION
Fix #3270

I don't dare reduce this much more. Sometimes units that fall unconscious might partially clip through objects; the threshold distance prevents those units from getting inaccessible.

Anyway, the reduction seems enough to avoid the bug in common cases.
![2016-02-08_00006](https://cloud.githubusercontent.com/assets/7674951/12901296/a38733a2-ce99-11e5-9e59-d1c3f1576e4b.jpg)

![2016-02-08_00007](https://cloud.githubusercontent.com/assets/7674951/12901305/ab444134-ce99-11e5-93b7-35640e507487.jpg)
