### PR TITLE
Raise a local event when a weapon is jammed

### DIFF
--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -43,6 +43,9 @@ if (_ammo > 0) then {
 // only display the hint once, after you try to shoot an already jammed weapon
 GVAR(knowAboutJam) = false;
 
+["overheating_jammed", [_unit,_weapon]] call EFUNC(common,localEvent);
+
+
 if (_unit getVariable [QGVAR(JammingActionID), -1] == -1) then {
 
     private _condition = {

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -43,7 +43,7 @@ if (_ammo > 0) then {
 // only display the hint once, after you try to shoot an already jammed weapon
 GVAR(knowAboutJam) = false;
 
-["overheating_jammed", [_unit,_weapon]] call EFUNC(common,localEvent);
+["weaponJammed", [_unit,_weapon]] call EFUNC(common,localEvent);
 
 
 if (_unit getVariable [QGVAR(JammingActionID), -1] == -1) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Raise an event when a player's weapon jams. 



This is a very minor (1 line!) change which will add an event upon weapon jamming to the public API. I personally have a use for it in an existing addon I am working on and I am sure that others may find it useful. 

