### PR TITLE
Fix no gray screen for advanced medical

### DIFF
--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -151,11 +151,16 @@ GVAR(effectTimeBlood) = CBA_missionTime;
     // Bleeding Indicator
     if (_bleeding > 0 and GVAR(effectTimeBlood) + 3.5 < CBA_missionTime) then {
         GVAR(effectTimeBlood) = CBA_missionTime;
-        [600 * _bleeding] call BIS_fnc_bloodEffect;
+        [600 * _bleeding] call FUNC(showBloodEffect);
     };
 
     // Blood Volume Effect
-    _blood = (ACE_player getVariable [QGVAR(bloodVolume), 100]) / 100;
+    _blood = if (GVAR(level) < 2) then {
+        (ACE_player getVariable [QGVAR(bloodVolume), 100]) / 100;
+    } else {
+        (((ACE_player getVariable [QGVAR(bloodVolume), 100]) - 60) max 0) / 40;
+    };
+
     if (_blood > 0.99) then {
         GVAR(effectBloodVolumeCC) ppEffectEnable false;
     } else {


### PR DESCRIPTION
Advanced medical was never displaying the gray screen on low blood volume. This is because for advanced medical, the blood volume minimum level is around 40 before death. For basic medical, this is 0.

This PR scales the gray screen for advanced medical to the correct levels.

#3134 