### PR TITLE
Only play fastroping sounds for player

### DIFF
--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -38,12 +38,14 @@ if (isNull attachedTo _unit) exitWith {
     [_unit, "", 2] call EFUNC(common,doAnimation);
     _unit setVectorUp [0, 0, 1];
 
-    playSound QGVAR(Thud);
+    if (_unit == ACE_player) then {
+        playSound QGVAR(Thud);
+    };
 
     [_pfhHandle] call CBA_fnc_removePerFrameHandler;
 };
 
-if (diag_tickTime > _timeToPlayRopeSound) then {
+if (_unit == ACE_player && {diag_tickTime > _timeToPlayRopeSound}) then {
     _arguments set [4, (_timeToPlayRopeSound + 1)];
     playSound QGVAR(Rope);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Only play fastroping sounds for player

When local hosting, the sounds were played for every AI unit fastroping.