### PR TITLE
Disable ACE_Laser for choppers (aka Changes to DAGR)

### DIFF
--- a/addons/laser_selfdesignate/CfgVehicles.hpp
+++ b/addons/laser_selfdesignate/CfgVehicles.hpp
@@ -17,18 +17,18 @@ class CfgVehicles {
     class B_Heli_Attack_01_F: Heli_Attack_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;      // Enable laser self-designation
+                GVAR(Enabled) = 0;      // Enable laser self-designation
             };
         };
     };
-    
+
     class Plane: Air {};
     class Plane_Base_F: Plane {
         class Turrets {
             class CopilotTurret;
         };
     };
-    
+
     /* @TODO: LGB GBU
     class Plane_CAS_01_base_F: Plane_Base_F {
         class Turrets: Turrets {

--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -5,15 +5,15 @@ enum {
 
 class CfgAmmo {
     class MissileBase;
-    
+
     class M_PG_AT: MissileBase {
         model = "\A3\Weapons_F\Ammo\Rocket_01_fly_F";
         proxyShape = "\A3\Weapons_F\Ammo\Rocket_01_F";
 
         irLock = 0;
-        laserLock = 0;
+        laserLock = 1;
         airLock = 0;
-        weaponLockSystem = "2 + 16";
+        weaponLockSystem = "4 + 16";
 
         maxSpeed = 720;
         maxControlRange = 5000;
@@ -38,8 +38,17 @@ class CfgAmmo {
         // ACE uses these values
         trackOversteer = 1;
         trackLead = 0;
+    };
 
-        // Begin ACE guidance Configs
+    class ACE_Hydra70_DAGR: M_PG_AT {
+        displayName = CSTRING(Hydra70_DAGR);
+        displayNameShort = CSTRING(Hydra70_DAGR_Short);
+
+        description = CSTRING(Hydra70_DAGR_Desc);
+        descriptionShort = CSTRING(Hydra70_DAGR_Desc);
+
+        EGVAR(rearm,caliber) = 70;
+
         class ADDON {
             enabled = 1;
 
@@ -67,20 +76,7 @@ class CfgAmmo {
             attackProfiles[] = { "LIN", "DIR", "MID", "HI" };
         };
     };
-    
-    class ACE_Hydra70_DAGR: M_PG_AT {
-        displayName = CSTRING(Hydra70_DAGR);
-        displayNameShort = CSTRING(Hydra70_DAGR_Short);
 
-        description = CSTRING(Hydra70_DAGR_Desc);
-        descriptionShort = CSTRING(Hydra70_DAGR_Desc);
-        
-        EGVAR(rearm,caliber) = 70;
-        
-        //Explicity add guidance config
-        class ADDON: ADDON {};
-    };
-    
     class ACE_Hellfire_AGM114K: ACE_Hydra70_DAGR {
         displayName = CSTRING(Hellfire_AGM114K);
         displayNameShort = CSTRING(Hellfire_AGM114K_Short);
@@ -96,7 +92,7 @@ class CfgAmmo {
         indirectHit = 71;
         indirectHitRange = 4.5;
         effectsMissile = "missile2";
-        
+
         //Explicity add guidance config
         class ADDON: ADDON {};
     };

--- a/addons/missileguidance/CfgWeapons.hpp
+++ b/addons/missileguidance/CfgWeapons.hpp
@@ -2,12 +2,11 @@ class Mode_SemiAuto;
 class CfgWeapons {
     class CannonCore;
     class LauncherCore;
-    
+
     class RocketPods: LauncherCore {
         // canLock = 1;
     };
     class missiles_DAGR : RocketPods {
-        canLock = 1;
-        magazines[] += {"24Rnd_ACE_Hydra70_DAGR", "12Rnd_ACE_Hydra70_DAGR", "6Rnd_ACE_Hydra70_DAGR", "24Rnd_ACE_Hellfire_AGM114K", "12Rnd_ACE_Hellfire_AGM114K", "6Rnd_ACE_Hellfire_AGM114K" };
+        canLock = 2;
     };
 };


### PR DESCRIPTION
As discussed with @Glowbal on slack, an intermediary change to fix the DAGR missile on both Comanche and Ka-60 Kasatka Helicopter.

[Demo](https://www.youtube.com/watch?v=nzmm5ExG_14)

Allow laserLock, set weaponLockSystem to Laser and move class ADDON to ACE_Hydra70_DAGR so it can be further tested on e.g. ACE_Comanche.