### PR TITLE
Filter minor falling damage to non-leg hitpoints

### DIFF
--- a/addons/medical/functions/fnc_handleDamage_caching.sqf
+++ b/addons/medical/functions/fnc_handleDamage_caching.sqf
@@ -58,6 +58,7 @@ if (_unit getVariable [QGVAR(isFalling), false]) then {
         } else {
             _newDamage = _newDamage * 0.5;
         };
+        if (_newDamage < 0.075) then {_newDamage = 0;}; //Filter minor falling damage to non-leg hitpoints
     } else {
         if (_selectionName == "") then {
             _selectionName = selectRandom ["leg_l", "leg_r"];


### PR DESCRIPTION
**When merged this pull request will:**
- Filter minor falling damage to non-leg hitpoints

With basic medical, a short fall will often cause bleeding from all 6 hitpoints, this increase the threshold for non-leg hitpoints to actually take damage from falls.