### PR TITLE
Greatly improve the accuracy of the protractor display

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_displayProtractor.sqf
+++ b/addons/advanced_ballistics/functions/fnc_displayProtractor.sqf
@@ -47,7 +47,7 @@ GVAR(Protractor) = true;
     __ctrl1 ctrlSetTextColor [1, 1, 1, 1];
 
     __ctrl2 ctrlSetScale 1;
-    __ctrl2 ctrlSetPosition [SafeZoneX + 0.001, SafeZoneY + 0.001 - 0.0012 * (-58 max (asin((ACE_player weaponDirection currentWeapon ACE_player) select 2)) min 58), 0.2, 0.2 * 4/3];
+    __ctrl2 ctrlSetPosition [SafeZoneX + 0.001, SafeZoneY - 0.001 - 0.1074 * (-0.86 max ((ACE_player weaponDirection currentWeapon ACE_player) select 2) min 0.86), 0.2, 0.2 * 4/3];
     __ctrl2 ctrlCommit 0;
     __ctrl2 ctrlSetText QUOTE(PATHTOF(UI\protractor_marker.paa));
     __ctrl2 ctrlSetTextColor [1, 1, 1, 1];


### PR DESCRIPTION
**When merged this pull request will:**
- Improve accuracy of the protractor display. The movement is now linear with the sin of the angle instead of the angle itself, to account for the distorsion in the dial.
- Close #3606

For best results, the needle should match the center of the numbers in the dial.

![20160320222308_1](https://cloud.githubusercontent.com/assets/7674951/13908861/ed9788d6-eeea-11e5-8b09-ad410ef87236.jpg)
