### PR TITLE
Cleanup some module descriptions

### DIFF
--- a/addons/captives/stringtable.xml
+++ b/addons/captives/stringtable.xml
@@ -170,16 +170,16 @@
             <Italian>Fai arrendere l'unità</Italian>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleSurrender_Description">
-            <English>Sync a unit to make them surrender.&lt;br /&gt;Source: ace_captives</English>
-            <Polish>Zsynchronizuj z jednostką, aby skapitulowała.&lt;br /&gt;Źródło: ace_captives</Polish>
-            <Spanish>Sincroniza una unidad para hacer que se rinda.&lt;br /&gt;Fuente: ace_captives</Spanish>
-            <German>Einheit synchronisieren, um sie kapitulieren zu lassen.&lt;br /&gt;Quelle: ace_captives</German>
-            <Czech>Synchronizuj s jednotkou, která se má vzdát.&lt;br /&gt;Zdroj: ace_captives</Czech>
-            <Portuguese>Sincroniza uma unidade para fazer com que ela se renda. &lt;br/&gt;Fonte: ace_captives</Portuguese>
-            <French>Synchronise une unité pour la rendre captive. &lt;br/&gt;Source: ace_captives</French>
-            <Hungarian>Egység szinkronizálása, hogy kapituláljon.&lt;br /&gt;Forrás: ace_captives</Hungarian>
-            <Russian>Синхронизируйте с юнитами, чтобы заставить их сдаться в плен.&lt;br /&gt;Источник: ace_captives</Russian>
-            <Italian>Sincronizza una unità per farla arrendere.&lt;br/&gt;Fonte: ace_captives</Italian>
+            <English>Sync a unit to make them surrender.</English>
+            <Polish>Zsynchronizuj z jednostką, aby skapitulowała.</Polish>
+            <Spanish>Sincroniza una unidad para hacer que se rinda.</Spanish>
+            <German>Einheit synchronisieren, um sie kapitulieren zu lassen.</German>
+            <Czech>Synchronizuj s jednotkou, která se má vzdát.</Czech>
+            <Portuguese>Sincroniza uma unidade para fazer com que ela se renda.</Portuguese>
+            <French>Synchronise une unité pour la rendre captive.</French>
+            <Hungarian>Egység szinkronizálása, hogy kapituláljon.</Hungarian>
+            <Russian>Синхронизируйте с юнитами, чтобы заставить их сдаться в плен.es</Russian>
+            <Italian>Sincronizza una unità per farla arrendere</Italian>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleHandcuffed_DisplayName">
             <English>Make Unit Handcuffed</English>
@@ -191,13 +191,13 @@
             <Italian>Metti manette all'unità</Italian>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleHandcuffed_Description">
-            <English>Sync a unit to make them handcuffed.&lt;br /&gt;Source: ace_captives</English>
-            <German>Synchronisiere eine Einheit um sie in Handschellen zu legen.&lt;br /&gt;Quelle: ace_captives</German>
-            <Polish>Zsynchronizuj z jednostką, aby została skuta.&lt;br /&gt;Źródło: ace_captives</Polish>
-            <Portuguese>Sincronizar uma unidade para deixá-la algemada.&lt;br/&gt;Source: ace_captives</Portuguese>
-            <Russian>Синхронизируйте с юнитами, чтобы сделать их связанными.&lt;br /&gt;Источник: ace_captives</Russian>
-            <Czech>Synchronizovat s jednotkou, která má být v poutech.&lt;br /&gt;Zdroj: ace_captives</Czech>
-            <Italian>Sincronizza un'unità per metterle le manette.&lt;br/&gt;Fonte: ace_captives</Italian>
+            <English>Sync a unit to make them handcuffed.</English>
+            <German>Synchronisiere eine Einheit um sie in Handschellen zu legen.</German>
+            <Polish>Zsynchronizuj z jednostką, aby została skuta.</Polish>
+            <Portuguese>Sincronizar uma unidade para deixá-la algemada.</Portuguese>
+            <Russian>Синхронизируйте с юнитами, чтобы сделать их связанными.</Russian>
+            <Czech>Synchronizovat s jednotkou, která má být v poutech.</Czech>
+            <Italian>Sincronizza un'unità per metterle le manette.<Italian>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleSettings_DisplayName">
             <English>Captives Settings</English>

--- a/addons/captives/stringtable.xml
+++ b/addons/captives/stringtable.xml
@@ -178,8 +178,8 @@
             <Portuguese>Sincroniza uma unidade para fazer com que ela se renda.</Portuguese>
             <French>Synchronise une unité pour la rendre captive.</French>
             <Hungarian>Egység szinkronizálása, hogy kapituláljon.</Hungarian>
-            <Russian>Синхронизируйте с юнитами, чтобы заставить их сдаться в плен.es</Russian>
-            <Italian>Sincronizza una unità per farla arrendere</Italian>
+            <Russian>Синхронизируйте с юнитами, чтобы заставить их сдаться в плен.</Russian>
+            <Italian>Sincronizza una unità per farla arrendere.</Italian>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleHandcuffed_DisplayName">
             <English>Make Unit Handcuffed</English>
@@ -197,7 +197,7 @@
             <Portuguese>Sincronizar uma unidade para deixá-la algemada.</Portuguese>
             <Russian>Синхронизируйте с юнитами, чтобы сделать их связанными.</Russian>
             <Czech>Synchronizovat s jednotkou, která má být v poutech.</Czech>
-            <Italian>Sincronizza un'unità per metterle le manette.<Italian>
+            <Italian>Sincronizza un'unità per metterle le manette.</Italian>
         </Key>
         <Key ID="STR_ACE_Captives_ModuleSettings_DisplayName">
             <English>Captives Settings</English>

--- a/addons/finger/CfgVehicles.hpp
+++ b/addons/finger/CfgVehicles.hpp
@@ -12,6 +12,7 @@ class CfgVehicles {
         class Arguments {
             class enabled {
                 displayName = CSTRING(enabled_DisplayName);
+                description = CSTRING(enabled_DisplayName);
                 typeName = "BOOL";
                 defaultValue = 1;
             };

--- a/addons/microdagr/stringtable.xml
+++ b/addons/microdagr/stringtable.xml
@@ -382,7 +382,7 @@
             <Portuguese>Controla quantos dados são preenchidos nos itens microDAGR. Menos dados restringe a visualização de mapa para mostrar menos informações no minimapa.</Portuguese>
             <French>Contrôle le nombre d'information disponible sur la carte du MicroDAGR.</French>
             <Hungarian>Meghatárroza a MicroDAGR objektumok térképének tartalmát. A kevesebb adat korlátozza a térképnézeti módot az eszközön.</Hungarian>
-            <Russian>Контролирует, сколько данных должно отображаться на карте устройств MicroDAGR. Ограничивает объем отображаемых данных на миникарте.bo</Russian>
+            <Russian>Контролирует, сколько данных должно отображаться на карте устройств MicroDAGR. Ограничивает объем отображаемых данных на миникарте.</Russian>
             <Italian>Controlla quanti dati sono presenti negli oggetti MicroDAGR. Meno dati costringono la vista mappa a mostrare meno informazioni nella minimappa.</Italian>
         </Key>
     </Package>

--- a/addons/microdagr/stringtable.xml
+++ b/addons/microdagr/stringtable.xml
@@ -374,16 +374,16 @@
             <Italian>Nessuno (Non puoi usare la vista mappa)</Italian>
         </Key>
         <Key ID="STR_ACE_MicroDAGR_Module_Description">
-            <English>Controls how much data is filled on the microDAGR items.  Less data restricts the map view to show less on the minimap.&lt;br /&gt;Source: microDAGR.pbo</English>
-            <Polish>Moduł ten pozwala kontrolować jak duża ilość informacji jest załadowana do przedmiotów MicroDAGR. Mniejsza ilość danych ogranicza widok mapy pokazując mniej rzeczy na minimapie.&lt;br /&gt;Źródło: microDAGR.pbo</Polish>
-            <Spanish>Controla la cantidad de información disponible en el microDAGR. Menos datos limitan la vista del mapa a mostrar menos en el minimapa.&lt;br /&gt;Fuente: microDAGR.pbo</Spanish>
-            <German>Steuert wie viel Daten auf dem microDAGR zu sehen ist. Weniger Daten schränken die Kartenansicht ein, um mehr auf der Minimap zu sehen.&lt;br /&gt;Quelle: microDAGR.pbo</German>
-            <Czech>Tento modul umožňuje kontrolovat, kolik informací je obsaženo v MicroDAGR. Menší množství dat omezené zobrazením mapy ukazují méně věcí na minimapě.&lt;br /&gt;Zdroj: microDAGR.pbo</Czech>
-            <Portuguese>Controla quantos dados são preenchidos nos itens microDAGR. Menos dados restringe a visualização de mapa para mostrar menos informações no minimapa&lt;br/&gt;Fonte: MicroDAGR.pbo</Portuguese>
-            <French>Contrôle le nombre d'information disponible sur la carte du MicroDAGR. &lt;br/&gt;Source: microDAGR.pbo</French>
-            <Hungarian>Meghatárroza a MicroDAGR objektumok térképének tartalmát. A kevesebb adat korlátozza a térképnézeti módot az eszközön. &lt;br /&gt;Forrás: microDAGR.pbo</Hungarian>
-            <Russian>Контролирует, сколько данных должно отображаться на карте устройств MicroDAGR. Ограничивает объем отображаемых данных на миникарте.&lt;br /&gt;Источник: microDAGR.pbo</Russian>
-            <Italian>Controlla quanti dati sono presenti negli oggetti MicroDAGR. Meno dati costringono la vista mappa a mostrare meno informazioni nella minimappa. &lt;br/&gt;Fonte: microDAGR.pbo</Italian>
+            <English>Controls how much data is filled on the microDAGR items.  Less data restricts the map view to show less on the minimap.</English>
+            <Polish>Moduł ten pozwala kontrolować jak duża ilość informacji jest załadowana do przedmiotów MicroDAGR. Mniejsza ilość danych ogranicza widok mapy pokazując mniej rzeczy na minimapie.</Polish>
+            <Spanish>Controla la cantidad de información disponible en el microDAGR. Menos datos limitan la vista del mapa a mostrar menos en el minimapa.</Spanish>
+            <German>Steuert wie viel Daten auf dem microDAGR zu sehen ist. Weniger Daten schränken die Kartenansicht ein, um mehr auf der Minimap zu sehen.</German>
+            <Czech>Tento modul umožňuje kontrolovat, kolik informací je obsaženo v MicroDAGR. Menší množství dat omezené zobrazením mapy ukazují méně věcí na minimapě.</Czech>
+            <Portuguese>Controla quantos dados são preenchidos nos itens microDAGR. Menos dados restringe a visualização de mapa para mostrar menos informações no minimapa.</Portuguese>
+            <French>Contrôle le nombre d'information disponible sur la carte du MicroDAGR.</French>
+            <Hungarian>Meghatárroza a MicroDAGR objektumok térképének tartalmát. A kevesebb adat korlátozza a térképnézeti módot az eszközön.</Hungarian>
+            <Russian>Контролирует, сколько данных должно отображаться на карте устройств MicroDAGR. Ограничивает объем отображаемых данных на миникарте.bo</Russian>
+            <Italian>Controlla quanti dati sono presenti negli oggetti MicroDAGR. Meno dati costringono la vista mappa a mostrare meno informazioni nella minimappa.</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/sitting/CfgVehicles.hpp
+++ b/addons/sitting/CfgVehicles.hpp
@@ -12,6 +12,7 @@ class CfgVehicles {
         class Arguments {
             class enable {
                 displayName = CSTRING(Enable);
+                description = CSTRING(Enable)
                 typeName = "BOOL";
                 defaultValue = 1;
             };

--- a/addons/sitting/CfgVehicles.hpp
+++ b/addons/sitting/CfgVehicles.hpp
@@ -12,7 +12,7 @@ class CfgVehicles {
         class Arguments {
             class enable {
                 displayName = CSTRING(Enable);
-                description = CSTRING(Enable)
+                description = CSTRING(Enable);
                 typeName = "BOOL";
                 defaultValue = 1;
             };

--- a/addons/vehiclelock/stringtable.xml
+++ b/addons/vehiclelock/stringtable.xml
@@ -258,7 +258,7 @@
             <Polish>Ustawienia czasu włamywania oraz domyślnego stanu blokady pojazdów. Wyłącza dwuznaczne ustawienia blokady. Moduł ten umożliwia więc np. zamknięcie pojazdów przeciwnika na klucz tak, że gracze bez odpowiedniego sprzętu (wytrycha) nie będą mogli ich używać.</Polish>
             <Spanish>Ajustes de la durabilidad de la ganzua y el estado inicial del cierre de los vehículos. Elimina estados de cierre ambiguos.</Spanish>
             <German>Einstellungen für Pick-Stärke und anfänglichen Fahrzeugsperrzustand. Entfernt unklare Sperrzustände.</German>
-            <Czech>Nastavení síly vypáčení a počáteční stav zámku vozidla. Odstraňuje nejednoznačné stavy zámků.<Czech>
+            <Czech>Nastavení síly vypáčení a počáteční stav zámku vozidla. Odstraňuje nejednoznačné stavy zámků.</Czech>
             <Portuguese>Definições para a durabilidade da chave micha e estado inicial da fechadura do veículo. Remove estados de fechadura ambíguas</Portuguese>
             <French>Paramètres pour le crochetage et état inital des véhicules. Supprime les états de verrouillage ambigue.</French>
             <Hungarian>Beállítások a zártörő erősségére és alapértelmezett zár-állapotra a járműveken. Eltávolítja az azonosíthatatlan zár-állapotokat.</Hungarian>
@@ -284,9 +284,9 @@
             <German>Synchronisiere mit Fahrzeugen und Spielern. Wird eigene Schlüssel an Spieler für jedes synchronisierte Fahrzeuge aushändigen. Nur gültig für am Missionsstart existierende Fahrzeuge.</German>
             <Czech>Synchronizuj s vozidly a hráči. Hráč dostane klíč ke každému synchonizovanému vozidlu. Platné pouze pro objekty přítomné na začátku mise.</Czech>
             <Portuguese>Sincronizar com veículos e jogadores. Irá distribuir chaves personalizadas para os jogadores para cada veículo sincronizado. Só é válido para objetos presentes no início da missão.</Portuguese>
-            <French>Synchronise avec les véhicules et les joueurs. Distribue les clés aux joueurs pour chaque véhicule synchronisé. Uniquement valide pour les objects présent au démarrage. </French>
+            <French>Synchronise avec les véhicules et les joueurs. Distribue les clés aux joueurs pour chaque véhicule synchronisé. Uniquement valide pour les objects présent au démarrage.</French>
             <Hungarian>Szinkronizál a járművekkel és játékosokkal. Egyedi kulcsokat oszt ki a játékosoknak minden szinkronizált járműhöz. Csak a küldetés indításakor jelenlévő járművekhez érvényes.</Hungarian>
-            <Russian>Синхронизируйте с транспортом и игроком. Это выдаст игроку ключи от всех синхронизированных транспортных средств. Работает только для объектов, присутствующих на старте миссииpbo</Russian>
+            <Russian>Синхронизируйте с транспортом и игроком. Это выдаст игроку ключи от всех синхронизированных транспортных средств. Работает только для объектов, присутствующих на старте миссии</Russian>
             <Italian>Sincronizza con veicoli e giocatori. Distribuirà chiavi ai giocatori per ogni veicolo sincronizzato. Valido solo per oggetti presenti ad inizio missione.</Italian>
         </Key>
     </Package>

--- a/addons/vehiclelock/stringtable.xml
+++ b/addons/vehiclelock/stringtable.xml
@@ -254,16 +254,16 @@
             <Italian>Tempo Default richiesto per forzare serrature (in secondi). Default: 10</Italian>
         </Key>
         <Key ID="STR_ACE_VehicleLock_Module_Description">
-            <English>Settings for lockpick strength and initial vehicle lock state. Removes ambiguous lock states.&lt;br /&gt;Source: vehiclelock.pbo</English>
-            <Polish>Ustawienia czasu włamywania oraz domyślnego stanu blokady pojazdów. Wyłącza dwuznaczne ustawienia blokady. Moduł ten umożliwia więc np. zamknięcie pojazdów przeciwnika na klucz tak, że gracze bez odpowiedniego sprzętu (wytrycha) nie będą mogli ich używać.&lt;br /&gt;Źródło: vehiclelock.pbo</Polish>
-            <Spanish>Ajustes de la durabilidad de la ganzua y el estado inicial del cierre de los vehículos. Elimina estados de cierre ambiguos.&lt;br /&gt;Fuente: vehiclelock.pbo</Spanish>
-            <German>Einstellungen für Pick-Stärke und anfänglichen Fahrzeugsperrzustand. Entfernt unklare Sperrzustände.&lt;br /&gt;Quelle: vehiclelock.pbo</German>
-            <Czech>Nastavení síly vypáčení a počáteční stav zámku vozidla. Odstraňuje nejednoznačné stavy zámků.&lt;br /&gt;Zdroj: vehiclelock.pbo</Czech>
-            <Portuguese>Definições para a durabilidade da chave micha e estado inicial da fechadura do veículo. Remove estados de fechadura ambíguas &lt;br /&gt; Fonte: Vehiclelock.pbo</Portuguese>
-            <French>Paramètres pour le crochetage et état inital des véhicules. Supprime les états de verrouillage ambigue. &lt;br/&gt;Source: véhicle.pbo</French>
-            <Hungarian>Beállítások a zártörő erősségére és alapértelmezett zár-állapotra a járműveken. Eltávolítja az azonosíthatatlan zár-állapotokat. &lt;br /&gt;Forrás: vehiclelock.pbo</Hungarian>
-            <Russian>Настройки силы отмычек и начальное состояние замков транспорта. Устраняет неоднозначные состояния замков.&lt;br /&gt;Источник: vehiclelock.pbo</Russian>
-            <Italian>Impostazioni per resistenza iniziale delle serrature e stato di blocco dei veicoli. Rimuove stati di blocco ambigui. &lt;br/&gt;Fonte: vehiclelock.pbo</Italian>
+            <English>Settings for lockpick strength and initial vehicle lock state. Removes ambiguous lock states.</English>
+            <Polish>Ustawienia czasu włamywania oraz domyślnego stanu blokady pojazdów. Wyłącza dwuznaczne ustawienia blokady. Moduł ten umożliwia więc np. zamknięcie pojazdów przeciwnika na klucz tak, że gracze bez odpowiedniego sprzętu (wytrycha) nie będą mogli ich używać.</Polish>
+            <Spanish>Ajustes de la durabilidad de la ganzua y el estado inicial del cierre de los vehículos. Elimina estados de cierre ambiguos.</Spanish>
+            <German>Einstellungen für Pick-Stärke und anfänglichen Fahrzeugsperrzustand. Entfernt unklare Sperrzustände.</German>
+            <Czech>Nastavení síly vypáčení a počáteční stav zámku vozidla. Odstraňuje nejednoznačné stavy zámků.<Czech>
+            <Portuguese>Definições para a durabilidade da chave micha e estado inicial da fechadura do veículo. Remove estados de fechadura ambíguas</Portuguese>
+            <French>Paramètres pour le crochetage et état inital des véhicules. Supprime les états de verrouillage ambigue.</French>
+            <Hungarian>Beállítások a zártörő erősségére és alapértelmezett zár-állapotra a járműveken. Eltávolítja az azonosíthatatlan zár-állapotokat.</Hungarian>
+            <Russian>Настройки силы отмычек и начальное состояние замков транспорта. Устраняет неоднозначные состояния замков.</Russian>
+            <Italian>Impostazioni per resistenza iniziale delle serrature e stato di blocco dei veicoli. Rimuove stati di blocco ambigui.</Italian>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleKeyAssign_Module_DisplayName">
             <English>Vehicle Key Assign</English>
@@ -278,16 +278,16 @@
             <Italian>Assegna Chiavi Veicoli</Italian>
         </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleKeyAssign_Module_Description">
-            <English>Sync with vehicles and players.  Will handout custom keys to players for every synced vehicle. Only valid for objects present at mission start.&lt;br /&gt;Source: vehiclelock.pbo</English>
-            <Polish>Zsynchronizuj z pojazdami i graczami. Rozda klucze dla graczy dla każdego zsynchronizowanego pojazdu. Działa tylko na pojazdy obecne na misji od samego początku (postawione w edytorze).&lt;br /&gt;Źródło: vehiclelock.pbo</Polish>
-            <Spanish>Sincronizar con vehiculos y jugadores. Distribuirá llaves personalizadas a los jugadores para todos los vehículos sincronizados. Solo valido para objetos presentes al inicio de la mision.&lt;br /&gt;Fuente: vehiclelock.pbo</Spanish>
-            <German>Synchronisiere mit Fahrzeugen und Spielern. Wird eigene Schlüssel an Spieler für jedes synchronisierte Fahrzeuge aushändigen. Nur gültig für am Missionsstart existierende Fahrzeuge.&lt;br /&gt;Quelle: vehiclelock.pbo</German>
-            <Czech>Synchronizuj s vozidly a hráči. Hráč dostane klíč ke každému synchonizovanému vozidlu. Platné pouze pro objekty přítomné na začátku mise.&lt;br /&gt;Zdroj: vehiclelock.pbo</Czech>
-            <Portuguese>Sincronizar com veículos e jogadores. Irá distribuir chaves personalizadas para os jogadores para cada veículo sincronizado. Só é válido para objetos presentes no início da missão &lt;br /&gt; Fonte: vehiclelock.pbo</Portuguese>
-            <French>Synchronise avec les véhicules et les joueurs. Distribue les clés aux joueurs pour chaque véhicule synchronisé. Uniquement valide pour les objects présent au démarrage. &lt;br/&gt;Source: vehiclelock.pbo</French>
-            <Hungarian>Szinkronizál a járművekkel és játékosokkal. Egyedi kulcsokat oszt ki a játékosoknak minden szinkronizált járműhöz. Csak a küldetés indításakor jelenlévő járművekhez érvényes. &lt;br /&gt;Forrás: vehiclelock.pbo</Hungarian>
-            <Russian>Синхронизируйте с транспортом и игроком. Это выдаст игроку ключи от всех синхронизированных транспортных средств. Работает только для объектов, присутствующих на старте миссии.&lt;br /&gt;Источник: vehiclelock.pbo</Russian>
-            <Italian>Sincronizza con veicoli e giocatori. Distribuirà chiavi ai giocatori per ogni veicolo sincronizzato. Valido solo per oggetti presenti ad inizio missione. &lt;br/&gt;Fonte vehiclelock.pbo</Italian>
+            <English>Sync with vehicles and players.  Will handout custom keys to players for every synced vehicle. Only valid for objects present at mission start.</English>
+            <Polish>Zsynchronizuj z pojazdami i graczami. Rozda klucze dla graczy dla każdego zsynchronizowanego pojazdu. Działa tylko na pojazdy obecne na misji od samego początku (postawione w edytorze).</Polish>
+            <Spanish>Sincronizar con vehiculos y jugadores. Distribuirá llaves personalizadas a los jugadores para todos los vehículos sincronizados. Solo valido para objetos presentes al inicio de la mision.</Spanish>
+            <German>Synchronisiere mit Fahrzeugen und Spielern. Wird eigene Schlüssel an Spieler für jedes synchronisierte Fahrzeuge aushändigen. Nur gültig für am Missionsstart existierende Fahrzeuge.</German>
+            <Czech>Synchronizuj s vozidly a hráči. Hráč dostane klíč ke každému synchonizovanému vozidlu. Platné pouze pro objekty přítomné na začátku mise.</Czech>
+            <Portuguese>Sincronizar com veículos e jogadores. Irá distribuir chaves personalizadas para os jogadores para cada veículo sincronizado. Só é válido para objetos presentes no início da missão.</Portuguese>
+            <French>Synchronise avec les véhicules et les joueurs. Distribue les clés aux joueurs pour chaque véhicule synchronisé. Uniquement valide pour les objects présent au démarrage. </French>
+            <Hungarian>Szinkronizál a járművekkel és játékosokkal. Egyedi kulcsokat oszt ki a játékosoknak minden szinkronizált járműhöz. Csak a küldetés indításakor jelenlévő járművekhez érvényes.</Hungarian>
+            <Russian>Синхронизируйте с транспортом и игроком. Это выдаст игроку ключи от всех синхронизированных транспортных средств. Работает только для объектов, присутствующих на старте миссииpbo</Russian>
+            <Italian>Sincronizza con veicoli e giocatori. Distribuirà chiavi ai giocatori per ogni veicolo sincronizzato. Valido solo per oggetti presenti ad inizio missione.</Italian>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
### When merged this pull request will:

1. Closes #2561
2. Remove `Source: <pboname>.pbo` from captives, microdagr and vehiclelock, only those had it and that should be on the documentation pages, it has no direct meaning for the mission maker.
3. Add missing finger module on-hover description.