### PR TITLE
Add backwards compatability for InventoryChanged

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -385,7 +385,7 @@ GVAR(OldIsCamera) = false;
     if !(_data isEqualTo GVAR(OldPlayerInventory)) then {
         // Raise ACE event locally
         GVAR(OldPlayerInventory) = _data;
-        ["playerInventoryChanged", [ACE_player, _data]] call FUNC(localEvent);
+        ["playerInventoryChanged", [ACE_player, [ACE_player, false] call FUNC(getAllGear) ]] call FUNC(localEvent);
     };
 
     // "playerVisionModeChanged" event

--- a/addons/common/functions/fnc_assignedItemFix.sqf
+++ b/addons/common/functions/fnc_assignedItemFix.sqf
@@ -29,9 +29,9 @@ GVAR(AssignedItemsShownItems) = [
 ];
 
 ["playerInventoryChanged", {
-    params ["_unit", "_assignedItems"];
+    params ["_unit"];
 
-    _assignedItems = _assignedItems param [9, ["","","","","",""]]; // ["ItemMap","ItemGPS","ItemRadio","ItemCompass","ItemWatch","NVGoggles"]
+    private _assignedItems = getUnitLoadout _unit param [9, ["","","","","",""]]; // ["ItemMap","ItemGPS","ItemRadio","ItemCompass","ItemWatch","NVGoggles"]
 
     GVAR(AssignedItemsShownItems) = [
         !((_assignedItems select 0) isEqualTo "") && {getText (configFile >> "CfgWeapons" >> _assignedItems select 0 >> "ACE_hideItemType") != "map"},

--- a/addons/common/functions/fnc_getAllGear.sqf
+++ b/addons/common/functions/fnc_getAllGear.sqf
@@ -33,9 +33,11 @@
  */
 #include "script_component.hpp"
 
-ACE_DEPRECATED("ace_common_fnc_getAllGear","3.7.0","getUnitLoadout");
+params ["_unit", ["_showDeprecated", true]];
 
-params ["_unit"];
+if (_showDeprecated) then {
+    ACE_DEPRECATED("ace_common_fnc_getAllGear","3.7.0","getUnitLoadout");
+};
 
 if (isNull _unit) exitWith {[
     "",

--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -45,10 +45,12 @@ GVAR(surfaceCacheIsDust) = false;
 GVAR(OldGlasses) = "<null>";
 
 ["playerInventoryChanged", {
-    private _currentGlasses = (_this select 1) param [7, ""];
+    params ["_unit"];
+
+    private _currentGlasses = goggles _unit;
 
     if (GVAR(OldGlasses) != _currentGlasses) then {
-        ["GlassesChanged", [ACE_player, _currentGlasses]] call EFUNC(common,localEvent);
+        ["GlassesChanged", [_unit, _currentGlasses]] call EFUNC(common,localEvent);
         GVAR(OldGlasses) = _currentGlasses;
     };
 }] call EFUNC(common,addEventHandler);


### PR DESCRIPTION
The output of `getUnitLoadout` is different as `getAllGear`. Using a different format in the event would mean that any eventhandler depending on the inventory output would now be broken.

