### PR TITLE
missleGuidance - Fix seeker los check

### DIFF
--- a/addons/missileguidance/functions/fnc_seekerType_Optic.sqf
+++ b/addons/missileguidance/functions/fnc_seekerType_Optic.sqf
@@ -27,7 +27,7 @@ _angleOkay = [_projectile, _foundTargetPos, _angleFov] call FUNC(checkSeekerAngl
 
 _losOkay = false;
 if(_angleOkay) then {
-    _losOkay = [_projectile, _target] call FUNC(checkSeekerLos); //Note: Func does not exist?  probably FUNC(checkLos)??
+    _losOkay = [_projectile, _target] call FUNC(checkLos);
 };
 TRACE_2("", _angleOkay, _losOkay);
 
@@ -36,16 +36,17 @@ if(!_angleOkay || !_losOkay) then {
     _foundTargetPos = _sensorPos vectorAdd ((velocity _projectile) vectorMultiply 5);
 } else {
     TRACE_2("", _target, _foundTargetPos);
-    private["_projectileSpeed", "_distanceToTarget", "_eta", "_adjustVelocity"];
+    private["_projectileSpeed", "_distanceToTarget", "_eta", "_adjustDistance"];
     // @TODO: Configurable lead for seekers
     _projectileSpeed = (vectorMagnitude velocity _projectile);
     _distanceToTarget = (getPosASL _projectile) vectorDistance _foundTargetPos; 
 
     _eta = _distanceToTarget / _projectileSpeed;
 
-    _adjustVelocity = (velocity _target) vectorMultiply _eta;
-    _foundTargetPos = _foundTargetPos vectorAdd _adjustVelocity;
+    _adjustDistance = (velocity _target) vectorMultiply _eta;
+    TRACE_3("leading target",_distanceToTarget,_eta,_adjustDistance);
+    _foundTargetPos = _foundTargetPos vectorAdd _adjustDistance;
 };
 
-
+TRACE_2("return",_foundTargetPos,(aimPos _target) distance _foundTargetPos);
 _foundTargetPos;


### PR DESCRIPTION
Close #3374
Because func was undefined `_losOkay` was nil, so target leading was always skipped.