### PR TITLE
ace_map: More realistic flashlight glow + minor fix

### DIFF
--- a/addons/map/CfgAmmo.hpp
+++ b/addons/map/CfgAmmo.hpp
@@ -1,32 +1,5 @@
 class CfgAmmo {
     
-    class FlareCore;
-    
-    class FlareBase: FlareCore {};
-    class F_20mm_White: FlareBase {};
-    
-    class ACE_FlashlightProxy_Old: F_20mm_White {
-        model = "\A3\Weapons_f\empty";
-        effectFlare = "FlareShell";
-        
-        triggerTime = 0;
-        intensity = 0.5;
-        flareSize = 1;
-        timeToLive = 10e10;
-        
-        lightColor[] = {1,1,1,1};
-        
-        grenadeBurningSound[] = {};
-        grenadeFireSound[] = {};
-        soundTrigger[] = {};
-        SmokeShellSoundHit1[] = {};
-        SmokeShellSoundHit2[] = {};
-        SmokeShellSoundHit3[] = {};
-        SmokeShellSoundLoop1[] = {};
-        SmokeShellSoundLoop2[] = {};
-    };
-    
-    
     class Chemlight_base;
     
     class ACE_FlashlightProxy_White: Chemlight_base {

--- a/addons/map/CfgAmmo.hpp
+++ b/addons/map/CfgAmmo.hpp
@@ -1,21 +1,21 @@
 class CfgAmmo {
-
+    
     class FlareCore;
-
+    
     class FlareBase: FlareCore {};
     class F_20mm_White: FlareBase {};
-
-    class ACE_FlashlightProxy_White: F_20mm_White {
+    
+    class ACE_FlashlightProxy_Old: F_20mm_White {
         model = "\A3\Weapons_f\empty";
         effectFlare = "FlareShell";
-
+        
         triggerTime = 0;
         intensity = 0.5;
         flareSize = 1;
         timeToLive = 10e10;
-
+        
         lightColor[] = {1,1,1,1};
-
+        
         grenadeBurningSound[] = {};
         grenadeFireSound[] = {};
         soundTrigger[] = {};
@@ -25,24 +25,57 @@ class CfgAmmo {
         SmokeShellSoundLoop1[] = {};
         SmokeShellSoundLoop2[] = {};
     };
-
+    
+    
+    class Chemlight_base;
+    
+    class ACE_FlashlightProxy_White: Chemlight_base {
+        model = "\A3\Weapons_f\empty";
+        effectsSmoke = "ACE_FlashlightEffect_White";
+        explosionTime = 0.01;
+        timeToLive = 1e10;
+        
+        soundImpactHard1[] = {"",1,1};
+        soundImpactHard2[] = {"",1,1};
+        soundImpactHard3[] = {"",1,1};
+        soundImpactHard4[] = {"",1,1};
+        soundImpactHard5[] = {"",1,1};
+        soundImpactHard6[] = {"",1,1};
+        soundImpactHard7[] = {"",1,1};
+        soundImpactIron1[] = {"",1,1};
+        soundImpactIron2[] = {"",1,1};
+        soundImpactIron3[] = {"",1,1};
+        soundImpactIron4[] = {"",1,1};
+        soundImpactIron5[] = {"",1,1};
+        soundImpactSoft1[] = {"",1,1};
+        soundImpactSoft2[] = {"",1,1};
+        soundImpactSoft3[] = {"",1,1};
+        soundImpactSoft4[] = {"",1,1};
+        soundImpactSoft5[] = {"",1,1};
+        soundImpactSoft6[] = {"",1,1};
+        soundImpactSoft7[] = {"",1,1};
+        soundImpactWater1[] = {"",1,1};
+        soundImpactWater2[] = {"",1,1};
+        soundImpactWater3[] = {"",1,1};
+        soundImpactWoodExt1[] = {"",1,1};
+        soundImpactWoodExt2[] = {"",1,1};
+        soundImpactWoodExt3[] = {"",1,1};
+        soundImpactWoodExt4[] = {"",1,1};
+    };
+    
     class ACE_FlashlightProxy_Red: ACE_FlashlightProxy_White {
-        intensity = 1;
-        lightColor[] = {1,0,0,1};
+        effectsSmoke = "ACE_FlashlightEffect_Red";
     };
-
-    class ACE_FlashlightProxy_Green: ACE_FlashlightProxy_White {
-        intensity = 1;
-        lightColor[] = {0,1,0,1};
-    };
-
+    
     class ACE_FlashlightProxy_Blue: ACE_FlashlightProxy_White {
-        intensity = 1.5;
-        lightColor[] = {0.25,0.25,1,1};
+        effectsSmoke = "ACE_FlashlightEffect_Blue";
     };
-
+    
+    class ACE_FlashlightProxy_Green: ACE_FlashlightProxy_White {
+        effectsSmoke = "ACE_FlashlightEffect_Green";
+    };
+    
     class ACE_FlashlightProxy_Yellow: ACE_FlashlightProxy_White {
-        intensity = 1;
-        lightColor[] = {1,1,0.5,1};
+        effectsSmoke = "ACE_FlashlightEffect_Yellow";
     };
 };

--- a/addons/map/CfgLights.hpp
+++ b/addons/map/CfgLights.hpp
@@ -1,0 +1,35 @@
+class CfgLights {
+    
+    class Chemlight_Blue;
+    
+    class ACE_FlashlightLight_White: Chemlight_Blue {
+        brightness = 100;
+        color[] = {1,1,1,1};
+        diffuse[] = {1,1,1};
+        intensity = 100;
+        position[] = {0,0,0};
+
+        class Attenuation {
+            constant = 0;
+            linear = 0;
+            quadratic = 10000;
+            start = 0.075;
+        };
+    };
+    
+    class ACE_FlashlightLight_Red: ACE_FlashlightLight_White {
+        diffuse[] = {1,0,0};
+    };
+    
+    class ACE_FlashlightLight_Blue: ACE_FlashlightLight_White {
+        diffuse[] = {0.25,0.25,1};
+    };
+    
+    class ACE_FlashlightLight_Green: ACE_FlashlightLight_White {
+        diffuse[] = {0,1,0};
+    };
+    
+    class ACE_FlashlightLight_Yellow: ACE_FlashlightLight_White {
+        diffuse[] = {1,1,0.4};
+    };
+};

--- a/addons/map/Effects.hpp
+++ b/addons/map/Effects.hpp
@@ -1,0 +1,36 @@
+// "Smoke" effect classes for global flashlight glow
+
+class ACE_FlashlightEffect_White {
+    class Light1 {
+        simulation = "light";
+        type = "ACE_FlashlightLight_White";
+    };
+};
+
+class ACE_FlashlightEffect_Red {
+    class Light1 {
+        simulation = "light";
+        type = "ACE_FlashlightLight_Red";
+    };
+};
+
+class ACE_FlashlightEffect_Blue {
+    class Light1 {
+        simulation = "light";
+        type = "ACE_FlashlightLight_Blue";
+    };
+};
+
+class ACE_FlashlightEffect_Green {
+    class Light1 {
+        simulation = "light";
+        type = "ACE_FlashlightLight_Green";
+    };
+};
+
+class ACE_FlashlightEffect_Yellow {
+    class Light1 {
+        simulation = "light";
+        type = "ACE_FlashlightLight_Yellow";
+    };
+};

--- a/addons/map/XEH_postInitClient.sqf
+++ b/addons/map/XEH_postInitClient.sqf
@@ -9,6 +9,7 @@ if (isServer) then {
         {
             if (_x isKindOf "ACE_FlashlightProxy_White") then {
                 // ACE_LOGINFO_2("Deleting leftover light [%1:%2] from DC player [%3]", _x, typeOf _x, _disconnectedPlayer);
+                detach _x;
                 deleteVehicle _x;
             };
         } forEach attachedObjects _disconnectedPlayer;

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -30,6 +30,7 @@ class RscEdit;
 #include "CfgAmmo.hpp"
 #include "CfgSounds.hpp"
 #include "CfgLights.hpp"
+#include "Effects.hpp"
 
 class RscMapControl {
     maxSatelliteAlpha = 0.5;
@@ -160,42 +161,5 @@ class RscDisplayServerGetReady: RscDisplayGetReady {
         class TopRight: RscControlsGroup {
             #include "MapControls.hpp"
         };
-    };
-};
-
-// "Smoke" effect classes for global flashlight glow
-
-class ACE_FlashlightEffect_White {
-    class Light1 {
-        simulation = "light";
-        type = "ACE_FlashlightLight_White";
-    };
-};
-
-class ACE_FlashlightEffect_Red {
-    class Light1 {
-        simulation = "light";
-        type = "ACE_FlashlightLight_Red";
-    };
-};
-
-class ACE_FlashlightEffect_Blue {
-    class Light1 {
-        simulation = "light";
-        type = "ACE_FlashlightLight_Blue";
-    };
-};
-
-class ACE_FlashlightEffect_Green {
-    class Light1 {
-        simulation = "light";
-        type = "ACE_FlashlightLight_Green";
-    };
-};
-
-class ACE_FlashlightEffect_Yellow {
-    class Light1 {
-        simulation = "light";
-        type = "ACE_FlashlightLight_Yellow";
     };
 };

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -167,35 +167,35 @@ class RscDisplayServerGetReady: RscDisplayGetReady {
 
 class ACE_FlashlightEffect_White {
     class Light1 {
-        simulation="light";
-        type="ACE_FlashlightLight_White";
+        simulation = "light";
+        type = "ACE_FlashlightLight_White";
     };
 };
 
 class ACE_FlashlightEffect_Red {
     class Light1 {
-        simulation="light";
-        type="ACE_FlashlightLight_Red";
+        simulation = "light";
+        type = "ACE_FlashlightLight_Red";
     };
 };
 
 class ACE_FlashlightEffect_Blue {
     class Light1 {
-        simulation="light";
-        type="ACE_FlashlightLight_Blue";
+        simulation = "light";
+        type = "ACE_FlashlightLight_Blue";
     };
 };
 
 class ACE_FlashlightEffect_Green {
     class Light1 {
-        simulation="light";
-        type="ACE_FlashlightLight_Green";
+        simulation = "light";
+        type = "ACE_FlashlightLight_Green";
     };
 };
 
 class ACE_FlashlightEffect_Yellow {
     class Light1 {
-        simulation="light";
-        type="ACE_FlashlightLight_Yellow";
+        simulation = "light";
+        type = "ACE_FlashlightLight_Yellow";
     };
 };

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -29,6 +29,7 @@ class RscEdit;
 #include "CfgVehicles.hpp"
 #include "CfgAmmo.hpp"
 #include "CfgSounds.hpp"
+#include "CfgLights.hpp"
 
 class RscMapControl {
     maxSatelliteAlpha = 0.5;
@@ -159,5 +160,42 @@ class RscDisplayServerGetReady: RscDisplayGetReady {
         class TopRight: RscControlsGroup {
             #include "MapControls.hpp"
         };
+    };
+};
+
+// "Smoke" effect classes for global flashlight glow
+
+class ACE_FlashlightEffect_White {
+    class Light1 {
+        simulation="light";
+        type="ACE_FlashlightLight_White";
+    };
+};
+
+class ACE_FlashlightEffect_Red {
+    class Light1 {
+        simulation="light";
+        type="ACE_FlashlightLight_Red";
+    };
+};
+
+class ACE_FlashlightEffect_Blue {
+    class Light1 {
+        simulation="light";
+        type="ACE_FlashlightLight_Blue";
+    };
+};
+
+class ACE_FlashlightEffect_Green {
+    class Light1 {
+        simulation="light";
+        type="ACE_FlashlightLight_Green";
+    };
+};
+
+class ACE_FlashlightEffect_Yellow {
+    class Light1 {
+        simulation="light";
+        type="ACE_FlashlightLight_Yellow";
     };
 };

--- a/addons/map/functions/fnc_flashlightGlow.sqf
+++ b/addons/map/functions/fnc_flashlightGlow.sqf
@@ -20,7 +20,10 @@ private ["_light", "_color", "_class"];
 params ["_flashlight"];
 
 _light = GVAR(glow);
-if (!isNull _light) then {deleteVehicle _light};
+if (!isNull _light) then {
+    detach _light;
+    deleteVehicle _light;
+};
 
 if (_flashlight != "") then {
     _color = getText (configFile >> "CfgWeapons" >> _flashlight >> "ItemInfo" >> "FlashLight" >> "ACE_Flashlight_Colour");
@@ -28,7 +31,7 @@ if (_flashlight != "") then {
     _class = format["ACE_FlashlightProxy_%1", _color];
 
     _light = _class createVehicle [0,0,0];
-    _light attachTo [ACE_player, [0,0.5,-0.1], "head"];
+    _light attachTo [ACE_player, [0,0.1,-0.05], "neck"];
 } else {
     _light = objNull;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix https://github.com/acemod/ACE3/issues/3605
- Change external flashlight glow object from a sprite effect (infinite visibility) to a light source (~500m visibility; depends on conditions)
- Glow appears on unit's neck/chest, so you can no longer see it from behind or, when he's prone, from above
- Glow objects are now detached before being deleted, preventing dozens (potentially hundreds) of duplicate objNulls attached to players

**Preview Images**

5m old: http://i.imgur.com/0hEeKYq.png [plain] http://i.imgur.com/GeCLSQr.png [nvg]
5m new: http://i.imgur.com/YRHl50J.png [plain] http://i.imgur.com/kSa7AMP.png [nvg]
100m old: http://i.imgur.com/C1bKiJE.png [plain] http://i.imgur.com/rqun1L1.png [nvg]
100m new: http://i.imgur.com/jtFNK7l.png [plain] http://i.imgur.com/BRlV6nA.png [nvg]
300m old: http://i.imgur.com/1Wsu9CX.png [plain] http://i.imgur.com/fHJTvjC.png [nvg]
300m new: http://i.imgur.com/zAZR288.png [plain] http://i.imgur.com/ZBvHJEP.png [nvg]