### PR TITLE
Goggles - Fix script error from CBA_fnc_waitAndExecute

### DIFF
--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -31,7 +31,6 @@ GVAR(EffectsActive) = false;
 
 SETGLASSES(ace_player,GLASSESDEFAULT);
 
-GVAR(EyesDamageScript) = -1;
 GVAR(FrameEvent) = [false, [false, 20]];
 GVAR(PostProcessEyes_Enabled) = false;
 GVAR(DustHandler) = -1;
@@ -83,7 +82,7 @@ GVAR(OldGlasses) = "<null>";
         GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [1, 1, 1, 1], [1, 1, 1, 0]];
         GVAR(PostProcessEyes) ppEffectCommit 5;
 
-        GVAR(EyesDamageScript) = [{
+        [{
             params ["_unit"];
 
             GVAR(PostProcessEyes) ppEffectEnable false;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix script error

```
x5 = [{systemChat "z"}, [], 1] call CBA_fnc_waitAndExecute
```
Will throw an error. Way back, waitAndExecute returned the PFEH-ID, so there might be more of these. 