### PR TITLE
fullCrew new parameter to improve FUNC(getTurretX)

### DIFF
--- a/addons/common/functions/fnc_getTurretCommander.sqf
+++ b/addons/common/functions/fnc_getTurretCommander.sqf
@@ -14,19 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-private _turrets = allTurrets [_vehicle, true];
-
-private _turret = [];
-
-{
-    private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-
-    _config = [_config, _x] call FUNC(getTurretConfigPath);
-
-    if (getNumber (_config >> "primaryObserver") == 1) exitWith {
-        _turret = _x;
-    };
-    false
-} count _turrets;
-
-_turret
+fullCrew [_vehicle, "commander", true] apply {_x select 3} param [0, []] // return

--- a/addons/common/functions/fnc_getTurretCommander.sqf
+++ b/addons/common/functions/fnc_getTurretCommander.sqf
@@ -14,4 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-fullCrew [_vehicle, "commander", true] apply {_x select 3} param [0, []] // return
+(fullCrew [_vehicle, "commander", true] apply {_x select 3}) param [0, []] // return

--- a/addons/common/functions/fnc_getTurretCommander.sqf
+++ b/addons/common/functions/fnc_getTurretCommander.sqf
@@ -14,4 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-(fullCrew [_vehicle, "commander", true] apply {_x select 3}) param [0, []] // return
+fullCrew [_vehicle, "commander", true] apply {_x select 3} param [0, []] // return

--- a/addons/common/functions/fnc_getTurretCopilot.sqf
+++ b/addons/common/functions/fnc_getTurretCopilot.sqf
@@ -14,19 +14,6 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-private _turrets = allTurrets [_vehicle, true];
-
-private _turret = [];
-
-{
-    private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-
-    _config = [_config, _x] call FUNC(getTurretConfigPath);
-
-    if (getNumber (_config >> "isCopilot") == 1 && {getNumber (_config >> "primaryGunner") != 1} && {getNumber (_config >> "primaryObserver") != 1}) exitWith {
-        _turret = _x;
-    };
-    false
-} count _turrets;
-
-_turret
+fullCrew [_vehicle, "turret", true] apply {_x select 3} select {
+    getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") == 1
+} param [0, []] // return

--- a/addons/common/functions/fnc_getTurretCopilot.sqf
+++ b/addons/common/functions/fnc_getTurretCopilot.sqf
@@ -14,4 +14,6 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-((fullCrew [_vehicle, "turret", true] apply {_x select 3}) select {getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") == 1}) param [0, []] // return
+fullCrew [_vehicle, "turret", true] apply {_x select 3} select {
+    getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") == 1
+} param [0, []] // return

--- a/addons/common/functions/fnc_getTurretCopilot.sqf
+++ b/addons/common/functions/fnc_getTurretCopilot.sqf
@@ -14,6 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-fullCrew [_vehicle, "turret", true] apply {_x select 3} select {
-    getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") == 1
-} param [0, []] // return
+((fullCrew [_vehicle, "turret", true] apply {_x select 3}) select {getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") == 1}) param [0, []] // return

--- a/addons/common/functions/fnc_getTurretGunner.sqf
+++ b/addons/common/functions/fnc_getTurretGunner.sqf
@@ -14,19 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-private _turrets = allTurrets [_vehicle, true];
-
-private _turret = [];
-
-{
-    private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-
-    _config = [_config, _x] call FUNC(getTurretConfigPath);
-
-    if (getNumber (_config >> "primaryGunner") == 1) exitWith {
-        _turret = _x;
-    };
-    false
-} count _turrets;
-
-_turret
+fullCrew [_vehicle, "gunner", true] apply {_x select 3} param [0, []] // return

--- a/addons/common/functions/fnc_getTurretGunner.sqf
+++ b/addons/common/functions/fnc_getTurretGunner.sqf
@@ -14,4 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-fullCrew [_vehicle, "gunner", true] apply {_x select 3} param [0, []] // return
+(fullCrew [_vehicle, "gunner", true] apply {_x select 3}) param [0, []] // return

--- a/addons/common/functions/fnc_getTurretGunner.sqf
+++ b/addons/common/functions/fnc_getTurretGunner.sqf
@@ -14,4 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-(fullCrew [_vehicle, "gunner", true] apply {_x select 3}) param [0, []] // return
+fullCrew [_vehicle, "gunner", true] apply {_x select 3} param [0, []] // return

--- a/addons/common/functions/fnc_getTurrets.sqf
+++ b/addons/common/functions/fnc_getTurrets.sqf
@@ -8,11 +8,13 @@
  * Return Value:
  * Turret Indecies <ARRAY>
  *
- * Public: Yes
+ * Public: No
  *
  * Note: It's advised to use allTurrets [_vehicle, true] instead whenever possible
  */
 #include "script_component.hpp"
+
+ACE_DEPRECATED("ace_common_fnc_getTurrets","3.7.0","allTurrets [_vehicle, true]");
 
 params ["_type"];
 

--- a/addons/common/functions/fnc_getTurretsFFV.sqf
+++ b/addons/common/functions/fnc_getTurretsFFV.sqf
@@ -14,19 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-private _turrets = allTurrets [_vehicle, true];
-
-private _turret = [];
-
-{
-    private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-
-    _config = [_config, _x] call FUNC(getTurretConfigPath);
-
-    if (getNumber (_config >> "isPersonTurret") == 1) then {
-        _turret pushBack _x;
-    };
-    false
-} count _turrets;
-
-_turret
+fullCrew [_vehicle, "turret", true] select {_x select 4} apply {_x select 3} // return

--- a/addons/common/functions/fnc_getTurretsFFV.sqf
+++ b/addons/common/functions/fnc_getTurretsFFV.sqf
@@ -14,4 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-fullCrew [_vehicle, "turret", true] select {_x select 4} apply {_x select 3} // return
+(fullCrew [_vehicle, "turret", true] select {_x select 4}) apply {_x select 3} // return

--- a/addons/common/functions/fnc_getTurretsFFV.sqf
+++ b/addons/common/functions/fnc_getTurretsFFV.sqf
@@ -14,4 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-(fullCrew [_vehicle, "turret", true] select {_x select 4}) apply {_x select 3} // return
+fullCrew [_vehicle, "turret", true] select {_x select 4} apply {_x select 3} // return

--- a/addons/common/functions/fnc_getTurretsOther.sqf
+++ b/addons/common/functions/fnc_getTurretsOther.sqf
@@ -14,24 +14,6 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-private _turrets = allTurrets [_vehicle, true];
-
-private _turret = [];
-
-{
-    private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-
-    _config = [_config, _x] call FUNC(getTurretConfigPath);
-
-    if (
-        getNumber (_config >> "isCopilot") != 1
-        && {getNumber (_config >> "primaryGunner") != 1}
-        && {getNumber (_config >> "primaryObserver") != 1}
-        && {getNumber (_config >> "isPersonTurret") != 1}
-    ) then {
-        _turret pushBack _x;
-    };
-    false
-} count _turrets;
-
-_turret
+fullCrew [_vehicle, "turret", true] select {!(_x select 4)} apply {_x select 3} select {
+    getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") != 1
+} // return

--- a/addons/common/functions/fnc_getTurretsOther.sqf
+++ b/addons/common/functions/fnc_getTurretsOther.sqf
@@ -14,4 +14,6 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-((fullCrew [_vehicle, "turret", true] select {!(_x select 4)}) apply {_x select 3}) select {getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") != 1} // return
+fullCrew [_vehicle, "turret", true] select {!(_x select 4)} apply {_x select 3} select {
+    getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") != 1
+} // return

--- a/addons/common/functions/fnc_getTurretsOther.sqf
+++ b/addons/common/functions/fnc_getTurretsOther.sqf
@@ -14,6 +14,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-fullCrew [_vehicle, "turret", true] select {!(_x select 4)} apply {_x select 3} select {
-    getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") != 1
-} // return
+((fullCrew [_vehicle, "turret", true] select {!(_x select 4)}) apply {_x select 3}) select {getNumber ([_vehicle, _x] call CBA_fnc_getTurret >> "isCopilot") != 1} // return


### PR DESCRIPTION
**When merged this pull request will:**
- Since 1.55dev `fullCrew` can show unmanned positions. Since it also has a filter for specific turret types, it can replace the manual SQF filtering of `allTurrets`.

```
// merkava
cursorTarget call ACE_common_fnc_getTurretCommander

Before:
0.0758 ms

After:
0.0108 ms
```
