### PR TITLE
Repair - Improve wheel detection for RHS

### DIFF
--- a/addons/repair/functions/fnc_getWheelHitPointsWithSelections.sqf
+++ b/addons/repair/functions/fnc_getWheelHitPointsWithSelections.sqf
@@ -72,7 +72,7 @@ _wheelHitPointSelections = [];
                 if (_x != "") then {
                      //Filter out things that definitly aren't wheeels (#3759)
                     if ((toLower (_hitPoints select _forEachIndex)) in ["hitengine", "hitfuel", "hitbody"]) exitWith {TRACE_1("filter",_x)};
-                    _xPos = _vehicle selectionPosition [_x, 'HitPoints'];
+                    _xPos = _vehicle selectionPosition _x;
                     if (_xPos isEqualTo [0,0,0]) exitWith {};
                     _xDist = _wheelCenterPos distance _xPos;
                     if (_xDist < _bestDist) then {

--- a/addons/repair/functions/fnc_getWheelHitPointsWithSelections.sqf
+++ b/addons/repair/functions/fnc_getWheelHitPointsWithSelections.sqf
@@ -70,7 +70,9 @@ _wheelHitPointSelections = [];
             _bestIndex = -1;
             {
                 if (_x != "") then {
-                    _xPos = _vehicle selectionPosition _x;
+                     //Filter out things that definitly aren't wheeels (#3759)
+                    if ((toLower (_hitPoints select _forEachIndex)) in ["hitengine", "hitfuel", "hitbody"]) exitWith {TRACE_1("filter",_x)};
+                    _xPos = _vehicle selectionPosition [_x, 'HitPoints'];
                     if (_xPos isEqualTo [0,0,0]) exitWith {};
                     _xDist = _wheelCenterPos distance _xPos;
                     if (_xDist < _bestDist) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #3759

The backup wheel detection just tries to find the closest hitpoint to the wheel, and for one RHS vic the engine is close than the actual wheel hitpoint. This just adds a blacklist for the engine.

![image](https://cloud.githubusercontent.com/assets/9376747/15036522/8e4dc474-1255-11e6-8c1f-e83675858161.png)
