### PR TITLE
Fix rearm events

### DIFF
--- a/addons/rearm/functions/fnc_rearmEntireVehicleSuccess.sqf
+++ b/addons/rearm/functions/fnc_rearmEntireVehicleSuccess.sqf
@@ -17,11 +17,21 @@
 
 private ["_turretPath", "_magazines", "_magazine", "_currentMagazines", "_maxMagazines", "_maxRounds", "_currentRounds"];
 params [["_vehicle", objNull, [objNull]]];
+TRACE_1("params",_vehicle);
 
+
+//ToDo: Cleanup with CBA_fnc_ownerEvent in CBA 2.4.2
+{
+    [QGVAR(rearmEntireVehicleSuccessLocalEH), [_vehicle, _x]] call CBA_fnc_globalEvent;
+} forEach REARM_TURRET_PATHS;
+
+
+/* 
 if (isServer) then {
     {
         _turretOwnerID = _vehicle turretOwner _x;
         if (_turretOwnerID == 0) then {
+            //wtf is _truck from???
             [QGVAR(rearmEntireVehicleSuccessLocalEH), [_truck, _vehicle, _x], _truck] call CBA_fnc_targetEvent;
         } else {
             [QGVAR(rearmEntireVehicleSuccessLocalEH), [_truck, _vehicle, _x], _turretOwnerID] call CBA_fnc_targetEvent;
@@ -30,3 +40,4 @@ if (isServer) then {
 } else {
     [QGVAR(rearmEntireVehicleSuccessLocalEH), _this] call CBA_fnc_serverEvent;
 };
+*/

--- a/addons/rearm/functions/fnc_rearmEntireVehicleSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmEntireVehicleSuccessLocal.sqf
@@ -18,6 +18,10 @@
 
 private ["_magazines", "_magazine", "_currentMagazines", "_maxMagazines", "_maxRounds", "_currentRounds"];
 params [["_vehicle", objNull, [objNull]], ["_turretPath", [], [[]]]];
+TRACE_2("params",_vehicle,_turretPath);
+
+//ToDo: Cleanup with CBA_fnc_ownerEvent in CBA 2.4.2
+if (!(_vehicle turretLocal _turretPath)) exitWith {TRACE_1("not local turret",_turretPath);};
 
 _magazines = [_vehicle, _turretPath] call FUNC(getConfigMagazines);
 {

--- a/addons/rearm/functions/fnc_rearmSuccess.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccess.sqf
@@ -24,6 +24,7 @@
 private ["_dummy", "_weaponSelect", "_turretOwnerID"];
 params [["_args", [objNull, objNull, [], 0, "", 0], [[]], [6]]];
 _args params ["_target", "_unit", "_turretPath", "_numMagazines", "_magazineClass", "_numRounds"];
+TRACE_6("params",_target,_unit,_turretPath,_numMagazines,_magazineClass,_numRounds);
 
 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMagazine: %4\nNumRounds: %5", _target, _turretPath, _numMagazines, _magazineClass, _numRounds];
 
@@ -31,6 +32,10 @@ if (local _unit) then {
     [_unit, true, true] call FUNC(dropAmmo);
 };
 
+//ToDo: Cleanup with CBA_fnc_ownerEvent in CBA 2.4.2
+[QGVAR(rearmSuccessLocalEH), _this] call CBA_fnc_globalEvent;
+
+/* 
 if (isServer) then {
     _turretOwnerID = _target turretOwner _turretPath;
     if (_turretOwnerID == 0) then {
@@ -41,3 +46,4 @@ if (isServer) then {
 } else {
     [QGVAR(rearmSuccessLocalEH), _this] call CBA_fnc_serverEvent;
 };
+ */

--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -24,6 +24,10 @@
 private ["_rounds", "_currentRounds", "_maxMagazines", "_currentMagazines", "_dummy", "_weaponSelect"];
 params [["_args", [objNull, objNull, [], 0, "", 0], [[]], [6]]];
 _args params ["_target", "_unit", "_turretPath", "_numMagazines", "_magazineClass", "_numRounds"];
+TRACE_6("params",_target,_unit,_turretPath,_numMagazines,_magazineClass,_numRounds);
+
+//ToDo: Cleanup with CBA_fnc_ownerEvent in CBA 2.4.2
+if (!(_target turretLocal _turretPath)) exitWith {TRACE_1("not local turret",_turretPath);};
 
 //hint format ["Target: %1\nTurretPath: %2\nNumMagazines: %3\nMagazine: %4\nNumRounds: %5\nUnit: %6", _target, _turretPath, _numMagazines, _magazineClass, _numRounds, _unit];
 


### PR DESCRIPTION
Rearm was doing some weird stuff with old execRemoteFnc:
`_turretOwnerID publicVariableClient QEGVAR(common,remoteFnc);` 

(https://github.com/acemod/ACE3/commit/0723df7dea5c0a0edbf5dd6f8698dbc93a615e87#diff-e700393f0d5b2d9446845839cb7e854bL40)

We can't do events to owners until cba 2.4.2, so I switched it to just blast a global event and filter using `turretLocal` on all recievers so it works.

Still need to test on dedicated, will do tomorrow.