### PR TITLE
add a line to support JSRS Eden (getting rid of JSRS explosion sound …

### DIFF
--- a/addons/huntir/CfgAmmo.hpp
+++ b/addons/huntir/CfgAmmo.hpp
@@ -26,6 +26,7 @@ class CfgAmmo {
         soundHit6[] = {"",3.16228,1,2000};
         soundHit7[] = {"",3.16228,1,2000};
         soundHit8[] = {"",3.16228,1,2000};
+        SoundSetExplosion[] = {};
         multiSoundHit[] = {};
         class HitEffects {};
         soundFakeFall0[] = {"",3.16228,1,1000};


### PR DESCRIPTION
**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Respect the [Development Guidelines](http://ace3mod.com/wiki/development/)

…effect)

`class ShellBase: ShellCore
	{
		SoundSetExplosion[] = {"DFyre_Shell_Exp_SoundSet","DFyre_Shell_Tail_SoundSet","DFyre_Explosion_Big_Debris_SoundSet"};
	};`
JSRS DFyre Eden 1.2 defines a SoundSetExplosion[] on ShellBase to define explosion sounds, which gives HuntIR undesirable exploding sound when used together. Though it's a mod's fault, it's pretty much avoidable by applying minor changes to ACE 3. Adding SoundSetExplosion[] = {}; shall fix the problem.