### PR TITLE
Fix injuries shown as blue instead of red

### DIFF
--- a/addons/medical/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical/functions/fnc_displayPatientInformation.sqf
@@ -129,7 +129,7 @@ if (_show) then {
                 };
             } foreach _bandagedwounds;
         } else {
-            private _damaged = [true, true, true, true, true, true];
+            _damaged = [true, true, true, true, true, true];
             {
                 private _hitPoint = [_target, _x, true] call FUNC(translateSelections);
                 _selectionBloodLoss set [_forEachIndex, _target getHitPointDamage _hitPoint];


### PR DESCRIPTION
This fixes an issue were injured body parts were displayed as blue instead of red. Happens when using advanced medical with AI running in basic mode. @alganthe 

