### PR TITLE
Rename events

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-["ace_addCargoByClass", {_this call FUNC(addCargoItem)}] call CBA_fnc_addEventHandler;
+["ace_addCargo", {_this call FUNC(addCargoItem)}] call CBA_fnc_addEventHandler;
 
 ["ace_loadCargo", {
     params ["_item", "_vehicle"];

--- a/addons/cargo/config.cpp
+++ b/addons/cargo/config.cpp
@@ -23,8 +23,8 @@ class ACE_newEvents {
     LoadCargo = "ace_loadCargo";
     cargoUnloaded = "ace_cargoUnloaded";
     cargoLoaded = "ace_cargoLoaded";
-    AddCargoByClass = "ace_addCargoByClass";
+    AddCargoByClass = "ace_addCargo";
     ServerUnloadCargo = QGVAR(serverUnload);
     UnloadCargo = "ace_unloadCargo";
-    cargoAddedByClass = "ace_cargoByClassAdded";
+    cargoAddedByClass = "ace_cargoAdded";
 };

--- a/addons/cargo/config.cpp
+++ b/addons/cargo/config.cpp
@@ -26,5 +26,5 @@ class ACE_newEvents {
     AddCargoByClass = "ace_addCargoByClass";
     ServerUnloadCargo = QGVAR(serverUnload);
     UnloadCargo = "ace_unloadCargo";
-    cargoAddedByClass = "ace_cargoAddedByClass";
+    cargoAddedByClass = "ace_cargoByClassAdded";
 };

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -26,4 +26,4 @@ for "_i" from 1 to _amount do {
 };
 
 // Invoke listenable event
-["ace_cargoByClassAdded", [_itemClass, _vehicle, _amount]] call CBA_fnc_globalEvent;
+["ace_cargoAdded", [_itemClass, _vehicle, _amount]] call CBA_fnc_globalEvent;

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -26,4 +26,4 @@ for "_i" from 1 to _amount do {
 };
 
 // Invoke listenable event
-["ace_cargoAddedByClass", [_itemClass, _vehicle, _amount]] call CBA_fnc_globalEvent;
+["ace_cargoByClassAdded", [_itemClass, _vehicle, _amount]] call CBA_fnc_globalEvent;

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -29,7 +29,7 @@ if (isServer) then {
             _cargoClassname = getText (_x >> "type");
             _cargoCount = getNumber (_x >> "amount");
             TRACE_3("adding ACE_Cargo", (configName _x), _cargoClassname, _cargoCount);
-            ["ace_addCargoByClass", [_cargoClassname, _vehicle, _cargoCount]] call CBA_fnc_localEvent;
+            ["ace_addCargo", [_cargoClassname, _vehicle, _cargoCount]] call CBA_fnc_localEvent;
         };
     } count ("true" configClasses (configFile >> "CfgVehicles" >> _type >> "ACE_Cargo" >> "Cargo"));
 };

--- a/addons/explosives/XEH_postInit.sqf
+++ b/addons/explosives/XEH_postInit.sqf
@@ -29,16 +29,16 @@ if (isServer) then {
         [_unit] call FUNC(onIncapacitated);
     }] call CBA_fnc_addEventHandler;
 
-    [QGVAR(clientRequestOrientations), {
+    [QGVAR(requestOrientations), {
         params ["_logic"];
-        TRACE_1("clientRequestsOrientations received:",_logic);
+        TRACE_1("requestOrientations received:",_logic);
         // Filter the array before sending it
         GVAR(explosivesOrientations) = GVAR(explosivesOrientations) select {
             _x params ["_explosive"];
             (!isNull _explosive && {alive _explosive})
         };
-        TRACE_1("serverSendsOrientations sent:",GVAR(explosivesOrientations));
-        [QGVAR(serverSendOrientations), [GVAR(explosivesOrientations)], _logic] call CBA_fnc_targetEvent;
+        TRACE_1("sendOrientations sent:",GVAR(explosivesOrientations));
+        [QGVAR(sendOrientations), [GVAR(explosivesOrientations)], _logic] call CBA_fnc_targetEvent;
     }] call CBA_fnc_addEventHandler;
 };
 
@@ -52,9 +52,9 @@ GVAR(CurrentSpeedDial) = 0;
 // In case we are a JIP client, ask the server for orientation of any previously
 // placed mine.
 if (didJIP) then {
-    [QGVAR(serverSendOrientations), {
+    [QGVAR(sendOrientations), {
         params ["_explosivesOrientations"];
-        TRACE_1("serverSendsOrientations received:",_explosivesOrientations);
+        TRACE_1("sendOrientations received:",_explosivesOrientations);
         {
             _x params ["_explosive","_direction","_pitch"];
             TRACE_3("orientation set:",_explosive,_direction,_pitch);
@@ -66,8 +66,8 @@ if (didJIP) then {
 
     //  Create a logic to get the client ID
     GVAR(localLogic) = ([sideLogic] call CBA_fnc_getSharedGroup) createUnit ["Logic", [0,0,0], [], 0, "NONE"];
-    TRACE_1("clientRequestsOrientations sent:",GVAR(localLogic));
-    [QGVAR(clientRequestOrientations), [GVAR(localLogic)]] call CBA_fnc_serverEvent;
+    TRACE_1("requestOrientations sent:",GVAR(localLogic));
+    [QGVAR(requestOrientations), [GVAR(localLogic)]] call CBA_fnc_serverEvent;
 };
 
 ["ace_interactMenuOpened", {

--- a/addons/explosives/XEH_postInit.sqf
+++ b/addons/explosives/XEH_postInit.sqf
@@ -29,16 +29,16 @@ if (isServer) then {
         [_unit] call FUNC(onIncapacitated);
     }] call CBA_fnc_addEventHandler;
 
-    [QGVAR(requestOrientations), {
+    [QGVAR(sendOrientations), {
         params ["_logic"];
-        TRACE_1("requestOrientations received:",_logic);
+        TRACE_1("sendOrientations received:",_logic);
         // Filter the array before sending it
         GVAR(explosivesOrientations) = GVAR(explosivesOrientations) select {
             _x params ["_explosive"];
             (!isNull _explosive && {alive _explosive})
         };
-        TRACE_1("sendOrientations sent:",GVAR(explosivesOrientations));
-        [QGVAR(sendOrientations), [GVAR(explosivesOrientations)], _logic] call CBA_fnc_targetEvent;
+        TRACE_1("orientationsSent sent:",GVAR(explosivesOrientations));
+        [QGVAR(orientationsSent), [GVAR(explosivesOrientations)], _logic] call CBA_fnc_targetEvent;
     }] call CBA_fnc_addEventHandler;
 };
 
@@ -52,9 +52,9 @@ GVAR(CurrentSpeedDial) = 0;
 // In case we are a JIP client, ask the server for orientation of any previously
 // placed mine.
 if (didJIP) then {
-    [QGVAR(sendOrientations), {
+    [QGVAR(orientationsSent), {
         params ["_explosivesOrientations"];
-        TRACE_1("sendOrientations received:",_explosivesOrientations);
+        TRACE_1("orientationsSent received:",_explosivesOrientations);
         {
             _x params ["_explosive","_direction","_pitch"];
             TRACE_3("orientation set:",_explosive,_direction,_pitch);
@@ -66,8 +66,8 @@ if (didJIP) then {
 
     //  Create a logic to get the client ID
     GVAR(localLogic) = ([sideLogic] call CBA_fnc_getSharedGroup) createUnit ["Logic", [0,0,0], [], 0, "NONE"];
-    TRACE_1("requestOrientations sent:",GVAR(localLogic));
-    [QGVAR(requestOrientations), [GVAR(localLogic)]] call CBA_fnc_serverEvent;
+    TRACE_1("sendOrientations sent:",GVAR(localLogic));
+    [QGVAR(sendOrientations), [GVAR(localLogic)]] call CBA_fnc_serverEvent;
 };
 
 ["ace_interactMenuOpened", {

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -46,6 +46,6 @@ class CfgMineTriggers {
 };
 
 class ACE_newEvents {
-    clientRequestsOrientations = QGVAR(requestOrientations);
-    serverSendsOrientations = QGVAR(sendOrientations);
+    clientRequestsOrientations = QGVAR(sendOrientations);
+    serverSendsOrientations = QGVAR(orientationsSent);
 };

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -46,6 +46,6 @@ class CfgMineTriggers {
 };
 
 class ACE_newEvents {
-    clientRequestsOrientations = QGVAR(clientRequestOrientations);
-    serverSendsOrientations = QGVAR(serverSendOrientations);
+    clientRequestsOrientations = QGVAR(requestOrientations);
+    serverSendsOrientations = QGVAR(sendOrientations);
 };

--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -18,12 +18,12 @@ ACE_Modifier = 0;
     _unit doMove _position;
 }] call CBA_fnc_addEventHandler;
 
-[QGVAR(lampTurnOn), {
+[QGVAR(setLampOn), {
     params ["_lamp", "_hitPointsDamage", "_disabledLampDMG"];
     {if((_x select 1) == _disabledLampDMG) then {_lamp setHit [_x select 0, 0];};nil} count _hitPointsDamage;
 }] call CBA_fnc_addEventHandler;
 
-[QGVAR(lampTurnOff), {
+[QGVAR(setLampOff), {
     params ["_lamp", "_hitPointsDamage", "_disabledLampDMG"];
     {_lamp setHit [_x select 0, (_x select 1) max _disabledLampDMG];nil} count _hitPointsDamage;
 }] call CBA_fnc_addEventHandler;

--- a/addons/interaction/config.cpp
+++ b/addons/interaction/config.cpp
@@ -25,6 +25,6 @@ class ACE_newEvents {
     pardon = QGVAR(pardon);
     tapShoulder = QGVAR(tapShoulder);
     sendAway = QGVAR(sendAway);
-    lampTurnOff = QGVAR(lampTurnOff);
-    lampTurnOn = QGVAR(lampTurnOn);
+    lampTurnOff = QGVAR(setLampOff);
+    lampTurnOn = QGVAR(setLampOn);
 };

--- a/addons/interaction/functions/fnc_switchLamp.sqf
+++ b/addons/interaction/functions/fnc_switchLamp.sqf
@@ -29,7 +29,7 @@ private _hitPointsDamage = [];
 } count _reflectors;
 
 //if lamp is on turn it off
-private _eventName = [QGVAR(lampTurnOn), QGVAR(lampTurnOff)] select _isOn;
+private _eventName = [QGVAR(setLampOn), QGVAR(setLampOff)] select _isOn;
 [_eventName, [_lamp, _hitPointsDamage, DISABLED_LAMP_DMG], [_lamp]] call CBA_fnc_targetEvent;
 
 _lamp setVariable ["ACE_lampOn", !_isOn, true];

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -29,12 +29,12 @@ class CfgPatches {
 
 class ACE_newEvents {
     medical_onUnconscious = "ace_unconscious";
-    medical_treatmentSuccess = "ace_treatmentSuccess";
+    medical_treatmentSuccess = "ace_treatmentSucceded";
     medical_onSetDead = "ace_killed";
-    Medical_onEnteredCardiacArrest = "ace_enteredCardiacArrest";
-    Medical_onItemAddedToTriageCard = "ace_itemAddedToTriageCard";
+    Medical_onEnteredCardiacArrest = "ace_cardiacArrestEntered";
+    Medical_onItemAddedToTriageCard = "ace_triageCardItemAdded";
     medical_onLogEntryAdded = "ace_medicalLogEntryAdded";
-    Medical_onHeartRateAdjustmentAdded = "ace_addedHeartRateAdjustment";
+    Medical_onHeartRateAdjustmentAdded = "ace_heartRateAdjustmentAdded";
     placedInBodyBag = "ace_placedInBodyBag";
     actionPlaceInBodyBag = QGVAR(actionPlaceInBodyBag);
     treatmentTourniquetLocal = QGVAR(treatmentTourniquetLocal);

--- a/addons/medical/functions/fnc_addHeartRateAdjustment.sqf
+++ b/addons/medical/functions/fnc_addHeartRateAdjustment.sqf
@@ -22,4 +22,4 @@ private _adjustment = _unit getVariable [QGVAR(heartRateAdjustments), []];
 _adjustment pushBack [_value, _time, _callBack];
 _unit setVariable [QGVAR(heartRateAdjustments), _adjustment];
 
-["ace_addedHeartRateAdjustment", [_unit, _value, _time]] call CBA_fnc_localEvent;
+["ace_heartRateAdjustmentAdded", [_unit, _value, _time]] call CBA_fnc_localEvent;

--- a/addons/medical/functions/fnc_addToTriageCard.sqf
+++ b/addons/medical/functions/fnc_addToTriageCard.sqf
@@ -39,4 +39,4 @@ if (!_inList) then {
     _log pushBack [_newItem, 1, CBA_missionTime];
 };
 _unit setVariable [QGVAR(triageCard), _log, true];
-["ace_itemAddedToTriageCard", [_unit, _newItem, _amount]] call CBA_fnc_localEvent;
+["ace_triageCardItemAdded", [_unit, _newItem, _amount]] call CBA_fnc_localEvent;

--- a/addons/medical/functions/fnc_setCardiacArrest.sqf
+++ b/addons/medical/functions/fnc_setCardiacArrest.sqf
@@ -21,7 +21,7 @@ if (_unit getVariable [QGVAR(inCardiacArrest),false]) exitWith {};
 _unit setVariable [QGVAR(inCardiacArrest), true,true];
 _unit setVariable [QGVAR(heartRate), 0];
 
-["ace_enteredCardiacArrest", [_unit]] call CBA_fnc_localEvent;
+["ace_cardiacArrestEntered", [_unit]] call CBA_fnc_localEvent;
 
 [_unit, true] call FUNC(setUnconscious);
 _timeInCardiacArrest = 120 + round(random(600));

--- a/addons/medical/functions/fnc_treatment_success.sqf
+++ b/addons/medical/functions/fnc_treatment_success.sqf
@@ -94,4 +94,4 @@ if (!(_target getVariable [QGVAR(addedToUnitLoop),false])) then {
     [_target] call FUNC(addVitalLoop);
 };
 
-["ace_treatmentSuccess", [_caller, _target, _selectionName, _className]] call CBA_fnc_localEvent;
+["ace_treatmentSucceded", [_caller, _target, _selectionName, _className]] call CBA_fnc_localEvent;

--- a/addons/medical_menu/XEH_postInit.sqf
+++ b/addons/medical_menu/XEH_postInit.sqf
@@ -6,7 +6,7 @@ GVAR(MenuPFHID) = -1;
 GVAR(lastOpenedOn) = -1;
 GVAR(pendingReopen) = false;
 
-["ace_treatmentSuccess", {
+["ace_treatmentSucceded", {
     if (GVAR(openAfterTreatment) && {GVAR(pendingReopen)}) then {
         GVAR(pendingReopen) = false;
         [{

--- a/addons/overheating/XEH_postInit.sqf
+++ b/addons/overheating/XEH_postInit.sqf
@@ -35,8 +35,8 @@ if (hasInterface) then {
         GVAR(storedSpareBarrels) = [] call CBA_fnc_hashCreate;
 
         // Install event handlers for spare barrels
-        [QGVAR(spareBarrelsSendTemperatureHint), FUNC(sendSpareBarrelsTemperaturesHint)] call CBA_fnc_addEventHandler;
-        [QGVAR(spareBarrelsLoadCoolest), FUNC(loadCoolestSpareBarrel)] call CBA_fnc_addEventHandler;
+        [QGVAR(sendSpareBarrelTemperatureHint), FUNC(sendSpareBarrelsTemperaturesHint)] call CBA_fnc_addEventHandler;
+        [QGVAR(loadCoolestSpareBarrel), FUNC(loadCoolestSpareBarrel)] call CBA_fnc_addEventHandler;
 
         // Schedule cool down calculation of stored spare barrels
         [] call FUNC(updateSpareBarrelsTemperaturesThread);
@@ -60,7 +60,7 @@ if (hasInterface) then {
 
     // Schedule cool down calculation of player weapons at (infrequent) regular intervals
     [] call FUNC(updateTemperatureThread);
-    
+
     // Install event handler to display temp when a barrel was swapped
     [QGVAR(showWeaponTemperature), DFUNC(displayTemperature)] call CBA_fnc_addEventHandler;
     // Install event handler to initiate an assisted barrel swap

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -55,7 +55,7 @@ class CfgGesturesMale {
 class ACE_newEvents {
     initiateSwapBarrelAssisted = QGVAR(initiateSwapBarrelAssisted);
     showWeaponTemperature = QGVAR(showWeaponTemperature);
-    spareBarrelsLoadCoolest = QGVAR(spareBarrelsLoadCoolest);
-    spareBarrelsSendTemperatureHint = QGVAR(spareBarrelsSendTemperatureHint);
+    loadCoolestSpareBarrel = QGVAR(loadCoolestSpareBarrel);
+    sendSpareBarrelTemperatureHint = QGVAR(sendSpareBarrelTemperatureHint);
     weaponJammed = "ace_weaponJammed";
 };

--- a/addons/overheating/functions/fnc_checkSpareBarrelsTemperatures.sqf
+++ b/addons/overheating/functions/fnc_checkSpareBarrelsTemperatures.sqf
@@ -29,7 +29,7 @@ if (!([_player, objNull, ["isNotInside", "isNotSitting"]] call EFUNC(common,canI
         params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
         _args params ["_player"];
         // Time has enlapsed, ask the server to send the hint
-        [QGVAR(spareBarrelsSendTemperatureHint), [_player, _player]] call CBA_fnc_serverEvent;
+        [QGVAR(sendSpareBarrelTemperatureHint), [_player, _player]] call CBA_fnc_serverEvent;
     },
     {},
     (localize LSTRING(CheckingSpareBarrelsTemperatures)),

--- a/addons/overheating/functions/fnc_swapBarrelCallback.sqf
+++ b/addons/overheating/functions/fnc_swapBarrelCallback.sqf
@@ -37,7 +37,7 @@ private _barrelMass = 0.50 * (getNumber (configFile >> "CfgWeapons" >> _weapon >
 // store the removed barrel with the former weapon temperature. The server
 // also updates the current weapon temperature to match that of the new
 // loaded barrel.
-[QGVAR(spareBarrelsLoadCoolest), [_assistant, _gunner, _weapon, _temp, _barrelMass]] call CBA_fnc_serverEvent;
+[QGVAR(loadCoolestSpareBarrel), [_assistant, _gunner, _weapon, _temp, _barrelMass]] call CBA_fnc_serverEvent;
 
 // Store the update time
 _gunner setVariable [format [QGVAR(%1_time), _weapon], CBA_missionTime];

--- a/addons/reload/XEH_postInit.sqf
+++ b/addons/reload/XEH_postInit.sqf
@@ -27,7 +27,7 @@ if (!hasInterface) exitWith {};
 }] call CBA_fnc_addEventHandler;
 
 // Listen for attempts to link ammo
-[QGVAR(linkedAmmo), {
+[QGVAR(ammoLinked), {
     params ["_receiver", "_giver", "_magazine"];
 
     private _magazineType = currentMagazine _receiver;
@@ -35,7 +35,7 @@ if (!hasInterface) exitWith {};
 
     // Return the magazine if it's the wrong type
     if (_magazineType != (_magazine select 0)) exitWith {
-        [QGVAR(returnedAmmo), [_giver,_receiver,_magazine], [_giver]] call CBA_fnc_targetEvent;
+        [QGVAR(ammoReturned), [_giver,_receiver,_magazine], [_giver]] call CBA_fnc_targetEvent;
     };
 
     private _ammoCount = _receiver ammo currentWeapon _receiver;
@@ -43,7 +43,7 @@ if (!hasInterface) exitWith {};
 
     // Return the magazine if the belt is full or empty
     if ((_ammoCount == 0)  || _ammoMissing == 0) exitWith {
-        [QGVAR(returnedAmmo), [_giver,_receiver,_magazine], [_giver]] call CBA_fnc_targetEvent;
+        [QGVAR(ammoReturned), [_giver,_receiver,_magazine], [_giver]] call CBA_fnc_targetEvent;
     };
 
     // Add the ammo
@@ -51,14 +51,14 @@ if (!hasInterface) exitWith {};
     [QGVAR(syncAmmo), [_receiver, currentWeapon _receiver, _ammoCount + _ammoAdded]] call CBA_fnc_globalEvent;
 
     if ((_magazine select 1) - _ammoAdded > 0) then {
-        [QGVAR(returnedAmmo), [_giver, _receiver, [_magazineType, (_magazine select 1) - _ammoAdded]], [_giver]] call CBA_fnc_targetEvent;
+        [QGVAR(ammoReturned), [_giver, _receiver, [_magazineType, (_magazine select 1) - _ammoAdded]], [_giver]] call CBA_fnc_targetEvent;
     };
 }] call CBA_fnc_addEventHandler;
 
 // Listen for returned magazines
-[QGVAR(returnedAmmo), {
+[QGVAR(ammoReturned), {
     params ["_receiver", "", "_magazine"];
-    TRACE_2("returnedAmmo EH",_receiver,_magazine);
+    TRACE_2("ammoReturned EH",_receiver,_magazine);
 
     _receiver addMagazine _magazine;
 }] call CBA_fnc_addEventHandler;

--- a/addons/reload/config.cpp
+++ b/addons/reload/config.cpp
@@ -23,6 +23,6 @@ class CfgPatches {
 
 class ACE_newEvents {
     setAmmoSync = QGVAR(syncAmmo);
-    returnedAmmo = QGVAR(returnedAmmo);
-    linkedAmmo = QGVAR(linkedAmmo);
+    returnedAmmo = QGVAR(ammoReturned);
+    linkedAmmo = QGVAR(ammoLinked);
 };

--- a/addons/reload/functions/fnc_startLinkingBelt.sqf
+++ b/addons/reload/functions/fnc_startLinkingBelt.sqf
@@ -46,7 +46,7 @@ private _onFinish = {
     (_this select 0) params ["_player", "_target", "_magazine"];
 
     // Raise event on remote unit
-    [QGVAR(linkedAmmo), [_target, _player, _magazine], [_target]] call CBA_fnc_targetEvent;
+    [QGVAR(ammoLinked), [_target, _player, _magazine], [_target]] call CBA_fnc_targetEvent;
 };
 
 private _onFailure = {


### PR DESCRIPTION
**When merged this pull request will:**
- Rename the following events
    - `ace_addedHeartRateAdjustment` -> `ace_heartRateAdjustmentAdded`
    - `ace_cargoAddedByClass` -> `ace_cargoAdded`
    - `ace_enteredCardiacArrest` -> `ace_cardiacArrestEntered`
    - `ace_itemAddedToTriageCard` -> `ace_triageCardItemAdded`
    - `ace_reload_linkedAmmo` -> ` ace_reload_ammoLinked`
    - `ace_reload_returnedAmmo` -> `ace_reload_ammoReturned`
    - `ace_treatmentSuccess` -> ` ace_treatmentSucceded`
    - `ace_addedCargoByClass` -> `ace_addCargo`
    - `ace_common_engineOn` -> `ace_common_setEngine`
    - `ace_explosives_clientRequestOrientations` -> `ace_explosives_sendOrientations`
    - `ace_explosives_serverSendOrientations` -> `ace_explosives_orientationsSent`
    - `ace_interaction_lampTurnOff` -> `ace_interaction_setLampOff`
    - `ace_interaction_lampTurnOn` -> `ace_interaction_setLampOn`
    - `ace_overheating_spareBarrelsLoadCoolest` -> `ace_overheating_loadCoolestSpareBarrel`
    - `ace_overheating_spareBarrelsSendTemperatureHint` -> `ace_overheating_sendSpareBarrelTemperatureHint`
- Close #3533