### PR TITLE
Only get passenger actions for selected unit

### DIFF
--- a/addons/interaction/functions/fnc_addPassengerActions.sqf
+++ b/addons/interaction/functions/fnc_addPassengerActions.sqf
@@ -20,12 +20,10 @@
 params ["", "", "_parameters"];
 _parameters params ["_unit"];
 
-private ["_varName", "_actionTrees", "_actions"];
+private _varName = format [QEGVAR(interact_menu,Act_%1), typeOf _unit];
+private _actionTrees = missionNamespace getVariable [_varName, []];
 
-_varName = format [QEGVAR(interact_menu,Act_%1), typeOf _unit];
-_actionTrees = missionNamespace getVariable [_varName, []];
-
-_actions = [];
+private _actions = [];
 
 // Mount unit MainActions menu
 {

--- a/addons/interaction/functions/fnc_addPassengersActions.sqf
+++ b/addons/interaction/functions/fnc_addPassengersActions.sqf
@@ -23,12 +23,10 @@ private "_actions";
 _actions = [];
 
 {
-    private ["_unit", "_icon"];
-
-    _unit = _x;
+    private _unit = _x;
 
     if (_unit != _player && {getText (configFile >> "CfgVehicles" >> typeOf _unit >> "simulation") != "UAVPilot"}) then {
-        _icon = [
+        private _icon = [
             "",
             "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_driver_ca.paa",
             "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_gunner_ca.paa",
@@ -44,14 +42,27 @@ _actions = [];
                 format ["%1", _unit],
                 [_unit, true] call EFUNC(common,getName),
                 _icon,
-                {},
+                { 
+                    //statement (Run on hover) - reset the cache so we will insert actions immedietly when hovering over new unit
+                    TRACE_2("Cleaning Cache",_target,vehicle _target);
+                    [vehicle _target, QEGVAR(interact_menu,ATCache_ACE_SelfActions)] call EFUNC(common,eraseCache);
+                },
                 {true},
-                {_this call FUNC(addPassengerActions)},
-                [_unit]
-            ] call EFUNC(interact_menu,createAction),
-            [],
-            _unit
-        ];
+                {
+                    if (EGVAR(interact_menu,selectedTarget) isEqualTo _target) then {
+                        _this call FUNC(addPassengerActions)
+                    } else {
+                        [] //not selected, don't waste time on actions
+                    };
+                },
+                [_unit],
+                {[0, 0, 0]},
+                2,
+                [false,false,false,true,false] //add run on hover (4th bit true)
+                ] call EFUNC(interact_menu,createAction),
+                [],
+                _unit
+            ];
     };
     false
 } count crew _vehicle;


### PR DESCRIPTION
Fix #1690 #3309

When interacting with vehicle passangers we collected all actions for all crew which was very expensive for large transports (>100ms stutter each second). This only collects the passenger actions for the selected crew member.

ace_interact_menu_fnc_collectActiveActionTree_counter: Average: 8.04395s / 1326 = 6.06632ms
vs
ace_interact_menu_fnc_collectActiveActionTree_counter: Average: 0.46582s / 1175 = 0.396443ms