### PR TITLE
Fix order of revive loop

### DIFF
--- a/addons/medical/functions/fnc_reviveStateLoop.sqf
+++ b/addons/medical/functions/fnc_reviveStateLoop.sqf
@@ -21,13 +21,6 @@ if (!local _unit) exitWith {};
 
 private _startTime = _unit getVariable [QGVAR(reviveStartTime), 0];
 
-// Remove heartbeat
-if (GVAR(level) >= 2) then {
-    if (_unit getVariable [QGVAR(heartRate), 60] > 0) then {
-        _unit setVariable [QGVAR(heartRate), 0];
-    };
-};
-
 // If we are in revive state in a blown up vehicle, try to unload so that people can access the body
 if ((alive _unit) && {(vehicle _unit) != _unit} && {!alive (vehicle _unit)}) then {
     TRACE_2("Unloading", _unit, vehicle _unit);
@@ -50,6 +43,13 @@ if !(_unit getVariable [QGVAR(inReviveState), false]) exitwith {
     };
 
     _unit setVariable [QGVAR(reviveStartTime), nil];
+};
+
+// Remove heartbeat
+if (GVAR(level) >= 2) then {
+    if (_unit getVariable [QGVAR(heartRate), 60] > 0) then {
+        _unit setVariable [QGVAR(heartRate), 0];
+    };
 };
 
 // Schedule the loop to be executed again 1 sec later


### PR DESCRIPTION
Fix #4035
Revive loop was always killing heartrate before it exited, even if they were healed by PAK