### PR TITLE
Add Drag/Drop Keybind

### DIFF
--- a/addons/dragging/XEH_postInit.sqf
+++ b/addons/dragging/XEH_postInit.sqf
@@ -28,3 +28,30 @@ if (isNil "ACE_maxWeightCarry") then {
 ["ace_unconscious", {_this call FUNC(handleUnconscious)}] call CBA_fnc_addEventHandler;
 
 //@todo Captivity?
+
+//Add Keybind:
+["ACE3 Common", QGVAR(drag), (localize LSTRING(DragKeybind)),
+{
+    if (!alive ACE_player) exitWith {false};
+    if !([ACE_player, objNull, ["isNotDragging", "isNotCarrying"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    
+    // If we are drag/carrying something right now then just drop it:
+    if (ACE_player getVariable [QGVAR(isDragging), false]) exitWith {
+        [ACE_player, ACE_player getVariable [QGVAR(draggedObject), objNull]] call FUNC(dropObject);
+        false
+    };
+    if (ACE_player getVariable [QGVAR(isCarrying), false]) exitWith {
+        [ACE_player, ACE_player getVariable [QGVAR(carriedObject), objNull]] call FUNC(dropObject_carry);
+        false
+    };
+
+    private _cursor = cursorObject;
+    if ((isNull _cursor) || {(_cursor distance ACE_player) > 2.6}) exitWith {false};
+    if (!([ACE_player, _cursor] call FUNC(canDrag))) exitWith {false};
+
+    [ACE_player, _cursor] call FUNC(startDrag);
+    false
+},
+{false},
+[-1, [false, false, false]]] call CBA_fnc_addKeybind; // UNBOUND
+

--- a/addons/dragging/stringtable.xml
+++ b/addons/dragging/stringtable.xml
@@ -32,7 +32,7 @@
             <Polish>Ciągnij/Puść Obiekt</Polish>
             <Czech>Táhnout/Položit Objekt</Czech>
             <French>Trainer/Lâcher Objets</French>
-            <German>Ziehen/Loslassen Objekt</German>
+            <German>Objekt ziehen/loslassen</German>
             <Portuguese>Arrastar/Soltar Objeto</Portuguese>
             <Italian>Trascina/Lascia Oggetto</Italian>
             <Hungarian>Húzás/Elengedés Objektum</Hungarian>

--- a/addons/dragging/stringtable.xml
+++ b/addons/dragging/stringtable.xml
@@ -25,6 +25,18 @@
             <Italian>Lascia</Italian>
             <Hungarian>Elengedés</Hungarian>
         </Key>
+        <Key ID="STR_ACE_Dragging_DragKeybind">
+            <English>Drag/Release Object</English>
+            <Russian>Тащить/Отпустить Объекты</Russian>
+            <Spanish>Arrastrar/Soltar Objeto</Spanish>
+            <Polish>Ciągnij/Puść Obiekt</Polish>
+            <Czech>Táhnout/Položit Objekt</Czech>
+            <French>Trainer/Lâcher Objets</French>
+            <German>Ziehen/Loslassen Objekt</German>
+            <Portuguese>Arrastar/Soltar Objeto</Portuguese>
+            <Italian>Trascina/Lascia Oggetto</Italian>
+            <Hungarian>Húzás/Elengedés Objektum</Hungarian>
+        </Key>
         <Key ID="STR_ACE_Dragging_UnableToDrag">
             <English>Item too heavy</English>
             <German>Gegenstand ist zu schwer</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a keybind to start dragging the cursorObject.
- If player is currently dragging/carring it will be dropped (Just like Joko's #2333)
- Unbound by default.

I had a feature request for this from someone who had trouble finding the drag interaction point on a body that was laying oddly. Given all the interaction points on people it is easy for them to overlap; so this does seem reasonable to me.

Should let us close out https://github.com/acemod/ACE3/issues/2284#issuecomment-136550815
and might work for #3724