### PR TITLE
FCS and Scopes with no compat pbo required

### DIFF
--- a/addons/fcs/CfgVehicles.hpp
+++ b/addons/fcs/CfgVehicles.hpp
@@ -90,8 +90,8 @@ class CfgVehicles {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
                 GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };
@@ -113,8 +113,8 @@ class CfgVehicles {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
                 GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };
@@ -142,8 +142,9 @@ class CfgVehicles {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
                 GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;};
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
+            };
             class CommanderTurret: CommanderTurret {
                 GVAR(Enabled) = 0;
             };
@@ -173,8 +174,8 @@ class CfgVehicles {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };
@@ -184,8 +185,8 @@ class CfgVehicles {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
                 GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
 
             // class CommanderOptics: CommanderOptics {};
@@ -196,8 +197,8 @@ class CfgVehicles {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
 
                 /*class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -233,8 +234,8 @@ class CfgVehicles {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
                 GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
             class CommanderOptics: CommanderOptics {};
         };
@@ -247,8 +248,8 @@ class CfgVehicles {
     class B_APC_Tracked_01_AA_F: B_APC_Tracked_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
                 magazines[] += {"ACE_120Rnd_35mm_ABM_shells_Tracer_Red"};
 
                 /*class Turrets: Turrets {
@@ -291,8 +292,8 @@ class CfgVehicles {
     class APC_Tracked_03_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
 
                 /*class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -304,8 +305,8 @@ class CfgVehicles {
     class MBT_01_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
 
                 /*class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {};
@@ -321,14 +322,14 @@ class CfgVehicles {
     class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
 
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {
                         GVAR(Enabled) = 1;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
+                        //discreteDistance[] = {};
+                        //discreteDistanceInitIndex = 0;
                     };
                 };
             };
@@ -344,8 +345,8 @@ class CfgVehicles {
                     class CommanderOptics: CommanderOptics {
                         GVAR(Enabled) = 1;
                         GVAR(MaxDistance) = 2000;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
+                        //discreteDistance[] = {};
+                        //discreteDistanceInitIndex = 0;
                     };
                 };
             };
@@ -364,14 +365,14 @@ class CfgVehicles {
     class MBT_02_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
 
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {
                         GVAR(Enabled) = 1;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
+                        //discreteDistance[] = {};
+                        //discreteDistanceInitIndex = 0;
                     };
                 };
             };
@@ -387,8 +388,8 @@ class CfgVehicles {
                     class CommanderOptics: CommanderOptics {
                         GVAR(Enabled) = 1;
                         GVAR(MaxDistance) = 2000;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
+                        //discreteDistance[] = {};
+                        //discreteDistanceInitIndex = 0;
                     };
                 };
             };
@@ -398,14 +399,14 @@ class CfgVehicles {
     class MBT_03_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
 
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {
                         GVAR(Enabled) = 1;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
+                        //discreteDistance[] = {};
+                        //discreteDistanceInitIndex = 0;
                     };
                 };
             };
@@ -430,8 +431,8 @@ class CfgVehicles {
                 GVAR(minDistance) = 100;
                 GVAR(maxDistance) = 2000;
                 GVAR(distanceInterval) = 5;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
             class RearTurret: FrontTurret {
                 discreteDistance[] = {100,200,300,400,600,800,1000,1200};  // Originally inherited from FrontTurret
@@ -499,8 +500,8 @@ class CfgVehicles {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };
@@ -509,8 +510,8 @@ class CfgVehicles {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };
@@ -569,8 +570,8 @@ class CfgVehicles {
                 GVAR(MinDistance) = 200;
                 GVAR(MaxDistance) = 2000;
                 GVAR(DistanceInterval) = 5;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };
@@ -585,8 +586,8 @@ class CfgVehicles {
                 GVAR(MinDistance) = 200;
                 GVAR(MaxDistance) = 2000;
                 GVAR(DistanceInterval) = 5;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                //discreteDistance[] = {};
+                //discreteDistanceInitIndex = 0;
             };
         };
     };

--- a/addons/fcs/functions/fnc_firedEH.sqf
+++ b/addons/fcs/functions/fnc_firedEH.sqf
@@ -29,6 +29,27 @@ private _offset = 0;
     };
 } forEach _FCSMagazines;
 
+// Calculate the correction due to vanilla zeroing
+private _zeroDistance = currentZeroing _gunner;
+if (_zeroDistance > 0) then {
+    private _weaponCombo = [_weapon, _magazine, _ammo, _zeroDistance];
+    if !(_weaponCombo isEqualTo (_gunner getVariable [QGVAR(lastWeaponCombo), []])) then {
+        // Hackish way of getting initSpeed. @todo: replace it by correct calculation and caching
+        private _initSpeed = vectorMagnitude velocity _projectile;
+
+        private _airFriction = getNumber (configFile >> "CfgAmmo" >> _ammo >> "airFriction");
+        private _antiOffset = "ace_fcs" callExtension format ["%1,%2,%3,%4", _initSpeed, _airFriction, 0, _zeroDistance];
+        _antiOffset = parseNumber _antiOffset;
+
+        _gunner setVariable [QGVAR(lastWeaponCombo), _weaponCombo];
+        _gunner setVariable [QGVAR(lastAntiOffset), _antiOffset];
+    };
+    private _antiOffset = _gunner getVariable QGVAR(lastAntiOffset);
+
+    _offset = _offset - _antiOffset;
+    TRACE_4("fired",_gunner, currentZeroing _gunner, _antiOffset, _offset);
+};
+
 [_projectile, (_vehicle getVariable format ["%1_%2", QGVAR(Azimuth), _turret]), _offset, 0] call EFUNC(common,changeProjectileDirection);
 
 // Remove the platform velocity

--- a/addons/fcs/functions/fnc_firedEH.sqf
+++ b/addons/fcs/functions/fnc_firedEH.sqf
@@ -64,7 +64,7 @@ if (vectorMagnitude velocity _vehicle > 2) then {
 if (!local _gunner) exitWith {};
 
 if (getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(Airburst)) == 1) then {
-    private _zeroing = _vehicle getVariable [format ["%1_%2", QGVAR(Distance), _turret], currentZeroing _vehicle];
+    private _zeroing = _vehicle getVariable [format ["%1_%2", QGVAR(Distance), _turret], currentZeroing _gunner];
 
     if (_zeroing < 50) exitWith {};
     if (_zeroing > 1500) exitWith {};

--- a/addons/scopes/ACE_Settings.hpp
+++ b/addons/scopes/ACE_Settings.hpp
@@ -1,0 +1,8 @@
+class ACE_Settings {
+    class GVAR(enabled) {
+        typeName = "BOOL";
+        value = 1;
+        displayName = CSTRING(Enabled_displayName);
+        description = CSTRING(Enabled_description);
+    };
+};

--- a/addons/scopes/ACE_Settings.hpp
+++ b/addons/scopes/ACE_Settings.hpp
@@ -5,4 +5,10 @@ class ACE_Settings {
         displayName = CSTRING(Enabled_displayName);
         description = CSTRING(Enabled_description);
     };
+    class GVAR(defaultZeroDistance) {
+        typeName = "SCALAR";
+        value = 100;
+        displayName = CSTRING(defaultZeroDistance_displayName);
+        description = CSTRING(defaultZeroDistance_description);
+    };
 };

--- a/addons/scopes/XEH_postInit.sqf
+++ b/addons/scopes/XEH_postInit.sqf
@@ -9,135 +9,140 @@
 
 if (!hasInterface) exitWith {};
 
-// Check inventory when it changes
-["playerInventoryChanged", {
-    [ACE_player] call FUNC(inventoryCheck);
-}] call EFUNC(common,addEventhandler);
+// Wait until the colors are defined before initializing the module
+["SettingsInitialized", {
+    if !(GVAR(enabled)) exitWith {false};
+
+    // Check inventory when it changes
+    ["playerInventoryChanged", {
+        [ACE_player] call FUNC(inventoryCheck);
+    }] call EFUNC(common,addEventhandler);
 
 
-// Instantly hide knobs when scoping in
-["cameraViewChanged", {
-    EXPLODE_2_PVT(_this,_player,_newCameraView);
-    if (_newCameraView == "GUNNER") then {
-        private "_layer";
-        _layer = [QGVAR(Zeroing)] call BIS_fnc_rscLayer;
-        _layer cutText ["", "PLAIN", 0];
+    // Instantly hide knobs when scoping in
+    ["cameraViewChanged", {
+        EXPLODE_2_PVT(_this,_player,_newCameraView);
+        if (_newCameraView == "GUNNER") then {
+            private "_layer";
+            _layer = [QGVAR(Zeroing)] call BIS_fnc_rscLayer;
+            _layer cutText ["", "PLAIN", 0];
 
 
-        if !(isNil QGVAR(fadePFH)) then {
-            [GVAR(fadePFH)] call CBA_fnc_removePerFrameHandler;
-            GVAR(fadePFH) = nil;
+            if !(isNil QGVAR(fadePFH)) then {
+                [GVAR(fadePFH)] call CBA_fnc_removePerFrameHandler;
+                GVAR(fadePFH) = nil;
+            };
         };
-    };
-}] call EFUNC(common,addEventhandler);
+    }] call EFUNC(common,addEventhandler);
 
 
-// Add keybinds
-["ACE3 Scope Adjustment", QGVAR(AdjustUpMinor), localize LSTRING(AdjustUpMinor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    // Add keybinds
+    ["ACE3 Scope Adjustment", QGVAR(AdjustUpMinor), localize LSTRING(AdjustUpMinor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, ELEVATION_UP, MINOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[201, [false, false, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, ELEVATION_UP, MINOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [201, [false, false, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustDownMinor), localize LSTRING(AdjustDownMinor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustDownMinor), localize LSTRING(AdjustDownMinor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, ELEVATION_DOWN, MINOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[209, [false, false, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, ELEVATION_DOWN, MINOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [209, [false, false, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustLeftMinor), localize LSTRING(AdjustLeftMinor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustLeftMinor), localize LSTRING(AdjustLeftMinor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, WINDAGE_LEFT, MINOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[209, [false, true, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, WINDAGE_LEFT, MINOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [209, [false, true, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustRightMinor), localize LSTRING(AdjustRightMinor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustRightMinor), localize LSTRING(AdjustRightMinor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, WINDAGE_RIGHT, MINOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[201, [false, true, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, WINDAGE_RIGHT, MINOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [201, [false, true, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustUpMajor), localize LSTRING(AdjustUpMajor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustUpMajor), localize LSTRING(AdjustUpMajor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, ELEVATION_UP, MAJOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[201, [true, false, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, ELEVATION_UP, MAJOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [201, [true, false, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustDownMajor), localize LSTRING(AdjustDownMajor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustDownMajor), localize LSTRING(AdjustDownMajor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, ELEVATION_DOWN, MAJOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[209, [true, false, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, ELEVATION_DOWN, MAJOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [209, [true, false, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustLeftMajor), localize LSTRING(AdjustLeftMajor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustLeftMajor), localize LSTRING(AdjustLeftMajor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, WINDAGE_LEFT, MAJOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[209, [true, true, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, WINDAGE_LEFT, MAJOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [209, [true, true, false]], true] call CBA_fnc_addKeybind;
 
-["ACE3 Scope Adjustment", QGVAR(AdjustRightMajor), localize LSTRING(AdjustRightMajor),
-{
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    [ACE_player] call FUNC(inventoryCheck);
+    ["ACE3 Scope Adjustment", QGVAR(AdjustRightMajor), localize LSTRING(AdjustRightMajor),
+    {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        [ACE_player] call FUNC(inventoryCheck);
 
-    // Statement
-    [ACE_player, WINDAGE_RIGHT, MAJOR_INCREMENT] call FUNC(adjustScope);
-},
-{false},
-[201, [true, true, false]], true] call CBA_fnc_addKeybind;
+        // Statement
+        [ACE_player, WINDAGE_RIGHT, MAJOR_INCREMENT] call FUNC(adjustScope);
+    },
+    {false},
+    [201, [true, true, false]], true] call CBA_fnc_addKeybind;
 
 
-// Register fire event handler
-["firedPlayer", DFUNC(firedEH)] call EFUNC(common,addEventHandler);
-["firedPlayerNonLocal", DFUNC(firedEH)] call EFUNC(common,addEventHandler);
+    // Register fire event handler
+    ["firedPlayer", DFUNC(firedEH)] call EFUNC(common,addEventHandler);
+    ["firedPlayerNonLocal", DFUNC(firedEH)] call EFUNC(common,addEventHandler);
+}] call EFUNC(common,addEventHandler);

--- a/addons/scopes/config.cpp
+++ b/addons/scopes/config.cpp
@@ -12,6 +12,8 @@ class CfgPatches {
     };
 };
 
+#include "ACE_Settings.hpp"
+
 #include "CfgEventHandlers.hpp"
 
 #include "CfgSounds.hpp"

--- a/addons/scopes/functions/fnc_adjustScope.sqf
+++ b/addons/scopes/functions/fnc_adjustScope.sqf
@@ -32,11 +32,9 @@ if (isNil "_adjustment") then {
     _adjustment = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]; // [Windage, Elevation, Zero]
 };
 
-if (isNil QGVAR(Optics)) then {
-    GVAR(Optics) = ["", "", ""];
-};
+private _optics = _unit getVariable [QGVAR(Optics), ["", "", ""]];
 
-_optic = GVAR(Optics) select _weaponIndex;
+_optic = _optics select _weaponIndex;
 _opticConfig = configFile >> "CfgWeapons" >> _optic;
 _verticalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement");
 _horizontalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_HorizontalIncrement");

--- a/addons/scopes/functions/fnc_canAdjustZero.sqf
+++ b/addons/scopes/functions/fnc_canAdjustZero.sqf
@@ -19,6 +19,7 @@ private ["_weaponIndex", "_adjustment", "_elevation"];
 
 params ["_unit"];
 
+if !(GVAR(enabled)) exitWith {false};
 if (cameraView == "GUNNER") exitWith {false};
 if (vehicle _unit != _unit) exitWith {false};
 if (!(missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false])) exitWith {false};

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -27,7 +27,7 @@ if (_adjustment isEqualTo []) then {
     _adjustment = [0,0,0];
 } else {
     _adjustment = _adjustment select _weaponIndex;
-}
+};
 // Convert it from mils to degrees
 private _zeroing = _adjustment vectorMultiply 0.05625;
 _zeroing params ["_elevation", "_windage", "_zero"];
@@ -38,7 +38,7 @@ _elevation = _elevation + _zero;
 if (_adjustVertical) then {
     // Calculate the correction due to vanilla zeroing
     private _zeroDistance = (currentZeroing _unit - GVAR(defaultZeroDistance));
-    if (_zeroDistance == 0) then {
+    if (_zeroDistance != 0) then {
         private _weaponCombo = [_weapon, _magazine, _ammo, _zeroDistance];
         if !(_weaponCombo isEqualTo (_unit getVariable [QGVAR(lastWeaponCombo), []])) then {
             // Hackish way of getting initSpeed. @todo: replace it by correct calculation and caching

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -15,20 +15,49 @@
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
 TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile, _vehicle, _gunner, _turret);
 
-private ["_adjustment", "_weaponIndex", "_zeroing", "_adjustment"];
-
-_adjustment = _unit getVariable [QGVAR(Adjustment), []];
-if (_adjustment isEqualTo []) exitWith {};
-
-_weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
+// Quit if the scope doesn't support adjusting
+private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
 if (_weaponIndex < 0) exitWith {};
+((_unit getVariable [QGVAR(SupportsAdjustment), [[false, false], [false, false], [false, false]]]) select _weaponIndex) params ["_adjustHorizontal", "_adjustVertical"];
+if !(_adjustHorizontal || _adjustVertical) exitWith {};
 
-_zeroing = _adjustment select _weaponIndex;
-
-if (_zeroing isEqualTo [0, 0, 0]) exitWith {};
-
-// Convert zeroing from mils to degrees
-_zeroing = _zeroing vectorMultiply 0.05625;
+// Get current scope adjustment
+private _adjustment = _unit getVariable [QGVAR(Adjustment), []];
+if (_adjustment isEqualTo []) then {
+    _adjustment = [0,0,0];
+} else {
+    _adjustment = _adjustment select _weaponIndex;
+}
+// Convert it from mils to degrees
+private _zeroing = _adjustment vectorMultiply 0.05625;
 _zeroing params ["_elevation", "_windage", "_zero"];
+_elevation = _elevation + _zero;
 
-[_projectile, _windage, _elevation + _zero, 0] call EFUNC(common,changeProjectileDirection);
+// The scope supports vertical adjustment, so even if _zeroing is [0,0,0] we
+// still need to compute the correction to compensate for vanilla zeroing
+if (_adjustVertical) then {
+    // Calculate the correction due to vanilla zeroing
+    private _zeroDistance = (currentZeroing _unit - GVAR(defaultZeroDistance));
+    if (_zeroDistance == 0) then {
+        private _weaponCombo = [_weapon, _magazine, _ammo, _zeroDistance];
+        if !(_weaponCombo isEqualTo (_unit getVariable [QGVAR(lastWeaponCombo), []])) then {
+            // Hackish way of getting initSpeed. @todo: replace it by correct calculation and caching
+            private _initSpeed = vectorMagnitude velocity _projectile;
+
+            private _airFriction = getNumber (configFile >> "CfgAmmo" >> _ammo >> "airFriction");
+            private _antiOffset = "ace_fcs" callExtension format ["%1,%2,%3,%4", _initSpeed, _airFriction, 0, _zeroDistance];
+            _antiOffset = parseNumber _antiOffset;
+
+            _unit setVariable [QGVAR(lastWeaponCombo), _weaponCombo];
+            _unit setVariable [QGVAR(lastAntiOffset), _antiOffset];
+        };
+        private _antiOffset = _unit getVariable QGVAR(lastAntiOffset);
+
+        _elevation = _elevation - _antiOffset;
+        TRACE_4("fired",_unit, currentZeroing _unit, _antiOffset, _offset);
+    };
+};
+
+// Make a final check to see if all the adjustments compensated after all
+if (_windage == 0 && {_elevation == 0}) exitWith {};
+[_projectile, _windage, _elevation, 0] call EFUNC(common,changeProjectileDirection);

--- a/addons/scopes/stringtable.xml
+++ b/addons/scopes/stringtable.xml
@@ -7,6 +7,12 @@
         <Key ID="STR_ACE_Scopes_Enabled_description">
             <English>Enable adjustment in mils for high powered scopes</English>
         </Key>
+        <Key ID="STR_ACE_Scopes_defaultZeroDistance_displayName">
+            <English>Default zero distance</English>
+        </Key>
+        <Key ID="STR_ACE_Scopes_defaultZeroDistance_description">
+            <English>High power scopes will start zeroed at this distance</English>
+        </Key>
         <Key ID="STR_ACE_Scopes_AdjustUpMinor">
             <English>Minor adjustment up</English>
             <Polish>Zerowanie powoli w górę</Polish>

--- a/addons/scopes/stringtable.xml
+++ b/addons/scopes/stringtable.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Scopes">
+        <Key ID="STR_ACE_Scopes_Enabled_displayName">
+            <English>Enable ACE Scope Adjustment</English>
+        </Key>
+        <Key ID="STR_ACE_Scopes_Enabled_description">
+            <English>Enable adjustment in mils for high powered scopes</English>
+        </Key>
         <Key ID="STR_ACE_Scopes_AdjustUpMinor">
             <English>Minor adjustment up</English>
             <Polish>Zerowanie powoli w górę</Polish>


### PR DESCRIPTION
**Experimental**

**When merged this pull request will:**
- Add a correction to ACE_FCS to account for vanilla zeroing
- Allow ACE_FCS to work without requiring a compatibility PBO
- Add a correction to ACE_Scopes to account for vanilla zeroing
- Allow ACE_Scopes to work without requiring a compatibility PBO

**Rationale**
There are currently 4 ACE systems that require "ACE-Exclusive" compatibility PBOs (that cannot be included in the content without breaking it for vanilla):
- FCS (`discreteDistance[] = {}`)
- Scopes (`discreteDistance[] = {}`)
- Explosives
- Disposable

~~The technique applied in this PR could also be applied to scopes~~ (done), so the only remaining systems would be explosives and disposable, which affect only a minimum fraction of third party content (e.g., doesn't affect vehicles nor small arms).

The current fix is fast (the extension takes 0.01 ms to calculate, and only is required to do so once every time the unit changes zeroing, weapon or ammo) and seems to be as accurate. Fortunately `currentZeroing` works properly with remote units.

**TODO** 
- [ ] Hide the vanilla zeroing control when appropiate, so the end user won't even know it's still enabled. Tagging @jonpas for advice
- [ ] Restore `discreteDistance[] = {}` for vanilla content?
- [ ] Correctly compute the initSpeed from config instead of getting it from the bullet?
