### PR TITLE
use namespace for cargo filters, fixes problem with save games

### DIFF
--- a/addons/inventory/XEH_postInit.sqf
+++ b/addons/inventory/XEH_postInit.sqf
@@ -22,27 +22,14 @@ private _fnc_addToCache = {
     GVAR(ItemKeyNamespace) setVariable [format ["%1:%2", _displayName, _picture], _this];
 };
 
-// weapons and items
-{
-    if (getNumber (_x >> "scope") > 0) then {_x call _fnc_addToCache};
-    false
-} count (
-    ("true" configClasses (configFile >> "CfgWeapons")) + 
-    ("true" configClasses (configFile >> "CfgGlasses"))
-);
+private _allItems = [];
 
-// magazines
-{
-    if (getNumber (_x >> "scope") == 2) then {_x call _fnc_addToCache};
-    false
-} count ("true" configClasses (configFile >> "CfgMagazines"));
+_allItems append ("getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons"));
+_allItems append ("getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgGlasses"));
+_allItems append ("getNumber (_x >> 'scope') == 2" configClasses (configFile >> "CfgMagazines"));
+_allItems append ("getNumber (_x >> 'scope') > 0 && {getNumber (_x >> 'isBackpack') == 1}" configClasses (configFile >> "CfgVehicles"));
 
-// backpacks
-{
-    if (getNumber (_x >> "scope") > 0 && {getNumber (_x >> "isBackpack") == 1}) then {_x call _fnc_addToCache};
-    false
-} count ("true" configClasses (configFile >> "CfgVehicles"));
-
+{_x call _fnc_addToCache; false} count _allItems;
 
 GVAR(customFilters) = [];
 GVAR(selectedFilterIndex) = -1;

--- a/addons/inventory/XEH_postInit.sqf
+++ b/addons/inventory/XEH_postInit.sqf
@@ -2,6 +2,48 @@
 
 if (!hasInterface) exitWith {};
 
+// cache config
+// items in the inventory display can only be distinguished by their lb names and pictures
+// this can cause collisions (mainly weapons with attachments),
+// but if the item has the same name and picture it at least shouldn't change the filter anyway
+// luckily we don't need private items, so dummy and parent classes are out of the picture
+
+GVAR(ItemKeyNamespace) = [] call CBA_fnc_createNamespace;
+
+private _fnc_addToCache = {
+    private _displayName = getText (_this >> "displayName");
+    private _picture = getText (_this >> "picture");
+
+    // list box seems to delete the leading backslash
+    if (_picture select [0,1] == "\") then {
+        _picture = _picture select [1];
+    };
+
+    GVAR(ItemKeyNamespace) setVariable [format ["%1:%2", _displayName, _picture], _this];
+};
+
+// weapons and items
+{
+    if (getNumber (_x >> "scope") > 0) then {_x call _fnc_addToCache};
+    false
+} count (
+    ("true" configClasses (configFile >> "CfgWeapons")) + 
+    ("true" configClasses (configFile >> "CfgGlasses"))
+);
+
+// magazines
+{
+    if (getNumber (_x >> "scope") == 2) then {_x call _fnc_addToCache};
+    false
+} count ("true" configClasses (configFile >> "CfgMagazines"));
+
+// backpacks
+{
+    if (getNumber (_x >> "scope") > 0 && {getNumber (_x >> "isBackpack") == 1}) then {_x call _fnc_addToCache};
+    false
+} count ("true" configClasses (configFile >> "CfgVehicles"));
+
+
 GVAR(customFilters) = [];
 GVAR(selectedFilterIndex) = -1;
 

--- a/addons/inventory/XEH_preInit.sqf
+++ b/addons/inventory/XEH_preInit.sqf
@@ -4,47 +4,4 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
-// cache config
-// items in the inventory display can only be distinguished by their lb names and pictures
-// this can cause collisions (mainly weapons with attachments),
-// but if the item has the same name and picture it at least shouldn't change the filter anyway
-// luckily we don't need private items, so dummy and parent classes are out of the picture
-
-if !(uiNamespace getVariable [QGVAR(configCached), false]) then {
-    private _fnc_addToCache = {
-        private _displayName = getText (_this >> "displayName");
-        private _picture = getText (_this >> "picture");
-
-        // list box seems to delete the leading backslash
-        if (_picture select [0,1] == "\") then {
-            _picture = _picture select [1];
-        };
-
-        uiNamespace setVariable [format [QGVAR(ItemKey:%1:%2), _displayName, _picture], _this];
-    };
-
-    // weapons and items
-    {
-        if (getNumber (_x >> "scope") > 0) then {_x call _fnc_addToCache};
-        false
-    } count (
-        ("true" configClasses (configFile >> "CfgWeapons")) + 
-        ("true" configClasses (configFile >> "CfgGlasses"))
-    );
-
-    // magazines
-    {
-        if (getNumber (_x >> "scope") == 2) then {_x call _fnc_addToCache};
-        false
-    } count ("true" configClasses (configFile >> "CfgMagazines"));
-
-    // backpacks
-    {
-        if (getNumber (_x >> "scope") > 0 && {getNumber (_x >> "isBackpack") == 1}) then {_x call _fnc_addToCache};
-        false
-    } count ("true" configClasses (configFile >> "CfgVehicles"));
-
-    uiNamespace setVariable [QGVAR(configCached), true];
-};
-
 ADDON = true;

--- a/addons/inventory/functions/fnc_forceItemListUpdate.sqf
+++ b/addons/inventory/functions/fnc_forceItemListUpdate.sqf
@@ -23,12 +23,9 @@ if (_filterFunction isEqualType {}) then {
     private _i = 0;
 
     while {_i < lbSize _itemList} do {
-        private _config = uiNamespace getVariable [
-            format [QGVAR(ItemKey:%1:%2), _itemList lbText _i, _itemList lbPicture _i],
-            configNull
-        ];
+        private _config = GVAR(ItemKeyNamespace) getVariable format ["%1:%2", _itemList lbText _i, _itemList lbPicture _i];
 
-        if (!isNull _config && {!(_config call _filterFunction)}) then {
+        if (!isNil "_config" && {!(_config call _filterFunction)}) then {
             _itemList lbDelete _i;
 
             // in case the filter function returns nil. Otherwise could lock up the game.


### PR DESCRIPTION
**When merged this pull request will:**
- Use a CBA namespace for storing item configs by gui information
- fixes a bug where variables would not be defined when loading a savegame without ever loading a mission from start during the session

