### PR TITLE
Disable only action menu on mouse hint and modifier where unnecessary

### DIFF
--- a/addons/explosives/functions/fnc_handleScrollWheel.sqf
+++ b/addons/explosives/functions/fnc_handleScrollWheel.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-if ((!GVAR(pfeh_running)) || {ACE_Modifier == 0}) exitWith {false};
+if (!GVAR(pfeh_running)) exitWith {false};
 
 GVAR(TweakedAngle) = ((GVAR(TweakedAngle) + 7.2 * _this) + 360) % 360;
 

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -107,16 +107,16 @@
             <Russian>Отмена</Russian>
         </Key>
         <Key ID="STR_ACE_Explosives_ScrollAction">
-            <English>+Ctrl rotate</English>
-            <German>+Strg drehen</German>
-            <Spanish>+Ctrl girar</Spanish>
-            <French>+Ctrl tourner</French>
-            <Italian>+Ctrl rotazione</Italian>
-            <Czech>+Ctrl otočit</Czech>
-            <Hungarian>+Ctrl forgatás</Hungarian>
-            <Polish>+Ctrl obrót</Polish>
-            <Portuguese>+Ctrl rotaciona</Portuguese>
-            <Russian>+Ctrl Bращать</Russian>
+            <English>Rotate</English>
+            <German>Drehen</German>
+            <Spanish>Girar</Spanish>
+            <French>Tourner</French>
+            <Italian>Rotazione</Italian>
+            <Czech>Otočit</Czech>
+            <Hungarian>Forgatás</Hungarian>
+            <Polish>Obrót</Polish>
+            <Portuguese>Rotaciona</Portuguese>
+            <Russian>Bращать</Russian>
         </Key>
         <Key ID="STR_ACE_Explosives_Jammer_TurnOn">
             <English>Turn On Thor III</English>

--- a/addons/interaction/functions/fnc_hideMouseHint.sqf
+++ b/addons/interaction/functions/fnc_hideMouseHint.sqf
@@ -19,4 +19,7 @@ if (isNull (uiNamespace getVariable ["ACE_Helper_Display", objNull])) exitWith {
 
 (QGVAR(InteractionHelper) call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
 
-["mouseHint", []] call EFUNC(common,showHud); //This is equivalent to the old showHud true
+// Disable action menu, showHud also disables all scripted UI (such as drawIcon3D)
+inGameUISetEventHandler ["PrevAction", "false"];
+inGameUISetEventHandler ["NextAction", "false"];
+inGameUISetEventHandler ["Action", "false"];

--- a/addons/interaction/functions/fnc_showMouseHint.sqf
+++ b/addons/interaction/functions/fnc_showMouseHint.sqf
@@ -50,4 +50,7 @@ if (_scroll == "") exitWith {
 
 (_display displayCtrl 1002) ctrlSetText _scroll;
 
-["mouseHint", [false, true, true, true, true, true, true, false]] call EFUNC(common,showHud); //This is equivalent to the old showHud false
+// Enable action menu
+inGameUISetEventHandler ["PrevAction", "true"];
+inGameUISetEventHandler ["NextAction", "true"];
+inGameUISetEventHandler ["Action", "true"];

--- a/addons/sandbag/functions/fnc_handleScrollWheel.sqf
+++ b/addons/sandbag/functions/fnc_handleScrollWheel.sqf
@@ -15,9 +15,9 @@
  */
 #include "script_component.hpp"
 
-params ["_scroll"];
+if (GVAR(deployPFH) == -1) exitWith {false};
 
-if (GETMVAR(ACE_Modifier,0) == 0 || GVAR(deployPFH) == -1) exitWith { false };
+params ["_scroll"];
 
 GVAR(deployDirection) = GVAR(deployDirection) + (_scroll * 5);
 

--- a/addons/sandbag/stringtable.xml
+++ b/addons/sandbag/stringtable.xml
@@ -146,16 +146,16 @@
             <Portuguese>Aqui não tem areia</Portuguese>
         </Key>
         <Key ID="STR_ACE_Sandbag_ScrollAction">
-            <English>+Ctrl rotate</English>
-            <German>+Strg drehen</German>
-            <Spanish>+Ctrl girar</Spanish>
-            <French>+Ctrl tourner</French>
-            <Italian>+Ctrl rotazione</Italian>
-            <Czech>+Ctrl otočit</Czech>
-            <Hungarian>+Ctrl forgatás</Hungarian>
-            <Polish>+Ctrl obrót</Polish>
-            <Portuguese>+Ctrl rotaciona</Portuguese>
-            <Russian>+Ctrl Bращать</Russian>
+            <English>Rotate</English>
+            <German>Drehen</German>
+            <Spanish>Girar</Spanish>
+            <French>Tourner</French>
+            <Italian>Rotazione</Italian>
+            <Czech>Otočit</Czech>
+            <Hungarian>Forgatás</Hungarian>
+            <Polish>Obrót</Polish>
+            <Portuguese>Rotaciona</Portuguese>
+            <Russian>Bращать</Russian>
         </Key>
     </Package>
 </Project>

--- a/addons/tacticalladder/functions/fnc_handleScrollWheel.sqf
+++ b/addons/tacticalladder/functions/fnc_handleScrollWheel.sqf
@@ -19,7 +19,7 @@ params ["_scroll"];
 
 if (isNull GVAR(ladder)) exitWith { false };
 
-if (GETMVAR(ACE_Modifier,0) == 0) then {
+if (ACE_Modifier == 0) then {
     private ["_currentStep"];
     // Lengthening
     if (_scroll > 0) then {

--- a/addons/trenches/functions/fnc_handleScrollWheel.sqf
+++ b/addons/trenches/functions/fnc_handleScrollWheel.sqf
@@ -15,9 +15,9 @@
  */
 #include "script_component.hpp"
 
-params ["_scroll"];
+if (GVAR(digPFH) == -1) exitWith {false};
 
-if (GETMVAR(ACE_Modifier,0) == 0 || GVAR(digPFH) == -1) exitWith { false };
+params ["_scroll"];
 
 GVAR(digDirection) = GVAR(digDirection) + (_scroll * 5);
 

--- a/addons/trenches/stringtable.xml
+++ b/addons/trenches/stringtable.xml
@@ -82,12 +82,16 @@
             <French>Annuler la creusée</French>
         </Key>
         <Key ID="STR_ACE_Trenches_ScrollAction">
-            <English>+Ctrl rotate</English>
-            <German>+Strg drehen</German>
-            <Polish>+Ctrl obrót</Polish>
-            <Italian>+Ctrl ruota</Italian>
-            <Spanish>+Ctrl rotar</Spanish>
-            <French>+Ctrl rotation</French>
+            <English>Rotate</English>
+            <German>Drehen</German>
+            <Spanish>Girar</Spanish>
+            <French>Tourner</French>
+            <Italian>Rotazione</Italian>
+            <Czech>Otočit</Czech>
+            <Hungarian>Forgatás</Hungarian>
+            <Polish>Obrót</Polish>
+            <Portuguese>Rotaciona</Portuguese>
+            <Russian>Bращать</Russian>
         </Key>
         <Key ID="STR_ACE_Trenches_DiggingTrench">
             <English>Digging Trench</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Allow scripted UI when using `showMouseHint` and `hideMouseHint`
- Remove `ACE_Modifier` requirement for rotating sandbags, tactical ladders, explosives and trenches