### PR TITLE
Fixed strncpy in parse_imagepath

### DIFF
--- a/extensions/parse_imagepath/ace_parse_imagepath.cpp
+++ b/extensions/parse_imagepath/ace_parse_imagepath.cpp
@@ -36,18 +36,17 @@ std::string getImagePathFromStructuredText(const std::string & input) {
 	return returnValue;
 }
 
-// i like to live dangerously. jk, fix strncpy sometime pls.
 #pragma warning( push )
 #pragma warning( disable : 4996 )
 
 void __stdcall RVExtension(char *output, int outputSize, const char *function) {
 	ZERO_OUTPUT();
-    if (!strcmp(function, "version")) {
-        strncpy(output, ACE_FULL_VERSION_STR, outputSize);
-    } else {
-        strncpy(output, getImagePathFromStructuredText(function).c_str(), outputSize);
-        output[outputSize - 1] = '\0';
-    }
+	if (!strcmp(function, "version")) {
+		strncpy_s(output, outputSize, ACE_FULL_VERSION_STR, _TRUNCATE);
+	} else {
+		strncpy_s(output, outputSize, getImagePathFromStructuredText(function).c_str(), _TRUNCATE);
+		output[outputSize - 1] = '\0';
+	}
 	EXTENSION_RETURN();
 }
 


### PR DESCRIPTION
When merged this pull request will:
Replace unsafe strncpy with safe strncpy_s.