### PR TITLE
Store Interact Menus on CBA Namespaces

### DIFF
--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -4,6 +4,9 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
+GVAR(ActNamespace) = [] call CBA_fnc_createNamespace;
+GVAR(ActSelfNamespace) = [] call CBA_fnc_createNamespace;
+
 // Event handlers for all interact menu controls
 DFUNC(handleMouseMovement) = {
     if (GVAR(cursorKeepCentered)) then {

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -30,10 +30,11 @@ if (_typeNum == 0) then {
     [_objectType] call FUNC(compileMenuSelfAction);
 };
 
-private _varName = format [[QGVAR(Act_%1), QGVAR(SelfAct_%1)] select _typeNum, _objectType];
-private _actionTrees = missionNamespace getVariable [_varName, []];
-if((count _actionTrees) == 0) then {
-    missionNamespace setVariable [_varName, _actionTrees];
+private _namespace = [GVAR(ActNamespace), GVAR(ActSelfNamespace)] select _typeNum;
+private _actionTrees = _namespace getVariable _objectType;
+if (isNil "_actionTrees") then {
+    _actionTrees = [];
+    _namespace setVariable [_objectType, _actionTrees];
 };
 
 if (_parentPath isEqualTo ["ACE_MainActions"]) then {

--- a/addons/interact_menu/functions/fnc_addMainAction.sqf
+++ b/addons/interact_menu/functions/fnc_addMainAction.sqf
@@ -18,8 +18,12 @@
 
 params ["_objectType", "_typeNum"];
 
-private _varName = format [[QGVAR(Act_%1), QGVAR(SelfAct_%1)] select _typeNum, _objectType];
-private _actionTrees = missionNamespace getVariable [_varName, []];
+private _namespace = [GVAR(ActNamespace), GVAR(ActSelfNamespace)] select _typeNum;
+private _actionTrees = _namespace getVariable _objectType;
+if (isNil "_actionTrees") then {
+    _actionTrees = [];
+};
+
 private _parentNode = [_actionTrees, ["ACE_MainActions"]] call FUNC(findActionNode);
 
 if (isNil {_parentNode}) then {

--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -18,10 +18,10 @@ private _objectType = _target;
 if (_target isEqualType objNull) then {
     _objectType = typeOf _target;
 };
-private _actionsVarName = format [QGVAR(Act_%1), _objectType];
+private _namespace = GVAR(ActNamespace);
 
 // Exit if the action menu is already compiled for this class
-if !(isNil {missionNamespace getVariable [_actionsVarName, nil]}) exitWith {};
+if !(isNil {_namespace getVariable _objectType}) exitWith {};
 
 private _recurseFnc = {
     params ["_actionsCfg", "_parentDistance"];
@@ -104,7 +104,7 @@ private _actionsCfg = configFile >> "CfgVehicles" >> _objectType >> "ACE_Actions
 TRACE_1("Building ACE_Actions",_objectType);
 private _actions = [_actionsCfg, 0] call _recurseFnc;
 
-missionNamespace setVariable [_actionsVarName, _actions];
+_namespace setVariable [_objectType, _actions];
 
 /*
 [

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -18,10 +18,10 @@ private _objectType = _target;
 if (_target isEqualType objNull) then {
     _objectType = typeOf _target;
 };
-private _actionsVarName = format [QGVAR(SelfAct_%1), _objectType];
+private _namespace = GVAR(ActSelfNamespace);
 
 // Exit if the action menu is already compiled for this class
-if !(isNil {missionNamespace getVariable [_actionsVarName, nil]}) exitWith {};
+if !(isNil {_namespace getVariable _objectType}) exitWith {};
 
 
 private _recurseFnc = {
@@ -125,4 +125,4 @@ private _actions = [
         ]
     ];
 
-missionNamespace setVariable [_actionsVarName, _actions];
+_namespace setVariable [_objectType, _actions];

--- a/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
+++ b/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
@@ -19,18 +19,20 @@
 
 params ["_objectType", "_typeNum", "_fullPath"];
 
-private ["_res","_varName","_actionTrees", "_parentNode", "_found"];
-_res = _fullPath call FUNC(splitPath);
+private _res = _fullPath call FUNC(splitPath);
 _res params ["_parentPath", "_actionName"];
 
-_varName = format [[QGVAR(Act_%1), QGVAR(SelfAct_%1)] select _typeNum, _objectType];
-_actionTrees = missionNamespace getVariable [_varName, []];
+private _namespace = [GVAR(ActNamespace), GVAR(ActSelfNamespace)] select _typeNum;
+private _actionTrees = _namespace getVariable _objectType;
+if (isNil "_actionTrees") then {
+    _actionTrees = [];
+};
 
-_parentNode = [_actionTrees, _parentPath] call FUNC(findActionNode);
+private _parentNode = [_actionTrees, _parentPath] call FUNC(findActionNode);
 if (isNil {_parentNode}) exitWith {};
 
 // Iterate through children of the father
-_found = false;
+private _found = false;
 {
     if (((_x select 0) select 0) == _actionName) exitWith {
         TRACE_2("Deleting Action", _forEachIndex, _x);

--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -54,8 +54,9 @@ private _fnc_renderNearbyActions = {
                 } count GVAR(objectActionList);
 
                 // Iterate through base level class actions and render them if appropiate
-                private _actionsVarName = format [QGVAR(Act_%1), typeOf _target];
-                private _classActions = missionNamespace getVariable [_actionsVarName, []];
+                private _namespace = GVAR(ActNamespace);
+                private _classActions = _namespace getVariable typeOf _target;
+
                 {
                     private _action = _x;
                     // Try to render the menu
@@ -95,8 +96,8 @@ private _fnc_renderSelfActions = {
     GVAR(objectActionList) = _target getVariable [QGVAR(selfActions), []];
 
     // Iterate through base level class actions and render them if appropiate
-    private _actionsVarName = format [QGVAR(SelfAct_%1), typeOf _target];
-    private _classActions = missionNamespace getVariable [_actionsVarName, []];
+    private _namespace = GVAR(ActSelfNamespace);
+    private _classActions = _namespace getVariable typeOf _target;
 
     private _pos = if !(GVAR(useCursorMenu)) then {
         //Convert to ASL, add offset and then convert back to AGL (handles waves when over water)

--- a/addons/interaction/functions/fnc_addPassengerActions.sqf
+++ b/addons/interaction/functions/fnc_addPassengerActions.sqf
@@ -20,8 +20,11 @@
 params ["", "", "_parameters"];
 _parameters params ["_unit"];
 
-private _varName = format [QEGVAR(interact_menu,Act_%1), typeOf _unit];
-private _actionTrees = missionNamespace getVariable [_varName, []];
+private _namespace = EGVAR(interact_menu,ActNamespace);
+private _actionTrees = _namespace getVariable typeOf _unit;
+if (isNil "_actionTrees") then {
+    _actionTrees = [];
+};
 
 private _actions = [];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Store action menues in CBA pseudo namespaces instead of `format`ed mission namespace variables
- I can't reproduce the save game crash with this anymore
- I don't know why though, so don't close the issue for now (requires feedback)

ref #3397, #1098