### PR TITLE
add function to report a blood type which is fixed to the units name

### DIFF
--- a/addons/dogtags/XEH_PREP.hpp
+++ b/addons/dogtags/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 PREP(addDogtagActions);
 PREP(addDogtagItem);
+PREP(bloodType);
 PREP(canCheckDogtag);
 PREP(canTakeDogtag);
 PREP(checkDogtag);

--- a/addons/dogtags/functions/fnc_bloodType.sqf
+++ b/addons/dogtags/functions/fnc_bloodType.sqf
@@ -1,0 +1,24 @@
+/*
+ * Author: commy2
+ * Reports a blood type depending on the units name.
+ *
+ * Arguments:
+ * 0: Name of a unit <STRING>
+ *
+ * Return Value:
+ * A random blood type <STRING>
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+#define BLOOD_TYPES ["O POS", "O NEG", "A POS", "A NEG", "B POS", "B NEG", "AB POS", "AB NEG"]
+
+params ["_name"];
+
+private _num = 0;
+private _count = {_num = _num + _x} count toArray _name;
+
+_num = _num + _count;
+
+BLOOD_TYPES select (_num % count BLOOD_TYPES)

--- a/addons/dogtags/functions/fnc_getDogtagData.sqf
+++ b/addons/dogtags/functions/fnc_getDogtagData.sqf
@@ -19,13 +19,14 @@ private _dogTagData = _target getVariable QGVAR(dogtagData);
 if (!isNil "_dogTagData") exitWith {_dogTagData};
 
 // Create dog tag data once for the unit: nickname, code (eg. 135-13-900) and blood type
+private _targetName = [_target, false, true] call EFUNC(common,getName);
+
 private _dogTagData = [
-    [_target, false, true] call EFUNC(common,getName),
+    _targetName,
     str(floor random 9) + str(floor random 9) + str(floor random 9) + "-" +
         str(floor random 9) + str(floor random 9) + "-" +
         str(floor random 9) + str(floor random 9) + str(floor random 9),
-    selectRandom ["O POS", "O NEG", "A POS", "A NEG", "B POS", "B NEG",
-        "AB POS", "AB NEG"]
+    _targetName call FUNC(bloodType)
 ];
 // Store it
 _target setVariable [QGVAR(dogtagData), _dogTagData, true];


### PR DESCRIPTION
**When merged this pull request will:**
- adds a function that reports a blood type depending on the units name
- This will make sure the blood type of a player doesn't change each mission or even each respawn
