### PR TITLE
Replace usage of filter to select in tagging

### DIFF
--- a/addons/tagging/functions/fnc_tagTestingThread.sqf
+++ b/addons/tagging/functions/fnc_tagTestingThread.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-_fnc_isLeaning = {
+GVAR(tagsToTest) = GVAR(tagsToTest) select {
     params ["_tag", "_tagPosASL", "_vectorDirAndUp"];
 
     _vectorDirAndUp params ["_v1", "_v2"];
@@ -34,7 +34,6 @@ _fnc_isLeaning = {
     };
     true
 };
-GVAR(tagsToTest) = [GVAR(tagsToTest), _fnc_isLeaning] call EFUNC(common,filter);
 
 // If there's no more tag
 if (GVAR(tagsToTest) isEqualTo []) exitWith {


### PR DESCRIPTION
**When merged this pull request will:**
- Replace usage of `ace_common_fnc_filter` in tagging component with `select CODE`
- Remove the last trace of `ace_common_fnc_filter` usage