### PR TITLE
docs: mark waitUntilAndExecute as Public: Yes

### DIFF
--- a/addons/common/functions/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/functions/fnc_waitUntilAndExecute.sqf
@@ -13,7 +13,7 @@
  * Example:
  * [{(_this select 0) == vehicle (_this select 0)}, {(_this select 0) setDamage 1;}, [ACE_player]] call ace_common_fnc_waitUntilAndExecute
  *
- * Public: No
+ * Public: Yes
  */
 #include "script_component.hpp"
 


### PR DESCRIPTION
**When merged this pull request will:**
- Describe what this pull request will do: update docs
- Each change in a separate line: 

-mark waitUntilAndExecute as public


Is there a reason not to? Noticed it wasn't available in Atom