### PR TITLE
virtualMass - Fix div0 error when naked

### DIFF
--- a/addons/movement/functions/fnc_handleVirtualMass.sqf
+++ b/addons/movement/functions/fnc_handleVirtualMass.sqf
@@ -27,7 +27,7 @@ private _virtualLoad = 0;
 ];
 
 // get absolute vanilla load
-private _absLoad = loadAbs _unit / load _unit;
+private _absLoad = getNumber (configFile >> "CfgInventoryGlobalVariable" >> "maxSoldierLoad");
 
 // try to preserve other changes to the "LoadCoef" unitTrait
 private _loadCoef = _unit getVariable QGVAR(loadCoef);


### PR DESCRIPTION
Playing as animal or human and removing everything throws div0 error as `load _unit` is 0.

@commy2 as best I can tell ` loadAbs _unit / load _unit;` is the same as the config
```
class CfgInventoryGlobalVariable {
    maxSoldierLoad = 1000;
};
```

So using that should be faster and prevent the error.