### PR TITLE
Add german translations

### DIFF
--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Explosives">
         <Key ID="STR_ACE_Explosives_Menu">
@@ -90,6 +90,7 @@
             <Czech>Blokováno</Czech>
             <Polish>Zablokowany</Polish>
             <Italian>Bloccato</Italian>
+            <German>Blockiert</German>
         </Key>
         <Key ID="STR_ACE_Explosives_CancelAction">
             <English>Cancel</English>

--- a/addons/frag/stringtable.xml
+++ b/addons/frag/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Frag">
         <Key ID="STR_ACE_Frag_Module_DisplayName">
@@ -65,11 +65,13 @@
             <English>Explosion Reflections Simulation</English>
             <Polish>Symulacja odbicia eksplozji</Polish>
             <Italian>Simulazione Riflessi Esplosioni</Italian>
+            <German>Druckwellensimulation</German>
         </Key>
         <Key ID="STR_ACE_Frag_EnableReflections_Desc">
             <English>Enable the ACE Explosion Reflection Simulation</English>
             <Polish>Włącz symulację odbicia eksplozji ACE</Polish>
             <Italian>Abilita la Simulazione Riflessi Esplosioni di ACE</Italian>
+            <German>Aktiviere die ACE-Druckwellensimulation</German>
         </Key>
         <Key ID="STR_ACE_Frag_MaxTrack">
             <English>Maximum Projectiles Tracked</English>

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Interaction">
         <Key ID="STR_ACE_Interaction_MainAction">
@@ -353,6 +353,7 @@
             <English>Get Out</English>
             <Polish>Wyjdź</Polish>
             <Italian>Esci</Italian>
+            <German>Aussteigen!</German>
         </Key>
         <Key ID="STR_ACE_Interaction_TeamManagement">
             <English>Team Management</English>
@@ -652,6 +653,7 @@
             <Portuguese>Abrir</Portuguese>
             <Russian>Открыть</Russian>
             <Italian>Apri</Italian>
+            <German>Öffnen</German>
         </Key>
         <Key ID="STR_ACE_Interaction_Module_DisplayName">
             <English>Interaction System</English>

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="map_gestures">
         <Key ID="STR_ACE_map_gestures_moduleSettings_displayName">
@@ -8,6 +8,7 @@
             <Russian>Жесты на карте</Russian>
             <Czech>Ukazování v mapě</Czech>
             <Italian>Gesti Mappa</Italian>
+            <German>Kartenzeichen</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_enabled_displayName">
             <English>Enabled</English>
@@ -16,6 +17,7 @@
             <Russian>Включено</Russian>
             <Czech>Povolit</Czech>
             <Italian>Abilita</Italian>
+            <German>Aktiviert</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_maxRange_displayName">
             <English>Map Gesture Max Range</English>
@@ -24,6 +26,7 @@
             <Russian>Макс. дистанция жестов на карте</Russian>
             <Czech>Max. vzdálenost pro ukazování v mapě</Czech>
             <Italian>Distanza Massima Gesti Mappa</Italian>
+            <German>Maximale Reichweite der Kartenzeichen</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_maxRange_description">
             <English>Max range between players to show the map gesture indicator [default: 7 meters]</English>
@@ -32,6 +35,7 @@
             <Russian>Макс. дистанция между игроками для отображения жестов на карте [по-умолчанию: 7 метров]</Russian>
             <Czech>Maximální vzdálenost mezi hráči pro zobrazení indikátoru ukázání v mapě [výchozí: 7 metrů] </Czech>
             <Italian>Distanza massima tra giocatori per mostrare i gesti in mappa [default: 7 metri]</Italian>
+            <German>Maximale Reichweite zwischen Spielern um Kartenzeichen anzuzeigen (Standard: 7 Meter)</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_defaultLeadColor_displayName">
             <English>Lead Default Color</English>
@@ -40,6 +44,7 @@
             <Russian>Лид. цвет по-умолчанию</Russian>
             <Czech>Výchozí barva velitele</Czech>
             <Italian>Colore Default Caposquadra</Italian>
+            <German>Gruppenführer-Standardfarbe</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_defaultLeadColor_description">
             <English>Fallback Color value for group leaders when there is no group setting. [Module: leave blank to not force on clients]</English>
@@ -47,6 +52,7 @@
             <Polish>Domyślny kolor dla liderów grup.</Polish>
             <Russian>Значение цвета для лидеров групп.</Russian>
             <Italian>Colore di riserva dei capisquadra quando non c'è nessuna impostazione gruppo. [Modulo: lascia vuoto per non forzare su clients]</Italian>
+            <German>Ersat-Farbwert für Gruppenführer wenn keine Gruppeneinstellung vorhanden ist. [Modul: leer lassen um Anwedung bei Clients nicht zu erzwingen]</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_defaultColor_displayName">
             <English>Default Color</English>
@@ -55,6 +61,7 @@
             <Russian>Цвет по-умолчанию</Russian>
             <Czech>Výchozí barva</Czech>
             <Italian>Colore Default</Italian>
+            <German>Standardfarbe</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_defaultColor_description">
             <English>Fallback Color value when there is no group setting. [Module: leave blank to not force on clients]</English>
@@ -62,6 +69,7 @@
             <Polish>Kolor domyślny</Polish>
             <Russian>Значение цвета.</Russian>
             <Italian>Colore di riserva quando non ci sono impostazioni gruppo. [Modulo: lascia vuto per non forzare sui clients]</Italian>
+            <German>Ersat-Farbwert wenn keine Gruppeneinstellung vorhanden ist. [Modul: leer lassen um Anwedung bei Clients nicht zu erzwingen]</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_leadColor_displayName">
             <English>Lead Color</English>
@@ -70,6 +78,7 @@
             <Russian>Лид. цвет</Russian>
             <Czech>Barva velitele</Czech>
             <Italian>Colore Caposquadra</Italian>
+            <German>Gruppenführer-Farbe</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_leadColor_description">
             <English>Color value for group leaders of groups synced with this module.</English>
@@ -77,6 +86,7 @@
             <Polish>Kolor dla liderów grup zsynchronizowanych z tym modułem.</Polish>
             <Russian>Значение цвета для лидеров групп, которые [группы] синхронизированы с этим модулем.</Russian>
             <Italian>Colore dei Caposquadra per gruppi sincronizzati con questo modulo.</Italian>
+            <German>Farbwert für Gruppenführer, die mit diesem Modul synchronisiert werden.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_color_displayName">
             <English>Color</English>
@@ -85,6 +95,7 @@
             <Russian>Цвет</Russian>
             <Czech>Barva</Czech>
             <Italian>Colore</Italian>
+            <German>Farbe</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_color_description">
             <English>Color value for group members of groups synced with this module.</English>
@@ -92,6 +103,7 @@
             <Polish>Kolor dla członków grup zsynchronizowanych z tym modułem.</Polish>
             <Russian>Значение цвета для членов групп, которые [группы] синхронизированы с этим модулем.</Russian>
             <Italian>Colore per membri di gruppi sincronizzati con questo modulo.</Italian>
+            <German>Farbwert für Gruppenmitglieder, die mit diesem Modul synchronisiert werden.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_moduleGroupSettings_displayName">
             <English>Map Gestures - Group Settings</English>
@@ -100,6 +112,7 @@
             <Russian>Жесты на карте - настройки групп</Russian>
             <Czech>Ukazování v mapě - nastavení skupiny</Czech>
             <Italian>Gesti Mappa - Impostazioni Gruppi</Italian>
+            <German>Kartenzeichen - Gruppeneinstellungen</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_interval_displayName">
             <English>Update Interval</English>
@@ -108,6 +121,7 @@
             <Russian>Интервал обновления</Russian>
             <Czech>Interval aktualizace</Czech>
             <Italian>Intervallo Aggiornamento</Italian>
+            <German>Update-Intervall</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_interval_description">
             <English>Time between data updates.</English>
@@ -116,6 +130,7 @@
             <Russian>Время между обновлениями данных.</Russian>
             <Czech>Čas mezi aktualizacemi dat.</Czech>
             <Italian>Intervallo tra aggiornamenti dati.</Italian>
+            <German>Zeit zwischen Datenupdates.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_GroupColorConfigurations_displayName">
             <English>Group color configurations</English>
@@ -124,6 +139,7 @@
             <Russian>Конфигурация цвета групп</Russian>
             <Czech>Konfigurace barvy pro skupinu</Czech>
             <Italian>Configurazioni colori dei gruppi</Italian>
+            <German>Konfiguration der Gruppenfarbe</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_GroupColorConfigurations_description">
             <English>Group color configuration containing arrays of color pairs ([leadColor, color]).</English>
@@ -131,6 +147,7 @@
             <Polish>Konfiguracja kolorów grup zawierająca tablice par kolorów ([kolorLidera, kolor]).</Polish>
             <Russian>Конфигурация цвета групп содержит массив цветовых пар ([лид. цвет, цвет]).</Russian>
             <Italian>Configurazioni colori gruppi contenenti array di coppie di colori ([leadColor, color]).</Italian>
+            <German>Konfiguration der Gruppenfarbe mit zugeordneten Farbpaaren der Aufstellung ([leadColor, color]).</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_GroupColorConfigurationMapping_description">
             <English>Hash of Group ID mapped to the Group color configuration index.</English>
@@ -138,6 +155,7 @@
             <Polish>Hasz ID grup zmapowanych w indeksie konfiguracji koloru grup.</Polish>
             <Russian>Хеш ID групп, соответствующих индексам конфигурации цвета групп.</Russian>
             <Italian>Hash degli ID Gruppi mappati nell'indice configurazioni colori gruppi.</Italian>
+            <German>Hashwert der Gruppen-ID die dem Konfigurations-Index der Gruppenfarbe zugeordnet werden.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_GroupColorConfigurationMapping_displayName">
             <English>GroupID Color configuration mapping</English>
@@ -145,6 +163,7 @@
             <Polish>Mapowanie kolorów poprzez GroupID</Polish>
             <Russian>Соответствие ID групп конфигурации цвета групп</Russian>
             <Italian>Mappatura configurazioni colori GroupID</Italian>
+            <German>Gruppen-ID-Farbe Konfigurationszuordnung</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_enabled_description">
             <English>Enables the Map Gestures.</English>
@@ -153,6 +172,7 @@
             <Russian>Включает указания на карте.</Russian>
             <Czech>Povolit ukazování v mapě</Czech>
             <Italian>Abilita i Gesti Mappa</Italian>
+            <German>Aktiviert die Kartenzeichen.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_nameTextColor_displayName">
             <English>Name Text Color</English>
@@ -161,6 +181,7 @@
             <Russian>Цвет текста имени</Russian>
             <Czech>Barva textu pro jména</Czech>
             <Italian>Colore Testo Nome</Italian>
+            <German>Farbe der Namenstexte.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_nameTextColor_description">
             <English>Color of the name tag text besides the map gestures mark.</English>
@@ -168,6 +189,7 @@
             <Polish>Kolor nazwy gracza obok markera gestu mapy.</Polish>
             <Russian>Цвет инмени игрока рядом с маркером жестов.</Russian>
             <Italian>Colore del testo dei nametag oltre a quello dei Gesti Mappa</Italian>
+            <German>Farbe der Namenstexte neben der Kartenzeichen-Markierung.</German>
         </Key>
         <Key ID="STR_ACE_map_gestures_mapGestures_category">
             <English>Map Gestures</English>
@@ -176,6 +198,7 @@
             <Russian>Жесты на карте</Russian>
             <Czech>Ukazovní v mapě</Czech>
             <Italian>Gesti Mappa</Italian>
+            <German>Kartenzeichen</German>
         </Key>
     </Package>
 </Project>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Medical">
         <Key ID="STR_ACE_Medical_Injuries">
@@ -51,6 +51,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Inject_Adenosine">
             <English>Inject Adenosine</English>
+            <German>Adenosin injizieren</German>
         </Key>
         <Key ID="STR_ACE_Medical_Inject_Atropine">
             <English>Inject Atropine</English>
@@ -246,6 +247,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Injecting_Adenosine">
             <English>Injecting Adenosine...</English>
+            <German>Adenosin injizieren...</German>
         </Key>
         <Key ID="STR_ACE_Medical_Injecting_Atropine">
             <English>Injecting Atropine...</English>
@@ -933,7 +935,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Morphine_Desc_Short">
             <English>Used to combat moderate to severe pain experiences</English>
-            <German>Wird verwendet um moderate bis starke Schmärzen zu lindern.</German>
+            <German>Wird verwendet um moderate bis starke Schmerzen zu lindern.</German>
             <Russian>Для снятия средних и сильных болевых ощущений</Russian>
             <Spanish>Usado para combatir los estados dolorosos de moderados a severos</Spanish>
             <French>Utilisé pour réduire les douleurs modérées à sévères.</French>
@@ -957,12 +959,15 @@
         </Key>
         <Key ID="STR_ACE_Medical_Adenosine_Display">
             <English>Adenosine autoinjector</English>
+            <German>Adenosin-Autoinjektor</German>
         </Key>
         <Key ID="STR_ACE_Medical_Adenosine_Desc_Short">
             <English>Used to counter effects of Epinephrine</English>
+            <German>Wird verwendet um die Symptome von Epiniphrin zu lindern</German>
         </Key>
         <Key ID="STR_ACE_Medical_Adenosine_Desc_Use">
             <English>A drug used to counter the effects of Epinephrine</English>
+            <German>Ein Medikament, das die Symptome von Epiniphrin bekämpft.</German>
         </Key>
         <Key ID="STR_ACE_Medical_Atropine_Display">
             <English>Atropine autoinjector</English>
@@ -2081,7 +2086,14 @@
             <Czech>%1 již obvázal pacienta</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Activity_cpr">
-            <English>%1 started CPR</English>
+            <English>%1 performed CPR</English>
+            <German>%1 hat eine Reanimation durchgeführt</German>
+            <Czech>%1 provádí CPR</Czech>
+            <Italian>%1 ha eseguito CPR</Italian>
+            <Polish>%1 wykonał cykl RKO</Polish>
+            <Portuguese>%1 realizou RCP</Portuguese>
+            <Russian>%1 провел сердечно-легочную реанимацию</Russian>
+            <Spanish>%1 realicó RCP</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_Activity_usedItem">
             <English>%1 used %2</English>
@@ -2111,7 +2123,7 @@
             <English>%1 applied a tourniquet</English>
             <Spanish>%1 aplicado torniquete</Spanish>
             <Russian>%1 наложил жгут</Russian>
-            <German>%1 hat einen Tourniquet angelegt</German>
+            <German>%1 hat ein Tourniquet angelegt</German>
             <Polish>%1 założył stazę</Polish>
             <French>%1 a appliqué un garrot</French>
             <Hungarian>%1 felhelyezett egy érszorítót</Hungarian>
@@ -2254,6 +2266,7 @@
             <Portuguese>Curar hitpoints totalmente enfaixados</Portuguese>
             <Czech>Heal fully bandaged hitpoints</Czech>
             <Italian>Cura hitpoints completamente bendati</Italian>
+            <German>Heilt vollständig bandagierte Trefferpunkte</German>
         </Key>
         <Key ID="STR_ACE_Medical_painIsOnlySuppressed">
             <English>Pain is only temporarily suppressed</English>
@@ -2871,11 +2884,13 @@
             <English>Locations boost training</English>
             <Czech>Místa pro vylepšení zkušeností</Czech>
             <Italian>Località aumentano addestramento</Italian>
+            <German>Örtliche Trainingssteigerung</German>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_increaseTrainingInLocations_Description">
             <English>Boost medic rating in medical vehicles or near medical facilities [untrained becomes medic, medic becomes doctor]</English>
             <Czech>Zlepšit zkušenosti zdravotníka v medickém vozidle nebo poblíž zdravotního zařízení [nezkušení se stane zdravotníkem, zdravotník se stane doktorem] </Czech>
             <Italian>Aumenta il rating medico in veicoli medici o vicino strutture mediche [non addestrato diventa medico, medico diventa dottore]</Italian>
+            <German>Steigert die medizinische Einstufung eines Soldaten in Sanitätsfarhzeugen oder in der Nähe von Sanitätseinrichtungen [untrainiert wird zu Sanitäter, Sanitäter zu Doktor]</German>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_medicSetting_disable">
             <English>Disable medics</English>
@@ -3167,6 +3182,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_BasicMedicalSettings_Module_DisplayName">
             <English>Basic Medical Settings [ACE]</English>
+            <German>Grundlegende Sanitätseinstellungen [ACE]</German>
         </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_Module_DisplayName">
             <English>Advanced Medical Settings [ACE]</English>
@@ -3278,9 +3294,11 @@
         </Key>
         <Key ID="STR_ACE_Medical_BasicMedicalSettings_medicSetting_basicEpi_DisplayName">
             <English>Allow Epinephrine</English>
+            <German>Erlaube Epiniphrin</German>
         </Key>
         <Key ID="STR_ACE_Medical_BasicMedicalSettings_medicSetting_basicEpi_Description">
             <English>Who can use Epinephrine for full heal? (Basic medical only)</English>
+            <German>Wer darf Epiniphrin zur vollständigen Heilung benutzen? (grundlegende Sanitätseinstellungen)</German>
         </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_medicSetting_PAK_DisplayName">
             <English>Allow PAK</English>
@@ -3368,9 +3386,11 @@
         </Key>
         <Key ID="STR_ACE_Medical_BasicMedicalSettings_useLocation_basicEpi_DisplayName">
             <English>Locations Epinephrine</English>
+            <German>Orte für Epiniphrin</German>
         </Key>
         <Key ID="STR_ACE_Medical_BasicMedicalSettings_useLocation_basicEpi_Description">
             <English>Where can the Epinephrine be used? (Basic Medical)</English>
+            <German>Wo kann Epiniphrin verwendet werden? (grundlegende Sanitätseinstellungen)</German>
         </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useLocation_PAK_DisplayName">
             <English>Locations PAK</English>
@@ -3610,13 +3630,14 @@
         </Key>
         <Key ID="STR_ACE_Medical_BasicMedicalSettings_Module_Description">
             <English>Configure the treatment settings from ACE Basic Medical</English>
+            <German>Behandlungseinstellungen der Grundlegenden ACE-Medizin konfigurieren</German>
         </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_Module_Description">
             <English>Configure the treatment settings from ACE Advanced Medical</English>
             <Russian>Настройка лечения в медицинской системе ACE</Russian>
             <Polish>Skonfiguruj zaawansowane ustawienia leczenia systemu medycznego ACE</Polish>
             <Spanish>Configure las opciones de tratamiento del ACE Médico</Spanish>
-            <German>Behandlungseinstellungen vom ACE-Medizin konfigurieren</German>
+            <German>Behandlungseinstellungen der Erweiterten ACE-Medizin konfigurieren</German>
             <Czech>Konfigurace nastavení léčby ze zdravotnické systému ACE</Czech>
             <Portuguese>Configure as opções de tratamento do ACE Médico</Portuguese>
             <French>Configure les paramètres de traitement du système de soin ACE</French>
@@ -4041,7 +4062,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_noTourniquetOnBodyPart">
             <English>There is no tourniquet on this body part!</English>
-            <German>An diesem Körperteil befindet sich kein Tourniquet</German>
+            <German>An diesem Körperteil befindet sich kein Tourniquet!</German>
             <Polish>Na tej części ciała nie ma stazy!</Polish>
             <Spanish>No hay torniquete en esta parte del cuerpo!</Spanish>
             <Russian>Нет жгута на этой части тела!</Russian>
@@ -4053,20 +4074,17 @@
             <English>Medical training</English>
             <Polish>Wyszkolenie medyczne</Polish>
             <Italian>Addestramento Medico</Italian>
+            <German>Sanitätsausbildung</German>
         </Key>
         <Key ID="STR_ACE_Medical_Attributes_isMedicalVehicle_Description">
             <English>Whether or not the object will be a medical vehicle.</English>
             <Polish>Czy pojazdy ma być pojazdem medycznym?</Polish>
             <Italian>L'oggetto in questione sarà un veicolo medico o meno.</Italian>
+            <German>Ist das Objekt ein Sanitätsfahrzeug?</German>
         </Key>
         <Key ID="STR_ACE_Medical_delayUnconCaptive">
             <English>Delay Medical Unconscious Captivity</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_MedicalSettings_delayUnconCaptive_Description">
-            <English>Delay Medical Unconscious Captivity</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_MedicalSettings_delayUnconCaptive_DisplayName">
-            <English>Delay Medical Unconscious Captivity</English>
+            <German>Verzögert Gefangenschaft bei medizinischer Bewustlosigkeit</German>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_menu/stringtable.xml
+++ b/addons/medical_menu/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Medical Menu">
         <Key ID="STR_ACE_Medical_Menu_OpenMenu">
@@ -209,6 +209,7 @@
             <Portuguese>Vias aéreas</Portuguese>
             <Czech>Dýchací systém</Czech>
             <Italian>Gestione Vie Respiratorie</Italian>
+            <German>Atemwegssicherung</German>
         </Key>
         <Key ID="STR_ACE_Medical_Menu_ADVANCED_TREATMENT">
             <English>Advanced Treatments</English>

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Overheating">
         <Key ID="STR_ACE_Overheating_DisplayTextOnJam_displayName">
@@ -39,7 +39,7 @@
         </Key>
         <Key ID="STR_ACE_Overheating_showParticleEffectsForEveryone_displayName">
             <English>Overheating Particle Effects for everyone</English>
-            <German>Zeige Partikeleffekt bei allen</German>
+            <German>Zeige Partikeleffekt bei Überhitzung für jeden</German>
             <Polish>Pokaż efekty cząsteczkowe dla wszystkich</Polish>
             <Italian>Effetti Particellari Surriscaldamento per tutti</Italian>
         </Key>
@@ -63,15 +63,19 @@
         </Key>
         <Key ID="STR_ACE_Overheating_unJamOnreload_displayName">
             <English>Unjam weapon on reload</English>
+            <German>Behebt Ladehemmung beim Nachladen</German>
         </Key>
         <Key ID="STR_ACE_Overheating_unJamOnreload_description">
             <English>Reloading clears a weapon jam.</English>
+            <German>Nachladen behebt eine Ladehemmung.</German>
         </Key>
         <Key ID="STR_ACE_Overheating_unJamFailChance_displayName">
             <English>Chance of unjam failing</English>
+            <German>Wahrscheinlichkeit das Ladehemmung nicht behoben wird</German>
         </Key>
         <Key ID="STR_ACE_Overheating_unJamFailChance_description">
             <English>Probability that an unjam action might fail, requiring to be repeated.</English>
+            <German>Wahrscheinlichkeit das der Versuch eine Ladehemmung zu beheben fehl schlägt und erneut durchgeführt werden muss.</German>
         </Key>
         <Key ID="STR_ACE_Overheating_SpareBarrelName">
             <English>Spare barrel</English>
@@ -135,6 +139,7 @@
         </Key>
         <Key ID="STR_ACE_Overheating_WeaponUnjamFailed">
             <English>Jam failed to clear</English>
+            <German>Ladehemmung nicht behoben</German>
         </Key>
         <Key ID="STR_ACE_Overheating_SwapBarrel">
             <English>Swap barrel</English>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="repair">
         <Key ID="STR_ACE_Repair_SpareTrack">
@@ -381,6 +381,7 @@
             <Spanish>Estabilizador horizontal izquierdo</Spanish>
             <Czech>Levý horizontální stabilizátor</Czech>
             <Italian>Stabilizzatore Orizzontale Sinistro</Italian>
+            <German>Linkes Höhenleitwerk</German>
         </Key>
         <Key ID="STR_ACE_Repair_HitHStabilizerR1">
             <English>Right Horizontal Stabilizer</English>
@@ -390,6 +391,7 @@
             <Spanish>Estabilizador horizontal derecho</Spanish>
             <Czech>Pravý horizontální stabilizátor</Czech>
             <Italian>Stabilizzatore Orizzontale Destro</Italian>
+            <German>Rechtes Höhenleitwerk</German>
         </Key>
         <Key ID="STR_ACE_Repair_HitVStabilizer1">
             <English>Vertical Stabilizer</English>
@@ -399,6 +401,7 @@
             <Portuguese>Estabilizador Vertical</Portuguese>
             <Spanish>Estabilizador vertical</Spanish>
             <Italian>Stabilizzatore Verticale</Italian>
+            <German>Seitenleitwerk</German>
         </Key>
         <Key ID="STR_ACE_Repair_HitFuel">
             <English>Fuel Tank</English>
@@ -723,6 +726,7 @@
             <Czech>ERA</Czech>
             <Polish>ERA</Polish>
             <Italian>ERA</Italian>
+            <German>Reaktivpanzerung</German>
         </Key>
         <Key ID="STR_ACE_Repair_moduleName">
             <English>Repair Settings</English>

--- a/addons/slideshow/stringtable.xml
+++ b/addons/slideshow/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Slideshow">
         <Key ID="STR_ACE_Slideshow_DisplayName">
@@ -106,6 +106,7 @@
             <Czech>Názvy interakcí</Czech>
             <Spanish>Nombres de interacción</Spanish>
             <Italian>Nomi Interazioni</Italian>
+            <German>Interaktionsnamen</German>
         </Key>
         <Key ID="STR_ACE_Slideshow_Names_Description">
             <English>List of names that will be used for interaction entries, separated by commas, in order of images.</English>
@@ -116,6 +117,7 @@
             <Russian>Список имен, которые будут использованы при взаимодействии, разделенные запятыми, в порядке следования изображений.</Russian>
             <Spanish>Lista de nombres que se utilizarán para las entradas de interacción, separados por comas, en el orden de las imágenes.</Spanish>
             <Italian>Lista di nomi che verranno usati per per le interazioni, separati da virgole, in ordine per immagini.</Italian>
+            <German>Liste aller Namen die für Interaktionseinträge genutzt werden. Mit Komma getrennt, in Reihenfolge der Bilder.</German>
         </Key>
         <Key ID="STR_ACE_Slideshow_Duration_DisplayName">
             <English>Slide Duration</English>
@@ -127,6 +129,7 @@
             <Spanish>Duración de diapositiva</Spanish>
             <Czech>Doba trvání snímku</Czech>
             <Italian>Durata Diapositiva</Italian>
+            <German>Länge der Diavorführung pro Bild</German>
         </Key>
         <Key ID="STR_ACE_Slideshow_Duration_Description">
             <English>Duration of each slide. Default: 0 (Automatic Transitions Disabled)</English>
@@ -138,6 +141,7 @@
             <Spanish>Duración de cada diapositiva. Por defecto: 0 (Transiciones automáticas desactivadas)</Spanish>
             <Czech>Doba trvání každého snímku. Výchozí: 0 (Automatické posouvání je zakázáno)</Czech>
             <Italian>Durata di ogni diapositiva. Default: 0 (Transizioni Automatiche Disabilitate)</Italian>
+            <German>Länge der Diavorführung pro Bild. Standard: 0 (Automatischer Wechsel deaktiviert)</German>
         </Key>
         <Key ID="STR_ACE_Slideshow_Interaction">
             <English>Slides</English>
@@ -149,6 +153,7 @@
             <Spanish>Diapositivas</Spanish>
             <Czech>Snímky</Czech>
             <Italian>Diapositive</Italian>
+            <German>Dias</German>
         </Key>
     </Package>
 </Project>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Zeus">
         <Key ID="STR_ACE_Zeus_Settings_DisplayName">
@@ -242,6 +242,7 @@
             <Russian>Добавить запасное колесо</Russian>
             <Czech>Přidat rezervní kolo</Czech>
             <Italian>Aggiungi Ruota di Scorta</Italian>
+            <German>Ersatzrad hinzufügen</German>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleAddSpareWheel_Description">
             <English>Adds a Spare Wheel to the vehicle</English>
@@ -250,6 +251,7 @@
             <Russian>Добавляет запасное колесо в транспорт</Russian>
             <Czech>Přidá rezervní kolo do vozidla</Czech>
             <Italian>Aggiungi una ruota di scorta al veicolo</Italian>
+            <German>Fügt dem Fahrzeug ein Ersatzrad hinzu</German>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleAddSpareTrack_DisplayName">
             <English>Add Spare Track</English>
@@ -258,6 +260,7 @@
             <Russian>Дабавить запасную гусеницу</Russian>
             <Czech>Přidat náhradní pás</Czech>
             <Italian>Aggiungi Cingolo di Scorta</Italian>
+            <German>Ersatzkette hinzufügen</German>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleAddSpareTrack_Description">
             <English>Adds a Spare Track to the vehicle</English>
@@ -266,6 +269,7 @@
             <Russian>Добавляет запасную гусеницу в транспорт</Russian>
             <Czech>Přidá náhradní pás do vozidla</Czech>
             <Italian>Aggiungi un cingolo di scorta al veicolo</Italian>
+            <German>Fügt dem Fahrzeug eine Ersatzkette hinzu</German>
         </Key>
         <Key ID="STR_ACE_Zeus_OnlyAlive">
             <English>Unit must be alive</English>
@@ -318,6 +322,7 @@
             <Russian>Юнит должен быть транспортом с грузовым отсеком</Russian>
             <Czech>Jednotka musí být vozidlo s úložným prostorem</Czech>
             <Italian>L'unità dev'essere un veicolo con spazio di carico</Italian>
+            <German>Einheit muss ein Fahrzeug mit Ladekapazität sein</German>
         </Key>
         <Key ID="STR_ACE_Zeus_OnlyEnoughCargoSpace">
             <English>Unit must have cargo space left</English>
@@ -326,6 +331,7 @@
             <Russian>Юнит должен иметь свободное место в грузовом отсеке</Russian>
             <Czech>Jednotka musí mít místo v úložném prostoru</Czech>
             <Italian>L'unità deve avere spazio di carico disponibile</Italian>
+            <German>Einheit muss freie Ladekapazität haben</German>
         </Key>
         <Key ID="STR_ACE_Zeus_OnlyNonCaptive">
             <English>Unit must not be captive</English>
@@ -371,6 +377,7 @@
             <Spanish>Agregar objetos al director</Spanish>
             <Czech>Přidat objekty kurátorovi</Czech>
             <Italian>Aggiungi Oggetti al Curatore</Italian>
+            <German>Fügt Objekte zum Kurator hinzu</German>
         </Key>
         <Key ID="STR_ACE_Zeus_AddObjectsToCurator_desc">
             <English>Adds any spawned object to all curators in the mission</English>
@@ -380,6 +387,7 @@
             <Spanish>Añadir cualquier objeto creado a todos los directores en la misión</Spanish>
             <Czech>Přidá jakékoliv spawnuté objekty všem kurátorům v misi</Czech>
             <Italian>Aggiungi ogni oggetto creato a tutti i Curatori in missione</Italian>
+            <German>Fügt jedes gespawnte Objekt allen Kuratoren der Mission hinzu </German>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
When merged this pull request will:

1. add missing german translations in "explosives, frag, interaction, map_gestures, medical, medical_menu, overheating, repair, slideshow, zeus" addons
2. fix a few existing texts
3. remove two unused strings in "medical" addon


