### PR TITLE
Add key to toggle wind info display

### DIFF
--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -39,6 +39,19 @@ GVAR(WindInfo) = false;
 },
 {false},
 [37, [true, false, false]], false, 0] call CBA_fnc_addKeybind; // (SHIFT + K)
+["ACE3 Common", QGVAR(WindInfoKey_hold), localize LSTRING(WindInfoKey_hold),
+{
+    // Conditions: canInteract
+    if !([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
+
+    // Statement
+    [] call FUNC(displayWindInfo);
+},
+{
+    GVAR(WindInfo) = false;
+    (["RscWindIntuitive"] call BIS_fnc_rscLayer) cutText ["", "PLAIN", 2];
+},
+[0, [false, false, false]], false, 0] call CBA_fnc_addKeybind; // (empty default key)
 
 simulWeatherSync;
 

--- a/addons/weather/stringtable.xml
+++ b/addons/weather/stringtable.xml
@@ -13,6 +13,18 @@
             <Czech>Zobrazit údaje o větru</Czech>
             <Portuguese>Mostrar informação do vento</Portuguese>
         </Key>
+        <Key ID="STR_ACE_Weather_WindInfoKey_hold">
+            <English>Show Wind Info (Toggle)</English>
+            <Polish>Pokaż inf. o wietrze (przełącz)</Polish>
+            <Russian>Показать информацию о ветре (перекл.)</Russian>
+            <French>Afficher information sur le vent (bascule)</French>
+            <Spanish>Mostrar información del viento (cambiar)</Spanish>
+            <Italian>Mostra informazioni sul vento (camb.)</Italian>
+            <German>Zeige Windinformationen (umsch.)</German>
+            <Hungarian>Széladatok mutatása (pecek)</Hungarian>
+            <Czech>Zobrazit údaje o větru (přep.)</Czech>
+            <Portuguese>Mostrar informação do vento (alternar)</Portuguese>
+        </Key>
         <Key ID="STR_ACE_Weather_Module_DisplayName">
             <English>Weather</English>
             <Polish>Pogoda</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- Add key to toggle wind info display

This would match the default behaviour of the compass, where it only shows up while the key is held down.  By default key is unbound so this will have no effect unless chosen by user.

Tag @Gwynblade