### PR TITLE
Fix showHud if set before display loaded

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -303,6 +303,15 @@ call FUNC(assignedItemFix);
 enableCamShake true;
 
 
+//FUNC(showHud) needs to be refreshed if it was set during mission init
+["ace_infoDisplayChanged", {
+    GVAR(showHudHash) params ["", "_masks"];
+    if (!(_masks isEqualTo [])) then {
+        [] call FUNC(showHud);
+    };
+}] call CBA_fnc_addEventHandler;
+
+
 //////////////////////////////////////////////////
 // Eventhandler to set player names
 //////////////////////////////////////////////////


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `showHud` command is ignored if set before display loaded

@jonpas  - This was causing `ace_ui_groupBar` to have no effect in multiplayer.