### PR TITLE
Update showHud func for 1.62 (squad radar)

### DIFF
--- a/addons/captives/functions/fnc_handlePlayerChanged.sqf
+++ b/addons/captives/functions/fnc_handlePlayerChanged.sqf
@@ -21,7 +21,7 @@ params ["_newUnit","_oldUnit"];
 //set showHUD based on new unit status:
 if ((_newUnit getVariable [QGVAR(isHandcuffed), false]) || {_newUnit getVariable [QGVAR(isSurrendering), false]}) then {
     TRACE_1("Player Change (showHUD false)",_newUnit);
-    ["captive", [false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
+    ["captive", [false, false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
 } else {
     TRACE_1("Player Change (showHUD true)",_newUnit);
     ["captive", []] call EFUNC(common,showHud); //same as showHud true;

--- a/addons/captives/functions/fnc_handleZeusDisplayChanged.sqf
+++ b/addons/captives/functions/fnc_handleZeusDisplayChanged.sqf
@@ -19,7 +19,7 @@
 
 if ((ACE_player getVariable [QGVAR(isHandcuffed), false]) || {ACE_player getVariable [QGVAR(isSurrendering), false]}) then {
     TRACE_1("Player Change (showHUD false)",ACE_player);
-    ["captive", [false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
+    ["captive", [false, false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
 } else {
     TRACE_1("Player Change (showHUD true)",ACE_player);
     ["captive", []] call EFUNC(common,showHud); //same as showHud true;

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -50,7 +50,7 @@ if (_state) then {
     _unit setVariable [QGVAR(CargoIndex), ((vehicle _unit) getCargoIndex _unit), true];
 
     if (_unit == ACE_player) then {
-        ["captive", [false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
+        ["captive", [false, false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
     };
 
     // fix anim on mission start (should work on dedicated servers)

--- a/addons/captives/functions/fnc_setSurrendered.sqf
+++ b/addons/captives/functions/fnc_setSurrendered.sqf
@@ -47,7 +47,7 @@ if (_state) then {
     [_unit, "setCaptive", QGVAR(Surrendered), true] call EFUNC(common,statusEffect_set);
 
     if (_unit == ACE_player) then {
-        ["captive", [false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
+        ["captive", [false, false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
     };
 
     [_unit] call EFUNC(common,fixLoweredRifleAnimation);

--- a/addons/common/functions/fnc_showHud.sqf
+++ b/addons/common/functions/fnc_showHud.sqf
@@ -15,6 +15,7 @@
  * - menu: Boolean - show commanding menu (hides HC related menus)
  * - group: Boolean - show group info bar (hides squad leader info bar)
  * - cursors: Boolean - show HUD weapon cursors (connected with scripted HUD)
+ * - squadRadar: Boolean - show HUD squad radar (since 1.62)
  *
  * Return Value:
  * Resulting ShowHud Array <ARRAY>
@@ -29,7 +30,12 @@
 
 if (!hasInterface) exitWith {[-1]};
 
-params [["_reason", "", [""]], ["_mask", [], [[]], [0,8]]];
+params [["_reason", "", [""]], ["_mask", [], [[]], [0,8,9]]];
+
+if ((count _mask) == 8) then {
+    ACE_LOGWARNING_1("ace_common_fnc_showHud - mask now takes 9 arguements in 1.62 [called with %1]",_this);
+    _mask pushBack true;
+};
 
 if (isArray (missionConfigFile >> "showHUD")) then {
     //(showHud = 0;) is fine - the array is the problem
@@ -50,7 +56,7 @@ if (_reason != "") then {
 GVAR(showHudHash) params ["_reasons", "_masks"];
 private _resultMask = [];
 
-for "_index" from 0 to 7 do {
+for "_index" from 0 to 8 do {
     private _set = true; //Default to true
     {
         if (!(_x select _index)) exitWith {

--- a/addons/common/functions/fnc_showHud.sqf
+++ b/addons/common/functions/fnc_showHud.sqf
@@ -33,7 +33,7 @@ if (!hasInterface) exitWith {[-1]};
 params [["_reason", "", [""]], ["_mask", [], [[]], [0,8,9]]];
 
 if ((count _mask) == 8) then {
-    ACE_LOGWARNING_1("ace_common_fnc_showHud - mask now takes 9 arguements in 1.62 [called with %1]",_this);
+    ACE_LOGWARNING_1("ace_common_fnc_showHud - mask now takes 9 arguments in 1.62 [called with %1]",_this);
     _mask pushBack true;
 };
 

--- a/addons/ui/ACE_Settings.hpp
+++ b/addons/ui/ACE_Settings.hpp
@@ -43,6 +43,13 @@ class ACE_Settings {
         value = 0;
         isClientSettable = 1;
     };
+    class GVAR(squadRadar) {
+        category = CSTRING(Category);
+        displayName = CSTRING(SquadRadar);
+        typeName = "BOOL";
+        value = 1;
+        isClientSettable = 1;
+    };
 
 // ADVANCED
     // Soldier

--- a/addons/ui/CfgVehicles.hpp
+++ b/addons/ui/CfgVehicles.hpp
@@ -42,6 +42,11 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 0;
             };
+            class squadRadar {
+                displayName = CSTRING(SquadRadar);
+                typeName = "BOOL";
+                defaultValue = 1;
+            };
 
             // ADVANCED
             // Soldier

--- a/addons/ui/functions/fnc_moduleInit.sqf
+++ b/addons/ui/functions/fnc_moduleInit.sqf
@@ -30,6 +30,7 @@ if (isArray (missionConfigFile >> "showHUD")) then {
     [_logic, QGVAR(vehicleCompass), "vehicleCompass"] call EFUNC(common,readSettingFromModule);
     [_logic, QGVAR(commandMenu), "commandMenu"] call EFUNC(common,readSettingFromModule);
     [_logic, QGVAR(groupBar), "groupBar"] call EFUNC(common,readSettingFromModule);
+    [_logic, QGVAR(squadRadar), "squadRadar"] call EFUNC(common,readSettingFromModule);
 };
 
 // Advanced

--- a/addons/ui/functions/fnc_setElements.sqf
+++ b/addons/ui/functions/fnc_setElements.sqf
@@ -32,5 +32,5 @@ if (isArray (missionConfigFile >> "showHUD")) exitWith {
     GVAR(commandMenu),
     GVAR(groupBar),
     true,
-    true
+    GVAR(squadRadar)
 ]] call EFUNC(common,showHud);

--- a/addons/ui/functions/fnc_setElements.sqf
+++ b/addons/ui/functions/fnc_setElements.sqf
@@ -31,5 +31,6 @@ if (isArray (missionConfigFile >> "showHUD")) exitWith {
     true,
     GVAR(commandMenu),
     GVAR(groupBar),
+    true,
     true
 ]] call EFUNC(common,showHud);

--- a/addons/ui/script_component.hpp
+++ b/addons/ui/script_component.hpp
@@ -19,7 +19,7 @@
 
 
 // Basic Elements
-#define ELEMENTS_BASIC [QGVAR(soldierVehicleWeaponInfo), QGVAR(vehicleRadar), QGVAR(vehicleCompass), QGVAR(commandMenu), QGVAR(groupBar)]
+#define ELEMENTS_BASIC [QGVAR(soldierVehicleWeaponInfo), QGVAR(vehicleRadar), QGVAR(vehicleCompass), QGVAR(commandMenu), QGVAR(groupBar), QGVAR(squadRadar)]
 
 /*
 RscUnitInfo = 300

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -60,6 +60,9 @@
             <Portuguese>Barra de Grupo</Portuguese>
             <French>Barre de groupe</French>
         </Key>
+        <Key ID="STR_ACE_UI_SquadRadar">
+            <English>Squad Radar</English>
+        </Key>
         <Key ID="STR_ACE_UI_WeaponName">
             <English>Weapon Name</English>
             <Czech>Název zbraně</Czech>


### PR DESCRIPTION
In 1.62 `showHud`/`shownHud` now has 9 arguements.
- Changed ace_common_fnc_showHud to use 9 (and be backwards compatible)
- Updated all calls to func to use 9