### PR TITLE
Fixed fastroping race condition

### DIFF
--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -7,8 +7,3 @@
 [QGVAR(startFastRope), {
     [FUNC(fastRopeServerPFH), 0, _this] call CBA_fnc_addPerFrameHandler;
 }] call EFUNC(common,addEventHandler);
-
-[QGVAR(ropeDetach), {
-    params ["_object", "_rope"];
-    _object ropeDetach _rope;
-}] call EFUNC(common,addEventHandler);

--- a/addons/fastroping/functions/fnc_cutRopes.sqf
+++ b/addons/fastroping/functions/fnc_cutRopes.sqf
@@ -32,8 +32,11 @@ _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
         };
     };
 
-    [QGVAR(ropeDetach), [_hook, _ropeTop]] call EFUNC(common,serverEvent);
-    [{{deleteVehicle _x} count _this}, [_ropeTop, _ropeBottom, _dummy, _hook], 60] call EFUNC(common,waitAndExecute);
+    //Destroy rope
+    //Only delete the hook first so the rope falls down.
+    //Note: ropeDetach was used here before, but the command seems a bit broken.
+    deleteVehicle _hook;
+    [{{deleteVehicle _x} count _this}, [_ropeTop, _ropeBottom, _dummy], 60] call EFUNC(common,waitAndExecute);
 } count _deployedRopes;
 
 _vehicle setVariable [QGVAR(deployedRopes), [], true];

--- a/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
@@ -25,7 +25,7 @@ private ["_vectorUp", "_vectorDir", "_origin"];
 if (vehicle _unit != _unit) exitWith {};
 
 //Start fast roping
-if (animationState _unit != "ACE_FastRoping") exitWith {
+if (getMass _dummy != 80) exitWith {
     //Fix for twitchyness
     _dummy setMass 80;
     _dummy setCenterOfMass [0, 0, -2];
@@ -38,7 +38,9 @@ if (animationState _unit != "ACE_FastRoping") exitWith {
 };
 
 //Check if rope broke and unit is falling
-if (isNull attachedTo _unit) exitWith {
+//Make sure this isn't executed before the unit is actually fastroping
+//Note: Stretching ropes does not change ropeLength
+if ((isNull attachedTo _unit) && {ropeLength _ropeTop > 0.5}) exitWith {
     [_pfhHandle] call CBA_fnc_removePerFrameHandler;
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix a network race condition that broke fastroping and got people stuck in mid air
- Fix ropes not properly detaching when cut

---

**Details on the network race condition that occured:**
Expected order on commands ran was:
- player gets moved out of the helicopter
- server PFH runs once, starts ropes unwinding
- player changes animation
- nothing really happens until the fast rope is done

What happened sometimes was:
- player gets moved out of the helicopter
- server PFH does *not* run in between here
- player changes animation
- server skips the ropes unwinding command
- ropes are stuck, player is stuck

The condition was changed and the rope unwinding command is now guaranteed to run once, which gets rid of the issue.