### PR TITLE
Disable drag and carry for StaticCannon

### DIFF
--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -14,6 +14,11 @@ class CfgVehicles {
         GVAR(dragDirection) = 0;
     };
 
+    class StaticCannon: StaticWeapon {
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+
     //remove actions from Taru Pods
     class Pod_Heli_Transport_04_base_F: StaticWeapon {
         GVAR(canCarry) = 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Disable drag and carry for StaticCannon

In RHS this covers M119 (2000 kilos) and the D-30A (3000 kilos)
Close #3528