### PR TITLE
Handle bad target when using apex titans

### DIFF
--- a/addons/missileguidance/functions/fnc_checkLos.sqf
+++ b/addons/missileguidance/functions/fnc_checkLos.sqf
@@ -14,6 +14,8 @@ private["_seeker", "_seekerPos", "_target", "_targetPos", "_return", "_vectorTo"
 _seeker = _this select 0;
 _target = _this select 1;
 
+if ((isNil "_seeker") || {isNil "_target"}) exitWith {false};
+
 _targetPos = getPosASL _target;
 _seekerPos = getPosASL _seeker;
 _return = true;

--- a/addons/missileguidance/functions/fnc_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_onFired.sqf
@@ -70,6 +70,12 @@ if(isNil "_target") then {
     };
 };
 
+//ToDo: Add correct configs for new apex titans (in ace_javelin)
+if ((isNil "_target") && {(_weapon == "launch_B_Titan_short_tna_F") || {_weapon == "launch_O_Titan_short_ghex_F"}}) then {
+    ACE_LOGWARNING_1("APEX Launcher [%1] not supported - Wait for ACE 3.6.1",_weapon);
+    if (!isNull cursorObject) then {_target = cursorObject;}; //Attempt to give some kind of target or it will
+};
+
 TRACE_4("Beginning ACE guidance system",_target,_ammo,_seekerType,_attackProfile);
 _args = [_this,
             [_shooter,


### PR DESCRIPTION
Fix #4007

The onFired stuff is just a bandAid until 1.62 is out. 
We need to explicitly add config's to the new weapons (it's designed to ignore inheritance)