### PR TITLE
Optics - Create PIP camera only when needed

### DIFF
--- a/addons/optics/XEH_postInit.sqf
+++ b/addons/optics/XEH_postInit.sqf
@@ -5,30 +5,9 @@ if (!hasInterface) exitWith {};
 
 GVAR(camera) = objNull;
 
-0 = 0 spawn {
-    // Workarround for the ThreeDen Editor Camera
-    if ((!isNil {is3DEN}) && {is3DEN}) exitWith {
-        ACE_LOGINFO("Eden detected: disabling Optics PIP Camera");
-    };
-
-    waitUntil {!isNull ACE_player};
-    waitUntil {sleep 1; {_x != GVAR(camera)} count allMissionObjects "camera" == 0 && {isNull curatorCamera}};
-
-    GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
-    camDestroy GVAR(camera);
-
-    // PiP technique by BadBenson
-    GVAR(camera) = "camera" camCreate positionCameraToWorld [0,0,0];
-    GVAR(camera) camSetFov 0.7;
-    GVAR(camera) camSetTarget ACE_player;
-    GVAR(camera) camCommit 1;
-
-    "ace_optics_rendertarget0" setPiPEffect [0];
-    GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
-};
-
 // save control for fired EH
 ["ace_infoDisplayChanged", {
+    TRACE_1("ace_infoDisplayChanged",_this);
     if (!isNull ((_this select 0) displayCtrl 1713001)) then {
         uiNamespace setVariable [QGVAR(RscWeaponInfo2D), _this select 0];
     };
@@ -36,18 +15,15 @@ GVAR(camera) = objNull;
 
 // camera has to be re-created every time another camera is created. Otherwise r2t is either black or transparent. @todo Add popular custom cameras to the event in ACE_common.
 ["ace_activeCameraChanged", {
-    if !(_this select 1) then {
-        GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
-        camDestroy GVAR(camera);
-
-        // PiP technique by BadBenson
-        GVAR(camera) = "camera" camCreate positionCameraToWorld [0,0,0];
-        GVAR(camera) camSetFov 0.7;
-        GVAR(camera) camSetTarget ACE_player;
-        GVAR(camera) camCommit 1;
-
-        "ace_optics_rendertarget0" setPiPEffect [0];
-        GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
+    params ["", "_isfeatureCameraActive"];
+    TRACE_1("ace_activeCameraChanged",_isfeatureCameraActive);
+    if (!_isfeatureCameraActive) then {
+        //Destroy the camera, and it will be re-created in the onDrawScope2d helper
+        if (!isNull GVAR(camera)) then {
+            GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
+            camDestroy GVAR(camera);
+            TRACE_1("destroying pip camera for restart",GVAR(camera));
+        };
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/optics/functions/fnc_handleFired.sqf
+++ b/addons/optics/functions/fnc_handleFired.sqf
@@ -16,8 +16,7 @@
 TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile, _vehicle, _gunner, _turret);
 
 // check if compatible scope is used
-private "_display";
-_display = uiNamespace getVariable [QGVAR(RscWeaponInfo2D), displayNull];
+private _display = uiNamespace getVariable [QGVAR(RscWeaponInfo2D), displayNull];
 
 if (isNull _display) exitWith {};
 

--- a/addons/optics/functions/fnc_onDrawScope2D.sqf
+++ b/addons/optics/functions/fnc_onDrawScope2D.sqf
@@ -20,16 +20,6 @@ disableSerialization;
 
 private _display = _this select 0;
 
-//If we are not zoomed into the actual scope (not collimator)
-if (!ctrlShown (_display displayCtrl 154)) exitWith {
-    (_display displayCtrl 1713001) ctrlShow false;
-    (_display displayCtrl 1713002) ctrlShow false;
-    (_display displayCtrl 1713005) ctrlShow false;
-    (_display displayCtrl 1713006) ctrlShow false;
-    (_display displayCtrl 1713010) ctrlShow false;
-    (_display displayCtrl 1713011) ctrlShow false;
-};
-
 // @todo, all weapon types
 private _optic = (primaryWeaponItems ACE_player) select 2;
 private _isPIP = (getText (configFile >> "CfgWeapons" >> _optic >> "ItemInfo" >> "modelOptics")) == QPATHTOF(models\ace_optics_pip.p3d);
@@ -40,7 +30,7 @@ if (_isPIP) then {
         if ((({_x != GVAR(camera)} count allMissionObjects "camera") > 0) || {!isNull curatorCamera}) exitWith {
             TRACE_1("waiting for feature camera to end",GVAR(camera));
         };
-    
+
         // PiP technique by BadBenson
         GVAR(camera) = "camera" camCreate positionCameraToWorld [0,0,0];
         GVAR(camera) camSetFov 0.7;
@@ -51,7 +41,7 @@ if (_isPIP) then {
         GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
 
         TRACE_2("created new pip camera",GVAR(camera),isNull GVAR(camera));
-        
+
         //Start a waitUntil to handle destruction after GVAR(pipLastFrame) is no longer updated
         [{
             (abs (diag_frameno - GVAR(pipLastFrame))) > 1
@@ -61,7 +51,19 @@ if (_isPIP) then {
             TRACE_2("destroyed pip camera",GVAR(camera),isNull GVAR(camera));
         }, []] call CBA_fnc_waitUntilAndExecute;
     };
+};
 
+//If we are not zoomed into the actual scope (not collimator)
+if (!ctrlShown (_display displayCtrl 154)) exitWith {
+    (_display displayCtrl 1713001) ctrlShow false;
+    (_display displayCtrl 1713002) ctrlShow false;
+    (_display displayCtrl 1713005) ctrlShow false;
+    (_display displayCtrl 1713006) ctrlShow false;
+    (_display displayCtrl 1713010) ctrlShow false;
+    (_display displayCtrl 1713011) ctrlShow false;
+};
+
+if (_isPIP) then {
     GVAR(camera) setPosATL positionCameraToWorld [0,0,0.4];
     GVAR(camera) camPrepareTarget positionCameraToWorld [0,0,50];
     GVAR(camera) camCommitPrepared 0;

--- a/addons/optics/functions/fnc_onDrawScope2D.sqf
+++ b/addons/optics/functions/fnc_onDrawScope2D.sqf
@@ -1,12 +1,26 @@
-// by commy2
+/*
+ * Author: commy2
+ * Helper function for updating the 2d and 3d scope controls
+ * Called from a dummy map controls onDraw.
+ *
+ * Arguments:
+ * 0: Display (RscInGameUI for a weapon) <DISPLAY>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [ACE_RscWeapon_Arco's Display] call ace_optics_fnc_onDrawScope2D
+ *
+ * Public: No
+ */
 #include "script_component.hpp"
 
 disableSerialization;
 
-private "_display";
+private _display = _this select 0;
 
-_display = _this select 0;
-
+//If we are not zoomed into the actual scope (not collimator)
 if (!ctrlShown (_display displayCtrl 154)) exitWith {
     (_display displayCtrl 1713001) ctrlShow false;
     (_display displayCtrl 1713002) ctrlShow false;
@@ -17,11 +31,37 @@ if (!ctrlShown (_display displayCtrl 154)) exitWith {
 };
 
 // @todo, all weapon types
-private ["_optic", "_isPIP"];
-_optic = (primaryWeaponItems ACE_player) select 2;
-_isPIP = (getText (configFile >> "CfgWeapons" >> _optic >> "ItemInfo" >> "modelOptics")) == QPATHTOF(models\ace_optics_pip.p3d);
+private _optic = (primaryWeaponItems ACE_player) select 2;
+private _isPIP = (getText (configFile >> "CfgWeapons" >> _optic >> "ItemInfo" >> "modelOptics")) == QPATHTOF(models\ace_optics_pip.p3d);
 
 if (_isPIP) then {
+    GVAR(pipLastFrame) = diag_frameno;
+    if (isNull GVAR(camera)) then {
+        if ((({_x != GVAR(camera)} count allMissionObjects "camera") > 0) || {!isNull curatorCamera}) exitWith {
+            TRACE_1("waiting for feature camera to end",GVAR(camera));
+        };
+    
+        // PiP technique by BadBenson
+        GVAR(camera) = "camera" camCreate positionCameraToWorld [0,0,0];
+        GVAR(camera) camSetFov 0.7;
+        GVAR(camera) camSetTarget ACE_player;
+        GVAR(camera) camCommit 1;
+
+        "ace_optics_rendertarget0" setPiPEffect [0];
+        GVAR(camera) cameraEffect ["INTERNAL", "BACK", "ace_optics_rendertarget0"];
+
+        TRACE_2("created new pip camera",GVAR(camera),isNull GVAR(camera));
+        
+        //Start a waitUntil to handle destruction after GVAR(pipLastFrame) is no longer updated
+        [{
+            (abs (diag_frameno - GVAR(pipLastFrame))) > 1
+        }, {
+            GVAR(camera) cameraEffect ["TERMINATE", "BACK"];
+            camDestroy GVAR(camera);
+            TRACE_2("destroyed pip camera",GVAR(camera),isNull GVAR(camera));
+        }, []] call CBA_fnc_waitUntilAndExecute;
+    };
+
     GVAR(camera) setPosATL positionCameraToWorld [0,0,0.4];
     GVAR(camera) camPrepareTarget positionCameraToWorld [0,0,50];
     GVAR(camera) camCommitPrepared 0;
@@ -37,10 +77,8 @@ if (_isPIP) then {
 };
 
 // calculate lighting
-private ["_dayOpacity", "_nightOpacity"];
-
-_dayOpacity = call EFUNC(common,ambientBrightness);
-_nightOpacity = [1,0] select (_dayOpacity == 1);
+private _dayOpacity = call EFUNC(common,ambientBrightness);
+private _nightOpacity = [1,0] select (_dayOpacity == 1);
 
 // Apply lighting and make layers visible
 (_display displayCtrl 1713001) ctrlSetTextColor [1,1,1,1];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #3899

Instead of creating the PIP camera at mission start, we only create it when actually needed when in scoped view, and destroy it after leaving.

Should clear up problems we've seen with mission's using camera scripts due to us always calling `cameraEffect`.