### PR TITLE
Less aggressive overlap detection

### DIFF
--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -159,7 +159,7 @@ if (count GVAR(collectedActionPoints) > 1) then {
             private _delta = vectorNormalized ((GVAR(collectedActionPoints) select _i select 1) vectorDiff (GVAR(collectedActionPoints) select _j select 1));
 
             // If _i is inside a cone with 20º half angle with origin on _j
-            if (_delta select 2 > 0.94) exitWith {
+            if ((_delta select 2 > 0.94) && {((GVAR(collectedActionPoints) select _i select 1) distance2d (GVAR(collectedActionPoints) select _j select 1)) < 0.1}) exitWith {
                 GVAR(collectedActionPoints) deleteAt _i;
             };
         };


### PR DESCRIPTION
This should be a fix for a side effect of #3342
I could not find the interaction point for the attached refuel nozzle.
In the cropped screenshot below, the refuel action would not be shown without this fix.

![20160702223642_1](https://cloud.githubusercontent.com/assets/9376747/16543693/f8be519a-40a7-11e6-9474-bf3ca4f4b8a4.jpg)

Interaction _sPos: [0.768666,0.525559,0.346336]
Refuel _sPos: [0.453124,0.457705,1.23955]

Delta: [-0.332239,-0.0714445,0.940485]
Distance2d: 0.322755

I think the vehicle's dynamic position is pushed so close to the player that it obscures things that it shouldn't.
This PR adds a 2nd requirement that the 2d screen pos distance needs to be small enough to make obscuring worthwhile.
