### PR TITLE
Exclude FRIES from repair interactions

### DIFF
--- a/addons/repair/CfgEventHandlers.hpp
+++ b/addons/repair/CfgEventHandlers.hpp
@@ -35,7 +35,7 @@ class Extended_InitPost_EventHandlers {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
             serverInit = QUOTE(_this call DFUNC(addSpareParts));
-            exclude[] = {QEGVAR(fastroping,helper), "ACE_friesAnchorBar"};
+            exclude[] = {QEGVAR(fastroping,helper), "ACE_friesBase"};
         };
     };
     class Plane {

--- a/addons/repair/CfgEventHandlers.hpp
+++ b/addons/repair/CfgEventHandlers.hpp
@@ -35,7 +35,7 @@ class Extended_InitPost_EventHandlers {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
             serverInit = QUOTE(_this call DFUNC(addSpareParts));
-            exclude[] = {QEGVAR(fastroping,helper)};
+            exclude[] = {QEGVAR(fastroping,helper), "ACE_friesAnchorBar"};
         };
     };
     class Plane {


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent `repair` component from trying to add repair interactions to `ACE_friendsAnchorBar`

```
13:40:49 0:00:50.916 (0) [z\ace\addons\interact_menu\functions\fnc_addActionToClass.sqf:46] -ERROR- ERROR
13:40:49             Failed to add action
13:40:49 [ACE] (interact_menu) ERROR: action (ace_repair_fullRepair) to parent ["ACE_MainActions","ace_repair_Repair"] on object ACE_friesAnchorBar [0]
```
