### PR TITLE
Fix Can't toggle safemode in FFV seats

### DIFF
--- a/addons/safemode/XEH_postInit.sqf
+++ b/addons/safemode/XEH_postInit.sqf
@@ -11,9 +11,9 @@ if (!hasInterface) exitWith {};
 ["ACE3 Weapons", QGVAR(safeMode), localize LSTRING(SafeMode),
 {
     // Conditions: canInteract
-    if !([ACE_player, objNull, ["isNotEscorting"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, objNull, ["isNotEscorting", "isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
     // Conditions: specific
-    if !([ACE_player] call CBA_fnc_canUseWeapon && {currentWeapon ACE_player != binocular ACE_player}) exitWith {false};
+    if !([ACE_player] call CBA_fnc_canUseWeapon && {currentWeapon ACE_player != binocular ACE_player} && {currentWeapon ACE_player != ""}) exitWith {false};
 
     // Statement
     [ACE_player, currentWeapon ACE_player, currentMuzzle ACE_player] call FUNC(lockSafety);


### PR DESCRIPTION
**When merged this pull request will:**
 - Close  #3819
- Fix Can't toggle safemode in FFV seat
Also block safemode when no weapon