### PR TITLE
Fix issue with dogtag respawn/setVariable

### DIFF
--- a/addons/dogtags/functions/fnc_canCheckDogtag.sqf
+++ b/addons/dogtags/functions/fnc_canCheckDogtag.sqf
@@ -17,4 +17,4 @@ params ["_player", "_target"];
 
 if (isNull _target) exitWith {false};
 
-!alive _target || _target getVariable ["ACE_isUnconscious", false]
+(!alive _target) || {_target getVariable ["ACE_isUnconscious", false]}

--- a/addons/dogtags/functions/fnc_canTakeDogtag.sqf
+++ b/addons/dogtags/functions/fnc_canTakeDogtag.sqf
@@ -17,4 +17,4 @@ params ["_player", "_target"];
 
 if (isNull _target) exitWith {false};
 
-!alive _target || _target getVariable ["ACE_isUnconscious", false]
+(!alive _target) || {_target getVariable ["ACE_isUnconscious", false]}

--- a/addons/dogtags/functions/fnc_checkDogtag.sqf
+++ b/addons/dogtags/functions/fnc_checkDogtag.sqf
@@ -15,7 +15,7 @@
 
 params ["_player", "_target"];
 
-private _doubleTags = !(_target getVariable [QGVAR(dogtagTaken), false]);
+private _doubleTags = (_target getVariable [QGVAR(dogtagTaken), objNull]) != _target;
 private _dogTagData = [_target] call FUNC(getDogTagData);
 
 [QGVAR(showDogtag), [_dogTagData, _doubleTags]] call CBA_fnc_localEvent;

--- a/addons/dogtags/functions/fnc_getDogtagItem.sqf
+++ b/addons/dogtags/functions/fnc_getDogtagItem.sqf
@@ -23,7 +23,7 @@ private _allDogtagDatas = missionNamespace getVariable [QGVAR(allDogtagDatas), [
 
 private _nextID = count _allDogtags + 1;
 
-if (_nextID > 999) exitWith {};
+if (_nextID > 999) exitWith {ACE_LOGERROR("Ran out of IDs");};
 
 private _dogTagData = [_target] call FUNC(getDogTagData);
 private _item = format ["ACE_dogtag_%1", _nextID];

--- a/addons/dogtags/functions/fnc_takeDogtag.sqf
+++ b/addons/dogtags/functions/fnc_takeDogtag.sqf
@@ -16,9 +16,9 @@
 
 params ["_player", "_target"];
 
-if (_target getVariable [QGVAR(dogtagTaken), false]) then {
+if ((_target getVariable [QGVAR(dogtagTaken), objNull]) == _target) then {
     [localize LSTRING(dogtagAlreadyTaken)] call EFUNC(common,displayText);
 } else {
-    _target setVariable [QGVAR(dogtagTaken), true, true];
+    _target setVariable [QGVAR(dogtagTaken), _target, true];
     [QGVAR(getDogtagItem), [_player, _target]] call CBA_fnc_serverEvent;
 };


### PR DESCRIPTION
Because you can take dogtags when they are just unconscios, you can set the `dogtagTaken` var before they die, so it will get copied over to respawned unit.

This PR will:
Store object instead of bool to indicate when dogtags have been taken
When object re-spawns, the the old object reference won't apply