### PR TITLE
Javelin - Verify player has LOS to cursorTarget

### DIFF
--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -98,11 +98,17 @@ if (_range > 50 && {_range < 2500}) then {
     };
 };
 
-if (isNull _newTarget) then {
-    private _intersectionsToCursorTarget = lineIntersectsSurfaces [(AGLtoASL positionCameraToWorld [0,0,0]), aimPos cursorTarget, ace_player, cursorTarget, true, 1];
-    if (_intersectionsToCursorTarget isEqualTo []) then {
-        _newTarget = cursorTarget;
-    };
+if ((isNull _newTarget) && {cursorObject isKindOf "AllVehicles"}) then {
+        private _intersectionsToCursorTarget = lineIntersectsSurfaces [(AGLtoASL positionCameraToWorld [0,0,0]), aimPos cursorObject, ace_player, cursorObject, true, 1];
+        if (_intersectionsToCursorTarget isEqualTo []) then {
+            _newTarget = cursorObject;
+        };
+};
+if ((isNull _newTarget) && {cursorTarget isKindOf "AllVehicles"}) then {
+        private _intersectionsToCursorTarget = lineIntersectsSurfaces [(AGLtoASL positionCameraToWorld [0,0,0]), aimPos cursorTarget, ace_player, cursorTarget, true, 1];
+        if (_intersectionsToCursorTarget isEqualTo []) then {
+            _newTarget = cursorTarget;
+        };
 };
 
 // Create constants

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -99,7 +99,10 @@ if (_range > 50 && {_range < 2500}) then {
 };
 
 if (isNull _newTarget) then {
-    _newTarget = cursorTarget;
+    private _intersectionsToCursorTarget = lineIntersectsSurfaces [(AGLtoASL positionCameraToWorld [0,0,0]), aimPos cursorTarget, ace_player, cursorTarget, true, 1];
+    if (_intersectionsToCursorTarget isEqualTo []) then {
+        _newTarget = cursorTarget;
+    };
 };
 
 // Create constants


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #3668

`cursorTarget` will work through hills if the unit has prior knoweldge of target

Example: Green X is cursorTarget car:
![20160412014636_1](https://cloud.githubusercontent.com/assets/9376747/14452502/acc1ccc4-0054-11e6-8bb1-4f5de641b430.jpg)
