### PR TITLE
Revert the "Improve rope glitchyness" commit

### DIFF
--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -7,3 +7,8 @@
 [QGVAR(startFastRope), {
     [FUNC(fastRopeServerPFH), 0, _this] call CBA_fnc_addPerFrameHandler;
 }] call EFUNC(common,addEventHandler);
+
+[QGVAR(ropeDetach), {
+    params ["_object", "_rope"];
+    _object ropeDetach _rope;
+}] call EFUNC(common,addEventHandler);

--- a/addons/fastroping/functions/fnc_cutRopes.sqf
+++ b/addons/fastroping/functions/fnc_cutRopes.sqf
@@ -32,10 +32,8 @@ _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
         };
     };
 
-    detach _dummy;
-    deleteVehicle _ropeTop;
-    deleteVehicle _hook;
-    [{{deleteVehicle _x} count _this}, [_ropeBottom, _dummy], 60] call EFUNC(common,waitAndExecute);
+    [QGVAR(ropeDetach), [_hook, _ropeTop]] call EFUNC(common,serverEvent);
+    [{{deleteVehicle _x} count _this}, [_ropeTop, _ropeBottom, _dummy, _hook], 60] call EFUNC(common,waitAndExecute);
 } count _deployedRopes;
 
 _vehicle setVariable [QGVAR(deployedRopes), [], true];

--- a/addons/fastroping/functions/fnc_deployRopes.sqf
+++ b/addons/fastroping/functions/fnc_deployRopes.sqf
@@ -35,14 +35,13 @@ _hookAttachment = _vehicle getVariable [QGVAR(FRIES), _vehicle];
 
     _origin = getPosATL _hook;
 
-    _dummy = createVehicle [QGVAR(helper), _origin, [], 0, "CAN_COLLIDE"];
+    _dummy = createVehicle [QGVAR(helper), _origin vectorAdd [0, 0, -1], [], 0, "CAN_COLLIDE"];
     _dummy allowDamage false;
     _dummy disableCollisionWith _vehicle;
-    _dummy attachTo [_hook, [0, 0, 0]];
 
     _ropeTop = ropeCreate [_dummy, [0, 0, 0], _hook, [0, 0, 0], 0.5];
     _ropeBottom = ropeCreate [_dummy, [0, 0, 0], 1];
-    ropeUnwind [_ropeBottom, 30, 35, false];
+    ropeUnwind [_ropeBottom, 30, 34.5, false];
 
     _ropeTop addEventHandler ["RopeBreak", {[_this, "top"] call FUNC(onRopeBreak)}];
     _ropeBottom addEventHandler ["RopeBreak", {[_this, "bottom"] call FUNC(onRopeBreak)}];

--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -26,7 +26,6 @@ if (vehicle _unit != _unit) exitWith {};
 
 //Start fast roping
 if (animationState _unit != "ACE_FastRoping") exitWith {
-    detach _dummy;
     _unit disableCollisionWith _dummy;
     _unit attachTo [_dummy, [0, 0, -1.45]];
     [_unit, "ACE_FastRoping", 2] call EFUNC(common,doAnimation);

--- a/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
@@ -54,14 +54,14 @@ if (((getPos _unit select 2) < 0.2) || {ropeLength _ropeTop == 34.5} || {vectorM
     deleteVehicle _ropeBottom;
 
     _origin = getPosASL _hook;
-    _dummy attachTo [_hook, [0, 0, 0]];
+    _dummy setPosASL (_origin vectorAdd [0, 0, -1]);
 
     //Restore original mass and center of mass
     _dummy setMass 40;
     _dummy setCenterOfMass [0.000143227,0.00105986,-0.246147];
 
     _ropeTop = ropeCreate [_dummy, [0, 0, 0], _hook, [0, 0, 0], 0.5];
-    _ropeBottom = ropeCreate [_dummy, [0, 0, 0], 35];
+    _ropeBottom = ropeCreate [_dummy, [0, 0, 0], 34.5];
 
     _ropeTop addEventHandler ["RopeBreak", {[_this, "top"] call FUNC(onRopeBreak)}];
     _ropeBottom addEventHandler ["RopeBreak", {[_this, "bottom"] call FUNC(onRopeBreak)}];


### PR DESCRIPTION
**When merged this pull request will:**
- Revert a commit that broke the system after the first unit has fastroped

The bug is probably caused by the new way of resetting the helper. For 3.6.0 we could test deleting and recreating the "dummy" object, which is what AGM did. 

