### PR TITLE
Change macro for pboProject

### DIFF
--- a/addons/particles/script_component.hpp
+++ b/addons/particles/script_component.hpp
@@ -44,7 +44,7 @@
         interval = 1; \
     }; \
 }
-#define MERGE(var1,var2) var1##var2
+#define MERGE(var1,var2) ##var1####var2
 #define EFFECT_AFTER_WATER(color) class ACE_SmokeAfterWater##color##: ACE_SmokeAfterWaterWhite { \
     class SmokeAfterWater: SmokeAfterWater { \
         type = QUOTE(MERGE(ACE_SmokeAfterWater,color)); \


### PR DESCRIPTION
I am not sure why, but pboProject fails to build particles:
```
In File z\ace\addons\particles\script_component.hpp: Line 47 Cannot Handle single# in defines
```

This "fix" should work the same.