### PR TITLE
Allow defusing naval mines

### DIFF
--- a/addons/explosives/functions/fnc_canDefuse.sqf
+++ b/addons/explosives/functions/fnc_canDefuse.sqf
@@ -4,7 +4,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 0: Target <OBJECT>
+ * 0: Target (ACE_DefuseObject) <OBJECT>
  *
  * Return Value:
  * Able to defuse <BOOL>
@@ -19,15 +19,16 @@
 params ["_unit", "_target"];
 TRACE_2("params",_unit,_target);
 
-private ["_isSpecialist"];
-
-if (isNull(_target getVariable [QGVAR(Explosive),objNull])) exitWith {
+private _explosive = _target getVariable [QGVAR(Explosive), objNull];
+if (isNull _explosive) exitWith {
     deleteVehicle _target;
     false
 };
 if (vehicle _unit != _unit || {!("ACE_DefusalKit" in (items _unit))}) exitWith {false};
-_isSpecialist = [_unit] call EFUNC(Common,isEOD);
 
-if (GVAR(RequireSpecialist) && {!_isSpecialist}) exitWith {false};
+if (GVAR(RequireSpecialist) && {!([_unit] call EFUNC(Common,isEOD))}) exitWith {false};
+
+//Handle the naval mines (which doens't get turned into items when defused):
+if ((_explosive isKindOf "UnderwaterMine_Range_Ammo") && {!mineActive _explosive}) exitWith {false};
 
 true

--- a/addons/explosives/functions/fnc_defuseExplosive.sqf
+++ b/addons/explosives/functions/fnc_defuseExplosive.sqf
@@ -25,5 +25,12 @@ if (GVAR(ExplodeOnDefuse) && {(random 1.0) < (getNumber (ConfigFile >> "CfgAmmo"
     [QGVAR(explodeOnDefuse), [_explosive, _unit]] call CBA_fnc_globalEvent;
 };
 
-_unit action ["Deactivate", _unit, _explosive];
 [QGVAR(defuse), [_explosive, _unit]] call CBA_fnc_globalEvent;
+
+if (!(_explosive isKindOf "UnderwaterMine_Range_Ammo")) then {
+    _unit action ["Deactivate", _unit, _explosive];
+} else {
+    // Underwater naval mines don't seem to respond to the deactivate action
+    // For now, lets just delete them
+    deleteVehicle _explosive;
+};

--- a/addons/explosives/functions/fnc_defuseExplosive.sqf
+++ b/addons/explosives/functions/fnc_defuseExplosive.sqf
@@ -25,12 +25,5 @@ if (GVAR(ExplodeOnDefuse) && {(random 1.0) < (getNumber (ConfigFile >> "CfgAmmo"
     [QGVAR(explodeOnDefuse), [_explosive, _unit]] call CBA_fnc_globalEvent;
 };
 
+_unit action ["Deactivate", _unit, _explosive];
 [QGVAR(defuse), [_explosive, _unit]] call CBA_fnc_globalEvent;
-
-if (!(_explosive isKindOf "UnderwaterMine_Range_Ammo")) then {
-    _unit action ["Deactivate", _unit, _explosive];
-} else {
-    // Underwater naval mines don't seem to respond to the deactivate action
-    // For now, lets just delete them
-    deleteVehicle _explosive;
-};

--- a/addons/explosives/functions/fnc_startDefuse.sqf
+++ b/addons/explosives/functions/fnc_startDefuse.sqf
@@ -63,6 +63,6 @@ if (ACE_player != _unit) then {
     _isEOD = [_unit] call EFUNC(Common,isEOD);
     _defuseTime = [_isEOD, _target] call _fnc_DefuseTime;
     if (_isEOD || {!GVAR(RequireSpecialist)}) then {
-        [_defuseTime, [_unit,_target], {(_this select 0) call FUNC(defuseExplosive)}, {}, (localize LSTRING(DefusingExplosive))] call EFUNC(common,progressBar);
+        [_defuseTime, [_unit,_target], {(_this select 0) call FUNC(defuseExplosive)}, {}, (localize LSTRING(DefusingExplosive)), {true}, ["isNotSwimming"]] call EFUNC(common,progressBar);
     };
 };


### PR DESCRIPTION
Fix #4074
- Workaround for naval mines not working with deactivate
- Add "isNotSwimming" exception to defuse progress bar