### PR TITLE
Replace execRemoteFnc with events and increase fuel update delay in refuel

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -158,6 +158,9 @@ if (isServer) then {
     ["enableSimulationGlobal", {(_this select 0) enableSimulationGlobal (_this select 1)}] call FUNC(addEventHandler);
 };
 
+["setVectorDirAndUp", {(_this select 0) setVectorDirAndUp (_this select 1)}] call FUNC(addEventHandler);
+["setHitPointDamage", {(_this select 0) setHitPointDamage (_this select 1)}] call FUNC(addEventHandler);
+
 
 //////////////////////////////////////////////////
 // Set up remote execution

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -153,7 +153,7 @@ if (isServer) then {
 ["playMoveNow", {(_this select 0) playMoveNow (_this select 1)}] call FUNC(addEventHandler);
 ["switchMove", {(_this select 0) switchMove (_this select 1)}] call FUNC(addEventHandler);
 ["setVectorDirAndUp", {(_this select 0) setVectorDirAndUp (_this select 1)}] call FUNC(addEventHandler);
-["setHitPointDamage", {(_this select 0) setHitPointDamage (_this select 1)}] call FUNC(addEventHandler);
+["setVanillaHitPointDamage", {(_this select 0) setHitPointDamage (_this select 1)}] call FUNC(addEventHandler);
 
 if (isServer) then {
     ["hideObjectGlobal", {(_this select 0) hideObjectGlobal (_this select 1)}] call FUNC(addEventHandler);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -152,14 +152,13 @@ if (isServer) then {
 ["playMove", {(_this select 0) playMove (_this select 1)}] call FUNC(addEventHandler);
 ["playMoveNow", {(_this select 0) playMoveNow (_this select 1)}] call FUNC(addEventHandler);
 ["switchMove", {(_this select 0) switchMove (_this select 1)}] call FUNC(addEventHandler);
+["setVectorDirAndUp", {(_this select 0) setVectorDirAndUp (_this select 1)}] call FUNC(addEventHandler);
+["setHitPointDamage", {(_this select 0) setHitPointDamage (_this select 1)}] call FUNC(addEventHandler);
 
 if (isServer) then {
     ["hideObjectGlobal", {(_this select 0) hideObjectGlobal (_this select 1)}] call FUNC(addEventHandler);
     ["enableSimulationGlobal", {(_this select 0) enableSimulationGlobal (_this select 1)}] call FUNC(addEventHandler);
 };
-
-["setVectorDirAndUp", {(_this select 0) setVectorDirAndUp (_this select 1)}] call FUNC(addEventHandler);
-["setHitPointDamage", {(_this select 0) setHitPointDamage (_this select 1)}] call FUNC(addEventHandler);
 
 
 //////////////////////////////////////////////////

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -5,3 +5,20 @@
 if (isServer) then {
     addMissionEventHandler ["HandleDisconnect", {_this call FUNC(handleDisconnect)}];
 };
+
+// @todo move to common?
+[QGVAR(setVectorDirAndUp), {
+    params ["_vehicle", "_vectorDirAndUp"];
+
+    if (local _vehicle) then {
+        (_this select 0) setVectorDirAndUp (_this select 1)
+    };
+}] call EFUNC(common,addEventHandler);
+
+[QGVAR(setVehicleHitPointDamage), {
+    (_this select 0) setHitPointDamage (_this select 1);
+}] call EFUNC(common,addEventHandler);
+
+[QGVAR(resetLocal), {
+    _this call FUNC(resetLocal);
+}] call EFUNC(common,addEventHandler);

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -6,19 +6,6 @@ if (isServer) then {
     addMissionEventHandler ["HandleDisconnect", {_this call FUNC(handleDisconnect)}];
 };
 
-// @todo move to common?
-[QGVAR(setVectorDirAndUp), {
-    params ["_vehicle", "_vectorDirAndUp"];
-
-    if (local _vehicle) then {
-        (_this select 0) setVectorDirAndUp (_this select 1)
-    };
-}] call EFUNC(common,addEventHandler);
-
-[QGVAR(setVehicleHitPointDamage), {
-    (_this select 0) setHitPointDamage (_this select 1);
-}] call EFUNC(common,addEventHandler);
-
 [QGVAR(resetLocal), {
     _this call FUNC(resetLocal);
 }] call EFUNC(common,addEventHandler);

--- a/addons/refuel/functions/fnc_checkFuel.sqf
+++ b/addons/refuel/functions/fnc_checkFuel.sqf
@@ -27,9 +27,9 @@ private _fuel = [_target] call FUNC(getFuel);
         params ["_args"];
         _args params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]], ["_fuel", 0, [0]]];
         if (_fuel > 0 ) then {
-            ["displayTextStructured", [_unit], [[LSTRING(Hint_RemainingFuel), _fuel], 2, _unit]] call EFUNC(common,targetEvent);
+            ["displayTextStructured", _unit, [[LSTRING(Hint_RemainingFuel), _fuel], 2, _unit]] call EFUNC(common,objectEvent);
         } else {
-            ["displayTextStructured", [_unit], [LSTRING(Hint_Empty), 2, _unit]] call EFUNC(common,targetEvent);
+            ["displayTextStructured", _unit, [LSTRING(Hint_Empty), 2, _unit]] call EFUNC(common,objectEvent);
         };
         true
     },

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -119,7 +119,7 @@ _endPosTestOffset set [2, (_startingOffset select 2)];
                 };
             };
         };
-        [QGVAR(setVectorDirAndUp), [_nozzle, _dirAndUp]] call EFUNC(common,globalEvent);
+        ["setVectorDirAndUp", _nozzle, [_nozzle, _dirAndUp]] call EFUNC(common,targetEvent);
         _nozzle setVariable [QGVAR(sink), _target, true];
         _nozzle setVariable [QGVAR(isConnected), true, true];
         _target setVariable [QGVAR(nozzle), _nozzle, true];

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -119,7 +119,7 @@ _endPosTestOffset set [2, (_startingOffset select 2)];
                 };
             };
         };
-        ["setVectorDirAndUp", _nozzle, [_nozzle, _dirAndUp]] call EFUNC(common,targetEvent);
+        ["setVectorDirAndUp", _nozzle, [_nozzle, _dirAndUp]] call EFUNC(common,objectEvent);
         _nozzle setVariable [QGVAR(sink), _target, true];
         _nozzle setVariable [QGVAR(isConnected), true, true];
         _target setVariable [QGVAR(nozzle), _nozzle, true];

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -119,7 +119,7 @@ _endPosTestOffset set [2, (_startingOffset select 2)];
                 };
             };
         };
-        [[_nozzle, _dirAndUp], "{(_this select 0) setVectorDirAndUp (_this select 1)}", 2] call EFUNC(common,execRemoteFnc);
+        [QGVAR(setVectorDirAndUp), [_nozzle, _dirAndUp]] call EFUNC(common,globalEvent);
         _nozzle setVariable [QGVAR(sink), _target, true];
         _nozzle setVariable [QGVAR(isConnected), true, true];
         _target setVariable [QGVAR(nozzle), _nozzle, true];

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -77,7 +77,7 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
         _unit setVariable [QGVAR(tempFuel), _fuelInSink];
 
         if !(local _sink) then {
-            ["setFuel", _sink [_sink, _fuelInSink]] call EFUNC(common,targetEvent);
+            ["setFuel", _sink, [_sink, _fuelInSink]] call EFUNC(common,targetEvent);
         } else {
             _sink setFuel _fuelInSink;
         };

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -77,7 +77,7 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
         _unit setVariable [QGVAR(tempFuel), _fuelInSink];
 
         if !(local _sink) then {
-            [[_sink, _fuelInSink], "{(_this select 0) setFuel (_this select 1)}", _sink] call EFUNC(common,execRemoteFnc);
+            ["setFuel", _sink [_sink, _fuelInSink]] call EFUNC(common,targetEvent);
         } else {
             _sink setFuel _fuelInSink;
         };

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-#define PFH_STEPSIZE 0.1
+#define PFH_STEPSIZE 1
 
 params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]], ["_nozzle", objNull, [objNull]], ["_connectToPoint", [0,0,0], [[]], 3]];
 

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -76,11 +76,7 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
         };
         _unit setVariable [QGVAR(tempFuel), _fuelInSink];
 
-        if !(local _sink) then {
-            ["setFuel", _sink, [_sink, _fuelInSink]] call EFUNC(common,targetEvent);
-        } else {
-            _sink setFuel _fuelInSink;
-        };
+        ["setFuel", _sink, [_sink, _fuelInSink]] call EFUNC(common,objectEvent);
         [_source, _fuelInSource] call FUNC(setFuel);
     } else {
         _unit setVariable [QGVAR(tempFuel), fuel _sink];

--- a/addons/refuel/functions/fnc_reset.sqf
+++ b/addons/refuel/functions/fnc_reset.sqf
@@ -17,7 +17,7 @@
 
 params [["_target", objNull, [objNull]]];
 
-["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,objectEvent);
+["setVanillaHitPointDamage", _target, [_target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]] ] ] call EFUNC(common,objectEvent);
 
 _target setVariable [QGVAR(engineHit), nil, true];
 _target setVariable [QGVAR(isConnected), false, true];

--- a/addons/refuel/functions/fnc_reset.sqf
+++ b/addons/refuel/functions/fnc_reset.sqf
@@ -20,7 +20,7 @@ params [["_target", objNull, [objNull]]];
 if (local _target) then {
     _target setHitPointDamage ["HitEngine", _target getVariable [QGVAR(engineHit), 0]];
 } else {
-    [QGVAR(setVehicleHitPointDamage), _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
+    ["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
 };
 _target setVariable [QGVAR(engineHit), nil, true];
 _target setVariable [QGVAR(isConnected), false, true];

--- a/addons/refuel/functions/fnc_reset.sqf
+++ b/addons/refuel/functions/fnc_reset.sqf
@@ -17,11 +17,8 @@
 
 params [["_target", objNull, [objNull]]];
 
-if (local _target) then {
-    _target setHitPointDamage ["HitEngine", _target getVariable [QGVAR(engineHit), 0]];
-} else {
-    ["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
-};
+["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,objectEvent);
+
 _target setVariable [QGVAR(engineHit), nil, true];
 _target setVariable [QGVAR(isConnected), false, true];
 
@@ -38,11 +35,7 @@ if !(isNil "_nozzle") then {
     };
 
     {
-        if (local _x) then {
-            [_x, _nozzle] call FUNC(resetLocal);
-        } else {
-            [QGVAR(resetLocal), _x, [_x, _nozzle]] call EFUNC(common,targetEvent);
-        };
+        [QGVAR(resetLocal), _x, [_x, _nozzle]] call EFUNC(common,objectEvent);
     } count allPlayers;
     deleteVehicle _nozzle;
 };

--- a/addons/refuel/functions/fnc_reset.sqf
+++ b/addons/refuel/functions/fnc_reset.sqf
@@ -20,7 +20,7 @@ params [["_target", objNull, [objNull]]];
 if (local _target) then {
     _target setHitPointDamage ["HitEngine", _target getVariable [QGVAR(engineHit), 0]];
 } else {
-    [[_target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]], "{(_this select 0) setHitPointDamage (_this select 1)}", _target] call EFUNC(common,execRemoteFnc);
+    [QGVAR(setVehicleHitPointDamage), _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
 };
 _target setVariable [QGVAR(engineHit), nil, true];
 _target setVariable [QGVAR(isConnected), false, true];
@@ -41,7 +41,7 @@ if !(isNil "_nozzle") then {
         if (local _x) then {
             [_x, _nozzle] call FUNC(resetLocal);
         } else {
-            [[_x, _nozzle], "{_this call FUNC(resetLocal)}", _x] call EFUNC(common,execRemoteFnc);
+            [QGVAR(resetLocal), _x, [_x, _nozzle]] call EFUNC(common,targetEvent);
         };
     } count allPlayers;
     deleteVehicle _nozzle;

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -48,7 +48,7 @@ if (isNull _nozzle || {_source != _target}) exitWith {false};
         };
         deleteVehicle _nozzle;
 
-        ["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,objectEvent);
+        ["setVanillaHitPointDamage", _target, [_target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]] ] ] call EFUNC(common,objectEvent);
         _target setVariable [QGVAR(engineHit), nil, true];
     },
     "",

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -49,7 +49,7 @@ if (isNull _nozzle || {_source != _target}) exitWith {false};
         deleteVehicle _nozzle;
 
         if !(local _target) then {
-            [QGVAR(setVehicleHitPointDamage), _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
+            ["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
         } else {
             _target setHitPointDamage ["HitEngine", _target getVariable [QGVAR(engineHit), 0]];
         };

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -48,11 +48,7 @@ if (isNull _nozzle || {_source != _target}) exitWith {false};
         };
         deleteVehicle _nozzle;
 
-        if !(local _target) then {
-            ["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
-        } else {
-            _target setHitPointDamage ["HitEngine", _target getVariable [QGVAR(engineHit), 0]];
-        };
+        ["setHitPointDamage", _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,objectEvent);
         _target setVariable [QGVAR(engineHit), nil, true];
     },
     "",

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -49,7 +49,7 @@ if (isNull _nozzle || {_source != _target}) exitWith {false};
         deleteVehicle _nozzle;
 
         if !(local _target) then {
-            [[_target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]], "{(_this select 0) setHitPointDamage (_this select 1)}", _sink] call EFUNC(common,execRemoteFnc);
+            [QGVAR(setVehicleHitPointDamage), _target, ["HitEngine", _target getVariable [QGVAR(engineHit), 0]]] call EFUNC(common,targetEvent);
         } else {
             _target setHitPointDamage ["HitEngine", _target getVariable [QGVAR(engineHit), 0]];
         };

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -27,7 +27,7 @@ REFUEL_HOLSTER_WEAPON
 private _endPosOffset = [0, 0, 0];
 if (isNull _nozzle) then { // func is called on fuel truck
     _target setVariable [QGVAR(engineHit), _target getHitPointDamage "HitEngine", true];
-    ["setHitPointDamage", _target, ["HitEngine", 1]] call EFUNC(common,objectEvent);
+    ["setVanillaHitPointDamage", _target, [_target, ["HitEngine", 1]] ] call EFUNC(common,objectEvent);
 
     _target setVariable [QGVAR(isConnected), true, true];
     _endPosOffset = getArray (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hooks));

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -28,7 +28,7 @@ private _endPosOffset = [0, 0, 0];
 if (isNull _nozzle) then { // func is called on fuel truck
     _target setVariable [QGVAR(engineHit), _target getHitPointDamage "HitEngine", true];
     if !(local _target) then {
-        [[_target, ["HitEngine", 1]], "{(_this select 0) setHitPointDamage (_this select 1)}", _sink] call EFUNC(common,execRemoteFnc);
+        [QGVAR(setVehicleHitPointDamage), _target, ["HitEngine", 1]] call EFUNC(common,targetEvent);
     } else {
         _target setHitPointDamage ["HitEngine", 1];
     };

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -28,7 +28,7 @@ private _endPosOffset = [0, 0, 0];
 if (isNull _nozzle) then { // func is called on fuel truck
     _target setVariable [QGVAR(engineHit), _target getHitPointDamage "HitEngine", true];
     if !(local _target) then {
-        [QGVAR(setVehicleHitPointDamage), _target, ["HitEngine", 1]] call EFUNC(common,targetEvent);
+        ["setHitPointDamage", _target, ["HitEngine", 1]] call EFUNC(common,targetEvent);
     } else {
         _target setHitPointDamage ["HitEngine", 1];
     };

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -27,11 +27,7 @@ REFUEL_HOLSTER_WEAPON
 private _endPosOffset = [0, 0, 0];
 if (isNull _nozzle) then { // func is called on fuel truck
     _target setVariable [QGVAR(engineHit), _target getHitPointDamage "HitEngine", true];
-    if !(local _target) then {
-        ["setHitPointDamage", _target, ["HitEngine", 1]] call EFUNC(common,targetEvent);
-    } else {
-        _target setHitPointDamage ["HitEngine", 1];
-    };
+    ["setHitPointDamage", _target, ["HitEngine", 1]] call EFUNC(common,objectEvent);
 
     _target setVariable [QGVAR(isConnected), true, true];
     _endPosOffset = getArray (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hooks));


### PR DESCRIPTION
**When merged this pull request will:**
- Closes #3541 
- Replaces all `execRemoteFnc` with `globalEvent` or `objectEvent`
- Increases refuel PFH to every 1 second (refuel rate stays the same as it's part of the pre-PFH calculation)
- Add `setVectorDirAndUp` and `setHitPointDamage` functions to common (both require object to be local)

Tagging @GitHawk for review. Tested locally only.