### PR TITLE
gforces - Fix missing ace_settings.hpp include

### DIFF
--- a/addons/gforces/config.cpp
+++ b/addons/gforces/config.cpp
@@ -12,8 +12,7 @@ class CfgPatches {
     };
 };
 
+#include "ACE_Settings.hpp"
 #include "CfgEventHandlers.hpp"
-
 #include "CfgWeapons.hpp"
-
 #include "CfgVehicles.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Fix nil settings mistake from PR #3705