### PR TITLE
Execute take nozzle actions only on progress bar success

### DIFF
--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -18,17 +18,14 @@
  */
 #include "script_component.hpp"
 
-params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
-
-[_unit, "forceWalk", "ACE_refuel", true] call EFUNC(common,statusEffect_set);
-
-REFUEL_HOLSTER_WEAPON
+params [
+    ["_unit", objNull, [objNull]],
+    ["_target", objNull, [objNull]],
+    ["_nozzle", objNull, [objNull]]
+];
 
 private _endPosOffset = [0, 0, 0];
 if (isNull _nozzle) then { // func is called on fuel truck
-    [_target, "blockEngine", "ACE_Refuel", true] call EFUNC(common,statusEffect_set);
-
-    _target setVariable [QGVAR(isConnected), true, true];
     _endPosOffset = getArray (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hooks));
     if (count _endPosOffset == 2) then {
         if (_unit distance (_target modelToWorld (_endPosOffset select 0)) <  _unit distance (_target modelToWorld (_endPosOffset select 1))) then {
@@ -44,7 +41,11 @@ if (isNull _nozzle) then { // func is called on fuel truck
         [_unit, _target, _endPosOffset],
         {
             params ["_args"];
-            _args params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]], ["_endPosOffset", [0,0,0], [[]], 3]];
+            _args params [
+                ["_unit", objNull, [objNull]],
+                ["_target", objNull, [objNull]],
+                ["_endPosOffset", [0, 0, 0], [[]], 3]
+            ];
 
             private _newNozzle = "ACE_refuel_fuelNozzle" createVehicle position _unit;
             _newNozzle attachTo [_unit, [-0.02,0.05,-0.12], "righthandmiddle1"];
@@ -57,8 +58,13 @@ if (isNull _nozzle) then { // func is called on fuel truck
             };
             _newNozzle setVariable [QGVAR(attachPos), _endPosOffset, true];
             _newNozzle setVariable [QGVAR(source), _target, true];
+
+            [_target, "blockEngine", "ACE_Refuel", true] call EFUNC(common,statusEffect_set);
+            _target setVariable [QGVAR(isConnected), true, true];
             _target setVariable [QGVAR(ownedNozzle), _newNozzle, true];
 
+            [_unit, "forceWalk", "ACE_refuel", true] call EFUNC(common,statusEffect_set);
+            REFUEL_HOLSTER_WEAPON
             _unit setVariable [QGVAR(isRefueling), true];
             private _actionID = _unit getVariable [QGVAR(ReleaseActionID), -1];
             if (_actionID != -1) then {
@@ -87,7 +93,11 @@ if (isNull _nozzle) then { // func is called on fuel truck
         [_unit, _nozzle],
         {
             params ["_args"];
-            _args params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
+            _args params [
+                ["_unit", objNull, [objNull]],
+                ["_nozzle", objNull, [objNull]]
+            ];
+
             if (_nozzle getVariable [QGVAR(jerryCan), false]) then {
                 _nozzle attachTo [_unit, [0,1,0], "pelvis"];
             } else {
@@ -95,6 +105,8 @@ if (isNull _nozzle) then { // func is called on fuel truck
             };
             _unit setVariable [QGVAR(nozzle), _nozzle, true];
 
+            [_unit, "forceWalk", "ACE_refuel", true] call EFUNC(common,statusEffect_set);
+            REFUEL_HOLSTER_WEAPON
             _unit setVariable [QGVAR(isRefueling), true];
             private _actionID = _unit getVariable [QGVAR(ReleaseActionID), -1];
             if (_actionID != -1) then {
@@ -124,8 +136,13 @@ if (isNull _nozzle) then { // func is called on fuel truck
 if !(_nozzle getVariable [QGVAR(jerryCan), false]) then {
     [{
         params ["_args", "_pfID"];
-        _args params [["_unit", player, [objNull]], ["_source", objNull, [objNull]], ["_endPosOffset", [0, 0, 0], [[]], 3]];
-        _args params ["", "", "", ["_nozzle", _unit getVariable [QGVAR(nozzle), objNull], [objNull]]];
+        _args params [
+            ["_unit", player, [objNull]],
+            ["_source", objNull, [objNull]],
+            ["_endPosOffset", [0, 0, 0], [[]], 3],
+            ["_nozzle", _unit getVariable [QGVAR(nozzle), objNull], [objNull]]
+        ];
+
         if (isNull _source || {_unit distance (_source modelToWorld _endPosOffset) > (REFUEL_HOSE_LENGTH - 2)} || {!alive _source}) exitWith {
             if !(isNull _nozzle) then {
                 [_unit, _nozzle] call FUNC(dropNozzle);

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -24,6 +24,8 @@ params [
     ["_nozzle", objNull, [objNull]]
 ];
 
+REFUEL_HOLSTER_WEAPON
+
 private _endPosOffset = [0, 0, 0];
 if (isNull _nozzle) then { // func is called on fuel truck
     _endPosOffset = getArray (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hooks));
@@ -64,7 +66,6 @@ if (isNull _nozzle) then { // func is called on fuel truck
             _target setVariable [QGVAR(ownedNozzle), _newNozzle, true];
 
             [_unit, "forceWalk", "ACE_refuel", true] call EFUNC(common,statusEffect_set);
-            REFUEL_HOLSTER_WEAPON
             _unit setVariable [QGVAR(isRefueling), true];
             private _actionID = _unit getVariable [QGVAR(ReleaseActionID), -1];
             if (_actionID != -1) then {
@@ -82,7 +83,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
             ];
             _unit setVariable [QGVAR(ReleaseActionID), _actionID];
         },
-        "",
+        {REFUEL_UNHOLSTER_WEAPON},
         localize LSTRING(TakeNozzleAction),
         {true},
         ["isnotinside"]
@@ -106,7 +107,6 @@ if (isNull _nozzle) then { // func is called on fuel truck
             _unit setVariable [QGVAR(nozzle), _nozzle, true];
 
             [_unit, "forceWalk", "ACE_refuel", true] call EFUNC(common,statusEffect_set);
-            REFUEL_HOLSTER_WEAPON
             _unit setVariable [QGVAR(isRefueling), true];
             private _actionID = _unit getVariable [QGVAR(ReleaseActionID), -1];
             if (_actionID != -1) then {
@@ -124,7 +124,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
             ];
             _unit setVariable [QGVAR(ReleaseActionID), _actionID];
         },
-        "",
+        {REFUEL_UNHOLSTER_WEAPON},
         localize LSTRING(TakeNozzleAction),
         {true},
         ["isnotinside"]

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -83,7 +83,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
             ];
             _unit setVariable [QGVAR(ReleaseActionID), _actionID];
         },
-        {REFUEL_UNHOLSTER_WEAPON},
+        "",
         localize LSTRING(TakeNozzleAction),
         {true},
         ["isnotinside"]
@@ -124,7 +124,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
             ];
             _unit setVariable [QGVAR(ReleaseActionID), _actionID];
         },
-        {REFUEL_UNHOLSTER_WEAPON},
+        "",
         localize LSTRING(TakeNozzleAction),
         {true},
         ["isnotinside"]

--- a/addons/refuel/script_component.hpp
+++ b/addons/refuel/script_component.hpp
@@ -22,6 +22,7 @@
 
 #define REFUEL_HOLSTER_WEAPON \
     _unit setVariable [QGVAR(selectedWeaponOnRefuel), currentWeapon _unit]; \
+    _unit call EFUNC(common,fixLoweredRifleAnimation); \
     _unit action ["SwitchWeapon", _unit, _unit, 99];
 
 #define REFUEL_UNHOLSTER_WEAPON \


### PR DESCRIPTION
**When merged this pull request will:**
- Moves part of "Take Nozzle" action execution into progress bar on success (set force walk, holster weapon and 2 variables) - fixes #3739 
- Prettifies `params` usage in take nozzle function.

Tagging @GitHawk for review