### PR TITLE
Block FCS when controlling a UAV

### DIFF
--- a/addons/fcs/functions/fnc_canUseFCS.sqf
+++ b/addons/fcs/functions/fnc_canUseFCS.sqf
@@ -18,3 +18,4 @@
 getNumber ([configFile >> "CfgVehicles" >> typeOf vehicle ACE_player, [ACE_player] call EFUNC(common,getTurretIndex)] call EFUNC(common,getTurretConfigPath) >> QGVAR(Enabled)) == 1
 && {cameraView == "GUNNER"}
 && {!([ACE_player] call CBA_fnc_canUseWeapon)} //Not Turned Out
+&& {cameraOn != (getConnectedUAV ACE_player)} //Not Controlling a UAV


### PR DESCRIPTION
Redo #3983 for 3.6/release

Fix doing FCS keyUp calculations/setVariable
when controlling a UAV while also in a turret with FCS enabled.

Normal rangefinder on the UAV will still work as FUNC(canUseRangefinder)
is still true