### PR TITLE
Add maxDam for medium velocity wounds

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -590,6 +590,7 @@ class ACE_Medical_Advanced {
                 class Medium {
                     name = CSTRING(Wounds_VelocityWound_Medium);
                     minDamage = 0.3;
+                    maxDamage = 0.75;
                     bleedingRate = 0.05;
                 };
                 class Large {


### PR DESCRIPTION
Cherry picking a minor fix from PR #3632

Ensures that velocity wounds from a major hit will use the "Large" type of wound 
(which has more bleeding).

Otherwise something like 
```
[player, 2, "leg_r", "bullet"] call ace_medical_fnc_addDamageToUnit
```
Has a chance to only cause a medium wound