### PR TITLE
Delay calling addCuratorEditableObjects for a frame

### DIFF
--- a/addons/zeus/functions/fnc_addObjectToCurator.sqf
+++ b/addons/zeus/functions/fnc_addObjectToCurator.sqf
@@ -13,12 +13,13 @@
 
 #include "script_component.hpp"
 
-if (!isServer) exitWith {};
-
 params ["_object"];
 
 if (!(_object getVariable [QGVAR(addObject), GVAR(autoAddObjects)])) exitWith {};
 
-{
-    _x addCuratorEditableObjects [[_object], true];
-}forEach allCurators;
+[{
+    TRACE_1("Delayed addCuratorEditableObjects",_this);
+    {
+        _x addCuratorEditableObjects [[_this], true];
+    } forEach allCurators;
+}, _object] call EFUNC(common,execNextFrame);


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes a `createVehicle` vehicle not always being added to zeus when on dedicated server.

Not sure why this is needed, but when using something like:
`"I_G_Offroad_01_repair_F" createVehicle getpos (allUnits select 0);`
on a dedicated server, the vehicle is not always added to zeus, delaying a frame seems to fix.