### PR TITLE
Add alive _unit to the conditions required for interaction

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -444,6 +444,11 @@ if (!isNil QGVAR(PreInit_playerChanged_PFHID)) then {
 // Add various canInteractWith conditions
 //////////////////////////////////////////////////
 
+["isNotDead", {
+    params ["_unit", "_target"];
+    alive _unit
+}] call FUNC(addCanInteractWithCondition);
+
 ["notOnMap", {!visibleMap}] call FUNC(addCanInteractWithCondition);
 
 ["isNotInside", {


### PR DESCRIPTION
**When merged this pull request will:**
- Add alive _unit to the conditions required for interaction
- Prevent the interaction menu from being accessible while dead
- Prevent all keybinded actions from executing while dead (e.g. check ammo)
- Close #2900

