### PR TITLE
Fix Comanche's weapon lock and guidance

### DIFF
--- a/addons/laser_selfdesignate/CfgWeapons.hpp
+++ b/addons/laser_selfdesignate/CfgWeapons.hpp
@@ -6,6 +6,6 @@ class CfgWeapons {
     };
 
     class missiles_DAGR: RocketPods {
-        canLock = 1;
+        //canLock = 1;
     };
 };

--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -10,34 +10,34 @@ class CfgAmmo {
         model = "\A3\Weapons_F\Ammo\Rocket_01_fly_F";
         proxyShape = "\A3\Weapons_F\Ammo\Rocket_01_F";
 
-        irLock = 0;
-        laserLock = 1;
-        airLock = 0;
-        weaponLockSystem = "4 + 16";
+        // Reenable this settings when ACE laser targeting and missile guidance is reenabled
+        //laserLock = 1;
+        //airLock = 0;
+        //irLock = 0;
+        //weaponLockSystem = "4 + 16";
+        //fuseDistance = 2;
+        //timeToLive = 60;
+        // Turn off arma crosshair-guidance
+        //manualControl = 0;
+        // ACE uses these values
+        //trackOversteer = 1;
+        //trackLead = 0;
 
         maxSpeed = 720;
         maxControlRange = 5000;
         maneuvrability = 8;
-        timeToLive = 60;
+
         simulationStep = 0.01;
         airFriction = 0.1;
         sideAirFriction = 0.16;
         initTime = 0.002;
         thrustTime = 1.07;
         thrust = 530;
-        fuseDistance = 2;
 
         effectsMissileInit = "MissileDAR1";
         effectsMissile = "missile2";
         whistleDist = 4;
         muzzleEffect = "";
-
-        // Turn off arma crosshair-guidance
-        manualControl = 0;
-
-        // ACE uses these values
-        trackOversteer = 1;
-        trackLead = 0;
     };
 
     class ACE_Hydra70_DAGR: M_PG_AT {


### PR DESCRIPTION
**When merged this pull request will:**
- Completely restore the Comanche's DAGRs to vanilla. 
- Close #3671

If you recall, for 3.5 we decided to restore vanilla locking guidance for the Comanche, until ACE_Laser and ACE_MissileGuidance were made to work properly with non-self designators. That was done in #3305. However, there were some wrong config entries remaining on the DAGR ammo, which messed up vanilla behaviour, causing #3671. In this PR those entries are removed.

I still hope we can reenable ACE_Laser at some point, but there are still quite a few tasks remaining, tracked in #3308. In the meantime, hopefully this will make Comanche as OP as it is in Vanilla ;)

