### PR TITLE
Replace addScrollWheelEventHandler with MouseZChanged Display EH

### DIFF
--- a/addons/common/functions/fnc_addScrollWheelEventHandler.sqf
+++ b/addons/common/functions/fnc_addScrollWheelEventHandler.sqf
@@ -15,6 +15,8 @@
 
 params ["_statement"];
 
+ACE_DEPRECATED("ace_common_fnc_addScrollWheelEventHandler", "3.8.0", "'MouseZChanged' Display EventHandler");
+
 if (_statement isEqualType "") then {
     _statement = compile _statement;
 };

--- a/addons/common/init_handleModifierKey.sqf
+++ b/addons/common/init_handleModifierKey.sqf
@@ -12,9 +12,17 @@
  */
 #include "script_component.hpp"
 
-disableSerialization;
+_this spawn {//
+    waitUntil {!isNull findDisplay 46};//
+    sleep 2;//
 
-params ["_display"];
+    disableSerialization;
 
-_display displayAddEventHandler ["KeyDown", FUNC(handleModifierKey)];
-_display displayAddEventHandler ["KeyUp", FUNC(handleModifierKeyUp)];
+    params ["_display"];
+
+    _display displayAddEventHandler ["KeyDown", {_this call FUNC(handleModifierKey)}];
+    _display displayAddEventHandler ["KeyUp", {_this call FUNC(handleModifierKeyUp)}];
+};//
+
+//@todo, remove all lines with comments after CBA update, events rewrite branch
+// note 2, will break in save games after ~ 10 seconds thanks to CBA, fixed with above

--- a/addons/dragging/CfgEventHandlers.hpp
+++ b/addons/dragging/CfgEventHandlers.hpp
@@ -55,3 +55,9 @@ class Extended_AnimChanged_EventHandlers {
         };
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/dragging/XEH_missionDisplayLoad.sqf
+++ b/addons/dragging/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/dragging/XEH_postInit.sqf
+++ b/addons/dragging/XEH_postInit.sqf
@@ -8,8 +8,6 @@ if (isServer) then {
 
 if (!hasInterface) exitWith {};
 
-[{_this call FUNC(handleScrollWheel)}] call EFUNC(common,addScrollWheelEventHandler);
-
 if (isNil "ACE_maxWeightDrag") then {
     ACE_maxWeightDrag = 800;
 };

--- a/addons/explosives/CfgEventHandlers.hpp
+++ b/addons/explosives/CfgEventHandlers.hpp
@@ -32,3 +32,9 @@ class Extended_Put_EventHandlers {
         GVAR(takeHandler) = QUOTE([ARR_3(_this select 1, _this select 0, _this select 2)] call FUNC(onInventoryChanged));
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/explosives/XEH_missionDisplayLoad.sqf
+++ b/addons/explosives/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/explosives/XEH_postInit.sqf
+++ b/addons/explosives/XEH_postInit.sqf
@@ -81,5 +81,3 @@ if (isServer) then {
     _this call FUNC(interactEH);
 
 }] call EFUNC(common,addEventHandler);
-
-[{(_this select 0) call FUNC(handleScrollWheel);}] call EFUNC(common,addScrollWheelEventHandler);

--- a/addons/interaction/CfgEventHandlers.hpp
+++ b/addons/interaction/CfgEventHandlers.hpp
@@ -24,3 +24,9 @@ class Extended_Respawn_EventHandlers {
         };
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/interaction/XEH_missionDisplayLoad.sqf
+++ b/addons/interaction/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -32,8 +32,6 @@ if (!hasInterface) exitWith {};
 
 GVAR(isOpeningDoor) = false;
 
-[{_this call FUNC(handleScrollWheel)}] call EFUNC(common,addScrollWheelEventHandler);
-
 ["tapShoulder", {
     params ["_unit", "_shoulderNum"];
 

--- a/addons/sandbag/CfgEventHandlers.hpp
+++ b/addons/sandbag/CfgEventHandlers.hpp
@@ -32,3 +32,9 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/sandbag/XEH_missionDisplayLoad.sqf
+++ b/addons/sandbag/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/sandbag/XEH_postInit.sqf
+++ b/addons/sandbag/XEH_postInit.sqf
@@ -11,8 +11,6 @@ GVAR(sandBag) = objNull;
 GVAR(deployPFH) = -1;
 GVAR(deployDirection) = 0;
 
-[{_this call FUNC(handleScrollWheel)}] call EFUNC(common,addScrollWheelEventHandler);
-
 // Cancel deploy sandbag if interact menu opened
 ["interactMenuOpened", {[ACE_player] call FUNC(handleInteractMenuOpened)}] call EFUNC(common,addEventHandler);
 

--- a/addons/tacticalladder/CfgEventHandlers.hpp
+++ b/addons/tacticalladder/CfgEventHandlers.hpp
@@ -24,3 +24,9 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/tacticalladder/XEH_missionDisplayLoad.sqf
+++ b/addons/tacticalladder/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/tacticalladder/XEH_postInit.sqf
+++ b/addons/tacticalladder/XEH_postInit.sqf
@@ -16,8 +16,6 @@ GVAR(currentAngle) = 0;
 // Cancel adjustment if interact menu opens
 ["interactMenuOpened", {[ACE_player] call FUNC(handleInteractMenuOpened)}] call EFUNC(common,addEventHandler);
 
-[{_this call FUNC(handleScrollWheel)}] call EFUNC(common,addScrollWheelEventHandler);
-
 // Cancel adjusting on player change.
 ["playerChanged", {_this call FUNC(handlePlayerChanged)}] call EFUNC(common,addEventhandler);
 ["playerVehicleChanged", {[ACE_player, objNull] call FUNC(handlePlayerChanged)}] call EFUNC(common,addEventhandler);

--- a/addons/trenches/CfgEventHandlers.hpp
+++ b/addons/trenches/CfgEventHandlers.hpp
@@ -24,3 +24,9 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/trenches/XEH_missionDisplayLoad.sqf
+++ b/addons/trenches/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/trenches/XEH_postInit.sqf
+++ b/addons/trenches/XEH_postInit.sqf
@@ -12,8 +12,6 @@ GVAR(trench) = objNull;
 GVAR(digPFH) = -1;
 GVAR(digDirection) = 0;
 
-[{_this call FUNC(handleScrollWheel)}] call EFUNC(common,addScrollWheelEventHandler);
-
 // Cancel dig sandbag if interact menu opened
 ["interactMenuOpened", {[ACE_player] call FUNC(handleInteractMenuOpened)}] call EFUNC(common,addEventHandler);
 

--- a/addons/tripod/CfgEventHandlers.hpp
+++ b/addons/tripod/CfgEventHandlers.hpp
@@ -32,3 +32,9 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
+    };
+};

--- a/addons/tripod/XEH_missionDisplayLoad.sqf
+++ b/addons/tripod/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];

--- a/addons/tripod/XEH_postInit.sqf
+++ b/addons/tripod/XEH_postInit.sqf
@@ -9,8 +9,6 @@ GVAR(height) = 0;
 // Cancel adjustment if interact menu opens
 ["interactMenuOpened", {[ACE_player] call FUNC(handleInteractMenuOpened)}] call EFUNC(common,addEventHandler);
 
-[{_this call FUNC(handleScrollWheel)}] call EFUNC(common,addScrollWheelEventHandler);
-
 // Cancel adjusting on player change.
 ["playerChanged", {_this call FUNC(handlePlayerChanged)}] call EFUNC(common,addEventhandler);
 ["playerVehicleChanged", {[ACE_player, objNull] call FUNC(handlePlayerChanged)}] call EFUNC(common,addEventhandler);


### PR DESCRIPTION
**When merged this pull request will:**
- Deprecate `EFUNC(common,addScrollWheelEventHandler)`
- Use `MouseZChanged` instead of `EFUNC(common,addScrollWheelEventHandler)`
- Fixes part of #3499 

Needs some testing to make sure it all works.
Also make sure to test with `ACE_Modifier = 1` as that has it's own problems.