### PR TITLE
Fix lead indicator for B_APC_Tracked_01_AA_F

### DIFF
--- a/addons/fcs/CfgWeapons.hpp
+++ b/addons/fcs/CfgWeapons.hpp
@@ -12,7 +12,7 @@ class CfgWeapons {
     };
     class autocannon_35mm: CannonCore {
         canLock = 0;
-        ballisticsComputer = 0;
+        ballisticsComputer = 4; //was "4 + 2", 2 is for manual zeroing, 4 is for the lead indicator - https://community.bistudio.com/wiki/A3_Locking_Review#ballisticsComputer
         magazines[] += {"ACE_120Rnd_35mm_ABM_shells","ACE_120Rnd_35mm_ABM_shells_Tracer_Red","ACE_120Rnd_35mm_ABM_shells_Tracer_Green","ACE_120Rnd_35mm_ABM_shells_Tracer_Yellow"};
     };
 


### PR DESCRIPTION
Ref https://community.bistudio.com/wiki/A3_Locking_Review#ballisticsComputer

Prior to 1.60 I think it was `1` 
1.60 changed it to `4+2`

We want to disable the manual zeroing for FCS, 
but I don't see any reason to disable the "Target lead indication"

The thing in red:
![image](https://cloud.githubusercontent.com/assets/9376747/16354866/4ce7a580-3a6a-11e6-9b2b-d5c30039a71d.png)
