### PR TITLE
movement - Handle objNull in virtualMass

### DIFF
--- a/addons/movement/functions/fnc_handleVirtualMass.sqf
+++ b/addons/movement/functions/fnc_handleVirtualMass.sqf
@@ -14,6 +14,8 @@
 
 params ["_unit"];
 
+if (isNull _unit) exitWith {};
+
 // add sum of virtual loads
 private _virtualLoad = 0;
 


### PR DESCRIPTION
`[objNull] call ace_movement_fnc_handleVirtualMass` throws error

`objNull getUnitTrait "loadCoef"` is nil, which breaks everything