### PR TITLE
Improve creation time of house actions dummy

### DIFF
--- a/addons/interact_menu/functions/fnc_userActions_addHouseActions.sqf
+++ b/addons/interact_menu/functions/fnc_userActions_addHouseActions.sqf
@@ -80,7 +80,7 @@ if ((vehicle ACE_player) != ACE_player) exitWith {};
             // systemChat format ["Add Actions for [%1] (count %2) @ %3", _typeOfHouse, (count _memPoints), diag_tickTime];
             {
                 private _helperPos = AGLtoASL (_houseBeingScaned modelToWorld (_houseBeingScaned selectionPosition _x));
-                private _helperObject = "ACE_LogicDummy" createVehicleLocal _helperPos;
+                private _helperObject = "ACE_LogicDummy" createVehicleLocal [0,0,0];
                 _addedHelpers pushBack _helperObject;
                 _helperObject setVariable [QGVAR(building), _houseBeingScaned];
                 _helperObject setPosASL _helperPos;


### PR DESCRIPTION
- impmrove speed of creating actions for buildings

On mission from jonpas with lots of wall objects inside of a warehouse, there was a huge stutter when creating actions (the building had ~8 doors + 2 ladders).

This PR improves the time from 137.893 ms -> 1.17631 ms

Thanks to @esteldunedain for the idea from the casing PR.

