### PR TITLE
Add cargo to Taru pods

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -304,6 +304,25 @@ class CfgVehicles {
         GVAR(canLoad) = 1;
     };
 
+    // Taru pods
+    class Pod_Heli_Transport_04_base_F;
+    class Land_Pod_Heli_Transport_04_ammo_F: Pod_Heli_Transport_04_base_F {
+        GVAR(space) = 8;
+        GVAR(hasCargo) = 1;
+    };
+    class Land_Pod_Heli_Transport_04_box_F: Pod_Heli_Transport_04_base_F {
+        GVAR(space) = 20;
+        GVAR(hasCargo) = 1;
+    };
+    class Land_Pod_Heli_Transport_04_medevac_F: Pod_Heli_Transport_04_base_F {
+        GVAR(space) = 8;
+        GVAR(hasCargo) = 1;
+    };
+    class Land_Pod_Heli_Transport_04_repair_F: Pod_Heli_Transport_04_base_F {
+        GVAR(space) = 12;
+        GVAR(hasCargo) = 1;
+    };
+
     class StaticMortar;
     class Mortar_01_base_F: StaticMortar {
         GVAR(size) = 2; // 1 = small, 2 = large


### PR DESCRIPTION
**When merged this pull request will:**
- Adds cargo space to Taru Ammo, Cargo, Medical and Repair pods (same as their pre-attached to helicopter counterparts)