### PR TITLE
Per-Ammo fired events

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -137,6 +137,7 @@ PREP(progressBar);
 PREP(readSettingFromModule);
 PREP(readSettingsFromParamsArray);
 PREP(receiveRequest);
+PREP(registerAmmoFiredEvent);
 PREP(removeCanInteractWithCondition);
 PREP(removeSpecificMagazine);
 PREP(requestCallback);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -3,6 +3,14 @@
 // #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
+//
+GVAR(ammoFiredEvents_ForPlayer) = call CBA_fnc_createNamespace;
+GVAR(ammoFiredEvents_ForPlayerNonLocal) = call CBA_fnc_createNamespace;
+GVAR(ammoFiredEvents_ForNonPlayer) = call CBA_fnc_createNamespace;
+GVAR(ammoFiredEvents_ForPlayerVehicle) = call CBA_fnc_createNamespace;
+GVAR(ammoFiredEvents_ForPlayerVehicleNonLocal) = call CBA_fnc_createNamespace;
+GVAR(ammoFiredEvents_ForNonPlayerVehicle) = call CBA_fnc_createNamespace;
+
 //////////////////////////////////////////////////
 // Get Map Data
 //////////////////////////////////////////////////

--- a/addons/common/functions/fnc_firedEH.sqf
+++ b/addons/common/functions/fnc_firedEH.sqf
@@ -26,12 +26,27 @@ TRACE_7("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile
 if (_unit isKindOf "CAManBase") then {
     // The unit it on foot
     if (_unit == ACE_player) then {
+
         ["ace_firedPlayer", _this] call CBA_fnc_localEvent;
+        {
+            [_x, _this] call CBA_fnc_localEvent;
+        } forEach ([GVAR(ammoFiredEvents_ForPlayer) getVariable _ammo] param [0, []]);
+
     } else {
         if ([_unit] call EFUNC(common,isPlayer)) then {
+
             ["ace_firedPlayerNonLocal", _this] call CBA_fnc_localEvent;
+            {
+                [_x, _this] call CBA_fnc_localEvent;
+            } forEach ([GVAR(ammoFiredEvents_ForPlayerNonLocal) getVariable _ammo] param [0, []]);
+
         } else {
+
             ["ace_firedNonPlayer", _this] call CBA_fnc_localEvent;
+            {
+                [_x, _this] call CBA_fnc_localEvent;
+            } forEach ([GVAR(ammoFiredEvents_ForNonPlayer) getVariable _ammo] param [0, []]);
+
         };
     };
 } else {
@@ -55,12 +70,27 @@ if (_unit isKindOf "CAManBase") then {
     };
 
     if (_gunner == ACE_player) then {
+
         ["ace_firedPlayerVehicle", _this] call CBA_fnc_localEvent;
+        {
+            [_x, _this] call CBA_fnc_localEvent;
+        } forEach ([GVAR(ammoFiredEvents_ForPlayerVehicle) getVariable _ammo] param [0, []]);
+
     } else {
         if ([_gunner] call EFUNC(common,isPlayer)) then {
+
             ["ace_firedPlayerVehicleNonLocal", _this] call CBA_fnc_localEvent;
+            {
+                [_x, _this] call CBA_fnc_localEvent;
+            } forEach ([GVAR(ammoFiredEvents_ForPlayerVehicleNonLocal) getVariable _ammo] param [0, []]);
+
         } else {
+
             ["ace_firedNonPlayerVehicle", _this] call CBA_fnc_localEvent;
+            {
+                [_x, _this] call CBA_fnc_localEvent;
+            } forEach ([GVAR(ammoFiredEvents_ForNonPlayerVehicle) getVariable _ammo] param [0, []]);
+
         };
     };
 };

--- a/addons/common/functions/fnc_registerAmmoFiredEvent.sqf
+++ b/addons/common/functions/fnc_registerAmmoFiredEvent.sqf
@@ -1,0 +1,54 @@
+/*
+ * Author: esteldunedain
+ * Register an ammo fired event that should be launched when ammo following a
+ * given criteria is fired. The criteria is analyzed on mission start and is
+ * cached.
+ *
+ * Arguments:
+ * 0: Name of the event <STRING>
+ * 1: Condition code <CODE>
+ * 2: Call for the local player on foot? <BOOL>
+ * 3: Call for non local players on foot? <BOOL>
+ * 4: Call for non players on foot? <BOOL>
+ * 5: Call for the local player vehicle? <BOOL>
+ * 6: Call for non local players vehicles? <BOOL>
+ * 7: Call for non players vehicles? <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_eventName", "_condition", "_fireForPlayer", "_fireForPlayerNonLocal", "_fireForNonPlayer", "_fireForPlayerVehicle", "_fireForPlayerVehicleNonLocal", "_fireForNonPlayerVehicle"];
+
+private _fnc_addEvent = {
+    params ["_namespace", "_condition"];
+    if (_condition) then {
+        private _events = _namespace getVariable _ammo;
+        if (isNil "_events") then {
+            _events = [];
+            _namespace setVariable [_ammo, _events];
+        };
+        _events pushBack _eventName;
+    };
+};
+
+private _cfgAmmo = configFile >> "CfgAmmo";
+for "_i" from 0 to (count _cfgAmmo) - 1 do {
+    private _ammoConfig = _cfgAmmo select _i;
+    private _ammo = configName _ammoConfig;
+
+    // The condition code receives the following as parameter:
+    // 0: Name of the ammo <STRING>
+    // 1: Config of the ammo <CONFIG>
+    if ([_ammo, _ammoConfig] call _condition) then {
+        [GVAR(ammoFiredEvents_ForPlayer), _fireForPlayer] call _fnc_addEvent;
+        [GVAR(ammoFiredEvents_ForPlayerNonLocal), _fireForPlayerNonLocal] call _fnc_addEvent;
+        [GVAR(ammoFiredEvents_ForNonPlayer), _fireForNonPlayer] call _fnc_addEvent;
+        [GVAR(ammoFiredEvents_ForPlayerVehicle), _fireForPlayerVehicle] call _fnc_addEvent;
+        [GVAR(ammoFiredEvents_ForPlayerVehicleNonLocal), _fireForPlayerVehicleNonLocal] call _fnc_addEvent;
+        [GVAR(ammoFiredEvents_ForNonPlayerVehicle), _fireForNonPlayerVehicle] call _fnc_addEvent;
+    };
+};

--- a/addons/frag/XEH_postInit.sqf
+++ b/addons/frag/XEH_postInit.sqf
@@ -14,17 +14,29 @@ if(isServer) then {
     if (!GVAR(enabled)) exitWith {};
 
     // Register fire event handler
-    ["ace_firedPlayer", DFUNC(fired)] call CBA_fnc_addEventHandler;
-    ["ace_firedPlayerNonLocal", DFUNC(fired)] call CBA_fnc_addEventHandler;
-    ["ace_firedNonPlayer", DFUNC(fired)] call CBA_fnc_addEventHandler;
-    ["ace_firedPlayerVehicle", DFUNC(fired)] call CBA_fnc_addEventHandler;
-    ["ace_firedPlayerVehicleNonLocal", DFUNC(fired)] call CBA_fnc_addEventHandler;
-    ["ace_firedNonPlayerVehicle", DFUNC(fired)] call CBA_fnc_addEventHandler;
+    [QGVAR(fragFired), DFUNC(fired)] call CBA_fnc_addEventHandler;
+    [QGVAR(fragFired), {
+        params ["_ammo", "_ammoConfig"];
+
+        private _shouldTrack = false;
+        if (GVAR(SpallEnabled)) then {
+            private _caliber = getNumber(configFile >> "CfgAmmo" >> _roundType >> "caliber");
+            private _explosive = getNumber(configFile >> "CfgAmmo" >> _roundType >> "explosive");
+            private _idh = getNumber(configFile >> "CfgAmmo" >> _roundType >> "indirectHitRange");
+            _shouldTrack = (_caliber >= 2.5) || {(_explosive > 0 && {_idh >= 1})};
+        };
+        if (_shouldTrack) exitWith {true};
+
+        // Read configs and test if it would actually cause a frag, using same logic as FUNC(pfhRound)
+        private _skip = getNumber (_ammoConfig >> QGVAR(skip));
+        private _explosive = getNumber (_ammoConfig >> "explosive");
+        private _indirectRange = getNumber (_ammoConfig >> "indirectHitRange");
+        private _force = getNumber (_ammoConfig >> QGVAR(force));
+        private _fragPower = getNumber(_ammoConfig >> "indirecthit")*(sqrt((getNumber (_ammoConfig >> "indirectHitRange"))));
+        (_skip == 0) && {(_force == 1) || {_explosive > 0.5 && {_indirectRange >= 4.5} && {_fragPower >= 35}}}
+
+    }, true, true, true, true, true, true] call EFUNC(common,registerAmmoFiredEvent);
 
     [FUNC(masterPFH), 0, []] call CBA_fnc_addPerFrameHandler;
 
 }] call CBA_fnc_addEventHandler;
-
-//Cache for ammo type configs
-GVAR(cacheRoundsTypesToTrack) = createLocation ["ACE_HashLocation", [-10000,-10000,-10000], 0, 0];
-GVAR(cacheRoundsTypesToTrack) setText QGVAR(cacheRoundsTypesToTrack);

--- a/addons/frag/functions/fnc_fired.sqf
+++ b/addons/frag/functions/fnc_fired.sqf
@@ -1,7 +1,6 @@
 /*
  * Author: nou, jaynus, PabstMirror
- * Called from the unified fired EH for all.
- * If spall is not enabled (default), then cache and only track those that will actually trigger fragmentation.
+ * Called from the ammo fired EH for all round that trigger frag or spall.
  *
  * Arguments:
  * None. Parameters inherited from EFUNC(common,firedEH)
@@ -20,36 +19,5 @@
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
 TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile, _vehicle, _gunner, _turret);
 
-private _shouldAdd = GVAR(cacheRoundsTypesToTrack) getVariable _ammo;
-if (isNil "_shouldAdd") then {
-    TRACE_1("no cache for round",_ammo);
-
-    if (!EGVAR(common,settingsInitFinished)) exitWith {
-        //Just incase fired event happens before settings init, don't want to set cache wrong if spall setting changes
-        TRACE_1("Settings not init yet - exit without setting cache",_ammo);
-        _shouldAdd = false;
-    };
-
-    if (GVAR(SpallEnabled)) exitWith {
-        //Always want to run whenever spall is enabled?
-        _shouldAdd = true;
-        TRACE_2("SettingCache[spallEnabled]",_ammo,_shouldAdd);
-        GVAR(cacheRoundsTypesToTrack) setVariable [_ammo, _shouldAdd];
-    };
-
-    //Read configs and test if it would actually cause a frag, using same logic as FUNC(pfhRound)
-    private _skip = getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(skip));
-    private _explosive = getNumber (configFile >> "CfgAmmo" >> _ammo >> "explosive");
-    private _indirectRange = getNumber (configFile >> "CfgAmmo" >> _ammo >> "indirectHitRange");
-    private _force = getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(force));
-    private _fragPower = getNumber(configFile >> "CfgAmmo" >> _ammo >> "indirecthit")*(sqrt((getNumber (configFile >> "CfgAmmo" >> _ammo >> "indirectHitRange"))));
-
-    _shouldAdd = (_skip == 0) && {(_force == 1) || {_explosive > 0.5 && {_indirectRange >= 4.5} && {_fragPower >= 35}}};
-    TRACE_6("SettingCache[willFrag?]",_skip,_explosive,_indirectRange,_force,_fragPower,_shouldAdd);
-    GVAR(cacheRoundsTypesToTrack) setVariable [_ammo, _shouldAdd];
-};
-
-if (_shouldAdd) then {
-    TRACE_3("Running Frag Tracking",_unit,_ammo,_projectile);
-    [_unit, _ammo, _projectile] call FUNC(addPfhRound);
-};
+TRACE_3("Running Frag Tracking",_unit,_ammo,_projectile);
+[_unit, _ammo, _projectile] call FUNC(addPfhRound);

--- a/addons/grenades/XEH_postInit.sqf
+++ b/addons/grenades/XEH_postInit.sqf
@@ -28,3 +28,36 @@ GVAR(flashbangPPEffectCC) ppEffectForceInNVG true;
 ["ace_firedPlayer", DFUNC(throwGrenade)] call CBA_fnc_addEventHandler;
 ["ace_firedPlayerNonLocal", DFUNC(throwGrenade)] call CBA_fnc_addEventHandler;
 ["ace_firedNonPlayer", DFUNC(throwGrenade)] call CBA_fnc_addEventHandler;
+
+
+// Code to handle flashbangs being fired
+[QGVAR(flashbangFired), {
+    //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
+    if (local _unit) then {
+        private _ammoConfig = configFile >> "CfgAmmo" >> _ammo;
+        private _fuzeTime = getNumber (_ammoConfig >> "explosionTime");
+        [FUNC(flashbangThrownFuze), [_projectile], _fuzeTime] call CBA_fnc_waitAndExecute;
+    };
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(flashbangFired), {
+    params ["_ammo", "_ammoConfig"];
+    getNumber (_ammoConfig >> QGVAR(flashbang)) == 1)
+}, true, true, true, false, false, false] call EFUNC(common,registerAmmoFiredEvent);
+
+
+// Code to handle flares being fired
+[QGVAR(flareFired), {
+    //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
+    private _ammoConfig = configFile >> "CfgAmmo" >> _ammo
+    private _fuzeTime = getNumber (_ammoConfig >> "explosionTime");
+    private _timeToLive = getNumber (_config >> "timeToLive");
+    private _color = getArray (_config >> QGVAR(color));
+    private _intensity = _color deleteAt 3;
+    [FUNC(flare), [_projectile, _color, _intensity, _timeToLive], _fuzeTime, 0] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(flareFired), {
+    params ["_ammo", "_ammoConfig"];
+    getNumber (_ammoConfig >> QGVAR(flare)) == 1)
+}, true, true, true, false, false, false] call EFUNC(common,registerAmmoFiredEvent);

--- a/addons/grenades/XEH_postInit.sqf
+++ b/addons/grenades/XEH_postInit.sqf
@@ -42,7 +42,7 @@ GVAR(flashbangPPEffectCC) ppEffectForceInNVG true;
 
 [QGVAR(flashbangFired), {
     params ["_ammo", "_ammoConfig"];
-    getNumber (_ammoConfig >> QGVAR(flashbang)) == 1)
+    getNumber (_ammoConfig >> QGVAR(flashbang)) == 1
 }, true, true, true, false, false, false] call EFUNC(common,registerAmmoFiredEvent);
 
 
@@ -59,5 +59,5 @@ GVAR(flashbangPPEffectCC) ppEffectForceInNVG true;
 
 [QGVAR(flareFired), {
     params ["_ammo", "_ammoConfig"];
-    getNumber (_ammoConfig >> QGVAR(flare)) == 1)
+    getNumber (_ammoConfig >> QGVAR(flare)) == 1
 }, true, true, true, false, false, false] call EFUNC(common,registerAmmoFiredEvent);

--- a/addons/grenades/functions/fnc_throwGrenade.sqf
+++ b/addons/grenades/functions/fnc_throwGrenade.sqf
@@ -35,21 +35,6 @@ if (local _unit) then {
         _soundConfig params ["_file", "_volume", "_pitch", "_distance"];
         playSound3D [_file, objNull, false, getPosASL _projectile, _volume, _pitch, _distance];
     };
-
-    if (getNumber (_config >> QGVAR(flashbang)) == 1) then {
-        private _fuzeTime = getNumber (_config >> "explosionTime");
-
-        [FUNC(flashbangThrownFuze), [_projectile], _fuzeTime] call CBA_fnc_waitAndExecute;
-    };
-};
-
-if (getNumber (_config >> QGVAR(flare)) == 1) then {
-    private _fuzeTime = getNumber (_config >> "explosionTime");
-    private _timeToLive = getNumber (_config >> "timeToLive");
-    private _color = getArray (_config >> QGVAR(color));
-    private _intensity = _color deleteAt 3;
-
-    [FUNC(flare), [_projectile, _color, _intensity, _timeToLive], _fuzeTime, 0] call CBA_fnc_waitAndExecute;
 };
 
 // handle throw modes

--- a/addons/huntir/XEH_postInit.sqf
+++ b/addons/huntir/XEH_postInit.sqf
@@ -10,4 +10,9 @@ GVAR(ELEVAT) = 0.01;
 
 // Register fire event handler
 // Don't run for non players, as they are too dumb to launch huntirs anyway
-["ace_firedPlayer", DFUNC(handleFired)] call CBA_fnc_addEventHandler;
+[QGVAR(huntirFired), DFUNC(handleFired)] call CBA_fnc_addEventHandler;
+
+[QGVAR(huntirFired), {
+    params ["_ammo", "_ammoConfig"];
+    hasInterface && (_ammo == "F_HuntIR")
+}, true, false, false, false, false, false] call EFUNC(common,registerAmmoFiredEvent);

--- a/addons/huntir/functions/fnc_handleFired.sqf
+++ b/addons/huntir/functions/fnc_handleFired.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: Norrin, Rocko, Ruthberg
  *
- * Handles HuntIR projectiles. Called from the unified fired EH for the local player.
+ * Handles HuntIR projectiles. Called from the ammo fired EH for the local player.
  *
  * Arguments:
  * None. Parameters inherited from EFUNC(common,firedEH)
@@ -15,10 +15,6 @@
 
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
 TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile, _vehicle, _gunner, _turret);
-
-if (_ammo != "F_HuntIR") exitWith {};
-
-if (!hasInterface) exitWith {};
 
 [{
     params ["_projectile"];


### PR DESCRIPTION
**When merged this pull request will:**
- Add framework to support per-ammo fired events, inspired on ACE 2 registerSimulation.
- Leverage this framework in a lot of modules (WIP)
## Rationale

In various cases we need to run special code when certain types of projectiles are fired, like the huntir, different types of grenades, missiles, heavy caliber bullets, cannon shells, explosives, etc. The way we are currently doing that is by stacking handlers to the fired EH and checking if every single projectile fired matches each criteria. The pattern is O(N) with the number of custom scripts. 

This is currently not that bad because we don't have a huge N and the unified fired event handler filters out AI from most of the checks. We've also been clever enough to attach each FEH to the minimum amount of classess we need, etc. But still, this pattern clearly doesn't scale very well if we want to keep adding a bunch of custom stuff.

ACE 2 had a framework for this called `ACE_Simulation`. That was a config entry on each ammo type which indicated which code should be called when the bullet was fired. ACE 2 had a much larger number of processes, so that made sense.  But it had the problem of only allowing a single process to be simulated per ammo type.

This PR proposes a similar framework for ACE3, but with the added flexibility of allowing any number of simulations to be carried out for each ammo. Also the criteria to determine is a process should be called is now defined via a script (instead of a fixed config entry), allowing for greater flexibility. Obviously the code is only run on mission start and then the events that should be called for each ammo are cached for later usage from the UFEH. This potentially comes at the expense of slightly increased memory usage and mission start times.

As I said, I think we don't really need this ATM. However it should provide some gain already (untested yet) and can serve as a preparation for the future.
