### PR TITLE
Allow string input for isBackpack

### DIFF
--- a/addons/backpacks/functions/fnc_isBackpack.sqf
+++ b/addons/backpacks/functions/fnc_isBackpack.sqf
@@ -12,7 +12,7 @@
  */
 #include "script_component.hpp"
 
-params [["_backpack", objNull, [objNull]]];
+params [["_backpack", objNull, [objNull, ""]]];
 
 if (_backpack isEqualType objNull) then {
     _backpack = typeOf _backpack;


### PR DESCRIPTION
**When merged this pull request will:**
- Revert change in `params` in #3125
- Allow string input in `isBackpack` function again
- Restores compatibility, this is a public function