### PR TITLE
Generate SSN of unit from their name

### DIFF
--- a/addons/dogtags/XEH_PREP.hpp
+++ b/addons/dogtags/XEH_PREP.hpp
@@ -9,4 +9,5 @@ PREP(getDogtagData);
 PREP(getDogtagItem);
 PREP(sendDogtagData);
 PREP(showDogtag);
+PREP(ssn);
 PREP(takeDogtag);

--- a/addons/dogtags/functions/fnc_getDogtagData.sqf
+++ b/addons/dogtags/functions/fnc_getDogtagData.sqf
@@ -23,9 +23,7 @@ private _targetName = [_target, false, true] call EFUNC(common,getName);
 
 private _dogTagData = [
     _targetName,
-    str(floor random 10) + str(floor random 10) + str(floor random 10) + "-" +
-        str(floor random 10) + str(floor random 10) + "-" +
-        str(floor random 10) + str(floor random 10) + str(floor random 10),
+    _targetName call FUNC(ssn),
     _targetName call FUNC(bloodType)
 ];
 // Store it

--- a/addons/dogtags/functions/fnc_ssn.sqf
+++ b/addons/dogtags/functions/fnc_ssn.sqf
@@ -6,18 +6,26 @@
  * 0: Name of a unit <STRING>
  *
  * Return Value:
- * A random social security number <STRING>
+ * A random three/two/four format social security number <STRING>
  *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_name"];
+private _length = count _name;
+private _chars = toArray _name;
 
-private _nums = ((toArray _name) select [0,9]) apply { _x % 10 };
-
-while {count _nums < 9} do {
-    _nums pushBack (floor random 10);
+// For short names, reuse characters
+if (_length < 9) then {
+    // Iterates every second character, swapping odd/even with each loop
+    for [{_i = 0},{_i < 2*(9 - _length)},{_i = _i + 2}] do {
+        _chars pushBack (_chars select floor((_i + (_i/_length % 2)) % _length));
+    };
 };
+
+// Offset array slice for long names to make generation more unique
+private _slice = [0, _length % 9] select (_length > 9);
+private _nums = (_chars select [_slice, 9]) apply { _x % 10 };
 
 ([_nums select [0,3],_nums select [3,2], _nums select [5,4]] apply { _x joinString "" }) joinString "-"

--- a/addons/dogtags/functions/fnc_ssn.sqf
+++ b/addons/dogtags/functions/fnc_ssn.sqf
@@ -1,0 +1,23 @@
+/*
+ * Author: SilentSpike
+ * Reports a social security number generated from the units name.
+ *
+ * Arguments:
+ * 0: Name of a unit <STRING>
+ *
+ * Return Value:
+ * A random social security number <STRING>
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_name"];
+
+private _nums = ((toArray _name) select [0,9]) apply { _x % 10 };
+
+while {count _nums < 9} do {
+    _nums pushBack (floor random 10);
+};
+
+([_nums select [0,3],_nums select [3,2], _nums select [5,4]] apply { _x joinString "" }) joinString "-"


### PR DESCRIPTION
Similar to how we're handling blood types, uses the unit's name to generate a valid three/two/four format SSN.

For names less than 9 characters long this will currently generate a unique SSN only up to the length of the name and append valid digits as necessary. Not sure how best to handle those cases.

Output of some tests:

SilentSpike: 358-10-6325
esteldunedain: 156-18-0701
commy2: 919-91-0645 / 919-91-0774 / 919-91-0750
Glowbal: 181-98-7836 / 181-98-7837 / 181-98-7805
jonpas: 610-27-5955 / 610-27-5081 / 610-27-5438

#3962