### PR TITLE
Disallow refueling with running engine

### DIFF
--- a/addons/refuel/functions/fnc_canTurnOn.sqf
+++ b/addons/refuel/functions/fnc_canTurnOn.sqf
@@ -27,4 +27,5 @@ if (isNull _unit  ||
 !(_nozzle getVariable [QGVAR(isRefueling), false]) &&
     {[_nozzle getVariable QGVAR(source)] call FUNC(getFuel) != 0} &&
     {!isNull (_nozzle getVariable [QGVAR(sink), objNull])} &&
-    {(fuel (_nozzle getVariable QGVAR(sink))) < 1}
+    {(fuel (_nozzle getVariable QGVAR(sink))) < 1} &&
+    {!(isEngineOn (_nozzle getVariable QGVAR(sink)))}

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -52,6 +52,9 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
     private _finished = false;
     private _fueling = _nozzle getVariable [QGVAR(isRefueling), false];
     if (_fueling) then {
+        if (isEngineOn _sink) exitWith {
+            _nozzle setVariable [QGVAR(isRefueling), false, true];
+        };
         private _fuelInSource = [_source] call FUNC(getFuel);
         if (_fuelInSource == 0) exitWith {
             [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);


### PR DESCRIPTION
Extending #2954 by disallowing refueling with a running engine in both canTurnOn and the refuel PFH