### PR TITLE
reset interaction menu time variables on save game load

### DIFF
--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -45,6 +45,13 @@ GVAR(expanded) = false;
 
 GVAR(startHoverTime) = ACE_diagTime;
 GVAR(expandedTime) = ACE_diagTime;
+
+// reset on mission load
+addMissionEventHandler ["Loaded", {
+    GVAR(startHoverTime) = 0;
+    GVAR(expandedTime) = 0;
+}];
+
 GVAR(iconCtrls) = [];
 GVAR(iconCount) = 0;
 


### PR DESCRIPTION
**When merged this pull request will:**
- cherry pick a save game fix from master into release, because we want it for 3.5.1

