### PR TITLE
Fix AB Terrain Extension

### DIFF
--- a/addons/advanced_ballistics/XEH_postInit.sqf
+++ b/addons/advanced_ballistics/XEH_postInit.sqf
@@ -21,13 +21,15 @@ if (!GVAR(extensionAvailable)) exitWith {
     };
 };
 */
-[] call FUNC(initializeTerrainExtension);
 
 if (!hasInterface) exitWith {};
 
 ["SettingsInitialized", {
     //If not enabled, dont't add PFEH
     if (!GVAR(enabled)) exitWith {};
+
+    //Run the terrain processor
+    [] call FUNC(initializeTerrainExtension);
 
     // Register fire event handler
     ["firedPlayer", DFUNC(handleFired)] call EFUNC(common,addEventHandler);

--- a/addons/advanced_ballistics/functions/fnc_initializeTerrainExtension.sqf
+++ b/addons/advanced_ballistics/functions/fnc_initializeTerrainExtension.sqf
@@ -24,7 +24,7 @@ _mapSize = getNumber (configFile >> "CfgWorlds" >> worldName >> "MapSize");
 if (("ace_advanced_ballistics" callExtension format["init:%1:%2", worldName, _mapSize]) == "Terrain already initialized") exitWith {
     #ifdef DEBUG_MODE_FULL
         systemChat "AdvancedBallistics: Terrain already initialized";
-    #endIf
+    #endif
 };
 
 _mapGrids = ceil(_mapSize / 50) + 1;


### PR DESCRIPTION
Fix Terrain processor never running

 - `FUNC(initializeTerrainExtension)` was called at postInit, before modules are read so `GVAR(enabled)` would be false

 - `#endIf` - That capital I breaks everything with arma preProcessor. `ace_advanced_ballistics_fnc_initializeTerrainExtension` was compiling to just `{}`