### PR TITLE
Add registering last damage source

### DIFF
--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -77,6 +77,10 @@ _minLethalDamage = if (_typeIndex >= 0) then {
     0.01
 };
 
+if (!isNull _shooter) then {
+    _unit setvariable [QGVAR(lastDamageSource), _shooter, false];
+};
+
 private _vehicle = vehicle _unit;
 private _effectiveSelectionName = _selection;
 if ((_vehicle != _unit) && {!(_vehicle isKindOf "StaticWeapon")} && {_shooter in [objNull, driver _vehicle, _vehicle]} && {_projectile == ""} && {_selection == ""}) then {
@@ -97,6 +101,7 @@ if ((_minLethalDamage <= _newDamage) && {[_unit, [_effectiveSelectionName] call 
 } else {
     _damageReturn = _damageReturn min 0.89;
 };
+
 
 [_unit] call FUNC(addToInjuredCollection);
 


### PR DESCRIPTION
Add registration of the latest damage source.

Systems like ALiVE depend on the killed event handler to provide them with the source of whatever killed a unit. Since we are using `setDamage`, this source is always objNull. 

The goal of this PR is to introduce a solution that allows third party mods to do kill count registration without to much complication.