### PR TITLE
replace XEH_ENABLED macro with actual class, fix #3482, fix #3483

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -1,3 +1,6 @@
+
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Logic;
     class Module_F: Logic {
@@ -192,7 +195,7 @@ class CfgVehicles {
     };
 
     class Heli_Transport_02_base_F;
-    class I_Heli_Transport_02_F : Heli_Transport_02_base_F {
+    class I_Heli_Transport_02_F: Heli_Transport_02_base_F {
         GVAR(space) = 20;
         GVAR(hasCargo) = 1;
     };
@@ -284,14 +287,16 @@ class CfgVehicles {
         GVAR(size) = 2;
     };
 
-
     class Scrapyard_base_F;
     class Land_PaperBox_closed_F: Scrapyard_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 10;
         GVAR(hasCargo) = 1;
         GVAR(size) = 11;
         GVAR(canLoad) = 1;
-        XEH_ENABLED;
 
         class ACE_Actions {
             class ACE_MainActions {
@@ -323,163 +328,253 @@ class CfgVehicles {
         };
     };
     class Cargo10_base_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 14;
         GVAR(size) = 15;
-        XEH_ENABLED;
     };
     class Land_Cargo20_blue_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_brick_red_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_cyan_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_grey_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_light_blue_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_light_green_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_military_green_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
 
     class Ruins_F;
     class Land_Cargo20_military_ruins_F: Ruins_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
 
     class Land_Cargo20_orange_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_red_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_sand_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_vr_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_white_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
     class Land_Cargo20_yellow_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 49;
         GVAR(size) = 50;
-        XEH_ENABLED;
     };
 
     class Land_Cargo40_blue_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_brick_red_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_cyan_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_grey_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_light_blue_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_light_green_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_military_green_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
 
     class Land_Cargo40_military_ruins_F: Ruins_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
 
     class Land_Cargo40_orange_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_red_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_sand_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_vr_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_white_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
     class Land_Cargo40_yellow_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 99;
         GVAR(size) = 100;
-        XEH_ENABLED;
     };
 
     // small
     class Land_CargoBox_V1_F: ThingX {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(space) = 7;
         GVAR(hasCargo) = 1;
         GVAR(size) = 7;
-        XEH_ENABLED;
 
         class ACE_Actions {
             class ACE_MainActions {

--- a/addons/concertina_wire/CfgVehicles.hpp
+++ b/addons/concertina_wire/CfgVehicles.hpp
@@ -1,11 +1,13 @@
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Fence;
-    class ThingX;
-    class NonStrategic;
-
     class ACE_ConcertinaWireNoGeo: Fence {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         scope = 1;
         displayName = "";
         model = PATHTOF(data\ACE_ConcertinaWireNoGeo.p3d);
@@ -94,8 +96,13 @@ class CfgVehicles {
             };
         };
     };
+
+    class ThingX;
     class ACE_ConcertinaWireCoil: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         scope = 2;
         displayName = $STR_ACE_CONCERTINA_WIRECOIL;
         model = PATHTOF(data\ACE_ConcertinaWireCoil.p3d);
@@ -137,7 +144,10 @@ class CfgVehicles {
         };
     };
 
+    class NonStrategic;
     class Land_Razorwire_F: NonStrategic {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
     };
 };

--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -1,4 +1,6 @@
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     // Static weapons
     class LandVehicle;
@@ -85,7 +87,10 @@ class CfgVehicles {
 
     // Barrier
     class RoadCone_F: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canCarry) = 1;
         GVAR(carryPosition[]) = {0,1,1};
         GVAR(carryDirection) = 0;

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -1,3 +1,6 @@
+
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Man;
     class CAManBase: Man {
@@ -37,7 +40,10 @@ class CfgVehicles {
 
     class Items_base_F;
     class ACE_DefuseObject: Items_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         author = "ACE";
         _generalMacro = "ACE_DefuseObject";
         displayName = "ACE Defuse Helper";
@@ -66,7 +72,10 @@ class CfgVehicles {
         };
     };
     class ACE_Explosives_Place: Items_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         author = "ACE";
         _generalMacro = "ACE_Explosives_Place";
         displayName = "Multi-meter";

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -1,3 +1,6 @@
+
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class ACE_Module;
     class ACE_ModuleInteraction: ACE_Module {
@@ -539,8 +542,11 @@ class CfgVehicles {
 
     class Lamps_base_F;
     class Land_PortableLight_single_F: Lamps_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         scope = 2;
-        XEH_ENABLED;
         class ACE_Actions {
             class ACE_MainActions {
                 displayName = CSTRING(MainAction);

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -1,6 +1,8 @@
 
 #define MEDICAL_ACTION_DISTANCE 1.75
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Logic;
     class Module_F: Logic {
@@ -650,7 +652,10 @@ class CfgVehicles {
 
     class MapBoard_altis_F;
     class ACE_bodyBagObject: MapBoard_altis_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         scope = 1;
         scopeCurator = 2;
         side = -1;

--- a/addons/rearm/CfgVehicles.hpp
+++ b/addons/rearm/CfgVehicles.hpp
@@ -1,3 +1,4 @@
+
 #define MACRO_REARM_ACTIONS \
         class ACE_Actions { \
             class ACE_MainActions { \
@@ -13,8 +14,8 @@
         };
 
 #define MACRO_REARM_TRUCK_ACTIONS \
-        class ACE_Actions : ACE_Actions { \
-            class ACE_MainActions : ACE_MainActions { \
+        class ACE_Actions: ACE_Actions { \
+            class ACE_MainActions: ACE_MainActions { \
                 class GVAR(TakeAmmo) { \
                     displayName = CSTRING(TakeAmmo); \
                     distance = REARM_ACTION_DISTANCE; \
@@ -36,9 +37,11 @@
             }; \
         };
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class ACE_Module;
-    class ACE_moduleRearmSettings : ACE_Module {
+    class ACE_moduleRearmSettings: ACE_Module {
         scope = 2;
         displayName = CSTRING(RearmSettings_Module_DisplayName);
         icon = QUOTE(PATHTOF(ui\icon_module_rearm.paa));
@@ -76,66 +79,66 @@ class CfgVehicles {
     };
 
     class LandVehicle;
-    class Car : LandVehicle {
+    class Car: LandVehicle {
         MACRO_REARM_ACTIONS
     };
 
-    class Tank : LandVehicle {
+    class Tank: LandVehicle {
         MACRO_REARM_ACTIONS
     };
 
-    class StaticWeapon : LandVehicle {
+    class StaticWeapon: LandVehicle {
         MACRO_REARM_ACTIONS
     };
 
     class Air;
-    class Helicopter : Air {
+    class Helicopter: Air {
         MACRO_REARM_ACTIONS
     };
 
-    class Plane : Air {
+    class Plane: Air {
         MACRO_REARM_ACTIONS
     };
 
     class Ship;
-    class Ship_F : Ship {
+    class Ship_F: Ship {
         MACRO_REARM_ACTIONS
     };
 
 
     // Ammo Vehicles (with full inheritance for granted ACE_Actions)
-    class Car_F : Car {};
-    class Truck_F : Car_F {};
+    class Car_F: Car {};
+    class Truck_F: Car_F {};
 
-    class Truck_03_base_F : Truck_F {};
-    class O_Truck_03_ammo_F : Truck_03_base_F {
+    class Truck_03_base_F: Truck_F {};
+    class O_Truck_03_ammo_F: Truck_03_base_F {
         transportAmmo = 0;
         MACRO_REARM_TRUCK_ACTIONS
     };
 
-    class Truck_02_base_F : Truck_F {};
-    class Truck_02_Ammo_base_F : Truck_02_base_F {};
-    class I_Truck_02_ammo_F : Truck_02_Ammo_base_F {
+    class Truck_02_base_F: Truck_F {};
+    class Truck_02_Ammo_base_F: Truck_02_base_F {};
+    class I_Truck_02_ammo_F: Truck_02_Ammo_base_F {
         transportAmmo = 0;
         MACRO_REARM_TRUCK_ACTIONS
     };
-    class O_Truck_02_Ammo_F : Truck_02_Ammo_base_F {
-        transportAmmo = 0;
-        MACRO_REARM_TRUCK_ACTIONS
-    };
-
-    class Truck_01_base_F : Truck_F {};
-    class B_Truck_01_transport_F : Truck_01_base_F {};
-    class B_Truck_01_mover_F : B_Truck_01_transport_F {};
-    class B_Truck_01_ammo_F : B_Truck_01_mover_F {
+    class O_Truck_02_Ammo_F: Truck_02_Ammo_base_F {
         transportAmmo = 0;
         MACRO_REARM_TRUCK_ACTIONS
     };
 
-    class Helicopter_Base_F : Helicopter {};
-    class Helicopter_Base_H : Helicopter_Base_F {};
-    class Heli_Transport_04_base_F : Helicopter_Base_H {};
-    class O_Heli_Transport_04_ammo_F : Heli_Transport_04_base_F {
+    class Truck_01_base_F: Truck_F {};
+    class B_Truck_01_transport_F: Truck_01_base_F {};
+    class B_Truck_01_mover_F: B_Truck_01_transport_F {};
+    class B_Truck_01_ammo_F: B_Truck_01_mover_F {
+        transportAmmo = 0;
+        MACRO_REARM_TRUCK_ACTIONS
+    };
+
+    class Helicopter_Base_F: Helicopter {};
+    class Helicopter_Base_H: Helicopter_Base_F {};
+    class Heli_Transport_04_base_F: Helicopter_Base_H {};
+    class O_Heli_Transport_04_ammo_F: Heli_Transport_04_base_F {
         transportAmmo = 0;
         MACRO_REARM_TRUCK_ACTIONS
     };
@@ -158,8 +161,7 @@ class CfgVehicles {
         };
     };
 
-    class B_Slingload_01_Ammo_F : Slingload_01_Base_F {
-        XEH_ENABLED;
+    class B_Slingload_01_Ammo_F: Slingload_01_Base_F {
         transportAmmo = 0;
         MACRO_REARM_TRUCK_ACTIONS
     };
@@ -167,8 +169,11 @@ class CfgVehicles {
 
     // Dummy Vehicles
     class ThingX;
-    class GVAR(defaultCarriedObject) : ThingX {
-        XEH_ENABLED;
+    class GVAR(defaultCarriedObject): ThingX {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         displayName = QGVAR(dummy_obj);
         scope = 1;
         scopeCurator = 1;
@@ -187,59 +192,59 @@ class CfgVehicles {
             };
         };
     };
-    class GVAR(Bo_GBU12_LGB) : GVAR(defaultCarriedObject) {
+    class GVAR(Bo_GBU12_LGB): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Bomb_01_F.p3d";
     };
-    class GVAR(Bo_Mk82) : GVAR(defaultCarriedObject) {
+    class GVAR(Bo_Mk82): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Bomb_02_F";
     };
-    class GVAR(Bomb_04_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Bomb_04_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Bomb_04_F.p3d";
     };
-    class GVAR(Bomb_03_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Bomb_03_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Bomb_03_F.p3d";
     };
-    class GVAR(Missile_AA_04_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Missile_AA_04_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Missile_AA_04_F.p3d";
     };
-    class GVAR(Missile_AA_03_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Missile_AA_03_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Missile_AA_03_F.p3d";
     };
-    class GVAR(Missile_AGM_02_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Missile_AGM_02_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Missile_AGM_02_F.p3d";
     };
-    class GVAR(Missile_AGM_01_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Missile_AGM_01_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Missile_AGM_01_F.p3d";
     };
-    class GVAR(R_230mm_fly) : GVAR(defaultCarriedObject) {
+    class GVAR(R_230mm_fly): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Missile_AT_02_F";
     };
-    class GVAR(R_230mm_HE) : GVAR(defaultCarriedObject) {
+    class GVAR(R_230mm_HE): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Missile_AT_02_F";
     };
-    class GVAR(M_PG_AT) : GVAR(defaultCarriedObject) {
+    class GVAR(M_PG_AT): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Rocket_01_F";
     };
-    class GVAR(Rocket_04_HE_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Rocket_04_HE_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_04_HE_F.p3d";
     };
-    class GVAR(Rocket_03_HE_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Rocket_03_HE_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_03_HE_F.p3d";
     };
-    class GVAR(Rocket_04_AP_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Rocket_04_AP_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_04_AP_F.p3d";
     };
-    class GVAR(Rocket_03_AP_F) : GVAR(defaultCarriedObject) {
+    class GVAR(Rocket_03_AP_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_03_AP_F.p3d";
     };
     // Using wrong model
-    class GVAR(R_80mm_HE) : GVAR(defaultCarriedObject) {
+    class GVAR(R_80mm_HE): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_03_HE_F.p3d";
     };
-    class GVAR(R_60mm_HE) : GVAR(defaultCarriedObject) {
+    class GVAR(R_60mm_HE): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_03_HE_F.p3d";
     };
-    class GVAR(R_Hydra_HE) : GVAR(defaultCarriedObject) {
+    class GVAR(R_Hydra_HE): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Rocket_03_HE_F.p3d";
     };
 };

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -1,3 +1,4 @@
+
 #define MACRO_REFUEL_ACTIONS \
     class ACE_Actions: ACE_Actions { \
         class ACE_MainActions: ACE_MainActions { \
@@ -111,6 +112,8 @@
         }; \
     };
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class ACE_Module;
     class ACE_moduleRefuelSettings: ACE_Module {
@@ -135,7 +138,10 @@ class CfgVehicles {
 
     class ThingX;
     class ACE_refuel_fuelNozzle: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         MACRO_NOZZLE_ACTIONS
         displayName = QGVAR(fuelNozzle);
         scope = 1;
@@ -144,20 +150,16 @@ class CfgVehicles {
     };
 
     class All;
-
     class Static: All {};
-
     class Building: Static {};
-
     class NonStrategic: Building {};
-
     class HouseBase: NonStrategic {};
-
     class House: HouseBase {};
-
     class House_F: House {};
 
     class House_Small_F: House_F {
+        class EventHandlers;
+
         class ACE_Actions {
             class ACE_MainActions {
                 displayName = ECSTRING(interaction,MainAction);
@@ -490,8 +492,7 @@ class CfgVehicles {
         };
     };
 
-    class B_Slingload_01_Fuel_F: Slingload_01_Base_F  {
-        XEH_ENABLED;
+    class B_Slingload_01_Fuel_F: Slingload_01_Base_F {
         transportFuel = 0; //3k
         MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{0.55,3.02,-0.5},{-0.52,3.02,-0.5}};
@@ -524,7 +525,10 @@ class CfgVehicles {
         };
     };
     class Land_StorageBladder_01_F: StorageBladder_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         MACRO_REFUEL_ACTIONS
         transportFuel = 0; //60k
         GVAR(hooks)[] = {{-3.35,2.45,0.17}};
@@ -533,7 +537,10 @@ class CfgVehicles {
 
     // Vanilla buildings
     class Land_Fuelstation_Feed_F: House_Small_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         transportFuel = 0; //50k
         MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{0,0,-0.5}};
@@ -541,7 +548,10 @@ class CfgVehicles {
     };
 
     class Land_fs_feed_F: House_Small_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         transportFuel = 0; //50k
         MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{-0.4,0.022,-.23}};

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -15,6 +15,8 @@
         }; \
     };
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class ACE_Module;
     class ACE_moduleRepairSettings: ACE_Module {
@@ -304,7 +306,10 @@ class CfgVehicles {
 
     class ThingX;
     class ACE_RepairItem_Base: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         icon = "iconObject_circle";
         mapSize = 0.7;
         accuracy = 0.2;

--- a/addons/respawn/CfgEventHandlers.hpp
+++ b/addons/respawn/CfgEventHandlers.hpp
@@ -36,37 +36,37 @@ class Extended_Respawn_EventHandlers {
 class Extended_Init_EventHandlers {
     class ACE_Rallypoint_West {
         class ADDON {
-            init = QUOTE((_this select 0) setFlagTexture '\A3\Data_F\Flags\Flag_nato_CO.paa'; [ARR_3(_this select 0,'',west)] call FUNC(initRallypoint));
+            init = QUOTE([ARR_3(_this select 0,'',west)] call FUNC(initRallypoint));
         };
     };
 
     class ACE_Rallypoint_East {
         class ADDON {
-            init = QUOTE((_this select 0) setFlagTexture '\A3\Data_F\Flags\Flag_CSAT_CO.paa'; [ARR_3(_this select 0,'',east)] call FUNC(initRallypoint));
+            init = QUOTE([ARR_3(_this select 0,'',east)] call FUNC(initRallypoint));
         };
     };
 
     class ACE_Rallypoint_Independent {
         class ADDON {
-            init = QUOTE((_this select 0) setFlagTexture '\A3\Data_F\Flags\Flag_AAF_CO.paa'; [ARR_3(_this select 0,'',independent)] call FUNC(initRallypoint));
+            init = QUOTE([ARR_3(_this select 0,'',independent)] call FUNC(initRallypoint));
         };
     };
 
     class ACE_Rallypoint_West_Base {
         class ADDON {
-            init = QUOTE((_this select 0) setFlagTexture '\A3\Data_F\Flags\Flag_nato_CO.paa'; [ARR_3(_this select 0,'respawn_west',west)] call FUNC(initRallypoint));
+            init = QUOTE([ARR_3(_this select 0,'respawn_west',west)] call FUNC(initRallypoint));
         };
     };
 
     class ACE_Rallypoint_East_Base {
         class ADDON {
-            init = QUOTE((_this select 0) setFlagTexture '\A3\Data_F\Flags\Flag_CSAT_CO.paa'; [ARR_3(_this select 0,'respawn_east',east)] call FUNC(initRallypoint));
+            init = QUOTE([ARR_3(_this select 0,'respawn_east',east)] call FUNC(initRallypoint));
         };
     };
 
     class ACE_Rallypoint_Independent_Base {
         class ADDON {
-            init = QUOTE((_this select 0) setFlagTexture '\A3\Data_F\Flags\Flag_AAF_CO.paa'; [ARR_3(_this select 0,'respawn_guerrila',independent)] call FUNC(initRallypoint));  //respawn_civilian
+            init = QUOTE([ARR_3(_this select 0,'respawn_guerrila',independent)] call FUNC(initRallypoint));  //respawn_civilian
         };
     };
 };

--- a/addons/respawn/CfgVehicles.hpp
+++ b/addons/respawn/CfgVehicles.hpp
@@ -1,4 +1,6 @@
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class ACE_Module;
     class ACE_ModuleRespawn: ACE_Module {
@@ -78,20 +80,25 @@ class CfgVehicles {
     // rallypoints
     class FlagCarrier;
     class Flag_NATO_F: FlagCarrier {
+        class EventHandlers;
         class ACE_Actions;
     };
 
     class Flag_CSAT_F: FlagCarrier {
+        class EventHandlers;
         class ACE_Actions;
     };
 
     class Flag_AAF_F: FlagCarrier {
+        class EventHandlers;
         class ACE_Actions;
     };
 
     // static
     class ACE_Rallypoint_West_Base: Flag_NATO_F {
-        XEH_ENABLED;
+        class EventHandlers: EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
 
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(RallypointWestBase);
@@ -111,7 +118,9 @@ class CfgVehicles {
     };
 
     class ACE_Rallypoint_East_Base: Flag_CSAT_F {
-        XEH_ENABLED;
+        class EventHandlers: EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
 
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(RallypointEastBase);
@@ -131,7 +140,9 @@ class CfgVehicles {
     };
 
     class ACE_Rallypoint_Independent_Base: Flag_AAF_F {
-        XEH_ENABLED;
+        class EventHandlers: EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
 
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(RallypointIndependentBase);
@@ -152,7 +163,9 @@ class CfgVehicles {
 
     // moveable
     class ACE_Rallypoint_West: Flag_NATO_F {
-        XEH_ENABLED;
+        class EventHandlers: EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
 
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(RallypointWest);
@@ -172,7 +185,9 @@ class CfgVehicles {
     };
 
     class ACE_Rallypoint_East: Flag_CSAT_F {
-        XEH_ENABLED;
+        class EventHandlers: EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
 
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(RallypointEast);
@@ -192,7 +207,9 @@ class CfgVehicles {
     };
 
     class ACE_Rallypoint_Independent: Flag_AAF_F {
-        XEH_ENABLED;
+        class EventHandlers: EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
 
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(RallypointIndependent);

--- a/addons/sandbag/CfgVehicles.hpp
+++ b/addons/sandbag/CfgVehicles.hpp
@@ -1,4 +1,6 @@
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Man;
     class CAManBase: Man {
@@ -44,8 +46,11 @@ class CfgVehicles {
 
     class ThingX;
     class ACE_SandbagObject: ThingX {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         author = ECSTRING(common,ACETeam);
-        XEH_ENABLED;
         scope = 2;
         side = -1;
         model = PATHTOF(data\ace_sandbag_build.p3d);

--- a/addons/sitting/CfgVehicles.hpp
+++ b/addons/sitting/CfgVehicles.hpp
@@ -1,3 +1,6 @@
+
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class ACE_Module;
     class ACE_ModuleSitting: ACE_Module {
@@ -36,10 +39,13 @@ class CfgVehicles {
         };
     };
 
-    class ThingX;
     // Folding Chair
+    class ThingX;
     class Land_CampingChair_V1_F: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
         GVAR(sitPosition[]) = {0, -0.1, -0.45};
@@ -49,7 +55,10 @@ class CfgVehicles {
     };
     // Camping Chair
     class Land_CampingChair_V2_F: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
         GVAR(sitPosition[]) = {0, -0.1, -0.45};
@@ -58,10 +67,13 @@ class CfgVehicles {
         EGVAR(dragging,carryDirection) = 180;
     };
 
-    class Furniture_base_F;
     // Chair (Plastic)
+    class Furniture_base_F: ThingX {};
     class Land_ChairPlastic_F: Furniture_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 90;
         GVAR(sitPosition[]) = {0, 0, -0.5};
@@ -71,7 +83,10 @@ class CfgVehicles {
     };
     // Chair (Wooden)
     class Land_ChairWood_F: Furniture_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
         GVAR(sitPosition[]) = {0, -0.05, 0};
@@ -81,7 +96,10 @@ class CfgVehicles {
     };
     // Office Chair
     class Land_OfficeChair_01_F: Furniture_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
         GVAR(sitPosition[]) = {0, 0, -0.6};
@@ -91,7 +109,10 @@ class CfgVehicles {
     };
     // Rattan Chair
     class Land_RattanChair_01_F: Furniture_base_F {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         GVAR(canSit) = 1;
         GVAR(sitDirection) = 180;
         GVAR(sitPosition[]) = {0, -0.1, -1}; // Z must be -1 due to chair's geometry (magic floating seat point)

--- a/addons/spottingscope/CfgVehicles.hpp
+++ b/addons/spottingscope/CfgVehicles.hpp
@@ -1,4 +1,6 @@
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Man;
     class CAManBase: Man {
@@ -51,7 +53,10 @@ class CfgVehicles {
         };
     };
     class ACE_SpottingScopeObject: StaticATWeapon {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         scope = 1;
         side = 1;
         typicalCargo[] = {"Soldier"};

--- a/addons/tacticalladder/CfgVehicles.hpp
+++ b/addons/tacticalladder/CfgVehicles.hpp
@@ -1,4 +1,6 @@
 
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Man;
     class CAManBase: Man {
@@ -34,7 +36,10 @@ class CfgVehicles {
 
     class House;
     class ACE_TacticalLadder: House {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         displayName = CSTRING(DisplayName);
         class DestructionEffects {};
         model = PATHTOF(data\ace_tacticalladder.p3d);

--- a/addons/tripod/CfgVehicles.hpp
+++ b/addons/tripod/CfgVehicles.hpp
@@ -1,3 +1,6 @@
+
+class CBA_Extended_EventHandlers;
+
 class CfgVehicles {
     class Man;
     class CAManBase: Man {
@@ -34,7 +37,10 @@ class CfgVehicles {
 
     class ThingX;
     class ACE_TripodObject: ThingX {
-        XEH_ENABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
         EGVAR(dragging,canDrag) = 1;
         EGVAR(dragging,dragPosition[]) = {0,1,0};
         EGVAR(dragging,dragDirection) = 0;


### PR DESCRIPTION
### When merged this pull request will:

1. replace XEHENABLED macro with CBA_ExtendedEventHandlers class.
2. fix #3482, fix #3483

This way we can also add event handlers to these objects without updating CBA, because the classes are more flexible.

!!! You should still update your unbined CBA for the release / other RCs @Glowbal 