### PR TITLE
Fix nametag error when rank is empty string

### DIFF
--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -36,7 +36,7 @@ _fnc_parameters = {
         _icon = format [QUOTE(PATHTOF(UI\soundwave%1.paa)), floor random 10];
         _size = 1;
     } else {
-        if (_drawRank) then {
+        if (_drawRank && {rank _target != ""}) then {
             _icon = format["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", toLower rank _target];
             _size = 1;
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix nametag error popup

![image](https://cloud.githubusercontent.com/assets/9376747/13854021/6bb74d52-ec37-11e5-8ee2-da065a745802.png)

`rank` seems like it can return `""` right as unit is respawning.

```
Rank qq_1 is [LIEUTENANT]
Rank qq_1 is []
Rank qq_1 is [LIEUTENANT]
```

This might be a side-effect from using cachedCall to get all near men?