### PR TITLE
Definable classname for Spare Barrel

### DIFF
--- a/addons/overheating/CfgVehicles.hpp
+++ b/addons/overheating/CfgVehicles.hpp
@@ -15,7 +15,7 @@ class CfgVehicles {
                 };
                 class GVAR(SwapBarrel) {
                     displayName = CSTRING(SwapBarrel);
-                    condition = QUOTE( GVAR(enabled) && {'ACE_SpareBarrel' in magazines _player} && {getNumber (configFile >> 'CfgWeapons' >> currentWeapon _player >> 'ACE_Overheating_allowSwapBarrel') == 1} );
+                    condition = QUOTE( [ARR_2(_player, currentWeapon _player)] call FUNC(canSwapBarrel) );
                     statement = QUOTE( [ARR_3(_player, _player, currentWeapon _player)] call FUNC(swapBarrel); );
                     showDisabled = 0;
                     priority = 3;
@@ -32,7 +32,7 @@ class CfgVehicles {
                 };
                 class GVAR(CheckTemperatureSpareBarrels) {
                     displayName = CSTRING(CheckTemperatureSpareBarrelsShort);
-                    condition = QUOTE( GVAR(enabled) && {'ACE_SpareBarrel' in magazines _player});
+                    condition = QUOTE((_player) call FUNC(canCheckSpareBarrelsTemperatures) );
                     exceptions[] = {"isNotInside", "isNotSitting"};
                     statement = QUOTE( [_player] call FUNC(checkSpareBarrelsTemperatures); );
                     showDisabled = 0;
@@ -46,7 +46,7 @@ class CfgVehicles {
             class ACE_Weapon {
                 class GVAR(SwapBarrel) {
                     displayName = CSTRING(SwapBarrel);
-                    condition = QUOTE( GVAR(enabled) && {'ACE_SpareBarrel' in magazines _player} && {getNumber (configFile >> 'CfgWeapons' >> currentWeapon _target >> 'ACE_Overheating_allowSwapBarrel') == 1} );
+                    condition = QUOTE( [ARR_2(_player, currentWeapon _target)] call FUNC(canSwapBarrel) );
                     statement = QUOTE([ARR_3(_player, _target, currentWeapon _target)] call FUNC(swapBarrelAssistant););
                     icon = QUOTE(PATHTOF(UI\spare_barrel_ca.paa));
                 };

--- a/addons/overheating/XEH_PREP.hpp
+++ b/addons/overheating/XEH_PREP.hpp
@@ -1,6 +1,8 @@
 
 PREP(calculateCooling);
 PREP(canUnjam);
+PREP(canSwapBarrel);
+PREP(canCheckSpareBarrelsTemperatures);
 PREP(checkSpareBarrelsTemperatures);
 PREP(checkTemperature);
 PREP(clearJam);

--- a/addons/overheating/functions/fnc_canCheckSpareBarrelsTemperatures.sqf
+++ b/addons/overheating/functions/fnc_canCheckSpareBarrelsTemperatures.sqf
@@ -12,14 +12,14 @@
  */
 #include "script_component.hpp"
 params["_unit"];
-private ["_canCheckTemperature","_weaponBarrelClass"];
+
 //Get the classname of the spare barrel for the weapon
-_weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> currentWeapon _player >> QGVAR(barrelClassname));
+private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> currentWeapon _player >> QGVAR(barrelClassname));
 //If the weapon has no defined classname then use the ACE one
 if(_weaponBarrelClass == "") then {
     _weaponBarrelClass = "ACE_SpareBarrel";
 };
 //Check if the player has the barrel and the weapon can have its barrel swapped
-_canCheckTemperature = GVAR(enabled) && {_weaponBarrelClass in magazines _player};
+private _canCheckTemperature = GVAR(enabled) && {_weaponBarrelClass in magazines _player};
 
 _canCheckTemperature;

--- a/addons/overheating/functions/fnc_canCheckSpareBarrelsTemperatures.sqf
+++ b/addons/overheating/functions/fnc_canCheckSpareBarrelsTemperatures.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Grey-Soldierman
+ * Return true if player can check temperatures of spare barrels
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ *
+ * Return Value:
+ * Bool
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+params["_unit"];
+private ["_canCheckTemperature","_weaponBarrelClass"];
+//Get the classname of the spare barrel for the weapon
+_weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> currentWeapon _player >> 'ACE_Overheating_barrelClassname');
+//If the weapon has no defined classname then use the ACE one
+if(_weaponBarrelClass == "") then {
+    _weaponBarrelClass = 'ACE_SpareBarrel';
+};
+//Check if the player has the barrel and the weapon can have its barrel swapped
+_canCheckTemperature = GVAR(enabled) && {_weaponBarrelClass in magazines _player};
+
+_canCheckTemperature;

--- a/addons/overheating/functions/fnc_canCheckSpareBarrelsTemperatures.sqf
+++ b/addons/overheating/functions/fnc_canCheckSpareBarrelsTemperatures.sqf
@@ -14,10 +14,10 @@
 params["_unit"];
 private ["_canCheckTemperature","_weaponBarrelClass"];
 //Get the classname of the spare barrel for the weapon
-_weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> currentWeapon _player >> 'ACE_Overheating_barrelClassname');
+_weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> currentWeapon _player >> QGVAR(barrelClassname));
 //If the weapon has no defined classname then use the ACE one
 if(_weaponBarrelClass == "") then {
-    _weaponBarrelClass = 'ACE_SpareBarrel';
+    _weaponBarrelClass = "ACE_SpareBarrel";
 };
 //Check if the player has the barrel and the weapon can have its barrel swapped
 _canCheckTemperature = GVAR(enabled) && {_weaponBarrelClass in magazines _player};

--- a/addons/overheating/functions/fnc_canSwapBarrel.sqf
+++ b/addons/overheating/functions/fnc_canSwapBarrel.sqf
@@ -23,4 +23,4 @@ if(_weaponBarrelClass == "") then {
     _weaponBarrelClass = "ACE_SpareBarrel";
 };
 //If the player has the spare barrel then it can be swapped
-if (_weaponBarrelClass in magazines _unit) exitWith{true};
+(_weaponBarrelClass in magazines _unit)

--- a/addons/overheating/functions/fnc_canSwapBarrel.sqf
+++ b/addons/overheating/functions/fnc_canSwapBarrel.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Grey-Soldierman
+ * Return true if player can swap barrel
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ * 1: Weapon <STRING>
+ * Return Value:
+ * Bool
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+params["_unit","_weapon"];
+private ["_canSwapBarrel","_weaponBarrelClass"];
+//Get the classname of the spare barrel for the weapon
+_weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_barrelClassname');
+//If the weapon has no defined classname then use the ACE one
+if(_weaponBarrelClass == "") then {
+    _weaponBarrelClass = 'ACE_SpareBarrel';
+};
+//Check if the player has the barrel and the weapon can have its barrel swapped
+_canSwapBarrel = GVAR(enabled) && {_weaponBarrelClass in magazines _unit} && {getNumber (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_allowSwapBarrel') == 1};
+
+_canSwapBarrel;

--- a/addons/overheating/functions/fnc_canSwapBarrel.sqf
+++ b/addons/overheating/functions/fnc_canSwapBarrel.sqf
@@ -12,14 +12,15 @@
  */
 #include "script_component.hpp"
 params["_unit","_weapon"];
-private ["_canSwapBarrel","_weaponBarrelClass"];
+
+//Check if weapon can have its barrel swapped. If not exit out of function
+if( !GVAR(enabled) && (getNumber (configFile >> 'CfgWeapons' >> _weapon >> QGVAR(allowSwapBarrel))) != 1) exitWith{false};
+
 //Get the classname of the spare barrel for the weapon
-_weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_barrelClassname');
+private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> QGVAR(barrelClassname));
 //If the weapon has no defined classname then use the ACE one
 if(_weaponBarrelClass == "") then {
-    _weaponBarrelClass = 'ACE_SpareBarrel';
+    _weaponBarrelClass = "ACE_SpareBarrel";
 };
-//Check if the player has the barrel and the weapon can have its barrel swapped
-_canSwapBarrel = GVAR(enabled) && {_weaponBarrelClass in magazines _unit} && {getNumber (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_allowSwapBarrel') == 1};
-
-_canSwapBarrel;
+//If the player has the spare barrel then it can be swapped
+if (_weaponBarrelClass in magazines _unit) exitWith{true};

--- a/addons/overheating/functions/fnc_loadCoolestSpareBarrel.sqf
+++ b/addons/overheating/functions/fnc_loadCoolestSpareBarrel.sqf
@@ -20,10 +20,10 @@
 
 params ["_assistant", "_gunner", "_weapon", "_weaponTemp", "_barrelMass"];
 TRACE_5("loadCoolestSpareBarrel1",_assistant,_gunner,_weapon,_weaponTemp,_barrelMass);
-private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_barrelClassname');
+private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> QGVAR(barrelClassname));
 //If the weapon has no defined classname then use the ACE one
 if(_weaponBarrelClass == "") then {
-    _weaponBarrelClass = 'ACE_SpareBarrel';
+    _weaponBarrelClass = "ACE_SpareBarrel";
 };
 // Find all spare barrel the player has
 private _allBarrels = [_assistant, _weaponBarrelClass] call CBA_fnc_getMagazineIndex;

--- a/addons/overheating/functions/fnc_loadCoolestSpareBarrel.sqf
+++ b/addons/overheating/functions/fnc_loadCoolestSpareBarrel.sqf
@@ -20,9 +20,13 @@
 
 params ["_assistant", "_gunner", "_weapon", "_weaponTemp", "_barrelMass"];
 TRACE_5("loadCoolestSpareBarrel1",_assistant,_gunner,_weapon,_weaponTemp,_barrelMass);
-
+private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_barrelClassname');
+//If the weapon has no defined classname then use the ACE one
+if(_weaponBarrelClass == "") then {
+    _weaponBarrelClass = 'ACE_SpareBarrel';
+};
 // Find all spare barrel the player has
-private _allBarrels = [_assistant, "ACE_SpareBarrel"] call CBA_fnc_getMagazineIndex;
+private _allBarrels = [_assistant, _weaponBarrelClass] call CBA_fnc_getMagazineIndex;
 TRACE_1("_allBarrels",_allBarrels);
 if ((count _allBarrels) < 1) exitWith {};
 

--- a/addons/overheating/functions/fnc_sendSpareBarrelsTemperaturesHint.sqf
+++ b/addons/overheating/functions/fnc_sendSpareBarrelsTemperaturesHint.sqf
@@ -19,7 +19,15 @@ params ["_player","_unit"];
 
 // Find all spare barrel the player has
 TRACE_2("sendSpareBarrelsTemperatureHunt",_player,_unit);
-private _allBarrels = [_unit, "ACE_SpareBarrel"] call CBA_fnc_getMagazineIndex;
+//Get the weapon of the target unit
+private _weapon = currentWeapon _player;
+//Get the classname of the spare barrel of that weapon
+private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_barrelClassname');
+//If the weapon has no defined classname then use the ACE one
+if(_weaponBarrelClass == "") then {
+    _weaponBarrelClass = 'ACE_SpareBarrel';
+};
+private _allBarrels = [_unit, _weaponBarrelClass] call CBA_fnc_getMagazineIndex;
 TRACE_1("_allBarrels",_allBarrels);
 if ((count _allBarrels) < 1) exitWith {};
 

--- a/addons/overheating/functions/fnc_sendSpareBarrelsTemperaturesHint.sqf
+++ b/addons/overheating/functions/fnc_sendSpareBarrelsTemperaturesHint.sqf
@@ -22,10 +22,10 @@ TRACE_2("sendSpareBarrelsTemperatureHunt",_player,_unit);
 //Get the weapon of the target unit
 private _weapon = currentWeapon _player;
 //Get the classname of the spare barrel of that weapon
-private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> 'ACE_Overheating_barrelClassname');
+private _weaponBarrelClass = getText (configFile >> 'CfgWeapons' >> _weapon >> QGVAR(barrelClassname));
 //If the weapon has no defined classname then use the ACE one
 if(_weaponBarrelClass == "") then {
-    _weaponBarrelClass = 'ACE_SpareBarrel';
+    _weaponBarrelClass = "ACE_SpareBarrel";
 };
 private _allBarrels = [_unit, _weaponBarrelClass] call CBA_fnc_getMagazineIndex;
 TRACE_1("_allBarrels",_allBarrels);


### PR DESCRIPTION
When merged this pull request will:
- Allow users to define custom spare barrel for a weapon 
- ACE_Overheating_barrelClassname = "GREY_GPMG_SpareBarrel"; to define a weapons spare barrel classname.
- If no custom spare barrel is defined then 'ACE_SpareBarrel' is used. 
