### PR TITLE
skip 'playerInventoryChanged' after firing

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -386,7 +386,6 @@ GVAR(OldIsCamera) = false;
     if !(_data isEqualTo GVAR(OldPlayerInventory)) then {
         // Raise ACE event locally
         GVAR(OldPlayerInventory) = _data;
-<<<<<<< HEAD
 
         // we don't want to trigger this just because your ammo counter decreased.
         _data = + GVAR(OldPlayerInventory);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -389,18 +389,25 @@ GVAR(OldIsCamera) = false;
 
         // we don't want to trigger this just because your ammo counter decreased.
         _data = + GVAR(OldPlayerInventory);
-        if (!((_data select 0) isEqualTo [])) then { 
-            (_data param [0, []]) set [4, primaryWeaponMagazine ACE_player];
-            (_data param [0, []]) set [5, []];
+
+        private _weaponInfo = _data param [0, []];
+        if !(_weaponInfo isEqualTo []) then {
+            _weaponInfo set [4, primaryWeaponMagazine ACE_player];
+            _weaponInfo deleteAt 5;
         };
-        if (!((_data select 1) isEqualTo [])) then { 
-            (_data param [1, []]) set [4, secondaryWeaponMagazine ACE_player];
-            (_data param [1, []]) set [5, []];
+
+        _weaponInfo = _data param [1, []];
+        if !(_weaponInfo isEqualTo []) then {
+            _weaponInfo set [4, secondaryWeaponMagazine ACE_player];
+            _weaponInfo deleteAt 5;
         };
-        if (!((_data select 2) isEqualTo [])) then { 
-            (_data param [2, []]) set [4, handgunMagazine ACE_player];
-            (_data param [2, []]) set [5, []];
+
+        _weaponInfo = _data param [2, []];
+        if !(_weaponInfo isEqualTo []) then {
+            _weaponInfo set [4, handgunMagazine ACE_player];
+            _weaponInfo deleteAt 5;
         };
+
         if !(_data isEqualTo GVAR(OldPlayerInventoryNoAmmo)) then {
             GVAR(OldPlayerInventoryNoAmmo) = _data;
             ["playerInventoryChanged", [ACE_player, GVAR(OldPlayerInventory)]] call FUNC(localEvent);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -389,12 +389,18 @@ GVAR(OldIsCamera) = false;
 
         // we don't want to trigger this just because your ammo counter decreased.
         _data = + GVAR(OldPlayerInventory);
-        (_data param [0, []]) set [4, primaryWeaponMagazine ACE_player];
-        (_data param [0, []]) set [5, nil];
-        (_data param [1, []]) set [4, secondaryWeaponMagazine ACE_player];
-        (_data param [1, []]) set [5, nil];
-        (_data param [2, []]) set [4, handgunMagazine ACE_player];
-        (_data param [2, []]) set [5, nil];
+        if (!((_data select 0) isEqualTo [])) then { 
+            (_data param [0, []]) set [4, primaryWeaponMagazine ACE_player];
+            (_data param [0, []]) set [5, []];
+        };
+        if (!((_data select 1) isEqualTo [])) then { 
+            (_data param [1, []]) set [4, secondaryWeaponMagazine ACE_player];
+            (_data param [1, []]) set [5, []];
+        };
+        if (!((_data select 2) isEqualTo [])) then { 
+            (_data param [2, []]) set [4, handgunMagazine ACE_player];
+            (_data param [2, []]) set [5, []];
+        };
         if !(_data isEqualTo GVAR(OldPlayerInventoryNoAmmo)) then {
             GVAR(OldPlayerInventoryNoAmmo) = _data;
             ["playerInventoryChanged", [ACE_player, GVAR(OldPlayerInventory)]] call FUNC(localEvent);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -334,6 +334,7 @@ GVAR(OldPlayerVehicle) = vehicle objNull;
 GVAR(OldPlayerTurret) = [objNull] call FUNC(getTurretIndex);
 GVAR(OldPlayerWeapon) = currentWeapon objNull;
 GVAR(OldPlayerInventory) = [];
+GVAR(OldPlayerInventoryNoAmmo) = [];
 GVAR(OldPlayerVisionMode) = currentVisionMode objNull;
 GVAR(OldCameraView) = "";
 GVAR(OldVisibleMap) = false;
@@ -385,7 +386,19 @@ GVAR(OldIsCamera) = false;
     if !(_data isEqualTo GVAR(OldPlayerInventory)) then {
         // Raise ACE event locally
         GVAR(OldPlayerInventory) = _data;
-        ["playerInventoryChanged", [ACE_player, _data]] call FUNC(localEvent);
+
+        // we don't want to trigger this just because your ammo counter decreased.
+        _data = + GVAR(OldPlayerInventory);
+        (_data param [0, []]) set [4, primaryWeaponMagazine ACE_player];
+        (_data param [0, []]) set [5, nil];
+        (_data param [1, []]) set [4, secondaryWeaponMagazine ACE_player];
+        (_data param [1, []]) set [5, nil];
+        (_data param [2, []]) set [4, handgunMagazine ACE_player];
+        (_data param [2, []]) set [5, nil];
+        if !(_data isEqualTo GVAR(OldPlayerInventoryNoAmmo)) then {
+            GVAR(OldPlayerInventoryNoAmmo) = _data;
+            ["playerInventoryChanged", [ACE_player, GVAR(OldPlayerInventory)]] call FUNC(localEvent);
+        };
     };
 
     // "playerVisionModeChanged" event

--- a/addons/medical/functions/fnc_reviveStateLoop.sqf
+++ b/addons/medical/functions/fnc_reviveStateLoop.sqf
@@ -13,7 +13,7 @@
 
 #include "script_component.hpp"
 
-params ["_unit"]
+params ["_unit"];
 
 // If locality changed finish the local loop
 // @todo: reinitiate the loop elsewhere


### PR DESCRIPTION
**When merged this pull request will:**
- don't do 'playerInventoryChanged' just because ammo decreased after firing

ref: #3792