### PR TITLE
RHS Fastroping compatibility

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgEventHandlers.hpp
+++ b/optionals/compat_rhs_afrf3/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -1,4 +1,4 @@
-class cfgVehicles {
+class CfgVehicles {
     class LandVehicle;
     class Tank: LandVehicle {
         class NewTurret;
@@ -201,9 +201,58 @@ class cfgVehicles {
         EGVAR(refuel,fuelCapacity) = 3600;
     };
 
-    class Heli_Light_02_base_F;
+    class Helicopter_Base_F;
+    class Helicopter_Base_H: Helicopter_Base_F {
+        class EventHandlers;
+    };
+    class Heli_Light_02_base_F: Helicopter_Base_H {};
     class RHS_Mi8_base : Heli_Light_02_base_F {
         EGVAR(refuel,fuelCapacity) = 3700;
+        class EventHandlers: EventHandlers {
+            class RHS_EventHandlers;
+        };
+    };
+
+    class RHS_Mi8amt_base: RHS_Mi8_base {
+        EGVAR(fastroping,enabled) = 1;
+        EGVAR(fastroping,ropeOrigins)[] = {{-1.13, 4.67, -0.89}};
+        EGVAR(fastroping,onCut) = QFUNC(onCut);
+        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
+
+        class UserActions {
+            class openDoor;
+            class closeDoor_L: openDoor {
+                condition = QUOTE((this doorPhase 'LeftDoor' > 0.5) && {alive this} && {!(this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)])});
+            };
+        };
+
+        class EventHandlers: EventHandlers {
+            class RHS_EventHandlers: RHS_EventHandlers {
+                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
+            };
+        };
+    };
+
+    class RHS_Mi8_VVS_Base: RHS_Mi8_base {};
+    class RHS_Mi8mt_vvs: RHS_Mi8_VVS_Base {};
+    class RHS_Mi8mt_Cargo_vvs: RHS_Mi8mt_vvs {
+        EGVAR(fastroping,enabled) = 1;
+        EGVAR(fastroping,ropeOrigins)[] = {{-1.13, 4.67, -0.89}};
+        EGVAR(fastroping,onCut) = QFUNC(onCut);
+        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
+
+        class UserActions {
+            class openDoor;
+            class closeDoor_L: openDoor {
+                condition = QUOTE((this doorPhase 'LeftDoor' > 0.5) && {alive this} && {!(this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)])});
+            };
+        };
+
+        class EventHandlers: EventHandlers {
+            class RHS_EventHandlers: RHS_EventHandlers {
+                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
+            };
+        };
     };
 
     class Heli_Attack_02_base_F;

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -208,6 +208,7 @@ class CfgVehicles {
     class Heli_Light_02_base_F: Helicopter_Base_H {};
     class RHS_Mi8_base : Heli_Light_02_base_F {
         EGVAR(refuel,fuelCapacity) = 3700;
+        EGVAR(fastroping,enabled) = 0;
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers;
         };
@@ -228,7 +229,7 @@ class CfgVehicles {
 
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers: RHS_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
             };
         };
     };
@@ -250,7 +251,7 @@ class CfgVehicles {
 
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers: RHS_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
             };
         };
     };
@@ -258,10 +259,12 @@ class CfgVehicles {
     class Heli_Attack_02_base_F;
     class RHS_Ka52_base : Heli_Attack_02_base_F {
         EGVAR(refuel,fuelCapacity) = 1870;
+        EGVAR(fastroping,enabled) = 0;
     };
 
     class RHS_Mi24_base : Heli_Attack_02_base_F {
         EGVAR(refuel,fuelCapacity) = 1851;
+        EGVAR(fastroping,enabled) = 0;
     };
 
     class rhs_t80b : rhs_tank_base {

--- a/optionals/compat_rhs_afrf3/XEH_PREP.hpp
+++ b/optionals/compat_rhs_afrf3/XEH_PREP.hpp
@@ -1,0 +1,2 @@
+PREP(onCut);
+PREP(onPrepare);

--- a/optionals/compat_rhs_afrf3/XEH_preInit.sqf
+++ b/optionals/compat_rhs_afrf3/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/optionals/compat_rhs_afrf3/XEH_preStart.sqf
+++ b/optionals/compat_rhs_afrf3/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -6,12 +6,13 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_2s3", "rhs_c_rva"};
-        author[]={"Ruthberg", "GitHawk"};
+        author[]={"Ruthberg", "GitHawk", "BaerMitUmlaut"};
         VERSION_CONFIG;
     };
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_afrf3/functions/fnc_onCut.sqf
+++ b/optionals/compat_rhs_afrf3/functions/fnc_onCut.sqf
@@ -1,0 +1,23 @@
+/*
+ * Author: BaerMitUmlaut
+ * Function for closing doors and retracting the hooks for RHS USF helos.
+ *
+ * Arguments:
+ * 0: Helicopter <OBJECT>
+ *
+ * Return Value:
+ * Amount of time to wait before cutting ropes <NUMBER>
+ *
+ * Example:
+ * [_vehicle] call ace_compat_rhs_afrf3_fnc_onCut
+ *
+ * Public: No
+ */
+
+#include "..\script_component.hpp"
+params ["_vehicle"];
+
+_vehicle setVariable [QEGVAR(fastroping,doorsLocked), false, true];
+_vehicle animateDoor ["LeftDoor", 0];
+
+2

--- a/optionals/compat_rhs_afrf3/functions/fnc_onCut.sqf
+++ b/optionals/compat_rhs_afrf3/functions/fnc_onCut.sqf
@@ -14,7 +14,7 @@
  * Public: No
  */
 
-#include "..\script_component.hpp"
+#include "script_component.hpp"
 params ["_vehicle"];
 
 _vehicle setVariable [QEGVAR(fastroping,doorsLocked), false, true];

--- a/optionals/compat_rhs_afrf3/functions/fnc_onPrepare.sqf
+++ b/optionals/compat_rhs_afrf3/functions/fnc_onPrepare.sqf
@@ -1,0 +1,23 @@
+/*
+ * Author: BaerMitUmlaut
+ * Function for opening doors and extending the hook for most vanilla helos.
+ *
+ * Arguments:
+ * 0: Helicopter <OBJECT>
+ *
+ * Return Value:
+ * Amount of time to wait before deploying ropes <NUMBER>
+ *
+ * Example:
+ * [_vehicle] call ace_compat_rhs_afrf3_fnc_onPrepare
+ *
+ * Public: No
+ */
+
+#include "..\script_component.hpp"
+params ["_vehicle"];
+
+_vehicle setVariable [QEGVAR(fastroping,doorsLocked), true, true];
+_vehicle animateDoor ["LeftDoor", 1];
+
+2

--- a/optionals/compat_rhs_afrf3/functions/fnc_onPrepare.sqf
+++ b/optionals/compat_rhs_afrf3/functions/fnc_onPrepare.sqf
@@ -14,7 +14,7 @@
  * Public: No
  */
 
-#include "..\script_component.hpp"
+#include "script_component.hpp"
 params ["_vehicle"];
 
 _vehicle setVariable [QEGVAR(fastroping,doorsLocked), true, true];

--- a/optionals/compat_rhs_afrf3/functions/script_component.hpp
+++ b/optionals/compat_rhs_afrf3/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\ace\addons\compat_rhs_afrf3\script_component.hpp"

--- a/optionals/compat_rhs_afrf3/script_component.hpp
+++ b/optionals/compat_rhs_afrf3/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT rhs_c_weapons_comp
+#define COMPONENT compat_rhs_afrf3
 
 #include "\z\ace\addons\main\script_mod.hpp"
 

--- a/optionals/compat_rhs_usf3/CfgEventHandlers.hpp
+++ b/optionals/compat_rhs_usf3/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -1,4 +1,17 @@
-class cfgVehicles {
+#define EQUIP_FRIES_ATTRIBUTE class Attributes { \
+    class EGVAR(fastroping,equipFRIES) { \
+        property = QEGVAR(fastroping,equipFRIES); \
+        control = "Checkbox"; \
+        displayName = ECSTRING(fastroping,Eden_equipFRIES); \
+        tooltip = ECSTRING(fastroping,Eden_equipFRIES_Tooltip); \
+        expression = QUOTE([_this] call EFUNC(fastroping,equipFRIES)); \
+        typeName = "BOOL"; \
+        condition = "objectVehicle"; \
+        defaultValue = false; \
+    }; \
+}
+
+class CfgVehicles {
     class LandVehicle;
     class Tank: LandVehicle {
         class NewTurret;
@@ -44,19 +57,116 @@ class cfgVehicles {
         ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint", "era_33_hitpoint", "era_34_hitpoint", "era_35_hitpoint", "era_36_hitpoint", "era_37_hitpoint", "era_38_hitpoint", "era_39_hitpoint", "era_40_hitpoint", "era_41_hitpoint", "era_42_hitpoint", "era_43_hitpoint", "era_44_hitpoint", "era_45_hitpoint", "era_46_hitpoint"}}};
     };
 
-    class Heli_light_03_base_F;
+    class Helicopter;
+    class Helicopter_Base_F: Helicopter {
+        class Eventhandlers;
+    };
+    class Heli_Light_03_base_F: Helicopter_Base_F {};
     class RHS_UH1_Base: Heli_light_03_base_F {
         EGVAR(refuel,fuelCapacity) = 1447;
     };
 
-    class Heli_Transport_01_base_F;
+    class RHS_UH1Y_base: RHS_UH1_Base {};
+    class RHS_UH1Y_US_base: RHS_UH1Y_base {};
+    class RHS_UH1Y: RHS_UH1Y_US_base {
+        EGVAR(fastroping,enabled) = 2;
+        EGVAR(fastroping,friesType) = "ACE_friesAnchorBar";
+        EGVAR(fastroping,friesAttachmentPoint)[] = {0, 2.38, -0.135};
+        EGVAR(fastroping,onCut) = QFUNC(onCut);
+        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
+        EGVAR(fastroping,ropeOrigins)[] = {"ropeOriginLeft", "ropeOriginRight"};
+
+        class UserActions;
+        class EventHandlers: EventHandlers {
+            class RHSUSF_EventHandlers;
+        };
+
+        EQUIP_FRIES_ATTRIBUTE;
+    };
+    class RHS_UH1Y_FFAR: RHS_UH1Y {
+        class UserActions: UserActions {
+            class OpenCargoDoor;
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));
+            };
+            class CloseCargoLDoor: OpenCargoDoor {
+                condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
+            };
+        };
+
+        class EventHandlers: EventHandlers {
+            class RHSUSF_EventHandlers: RHSUSF_EventHandlers {
+                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
+            };
+        };
+    };
+
+    class Helicopter_Base_H: Helicopter_Base_F {
+        class Eventhandlers;
+    };
+    class Heli_Transport_01_base_F: Helicopter_Base_H {};
     class RHS_UH60_Base: Heli_Transport_01_base_F {
         EGVAR(refuel,fuelCapacity) = 1360;
+    };
+
+    class RHS_UH60M_base: RHS_UH60_Base {};
+    class RHS_UH60M_US_base: RHS_UH60M_base {};
+    class RHS_UH60M: RHS_UH60M_US_base {
+        EGVAR(fastroping,enabled) = 2;
+        EGVAR(fastroping,friesType) = "ACE_friesAnchorBar";
+        EGVAR(fastroping,friesAttachmentPoint)[] = {0, 1.25, -0.65};
+        EGVAR(fastroping,onCut) = QFUNC(onCut);
+        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
+        EGVAR(fastroping,ropeOrigins)[] = {"ropeOriginLeft", "ropeOriginRight"};
+
+        class UserActions {
+            class OpenCargoDoor;
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));
+            };
+            class CloseCargoLDoor: OpenCargoDoor {
+                condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
+            };
+        };
+
+        class EventHandlers: EventHandlers {
+            class RHSUSF_EventHandlers {
+                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
+            };
+        };
+
+        EQUIP_FRIES_ATTRIBUTE;
+    };
+
+    class RHS_UH60M_MEV: RHS_UH60M {
+        EGVAR(fastroping,enabled) = 0;
+        class Attributes {
+            delete EGVAR(fastroping,equipFRIES);
+        };
+    };
+
+    class RHS_UH60M_MEV2: RHS_UH60M_MEV {
+        EGVAR(fastroping,enabled) = 2;
+        EQUIP_FRIES_ATTRIBUTE;
     };
 
     class Heli_Transport_02_base_F;
     class RHS_CH_47F_base: Heli_Transport_02_base_F {
         EGVAR(refuel,fuelCapacity) = 3914;
+    };
+
+    class RHS_CH_47F: RHS_CH_47F_base {
+        EGVAR(fastroping,enabled) = 1;
+        EGVAR(fastroping,ropeOrigins)[] = {{0.5, -7.15, -0.95}, {-0.5, -7.15, -0.95}};
+        EGVAR(fastroping,onCut) = QFUNC(onCut);
+        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
+
+        class UserActions {
+            class OpenCargoDoor;
+            class CloseCargoDoor: OpenCargoDoor {
+                condition = QUOTE([ARR_2(this,'ramp_anim')] call FUNC(canCloseDoor));
+            };
+        };
     };
 
     class Heli_Attack_01_base_F;

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -96,7 +96,7 @@ class CfgVehicles {
 
         class EventHandlers: EventHandlers {
             class RHSUSF_EventHandlers: RHSUSF_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
             };
         };
     };
@@ -128,10 +128,9 @@ class CfgVehicles {
                 condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
             };
         };
-
         class EventHandlers: EventHandlers {
             class RHSUSF_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
             };
         };
 

--- a/optionals/compat_rhs_usf3/XEH_PREP.hpp
+++ b/optionals/compat_rhs_usf3/XEH_PREP.hpp
@@ -1,0 +1,3 @@
+PREP(canCloseDoor);
+PREP(onCut);
+PREP(onPrepare);

--- a/optionals/compat_rhs_usf3/XEH_preInit.sqf
+++ b/optionals/compat_rhs_usf3/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/optionals/compat_rhs_usf3/XEH_preStart.sqf
+++ b/optionals/compat_rhs_usf3/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -6,12 +6,13 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
-        author[]={"Ruthberg", "GitHawk"};
+        author[]={"Ruthberg", "GitHawk", "BaerMitUmlaut"};
         VERSION_CONFIG;
     };
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
@@ -1,0 +1,30 @@
+/*
+ * Author: BaerMitUmlaut
+ * Checks if the door can be closed.
+ *
+ * Arguments:
+ * 0: Helicopter <OBJECT>
+ * 1: Door <STRING>
+ *
+ * Return Value:
+ * Door can be closed <BOOL>
+ *
+ * Example:
+ * [_vehicle, "DoorLB"] call ace_compat_rhs_usf3_fnc_canCloseDoor
+ *
+ * Public: No
+ */
+
+#include "..\script_component.hpp"
+params ["_vehicle", "_door"];
+
+(_vehicle doorPhase _door > 0) &&
+{alive _vehicle} &&
+{!(_vehicle getVariable QEGVAR(fastroping,doorsLocked),false])} &&
+{
+    if (_vehicle isKindOf "RHS_CH_47F") then {
+        ACE_player in [driver _vehicle, _vehicle turretUnit [3], _vehicle turretUnit [4]]
+    } else {
+        ACE_player in _vehicle
+    }
+}

--- a/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-#include "..\script_component.hpp"
+#include "script_component.hpp"
 params ["_vehicle", "_door"];
 
 (_vehicle doorPhase _door > 0) &&

--- a/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
@@ -20,7 +20,7 @@ params ["_vehicle", "_door"];
 
 (_vehicle doorPhase _door > 0) &&
 {alive _vehicle} &&
-{!(_vehicle getVariable QEGVAR(fastroping,doorsLocked),false])} &&
+{!(_vehicle getVariable [QEGVAR(fastroping,doorsLocked),false])} &&
 {
     if (_vehicle isKindOf "RHS_CH_47F") then {
         ACE_player in [driver _vehicle, _vehicle turretUnit [3], _vehicle turretUnit [4]]

--- a/optionals/compat_rhs_usf3/functions/fnc_onCut.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_onCut.sqf
@@ -1,0 +1,36 @@
+/*
+ * Author: BaerMitUmlaut
+ * Function for closing doors and retracting the hooks for RHS USF helos.
+ *
+ * Arguments:
+ * 0: Helicopter <OBJECT>
+ *
+ * Return Value:
+ * Amount of time to wait before cutting ropes <NUMBER>
+ *
+ * Example:
+ * [_vehicle] call ace_compat_rhs_usf3_fnc_onCut
+ *
+ * Public: No
+ */
+
+#include "..\script_component.hpp"
+params ["_vehicle"];
+
+_vehicle setVariable [QEGVAR(fastroping,doorsLocked), false, true];
+
+private _fries = _vehicle getVariable [QEGVAR(fastroping,FRIES), objNull];
+if !(isNull _fries) then {
+    _fries animate ["extendHookRight", 0];
+    _fries animate ["extendHookLeft", 0];
+    [{
+        _this animateDoor ["doorRB", 0];
+        _this animateDoor ["doorLB", 0];
+    }, _vehicle, 2] call EFUNC(common,waitAndExecute);
+
+    4
+} else {
+    _vehicle animateDoor ["ramp_anim", 0];
+
+    2
+};

--- a/optionals/compat_rhs_usf3/functions/fnc_onCut.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_onCut.sqf
@@ -14,7 +14,7 @@
  * Public: No
  */
 
-#include "..\script_component.hpp"
+#include "script_component.hpp"
 params ["_vehicle"];
 
 _vehicle setVariable [QEGVAR(fastroping,doorsLocked), false, true];

--- a/optionals/compat_rhs_usf3/functions/fnc_onPrepare.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_onPrepare.sqf
@@ -1,0 +1,38 @@
+/*
+ * Author: BaerMitUmlaut
+ * Function for opening doors and extending the hook for most vanilla helos.
+ *
+ * Arguments:
+ * 0: Helicopter <OBJECT>
+ *
+ * Return Value:
+ * Amount of time to wait before deploying ropes <NUMBER>
+ *
+ * Example:
+ * [_vehicle] call ace_compat_rhs_usf3_fnc_onPrepare
+ *
+ * Public: No
+ */
+
+#include "..\script_component.hpp"
+params ["_vehicle"];
+private ["_fries", "_waitTime"];
+
+_vehicle setVariable [QEGVAR(fastroping,doorsLocked), true, true];
+
+_waitTime = 2;
+
+_vehicle animateDoor ["doorRB", 1];
+_vehicle animateDoor ["doorLB", 1];
+_vehicle animateDoor ["ramp_anim", 1];
+
+_fries = _vehicle getVariable [QEGVAR(fastroping,FRIES), objNull];
+if !(isNull _fries) then {
+    [{
+        _this animate ["extendHookRight", 1];
+        _this animate ["extendHookLeft", 1];
+    }, _fries, 2] call EFUNC(common,waitAndExecute);
+    _waitTime = 4;
+};
+
+_waitTime

--- a/optionals/compat_rhs_usf3/functions/fnc_onPrepare.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_onPrepare.sqf
@@ -14,7 +14,7 @@
  * Public: No
  */
 
-#include "..\script_component.hpp"
+#include "script_component.hpp"
 params ["_vehicle"];
 private ["_fries", "_waitTime"];
 

--- a/optionals/compat_rhs_usf3/functions/script_component.hpp
+++ b/optionals/compat_rhs_usf3/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\ace\addons\compat_rhs_usf3\script_component.hpp"

--- a/optionals/compat_rhs_usf3/script_component.hpp
+++ b/optionals/compat_rhs_usf3/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT rhsusf_c_weapons_comp
+#define COMPONENT compat_rhs_usf3
 
 #include "\z\ace\addons\main\script_mod.hpp"
 


### PR DESCRIPTION
### When merged this pull request will:

1. Add fastroping compatibility to the UH-60, CH-47, UH-1Y and Mi-8 Helicopters. Note that only the Mi-8 variants without a door gunner are supported.
2. ~~***Not work as of right now.***  
For some reason, the `ARR_2` macros do not resolve properly, and I need some help because I have no idea why.
For example `condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));` resolves to `condition="[this";` which is obviously not correct.~~  
Works now, the issue were outdated Mikero tools.
