### PR TITLE
Don't try adding repair actions to fastrope helper

### DIFF
--- a/addons/repair/CfgEventHandlers.hpp
+++ b/addons/repair/CfgEventHandlers.hpp
@@ -35,6 +35,7 @@ class Extended_InitPost_EventHandlers {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
             serverInit = QUOTE(_this call DFUNC(addSpareParts));
+            exclude[] = {QEGVAR(fastroping,helper)};
         };
     };
     class Plane {


### PR DESCRIPTION
### When merged this pull request will:

Don't throw error when createing fast rope helper.
