### PR TITLE
Fix vehicle crashes

### DIFF
--- a/addons/medical/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical/functions/fnc_determineIfFatal.sqf
@@ -26,8 +26,8 @@ private ["_damageThreshold", "_damageBodyPart", "_chanceFatal"];
 params ["_unit", "_part", ["_withDamage", 0]];
 
 if (!alive _unit) exitWith {true};
-if (_part < 0 || _part > 5) exitWith {false};
 if ((vehicle _unit != _unit) && {!alive (vehicle _unit)}) exitWith { true };
+if (_part < 0 || _part > 5) exitWith {false};
 
 // Find the correct Damage threshold for unit.
 _damageThreshold = [1,1,1];

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -26,6 +26,8 @@ if !(local _unit) exitWith {
     nil
 };
 
+// if (alive _unit) then {diag_log text format ["HD: %1", _this];};
+
 private ["_damageReturn",  "_typeOfDamage", "_minLethalDamage", "_newDamage", "_typeIndex", "_preventDeath"];
 
 // bug, assumed fixed, @todo excessive testing, if nothing happens remove
@@ -78,14 +80,14 @@ _minLethalDamage = if (_typeIndex >= 0) then {
 };
 
 private _vehicle = vehicle _unit;
+private _effectiveSelectionName = _selection;
 if ((_vehicle != _unit) && {!(_vehicle isKindOf "StaticWeapon")} && {_shooter in [objNull, driver _vehicle, _vehicle]} && {_projectile == ""} && {_selection == ""}) then {
     if (GVAR(enableVehicleCrashes)) then {
-        _selection = _this select 1; //pull random selection from HDC
-        TRACE_1("Veh Crash",_selection);
+        _effectiveSelectionName = _this select 1; //pull random selection from HDC
     };
 };
 
-if ((_minLethalDamage <= _newDamage) && {[_unit, [_selection] call FUNC(selectionNameToNumber), _newDamage] call FUNC(determineIfFatal)}) then {
+if ((_minLethalDamage <= _newDamage) && {[_unit, [_effectiveSelectionName] call FUNC(selectionNameToNumber), _newDamage] call FUNC(determineIfFatal)}) then {
     if ((_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)])) exitwith {
         _damageReturn = 0.9;
     };
@@ -101,13 +103,8 @@ if ((_minLethalDamage <= _newDamage) && {[_unit, [_selection] call FUNC(selectio
 [_unit] call FUNC(addToInjuredCollection);
 
 if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitWith {
-    if (vehicle _unit != _unit and {damage (vehicle _unit) >= 1}) then {
-        [_unit] call EFUNC(common,unloadPerson);
-    };
-
-    private "_delayedUnconsicous";
-    _delayedUnconsicous = false;
-    if (vehicle _unit != _unit and {damage (vehicle _unit) >= 1}) then {
+    private _delayedUnconsicous = false;
+    if (_vehicle != _unit and {damage _vehicle >= 1}) then {
         [_unit] call EFUNC(common,unloadPerson);
         _delayedUnconsicous = true;
     };
@@ -120,7 +117,7 @@ if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitW
         if (_delayedUnconsicous) then {
             [{
                 [_this select 0, true] call FUNC(setUnconscious);
-            }, [_unit], 0.7, 0] call EFUNC(common,waitAndExecute);
+            }, [_unit], 0.7] call EFUNC(common,waitAndExecute);
         } else {
             [{
                 [_this select 0, true] call FUNC(setUnconscious);

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -26,8 +26,6 @@ if !(local _unit) exitWith {
     nil
 };
 
-// if (alive _unit) then {diag_log text format ["HD: %1", _this];};
-
 private ["_damageReturn",  "_typeOfDamage", "_minLethalDamage", "_newDamage", "_typeIndex", "_preventDeath"];
 
 // bug, assumed fixed, @todo excessive testing, if nothing happens remove

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -77,9 +77,11 @@ _minLethalDamage = if (_typeIndex >= 0) then {
     0.01
 };
 
-if (vehicle _unit != _unit && {!(vehicle _unit isKindOf "StaticWeapon")} && {isNull _shooter} && {_projectile == ""} && {_selection == ""}) then {
+private _vehicle = vehicle _unit;
+if ((_vehicle != _unit) && {!(_vehicle isKindOf "StaticWeapon")} && {_shooter in [objNull, driver _vehicle, _vehicle]} && {_projectile == ""} && {_selection == ""}) then {
     if (GVAR(enableVehicleCrashes)) then {
-        _selection = GVAR(SELECTIONS) select (floor(random(count GVAR(SELECTIONS))));
+        _selection = _this select 1; //pull random selection from HDC
+        TRACE_1("Veh Crash",_selection);
     };
 };
 

--- a/addons/medical/functions/fnc_handleDamage_caching.sqf
+++ b/addons/medical/functions/fnc_handleDamage_caching.sqf
@@ -29,9 +29,11 @@ if (_hitPointIndex >= 0) then {_newDamage = _damage - (_unit getHitIndex _hitPoi
 TRACE_7("ACE_DEBUG: HandleDamage_Caching Called",_unit, _selectionName, _damage, _source, _projectile,_hitPointIndex,_newDamage);
 
 // Check for vehicle crash
-if (vehicle _unit != _unit && {!(vehicle _unit isKindOf "StaticWeapon")} && {isNull _source} && {_projectile == ""} && {_selectionName == ""}) then {
+private _vehicle = vehicle _unit;
+if ((_vehicle != _unit) && {!(_vehicle isKindOf "StaticWeapon")} && {_source in [objNull, driver _vehicle, _vehicle]} && {_projectile == ""} && {_selectionName == ""}) then {
     if (GVAR(enableVehicleCrashes)) then {
         _selectionName = _hitSelections select (floor(random(count _hitSelections)));
+        TRACE_1("Veh Crash",_selectionName);
         _projectile = "vehiclecrash";
         _this set [1, _selectionName];
         _this set [4, _projectile];
@@ -40,7 +42,7 @@ if (vehicle _unit != _unit && {!(vehicle _unit isKindOf "StaticWeapon")} && {isN
 
 // Handle falling damage
 _impactVelocity = (velocity _unit) select 2;
-if (_impactVelocity < -5 && {vehicle _unit == _unit}) then {
+if (_impactVelocity < -5 && {_vehicle == _unit}) then {
      TRACE_1("Starting isFalling", time);
     _unit setVariable [QGVAR(isFalling), true];
     _unit setVariable [QGVAR(impactVelocity), _impactVelocity];

--- a/addons/medical/functions/fnc_handleDamage_caching.sqf
+++ b/addons/medical/functions/fnc_handleDamage_caching.sqf
@@ -33,7 +33,6 @@ private _vehicle = vehicle _unit;
 if ((_vehicle != _unit) && {!(_vehicle isKindOf "StaticWeapon")} && {_source in [objNull, driver _vehicle, _vehicle]} && {_projectile == ""} && {_selectionName == ""}) then {
     if (GVAR(enableVehicleCrashes)) then {
         _selectionName = _hitSelections select (floor(random(count _hitSelections)));
-        TRACE_1("Veh Crash",_selectionName);
         _projectile = "vehiclecrash";
         _this set [1, _selectionName];
         _this set [4, _projectile];

--- a/addons/medical/functions/fnc_setDead.sqf
+++ b/addons/medical/functions/fnc_setDead.sqf
@@ -47,6 +47,12 @@ if (((_reviveVal == 1 && {[_unit] call EFUNC(common,isPlayer)} || _reviveVal == 
         _args params ["_unit"];
         _startTime = _unit getVariable [QGVAR(reviveStartTime), 0];
 
+        //If we are in reivie state in a blown up vehicle, try to unload so that people can access the body
+        if ((alive _unit) && {(vehicle _unit) != _unit} && {!alive (vehicle _unit)}) then {
+            TRACE_2("Unloading", _unit, vehicle _unit);
+            [_unit] call EFUNC(common,unloadPerson);
+        };
+
         if (GVAR(maxReviveTime) > 0 && {ACE_time - _startTime > GVAR(maxReviveTime)}) exitwith {
             [_idPFH] call CBA_fnc_removePerFrameHandler;
             _unit setVariable [QGVAR(inReviveState), nil, true];


### PR DESCRIPTION
Fix #3306
Fix #3269

Enemy RPG to MRAP (driver):
```
HD: [carrd,"",1,<NULL-object>,"",-1]
HD: [carrd,"",1,<NULL-object>,"",-1]
HD: [carrd,"",1,O Alpha 1-1:1,"R_PG32V_F",-1]
```
Enemy RPG to MRAP (gunner):
```
HD: [carrg,"",1,O Alpha 1-1:1 REMOTE,"R_PG32V_F",-1]
```

35m fall veh explodes (driver):
```
HD: [carrd,"",1,<NULL-object>,"",-1]
HD: [carrd,"",1,<NULL-object>,"",-1]
HD: [carrd,"",1,carrd,"",-1]
```

35m fall veh explodes (gunner):
```
HD: [carrg,"",1,carrd,"",-1]
```

So in crashes, the shooter/source can be the pilot for non-drivers.
Switching the order in determine if fatal will handle RPG shots that blow up vehicles as there doesn't seem to be any hit point damage.