### PR TITLE
Fix CfgPatches author/ is not a value

### DIFF
--- a/addons/advanced_ballistics/config.cpp
+++ b/addons/advanced_ballistics/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_ballistics", "ace_weather"};
-        author[] = {"Ruthberg"};
-        authorUrl = "https://github.com/ulteq";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/advanced_ballistics/config.cpp
+++ b/addons/advanced_ballistics/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_ballistics", "ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/advanced_ballistics/config.cpp
+++ b/addons/advanced_ballistics/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_ballistics", "ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"KoffeinFlummi","commy2"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi","commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/aircraft/config.cpp
+++ b/addons/aircraft/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","Crusty","commy2","jaynus","Kimi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/aircraft/config.cpp
+++ b/addons/aircraft/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"KoffeinFlummi","Crusty","commy2","jaynus","Kimi"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi","Crusty","commy2","jaynus","Kimi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/aircraft/config.cpp
+++ b/addons/aircraft/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","Crusty","commy2","jaynus","Kimi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/apl/config.cpp
+++ b/addons/apl/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main"};
         author = "Bohemia Interactive";
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/apl/config.cpp
+++ b/addons/apl/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main"};
         author = "Bohemia Interactive";
-        url = "https://www.bistudio.com/";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/apl/config.cpp
+++ b/addons/apl/config.cpp
@@ -6,8 +6,8 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main"};
-        author[] = {"Bohemia Interactive"};
-        authorUrl = "http://ace3mod.com";
+        author = "Bohemia Interactive";
+        url = "https://www.bistudio.com/";
         VERSION_CONFIG;
     };
 };

--- a/addons/atragmx/config.cpp
+++ b/addons/atragmx/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_common", "ACE_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/atragmx/config.cpp
+++ b/addons/atragmx/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_common", "ACE_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/atragmx/config.cpp
+++ b/addons/atragmx/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_ATragMX"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ACE_common", "ACE_weather"};
-        author = "Ruthberg";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/attach/config.cpp
+++ b/addons/attach/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_IR_Strobe_Item"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"KoffeinFlummi","eRazeri","esteldunedain"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi","eRazeri","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/attach/config.cpp
+++ b/addons/attach/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","eRazeri","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/attach/config.cpp
+++ b/addons/attach/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","eRazeri","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/backpacks/config.cpp
+++ b/addons/backpacks/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"bux","commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/backpacks/config.cpp
+++ b/addons/backpacks/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"bux","commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/backpacks/config.cpp
+++ b/addons/backpacks/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"bux","commy2"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"bux","commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/ballistics/config.cpp
+++ b/addons/ballistics/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/ballistics/config.cpp
+++ b/addons/ballistics/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/ballistics/config.cpp
+++ b/addons/ballistics/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2","Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/captives/config.cpp
+++ b/addons/captives/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_CableTie"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ACE_Interaction"};
-        author[] = {"commy2", "KoffeinFlummi"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "KoffeinFlummi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/captives/config.cpp
+++ b/addons/captives/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_Interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/captives/config.cpp
+++ b/addons/captives/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_Interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/cargo/config.cpp
+++ b/addons/cargo/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "Glowbal"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/cargo/config.cpp
+++ b/addons/cargo/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"commy2", "Glowbal"};
-        authorUrl = "https://ace3mod.com/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "Glowbal"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/cargo/config.cpp
+++ b/addons/cargo/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "Glowbal"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_main","ace_modules"};
         author = CSTRING(ACETeam);
         authors[] = {"KoffeinFlummi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG_COMMON;
     };
 };

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_ItemCore","ACE_FakePrimaryWeapon", "ACE_Banana"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main","ace_modules"};
-        author[] = {"KoffeinFlummi"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = CSTRING(ACETeam);
+        authors[] = {"KoffeinFlummi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG_COMMON;
     };
 };

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_main","ace_modules"};
         author = CSTRING(ACETeam);
         authors[] = {"KoffeinFlummi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG_COMMON;
     };
 };

--- a/addons/concertina_wire/config.cpp
+++ b/addons/concertina_wire/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_apl", "ace_interaction"};
-        author[] = {"Rocko", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Rocko", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/concertina_wire/config.cpp
+++ b/addons/concertina_wire/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/concertina_wire/config.cpp
+++ b/addons/concertina_wire/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/dagr/config.cpp
+++ b/addons/dagr/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rosuto", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/dagr/config.cpp
+++ b/addons/dagr/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_DAGR"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_weather"};
-        author[] = {"Rosuto", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Rosuto", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/dagr/config.cpp
+++ b/addons/dagr/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rosuto", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/disarming/config.cpp
+++ b/addons/disarming/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_Interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/disarming/config.cpp
+++ b/addons/disarming/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_Interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/disarming/config.cpp
+++ b/addons/disarming/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_DebugPotato"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ACE_Interaction"};
-        author[] = {"PabstMirror"};
-        authorUrl = "https://github.com/PabstMirror/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"PabstMirror"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/disposable/config.cpp
+++ b/addons/disposable/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/disposable/config.cpp
+++ b/addons/disposable/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/disposable/config.cpp
+++ b/addons/disposable/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"Garth 'L-H' de Wet", "commy2"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Garth 'L-H' de Wet", "commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet", "commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet", "commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Clacker", "ACE_DefusalKit", "ACE_M26_Clacker", "ACE_DeadManSwitch", "ACE_Cellphone"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"Garth 'L-H' de Wet"};
-        authorUrl = "http://garth.snakebiteink.co.za/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Garth 'L-H' de Wet"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/fastroping/config.cpp
+++ b/addons/fastroping/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "BaerMitUmlaut"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/fastroping/config.cpp
+++ b/addons/fastroping/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"KoffeinFlummi", "BaerMitUmlaut"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi", "BaerMitUmlaut"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/fastroping/config.cpp
+++ b/addons/fastroping/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "BaerMitUmlaut"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/fcs/config.cpp
+++ b/addons/fcs/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","BadGuy (simon84)","commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/fcs/config.cpp
+++ b/addons/fcs/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","BadGuy (simon84)","commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/fcs/config.cpp
+++ b/addons/fcs/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"KoffeinFlummi","BadGuy (simon84)","commy2"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi","BadGuy (simon84)","commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/finger/config.cpp
+++ b/addons/finger/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Drill"};
-        authorUrl = "https://github.com/TheDrill/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Drill"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/finger/config.cpp
+++ b/addons/finger/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Drill"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/finger/config.cpp
+++ b/addons/finger/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Drill"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/flashlights/config.cpp
+++ b/addons/flashlights/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"voiper"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/flashlights/config.cpp
+++ b/addons/flashlights/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"voiper"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/flashlights/config.cpp
+++ b/addons/flashlights/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Flashlight_MX991", "ACE_Flashlight_KSF1", "ACE_Flashlight_XL50"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"voiper"};
-        authorUrl = "https://github.com/voiperr/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"voiper"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/flashsuppressors/config.cpp
+++ b/addons/flashsuppressors/config.cpp
@@ -16,7 +16,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/flashsuppressors/config.cpp
+++ b/addons/flashsuppressors/config.cpp
@@ -14,8 +14,9 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/flashsuppressors/config.cpp
+++ b/addons/flashsuppressors/config.cpp
@@ -16,7 +16,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/fonts/config.cpp
+++ b/addons/fonts/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"jaynus"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/fonts/config.cpp
+++ b/addons/fonts/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main"};
-        author[] = {"jaynus"};
-        authorUrl = "https://github.com/jaynus/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"jaynus"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/fonts/config.cpp
+++ b/addons/fonts/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"jaynus"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/frag/config.cpp
+++ b/addons/frag/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Nou"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/frag/config.cpp
+++ b/addons/frag/config.cpp
@@ -5,7 +5,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Nou"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Nou"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/frag/config.cpp
+++ b/addons/frag/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Nou"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/gestures/config.cpp
+++ b/addons/gestures/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interact_menu"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"joko // Jonas", "Emperias", "Zigomarvin"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/gestures/config.cpp
+++ b/addons/gestures/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interact_menu"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"joko // Jonas", "Emperias", "Zigomarvin"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/gestures/config.cpp
+++ b/addons/gestures/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interact_menu"};
-        author[] = {"joko // Jonas", "Emperias", "Zigomarvin"};
-        authorUrl = "https://github.com/jokoho48";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"joko // Jonas", "Emperias", "Zigomarvin"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/gforces/config.cpp
+++ b/addons/gforces/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/gforces/config.cpp
+++ b/addons/gforces/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"KoffeinFlummi", "esteldunedain"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi", "esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/gforces/config.cpp
+++ b/addons/gforces/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/goggles/config.cpp
+++ b/addons/goggles/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/goggles/config.cpp
+++ b/addons/goggles/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/goggles/config.cpp
+++ b/addons/goggles/config.cpp
@@ -7,8 +7,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Garth 'L-H' de Wet"};
-        authorUrl = "http://garth.snakebiteink.co.za/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Garth 'L-H' de Wet"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/grenades/config.cpp
+++ b/addons/grenades/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/grenades/config.cpp
+++ b/addons/grenades/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/grenades/config.cpp
+++ b/addons/grenades/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2", "KoffeinFlummi"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "KoffeinFlummi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_EarPlugs"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction", "A3_Characters_F", "A3_Characters_F_Kart"};
-        author[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2", "Rocko", "Rommel", "Ruthberg"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2", "Rocko", "Rommel", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction", "A3_Characters_F", "A3_Characters_F_Kart"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2", "Rocko", "Rommel", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction", "A3_Characters_F", "A3_Characters_F_Kart"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2", "Rocko", "Rommel", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/hitreactions/config.cpp
+++ b/addons/hitreactions/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/hitreactions/config.cpp
+++ b/addons/hitreactions/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/hitreactions/config.cpp
+++ b/addons/hitreactions/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/huntir/config.cpp
+++ b/addons/huntir/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Norrin", "Rocko", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/huntir/config.cpp
+++ b/addons/huntir/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Norrin", "Rocko", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/huntir/config.cpp
+++ b/addons/huntir/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_HuntIR_monitor"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Norrin", "Rocko", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Norrin", "Rocko", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/interact_menu/config.cpp
+++ b/addons/interact_menu/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"NouberNou", "esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/interact_menu/config.cpp
+++ b/addons/interact_menu/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"NouberNou", "esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/interact_menu/config.cpp
+++ b/addons/interact_menu/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"NouberNou", "esteldunedain"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"NouberNou", "esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/interaction/config.cpp
+++ b/addons/interaction/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interact_menu"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi", "esteldunedain", "bux578", "dixon13"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/interaction/config.cpp
+++ b/addons/interaction/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interact_menu"};
-        author[] = {"commy2", "KoffeinFlummi", "esteldunedain", "bux578", "dixon13"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "KoffeinFlummi", "esteldunedain", "bux578", "dixon13"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/interaction/config.cpp
+++ b/addons/interaction/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interact_menu"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi", "esteldunedain", "bux578", "dixon13"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Pabst Mirror, commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Pabst Mirror, commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/inventory/config.cpp
+++ b/addons/inventory/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Pabst Mirror, commy2"};
-        authorUrl = "https://github.com/PabstMirror/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Pabst Mirror, commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/kestrel4500/config.cpp
+++ b/addons/kestrel4500/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Kestrel4500"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ACE_common", "ACE_weather"};
-        author[] = {ECSTRING(common,ACETeam), "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {ECSTRING(common,ACETeam), "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/kestrel4500/config.cpp
+++ b/addons/kestrel4500/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_common", "ACE_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam), "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/kestrel4500/config.cpp
+++ b/addons/kestrel4500/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_common", "ACE_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam), "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/laserpointer/config.cpp
+++ b/addons/laserpointer/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/laserpointer/config.cpp
+++ b/addons/laserpointer/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_acc_pointer_red","ACE_acc_pointer_green","ACE_acc_pointer_green_IR"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/laserpointer/config.cpp
+++ b/addons/laserpointer/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/logistics_uavbattery/config.cpp
+++ b/addons/logistics_uavbattery/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_UAVBattery"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"marc_book"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"marc_book"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/logistics_uavbattery/config.cpp
+++ b/addons/logistics_uavbattery/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"marc_book"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/logistics_uavbattery/config.cpp
+++ b/addons/logistics_uavbattery/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"marc_book"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/logistics_wirecutter/config.cpp
+++ b/addons/logistics_wirecutter/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"gpgpgpgp", "PabstMirror"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/logistics_wirecutter/config.cpp
+++ b/addons/logistics_wirecutter/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_wirecutter"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"gpgpgpgp", "PabstMirror"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"gpgpgpgp", "PabstMirror"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/logistics_wirecutter/config.cpp
+++ b/addons/logistics_wirecutter/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"gpgpgpgp", "PabstMirror"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/magazinerepack/config.cpp
+++ b/addons/magazinerepack/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/magazinerepack/config.cpp
+++ b/addons/magazinerepack/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"commy2","esteldunedain"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/magazinerepack/config.cpp
+++ b/addons/magazinerepack/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -569,7 +569,7 @@ class CfgPatches {
         };
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam)};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -569,7 +569,7 @@ class CfgPatches {
         };
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam)};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -567,8 +567,9 @@ class CfgPatches {
             "cba_xeh_a3",
             "cba_jr"
         };
-        author[] = {ECSTRING(common,ACETeam)};
-        authorUrl = "http://ace3mod.com/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {ECSTRING(common,ACETeam)};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -11,6 +11,9 @@
 #define VERSION MAJOR.MINOR.PATCHLVL.BUILD
 #define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
 
+#define WEB_URL "http://ace3mod.com/"
+#define PBO_URL url = WEB_URL;
+
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.56
 #define REQUIRED_CBA_VERSION {2,3,1}

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -12,7 +12,7 @@
 #define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
 
 #define WEB_URL "http://ace3mod.com/"
-#define PBO_URL url = WEB_URL;
+#define PBO_URL url = WEB_URL
 
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.56

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","Rocko","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"KoffeinFlummi","Rocko","esteldunedain"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi","Rocko","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","Rocko","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/map_gestures/config.cpp
+++ b/addons/map_gestures/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Dslyecxi", "MikeMatrix"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/map_gestures/config.cpp
+++ b/addons/map_gestures/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Dslyecxi", "MikeMatrix"};
-        authorUrl = "https://github.com/MikeMatrix";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Dslyecxi", "MikeMatrix"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/map_gestures/config.cpp
+++ b/addons/map_gestures/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Dslyecxi", "MikeMatrix"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/maptools/config.cpp
+++ b/addons/maptools/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_MapTools"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"esteldunedain"};
-        authorUrl = "https://github.com/esteldunedain/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/maptools/config.cpp
+++ b/addons/maptools/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/maptools/config.cpp
+++ b/addons/maptools/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/markers/config.cpp
+++ b/addons/markers/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/markers/config.cpp
+++ b/addons/markers/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/markers/config.cpp
+++ b/addons/markers/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction", "ace_apl"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal", "KoffeinFlummi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction", "ace_apl"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal", "KoffeinFlummi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_tourniquet", "ACE_morphine", "ACE_atropine", "ACE_epinephrine", "ACE_plasmaIV", "ACE_plasmaIV_500", "ACE_plasmaIV_250", "ACE_bloodIV", "ACE_bloodIV_500", "ACE_bloodIV_250", "ACE_salineIV", "ACE_salineIV_500", "ACE_salineIV_250", "ACE_quikclot", "ACE_personalAidKit", "ACE_surgicalKit", "ACE_bodyBag"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction", "ace_apl"};
-        author[] = {"Glowbal", "KoffeinFlummi"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Glowbal", "KoffeinFlummi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/medical_menu/config.cpp
+++ b/addons/medical_menu/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_medical"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG
     };
 };

--- a/addons/medical_menu/config.cpp
+++ b/addons/medical_menu/config.cpp
@@ -6,9 +6,10 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_medical"};
-        author[] = {$STR_ACE_Common_ACETeam, "Glowbal"};
-        authorUrl = "http://ace3mod.com"; 
-        VERSION_CONFIG;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Glowbal"};
+        url = "http://ace3mod.com";
+        VERSION_CONFIG
     };
 };
 

--- a/addons/medical_menu/config.cpp
+++ b/addons/medical_menu/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_medical"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG
     };
 };

--- a/addons/microdagr/config.cpp
+++ b/addons/microdagr/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_microDAGR"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"PabstMirror"};
-        authorUrl = "https://github.com/PabstMirror/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"PabstMirror"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/microdagr/config.cpp
+++ b/addons/microdagr/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/microdagr/config.cpp
+++ b/addons/microdagr/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/missionmodules/config.cpp
+++ b/addons/missionmodules/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/missionmodules/config.cpp
+++ b/addons/missionmodules/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Glowbal"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Glowbal"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/missionmodules/config.cpp
+++ b/addons/missionmodules/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/mk6mortar/config.cpp
+++ b/addons/mk6mortar/config.cpp
@@ -7,8 +7,9 @@ class CfgPatches {
         weapons[] = {"ACE_RangeTable_82mm","ace_mortar_82mm"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"PabstMirror","Grey","VKing"};
-        authorUrl = "https://github.com/acemod";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"PabstMirror","Grey","VKing"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/mk6mortar/config.cpp
+++ b/addons/mk6mortar/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror","Grey","VKing"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/mk6mortar/config.cpp
+++ b/addons/mk6mortar/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror","Grey","VKing"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_main"};
-        author[] = {"Glowbal"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Glowbal"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/movement/config.cpp
+++ b/addons/movement/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","Tachii"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/movement/config.cpp
+++ b/addons/movement/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2","KoffeinFlummi","Tachii"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","KoffeinFlummi","Tachii"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/movement/config.cpp
+++ b/addons/movement/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","Tachii"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/mx2a/config.cpp
+++ b/addons/mx2a/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Spooner", "tcp"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/mx2a/config.cpp
+++ b/addons/mx2a/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Spooner", "tcp"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/mx2a/config.cpp
+++ b/addons/mx2a/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_MX2A"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_apl"};
-        author[] = {"Spooner", "tcp"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Spooner", "tcp"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/nametags/config.cpp
+++ b/addons/nametags/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = { "commy2", "esteldunedain" };
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/nametags/config.cpp
+++ b/addons/nametags/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = { "commy2", "esteldunedain" };
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/nametags/config.cpp
+++ b/addons/nametags/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = { "commy2", "esteldunedain" };
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = { "commy2", "esteldunedain" };
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_NVG_Gen1", "ACE_NVG_Gen2", /*"ACE_NVG_Gen3",*/ "ACE_NVG_Gen4", "ACE_NVG_Wide"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2", "KoffeinFlummi", "PabstMirror"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "KoffeinFlummi", "PabstMirror"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi", "PabstMirror"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi", "PabstMirror"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/noidle/config.cpp
+++ b/addons/noidle/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/noidle/config.cpp
+++ b/addons/noidle/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/noidle/config.cpp
+++ b/addons/noidle/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/noradio/config.cpp
+++ b/addons/noradio/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/noradio/config.cpp
+++ b/addons/noradio/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/noradio/config.cpp
+++ b/addons/noradio/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/norearm/config.cpp
+++ b/addons/norearm/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/norearm/config.cpp
+++ b/addons/norearm/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/norearm/config.cpp
+++ b/addons/norearm/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/optics/config.cpp
+++ b/addons/optics/config.cpp
@@ -18,8 +18,9 @@ class CfgPatches {
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Taosenai","KoffeinFlummi","commy2"};
-        authorUrl = "http://www.ryanschultz.org/tmr/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Taosenai","KoffeinFlummi","commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/optics/config.cpp
+++ b/addons/optics/config.cpp
@@ -20,7 +20,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Taosenai","KoffeinFlummi","commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/optics/config.cpp
+++ b/addons/optics/config.cpp
@@ -20,7 +20,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Taosenai","KoffeinFlummi","commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/optionsmenu/config.cpp
+++ b/addons/optionsmenu/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal", "PabstMirror"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/optionsmenu/config.cpp
+++ b/addons/optionsmenu/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal", "PabstMirror"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/optionsmenu/config.cpp
+++ b/addons/optionsmenu/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Glowbal", "PabstMirror"};
-        authorUrl = "http://github.com/Glowbal";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Glowbal", "PabstMirror"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi", "esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_SpareBarrel"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"commy2", "KoffeinFlummi", "esteldunedain"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "KoffeinFlummi", "esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "KoffeinFlummi", "esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/overpressure/config.cpp
+++ b/addons/overpressure/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/overpressure/config.cpp
+++ b/addons/overpressure/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/overpressure/config.cpp
+++ b/addons/overpressure/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/parachute/config.cpp
+++ b/addons/parachute/config.cpp
@@ -7,8 +7,9 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
         VERSION_CONFIG;
-        author[] = {"Garth 'LH' de Wet"};
-        authorUrl = "http://garth.snakebiteink.co.za/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Garth 'LH' de Wet"};
+        url = "http://ace3mod.com";
     };
 };
 

--- a/addons/parachute/config.cpp
+++ b/addons/parachute/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         VERSION_CONFIG;
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'LH' de Wet"};
-        url = "http://ace3mod.com";
+        PBO_URL
     };
 };
 

--- a/addons/parachute/config.cpp
+++ b/addons/parachute/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         VERSION_CONFIG;
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'LH' de Wet"};
-        PBO_URL
+        PBO_URL;
     };
 };
 

--- a/addons/rangecard/config.cpp
+++ b/addons/rangecard/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_RangeCard"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ACE_Advanced_Ballistics"};
-        author = "Ruthberg";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/rangecard/config.cpp
+++ b/addons/rangecard/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_Advanced_Ballistics"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/rangecard/config.cpp
+++ b/addons/rangecard/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ACE_Advanced_Ballistics"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/realisticnames/config.cpp
+++ b/addons/realisticnames/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","TaoSensai","commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/realisticnames/config.cpp
+++ b/addons/realisticnames/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"KoffeinFlummi","TaoSensai","commy2"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi","TaoSensai","commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/realisticnames/config.cpp
+++ b/addons/realisticnames/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi","TaoSensai","commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/rearm/config.cpp
+++ b/addons/rearm/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"GitHawk", "Jonpas"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/rearm/config.cpp
+++ b/addons/rearm/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"GitHawk", "Jonpas"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/rearm/config.cpp
+++ b/addons/rearm/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"GitHawk", "Jonpas"};
-        authorUrl = "https://ace3mod.com";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"GitHawk", "Jonpas"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/recoil/config.cpp
+++ b/addons/recoil/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/recoil/config.cpp
+++ b/addons/recoil/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/recoil/config.cpp
+++ b/addons/recoil/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/refuel/config.cpp
+++ b/addons/refuel/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"GitHawk"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/refuel/config.cpp
+++ b/addons/refuel/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_refuel_fuelNozzle"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"GitHawk"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"GitHawk"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/refuel/config.cpp
+++ b/addons/refuel/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"GitHawk"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/reload/config.cpp
+++ b/addons/reload/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/reload/config.cpp
+++ b/addons/reload/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/reload/config.cpp
+++ b/addons/reload/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/reloadlaunchers/config.cpp
+++ b/addons/reloadlaunchers/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/reloadlaunchers/config.cpp
+++ b/addons/reloadlaunchers/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/reloadlaunchers/config.cpp
+++ b/addons/reloadlaunchers/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/repair/config.cpp
+++ b/addons/repair/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "Glowbal", "Jonpas"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/repair/config.cpp
+++ b/addons/repair/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2", "Glowbal", "Jonpas"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/repair/config.cpp
+++ b/addons/repair/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"commy2", "Glowbal", "Jonpas"};
-        authorUrl = "https://ace3mod.com";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2", "Glowbal", "Jonpas"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/respawn/config.cpp
+++ b/addons/respawn/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = { "ace_common" };
         author = ECSTRING(common,ACETeam);
         authors[] = { "bux578", "commy2" };
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/respawn/config.cpp
+++ b/addons/respawn/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Rallypoint_West", "ACE_Rallypoint_East", "ACE_Rallypoint_Independent", "ACE_Rallypoint_West_Base", "ACE_Rallypoint_East_Base", "ACE_Rallypoint_Independent_Base"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "ace_common" };
-        author[] = { "bux578", "commy2" };
-        authorUrl = "https://github.com/bux578/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = { "bux578", "commy2" };
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/respawn/config.cpp
+++ b/addons/respawn/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = { "ace_common" };
         author = ECSTRING(common,ACETeam);
         authors[] = { "bux578", "commy2" };
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/safemode/config.cpp
+++ b/addons/safemode/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/safemode/config.cpp
+++ b/addons/safemode/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/safemode/config.cpp
+++ b/addons/safemode/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/sandbag/config.cpp
+++ b/addons/sandbag/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/sandbag/config.cpp
+++ b/addons/sandbag/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Sandbag", "ACE_Sandbag_empty"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"Rocko", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Rocko", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/sandbag/config.cpp
+++ b/addons/sandbag/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/scopes/config.cpp
+++ b/addons/scopes/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = { "ace_common" };
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/scopes/config.cpp
+++ b/addons/scopes/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = { "ace_common" };
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/scopes/config.cpp
+++ b/addons/scopes/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "ace_common" };
-        author[] = {"KoffeinFlummi", "esteldunedain"};
-        authorUrl = "https://github.com/KoffeinFlummi";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"KoffeinFlummi", "esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/sitting/config.cpp
+++ b/addons/sitting/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Jonpas"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/sitting/config.cpp
+++ b/addons/sitting/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Jonpas"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/sitting/config.cpp
+++ b/addons/sitting/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"Jonpas"};
-        authorUrl = "https://github.com/jonpas";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Jonpas"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/slideshow/config.cpp
+++ b/addons/slideshow/config.cpp
@@ -7,7 +7,6 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
         author[]= {"Jonpas", "DaC"};
-        authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };
 };

--- a/addons/smallarms/config.cpp
+++ b/addons/smallarms/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"TaoSensai", "KoffeinFlummi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/smallarms/config.cpp
+++ b/addons/smallarms/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"TaoSensai", "KoffeinFlummi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/smallarms/config.cpp
+++ b/addons/smallarms/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"TaoSensai", "KoffeinFlummi"};
-        authorUrl = "https://github.com/Taosenai/tmr";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"TaoSensai", "KoffeinFlummi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"F3 Project","Head","SilentSpike","voiper"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"F3 Project","Head","SilentSpike","voiper"};
-        authorUrl = "https://github.com/acemod";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"F3 Project","Head","SilentSpike","voiper"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"F3 Project","Head","SilentSpike","voiper"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/spottingscope/config.cpp
+++ b/addons/spottingscope/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Scubaman3D", "Ruthberg", "commy2", "p1nga"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/spottingscope/config.cpp
+++ b/addons/spottingscope/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_SpottingScope"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_apl", "ace_interaction"};
-        author[] = {"Rocko", "Scubaman3D", "Ruthberg", "commy2", "p1nga"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Rocko", "Scubaman3D", "Ruthberg", "commy2", "p1nga"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/spottingscope/config.cpp
+++ b/addons/spottingscope/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Scubaman3D", "Ruthberg", "commy2", "p1nga"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/switchunits/config.cpp
+++ b/addons/switchunits/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"bux578"};
-        authorUrl = "https://github.com/bux578/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"bux578"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/switchunits/config.cpp
+++ b/addons/switchunits/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"bux578"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/switchunits/config.cpp
+++ b/addons/switchunits/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"bux578"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/tacticalladder/config.cpp
+++ b/addons/tacticalladder/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_apl", "ace_interaction"};
-        author[] = {"Rocko", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Rocko", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/tacticalladder/config.cpp
+++ b/addons/tacticalladder/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/tacticalladder/config.cpp
+++ b/addons/tacticalladder/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/tagging/config.cpp
+++ b/addons/tagging/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"BaerMitUmlaut","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/tagging/config.cpp
+++ b/addons/tagging/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"BaerMitUmlaut","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/tagging/config.cpp
+++ b/addons/tagging/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_SpraypaintBlack", "ACE_SpraypaintRed", "ACE_SpraypaintGreen", "ACE_SpraypaintBlue"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"BaerMitUmlaut","esteldunedain"};
-        authorUrl = "https://github.com/BaerMitUmlaut";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"BaerMitUmlaut","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/thermals/config.cpp
+++ b/addons/thermals/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"[TF]Nkey"};
-        authorUrl = "https://github.com/michail-nikolaev/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"[TF]Nkey"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/thermals/config.cpp
+++ b/addons/thermals/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"[TF]Nkey"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/thermals/config.cpp
+++ b/addons/thermals/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"[TF]Nkey"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/trenches/config.cpp
+++ b/addons/trenches/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Grey", "esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/trenches/config.cpp
+++ b/addons/trenches/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Grey", "esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/trenches/config.cpp
+++ b/addons/trenches/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_EntrenchingTool"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"Grey", "esteldunedain"};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Grey", "esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/tripod/config.cpp
+++ b/addons/tripod/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Scubaman3D", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/tripod/config.cpp
+++ b/addons/tripod/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Rocko", "Scubaman3D", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/tripod/config.cpp
+++ b/addons/tripod/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Tripod"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
-        author[] = {"Rocko", "Scubaman3D", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Rocko", "Scubaman3D", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"VKing", "Jonpas"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"VKing", "Jonpas"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"VKing", "Jonpas"};
-        authorUrl = "http://ace3mod.com/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"VKing", "Jonpas"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/vector/config.cpp
+++ b/addons/vector/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ghost","Hamburger SV","commy2","bux578"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/vector/config.cpp
+++ b/addons/vector/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Vector", "ACE_VectorDay"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Ghost","Hamburger SV","commy2","bux578"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ghost","Hamburger SV","commy2","bux578"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/vector/config.cpp
+++ b/addons/vector/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ghost","Hamburger SV","commy2","bux578"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
     requiredVersion = REQUIRED_VERSION;
     requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
-        url = "http://ace3mod.com";
+        PBO_URL
     authors[] = {"PabstMirror"};
     authorUrl = "https://github.com/acemod/ACE3";
     VERSION_CONFIG;

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
     requiredVersion = REQUIRED_VERSION;
     requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
-        PBO_URL
+        PBO_URL;
     authors[] = {"PabstMirror"};
     authorUrl = "https://github.com/acemod/ACE3";
     VERSION_CONFIG;

--- a/addons/vehiclelock/config.cpp
+++ b/addons/vehiclelock/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
     weapons[] = {};
     requiredVersion = REQUIRED_VERSION;
     requiredAddons[] = {"ace_interaction"};
-    author[] = {"PabstMirror"};
+        author = ECSTRING(common,ACETeam);
+        url = "http://ace3mod.com";
+    authors[] = {"PabstMirror"};
     authorUrl = "https://github.com/acemod/ACE3";
     VERSION_CONFIG;
   };

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2","KoffeinFlummi"};
-        authorUrl = "https://github.com/KoffeinFlummi/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","KoffeinFlummi"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/viewdistance/config.cpp
+++ b/addons/viewdistance/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Winter", "Jonpas", "Arkhir"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/viewdistance/config.cpp
+++ b/addons/viewdistance/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Winter", "Jonpas", "Arkhir"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/viewdistance/config.cpp
+++ b/addons/viewdistance/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Winter", "Jonpas", "Arkhir"};
-        authorUrl = "https://github.com/Winter259";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Winter", "Jonpas", "Arkhir"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/weaponselect/config.cpp
+++ b/addons/weaponselect/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        authorUrl = "https://github.com/commy2/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/weaponselect/config.cpp
+++ b/addons/weaponselect/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/weaponselect/config.cpp
+++ b/addons/weaponselect/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2","KoffeinFlummi","esteldunedain"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/weather/config.cpp
+++ b/addons/weather/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"q1184", "Rocko", "esteldunedain", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/weather/config.cpp
+++ b/addons/weather/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"q1184", "Rocko", "esteldunedain", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"q1184", "Rocko", "esteldunedain", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/weather/config.cpp
+++ b/addons/weather/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"q1184", "Rocko", "esteldunedain", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/winddeflection/config.cpp
+++ b/addons/winddeflection/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam), "Glowbal", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/winddeflection/config.cpp
+++ b/addons/winddeflection/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam), "Glowbal", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/winddeflection/config.cpp
+++ b/addons/winddeflection/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_weather"};
-        author[] = {ECSTRING(common,ACETeam), "Glowbal", "Ruthberg"};
-        authorUrl = "http://ace3mod.com/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {ECSTRING(common,ACETeam), "Glowbal", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/yardage450/config.cpp
+++ b/addons/yardage450/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_laser"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Spooner", "tcp", "Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/addons/yardage450/config.cpp
+++ b/addons/yardage450/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_apl", "ace_laser"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Spooner", "tcp", "Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/addons/yardage450/config.cpp
+++ b/addons/yardage450/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {"ACE_Yardage450"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_apl", "ace_laser"};
-        author[] = {"Spooner", "tcp", "Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Spooner", "tcp", "Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"SilentSpike"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
     // Use additional cfgPatches to contextually remove modules from zeus

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"SilentSpike"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
     // Use additional cfgPatches to contextually remove modules from zeus

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"SilentSpike"};
-        authorUrl = "https://github.com/SilentSpike";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"SilentSpike"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
     // Use additional cfgPatches to contextually remove modules from zeus

--- a/extras/blank/config.cpp
+++ b/extras/blank/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {""};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/extras/blank/config.cpp
+++ b/extras/blank/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {""};
-        authorUrl = "";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {""};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/extras/blank/config.cpp
+++ b/extras/blank/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {""};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_adr_97/config.cpp
+++ b/optionals/compat_adr_97/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"A3_Weapons_F_Mod"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Nic547"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_adr_97/config.cpp
+++ b/optionals/compat_adr_97/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"A3_Weapons_F_Mod"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Nic547"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_adr_97/config.cpp
+++ b/optionals/compat_adr_97/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F_Mod"};
-        author[] = {"Nic547"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Nic547"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_r3f/config.cpp
+++ b/optionals/compat_r3f/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"R3F_Armes", "R3F_Acc"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_r3f/config.cpp
+++ b/optionals/compat_r3f/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"R3F_Armes", "R3F_Acc"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_r3f/config.cpp
+++ b/optionals/compat_r3f/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"R3F_Armes", "R3F_Acc"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_acc/config.cpp
+++ b/optionals/compat_rh_acc/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"RH_acc"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_acc/config.cpp
+++ b/optionals/compat_rh_acc/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_acc"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_acc/config.cpp
+++ b/optionals/compat_rh_acc/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_acc"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_de/config.cpp
+++ b/optionals/compat_rh_de/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_de_cfg"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_de/config.cpp
+++ b/optionals/compat_rh_de/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_de_cfg"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_de/config.cpp
+++ b/optionals/compat_rh_de/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"RH_de_cfg"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_m4/config.cpp
+++ b/optionals/compat_rh_m4/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_m4_cfg"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_m4/config.cpp
+++ b/optionals/compat_rh_m4/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_m4_cfg"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_m4/config.cpp
+++ b/optionals/compat_rh_m4/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"RH_m4_cfg"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_pdw/config.cpp
+++ b/optionals/compat_rh_pdw/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_PDW"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_pdw/config.cpp
+++ b/optionals/compat_rh_pdw/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"RH_PDW"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rh_pdw/config.cpp
+++ b/optionals/compat_rh_pdw/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RH_PDW"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_2s3", "rhs_c_rva"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_2s3", "rhs_c_rva"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_2s3", "rhs_c_rva"};
-        author[]={"Ruthberg", "GitHawk", "BaerMitUmlaut"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
-        author[]={"Ruthberg", "GitHawk", "BaerMitUmlaut"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rksl_pm_ii/config.cpp
+++ b/optionals/compat_rksl_pm_ii/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"RKSL_PMII"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rksl_pm_ii/config.cpp
+++ b/optionals/compat_rksl_pm_ii/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RKSL_PMII"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_rksl_pm_ii/config.cpp
+++ b/optionals/compat_rksl_pm_ii/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"RKSL_PMII"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_sma3_iansky/config.cpp
+++ b/optionals/compat_sma3_iansky/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"iansky_opt"};
-        author[]={"Ruthberg"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Ruthberg"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_sma3_iansky/config.cpp
+++ b/optionals/compat_sma3_iansky/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"iansky_opt"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/compat_sma3_iansky/config.cpp
+++ b/optionals/compat_sma3_iansky/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"iansky_opt"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/noactionmenu/config.cpp
+++ b/optionals/noactionmenu/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/noactionmenu/config.cpp
+++ b/optionals/noactionmenu/config.cpp
@@ -7,8 +7,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"commy2"};
-        authorUrl = "https://github.com/commy2";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"commy2"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/noactionmenu/config.cpp
+++ b/optionals/noactionmenu/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"commy2"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/server/config.cpp
+++ b/optionals/server/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/server/config.cpp
+++ b/optionals/server/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};
-        author[] = {"Glowbal"};
-        authorUrl = "https://github.com/Glowbal/";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Glowbal"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };

--- a/optionals/server/config.cpp
+++ b/optionals/server/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/tracers/config.cpp
+++ b/optionals/tracers/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_ballistics"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"ACE2 Team"};
-        PBO_URL
+        PBO_URL;
         VERSION_CONFIG;
     };
 };

--- a/optionals/tracers/config.cpp
+++ b/optionals/tracers/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredAddons[] = {"ace_ballistics"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"ACE2 Team"};
-        url = "http://ace3mod.com";
+        PBO_URL
         VERSION_CONFIG;
     };
 };

--- a/optionals/tracers/config.cpp
+++ b/optionals/tracers/config.cpp
@@ -6,8 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_ballistics"};
-        author[] = {"ACE2 Team"};
-        authorUrl = "https://www.ace3mod.com";
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"ACE2 Team"};
+        url = "http://ace3mod.com";
         VERSION_CONFIG;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #3839 
- Convert all `author[]` to `authors[]` in all CfgPatches - [CBA is changing that](https://github.com/CBATeam/CBA_A3/pull/345) for compatibility with vanilla `author`
- Remove `"ACE-Team"` (strinbtabled) from `authors[]` in all CfgPatches - CBA will pull both `author` and `authors[]` together
- Add `author` with value `"ACE-Team"` (stringtabled) to all CfgPatches
- Add `url` with value `"http://ace3mod.com"`` to all CfgPatches
- Update `blank` component as well

#### Regex used
**Converting `author[]` to `authors[]`:**
Find:
```
author\[\] = {([\s\S]*?)};
```
Replace:
```
authors\[\] = {$1};
```

**Adding `author` and `url`:**
Find:
```
class CfgPatches([\s\S]*?);([\s]*?)authors\[\]
```
Replace:
```
class CfgPatches$1;\n        author = ECSTRING\(common,ACETeam\);$2authors\[\]
class CfgPatches$1;\n        url = "http://ace3mod.com";$2authors\[\]
```