### PR TITLE
Added Show Player Names option to Blue Force Tracking Module

### DIFF
--- a/addons/map/ACE_Settings.hpp
+++ b/addons/map/ACE_Settings.hpp
@@ -1,59 +1,69 @@
 class ACE_Settings {
     class GVAR(BFT_Interval) {
+        category = CSTRING(Module_DisplayName);
         value = 1.0;
         typeName = "SCALAR";
         displayName = CSTRING(BFT_Interval_DisplayName);
         description = CSTRING(BFT_Interval_Description);
     };
     class GVAR(BFT_Enabled) {
+        category = CSTRING(Module_DisplayName);
         value = 0;
         typeName = "BOOL";
         displayName = CSTRING(BFT_Enabled_DisplayName);
         description = CSTRING(BFT_Enabled_Description);
     };
     class GVAR(BFT_HideAiGroups) {
+        category = CSTRING(Module_DisplayName);
         value = 0;
         typeName = "BOOL";
         displayName = CSTRING(BFT_HideAiGroups_DisplayName);
         description = CSTRING(BFT_HideAiGroups_Description);
     };
     class GVAR(BFT_ShowPlayerNames) {
+        category = CSTRING(Module_DisplayName);
         value = 0;
         typeName = "BOOL";
         displayName = CSTRING(BFT_ShowPlayerNames_DisplayName);
         description = CSTRING(BFT_ShowPlayerNames_Description);
     };
     class GVAR(mapIllumination) {
+        category = CSTRING(Module_DisplayName);
         value = 1;
         typeName = "BOOL";
         displayName = CSTRING(MapIllumination_DisplayName);
         description = CSTRING(MapIllumination_Description);
     };
     class GVAR(mapGlow) {
+        category = CSTRING(Module_DisplayName);
         value = 1;
         typeName = "BOOL";
         displayName = CSTRING(MapGlow_DisplayName);
         description = CSTRING(MapGlow_Description);
     };
     class GVAR(mapShake) {
+        category = CSTRING(Module_DisplayName);
         value = 1;
         typeName = "BOOL";
         displayName = CSTRING(MapShake_DisplayName);
         description = CSTRING(MapShake_Description);
     };
     class GVAR(mapLimitZoom) {
+        category = CSTRING(Module_DisplayName);
         value = 0;
         typeName = "BOOL";
         displayName = CSTRING(MapLimitZoom_DisplayName);
         description = CSTRING(MapLimitZoom_Description);
     };
     class GVAR(mapShowCursorCoordinates) {
+        category = CSTRING(Module_DisplayName);
         value = 0;
         typeName = "BOOL";
         displayName = CSTRING(MapShowCursorCoordinates_DisplayName);
         description = CSTRING(MapShowCursorCoordinates_Description);
     };
     class GVAR(DefaultChannel) {
+        category = CSTRING(Module_DisplayName);
         value = -1;
         typeName = "SCALAR";
         displayName = CSTRING(DefaultChannel_DisplayName);

--- a/addons/map/ACE_Settings.hpp
+++ b/addons/map/ACE_Settings.hpp
@@ -17,6 +17,12 @@ class ACE_Settings {
         displayName = CSTRING(BFT_HideAiGroups_DisplayName);
         description = CSTRING(BFT_HideAiGroups_Description);
     };
+    class GVAR(BFT_ShowPlayerNames) {
+        value = 0;
+        typeName = "BOOL";
+        displayName = CSTRING(BFT_ShowPlayerNames_DisplayName);
+        description = CSTRING(BFT_ShowPlayerNames_Description);
+    };
     class GVAR(mapIllumination) {
         value = 1;
         typeName = "BOOL";

--- a/addons/map/CfgVehicles.hpp
+++ b/addons/map/CfgVehicles.hpp
@@ -104,6 +104,12 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 0;
             };
+            class ShowPlayerNames {
+                displayName = CSTRING(BFT_ShowPlayerNames_DisplayName);
+                description = CSTRING(BFT_ShowPlayerNames_Description);
+                typeName = "BOOL";
+                defaultValue = 0;
+            };
         };
         class ModuleDescription {
             description = CSTRING(BFT_Module_Description);

--- a/addons/map/functions/fnc_blueForceTrackingModule.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingModule.sqf
@@ -18,5 +18,6 @@ params ["_logic"];
 [_logic, QGVAR(BFT_Enabled), "Enabled"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(BFT_Interval), "Interval"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(BFT_HideAiGroups), "HideAiGroups"] call EFUNC(common,readSettingFromModule);
+[_logic, QGVAR(BFT_ShowPlayerNames), "ShowPlayerNames"] call EFUNC(common,readSettingFromModule);
 
 ACE_LOGINFO_3("Blue Force Tracking Module Initialized:", GVAR(BFT_Enabled), GVAR(BFT_Interval), GVAR(BFT_HideAiGroups));

--- a/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
@@ -2,7 +2,7 @@
 #include "script_component.hpp"
 // BEGIN_COUNTER(blueForceTrackingUpdate);
 
-private ["_groupsToDrawMarkers", "_playerSide", "_anyPlayers", "_colour", "_marker"];
+private ["_groupsToDrawMarkers", "_playersToDrawMarkers", "_playerSide", "_anyPlayers", "_colour", "_marker"];
 
 // Delete last set of markers (always)
 {
@@ -17,11 +17,32 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
     _playerSide = call EFUNC(common,playerSide);
 
     _groupsToDrawMarkers = allGroups select {side _x == _playerSide};
+    _playersToDrawMarkers = allPlayers select {side _x == _playerSide};
 
     if (GVAR(BFT_HideAiGroups)) then {
         _groupsToDrawMarkers = _groupsToDrawMarkers select {
             {
                 _x call EFUNC(common,isPlayer);
+            } count units _x > 0;
+        };
+    };
+
+    if (GVAR(BFT_ShowPlayerNames)) then {
+        {
+            private _markerType = [_x] call EFUNC(common,getMarkerType);
+            private _colour = format ["Color%1", side _x];
+
+            private _marker = createMarkerLocal [format ["ACE_BFT_%1", _forEachIndex], [(getPos leader _x) select 0, (getPos leader _x) select 1]];
+            _marker setMarkerTypeLocal _markerType;
+            _marker setMarkerColorLocal _colour;
+            _marker setMarkerTextLocal (name _x);
+
+            GVAR(BFT_markers) pushBack _marker;
+        } forEach _playersToDrawMarkers;
+
+        _groupsToDrawMarkers = _groupsToDrawMarkers select {
+            {
+                !(_x call EFUNC(common,isPlayer));
             } count units _x > 0;
         };
     };
@@ -33,7 +54,7 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
         private _marker = createMarkerLocal [format ["ACE_BFT_%1", _forEachIndex], [(getPos leader _x) select 0, (getPos leader _x) select 1]];
         _marker setMarkerTypeLocal _markerType;
         _marker setMarkerColorLocal _colour;
-        _marker setMarkerTextLocal (groupID _x);
+        _marker setMarkerTextLocal (groupId _x);
 
         GVAR(BFT_markers) pushBack _marker;
     } forEach _groupsToDrawMarkers;

--- a/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
@@ -41,13 +41,10 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
             GVAR(BFT_markers) pushBack _marker;
         } forEach _playersToDrawMarkers;
 
-        if (not GVAR(BFG_HideAiGroups)) then
-        {
-            _groupsToDrawMarkers = _groupsToDrawMarkers select {
-                {
-                    !(_x call EFUNC(common,isPlayer));
-                } count units _x > 0;
-            };
+        _groupsToDrawMarkers = _groupsToDrawMarkers select {
+            {
+                !(_x call EFUNC(common,isPlayer));
+            } count units _x > 0;
         };
     };
 

--- a/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
@@ -41,10 +41,13 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
             GVAR(BFT_markers) pushBack _marker;
         } forEach _playersToDrawMarkers;
 
-        _groupsToDrawMarkers = _groupsToDrawMarkers select {
-            {
-                !(_x call EFUNC(common,isPlayer));
-            } count units _x > 0;
+        if (not GVAR(BFG_HideAiGroups)) then
+        {
+            _groupsToDrawMarkers = _groupsToDrawMarkers select {
+                {
+                    !(_x call EFUNC(common,isPlayer));
+                } count units _x > 0;
+            };
         };
     };
 

--- a/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
@@ -17,7 +17,6 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
     _playerSide = call EFUNC(common,playerSide);
 
     _groupsToDrawMarkers = allGroups select {side _x == _playerSide};
-    _playersToDrawMarkers = allPlayers select {side _x == _playerSide};
 
     if (GVAR(BFT_HideAiGroups)) then {
         _groupsToDrawMarkers = _groupsToDrawMarkers select {
@@ -28,6 +27,8 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
     };
 
     if (GVAR(BFT_ShowPlayerNames)) then {
+        _playersToDrawMarkers = allPlayers select {side _x == _playerSide};
+
         {
             private _markerType = [_x] call EFUNC(common,getMarkerType);
             private _colour = format ["Color%1", side _x];

--- a/addons/map/stringtable.xml
+++ b/addons/map/stringtable.xml
@@ -225,6 +225,30 @@
             <Russian>Скрыть маркеры групп, которые состоят полностью из ботов?</Russian>
             <Italian>Nascondi markers per gruppi di sole IA?</Italian>
         </Key>
+        <Key ID="STR_ACE_Map_BFT_ShowPlayerNames_DisplayName">
+            <English>Show player names?</English>
+            <Polish>Pokaż imiona graczy?</Polish>
+            <Spanish>Mostrar nombres de los jugadores?</Spanish>
+            <German>Zeigen Sie die Namen der Spieler?</German>
+            <Czech>Zobrazit jména hráčů?</Czech>
+            <Portuguese>Mostrar os nomes dos jogadores?</Portuguese>
+            <French>Afficher les noms des joueurs?</French>
+            <Hungarian>Itt található az a játékos nevét?</Hungarian>
+            <Russian>Показать имена игроков?</Russian>
+            <Italian>Mostra i nomi dei giocatori?</Italian>
+        </Key>
+        <Key ID="STR_ACE_Map_BFT_ShowPlayerNames_Description">
+            <English>Show individual player names?</English>
+            <Polish>Pokaż poszczególne imiona graczy?</Polish>
+            <Spanish>Mostrar nombres de los jugadores individuales?</Spanish>
+            <German>Zeigen einzelnen Spielernamen?</German>
+            <Czech>Zobrazit názvy jednotlivých hráčů?</Czech>
+            <Portuguese>Mostrar nomes individuais dos jogadores?</Portuguese>
+            <French>Afficher les noms des joueurs individuels?</French>
+            <Hungarian>Itt található az adott játékos neveket?</Hungarian>
+            <Russian>Показать отдельные имена игроков?</Russian>
+            <Italian>Mostra i nomi dei giocatori singoli?</Italian>
+        </Key>
         <Key ID="STR_ACE_Map_BFT_Module_Description">
             <English>This module allows the tracking of allied units with BFT map markers.</English>
             <Polish>Pozwala śledzić na mapie pozycje sojuszniczych jednostek za pomocą markerów BFT.</Polish>


### PR DESCRIPTION
### When merged this pull request will:

1. Add an option to the "Blue Force Tracking" module that will show individual players names instead of their group IDs, defaults to false.
