### PR TITLE
add possibility to overwrite a units faction for determining name tags

### DIFF
--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -37,7 +37,7 @@ _fnc_parameters = {
         _size = 1;
     } else {
         if (_drawRank && {rank _target != ""}) then {
-            _icon = GVAR(factionRanks) getVariable faction _target;
+            _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
             if (!isNil "_icon") then {
                 _icon = _icon param [ALL_RANKS find rank _target, ""];
             } else {


### PR DESCRIPTION
**When merged this pull request will:**
- This adds the possibility to overrule the `faction` reported by the game with a custom one
- It can be used together with `setUnitLoadout` and `setUnitTrait` to fully change a unit from, e.g. B_Soldier_F to a Bundeswehr soldier.

`_unit setVariable ["ace_nametags_faction", "BWA3_Faction"]`