### PR TITLE
Improve SSN hash

### DIFF
--- a/addons/dogtags/functions/fnc_ssn.sqf
+++ b/addons/dogtags/functions/fnc_ssn.sqf
@@ -8,24 +8,27 @@
  * Return Value:
  * A random three/two/four format social security number <STRING>
  *
+ * Example:
+ * ["AAA"] call ace_dogtags_fnc_ssn
+ *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_name"];
+
 private _length = count _name;
 private _chars = toArray _name;
+_chars pushBack _length;
+_length = _length + 1;
 
-// For short names, reuse characters
-if (_length < 9) then {
-    // Iterates every second character, swapping odd/even with each loop
-    for [{_i = 0},{_i < 2*(9 - _length)},{_i = _i + 2}] do {
-        _chars pushBack (_chars select floor((_i + (_i/_length % 2)) % _length));
-    };
+private _remainder = 0;
+private _nums = [0,0,0,0,0,0,0,0,0];
+
+for "_index" from 0 to (8 max _length) do {
+    private _inputChar = _chars select (_index % _length);
+    _nums set [(_index % 9), ((_nums select (_index % 9)) + _inputChar + _remainder) % 10];
+    _remainder = (_inputChar + _remainder) % 256;
 };
-
-// Offset array slice for long names to make generation more unique
-private _slice = [0, _length % 9] select (_length > 9);
-private _nums = (_chars select [_slice, 9]) apply { _x % 10 };
 
 ([_nums select [0,3],_nums select [3,2], _nums select [5,4]] apply { _x joinString "" }) joinString "-"


### PR DESCRIPTION
Passes @bux578 's splendid test code: https://codeshare.io/jorDJ

Uses all chars of long names, and remixes input so that "A" does not always turn into 5