### PR TITLE
Fix for player markers not showing up correctly with BFT_ShowPlayerNames

### DIFF
--- a/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
@@ -33,7 +33,7 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
             private _markerType = [_x] call EFUNC(common,getMarkerType);
             private _colour = format ["Color%1", side _x];
 
-            private _marker = createMarkerLocal [format ["ACE_BFT_%1", _forEachIndex], [(getPos leader _x) select 0, (getPos leader _x) select 1]];
+            private _marker = createMarkerLocal [format ["ACE_BFT_%1", _forEachIndex], [(getPos _x) select 0, (getPos _x) select 1]];
             _marker setMarkerTypeLocal _markerType;
             _marker setMarkerColorLocal _colour;
             _marker setMarkerTextLocal (name _x);


### PR DESCRIPTION
### When merged this pull request will:

1. Fix player markers not showing up correctly in multiplayer when BFT_ShowPlayerNames is enabled
