### PR TITLE
Googles - Only play wipe anim for primary weapon

### DIFF
--- a/addons/goggles/functions/fnc_clearGlasses.sqf
+++ b/addons/goggles/functions/fnc_clearGlasses.sqf
@@ -26,7 +26,7 @@ _effects set [BROKEN, _broken];
 
 SETGLASSES(_unit,_effects);
 
-if (stance _unit != "PRONE") then {
+if ((stance _unit != "PRONE") && {primaryWeapon _unit != ""} && {currentWeapon _unit == primaryWeapon _unit}) then {
     _unit playActionNow "gestureWipeFace";
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Close #3638

Animation only makes sense for primary weapon, so skip for others.