### PR TITLE
Change use backpack command for backpack classname

### DIFF
--- a/addons/parachute/functions/fnc_storeParachute.sqf
+++ b/addons/parachute/functions/fnc_storeParachute.sqf
@@ -7,7 +7,6 @@
    *
    * Return Value:
    * 0: Unit
-   * 1: getAllGear-Array
    *
    * Example:
    * None
@@ -16,7 +15,7 @@
    */
 #include "script_component.hpp"
 
-params ["_unit", "_gear"];
+params ["_unit"];
 private _backpack = backpack _unit;
 
 if ((vehicle _unit) isKindOf "ParachuteBase" && {backpack _unit == ""} && {!(_unit getVariable [QGVAR(chuteIsCut),false])} && {_unit getVariable [QGVAR(hasReserve),false]}) then {

--- a/addons/parachute/functions/fnc_storeParachute.sqf
+++ b/addons/parachute/functions/fnc_storeParachute.sqf
@@ -17,7 +17,7 @@
 #include "script_component.hpp"
 
 params ["_unit", "_gear"];
-private _backpack = _gear param [6, ""];
+private _backpack = backpack _unit;
 
 if ((vehicle _unit) isKindOf "ParachuteBase" && {backpack _unit == ""} && {!(_unit getVariable [QGVAR(chuteIsCut),false])} && {_unit getVariable [QGVAR(hasReserve),false]}) then {
     _unit addBackpackGlobal (_unit getVariable[QGVAR(backpackClass),"ACE_NonSteerableParachute"]);


### PR DESCRIPTION
Uses the backpack command to retrieve the classname of a unit's backpack instead of a select. Fixes incorrect index.