### PR TITLE
Fix ship view distance using foot instead of vehicle setting

### DIFF
--- a/addons/viewdistance/CfgVehicles.hpp
+++ b/addons/viewdistance/CfgVehicles.hpp
@@ -1,6 +1,6 @@
 class CfgVehicles {
     class ACE_Module;
-    class GVAR(ModuleSettings) : ACE_Module {
+    class GVAR(ModuleSettings): ACE_Module {
         author = ECSTRING(common,ACETeam);
         category = "ACE";
         function = QUOTE(DFUNC(initModule));

--- a/addons/viewdistance/XEH_PREP.hpp
+++ b/addons/viewdistance/XEH_PREP.hpp
@@ -1,4 +1,3 @@
-
 PREP(adaptViewDistance);
 PREP(changeViewDistance);
 PREP(initModule);

--- a/addons/viewdistance/XEH_clientInit.sqf
+++ b/addons/viewdistance/XEH_clientInit.sqf
@@ -24,6 +24,6 @@ if (!hasInterface) exitWith {};
     // Set the EH which waits for a vehicle change to automatically swap between On Foot/In Land Vehicle/In Air Vehicle
     // Also run when SettingsInitialized runs (not guaranteed)
     ["playerVehicleChanged",{
-        [false] call FUNC(adaptViewDistance)
+        [false] call FUNC(adaptViewDistance);
     }] call EFUNC(common,addEventHandler);
 }] call EFUNC(common,addEventHandler);

--- a/addons/viewdistance/functions/fnc_adaptViewDistance.sqf
+++ b/addons/viewdistance/functions/fnc_adaptViewDistance.sqf
@@ -22,7 +22,7 @@ if (!GVAR(enabled) || isNull ACE_player) exitWith {};
 
 private _vehicle = vehicle ACE_player;
 
-private _landVehicle = _vehicle isKindOf "LandVehicle" || _vehicle isKindOf "Ship_F";
+private _landVehicle = _vehicle isKindOf "LandVehicle" || {_vehicle isKindOf "Ship_F"};
 private _airVehicle = _vehicle isKindOf "Air";
 
 if (!_landVehicle && !_airVehicle) exitWith {

--- a/addons/viewdistance/functions/fnc_adaptViewDistance.sqf
+++ b/addons/viewdistance/functions/fnc_adaptViewDistance.sqf
@@ -2,7 +2,6 @@
  * Author: Winter
  * Sets the player's current view distance according to whether s/he is on foot, in a land vehicle or in an air vehicle.
  *
- *
  * Arguments:
  * 0: Show Prompt <BOOL>
  *
@@ -17,23 +16,23 @@
 
 #include "script_component.hpp"
 
-private["_land_vehicle","_air_vehicle"];
-
-params ["_show_prompt"];
+params ["_showPrompt"];
 
 if (!GVAR(enabled) || isNull ACE_player) exitWith {};
 
-_land_vehicle = (vehicle ACE_player) isKindOf "LandVehicle";
-_air_vehicle = (vehicle ACE_player) isKindOf "Air";
+private _vehicle = vehicle ACE_player;
 
-if (!_land_vehicle && !_air_vehicle) exitWith {
-    [GVAR(viewDistanceOnFoot),_show_prompt] call FUNC(changeViewDistance);
+private _landVehicle = _vehicle isKindOf "LandVehicle" || _vehicle isKindOf "Ship_F";
+private _airVehicle = _vehicle isKindOf "Air";
+
+if (!_landVehicle && !_airVehicle) exitWith {
+    [GVAR(viewDistanceOnFoot), _showPrompt] call FUNC(changeViewDistance);
 };
 
-if (_land_vehicle) exitWith {
-    [GVAR(viewDistanceLandVehicle),_show_prompt] call FUNC(changeViewDistance);
+if (_landVehicle) exitWith {
+    [GVAR(viewDistanceLandVehicle), _showPrompt] call FUNC(changeViewDistance);
 };
 
-if (_air_vehicle) exitWith {
-    [GVAR(viewDistanceAirVehicle),_show_prompt] call FUNC(changeViewDistance);
+if (_airVehicle) exitWith {
+    [GVAR(viewDistanceAirVehicle), _showPrompt] call FUNC(changeViewDistance);
 };

--- a/addons/viewdistance/functions/fnc_returnObjectCoeff.sqf
+++ b/addons/viewdistance/functions/fnc_returnObjectCoeff.sqf
@@ -16,11 +16,9 @@
 
 #include "script_component.hpp"
 
-private ["_return"];
-
 params ["_index"];
 
-_return = switch (_index) do {
+switch (_index) do {
     case 0: {0.00}; // Off
     case 1: {0.20}; // Very Low
     case 2: {0.40}; // Low
@@ -30,5 +28,3 @@ _return = switch (_index) do {
     case 6: {"fov"}; // FoV Based
     default {0.50}; // something broke if this returns
 };
-
-_return;

--- a/addons/viewdistance/functions/fnc_returnValue.sqf
+++ b/addons/viewdistance/functions/fnc_returnValue.sqf
@@ -16,28 +16,23 @@
 
 #include "script_component.hpp"
 
-private ["_return"];
-
 params ["_index"];
 
-_return = switch (_index) do {
-    case 0:   {viewDistance}; // Video Settings option
-    case 1:   {500};
-    case 2:   {1000};
-    case 3:   {1500};
-    case 4:   {2000};
-    case 5:   {2500};
-    case 6:   {3000};
-    case 7:   {3500};
-    case 8:   {4000};
-    case 9:   {5000};
-    case 10:  {6000};
-    case 11:  {7000};
-    case 12:  {8000};
-    case 13:  {9000};
-    case 14:  {10000};
-    default   {1000};
+switch (_index) do {
+    case 0: {viewDistance}; // Video Settings option
+    case 1: {500};
+    case 2: {1000};
+    case 3: {1500};
+    case 4: {2000};
+    case 5: {2500};
+    case 6: {3000};
+    case 7: {3500};
+    case 8: {4000};
+    case 9: {5000};
+    case 10: {6000};
+    case 11: {7000};
+    case 12: {8000};
+    case 13: {9000};
+    case 14: {10000};
+    default {1000};
 };
-
-TRACE_1("VD Index Return",_return);
-_return

--- a/addons/viewdistance/functions/fnc_setFovBasedOvdPFH.sqf
+++ b/addons/viewdistance/functions/fnc_setFovBasedOvdPFH.sqf
@@ -17,10 +17,6 @@
 
 #include "script_component.hpp"
 
-#define VD_ZOOM_NORMAL 1.00041
-#define VD_ZOOM_DIVISION 35
-#define VD_ZOOM_DIVISION_AIR 10
-
 params ["", "_idPFH"];
 
 // Remove PFH and set Object View Distance back to what it was before
@@ -29,25 +25,20 @@ if (GVAR(objectViewDistanceCoeff) < 6) exitWith {
     GVAR(fovBasedPFHminimalViewDistance) = nil;
 };
 
-private ["_zoom"];
-_zoom = (call CBA_fnc_getFov) select 1;
+private _zoom = (call CBA_fnc_getFov) select 1;
 
-// Air
-if ((vehicle ACE_player) isKindOf "Air") exitWith {
-    if (_zoom > VD_ZOOM_NORMAL) then {
-        // Dynamically set Object View Distance based on player's Zoom Level and View Distance
-        setObjectViewDistance ((_zoom / VD_ZOOM_DIVISION_AIR * (viewDistance - GVAR(fovBasedPFHminimalViewDistance))) + GVAR(fovBasedPFHminimalViewDistance));
-    } else {
-        setObjectViewDistance (GVAR(fovBasedPFHminimalViewDistance) + viewDistance / 10);
-    };
-    TRACE_2("FoV Based",getObjectViewDistance select 0,_zoom);
-};
-
-// Land
 if (_zoom > VD_ZOOM_NORMAL) then {
     // Dynamically set Object View Distance based on player's Zoom Level and View Distance
-    setObjectViewDistance ((_zoom / VD_ZOOM_DIVISION * (viewDistance - GVAR(fovBasedPFHminimalViewDistance))) + GVAR(fovBasedPFHminimalViewDistance));
+    if ((vehicle ACE_player) isKindOf "Air") then {
+        setObjectViewDistance ((_zoom / VD_ZOOM_DIVISION_AIR * (viewDistance - GVAR(fovBasedPFHminimalViewDistance))) + GVAR(fovBasedPFHminimalViewDistance));
+    } else {
+        setObjectViewDistance ((_zoom / VD_ZOOM_DIVISION * (viewDistance - GVAR(fovBasedPFHminimalViewDistance))) + GVAR(fovBasedPFHminimalViewDistance));
+    };
 } else {
-    setObjectViewDistance GVAR(fovBasedPFHminimalViewDistance);
+    if ((vehicle ACE_player) isKindOf "Air") then {
+        setObjectViewDistance (GVAR(fovBasedPFHminimalViewDistance) + viewDistance / 10);
+    } else {
+        setObjectViewDistance GVAR(fovBasedPFHminimalViewDistance);
+    };
 };
 TRACE_2("FoV Based",getObjectViewDistance select 0,_zoom);

--- a/addons/viewdistance/script_component.hpp
+++ b/addons/viewdistance/script_component.hpp
@@ -15,3 +15,8 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+
+
+#define VD_ZOOM_NORMAL 1.00041
+#define VD_ZOOM_DIVISION 35
+#define VD_ZOOM_DIVISION_AIR 10


### PR DESCRIPTION
**When merged this pull request will:**
- Fix view distance using "on foot" setting when in boats/ships instead of "in vehicle" setting.
- Cleanup view distance component (`params`, `private` keyword, camel case, `isEqualType `)
- Move constants to `script_component.hpp`