### PR TITLE
Better flash effects

### DIFF
--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -46,7 +46,7 @@ private _affected = (ASLtoAGL _grenadePosASL) nearEntities ["CAManBase", 20];
 _affected = _affected - [ACE_player];
 {
     if (local _x && {alive _x}) then {
-        private _strength = 1 - (((getPosASL _x) vectorDistance _grenadePosASL) min 15) / 15;
+        private _strength = 1 - (((getPosASL _x) vectorDistance _grenadePosASL) min 20) / 20;
 
         TRACE_3("FlashBangEffect Start",_x,((getPosASL _x) vectorDistance _grenadePosASL),_strength);
 
@@ -71,14 +71,14 @@ _affected = _affected - [ACE_player];
     };
 } count _affected;
 
-// Affect local player, independently of distance (all effects except light finish at 15m)
+// Affect local player, independently of distance
 if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
     // Do effects for player
     // is there line of sight to the grenade?
     private _eyePos = eyePos ACE_player; //PositionASL
     _grenadePosASL set [2, (_grenadePosASL select 2) + 0.2]; // compensate for grenade glitching into ground
 
-    private _strength = 1 - ((_eyePos vectorDistance _grenadePosASL) min 15) / 15;
+    private _strength = 1 - ((_eyePos vectorDistance _grenadePosASL) min 20) / 20;
 
     // Check for line of sight (check 4 points in case grenade is stuck in an object or underground)
     private _losCoefficient = 1;

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -54,6 +54,10 @@ _affected = _affected - [ACE_player];
 
         _x setSkill (skill _x / 50);
 
+        if (_strength > 0.2) then {
+            _x setVectorDir ((getPosASL _x) vectorDiff _grenadePosASL);
+        };
+
         [{
             params ["_unit"];
 
@@ -87,7 +91,6 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
     };
     _strength = _strength * _losCoefficient;
 
-    };
 
     // Add ace_hearing ear ringing sound effect
     if (isClass (configFile >> "CfgPatches" >> "ACE_Hearing") && {_strength > 0}) then {
@@ -129,6 +132,10 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
         [{
             GVAR(flashbangPPEffectCC) ppEffectEnable false;
         }, [], 17 * _strength] call EFUNC(common,waitAndExecute);
+    };
+
+    if (_strength > 0.2) then {
+        ACE_player setVectorDir (_eyePos vectorDiff _grenadePosASL);
     };
 };
 true

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -18,105 +18,115 @@
 params ["_grenadePosASL"];
 TRACE_1("params",_grenadePosASL);
 
-private _affected = (ASLtoAGL _grenadePosASL) nearEntities ["CAManBase", 20];
+// Create flash to illuminate environment
+if (hasInterface) then {
+    private _light = "#lightpoint" createVehicleLocal ASLtoAGL _grenadePosASL;
+    _light setPosASL _grenadePosASL;
 
+    _light setLightBrightness 20;
+    _light setLightAmbient [1,1,1];
+    _light setLightColor [1,1,1];
+    _light setLightDayLight true;
+
+    // Reduce the light after 0.1 seconds
+    [{
+        params ["_light"];
+        _light setLightBrightness 5;
+        // Delete the light after 0.2 more seconds
+        [{
+            params ["_light"];
+            deleteVehicle _light;
+        }, [_light], 0.2] call EFUNC(common,waitAndExecute);
+    }, [_light], 0.1] call EFUNC(common,waitAndExecute);
+};
+
+// Affect local AI
+// @todo: Affect units in static weapons, turned out, etc
+private _affected = (ASLtoAGL _grenadePosASL) nearEntities ["CAManBase", 20];
+_affected = _affected - [ACE_player];
 {
     if (local _x && {alive _x}) then {
-
         private _strength = 1 - (((getPosASL _x) vectorDistance _grenadePosASL) min 15) / 15;
 
         TRACE_3("FlashBangEffect Start",_x,((getPosASL _x) vectorDistance _grenadePosASL),_strength);
 
-        if (_x != ACE_player) then {
-            //must be AI
-            [_x, true] call EFUNC(common,disableAI);
+        [_x, true] call EFUNC(common,disableAI);
 
-            _x setSkill (skill _x / 50);
+        _x setSkill (skill _x / 50);
 
-            [{
-                params ["_unit"];
+        [{
+            params ["_unit"];
 
-                //Make sure we don't enable AI for unconscious units
-                if !(_unit getVariable ["ace_isUnconscious", false]) then {
-                    [_unit, false] call EFUNC(common,disableAI);
-                };
-
-                _unit setSkill (skill _unit * 50);
-            }, [_x], 7 * _strength] call EFUNC(common,waitAndExecute);
-        } else {
-            //Do effects for player
-            // is there line of sight to the grenade?
-            private _eyePos = eyePos ACE_player; //PositionASL
-            _posGrenade set [2, (_posGrenade select 2) + 0.2]; // compensate for grenade glitching into ground
-
-            //Check for line of sight (check 4 points in case grenade is stuck in an object or underground)
-            private _losCount = {
-                !lineIntersects [_grenadePosASL vectorAdd _x, _eyePos, ACE_player]
-            } count [[0,0,0], [0,0,0.2], [0.1, 0.1, 0.1], [-0.1, -0.1, 0.1]];
-
-            TRACE_1("Line of sight count (out of 4)",_losCount);
-            if (_losCount <= 1) then {
-                _strength = _strength / 10;
+            //Make sure we don't enable AI for unconscious units
+            if !(_unit getVariable ["ace_isUnconscious", false]) then {
+                [_unit, false] call EFUNC(common,disableAI);
             };
 
-            // add ace_hearing ear ringing sound effect
-            if (isClass (configFile >> "CfgPatches" >> "ACE_Hearing") && {_strength > 0}) then {
-                [_x, 20 * _strength] call EFUNC(hearing,earRinging);
-            };
-
-            // account for people looking away by slightly
-            // reducing the effect for visual effects.
-            private _eyeDir = (positionCameraToWorld [0,0,1] vectorDiff positionCameraToWorld [0,0,0]);
-            private _dirToUnitVector = _eyePos vectorFromTo _posGrenade;
-            private _angleDiff = acos (_eyeDir vectorDotProduct _dirToUnitVector);
-
-            // from 0-45deg, full effect
-            if (_angleDiff > 45) then {
-                _strength = _strength - _strength * ((_angleDiff - 45) / 120);
-            };
-
-            TRACE_1("Final strength for player",_strength);
-
-            // add ace_medical pain effect:
-            if (isClass (configFile >> "CfgPatches" >> "ACE_Medical") && {_strength > 0.1}) then {
-                [ACE_player, _strength / 2] call EFUNC(medical,adjustPainLevel);
-            };
-
-            // create flash to illuminate environment
-            private _light = "#lightpoint" createVehicleLocal _grenadePosASL;
-            _light setPosASL _grenadePosASL;
-
-            _light setLightBrightness 200;
-            _light setLightAmbient [1,1,1];
-            _light setLightColor [1,1,1];
-            _light setLightDayLight true;
-
-            // delete the light after 0.1 seconds
-            [{
-                params ["_light"];
-                deleteVehicle _light;
-            }, [_light], 0.1] call EFUNC(common,waitAndExecute);
-
-            // blind player
-            if (hasInterface && {_strength > 0.1}) then {
-                GVAR(flashbangPPEffectCC) ppEffectEnable true;
-                GVAR(flashbangPPEffectCC) ppEffectAdjust [1,1,(0.8 + _strength) min 1,[1,1,1,0],[0,0,0,1],[0,0,0,0]];
-                GVAR(flashbangPPEffectCC) ppEffectCommit 0.01;
-
-                //PARTIALRECOVERY - start decreasing effect over time
-                [{
-                    params ["_strength"];
-
-                    GVAR(flashbangPPEffectCC) ppEffectAdjust [1,1,0,[1,1,1,0],[0,0,0,1],[0,0,0,0]];
-                    GVAR(flashbangPPEffectCC) ppEffectCommit (10 * _strength);
-                }, [_strength], 7 * _strength] call EFUNC(common,waitAndExecute);
-
-                //FULLRECOVERY - end effect
-                [{
-                    GVAR(flashbangPPEffectCC) ppEffectEnable false;
-                }, [], 17 * _strength] call EFUNC(common,waitAndExecute);
-            };
-        };
+            _unit setSkill (skill _unit * 50);
+        }, [_x], 7 * _strength] call EFUNC(common,waitAndExecute);
     };
-    true
 } count _affected;
+
+// Affect local player, independently of distance (all effects except light finish at 15m)
+if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
+    // Do effects for player
+    // is there line of sight to the grenade?
+    private _eyePos = eyePos ACE_player; //PositionASL
+    _grenadePosASL set [2, (_grenadePosASL select 2) + 0.2]; // compensate for grenade glitching into ground
+
+    private _strength = 1 - ((_eyePos vectorDistance _grenadePosASL) min 15) / 15;
+
+    //Check for line of sight (check 4 points in case grenade is stuck in an object or underground)
+    private _losCount = {
+        !lineIntersects [_grenadePosASL vectorAdd _x, _eyePos, ACE_player]
+    } count [[0,0,0], [0,0,0.2], [0.1, 0.1, 0.1], [-0.1, -0.1, 0.1]];
+
+    TRACE_1("Line of sight count (out of 4)",_losCount);
+    if (_losCount <= 1) then {
+        _strength = _strength / 10;
+    };
+
+    // add ace_hearing ear ringing sound effect
+    if (isClass (configFile >> "CfgPatches" >> "ACE_Hearing") && {_strength > 0}) then {
+        [_x, 40 * _strength] call EFUNC(hearing,earRinging);
+    };
+
+    // account for people looking away by slightly
+    // reducing the effect for visual effects.
+    private _eyeDir = ((AGLtoASL positionCameraToWorld [0,0,1]) vectorDiff (AGLtoASL positionCameraToWorld [0,0,0]));
+    private _dirToUnitVector = _eyePos vectorFromTo _posGrenade;
+    private _angleDiff = acos (_eyeDir vectorDotProduct _dirToUnitVector);
+
+    // from 0-45deg, full effect
+    if (_angleDiff > 45) then {
+        _strength = _strength - _strength * ((_angleDiff - 45) / 120);
+    };
+
+    TRACE_1("Final strength for player",_strength);
+
+    // add ace_medical pain effect:
+    if (isClass (configFile >> "CfgPatches" >> "ACE_Medical") && {_strength > 0.1}) then {
+        [ACE_player, _strength / 2] call EFUNC(medical,adjustPainLevel);
+    };
+
+    // blind player
+    if (_strength > 0.1) then {
+        GVAR(flashbangPPEffectCC) ppEffectEnable true;
+        GVAR(flashbangPPEffectCC) ppEffectAdjust [1,1,(0.8 + _strength) min 1,[1,1,1,0],[0,0,0,1],[0,0,0,0]];
+        GVAR(flashbangPPEffectCC) ppEffectCommit 0.01;
+
+        //PARTIALRECOVERY - start decreasing effect over time
+        [{
+            params ["_strength"];
+
+            GVAR(flashbangPPEffectCC) ppEffectAdjust [1,1,0,[1,1,1,0],[0,0,0,1],[0,0,0,0]];
+            GVAR(flashbangPPEffectCC) ppEffectCommit (10 * _strength);
+        }, [_strength], 7 * _strength] call EFUNC(common,waitAndExecute);
+
+        //FULLRECOVERY - end effect
+        [{
+            GVAR(flashbangPPEffectCC) ppEffectEnable false;
+        }, [], 17 * _strength] call EFUNC(common,waitAndExecute);
+    };
+};
+true

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -107,11 +107,12 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
     _strength = _strength * _losCoefficient;
     // Account for people looking away by slightly reducing the effect for visual effects.
     private _eyeDir = ((AGLtoASL positionCameraToWorld [0,0,1]) vectorDiff (AGLtoASL positionCameraToWorld [0,0,0]));
-    private _dirToUnitVector = _eyePos vectorFromTo _posGrenade;
+    private _dirToUnitVector = _eyePos vectorFromTo _grenadePosASL;
     private _angleDiff = acos (_eyeDir vectorDotProduct _dirToUnitVector);
-    // from 0-60deg, full effect
-    if (_angleDiff > 60) then {
-        _strength = _strength - _strength * ((_angleDiff - 60) / 120);
+    TRACE_2("",_angleDiff,((1 - (_angleDiff - 45) / (120 - 45)) max 0));
+    // from 0-45deg, full effect
+    if (_angleDiff > 45) then {
+        _strength = _strength * ((1 - (_angleDiff - 45) / (120 - 45)) max 0);
     };
 
     // Blind player

--- a/addons/grenades/functions/fnc_flashbangThrownFuze.sqf
+++ b/addons/grenades/functions/fnc_flashbangThrownFuze.sqf
@@ -21,8 +21,5 @@ TRACE_1("params",_projectile);
 if (alive _projectile) then {
     playSound3D ["A3\Sounds_F\weapons\Explosion\explosion_mine_1.wss", _projectile, false, getPosASL _projectile, 5, 1.2, 400];
 
-    private _affected = _projectile nearEntities ["CAManBase", 20];
-    TRACE_2("people hit",_affected,getPosASL _projectile);
-
-    ["flashbangExplosion", _affected, [getPosASL _projectile]] call EFUNC(common,targetEvent);
+    ["flashbangExplosion", [getPosASL _projectile]] call EFUNC(common,globalEvent);
 };


### PR DESCRIPTION
### When merged this pull request will:

1. Make sure the light effect is rendered even if the grenade explodes further than 20m from the player. This provides much better feedback that the grenade exploded, even if the player is not affected.
2. Increase the amount of hearing damage from the bang. Should work nicely with the new hearing overhaul.
3. Increase the maximum range for blinding effect to 25m, but with a higher-than-linear falloff. Close #1539.
4. Make units heavily affected by the blast turn away from the light, as per @bux578 request.

Bottom line, this should improve both the UX of throwing flashbangs and their effectiveness.