### PR TITLE
Add size parameter to displayTextPicture, Improve parameter checking …

### DIFF
--- a/addons/common/functions/fnc_displayTextPicture.sqf
+++ b/addons/common/functions/fnc_displayTextPicture.sqf
@@ -5,17 +5,22 @@
  * Arguments:
  * 0: Text <ANY>
  * 1: Image <STRING>
- * 2: Image color (default: [0, 0, 0, 0]) <ARRAY>
- * 3: Target Unit. Will only display if target is the player controlled object (default: ACE_player) <OBJECT>
+ * 2: Image color <ARRAY> (default: [1, 1, 1])
+ * 3: Target Unit. Will only display if target is the player controlled object <OBJECT> (default: ACE_player)
+ * 4: Size <NUMBER> (default: 2)
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * ["text", "image", [1, 1, 1], ACE_player, 2] call ace_common_fnc_displayTextPicture
+ * ["text", "image", nil, nil, 3] call ace_common_fnc_displayTextPicture
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-params ["_text", "_image", ["_imageColor", [1,1,1]], ["_target", ACE_player]];
+params [["_text", ""], ["_image", "", [""]], ["_imageColor", [1,1,1], [[]]], ["_target", ACE_player, [objNull]], ["_size", 2, [0]]];
 
 if (_target != ACE_player) exitWith {};
 
@@ -41,4 +46,4 @@ if (typeName _text != "TEXT") then {
 
 _text = composeText [parseText format ["<img size='2' align='center' color='%2' image='%1'/>", _image, _imageColor call BIS_fnc_colorRGBtoHTML], lineBreak, _text];
 
-[_text, 2] call FUNC(displayTextStructured);
+[_text, _size] call FUNC(displayTextStructured);

--- a/addons/common/functions/fnc_displayTextStructured.sqf
+++ b/addons/common/functions/fnc_displayTextStructured.sqf
@@ -4,17 +4,20 @@
  *
  * Arguments:
  * 0: Text <ANY>
- * 1: Size of the textbox (default: 1.5) <NUMBER>
- * 2: Target Unit. Will only display if target is the player controlled object (default: ACE_player) <OBJECT>
+ * 1: Size of the textbox <NUMBER> (default: 1.5)
+ * 2: Target Unit. Will only display if target is the player controlled object <OBJECT> (default: ACE_player)
  *
  * Return Value:
  * None
+ *
+ * Example:
+ *
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-params ["_text", ["_size", 1.5], ["_target", ACE_player]];
+params [["_text", ""], ["_size", 1.5, [0]], ["_target", ACE_player, [objNull]]];
 
 if (_target != ACE_player) exitWith {};
 

--- a/addons/magazinerepack/functions/fnc_getMagazineChildren.sqf
+++ b/addons/magazinerepack/functions/fnc_getMagazineChildren.sqf
@@ -1,6 +1,6 @@
 /*
- * Author: PabstMirror,commy2, esteldunedain, Ruthberg
- * Gets magazine children for interaciton menu
+ * Author: PabstMirror, commy2, esteldunedain, Ruthberg
+ * Gets magazine children for interaciton menu.
  *
  * Argument:
  * 0: Target <OBJECT>
@@ -16,13 +16,11 @@
  */
 #include "script_component.hpp"
 
-private ["_unitMagazines", "_unitMagCounts", "_index", "_actions", "_displayName", "_picture", "_action"];
-
 params ["_target", "_player"];
 
 // get all mags and ammo count
-_unitMagazines = [];
-_unitMagCounts = [];
+private _unitMagazines = [];
+private _unitMagCounts = [];
 {
     private "_xFullMagazineCount";
     _x params ["_xClassname", "_xCount", "_xLoaded", "_xType"];
@@ -31,7 +29,7 @@ _unitMagCounts = [];
 
     //for every partial magazine, that is either in inventory or can be moved there
     if ((_xCount < _xFullMagazineCount) && {_xCount > 0} && {(!_xLoaded) || {_player canAdd _xClassname}}) then {
-        _index = _unitMagazines find _xClassname;
+        private _index = _unitMagazines find _xClassname;
         if (_index == -1) then {
             _unitMagazines pushBack _xClassname;
             _unitMagCounts pushBack [_xCount];
@@ -42,13 +40,13 @@ _unitMagCounts = [];
 } forEach (magazinesAmmoFull _player);
 
 //Create the action children for all appropriate magazines
-_actions = [];
+private _actions = [];
 {
     if ((count (_unitMagCounts select _forEachIndex)) >= 2) then {// Ignore invalid magazines types (need 2+ partial mags to do anything)
-        _displayName = getText (configFile >> "CfgMagazines" >> _x >> "displayName");
-        _picture = getText (configFile >> "CfgMagazines" >> _x >> "picture");
+        private _displayName = getText (configFile >> "CfgMagazines" >> _x >> "displayName");
+        private _picture = getText (configFile >> "CfgMagazines" >> _x >> "picture");
 
-        _action = [_x, _displayName, _picture, {_this call FUNC(startRepackingMagazine)}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+        private _action = [_x, _displayName, _picture, {_this call FUNC(startRepackingMagazine)}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
         _actions pushBack [_action, [], _player];
     };
 } forEach _unitMagazines;

--- a/addons/magazinerepack/functions/fnc_magazineRepackProgress.sqf
+++ b/addons/magazinerepack/functions/fnc_magazineRepackProgress.sqf
@@ -18,19 +18,16 @@
  */
 #include "script_component.hpp"
 
-private ["_currentAmmoCount", "_addedMagazines", "_missingAmmo", "_index", "_updateMagazinesOnPlayerFnc"];
-
 params ["_ars", "_elapsedTime", "_totalTime"];
 _args params ["_magazineClassname", "_lastAmmoCount", "_simEvents"];
 
 if !((_simEvents select 0) params ["_nextEventTime", "_nextEventIsBullet", "_nextEventMags"]) exitWith { ERROR("No Event"); false };
 
 
-
 if (_nextEventTime > _elapsedTime) exitWith { true };//waiting on next event
 
 //Verify we aren't missing any ammo
-_currentAmmoCount = [];
+private _currentAmmoCount = [];
 {
     _x params ["_xClassname", "_xCount"];
     if (_xClassname == _magazineClassname) then {
@@ -39,11 +36,11 @@ _currentAmmoCount = [];
 } forEach (magazinesAmmo ACE_player);  //only inventory mags
 
 //Go through mags we currently have and check off the ones we should have
-_addedMagazines = +_currentAmmoCount;
-_missingAmmo = false;
+private _addedMagazines = +_currentAmmoCount;
+private _missingAmmo = false;
 {
     if (_x > 0) then {
-        _index = _addedMagazines find _x;
+        private _index = _addedMagazines find _x;
         if (_index != -1) then {
             _addedMagazines deleteAt _index;
         } else {
@@ -54,7 +51,7 @@ _missingAmmo = false;
 
 if (_missingAmmo) exitWith { false };  //something removed ammo that was being repacked (could be other players or scripts)
 
-_updateMagazinesOnPlayerFnc = {
+private _updateMagazinesOnPlayerFnc = {
     ACE_player removeMagazines _magazineClassname;  //remove inventory magazines
     {
         if (_x > 0) then {

--- a/addons/magazinerepack/functions/fnc_simulateRepackEvents.sqf
+++ b/addons/magazinerepack/functions/fnc_simulateRepackEvents.sqf
@@ -19,47 +19,26 @@
  */
 #include "script_component.hpp"
 
-private ["_fnc_newMag", "_time", "_events", "_fnc_swapAmmo", "_ammoSwaped", "_lowIndex", "_highIndex", "_ammoToTransfer", "_ammoAvailable", "_ammoNeeded", "_swapProgress"];
-
 params ["_fullMagazineCount", "_arrayOfAmmoCounts", "_isBelt"];
 
 // Sort Ascending - Don't modify original
 _arrayOfAmmoCounts = +_arrayOfAmmoCounts;
 _arrayOfAmmoCounts sort true;
 
-_fnc_newMag = {
+private _fnc_newMag = {
     _time = _time + GVAR(TimePerMagazine);
     _events pushBack [_time, false, +_arrayOfAmmoCounts];
 };
 
-_fnc_swapAmmo = if (_isBelt) then {
-    {
-        _time = _time + GVAR(TimePerBeltLink);
-        _arrayOfAmmoCounts set [_lowIndex, ((_arrayOfAmmoCounts select _lowIndex) - _ammoSwaped)];
-        _arrayOfAmmoCounts set [_highIndex, ((_arrayOfAmmoCounts select _highIndex) + _ammoSwaped)];
-        _events pushBack [_time, true, +_arrayOfAmmoCounts];
-    }
-} else {
-    {
-        for "_swapProgress" from 0 to (_ammoSwaped - 1) do {
-            _time = _time + GVAR(TimePerAmmo);
-            _arrayOfAmmoCounts set [_lowIndex, ((_arrayOfAmmoCounts select _lowIndex) - 1)];
-            _arrayOfAmmoCounts set [_highIndex, ((_arrayOfAmmoCounts select _highIndex) + 1)];
-            _events pushBack [_time, true, +_arrayOfAmmoCounts];
-        };
-    }
-};
-
-_lowIndex = 0;
-_highIndex = (count _arrayOfAmmoCounts) - 1;
-_ammoToTransfer = 0;
-_ammoAvailable = 0;
-
-_time = 0;
-_events = [];
+private _lowIndex = 0;
+private _highIndex = (count _arrayOfAmmoCounts) - 1;
+private _ammoToTransfer = 0;
+private _ammoAvailable = 0;
+private _time = 0;
+private _events = [];
 
 while {_lowIndex < _highIndex} do {
-    _ammoNeeded = _fullMagazineCount - (_arrayOfAmmoCounts select _highIndex);
+    private _ammoNeeded = _fullMagazineCount - (_arrayOfAmmoCounts select _highIndex);
     _ammoAvailable = _arrayOfAmmoCounts select _lowIndex;
 
     if (_ammoAvailable == 0) then {
@@ -70,8 +49,20 @@ while {_lowIndex < _highIndex} do {
             _highIndex = _highIndex - 1;
             call _fnc_newMag;
         } else {
-            _ammoSwaped = _ammoAvailable min _ammoNeeded;
-            call _fnc_swapAmmo;
+            private _ammoSwaped = _ammoAvailable min _ammoNeeded;
+            if (_isBelt) then {
+                _time = _time + GVAR(TimePerBeltLink);
+                _arrayOfAmmoCounts set [_lowIndex, (_arrayOfAmmoCounts select _lowIndex) - _ammoSwaped];
+                _arrayOfAmmoCounts set [_highIndex, (_arrayOfAmmoCounts select _highIndex) + _ammoSwaped];
+                _events pushBack [_time, true, +_arrayOfAmmoCounts];
+            } else {
+                for "_swapProgress" from 0 to (_ammoSwaped - 1) do {
+                    _time = _time + GVAR(TimePerAmmo);
+                    _arrayOfAmmoCounts set [_lowIndex, (_arrayOfAmmoCounts select _lowIndex) - 1];
+                    _arrayOfAmmoCounts set [_highIndex, (_arrayOfAmmoCounts select _highIndex) + 1];
+                    _events pushBack [_time, true, +_arrayOfAmmoCounts];
+                };
+            };
         };
     };
 };

--- a/addons/magazinerepack/functions/fnc_startRepackingMagazine.sqf
+++ b/addons/magazinerepack/functions/fnc_startRepackingMagazine.sqf
@@ -13,39 +13,37 @@
  * Nothing
  *
  * Example:
- * ["30Rnd_65x39_caseless_mag"] call ace_magazinerepack_fnc_startRepackingMagazine
+ * [player, player, "30Rnd_65x39_caseless_mag"] call ace_magazinerepack_fnc_startRepackingMagazine
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-private ["_magazineCfg", "_fullMagazineCount", "_isBelt", "_startingAmmoCounts", "_simEvents", "_totalTime"];
-
 params ["_target", "_player", "_magazineClassname"];
 
 if (isNil "_magazineClassname" || {_magazineClassname == ""}) exitWith {ERROR("Bad Mag Classname");};
-_magazineCfg = configFile >> "CfgMagazines" >> _magazineClassname;
+private _magazineCfg = configFile >> "CfgMagazines" >> _magazineClassname;
 // Calculate actual ammo to transfer during repack
-_fullMagazineCount = getNumber (_magazineCfg >> "count");
+private _fullMagazineCount = getNumber (_magazineCfg >> "count");
 //Is linked belt magazine:
-_isBelt = (isNumber (_magazineCfg >> "ACE_isBelt")) && {(getNumber (_magazineCfg >> "ACE_isBelt")) == 1};
+private _isBelt = isNumber (_magazineCfg >> "ACE_isBelt") && {(getNumber (_magazineCfg >> "ACE_isBelt")) == 1};
 
 //Check canInteractWith:
-if (!([_player, objNull, ["isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))) exitWith {};
+if !([_player, objNull, ["isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
 
 [_player] call EFUNC(common,goKneeling);
 
-_startingAmmoCounts = [];
+private _startingAmmoCounts = [];
 {
-    EXPLODE_4_PVT(_x,_xClassname,_xCount,_xLoaded,_xType);
-    if ((_xClassname == _magazineClassname) && {(_xCount != _fullMagazineCount) && {_xCount > 0}}) then {
+    _x params ["_xClassname", "_xCount", "_xLoaded", "_xType"];
+    if (_xClassname == _magazineClassname && {_xCount != _fullMagazineCount && {_xCount > 0}}) then {
         if (_xLoaded) then {
             //Try to Remove from weapon and add to inventory, otherwise ignore
             if (_player canAdd _magazineClassname) then {
                 switch (_xType) do {
-                case (1): {_player removePrimaryWeaponItem _magazineClassname;};
-                case (2): {_player removeHandgunItem _magazineClassname;};
-                case (4): {_player removeSecondaryWeaponItem _magazineClassname;};
+                    case (1): {_player removePrimaryWeaponItem _magazineClassname};
+                    case (2): {_player removeHandgunItem _magazineClassname};
+                    case (4): {_player removeSecondaryWeaponItem _magazineClassname};
                     default {ERROR("Loaded Location Invalid");};
                 };
                 _player addMagazine [_magazineClassname, _xCount];
@@ -57,10 +55,10 @@ _startingAmmoCounts = [];
     };
 } forEach (magazinesAmmoFull _player);
 
-if ((count _startingAmmoCounts) < 2) exitWith {ERROR("Not Enough Mags to Repack");};
+if (count _startingAmmoCounts < 2) exitWith {ERROR("Not Enough Mags to Repack");};
 
-_simEvents = [_fullMagazineCount, _startingAmmoCounts, _isBelt] call FUNC(simulateRepackEvents);
-_totalTime = (_simEvents select ((count _simEvents) - 1) select 0);
+private _simEvents = [_fullMagazineCount, _startingAmmoCounts, _isBelt] call FUNC(simulateRepackEvents);
+private _totalTime = _simEvents select (count _simEvents - 1) select 0;
 
 [
     _totalTime,


### PR DESCRIPTION
**When merged this pull request will:**
- Add number of full and partial magazines after repack to displayed text after repack finishes or is interrupted
- Use `displayTextPicture` instead of `displayTextStructured` with its own picture handling in magazine repack
- Add size parameter to `displayTextPicture` function (required for above) - as last parameter to keep backwards compatibility.
- Improve parameter checking in `displayText*` functions
- Cleanup magazine repack (privates, deprecated macros, style)