### PR TITLE
Fixed MicroDAGR trailing zero

### DIFF
--- a/addons/microdagr/functions/fnc_updateDisplay.sqf
+++ b/addons/microdagr/functions/fnc_updateDisplay.sqf
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Author: PabstMirror
  * Updates the display (several times a second) called from the pfeh
  *
@@ -49,7 +49,7 @@ case (APP_MODE_INFODISPLAY): {
         _compassAngleText = if (GVAR(settingUseMils)) then {
             [(floor ((6400 / 360) * (([ACE_player] call CBA_fnc_headDir) select 0))), 4, 0] call CBA_fnc_formatNumber;
         } else {
-            ([(floor (([ACE_player] call CBA_fnc_headDir) select 0)), 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
+            ([([ACE_player] call CBA_fnc_headDir) select 0, 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
         };
         (_display displayCtrl IDC_MODEDISPLAY_HEADINGNUM) ctrlSetText _compassAngleText;
 
@@ -89,7 +89,7 @@ case (APP_MODE_INFODISPLAY): {
                 _bearingText = if (GVAR(settingUseMils)) then {
                     [(floor ((6400 / 360) * (_bearing))), 4, 0] call CBA_fnc_formatNumber;
                 } else {
-                    ([(floor (_bearing)), 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
+                    ([_bearing, 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
                 };
                 _2dDistanceKm = ((getPosASL ACE_player) distance2D _targetPosLocationASL) / 1000;
                 _rangeText = format ["%1km", ([_2dDistanceKm, 1, 1] call CBA_fnc_formatNumber)];
@@ -109,7 +109,7 @@ case (APP_MODE_COMPASS): {
         _compassAngleText = if (GVAR(settingUseMils)) then {
             [(floor ((6400 / 360) * (([ACE_player] call CBA_fnc_headDir) select 0))), 4, 0] call CBA_fnc_formatNumber;
         } else {
-            ([(floor (([ACE_player] call CBA_fnc_headDir) select 0)), 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
+            ([([ACE_player] call CBA_fnc_headDir) select 0, 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
         };
         (_display displayCtrl IDC_MODECOMPASS_HEADING) ctrlSetText _compassAngleText;
 
@@ -145,7 +145,7 @@ case (APP_MODE_COMPASS): {
                 _bearingText = if (GVAR(settingUseMils)) then {
                     [(floor ((6400 / 360) * (_bearing))), 4, 0] call CBA_fnc_formatNumber;
                 } else {
-                    ([(floor (_bearing)), 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
+                    ([_bearing, 3, 1] call CBA_fnc_formatNumber) + "°" //degree symbol is in UTF-8
                 };
                 _2dDistanceKm = ((getPosASL ACE_player) distance2D _targetPosLocationASL) / 1000;
                 _rangeText = format ["%1km", ([_2dDistanceKm, 1, 1] call CBA_fnc_formatNumber)];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the degree displays on the MicroDAGR always having a trailing `.0`