### PR TITLE
Reimplement old parameter syntax for (Un)LoadCargo events

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -3,7 +3,7 @@
 ["AddCargoByClass", {_this call FUNC(addCargoItem)}] call EFUNC(common,addEventHandler);
 
 ["LoadCargo", {
-    (_this select 0) params ["_item","_vehicle"];
+    params ["_item", "_vehicle"];
     TRACE_2("LoadCargo EH",_item,_vehicle);
 
     private _loaded = [_item, _vehicle] call FUNC(loadItem);
@@ -22,9 +22,9 @@
 }] call EFUNC(common,addEventHandler);
 
 ["UnloadCargo", {
-    (_this select 0) params ["_item","_vehicle", ["_unloader", objNull]];
+    params ["_item", "_vehicle", ["_unloader", objNull]];
     TRACE_3("UnloadCargo EH",_item,_vehicle,_unloader);
-    
+
     private _unloaded = [_item, _vehicle, _unloader] call FUNC(unloadItem); //returns true if sucessful
 
     private _itemClass = if (_item isEqualType "") then {_item} else {typeOf _item};

--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -37,7 +37,13 @@ private _return = false;
 if ([_object, _vehicle] call FUNC(canLoadItemIn)) then {
     private _size = [_object] call FUNC(getSizeItem);
 
-    [5 * _size, [_object,_vehicle], "LoadCargo", {}, localize LSTRING(LoadingItem)] call EFUNC(common,progressBar);
+    [
+        5 * _size,
+        [_object,_vehicle],
+        {["LoadCargo", _this select 0] call EFUNC(common,localEvent)},
+        {},
+        localize LSTRING(LoadingItem)
+    ] call EFUNC(common,progressBar);
     _return = true;
 } else {
     private _displayName = getText (configFile >> "CfgVehicles" >> typeOf _object >> "displayName");

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -34,7 +34,15 @@ private _item = _loaded select _selected; //This can be an object or a classname
 if ([_item, GVAR(interactionVehicle), ACE_player] call FUNC(canUnloadItem)) then {
     private _size = [_item] call FUNC(getSizeItem);
 
-    [5 * _size, [_item, GVAR(interactionVehicle), ACE_player], "UnloadCargo", {}, localize LSTRING(UnloadingItem), {true}, ["isNotSwimming"]] call EFUNC(common,progressBar);
+    [
+        5 * _size,
+        [_item, GVAR(interactionVehicle), ACE_player],
+        {["UnloadCargo", _this select 0] call EFUNC(common,localEvent)},
+        {},
+        localize LSTRING(UnloadingItem),
+        {true},
+        ["isNotSwimming"]
+    ] call EFUNC(common,progressBar);
 } else {
     private _itemClass = if (_item isEqualType "") then {_item} else {typeOf _item};
     private _displayName = getText (configFile >> "CfgVehicles" >> _itemClass >> "displayName");


### PR DESCRIPTION
### When merged this pull request will:

1. Reimplement the `[object, vehicle]` syntax for arguments as it initially was and as it is documented

Those events are considered public API, that's why I am tagging this with "Bug fix".