### PR TITLE
Allow drivers of vehicles to show microDagr

### DIFF
--- a/addons/microdagr/functions/fnc_canShow.sqf
+++ b/addons/microdagr/functions/fnc_canShow.sqf
@@ -27,8 +27,10 @@ _returnValue = switch (_showType) do {
          ("ACE_microDAGR" in (items ACE_player)) && {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
     };
     case (DISPLAY_MODE_DISPLAY): {
-        //Can't have minimap up while zoomed in
-        (cameraview != "GUNNER") && {"ACE_microDAGR" in (items ACE_player)} && {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
+        //Can't have minimap up while zoomed in on foot, but allow drivers to use while in "Gunner" to handle non-3d vehicles like most tanks
+        ((cameraView != "GUNNER") || {(vehicle ACE_player != ACE_player) && {driver vehicle ACE_player == ACE_player}}) &&
+        {"ACE_microDAGR" in (items ACE_player)} && 
+        {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
     };
     default { false };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Allow drivers of vehicles to show microDagr

Currently the microDagr follows the same rules as the vanilla GPS which blocks display when in "gunner" camera view. A lot of armored vehicles don't have a 3d interior and all crew are locked to gunner mode at all times making it difficult to use just because of a limitation of the vehicle.

This removes the "gunner" restriction for drivers.