### PR TITLE
Make explosives helpers hidden in eden.

### DIFF
--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -50,7 +50,7 @@ class CfgVehicles {
         mapSize = 0.2;
         icon = "iconObject_1x2";
         model = "\A3\Weapons_f\dummyweapon.p3d";
-        scope = 2;
+        scope = 1;
         scopeCurator = 1;
         vehicleClass = "Cargo";
         class ACE_Actions {
@@ -81,7 +81,7 @@ class CfgVehicles {
         mapSize = 0.2;
         icon = "iconObject_1x2";
         model = "\A3\Structures_F\Items\Tools\MultiMeter_F.p3d";
-        scope = 2;
+        scope = 1;
         scopeCurator = 1;
         vehicleClass = "Cargo";
         class ACE_Actions {

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -51,7 +51,6 @@ class CfgVehicles {
         icon = "iconObject_1x2";
         model = "\A3\Weapons_f\dummyweapon.p3d";
         scope = 1;
-        scopeCurator = 1;
         vehicleClass = "Cargo";
         class ACE_Actions {
             class ACE_MainActions {
@@ -82,7 +81,6 @@ class CfgVehicles {
         icon = "iconObject_1x2";
         model = "\A3\Structures_F\Items\Tools\MultiMeter_F.p3d";
         scope = 1;
-        scopeCurator = 1;
         vehicleClass = "Cargo";
         class ACE_Actions {
             class ACE_MainActions {


### PR DESCRIPTION
**When merged this pull request will:**
- Removes duplicate entries for explosives in eden, placing in editor makes no sense as they won't have needed `setVariables`

