### PR TITLE
Fix selective UI script error when changing certain other settings

### DIFF
--- a/addons/ui/XEH_clientInit.sqf
+++ b/addons/ui/XEH_clientInit.sqf
@@ -32,7 +32,9 @@ if (!hasInterface) exitWith {};
         if (_name in ELEMENTS_BASIC) then {
             [false] call FUNC(setElements);
         } else {
-            [_name select [7], missionNamespace getVariable _name, true] call FUNC(setAdvancedElement);
+            if (isClass (configFile >> "ACE_UI" >> _name)) then {
+                [_name select [7], missionNamespace getVariable _name, true] call FUNC(setAdvancedElement);
+            };
         };
     }] call EFUNC(common,addEventHandler);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add check if a UI class even exists in `SettingChanged` event
- Fix script error when changing certain other settings:
```
21:18:53 Error in expression <ex = ace_ui_elementsSet find [_element, !_show];
if (_index != -1) then {
if (_s>
21:18:53   Error position: <!_show];
if (_index != -1) then {
if (_s>
21:18:53   Error Generic error in expression
21:18:53 File z\ace\addons\ui\functions\fnc_setAdvancedElement.sqf, line 38
```