### PR TITLE
Fix freeing prisoners after they've switched locality

### DIFF
--- a/addons/captives/CfgEventHandlers.hpp
+++ b/addons/captives/CfgEventHandlers.hpp
@@ -55,3 +55,11 @@ class Extended_Respawn_EventHandlers {
         };
     };
 };
+
+class Extended_Local_EventHandlers {
+    class CAManBase {
+        class ADDON {
+            local = QUOTE(call FUNC(handleLocal));
+        };
+    };
+};

--- a/addons/captives/XEH_PREP.hpp
+++ b/addons/captives/XEH_PREP.hpp
@@ -16,6 +16,7 @@ PREP(doUnloadCaptive);
 PREP(findEmptyNonFFVCargoSeat);
 PREP(handleGetIn);
 PREP(handleGetOut);
+PREP(handleLocal);
 PREP(handleOnUnconscious);
 PREP(handlePlayerChanged);
 PREP(handleRespawn);

--- a/addons/captives/XEH_PREP.hpp
+++ b/addons/captives/XEH_PREP.hpp
@@ -15,6 +15,7 @@ PREP(doRemoveHandcuffs);
 PREP(doUnloadCaptive);
 PREP(findEmptyNonFFVCargoSeat);
 PREP(handleAnimChangedHandcuffed);
+PREP(handleAnimChangedSurrendered);
 PREP(handleGetIn);
 PREP(handleGetOut);
 PREP(handleLocal);

--- a/addons/captives/XEH_PREP.hpp
+++ b/addons/captives/XEH_PREP.hpp
@@ -14,6 +14,7 @@ PREP(doLoadCaptive);
 PREP(doRemoveHandcuffs);
 PREP(doUnloadCaptive);
 PREP(findEmptyNonFFVCargoSeat);
+PREP(handleAnimChangedHandcuffed);
 PREP(handleGetIn);
 PREP(handleGetOut);
 PREP(handleLocal);

--- a/addons/captives/functions/fnc_handleAnimChangedHandcuffed.sqf
+++ b/addons/captives/functions/fnc_handleAnimChangedHandcuffed.sqf
@@ -1,0 +1,37 @@
+/*
+ * Author: Nic547, commy2
+ * Restart the handcuffing animation if it got interrupted. Called from a AnimChanged EH.
+ *
+ * Arguments:
+ * 0: The Unit <OBJECT>
+ * 1: New animation <STRING>
+ *
+ * ReturnValue:
+ * None
+ *
+ * Public: No
+ */
+
+
+#include "script_component.hpp"
+
+params ["_unit", "_newAnimation"];
+TRACE_2("AnimChanged",_unit,_newAnimation);
+if (_unit == (vehicle _unit)) then {
+    if ((_newAnimation != "ACE_AmovPercMstpSsurWnonDnon") && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
+        TRACE_1("Handcuff animation interrupted",_newAnimation);
+        [_unit, "ACE_AmovPercMstpScapWnonDnon", 1] call EFUNC(common,doAnimation);
+    };
+} else {
+    _turretPath = [];
+    {
+        _x params ["_xUnit", "", "", "_xTurretPath"];
+        if (_unit == _xUnit) exitWith {_turretPath = _xTurretPath};
+    } forEach (fullCrew (vehicle _unit));
+    TRACE_1("turret Path",_turretPath);
+    if (_turretPath isEqualTo []) exitWith {};
+
+    TRACE_1("Handcuff (FFV) animation interrupted",_newAnimation);
+    [_unit, "ACE_HandcuffedFFV", 2] call EFUNC(common,doAnimation);
+    [_unit, "ACE_HandcuffedFFV", 1] call EFUNC(common,doAnimation);
+};

--- a/addons/captives/functions/fnc_handleAnimChangedSurrendered.sqf
+++ b/addons/captives/functions/fnc_handleAnimChangedSurrendered.sqf
@@ -1,0 +1,24 @@
+/*
+ * Author: Nic547, commy2
+ * Restart the surrendering animation if it got interrupted. Called from a AnimChanged EH.
+ *
+ * Arguments:
+ * 0: The Unit <OBJECT>
+ * 1: New animation <STRING>
+ *
+ * ReturnValue:
+ * None
+ *
+ * Public: No
+ */
+
+
+#include "script_component.hpp"
+
+params ["_unit", "_newAnimation"];
+
+TRACE_2("AnimChanged",_unit,_newAnimation);
+if ((_newAnimation != "ACE_AmovPercMstpSsurWnonDnon") && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
+    TRACE_1("Surrender animation interrupted",_newAnimation);
+    [_unit, "ACE_AmovPercMstpSsurWnonDnon", 1] call EFUNC(common,doAnimation);
+};

--- a/addons/captives/functions/fnc_handleLocal.sqf
+++ b/addons/captives/functions/fnc_handleLocal.sqf
@@ -25,28 +25,7 @@ if (_local) then {
     if (_unit getVariable [QGVAR(handcuffAnimEHID), -1] != -1) exitWith {};
 
     // Otherwise, restart the AnimChanged EH in the new machine
-    _animChangedEHID = _unit addEventHandler ["AnimChanged", {
-        params ["_unit", "_newAnimation"];
-        TRACE_2("AnimChanged",_unit,_newAnimation);
-        if (_unit == (vehicle _unit)) then {
-            if ((_newAnimation != "ACE_AmovPercMstpSsurWnonDnon") && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
-                TRACE_1("Handcuff animation interrupted",_newAnimation);
-                [_unit, "ACE_AmovPercMstpScapWnonDnon", 1] call EFUNC(common,doAnimation);
-            };
-        } else {
-            _turretPath = [];
-            {
-                _x params ["_xUnit", "", "", "_xTurretPath"];
-                if (_unit == _xUnit) exitWith {_turretPath = _xTurretPath};
-            } forEach (fullCrew (vehicle _unit));
-            TRACE_1("turret Path",_turretPath);
-            if (_turretPath isEqualTo []) exitWith {};
-
-            TRACE_1("Handcuff (FFV) animation interrupted",_newAnimation);
-            [_unit, "ACE_HandcuffedFFV", 2] call EFUNC(common,doAnimation);
-            [_unit, "ACE_HandcuffedFFV", 1] call EFUNC(common,doAnimation);
-        };
-    }];
+    _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChanged)];
     TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
     _unit setVariable [QGVAR(handcuffAnimEHID), _animChangedEHID];
 } else {
@@ -55,7 +34,7 @@ if (_local) then {
     if (_animChangedEHID == -1) exitWith {};
 
     // If the unit had a AnimChanged EH in the old machine then remove it
-    TRACE_1("removing animChanged EH",_animChangedEHID);
+    TRACE_1("Removing animChanged EH",_animChangedEHID);
     _unit removeEventHandler ["AnimChanged", _animChangedEHID];
     _unit setVariable [QGVAR(handcuffAnimEHID), -1];
 };

--- a/addons/captives/functions/fnc_handleLocal.sqf
+++ b/addons/captives/functions/fnc_handleLocal.sqf
@@ -17,24 +17,47 @@
 
 params ["_unit", "_local"];
 
-// Make sure that if the unit is captive it has a AnimChanged EH running ONLY on the machine that owns it
+// Make sure that if the unit is captive or surrendered it has a AnimChanged EH running ONLY on the machine that owns it
 if (_local) then {
-    // If the unit is not handcuffed there's nothing to do
-    if !(_unit getVariable [QGVAR(isHandcuffed), false]) exitWith {};
-    // If the unit already has an AnimChanged EH here then there's nothing to do either
-    if (_unit getVariable [QGVAR(handcuffAnimEHID), -1] != -1) exitWith {};
 
-    // Otherwise, restart the AnimChanged EH in the new machine
-    _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChanged)];
-    TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
-    _unit setVariable [QGVAR(handcuffAnimEHID), _animChangedEHID];
+    // If the unit is handcuffed
+    if (_unit getVariable [QGVAR(isHandcuffed), false]) then {
+        // If the unit already has an AnimChanged EH here then there's nothing to do either
+        if (_unit getVariable [QGVAR(handcuffAnimEHID), -1] != -1) exitWith {};
+
+        // Otherwise, restart the AnimChanged EH in the new machine
+        private _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChangedHandcuffed)];
+        TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
+        _unit setVariable [QGVAR(handcuffAnimEHID), _animChangedEHID];
+    };
+
+    // If the unit is surrendering
+    if (_unit getVariable [QGVAR(isSurrendering), false]) then {
+        // If the unit already has an AnimChanged EH here then there's nothing to do either
+        if (_unit getVariable [QGVAR(surrenderAnimEHID), -1] != -1) exitWith {};
+
+        // Otherwise, restart the AnimChanged EH in the new machine
+        private _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChangedSurrendered)];
+        TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
+        _unit setVariable [QGVAR(surrenderAnimEHID), _animChangedEHID];
+    };
+
 } else {
-    private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];
-    // If the unit didn't have an AnimChanged EH here, do nothing
-    if (_animChangedEHID == -1) exitWith {};
 
-    // If the unit had a AnimChanged EH in the old machine then remove it
-    TRACE_1("Removing animChanged EH",_animChangedEHID);
-    _unit removeEventHandler ["AnimChanged", _animChangedEHID];
-    _unit setVariable [QGVAR(handcuffAnimEHID), -1];
+    private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];
+    if (_animChangedEHID != -1) then {
+        // If the unit had a AnimChanged EH for handcuffing in the old machine then remove it
+        TRACE_1("Removing animChanged EH",_animChangedEHID);
+        _unit removeEventHandler ["AnimChanged", _animChangedEHID];
+        _unit setVariable [QGVAR(handcuffAnimEHID), -1];
+    };
+
+    _animChangedEHID = _unit getVariable [QGVAR(surrenderAnimEHID), -1];
+    if (_animChangedEHID != -1) then {
+        // If the unit had a AnimChanged EH for handcuffing in the old machine then remove it
+        TRACE_1("Removing animChanged EH",_animChangedEHID);
+        _unit removeEventHandler ["AnimChanged", _animChangedEHID];
+        _unit setVariable [QGVAR(surrenderAnimEHID), -1];
+    };
+
 };

--- a/addons/captives/functions/fnc_handleLocal.sqf
+++ b/addons/captives/functions/fnc_handleLocal.sqf
@@ -1,0 +1,61 @@
+/*
+ * Author: esteldunedain
+ * Called when a unit switched locality
+ *
+ * Arguments:
+ * 0: The Unit <OBJECT>
+ * 1: Is local <BOOL>
+ *
+ * ReturnValue:
+ * None
+ *
+ * Public: No
+ */
+
+
+#include "script_component.hpp"
+
+params ["_unit", "_local"];
+
+// Make sure that if the unit is captive it has a AnimChanged EH running ONLY on the machine that owns it
+if (_local) then {
+    // If the unit is not handcuffed there's nothing to do
+    if !(_unit getVariable [QGVAR(isHandcuffed), false]) exitWith {};
+    // If the unit already has an AnimChanged EH here then there's nothing to do either
+    if (_unit getVariable [QGVAR(handcuffAnimEHID), -1] != -1) exitWith {};
+
+    // Otherwise, restart the AnimChanged EH in the new machine
+    _animChangedEHID = _unit addEventHandler ["AnimChanged", {
+        params ["_unit", "_newAnimation"];
+        TRACE_2("AnimChanged",_unit,_newAnimation);
+        if (_unit == (vehicle _unit)) then {
+            if ((_newAnimation != "ACE_AmovPercMstpSsurWnonDnon") && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
+                TRACE_1("Handcuff animation interrupted",_newAnimation);
+                [_unit, "ACE_AmovPercMstpScapWnonDnon", 1] call EFUNC(common,doAnimation);
+            };
+        } else {
+            _turretPath = [];
+            {
+                _x params ["_xUnit", "", "", "_xTurretPath"];
+                if (_unit == _xUnit) exitWith {_turretPath = _xTurretPath};
+            } forEach (fullCrew (vehicle _unit));
+            TRACE_1("turret Path",_turretPath);
+            if (_turretPath isEqualTo []) exitWith {};
+
+            TRACE_1("Handcuff (FFV) animation interrupted",_newAnimation);
+            [_unit, "ACE_HandcuffedFFV", 2] call EFUNC(common,doAnimation);
+            [_unit, "ACE_HandcuffedFFV", 1] call EFUNC(common,doAnimation);
+        };
+    }];
+    TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
+    _unit setVariable [QGVAR(handcuffAnimEHID), _animChangedEHID];
+} else {
+    private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];
+    // If the unit didn't have an AnimChanged EH here, do nothing
+    if (_animChangedEHID == -1) exitWith {};
+
+    // If the unit had a AnimChanged EH in the old machine then remove it
+    TRACE_1("removing animChanged EH",_animChangedEHID);
+    _unit removeEventHandler ["AnimChanged", _animChangedEHID];
+    _unit setVariable [QGVAR(handcuffAnimEHID), -1];
+};

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -73,7 +73,7 @@ if (_state) then {
             TRACE_1("removing animChanged EH",_animChangedEHID);
             _unit removeEventHandler ["AnimChanged", _animChangedEHID];
         };
-        _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChanged)];
+        _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChangedHandcuffed)];
         TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
         _unit setVariable [QGVAR(handcuffAnimEHID), _animChangedEHID];
 

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -73,28 +73,7 @@ if (_state) then {
             TRACE_1("removing animChanged EH",_animChangedEHID);
             _unit removeEventHandler ["AnimChanged", _animChangedEHID];
         };
-        _animChangedEHID = _unit addEventHandler ["AnimChanged", {
-            params ["_unit", "_newAnimation"];
-            TRACE_2("AnimChanged",_unit,_newAnimation);
-            if (_unit == (vehicle _unit)) then {
-                if ((_newAnimation != "ACE_AmovPercMstpSsurWnonDnon") && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
-                    TRACE_1("Handcuff animation interrupted",_newAnimation);
-                    [_unit, "ACE_AmovPercMstpScapWnonDnon", 1] call EFUNC(common,doAnimation);
-                };
-            } else {
-                _turretPath = [];
-                {
-                    _x params ["_xUnit", "", "", "_xTurretPath"];
-                    if (_unit == _xUnit) exitWith {_turretPath = _xTurretPath};
-                } forEach (fullCrew (vehicle _unit));
-                TRACE_1("turret Path",_turretPath);
-                if (_turretPath isEqualTo []) exitWith {};
-
-                TRACE_1("Handcuff (FFV) animation interrupted",_newAnimation);
-                [_unit, "ACE_HandcuffedFFV", 2] call EFUNC(common,doAnimation);
-                [_unit, "ACE_HandcuffedFFV", 1] call EFUNC(common,doAnimation);
-            };
-        }];
+        _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChanged)];
         TRACE_2("Adding animChangedEH",_unit,_animChangedEHID);
         _unit setVariable [QGVAR(handcuffAnimEHID), _animChangedEHID];
 

--- a/addons/captives/functions/fnc_setSurrendered.sqf
+++ b/addons/captives/functions/fnc_setSurrendered.sqf
@@ -64,13 +64,7 @@ if (_state) then {
                 TRACE_1("removing animChanged EH",_animChangedEHID);
                 _unit removeEventHandler ["AnimChanged", _animChangedEHID];
             };
-            _animChangedEHID = _unit addEventHandler ["AnimChanged", {
-                params ["_unit", "_newAnimation"];
-                if ((_newAnimation != "ACE_AmovPercMstpSsurWnonDnon") && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
-                    TRACE_1("Surrender animation interrupted",_newAnimation);
-                    [_unit, "ACE_AmovPercMstpSsurWnonDnon", 1] call EFUNC(common,doAnimation);
-                };
-            }];
+            _animChangedEHID = _unit addEventHandler ["AnimChanged", DFUNC(handleAnimChangedSurrendered)];
             _unit setVariable [QGVAR(surrenderAnimEHID), _animChangedEHID];
         };
     }, [_unit], 0.01] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Make sure that if a captive unit switches locality, it's AnimChanged EH switches with it.
- Close #3950

I only did limited testing, but it seems to work as expected.