### PR TITLE
vehicle inventory lock - compatibility with acre

### DIFF
--- a/addons/vehiclelock/CfgEventHandlers.hpp
+++ b/addons/vehiclelock/CfgEventHandlers.hpp
@@ -17,14 +17,6 @@ class Extended_PostInit_EventHandlers {
     };
 };
 
-class Extended_InventoryOpened_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            clientInventoryOpened = QUOTE(_this call FUNC(onOpenInventory););
-        };
-    };
-};
-
 class Extended_InitPost_EventHandlers {
     class Car {
         class ADDON {

--- a/addons/vehiclelock/XEH_postInit.sqf
+++ b/addons/vehiclelock/XEH_postInit.sqf
@@ -3,3 +3,13 @@
 //Add Event Handlers
 ["VehicleLock_SetupCustomKey", {_this call FUNC(serverSetupCustomKeyEH)}] call EFUNC(common,addEventHandler);
 ["VehicleLock_SetVehicleLock", {_this call FUNC(setVehicleLockEH)}] call EFUNC(common,addEventHandler);
+
+if (!hasInterface) exitwith {};
+
+["SettingsInitialized", {
+    TRACE_1("SettingsInitialized eh",GVAR(LockVehicleInventory));
+
+    if (GVAR(LockVehicleInventory)) then {
+        ["CAManBase", "InventoryOpened", {_this call FUNC(onOpenInventory);}] call CBA_fnc_addClassEventHandler;
+    };
+}] call EFUNC(common,addEventHandler);

--- a/addons/vehiclelock/functions/fnc_onOpenInventory.sqf
+++ b/addons/vehiclelock/functions/fnc_onOpenInventory.sqf
@@ -7,7 +7,7 @@
  * 1: Container <OBJECT>
  *
  * Return Value:
- * Handeled <BOOL>
+ * None
  *
  * Example:
  * [player, car] call ACE_VehicleLock_fnc_onOpenInventory;
@@ -20,10 +20,7 @@ params ["_unit", "_container"];
 TRACE_2("params",_unit,_container);
 
 //Only check for player:
-if (_unit != ace_player) exitWith {false};
-
-private "_handeled";
-_handeled = false;
+if (_unit != ace_player) exitWith {};
 
 if (GVAR(LockVehicleInventory) && //if setting not enabled
         {(vehicle ace_player) == ace_player} && //Player dismounted
@@ -33,15 +30,19 @@ if (GVAR(LockVehicleInventory) && //if setting not enabled
         ) then {
     //Give feedback that vehicle is locked
     playSound "ACE_Sound_Click";
-    //don't open the vehicles inventory
-    _handeled = true;
 
-    // As of 1.54 the action needs to be delayed a frame to work, which used not to be the case
+    //For compatibiltiy with ACRE, wait until the display is open, close it and then reopen the player's own inventory
+    //ref: http://gitlab.idi-systems.com/idi-systems/acre2-public/issues/70
     [{
-        TRACE_1("delaying a frame", ace_player);
-        //Just opens a dummy groundContainer (so the player can still see their own inventory)
-        ACE_player action ["Gear", objNull];
-    }, []] call EFUNC(common,execNextFrame);
+        !isNull (findDisplay 602)
+    },
+    {
+        TRACE_1("car display open: closing", _this);
+        (findDisplay 602) closeDisplay 0;
+        [{
+            TRACE_1("Opening Player Inventory", _this);
+            ACE_player action ["Gear", objNull]
+        }, []] call EFUNC(common,execNextFrame);
+    },
+    []] call EFUNC(common,waitUntilAndExecute);
 };
-
-_handeled


### PR DESCRIPTION
**When merged this pull request will:**
 - Make locked vehicle inventory more compatible with ACRE

Before, the vehicle's inventory display and the player's would be open in the same frame, which broke a script ACRE uses to add actions to the radios and to hide the linked radio slot.

Also switched to using `CBA_fnc_addClassEventHandler` to only add the inventory event handler when this feature is selected.