### PR TITLE
Minor improvements to ACE medical code part 2

### DIFF
--- a/addons/medical/functions/fnc_actionCheckBloodPressureLocal.sqf
+++ b/addons/medical/functions/fnc_actionCheckBloodPressureLocal.sqf
@@ -14,17 +14,16 @@
 
 #include "script_component.hpp"
 
-private ["_bloodPressure", "_logOutPut", "_output"];
 params ["_caller", "_target", "_selectionName"];
 
-_bloodPressure = if (!alive _target) then {
+private _bloodPressure = if (!alive _target) then {
     [0,0]
 } else {
     [_target] call FUNC(getBloodPressure)
 };
 _bloodPressure params [ "_bloodPressureLow", "_bloodPressureHigh"];
-_output = "";
-_logOutPut = "";
+private _output = "";
+private _logOutPut = "";
 if ([_caller] call FUNC(isMedic)) then {
     _output = LSTRING(Check_Bloodpressure_Output_1);
     _logOutPut = format["%1/%2",round(_bloodPressureHigh),round(_bloodPressureLow)];

--- a/addons/medical/functions/fnc_actionCheckPulseLocal.sqf
+++ b/addons/medical/functions/fnc_actionCheckPulseLocal.sqf
@@ -14,15 +14,14 @@
 
 #include "script_component.hpp"
 
-private ["_heartRateOutput", "_heartRate", "_logOutPut"];
 params ["_caller", "_unit", "_selectionName"];
 
-_heartRate = _unit getVariable [QGVAR(heartRate), 80];
+private _heartRate = _unit getVariable [QGVAR(heartRate), 80];
 if (!alive _unit) then {
     _heartRate = 0;
 };
-_heartRateOutput = LSTRING(Check_Pulse_Output_5);
-_logOutPut = LSTRING(Check_Pulse_None);
+private _heartRateOutput = LSTRING(Check_Pulse_Output_5);
+private _logOutPut = LSTRING(Check_Pulse_None);
 
 if (_heartRate > 1.0) then {
     if ([_caller] call FUNC(isMedic)) then {

--- a/addons/medical/functions/fnc_actionCheckResponse.sqf
+++ b/addons/medical/functions/fnc_actionCheckResponse.sqf
@@ -14,12 +14,11 @@
 
 #include "script_component.hpp"
 
-private ["_output"];
 params ["_caller", "_target"];
 
-_output = [LSTRING(Check_Response_Unresponsive), LSTRING(Check_Response_Responsive)] select ([_target] call EFUNC(common,isAwake));
+private _output = [LSTRING(Check_Response_Unresponsive), LSTRING(Check_Response_Responsive)] select ([_target] call EFUNC(common,isAwake));
 
 [QEGVAR(common,displayTextStructured), [[_output, [_target] call EFUNC(common,getName)], 2, _caller], [_caller]] call CBA_fnc_targetEvent;
 
-[_target,"activity",_output, [[_target, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
-[_target,"quick_view",_output, [[_target, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
+[_target ,"activity", _output, [[_target, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
+[_target, "quick_view", _output, [[_target, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);

--- a/addons/medical/functions/fnc_actionDiagnose.sqf
+++ b/addons/medical/functions/fnc_actionDiagnose.sqf
@@ -17,14 +17,14 @@
 private "_genericMessages";
 params ["_caller", "_target"];
 
-_genericMessages = [LSTRING(diagnoseMessage)];
+private _genericMessages = [LSTRING(diagnoseMessage), [_target] call EFUNC(common,getName)];
 
-_genericMessages pushBack ([_target] call EFUNC(common,getName));
 if (alive _target) then {
     _genericMessages pushBack LSTRING(diagnoseAlive);
 } else {
     _genericMessages pushBack LSTRING(diagnoseDead);
 };
+
 if (_target getVariable[QGVAR(hasLostBlood), 0] > 0) then {
     if (_target getVariable[QGVAR(hasLostBlood), 0] > 1) then {
         _genericMessages pushBack LSTRING(lostBloodALot);

--- a/addons/medical/functions/fnc_addUnloadPatientActions.sqf
+++ b/addons/medical/functions/fnc_addUnloadPatientActions.sqf
@@ -15,11 +15,10 @@
 #include "script_component.hpp"
 params ["_vehicle", "_player", "_parameters"];
 
-private ["_actions", "_unit"];
-_actions = [];
+private _actions = [];
 
 {
-    _unit = _x;
+    private _unit = _x;
     if (_unit != _player && {(alive _unit) && {_unit getVariable ["ACE_isUnconscious", false]}}) then {
         _actions pushBack
             [

--- a/addons/medical/functions/fnc_canAccessMedicalEquipment.sqf
+++ b/addons/medical/functions/fnc_canAccessMedicalEquipment.sqf
@@ -14,12 +14,11 @@
 
 #include "script_component.hpp"
 
-private ["_accessLevel", "_return"];
 params ["_caller", "_target"];
 
-_accessLevel = _target getVariable [QGVAR(allowSharedEquipmentAccess), -1];
+private _accessLevel = _target getVariable [QGVAR(allowSharedEquipmentAccess), -1];
 
-_return = false;
+private _return = false;
 
 if (_accessLevel >= 0) then {
     if (_accessLevel == 0) exitWith { _return = true; };

--- a/addons/medical/functions/fnc_canTreat.sqf
+++ b/addons/medical/functions/fnc_canTreat.sqf
@@ -19,20 +19,18 @@
 
 #include "script_component.hpp"
 
-private ["_config", "_medicRequired", "_items", "_locations", "_return", "_condition", "_patientStateCondition", "_allowedSelections"];
 params ["_caller", "_target", "_selectionName", "_className"];
 
 if !(_target isKindOf "CAManBase") exitWith { false };
 
-
-_config = (ConfigFile >> "ACE_Medical_Actions" >> (["Basic", "Advanced"] select (GVAR(level)>=2)) >> _className);
+private _config = (ConfigFile >> "ACE_Medical_Actions" >> (["Basic", "Advanced"] select (GVAR(level)>=2)) >> _className);
 
 if !(isClass _config) exitwith {false};
 
 // Allow self treatment check
 if (_caller == _target && {getNumber (_config >> "allowSelfTreatment") == 0}) exitwith {false};
 
-_medicRequired = if (isNumber (_config >> "requiredMedic")) then {
+private _medicRequired = if (isNumber (_config >> "requiredMedic")) then {
     getNumber (_config >> "requiredMedic");
 } else {
     // Check for required class
@@ -43,15 +41,15 @@ _medicRequired = if (isNumber (_config >> "requiredMedic")) then {
 };
 if !([_caller, _medicRequired] call FUNC(isMedic)) exitwith { false };
 
-_items = getArray (_config >> "items");
+private _items = getArray (_config >> "items");
 if (count _items > 0 && {!([_caller, _target, _items] call FUNC(hasItems))}) exitwith { false };
 
-_allowedSelections = getArray (_config >> "allowedSelections");
+private _allowedSelections = getArray (_config >> "allowedSelections");
 if !("All" in _allowedSelections || {(_selectionName in _allowedSelections)}) exitwith { false };
 
-_return = true;
+private _return = true;
 if (getText (_config >> "condition") != "") then {
-    _condition = getText (_config >> "condition");
+    private _condition = getText (_config >> "condition");
     if (isnil _condition) then {
         _condition = compile _condition;
     } else {
@@ -65,27 +63,25 @@ if (getText (_config >> "condition") != "") then {
 };
 if (!_return) exitwith { false };
 
-_patientStateCondition = if (isText(_config >> "patientStateCondition")) then {
+private _patientStateCondition = if (isText(_config >> "patientStateCondition")) then {
     missionNamespace getVariable [getText(_config >> "patientStateCondition"), 0]
 } else {
     getNumber(_config >> "patientStateCondition")
 };
 if (_patientStateCondition == 1 && {!([_target] call FUNC(isInStableCondition))}) exitwith {false};
 
-_locations = getArray (_config >> "treatmentLocations");
+private _locations = getArray (_config >> "treatmentLocations");
 if ("All" in _locations) exitwith { true };
 
-private [ "_medFacility", "_medVeh"];
-_medFacility = {([_caller] call FUNC(isInMedicalFacility)) || ([_target] call FUNC(isInMedicalFacility))};
-_medVeh = {([_caller] call FUNC(isInMedicalVehicle)) || ([_target] call FUNC(isInMedicalVehicle))};
+private _medFacility = {([_caller] call FUNC(isInMedicalFacility)) || ([_target] call FUNC(isInMedicalFacility))};
+private _medVeh = {([_caller] call FUNC(isInMedicalVehicle)) || ([_target] call FUNC(isInMedicalVehicle))};
 
 {
     if (_x == "field") exitwith {_return = true;};
     if (_x == "MedicalFacility" && _medFacility) exitwith {_return = true;};
     if (_x == "MedicalVehicle" && _medVeh) exitwith {_return = true;};
     if !(isnil _x) exitwith {
-        private "_val";
-        _val = missionNamespace getVariable _x;
+        private _val = missionNamespace getVariable _x;
         if (_val isEqualType 0) then {
             _return = switch (_val) do {
                 case 0: {true}; //AdvancedMedicalSettings_anywhere

--- a/addons/medical/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical/functions/fnc_displayPatientInformation.sqf
@@ -18,7 +18,7 @@
 
 // Exit for basic medical
 if (GVAR(level) < 2) exitWith {};
-private ["_amountOfGeneric", "_bandagedwounds", "_logCtrl", "_part", "_partText", "_pointDamage", "_severity", "_total", "_totalIvVolume", "_triageStatus", "_type"];
+
 params ["_target", ["_show", true], ["_selectionN", 0]];
 
 GVAR(currentSelectedSelectionN) = [0, _selectionN] select (IS_SCALAR(_selectionN));
@@ -46,16 +46,16 @@ if (_show) then {
         };
 
         disableSerialization;
-        _display = uiNamespace getVariable QGVAR(DisplayInformation);
+        private _display = uiNamespace getVariable QGVAR(DisplayInformation);
         if (isnil "_display") exitwith {
             [_idPFH] call CBA_fnc_removePerFrameHandler;
         };
 
-        _allInjuryTexts = [];
-        _genericMessages = [];
+        private _allInjuryTexts = [];
+        private _genericMessages = [];
 
         if (GVAR(level) >= 2 && {([_unit] call FUNC(hasMedicalEnabled))}) then {
-            _partText = [LSTRING(Head), LSTRING(Torso), LSTRING(LeftArm) ,LSTRING(RightArm) ,LSTRING(LeftLeg), LSTRING(RightLeg)] select _selectionN;
+            private _partText = [LSTRING(Head), LSTRING(Torso), LSTRING(LeftArm) ,LSTRING(RightArm) ,LSTRING(LeftLeg), LSTRING(RightLeg)] select _selectionN;
             _genericMessages pushback [localize _partText, [1, 1, 1, 1]];
         };
 
@@ -73,10 +73,9 @@ if (_show) then {
             _genericMessages pushback [localize LSTRING(Status_Pain), [1, 1, 1, 1]];
         };
 
-        _totalIvVolume = 0;
+        private _totalIvVolume = 0;
         {
-            private "_value";
-            _value = _target getVariable _x;
+            private _value = _target getVariable _x;
             if !(isnil "_value") then {
                 _totalIvVolume = _totalIvVolume + (_target getVariable [_x, 0]);
             };
@@ -85,16 +84,15 @@ if (_show) then {
             _genericMessages pushback [format[localize LSTRING(receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
         };
 
-        _damaged = [false, false, false, false, false, false];
-        _selectionBloodLoss = [0,0,0,0,0,0];
+        private _damaged = [false, false, false, false, false, false];
+        private _selectionBloodLoss = [0,0,0,0,0,0];
         if (GVAR(level) >= 2 && {([_target] call FUNC(hasMedicalEnabled))}) then {
-            _openWounds = _target getVariable [QGVAR(openWounds), []];
-            private "_amountOf";
+            private _openWounds = _target getVariable [QGVAR(openWounds), []];
             {
                 _x params ["", "_x1", "_selectionX", "_amountOf", "_x4"];
                 // Find how much this bodypart is bleeding
                 if (_amountOf > 0) then {
-                    _damaged set[_selectionX, true];
+                    _damaged set [_selectionX, true];
                     _selectionBloodLoss set [_selectionX, (_selectionBloodLoss select _selectionX) + (20 * (_x4 * _amountOf))];
 
                     if (_selectionN == _selectionX) then {
@@ -110,7 +108,7 @@ if (_show) then {
                 };
             } foreach _openWounds;
 
-            _bandagedwounds = _target getVariable [QGVAR(bandagedWounds), []];
+            private _bandagedwounds = _target getVariable [QGVAR(bandagedWounds), []];
             {
                 _x params ["", "", "_selectionX", "_amountOf", "_x4"];
                 // Find how much this bodypart is bleeding
@@ -131,18 +129,18 @@ if (_show) then {
                 };
             } foreach _bandagedwounds;
         } else {
-            _damaged = [true, true, true, true, true, true];
+            private _damaged = [true, true, true, true, true, true];
             {
                 private _hitPoint = [_target, _x, true] call FUNC(translateSelections);
                 _selectionBloodLoss set [_forEachIndex, _target getHitPointDamage _hitPoint];
                 if (_target getHitPointDamage _hitPoint > 0 && {_forEachIndex == _selectionN}) then {
-                    _pointDamage = _target getHitPointDamage _hitPoint;
-                    _severity = switch (true) do {
+                    private _pointDamage = _target getHitPointDamage _hitPoint;
+                    private _severity = switch (true) do {
                         case (_pointDamage > 0.5): {localize LSTRING(HeavilyWounded)};
                         case (_pointDamage > 0.1): {localize LSTRING(LightlyWounded)};
                         default                    {localize LSTRING(VeryLightlyWounded)};
                     };
-                    _part = localize ([
+                    private _part = localize ([
                         LSTRING(Head),
                         LSTRING(Torso),
                         LSTRING(LeftArm),
@@ -157,14 +155,13 @@ if (_show) then {
 
         // Handle the body image coloring
 
-        _availableSelections = [50,51,52,53,54,55];
+        private _availableSelections = [50,51,52,53,54,55];
         {
-            private ["_red", "_green", "_blue", "_total"];
-            _total = _x;
+            private _total = _x;
+            private _red = 1;
+            private _green = 1;
+            private _blue = 1;
 
-            _red = 1;
-            _green = 1;
-            _blue = 1;
             if (_total > 0) then {
                 if (_damaged select _forEachIndex) then {
                     _green = (0.9 - _total) max 0;
@@ -178,7 +175,7 @@ if (_show) then {
             (_display displayCtrl (_availableSelections select _foreachIndex)) ctrlSetTextColor [_red, _green, _blue, 1.0];
         } foreach _selectionBloodLoss;
 
-        _lbCtrl = (_display displayCtrl 200);
+        private _lbCtrl = (_display displayCtrl 200);
         lbClear _lbCtrl;
         {
             _x params ["_add", "_color"];
@@ -186,7 +183,7 @@ if (_show) then {
             _lbCtrl lbSetColor [_foreachIndex, _color];
         } foreach _genericMessages;
 
-        _amountOfGeneric = count _genericMessages;
+        private _amountOfGeneric = count _genericMessages;
         {
             _x params ["_add", "_color"];
             _lbCtrl lbAdd _add;
@@ -196,13 +193,11 @@ if (_show) then {
             _lbCtrl lbAdd (localize LSTRING(NoInjuriesBodypart));
         };
 
-        _logCtrl = (_display displayCtrl 302);
+        private _logCtrl = (_display displayCtrl 302);
         lbClear _logCtrl;
 
-        private ["_logs", "_message", "_moment", "_arguments", "_lbCtrl"];
-        _logs = _target getVariable [QGVAR(logFile_Activity), []];
+        private _logs = _target getVariable [QGVAR(logFile_Activity), []];
         {
-            // [_message,_moment,_type, _arguments]
             _x params ["_message", "_moment", "_type", "_arguments"];
             if (isLocalized _message) then {
                 _message = localize _message;
@@ -217,7 +212,7 @@ if (_show) then {
             _logCtrl lbAdd format["%1 %2", _moment, _message];
         } foreach _logs;
 
-        _triageStatus = [_target] call FUNC(getTriageStatus);
+        private _triageStatus = [_target] call FUNC(getTriageStatus);
         (_display displayCtrl 303) ctrlSetText (_triageStatus select 0);
         (_display displayCtrl 303) ctrlSetBackgroundColor (_triageStatus select 2);
 

--- a/addons/medical/functions/fnc_displayTriageCard.sqf
+++ b/addons/medical/functions/fnc_displayTriageCard.sqf
@@ -14,7 +14,6 @@
 
 #include "script_component.hpp"
 
-private ["_amount", "_item", "_log", "_message", "_triageCardTexts", "_triageStatus"];
 params ["_target", ["_show", true]];
 
 GVAR(TriageCardTarget) = if (_show) then {_target} else {ObjNull};
@@ -24,7 +23,6 @@ if (_show) then {
     createDialog QGVAR(triageCard);
 
     [{
-        private ["_target", "_display", "_alphaLevel", "_alphaLevel", "_lbCtrl"];
         params ["_args", "_idPFH"];
         _args params ["_target"];
         if (GVAR(TriageCardTarget) != _target) exitWith {
@@ -32,21 +30,21 @@ if (_show) then {
         };
 
         disableSerialization;
-        _display = uiNamespace getVariable QGVAR(triageCard);
+        private _display = uiNamespace getVariable QGVAR(triageCard);
         if (isNil "_display") exitWith {
             [_idPFH] call CBA_fnc_removePerFrameHandler;
         };
 
-        _triageCardTexts = [];
+        private _triageCardTexts = [];
 
         // TODO fill the lb with the appropiate information for the patient
-        _lbCtrl = (_display displayCtrl 200);
+        private _lbCtrl = (_display displayCtrl 200);
         lbClear _lbCtrl;
 
-        _log = _target getVariable [QGVAR(triageCard), []];
+        private _log = _target getVariable [QGVAR(triageCard), []];
         {
             _x params ["_item", "_amount"];
-            _message = _item;
+            private _message = _item;
             if (isClass(configFile >> "CfgWeapons" >> _item)) then {
                 _message = getText(configFile >> "CfgWeapons" >> _item >> "DisplayName");
             } else {
@@ -64,8 +62,7 @@ if (_show) then {
             _lbCtrl lbAdd _x;
         } forEach _triageCardTexts;
 
-        _triageStatus = [_target] call FUNC(getTriageStatus);
-
+        private _triageStatus = [_target] call FUNC(getTriageStatus);
         _triageStatus params ["_text", "", "_color"];
 
         (_display displayCtrl 2000) ctrlSetText _text;

--- a/addons/medical/functions/fnc_dropDownTriageCard.sqf
+++ b/addons/medical/functions/fnc_dropDownTriageCard.sqf
@@ -13,20 +13,19 @@
 
 #include "script_component.hpp"
 
-private ["_ctrl", "_display", "_idc", "_pos"];
 params ["_show"];
-disableSerialization;
 
-_display = uiNamespace getVariable QGVAR(triageCard);
+disableSerialization;
+private _display = uiNamespace getVariable QGVAR(triageCard);
 if (isNil "_display") exitWith {};
 
-_pos = [0,0,0,0];
+private _pos = [0,0,0,0];
 if (_show) then {
     _pos = ctrlPosition (_display displayCtrl 2001);
 };
 for "_idc" from 2002 to 2006 step 1 do {
     _pos set [1, (_pos select 1) + (_pos select 3)];
-    _ctrl = (_display displayCtrl _idc);
+    private _ctrl = (_display displayCtrl _idc);
     _ctrl ctrlSetPosition _pos;
     _ctrl ctrlCommit 0;
 };

--- a/addons/medical/functions/fnc_getUnconsciousCondition.sqf
+++ b/addons/medical/functions/fnc_getUnconsciousCondition.sqf
@@ -13,14 +13,13 @@
 
 #include "script_component.hpp"
 
-private ["_unit","_return"];
 params ["_unit"];
 
 if (isnil QGVAR(unconsciousConditions)) then {
     GVAR(unconsciousConditions) = [];
 };
 
-_return = false;
+private _return = false;
 {
     if ((_x isEqualType {}) && {([_unit] call _x)}) exitwith {
        _return = true;

--- a/addons/medical/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical/functions/fnc_handleBandageOpening.sqf
@@ -21,16 +21,16 @@
 private ["_className", "_reopeningChance", "_reopeningMinDelay", "_reopeningMaxDelay", "_config", "_woundTreatmentConfig", "_bandagedWounds", "_exist", "_injuryId", "_existingInjury", "_delay", "_openWounds", "_selectedInjury", "_bandagedInjury"];
 params ["_target", "_impact", "_part", "_injuryIndex", "_injury", "_bandage"];
 
-_classID = _injury select 1;
-_className = GVAR(woundClassNames) select _classID;
+private _classID = _injury select 1;
+private _className = GVAR(woundClassNames) select _classID;
 
 // default, just in case..
-_reopeningChance = 0.1;
-_reopeningMinDelay = 120;
-_reopeningMaxDelay = 200;
+private _reopeningChance = 0.1;
+private _reopeningMinDelay = 120;
+private _reopeningMaxDelay = 200;
 
 // Get the default values for the used bandage
-_config = (ConfigFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Bandaging");
+private _config = (ConfigFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Bandaging");
 if (isClass (_config >> _bandage)) then {
     _config = (_config >> _bandage);
     _reopeningChance = getNumber (_config >> "reopeningChance");
@@ -41,7 +41,7 @@ if (isClass (_config >> _bandage)) then {
 };
 
 if (isClass (_config >> _className)) then {
-    _woundTreatmentConfig = (_config >> _className);
+    private _woundTreatmentConfig = (_config >> _className);
     if (isNumber (_woundTreatmentConfig >> "reopeningChance")) then {
         _reopeningChance = getNumber (_woundTreatmentConfig >> "reopeningChance");
     };
@@ -56,10 +56,10 @@ if (isClass (_config >> _className)) then {
 };
 TRACE_5("configs",_bandage,_className,_reopeningChance,_reopeningMinDelay,_reopeningMaxDelay);
 
-_bandagedWounds = _target getVariable [QGVAR(bandagedWounds), []];
-_injuryType = _injury select 1;
-_exist = false;
-_bandagedInjury = [];
+private _bandagedWounds = _target getVariable [QGVAR(bandagedWounds), []];
+private _injuryType = _injury select 1;
+private _exist = false;
+private _bandagedInjury = [];
 {
     if ((_x select 1) == _injuryType && (_x select 2) == (_injury select 2)) exitwith {
         _exist = true;
@@ -85,19 +85,18 @@ if (random(1) <= _reopeningChance) then {
     _delay = _reopeningMinDelay + random(_reopeningMaxDelay - _reopeningMinDelay);
     TRACE_1("Will open",_delay);
     [{
-        private ["_bandage", "_openWounds", "_selectedInjury","_bandagedWounds","_exist"];
         params ["_target", "_impact", "_part", "_injuryIndex", "_injury"];
         TRACE_5("params",_target,_impact,_part,_injuryIndex,_injury);
 
         //if (alive _target) then {
-            _openWounds = _target getVariable [QGVAR(openWounds), []];
-            if ((count _openWounds)-1 < _injuryIndex) exitwith {};
-            _selectedInjury = _openWounds select _injuryIndex;
+            private _openWounds = _target getVariable [QGVAR(openWounds), []];
+            if ((count _openWounds) - 1 < _injuryIndex) exitwith {};
+            private _selectedInjury = _openWounds select _injuryIndex;
             if (_selectedInjury select 1 == _injury select 1 && (_selectedInjury select 2) == (_injury select 2)) then { // matching the IDs
 
-                _bandagedWounds = _target getVariable [QGVAR(bandagedWounds), []];
-                _exist = false;
-                _injuryId = _injury select 1;
+                private _bandagedWounds = _target getVariable [QGVAR(bandagedWounds), []];
+                private _exist = false;
+                private _injuryId = _injury select 1;
                 {
                     if ((_x select 1) == _injuryId && (_x select 2) == (_injury select 2)) exitwith {
                         _exist = true;

--- a/addons/medical/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical/functions/fnc_onMedicationUsage.sqf
@@ -18,12 +18,11 @@
 
 #include "script_component.hpp"
 
-private ["_foundEntry", "_allUsedMedication","_allMedsFromClassname", "_usedMeds", "_hasOverDosed", "_med", "_limit", "_decreaseAmount", "_viscosityAdjustment", "_medicationConfig", "_onOverDose"];
 params ["_target", "_className", "_variable", "_maxDosage", "_timeInSystem", "_incompatabileMeds", "_viscosityChange", "_painReduce"];
 TRACE_8("params",_target,_className,_variable,_maxDosage,_timeInSystem,_incompatabileMeds,_viscosityChange,_painReduce);
 
-_foundEntry = false;
-_allUsedMedication = _target getVariable [QGVAR(allUsedMedication), []];
+private _foundEntry = false;
+private _allUsedMedication = _target getVariable [QGVAR(allUsedMedication), []];
 {
     _x params ["_variableX", "_allMedsFromClassname"];
     if (_variableX== _variable) exitWith {
@@ -43,12 +42,12 @@ if (!_foundEntry) then {
 };
 
 
-_usedMeds = _target getVariable [_variable, 0];
+private _usedMeds = _target getVariable [_variable, 0];
 if (_usedMeds >= floor (_maxDosage + round(random(2))) && _maxDosage >= 1 && GVAR(enableOverdosing)) then {
     [_target] call FUNC(setDead);
 };
 
-_hasOverDosed = 0;
+private _hasOverDosed = 0;
 {
     _x params ["_med", "_limit"];
     {
@@ -60,8 +59,8 @@ _hasOverDosed = 0;
 } forEach _incompatabileMeds;
 
 if (_hasOverDosed > 0 && GVAR(enableOverdosing)) then {
-    _medicationConfig = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Medication");
-    _onOverDose = getText (_medicationConfig >> "onOverDose");
+    private _medicationConfig = (configFile >> "ACE_Medical_Advanced" >> "Treatment" >> "Medication");
+    private _onOverDose = getText (_medicationConfig >> "onOverDose");
     if (isClass (_medicationConfig >> _className)) then {
         _medicationConfig = (_medicationConfig >> _className);
          if (isText (_medicationConfig  >> "onOverDose")) then { _onOverDose = getText (_medicationConfig >> "onOverDose"); };
@@ -74,8 +73,8 @@ if (_hasOverDosed > 0 && GVAR(enableOverdosing)) then {
     [_target, _className] call _onOverDose;
 };
 
-_decreaseAmount = 1 / _timeInSystem;
-_viscosityAdjustment = _viscosityChange / _timeInSystem;
+private _decreaseAmount = 1 / _timeInSystem;
+private _viscosityAdjustment = _viscosityChange / _timeInSystem;
 
 // Run the loop that computes the effect of the medication over time
 [_target, _variable, 0, _decreaseAmount, _viscosityAdjustment, _painReduce / _timeInSystem] call FUNC(medicationEffectLoop);

--- a/addons/medical/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical/functions/fnc_playInjuredSound.sqf
@@ -16,7 +16,6 @@
 
 #include "script_component.hpp"
 
-private ["_unit","_availableSounds_A","_availableSounds_B","_availableSounds_C","_sound", "_pain"];
 params ["_unit", "_pain"];
 if (!local _unit || !GVAR(enableScreams)) exitWith{};
 
@@ -27,7 +26,7 @@ _unit setVariable [QGVAR(playingInjuredSound),true];
 // Play the sound if there is any damage present.
 if (_pain > 0 && {[_unit] call EFUNC(common,isAwake)}) exitWith {
     // Classnames of the available sounds.
-    _availableSounds_A = [
+    private _availableSounds_A = [
         "WoundedGuyA_01",
         "WoundedGuyA_02",
         "WoundedGuyA_03",
@@ -37,7 +36,7 @@ if (_pain > 0 && {[_unit] call EFUNC(common,isAwake)}) exitWith {
         "WoundedGuyA_07",
         "WoundedGuyA_08"
     ];
-    _availableSounds_B = [
+    private _availableSounds_B = [
         "WoundedGuyB_01",
         "WoundedGuyB_02",
         "WoundedGuyB_03",
@@ -47,14 +46,14 @@ if (_pain > 0 && {[_unit] call EFUNC(common,isAwake)}) exitWith {
         "WoundedGuyB_07",
         "WoundedGuyB_08"
     ];
-    _availableSounds_C = [
+    private _availableSounds_C = [
         "WoundedGuyC_01",
         "WoundedGuyC_02",
         "WoundedGuyC_03",
         "WoundedGuyC_04",
         "WoundedGuyC_05"
     ];
-    _sound = "";
+    private _sound = "";
 
     // Select the to be played sound based upon damage amount.
     if (_pain > 0.5) then {
@@ -70,14 +69,13 @@ if (_pain > 0 && {[_unit] call EFUNC(common,isAwake)}) exitWith {
     playSound3D [(getArray(configFile >> "CfgSounds" >> _sound >> "sound") select 0) + ".wss", objNull, false, getPos _unit, 15, 1, 25]; // +2db, 15 meters.
 
     // Figure out what the delay will be before it is possible to play a sound again.
-    private "_delay";
-    _delay = (30 - (random(25) * _pain)) max (3.5 + random(2));
+    private _delay = (30 - (random(25) * _pain)) max (3.5 + random(2));
 
     // Clean up the lock
     [{
-        (_this select 0) setVariable [QGVAR(playingInjuredSound),nil];
+        (_this select 0) setVariable [QGVAR(playingInjuredSound), nil];
     }, [_unit], _delay, _delay] call CBA_fnc_waitAndExecute;
 };
 
 // Clean up in case there has not been played any sounds.
-_unit setVariable [QGVAR(playingInjuredSound),nil];
+_unit setVariable [QGVAR(playingInjuredSound), nil];

--- a/addons/medical/functions/fnc_treatment.sqf
+++ b/addons/medical/functions/fnc_treatment.sqf
@@ -16,28 +16,26 @@
 
 #include "script_component.hpp"
 
-private ["_config", "_medicRequired", "_items", "_locations", "_return", "_callbackProgress", "_treatmentTime", "_callerAnim", "_patientAnim", "_iconDisplayed", "_return", "_usersOfItems", "_consumeItems", "_condition", "_displayText", "_wpn", "_treatmentTimeConfig", "_patientStateCondition", "_allowedSelections"];
 params ["_caller", "_target", "_selectionName", "_className"];
 
 // If the cursorMenu is open, the loading bar will fail. If we execute the function one frame later, it will work fine
 if (uiNamespace getVariable [QEGVAR(interact_menu,cursorMenuOpened),false]) exitwith {
-    [{
-        _this call FUNC(treatment);
-    }, _this] call CBA_fnc_execNextFrame;
+    [DFUNC(treatment), _this] call CBA_fnc_execNextFrame;
 };
 
 if !(_target isKindOf "CAManBase") exitWith {false};
 
-_config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
+private _config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
 if (GVAR(level) >= 2) then {
     _config = (configFile >> "ACE_Medical_Actions" >> "Advanced" >> _className);
 };
+
 if !(isClass _config) exitwith {false};
 
 // Allow self treatment check
 if (_caller == _target && {getNumber (_config >> "allowSelfTreatment") == 0}) exitwith {false};
 
-_medicRequired = if (isNumber (_config >> "requiredMedic")) then {
+private _medicRequired = if (isNumber (_config >> "requiredMedic")) then {
     getNumber (_config >> "requiredMedic");
 } else {
     // Check for required class
@@ -49,16 +47,16 @@ _medicRequired = if (isNumber (_config >> "requiredMedic")) then {
 
 if !([_caller, _medicRequired] call FUNC(isMedic)) exitwith {false};
 
-_allowedSelections = getArray (_config >> "allowedSelections");
+private _allowedSelections = getArray (_config >> "allowedSelections");
 if !("All" in _allowedSelections || {(_selectionName in _allowedSelections)}) exitwith {false};
 
 // Check item
-_items = getArray (_config >> "items");
+private _items = getArray (_config >> "items");
 if (count _items > 0 && {!([_caller, _target, _items] call FUNC(hasItems))}) exitwith {false};
 
-_return = true;
+private _return = true;
 if (isText (_config >> "Condition")) then {
-    _condition = getText(_config >> "condition");
+    private _condition = getText(_config >> "condition");
     if (_condition != "") then {
         if (isnil _condition) then {
             _condition = compile _condition;
@@ -74,7 +72,7 @@ if (isText (_config >> "Condition")) then {
 };
 if (!_return) exitwith {false};
 
-_patientStateCondition = if (isText(_config >> "patientStateCondition")) then {
+private _patientStateCondition = if (isText(_config >> "patientStateCondition")) then {
     missionNamespace getVariable [getText(_config >> "patientStateCondition"), 0]
 } else {
     getNumber(_config >> "patientStateCondition")
@@ -82,22 +80,20 @@ _patientStateCondition = if (isText(_config >> "patientStateCondition")) then {
 if (_patientStateCondition == 1 && {!([_target] call FUNC(isInStableCondition))}) exitwith {false};
 
 // Check allowed locations
-_locations = getArray (_config >> "treatmentLocations");
+private _locations = getArray (_config >> "treatmentLocations");
 
 if ("All" in _locations) then {
     _return = true;
 } else {
-    private [ "_medFacility", "_medVeh"];
-    _medFacility = {([_caller] call FUNC(isInMedicalFacility)) || ([_target] call FUNC(isInMedicalFacility))};
-    _medVeh = {([_caller] call FUNC(isInMedicalVehicle)) || ([_target] call FUNC(isInMedicalVehicle))};
+    private _medFacility = {([_caller] call FUNC(isInMedicalFacility)) || ([_target] call FUNC(isInMedicalFacility))};
+    private _medVeh = {([_caller] call FUNC(isInMedicalVehicle)) || ([_target] call FUNC(isInMedicalVehicle))};
 
     {
         if (_x == "field") exitwith {_return = true;};
         if (_x == "MedicalFacility" && _medFacility) exitwith {_return = true;};
         if (_x == "MedicalVehicle" && _medVeh) exitwith {_return = true;};
         if !(isnil _x) exitwith {
-            private "_val";
-            _val = missionNamespace getVariable _x;
+            private _val = missionNamespace getVariable _x;
             if (_val isEqualType 0) then {
                 _return = switch (_val) do {
                     case 0: {true}; //AdvancedMedicalSettings_anywhere
@@ -113,8 +109,8 @@ if ("All" in _locations) then {
 
 if !(_return) exitwith {false};
 
-_usersOfItems = [];
-_consumeItems = if (isNumber (_config >> "itemConsumed")) then {
+private _usersOfItems = [];
+private _consumeItems = if (isNumber (_config >> "itemConsumed")) then {
     getNumber (_config >> "itemConsumed");
 } else {
     // Check for required class
@@ -128,7 +124,7 @@ if (_consumeItems > 0) then {
 };
 
 // Parse the config for the progress callback
-_callbackProgress = getText (_config >> "callbackProgress");
+private _callbackProgress = getText (_config >> "callbackProgress");
 if (_callbackProgress == "") then {
     _callbackProgress = "true";
 };
@@ -139,7 +135,7 @@ if (isNil _callbackProgress) then {
 };
 
 // Patient Animation
-_patientAnim = getText (_config >> "animationPatient");
+private _patientAnim = getText (_config >> "animationPatient");
 if (_target getVariable ["ACE_isUnconscious", false] && GVAR(allowUnconsciousAnimationOnTreatment)) then {
     if !(animationState _target in (getArray (_config >> "animationPatientUnconsciousExcludeOn"))) then {
         _patientAnim = getText (_config >> "animationPatientUnconscious");
@@ -155,7 +151,7 @@ if (_caller != _target && {vehicle _target == _target} && {_patientAnim != ""}) 
 };
 
 // Player Animation
-_callerAnim = [getText (_config >> "animationCaller"), getText (_config >> "animationCallerProne")] select (stance _caller == "PRONE");
+private _callerAnim = [getText (_config >> "animationCaller"), getText (_config >> "animationCallerProne")] select (stance _caller == "PRONE");
 if (_caller == _target) then {
     _callerAnim = [getText (_config >> "animationCallerSelf"), getText (_config >> "animationCallerSelfProne")] select (stance _caller == "PRONE");
 };
@@ -167,8 +163,8 @@ if (currentWeapon _caller == secondaryWeapon _caller) then {
     _caller selectWeapon (primaryWeapon _caller);
 };
 
-_wpn = ["non", "rfl", "pst"] select (1 + ([primaryWeapon _caller, handgunWeapon _caller] find (currentWeapon _caller)));
-_callerAnim = [_callerAnim, "[wpn]", _wpn] call CBA_fnc_replace;
+private _wpn = ["non", "rfl", "pst"] select (1 + ([primaryWeapon _caller, handgunWeapon _caller] find (currentWeapon _caller)));
+private _callerAnim = [_callerAnim, "[wpn]", _wpn] call CBA_fnc_replace;
 if (vehicle _caller == _caller && {_callerAnim != ""}) then {
     if (primaryWeapon _caller == "") then {
         _caller addWeapon "ACE_FakePrimaryWeapon";
@@ -195,11 +191,11 @@ if (vehicle _caller == _caller && {_callerAnim != ""}) then {
 };
 
 //Get treatment time
-_treatmentTime = if (isNumber (_config >> "treatmentTime")) then {
+private _treatmentTime = if (isNumber (_config >> "treatmentTime")) then {
     getNumber (_config >> "treatmentTime");
 } else {
     if (isText (_config >> "treatmentTime")) exitwith {
-        _treatmentTimeConfig = getText(_config >> "treatmentTime");
+        private _treatmentTimeConfig = getText(_config >> "treatmentTime");
         if (isnil _treatmentTimeConfig) then {
             _treatmentTimeConfig = compile _treatmentTimeConfig;
         } else {
@@ -225,13 +221,13 @@ _treatmentTime = if (isNumber (_config >> "treatmentTime")) then {
 ] call EFUNC(common,progressBar);
 
 // Display Icon
-_iconDisplayed = getText (_config >> "actionIconPath");
+private _iconDisplayed = getText (_config >> "actionIconPath");
 if (_iconDisplayed != "") then {
     [QGVAR(treatmentActionIcon), true, _iconDisplayed, [1,1,1,1], getNumber(_config >> "actionIconDisplayTime")] call EFUNC(common,displayIcon);
 };
 
 // handle display of text/hints
-_displayText = "";
+private _displayText = "";
 if (_target != _caller) then {
     _displayText = getText(_config >> "displayTextOther");
 } else {

--- a/addons/medical/functions/fnc_treatment_failure.sqf
+++ b/addons/medical/functions/fnc_treatment_failure.sqf
@@ -17,7 +17,6 @@
 
 #include "script_component.hpp"
 
-private ["_config", "_callback", "_weaponSelect", "_lastAnim"];
 params ["_args"];
 _args params ["_caller", "_target", "_selectionName", "_className", "_items", "_usersOfItems"];
 
@@ -25,7 +24,7 @@ if (primaryWeapon _caller == "ACE_FakePrimaryWeapon") then {
     _caller removeWeapon "ACE_FakePrimaryWeapon";
 };
 if (vehicle _caller == _caller) then {
-    _lastAnim = _caller getVariable [QGVAR(treatmentPrevAnimCaller), ""];
+    private _lastAnim = _caller getVariable [QGVAR(treatmentPrevAnimCaller), ""];
     //Don't play another medic animation (when player is rapidily treating)
     TRACE_2("Reseting to old animation", animationState player, _lastAnim);
     switch (toLower _lastAnim) do {
@@ -40,7 +39,7 @@ if (vehicle _caller == _caller) then {
 };
 _caller setVariable [QGVAR(treatmentPrevAnimCaller), nil];
 
-_weaponSelect = (_caller getVariable [QGVAR(selectedWeaponOnTreatment), []]);
+private _weaponSelect = (_caller getVariable [QGVAR(selectedWeaponOnTreatment), []]);
 if ((_weaponSelect params [["_previousWeapon", ""]]) && {(_previousWeapon != "") && {_previousWeapon in (weapons _caller)}}) then {
     for "_index" from 0 to 99 do {
         _caller action ["SwitchWeapon", _caller, _caller, _index];
@@ -58,12 +57,12 @@ if ((_weaponSelect params [["_previousWeapon", ""]]) && {(_previousWeapon != "")
 } forEach _usersOfItems;
 
 // Record specific callback
-_config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
+private _config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
 if (GVAR(level) >= 2) then {
     _config = (configFile >> "ACE_Medical_Actions" >> "Advanced" >> _className);
 };
 
-_callback = getText (_config >> "callbackFailure");
+private _callback = getText (_config >> "callbackFailure");
 _callback = if (isNil _callback) then {
      compile _callback
 } else {
@@ -72,5 +71,3 @@ _callback = if (isNil _callback) then {
 if (!(_callback isEqualType {})) then {_callback = {TRACE_1("callback was NOT code",_callback)};};
 
 _args call _callback;
-
-// _args call FUNC(createLitter);

--- a/addons/medical/functions/fnc_treatment_success.sqf
+++ b/addons/medical/functions/fnc_treatment_success.sqf
@@ -17,7 +17,6 @@
 
 #include "script_component.hpp"
 
-private ["_config", "_callback", "_weaponSelect", "_lastAnim"];
 params ["_args"];
 _args params ["_caller", "_target", "_selectionName", "_className", "_items", "_usersOfItems"];
 
@@ -25,7 +24,7 @@ if (primaryWeapon _caller == "ACE_FakePrimaryWeapon") then {
     _caller removeWeapon "ACE_FakePrimaryWeapon";
 };
 if (vehicle _caller == _caller) then {
-    _lastAnim = _caller getVariable [QGVAR(treatmentPrevAnimCaller), ""];
+    private _lastAnim = _caller getVariable [QGVAR(treatmentPrevAnimCaller), ""];
     //Don't play another medic animation (when player is rapidily treating)
     TRACE_2("Reseting to old animation", animationState player, _lastAnim);
     switch (toLower _lastAnim) do {
@@ -40,7 +39,7 @@ if (vehicle _caller == _caller) then {
 };
 _caller setVariable [QGVAR(treatmentPrevAnimCaller), nil];
 
-_weaponSelect = (_caller getVariable [QGVAR(selectedWeaponOnTreatment), []]);
+private _weaponSelect = (_caller getVariable [QGVAR(selectedWeaponOnTreatment), []]);
 if ((_weaponSelect params [["_previousWeapon", ""]]) && {(_previousWeapon != "") && {_previousWeapon in (weapons _caller)}}) then {
     for "_index" from 0 to 99 do {
         _caller action ["SwitchWeapon", _caller, _caller, _index];
@@ -53,12 +52,12 @@ if ((_weaponSelect params [["_previousWeapon", ""]]) && {(_previousWeapon != "")
 };
 
 // Record specific callback
-_config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
+private _config = (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className);
 if (GVAR(level) >= 2) then {
     _config = (configFile >> "ACE_Medical_Actions" >> "Advanced" >> _className);
 };
 
-_callback = getText (_config >> "callbackSuccess");
+private _callback = getText (_config >> "callbackSuccess");
 if (isNil _callback) then {
     _callback = compile _callback;
 } else {

--- a/addons/medical_menu/functions/fnc_collectActions.sqf
+++ b/addons/medical_menu/functions/fnc_collectActions.sqf
@@ -15,27 +15,25 @@
  */
 #include "script_component.hpp"
 
-private ["_configBasic", "_configAdvanced", "_fnc_compileActionsLevel"];
-_configBasic = (configFile >> "ACE_Medical_Actions" >> "Basic");
-_configAdvanced = (configFile >> "ACE_Medical_Actions" >> "Advanced");
+private _configBasic = (configFile >> "ACE_Medical_Actions" >> "Basic");
+private _configAdvanced = (configFile >> "ACE_Medical_Actions" >> "Advanced");
 
-_fnc_compileActionsLevel = {
-    private ["_actions", "_displayName", "_condition", "_category", "_statement"];
+private _fnc_compileActionsLevel = {
     params ["_config"];
-    _actions = [];
+    private _actions = [];
 
     {
         if (isClass _x) then {
-            _displayName = getText (_x >> "displayName");
-            _category = getText (_x >> "category");
-            _condition = format[QUOTE([ARR_4(ACE_player, GVAR(INTERACTION_TARGET), EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart), '%1')] call DEFUNC(medical,canTreatCached)), configName _x];
-            _statement = format[QUOTE([ARR_4(ACE_player, GVAR(INTERACTION_TARGET), EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart), '%1')] call DEFUNC(medical,treatment)), configName _x];
+            private _displayName = getText (_x >> "displayName");
+            private _category = getText (_x >> "category");
+            private _condition = format[QUOTE([ARR_4(ACE_player, GVAR(INTERACTION_TARGET), EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart), '%1')] call DEFUNC(medical,canTreatCached)), configName _x];
+            private _statement = format[QUOTE([ARR_4(ACE_player, GVAR(INTERACTION_TARGET), EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart), '%1')] call DEFUNC(medical,treatment)), configName _x];
             _actions pushBack [_displayName, _category, compile _condition, compile _statement];
         };
         nil
     } count ("true" configClasses _config);
 
-    _actions // return
+    _actions;
 };
 
 GVAR(actionsBasic) = [_configBasic] call _fnc_compileActionsLevel;
@@ -43,20 +41,20 @@ GVAR(actionsAdvanced) = [_configAdvanced] call _fnc_compileActionsLevel;
 
 //Manually add the drag actions, if dragging exists.
 if (["ace_dragging"] call EFUNC(common,isModLoaded)) then {
-    _condition = {
+    private _condition = {
         (ACE_player != GVAR(INTERACTION_TARGET)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call EFUNC(dragging,canDrag)}
     };
-    _statement = {
+    private _statement = {
         GVAR(pendingReopen) = false; //No medical_treatmentSuccess event after drag, so don't want this true
         [ACE_player, GVAR(INTERACTION_TARGET)] call EFUNC(dragging,startDrag);
     };
     GVAR(actionsBasic) pushBack [localize ELSTRING(dragging,Drag), "drag", _condition, _statement];
     GVAR(actionsAdvanced) pushBack [localize ELSTRING(dragging,Drag), "drag", _condition, _statement];
 
-    _condition = {
+    private _condition = {
         (ACE_player != GVAR(INTERACTION_TARGET)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call EFUNC(dragging,canCarry)}
     };
-    _statement = {
+    private _statement = {
         GVAR(pendingReopen) = false; //No medical_treatmentSuccess event after drag, so don't want this true
         [ACE_player, GVAR(INTERACTION_TARGET)] call EFUNC(dragging,startCarry);
     };

--- a/addons/medical_menu/functions/fnc_getTreatmentOptions.sqf
+++ b/addons/medical_menu/functions/fnc_getTreatmentOptions.sqf
@@ -19,19 +19,16 @@
 
 params ["_player", "_target", "_name"];
 
-private ["_actions", "_collectedActions", "_bodyPart"];
-
 if (!([ACE_player, _target, ["isNotInside"]] call EFUNC(common,canInteractWith))) exitWith {[]};
 
-_actions = if (EGVAR(medical,level) == 2) then {
+private _actions = if (EGVAR(medical,level) == 2) then {
     GVAR(actionsAdvanced);
 } else {
     GVAR(actionsBasic);
 };
 
-_collectedActions = [];
-
-_bodyPart = EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart);
+private _collectedActions = [];
+private _bodyPart = EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart);
 {
     _x params ["", "_currentCategory", "_currentCondition"];
     if (_name == _currentCategory && {call _currentCondition}) then {
@@ -40,4 +37,4 @@ _bodyPart = EGVAR(medical,SELECTIONS) select GVAR(selectedBodyPart);
     nil
 } count _actions;
 
-_collectedActions // return
+_collectedActions;

--- a/addons/medical_menu/functions/fnc_handleUI_dropDownTriageCard.sqf
+++ b/addons/medical_menu/functions/fnc_handleUI_dropDownTriageCard.sqf
@@ -15,13 +15,11 @@
  */
 #include "script_component.hpp"
 
-private ["_display", "_pos", "_ctrl", "_currentPos", "_idc"];
-
 disableSerialization;
 
-_display = uiNamespace getVariable QGVAR(medicalMenu);
-_pos = [0, 0, 0, 0];
-_currentPos = ctrlPosition (_display displayCtrl 2002);
+private _display = uiNamespace getVariable QGVAR(medicalMenu);
+private _pos = [0, 0, 0, 0];
+private _currentPos = ctrlPosition (_display displayCtrl 2002);
 _currentPos params ["_currentPosX", "_currentPosY"];
 if (_currentPosX == 0 && _currentPosY == 0) then {
     _pos = ctrlPosition (_display displayCtrl 2001);
@@ -29,7 +27,7 @@ if (_currentPosX == 0 && _currentPosY == 0) then {
 
 for "_idc" from 2002 to 2006 step 1 do {
     _pos set [1, (_pos select 1) + (_pos select 3)];
-    _ctrl = _display displayCtrl _idc;
+    private _ctrl = _display displayCtrl _idc;
     _ctrl ctrlSetPosition _pos;
     _ctrl ctrlCommit 0;
 };

--- a/addons/medical_menu/functions/fnc_onMenuOpen.sqf
+++ b/addons/medical_menu/functions/fnc_onMenuOpen.sqf
@@ -16,8 +16,6 @@
 #include "script_component.hpp"
 #define MAX_DISTANCE 10
 
-private "_target";
-
 params ["_display"];
 
 if (isNil "_display") exitWith {};
@@ -34,7 +32,7 @@ if (isNil QGVAR(LatestDisplayOptionMenu)) then {
     };
 };
 
-_target = GVAR(INTERACTION_TARGET);
+private _target = GVAR(INTERACTION_TARGET);
 if (isNil QGVAR(INTERACTION_TARGET_PREVIOUS)) then {
     GVAR(INTERACTION_TARGET_PREVIOUS) = _target;
 };

--- a/addons/medical_menu/functions/fnc_openMenu.sqf
+++ b/addons/medical_menu/functions/fnc_openMenu.sqf
@@ -20,15 +20,10 @@ params ["_interactionTarget"];
 if (dialog || {isNull _interactionTarget}) exitWith {
     disableSerialization;
 
-    private ["_display", "_handled"];
-    _handled = false;
-    _display = uiNamespace getVariable QGVAR(medicalMenu);
+    private _display = uiNamespace getVariable QGVAR(medicalMenu);
     if (!isNil "_display") then {
         closeDialog 314412;
-        _handled = true;
     };
-
-    _handled
 };
 
 GVAR(INTERACTION_TARGET) = _interactionTarget;

--- a/addons/medical_menu/functions/fnc_updateActivityLog.sqf
+++ b/addons/medical_menu/functions/fnc_updateActivityLog.sqf
@@ -16,11 +16,9 @@
  */
 #include "script_component.hpp"
 
-private "_logCtrl";
-
 params ["_display", "_logs"];
 
-_logCtrl = _display displayCtrl 214;
+private _logCtrl = _display displayCtrl 214;
 lbClear _logCtrl;
 
 {

--- a/addons/medical_menu/functions/fnc_updateBodyImage.sqf
+++ b/addons/medical_menu/functions/fnc_updateBodyImage.sqf
@@ -22,11 +22,9 @@ params ["_selectionBloodLoss", "_damaged", "_display"];
 // Handle the body image coloring
 private _availableSelections = [50, 51, 52, 53, 54, 55];
 {
-    private ["_red", "_green", "_blue"];
-
-    _red = 1;
-    _green = 1;
-    _blue = 1;
+    private _red = 1;
+    private _green = 1;
+    private _blue = 1;
 
     if (_x > 0) then {
         if (_damaged select _forEachIndex) then {

--- a/addons/medical_menu/functions/fnc_updateIcons.sqf
+++ b/addons/medical_menu/functions/fnc_updateIcons.sqf
@@ -18,15 +18,13 @@
 #define START_IDC 111
 #define END_IDC 118
 
-private ["_display", "_idc", "_options", "_amount"];
-
 disableSerialization;
 
-_display = uiNamespace getVariable QGVAR(medicalMenu);
+private _display = uiNamespace getVariable QGVAR(medicalMenu);
+private _options = ["triage" , "examine", "bandage", "medication", "airway", "advanced", "drag", "toggle"];
 
-_options = ["triage" , "examine", "bandage", "medication", "airway", "advanced", "drag", "toggle"];
 for "_idc" from START_IDC to END_IDC step 1 do {
-    _amount = [ACE_player, GVAR(INTERACTION_TARGET), _options select (_idc - START_IDC)] call FUNC(getTreatmentOptions);
+    private _amount = [ACE_player, GVAR(INTERACTION_TARGET), _options select (_idc - START_IDC)] call FUNC(getTreatmentOptions);
     if ((count _amount) > 0 || _idc == START_IDC || _idc == END_IDC) then {
         (_display displayCtrl _idc) ctrlSettextColor [1, 1, 1, 1];
     } else {

--- a/addons/medical_menu/functions/fnc_updateInformationLists.sqf
+++ b/addons/medical_menu/functions/fnc_updateInformationLists.sqf
@@ -14,11 +14,9 @@
  */
 #include "script_component.hpp"
 
-private ["_lbCtrl", "_amountOfGeneric"];
-
 params ["_display", "_genericMessages", "_allInjuryTexts"];
 
-_lbCtrl = _display displayCtrl 213;
+private _lbCtrl = _display displayCtrl 213;
 lbClear _lbCtrl;
 {
     _x params ["_add", "_color"];
@@ -26,7 +24,7 @@ lbClear _lbCtrl;
     _lbCtrl lbSetColor [_forEachIndex, _color];
 } forEach _genericMessages;
 
-_amountOfGeneric = count _genericMessages;
+private _amountOfGeneric = count _genericMessages;
 {
     _x params ["_add", "_color"];
     _lbCtrl lbAdd _add;

--- a/addons/medical_menu/functions/fnc_updateQuickViewLog.sqf
+++ b/addons/medical_menu/functions/fnc_updateQuickViewLog.sqf
@@ -16,19 +16,13 @@
  */
 #include "script_component.hpp"
 
-private "_logCtrl";
-
 params ["_display", "_logs"];
 
-_logCtrl = _display displayCtrl 215;
+private _logCtrl = _display displayCtrl 215;
 lbClear _logCtrl;
 
 {
     _x params ["_message", "_moment", "", "_arguments"];
-
-    if (isLocalized _message) then {
-        _message = localize _message;
-    };
 
     {
         if (_x isEqualType "" && {isLocalized _x}) then {
@@ -36,7 +30,7 @@ lbClear _logCtrl;
         };
     } forEach _arguments;
 
-    _message = format ([_message] + _arguments);
+    _message = format ([([_message, localize _message] select (isLocalized _message))] + _arguments);
     _logCtrl lbAdd format ["%1 %2", _moment, _message];
     nil
 } count _logs;


### PR DESCRIPTION
Minor improvements to ACE medical code part 2. Same as #3912.

Only a limited number of functions instead of everything, to avoid doing to many things at the same time in the same PR.

Biggest changes:

- Use private keyword.
- Remove excessive whitespace
- Add space where needed (set[ -> set [)
- Makes some lines more compact
