### PR TITLE
Fixed name for `Weapon_SMG_05_F` (MP5K) for EDEN item.

### DIFF
--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -514,7 +514,7 @@ class CfgVehicles {
         displayName = CSTRING(SMG_02_Name);
     };
     
-    class Weapon_SMG_05_F : Weapon_Base_F {
+    class Weapon_SMG_05_F: Weapon_Base_F {
         displayName = CSTRING(SMG_05);
     };
     

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -513,7 +513,11 @@ class CfgVehicles {
     class Weapon_SMG_02_F: Weapon_Base_F {
         displayName = CSTRING(SMG_02_Name);
     };
-
+    
+    class Weapon_SMG_05_F : Weapon_Base_F {
+        displayName = CSTRING(SMG_05);
+    };
+    
     class Weapon_hgun_PDW2000_F: Weapon_Base_F {
         displayName = CSTRING(hgun_PDW2000_Name);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- change the name of classname `Weapon_SMG_05_F` to `MP5K` in the editor.
