### PR TITLE
Add description and example to blur screen function

### DIFF
--- a/addons/common/functions/fnc_blurScreen.sqf
+++ b/addons/common/functions/fnc_blurScreen.sqf
@@ -1,12 +1,16 @@
 /*
  * Author: Glowbal
+ * Blurs screen.
  *
  * Arguments:
  * 0: ID <NUMBER>
- * 1: Show? <BOOL, NUMBER>
+ * 1: Show? <BOOL/NUMBER>
  *
  * Return Value:
  * None
+ *
+ * Example:
+ * [5, true] call ace_common_fnc_blurScreen
  *
  * Public: Yes
  */


### PR DESCRIPTION
**When merged this pull request will:**
- When updating language-arma-atom I noticed this public function is missing description and example (and was not included in the package for that reason). This just adds it as per our guidelines.