### PR TITLE
Gforces - Add ace_setting to only run in aircraft

### DIFF
--- a/addons/gforces/ACE_Settings.hpp
+++ b/addons/gforces/ACE_Settings.hpp
@@ -2,7 +2,7 @@ class ACE_Settings {
     class GVAR(enabledFor) {
         displayName = CSTRING(enabledFor_displayName);
         typeName = "SCALAR";
-        value = 2;
+        value = 1;
         values[] = {ECSTRING(Common,Disabled), CSTRING(enabledFor_onlyAircraft), ECSTRING(Common,Enabled)};
     };
 };

--- a/addons/gforces/ACE_Settings.hpp
+++ b/addons/gforces/ACE_Settings.hpp
@@ -1,0 +1,8 @@
+class ACE_Settings {
+    class GVAR(enabledFor) {
+        displayName = CSTRING(enabledFor_displayName);
+        typeName = "SCALAR";
+        value = 2;
+        values[] = {ECSTRING(Common,Disabled), CSTRING(enabledFor_onlyAircraft), ECSTRING(Common,Enabled)};
+    };
+};

--- a/addons/gforces/XEH_PREP.hpp
+++ b/addons/gforces/XEH_PREP.hpp
@@ -1,2 +1,2 @@
-
+PREP(addPFEH);
 PREP(pfhUpdateGForces);

--- a/addons/gforces/XEH_postInit.sqf
+++ b/addons/gforces/XEH_postInit.sqf
@@ -2,14 +2,38 @@
 
 if (!hasInterface) exitWith {};
 
-// Setup ppEffect
-GVAR(GForces_CC) = ppEffectCreate ["ColorCorrections", 4215];
-GVAR(GForces_CC) ppEffectEnable true;
-GVAR(GForces_CC) ppEffectForceInNVG true;
-GVAR(GForces_CC) ppEffectAdjust [1,1,0,[0,0,0,1],[0,0,0,0],[1,1,1,1],[10,10,0,0,0,0.1,0.5]];
-GVAR(GForces_CC) ppEffectCommit 0.4;
+GVAR(pfID) = -1;
 
-GVAR(lastUpdateTime) = 0;
-GVAR(oldVel) = [0,0,0];
+["SettingsInitialized", {
+    TRACE_1("SettingsInitialized eh",GVAR(enabledFor));
 
-[DFUNC(pfhUpdateGForces), 0, []] call CBA_fnc_addPerFrameHandler;
+    if (GVAR(enabledFor) == 0) exitWith {}; //Module has no effect if enabledFor is "None"
+    if (GVAR(enabledFor) == 2) exitWith { //PFEH is always on when enabledFor is "All"
+        [] call FUNC(addPFEH);
+        TRACE_1("adding perm PFEH",GVAR(pfID));
+    };
+
+    //PFEH only runs when player is in a type "Air" vehicle when enabledFor is "Aircraft"
+
+    if ((!isNull (vehicle ACE_player)) && {(vehicle ACE_player) isKindOf "Air"}) then { //"playerVehicleChanged" can happen before "settingInit"
+        [] call FUNC(addPFEH);
+        TRACE_1("adding temp PFEH [start in]",GVAR(pfID));
+    };
+    ["playerVehicleChanged", {
+        params ["", "_vehicle"];
+        TRACE_2("playerVehicleChanged",_vehicle,typeOf _vehicle);
+        if (_vehicle isKindOf "Air") then {
+            if (GVAR(pfID) == -1) then {
+                [] call FUNC(addPFEH);
+                TRACE_1("adding temp PFEH",GVAR(pfID));
+            };
+        } else {
+            if (GVAR(pfID) != -1) then {
+                TRACE_1("removing temp PFEH",GVAR(pfID));
+                ppEffectDestroy GVAR(GForces_CC);
+                [GVAR(pfID)] call CBA_fnc_removePerFrameHandler;
+                GVAR(pfID) = -1;
+            };
+        };
+    }] call EFUNC(common,addEventHandler);
+}] call EFUNC(common,addEventHandler);

--- a/addons/gforces/functions/fnc_addPFEH.sqf
+++ b/addons/gforces/functions/fnc_addPFEH.sqf
@@ -1,0 +1,29 @@
+/*
+ * Author: KoffeinFlummi and esteldunedain
+ * Adds the PFEH
+ *
+ * Argument:
+ * None
+ *
+ * Return value:
+ * None
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+//Reset forces array
+GVAR(GForces) = [];
+GVAR(GForces_Index) = 0;
+
+// Setup ppEffect
+GVAR(GForces_CC) = ppEffectCreate ["ColorCorrections", 4215];
+GVAR(GForces_CC) ppEffectEnable true;
+GVAR(GForces_CC) ppEffectForceInNVG true;
+GVAR(GForces_CC) ppEffectAdjust [1,1,0,[0,0,0,1],[0,0,0,0],[1,1,1,1],[10,10,0,0,0,0.1,0.5]];
+GVAR(GForces_CC) ppEffectCommit 0.4;
+
+GVAR(lastUpdateTime) = 0;
+GVAR(oldVel) = [0,0,0];
+
+GVAR(pfID) = [DFUNC(pfhUpdateGForces), 0, []] call CBA_fnc_addPerFrameHandler;

--- a/addons/gforces/functions/fnc_pfhUpdateGForces.sqf
+++ b/addons/gforces/functions/fnc_pfhUpdateGForces.sqf
@@ -13,13 +13,13 @@
  */
  #include "script_component.hpp"
 
-EXPLODE_2_PVT(_this,_params,_pfhId);
-
 // Update the g-forces at constant mission time intervals (taking accTime into account)
 if ((ACE_time - GVAR(lastUpdateTime)) < INTERVAL) exitWith {};
 GVAR(lastUpdateTime) = ACE_time;
 
 if (isNull ACE_player || !(alive ACE_player)) exitWith {};
+
+BEGIN_COUNTER(everyInterval);
 
 private _newVel = velocity (vehicle ACE_player);
 private _accel = ((_newVel vectorDiff GVAR(oldVel)) vectorMultiply (1 / INTERVAL)) vectorAdd [0, 0, 9.8];
@@ -91,3 +91,5 @@ if !(ACE_player getVariable ["ACE_isUnconscious", false]) then {
 };
 
 GVAR(GForces_CC) ppEffectCommit INTERVAL;
+
+END_COUNTER(everyInterval);

--- a/addons/gforces/stringtable.xml
+++ b/addons/gforces/stringtable.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACE">
+    <Package name="gforces">
+        <Key ID="STR_ACE_gforces_enabledFor_displayName">
+            <English>Gforces Effects</English>
+            <German>Gforces Effekte</German>
+            <Spanish>Efectos Gforces</Spanish>
+        </Key>
+        <Key ID="STR_ACE_gforces_enabledFor_onlyAircraft">
+            <English>Only Aircraft</English>
+            <German>Nur Luftfahrzeug</German>
+            <Spanish>Sólo Aeronave</Spanish>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add ace_setting to gforces so the PFEH only runs when player is inside of a aircraft

Default is unchanged, but we might want to make default aircraft only (`1`)?
I don't think any ground vehicle can accelerate enough to have any real effect.