### PR TITLE
FlashSuppressors - use next CBA's JM configs

### DIFF
--- a/addons/flashsuppressors/CfgWeapons.hpp
+++ b/addons/flashsuppressors/CfgWeapons.hpp
@@ -29,32 +29,73 @@ class asdg_MuzzleSlot_45ACP_SMG: asdg_MuzzleSlot { // for .45ACP universal mount
         ACE_muzzle_mzls_smg_01 = 1;
     };
 };
+class asdg_MuzzleSlot_762MG: asdg_MuzzleSlot { // for 7.62, 6.5 and 5.56 universal mount MG suppressors
+    class compatibleItems {
+        ACE_muzzle_mzls_B = 1;
+    };
+};
 
 class MuzzleSlot;
 
 class CfgWeapons {
-
-    /* MX */
-
-    class Rifle;
-    class Rifle_Base_F: Rifle {
+    class Rifle_Base_F;
+    
+    class Rifle_Long_Base_F: Rifle_Base_F {
         class WeaponSlotsInfo;
     };
 
-    class arifle_MX_Base_F: Rifle_Base_F {
+    /* MX */
+   class arifle_MX_Base_F: Rifle_Base_F {
+        class WeaponSlotsInfo;
+    };
+
+    class arifle_MXC_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_H"};
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
             };
         };
     };
-
+    class arifle_MX_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
+            };
+        };
+    };
+    class arifle_MX_GL_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
+            };
+        };
+    };
     class arifle_MX_SW_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                // Shit is broken again
-                //compatibleItems[] += {"ACE_muzzle_mzls_H"};
-                compatibleItems[] = {"muzzle_snds_H","muzzle_snds_H_SW","ACE_muzzle_mzls_H"};
+            class MuzzleSlot: asdg_MuzzleSlot_762MG {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
+            };
+        };
+    };
+    class arifle_MXM_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
             };
         };
     };
@@ -62,41 +103,49 @@ class CfgWeapons {
 
     /* Katiba */
 
-    class arifle_katiba_Base_F: Rifle_Base_F {
+    class arifle_Katiba_Base_F: Rifle_Base_F {
+        class WeaponSlotsInfo;
+    };
+    class arifle_Katiba_F: arifle_Katiba_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_H"};
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
+            };
+        };
+    };
+    class arifle_Katiba_C_F: arifle_Katiba_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
+            };
+        };
+    };
+    class arifle_Katiba_GL_F: arifle_Katiba_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot: asdg_MuzzleSlot_762 {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
             };
         };
     };
 
 
     /* Other */
-
-    class Rifle_Long_Base_F: Rifle_Base_F {
-        class WeaponSlotsInfo;
-    };
-
-    class DMR_01_base_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
-            };
-        };
-    };
-
     class LMG_Mk200_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_H"};
-            };
-        };
-    };
-
-    class LMG_Zafir_F: Rifle_Long_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: MuzzleSlot {
-                compatibleItems[] += {"ACE_muzzle_mzls_B"};
+            class MuzzleSlot: asdg_MuzzleSlot_762MG {
+                class compatibleItems: compatibleItems {
+                    ACE_muzzle_mzls_H = 1;
+                    ACE_muzzle_mzls_B = 0;
+                };
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Close #3700 - Fix UBC errors and properly configure the 6.5mm weapons to use the right flash suppressors.

Quick version of how it works:

For most weapons we can just add it to the generic muzzle
eg `class asdg_MuzzleSlot_762MG: asdg_MuzzleSlot { ` we add the `*_B` item which is 7.62mm and these should work on any mod using these joint muzles.

JR has the vanilla 6.5mm weapons using the 7.62mm muzzles, so we do
```
class compatibleItems: compatibleItems {
    ACE_muzzle_mzls_H = 1;
    ACE_muzzle_mzls_B = 0;
};
```
to disable our 7.62 attachment and enable our 6.5mm version.

ACE's 7.62mm still shows up in VA, but is not attachable (and exported itemName is wrong), problem with VA - https://github.com/CBATeam/CBA_A3/pull/246#issuecomment-174171284
