### PR TITLE
Fix overheating spare barrels

### DIFF
--- a/addons/overheating/CfgWeapons.hpp
+++ b/addons/overheating/CfgWeapons.hpp
@@ -2,17 +2,6 @@ class CfgWeapons {
     class ACE_ItemCore;
     class InventoryItem_Base_F;
 
-    class ACE_SpareBarrel: ACE_ItemCore {
-        displayname = CSTRING(SpareBarrelName);
-        descriptionshort = CSTRING(SpareBarrelDescription);
-        //model = "";
-        picture = QPATHTOF(UI\spare_barrel_ca.paa);
-        scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
-            mass = 30;
-        };
-    };
-
     class RifleCore;
     class Rifle: RifleCore {
         //Mean Rounds Between Stoppages (this will be scaled based on the barrel temp)

--- a/addons/overheating/functions/fnc_displayTemperature.sqf
+++ b/addons/overheating/functions/fnc_displayTemperature.sqf
@@ -3,7 +3,7 @@
  * Displays the weapon temperature
  *
  * Arguments:
- * 0: Player <OBJECT>
+ * 0: Unit <OBJECT>
  * 1: Weapon <STRING>
  *
  * Return Values:
@@ -16,11 +16,13 @@
  */
 #include "script_component.hpp"
 
-params ["_player", "_weapon"];
-TRACE_2("params",_player,_weapon);
+params ["_unit", "_weapon"];
+TRACE_2("params",_unit,_weapon);
 
-// Calculate cool down of weapon since last shot
-private _temperature = [_player, _weapon, 0] call FUNC(updateTemperature);
+// Get unit's weapon's temperature:
+private _tempVarName = format [QGVAR(%1_temp), _weapon];
+private _temperature = _unit getVariable [_tempVarName, 0];
+
 private _scaledTemperature = (_temperature / 1000) min 1;
 
 private _color = [
@@ -40,6 +42,8 @@ _string = "";
 for "_a" from (_count + 1) to 12 do {
     _string = _string + "|";
 };
+
+TRACE_3("",_temperature,_color,_string);
 
 _text = composeText [_text, [_string, [0.5, 0.5, 0.5]] call EFUNC(common,stringToColoredText)];
 

--- a/addons/overheating/functions/fnc_loadCoolestSpareBarrel.sqf
+++ b/addons/overheating/functions/fnc_loadCoolestSpareBarrel.sqf
@@ -50,4 +50,4 @@ _gunner setVariable [format [QGVAR(%1_temp), _weapon], _coolestTemp, true];
 [GVAR(storedSpareBarrels), _coolestMag, [_weaponTemp, CBA_missionTime, _barrelMass]] call CBA_fnc_hashSet;
 
 // Send an event so the machines of the assistant and gunner can show the hint
-[QGVAR(showWeaponTemperature), _gunner], [_gunner, _weapon], [_assistant] call CBA_fnc_targetEvent;
+[QGVAR(showWeaponTemperature), [_gunner, _weapon], [_assistant, _gunner]] call CBA_fnc_targetEvent;


### PR DESCRIPTION
Fix #4044 

- Remove ACE_SpareBarrel from CfgWeapons as it is now a magazine
- Don't call updateTemperature in displayTemp, as unit may not be local
- Fix targetEvent error in loadCoolestSpareBarrel