### PR TITLE
Increase interaction distance with explosives from 1m to 1.5m. 

### DIFF
--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -56,7 +56,7 @@ class CfgVehicles {
         class ACE_Actions {
             class ACE_MainActions {
                 selection = "";
-                distance = 1.5;
+                distance = 1;
                 condition = "true";
                 class ACE_Defuse {
                     displayName = CSTRING(Defuse);
@@ -66,7 +66,6 @@ class CfgVehicles {
                     showDisabled = 0;
                     icon = PATHTOF(UI\Defuse_ca.paa);
                     priority = 0.8;
-                    distance = 1;
                 };
             };
         };

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -56,7 +56,7 @@ class CfgVehicles {
         class ACE_Actions {
             class ACE_MainActions {
                 selection = "";
-                distance = 1;
+                distance = 1.5;
                 condition = "true";
                 class ACE_Defuse {
                     displayName = CSTRING(Defuse);
@@ -88,12 +88,11 @@ class CfgVehicles {
         class ACE_Actions {
             class ACE_MainActions {
                 selection = "";
-                distance = 1;
+                distance = 1.5;
                 condition = "true";
                 class ACE_SetTrigger {
                     selection = "";
                     displayName = CSTRING(TriggerMenu);
-                    distance = 1;
                     condition = "true";
                     statement = "";
                     insertChildren = QUOTE([ARR_3(_target getVariable QUOTE(QGVAR(class)),_target,_player)] call FUNC(addTriggerActions););
@@ -105,7 +104,6 @@ class CfgVehicles {
                 class ACE_PickUp {
                     selection = "";
                     displayName = CSTRING(Pickup);
-                    distance = 1;
                     condition = "true";
                     statement = QUOTE([ARR_2(_player,_target getVariable QUOTE(QGVAR(class)))] call EFUNC(common,addToInventory);deleteVehicle _target;);
                     showDisabled = 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Increase interaction distance with explosives from 1m to 1.5m. 
- Fix #3379

It's a nice usability enhancement, that makes placing explosives quicker and more streamlined.