### PR TITLE
Fastroping: post-release enhancements

### DIFF
--- a/addons/fastroping/CfgEventHandlers.hpp
+++ b/addons/fastroping/CfgEventHandlers.hpp
@@ -1,3 +1,9 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));

--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -35,11 +35,8 @@ class CfgVehicles {
         };
     };
 
-    class Helicopter_Base_F;
-    class ACE_friesBase: Helicopter_Base_F {
-        destrType = "";
-        class Turrets {};
-
+    class Helicopter;
+    class Helicopter_Base_F: Helicopter {
         class ACE_SelfActions {
             class ACE_prepareFRIES {
                 displayName = CSTRING(Interaction_prepareFRIES);
@@ -70,6 +67,10 @@ class CfgVehicles {
                 priority = 1;
             };
         };
+    };
+    class ACE_friesBase: Helicopter_Base_F {
+        destrType = "";
+        class Turrets {};
     };
     class ACE_friesAnchorBar: ACE_friesBase {
         author = "jokoho48";
@@ -175,10 +176,28 @@ class CfgVehicles {
     class Heli_Transport_02_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
         GVAR(ropeOrigins[]) = {{0.94, -4.82, -1.16}, {-0.94, -4.82, -1.16}};
+        GVAR(onPrepare) = QFUNC(onPrepareCommon);
+        GVAR(onCut) = QFUNC(onCutCommon);
+
+        class UserActions {
+            class Ramp_Open;
+            class Ramp_Close: Ramp_Open {
+                condition = QUOTE([ARR_5(this,'CargoRamp_Open',[[0],[1],[2]])] call FUNC(canCloseRamp));
+            };
+        };
     };
     class Heli_Transport_03_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
         GVAR(ropeOrigins[]) = {{0.75, -5.29, -0.11}, {-0.87, -5.29, -0.11}};
+        GVAR(onPrepare) = QFUNC(onPrepareCommon);
+        GVAR(onCut) = QFUNC(onCutCommon);
+
+        class UserActions {
+            class Ramp_Open;
+            class Ramp_Close: Ramp_Open {
+                condition = QUOTE([ARR_5(this,'Door_rear_source',[[0],[3],[4]])] call FUNC(canCloseRamp));
+            };
+        };
     };
     class Heli_light_03_base_F: Helicopter_Base_F {
         GVAR(enabled) = 2;
@@ -194,7 +213,9 @@ class CfgVehicles {
         GVAR(friesAttachmentPoint[]) = {-1.07, 3.26, -0.5};
         EQUIP_FRIES_ATTRIBUTE;
     };
-    class Heli_Transport_04_base_F;
+    class Heli_Transport_04_base_F: Helicopter_Base_H {
+        class UserActions;
+    };
     class O_Heli_Transport_04_bench_F: Heli_Transport_04_base_F {
         GVAR(enabled) = 1;
         GVAR(ropeOrigins[]) = {{1.03, 1.6, -0.23}, {1.03, -1.36, -0.23}, {-1.23, 1.6, -0.23}, {-1.23, -1.36, -0.23}};
@@ -202,5 +223,14 @@ class CfgVehicles {
     class O_Heli_Transport_04_covered_F: Heli_Transport_04_base_F {
         GVAR(enabled) = 1;
         GVAR(ropeOrigins[]) = {{0.83, -4.7, -0.03}, {-1.02, -4.7, -0.03}};
+        GVAR(onPrepare) = QFUNC(onPrepareCommon);
+        GVAR(onCut) = QFUNC(onCutCommon);
+
+        class UserActions: UserActions {
+            class CloseDoor_6;
+            class Ramp_Close: CloseDoor_6 {
+                condition = QUOTE([ARR_6(this,'Door_6_source',[[0],[1],[2],[3]])] call FUNC(canCloseRamp));
+            };
+        };
     };
 };

--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -110,10 +110,20 @@ class CfgVehicles {
                 initPhase = 0;
                 animPeriod = 0;
             };
+            class hideGantryLeft {
+                source = "user";
+                initPhase = 0;
+                animPeriod = 0;
+            };
+            class hideGantryRight {
+                source = "user";
+                initPhase = 0;
+                animPeriod = 0;
+            };
         };
     };
     class ACE_friesGantryReverse: ACE_friesGantry {
-        class AnimationSources {
+        class AnimationSources: AnimationSources {
             class adjustWidth {
                 source = "user";
                 initPhase = 0.213;

--- a/addons/fastroping/XEH_PREP.hpp
+++ b/addons/fastroping/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(canCloseRamp);
 PREP(canCutRopes);
 PREP(canDeployRopes);
 PREP(canFastRope);

--- a/addons/fastroping/XEH_PREP.hpp
+++ b/addons/fastroping/XEH_PREP.hpp
@@ -1,0 +1,16 @@
+PREP(canCutRopes);
+PREP(canDeployRopes);
+PREP(canFastRope);
+PREP(canPrepareFRIES);
+PREP(checkVehicleThread);
+PREP(cutRopes);
+PREP(deployRopes);
+PREP(equipFRIES);
+PREP(fastRope);
+PREP(fastRopeLocalPFH);
+PREP(fastRopeServerPFH);
+PREP(moduleEquipFRIES);
+PREP(onCutCommon);
+PREP(onPrepareCommon);
+PREP(onRopeBreak);
+PREP(prepareFRIES);

--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -7,8 +7,3 @@
 [QGVAR(startFastRope), {
     [FUNC(fastRopeServerPFH), 0, _this] call CBA_fnc_addPerFrameHandler;
 }] call EFUNC(common,addEventHandler);
-
-[QGVAR(ropeDetach), {
-    params ["_object", "_rope"];
-    _object ropeDetach _rope;
-}] call EFUNC(common,addEventHandler);

--- a/addons/fastroping/XEH_preStart.sqf
+++ b/addons/fastroping/XEH_preStart.sqf
@@ -1,7 +1,3 @@
 #include "script_component.hpp"
 
-ADDON = false;
-
 #include "XEH_PREP.hpp"
-
-ADDON = true;

--- a/addons/fastroping/data/model.cfg
+++ b/addons/fastroping/data/model.cfg
@@ -90,6 +90,24 @@ class CfgModels {
                 angle0 = "rad 0";
                 angle1 = "rad 360";
             };
+            class hideGantryLeft {
+                type = "hide";
+                source = "";
+                selection = "gantryLeft";
+                animPeriod = 0;
+                minValue = 0;
+                maxValue = 1;
+                hideValue = 0.99999;
+            };
+            class hideGantryRight {
+                type = "hide";
+                source = "";
+                selection = "gantryRight";
+                animPeriod = 0;
+                minValue = 0;
+                maxValue = 1;
+                hideValue = 0.99999;
+            };
         };
     };
 };

--- a/addons/fastroping/functions/fnc_canCloseRamp.sqf
+++ b/addons/fastroping/functions/fnc_canCloseRamp.sqf
@@ -1,0 +1,29 @@
+/*
+ * Author: BaerMitUmlaut
+ * Checks if the player can close the ramp of the given helo.
+ *
+ * Arguments:
+ * 0: The helicopter <OBJECT>
+ * 1: The ramp animation name <STRING>
+ * 2: Turret paths that can close the ramp <ARRAY>
+ *
+ * Return Value:
+ * Able to close ramp <BOOL>
+ *
+ * Example:
+ * [_player, _vehicle] call ace_fastroping_fnc_canCloseRamp
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+params ["_vehicle", "_door", "_turretPaths"];
+
+(_vehicle doorPhase _door > 0.5) &&
+{alive _vehicle} &&
+{(_vehicle getVariable ["bis_disabled_Ramp", 0]) != 1} &&
+{!(_vehicle getVariable [QGVAR(doorsLocked), false])} &&
+{
+    (ACE_player == driver _vehicle) ||
+    {((assignedVehicleRole ACE_player) param [1, []]) in _turretPaths}
+}

--- a/addons/fastroping/functions/fnc_canPrepareFRIES.sqf
+++ b/addons/fastroping/functions/fnc_canPrepareFRIES.sqf
@@ -19,7 +19,6 @@ params ["_vehicle"];
 
 private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
 
-(isNumber (_config >> QGVAR(enabled)) &&
-{(getNumber (_config >> QGVAR(enabled)) == 1) || {!(isNull (_vehicle getVariable [QGVAR(FRIES), objNull]))}} &&
+((getNumber (_config >> QGVAR(enabled)) == 1) || {!(isNull (_vehicle getVariable [QGVAR(FRIES), objNull]))}) &&
 {(_vehicle getVariable [QGVAR(deploymentStage), 0]) == 0} &&
-{isText (_config >> QGVAR(onPrepare))})
+{getText (_config >> QGVAR(onPrepare)) != ""}

--- a/addons/fastroping/functions/fnc_cutRopes.sqf
+++ b/addons/fastroping/functions/fnc_cutRopes.sqf
@@ -32,8 +32,10 @@ _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
         };
     };
 
-    [QGVAR(ropeDetach), [_hook, _ropeTop]] call EFUNC(common,serverEvent);
-    [{{deleteVehicle _x} count _this}, [_ropeTop, _ropeBottom, _dummy, _hook], 60] call EFUNC(common,waitAndExecute);
+    detach _dummy;
+    deleteVehicle _ropeTop;
+    deleteVehicle _hook;
+    [{{deleteVehicle _x} count _this}, [_ropeBottom, _dummy], 60] call EFUNC(common,waitAndExecute);
 } count _deployedRopes;
 
 _vehicle setVariable [QGVAR(deployedRopes), [], true];

--- a/addons/fastroping/functions/fnc_deployRopes.sqf
+++ b/addons/fastroping/functions/fnc_deployRopes.sqf
@@ -35,13 +35,14 @@ _hookAttachment = _vehicle getVariable [QGVAR(FRIES), _vehicle];
 
     _origin = getPosATL _hook;
 
-    _dummy = createVehicle [QGVAR(helper), _origin vectorAdd [0, 0, -1], [], 0, "CAN_COLLIDE"];
+    _dummy = createVehicle [QGVAR(helper), _origin, [], 0, "CAN_COLLIDE"];
     _dummy allowDamage false;
     _dummy disableCollisionWith _vehicle;
+    _dummy attachTo [_hook, [0, 0, 0]];
 
     _ropeTop = ropeCreate [_dummy, [0, 0, 0], _hook, [0, 0, 0], 0.5];
     _ropeBottom = ropeCreate [_dummy, [0, 0, 0], 1];
-    ropeUnwind [_ropeBottom, 30, 34.5, false];
+    ropeUnwind [_ropeBottom, 30, 35, false];
 
     _ropeTop addEventHandler ["RopeBreak", {[_this, "top"] call FUNC(onRopeBreak)}];
     _ropeBottom addEventHandler ["RopeBreak", {[_this, "bottom"] call FUNC(onRopeBreak)}];

--- a/addons/fastroping/functions/fnc_fastRope.sqf
+++ b/addons/fastroping/functions/fnc_fastRope.sqf
@@ -24,7 +24,7 @@ _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
 _usableRope = _deployedRopes select 0;
 _usableRopeIndex = 0;
 {
-    if !(_x select 6) exitWith {
+    if !(_x select 5) exitWith {
         _usableRope = _x;
         _usableRopeIndex = _forEachIndex;
     };

--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -26,6 +26,7 @@ if (vehicle _unit != _unit) exitWith {};
 
 //Start fast roping
 if (animationState _unit != "ACE_FastRoping") exitWith {
+    detach _dummy;
     _unit disableCollisionWith _dummy;
     _unit attachTo [_dummy, [0, 0, -1.45]];
     [_unit, "ACE_FastRoping", 2] call EFUNC(common,doAnimation);

--- a/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
@@ -54,14 +54,14 @@ if (((getPos _unit select 2) < 0.2) || {ropeLength _ropeTop == 34.5} || {vectorM
     deleteVehicle _ropeBottom;
 
     _origin = getPosASL _hook;
-    _dummy setPosASL (_origin vectorAdd [0, 0, -1]);
+    _dummy attachTo [_hook, [0, 0, 0]];
 
     //Restore original mass and center of mass
     _dummy setMass 40;
     _dummy setCenterOfMass [0.000143227,0.00105986,-0.246147];
 
     _ropeTop = ropeCreate [_dummy, [0, 0, 0], _hook, [0, 0, 0], 0.5];
-    _ropeBottom = ropeCreate [_dummy, [0, 0, 0], 34.5];
+    _ropeBottom = ropeCreate [_dummy, [0, 0, 0], 35];
 
     _ropeTop addEventHandler ["RopeBreak", {[_this, "top"] call FUNC(onRopeBreak)}];
     _ropeBottom addEventHandler ["RopeBreak", {[_this, "bottom"] call FUNC(onRopeBreak)}];

--- a/addons/fastroping/functions/fnc_onCutCommon.sqf
+++ b/addons/fastroping/functions/fnc_onCutCommon.sqf
@@ -24,16 +24,24 @@ if !(isNull _fries) then {
     [{
         _this animateDoor ["door_R", 0];
         _this animateDoor ["door_L", 0];
-        _vehicle animate ["dvere1_posunZ", 0];
-        _vehicle animate ["dvere2_posunZ", 0];
+        _this animateDoor ["CargoRamp_Open", 0];
+        _this animateDoor ["Door_rear_source", 0];
+        _this animateDoor ["Door_6_source", 0];
+        _this animate ["dvere1_posunZ", 0];
+        _this animate ["dvere2_posunZ", 0];
+        _this setVariable [QGVAR(doorsLocked), false, true];
     }, _vehicle, 2] call EFUNC(common,waitAndExecute);
 
     4
 } else {
     _vehicle animateDoor ["door_R", 0];
     _vehicle animateDoor ["door_L", 0];
+    _vehicle animateDoor ["CargoRamp_Open", 0];
+    _vehicle animateDoor ["Door_rear_source", 0];
+    _vehicle animateDoor ["Door_6_source", 0];
     _vehicle animate ["dvere1_posunZ", 0];
     _vehicle animate ["dvere2_posunZ", 0];
+    _vehicle setVariable [QGVAR(doorsLocked), false, true];
 
     2
 };

--- a/addons/fastroping/functions/fnc_onPrepareCommon.sqf
+++ b/addons/fastroping/functions/fnc_onPrepareCommon.sqf
@@ -22,8 +22,13 @@ _waitTime = 2;
 
 _vehicle animateDoor ["door_R", 1];
 _vehicle animateDoor ["door_L", 1];
+_vehicle animateDoor ["CargoRamp_Open", 1];
+_vehicle animateDoor ["Door_rear_source", 1];
+_vehicle animateDoor ["Door_6_source", 1];
 _vehicle animate ["dvere1_posunZ", 1];
 _vehicle animate ["dvere2_posunZ", 1];
+
+_vehicle setVariable [QGVAR(doorsLocked), true, true];
 
 _fries = _vehicle getVariable [QGVAR(FRIES), objNull];
 if !(isNull _fries) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Use the `preStart` XEH in fastroping
- Fix a major bug with multiple people fastroping simultaneously
- Add a hiding animation for either of the gantrys from the gantry type FRIES (#3475)
- Force ramps from vanilla helicopters open when fastroping
- Improve rope twitching and glitchyness *a lot*, additionally ropes no more break when flying too fast
- Fix a config change which broke all fastroping interactions

For some reason, the FRIES on the Wildcat is now completly misaligned on my machine. I didn't change anything in the model and have a feeling this is a problem on my side.

Also needs testing, please mark as WIP.