### PR TITLE
Fix #3334 replace Purista with Roboto in cargo menu

### DIFF
--- a/addons/cargo/menu.hpp
+++ b/addons/cargo/menu.hpp
@@ -33,7 +33,7 @@ class GVAR(menu) {
             w = "13 * (((safezoneW / safezoneH) min 1.2) / 40)";
             h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
             style = ST_LEFT + ST_SHADOW;
-            font = "PuristaMedium";
+            font = "RobotoCondensed";
             SizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
             colorText[] = {0.95, 0.95, 0.95, 0.75};
             colorBackground[] = {"(profilenamespace getVariable ['GUI_BCG_RGB_R',0.69])","(profilenamespace getVariable ['GUI_BCG_RGB_G',0.75])","(profilenamespace getVariable ['GUI_BCG_RGB_B',0.5])", "(profilenamespace getVariable ['GUI_BCG_RGB_A',0.9])"};


### PR DESCRIPTION
### When merged this pull request will:

1. Fix #3334 
2. Fix cargo menu cut off `g`
3. Replace Purista font with Roboto in cargo menu (the rest shall be done in the next version to not break anything - #3401 )