### PR TITLE
Remove redundant spare part adding and improve addSpareParts function

### DIFF
--- a/addons/repair/CfgEventHandlers.hpp
+++ b/addons/repair/CfgEventHandlers.hpp
@@ -22,32 +22,29 @@ class Extended_InitPost_EventHandlers {
     class Car {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            serverInit = QUOTE(_this call DFUNC(addSpareParts));
+            serverInit = QUOTE([ARR_3(_this select 0,1,'ACE_Wheel')] call DFUNC(addSpareParts));
         };
     };
     class Tank {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            serverInit = QUOTE(_this call DFUNC(addSpareParts));
+            serverInit = QUOTE([ARR_3(_this select 0,1,'ACE_Wheel')] call DFUNC(addSpareParts));
         };
     };
     class Helicopter {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            serverInit = QUOTE(_this call DFUNC(addSpareParts));
             exclude[] = {QEGVAR(fastroping,helper), "ACE_friesBase"};
         };
     };
     class Plane {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            serverInit = QUOTE(_this call DFUNC(addSpareParts));
         };
     };
     class Ship_F {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            serverInit = QUOTE(_this call DFUNC(addSpareParts));
         };
     };
 };

--- a/addons/repair/CfgEventHandlers.hpp
+++ b/addons/repair/CfgEventHandlers.hpp
@@ -28,7 +28,7 @@ class Extended_InitPost_EventHandlers {
     class Tank {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            serverInit = QUOTE([ARR_3(_this select 0,1,'ACE_Wheel')] call DFUNC(addSpareParts));
+            serverInit = QUOTE([ARR_3(_this select 0,1,'ACE_Track')] call DFUNC(addSpareParts));
         };
     };
     class Helicopter {

--- a/addons/repair/functions/fnc_addSpareParts.sqf
+++ b/addons/repair/functions/fnc_addSpareParts.sqf
@@ -21,8 +21,8 @@
 params ["_vehicle", ["_amount", 1], ["_part", ""], ["_force", false]];
 TRACE_2("params",_vehicle,_amount);
 
-// Exit if ace_cargo is not loaded
-if !(["ace_cargo"] call EFUNC(common,isModLoaded)) exitWith {};
+// Exit if ace_cargo is not loaded or no part supplied
+if (!(["ace_cargo"] call EFUNC(common,isModLoaded)) || {_part == ""}) exitWith {};
 
 // Collect until SettingsInitialized
 if (!EGVAR(common,settingsInitFinished)) exitWith {
@@ -31,14 +31,6 @@ if (!EGVAR(common,settingsInitFinished)) exitWith {
 
 // Exit if not forced and add spare parts is disabled (after settings initted to make sure it really is)
 if (!_force && !GVAR(addSpareParts)) exitWith {};
-
-// Select appropriate part
-if (_part == "") then {
-    if (_vehicle isKindOf "Car") then { _part = "ACE_Wheel" };
-    if (_vehicle isKindOf "Tank") then { _part = "ACE_Track" };
-};
-// Exit if no appropriate part
-if (_part == "") exitWith {};
 
 // Load
 ["AddCargoByClass", [_part, _vehicle, _amount]] call EFUNC(common,localEvent);


### PR DESCRIPTION
**When merged this pull request will:**
- Removes initial spare part adding for all classes except `Car` and `Tank` - it is used only to add spare wheels and tracks to those 2 classes.
- Improves `FUNC(addSpareParts)` - due to above manual checking is not needed, it just added overhead, this also allows improved checking without adding it to `runAtSettingsInitialized` even if no part name is supplied.