### PR TITLE
Remove download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
     <a href="https://github.com/acemod/ACE3/releases">
         <img src="https://img.shields.io/badge/Version-3.5.0-blue.svg?style=flat-square" alt="ACE3 Version">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.5.0/ace3_3.5.0.zip">
-        <img src="https://img.shields.io/badge/Download-72.6_MB-green.svg?style=flat-square" alt="ACE3 Download">
-    </a>
     <a href="https://github.com/acemod/ACE3/issues">
         <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?style=flat-square&label=Issues" alt="ACE3 Issues">
     </a>

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -6,9 +6,6 @@
     <a href="https://github.com/acemod/ACE3/releases">
         <img src="https://img.shields.io/badge/Version-3.5.0-blue.svg?style=flat-square" alt="ACE3 Version">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.5.0/ace3_3.5.0.zip">
-        <img src="https://img.shields.io/badge/Download-72.6_MB-green.svg?style=flat-square" alt="ACE3 Download">
-    </a>
     <a href="https://github.com/acemod/ACE3/issues">
         <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?style=flat-square&label=Issues" alt="ACE3 Fehlermeldungen">
     </a>

--- a/docs/README_PL.md
+++ b/docs/README_PL.md
@@ -5,9 +5,6 @@
     <a href="https://github.com/acemod/ACE3/releases">
         <img src="https://img.shields.io/badge/Wersja-3.5.0-blue.svg?style=flat-square" alt="ACE3 Wersja">
     </a>
-    <a href="https://github.com/acemod/ACE3/releases/download/v3.5.0/ace3_3.5.0.zip">
-        <img src="https://img.shields.io/badge/Pobierz-65.7_MB-green.svg?style=flat-square" alt="ACE3 Pobierz">
-    </a>
     <a href="https://github.com/acemod/ACE3/issues">
         <img src="https://img.shields.io/github/issues-raw/acemod/ACE3.svg?label=Zagadnienia&style=flat-square" alt="ACE3 Zagadnienia">
     </a>


### PR DESCRIPTION
**When merged this pull request will:**
- Remove "Download" badge from README.md (plus DE and PL versions)
- "Version" badge links to release page anyways
- Less stuff to maintain == more development time