### PR TITLE
Add canPush config entry

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -420,7 +420,7 @@ class CfgVehicles {
                 class ACE_Push {
                     displayName = CSTRING(Push);
                     distance = 6;
-                    condition = QUOTE(getMass _target <= 2600 && {alive _target} && {vectorMagnitude velocity _target < 3});
+                    condition = QUOTE(_target call FUNC(canPush));
                     statement = QUOTE(_this call FUNC(push));
                     showDisabled = 0;
                     priority = -1;

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -32,6 +32,7 @@ PREP(handleScrollWheel);
 PREP(openDoor);
 
 // interaction with boats
+PREP(canPush);
 PREP(push);
 
 PREP(switchLamp);

--- a/addons/interaction/functions/fnc_canPush.sqf
+++ b/addons/interaction/functions/fnc_canPush.sqf
@@ -1,0 +1,22 @@
+/*
+ * Author: Jonpas
+ * Checks if the boat can be pushed.
+ *
+ * Arguments:
+ * 0: Target <OBJECT>
+ *
+ * Return Value:
+ * Can Push <BOOL>
+ *
+ * Example:
+ * [target] call ace_interaction_fnc_canPush
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_target"];
+
+alive _target &&
+{getMass _target <= 2600 || getNumber (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(canPush)) == 1} &&
+{vectorMagnitude velocity _target < 3}

--- a/addons/interaction/functions/fnc_push.sqf
+++ b/addons/interaction/functions/fnc_push.sqf
@@ -18,8 +18,7 @@
 
 params ["_boat", "_unit"];
 
-private "_newVelocity";
-_newVelocity = vectorDir _unit;
+private _newVelocity = vectorDir _unit;
 _newVelocity set [2, 0.25];
 _newVelocity = _newVelocity vectorMultiply 2;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Adds `ace_interaction_canPush` config entry which enables pushing on boats with mass over 2600.
- Moves interaction condition to it's own function (no idea who wrote original condition, so I can't include it in authors).
- Closes #3744 - CUP needs to add `ace_interaction_canPush = 1` to the RHIB config.