### PR TITLE
Moved IR Strobe to left shoulder when attached.

### DIFF
--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -40,7 +40,7 @@ _onAtachText = format [localize LSTRING(Item_Attached), _onAtachText];
 
 if (_unit == _attachToVehicle) then {  //Self Attachment
     _attachedItem = _itemVehClass createVehicle [0,0,0];
-    _attachedItem attachTo [_unit, [-0.05, 0, 0.12], "rightshoulder"];
+    _attachedItem attachTo [_unit, [0.05, -0.09, 0.1], "leftshoulder"];
     if (!_silentScripted) then {
         _unit removeItem _itemClassname;  // Remove item
         [_onAtachText] call EFUNC(common,displayTextStructured);


### PR DESCRIPTION
**When merged this pull request will:**
- Moves attachment position of IR strobe/grenade to left shoulder. Previously, when on the right shoulder, the strobe was visible as a reflection when looking down some optics (Elcan from 3CB) which was intrusive whilst aiming.

