### PR TITLE
Fix basic UI being overwritten on RscDiary unload

### DIFF
--- a/addons/ui/CfgEventHandlers.hpp
+++ b/addons/ui/CfgEventHandlers.hpp
@@ -15,3 +15,10 @@ class Extended_PostInit_EventHandlers {
         clientInit = QUOTE(call COMPILE_FILE(XEH_clientInit));
     };
 };
+
+// Closing diary resets showHUD
+class Extended_DisplayUnload_EventHandlers {
+    class RscDiary {
+        ADDON = QUOTE([{[false] call FUNC(setElements)}] call CBA_fnc_execNextFrame);
+    };
+};

--- a/addons/ui/XEH_PREP.hpp
+++ b/addons/ui/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(findSetElement);
 PREP(moduleInit);
 PREP(setAdvancedElement);
 PREP(setElements);

--- a/addons/ui/XEH_clientInit.sqf
+++ b/addons/ui/XEH_clientInit.sqf
@@ -5,10 +5,11 @@ if (!hasInterface) exitWith {};
 
 ["ace_settingsInitialized", {
     // Initial settings
-    [true] call FUNC(setElements);
+    [true, false] call FUNC(setElements);
 
     // On load and entering/exiting a vehicle
     ["ace_infoDisplayChanged", {
+        systemChat format ["hint %1", time];
         // Selective UI Advanced
         // Defaults must be set in this EH to make sure controls are activated and advanced settings can be modified
         private _force = [true, false] select (GVAR(allowSelectiveUI));
@@ -30,7 +31,7 @@ if (!hasInterface) exitWith {};
         params ["_name"];
 
         if (_name in ELEMENTS_BASIC) then {
-            [false] call FUNC(setElements);
+            [false, true] call FUNC(setElements);
         } else {
             if (isClass (configFile >> "ACE_UI" >> _name select [7])) then {
                 [_name select [7], missionNamespace getVariable _name, true] call FUNC(setAdvancedElement);

--- a/addons/ui/XEH_clientInit.sqf
+++ b/addons/ui/XEH_clientInit.sqf
@@ -5,11 +5,10 @@ if (!hasInterface) exitWith {};
 
 ["ace_settingsInitialized", {
     // Initial settings
-    [true, false] call FUNC(setElements);
+    [false] call FUNC(setElements);
 
     // On load and entering/exiting a vehicle
     ["ace_infoDisplayChanged", {
-        systemChat format ["hint %1", time];
         // Selective UI Advanced
         // Defaults must be set in this EH to make sure controls are activated and advanced settings can be modified
         private _force = [true, false] select (GVAR(allowSelectiveUI));
@@ -31,7 +30,7 @@ if (!hasInterface) exitWith {};
         params ["_name"];
 
         if (_name in ELEMENTS_BASIC) then {
-            [false, true] call FUNC(setElements);
+            [true] call FUNC(setElements);
         } else {
             if (isClass (configFile >> "ACE_UI" >> _name select [7])) then {
                 [_name select [7], missionNamespace getVariable _name, true] call FUNC(setAdvancedElement);

--- a/addons/ui/functions/fnc_findSetElement.sqf
+++ b/addons/ui/functions/fnc_findSetElement.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Jonpas
+ * Finds set element by element name and returns index, source of the set element and state.
+ *
+ * Arguments:
+ * 0: Element Name <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["ace_ui_ammoCount"] call ace_ui_fnc_findSetElement
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_element"];
+
+{
+    if (_element in _x) exitWith {
+        [_forEachIndex, _x select 0, _x select 2]
+    };
+    [-1, "", false]
+} forEach GVAR(elementsSet);

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -39,7 +39,6 @@ private _elements = getArray (_config >> "elements");
 {
     private _condition = call compile (getText _x);
     if !(_condition) exitWith {
-        TRACE_2("Condition False",_element,_x);
         // Display and print info which component forced the element except for default vehicle check
         if (_showHint) then {
             [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
@@ -51,16 +50,15 @@ private _elements = getArray (_config >> "elements");
 
 // Get setting from scripted API
 if (!_force) then {
-    private _index = GVAR(elementsSet) find [_element, _show];
-    if (_index == -1) then {
-        _index = GVAR(elementsSet) find [_element, !_show];
-        if (_index != -1) then {
-            if (_showHint) then {
-                [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
-                ACE_LOGINFO_1("Attempted modification of a forced User Interface element '%1'",_element);
-            };
-            _show = ((GVAR(elementsSet)) select _index) select 1;
+    private _setElement = [_element] call FUNC(findSetElement);
+    _setElement params ["_indexSet", "_sourceSet", "_showSet"];
+
+    if (_indexSet != -1) then {
+        if (_showHint) then {
+            [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
+            ACE_LOGINFO_2("Attempted modification of a forced User Interface element '%1' by '%2'",_element,_sourceSet);
         };
+        _show = _showSet;
     };
 };
 

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -43,6 +43,7 @@ private _elements = getArray (_config >> "elements");
         // Display and print info which component forced the element except for default vehicle check
         if (_showHint) then {
             [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
+            ACE_LOGINFO_2("Attempted modification of a forced User Interface element '%1' by '%2'",_element,configName _x);
         };
         _show = false;
     };
@@ -56,6 +57,7 @@ if (!_force) then {
         if (_index != -1) then {
             if (_showHint) then {
                 [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
+                ACE_LOGINFO_1("Attempted modification of a forced User Interface element '%1'",_element);
             };
             _show = ((GVAR(elementsSet)) select _index) select 1;
         };

--- a/addons/ui/functions/fnc_setElementVisibility.sqf
+++ b/addons/ui/functions/fnc_setElementVisibility.sqf
@@ -3,21 +3,23 @@
  * Setter for toggling advanced element visibility.
  *
  * Arguments:
- * 0: Set/Unset <BOOL>
- * 1: Element Name <ARRAY/STRING>
- * 2: Show/Hide Element <BOOL> (default: false)
+ * 0: Source <STRING>
+ * 1: Set/Unset <BOOL>
+ * 2: Element Name <STRING>
+ * 3: Show/Hide Element <BOOL> (default: false)
  *
  * Return Value:
  * None
  *
  * Example:
- * [true, "ace_ui_ammoCount", false] call ace_ui_fnc_setElementVisibility
+ * ["ace_reload", true, "ace_ui_ammoCount", false] call ace_ui_fnc_setElementVisibility
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
 params [
+    ["_source", "", [""]],
     ["_set", true, [true]],
     ["_element", "", [""]],
     ["_show", false, [true]]
@@ -28,32 +30,35 @@ if (!isClass (configFile >> "ACE_UI" >> _element)) exitWith {
     ACE_LOGWARNING_1("Element '%1' does not exist",_element);
 };
 
+if (_source == "" || {_element == ""}) exitWith {
+    ACE_LOGWARNING("Source or Element may not be empty strings!");
+};
+
 private _return = false;
+
+private _setElement = [_element] call FUNC(findSetElement);
+_setElement params ["_indexSet", "_sourceSet"];
 
 if (_set) then {
     // Exit if element has been set from another component, print warning if after interface initialization
-    if ([_element, _show] in GVAR(elementsSet) || {[_element, !_show] in GVAR(elementsSet)}) exitWith {
+    if (_indexSet != -1) exitWith {
         if (GVAR(interfaceInitialized)) then {
-            ACE_LOGWARNING_2("Element '%1' already set in %2",_element,GVAR(elementsSet));
+            ACE_LOGWARNING_2("Element '%1' already set by %2",_element,_sourceSet);
         };
     };
 
-    TRACE_3("Setting element",_element,_show,GVAR(elementsSet));
+    TRACE_4("Setting element",_source,_element,_show,GVAR(elementsSet));
     private _success = [_element, _show, false, true] call FUNC(setAdvancedElement);
 
     if (_success) then {
-        GVAR(elementsSet) pushBack [_element, _show];
+        GVAR(elementsSet) pushBack [_source, _element, _show];
         _return = true;
     };
 } else {
-    if ([_element, _show] in GVAR(elementsSet) || {[_element, !_show] in GVAR(elementsSet)}) then {
-        TRACE_3("Unsetting element",_element,_show,GVAR(elementsSet));
+    if (_indexSet != -1) then {
+        TRACE_4("Unsetting element",_sourceSet,_element,_show,GVAR(elementsSet));
 
-        private _index = GVAR(elementsSet) find [_element, _show];
-        if (_index == -1) then {
-            _index = GVAR(elementsSet) find [_element, !_show];
-        };
-        GVAR(elementsSet) deleteAt _index;
+        GVAR(elementsSet) deleteAt _indexSet;
 
         [_element, _show, false, true] call FUNC(setAdvancedElement);
         _return = true;

--- a/addons/ui/functions/fnc_setElements.sqf
+++ b/addons/ui/functions/fnc_setElements.sqf
@@ -3,8 +3,7 @@
  * Sets basic visible elements of the UI using showHUD setter.
  *
  * Arguments:
- * 0: Force change even when disallowed <BOOL> (default: false)
- * 1: Show Hint <BOOL> (default: false)
+ * 0: Show Hint <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -16,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-params ["_force", ["_showHint", false]];
+params [["_showHint", false]];
 
 if (isArray (missionConfigFile >> "showHUD")) exitWith {
     if (_showHint) then {

--- a/addons/ui/functions/fnc_setElements.sqf
+++ b/addons/ui/functions/fnc_setElements.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Force change even when disallowed <BOOL> (default: false)
+ * 1: Show Hint <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -15,9 +16,13 @@
  */
 #include "script_component.hpp"
 
-if (isArray (missionConfigFile >> "showHUD")) exitWith {};
+params ["_force", ["_showHint", false]];
 
-params [ ["_force", false, [true]] ];
+if (isArray (missionConfigFile >> "showHUD")) exitWith {
+    if (_showHint) then {
+        [LSTRING(Disabled)] call EFUNC(common,displayTextStructured);
+    };
+};
 
 ["ui", [
     true,


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #3907 
- Add disabled message on changing basic config which has been set (forced) by mission config
- Remove redundant parameter from basic `setElements`

Todo:
- [x] Add condition source when false to hint
- [x] Add source to scripted element setting API