### PR TITLE
Prevent Self Interact Menu from bugging out during animations

### DIFF
--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -77,21 +77,31 @@ if (GVAR(useCursorMenu)) then {
 
 GVAR(selfMenuOffset) = (AGLtoASL (positionCameraToWorld [0, 0, 2])) vectorDiff (AGLtoASL (positionCameraToWorld [0, 0, 0]));
 
-if (GVAR(menuAnimationSpeed) > 0) then {
-    //Auto expand the first level when self, mounted vehicle or zeus (skips the first animation as there is only one choice)
-    if (GVAR(openedMenuType) == 0) then {
-        if (isNull curatorCamera) then {
-            if (vehicle ACE_player != ACE_player) then {
-                GVAR(menuDepthPath) = [["ACE_SelfActions", (vehicle ACE_player)]];
-            };
-        } else {
-            GVAR(menuDepthPath) = [["ACE_ZeusActions", (getAssignedCuratorLogic player)]];
+//Auto expand the first level when self, mounted vehicle or zeus (skips the first animation as there is only one choice)
+if (GVAR(openedMenuType) == 0) then {
+    if (isNull curatorCamera) then {
+        if (vehicle ACE_player != ACE_player) then {
+            GVAR(menuDepthPath) = [["ACE_SelfActions", (vehicle ACE_player)]];
+            GVAR(expanded) = true;
+            GVAR(expandedTime) = ACE_diagTime;
+            GVAR(lastPath) = +GVAR(menuDepthPath);
+            GVAR(startHoverTime) = -1000;
         };
     } else {
-        GVAR(menuDepthPath) = [["ACE_SelfActions", ACE_player]];
+        GVAR(menuDepthPath) = [["ACE_ZeusActions", (getAssignedCuratorLogic player)]];
+        GVAR(expanded) = true;
+        GVAR(expandedTime) = ACE_diagTime;
+        GVAR(lastPath) = +GVAR(menuDepthPath);
+        GVAR(startHoverTime) = -1000;
     };
-};                   
-                       
+} else {
+    GVAR(menuDepthPath) = [["ACE_SelfActions", ACE_player]];
+    GVAR(expanded) = true;
+    GVAR(expandedTime) = ACE_diagTime;
+    GVAR(lastPath) = +GVAR(menuDepthPath);
+    GVAR(startHoverTime) = -1000;
+};
+
 ["interactMenuOpened", [_menuType]] call EFUNC(common,localEvent);
 
 true

--- a/addons/interact_menu/functions/fnc_render.sqf
+++ b/addons/interact_menu/functions/fnc_render.sqf
@@ -116,8 +116,6 @@ if (GVAR(openedMenuType) >= 0) then {
 
 if(!_foundTarget && GVAR(actionSelected)) then {
     GVAR(actionSelected) = false;
-    GVAR(expanded) = false;
-    GVAR(lastPath) = [];
 };
 for "_i" from GVAR(iconCount) to (count GVAR(iconCtrls))-1 do {
     ctrlDelete (GVAR(iconCtrls) select _i);


### PR DESCRIPTION
#### Issues:

These is about two usability problems that happen in the IM while self interacting:
1. There are corner cases in which the interact menu collapses back to the action point while you try to select subactions while the expand animation is not complete. This makes lower speed animations a pain to use, specially if your are trying to be fast. This is visible in the video starting at time=6s
2. For slow animation speeds, the "Self Interact" opion doesn't auto expand instantly. That leads to the menu not expanding at all if you try to move the mouse to the right too quickly, That is visible in the video multiple times

**Video Before**:
https://youtu.be/dM18AVn-Yw8
**Video After**:
https://youtu.be/a7LcJgGKKL0

The issues described above happen both for the 3d and the cursor modes of the menu. The video is made for 3d interaction because otherwise the cursor wouldn't be visible.

#### When merged this pull request will:

1. Solve usability problem no.1. That is done by removing the code that collapses the menu if no action is selected and none is close to the cursor. That behaviour was outdated, and luckily only triggered on corner cases.

2. Make @PabstMirror auto-expansion of the "Self Actions" base menu happen also for the slower animation speed. However, now the expand animation does play for all velocities, to better convey what is happening. This ensures the menu always expand, independently of how fast you move the mouse.