### PR TITLE
Improve zeus auto-add XEH behaviour

### DIFF
--- a/addons/zeus/CfgEventHandlers.hpp
+++ b/addons/zeus/CfgEventHandlers.hpp
@@ -16,11 +16,3 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };
-
-class Extended_InitPost_EventHandlers {
-    class AllVehicles {
-        class ADDON {
-            serverInit = QUOTE(call FUNC(addObjectToCurator));
-        };
-    };
-};

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -1,5 +1,12 @@
 #include "script_component.hpp"
 
+["ace_settingsInitialized",{
+    // Only add an InitPost EH if setting is enabled (and apply retroactively)
+    if (isServer && GVAR(autoAddObjects)) then {
+        ["AllVehicles", "InitPost", FUNC(addObjectToCurator), true, [], true] call CBA_fnc_addClassEventHandler;
+    };
+}] call CBA_fnc_addEventHandler;
+
 // Global skill module PVs values for persistence, just listen for the PV
 QGVAR(GlobalSkillAI) addPublicVariableEventHandler FUNC(moduleGlobalSetSkill);
 

--- a/addons/zeus/functions/fnc_addObjectToCurator.sqf
+++ b/addons/zeus/functions/fnc_addObjectToCurator.sqf
@@ -15,11 +15,6 @@
 
 params ["_object"];
 
-if !(EGVAR(common,settingsInitFinished)) exitWith {
-    TRACE_1("pushing to runAtSettingsInitialized", _this);
-    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addObjectToCurator), _this];
-};
-
 if (!(_object getVariable [QGVAR(addObject), GVAR(autoAddObjects)])) exitWith {};
 
 [{


### PR DESCRIPTION
**When merged this pull request will:**
- Add the InitPost XEH event to `AllVehicles` only if the `autoAddObjects` setting is enabled

The XEH InitPost event only needs to be added if the `GVAR(autoAddObjects)` setting is enabled. This change will save on overhead when the setting is disabled and also removes some complexity from the function that runs in response to the event.