### PR TITLE
Integrate 1.60 marker shape color map interface

### DIFF
--- a/addons/markers/CfgEventHandlers.hpp
+++ b/addons/markers/CfgEventHandlers.hpp
@@ -16,3 +16,9 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDiary {
+        ADDON = QUOTE(_this call FUNC(mapDisplayInitEH));
+    };
+};

--- a/addons/markers/XEH_PREP.hpp
+++ b/addons/markers/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 
 PREP(getEnabledChannels);
 PREP(initInsertMarker);
+PREP(mapDisplayInitEH);
 PREP(mapDrawEH);
 PREP(onLBSelChangedChannel);
 PREP(onLBSelChangedColor);

--- a/addons/markers/functions/fnc_mapDisplayInitEH.sqf
+++ b/addons/markers/functions/fnc_mapDisplayInitEH.sqf
@@ -1,0 +1,34 @@
+/*
+ * Author: PabstMirror
+ * Handles XEH DisplayLoad for the various map displays (RscDiary)
+ *
+ * Arguments:
+ * 0: Map Display (idd 12,37,52,53) <Display>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [display] call ace_markers_fnc_mapDisplayInitEH
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+disableSerialization;
+
+params ["_display"];
+TRACE_1("params",_display);
+
+private _bisShapeLB = _display displayctrl 1091;
+private _curSelShape = missionNamespace getVariable [QGVAR(curSelMarkerShape), 0];
+TRACE_2("shape",_bisShapeLB,_curSelShape);
+_bisShapeLB ctrlAddEventHandler ["LBSelChanged", {_this call FUNC(onLBSelChangedShape)}];
+_bisShapeLB lbSetCurSel _curSelShape;
+
+
+private _bisColorLB = _display displayctrl 1090;
+private _curSelColor = missionNamespace getVariable [QGVAR(curSelMarkerColor), 0];
+TRACE_2("color",_bisColorLB,_curSelColor);
+_bisColorLB ctrlAddEventHandler ["LBSelChanged", {_this call FUNC(onLBSelChangedColor)}];
+_bisColorLB lbSetCurSel _curSelColor;

--- a/addons/markers/functions/fnc_onLBSelChangedColor.sqf
+++ b/addons/markers/functions/fnc_onLBSelChangedColor.sqf
@@ -26,3 +26,15 @@ GVAR(curSelMarkerColor) = _index;
 private _config = (configFile >> "CfgMarkerColors") select _data;
 
 GVAR(currentMarkerColorConfigName) = configName _config;
+
+//Set map display to same color:
+private _bisColorLB = switch (false) do {
+    case (isNull findDisplay 12): {(findDisplay 12) displayCtrl 1090};
+    case (isNull findDisplay 52): {(findDisplay 52) displayCtrl 1090};
+    case (isNull findDisplay 53): {(findDisplay 53) displayCtrl 1090};
+    case (isNull findDisplay 37): {(findDisplay 37) displayCtrl 1090};
+    default {controlNull};
+};
+if (_ctrl != _bisColorLB) then { //Don't set what we got a EH from
+    _bisColorLB lbSetCurSel GVAR(curSelMarkerColor);
+};

--- a/addons/markers/functions/fnc_onLBSelChangedShape.sqf
+++ b/addons/markers/functions/fnc_onLBSelChangedShape.sqf
@@ -26,3 +26,15 @@ GVAR(curSelMarkerShape) = _index;
 private _config = (configFile >> "CfgMarkers") select _data;
 
 GVAR(currentMarkerConfigName) = configName _config;
+
+//Set map display to same shape:
+private _bisShapeLB = switch (false) do {
+    case (isNull findDisplay 12): {(findDisplay 12) displayCtrl 1091};
+    case (isNull findDisplay 52): {(findDisplay 52) displayCtrl 1091};
+    case (isNull findDisplay 53): {(findDisplay 53) displayCtrl 1091};
+    case (isNull findDisplay 37): {(findDisplay 37) displayCtrl 1091};
+    default {controlNull};
+};
+if (_ctrl != _bisShapeLB) then { //Don't set what we got a EH from
+    _bisShapeLB lbSetCurSel GVAR(curSelMarkerShape);
+};


### PR DESCRIPTION
1.60 adds ability to set color and marker type from the map interface (top right corner)
Luckily they use the same values and indexes as ACE :wink: 

This PR connects the two systems:
Selecting a color from the 1.60 map display will set the color in the
ace marker display and vice versa