### PR TITLE
Add NonSteerable Reserve Parachute

### DIFF
--- a/addons/parachute/CfgVehicles.hpp
+++ b/addons/parachute/CfgVehicles.hpp
@@ -83,7 +83,8 @@ class CfgVehicles {
         //model = "\A3\Weapons_F\Ammoboxes\Bags\Backpack_Parachute";    // @todo
         // backpackSimulation = "ParachuteNonSteerable";    //ParachuteSteerable  //Bis broke this in 1.40
         ParachuteClass = "NonSteerable_Parachute_F";
-        MACRO_HASRESERVE
+        ace_hasReserveParachute = 1;
+        ace_reserveParachute = "ACE_NonSteerableReserveParachute";
         maximumLoad = 0;
         mass = 100;
     };
@@ -96,6 +97,10 @@ class CfgVehicles {
         ParachuteClass = "Steerable_Parachute_F";
         ace_reserveParachute = "";
         ace_hasReserveParachute = 0;
+    };
+    
+    class ACE_NonSteerableReserveParachute: ACE_ReserveParachute {
+        ParachuteClass = "NonSteerable_Parachute_F";
     };
 
     class B_Soldier_05_f; class B_Pilot_F: B_Soldier_05_f {backpack = "ACE_NonSteerableParachute";};

--- a/addons/parachute/functions/fnc_storeParachute.sqf
+++ b/addons/parachute/functions/fnc_storeParachute.sqf
@@ -15,16 +15,17 @@
    * Public: No
    */
 #include "script_component.hpp"
-private ["_unit","_backpack"];
-_unit = _this select 0;
-_backpack = (_this select 1) select 6;
-if ((vehicle _unit) isKindOf "ParachuteBase" && backpack _unit == "" && !(_unit getVariable [QGVAR(chuteIsCut),false]) && (_unit getVariable [QGVAR(hasReserve),false])) then {
+
+private _unit = _this select 0;
+private _backpack = (_this select 1) select 6;
+
+if ((vehicle _unit) isKindOf "ParachuteBase" && {backpack _unit == ""} && {!(_unit getVariable [QGVAR(chuteIsCut),false])} && {_unit getVariable [QGVAR(hasReserve),false]}) then {
     _unit addBackpackGlobal (_unit getVariable[QGVAR(backpackClass),"ACE_NonSteerableParachute"]);
 } else {
-    if ([false,true] select (getNumber(configFile >> "CfgVehicles" >> _backpack >> "ace_hasReserveParachute"))) then {
+    if ((getNumber(configFile >> "CfgVehicles" >> _backpack >> "ace_hasReserveParachute")) == 1) then {
         _unit setVariable[QGVAR(backpackClass),getText(configFile >> "CfgVehicles" >> _backpack >> "ace_reserveParachute"),true];
     };
-    if (!(_unit getVariable [QGVAR(chuteIsCut),false]) && !(animationState _unit == 'para_pilot')) then {
+    if (!(_unit getVariable [QGVAR(chuteIsCut),false]) && {!(animationState _unit == 'para_pilot')}) then {
         _unit setVariable [QGVAR(hasReserve),[false,true] select (getNumber(configFile >> "CfgVehicles" >> _backpack >> "ace_hasReserveParachute")),true];
     };
 };

--- a/addons/parachute/functions/fnc_storeParachute.sqf
+++ b/addons/parachute/functions/fnc_storeParachute.sqf
@@ -16,8 +16,8 @@
    */
 #include "script_component.hpp"
 
-private _unit = _this select 0;
-private _backpack = (_this select 1) select 6;
+params ["_unit", "_gear"];
+private _backpack = _gear select 6;
 
 if ((vehicle _unit) isKindOf "ParachuteBase" && {backpack _unit == ""} && {!(_unit getVariable [QGVAR(chuteIsCut),false])} && {_unit getVariable [QGVAR(hasReserve),false]}) then {
     _unit addBackpackGlobal (_unit getVariable[QGVAR(backpackClass),"ACE_NonSteerableParachute"]);


### PR DESCRIPTION
**When merged this pull request will:**
- Add NonSteerable Reserve Parachute
- Cleanup storeParachute

Close #3364

`ACE_NonSteerableParachute` -> `ACE_NonSteerableReserveParachute` - both are not steerable
`B_Parachute` -> `ACE_ReserveParachute` - both are steerable