### PR TITLE
Cleanup reload launchers

### DIFF
--- a/addons/reloadlaunchers/functions/fnc_addMissileReloadActions.sqf
+++ b/addons/reloadlaunchers/functions/fnc_addMissileReloadActions.sqf
@@ -3,28 +3,31 @@
  * Create one action per reloadable missile
  *
  * Argument:
- * 1: Player (Object)
- * 0: Target (Object)
- * 2: Parameters ??? (Array)
+ * 1: Target (Object)
+ * 0: Player (Object)
  *
  * Return value:
  * Children actions (Array)
  *
+ * Public: No
+ *
  */
 #include "script_component.hpp"
 
-private ["_unit", "_target", "_parameters"];
+params ["_target", "_unit"];
+TRACE_2("params",_target,_unit);
 
-_unit = _this select 1;
-_target = _this select 0;
-_parameters = _this select 2; // ???
+//Fast exit for common case:
+private _weapon = secondaryWeapon _target;
+if ((_weapon == "") || {(getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(enabled))) == 0}) exitWith {
+    TRACE_1("weapon not supported",_weapon);
+    []
+};
 
-private ["_actions", "_weapon", "_loadableMissiles"];
+private _actions = [];
 
-_actions = [];
-
-_weapon = secondaryWeapon _target;
-_loadableMissiles = [_unit, _weapon] call FUNC(getLoadableMissiles);
+private _loadableMissiles = [_unit, _weapon] call FUNC(getLoadableMissiles);
+TRACE_2("",_weapon,_loadableMissiles);
 
 {
     private ["_name", "_displayName", "_statement", "_condition", "_action"];
@@ -45,4 +48,5 @@ _loadableMissiles = [_unit, _weapon] call FUNC(getLoadableMissiles);
     _actions pushBack [_action, [], _unit];
 } forEach _loadableMissiles;
 
+TRACE_1("return",_actions);
 _actions

--- a/addons/reloadlaunchers/functions/fnc_canLoad.sqf
+++ b/addons/reloadlaunchers/functions/fnc_canLoad.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Check of the unit can reload the launcher of target unit.
  *
  * Argument:
@@ -11,15 +10,13 @@
  *
  * Return value:
  * NONE
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
-private ["_unit", "_target", "_weapon", "_magazine"];
-
-_unit = _this select 0;
-_target = _this select 1;
-_weapon = _this select 2;
-_magazine = _this select 3;
+params ["_unit", "_target", "_weapon", "_magazine"];
+TRACE_4("params",_unit,_target,_weapon,_magazine);
 
 if (!alive _target) exitWith {false};
 if (vehicle _target != _target) exitWith {false};

--- a/addons/reloadlaunchers/functions/fnc_getLoadableMissiles.sqf
+++ b/addons/reloadlaunchers/functions/fnc_getLoadableMissiles.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Return all magazine types from reloaders inventory that are compatible with given weapon.
  *
  * Argument:
@@ -9,17 +8,16 @@
  *
  * Return value:
  * Reloable magazines (Array)
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
-private ["_unit", "_weapon"];
-
-_unit = _this select 0;
-_weapon = _this select 1;
+params ["_unit", "_weapon"];
+TRACE_2("params",_unit,_weapon);
 
 // get available magazines of reloader, Note: "magazines" does not include currently loaded magazines
-private "_magazines";
-_magazines = magazines _unit;
+private _magazines = magazines _unit;
 
 // case sensitvity
 _magazines = _magazines apply {toLower _x};

--- a/addons/reloadlaunchers/functions/fnc_load.sqf
+++ b/addons/reloadlaunchers/functions/fnc_load.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Reload a launcher
  *
  * Argument:
@@ -11,15 +10,13 @@
  *
  * Return value:
  * NONE
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
-private ["_unit", "_target", "_weapon", "_magazine"];
-
-_unit = _this select 0;
-_target = _this select 1;
-_weapon = _this select 2;
-_magazine = _this select 3;
+params ["_unit", "_target", "_weapon", "_magazine"];
+TRACE_4("params",_unit,_target,_weapon,_magazine);
 
 private "_reloadTime";
 _reloadTime = getNumber (configFile >> "CfgWeapons" >> _weapon >> "magazineReloadTime");

--- a/addons/reloadlaunchers/functions/fnc_load.sqf
+++ b/addons/reloadlaunchers/functions/fnc_load.sqf
@@ -18,8 +18,11 @@
 params ["_unit", "_target", "_weapon", "_magazine"];
 TRACE_4("params",_unit,_target,_weapon,_magazine);
 
-// private _reloadTime = getNumber (configFile >> "CfgWeapons" >> _weapon >> "magazineReloadTime"); //Not a good config value, use a constant for now:
-private _reloadTime = 2.5;
+private _reloadTime = if (isNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(buddyReloadTime))) then {
+    getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(buddyReloadTime))
+} else {
+    2.5
+};
 
 // do animation
 [_unit] call EFUNC(common,goKneeling);

--- a/addons/reloadlaunchers/functions/fnc_load.sqf
+++ b/addons/reloadlaunchers/functions/fnc_load.sqf
@@ -18,8 +18,8 @@
 params ["_unit", "_target", "_weapon", "_magazine"];
 TRACE_4("params",_unit,_target,_weapon,_magazine);
 
-private "_reloadTime";
-_reloadTime = getNumber (configFile >> "CfgWeapons" >> _weapon >> "magazineReloadTime");
+// private _reloadTime = getNumber (configFile >> "CfgWeapons" >> _weapon >> "magazineReloadTime"); //Not a good config value, use a constant for now:
+private _reloadTime = 2.5;
 
 // do animation
 [_unit] call EFUNC(common,goKneeling);

--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -1,6 +1,5 @@
 /*
  * Author: commy2
- *
  * Reload a launcher
  *
  * Argument:
@@ -11,10 +10,13 @@
  *
  * Return value:
  * NONE
+ *
+ * Public: No
  */
 #include "script_component.hpp"
 
-PARAMS_4(_unit,_target,_weapon,_magazine);
+params ["_unit","_target","_weapon","_magazine"];
+TRACE_4("params",_unit,_target,_weapon,_magazine);
 
 _target selectWeapon _weapon;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Cleanup reload launchers

Minor cleanup of params, and adds a fast exit for non supported weapons.

**Todo**: None of the launcher seem to have a good config for reload time and right now it's a 12 second progress bar which make this module pretty hard to use.

```
        magazineReloadTime = 12;
```

I can't really find any good config value for the real reload time (about 3 seconds), it might be linked to the reload animation??