### PR TITLE
Wait until postInit to install playerChanged event

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -332,12 +332,6 @@ GVAR(OldVisibleMap) = false;
 GVAR(OldInventoryDisplayIsOpen) = nil; //@todo check this
 GVAR(OldIsCamera) = false;
 
-// clean up playerChanged eventhandler from preinit and put it in the same PFH as the other events to reduce overhead and guarantee advantageous execution order
-if (!isNil QGVAR(PreInit_playerChanged_PFHID)) then {
-    [GVAR(PreInit_playerChanged_PFHID)] call CBA_fnc_removePerFrameHandler;
-    GVAR(PreInit_playerChanged_PFHID) = nil;
-};
-
 // PFH to raise varios events
 [{
     BEGIN_COUNTER(stateChecker);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -47,28 +47,11 @@ GVAR(statusEffect_Names) = [];
 GVAR(statusEffect_isGlobal) = [];
 
 //////////////////////////////////////////////////
-// Set up PlayerChanged eventhandler for pre init
+// Set up PlayerChanged eventhandler for pre init (EH is installed in postInit)
 //////////////////////////////////////////////////
 
 ACE_player = objNull;
 uiNamespace setVariable ["ACE_player", objNull];
-
-// @todo check if this can be removed
-if (hasInterface) then {
-    // PFH to update the ACE_player variable
-    GVAR(PreInit_playerChanged_PFHID) = [{
-        if !(ACE_player isEqualTo (call FUNC(player))) then {
-            private _oldPlayer = ACE_player;
-
-            ACE_player = call FUNC(player);
-            uiNamespace setVariable ["ACE_player", ACE_player];
-
-            // Raise ACE event
-            ["playerChanged", [ACE_player, _oldPlayer]] call FUNC(localEvent);
-        };
-    }, 0, []] call CBA_fnc_addPerFrameHandler;
-};
-
 
 //////////////////////////////////////////////////
 // Time handling


### PR DESCRIPTION
Due to https://github.com/CBATeam/CBA_A3/pull/303
PFEH will be run between preInit and postInit, so the "playerChanged" event happens before most event handlers are installed in postInit.

This breaks noRadio, and other things that count on the `playerChanged` event always happening.