### PR TITLE
Fix nametag error when assignedTeam is nil

### DIFF
--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -55,7 +55,7 @@ _fnc_parameters = {
         _color = +GVAR(defaultNametagColor); //Make a copy, then multiply both alpha values (allows client to decrease alpha in settings)
         _color set [3, (_color select 3) * _alpha];
     } else {
-        _color = [[1, 1, 1, _alpha], [1, 0, 0, _alpha], [0, 1, 0, _alpha], [0, 0, 1, _alpha], [1, 1, 0, _alpha]] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find (assignedTeam _target)) max 0);
+        _color = [[1, 1, 1, _alpha], [1, 0, 0, _alpha], [0, 1, 0, _alpha], [0, 0, 1, _alpha], [1, 1, 0, _alpha]] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0);
     };
 
     private _scale = [0.333, 0.5, 0.666, 0.83333, 1] select GVAR(tagSize);


### PR DESCRIPTION
Originally fixed by joko in #2882 , must have been lost in the rewrite
New `param` solution from @commy2 in slack