### PR TITLE
Fix versioning true when compiled

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -594,7 +594,7 @@ class CfgSettings {
         class Versioning {
             class ACE {
                 class dependencies {
-                    CBA[] = {"cba_main", REQUIRED_CBA_VERSION, "true"};
+                    CBA[] = {"cba_main", REQUIRED_CBA_VERSION, "(true)"};
                 };
             };
         };


### PR DESCRIPTION
Trivial fix for mikero's dll 5.24 converting "true" to 1 in arrays, which will now causes minor rpt warning on cba dev build