### PR TITLE
UI - Don't overwrite other showHud indexes

### DIFF
--- a/addons/ui/functions/fnc_setElements.sqf
+++ b/addons/ui/functions/fnc_setElements.sqf
@@ -23,15 +23,13 @@ if (!_force && {!GVAR(allowSelectiveUI)}) exitWith {
     [LSTRING(Disallowed), 2] call EFUNC(common,displayTextStructured);
 };
 
-private _shownHUD = shownHUD; // [hud, info, radar, compass, direction, menu, group, cursors]
-
 ["ui", [
-    _shownHUD select 0,
+    true,
     GVAR(soldierVehicleWeaponInfo),
     GVAR(vehicleRadar),
     GVAR(vehicleCompass),
-    _shownHUD select 4,
+    true,
     GVAR(commandMenu),
     GVAR(groupBar),
-    _shownHUD select 7
+    true
 ]] call EFUNC(common,showHud);


### PR DESCRIPTION
**When merged this pull request will:**
- UI / ShowHud - Ignore the indexes that we aren't explicitly setting (pass true instead of current)


Prevents problems from something like this:
```
["test", [false,false,false,false,false,false,false,false]] call ace_common_fnc_showHud; 
```
then change UI settings, then clear
```
["test", []] call ace_common_fnc_showHud; 
```