### PR TITLE
Improve synced event error logging

### DIFF
--- a/addons/common/functions/fnc__handleRequestSyncedEvent.sqf
+++ b/addons/common/functions/fnc__handleRequestSyncedEvent.sqf
@@ -23,7 +23,7 @@ if (isServer) then {
     params ["_eventName", "_client"];
 
     if (!HASH_HASKEY(GVAR(syncedEvents),_eventName)) exitWith {
-        ACE_LOGERROR("Request for synced event - key not found.");
+        ACE_LOGERROR_1("Request for synced event - key [%1] not found.", _eventName);
         false
     };
 

--- a/addons/common/functions/fnc__handleSyncedEvent.sqf
+++ b/addons/common/functions/fnc__handleSyncedEvent.sqf
@@ -17,7 +17,7 @@
 params ["_name", "_args", "_ttl"];
 
 if (!HASH_HASKEY(GVAR(syncedEvents),_name)) exitWith {
-    ACE_LOGERROR("Synced event key not found.");
+    ACE_LOGERROR_1("Synced event key [%1] not found (_handleSyncedEvent).", _name);
     false
 };
 

--- a/addons/common/functions/fnc_addSyncedEventHandler.sqf
+++ b/addons/common/functions/fnc_addSyncedEventHandler.sqf
@@ -10,6 +10,9 @@
  * Return Value:
  * Boolean of success <BOOL>
  *
+ * Example:
+ * ["myEvent", {_this call x}, 0] call ace_common_fnc_addSyncedEventHandler
+ *
  * Public: Yes
  */
 #include "script_component.hpp"
@@ -17,7 +20,7 @@
 params ["_name", "_handler", ["_ttl", 0]];
 
 if (HASH_HASKEY(GVAR(syncedEvents),_name)) exitWith {
-    ACE_LOGERROR("Duplicate synced event creation.");
+    ACE_LOGERROR_1("Duplicate synced event [%1] creation.",_name);
     false
 };
 

--- a/addons/common/functions/fnc_removeSyncedEventHandler.sqf
+++ b/addons/common/functions/fnc_removeSyncedEventHandler.sqf
@@ -15,7 +15,7 @@
 params ["_name"];
 
 if (!HASH_HASKEY(GVAR(syncedEvents),_name)) exitWith {
-    ACE_LOGERROR("Synced event key not found.");
+    ACE_LOGERROR_1("Synced event key [%1] not found (removeSyncedEventHandler).", _name);
     false
 };
 

--- a/addons/common/functions/fnc_syncedEvent.sqf
+++ b/addons/common/functions/fnc_syncedEvent.sqf
@@ -17,7 +17,7 @@
 params ["_name", "_args", ["_ttl", 0]];
 
 if (!HASH_HASKEY(GVAR(syncedEvents),_name)) exitWith {
-    ACE_LOGERROR("Synced event key not found.");
+    ACE_LOGERROR_1("Synced event key [%1] not found (syncedEvent).", _name);
     false
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
-Better logging for synced events

Trying to track down cause of `[ACE] (common) ERROR: Synced event key not found.` on a jip
