### PR TITLE
Add flashsupressor to asdg_MuzzleSlot_338

### DIFF
--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -14,7 +14,6 @@ class CfgWeapons {
     class MMG_02_base_F;
     class Rifle_Base_F;
     class Rifle_Long_Base_F;
-    class WeaponSlotsInfo;
     class MuzzleSlot;
     
     /* Long Rifles */
@@ -74,22 +73,12 @@ class CfgWeapons {
     };
     
     class DMR_01_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
         class Single: Mode_SemiAuto {
             dispersion = 0.0004; // radians. Equal to 1.375 MOA.
         };
     };
     
     class EBR_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
         class Single: Mode_SemiAuto {
             dispersion = 0.00029; // radians. Equal to 1.00 MOA.
         };
@@ -101,13 +90,7 @@ class CfgWeapons {
     
     /* MX */
     
-    class arifle_MX_Base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_H"};
-            };
-        };
-    };
+    class arifle_MX_Base_F: Rifle_Base_F {};
     class arifle_MX_SW_F: arifle_MX_Base_F {
         magazines[] = {
             "100Rnd_65x39_caseless_mag_Tracer",
@@ -120,13 +103,6 @@ class CfgWeapons {
         initSpeed = -1.0;
         ACE_barrelTwist=228.6;
         ACE_barrelLength=406.4;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                // Shit is broken again
-                //compatibleItems[] += {"ACE_muzzle_mzls_H"};
-                compatibleItems[] = {"muzzle_snds_H","muzzle_snds_H_SW","ACE_muzzle_mzls_H"};
-            };
-        };
     };
     class arifle_MXM_F: arifle_MX_Base_F {
         magazines[] = {
@@ -150,13 +126,7 @@ class CfgWeapons {
 
 
     /* Katiba */
-    class arifle_katiba_Base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_H"};
-            };
-        };
-    };
+    class arifle_katiba_Base_F: Rifle_Base_F {};
 
 
     /* Other */
@@ -167,42 +137,16 @@ class CfgWeapons {
             "ACE_200Rnd_65x39_cased_Box_Tracer_Dim"
         };
         initSpeed = -0.9763;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_H"};
-            };
-        };
         ACE_barrelTwist=177.8;
         ACE_barrelLength=317.5;
     };
     class LMG_Zafir_F: Rifle_Long_Base_F {
         initSpeed = -1.0;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
         ACE_barrelTwist=304.8;
         ACE_barrelLength=459.74;
     };
-
-
-    /* Assault Rifles */
-    class Tavor_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_L"};
-            };
-        };
-    };
-    class mk20_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_L"};
-            };
-        };
-    };
-
+    class Tavor_base_F: Rifle_Base_F {};
+    class mk20_base_F: Rifle_Base_F {};
 
     /* SMGs */
     class SDAR_base_F: Rifle_Base_F {
@@ -219,93 +163,43 @@ class CfgWeapons {
             dispersion = 0.0008727; // radians. Equal to 3 MOA.
         };
     };
-    class pdw2000_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_02"};
-            };
-        };
-    };
-    class SMG_01_Base: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
-            };
-        };
-    };
-    class SMG_02_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_02"};
-            };
-        };
-    };
-    
+    class pdw2000_base_F: Rifle_Base_F {};
+    class SMG_01_Base: Rifle_Base_F {};
+    class SMG_02_base_F: Rifle_Base_F {};
+
     /* Pistols */
 
     class Pistol;
-    class Pistol_Base_F: Pistol {
-        class WeaponSlotsInfo;
-    };
+    class Pistol_Base_F: Pistol {};
 
     class hgun_P07_F: Pistol_Base_F {
         initSpeed = -0.9778;
         ACE_barrelTwist=254.0;
         ACE_barrelLength=101.6;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_02"};
-            };
-        };
     };
 
     class hgun_Rook40_F: Pistol_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=254.0;
         ACE_barrelLength=111.76;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_02"};
-            };
-        };
     };
 
     class hgun_ACPC2_F: Pistol_Base_F {
         initSpeed = -1.0;
         ACE_barrelTwist=406.4;
         ACE_barrelLength=127.0;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
-            };
-        };
     };
 
     class hgun_Pistol_heavy_01_F: Pistol_Base_F {
         initSpeed = -0.96;
         ACE_barrelTwist=406.4;
         ACE_barrelLength=114.3;
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
-            };
-        };
     };
 
     class hgun_Pistol_heavy_02_F: Pistol_Base_F {
         initSpeed = -0.92;
         ACE_barrelTwist=406.4;
         ACE_barrelLength=76.2;
-        /*
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot {
-                linkProxy = "\A3\data_f\proxies\weapon_slots\MUZZLE";
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
-            };
-        };
-        */
     };
     class hgun_PDW2000_F: pdw2000_base_F {
         initSpeed = -1.157;

--- a/addons/flashsuppressors/CfgWeapons.hpp
+++ b/addons/flashsuppressors/CfgWeapons.hpp
@@ -4,7 +4,21 @@ class asdg_MuzzleSlot_338: asdg_MuzzleSlot { // for .338 universal mount suppres
         ACE_muzzle_mzls_338 = 1;
     };
 };
-
+class asdg_MuzzleSlot_762: asdg_MuzzleSlot { // for 7.62x51 universal mount suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_B = 1;
+    };
+};
+class asdg_MuzzleSlot_93x64: asdg_MuzzleSlot { // for 9.3x64 universal mount suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_93mmg = 1;
+    };
+};
+class asdg_MuzzleSlot_9MM_SMG: asdg_MuzzleSlot { // for 9x19mm universal mount SMG suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_smg_02 = 1;
+    };
+};
 
 class MuzzleSlot;
 
@@ -53,58 +67,10 @@ class CfgWeapons {
         class WeaponSlotsInfo;
     };
 
-    class EBR_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
-    };
-
     class DMR_01_base_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
-    };
-
-    class DMR_03_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
-    };
-
-    class DMR_05_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_93mmg"};
-            };
-        };
-    };
-
-    class DMR_06_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
-    };
-
-    class MMG_01_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_93mmg"};
-            };
-        };
-    };
-
-    class MMG_02_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_338"};
             };
         };
     };
@@ -147,26 +113,10 @@ class CfgWeapons {
 
     /* SMGs */
 
-    class pdw2000_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_02"};
-            };
-        };
-    };
-
     class SMG_01_Base: Rifle_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
-            };
-        };
-    };
-
-    class SMG_02_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_02"};
             };
         };
     };

--- a/addons/flashsuppressors/CfgWeapons.hpp
+++ b/addons/flashsuppressors/CfgWeapons.hpp
@@ -1,3 +1,10 @@
+class asdg_MuzzleSlot;
+class asdg_MuzzleSlot_338: asdg_MuzzleSlot { // for .338 universal mount suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_338 = 1;
+    };
+};
+
 
 class MuzzleSlot;
 
@@ -58,14 +65,6 @@ class CfgWeapons {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class MuzzleSlot: MuzzleSlot {
                 compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
-    };
-
-    class DMR_02_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_338"};
             };
         };
     };

--- a/addons/flashsuppressors/CfgWeapons.hpp
+++ b/addons/flashsuppressors/CfgWeapons.hpp
@@ -19,6 +19,16 @@ class asdg_MuzzleSlot_9MM_SMG: asdg_MuzzleSlot { // for 9x19mm universal mount S
         ACE_muzzle_mzls_smg_02 = 1;
     };
 };
+class asdg_MuzzleSlot_556: asdg_MuzzleSlot { // for 5.56x45 universal mount suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_L = 1;
+    };
+};
+class asdg_MuzzleSlot_45ACP_SMG: asdg_MuzzleSlot { // for .45ACP universal mount SMG suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_smg_01 = 1;
+    };
+};
 
 class MuzzleSlot;
 
@@ -90,37 +100,6 @@ class CfgWeapons {
             };
         };
     };
-
-
-    /* Assault Rifles */
-
-    class Tavor_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_L"};
-            };
-        };
-    };
-
-    class mk20_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_L"};
-            };
-        };
-    };
-
-
-    /* SMGs */
-
-    class SMG_01_Base: Rifle_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_smg_01"};
-            };
-        };
-    };
-
 
     /* Pistols */
 


### PR DESCRIPTION
### When merged this pull request will:

Fix #3344 ?

I don't really know the JR stuff that well, but this seems to fix.
Should we switch other things to use the `compatibleItems` class instead of array?