### PR TITLE
Cut ropes keybind

### DIFF
--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -7,3 +7,12 @@
 [QGVAR(startFastRope), {
     [FUNC(fastRopeServerPFH), 0, _this] call CBA_fnc_addPerFrameHandler;
 }] call CBA_fnc_addEventHandler;
+
+["ACE3 Vehicles", QGVAR(cutRopes), localize LSTRING(Interaction_cutRopes), {
+    if ([vehicle ACE_player] call FUNC(canCutRopes)) then {
+        [vehicle ACE_player] call FUNC(cutRopes);
+        true
+    } else {
+        false
+    };
+}, {false}] call CBA_fnc_addKeybind;


### PR DESCRIPTION
**When merged this pull request will:**
- #4111 to `release`
- Add a keybind (default unbound) to cut fastroping ropes