### PR TITLE
Add goggle setting for level of effects

### DIFF
--- a/addons/goggles/ACE_Settings.hpp
+++ b/addons/goggles/ACE_Settings.hpp
@@ -1,11 +1,11 @@
 
 class ACE_Settings {
-    /*class GVAR(enable) { // @todo
-        value = 0;
-        typeName = "BOOL";
-        isClientSettable = 1;
-        displayName = CSTRING(enable);
-    };*/
+    class GVAR(effects) {
+        displayName = CSTRING(effects_displayName);
+        typeName = "SCALAR";
+        value = 2;
+        values[] = {ECSTRING(common,Disabled), CSTRING(effects_tintOnly), CSTRING(enabled_tintAndEffects)};
+    };
     class GVAR(showInThirdPerson) {
         value = 0;
         typeName = "BOOL";

--- a/addons/goggles/CfgEventHandlers.hpp
+++ b/addons/goggles/CfgEventHandlers.hpp
@@ -24,11 +24,3 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
-
-class Extended_Explosion_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            clientExplosion = QUOTE(if (local (_this select 0)) then {_this call FUNC(handleExplosion)});
-        };
-    };
-};

--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -3,6 +3,7 @@
 if (!hasInterface) exitWith {};
 
 ["ACE3 Common", QGVAR(wipeGlasses), localize LSTRING(WipeGlasses), {
+    if (GVAR(effects) != 2) exitWith {false}; //Can only wipe if full effects setting is set
     if (!(GETVAR(ace_player,ACE_isUnconscious,false))) exitWith {
         call FUNC(clearGlasses);
         true
@@ -12,126 +13,142 @@ if (!hasInterface) exitWith {};
 {false},
 [20, [true, true, false]], false] call CBA_fnc_addKeybind;
 
-// make sure to stack effect layers in correct order
-GVAR(GogglesEffectsLayer) = QGVAR(GogglesEffectsLayer) call BIS_fnc_RSCLayer;
-GVAR(GogglesLayer) = QGVAR(GogglesLayer) call BIS_fnc_RSCLayer;
 
-if (isNil QGVAR(UsePP)) then {
-    GVAR(UsePP) = true;
-};
+["ace_settingsInitialized", {
+    TRACE_2("ace_settingsInitialized eh",GVAR(effects),GVAR(showInThirdPerson));
 
-// init pp effects
-GVAR(PostProcess) =     ppEffectCreate ["ColorCorrections", 1995];
-GVAR(PostProcessEyes) = ppEffectCreate ["ColorCorrections", 1992];
-GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [1, 1, 1, 0]];
-GVAR(PostProcessEyes) ppEffectCommit 0;
-GVAR(PostProcessEyes) ppEffectEnable false;
+    if (GVAR(effects) == 0) exitWith {};
 
-GVAR(EffectsActive) = false;
+    // ---Add the TINT Effect---
+    
+    // make sure to stack effect layers in correct order
+    GVAR(GogglesEffectsLayer) = QGVAR(GogglesEffectsLayer) call BIS_fnc_RSCLayer;
+    GVAR(GogglesLayer) = QGVAR(GogglesLayer) call BIS_fnc_RSCLayer;
 
-SETGLASSES(ace_player,GLASSESDEFAULT);
-
-GVAR(FrameEvent) = [false, [false, 20]];
-GVAR(PostProcessEyes_Enabled) = false;
-GVAR(DustHandler) = -1;
-GVAR(RainDrops) = objNull;
-GVAR(RainActive) = false;
-GVAR(RainLastLevel) = 0;
-GVAR(surfaceCache) = "";
-GVAR(surfaceCacheIsDust) = false;
-
-// init GlassesChanged eventhandler
-GVAR(OldGlasses) = "<null>";
-
-["loadout", {
-    params ["_unit"];
-
-    private _currentGlasses = goggles _unit;
-
-    if (GVAR(OldGlasses) != _currentGlasses) then {
-        ["ace_glassesChanged", [_unit, _currentGlasses]] call CBA_fnc_localEvent;
-        GVAR(OldGlasses) = _currentGlasses;
+    if (isNil QGVAR(UsePP)) then {
+        GVAR(UsePP) = true;
     };
-}] call CBA_fnc_addPlayerEventHandler;
 
-// add glasses eventhandlers
-["ace_glassesChanged", {
-    params ["_unit", "_glasses"];
+    // init GlassesChanged eventhandler
+    GVAR(OldGlasses) = "<null>";
+    ["loadout", {
+        params ["_unit"];
 
-    SETGLASSES(_unit,GLASSESDEFAULT);
+        private _currentGlasses = goggles _unit;
 
-    if (call FUNC(ExternalCamera)) exitWith {call FUNC(RemoveGlassesEffect)};
+        if (GVAR(OldGlasses) != _currentGlasses) then {
+            ["ace_glassesChanged", [_unit, _currentGlasses]] call CBA_fnc_localEvent;
+            GVAR(OldGlasses) = _currentGlasses;
+        };
+    }] call CBA_fnc_addPlayerEventHandler;
 
-    if ([_unit] call FUNC(isGogglesVisible)) then {
-        _glasses call FUNC(applyGlassesEffect);
-    } else {
-        call FUNC(removeGlassesEffect);
+
+    // init pp effects
+    GVAR(PostProcess) =     ppEffectCreate ["ColorCorrections", 1995];
+    GVAR(EffectsActive) = false;
+
+    // check goggles
+    private _fnc_checkGoggles = {
+        params ["_unit"];
+
+        if (GVAR(EffectsActive)) then {
+            if (call FUNC(externalCamera) || {!([_unit] call FUNC(isGogglesVisible))}) then {
+                call FUNC(removeGlassesEffect);
+            };
+        } else {
+            if (!(call FUNC(externalCamera)) && {[_unit] call FUNC(isGogglesVisible)}) then {
+                [goggles _unit] call FUNC(applyGlassesEffect);
+            };
+        };
     };
-}] call CBA_fnc_addEventHandler;
 
-["ace_glassesCracked", {
-    params ["_unit"];
+    ["cameraView", _fnc_checkGoggles] call CBA_fnc_addPlayerEventHandler;
+    ["ace_activeCameraChanged", _fnc_checkGoggles] call CBA_fnc_addEventHandler;
 
-    _unit setVariable ["ACE_EyesDamaged", true];
 
-    GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0.5, 0.5, 0.5, 0.5], [1, 1, 1, 0]];
-    GVAR(PostProcessEyes) ppEffectCommit 0;
-    GVAR(PostProcessEyes) ppEffectEnable true;
+    // add glasses eventhandlers
+    ["ace_glassesChanged", {
+        params ["_unit", "_glasses"];
 
-    [{
-        GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [1, 1, 1, 1], [1, 1, 1, 0]];
-        GVAR(PostProcessEyes) ppEffectCommit 5;
+        SETGLASSES(_unit,GLASSESDEFAULT);
 
-        [{
-            params ["_unit"];
+        if (call FUNC(ExternalCamera)) exitWith {call FUNC(RemoveGlassesEffect)};
 
-            GVAR(PostProcessEyes) ppEffectEnable false;
-
-            _unit setVariable ["ACE_EyesDamaged", false];
-
-        }, _this, 5] call CBA_fnc_waitAndExecute;
-
-    }, _unit, 25] call CBA_fnc_waitAndExecute;
-
-}] call CBA_fnc_addEventHandler;
-
-// check goggles
-private _fnc_checkGoggles = {
-    params ["_unit"];
-
-    if (GVAR(EffectsActive)) then {
-        if (call FUNC(externalCamera) || {!([_unit] call FUNC(isGogglesVisible))}) then {
+        if ([_unit] call FUNC(isGogglesVisible)) then {
+            _glasses call FUNC(applyGlassesEffect);
+        } else {
             call FUNC(removeGlassesEffect);
         };
-    } else {
-        if (!(call FUNC(externalCamera)) && {[_unit] call FUNC(isGogglesVisible)}) then {
-            [goggles _unit] call FUNC(applyGlassesEffect);
-        };
+    }] call CBA_fnc_addEventHandler;
+
+
+    // // ---Add the Dust/Dirt/Rain Effects---
+    if (GVAR(effects) == 2) then {
+
+        // Register fire event handler
+        ["ace_firedPlayer", DFUNC(handleFired)] call CBA_fnc_addEventHandler;
+
+        //Add Explosion XEH
+        ["CAManBase", "explosion", FUNC(handleExplosion)] call CBA_fnc_addClassEventHandler;
+
+        GVAR(PostProcessEyes) = ppEffectCreate ["ColorCorrections", 1992];
+        GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [1, 1, 1, 0]];
+        GVAR(PostProcessEyes) ppEffectCommit 0;
+        GVAR(PostProcessEyes) ppEffectEnable false;
+        GVAR(PostProcessEyes_Enabled) = false;
+        
+        GVAR(FrameEvent) = [false, [false, 20]];
+        GVAR(DustHandler) = -1;
+        GVAR(RainDrops) = objNull;
+        GVAR(RainActive) = false;
+        GVAR(RainLastLevel) = 0;
+        GVAR(surfaceCache) = "";
+        GVAR(surfaceCacheIsDust) = false;
+
+        ["ace_glassesCracked", {
+            params ["_unit"];
+
+            _unit setVariable ["ACE_EyesDamaged", true];
+
+            GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0.5, 0.5, 0.5, 0.5], [1, 1, 1, 0]];
+            GVAR(PostProcessEyes) ppEffectCommit 0;
+            GVAR(PostProcessEyes) ppEffectEnable true;
+
+            [{
+                GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [1, 1, 1, 1], [1, 1, 1, 0]];
+                GVAR(PostProcessEyes) ppEffectCommit 5;
+
+                [{
+                    params ["_unit"];
+
+                    GVAR(PostProcessEyes) ppEffectEnable false;
+
+                    _unit setVariable ["ACE_EyesDamaged", false];
+
+                }, _this, 5] call CBA_fnc_waitAndExecute;
+
+            }, _unit, 25] call CBA_fnc_waitAndExecute;
+
+        }] call CBA_fnc_addEventHandler;
+
+        // goggles effects main PFH
+        [{
+            BEGIN_COUNTER(goggles);
+
+            // rain
+            call FUNC(applyRainEffect);
+
+            // auto remove effects under water
+            if (GVAR(EffectsActive) && {underwater ACE_player} && {[goggles ACE_player] call FUNC(isDivingGoggles)}) then {
+                call FUNC(removeRainEffect);
+                call FUNC(removeDirtEffect);
+                call FUNC(removeDustEffect);
+            };
+
+            // rotor wash effect
+            call FUNC(applyRotorWashEffect);
+
+            END_COUNTER(goggles);
+        }, 0.5, []] call CBA_fnc_addPerFrameHandler;
     };
-};
-
-["cameraView", _fnc_checkGoggles] call CBA_fnc_addPlayerEventHandler;
-["ace_activeCameraChanged", _fnc_checkGoggles] call CBA_fnc_addEventHandler;
-
-// goggles effects main PFH
-[{
-    BEGIN_COUNTER(goggles);
-
-    // rain
-    call FUNC(applyRainEffect);
-
-    // auto remove effects under water
-    if (GVAR(EffectsActive) && {underwater ACE_player} && {[goggles ACE_player] call FUNC(isDivingGoggles)}) then {
-        call FUNC(removeRainEffect);
-        call FUNC(removeDirtEffect);
-        call FUNC(removeDustEffect);
-    };
-
-    // rotor wash effect
-    call FUNC(applyRotorWashEffect);
-
-    END_COUNTER(goggles);
-}, 0.5, []] call CBA_fnc_addPerFrameHandler;
-
-// Register fire event handler
-["ace_firedPlayer", DFUNC(handleFired)] call CBA_fnc_addEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/goggles/functions/fnc_applyGlassesEffect.sqf
+++ b/addons/goggles/functions/fnc_applyGlassesEffect.sqf
@@ -46,13 +46,15 @@ if (_imagePath != "") then {
     (GLASSDISPLAY displayCtrl 10650) ctrlSetText _imagePath;
 };
 
-if (GETDIRT) then {
-    call FUNC(applyDirtEffect);
-};
+if (GVAR(effects) == 2) then {
+    if (GETDIRT) then {
+        call FUNC(applyDirtEffect);
+    };
 
-if (GETDUSTT(DACTIVE)) then {
-    SETDUST(DAMOUNT,CLAMP(GETDUSTT(DAMOUNT)-1,0,2));
-    call FUNC(applyDustEffect);
+    if (GETDUSTT(DACTIVE)) then {
+        SETDUST(DAMOUNT,CLAMP(GETDUSTT(DAMOUNT)-1,0,2));
+        call FUNC(applyDustEffect);
+    };
 };
 
 GVAR(EffectsActive) = true;

--- a/addons/goggles/functions/fnc_externalCamera.sqf
+++ b/addons/goggles/functions/fnc_externalCamera.sqf
@@ -16,7 +16,7 @@
 #include "script_component.hpp"
 
 // Handle the ThreeDen Editor Camera
-if ((!isNil {is3DEN}) && {is3DEN}) exitWith {true};
+if (is3DEN) exitWith {true};
 
 if (GVAR(showInThirdPerson)) then {
     cameraView in ["GROUP"] || EFUNC(common,isFeatureCameraActive) 

--- a/addons/goggles/functions/fnc_handleKilled.sqf
+++ b/addons/goggles/functions/fnc_handleKilled.sqf
@@ -15,20 +15,21 @@
 params ["_unit"];
 
 if (_unit != ACE_player) exitWith {true};
-
-GVAR(PostProcessEyes) ppEffectEnable false;
-
-SETGLASSES(_unit,GLASSESDEFAULT);
+if (GVAR(effects) == 0) exitWith {true};
 
 call FUNC(removeGlassesEffect);
 
-GVAR(EffectsActive) = false;
+if (GVAR(effects) == 2) then {
+    GVAR(PostProcessEyes) ppEffectEnable false;
 
-_unit setVariable ["ACE_EyesDamaged", false];
+    SETGLASSES(_unit,GLASSESDEFAULT);
 
-if (GVAR(DustHandler) != -1) then {
-    [GVAR(DustHandler)] call CBA_fnc_removePerFrameHandler;
+    _unit setVariable ["ACE_EyesDamaged", false];
+
+    if (GVAR(DustHandler) != -1) then {
+        [GVAR(DustHandler)] call CBA_fnc_removePerFrameHandler;
+    };
+    GVAR(DustHandler) = -1;
 };
-GVAR(DustHandler) = -1;
 
 true

--- a/addons/goggles/functions/fnc_removeGlassesEffect.sqf
+++ b/addons/goggles/functions/fnc_removeGlassesEffect.sqf
@@ -22,6 +22,8 @@ if (!isNull (GLASSDISPLAY)) then {
     GLASSDISPLAY closeDisplay 0;
 };
 
-call FUNC(removeDirtEffect);
-call FUNC(removeRainEffect);
-call FUNC(removeDustEffect);
+if (GVAR(effects) == 2) then {
+    call FUNC(removeDirtEffect);
+    call FUNC(removeRainEffect);
+    call FUNC(removeDustEffect);
+};

--- a/addons/goggles/stringtable.xml
+++ b/addons/goggles/stringtable.xml
@@ -25,5 +25,14 @@
             <Portuguese>Limpar Óculos</Portuguese>
             <Italian>Pulisci gli occhiali</Italian>
         </Key>
+        <Key ID="STR_ACE_Goggles_effects_displayName">
+            <English>Goggle Effects</English>
+        </Key>
+        <Key ID="STR_ACE_Goggles_effects_tintOnly">
+            <English>Tint</English>
+        </Key>
+        <Key ID="STR_ACE_Goggles_enabled_tintAndEffects">
+            <English>Tint + Effects</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a ace_setting for change the level of effect simulation or goggles.

Can chose between none, tint/colorCC and full dust/dirt/rain/rotorwash.

XEH_postInit diff is a mess but it's mainly just skipping adding firedEH/PFEH depending on setting.

Not sure if this should be a client setting??