### PR TITLE
Detached cursor menus for action points

### DIFF
--- a/addons/interact_menu/ACE_Settings.hpp
+++ b/addons/interact_menu/ACE_Settings.hpp
@@ -21,12 +21,12 @@ class ACE_Settings {
         category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(AlwaysUseCursorInteraction);
     };
-    class GVAR(modeX) {
+    class GVAR(detachedCursorMenu) {
         value = 1;
         typeName = "BOOL";
         isClientSettable = 1;
         category = CSTRING(Category_InteractionMenu);
-        displayName = "Mode X";
+        displayName = "Use detached cursor menus for actions (Requires Always use Cursor for Interaction)";
     };
     class GVAR(useListMenu) {
         value = 0;

--- a/addons/interact_menu/ACE_Settings.hpp
+++ b/addons/interact_menu/ACE_Settings.hpp
@@ -21,6 +21,13 @@ class ACE_Settings {
         category = CSTRING(Category_InteractionMenu);
         displayName = CSTRING(AlwaysUseCursorInteraction);
     };
+    class GVAR(modeX) {
+        value = 1;
+        typeName = "BOOL";
+        isClientSettable = 1;
+        category = CSTRING(Category_InteractionMenu);
+        displayName = "Mode X";
+    };
     class GVAR(useListMenu) {
         value = 0;
         typeName = "BOOL";

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -17,16 +17,25 @@ DFUNC(handleMouseMovement) = {
     };
 };
 DFUNC(handleMouseButtonDown) = {
+    params ["", "_button"];
+
     if (GVAR(useDetachedCursorMenu)) then {
-        if (GVAR(dettachedMenuBasePath) isEqualTo [] && GVAR(actionSelected)) then {
-            GVAR(dettachedMenuBasePath) = +GVAR(lastPath); [(GVAR(lastPath) select 0 select 1), (GVAR(lastPath) select 0 select 0), []];
-            GVAR(cursorPos) = [0.5, 0.5, 0];
-            setMousePosition [0.50, 0.5];
-            GVAR(menuDepthPath) = +GVAR(lastPath);
-            GVAR(expanded) = true;
-            GVAR(expandedTime) = diag_tickTime-1000;
-            GVAR(startHoverTime) = -1000;
+        if (GVAR(dettachedMenuBasePath) isEqualTo []) then {
+            if (_button == 0 && GVAR(actionSelected)) then {
+                // Detach the menu to render the selected action
+                GVAR(dettachedMenuBasePath) = +GVAR(lastPath); [(GVAR(lastPath) select 0 select 1), (GVAR(lastPath) select 0 select 0), []];
+                GVAR(cursorPos) = [0.5, 0.5, 0];
+                setMousePosition [0.50, 0.5];
+                GVAR(menuDepthPath) = +GVAR(lastPath);
+                GVAR(expanded) = true;
+                GVAR(expandedTime) = diag_tickTime-1000;
+                GVAR(startHoverTime) = -1000;
+            };
         } else {
+            if (_button == 1) exitWith {
+                // Close the detached menu
+                GVAR(dettachedMenuBasePath) = [];
+            };
             // Only terminate the menu if an action with an statement was clicked
             if (GVAR(actionSelected)) then {
                 private _actionData = GVAR(selectedAction) select 0;

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -39,7 +39,6 @@ DFUNC(handleMouseButtonDown) = {
             // Only terminate the menu if an action with an statement was clicked
             if (GVAR(actionSelected)) then {
                 private _actionData = GVAR(selectedAction) select 0;
-                player globalChat str (_actionData select 3);
                 if !(_actionData select 3 isEqualTo {}) then {
                     if !(GVAR(actionOnKeyRelease)) then {
                         [GVAR(openedMenuType),true] call FUNC(keyUp);

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -23,9 +23,11 @@ DFUNC(handleMouseButtonDown) = {
         if (GVAR(dettachedMenuBasePath) isEqualTo []) then {
             if (_button == 0 && GVAR(actionSelected)) then {
                 // Detach the menu to render the selected action
-                GVAR(dettachedMenuBasePath) = +GVAR(lastPath); [(GVAR(lastPath) select 0 select 1), (GVAR(lastPath) select 0 select 0), []];
-                GVAR(cursorPos) = [0.5, 0.5, 0];
+                GVAR(dettachedMenuBasePath) = +GVAR(lastPath);
                 setMousePosition [0.50, 0.5];
+                // handleMouseMovement is launched after handleMouseButtonDown and it returns the former mouse position
+                // GVAR(cursorPos) needs to be overriden manually after that
+                [{GVAR(cursorPos) = [0.5, 0.5, 0]}, []] call CBA_fnc_execNextFrame;
                 GVAR(menuDepthPath) = +GVAR(lastPath);
                 GVAR(expanded) = true;
                 GVAR(expandedTime) = diag_tickTime-1000;

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -17,10 +17,27 @@ DFUNC(handleMouseMovement) = {
     };
 };
 DFUNC(handleMouseButtonDown) = {
+    if (GVAR(openedMenuType) == 0 && GVAR(modeX)) exitWith {
+        if (GVAR(modeXAction) isEqualTo [] && GVAR(actionSelected)) then {
+            GVAR(modeXAction) = [(GVAR(lastPath) select 0 select 1), (GVAR(lastPath) select 0 select 0), []];
+            GVAR(cursorPos) = [0.5, 0.5, 0];
+            setMousePosition [0.50, 0.5];
+            GVAR(menuDepthPath) = +GVAR(lastPath);
+            GVAR(expanded) = true;
+            GVAR(expandedTime) = diag_tickTime-1000;
+            GVAR(startHoverTime) = -1000;
+        } else {
+            if !(GVAR(actionOnKeyRelease)) then {
+                [GVAR(openedMenuType),true] call FUNC(keyUp);
+            };
+        };
+    };
+
     if !(GVAR(actionOnKeyRelease)) then {
         [GVAR(openedMenuType),true] call FUNC(keyUp);
     };
 };
+GVAR(modeXAction) = [];
 
 GVAR(keyDown) = false;
 GVAR(keyDownSelfAction) = false;

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -17,9 +17,9 @@ DFUNC(handleMouseMovement) = {
     };
 };
 DFUNC(handleMouseButtonDown) = {
-    if (GVAR(openedMenuType) == 0 && GVAR(modeX)) exitWith {
-        if (GVAR(modeXAction) isEqualTo [] && GVAR(actionSelected)) then {
-            GVAR(modeXAction) = [(GVAR(lastPath) select 0 select 1), (GVAR(lastPath) select 0 select 0), []];
+    if (GVAR(useDetachedCursorMenu)) then {
+        if (GVAR(dettachedMenuBasePath) isEqualTo [] && GVAR(actionSelected)) then {
+            GVAR(dettachedMenuBasePath) = +GVAR(lastPath); [(GVAR(lastPath) select 0 select 1), (GVAR(lastPath) select 0 select 0), []];
             GVAR(cursorPos) = [0.5, 0.5, 0];
             setMousePosition [0.50, 0.5];
             GVAR(menuDepthPath) = +GVAR(lastPath);
@@ -31,13 +31,14 @@ DFUNC(handleMouseButtonDown) = {
                 [GVAR(openedMenuType),true] call FUNC(keyUp);
             };
         };
-    };
-
-    if !(GVAR(actionOnKeyRelease)) then {
-        [GVAR(openedMenuType),true] call FUNC(keyUp);
+    } else {
+        if !(GVAR(actionOnKeyRelease)) then {
+            [GVAR(openedMenuType),true] call FUNC(keyUp);
+        };
     };
 };
-GVAR(modeXAction) = [];
+GVAR(useDetachedCursorMenu) = false;
+GVAR(dettachedMenuBasePath) = [];
 
 GVAR(keyDown) = false;
 GVAR(keyDownSelfAction) = false;

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -27,8 +27,15 @@ DFUNC(handleMouseButtonDown) = {
             GVAR(expandedTime) = diag_tickTime-1000;
             GVAR(startHoverTime) = -1000;
         } else {
-            if !(GVAR(actionOnKeyRelease)) then {
-                [GVAR(openedMenuType),true] call FUNC(keyUp);
+            // Only terminate the menu if an action with an statement was clicked
+            if (GVAR(actionSelected)) then {
+                private _actionData = GVAR(selectedAction) select 0;
+                player globalChat str (_actionData select 3);
+                if !(_actionData select 3 isEqualTo {}) then {
+                    if !(GVAR(actionOnKeyRelease)) then {
+                        [GVAR(openedMenuType),true] call FUNC(keyUp);
+                    };
+                };
             };
         };
     } else {

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -37,12 +37,23 @@ GVAR(openedMenuType) = _menuType;
 GVAR(lastTimeSearchedActions) = -1000;
 GVAR(ParsedTextCached) = [];
 
+// Decide if cursor menu shoud be used
 GVAR(useCursorMenu) = (vehicle ACE_player != ACE_player) ||
                       visibleMap ||
                       (!isNull curatorCamera) ||
                       {(_menuType == 1) && {(isWeaponDeployed ACE_player) || GVAR(AlwaysUseCursorSelfInteraction) || {cameraView == "GUNNER"}}} ||
                       {(_menuType == 0) && GVAR(AlwaysUseCursorInteraction)};
 
+// Decide if detached menus should be used
+GVAR(useDetachedCursorMenu) = GVAR(detachedCursorMenu) &&
+                    {_menuType == 0} &&
+                    {GVAR(AlwaysUseCursorInteraction)} &&
+                    {vehicle ACE_player == ACE_player} &&
+                    {!visibleMap} &&
+                    {isNull curatorCamera};
+GVAR(dettachedMenuBasePath) = [];
+
+player globalChat str GVAR(useDettachedCursorMenu);
 // Delete existing controls in case there's any left
 GVAR(iconCount) = 0;
 for "_i" from 0 to (count GVAR(iconCtrls))-1 do {
@@ -77,7 +88,7 @@ if (GVAR(useCursorMenu)) then {
 
 GVAR(selfMenuOffset) = (AGLtoASL (positionCameraToWorld [0, 0, 2])) vectorDiff (AGLtoASL (positionCameraToWorld [0, 0, 0]));
 
-//Auto expand the first level when self, mounted vehicle or zeus (skips the first animation as there is only one choice)
+// Auto expand the first level when self, mounted vehicle or zeus (skips the first animation as there is only one choice)
 if (GVAR(openedMenuType) == 0) then {
     if (isNull curatorCamera) then {
         if (vehicle ACE_player != ACE_player) then {
@@ -101,8 +112,6 @@ if (GVAR(openedMenuType) == 0) then {
     GVAR(lastPath) = +GVAR(menuDepthPath);
     GVAR(startHoverTime) = -1000;
 };
-
-GVAR(modeXAction) = [];
 
 ["ace_interactMenuOpened", [_menuType]] call CBA_fnc_localEvent;
 

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -53,7 +53,6 @@ GVAR(useDetachedCursorMenu) = GVAR(detachedCursorMenu) &&
                     {isNull curatorCamera};
 GVAR(dettachedMenuBasePath) = [];
 
-player globalChat str GVAR(useDettachedCursorMenu);
 // Delete existing controls in case there's any left
 GVAR(iconCount) = 0;
 for "_i" from 0 to (count GVAR(iconCtrls))-1 do {

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -102,6 +102,8 @@ if (GVAR(openedMenuType) == 0) then {
     GVAR(startHoverTime) = -1000;
 };
 
+GVAR(modeXAction) = [];
+
 ["ace_interactMenuOpened", [_menuType]] call CBA_fnc_localEvent;
 
 true

--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -113,6 +113,29 @@ private _fnc_renderSelfActions = {
     } count _classActions;
 };
 
+private _fnc_renderSubActions = {
+    params ["_target", "_basePath"];
+    TRACE_2("_fnc_renderSubActions",_target,_basePath);
+    // Set object actions for collectActiveActionTree
+    GVAR(objectActionList) = _target getVariable [QGVAR(actions), []];
+
+    // Iterate through base level class actions and render them if appropiate
+    private _namespace = GVAR(ActNamespace);
+    private _classActions = _namespace getVariable typeOf _target;
+
+    _pos = [0.5, 0.5];
+
+    {
+        _action = _x;
+        private _path = _action select 0 select 0;
+        if (_path isEqualTo _basePath) then {
+            TRACE_2("_fnc_renderSubActions",_path,_basePath);
+            [_target, _action, _pos] call FUNC(renderBaseMenu);
+        };
+        nil
+    } count _classActions;
+};
+
 private _fnc_renderZeusActions = {
     {
         private _action = _x;
@@ -128,12 +151,16 @@ GVAR(collectedActionPoints) resize 0;
 if (GVAR(openedMenuType) == 0) then {
     if (isNull curatorCamera) then {
         if (vehicle ACE_player == ACE_player) then {
-            if (diag_tickTime > GVAR(lastTimeSearchedActions) + 0.20) then {
-                // Once every 0.2 secs, collect nearby objects active and visible action points and render them
-                call _fnc_renderNearbyActions;
+            if (!GVAR(modeX) || (GVAR(modeXAction) isEqualTo [])) then {
+                if (diag_tickTime > GVAR(lastTimeSearchedActions) + 0.20) then {
+                    // Once every 0.2 secs, collect nearby objects active and visible action points and render them
+                    call _fnc_renderNearbyActions;
+                } else {
+                    // The rest of the frames just draw the same action points rendered the last frame
+                    call _fnc_renderLastFrameActions;
+                };
             } else {
-                // The rest of the frames just draw the same action points rendered the last frame
-                call _fnc_renderLastFrameActions;
+                GVAR(modeXAction) call _fnc_renderSubActions;
             };
         } else {
             // Render vehicle self actions when in vehicle

--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -117,7 +117,7 @@ private _fnc_renderSelfActions = {
 private _fnc_renderDettachedAction = {
     params ["_baseAction"];
     _baseAction params ["_detachedActionName", "_target"];
-    player globalChat str _baseAction;
+
     TRACE_2("_fnc_renderDettachedAction",_target,_detachedActionName);
     // Set object actions for collectActiveActionTree
     GVAR(objectActionList) = _target getVariable [QGVAR(actions), []];

--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -82,6 +82,7 @@ private _fnc_renderNearbyActions = {
 private _fnc_renderLastFrameActions = {
     {
         _x params ["_target", "_action", "_objectActionList"];
+        //TRACE_3("_fnc_renderLastFrameActions",_target,_action,_objectActionList);
 
         GVAR(objectActionList) = _objectActionList;
         [_target, _action] call FUNC(renderBaseMenu);
@@ -113,9 +114,11 @@ private _fnc_renderSelfActions = {
     } count _classActions;
 };
 
-private _fnc_renderSubActions = {
-    params ["_target", "_basePath"];
-    TRACE_2("_fnc_renderSubActions",_target,_basePath);
+private _fnc_renderDettachedAction = {
+    params ["_baseAction"];
+    _baseAction params ["_detachedActionName", "_target"];
+    player globalChat str _baseAction;
+    TRACE_2("_fnc_renderDettachedAction",_target,_detachedActionName);
     // Set object actions for collectActiveActionTree
     GVAR(objectActionList) = _target getVariable [QGVAR(actions), []];
 
@@ -123,13 +126,13 @@ private _fnc_renderSubActions = {
     private _namespace = GVAR(ActNamespace);
     private _classActions = _namespace getVariable typeOf _target;
 
-    _pos = [0.5, 0.5];
+    private _pos = [0.5, 0.5];
 
     {
         _action = _x;
-        private _path = _action select 0 select 0;
-        if (_path isEqualTo _basePath) then {
-            TRACE_2("_fnc_renderSubActions",_path,_basePath);
+        private _actionName = _action select 0 select 0;
+        if (_actionName isEqualTo _detachedActionName) then {
+            TRACE_2("_fnc_renderDettachedAction",_actionBaseName,_detachedActionName);
             [_target, _action, _pos] call FUNC(renderBaseMenu);
         };
         nil
@@ -151,7 +154,7 @@ GVAR(collectedActionPoints) resize 0;
 if (GVAR(openedMenuType) == 0) then {
     if (isNull curatorCamera) then {
         if (vehicle ACE_player == ACE_player) then {
-            if (!GVAR(modeX) || (GVAR(modeXAction) isEqualTo [])) then {
+            if (!GVAR(useDetachedCursorMenu) || (GVAR(dettachedMenuBasePath) isEqualTo [])) then {
                 if (diag_tickTime > GVAR(lastTimeSearchedActions) + 0.20) then {
                     // Once every 0.2 secs, collect nearby objects active and visible action points and render them
                     call _fnc_renderNearbyActions;
@@ -160,7 +163,7 @@ if (GVAR(openedMenuType) == 0) then {
                     call _fnc_renderLastFrameActions;
                 };
             } else {
-                GVAR(modeXAction) call _fnc_renderSubActions;
+                GVAR(dettachedMenuBasePath) call _fnc_renderDettachedAction;
             };
         } else {
             // Render vehicle self actions when in vehicle

--- a/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
@@ -36,7 +36,7 @@ private _pos = if((count _this) > 2) then {
 private _distanceToBasePoint = 0; //This will be 0 for self/zeus/in-vehicle (used later to check sub action distance)
 if (GVAR(openedMenuType) == 0 && {vehicle ACE_player == ACE_player} && {isNull curatorCamera} &&
     {
-        if (GVAR(modeX) && {!(GVAR(modeXAction) isEqualTo [])}) exitWith {false};
+        if (GVAR(detachedCursorMenu) && {!(GVAR(dettachedMenuBasePath) isEqualTo [])}) exitWith {false};
 
         private _headPos = ACE_player modelToWorldVisual (ACE_player selectionPosition "pilot");
         _distanceToBasePoint = _headPos distance _pos;

--- a/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderBaseMenu.sqf
@@ -34,8 +34,10 @@ private _pos = if((count _this) > 2) then {
 
 // For non-self actions, exit if the action is too far away or ocluded
 private _distanceToBasePoint = 0; //This will be 0 for self/zeus/in-vehicle (used later to check sub action distance)
-if ((GVAR(openedMenuType) == 0) && {vehicle ACE_player == ACE_player} && {isNull curatorCamera} &&
+if (GVAR(openedMenuType) == 0 && {vehicle ACE_player == ACE_player} && {isNull curatorCamera} &&
     {
+        if (GVAR(modeX) && {!(GVAR(modeXAction) isEqualTo [])}) exitWith {false};
+
         private _headPos = ACE_player modelToWorldVisual (ACE_player selectionPosition "pilot");
         _distanceToBasePoint = _headPos distance _pos;
 

--- a/addons/interact_menu/functions/fnc_renderMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderMenu.sqf
@@ -64,7 +64,7 @@ GVAR(currentOptions) pushBack [_this, _sPos, _path];
 // Exit without rendering children if it isn't
 if !(_menuInSelectedPath) exitWith {true};
 
-if (GVAR(openedMenuType) == 0 && GVAR(modeX) && GVAR(modeXAction) isEqualTo []) exitWith {true};
+if (GVAR(useDetachedCursorMenu) && GVAR(dettachedMenuBasePath) isEqualTo []) exitWith {true};
 
 //BEGIN_COUNTER(children);
 

--- a/addons/interact_menu/functions/fnc_renderMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderMenu.sqf
@@ -64,6 +64,8 @@ GVAR(currentOptions) pushBack [_this, _sPos, _path];
 // Exit without rendering children if it isn't
 if !(_menuInSelectedPath) exitWith {true};
 
+if (GVAR(openedMenuType) == 0 && GVAR(modeX) && GVAR(modeXAction) isEqualTo []) exitWith {true};
+
 //BEGIN_COUNTER(children);
 
 private _numChildren = count _activeChildren;


### PR DESCRIPTION
Designed to work under these settings:
- Use Detached Cursor Menus = Yes
- Always display cursor for interaction = Yes
- Do action when releasing menu key = No
- Display interaction menus as lists = Yes (not mandatory)

Action points no longer expand on hover. Clicking with LMB expands them in "detached" mode, similar to how self interaction works. RMB closes the detached menu and returns to regular interaction.

The advanges are:
- prevents minor movements of the target from messing out the selection of subactions
- prevents the problem of subactions overlaping with other action, which often make the selection of subactions difficult.
- centers the menu asociated with the action, making it possible to display many subactions regardless of where in the screen the action point was originally located.
- it has a more "traditional" or "fleximenu" feel, but it stills allows interacting with arbitrary 3d points.

https://youtu.be/eSmA2wQYc80

Still to do:
- [ ] Support object actions (as opposed to class actions)
- [ ] Recheck interaction distance when a subaction is finally selected
- [ ] Better handle actions points without subactions (they should probably be executed right away)
- [ ] Maybe indicate which action points have subactions (maybe adding an ellipsis, some small icon or a different shape of selector).
- [ ] Better handle actions that have statements that should only run on hover.
- [ ] Stringtables
