### PR TITLE
fix FUNC(setName) for Zeus and alive spawned units

### DIFF
--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -33,7 +33,7 @@ class Extended_InitPost_EventHandlers {
     };
     class CAManBase {
         class GVAR(setName) {
-            init = QUOTE(if (local (_this select 0)) then {_this call FUNC(setName)};);
+            init = QUOTE(if (local (_this select 0)) then {[ARR_3(FUNC(setName), _this, DELAY_SETNAME)] call FUNC(waitAndExecute)};);
         };
         class GVAR(muteUnit) {
             init = QUOTE(_this call FUNC(muteUnitHandleInitPost));

--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -33,7 +33,7 @@ class Extended_InitPost_EventHandlers {
     };
     class CAManBase {
         class GVAR(setName) {
-            init = QUOTE(if (local (_this select 0)) then {[ARR_3(FUNC(setName), _this, DELAY_SETNAME)] call FUNC(waitAndExecute)};);
+            init = QUOTE(if (local (_this select 0)) then {[ARR_2(FUNC(setName),_this)] call FUNC(execNextFrame)};);
         };
         class GVAR(muteUnit) {
             init = QUOTE(_this call FUNC(muteUnitHandleInitPost));

--- a/addons/common/functions/fnc_setName.sqf
+++ b/addons/common/functions/fnc_setName.sqf
@@ -19,13 +19,7 @@ if (isNull _unit || {!alive _unit}) exitWith {};
 if (_unit isKindOf "CAManBase") then {
     private _sanitizedName = [name _unit, true] call FUNC(sanitizeString);
     private _rawName = [name _unit, false] call FUNC(sanitizeString);
-    
-    //Debug Testing Code (with html tags):    
-    // private _sanitizedName = ["<TAG>Name", true] call FUNC(sanitizeString);
-    // private _rawName = ["<TAG>Name", false] call FUNC(sanitizeString);
-    
-    //if (_name != _unit getVariable ["ACE_Name", ""]) then {
+
     _unit setVariable ["ACE_Name", _sanitizedName, true];
     _unit setVariable ["ACE_NameRaw", _rawName, true];
-    //};
 };

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -19,3 +19,5 @@
 #define VERSION_CONFIG_COMMON VERSION_CONFIG;\
     versionDesc = "ACE 3";\
     versionAct = QUOTE(call COMPILE_FILE(init_versionTooltip))
+
+#define DELAY_SETNAME 1

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -19,5 +19,3 @@
 #define VERSION_CONFIG_COMMON VERSION_CONFIG;\
     versionDesc = "ACE 3";\
     versionAct = QUOTE(call COMPILE_FILE(init_versionTooltip))
-
-#define DELAY_SETNAME 1


### PR DESCRIPTION
**When merged this pull request will:**
- artificially delay the FUNC(setName) to fix RPT spam
- fix nametags not working with zeus / alive spawned units
- close: #3622
- remove some commented out code

Should be noted that this worked before 1.56. The name was set on init, at least on local units. Not anymore. ~~The one second is arbitrary.~~ I spawned 1000 units and got no complaints in the RPT. `FUNC(setName)` itself is safe to be delayed and doesn't actually require a local unit.