### PR TITLE
Fix error in nametags when a player disconnects

### DIFF
--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -129,26 +129,28 @@ if (_enabledTagsNearby) then {
     {
         private _target = _x;
 
-        private _relPos = (visiblePositionASL _target) vectorDiff _camPosASL;
-        private _distance = vectorMagnitude _relPos;
-        private _projDist = _relPos vectorDistance (_vecy vectorMultiply (_relPos vectorDotProduct _vecy));
+        if !(isNull _target) then {
+            private _relPos = (visiblePositionASL _target) vectorDiff _camPosASL;
+            private _distance = vectorMagnitude _relPos;
+            private _projDist = _relPos vectorDistance (_vecy vectorMultiply (_relPos vectorDotProduct _vecy));
 
-        private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
-        private _alphaMax = _onKeyPressAlphaMax;
-        if ((GVAR(showSoundWaves) == 2) && _drawSoundwave) then {
-            _drawName = _drawSoundwave;
-            _drawRank = false;
-            _alphaMax = 1;
-        };
-        // Alpha:
-        // - base value determined by GVAR(playerNamesMaxAlpha)
-        // - decreases when _distance > _maxDistance
-        // - increases when the unit is speaking
-        // - it's clamped by the value of _onKeyPressAlphaMax unless soundwaves are forced on and the unit is talking
-        private _alpha = (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistance)) min 1) * GVAR(playerNamesMaxAlpha)) min _alphaMax;
+            private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
+            private _alphaMax = _onKeyPressAlphaMax;
+            if ((GVAR(showSoundWaves) == 2) && _drawSoundwave) then {
+                _drawName = _drawSoundwave;
+                _drawRank = false;
+                _alphaMax = 1;
+            };
+            // Alpha:
+            // - base value determined by GVAR(playerNamesMaxAlpha)
+            // - decreases when _distance > _maxDistance
+            // - increases when the unit is speaking
+            // - it's clamped by the value of _onKeyPressAlphaMax unless soundwaves are forced on and the unit is talking
+            private _alpha = (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistance)) min 1) * GVAR(playerNamesMaxAlpha)) min _alphaMax;
 
-        if (_alpha > 0) then {
-            [ACE_player, _target, _alpha, _distance * 0.026, _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
+            if (_alpha > 0) then {
+                [ACE_player, _target, _alpha, _distance * 0.026, _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
+            };
         };
         nil
     } count _targets;


### PR DESCRIPTION
### When merged this pull request will:

1. Fix error in nametags when a player disconnects due to object being null.

![2016-02-27_00001](https://cloud.githubusercontent.com/assets/7674951/13373063/982da530-dd3b-11e5-93f9-0722abb11260.jpg)