### PR TITLE
Set sandbag side to civ to show in 3den

### DIFF
--- a/addons/sandbag/CfgVehicles.hpp
+++ b/addons/sandbag/CfgVehicles.hpp
@@ -52,7 +52,7 @@ class CfgVehicles {
 
         author = ECSTRING(common,ACETeam);
         scope = 2;
-        side = -1;
+        side = 3;
         model = PATHTOF(data\ace_sandbag_build.p3d);
         displayName = CSTRING(sandbag_displayName);
         vehicleClass = "ACE_Logistics_Items";


### PR DESCRIPTION
Apparently `side = -1` will show in 2d, but not 3d.
ref #3102 #2633