### PR TITLE
Fix 3den attributes

### DIFF
--- a/addons/captives/CfgEden.hpp
+++ b/addons/captives/CfgEden.hpp
@@ -8,7 +8,7 @@ class Cfg3DEN {
                         control = "Checkbox";
                         displayName = CSTRING(ModuleHandcuffed_DisplayName);
                         tooltip = CSTRING(ModuleHandcuffed_Description);
-                        expression = QUOTE([ARR_2(_this,_value)]call FUNC(setHandcuffed));
+                        expression = QUOTE(if (_value) then {[ARR_3(objNull,[_this],true)] call FUNC(moduleHandcuffed)});
                         typeName = "BOOL";
                         condition = "objectBrain";
                         defaultValue = false;
@@ -18,7 +18,7 @@ class Cfg3DEN {
                         control = "Checkbox";
                         displayName = CSTRING(ModuleSurrender_DisplayName);
                         tooltip = CSTRING(ModuleSurrender_Description);
-                        expression = QUOTE([ARR_2(_this,_value)]call FUNC(setSurrendered));
+                        expression = QUOTE(if (_value) then {[ARR_3(objNull,[_this],true)] call FUNC(moduleSurrender)});
                         typeName = "BOOL";
                         condition = "objectBrain";
                         defaultValue = false;

--- a/addons/captives/functions/fnc_moduleHandcuffed.sqf
+++ b/addons/captives/functions/fnc_moduleHandcuffed.sqf
@@ -1,6 +1,7 @@
 /*
  * Author: PabstMirror
  * Module Function to make a unit handcuffed (can be called from editor)
+ * Also used for threeden attribute expression with dummy Logic Object
  *
  * Arguments:
  * 0: The Module Logic <OBJECT>
@@ -11,7 +12,7 @@
  * Nothing
  *
  * Example:
- * Called from module
+ * [objNull, [player], true] call ace_captives_fnc_moduleHandcuffed
  *
  * Public: No
  */
@@ -28,8 +29,11 @@ if (!isServer) exitWith {};
 [{
     params ["_units"];
     {
+        TRACE_2("event",_x,local _x);
         ["SetHandcuffed", [_x], [_x, true]] call EFUNC(common,targetEvent);
     } forEach _units;
 }, [_units], 0.05] call EFUNC(common,waitAndExecute);
 
-deleteVehicle _logic;
+if (!isNull _logic) then {
+    deleteVehicle _logic;
+};

--- a/addons/captives/functions/fnc_moduleSurrender.sqf
+++ b/addons/captives/functions/fnc_moduleSurrender.sqf
@@ -1,6 +1,7 @@
 /*
  * Author: PabstMirror
  * Module Function to make a unit surrender (can be called from editor)
+ * Also used for threeden attribute expression with dummy Logic Object
  *
  * Arguments:
  * 0: The Module Logic <OBJECT>
@@ -11,7 +12,7 @@
  * Nothing
  *
  * Example:
- * Called from module
+ * [objNull, [player], true] call ace_captives_fnc_moduleSurrender
  *
  * Public: No
  */
@@ -28,8 +29,11 @@ if (!isServer) exitWith {};
 [{
     params ["_units"];
     {
+        TRACE_2("event",_x,local _x);
         ["SetSurrendered", [_x], [_x, true]] call EFUNC(common,targetEvent);
     } forEach _units;
 }, [_units], 0.05] call EFUNC(common,waitAndExecute);
 
-deleteVehicle _logic;
+if (!isNull _logic) then {
+    deleteVehicle _logic;
+};

--- a/addons/medical/CfgEden.hpp
+++ b/addons/medical/CfgEden.hpp
@@ -1,23 +1,45 @@
+class ctrlToolbox;
+
 class Cfg3DEN {
+    class Attributes {
+        class Default;
+        class Title: Default {
+            class Controls {
+                class Title;
+            };
+        };
+        class GVAR(isMedicControl): Title {
+            attributeLoad = "(_this controlsGroupCtrl 100) lbsetcursel (((_value + 1) min 3) max 0);";
+            attributeSave = "(missionnamespace getvariable ['ace_isMeidc_temp',0]) - 1;";
+            class Controls: Controls {
+                class Title: Title{};
+                class Value: ctrlToolbox {
+                    idc = 100;
+                    style = "0x02";
+                    x = "48 * (pixelW * 1.25 * 4)";
+                    w = "82 * (pixelW * 1.25 * 4)";
+                    h = "5 * (pixelH * 1.25 * 4)";
+                    rows = 1;
+                    columns = 4;
+                    strings[] = {"$STR_3DEN_Attributes_Lock_Default_text", CSTRING(AssignMedicRoles_role_none), CSTRING(AssignMedicRoles_role_medic), CSTRING(AssignMedicRoles_role_doctorShort)};
+                    onToolboxSelChanged = "missionnamespace setvariable ['ace_isMeidc_temp',_this select 1];";
+                };
+            };
+        };
+    };
     class Object {
         class AttributeCategories {
             class ace_attributes {
                 class Attributes {
                     class ace_isMedic {
                         property = QUOTE(ace_isMedic);
-                        value = 0;
-                        control = "Combo";
+                        control = QGVAR(isMedicControl);
                         displayName = CSTRING(AssignMedicRoles_role_DisplayName);
                         tooltip = CSTRING(Attributes_isMedic_Description);
-                        expression = QUOTE(_this setVariable [ARR_2(QUOTE(QGVAR(medicClass)),_value)];);
+                        expression = QUOTE(if (_value != -1) then {_this setVariable [ARR_3(QUOTE(QGVAR(medicClass)),_value, true)];};);
                         typeName = "NUMBER";
                         condition = "objectBrain";
-                        defaultValue = 0;
-                        class values {
-                            class none {name = CSTRING(AssignMedicRoles_role_none); value = 0; default = 1;};
-                            class medic {name = CSTRING(AssignMedicRoles_role_medic); value = 1; default = 0;};
-                            class doctor {name = CSTRING(AssignMedicRoles_role_doctor); value = 2; default = 0;};
-                        };
+                        defaultValue = "-1";
                     };
                     class ace_isMedicalVehicle {
                         property = QUOTE(ace_isMedicalVehicle);
@@ -25,7 +47,7 @@ class Cfg3DEN {
                         control = "CheckboxNumber";
                         displayName = CSTRING(AssignMedicVehicle_enabled_DisplayName);
                         tooltip = CSTRING(Attributes_isMedicalVehicle_Description);
-                        expression = QUOTE(_this setVariable [ARR_2(QUOTE(QGVAR(medicClass)),_value)];);
+                        expression = QUOTE(_this setVariable [ARR_3(QUOTE(QGVAR(medicClass)),_value, true)];);
                         typeName = "NUMBER";
                         condition = "objectVehicle";
                         defaultValue = 0;
@@ -36,7 +58,7 @@ class Cfg3DEN {
                         control = "Checkbox";
                         displayName = CSTRING(AssignMedicalFacility_enabled_DisplayName);
                         tooltip = CSTRING(AssignMedicalFacility_enabled_Description);
-                        expression = QUOTE(_this setVariable [ARR_2(QUOTE(QGVAR(isMedicalFacility)),_value)];);
+                        expression = QUOTE(_this setVariable [ARR_3(QUOTE(QGVAR(isMedicalFacility)),_value, true)];);
                         typeName = "BOOL";
                         condition = "(1 - objectBrain) * (1 - objectVehicle)";
                         defaultValue = "false";

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -3815,6 +3815,18 @@
             <Hungarian>Doktor (csak fejlett orvosok)</Hungarian>
             <Italian>Dottore (Solo Medici Avanzati)</Italian>
         </Key>
+        <Key ID="STR_ACE_Medical_AssignMedicRoles_role_doctorShort">
+            <English>Doctor</English>
+            <Russian>Врач</Russian>
+            <Polish>Doktor</Polish>
+            <Spanish>Doctor</Spanish>
+            <German>Arzt</German>
+            <Czech>Doktor</Czech>
+            <Portuguese>Doutor</Portuguese>
+            <French>Médecin</French>
+            <Hungarian>Doktor</Hungarian>
+            <Italian>Dottore</Italian>
+        </Key>
         <Key ID="STR_ACE_Medical_AssignMedicRoles_Module_Description">
             <English>Assigns the ACE medic class to a unit</English>
             <Russian>Задает юниту класс медика</Russian>

--- a/addons/repair/CfgEden.hpp
+++ b/addons/repair/CfgEden.hpp
@@ -1,23 +1,50 @@
+class ctrlToolbox;
+class ctrlEdit;
+
 class Cfg3DEN {
+    class Attributes {
+        class Default;
+        class Title: Default {
+            class Controls {
+                class Title;
+            };
+        };
+        class GVAR(isEngineer): Title {
+            attributeLoad = "(_this controlsGroupCtrl 100) lbsetcursel (((_value + 1) min 3) max 0);";
+            attributeSave = "(missionnamespace getvariable ['ace_isEng_temp',0]) - 1;";
+            class Controls: Controls {
+                class Title: Title{};
+                class Value: ctrlToolbox {
+                    idc = 100;
+                    style = "0x02";
+                    x = "48 * (pixelW * 	1.25 * 4)";
+                    w = "82 * (pixelW * 	1.25 * 4)";
+                    h = "5 * (pixelH * 	1.25 * 4)";
+                    rows = 1;
+                    columns = 4;
+                    strings[] = {"$STR_3DEN_Attributes_Lock_Default_text", CSTRING(AssignEngineerRole_role_none), CSTRING(AssignEngineerRole_role_engineer), CSTRING(AssignEngineerRole_role_specialist)};
+                    // tooltips[] = {""};
+                    values[] = {-1,0,1,2};
+                    onToolboxSelChanged = "missionnamespace setvariable ['ace_isEng_temp',_this select 1];";
+                };
+            };
+        };
+
+    };
+
     class Object {
         class AttributeCategories {
             class ace_attributes {
                 class Attributes {
                     class ace_isEngineer {
                         property = QUOTE(ace_isEngineer);
-                        value = 0;
-                        control = "Combo";
                         displayName = CSTRING(AssignEngineerRole_role_DisplayName);
                         tooltip = CSTRING(AssignEngineerRole_role_Description);
-                        expression = "_this setVariable ['%s',_value];";
+                        expression = "if (_value != -1) then {_this setVariable ['%s',_value, true];}";
                         typeName = "NUMBER";
                         condition = "objectBrain";
-                        defaultValue = 0;
-                        class values {
-                            class none {name = CSTRING(AssignEngineerRole_role_none); value = 0; default = 1;};
-                            class engineer {name = CSTRING(AssignEngineerRole_role_engineer); value = 1; default = 0;};
-                            class specialist {name = CSTRING(AssignEngineerRole_role_specialist); value = 2; default = 0;};
-                        };
+                        defaultValue = "-1";
+                        control = QGVAR(isEngineer);
                     };
                     class ace_isRepairVehicle {
                         property = QUOTE(ace_isRepairVehicle);
@@ -25,7 +52,7 @@ class Cfg3DEN {
                         control = "CheckboxNumber";
                         displayName = CSTRING(AssignRepairVehicle_role_DisplayName);
                         tooltip = CSTRING(AssignRepairVehicle_role_Description);
-                        expression = "_this setVariable ['%s',_value];";
+                        expression = "_this setVariable ['%s',_value, true];";
                         typeName = "NUMBER";
                         condition = "objectVehicle";
                         defaultValue = 0;
@@ -36,7 +63,7 @@ class Cfg3DEN {
                         control = "CheckboxNumber";
                         displayName = CSTRING(AssignRepairFacility_role_DisplayName);
                         tooltip = CSTRING(AssignRepairFacility_role_Description);
-                        expression = "_this setVariable ['%s',_value];";
+                        expression = "_this setVariable ['%s',_value, true];";
                         typeName = "NUMBER";
                         condition = "(1 - objectBrain) * (1 - objectVehicle)";
                         defaultValue = 0;

--- a/addons/repair/CfgEden.hpp
+++ b/addons/repair/CfgEden.hpp
@@ -1,5 +1,4 @@
 class ctrlToolbox;
-class ctrlEdit;
 
 class Cfg3DEN {
     class Attributes {
@@ -9,7 +8,7 @@ class Cfg3DEN {
                 class Title;
             };
         };
-        class GVAR(isEngineer): Title {
+        class GVAR(isEngineerControl): Title {
             attributeLoad = "(_this controlsGroupCtrl 100) lbsetcursel (((_value + 1) min 3) max 0);";
             attributeSave = "(missionnamespace getvariable ['ace_isEng_temp',0]) - 1;";
             class Controls: Controls {
@@ -17,19 +16,16 @@ class Cfg3DEN {
                 class Value: ctrlToolbox {
                     idc = 100;
                     style = "0x02";
-                    x = "48 * (pixelW * 	1.25 * 4)";
-                    w = "82 * (pixelW * 	1.25 * 4)";
-                    h = "5 * (pixelH * 	1.25 * 4)";
+                    x = "48 * (pixelW * 1.25 * 4)";
+                    w = "82 * (pixelW * 1.25 * 4)";
+                    h = "5 * (pixelH * 1.25 * 4)";
                     rows = 1;
                     columns = 4;
                     strings[] = {"$STR_3DEN_Attributes_Lock_Default_text", CSTRING(AssignEngineerRole_role_none), CSTRING(AssignEngineerRole_role_engineer), CSTRING(AssignEngineerRole_role_specialist)};
-                    // tooltips[] = {""};
-                    values[] = {-1,0,1,2};
                     onToolboxSelChanged = "missionnamespace setvariable ['ace_isEng_temp',_this select 1];";
                 };
             };
         };
-
     };
 
     class Object {
@@ -44,7 +40,7 @@ class Cfg3DEN {
                         typeName = "NUMBER";
                         condition = "objectBrain";
                         defaultValue = "-1";
-                        control = QGVAR(isEngineer);
+                        control = QGVAR(isEngineerControl);
                     };
                     class ace_isRepairVehicle {
                         property = QUOTE(ace_isRepairVehicle);


### PR DESCRIPTION
### When merged this pull request will:

Fix the 3den attributes

 - Captives: expression only runs on server, so when checked on a remote unit it has no effect and throws
```
 [z\ace\addons\captives\functions\fnc_setSurrendered.sqf:23] -ERROR- ERROR running surrender on remote unit
```
Replace with `FUNC(moduleHandcuffed) which handles it.

 - Replace the broken `comboBox` control with custom ones for medical/repair. Looks nicer imho

 - Replace all setVariables with the public version
