### PR TITLE
Fix portable light floating / dir when carrying

### DIFF
--- a/addons/common/functions/fnc_fixPosition.sqf
+++ b/addons/common/functions/fnc_fixPosition.sqf
@@ -16,6 +16,16 @@
 // setVectorUp requires local object
 if (!local _this) exitWith {};
 
+if ((getText (configFile >> "CfgVehicles" >> (typeOf _this) >> "simulation")) == "house") then {
+    //Houses don't have gravity/physics, so make sure they are not floating
+    private _posAbove = (getPos _this) select 2;
+    TRACE_2("house",_this,_posAbove);
+    if (_posAbove > 0.1) then {
+        private _newPosASL = (getPosASL _this) vectorDiff [0,0,_posAbove];
+        _this setPosASL _newPosASL;
+    };
+};
+
 private _position = getPos _this;
 
 // don't place the object below the ground

--- a/addons/dragging/functions/fnc_handleScrollWheel.sqf
+++ b/addons/dragging/functions/fnc_handleScrollWheel.sqf
@@ -40,4 +40,8 @@ detach _carriedItem;
 _carriedItem setPosATL _position;
 _carriedItem attachTo [_unit];
 
+//reset the carry direction
+private _direction = _carriedItem getVariable [QGVAR(carryDirection), 0];
+["setDir", _carriedItem, [_carriedItem, _direction]] call EFUNC(common,targetEvent);
+
 true


### PR DESCRIPTION
### When merged this pull request will:

Fix #3486
 - Set "house" type objects to have a `getPos` hegiht of 0.
 - Also update `carryDirection` after each re-attach from mouse wheel scrolling