### PR TITLE
Fix spectator map click not changing cam pos

### DIFF
--- a/addons/spectator/functions/fnc_setCameraAttributes.sqf
+++ b/addons/spectator/functions/fnc_setCameraAttributes.sqf
@@ -60,7 +60,7 @@ GVAR(camZoom) = (_zoom min 2) max 0.01;
 
 // Apply if camera exists
 if (GVAR(isSet)) then {
-    GVAR(freeCamera) setPosATL _position;
+    GVAR(camPos) = (ATLtoASL _position); // Camera position will be updated in FUNC(handleCamera)
     [_mode,_unit,_vision] call FUNC(transitionCamera);
 } else {
     GVAR(camMode) = _mode;


### PR DESCRIPTION
Fix #3842

PFEH FUNC(handleCamera) will set camera position using GVAR(camPos)