### PR TITLE
Standardize GVAR array brackets in configs.

### DIFF
--- a/addons/concertina_wire/CfgVehicles.hpp
+++ b/addons/concertina_wire/CfgVehicles.hpp
@@ -112,7 +112,7 @@ class CfgVehicles {
         accuracy = 1000;
         autocenter = 0;
         EGVAR(dragging,canDrag) = 1;
-        EGVAR(dragging,dragPosition[]) = {0,0.5,0.5};
+        EGVAR(dragging,dragPosition)[] = {0,0.5,0.5};
         EGVAR(dragging,dragDirection) = 0;
         EGVAR(cargo,size) = 1;
         EGVAR(cargo,canLoad) = 1;

--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -4,11 +4,11 @@ class CfgVehicles {
     class LandVehicle;
     class StaticWeapon: LandVehicle {
         GVAR(canCarry) = 1;
-        GVAR(carryPosition[]) = {0,1.2,0};
+        GVAR(carryPosition)[] = {0,1.2,0};
         GVAR(carryDirection) = 0;
 
         GVAR(canDrag) = 1;
-        GVAR(dragPosition[]) = {0,1.2,0};
+        GVAR(dragPosition)[] = {0,1.2,0};
         GVAR(dragDirection) = 0;
     };
 
@@ -21,11 +21,11 @@ class CfgVehicles {
     class StaticMortar;
     class Mortar_01_base_F: StaticMortar {
         GVAR(canCarry) = 1;
-        GVAR(carryPosition[]) = {0,1.2,0};
+        GVAR(carryPosition)[] = {0,1.2,0};
         GVAR(carryDirection) = 0;
 
         GVAR(canDrag) = 1;
-        GVAR(dragPosition[]) = {0,1.2,0};
+        GVAR(dragPosition)[] = {0,1.2,0};
         GVAR(dragDirection) = 0;
     };
 
@@ -33,11 +33,11 @@ class CfgVehicles {
     class ThingX;
     class ReammoBox_F: ThingX {
         GVAR(canCarry) = 0;
-        GVAR(carryPosition[]) = {0,1,1};
+        GVAR(carryPosition)[] = {0,1,1};
         GVAR(carryDirection) = 0;
 
         GVAR(canDrag) = 0;
-        GVAR(dragPosition[]) = {0,1.2,0};
+        GVAR(dragPosition)[] = {0,1.2,0};
         GVAR(dragDirection) = 0;
     };
 
@@ -87,40 +87,40 @@ class CfgVehicles {
     class RoadCone_F: ThingX {
         XEH_ENABLED;
         GVAR(canCarry) = 1;
-        GVAR(carryPosition[]) = {0,1,1};
+        GVAR(carryPosition)[] = {0,1,1};
         GVAR(carryDirection) = 0;
 
         GVAR(canDrag) = 1;
-        GVAR(dragPosition[]) = {0,1.2,0};
+        GVAR(dragPosition)[] = {0,1.2,0};
         GVAR(dragDirection) = 0;
     };
 
     class RoadBarrier_F: RoadCone_F {
-        GVAR(carryPosition[]) = {0,1,0.300671};
+        GVAR(carryPosition)[] = {0,1,0.300671};
     };
 
     class ACE_RepairItem_Base: ThingX {};
 
     class ACE_Track: ACE_RepairItem_Base {
         GVAR(canCarry) = 1;
-        GVAR(carryPosition[]) = {0,1,1};
+        GVAR(carryPosition)[] = {0,1,1};
         GVAR(carryDirection) = 0;
     };
 
     class ACE_Wheel: ACE_RepairItem_Base {
         GVAR(canCarry) = 1;
-        GVAR(carryPosition[]) = {0,1,1};
+        GVAR(carryPosition)[] = {0,1,1};
         GVAR(carryDirection) = 0;
     };
 
     class Lamps_base_F;
     class Land_PortableLight_single_F: Lamps_base_F {
         GVAR(canCarry) = 1;
-        GVAR(carryPosition[]) = {0,1.2,0};
+        GVAR(carryPosition)[] = {0,1.2,0};
         GVAR(carryDirection) = 180;
 
         GVAR(canDrag) = 1;
-        GVAR(dragPosition[]) = {0,1.2,0};
+        GVAR(dragPosition)[] = {0,1.2,0};
         GVAR(dragDirection) = 180;
     };
 };

--- a/addons/explosives/CfgAmmo.hpp
+++ b/addons/explosives/CfgAmmo.hpp
@@ -31,14 +31,14 @@ class CfgAmmo {
     class ClaymoreDirectionalMine_Remote_Ammo: DirectionalBombBase {
         GVAR(magazine) = "ClaymoreDirectionalMine_Remote_Mag";
         GVAR(Explosive) = "ClaymoreDirectionalMine_Remote_Ammo_Scripted";
-        GVAR(defuseObjectPosition[]) = {0, 0, 0.038};
+        GVAR(defuseObjectPosition)[] = {0, 0, 0.038};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
     // class ClaymoreDirectionalMine_Remote_Ammo_Scripted: ClaymoreDirectionalMine_Remote_Ammo {};
 
     class APERSTripMine_Wire_Ammo: DirectionalBombBase {
-        GVAR(defuseObjectPosition[]) = {-1.415, 0, 0.12};
+        GVAR(defuseObjectPosition)[] = {-1.415, 0, 0.12};
     };
 
     class SLAMDirectionalMine_Wire_Ammo: DirectionalBombBase {
@@ -66,7 +66,7 @@ class CfgAmmo {
     class DemoCharge_Remote_Ammo: PipeBombBase {
         GVAR(magazine) = "DemoCharge_Remote_Mag";
         GVAR(Explosive) = "DemoCharge_Remote_Ammo_Scripted";
-        GVAR(defuseObjectPosition[]) = {0.07, 0, 0.055};
+        GVAR(defuseObjectPosition)[] = {0.07, 0, 0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
         hit = 500;
@@ -76,7 +76,7 @@ class CfgAmmo {
     class SatchelCharge_Remote_Ammo: PipeBombBase {
         GVAR(magazine) = "SatchelCharge_Remote_Mag";
         GVAR(Explosive) = "SatchelCharge_Remote_Ammo_Scripted";
-        GVAR(defuseObjectPosition[]) = {0.1, 0.1, 0.05};
+        GVAR(defuseObjectPosition)[] = {0.1, 0.1, 0.05};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };

--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -154,54 +154,54 @@ class CfgVehicles {
 
     class Heli_Light_02_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
-        GVAR(ropeOrigins[]) = {{1.41, 1.38, 0}, {-1.41, 1.38, 0}};
+        GVAR(ropeOrigins)[] = {{1.41, 1.38, 0}, {-1.41, 1.38, 0}};
         GVAR(onPrepare) = QFUNC(onPrepareCommon);
         GVAR(onCut) = QFUNC(onCutCommon);
     };
     class Heli_Attack_02_base_F: Helicopter_Base_F {
         GVAR(enabled) = 1;
-        GVAR(ropeOrigins[]) = {{1.25, 1.5, -0.6}, {-1.1, 1.5, -0.6}};
+        GVAR(ropeOrigins)[] = {{1.25, 1.5, -0.6}, {-1.1, 1.5, -0.6}};
         GVAR(onPrepare) = QFUNC(onPrepareCommon);
         GVAR(onCut) = QFUNC(onCutCommon);
     };
     class Heli_Transport_01_base_F: Helicopter_Base_H {
         GVAR(enabled) = 2;
-        GVAR(ropeOrigins[]) = {"ropeOriginRight", "ropeOriginLeft"};
+        GVAR(ropeOrigins)[] = {"ropeOriginRight", "ropeOriginLeft"};
         GVAR(friesType) = "ACE_friesAnchorBar";
-        GVAR(friesAttachmentPoint[]) = {0.065, 2.2, -0.15};
+        GVAR(friesAttachmentPoint)[] = {0.065, 2.2, -0.15};
         GVAR(onPrepare) = QFUNC(onPrepareCommon);
         GVAR(onCut) = QFUNC(onCutCommon);
         EQUIP_FRIES_ATTRIBUTE;
     };
     class Heli_Transport_02_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
-        GVAR(ropeOrigins[]) = {{0.94, -4.82, -1.16}, {-0.94, -4.82, -1.16}};
+        GVAR(ropeOrigins)[] = {{0.94, -4.82, -1.16}, {-0.94, -4.82, -1.16}};
     };
     class Heli_Transport_03_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
-        GVAR(ropeOrigins[]) = {{0.75, -5.29, -0.11}, {-0.87, -5.29, -0.11}};
+        GVAR(ropeOrigins)[] = {{0.75, -5.29, -0.11}, {-0.87, -5.29, -0.11}};
     };
     class Heli_light_03_base_F: Helicopter_Base_F {
         GVAR(enabled) = 2;
-        GVAR(ropeOrigins[]) = {"ropeOriginRight", "ropeOriginLeft"};
+        GVAR(ropeOrigins)[] = {"ropeOriginRight", "ropeOriginLeft"};
         GVAR(friesType) = "ACE_friesGantryReverse";
-        GVAR(friesAttachmentPoint[]) = {1.04, 2.5, -0.34};
+        GVAR(friesAttachmentPoint)[] = {1.04, 2.5, -0.34};
         EQUIP_FRIES_ATTRIBUTE;
     };
     class Heli_light_03_unarmed_base_F: Heli_light_03_base_F {
         GVAR(enabled) = 2;
-        GVAR(ropeOrigins[]) = {"ropeOriginRight", "ropeOriginLeft"};
+        GVAR(ropeOrigins)[] = {"ropeOriginRight", "ropeOriginLeft"};
         GVAR(friesType) = "ACE_friesGantry";
-        GVAR(friesAttachmentPoint[]) = {-1.07, 3.26, -0.5};
+        GVAR(friesAttachmentPoint)[] = {-1.07, 3.26, -0.5};
         EQUIP_FRIES_ATTRIBUTE;
     };
     class Heli_Transport_04_base_F;
     class O_Heli_Transport_04_bench_F: Heli_Transport_04_base_F {
         GVAR(enabled) = 1;
-        GVAR(ropeOrigins[]) = {{1.03, 1.6, -0.23}, {1.03, -1.36, -0.23}, {-1.23, 1.6, -0.23}, {-1.23, -1.36, -0.23}};
+        GVAR(ropeOrigins)[] = {{1.03, 1.6, -0.23}, {1.03, -1.36, -0.23}, {-1.23, 1.6, -0.23}, {-1.23, -1.36, -0.23}};
     };
     class O_Heli_Transport_04_covered_F: Heli_Transport_04_base_F {
         GVAR(enabled) = 1;
-        GVAR(ropeOrigins[]) = {{0.83, -4.7, -0.03}, {-1.02, -4.7, -0.03}};
+        GVAR(ropeOrigins)[] = {{0.83, -4.7, -0.03}, {-1.02, -4.7, -0.03}};
     };
 };

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -658,7 +658,7 @@ class CfgVehicles {
         icon = "";
         displayName = CSTRING(Bodybag_Display);
         EGVAR(dragging,canDrag) = 1;
-        EGVAR(dragging,dragPosition[]) = {0,1.2,0};
+        EGVAR(dragging,dragPosition)[] = {0,1.2,0};
         EGVAR(dragging,dragDirection) = 0;
         EGVAR(cargo,size) = 1;
         EGVAR(cargo,canLoad) = 1;

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -342,7 +342,7 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_04_base_F: Helicopter_Base_H {
-        GVAR(hitpointGroups[]) = { {"HitEngine", {"HitEngine1", "HitEngine2"}}, {"Glass_1_hitpoint", {"Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"}} };
+        GVAR(hitpointGroups)[] = { {"HitEngine", {"HitEngine1", "HitEngine2"}}, {"Glass_1_hitpoint", {"Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"}} };
     };
     class O_Heli_Transport_04_repair_F: Heli_Transport_04_base_F {
         GVAR(canRepair) = 1;
@@ -357,12 +357,12 @@ class CfgVehicles {
 
     class Heli_Transport_02_base_F;
     class I_Heli_Transport_02_F: Heli_Transport_02_base_F {
-        GVAR(hitpointPositions[]) = {{"HitVRotor", {-1,-9.4,1.8}}, {"HitHRotor", {0,1.8,1.3}}};
+        GVAR(hitpointPositions)[] = {{"HitVRotor", {-1,-9.4,1.8}}, {"HitHRotor", {0,1.8,1.3}}};
     };
 
     class Helicopter_Base_F;
     class Heli_light_03_base_F: Helicopter_Base_F {
-        GVAR(hitpointPositions[]) = {{"HitVRotor", {-0.5,-5.55,1.2}}, {"HitHRotor", {0,1.8,1.5}}};
+        GVAR(hitpointPositions)[] = {{"HitVRotor", {-0.5,-5.55,1.2}}, {"HitHRotor", {0,1.8,1.5}}};
     };
 
     class B_APC_Tracked_01_base_F;
@@ -372,12 +372,12 @@ class CfgVehicles {
     };
 
     class B_APC_Tracked_01_AA_F: B_APC_Tracked_01_base_F {
-        GVAR(hitpointPositions[]) = {{"HitTurret", {0,-2,0}}};
+        GVAR(hitpointPositions)[] = {{"HitTurret", {0,-2,0}}};
     };
 
     class Car_F;
     class Offroad_01_base_F: Car_F {
-        GVAR(hitpointGroups[]) = { {"HitGlass1", {"HitGlass2"}} };
+        GVAR(hitpointGroups)[] = { {"HitGlass1", {"HitGlass2"}} };
     };
     class Offroad_01_repair_base_F: Offroad_01_base_F {
         GVAR(canRepair) = 1;
@@ -385,7 +385,7 @@ class CfgVehicles {
     };
 
     class MRAP_01_base_F: Car_F {
-        GVAR(hitpointGroups[]) = { {"HitGlass1", {"HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6"}} };
+        GVAR(hitpointGroups)[] = { {"HitGlass1", {"HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6"}} };
     };
 
     class B_Truck_01_mover_F;
@@ -416,9 +416,9 @@ class CfgVehicles {
 
     class Quadbike_01_base_F;
     class B_Quadbike_01_F: Quadbike_01_base_F {
-        GVAR(hitpointPositions[]) = { {"HitEngine", {0, 0.5, -0.7}}, {"HitFuel", {0, 0, -0.5}} };
+        GVAR(hitpointPositions)[] = { {"HitEngine", {0, 0.5, -0.7}}, {"HitFuel", {0, 0, -0.5}} };
     };
     class Hatchback_01_base_F: Car_F {
-        GVAR(hitpointPositions[]) = {{"HitBody", {0, 0.7, -0.5}}, {"HitFuel", {0, -1.75, -0.75}}};
+        GVAR(hitpointPositions)[] = {{"HitBody", {0, 0.7, -0.5}}, {"HitFuel", {0, -1.75, -0.75}}};
     };
 };

--- a/addons/sitting/CfgVehicles.hpp
+++ b/addons/sitting/CfgVehicles.hpp
@@ -42,9 +42,9 @@ class CfgVehicles {
         XEH_ENABLED;
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
-        GVAR(sitPosition[]) = {0, -0.1, -0.45};
+        GVAR(sitPosition)[] = {0, -0.1, -0.45};
         EGVAR(dragging,canCarry) = 1;
-        EGVAR(dragging,carryPosition[]) = {0, 0.75, 0.5};
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
         EGVAR(dragging,carryDirection) = 180;
     };
     // Camping Chair
@@ -52,9 +52,9 @@ class CfgVehicles {
         XEH_ENABLED;
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
-        GVAR(sitPosition[]) = {0, -0.1, -0.45};
+        GVAR(sitPosition)[] = {0, -0.1, -0.45};
         EGVAR(dragging,canCarry) = 1;
-        EGVAR(dragging,carryPosition[]) = {0, 0.75, 0.5};
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
         EGVAR(dragging,carryDirection) = 180;
     };
 
@@ -64,9 +64,9 @@ class CfgVehicles {
         XEH_ENABLED;
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 90;
-        GVAR(sitPosition[]) = {0, 0, -0.5};
+        GVAR(sitPosition)[] = {0, 0, -0.5};
         EGVAR(dragging,canCarry) = 1;
-        EGVAR(dragging,carryPosition[]) = {0, 0.75, 0.5};
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
         EGVAR(dragging,carryDirection) = 270;
     };
     // Chair (Wooden)
@@ -74,9 +74,9 @@ class CfgVehicles {
         XEH_ENABLED;
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
-        GVAR(sitPosition[]) = {0, -0.05, 0};
+        GVAR(sitPosition)[] = {0, -0.05, 0};
         EGVAR(dragging,canCarry) = 1;
-        EGVAR(dragging,carryPosition[]) = {0, 0.75, 0.5};
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
         EGVAR(dragging,carryDirection) = 180;
     };
     // Office Chair
@@ -84,9 +84,9 @@ class CfgVehicles {
         XEH_ENABLED;
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
-        GVAR(sitPosition[]) = {0, 0, -0.6};
+        GVAR(sitPosition)[] = {0, 0, -0.6};
         EGVAR(dragging,canCarry) = 1;
-        EGVAR(dragging,carryPosition[]) = {0, 0.75, 0.5};
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
         EGVAR(dragging,carryDirection) = 180;
     };
     // Rattan Chair
@@ -94,9 +94,9 @@ class CfgVehicles {
         XEH_ENABLED;
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
-        GVAR(sitPosition[]) = {0, -0.1, -1}; // Z must be -1 due to chair's geometry (magic floating seat point)
+        GVAR(sitPosition)[] = {0, -0.1, -1}; // Z must be -1 due to chair's geometry (magic floating seat point)
         EGVAR(dragging,canCarry) = 1;
-        EGVAR(dragging,carryPosition[]) = {0, 0.75, 0.5};
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
         EGVAR(dragging,carryDirection) = 180;
     };
 };

--- a/addons/spottingscope/CfgVehicles.hpp
+++ b/addons/spottingscope/CfgVehicles.hpp
@@ -107,7 +107,7 @@ class CfgVehicles {
             };
         };
         EGVAR(dragging,canDrag) = 1;
-        EGVAR(dragging,dragPosition[]) = {0,1,0};
+        EGVAR(dragging,dragPosition)[] = {0,1,0};
         EGVAR(dragging,dragDirection) = 0;
         class ACE_Actions: ACE_Actions{
             class ACE_MainActions: ACE_MainActions {

--- a/addons/tripod/CfgVehicles.hpp
+++ b/addons/tripod/CfgVehicles.hpp
@@ -36,7 +36,7 @@ class CfgVehicles {
     class ACE_TripodObject: ThingX {
         XEH_ENABLED;
         EGVAR(dragging,canDrag) = 1;
-        EGVAR(dragging,dragPosition[]) = {0,1,0};
+        EGVAR(dragging,dragPosition)[] = {0,1,0};
         EGVAR(dragging,dragDirection) = 0;
         scope = 2;
         displayName = CSTRING(DisplayName);

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -36,7 +36,7 @@ class CfgPatches {
 class ACE_Curator {
     GVAR(captives) = "ace_captives";
     GVAR(medical) = "ace_medical";
-    GVAR(cargoAndRepair[]) = {"ace_cargo", "ace_repair"};
+    GVAR(cargoAndRepair)[] = {"ace_cargo", "ace_repair"};
 };
 
 #include "CfgEventHandlers.hpp"


### PR DESCRIPTION
Standardize grammar of GVAR arrays in configs to place the square brackets outside the GVAR macro.
This prevents any possible confusion when the GVARs are used in code.

Put in 3.6.0 for absolute lack of priority, but no reason it can't be merged earlier.