### PR TITLE
Temp fix for change to handleDamage in dev branch

### DIFF
--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -8,8 +8,12 @@
  * 2: Amount Of Damage <NUMBER>
  * 3: Shooter <OBJECT>
  * 4: Projectile <STRING>
- * 5: Current damage to be returned <NUMBER>
- * 6: Type of Damage <STRING>
+ * 5: Hit part index of the hit point <NUMBER>
+ * 6: Current damage to be returned <NUMBER>
+ *
+ * //On 1.63 dev:
+ * 6: Shooter? <OBJECT>
+ * 7: Current damage to be returned <NUMBER>
  *
  * Return Value:
  * None
@@ -21,6 +25,11 @@
 
 private ["_typeOfProjectile", "_part", "_damageBodyParts", "_hitPoints"];
 params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfProjectile", "_hitPointNumber", "_newDamage"];
+
+//Temp fix for 1.63 handleDamage changes
+if (_newDamage isEqualType objNull) then {
+    _newDamage = _this select 7;
+};
 
 _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitWith {};


### PR DESCRIPTION
Fix #3892

On current dev branch (1.63) they added an addition param to `HandleDamage` params.

When the changes are released we can do a simple proper fix with `params`, but for now I think this is a reasonable solution that will make adv medical compatible with both 1.60 and dev.