### PR TITLE
end spectator by global mission end event from server

### DIFF
--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -26,4 +26,4 @@ if (isServer) then {
     if (GVAR(isSet)) then {
         [false] call FUNC(setSpectator);
     };
-}] call EFUNC(common,addEventHandler)
+}] call EFUNC(common,addEventHandler);

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -16,4 +16,14 @@ if (isServer) then {
 };
 
 // Should prevent unending spectator on mission end
-addMissionEventHandler ["Ended",{ [QGVAR(EndMission)] call FUNC(interrupt) }];
+if (isServer) then {
+    addMissionEventHandler ["Ended", {
+        [QGVAR(endMission), []] call EFUNC(common,globalEvent);
+    }];
+};
+
+[QGVAR(endMission), {
+    if (GVAR(isSet)) then {
+        [false] call FUNC(setSpectator);
+    };
+}] call EFUNC(common,addEventHandler)

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -92,7 +92,7 @@ if (_set) then {
         if (_this) then {
             _display displayAddEventHandler ["KeyDown", {
                 if (_this select 1 == 1) then {
-                    [false] call ace_spectator_fnc_setSpectator;
+                    [false] call FUNC(setSpectator);
                     true
                 };
             }];


### PR DESCRIPTION
**When merged this pull request will:**
- title
- maybe fix #3614

Please someone test on a dedicated.

Note:
- This fix does not work for SP.
- This fix only kinda works for local hosted MP if the host him/herself is currently in the spectator view. Once the local host leaves the spectator mode by pressing ESC, the mission should end for everyone.
- On dedicated server, this should work without issues.