### PR TITLE
Add protocol version to meta.cpp

### DIFF
--- a/meta.cpp
+++ b/meta.cpp
@@ -1,1 +1,2 @@
+protocol = 1;
 publishedid = 463939057;


### PR DESCRIPTION
### When merged this pull request will:

1. Add protocol version to meta.cpp file. Without protocol version line Arma 3 Server ignores publishedid attribute and it won't propagate it to the client / Launcher.