### PR TITLE
Concertina Wire - Don't recoil broken wire, fix killer

### DIFF
--- a/addons/concertina_wire/CfgVehicles.hpp
+++ b/addons/concertina_wire/CfgVehicles.hpp
@@ -86,7 +86,7 @@ class CfgVehicles {
                     selection = "";
                     displayName = "$STR_ACE_UNROLLWIRE";
                     distance = 5;
-                    condition = "true";
+                    condition = "alive _target";
                     statement = QUOTE([ARR_2(_target,_player)] call FUNC(dismount));
                     showDisabled = 0;
                     exceptions[] = {};

--- a/addons/concertina_wire/functions/fnc_handleKilled.sqf
+++ b/addons/concertina_wire/functions/fnc_handleKilled.sqf
@@ -14,13 +14,17 @@
  */
 #include "script_component.hpp"
 params ["_wire", "_killer"];
+TRACE_2("params",_wire,_killer);
 
 private ["_distance", "_vehicle"];
 
 if (isNull _killer) then {
     _killer = _wire getVariable ["ace_concertina_wire_lastDamager", objNull];
     if (isNull _killer) then {
-        _killer = nearestObject [_wire, "car"];
+        private _midPoint = ((_wire selectionPosition "start") vectorAdd (_wire selectionPosition "deploy")) vectorMultiply 0.5;
+        {
+            if ((vectorMagnitude velocity _x) > 0) exitWith {_killer = _x};
+        } forEach (nearestObjects [(_wire modelToWorld _midPoint), ["Car"], 8]);
     };
 };
 if (isNull _killer || {_killer == _wire} || {_killer == gunner (vehicle _killer)}) exitWith {};


### PR DESCRIPTION
**When merged this pull request will:**
Close #3695
- Don't recoil broken wire
- Use midpoint to search for nearby cars, and ensure the veh was moving.