### PR TITLE
add a line to get rid of 4 first aid kits in the invisible fast roping helper

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -155,6 +155,7 @@ class CfgVehicles {
         model = QPATHTOF(data\helper.p3d);
         class ACE_Actions {};
         class Turrets {};
+        class TransportItems {};
     };
 
     class Helicopter_Base_H;


### PR DESCRIPTION
**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Respect the [Development Guidelines](http://ace3mod.com/wiki/development/)

The helper "ace_fastroping_helper" inherits from class "Helicopter_Base_F", and take a look at this chain of inheritance. Call that Bohemia's fault, lol.
class CfgVehicles
{
	class AllVehicles;
	class Air: AllVehicles
	{
		class TransportItems
		{
			class _xx_FirstAidKit
			{
				name = "FirstAidKit";
				count = 4;
			};
		};
	};
	class Helicopter: Air
	{
	};
	class Helicopter_Base_F: Helicopter
	{
	};
	class ace_fastroping_helper: Helicopter_Base_F
	{
		class TransportItems {};	// now overrides the first aid kits
	};
};
Was a happy and funny surprise to pick up some decent medical supplies from one end of a cut rope.