### PR TITLE
Remove redundant getMagazineIndex compatibility function

### DIFF
--- a/addons/overheating/XEH_preInit.sqf
+++ b/addons/overheating/XEH_preInit.sqf
@@ -4,16 +4,4 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
-if (isNil "CBA_fnc_getMagazineIndex") then {
-    CBA_fnc_getMagazineIndex = {
-        params [["_unit", objNull, [objNull]], ["_magazine", "", [""]]];
-
-        private _displayName = getText (configFile >> "CfgMagazines" >> _magazine >> "displayName");
-
-        if (_displayName isEqualTo "") exitWith {[]};
-
-        (magazinesDetail _unit select {_x find _displayName == 0}) apply {_x = _x splitString "[:]"; _x select (count _x - 1)};
-    };
-};
-
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Function definition was added in https://github.com/acemod/ACE3/commit/62f598b2a6bca3049438c52154e3b9c612aac952 (and later renamed in another commit) to keep compatibility with CBA at the time.