### PR TITLE
fix some rogue mission dependencies

### DIFF
--- a/addons/aircraft/config.cpp
+++ b/addons/aircraft/config.cpp
@@ -11,6 +11,9 @@ class CfgPatches {
         authors[] = {"KoffeinFlummi","Crusty","commy2","jaynus","Kimi"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
     };
 };
 

--- a/addons/fcs/config.cpp
+++ b/addons/fcs/config.cpp
@@ -11,6 +11,9 @@ class CfgPatches {
         authors[] = {"KoffeinFlummi","BadGuy (simon84)","commy2"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
     };
 };
 

--- a/addons/gforces/config.cpp
+++ b/addons/gforces/config.cpp
@@ -11,6 +11,9 @@ class CfgPatches {
         authors[] = {"KoffeinFlummi", "esteldunedain"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
     };
 };
 

--- a/addons/realisticnames/config.cpp
+++ b/addons/realisticnames/config.cpp
@@ -11,6 +11,9 @@ class CfgPatches {
         authors[] = {"KoffeinFlummi","TaoSensai","commy2"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
     };
 };
 

--- a/addons/vehicles/config.cpp
+++ b/addons/vehicles/config.cpp
@@ -11,6 +11,9 @@ class CfgPatches {
         authors[] = {"commy2","KoffeinFlummi"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- adds `addonRootClass` so some of our components are ignored by the 1.60 CfgPatches changes for mission dependencies.

