### PR TITLE
Fix empty callbacks in medical/repair

### DIFF
--- a/addons/medical/functions/fnc_treatment_failure.sqf
+++ b/addons/medical/functions/fnc_treatment_failure.sqf
@@ -69,6 +69,7 @@ _callback = if (isNil _callback) then {
 } else {
     missionNamespace getVariable _callback
 };
+if (!(_callback isEqualType {})) then {_callback = {TRACE_1("callback was NOT code",_callback)};};
 
 _args call _callback;
 

--- a/addons/medical/functions/fnc_treatment_success.sqf
+++ b/addons/medical/functions/fnc_treatment_success.sqf
@@ -64,6 +64,7 @@ if (isNil _callback) then {
 } else {
     _callback = missionNamespace getVariable _callback;
 };
+if (!(_callback isEqualType {})) then {_callback = {TRACE_1("callback was NOT code",_callback)};};
 
 //Get current blood loose on limb (for "bloody" litter)
 private _bloodLossOnSelection = 0;

--- a/addons/repair/functions/fnc_repair_failure.sqf
+++ b/addons/repair/functions/fnc_repair_failure.sqf
@@ -63,6 +63,7 @@ if (isNil _callback) then {
 } else {
     _callback = missionNamespace getVariable _callback;
 };
+if (!(_callback isEqualType {})) then {_callback = {TRACE_1("callback was NOT code",_callback)};};
 
 _args call _callback;
 

--- a/addons/repair/functions/fnc_repair_success.sqf
+++ b/addons/repair/functions/fnc_repair_success.sqf
@@ -58,6 +58,8 @@ if (isNil _callback) then {
 } else {
     _callback = missionNamespace getVariable _callback;
 };
+if (!(_callback isEqualType {})) then {_callback = {TRACE_1("callback was NOT code",_callback)};};
+
 _args call _callback;
 
 //todo: repair litter?


### PR DESCRIPTION
`typeof (missionNamespace getVariable "")` = "EmptyDetector"

causes
```
Error call: Type Object, expected code
File z\ace\addons\repair\functions\fnc_repair_failure.sqf, line 46
```