### PR TITLE
Fix cargo event name - spare parts not being added

### DIFF
--- a/addons/repair/config.cpp
+++ b/addons/repair/config.cpp
@@ -25,5 +25,5 @@ class ACE_newEvents {
     setWheelHitPointDamage = QGVAR(setWheelHitPointDamage);
     setVehicleHitPointDamage = QGVAR(setVehicleHitPointDamage);
     setVehicleDamage = QGVAR(setVehicleDamage);
-    AddCargoByClass = "ace_addCargoByClass";
+    AddCargoByClass = "ace_addCargo";
 };

--- a/addons/repair/functions/fnc_addSpareParts.sqf
+++ b/addons/repair/functions/fnc_addSpareParts.sqf
@@ -33,4 +33,4 @@ if (!EGVAR(common,settingsInitFinished)) exitWith {
 if (!_force && !GVAR(addSpareParts)) exitWith {};
 
 // Load
-["ace_addCargoByClass", [_part, _vehicle, _amount]] call CBA_fnc_localEvent;
+["ace_addCargo", [_part, _vehicle, _amount]] call CBA_fnc_localEvent;

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -58,5 +58,5 @@ class ACE_newEvents {
     zeusUnitAssigned = QGVAR(zeusUnitAssigned);
     SetSurrendered = QEGVAR(captives,setSurrendered);
     SetHandcuffed = QEGVAR(captives,setHandcuffed);
-    AddCargoByClass = "ace_addCargoByClass";
+    AddCargoByClass = "ace_addCargo";
 };

--- a/addons/zeus/functions/fnc_moduleAddSpareTrack.sqf
+++ b/addons/zeus/functions/fnc_moduleAddSpareTrack.sqf
@@ -32,7 +32,7 @@ if !(["ace_cargo"] call EFUNC(common,isModLoaded) && ["ace_repair"] call EFUNC(c
             if (getNumber (configFile >> "CfgVehicles" >> "ACE_Track" >> QEGVAR(cargo,size)) > [_mouseOverUnit] call EFUNC(cargo,getCargoSpaceLeft)) then {
                 [LSTRING(OnlyEnoughCargoSpace)] call EFUNC(common,displayTextStructured);
             } else {
-                ["ace_addCargoByClass", ["ACE_Track", _mouseOverUnit, 1, true]] call CBA_fnc_localEvent;
+                ["ace_addCargo", ["ACE_Track", _mouseOverUnit, 1, true]] call CBA_fnc_localEvent;
             };
         };
     };

--- a/addons/zeus/functions/fnc_moduleAddSpareWheel.sqf
+++ b/addons/zeus/functions/fnc_moduleAddSpareWheel.sqf
@@ -32,7 +32,7 @@ if !(["ace_cargo"] call EFUNC(common,isModLoaded) && ["ace_repair"] call EFUNC(c
             if (getNumber (configFile >> "CfgVehicles" >> "ACE_Wheel" >> QEGVAR(cargo,size)) > [_mouseOverUnit] call EFUNC(cargo,getCargoSpaceLeft)) then {
                 [LSTRING(OnlyEnoughCargoSpace)] call EFUNC(common,displayTextStructured);
             } else {
-                ["ace_addCargoByClass", ["ACE_Wheel", _mouseOverUnit, 1, true]] call CBA_fnc_localEvent;
+                ["ace_addCargo", ["ACE_Wheel", _mouseOverUnit, 1, true]] call CBA_fnc_localEvent;
             };
         };
     };


### PR DESCRIPTION
Fix Spare parts not being added in 3.6
Cargo event was renamed.