### PR TITLE
Improved misleading translation of german bandages

### DIFF
--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -345,7 +345,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Actions_FieldDressing">
             <English>Field Dressing</English>
-            <German>Bandage (Einfach)</German>
+            <German>Wundverband</German>
             <Spanish>Compresa de campaña</Spanish>
             <Russian>Бинтовая повязка</Russian>
             <Czech>Obinadlo</Czech>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -345,7 +345,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Actions_FieldDressing">
             <English>Field Dressing</English>
-            <German>Verbandpäckchen</German>
+            <German>Bandage (Einfach)</German>
             <Spanish>Compresa de campaña</Spanish>
             <Russian>Бинтовая повязка</Russian>
             <Czech>Obinadlo</Czech>
@@ -789,7 +789,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Bandage_Basic_Display">
             <English>Bandage (Basic)</English>
-            <German>Bandage (Standard)</German>
+            <German>Bandage (Einfach)</German>
             <Russian>Повязка (обычная)</Russian>
             <Spanish>Vendaje (Básico)</Spanish>
             <French>Bandage (Standard)</French>
@@ -1252,7 +1252,7 @@
             <Spanish>Vendaje básico (QuickClot)</Spanish>
             <French>Bandage basique (Hémostatique)</French>
             <Polish>Opatrunek QuikClot ACS</Polish>
-            <German>Verbandpäckchen (Gerinnungsmittel)</German>
+            <German>Verbandpäckchen (QuikClot)</German>
             <Hungarian>Általános zárókötszer (QuikClot)</Hungarian>
             <Italian>Bendaggio emostatico (QuikClot)</Italian>
             <Portuguese>Bandagem básica (Coagulante)</Portuguese>


### PR DESCRIPTION
**When merged this pull request will:**
- Change the names of certain bandages in the inventory and medical menu

The current german translation leads to confusion when it comes to bandages, because:

- "QuikClot" in the inventory is called "**Verbandpäckchen** (Gerinnungsmittel)"
- "Bandage (Basic)" in the interaction menu is called "**Verbandpäckchen**"

This lead to people confusing the basic bandages with QuikClots.