### PR TITLE
rearm - Skip selectWeapon on nil

### DIFF
--- a/addons/rearm/functions/fnc_dropAmmo.sqf
+++ b/addons/rearm/functions/fnc_dropAmmo.sqf
@@ -20,6 +20,8 @@
 private ["_dummy", "_actionID"];
 params [["_unit", objNull, [objNull]], ["_delete", false, [false]], ["_unholster", true, [true]]];
 
+if (isNull _unit) exitWith {};
+
 _dummy = _unit getVariable [QGVAR(dummy), objNull];
 if !(isNull _dummy) then {
     detach _dummy;

--- a/addons/rearm/script_component.hpp
+++ b/addons/rearm/script_component.hpp
@@ -33,5 +33,8 @@
 
 #define REARM_UNHOLSTER_WEAPON \
     _weaponSelect = _unit getVariable QGVAR(selectedWeaponOnRearm); \
-    _unit selectWeapon _weaponSelect; \
-    _unit setVariable [QGVAR(selectedWeaponOnRearm), nil];
+    TRACE_2("REARM_UNHOLSTER_WEAPON",_unit,_weaponSelect); \
+    if (!isNil "_weaponSelect") then { \
+        _unit selectWeapon _weaponSelect; \
+        _unit setVariable [QGVAR(selectedWeaponOnRearm), nil]; \
+    }; \


### PR DESCRIPTION
Should fix #4006
I could not reproduce the error, but I hope this will help.

In any case I dislike that with every vehicle change (even if not using the module) we did
` _unit selectWeapon nil`