### PR TITLE
Fix pboProject converting boolean to numbers in UI config

### DIFF
--- a/addons/fcs/ACE_UI.hpp
+++ b/addons/fcs/ACE_UI.hpp
@@ -1,7 +1,7 @@
 class ACE_UI {
     class gunnerZeroing {
         class conditions {
-            ADDON = "false";
+            ADDON = "(false)";
         };
     };
 };

--- a/addons/reload/ACE_UI.hpp
+++ b/addons/reload/ACE_UI.hpp
@@ -1,7 +1,7 @@
 class ACE_UI {
     class ammoCount {
         class conditions {
-            ADDON = "false";
+            ADDON = "(false)";
         };
     };
 };

--- a/addons/ui/ACE_Settings.hpp
+++ b/addons/ui/ACE_Settings.hpp
@@ -83,7 +83,7 @@ class ACE_Settings {
         displayName = CSTRING(AmmoCount);
         description = CSTRING(RequiresSoldierVehicleWeaponInfo);
         typeName = "BOOL";
-        value = 1;
+        value = 0;
         isClientSettable = 1;
     };
     class GVAR(magCount) {

--- a/addons/ui/CfgVehicles.hpp
+++ b/addons/ui/CfgVehicles.hpp
@@ -73,7 +73,7 @@ class CfgVehicles {
                 displayName = CSTRING(AmmoCount);
                 description = CSTRING(RequiresSoldierVehicleWeaponInfo);
                 typeName = "BOOL";
-                defaultValue = 1;
+                defaultValue = 0;
             };
             class magCount {
                 displayName = CSTRING(MagCount);


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Defaults `ammoCount` to off

I think braces prevent pboProject from converting them, correct me if I am wrong.