### PR TITLE
Update coding guidelines (fix typos, wording, formatting, links)

### DIFF
--- a/wiki/development/coding-guidelines.md
+++ b/wiki/development/coding-guidelines.md
@@ -70,25 +70,27 @@ All text that will be displayed to a user shall be defined in a `stingtable.xml`
 ### 2.1. Module/PBO specific Macro Usage
 The family of `GVAR` macros define global variable strings or constants for use within a module. Please use these to make sure we follow naming conventions across all modules and also prevent duplicate/overwriting between variables in different modules. The macro family expands as follows, for the example of the module 'balls':
 
-| Macros |  Expands to |
+| Macros | Expands to |
 | -------|---------|
 |`GVAR(face)` | `ace_balls_face` |
 |`QGVAR(face)` | `"ace_balls_face"` |
-|`EGVAR(balls,face)` | `ace_balls_face` |
+|`QQGVAR(face)` | `""ace_balls_face""` used inside `QUOTE` macros where double quotation is required.  |
 |`EGVAR(leg,face)` | `ace_leg_face` |
 |`QEGVAR(leg,face)` | `"ace_leg_face"` |
+|`QQEGVAR(leg,face)` | `""ace_leg_face""` used inside `QUOTE` macros where double quotation is required. |
 
 There also exists the `FUNC` family of Macros:
 
-| Macros  |  Expands to |
+| Macros | Expands to |
 | -------|---------|
 |`FUNC(face)` | `ace_balls_fnc_face` or the call trace wrapper for that function. |
-|`EFUNC(balls,face)` | `ace_balls_fnc_face` or the call trace wrapper for that function. |
-|`EFUNC(leg,face) `| `ace_leg_fnc_face` or the call trace wrapper for that function. |
+|`EFUNC(leg,face)` | `ace_leg_fnc_face` or the call trace wrapper for that function. |
 |`DFUNC(face)` | `ace_balls_fnc_face` and will ALWAYS be the function global variable. |
 |`DEFUNC(leg,face)` | `ace_leg_fnc_face` and will ALWAYS be the function global variable. |
 |`QFUNC(face)` | `"ace_balls_fnc_face"` |
 |`QEFUNC(leg,face)` | `"ace_leg_fnc_face"` |
+|`QQFUNC(face)` | `""ace_balls_fnc_face""` used inside `QUOTE` macros where double quotation is required.  |
+|`QQEFUNC(leg,face)` | `""ace_leg_fnc_face""` used inside `QUOTE` macros where double quotation is required.  |
 
 The `FUNC` and `EFUNC` macros shall NOT be used inside `QUOTE` macros if the intention is to get the function name or assumed to be the function variable due to call tracing (see below). If you need to 100% always be sure that you are getting the function name or variable use the `DFUNC` or `DEFUNC` macros. For example `QUOTE(FUNC(face)) == "ace_balls_fnc_face"` would be an illegal use of `FUNC` inside `QUOTE`.
 
@@ -97,7 +99,7 @@ Using `FUNC` or `EFUNC` inside a `QUOTE` macro is fine if the intention is for i
 #### 2.1.1. `FUNC` Macros, Call Tracing, and Non-ACE3/Anonymous Functions
 ACE3 implements a basic call tracing system that can dump the call stack on errors or wherever you want. To do this the `FUNC` macros in debug mode will expand out to include metadata about the call including line numbers and files. This functionality is automatic with the use of calls via `FUNC` and `EFUNC`, but any calls to other functions need to use the following macros:
 
-| Macro  | example |
+| Macro  | Example |
 | -------|---------|
 |`CALLSTACK(functionName)` | `[] call CALLSTACK(cba_fnc_someFunction)` |
 |`CALLSTACK_NAMED(function,functionName)` | `[] call CALLSTACK_NAMED(_anonymousFunction,'My anonymous function!')`|
@@ -113,7 +115,7 @@ These macros will call these functions with the appropriate wrappers and enable 
 #### 2.2.1. `setVariable`, `getVariable` family macros
 These macros are allowed but are not enforced.
 
-| Macro  | Expands to |
+| Macro | Expands to |
 | -------|---------|
 |`GETVAR(player,MyVarName,false)` | `player getVariable ["MyVarName", false]` |
 |`GETMVAR(MyVarName,objNull)` | `missionNamespace getVariable ["MyVarName", objNull]` |
@@ -123,25 +125,35 @@ These macros are allowed but are not enforced.
 |`SETUVAR(MyVarName,_control)` | `uiNamespace setVariable ["MyVarName", _control]` |
 
 #### 2.2.2. STRING family macros
-Note that you need the strings in module stringtable.xml in the correct format
+Note that you need the strings in module `stringtable.xml` in the correct format:
 `STR_ACE_<module>_<string>`
 
 Example: `STR_Balls_Banana`
 
 Script strings (still require `localize` to localize the string):
 
-| Macro  |  Expands to |
+| Macro | Expands to |
 | -------|---------|
 |`LSTRING(banana)` | `"STR_ACE_balls_banana"` |
-|`ELSTRING(balls,banana)` | `"STR_ACE_balls_banana"` |
+|`ELSTRING(leg,banana)` | `"STR_ACE_leg_banana"` |
 
 
 Config Strings (require `$` as first character):
 
-| Macro  |  Expands to |
+| Macro | Expands to |
 | -------|---------|
 |`CSTRING(banana)` | `"$STR_ACE_balls_banana"` |
-|`ECSTRING(balls,banana)` | `"$STR_ACE_balls_banana"` |
+|`ECSTRING(leg,banana)` | `"$STR_ACE_leg_banana"` |
+
+### 2.2.3. Path family macros
+The family of path macros define global paths to files for use within a module. Please use these to reference files in the ACE3 project. The macro family expands as follows, for the example of the module 'balls':
+
+| Macro | Expands to |
+| -------|---------|
+|`PATHTOF(data\banana.p3d)` | `\z\ace\addons\balls\data\banana.p3d` |
+|`QPATHTOF(data\banana.p3d)` | `"\z\ace\addons\balls\data\banana.p3d"` |
+|`PATHTOEF(leg,data\banana.p3d)` | `\z\ace\addons\leg\data\banana.p3d` |
+|`QPATHTOEF(leg,data\banana.p3d)` | `"\z\ace\addons\leg\data\banana.p3d"` |
 
 
 ## 3. Functions

--- a/wiki/development/coding-guidelines.md
+++ b/wiki/development/coding-guidelines.md
@@ -33,7 +33,7 @@ _For ACE this is done automatically through the usage of the `PREP` macro._
 ### 1.2. Files & Config
 
 #### 1.2.1. SQF files
-Files containing SQF scripts will always have a file name extension of `.sqf`.
+Files containing SQF scripts shall have a file name extension of `.sqf`.
 
 #### 1.2.2. Header files
 All header files shall have the file name extension of `.hpp`.
@@ -61,14 +61,14 @@ class ACE_Settings {
 ### 1.3. Stringtable
 All text that will be displayed to a user shall be defined in a `stingtable.xml` file for multi-language support.
 
-- There will not be any empty stringtable language values.
-- All stringtables will follow the format as specified by [Tabler](https://github.com/bux578/tabler) and the [translation guidelines](http://ace3mod.com/wiki/development/how-to-translate-ace3.html) form.
+- There shall be no empty stringtable language values.
+- All stringtables shall follow the format as specified by [Tabler](https://github.com/bux578/tabler) and the [translation guidelines](http://ace3mod.com/wiki/development/how-to-translate-ace3.html) form.
 
 
 ## 2. Macro Usage
 
 ### 2.1. Module/PBO specific Macro Usage
-The family of `GVAR` macro's define global variable strings or constants for use within a module. Please use these to make sure we follow naming conventions across all modules and also prevent duplicate/overwriting between variables in different modules. The macro family expands as follows, for the example of the module 'balls':
+The family of `GVAR` macros define global variable strings or constants for use within a module. Please use these to make sure we follow naming conventions across all modules and also prevent duplicate/overwriting between variables in different modules. The macro family expands as follows, for the example of the module 'balls':
 
 | Macros |  Expands to |
 | -------|---------|
@@ -90,7 +90,7 @@ There also exists the `FUNC` family of Macros:
 |`QFUNC(face)` | `"ace_balls_fnc_face"` |
 |`QEFUNC(leg,face)` | `"ace_leg_fnc_face"` |
 
-The `FUNC` and `EFUNC` macros should NOT be used inside `QUOTE` macros if the intention is to get the function name or assumed to be the function variable due to call tracing (see below). If you need to 100% always be sure that you are getting the function name or variable use the `DFUNC` or `DEFUNC` macros. For example `QUOTE(FUNC(face)) == "ace_balls_fnc_face"` would be an illegal use of `FUNC` inside `QUOTE`.
+The `FUNC` and `EFUNC` macros shall NOT be used inside `QUOTE` macros if the intention is to get the function name or assumed to be the function variable due to call tracing (see below). If you need to 100% always be sure that you are getting the function name or variable use the `DFUNC` or `DEFUNC` macros. For example `QUOTE(FUNC(face)) == "ace_balls_fnc_face"` would be an illegal use of `FUNC` inside `QUOTE`.
 
 Using `FUNC` or `EFUNC` inside a `QUOTE` macro is fine if the intention is for it to be executed as a function.
 
@@ -145,7 +145,7 @@ Config Strings (require `$` as first character):
 
 
 ## 3. Functions
-Functions should be created in the `functions\` subdirectory, named `fnc_functionName.sqf` They should then be indexed via the `PREP(functionName)` macro in the `XEH_preInit.sqf` file.
+Functions shall be created in the `functions\` subdirectory, named `fnc_functionName.sqf` They shall then be indexed via the `PREP(functionName)` macro in the `XEH_preInit.sqf` file.
 
 The `PREP` macro allows for CBA function caching, which drastically speeds up load times. **Beware though that function caching is enabled by default and as such to disable it you need to `#define DISABLE_COMPILE_CACHE` above your `#include "script_components.hpp"` include!**
 
@@ -186,8 +186,8 @@ This ensures every function starts of in an uniform way and enforces function do
 All Global Variables are defined in the `XEH_preInit.sqf` file of the component they will be used in with an initial default value.
 
 Exceptions:
-- Dynamically generated global variables
-- Variables that do not origin from he ACE project, such as BI global variables or third party such as CBA
+- Dynamically generated global variables.
+- Variables that do not origin from the ACE3 project, such as BI global variables or third party such as CBA.
 
 
 ## 5. Code Style
@@ -290,9 +290,9 @@ Example:
 ```
 
 ### 5.4. Comments in code
-All code should be documented by comments that describe what is being done. This can be done through the function header and/or inline comments.
+All code shall be documented by comments that describe what is being done. This can be done through the function header and/or inline comments.
 
-Comments within the code should be used when they are describing a complex and critical section of code or if the subject code does something a certain way because of a specific reason. Unnecessary comments in the code are not allowed.
+Comments within the code shall be used when they are describing a complex and critical section of code or if the subject code does something a certain way because of a specific reason. Unnecessary comments in the code are not allowed.
 
 Good:
 
@@ -351,7 +351,7 @@ However the following is allowed:
 _value = (_array select 0) select 1;
 ```
 
-Any conditions in statements should always be wrapped around brackets.
+Any conditions in statements shall always be wrapped around brackets.
 
 ```js
 if (!_value) then {};
@@ -387,7 +387,7 @@ Usage of the CBA Macro `PARAM_x` or `BIS_fnc_param` is deprecated and not allowe
 Functions and code blocks that specific a return a value must have a meaningful return value. If no meaningful return value, the function should return nil.
 
 ### 6.5. Private Variables
-All private variables shall make use of the `private` keyword on initialization. When declaring a private variable before initialization, usage of the private array syntax is allowed. All private variables must be either initialized using the private keyword, or declared using the private array syntax. Exceptions to this rule are variables obtained from an array. Note that this may only be down by making use of the `params` command family, as this ensures the variable is declared as private.
+All private variables shall make use of the `private` keyword on initialization. When declaring a private variable before initialization, usage of the `private ARRAY` syntax is allowed. All private variables must be either initialized using the `private` keyword, or declared using the `private ARRAY` syntax. Exceptions to this rule are variables obtained from an array, which shall be done with usage of the `params` command family, which ensures the variable is declared as private.
 
 Good:
 
@@ -482,13 +482,13 @@ private _myvariable = [1, 2] select _condition;
 ```
 
 ### 6.9. Initialization expression in `for` loops
-The initialization expression in a `for` loop will perform no actions other than to initialize the value of a single `for` loop parameter.
+The initialization expression in a `for` loop shall perform no actions other than to initialize the value of a single `for` loop parameter.
 
 ### 6.10. Increment expression in `for` loops
-The increment expression in a `for` loop will perform no action other than to change a single loop parameter to the next value for the loop.
+The increment expression in a `for` loop shall perform no action other than to change a single loop parameter to the next value for the loop.
 
 ### 6.11. `getVariable`
-When using `getVariable`, there should either be a default value given in the statement or the return value should be checked for correct data type as well as return value. A default value may not be given after a nil check.
+When using `getVariable`, there shall either be a default value given in the statement or the return value shall be checked for correct data type as well as return value. A default value may not be given after a `nil` check.
 
 Bad:
 
@@ -549,21 +549,21 @@ Code that is not used (commented out) shall be deleted.
 There shall be no constant global variables, constants shall be put in a `#define`.
 
 ### 6.16. Logging
-Functions should whenever possible and logical, make use of logging functionality through the logging and debugging macros from CBA and ACE.
+Functions shall whenever possible and logical, make use of logging functionality through the logging and debugging macros from CBA and ACE3.
 
 ### 6.17. Constant Private Variables
-Constant private variables that are used more as once should be put in a `#define`.
+Constant private variables that are used more as once shall be put in a `#define`.
 
 ### 6.18. Code used more than once
-Any piece of code that could/is used more than once, should be put in a function and it's separate `.sqf` file, unless this code is less as 5 lines and used only in a per frame handler.
+Any piece of code that could/is used more than once, shall be put in a function and it's separate `.sqf` file, unless this code is less as 5 lines and used only in a [per-frame handler](#waituntil).
 
 
 ## 7. Design considerations
 
 ### 7.1. Readability vs Performance
-This is a large open source project that will get many different maintainers in it's lifespan. When writing code, keep in mind that other developers also need to be able to understand your code. Balancing readability and performance of code is a non black and white subject. The rule of thumb is:
+This is a large open source project that will get many different maintainers in its lifespan. When writing code, keep in mind that other developers also need to be able to understand your code. Balancing readability and performance of code is a non black and white subject. The rule of thumb is:
 
-- When improving performance of code that sacrifices readability (or visa-versa), first see if the design of the implementation is done in the best possible way.
+- When improving performance of code that sacrifices readability (or visa-versa), first see if the design of the implementation is done in the best way possible.
 - Document that change with the reasoning in the code.
 
 ### 7.2. Scheduled vs Unscheduled
@@ -574,7 +574,7 @@ This also helps avoid various bugs as a result of unguaranteed execution sequenc
 ### 7.3. Event driven
 All ACE3 components shall be implemented in an event driven fashion. This is done to ensure code only runs when it is required and allows for modularity through low coupling components.
 
-Event handlers in ACE3 are implemented through CBA event system (ACE3's own event system is deprecated since 3.6.0). They should be used to trigger or allow triggering of specific functionality.
+Event handlers in ACE3 are implemented through the CBA event system (ACE3's own event system is deprecated since 3.6.0). They should be used to trigger or allow triggering of specific functionality.
 
 More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System) and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events) pages.
 
@@ -610,7 +610,7 @@ A description of the above macros is below.
 
 #### 7.4.1. Hashlists
 
-A hashlist is an extension of a hash. It is a list of hashes! The reason for having this special type of storage container rather than using a normal array is that an array of normal hashes that are similar will duplicate a large amount of data in their storage of keys. A hashlist on the other hand uses a common list of keys and an array of unique value containers. The following will demonstrate it's usage.
+A hashlist is an extension of a hash. It is a list of hashes! The reason for having this special type of storage container rather than using a normal array is that an array of normal hashes that are similar will duplicate a large amount of data in their storage of keys. A hashlist on the other hand uses a common list of keys and an array of unique value containers. The following will demonstrate its usage.
 
 ```js
 _defaultKeys = ["key1", "key2", "key3"];
@@ -699,7 +699,7 @@ When checking if an array is empty `isEqualTo` shall be used.
 for "_y" from # to # step # do { ... }
 ```
 
-should be used instead of
+shall be used instead of
 
 ```js
 for [{ ... },{ ... },{ ... }] do { ... };

--- a/wiki/development/coding-guidelines.md
+++ b/wiki/development/coding-guidelines.md
@@ -62,7 +62,7 @@ class ACE_Settings {
 All text that will be displayed to a user shall be defined in a `stingtable.xml` file for multi-language support.
 
 - There shall be no empty stringtable language values.
-- All stringtables shall follow the format as specified by [Tabler](https://github.com/bux578/tabler) and the [translation guidelines](http://ace3mod.com/wiki/development/how-to-translate-ace3.html) form.
+- All stringtables shall follow the format as specified by [Tabler](https://github.com/bux578/tabler){:target="_blank"} and the [translation guidelines](http://ace3mod.com/wiki/development/how-to-translate-ace3.html){:target="_blank"} form.
 
 
 ## 2. Macro Usage
@@ -106,7 +106,7 @@ These macros will call these functions with the appropriate wrappers and enable 
 
 ### 2.2. General Purpose Macros
 
-[CBA script_macros_common.hpp](https://github.com/CBATeam/CBA_A3/blob/master/addons/main/script_macros_common.hpp)
+[CBA script_macros_common.hpp](https://github.com/CBATeam/CBA_A3/blob/master/addons/main/script_macros_common.hpp){:target="_blank"}
 
 `QUOTE()` is utilized within configuration files for bypassing the quote issues in configuration macros. So, all code segments inside a given config should utilize wrapping in the `QUOTE()` macro instead of direct strings. This allows us to use our macros inside the string segments, such as `QUOTE(_this call FUNC(balls))`
 
@@ -367,7 +367,7 @@ Magic numbers are any of the following:
 - Distinctive unique values that are unlikely to be mistaken for other meanings
 - Unique values with unexplained meaning or multiple occurrences which could (preferably) be replaced with named constants
 
-[Source](http://en.wikipedia.org/wiki/Magic_number_%28programming%29)
+[Source](http://en.wikipedia.org/wiki/Magic_number_%28programming%29){:target="_blank"}
 
 
 ## 6. Code Standards
@@ -576,7 +576,7 @@ All ACE3 components shall be implemented in an event driven fashion. This is don
 
 Event handlers in ACE3 are implemented through the CBA event system (ACE3's own event system is deprecated since 3.6.0). They should be used to trigger or allow triggering of specific functionality.
 
-More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System) and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events) pages.
+More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events){:target="_blank"} pages.
 
 ### 7.4. Hashes
 

--- a/wiki/development/coding-guidelines.md
+++ b/wiki/development/coding-guidelines.md
@@ -7,17 +7,16 @@ parent: wiki
 order: 1
 ---
 
-
 ## 1. Naming Conventions
 
 ### 1.1. Variable Names
 
 #### 1.1.1. Global Variable naming
-All global variables must start with the ACE prefix followed by the component, separated by underscores. Global variables may not contain the fnc_ prefix if the value is not callable code.
+All global variables must start with the ACE prefix followed by the component, separated by underscores. Global variables may not contain the `fnc_` prefix if the value is not callable code.
 
-Example: `ACE_Component_myVariableName`
+Example: `ace_component_myVariableName`
 
-_For ACE this is done automatically through the usage of the GVAR macro family._
+_For ACE this is done automatically through the usage of the `GVAR` macro family._
 
 #### 1.1.2. Private Variable naming
 To make code as readable as possible, try to use self explanatory variable names and avoid using single character variable names.
@@ -25,33 +24,32 @@ To make code as readable as possible, try to use self explanatory variable names
 Example: `_velocity` instead of `_v`
 
 #### 1.1.3. Function naming
-All functions shall use ACE and the component name as a prefix, as well as the fnc_ prefix behind the component name.
+All functions shall use ACE and the component name as a prefix, as well as the `fnc_` prefix behind the component name.
 
 Example: `PREFIX_COMPONENT_fnc_functionName`
 
-_For ACE this is done automatically through the usage of the PREP macro_
+_For ACE this is done automatically through the usage of the `PREP` macro._
 
 ### 1.2. Files & Config
 
-#### 1.2.1. SQF File extension
-Files containing sqf scripts will always have a file name extension of `.sqf`.
+#### 1.2.1. SQF files
+Files containing SQF scripts will always have a file name extension of `.sqf`.
 
 #### 1.2.2. Header files
-All header files will always have the file name extension of `.hpp`.
+All header files shall have the file name extension of `.hpp`.
 
 #### 1.2.3. Own SQF File
-All functions shall be put in their own .sqf file.
+All functions shall be put in their own `.sqf` file.
 
 #### 1.2.4. Config elements
-Config files will be split up into different header files, each with the name of the config and be included in the `config.cpp` of the component.
-Example:
+Config files shall be split up into different header files, each with the name of the config and be included in the `config.cpp` of the component.
 
+Example:
 ```cpp
 #include "ACE_Settings.hpp"
 ```
 
 And in `ACE_Settings.hpp`:
-
 ```cpp
 class ACE_Settings {
     // Content
@@ -61,8 +59,8 @@ class ACE_Settings {
 ### 1.3. Stringtable
 All text that will be displayed to a user shall be defined in a `stingtable.xml` file for multi-language support.
 
-* There will not be any empty stringtable language values.
-* All stringtables will follow the format as specified by Tabler and the [translation guidelines](http://ace3mod.com/wiki/development/how-to-translate-ace3.html) form.
+- There will not be any empty stringtable language values.
+- All stringtables will follow the format as specified by [Tabler](https://github.com/bux578/tabler) and the [translation guidelines](http://ace3mod.com/wiki/development/how-to-translate-ace3.html) form.
 
 
 ## 2. Macro Usage
@@ -70,33 +68,31 @@ All text that will be displayed to a user shall be defined in a `stingtable.xml`
 ### 2.1. Module/PBO specific Macro Usage
 The family of `GVAR` macro's define global variable strings or constants for use within a module. Please use these to make sure we follow naming conventions across all modules and also prevent duplicate/overwriting between variables in different modules. The macro family expands as follows, for the example of the module 'balls':
 
-
 | Macros |  Expands to |
 | -------|---------|
-|`GVAR(face)` | ace_balls_face |
-|`QGVAR(face)` | "ace_balls_face" |
-|`EGVAR(balls,face)` | ace_balls_face |
-|`EGVAR(leg,face)` | ace_leg_face |
-|`QEGVAR(leg,face)` | "ace_leg_face" |
+|`GVAR(face)` | `ace_balls_face` |
+|`QGVAR(face)` | `"ace_balls_face"` |
+|`EGVAR(balls,face)` | `ace_balls_face` |
+|`EGVAR(leg,face)` | `ace_leg_face` |
+|`QEGVAR(leg,face)` | `"ace_leg_face"` |
 
-There also exists the FUNC family of Macros:
+There also exists the `FUNC` family of Macros:
 
 | Macros  |  Expands to |
 | -------|---------|
-|`FUNC(face)` | ace_balls_fnc_face or the call trace wrapper for that function.|
-|`EFUNC(balls,face)` | ace_balls_fnc_face or the call trace wrapper for that function.|
-|`EFUNC(leg,face) `| ace_leg_fnc_face or the call trace wrapper for that function.|
-|`DFUNC(face)` | ace_balls_fnc_face and will ALWAYS be the function global variable.|
-|`DEFUNC(leg,face)` | ace_leg_fnc_face and will ALWAYS be the function global variable.|
-|`QFUNC(face)` | "ace_balls_fnc_face" |
-|`QEFUNC(leg,face)` | "ace_leg_fnc_face" |
+|`FUNC(face)` | `ace_balls_fnc_face` or the call trace wrapper for that function. |
+|`EFUNC(balls,face)` | `ace_balls_fnc_face` or the call trace wrapper for that function. |
+|`EFUNC(leg,face) `| `ace_leg_fnc_face` or the call trace wrapper for that function. |
+|`DFUNC(face)` | `ace_balls_fnc_face` and will ALWAYS be the function global variable. |
+|`DEFUNC(leg,face)` | `ace_leg_fnc_face` and will ALWAYS be the function global variable. |
+|`QFUNC(face)` | `"ace_balls_fnc_face"` |
+|`QEFUNC(leg,face)` | `"ace_leg_fnc_face"` |
 
 The `FUNC` and `EFUNC` macros should NOT be used inside `QUOTE` macros if the intention is to get the function name or assumed to be the function variable due to call tracing (see below). If you need to 100% always be sure that you are getting the function name or variable use the `DFUNC` or `DEFUNC` macros. For example `QUOTE(FUNC(face)) == "ace_balls_fnc_face"` would be an illegal use of `FUNC` inside `QUOTE`.
 
 Using `FUNC` or `EFUNC` inside a `QUOTE` macro is fine if the intention is for it to be executed as a function.
 
-#### 2.1.1. FUNC Macros, Call Tracing, and Non-ACE3 /Anonymous Functions
-
+#### 2.1.1. `FUNC` Macros, Call Tracing, and Non-ACE3/Anonymous Functions
 ACE3 implements a basic call tracing system that can dump the call stack on errors or wherever you want. To do this the `FUNC` macros in debug mode will expand out to include metadata about the call including line numbers and files. This functionality is automatic with the use of calls via `FUNC` and `EFUNC`, but any calls to other functions need to use the following macros:
 
 | Macro  | example |
@@ -108,50 +104,47 @@ These macros will call these functions with the appropriate wrappers and enable 
 
 ### 2.2. General Purpose Macros
 
-[CBA script_macros_common.hpp](https://gist.github.com/commy2/9ed6cc73fbe6a2b3f4e1)
+[CBA script_macros_common.hpp](https://github.com/CBATeam/CBA_A3/blob/master/addons/main/script_macros_common.hpp)
 
-`QUOTE()` is utilized within configuration files for bypassing the quote issues in configuration macros. So, all code segments inside a given config should utilize wrapping in the QUOTE() macro instead of direct strings. This allows us to use our macros inside the string segments, such as `QUOTE(_this call FUNC(balls))`
+`QUOTE()` is utilized within configuration files for bypassing the quote issues in configuration macros. So, all code segments inside a given config should utilize wrapping in the `QUOTE()` macro instead of direct strings. This allows us to use our macros inside the string segments, such as `QUOTE(_this call FUNC(balls))`
 
-#### 2.2.1. setVariable, getVariable family macros
-
+#### 2.2.1. `setVariable`, `getVariable` family macros
 These macros are allowed but are not enforced.
 
 | Macro  | Expands to |
 | -------|---------|
-|`GETVAR(player,MyVarName,false)` | player getVariable ["MyVarName", false]|
-|`GETMVAR(MyVarName,objNull)` | missionNamespace getVariable ["MyVarName", objNull]|
-|`GETUVAR(MyVarName,displayNull)` | uiNamespace getVariable ["MyVarName", displayNull]|
-|`SETVAR(player,MyVarName,127)` |  player setVariable ["MyVarName", 127]  SETPVAR(player,MyVarName,127) player setVariable ["MyVarName", 127, true] |
-|`SETMVAR(MyVarName,player)` | missionNamespace setVariable ["MyVarName", player] |
-|`SETUVAR(MyVarName,_control)` | uiNamespace setVariable ["MyVarName", _control] |
+|`GETVAR(player,MyVarName,false)` | `player getVariable ["MyVarName", false]` |
+|`GETMVAR(MyVarName,objNull)` | `missionNamespace getVariable ["MyVarName", objNull]` |
+|`GETUVAR(MyVarName,displayNull)` | `uiNamespace getVariable ["MyVarName", displayNull]` |
+|`SETVAR(player,MyVarName,127)` |  `player setVariable ["MyVarName", 127]  SETPVAR(player,MyVarName,127) player setVariable ["MyVarName", 127, true]` |
+|`SETMVAR(MyVarName,player)` | `missionNamespace setVariable ["MyVarName", player]` |
+|`SETUVAR(MyVarName,_control)` | `uiNamespace setVariable ["MyVarName", _control]` |
 
 #### 2.2.2. STRING family macros
-
 Note that you need the strings in module stringtable.xml in the correct format
 `STR_ACE_<module>_<string>`
 
 Example:
 `STR_Balls_Banana`
 
-Script strings:
+Script strings (still require `localize` to localize the string):
 
 | Macro  |  Expands to |
 | -------|---------|
-|`LSTRING(banana)` |  "STR_ACE_balls_banana"|
-|`ELSTRING(balls,banana)` | "STR_ACE_balls_banana"|
+|`LSTRING(banana)` | `"STR_ACE_balls_banana"` |
+|`ELSTRING(balls,banana)` | `"STR_ACE_balls_banana"` |
 
 
 Config Strings (require `$` as first character):
 
 | Macro  |  Expands to |
 | -------|---------|
-|`CSTRING(banana)` |  "$STR_ACE_balls_banana" |
-|`ECSTRING(balls,banana)` | "$STR_ACE_balls_banana" |
+|`CSTRING(banana)` | `"$STR_ACE_balls_banana"` |
+|`ECSTRING(balls,banana)` | `"$STR_ACE_balls_banana"` |
 
 
 ## 3. Functions
-
-Functions should be created in the functions\ subdirectory, named `fnc_functionName.sqf` They should then be indexed via the `PREP(functionName)` macro in the XEH_preInit.sqf file.
+Functions should be created in the `functions\` subdirectory, named `fnc_functionName.sqf` They should then be indexed via the `PREP(functionName)` macro in the `XEH_preInit.sqf` file.
 
 The `PREP` macro allows for CBA function caching, which drastically speeds up load times. **Beware though that function caching is enabled by default and as such to disable it you need to `#define DISABLE_COMPILE_CACHE` above your `#include "script_components.hpp"` include!**
 
@@ -187,24 +180,24 @@ All scripts written must be below this include and any potential additional incl
 #### 3.2.1. Reasoning
 This ensures every function starts of in an uniform way and enforces function documentation.
 
+
 ## 4. Global Variables
-All Global Variables are defined in the XEH_preInit.sqf file of the component they will be used in with an initial default value.
+All Global Variables are defined in the `XEH_preInit.sqf` file of the component they will be used in with an initial default value.
 
 Exceptions:
+- Dynamically generated global variables
+- Variables that do not origin from he ACE project, such as BI global variables or third party such as CBA
 
-* Dynamically generated global variables
-* Variables that do not origin from he ACE project, such as BI global variables or third party such as CBA.
 
 ## 5. Code Style
 
 ### 5.1. Braces placement
-Braces "{ }" which enclose a code block will have the first bracket placed behind the statement in case of if, switch statements or while, waitUntil & for loops. The second bracket will be placed on the same column as the statement but on a separate line.
+Braces `{ }` which enclose a code block will have the first bracket placed behind the statement in case of `if`, `switch` statements or `while`, `waitUntil` & `for` loops. The second brace will be placed on the same column as the statement but on a separate line.
 
 - Opening brace on the same line as keyword
 - Closing brace in own line, same level of indentation as keyword
 
 **Yes:**
-
 ```cpp
 class Something: Or {
     class Other {
@@ -214,7 +207,6 @@ class Something: Or {
 ```
 
 **No:**
-
 ```cpp
 class Something : Or
 {
@@ -226,7 +218,6 @@ class Something : Or
 ```
 
 **Also no:**
-
 ```cpp
 class Something : Or {
     class Other {
@@ -236,7 +227,6 @@ class Something : Or {
 ```
 
 When using `if`/`else`, it is encouraged to put `else` on the same line as the closing brace to save space:
-
 ```js
 if (alive player) then {
     player setDamage 1;
@@ -246,7 +236,6 @@ if (alive player) then {
 ```
 
 In cases where there are a lot of one-liner classes, it is allowed to use something like this to save space:
-
 ```cpp
 class One {foo = 1;};
 class Two {foo = 2;};
@@ -254,14 +243,12 @@ class Three {foo = 3;};
 ```
 
 #### 5.1.1. Reasoning
-
-Putting the opening brace in it's own line wastes a lot of space, and keeping the closing brace on the same level as the keyword makes it easier to recognize what exactly the brace closes.
+Putting the opening brace in its own line wastes a lot of space, and keeping the closing brace on the same level as the keyword makes it easier to recognize what exactly the brace closes.
 
 ### 5.2. Indents
 Ever new scope should be on a new indent. This will make the code easier to understand and read. Indentations consist of 4 spaces. Tabs are not allowed.
 
-Good example:
-
+Good:
 ```js
 call {
     call {
@@ -272,8 +259,7 @@ call {
 };
 ```
 
-Bad Example:
-
+Bad:
 ```js
 call {
         call {
@@ -298,10 +284,9 @@ Example:
 ### 5.4. Comments in code
 All code should be documented by comments that describe what is being done. This can be done through the function header and/or inline comments.
 
-Comments within the code should be used when they are describing a complex and critical section of code or if the subject code does something a certain way because of a specific reason. Uncessary comments in the code are not allowed.
+Comments within the code should be used when they are describing a complex and critical section of code or if the subject code does something a certain way because of a specific reason. Unnecessary comments in the code are not allowed.
 
 Good:
-
 ```js
 // find the object with the most blood loss
 _highestObj = objNull;
@@ -315,28 +300,24 @@ _highestLoss = -1;
 ```
 
 Good:
-
 ```js
 // Check if the unit is an engineer
 (_obj getvariable [QGVAR(engineerSkill), 0] >= 1);
 ```
 
 Bad:
-
 ```js
 // Get the engineer skill and check if it is above 1
 (_obj getvariable [QGVAR(engineerSkill), 0] >= 1);
 ```
 
 Bad:
-
 ```js
 // Get the variable myValue from the object
 _myValue = _obj getvariable [QGVAR(myValue), 0];
 ```
 
 Bad:
-
 ```js
 // Loop through all units to increase the myvalue variable
 {
@@ -345,37 +326,33 @@ Bad:
 ```
 
 ### 5.5. Brackets around code
-When making use of brackets “( )”, use as few as possible, unless doing so decreases readability of the code. Avoid statements such as:
-
+When making use of brackets `( )`, use as few as possible, unless doing so decreases readability of the code. Avoid statements such as:
 ```js
 if (!(_value)) then { };
 ```
 
 However the following is allowed:
-
 ```js
 _value = (_array select 0) select 1;
 ```
 
 Any conditions in statements should always be wrapped around brackets.
-Example:
-
 ```js
 if (!_value) then {};
 if (_value) then {};
 ```
 
-
 ### 5.6. Magic Numbers
-There should be no magic numbers. Any magic number should be put in a define either on top of the .sqf file (below the header), or in the script_component.hpp file in the root directory of the component (recommended) in case it is used in multiple locations.
+There should be no magic numbers. Any magic number should be put in a define either on top of the `.sqf` file (below the header), or in the `script_component.hpp` file in the root directory of the component (recommended) in case it is used in multiple locations.
 
 Magic numbers are any of the following:
 
-* A constant numerical or text value used to identify a file format or protocol
-* Distinctive unique values that are unlikely to be mistaken for other meanings
-* Unique values with unexplained meaning or multiple occurrences which could (preferably) be replaced with named constants
+- A constant numerical or text value used to identify a file format or protocol
+- Distinctive unique values that are unlikely to be mistaken for other meanings
+- Unique values with unexplained meaning or multiple occurrences which could (preferably) be replaced with named constants
 
 [Source](http://en.wikipedia.org/wiki/Magic_number_%28programming%29)
+
 
 ## 6. Code Standards
 
@@ -386,35 +363,31 @@ If a function returns error information, then that error information will be tes
 There shall be no unreachable code.
 
 ### 6.3. Function Parameters
-Parameters of functions must be retrieved through the usage of the `param` or `params` commands. If the function is part of the public API, parameters must be checked on allowed data types and values through the usage of the param and params commands.
+Parameters of functions must be retrieved through the usage of the `param` or `params` commands. If the function is part of the public API, parameters must be checked on allowed data types and values through the usage of the `param` and `params` commands.
 
-Usage of the CBA Macro `PARAM_x` or `BIS_fnc_Param` is deprecated and not allowed within the ACE project unless very specific reasons allow no other alternative.
+Usage of the CBA Macro `PARAM_x` or `BIS_fnc_param` is deprecated and not allowed within the ACE project.
 
 ### 6.4. Return Values
-Functions and code blocks that specific a return a value must have a meaningfull return value. If no meaningfull return value, the function should return nil.
+Functions and code blocks that specific a return a value must have a meaningful return value. If no meaningful return value, the function should return nil.
 
 ### 6.5. Private Variables
-All private variables shall make use of the `private` keyword on initalization. When declaring a private variable before initalization, usage of the private array syntax is allowed. All private variables must be either initialized using the private key word, or declared using the private array syntax. Exceptions to this rule are variables obtained from an array. Note that this may only be down by making use of the `params` command family, as this ensures the variable is declared as private.
+All private variables shall make use of the `private` keyword on initialization. When declaring a private variable before initialization, usage of the private array syntax is allowed. All private variables must be either initialized using the private keyword, or declared using the private array syntax. Exceptions to this rule are variables obtained from an array. Note that this may only be down by making use of the `params` command family, as this ensures the variable is declared as private.
 
 Good:
-
 ```js
 private _myVariable = "hello world";
 ```
 
 Good:
-
 ```js
 _myArray params ["_elementOne", "_elementTwo"];
 ```
 
 Bad:
-
 ```js
 _elementOne = _myArray select 0;
 _elementTwo = _myArray select 1;
 ```
-
 
 ### 6.6. Lines of Code
 Any one function shall contain no more than 250 lines of code, excluding the function header and any includes.
@@ -423,17 +396,16 @@ Any one function shall contain no more than 250 lines of code, excluding the fun
 Declarations should be at the smallest feasible scope.
 
 Good:
-
 ```js
 if (call FUNC(myCondition)) then {
    private _areAllAboveTen = true; // <- smallest feasable scope
-   
+
    {
       if (_x >= 10) then {
          _areAllAboveTen = false;
       };
    } forEach _anArray;
-   
+
    if (_areAllAboveTen) then {
        hint "all values are above ten!";
    };
@@ -441,27 +413,25 @@ if (call FUNC(myCondition)) then {
 ```
 
 Bad:
-
 ```js
-private _areAllAboveTen = true; // <- this is bad, because it can be initalized in the if statement
-if (call FUNC(myCondition) then {
+private _areAllAboveTen = true; // <- this is bad, because it can be initialized in the if statement
+if (call FUNC(myCondition)) then {
    {
       if (_x >= 10) then {
          _areAllAboveTen = false;
       };
    } forEach _anArray;
-   
+
    if (_areAllAboveTen) then {
        hint "all values are above ten!";
    };
-}
+};
 ```
 
 ### 6.8. Variable initialization
 Private variables will not be introduced until they can be initialized with meaningful values.
 
 Good:
-
 ```js
 private _myVariable = 0; // good because the value will be used
 {
@@ -473,9 +443,8 @@ private _myVariable = 0; // good because the value will be used
 ```
 
 Bad:
-
 ```js
-private _myvariable = 0; // Bad because it is initalized with a zero, but this value does not mean anything
+private _myvariable = 0; // Bad because it is initialized with a zero, but this value does not mean anything
 if (_condition) then {
     _myVariable = 1;
 } else {
@@ -484,35 +453,31 @@ if (_condition) then {
 ```
 
 Good:
-
 ```js
 private _myvariable = [1, 2] select _condition;
 ```
 
-### 6.9. Initialization expression in for loops
-The initialization expression in a for loop will perform no actions other than to initialize the value of a single for loop parameter.
+### 6.9. Initialization expression in `for` loops
+The initialization expression in a `for` loop will perform no actions other than to initialize the value of a single `for` loop parameter.
 
-### 6.10. Increment expression in for loops
-The increment expression in a for loop will perform no action other than to change a single loop parameter to the next value for the loop.
+### 6.10. Increment expression in `for` loops
+The increment expression in a `for` loop will perform no action other than to change a single loop parameter to the next value for the loop.
 
-### 6.11. GetVariable
-When using getvariable, there should either be a default value given in the statement or the return value should be checked for correct data type as well as return value. A default value may not be given after a nil check.
+### 6.11. `getVariable`
+When using `getVariable`, there should either be a default value given in the statement or the return value should be checked for correct data type as well as return value. A default value may not be given after a nil check.
 
 Bad:
-
 ```js
 _return = obj getvariable "varName";
 if (isnil "_return") then {_return = 0 };
 ```
 
 Good:
-
 ```js
 _return = obj getvariable ["varName", 0];
 ```
 
 Good:
-
 ```js
 _return = obj getvariable "varName";
 if (isnil "_return") exitwith {};
@@ -522,31 +487,26 @@ if (isnil "_return") exitwith {};
 Global variables should not be used to pass along information from one function to another. Use arguments instead.
 
 Bad:
-
 ```js
 fnc_example = {
     hint GVAR(myVariable);
 };
 ```
-
 ```js
 GVAR(myVariable) = "hello my variable";
 call fnc_example;
 ```
 
 Good:
-
 ```js
 fnc_example = {
    params ["_content"];
    hint _content;
 };
 ```
-
 ```js
 ["hello my variable"] call fnc_example;
 ```
-
 
 ### 6.13. Temporary Objects & Variables
 Unnecessary temporary objects or variables should be avoided.
@@ -555,64 +515,41 @@ Unnecessary temporary objects or variables should be avoided.
 Code that is not used (commented out) shall be deleted.
 
 ### 6.15. Constant Global Variables
-All global variables that are intended to be used as a constant shall be written in all caps with underscores between the words, with the exception of the prefix. This should be done through the usage of the `GVAR` macro family.
-
-Good:
-
-```js
-ACE_Common_CATEGORY_NAME = 1;
-GVAR(CATEGORY_NAME) = 1
-```
+There shall be no constant global variables, constants shall be put in a `#define`.
 
 ### 6.16. Logging
 Functions should whenever possible and logical, make use of logging functionality through the logging and debugging macros from CBA and ACE.
 
 ### 6.17. Constant Private Variables
-Constant private variables that are used more as once should be put in a #define.
+Constant private variables that are used more as once should be put in a `#define`.
 
 ### 6.18. Code used more than once
-Any piece of code that could/is used more than once, should be put in a function and it’s seperate .sqf file, unless this code is less as 5 lines and used only in a per frame handler.
+Any piece of code that could/is used more than once, should be put in a function and it's separate `.sqf` file, unless this code is less as 5 lines and used only in a per frame handler.
+
 
 ## 7. Design considerations
 
 ### 7.1. Readability vs Performance
-This is a large open source project that will get many different maintainers in it's lifespan. When writing code, keep in mind that other developers also need to be able to understand your code. Balancing readability and performance of code is a non black and white subject. The rule of tumb is:
+This is a large open source project that will get many different maintainers in it's lifespan. When writing code, keep in mind that other developers also need to be able to understand your code. Balancing readability and performance of code is a non black and white subject. The rule of thumb is:
 
-* When improving performance of code that sacrifices readability (or visa-versa), first see if the design of the implementation is done in the best possible way.
-* Document that change with the reasoning in the code.
+- When improving performance of code that sacrifices readability (or visa-versa), first see if the design of the implementation is done in the best possible way.
+- Document that change with the reasoning in the code.
 
 ### 7.2. Scheduled vs Unscheduled
-Avoid the usage of scheduled space as much as possible and stay in unscheduled. This is to provide a smooth experience to the user by guaranteeing code to run when we want it. See Performance considerations, Spawn & ExecVm for more information.
+Avoid the usage of scheduled space as much as possible and stay in unscheduled. This is to provide a smooth experience to the user by guaranteeing code to run when we want it. See [Performance considerations, `spawn` & `execVM`](#avoid-spawn--execvm) for more information.
 
 This also helps avoid various bugs as a result of unguaranteed execution sequences when running multiple scripts.
 
 ### 7.3. Event driven
 All ACE3 components shall be implemented in an event driven fashion. This is done to ensure code only runs when it is required and allows for modularity through low coupling components.
 
-Event handlers in ACE3 are implemented through our event system. They should be used to trigger or allow triggering of specific functionality.
+Event handlers in ACE3 are implemented through CBA event system (ACE3's own event system is deprecated since 3.6.0). They should be used to trigger or allow triggering of specific functionality.
 
-The commands are listed below.
-
-| Even Handler  |  Use |
-| -------|---------|
-|`[eventName, eventCodeBlock] call ace_common_fnc_addEventHandler` | adds an event handler with the event name and returns the event handler id.|
-| `[eventName, args] call ace_common_fnc_globalEvent` | calls an event with the listed args on all machines, the local machine, and the server. |
-|`[eventName, args] call ace_common_fnc_serverEvent` | calls an event just on the server computer (dedicated or self-hosted).|
-| `[eventName, targetObject(s), args] call ace_common_fnc_targetEvent` | calls an event just on the targeted object or list of objects.|
-|`[eventName, args] call ace_common_fnc_localEvent` | calls an event just on the local machine, useful for inter-module events.|
-
-Events can be removed or cleared with the following commands.
-
-| Even Handler  |  Use |
-| -------|---------|
-|`[eventName, eventHandlerId] call ace_common_fnc_removeEventHandler` | will remove a specific event handler of the event name, using the ID returned from `ace_common_fnc_addEventHandler`.|
-|`[eventName] call ace_common_fnc_removeAllEventHandlers` | will remove all event handlers for that type of event.|
-
-More information on the [ACE3 Events System](https://ace3mod.com/wiki/ACE-Events-System) page.
+More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System) and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events) pages.
 
 ### 7.4. Hashes
 
-When a key value pair is required, make use of the Hash implementation from ACE.
+When a key value pair is required, make use of the hash implementation from ACE3.
 
 Hashes are a variable type that store key value pairs. They are not implemented natively in SQF, so there are a number of macros and functions for their usage in ACE3. If you are unfamiliar with the idea, they are similar in function to `setVariable`/`getVariable` but do not require an object to use.
 
@@ -620,32 +557,32 @@ The following example is a simple usage using our macros which will be explained
 
 ```js
 _hash = HASHCREATE;
-HASH_SET(_hash, "key", "value");
-if(HASH_HASKEY(_hash, "key")) then {
-    player sideChat format["val: %1", HASH_GET(_hash, "key"); // will print out "val: value"
+HASH_SET(_hash,"key","value");
+if (HASH_HASKEY(_hash,"key")) then {
+    player sideChat format ["val: %1", HASH_GET(_hash,"key"); // will print out "val: value"
 };
-HASH_REM(_hash, "key");
-if(HASH_HASKEY(_hash, "key")) then {
+HASH_REM(_hash,"key");
+if (HASH_HASKEY(_hash,"key")) then {
     // this will never execute because we removed the hash key/val pair "key"
 };
 ```
 
 A description of the above macros is below.
 
-| Macro  |  Use |
-| -------|---------|
-|`HASHCREATE` | used to create an empty hash.|
-| `HASH_SET(hash, key, val)` | will set the hash key to that value, a key can be anything, even objects. |
-|`HASH_GET(hash, key)` | will return the value of that key (or nil if it doesn't exist). |
-| `HASH_HASKEY(hash, key)` | will return true/false if that key exists in the hash. |
-| `HASH_REM(hash, key)` | will remove that hash key.|
+| Macro | Use |
+| ------|-------|
+|`HASHCREATE` | Used to create an empty hash. |
+|`HASH_SET(hash,key,val)` | Will set the hash key to that value, a key can be anything, even objects. |
+|`HASH_GET(hash,key)` | Will return the value of that key (or nil if it doesn't exist). |
+|`HASH_HASKEY(hash,key)` | Will return true/false if that key exists in the hash. |
+|`HASH_REM(hash,key)` | Will remove that hash key. |
 
 #### 7.4.1. Hashlists
 
-A hashlist is an extension of a hash. It is a list of hashes! The reason for having this special type of storage container rather than using a normal array is that an array of normal hashes that are are similar will duplicate a large amount of data in their storage of keys. A hashlist on the other hand uses a common list of keys and an array of unique value containers. The following will demonstrate it's usage.
+A hashlist is an extension of a hash. It is a list of hashes! The reason for having this special type of storage container rather than using a normal array is that an array of normal hashes that are similar will duplicate a large amount of data in their storage of keys. A hashlist on the other hand uses a common list of keys and an array of unique value containers. The following will demonstrate it's usage.
 
 ```js
-_defaultKeys = ["key1","key2","key3"];
+_defaultKeys = ["key1", "key2", "key3"];
 // create a new hashlist using the above keys as default
 _hashList = HASHLIST_CREATELIST(_defaultKeys);
 
@@ -653,98 +590,90 @@ _hashList = HASHLIST_CREATELIST(_defaultKeys);
 _hash = HASHLIST_CREATEHASH(_hashList);
 
 //_hash is now a standard hash...
-HASH_SET(_hash, "key1", "1");
+HASH_SET(_hash,"key1","1");
 
 //to store it to the list we need to push it to the list
 HASHLIST_PUSH(_hashList, _hash);
 
 //now lets get it out and store it in something else for fun
 //it was pushed to an empty list, so it's index is 0
-_anotherHash = HASHLIST_SELECT(_hashList, 0);
+_anotherHash = HASHLIST_SELECT(_hashList,0);
 
 // this should print "val: 1"
-player sideChat format["val: %1", HASH_GET(_anotherHash, "key1")];
+player sideChat format["val: %1", HASH_GET(_anotherHash,"key1")];
 
 //Say we need to add a new key to the hashlist
 //that we didn't initialize it with? We can simply
 //set a new key using the standard HASH_SET macro
-HASH_SET(_anotherHash, "anotherKey", "another value");
+HASH_SET(_anotherHash,"anotherKey","another value");
 ```
 
 As you can see above working with hashlists are fairly simple, a more in depth explanation of the macros is below.
 
-
 | Macro  |  Use |
 | -------|---------|
-|`HASHLIST_CREATELIST(keys)` | creates a new hashlist with the default keys, pass [] for no default keys.|
-|`HASHLIST_CREATEHASH(hashlist)` | returns a blank hash template from a hashlist.|
-|`HASHLIST_PUSH(hashList, hash)` | pushes a new hash onto the end of the list.|
-|`HASHLIST_SELECT(hashlist, index)` | returns the hash at that index in the list. |
-|`HASHLIST_SET(hashlist, index, hash)` | sets a specific index to that hash.|
+|`HASHLIST_CREATELIST(keys)` | Creates a new hashlist with the default keys, pass [] for no default keys. |
+|`HASHLIST_CREATEHASH(hashlist)` | Returns a blank hash template from a hashlist. |
+|`HASHLIST_PUSH(hashList, hash)` | Pushes a new hash onto the end of the list. |
+|`HASHLIST_SELECT(hashlist, index)` | Returns the hash at that index in the list. |
+|`HASHLIST_SET(hashlist, index, hash)` | Sets a specific index to that hash. |
 
 ##### 7.4.1.1. A note on pass by reference and hashes
 
-Hashes and hashlists are implemented with SQF arrays, and as such they are passed by reference to other functions. Remember to make copies (using the + operator) if you intend for the hash or hashlist to be modified with out the need for changing the original value.
+Hashes and hashlists are implemented with SQF arrays, and as such they are passed by reference to other functions. Remember to make copies (using the `+` operator) if you intend for the hash or hashlist to be modified with out the need for changing the original value.
 
 ## 8. Performance Considerations
 
 ### 8.1. Adding Elements to Arrays
-When adding new elements to an array, pushback shall be used instead of the binary addition or set. When adding multiple elements to an array `append` may be used instead of pushback.
+When adding new elements to an array, `pushBack` shall be used instead of the binary addition or `set`. When adding multiple elements to an array `append` may be used instead.
 
 Good:
-
 ```js
-_a pushback _value;
+_a pushBack _value;
 ```
 
 Also good:
-
 ```js
 _a append [1,2,3];
 ```
 
 Bad:
-
 ```js
 _a set [ count _a, _value];
 _a = a + _[value];
 ```
 
-When adding an new element to a dynamic location in an array or when the index is precaluclated, set may be used.
+When adding an new element to a dynamic location in an array or when the index is pre-calculated, `set` may be used.
 
 When adding multiple elements to an array, the binary addition may be used for the entire addition.
 
-### 8.2. CreateVehicle
-CreateVehicle array shall be used instead of createVehicle
+### 8.2. `createVehicle`
+`createVehicle` array shall be used.
 
 ### 8.3. Unscheduled vs Scheduled
-All code that has a visable effect for the user or requires time specific guaranteed excution shall be written in unscheduled space.
+All code that has a visible effect for the user or requires time specific guaranteed execution shall be written in unscheduled space.
 
-### 8.4. Avoid Spawn & execVM
-ExecVM and spawn are to be avoided wherever possible.
+### 8.4. Avoid `spawn` & `execVM`
+`execVM` and `spawn` are to be avoided wherever possible.
 
 ### 8.5. Empty Arrays
-When checking if an array is empty, you can use both count or isEqualTo.
+When checking if an array is empty `isEqualTo` shall be used.
 
-### 8.6. For Loops
+### 8.6. `for` Loops
 
 ```js
 for "_y" from # to # step # do { ... }
 ```
-
 should be used instead of
-
 ```js
 for [{ ... },{ ... },{ ... }] do { ... };
 ```
-
 whenever possible.
 
-### 8.7. While Loops
-While is only allowed when used to perform a unknown finite amount of steps with unknown or variable increments. Infinited while loops are not allowed.
+### 8.7. `while` Loops
+While is only allowed when used to perform a unknown finite amount of steps with unknown or variable increments. Infinite `while` loops are not allowed.
 
 Good:
-
 ```js
 _original = _obj getvariable [QGVAR(value), 0];
 while {_original < _weaponThreshold} do {
@@ -753,15 +682,14 @@ while {_original < _weaponThreshold} do {
 ```
 
 Bad:
-
 ```js
 while {true} do {
     // anything
 };
 ```
 
-### 8.8. waitUntil
-The waitUntil command shall not be used. Instead, make use of a per frame handler:
+### 8.8. `waitUntil`
+The `waitUntil` command shall not be used. Instead, make use of a per-frame handler:
 
 ```js
 [{

--- a/wiki/development/coding-guidelines.md
+++ b/wiki/development/coding-guidelines.md
@@ -45,11 +45,13 @@ All functions shall be put in their own `.sqf` file.
 Config files shall be split up into different header files, each with the name of the config and be included in the `config.cpp` of the component.
 
 Example:
+
 ```cpp
 #include "ACE_Settings.hpp"
 ```
 
 And in `ACE_Settings.hpp`:
+
 ```cpp
 class ACE_Settings {
     // Content
@@ -124,8 +126,7 @@ These macros are allowed but are not enforced.
 Note that you need the strings in module stringtable.xml in the correct format
 `STR_ACE_<module>_<string>`
 
-Example:
-`STR_Balls_Banana`
+Example: `STR_Balls_Banana`
 
 Script strings (still require `localize` to localize the string):
 
@@ -198,6 +199,7 @@ Braces `{ }` which enclose a code block will have the first bracket placed behin
 - Closing brace in own line, same level of indentation as keyword
 
 **Yes:**
+
 ```cpp
 class Something: Or {
     class Other {
@@ -207,6 +209,7 @@ class Something: Or {
 ```
 
 **No:**
+
 ```cpp
 class Something : Or
 {
@@ -218,6 +221,7 @@ class Something : Or
 ```
 
 **Also no:**
+
 ```cpp
 class Something : Or {
     class Other {
@@ -227,6 +231,7 @@ class Something : Or {
 ```
 
 When using `if`/`else`, it is encouraged to put `else` on the same line as the closing brace to save space:
+
 ```js
 if (alive player) then {
     player setDamage 1;
@@ -236,6 +241,7 @@ if (alive player) then {
 ```
 
 In cases where there are a lot of one-liner classes, it is allowed to use something like this to save space:
+
 ```cpp
 class One {foo = 1;};
 class Two {foo = 2;};
@@ -249,6 +255,7 @@ Putting the opening brace in its own line wastes a lot of space, and keeping the
 Ever new scope should be on a new indent. This will make the code easier to understand and read. Indentations consist of 4 spaces. Tabs are not allowed.
 
 Good:
+
 ```js
 call {
     call {
@@ -260,6 +267,7 @@ call {
 ```
 
 Bad:
+
 ```js
 call {
         call {
@@ -287,6 +295,7 @@ All code should be documented by comments that describe what is being done. This
 Comments within the code should be used when they are describing a complex and critical section of code or if the subject code does something a certain way because of a specific reason. Unnecessary comments in the code are not allowed.
 
 Good:
+
 ```js
 // find the object with the most blood loss
 _highestObj = objNull;
@@ -300,24 +309,28 @@ _highestLoss = -1;
 ```
 
 Good:
+
 ```js
 // Check if the unit is an engineer
 (_obj getvariable [QGVAR(engineerSkill), 0] >= 1);
 ```
 
 Bad:
+
 ```js
 // Get the engineer skill and check if it is above 1
 (_obj getvariable [QGVAR(engineerSkill), 0] >= 1);
 ```
 
 Bad:
+
 ```js
 // Get the variable myValue from the object
 _myValue = _obj getvariable [QGVAR(myValue), 0];
 ```
 
 Bad:
+
 ```js
 // Loop through all units to increase the myvalue variable
 {
@@ -327,16 +340,19 @@ Bad:
 
 ### 5.5. Brackets around code
 When making use of brackets `( )`, use as few as possible, unless doing so decreases readability of the code. Avoid statements such as:
+
 ```js
 if (!(_value)) then { };
 ```
 
 However the following is allowed:
+
 ```js
 _value = (_array select 0) select 1;
 ```
 
 Any conditions in statements should always be wrapped around brackets.
+
 ```js
 if (!_value) then {};
 if (_value) then {};
@@ -374,16 +390,19 @@ Functions and code blocks that specific a return a value must have a meaningful 
 All private variables shall make use of the `private` keyword on initialization. When declaring a private variable before initialization, usage of the private array syntax is allowed. All private variables must be either initialized using the private keyword, or declared using the private array syntax. Exceptions to this rule are variables obtained from an array. Note that this may only be down by making use of the `params` command family, as this ensures the variable is declared as private.
 
 Good:
+
 ```js
 private _myVariable = "hello world";
 ```
 
 Good:
+
 ```js
 _myArray params ["_elementOne", "_elementTwo"];
 ```
 
 Bad:
+
 ```js
 _elementOne = _myArray select 0;
 _elementTwo = _myArray select 1;
@@ -396,6 +415,7 @@ Any one function shall contain no more than 250 lines of code, excluding the fun
 Declarations should be at the smallest feasible scope.
 
 Good:
+
 ```js
 if (call FUNC(myCondition)) then {
    private _areAllAboveTen = true; // <- smallest feasable scope
@@ -413,6 +433,7 @@ if (call FUNC(myCondition)) then {
 ```
 
 Bad:
+
 ```js
 private _areAllAboveTen = true; // <- this is bad, because it can be initialized in the if statement
 if (call FUNC(myCondition)) then {
@@ -432,6 +453,7 @@ if (call FUNC(myCondition)) then {
 Private variables will not be introduced until they can be initialized with meaningful values.
 
 Good:
+
 ```js
 private _myVariable = 0; // good because the value will be used
 {
@@ -443,6 +465,7 @@ private _myVariable = 0; // good because the value will be used
 ```
 
 Bad:
+
 ```js
 private _myvariable = 0; // Bad because it is initialized with a zero, but this value does not mean anything
 if (_condition) then {
@@ -453,6 +476,7 @@ if (_condition) then {
 ```
 
 Good:
+
 ```js
 private _myvariable = [1, 2] select _condition;
 ```
@@ -467,17 +491,20 @@ The increment expression in a `for` loop will perform no action other than to ch
 When using `getVariable`, there should either be a default value given in the statement or the return value should be checked for correct data type as well as return value. A default value may not be given after a nil check.
 
 Bad:
+
 ```js
 _return = obj getvariable "varName";
 if (isnil "_return") then {_return = 0 };
 ```
 
 Good:
+
 ```js
 _return = obj getvariable ["varName", 0];
 ```
 
 Good:
+
 ```js
 _return = obj getvariable "varName";
 if (isnil "_return") exitwith {};
@@ -487,23 +514,27 @@ if (isnil "_return") exitwith {};
 Global variables should not be used to pass along information from one function to another. Use arguments instead.
 
 Bad:
+
 ```js
 fnc_example = {
     hint GVAR(myVariable);
 };
 ```
+
 ```js
 GVAR(myVariable) = "hello my variable";
 call fnc_example;
 ```
 
 Good:
+
 ```js
 fnc_example = {
    params ["_content"];
    hint _content;
 };
 ```
+
 ```js
 ["hello my variable"] call fnc_example;
 ```
@@ -628,16 +659,19 @@ Hashes and hashlists are implemented with SQF arrays, and as such they are passe
 When adding new elements to an array, `pushBack` shall be used instead of the binary addition or `set`. When adding multiple elements to an array `append` may be used instead.
 
 Good:
+
 ```js
 _a pushBack _value;
 ```
 
 Also good:
+
 ```js
 _a append [1,2,3];
 ```
 
 Bad:
+
 ```js
 _a set [ count _a, _value];
 _a = a + _[value];
@@ -664,16 +698,20 @@ When checking if an array is empty `isEqualTo` shall be used.
 ```js
 for "_y" from # to # step # do { ... }
 ```
+
 should be used instead of
+
 ```js
 for [{ ... },{ ... },{ ... }] do { ... };
 ```
+
 whenever possible.
 
 ### 8.7. `while` Loops
 While is only allowed when used to perform a unknown finite amount of steps with unknown or variable increments. Infinite `while` loops are not allowed.
 
 Good:
+
 ```js
 _original = _obj getvariable [QGVAR(value), 0];
 while {_original < _weaponThreshold} do {
@@ -682,6 +720,7 @@ while {_original < _weaponThreshold} do {
 ```
 
 Bad:
+
 ```js
 while {true} do {
     // anything

--- a/wiki/development/coding-guidelines.md
+++ b/wiki/development/coding-guidelines.md
@@ -359,7 +359,7 @@ if (_value) then {};
 ```
 
 ### 5.6. Magic Numbers
-There should be no magic numbers. Any magic number should be put in a define either on top of the `.sqf` file (below the header), or in the `script_component.hpp` file in the root directory of the component (recommended) in case it is used in multiple locations.
+There shall be no magic numbers. Any magic number shall be put in a define either on top of the `.sqf` file (below the header), or in the `script_component.hpp` file in the root directory of the component (recommended) in case it is used in multiple locations.
 
 Magic numbers are any of the following:
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix typos
- Correct some wording
- ~~Make formatting consistent (no empty lines after titles and before code blocks)~~ Kramdown needs this
- Use code syntax (`code`) for all commands
- Replace ACE3 events with CBA events (links to CBA wiki)
- Replace dead commy2's Gist link for CBA macros to CBA macros file in CBA repo