### PR TITLE
Remove remaining >> signs from interaction menu

### DIFF
--- a/addons/attach/stringtable.xml
+++ b/addons/attach/stringtable.xml
@@ -2,15 +2,15 @@
 <Project name="ACE">
     <Package name="Attach">
         <Key ID="STR_ACE_Attach_AttachDetach">
-            <English>Attach item &gt;&gt;</English>
-            <German>Gegenstand befestigen &gt;&gt;</German>
-            <Spanish>Acoplar objeto &gt;&gt;</Spanish>
-            <Polish>Przyczep &gt;&gt;</Polish>
-            <French>Attacher l'objet &gt;&gt;</French>
-            <Czech>Připnout &gt;&gt;</Czech>
-            <Portuguese>Fixar item &gt;&gt;</Portuguese>
-            <Italian>Attacca l'oggetto &gt;&gt;</Italian>
-            <Hungarian>Tárgy hozzácsatolása &gt;&gt;</Hungarian>
+            <English>Attach item</English>
+            <German>Gegenstand befestigen</German>
+            <Spanish>Acoplar objeto</Spanish>
+            <Polish>Przyczep</Polish>
+            <French>Attacher l'objet</French>
+            <Czech>Připnout</Czech>
+            <Portuguese>Fixar item</Portuguese>
+            <Italian>Attacca l'oggetto</Italian>
+            <Hungarian>Tárgy hozzácsatolása</Hungarian>
             <Russian>Прикрепить предмет</Russian>
         </Key>
         <Key ID="STR_ACE_Attach_Attach">

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -248,16 +248,16 @@
             <French>Ajouter des pièces de rechage aux véhicules ? (à besoin du système de cargaison)</French>
         </Key>
         <Key ID="STR_ACE_Repair_Repair">
-            <English>Repair &gt;&gt;</English>
-            <German>Reparieren &gt;&gt;</German>
-            <Spanish>Reparación &gt;&gt;</Spanish>
-            <French>Réparer &gt;&gt;</French>
-            <Polish>Napraw &gt;&gt;</Polish>
-            <Czech>Opravit &gt;&gt;</Czech>
-            <Portuguese>Reparar &gt;&gt;</Portuguese>
-            <Italian>Ripara &gt;&gt;</Italian>
-            <Hungarian>Szerelés &gt;&gt;</Hungarian>
-            <Russian>Ремонт &gt;&gt;</Russian>
+            <English>Repair</English>
+            <German>Reparieren</German>
+            <Spanish>Reparación</Spanish>
+            <French>Réparer</French>
+            <Polish>Napraw</Polish>
+            <Czech>Opravit</Czech>
+            <Portuguese>Reparar</Portuguese>
+            <Italian>Ripara</Italian>
+            <Hungarian>Szerelés</Hungarian>
+            <Russian>Ремонт</Russian>
         </Key>
         <Key ID="STR_ACE_Repair_SettingDisplayTextName">
             <English>Display text on repair</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Remove remaining >> signs from the interaction menu: "Attach >>" and "Repair >>"

We've removed most of these signs a long time ago, but for some reason these two actions kept them. For #3993 I'm planning on experimenting with adding some visual cue to indicate which actions have sub-actions.