### PR TITLE
Remove spare barrels from starting equipment, as they make some grena…

### DIFF
--- a/addons/overheating/CfgVehicles.hpp
+++ b/addons/overheating/CfgVehicles.hpp
@@ -99,29 +99,4 @@ class CfgVehicles {
             MACRO_ADDITEM(ACE_SpareBarrel,6);
         };
     };
-
-    // Add ACE_SpareBarrel to every machine gunner.
-    #define MACRO_ADDSPAREBARREL \
-        items[] = {"FirstAidKit", "ACE_SpareBarrel"}; \
-        respawnitems[] = {"FirstAidKit", "ACE_SpareBarrel"};
-
-    // NATO
-    class B_Soldier_02_f; class B_soldier_AR_F:B_Soldier_02_f {MACRO_ADDSPAREBARREL};
-    class B_Soldier_support_base_F; class B_soldier_AAR_F:B_Soldier_support_base_F {MACRO_ADDSPAREBARREL};
-    class B_Soldier_base_F; class B_CTRG_soldier_AR_A_F:B_Soldier_base_F {MACRO_ADDSPAREBARREL};
-
-    // Guerrilla
-    class I_G_Soldier_base_F; class I_G_Soldier_AR_F:I_G_Soldier_base_F {MACRO_ADDSPAREBARREL};
-    class B_G_Soldier_AR_F:I_G_Soldier_AR_F {MACRO_ADDSPAREBARREL};
-    class O_G_Soldier_AR_F:I_G_Soldier_AR_F {MACRO_ADDSPAREBARREL};
-
-    // Iran
-    class O_Soldier_base_F; class O_Soldier_AR_F:O_Soldier_base_F {MACRO_ADDSPAREBARREL};
-    class O_Soldier_support_base_F; class O_Soldier_AAR_F:O_Soldier_support_base_F {MACRO_ADDSPAREBARREL};
-    class O_Soldier_Urban_base; class O_soldierU_AR_F:O_Soldier_Urban_base {MACRO_ADDSPAREBARREL};
-    class O_soldierU_AAR_F:O_Soldier_Urban_base {MACRO_ADDSPAREBARREL};
-
-    // Czech
-    class I_Soldier_02_F; class I_Soldier_AR_F:I_Soldier_02_F {MACRO_ADDSPAREBARREL};
-    class I_Soldier_support_base_F; class I_Soldier_AAR_F:I_Soldier_support_base_F {MACRO_ADDSPAREBARREL};
 };


### PR DESCRIPTION
### When merged this pull request will:

1. Remove spare barrels from starting equipment, as they make some grenades not fit in the uniforms.