### PR TITLE
Realistic names for APEX content

### DIFF
--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -644,4 +644,39 @@ class CfgVehicles {
     class Item_acc_flashlight: Item_Base_F {
         displayName="UTG Defender 126";
     };
+
+    // APEX/Tanoa
+
+    // Jeep Wrangler
+    class Offroad_02_unarmed_base_F;
+    class C_Offroad_02_unarmed_F: Offroad_02_unarmed_base_F {
+        displayName = CSTRING(C_Offroad_02_unarmed);
+    };
+    class C_Offroad_02_unarmed_F_black: C_Offroad_02_unarmed_F {
+        displayName = CSTRING(C_Offroad_02_unarmed_black);
+    };
+    class C_Offroad_02_unarmed_F_blue: C_Offroad_02_unarmed_F {
+        displayName = CSTRING(C_Offroad_02_unarmed_blue);
+    };
+    class C_Offroad_02_unarmed_F_green: C_Offroad_02_unarmed_F {
+        displayName = CSTRING(C_Offroad_02_unarmed_green);
+    };
+    class C_Offroad_02_unarmed_F_orange: C_Offroad_02_unarmed_F {
+        displayName = CSTRING(C_Offroad_02_unarmed_orange);
+    };
+
+    // Cessna
+    class Plane_Civil_01_base_F;
+    class C_Plane_Civil_01_F: Plane_Civil_01_base_F {
+        displayName = CSTRING(C_Plane_Civil_01);
+    };
+    class C_Plane_Civil_01_racing_F: Plane_Civil_01_base_F {
+        displayName = CSTRING(C_Plane_Civil_01_racing);
+    };
+
+    // Burraq
+    class UAV_04_base_F;
+    class O_T_UAV_04_CAS_F: UAV_04_base_F {
+        displayName = CSTRING(O_T_UAV_04_CAS);
+    };
 };

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -578,4 +578,111 @@ class CfgWeapons {
     class acc_flashlight: ItemCore {
         displayName = "UTG Defender 126";
     };
+
+    // APEX/Tanoa
+
+    // QBZ-95 and variants
+    class arifle_CTAR_base_F;
+    class arifle_CTAR_blk_F: arifle_CTAR_base_F {
+        displayName = CSTRING(arifle_CTAR_blk);
+    };
+    class arifle_CTAR_GL_base_F;
+    class arifle_CTAR_GL_blk_F: arifle_CTAR_GL_base_F {
+        displayName = CSTRING(arifle_CTAR_GL_blk);
+    };
+    class arifle_CTARS_base_F;
+    class arifle_CTARS_blk_F: arifle_CTARS_base_F {
+        displayName = CSTRING(arifle_CTARS_blk);
+    };
+
+    // QBU-88
+    class DMR_07_base_F;
+    class srifle_DMR_07_blk_F: DMR_07_base_F {
+        displayName = CSTRING(srifle_DMR_07_blk);
+    };
+    class srifle_DMR_07_ghex_F: DMR_07_base_F {
+        displayName = CSTRING(srifle_DMR_07_ghex);
+    };
+    class srifle_DMR_07_hex_F: DMR_07_base_F {
+        displayName = CSTRING(srifle_DMR_07_hex);
+    };
+
+    // GM6
+    class srifle_GM6_ghex_F: srifle_GM6_F {
+        displayName = CSTRING(srifle_GM6_ghex);
+    };
+
+    // M249
+    class LMG_03_base_F;
+    class LMG_03_F: LMG_03_base_F {
+        displayName = CSTRING(LMG_03);
+    };
+
+    // Intervention
+    class srifle_LRR_tna_F: srifle_LRR_camo_F {
+        displayName = CSTRING(srifle_LRR_tna);
+    };
+
+    // MP5
+    class SMG_05_base_F;
+    class SMG_05_F: SMG_05_base_F {
+        displayName = CSTRING(SMG_05);
+    };
+
+    // HK416 and variants
+    class arifle_SPAR_01_base_F;
+    class arifle_SPAR_01_blk_F: arifle_SPAR_01_base_F {
+        displayName = CSTRING(arifle_SPAR_01_blk);
+    };
+    class arifle_SPAR_01_khk_F: arifle_SPAR_01_base_F {
+        displayName = CSTRING(arifle_SPAR_01_khk);
+    };
+    class arifle_SPAR_01_snd_F: arifle_SPAR_01_base_F {
+        displayName = CSTRING(arifle_SPAR_01_snd);
+    };
+    class arifle_SPAR_01_GL_base_F;
+    class arifle_SPAR_01_GL_blk_F: arifle_SPAR_01_GL_base_F {
+        displayName = CSTRING(arifle_SPAR_01_GL_blk);
+    };
+    class arifle_SPAR_01_GL_khk_F: arifle_SPAR_01_GL_base_F {
+        displayName = CSTRING(arifle_SPAR_01_GL_khk);
+    };
+    class arifle_SPAR_01_GL_snd_F: arifle_SPAR_01_GL_base_F {
+        displayName = CSTRING(arifle_SPAR_01_GL_snd);
+    };
+    class arifle_SPAR_02_base_F;
+    class arifle_SPAR_02_blk_F: arifle_SPAR_02_base_F {
+        displayName = CSTRING(arifle_SPAR_02_blk);
+    };
+    class arifle_SPAR_02_khk_F: arifle_SPAR_02_base_F {
+        displayName = CSTRING(arifle_SPAR_02_khk);
+    };
+    class arifle_SPAR_02_snd_F: arifle_SPAR_02_base_F {
+        displayName = CSTRING(arifle_SPAR_02_snd);
+    };
+    class arifle_SPAR_03_base_F;
+    class arifle_SPAR_03_blk_F: arifle_SPAR_03_base_F {
+        displayName = CSTRING(arifle_SPAR_03_blk);
+    };
+    class arifle_SPAR_03_khk_F: arifle_SPAR_03_base_F {
+        displayName = CSTRING(arifle_SPAR_03_khk);
+    };
+    class arifle_SPAR_03_snd_F: arifle_SPAR_03_base_F {
+        displayName = CSTRING(arifle_SPAR_03_snd);
+    };
+
+    // RPG-32
+    class launch_RPG32_ghex_F: launch_RPG32_F {
+        displayName = CSTRING(launch_RPG32_ghex);
+    };
+
+    // P99
+    class hgun_P07_khk_F: hgun_P07_F {
+        displayName = CSTRING(hgun_P07_khk);
+    };
+
+    // Makarov
+    class hgun_Pistol_01_F: Pistol_Base_F {
+        displayName = CSTRING(hgun_Pistol_01);
+    };
 };

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1920,5 +1920,425 @@
             <Hungarian>LWMMG (Homok)</Hungarian>
             <Portuguese>LWMMG (Deserto)</Portuguese>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed">
+            <English>Jeep Wrangler</English>
+            <Czech>Jeep Wrangler</Czech>
+            <French>Jeep Wrangler</French>
+            <Spanish>Jeep Wrangler</Spanish>
+            <Russian>Jeep Wrangler</Russian>
+            <Polish>Jeep Wrangler</Polish>
+            <German>Jeep Wrangler</German>
+            <Italian>Jeep Wrangler</Italian>
+            <Hungarian>Jeep Wrangler</Hungarian>
+            <Portuguese>Jeep Wrangler</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed_black">
+            <English>Jeep Wrangler (Black)</English>
+            <Czech>Jeep Wrangler (Černá)</Czech>
+            <French>Jeep Wrangler (Noir)</French>
+            <Spanish>Jeep Wrangler (Negro)</Spanish>
+            <Russian>Jeep Wrangler (Чёрный)</Russian>
+            <Polish>Jeep Wrangler (Czarny)</Polish>
+            <German>Jeep Wrangler (Schwarz)</German>
+            <Italian>Jeep Wrangler (Nero)</Italian>
+            <Hungarian>Jeep Wrangler (Fekete)</Hungarian>
+            <Portuguese>Jeep Wrangler (Preto)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed_blue">
+            <English>Jeep Wrangler (Blue)</English>
+            <Czech>Jeep Wrangler (Blau)</Czech>
+            <French>Jeep Wrangler (Azul)</French>
+            <Spanish>Jeep Wrangler (Niebieski)</Spanish>
+            <Russian>Jeep Wrangler (Modrý)</Russian>
+            <Polish>Jeep Wrangler (Bleue)</Polish>
+            <German>Jeep Wrangler (Синий)</German>
+            <Italian>Jeep Wrangler (Azul)</Italian>
+            <Hungarian>Jeep Wrangler (Kék)</Hungarian>
+            <Portuguese>Jeep Wrangler (Blu)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed_green">
+            <English>Jeep Wrangler (Green)</English>
+            <Czech>Jeep Wrangler (Grün)</Czech>
+            <French>Jeep Wrangler (Verde)</French>
+            <Spanish>Jeep Wrangler (Zielony)</Spanish>
+            <Russian>Jeep Wrangler (Zelený)</Russian>
+            <Polish>Jeep Wrangler (Verte)</Polish>
+            <German>Jeep Wrangler (Зелёный)</German>
+            <Italian>Jeep Wrangler (Verde)</Italian>
+            <Hungarian>Jeep Wrangler (Zöld)</Hungarian>
+            <Portuguese>Jeep Wrangler (Verde)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed_orange">
+            <English>Jeep Wrangler (Orange)</English>
+            <Czech>Jeep Wrangler (Orange)</Czech>
+            <French>Jeep Wrangler (Naranja)</French>
+            <Spanish>Jeep Wrangler (Pomarańczowy)</Spanish>
+            <Russian>Jeep Wrangler (Oranžový)</Russian>
+            <Polish>Jeep Wrangler (Orange)</Polish>
+            <German>Jeep Wrangler (Оранжевый)</German>
+            <Italian>Jeep Wrangler (Laranja)</Italian>
+            <Hungarian>Jeep Wrangler (Narancssárga)</Hungarian>
+            <Portuguese>Jeep Wrangler (Arancione)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed_red">
+            <English>Jeep Wrangler (Red)</English>
+            <Czech>Jeep Wrangler (Rot)</Czech>
+            <French>Jeep Wrangler (Rojo)</French>
+            <Spanish>Jeep Wrangler (Czerwony)</Spanish>
+            <Russian>Jeep Wrangler (Červený)</Russian>
+            <Polish>Jeep Wrangler (Rouge)</Polish>
+            <German>Jeep Wrangler (Красный)</German>
+            <Italian>Jeep Wrangler (Vermelha)</Italian>
+            <Hungarian>Jeep Wrangler (Piros)</Hungarian>
+            <Portuguese>Jeep Wrangler (Rosso)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_unarmed_white">
+            <English>Jeep Wrangler (White)</English>
+            <Czech>Jeep Wrangler (Weiss)</Czech>
+            <French>Jeep Wrangler (Blanco)</French>
+            <Spanish>Jeep Wrangler (Biały)</Spanish>
+            <Russian>Jeep Wrangler (Bílý)</Russian>
+            <Polish>Jeep Wrangler (Blanche)</Polish>
+            <German>Jeep Wrangler (Белый)</German>
+            <Italian>Jeep Wrangler (Branca)</Italian>
+            <Hungarian>Jeep Wrangler (Fehér)</Hungarian>
+            <Portuguese>Jeep Wrangler (Bianco)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Plane_Civil_01">
+            <English>Cessna TTx</English>
+            <Czech>Cessna TTx</Czech>
+            <French>Cessna TTx</French>
+            <Spanish>Cessna TTx</Spanish>
+            <Russian>Cessna TTx</Russian>
+            <Polish>Cessna TTx</Polish>
+            <German>Cessna TTx</German>
+            <Italian>Cessna TTx</Italian>
+            <Hungarian>Cessna TTx</Hungarian>
+            <Portuguese>Cessna TTx</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Plane_Civil_01_racing">
+            <English>Cessna TTx (Racing)</English>
+            <Czech>Cessna TTx (Racing)</Czech>
+            <French>Cessna TTx (Racing)</French>
+            <Spanish>Cessna TTx (Racing)</Spanish>
+            <Russian>Cessna TTx (Racing)</Russian>
+            <Polish>Cessna TTx (Racing)</Polish>
+            <German>Cessna TTx (Racing)</German>
+            <Italian>Cessna TTx (Racing)</Italian>
+            <Hungarian>Cessna TTx (Racing)</Hungarian>
+            <Portuguese>Cessna TTx (Racing)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_O_T_UAV_04_CAS">
+            <English>Burraq UCAV</English>
+            <Czech>Burraq UCAV</Czech>
+            <French>Burraq UCAV</French>
+            <Spanish>Burraq UCAV</Spanish>
+            <Russian>Burraq UCAV</Russian>
+            <Polish>Burraq UCAV</Polish>
+            <German>Burraq UCAV</German>
+            <Italian>Burraq UCAV</Italian>
+            <Hungarian>Burraq UCAV</Hungarian>
+            <Portuguese>Burraq UCAV</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_CTAR_blk">
+            <English>QBZ-95-1 (Black)</English>
+            <Czech>QBZ-95-1 (Černá)</Czech>
+            <French>QBZ-95-1 (Noir)</French>
+            <Spanish>QBZ-95-1 (Negro)</Spanish>
+            <Russian>QBZ-95-1 (Чёрный)</Russian>
+            <Polish>QBZ-95-1 (Czarny)</Polish>
+            <German>QBZ-95-1 (Schwarz)</German>
+            <Italian>QBZ-95-1 (Nero)</Italian>
+            <Hungarian>QBZ-95-1 (Fekete)</Hungarian>
+            <Portuguese>QBZ-95-1 (Preto)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_CTAR_GL_blk">
+            <English>QBZ-95-1 GL (Black)</English>
+            <Czech>QBZ-95-1 GL (Černá)</Czech>
+            <French>QBZ-95-1 GL (Noir)</French>
+            <Spanish>QBZ-95-1 GL (Negro)</Spanish>
+            <Russian>QBZ-95-1 GL (Чёрный)</Russian>
+            <Polish>QBZ-95-1 GL (Czarny)</Polish>
+            <German>QBZ-95-1 GL (Schwarz)</German>
+            <Italian>QBZ-95-1 GL (Nero)</Italian>
+            <Hungarian>QBZ-95-1 GL (Fekete)</Hungarian>
+            <Portuguese>QBZ-95-1 GL (Preto)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_CTARS_blk">
+            <English>QBZ-95-1 LSW (Black)</English>
+            <Czech>QBZ-95-1 LSW (Černá)</Czech>
+            <French>QBZ-95-1 LSW (Noir)</French>
+            <Spanish>QBZ-95-1 LSW (Negro)</Spanish>
+            <Russian>QBZ-95-1 LSW (Чёрный)</Russian>
+            <Polish>QBZ-95-1 LSW (Czarny)</Polish>
+            <German>QBZ-95-1 LSW (Schwarz)</German>
+            <Italian>QBZ-95-1 LSW (Nero)</Italian>
+            <Hungarian>QBZ-95-1 LSW (Fekete)</Hungarian>
+            <Portuguese>QBZ-95-1 LSW (Preto)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_srifle_DMR_07_blk">
+            <English>QBU-88 (Black)</English>
+            <Czech>QBU-88 (Černá)</Czech>
+            <French>QBU-88 (Noir)</French>
+            <Spanish>QBU-88 (Negro)</Spanish>
+            <Russian>QBU-88 (Чёрный)</Russian>
+            <Polish>QBU-88 (Czarny)</Polish>
+            <German>QBU-88 (Schwarz)</German>
+            <Italian>QBU-88 (Nero)</Italian>
+            <Hungarian>QBU-88 (Fekete)</Hungarian>
+            <Portuguese>QBU-88 (Preto)</Portuguese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_srifle_DMR_07_ghex">
+            <English>QBU-88 (Green Hex)</English>
+            <German>QBU-88 (Hex Grün)</German>
+            <Spanish>QBU-88 (Hex Verde)</Spanish>
+            <Polish>QBU-88 (Zielony Hex)</Polish>
+            <Czech>QBU-88 (Zelený Hex)</Czech>
+            <French>QBU-88 (Hex Verte)</French>
+            <Russian>QBU-88 (Зелёный Hex)</Russian>
+            <Portuguese>QBU-88 (Verde Hex)</Portuguese>
+            <Hungarian>QBU-88 (Zöld Hex)</Hungarian>
+            <Italian>QBU-88 (Hex Verde)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_srifle_DMR_07_hex">
+            <English>QBU-88 (Hex)</English>
+            <German>QBU-88 (Hex)</German>
+            <Spanish>QBU-88 (Hex)</Spanish>
+            <Polish>QBU-88 (Hex)</Polish>
+            <Czech>QBU-88 (Hex)</Czech>
+            <French>QBU-88 (Hex)</French>
+            <Russian>QBU-88 (Hex)</Russian>
+            <Portuguese>QBU-88 (Hex)</Portuguese>
+            <Hungarian>QBU-88 (Hex)</Hungarian>
+            <Italian>QBU-88 (Hex)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_srifle_GM6_ghex">
+            <English>GM6 Lynx (Green Hex)</English>
+            <German>GM6 Lynx (Hex Grün)</German>
+            <Spanish>GM6 Lynx (Hex Verde)</Spanish>
+            <Polish>GM6 Lynx (Zielony Hex)</Polish>
+            <Czech>GM6 Lynx (Zelený Hex)</Czech>
+            <French>GM6 Lynx (Hex Verte)</French>
+            <Russian>GM6 Lynx (Зелёный Hex)</Russian>
+            <Portuguese>GM6 Lynx (Verde Hex)</Portuguese>
+            <Hungarian>GM6 Lynx (Zöld Hex)</Hungarian>
+            <Italian>GM6 Lynx (Hex Verde)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_LMG_03">
+            <English>M249 SPW</English>
+            <German>M249 SPW</German>
+            <Spanish>M249 SPW</Spanish>
+            <Polish>M249 SPW</Polish>
+            <Czech>M249 SPW</Czech>
+            <French>M249 SPW</French>
+            <Russian>M249 SPW</Russian>
+            <Portuguese>M249 SPW</Portuguese>
+            <Hungarian>M249 SPW</Hungarian>
+            <Italian>M249 SPW</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_srifle_LRR_tna">
+            <English>M200 Intervention (Tropic)</English>
+            <German>M200 Intervention (Tropisch)</German>
+            <Czech>M200 Intervention (Obratník)</Czech>
+            <Polish>M200 Intervention (Zwrotnik)</Polish>
+            <French>M200 Intervention (Tropique)</French>
+            <Hungarian>M200 Intervention (Tropikus)</Hungarian>
+            <Spanish>M200 Intervention (Trópico)</Spanish>
+            <Russian>M200 Intervention (тропик)</Russian>
+            <Portuguese>M200 Intervention (Trópico)</Portuguese>
+            <Italian>M200 Intervention (Tropico)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_SMG_05">
+            <English>MP5K</English>
+            <German>MP5K</German>
+            <Spanish>MP5K</Spanish>
+            <Polish>MP5K</Polish>
+            <Czech>MP5K</Czech>
+            <French>MP5K</French>
+            <Russian>MP5K</Russian>
+            <Portuguese>MP5K</Portuguese>
+            <Hungarian>MP5K</Hungarian>
+            <Italian>MP5K</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_01_blk">
+            <English>HK416A5 10" (Black)</English>
+            <German>HK416A5 10" (Černá)</German>
+            <Spanish>HK416A5 10" (Noir)</Spanish>
+            <Polish>HK416A5 10" (Negro)</Polish>
+            <Czech>HK416A5 10" (Чёрный)</Czech>
+            <French>HK416A5 10" (Czarny)</French>
+            <Russian>HK416A5 10" (Schwarz)</Russian>
+            <Portuguese>HK416A5 10" (Nero)</Portuguese>
+            <Hungarian>HK416A5 10" (Fekete)</Hungarian>
+            <Italian>HK416A5 10" (Preto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_01_khk">
+            <English>HK416A5 10" (Khaki)</English>
+            <German>HK416A5 10" (Khaki)</German>
+            <Spanish>HK416A5 10" (Kaki)</Spanish>
+            <Polish>HK416A5 10" (Caqui)</Polish>
+            <Czech>HK416A5 10" (Хаки)</Czech>
+            <French>HK416A5 10" (Khaki)</French>
+            <Russian>HK416A5 10" (Khaki)</Russian>
+            <Portuguese>HK416A5 10" (Khaki)</Portuguese>
+            <Hungarian>HK416A5 10" (Khaki)</Hungarian>
+            <Italian>HK416A5 10" (Caqui)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_01_snd">
+            <English>HK416A5 10" (Sand)</English>
+            <German>HK416A5 10" (Písková)</German>
+            <Spanish>HK416A5 10" (Beige)</Spanish>
+            <Polish>HK416A5 10" (Arena)</Polish>
+            <Czech>HK416A5 10" (Песочный)</Czech>
+            <French>HK416A5 10" (Sand)</French>
+            <Russian>HK416A5 10" (piaskowy)</Russian>
+            <Portuguese>HK416A5 10" (Sabbia)</Portuguese>
+            <Hungarian>HK416A5 10" (Homok)</Hungarian>
+            <Italian>HK416A5 10" (Deserto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_01_GL_blk">
+            <English>HK416A5 10" GL (Black)</English>
+            <German>HK416A5 10" GL (Černá)</German>
+            <Spanish>HK416A5 10" GL (Noir)</Spanish>
+            <Polish>HK416A5 10" GL (Negro)</Polish>
+            <Czech>HK416A5 10" GL (Чёрный)</Czech>
+            <French>HK416A5 10" GL (Czarny)</French>
+            <Russian>HK416A5 10" GL (Schwarz)</Russian>
+            <Portuguese>HK416A5 10" GL (Nero)</Portuguese>
+            <Hungarian>HK416A5 10" GL (Fekete)</Hungarian>
+            <Italian>HK416A5 10" GL (Preto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_01_GL_khk">
+            <English>HK416A5 10" GL (Khaki)</English>
+            <German>HK416A5 10" GL (Khaki)</German>
+            <Spanish>HK416A5 10" GL (Kaki)</Spanish>
+            <Polish>HK416A5 10" GL (Caqui)</Polish>
+            <Czech>HK416A5 10" GL (Хаки)</Czech>
+            <French>HK416A5 10" GL (Khaki)</French>
+            <Russian>HK416A5 10" GL (Khaki)</Russian>
+            <Portuguese>HK416A5 10" GL (Khaki)</Portuguese>
+            <Hungarian>HK416A5 10" GL (Khaki)</Hungarian>
+            <Italian>HK416A5 10" GL (Caqui)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_01_GL_snd">
+            <English>HK416A5 10" GL (Sand)</English>
+            <German>HK416A5 10" GL (Písková)</German>
+            <Spanish>HK416A5 10" GL (Beige)</Spanish>
+            <Polish>HK416A5 10" GL (Arena)</Polish>
+            <Czech>HK416A5 10" GL (Песочный)</Czech>
+            <French>HK416A5 10" GL (Sand)</French>
+            <Russian>HK416A5 10" GL (piaskowy)</Russian>
+            <Portuguese>HK416A5 10" GL (Sabbia)</Portuguese>
+            <Hungarian>HK416A5 10" GL (Homok)</Hungarian>
+            <Italian>HK416A5 10" GL (Deserto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_02_blk">
+            <English>HK416A5 14.5" (Black)</English>
+            <German>HK416A5 14.5" (Černá)</German>
+            <Spanish>HK416A5 14.5" (Noir)</Spanish>
+            <Polish>HK416A5 14.5" (Negro)</Polish>
+            <Czech>HK416A5 14.5" (Чёрный)</Czech>
+            <French>HK416A5 14.5" (Czarny)</French>
+            <Russian>HK416A5 14.5" (Schwarz)</Russian>
+            <Portuguese>HK416A5 14.5" (Nero)</Portuguese>
+            <Hungarian>HK416A5 14.5" (Fekete)</Hungarian>
+            <Italian>HK416A5 14.5" (Preto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_02_khk">
+            <English>HK416A5 14.5" (Khaki)</English>
+            <German>HK416A5 14.5" (Khaki)</German>
+            <Spanish>HK416A5 14.5" (Kaki)</Spanish>
+            <Polish>HK416A5 14.5" (Caqui)</Polish>
+            <Czech>HK416A5 14.5" (Хаки)</Czech>
+            <French>HK416A5 14.5" (Khaki)</French>
+            <Russian>HK416A5 14.5" (Khaki)</Russian>
+            <Portuguese>HK416A5 14.5" (Khaki)</Portuguese>
+            <Hungarian>HK416A5 14.5" (Khaki)</Hungarian>
+            <Italian>HK416A5 14.5" (Caqui)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_02_snd">
+            <English>HK416A5 14.5" (Sand)</English>
+            <German>HK416A5 14.5" (Písková)</German>
+            <Spanish>HK416A5 14.5" (Beige)</Spanish>
+            <Polish>HK416A5 14.5" (Arena)</Polish>
+            <Czech>HK416A5 14.5" (Песочный)</Czech>
+            <French>HK416A5 14.5" (Sand)</French>
+            <Russian>HK416A5 14.5" (piaskowy)</Russian>
+            <Portuguese>HK416A5 14.5" (Sabbia)</Portuguese>
+            <Hungarian>HK416A5 14.5" (Homok)</Hungarian>
+            <Italian>HK416A5 14.5" (Deserto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_03_blk">
+            <English>HK417A2 20" (Black)</English>
+            <German>HK417A2 20" (Černá)</German>
+            <Spanish>HK417A2 20" (Noir)</Spanish>
+            <Polish>HK417A2 20" (Negro)</Polish>
+            <Czech>HK417A2 20" (Чёрный)</Czech>
+            <French>HK417A2 20" (Czarny)</French>
+            <Russian>HK417A2 20" (Schwarz)</Russian>
+            <Portuguese>HK417A2 20" (Nero)</Portuguese>
+            <Hungarian>HK417A2 20" (Fekete)</Hungarian>
+            <Italian>HK417A2 20" (Preto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_03_khk">
+            <English>HK417A2 20" (Khaki)</English>
+            <German>HK417A2 20" (Khaki)</German>
+            <Spanish>HK417A2 20" (Kaki)</Spanish>
+            <Polish>HK417A2 20" (Caqui)</Polish>
+            <Czech>HK417A2 20" (Хаки)</Czech>
+            <French>HK417A2 20" (Khaki)</French>
+            <Russian>HK417A2 20" (Khaki)</Russian>
+            <Portuguese>HK417A2 20" (Khaki)</Portuguese>
+            <Hungarian>HK417A2 20" (Khaki)</Hungarian>
+            <Italian>HK417A2 20" (Caqui)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_SPAR_03_snd">
+            <English>HK417A2 20" (Sand)</English>
+            <German>HK417A2 20" (Písková)</German>
+            <Spanish>HK417A2 20" (Beige)</Spanish>
+            <Polish>HK417A2 20" (Arena)</Polish>
+            <Czech>HK417A2 20" (Песочный)</Czech>
+            <French>HK417A2 20" (Sand)</French>
+            <Russian>HK417A2 20" (piaskowy)</Russian>
+            <Portuguese>HK417A2 20" (Sabbia)</Portuguese>
+            <Hungarian>HK417A2 20" (Homok)</Hungarian>
+            <Italian>HK417A2 20" (Deserto)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_launch_RPG32_ghex">
+            <English>RPG-32 (Green Hex)</English>
+            <German>RPG-32 (Hex Grün)</German>
+            <Spanish>RPG-32 (Hex Verde)</Spanish>
+            <Polish>RPG-32 (Zielony Hex)</Polish>
+            <Czech>RPG-32 (Zelený Hex)</Czech>
+            <French>RPG-32 (Hex Verte)</French>
+            <Russian>RPG-32 (Зелёный Hex)</Russian>
+            <Portuguese>RPG-32 (Verde Hex)</Portuguese>
+            <Hungarian>RPG-32 (Zöld Hex)</Hungarian>
+            <Italian>RPG-32 (Hex Verde)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_hgun_P07_khk">
+            <English>P99 (Khaki)</English>
+            <German>P99 (Khaki)</German>
+            <Spanish>P99 (Kaki)</Spanish>
+            <Polish>P99 (Caqui)</Polish>
+            <Czech>P99 (Хаки)</Czech>
+            <French>P99 (Khaki)</French>
+            <Russian>P99 (Khaki)</Russian>
+            <Portuguese>P99 (Khaki)</Portuguese>
+            <Hungarian>P99 (Khaki)</Hungarian>
+            <Italian>P99 (Caqui)</Italian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_hgun_Pistol_01">
+            <English>Makarov PM</English>
+            <German>Makarov PM</German>
+            <Spanish>Makarov PM</Spanish>
+            <Polish>Makarowa PM</Polish>
+            <Czech>Makarov PM</Czech>
+            <French>Makarov PM</French>
+            <Russian>Макарова ПМ</Russian>
+            <Portuguese>Makarov PM</Portuguese>
+            <Hungarian>Makarov PM</Hungarian>
+            <Italian>Makarov PM</Italian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add realistic names for APEX content

Note:
Both LSVs seem to look very similar to existing vehicles (namely the [Polaris Defense DAGOR](http://soldiersystems.net/blog1/wp-content/uploads/2014/10/WDP_8727-Front-Three-Quarters-mid-hight_Wht.jpg) and the [LSV Mk.II](http://www2.tnp.sg/sites/default/files/styles/medium/public/01c9c2cb.jpg?itok=dRpONFAw)), but they're not quite the same so they keep their original name.

*I would like some feedback on the translation of "Green Hex".*