### PR TITLE
Fix terrain LOS check for vehicles with low getPos

### DIFF
--- a/addons/missileguidance/functions/fnc_checkLos.sqf
+++ b/addons/missileguidance/functions/fnc_checkLos.sqf
@@ -5,24 +5,24 @@
  * Arguments:
  * 0: Seeker [Object]
  * 1: Target [Object]
- * 
+ *
  * Return Value:
  *    Boolean
  */
 #include "script_component.hpp"
-private["_seeker", "_seekerPos", "_target", "_targetPos", "_return", "_vectorTo", "_searchPos"];
-_seeker = _this select 0;
-_target = _this select 1;
+
+params ["_seeker", "_target"];
 
 if ((isNil "_seeker") || {isNil "_target"}) exitWith {false};
 
-_targetPos = getPosASL _target;
-_seekerPos = getPosASL _seeker;
-_return = true;
+private _targetPos = getPosASL _target;
+private _targetAimPos = aimPos _target;
+private _seekerPos = getPosASL _seeker;
+private _return = true;
 
-if(!(terrainIntersectASL [ _seekerPos, _targetPos])) then {
+if (!((terrainIntersectASL [_seekerPos, _targetPos]) && {terrainIntersectASL [_seekerPos, _targetAimPos]})) then {
     if(lineIntersects [_seekerPos, _targetPos, _seeker, _target]) then {
-        _return = false; 
+        _return = false;
     };
 } else {
     _return = false;


### PR DESCRIPTION
Fix #4126

RHS T72 `getPosASL` point is very low and can be bellow terrain level.

`ASLtoAGL getPosASL cursorObject` = [2457.5,820.846,-0.0508118]

So it would fail the terrainIntersectASL check.