### PR TITLE
Fix refuel not respecting time acceleration and pause

### DIFF
--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -16,11 +16,9 @@
 
 #include "script_component.hpp"
 
-#define PFH_STEPSIZE 1
-
 params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]], ["_nozzle", objNull, [objNull]], ["_connectToPoint", [0,0,0], [[]], 3]];
 
-private _rate =  getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(flowRate)) * GVAR(rate) * PFH_STEPSIZE;
+private _rate =  getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(flowRate)) * GVAR(rate);
 private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(fuelCapacity));
 
 [{
@@ -36,7 +34,7 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
         _nozzle setVariable [QGVAR(isConnected), false, true];
         _nozzle setVariable [QGVAR(sink), objNull, true];
         _sink setVariable [QGVAR(nozzle), objNull, true];
-        [_pfID] call cba_fnc_removePerFrameHandler;
+        [_pfID] call CBA_fnc_removePerFrameHandler;
     };
     private _tooFar = ((_sink modelToWorld _connectToPoint) distance (_source modelToWorld _connectFromPoint)) > (REFUEL_HOSE_LENGTH - 2);
     if (_tooFar && {!(_nozzle getVariable [QGVAR(jerryCan), false])}) exitWith {
@@ -46,24 +44,31 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
         _nozzle setVariable [QGVAR(isConnected), false, true];
         _nozzle setVariable [QGVAR(sink), objNull, true];
         _sink setVariable [QGVAR(nozzle), objNull, true];
-        [_pfID] call cba_fnc_removePerFrameHandler;
+        [_pfID] call CBA_fnc_removePerFrameHandler;
     };
 
     private _finished = false;
     private _fueling = _nozzle getVariable [QGVAR(isRefueling), false];
     if (_fueling) then {
         if (isEngineOn _sink) exitWith {
+            _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
             _nozzle setVariable [QGVAR(isRefueling), false, true];
         };
         private _fuelInSource = [_source] call FUNC(getFuel);
         if (_fuelInSource == 0) exitWith {
             [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);
+            _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
             _nozzle setVariable [QGVAR(isRefueling), false, true];
         };
+
+        // Calculate rate using mission time to take time acceleration and pause into account
+        private _rateTime = _rate * (CBA_missionTime - (_nozzle getVariable [QGVAR(lastTickMissionTime), CBA_missionTime]));
+        _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime, true];
+
         if !(_fuelInSource == REFUEL_INFINITE_FUEL) then {
-            _fuelInSource = _fuelInSource - _rate;
+            _fuelInSource = _fuelInSource - _rateTime;
         } else {
-            _source setVariable [QGVAR(fuelCounter), (_source getVariable [QGVAR(fuelCounter), 0]) + _rate, true];
+            _source setVariable [QGVAR(fuelCounter), (_source getVariable [QGVAR(fuelCounter), 0]) + _rateTime, true];
         };
         if (_fuelInSource < 0 && {_fuelInSource > REFUEL_INFINITE_FUEL}) then {
             _fuelInSource = 0;
@@ -71,7 +76,7 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
             [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);
         };
 
-        private _fuelInSink = (_unit getVariable [QGVAR(tempFuel), _startFuel])  + ( _rate / _maxFuel);
+        private _fuelInSink = (_unit getVariable [QGVAR(tempFuel), _startFuel])  + ( _rateTime / _maxFuel);
         if (_fuelInSink > 1) then {
             _fuelInSink = 1;
             _finished = true;
@@ -86,11 +91,11 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
     };
 
     if (_finished) exitWith {
+        _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
         _nozzle setVariable [QGVAR(isRefueling), false, true];
     };
-},
-PFH_STEPSIZE,
-[_nozzle getVariable QGVAR(source),
+}, 1, [
+    _nozzle getVariable QGVAR(source),
     _target,
     _unit,
     _nozzle,
@@ -98,5 +103,5 @@ PFH_STEPSIZE,
     fuel _target,
     _maxFuel,
     _nozzle getVariable [QGVAR(attachPos), [0,0,0]],
-    _connectToPoint]
-] call cba_fnc_addPerFrameHandler;
+    _connectToPoint
+]] call CBA_fnc_addPerFrameHandler;

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -51,19 +51,19 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
     private _fueling = _nozzle getVariable [QGVAR(isRefueling), false];
     if (_fueling) then {
         if (isEngineOn _sink) exitWith {
-            _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
+            _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
             _nozzle setVariable [QGVAR(isRefueling), false, true];
         };
         private _fuelInSource = [_source] call FUNC(getFuel);
         if (_fuelInSource == 0) exitWith {
             [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);
-            _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
+            _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
             _nozzle setVariable [QGVAR(isRefueling), false, true];
         };
 
         // Calculate rate using mission time to take time acceleration and pause into account
         private _rateTime = _rate * (CBA_missionTime - (_nozzle getVariable [QGVAR(lastTickMissionTime), CBA_missionTime]));
-        _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime, true];
+        _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime];
 
         if !(_fuelInSource == REFUEL_INFINITE_FUEL) then {
             _fuelInSource = _fuelInSource - _rateTime;
@@ -91,7 +91,7 @@ private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >>
     };
 
     if (_finished) exitWith {
-        _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
+        _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
         _nozzle setVariable [QGVAR(isRefueling), false, true];
     };
 }, 1, [

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -24,6 +24,7 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
     {
         params ["_args"];
         _args params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
+        _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
         _nozzle setVariable [QGVAR(isRefueling), false, true];
         [LSTRING(Hint_Stopped), 1.5, _unit] call EFUNC(common,displayTextStructured);
     },

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -24,7 +24,7 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
     {
         params ["_args"];
         _args params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
-        _nozzle setVariable [QGVAR(lastTickMissionTime), nil, true];
+        _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
         _nozzle setVariable [QGVAR(isRefueling), false, true];
         [LSTRING(Hint_Stopped), 1.5, _unit] call EFUNC(common,displayTextStructured);
     },

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -24,7 +24,7 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
     {
         params ["_args"];
         _args params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
-        _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime, true];
+        _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime];
         _nozzle setVariable [QGVAR(isRefueling), true, true];
         [LSTRING(Hint_Started), 1.5, _unit] call EFUNC(common,displayTextStructured);
     },

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -24,6 +24,7 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
     {
         params ["_args"];
         _args params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
+        _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime, true];
         _nozzle setVariable [QGVAR(isRefueling), true, true];
         [LSTRING(Hint_Started), 1.5, _unit] call EFUNC(common,displayTextStructured);
     },


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #4128 
- The PFH runs constantly while the nozzle is connected, even when not refueling, thus old time has to be set in `turnOn` function.