### PR TITLE
Small clean up to medical

### DIFF
--- a/addons/medical/functions/fnc_actionRemoveTourniquet.sqf
+++ b/addons/medical/functions/fnc_actionRemoveTourniquet.sqf
@@ -15,22 +15,20 @@
 
 #include "script_component.hpp"
 
-private ["_part", "_tourniquets", "_output"];
 params ["_caller", "_target", "_selectionName"];
 TRACE_3("params",_caller,_target,_selectionName);
 
 // grab the required data
-_part = [_selectionName] call FUNC(selectionNameToNumber);
-_tourniquets = _target getVariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
+private _part = [_selectionName] call FUNC(selectionNameToNumber);
+private _tourniquets = _target getVariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
 
 // Check if there is a tourniquet on this bodypart
 if ((_tourniquets select _part) == 0) exitWith {
-    _output = LSTRING(noTourniquetOnBodyPart);
-    [QEGVAR(common,displayTextStructured), [_output, 1.5, _caller], [_caller]] call CBA_fnc_targetEvent;
+    [QEGVAR(common,displayTextStructured), [LSTRING(noTourniquetOnBodyPart), 1.5, _caller], [_caller]] call CBA_fnc_targetEvent;
 };
 
 // Removing the tourniquet
-_tourniquets set[_part, 0];
+_tourniquets set [_part, 0];
 _target setVariable [QGVAR(tourniquets), _tourniquets, true];
 
 // Adding the tourniquet item to the caller
@@ -49,6 +47,7 @@ TRACE_2("meds",_part,_delayedMedications);
         _updatedArray = true;
     };
 } forEach _delayedMedications;
+
 if (_updatedArray) then {
     _delayedMedications = _delayedMedications - [-1];
     _target setVariable [QGVAR(occludedMedications), _delayedMedications, true];

--- a/addons/medical/functions/fnc_addHeartRateAdjustment.sqf
+++ b/addons/medical/functions/fnc_addHeartRateAdjustment.sqf
@@ -16,10 +16,10 @@
 
 #include "script_component.hpp"
 
-
 params [["_unit", objNull, [objNull]], ["_value", 0, [0]], ["_time", 1, [0]], ["_callBack", {}, [{}]]];
 
-_adjustment = _unit getVariable [QGVAR(heartRateAdjustments), []];
+private _adjustment = _unit getVariable [QGVAR(heartRateAdjustments), []];
 _adjustment pushBack [_value, _time, _callBack];
-_unit setVariable [QGVAR(heartRateAdjustments), _adjustment ];
+_unit setVariable [QGVAR(heartRateAdjustments), _adjustment];
+
 ["ace_addedHeartRateAdjustment", [_unit, _value, _time]] call CBA_fnc_localEvent;

--- a/addons/medical/functions/fnc_addToLog.sqf
+++ b/addons/medical/functions/fnc_addToLog.sqf
@@ -16,7 +16,6 @@
 
 #include "script_component.hpp"
 
-private ["_moment", "_logVarName", "_log","_newLog", "_logs"];
 params ["_unit", "_type", "_message", "_arguments"];
 
 if (!local _unit) exitWith {
@@ -25,13 +24,12 @@ if (!local _unit) exitWith {
 
 date params ["", "", "", "_hour", "_minute"];
 
-_moment = format [ (["%1:%2", "%1:0%2"] select (_minute < 10)), _hour, _minute];
+private _moment = format [ (["%1:%2", "%1:0%2"] select (_minute < 10)), _hour, _minute];
+private _logVarName = format[QGVAR(logFile_%1), _type];
 
-_logVarName = format[QGVAR(logFile_%1), _type];
-
-_log = _unit getVariable [_logVarName, []];
+private _log = _unit getVariable [_logVarName, []];
 if (count _log >= 8) then {
-    _newLog = [];
+    private _newLog = [];
     {
         // ensure the first element will not be added
         if (_forEachIndex > 0) then {
@@ -45,7 +43,7 @@ _log pushBack [_message, _moment, _type, _arguments];
 _unit setVariable [_logVarName, _log, true];
 ["ace_medicalLogEntryAdded", [_unit, _type, _message, _arguments]] call CBA_fnc_localEvent;
 
-_logs = _unit getVariable [QGVAR(allLogs), []];
+private _logs = _unit getVariable [QGVAR(allLogs), []];
 if !(_logVarName in _logs) then {
     _logs pushBack _logVarName;
     _unit setVariable [QGVAR(allLogs), _logs, true];

--- a/addons/medical/functions/fnc_addToTriageCard.sqf
+++ b/addons/medical/functions/fnc_addToTriageCard.sqf
@@ -14,20 +14,18 @@
 
 #include "script_component.hpp"
 
-private ["_log", "_inList", "_amount"];
 params ["_unit", "_newItem"];
 
 if (!local _unit) exitWith {
     [QGVAR(addToTriageCard), _this, _unit] call CBA_fnc_targetEvent;
 };
 
-_log = _unit getVariable [QGVAR(triageCard), []];
-_inList = false;
-_amount = 1;
+private _log = _unit getVariable [QGVAR(triageCard), []];
+private _inList = false;
+private _amount = 1;
 {
     if ((_x select 0) == _newItem) exitWith {
-        private "_info";
-        _info = _log select _forEachIndex;
+        private _info = _log select _forEachIndex;
         _info set [1,(_info select 1) + 1];
         _info set [2, CBA_missionTime];
         _log set [_forEachIndex, _info];

--- a/addons/medical/functions/fnc_adjustPainLevel.sqf
+++ b/addons/medical/functions/fnc_adjustPainLevel.sqf
@@ -26,15 +26,13 @@ TRACE_3("ACE_DEBUG: adjustPainLevel Called",_unit, _pain, _addedPain);
 //Ignore if medical system disabled:
 if (GVAR(level) == 0) exitWith {};
 
-_pain = _unit getVariable [QGVAR(pain), 0];
+private _pain = ((_unit getVariable [QGVAR(pain), 0]) + _addedPain) max 0;
 
-_pain = _pain + _addedPain;
 if (GVAR(level) == 1) then {_pain = _pain min 1;}; //for basic, cap at 1
-_pain = _pain max 0;
 
 _unit setVariable [QGVAR(pain), _pain];
 
 //Start up the vital watching (if not already running)
 [_unit] call FUNC(addVitalLoop);
 
-_pain
+_pain;

--- a/addons/medical/functions/fnc_createLitter.sqf
+++ b/addons/medical/functions/fnc_createLitter.sqf
@@ -21,7 +21,6 @@
 
 #define MIN_ENTRIES_LITTER_CONFIG 3
 
-private ["_config", "_litter", "_createLitter", "_position", "_createdLitter"];
 params ["_caller", "_target", "_selectionName", "_className", "", "_usersOfItems", "_bloodLossOnSelection"];
 
 //Ensures comptibilty with other possible medical treatment configs
@@ -30,28 +29,27 @@ private _previousDamage = _bloodLossOnSelection;
 if !(GVAR(allowLitterCreation)) exitwith {};
 if (vehicle _caller != _caller || vehicle _target != _target) exitwith {};
 
-_config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
-if (GVAR(level) >= 2) then {
-    _config = (configFile >> "ACE_Medical_Actions" >> "Advanced" >> _className);
+private _config = if (GVAR(level) >= 2) then {
+    (configFile >> "ACE_Medical_Actions" >> "Advanced" >> _className);
+} else {
+    (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className)
 };
 if !(isClass _config) exitwith {false};
 
-
 if !(isArray (_config >> "litter")) exitwith {};
-_litter = getArray (_config >> "litter");
+private _litter = getArray (_config >> "litter");
 
-_createLitter = {
-    private["_position", "_direction"];
+private _createLitter = {
     params ["_unit", "_litterClass"];
     // @TODO: handle carriers over water
     // For now, don't spawn litter if we are over water to avoid floating litter
-    if(surfaceIsWater (getPos _unit)) exitWith { false };
+    if (surfaceIsWater (getPos _unit)) exitWith { false };
 
-    _position = getPosATL _unit;
+    private _position = getPosATL _unit;
     _position params ["_posX", "_posY", "_posZ"];
     _position = [_posX + (random 2) - 1, _posY + (random 2) - 1, _posZ];
 
-    _direction = (random 360);
+    private _direction = (random 360);
 
     // Create the litter, and timeout the event based on the cleanup delay
     // The cleanup delay for events in MP is handled by the server side
@@ -60,7 +58,7 @@ _createLitter = {
     true
 };
 
-_createdLitter = [];
+private _createdLitter = [];
 {
     if (_x isEqualType []) then {
         if (count _x < MIN_ENTRIES_LITTER_CONFIG) exitwith {};

--- a/addons/medical/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical/functions/fnc_determineIfFatal.sqf
@@ -22,7 +22,6 @@
 #define CHANGE_FATAL_TORSO 0.6
 #define CHANGE_FATAL_LIMB 0.1
 
-private ["_damageThreshold", "_damageBodyPart", "_chanceFatal"];
 params ["_unit", "_part", ["_withDamage", 0]];
 
 if (!alive _unit) exitWith {true};
@@ -30,7 +29,7 @@ if ((vehicle _unit != _unit) && {!alive (vehicle _unit)}) exitWith { true };
 if (_part < 0 || _part > 5) exitWith {false};
 
 // Find the correct Damage threshold for unit.
-_damageThreshold = [1,1,1];
+private _damageThreshold = [1,1,1];
 if ([_unit] call EFUNC(common,IsPlayer)) then {
     _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(playerDamageThreshold), GVAR(playerDamageThreshold), GVAR(playerDamageThreshold) * 1.7]];
 } else {
@@ -38,20 +37,20 @@ if ([_unit] call EFUNC(common,IsPlayer)) then {
 };
 _damageThreshold params ["_thresholdHead", "_thresholdTorso",  "_thresholdLimbs"];
 
-_damageBodyPart = ((_unit getVariable [QGVAR(bodyPartStatus),[0, 0, 0, 0, 0, 0]]) select _part) + _withDamage;
+private _damageBodyPart = ((_unit getVariable [QGVAR(bodyPartStatus),[0, 0, 0, 0, 0, 0]]) select _part) + _withDamage;
 
 // Check if damage to body part is higher as damage head
 if (_part == 0) exitWith {
-    _chanceFatal = CHANGE_FATAL_HEAD + ((INCREASE_CHANCE_HEAD * (_damageBodyPart - _thresholdHead)) * 10);
+    private _chanceFatal = CHANGE_FATAL_HEAD + ((INCREASE_CHANCE_HEAD * (_damageBodyPart - _thresholdHead)) * 10);
     (_damageBodyPart >= _thresholdHead && {(_chanceFatal >= random(1))});
 };
 
 // Check if damage to body part is higher as damage torso
 if (_part == 1) exitWith {
-    _chanceFatal = CHANGE_FATAL_TORSO + ((INCREASE_CHANCE_TORSO * (_damageBodyPart - _thresholdTorso)) * 10);
+    private _chanceFatal = CHANGE_FATAL_TORSO + ((INCREASE_CHANCE_TORSO * (_damageBodyPart - _thresholdTorso)) * 10);
     (_damageBodyPart >= _thresholdTorso && {(_chanceFatal >= random(1))});
 };
 // Check if damage to body part is higher as damage limbs
 // We use a slightly lower decrease for limbs, as we want any injuries done to those to be less likely to be fatal compared to head shots or torso.
-_chanceFatal = CHANGE_FATAL_LIMB + ((INCREASE_CHANGE_LIMB * (_damageBodyPart - _thresholdLimbs)) * 10);
+private _chanceFatal = CHANGE_FATAL_LIMB + ((INCREASE_CHANGE_LIMB * (_damageBodyPart - _thresholdLimbs)) * 10);
 (_damageBodyPart >= _thresholdLimbs && {(_chanceFatal >= random(1))});

--- a/addons/medical/functions/fnc_getBloodPressure.sqf
+++ b/addons/medical/functions/fnc_getBloodPressure.sqf
@@ -20,14 +20,12 @@
 // Value is taken because with cardic output and resistance at default values, it will put blood pressure Low at 80.
 #define MODIFIER_BP_LOW     0.1524
 
-private ["_bloodPressureLow", "_bloodPressureHigh", "_cardiacOutput", "_resistance"];
-
 params ["_unit"];
 
-_cardiacOutput = [_unit] call FUNC(getCardiacOutput);
-_resistance = _unit getVariable [QGVAR(peripheralResistance), 100];
+private _cardiacOutput = [_unit] call FUNC(getCardiacOutput);
+private _resistance = _unit getVariable [QGVAR(peripheralResistance), 100];
 
-_bloodPressureHigh = (_cardiacOutput * MODIFIER_BP_HIGH) * _resistance;
-_bloodPressureLow = (_cardiacOutput * MODIFIER_BP_LOW) * _resistance;
+private _bloodPressureHigh = (_cardiacOutput * MODIFIER_BP_HIGH) * _resistance;
+private _bloodPressureLow = (_cardiacOutput * MODIFIER_BP_LOW) * _resistance;
 
 [_bloodPressureLow max 0, _bloodPressureHigh max 0]

--- a/addons/medical/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/medical/functions/fnc_getBloodVolumeChange.sqf
@@ -28,24 +28,26 @@
 */
 #define BLOOD_CHANGE_PER_SECOND        0.0595
 
+#define EMPTY_IV_BAG_VALUE 0
+#define IV_VOLUME (_unit getVariable [_x, EMPTY_IV_BAG_VALUE]) + IV_CHANGE_PER_SECOND
+
 private ["_bloodVolume", "_bloodVolumeChange", "_ivVolume"];
 params ["_unit"];
 
-_bloodVolume = _unit getVariable [QGVAR(bloodVolume), 100];
-_bloodVolumeChange = -([_unit] call FUNC(getBloodLoss));
+private _bloodVolume = _unit getVariable [QGVAR(bloodVolume), 100];
+private _bloodVolumeChange = -([_unit] call FUNC(getBloodLoss));
 
-if (_bloodVolume < 100.0) then {
+if (_bloodVolume < 100) then {
     {
-        if ((_unit getVariable [_x, 0]) > 0) then {
+        if ((_unit getVariable [_x, EMPTY_IV_BAG_VALUE]) > EMPTY_IV_BAG_VALUE) then {
             _bloodVolumeChange = _bloodVolumeChange + BLOOD_CHANGE_PER_SECOND;
-            _ivVolume = (_unit getVariable [_x, 0]) + IV_CHANGE_PER_SECOND;
-            _unit setVariable [_x,_ivVolume];
+            _unit setVariable [_x, IV_VOLUME];
         };
     } forEach GVAR(IVBags);
 } else {
     {
-        if ((_unit getVariable [_x, 0]) > 0) then {
-            _unit setVariable [_x, 0]; // lets get rid of exessive IV volume
+        if ((_unit getVariable [_x, EMPTY_IV_BAG_VALUE]) > EMPTY_IV_BAG_VALUE) then {
+            _unit setVariable [_x, EMPTY_IV_BAG_VALUE]; // lets get rid of exessive IV volume
         };
     } forEach GVAR(IVBags);
 };

--- a/addons/medical/functions/fnc_getHeartRateChange.sqf
+++ b/addons/medical/functions/fnc_getHeartRateChange.sqf
@@ -15,22 +15,21 @@
 
 #define HEART_RATE_MODIFIER 0.02
 
-private ["_heartRate", "_hrIncrease", "_bloodLoss", "_time", "_values", "_adjustment", "_change", "_callBack", "_bloodVolume"];
 params ["_unit"];
 
-_hrIncrease = 0;
+private _hrIncrease = 0;
 if (!(_unit getVariable [QGVAR(inCardiacArrest),false])) then {
-    _heartRate = _unit getVariable [QGVAR(heartRate), 80];
-    _bloodLoss = [_unit] call FUNC(getBloodLoss);
+    private _heartRate = _unit getVariable [QGVAR(heartRate), 80];
+    private _bloodLoss = [_unit] call FUNC(getBloodLoss);
 
-    _adjustment = _unit getVariable [QGVAR(heartRateAdjustments), []];
+    private _adjustment = _unit getVariable [QGVAR(heartRateAdjustments), []];
     {
         _x params ["_values", "_time", "_callBack"];
         if (abs _values > 0) then {
             if (_time <= 0) then {
                 _time = 1;
             };
-            _change = (_values / _time);
+            private _change = (_values / _time);
             _hrIncrease = _hrIncrease + _change;
 
             if ( (_time - 1) <= 0) then {
@@ -45,15 +44,15 @@ if (!(_unit getVariable [QGVAR(inCardiacArrest),false])) then {
             _adjustment set [_forEachIndex, ObjNull];
             [_unit] call _callBack;
         };
-
     } forEach _adjustment;
+
     _adjustment = _adjustment - [ObjNull];
     _unit setVariable [QGVAR(heartRateAdjustments), _adjustment];
 
-    _bloodVolume = _unit getVariable [QGVAR(bloodVolume), 100];
+    private _bloodVolume = _unit getVariable [QGVAR(bloodVolume), 100];
     if (_bloodVolume > 75) then {
-        if (_bloodLoss >0.0) then {
-            if (_bloodLoss <0.5) then {
+        if (_bloodLoss > 0.0) then {
+            if (_bloodLoss < 0.5) then {
                 if (_heartRate < 126) then {
                     _hrIncrease = _hrIncrease + 0.05;
                 };

--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -23,7 +23,6 @@
 
 #include "script_component.hpp"
 
-private ["_typeOfProjectile", "_part", "_damageBodyParts", "_hitPoints"];
 params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfProjectile", "_hitPointNumber", "_newDamage"];
 
 //Temp fix for 1.63 handleDamage changes
@@ -31,17 +30,17 @@ if (_newDamage isEqualType objNull) then {
     _newDamage = _this select 7;
 };
 
-_part = [_selectionName] call FUNC(selectionNameToNumber);
+private _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitWith {};
 
-_hitPoints = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
+private _hitPoints = ["HitHead", "HitBody", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"];
 // Sorting out the damage
-_damageBodyParts = _unit getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
+private _damageBodyParts = _unit getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
 
 _damageBodyParts set [_part, (_damageBodyParts select _part) + _newDamage];
 _unit setVariable [QGVAR(bodyPartStatus), _damageBodyParts, true];
 
-_typeOfDamage = [_typeOfProjectile] call FUNC(getTypeOfDamage);
+private _typeOfDamage = [_typeOfProjectile] call FUNC(getTypeOfDamage);
 
 [_unit, _selectionName, _newDamage, _typeOfProjectile, _typeOfDamage] call FUNC(handleDamage_assignWounds);
 

--- a/addons/medical/functions/fnc_handleDamage_advancedSetDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advancedSetDamage.sqf
@@ -17,10 +17,8 @@ params ["_unit"];
 
 if (!local _unit) exitWith {};
 
-private "_bodyStatus";
-
 // ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"]
-_bodyStatus = _unit getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
+private _bodyStatus = _unit getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
 
 _bodyStatus params ["_headDamage", "_torsoDamage", "_handsDamageR", "_handsDamageL", "_legsDamageR", "_legsDamageL"];
 

--- a/addons/medical/functions/fnc_handleDamage_basic.sqf
+++ b/addons/medical/functions/fnc_handleDamage_basic.sqf
@@ -12,13 +12,12 @@
 
 #include "script_component.hpp"
 
-private ["_damageBodyParts", "_cache_params", "_cache_damages"];
 params ["_target"];
 TRACE_1("ACE_DEBUG: HandleDamage_BASIC Called",_target);
 
-_damageBodyParts = _target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
-_cache_params = _target getVariable [QGVAR(cachedHandleDamageParams), []];
-_cache_damages = _target getVariable QGVAR(cachedDamages);
+private _damageBodyParts = _target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
+private _cache_params = _target getVariable [QGVAR(cachedHandleDamageParams), []];
+private _cache_damages = _target getVariable QGVAR(cachedDamages);
 
 TRACE_4("ACE_DEBUG: HandleDamage BASIC",_unit, _damageBodyParts,_cache_params,_cache_damages);
 

--- a/addons/medical/functions/fnc_hasItem.sqf
+++ b/addons/medical/functions/fnc_hasItem.sqf
@@ -15,7 +15,6 @@
 
 #include "script_component.hpp"
 
-private ["_medic", "_patient", "_item", "_return", "_crew"];
 params ["_medic", "_patient", "_item"];
 
 if (isNil QGVAR(setting_allowSharedEquipment)) then {
@@ -29,9 +28,9 @@ if ([_medic, _item] call EFUNC(common,hasItem)) exitWith {
     true
 };
 
-_return = false;
+private _return = false;
 if ((vehicle _medic != _medic) && {[vehicle _medic] call FUNC(isMedicalVehicle)}) then {
-    _crew = crew vehicle _medic;
+    private _crew = crew vehicle _medic;
     {
         if ([_medic, _x] call FUNC(canAccessMedicalEquipment) && {([_x, _item] call EFUNC(common,hasItem))}) exitWith {
             _return = true;

--- a/addons/medical/functions/fnc_hasItems.sqf
+++ b/addons/medical/functions/fnc_hasItems.sqf
@@ -15,10 +15,9 @@
 
 #include "script_component.hpp"
 
-private ["_medic", "_patient", "_items", "_return"];
 params ["_medic", "_patient", "_items"];
 
-_return = true;
+private _return = true;
 {
     //
     if (_x isEqualType [] && {({[_medic, _patient, _x] call FUNC(hasItem)}count _x == 0)}) exitwith {

--- a/addons/medical/functions/fnc_hasMedicalEnabled.sqf
+++ b/addons/medical/functions/fnc_hasMedicalEnabled.sqf
@@ -16,10 +16,9 @@
  */
 #include "script_component.hpp"
 
-private "_medicalEnabled";
 params ["_unit"];
 
-_medicalEnabled = _unit getVariable QGVAR(enableMedical);
+private _medicalEnabled = _unit getVariable QGVAR(enableMedical);
 if (isNil "_medicalEnabled") exitWith {
     (((GVAR(enableFor) == 0 && (isPlayer _unit || (_unit getVariable [QEGVAR(common,isDeadPlayer), false])))) || (GVAR(enableFor) == 1) || GVAR(level) == 1)
 };

--- a/addons/medical/functions/fnc_modifyMedicalAction.sqf
+++ b/addons/medical/functions/fnc_modifyMedicalAction.sqf
@@ -20,8 +20,7 @@
 params ["_target", "_player", "_selectionN", "_actionData"];
 
 if (GVAR(level) < 2 || {!([_target] call FUNC(hasMedicalEnabled))}) exitWith {
-    private ["_pointDamage"];
-    _pointDamage = (_target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]]) select _selectionN;
+    private _pointDamage = (_target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]]) select _selectionN;
 
     if (_pointDamage >= 0.8) exitWith {
         _actionData set [2, QPATHTOF(UI\icons\medical_crossRed.paa)];
@@ -31,8 +30,7 @@ if (GVAR(level) < 2 || {!([_target] call FUNC(hasMedicalEnabled))}) exitWith {
     };
 };
 
-private ["_openWounds", "_amountOf"];
-_openWounds = _target getVariable [QGVAR(openWounds), []];
+private _openWounds = _target getVariable [QGVAR(openWounds), []];
 {
     _x params ["", "", "_selectionX", "_amountOf", "_x4"];
     if (_amountOf > 0 && {(_selectionN == _selectionX)} && {_x4 > 0}) exitWith {

--- a/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
@@ -14,11 +14,10 @@
 
 #include "script_component.hpp"
 
-private "_reviveStartTime";
 params ["_caller","_target"];
 
 if (_target getVariable [QGVAR(inReviveState), false]) then {
-    _reviveStartTime = _target getVariable [QGVAR(reviveStartTime),0];
+    private _reviveStartTime = _target getVariable [QGVAR(reviveStartTime),0];
     if (_reviveStartTime > 0) then {
         _target setVariable [QGVAR(reviveStartTime), (_reviveStartTime + random(20)) min CBA_missionTime];
     };

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandage.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandage.sqf
@@ -17,6 +17,7 @@
  */
 
 #include "script_component.hpp"
+
 params ["_caller", "_target", "_selectionName", "_className", "_items", "", ["_specificSpot", -1]];
 
 [_target, "activity", LSTRING(Activity_bandagedPatient), [[_caller, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);

--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -15,44 +15,43 @@
 
 #include "script_component.hpp"
 
-private ["_openWounds", "_config", "_effectiveness","_mostEffectiveInjury", "_mostEffectiveSpot", "_woundEffectiveness", "_mostEffectiveInjury", "_impact", "_exit", "_classID", "_effectivenessFound", "_className", "_hitPoints", "_hitSelections", "_point", "_woundTreatmentConfig"];
 params ["_target", "_bandage", "_selectionName", ["_specificClass", -1]];
 
 // Ensure it is a valid bodypart
-_part = [_selectionName] call FUNC(selectionNameToNumber);
+private _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitWith {false};
 
 // Get the open wounds for this unit
-_openWounds = _target getVariable [QGVAR(openWounds), []];
+private _openWounds = _target getVariable [QGVAR(openWounds), []];
 if (count _openWounds == 0) exitWith {false}; // nothing to do here!
 
 // Get the default effectiveness for the used bandage
-_config = (ConfigFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Bandaging");
-_effectiveness = getNumber (_config >> "effectiveness");
+private _config = (ConfigFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Bandaging");
+private _effectiveness = getNumber (_config >> "effectiveness");
 if (isClass (_config >> _bandage)) then {
     _config = (_config >> _bandage);
     if (isNumber (_config >> "effectiveness")) then { _effectiveness = getNumber (_config >> "effectiveness");};
 };
 
 // Figure out which injury for this bodypart is the best choice to bandage
-_mostEffectiveSpot = 0;
-_effectivenessFound = -1;
-_mostEffectiveInjury = _openWounds select 0;
-_exit = false;
+private _mostEffectiveSpot = 0;
+private _effectivenessFound = -1;
+private _mostEffectiveInjury = _openWounds select 0;
+private _exit = false;
 {
     _x params ["", "_classID", "_partX"];
     TRACE_2("OPENWOUND: ", _target, _x);
     // Only parse injuries that are for the selected bodypart.
     if (_partX == _part) then {
-        _woundEffectiveness = _effectiveness;
+        private _woundEffectiveness = _effectiveness;
 
         // Select the classname from the wound classname storage
-        _className = GVAR(woundClassNames) select _classID;
+        private _className = GVAR(woundClassNames) select _classID;
 
         // Check if this wound type has attributes specified for the used bandage
         if (isClass (_config >> _className)) then {
             // Collect the effectiveness from the used bandage for this wound type
-            _woundTreatmentConfig = (_config >> _className);
+            private _woundTreatmentConfig = (_config >> _className);
             if (isNumber (_woundTreatmentConfig >> "effectiveness")) then {
                 _woundEffectiveness = getNumber (_woundTreatmentConfig >> "effectiveness");
             };
@@ -83,7 +82,7 @@ if (_effectivenessFound == -1) exitWith {}; // Seems everything is patched up on
 
 // TODO refactor this part
 // Find the impact this bandage has and reduce the amount this injury is present
-_impact = if ((_mostEffectiveInjury select 3) >= _effectivenessFound) then {_effectivenessFound} else { (_mostEffectiveInjury select 3) };
+private _impact = if ((_mostEffectiveInjury select 3) >= _effectivenessFound) then {_effectivenessFound} else { (_mostEffectiveInjury select 3) };
 _mostEffectiveInjury set [ 3, ((_mostEffectiveInjury select 3) - _impact) max 0];
 _openWounds set [_mostEffectiveSpot, _mostEffectiveInjury];
 
@@ -102,16 +101,14 @@ if (_impact > 0 && {GVAR(enableAdvancedWounds)}) then {
 // Arma combines left and right arms into a single body part (HitHands), same with left and right legs (HitLegs).
 // Arms are actually hands.
 if (GVAR(healHitPointAfterAdvBandage)) then {
-    private["_currentWounds", "_headWounds", "_bodyWounds", "_legsWounds", "_armWounds"];
-
     // Get the list of the wounds the target is currently suffering from.
-    _currentWounds = _target getVariable [QGVAR(openWounds), []];
+    private _currentWounds = _target getVariable [QGVAR(openWounds), []];
 
     // Tally of unbandaged wounds to each body part.
-    _headWounds = 0;
-    _bodyWounds = 0;
-    _legsWounds = 0;
-    _armWounds  = 0;
+    private _headWounds = 0;
+    private _bodyWounds = 0;
+    private _legsWounds = 0;
+    private _armWounds  = 0;
 
     // Loop through all current wounds and add up the number of unbandaged wounds on each body part.
     {
@@ -120,7 +117,7 @@ if (GVAR(healHitPointAfterAdvBandage)) then {
         // Use switch/case for early termination if wounded limb is found before all six are checked.
         // Number of wounds multiplied by blood loss will return zero for a fully
         // bandaged body part, not incrementing the wound counter; or it will return
-        // some other number which will increment the wound counter. 
+        // some other number which will increment the wound counter.
         switch (_bodyPart) do {
             // Head
             case 0: {

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf
@@ -10,7 +10,6 @@
 
 #include "script_component.hpp"
 
-private "_allUsedMedication";
 params ["_caller", "_target"];
 
 if (alive _target) exitWith {
@@ -60,7 +59,7 @@ if (alive _target) exitWith {
     _target setVariable [QGVAR(painSuppress), 0, true];
 
     // medication
-    _allUsedMedication = _target getVariable [QGVAR(allUsedMedication), []];
+    private _allUsedMedication = _target getVariable [QGVAR(allUsedMedication), []];
     {
        _target setVariable [_x select 0, nil];
     } forEach _allUsedMedication;

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
@@ -15,9 +15,7 @@
  */
 #include "script_component.hpp"
 
-private "_totalDamage";
-
-_totalDamage = 0;
+private _totalDamage = 0;
 
 {
     _totalDamage = _totalDamage + _x;

--- a/addons/medical/functions/fnc_treatmentAdvanced_medicationLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_medicationLocal.sqf
@@ -15,8 +15,6 @@
 
 #include "script_component.hpp"
 
-private ["_currentInSystem", "_medicationConfig", "_painReduce", "_hrIncreaseLow", "_hrIncreaseNorm", "_hrIncreaseHigh", "_maxDose", "_inCompatableMedication", "_timeInSystem", "_heartRate", "_pain", "_resistance", "_hrCallback", "_varName", "_viscosityChange"];
-
 params ["_target", "_className", "_partNumber"];
 TRACE_3("params",_target,_className,_partNumber);
 
@@ -30,23 +28,22 @@ if ((_tourniquets select _partNumber) > 0) exitWith {
 };
 
 // We have added a new dose of this medication to our system, so let's increase it
-_varName = format[QGVAR(%1_inSystem), _className];
-_currentInSystem = _target getVariable [_varName, 0];
-_currentInSystem = _currentInSystem + 1;
-_target setVariable [_varName, _currentInSystem];
+private _varName = format[QGVAR(%1_inSystem), _className];
+private _currentInSystem = _target getVariable [_varName, 0];
+_target setVariable [_varName, _currentInSystem + 1];
 
 // Find the proper attributes for the used medication
-_medicationConfig = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Medication");
-_painReduce = getNumber (_medicationConfig >> "painReduce");
-_hrIncreaseLow = getArray (_medicationConfig >> "hrIncreaseLow");
-_hrIncreaseNorm = getArray (_medicationConfig >> "hrIncreaseNormal");
-_hrIncreaseHigh = getArray (_medicationConfig >> "hrIncreaseHigh");
-_timeInSystem = getNumber (_medicationConfig >> "timeInSystem");
-_maxDose = getNumber (_medicationConfig >> "maxDose");
-_viscosityChange = getNumber (_medicationConfig >> "viscosityChange");
-_hrCallback = getText (_medicationConfig >> "hrCallback");
+private _medicationConfig = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Medication");
+private _painReduce = getNumber (_medicationConfig >> "painReduce");
+private _hrIncreaseLow = getArray (_medicationConfig >> "hrIncreaseLow");
+private _hrIncreaseNorm = getArray (_medicationConfig >> "hrIncreaseNormal");
+private _hrIncreaseHigh = getArray (_medicationConfig >> "hrIncreaseHigh");
+private _timeInSystem = getNumber (_medicationConfig >> "timeInSystem");
+private _maxDose = getNumber (_medicationConfig >> "maxDose");
+private _viscosityChange = getNumber (_medicationConfig >> "viscosityChange");
+private _hrCallback = getText (_medicationConfig >> "hrCallback");
 
-_inCompatableMedication = [];
+private _inCompatableMedication = [];
 if (isClass (_medicationConfig >> _className)) then {
     _medicationConfig = (_medicationConfig >> _className);
     if (isNumber (_medicationConfig >> "painReduce")) then { _painReduce = getNumber (_medicationConfig >> "painReduce");};
@@ -67,7 +64,7 @@ if (isNil _hrCallback) then {
 if (!(_hrCallback isEqualType {})) then {_hrCallback = {TRACE_1("callback was NOT code",_hrCallback)};};
 
 // Adjust the heart rate based upon config entry
-_heartRate = _target getVariable [QGVAR(heartRate), 70];
+private _heartRate = _target getVariable [QGVAR(heartRate), 70];
 if (alive _target) then {
     if (_heartRate > 0) then {
         if (_heartRate <= 45) then {
@@ -84,7 +81,7 @@ if (alive _target) then {
 
 if (_painReduce > 0) then {
     // Reduce pain
-    _painSuppress = _target getVariable [QGVAR(painSuppress), 0];
+    private _painSuppress = _target getVariable [QGVAR(painSuppress), 0];
     _target setVariable [QGVAR(painSuppress), (_painSuppress + _painReduce) max 0];
     if (!GVAR(painIsOnlySuppressed)) then {
         _pain = _target getVariable [QGVAR(pain), 0];
@@ -92,9 +89,8 @@ if (_painReduce > 0) then {
     };
 };
 
-_resistance = _target getVariable [QGVAR(peripheralResistance), 100];
-_resistance = _resistance + _viscosityChange;
-_target setVariable [QGVAR(peripheralResistance), _resistance max 0];
+private _resistance = _target getVariable [QGVAR(peripheralResistance), 100];
+_target setVariable [QGVAR(peripheralResistance), (_resistance + _viscosityChange) max 0];
 
 // Call back to ensure that the medication is decreased over time
 [_target, _classname, _varName, _maxDose, _timeInSystem, _inCompatableMedication, _viscosityChange, _painReduce] call FUNC(onMedicationUsage);

--- a/addons/medical/functions/fnc_treatmentBasic_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bandageLocal.sqf
@@ -18,14 +18,14 @@
 
 params ["_target", "_selectionName"];
 
-_damageBodyParts = _target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
+private _damageBodyParts = _target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
 
 // Ensure it is a valid bodypart
-_part = [_selectionName] call FUNC(selectionNameToNumber);
+private _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitwith {false};
 
 if ((_damageBodyParts select _part) > 0) then {
-    _damageOnPart = (_damageBodyParts select _part);
+    private _damageOnPart = (_damageBodyParts select _part);
     // Temp quick fix to change in behaviour of basic medical bandaging
     if (_damageOnPart - BANDAGEHEAL > 0) then {
         _damageOnPart = _damageOnPart - (_damageOnPart * BANDAGEHEAL);

--- a/addons/medical/functions/fnc_treatmentBasic_bloodbagLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_bloodbagLocal.sqf
@@ -17,13 +17,11 @@
 
 params ["_target", "_treatmentClassname"];
 
-private ["_blood", "_bloodAdded"];
-
-_bloodAdded = switch (true) do {
+private _bloodAdded = switch (true) do {
     case (_treatmentClassname == "BloodIV_250"): {0.25 * BLOODBAGHEAL};
     case (_treatmentClassname == "BloodIV_500"): {0.5 * BLOODBAGHEAL};
     default {BLOODBAGHEAL};
 };
 
-_blood = ((_target getVariable [QGVAR(bloodVolume), 100]) + _bloodAdded) min 100;
+private _blood = ((_target getVariable [QGVAR(bloodVolume), 100]) + _bloodAdded) min 100;
 _target setVariable [QGVAR(bloodVolume), _blood, true];

--- a/addons/medical/functions/fnc_treatmentBasic_morphineLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_morphineLocal.sqf
@@ -15,13 +15,13 @@
 #include "script_component.hpp"
 #define MORPHINEHEAL 0.4
 
-private ["_morphine", "_pain"];
 params ["_target"];
 
 // reduce pain, pain sensitivity
-_morphine = ((_target getVariable [QGVAR(morphine), 0]) + MORPHINEHEAL) min 1;
+private _morphine = ((_target getVariable [QGVAR(morphine), 0]) + MORPHINEHEAL) min 1;
 _target setVariable [QGVAR(morphine), _morphine, true];
-_pain = ((_target getVariable [QGVAR(pain), 0]) - MORPHINEHEAL) max 0;
+
+private _pain = ((_target getVariable [QGVAR(pain), 0]) - MORPHINEHEAL) max 0;
 _target setVariable [QGVAR(pain), _pain, true];
 
 // @todo overdose

--- a/addons/medical/functions/fnc_treatmentIVLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentIVLocal.sqf
@@ -15,16 +15,15 @@
 
 #include "script_component.hpp"
 
-private ["_config", "_volumeAdded", "_typeOf", "_varName", "_bloodVolume"];
 params ["_target", "_treatmentClassname"];
 
-_bloodVolume = _target getVariable [QGVAR(bloodVolume), 100];
+private _bloodVolume = _target getVariable [QGVAR(bloodVolume), 100];
 if (_bloodVolume >= 100) exitWith {};
 
 // Find the proper attributes for the used IV
-_config = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "IV");
-_volumeAdded = getNumber (_config >> "volume");
-_typeOf = getText (_config >> "type");
+private _config = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "IV");
+private _volumeAdded = getNumber (_config >> "volume");
+private _typeOf = getText (_config >> "type");
 
 if (isClass (_config >> _treatmentClassname)) then {
     _config = (_config >> _treatmentClassname);
@@ -34,7 +33,7 @@ if (isClass (_config >> _treatmentClassname)) then {
     ERROR("IV Treatment Classname not found");
 };
 
-_varName = format["ACE_Medical_IVVolume_%1",_typeOf];
+private _varName = format["ACE_Medical_IVVolume_%1",_typeOf];
 _target setVariable [_varName, (_target getVariable [_varName, 0]) + _volumeAdded, true];
 
 if !(_varName in GVAR(IVBags)) then {

--- a/addons/medical/functions/fnc_treatmentTourniquet.sqf
+++ b/addons/medical/functions/fnc_treatmentTourniquet.sqf
@@ -17,29 +17,24 @@
 
 #include "script_component.hpp"
 
-private ["_caller","_target","_part","_selectionName","_removeItem", "_tourniquets", "_items", "_output", "_className"];
-_caller = _this select 0;
-_target = _this select 1;
-_selectionName = _this select 2;
-_className = _this select 3;
-_items = _this select 4;
+params ["_caller", "_target", "_selectionName", "_className", "_items"];
 
 if (count _items == 0) exitWith {false};
 
-_part = [_selectionName] call FUNC(selectionNameToNumber);
+private _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part == 0 || _part == 1) exitWith {
     // [QEGVAR(common,displayTextStructured), ["You cannot apply a CAT on this body part!"], [_caller]] call CBA_fnc_targetEvent;
     false;
 };
 
-_tourniquets = _target getVariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
+private _tourniquets = _target getVariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
 if ((_tourniquets select _part) > 0) exitWith {
    _output = "There is already a tourniquet on this body part!"; // TODO localization
    [QEGVAR(common,displayTextStructured), [_output, 1.5, _caller], [_caller]] call CBA_fnc_targetEvent;
     false;
 };
 
-_removeItem = _items select 0;
+private _removeItem = _items select 0;
 if (local _target) then {
     [QGVAR(treatmentTourniquetLocal), [_target, _removeItem, _selectionName]] call CBA_fnc_localEvent;
 } else {
@@ -49,6 +44,5 @@ if (local _target) then {
 [_target, _removeItem] call FUNC(addToTriageCard);
 [_target, "activity", LSTRING(Activity_appliedTourniquet), [[_caller, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
 [_target, "activity_view", LSTRING(Activity_appliedTourniquet), [[_caller, false, true] call EFUNC(common,getName)]] call FUNC(addToLog); // TODO expand message
-
 
 true

--- a/addons/medical/functions/fnc_treatmentTourniquetLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentTourniquetLocal.sqf
@@ -13,15 +13,14 @@
  */
 #include "script_component.hpp"
 
-private ["_tourniquets", "_part", "_applyingTo"];
 params ["_target", "_tourniquetItem", "_selectionName"];
 
 //If we're not already tracking vitals, start:
 [_target] call FUNC(addVitalLoop);
 
-_part = [_selectionName] call FUNC(selectionNameToNumber);
+private _part = [_selectionName] call FUNC(selectionNameToNumber);
 
 // Place a tourniquet on the bodypart
-_tourniquets = _target getVariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
+private _tourniquets = _target getVariable [QGVAR(tourniquets), [0,0,0,0,0,0]];
 _tourniquets set [_part, CBA_missionTime];
 _target setVariable [QGVAR(tourniquets), _tourniquets, true];

--- a/addons/medical/functions/fnc_useItem.sqf
+++ b/addons/medical/functions/fnc_useItem.sqf
@@ -16,7 +16,6 @@
 
 #include "script_component.hpp"
 
-private ["_return","_crew"];
 params ["_medic", "_patient", "_item"];
 
 if (isNil QGVAR(setting_allowSharedEquipment)) then {
@@ -41,9 +40,9 @@ if ([_medic, _item] call EFUNC(common,hasItem)) exitWith {
     [true, _medic];
 };
 
-_return = [false, objNull];
+private _return = [false, objNull];
 if ([vehicle _medic] call FUNC(isMedicalVehicle) && {vehicle _medic != _medic}) then {
-    _crew = crew vehicle _medic;
+    private _crew = crew vehicle _medic;
     {
         if ([_medic, _x] call FUNC(canAccessMedicalEquipment) && {([_x, _item] call EFUNC(common,hasItem))}) exitWith {
             _return = [true, _x];

--- a/addons/medical/functions/fnc_useItems.sqf
+++ b/addons/medical/functions/fnc_useItems.sqf
@@ -15,22 +15,21 @@
 
 #include "script_component.hpp"
 
-private ["_medic", "_patient", "_items", "_itemUsedInfo", "_itemsUsedBy"];
 params ["_medic", "_patient", "_items"];
 
-_itemsUsedBy = [];
+private _itemsUsedBy = [];
 {
     // handle a one of type use item
     if (_x isEqualType []) then {
         {
-            _itemUsedInfo = [_medic, _patient, _x] call FUNC(useItem);
+            private _itemUsedInfo = [_medic, _patient, _x] call FUNC(useItem);
             if (_itemUsedInfo select 0) exitWith { _itemsUsedBy pushBack [(_itemUsedInfo select 1), _x]};
         } forEach _x;
     };
 
     // handle required item
     if (_x isEqualType "") then {
-        _itemUsedInfo = [_medic, _patient, _x] call FUNC(useItem);
+        private _itemUsedInfo = [_medic, _patient, _x] call FUNC(useItem);
         if (_itemUsedInfo select 0) exitWith { _itemsUsedBy pushBack [(_itemUsedInfo select 1), _x]};
     };
 } forEach _items;


### PR DESCRIPTION
Minor improvements to ACE medical code. Only a limited number of functions instead of everything, to avoid doing to many things at the same time in the same PR.

Biggest changes:

- Use `private` keyword.
- Remove excessive whitespace
- Add space where needed (`set[ -> set [`)
- Makes some lines more compact