### PR TITLE
Fix lamp unloading

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -24,7 +24,7 @@
 ["UnloadCargo", {
     (_this select 0) params ["_item","_vehicle", ["_unloader", objNull]];
     TRACE_3("UnloadCargo EH",_item,_vehicle,_unloader);
-    
+
     private _unloaded = [_item, _vehicle, _unloader] call FUNC(unloadItem); //returns true if sucessful
 
     private _itemClass = if (_item isEqualType "") then {_item} else {typeOf _item};
@@ -42,4 +42,11 @@
     };
 
     // TOOO maybe drag/carry the unloaded item?
+}] call EFUNC(common,addEventHandler);
+
+["ServerUnloadCargo", {
+    params ["_item", "_emptyPosAGL"];
+
+    _item hideObjectGlobal false;
+    _item setPosASL (AGLtoASL _emptyPosAGL);
 }] call EFUNC(common,addEventHandler);

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -50,8 +50,9 @@ _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
 if (_item isEqualType objNull) then {
     detach _item;
-    _item setPosASL (AGLtoASL _emptyPosAGL);
-    ["hideObjectGlobal", [_item, false]] call EFUNC(common,serverEvent);
+    // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
+    // do both on server to ensure they are executed in the correct order
+    ["ServerUnloadCargo", [_item, _emptyPosAGL]] call EFUNC(common,serverEvent);
 } else {
     private _newItem = createVehicle [_item, _emptyPosAGL, [], 0, ""];
     _newItem setPosASL (AGLtoASL _emptyPosAGL);

--- a/addons/cargo/menu.hpp
+++ b/addons/cargo/menu.hpp
@@ -67,7 +67,7 @@ class GVAR(menu) {
             colorSelectBackground[] = {0.3, 0.3, 0.3, 1.0};
             colorSelectBackground2[] = {0.3, 0.3, 0.3, 1.0};
         };
-        class btnUnload: ACE_gui_buttonBase {
+        class btnCancel: ACE_gui_buttonBase {
             text = "Cancel";
             idc = 11;
             x = "13.1 * (((safezoneW / safezoneH) min 1.2) / 40) + (safezoneX + (safezoneW - ((safezoneW / safezoneH) min 1.2))/2)";
@@ -93,7 +93,7 @@ class GVAR(menu) {
             periodOver = 1;
             action = QUOTE(closeDialog 0);
         };
-        class btnCancel: btnUnload {
+        class btnUnload: btnCancel {
             text = CSTRING(unloadObject);
             idc = 12;
             x = "20.9 * (((safezoneW / safezoneH) min 1.2) / 40) + (safezoneX + (safezoneW - ((safezoneW / safezoneH) min 1.2))/2)";


### PR DESCRIPTION
### When merged this pull request will:

1. Fix #3363 
2. Make sure `hideObjectGlobal` is executed before `setPosATL` by executing both on server, to ensure lamps will get rendered correctly