### PR TITLE
Add tool to upload ace and compats to workshop

### DIFF
--- a/tools/publish.py
+++ b/tools/publish.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
-#Author: PabstMirror
+# Author: PabstMirror
 
-#Uploads ace relases to workshop
-#Will slice up compats to their own folders
-
+# Uploads ace relases to workshop
+# Will slice up compats to their own folders
 
 import sys
 
@@ -62,7 +61,10 @@ def buildCompatFolder(folderName, copyFileNames):
     return compatRelease_dir
 
 def publishFolder(folder,modID,changeNotes):
-    cmd = [publisherTool_path, "update", "/id:{}".format(modID), "/changeNote:'{}'".format(changeNotes), "/path:{}".format(folder)]
+    cmd = [publisherTool_path, "update", "/id:{}".format(modID), "/changeNoteFile:{}".format(changeNotes), "/path:{}".format(folder)]
+
+    print ("running: {}".format(cmd))
+
     print("")
     print("Publishing folder {} to workshop ID {}".format(folder,modID))
     print("")
@@ -72,43 +74,49 @@ def publishFolder(folder,modID,changeNotes):
     ret = subprocess.call(cmd)
     if ret != 0:
         print("publisher faild with code {}".format(ret))
-        raise Exception("Publisher","Publisher shit the bed")
+        raise Exception("Publisher","Publisher had problems")
 
 
 #GLOBALS
 release_dir = "P:\\z\\ace\\release"
 project = "@ace"
 publisherTool_path = find_bi_tools()
+changelog_path = os.path.join(release_dir,"changelog.txt")
 ace_release_dir = os.path.join(release_dir, project)
 ace_optionals_dir = os.path.join(ace_release_dir, "optionals")
-do_publish = True #False will let you just build dirs and test without running publisher
+
+do_publish = True
+# do_publish = False #will let you just build dirs and test without running publisher
 
 
 def main(argv):
     if not os.path.exists(ace_release_dir):
-        raise Exception("No ACE Build","ACE not built")
+        raise Exception("ace_release_dir not found","ACE not built or in wrong path")
     if not os.path.exists(ace_optionals_dir):
-        raise Exception("No Optionals","ACE not built")
+        raise Exception("ace_optionals_dir not found","ACE not built or in wrong path")
     if not os.path.exists(publisherTool_path):
-        raise Exception("No Publisher","Arma Tools not found")
+        raise Exception("publisherTool_path not found","Arma Tools not found")
+    if not os.path.exists(changelog_path):
+        raise Exception("changelog_path not found","Requires changelog.txt be present in the release dir")
+
+    if do_publish:
+        repl = input("\nThis will publish to steam, are you positive release dir has correct files? (y/n): ")
+        if repl.lower() != "y":
+            return 0
 
 
-    #Simple changenotes
-    changeNotes = "Rebuilt for latest ace release"
+    #ACE Main - http://steamcommunity.com/sharedfiles/filedetails/?id=463939057
+    # publishFolder(ace_release_dir, "463939057", changelog_path)
 
 
-    #ACE Main
-    # publishFolder(ace_release_dir, "?", changeNotes)
-
-
-    #RHS Compats
+    #RHS Compats - http://steamcommunity.com/sharedfiles/filedetails/?id=758436163
     folder = buildCompatFolder("@ace_rhs_compat", ["ace_compat_rhs_afrf3.*", "ace_compat_rhs_usf3.*"])
-    # publishFolder(folder, "??", changeNotes)
+    publishFolder(folder, "758436163", changelog_path)
 
 
-    #ADR97 (p90)
-    folder = buildCompatFolder("@ace_adr97_compat", ["ace_compat_adr_97.*"])
-    publishFolder(folder, "731517232", changeNotes)
+    #ADR97 (p90)- ToDo
+    # folder = buildCompatFolder("@ace_adr97_compat", ["ace_compat_adr_97.*"])
+    # publishFolder(folder, "???", changelog_path)
 
 
 

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -106,7 +106,7 @@ def main(argv):
 
 
     #ACE Main - http://steamcommunity.com/sharedfiles/filedetails/?id=463939057
-    # publishFolder(ace_release_dir, "463939057", changelog_path)
+    publishFolder(ace_release_dir, "463939057", changelog_path)
 
 
     #RHS Compats - http://steamcommunity.com/sharedfiles/filedetails/?id=758436163

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+#Author: PabstMirror
+
+#Uploads ace relases to workshop
+#Will slice up compats to their own folders
+
+
+import sys
+
+if sys.version_info[0] == 2:
+    print("Python 3 is required.")
+    sys.exit(1)
+
+import os
+import os.path
+import shutil
+import platform
+import glob
+import subprocess
+import hashlib
+import configparser
+import json
+import traceback
+import time
+import timeit
+import re
+import fnmatch
+
+if sys.platform == "win32":
+    import winreg
+
+def find_bi_tools():
+    reg = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
+    try:
+        k = winreg.OpenKey(reg, r"Software\bohemia interactive\arma 3 tools")
+        arma3tools_path = winreg.QueryValueEx(k, "path")[0]
+        winreg.CloseKey(k)
+    except:
+        raise Exception("BadTools","Arma 3 Tools are not installed correctly or the P: drive needs to be created.")
+
+    publisher_path = os.path.join(arma3tools_path, "Publisher", "PublisherCmd.exe")
+
+    if os.path.isfile(publisher_path):
+        return publisher_path
+    else:
+        raise Exception("BadTools","Arma 3 Tools are not installed correctly or the P: drive needs to be created.")
+
+def buildCompatFolder(folderName, copyFileNames):
+    compatRelease_dir = os.path.join(release_dir, folderName)
+    if os.path.exists(compatRelease_dir):
+        shutil.rmtree(compatRelease_dir)
+    os.makedirs(compatRelease_dir)
+    os.makedirs(os.path.join(compatRelease_dir, "addons"))
+    print("Adding files for folder {}".format(folderName))
+    for copyFileName in copyFileNames:
+        for file in os.listdir(ace_optionals_dir):
+            if fnmatch.fnmatch(file, copyFileName):
+                print("    Copying: {}".format(file))
+                shutil.copyfile(os.path.join(ace_optionals_dir, file), os.path.join(compatRelease_dir, "addons", file))
+
+    return compatRelease_dir
+
+def publishFolder(folder,modID,changeNotes):
+    cmd = [publisherTool_path, "update", "/id:{}".format(modID), "/changeNote:'{}'".format(changeNotes), "/path:{}".format(folder)]
+    print("")
+    print("Publishing folder {} to workshop ID {}".format(folder,modID))
+    print("")
+    if (not do_publish):
+        print("Just doing test build")
+        return
+    ret = subprocess.call(cmd)
+    if ret != 0:
+        print("publisher faild with code {}".format(ret))
+        raise Exception("Publisher","Publisher shit the bed")
+
+
+#GLOBALS
+release_dir = "P:\\z\\ace\\release"
+project = "@ace"
+publisherTool_path = find_bi_tools()
+ace_release_dir = os.path.join(release_dir, project)
+ace_optionals_dir = os.path.join(ace_release_dir, "optionals")
+do_publish = True #False will let you just build dirs and test without running publisher
+
+
+def main(argv):
+    if not os.path.exists(ace_release_dir):
+        raise Exception("No ACE Build","ACE not built")
+    if not os.path.exists(ace_optionals_dir):
+        raise Exception("No Optionals","ACE not built")
+    if not os.path.exists(publisherTool_path):
+        raise Exception("No Publisher","Arma Tools not found")
+
+
+    #Simple changenotes
+    changeNotes = "Rebuilt for latest ace release"
+
+
+    #ACE Main
+    # publishFolder(ace_release_dir, "?", changeNotes)
+
+
+    #RHS Compats
+    folder = buildCompatFolder("@ace_rhs_compat", ["ace_compat_rhs_afrf3.*", "ace_compat_rhs_usf3.*"])
+    # publishFolder(folder, "??", changeNotes)
+
+
+    #ADR97 (p90)
+    folder = buildCompatFolder("@ace_adr97_compat", ["ace_compat_adr_97.*"])
+    publishFolder(folder, "731517232", changeNotes)
+
+
+
+if __name__ == "__main__":
+    main(sys.argv)
+

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -105,18 +105,23 @@ def main(argv):
             return 0
 
 
+            
     #ACE Main - http://steamcommunity.com/sharedfiles/filedetails/?id=463939057
-    publishFolder(ace_release_dir, "463939057", changelog_path)
+    # publishFolder(ace_release_dir, "463939057", changelog_path)
 
+    
+    
+    #RHS Compat USA - http://steamcommunity.com/sharedfiles/filedetails/?id=773125288
+    folder = buildCompatFolder("@ace_compat_rhs_afrf3", ["ace_compat_rhs_afrf3.*"])
+    publishFolder(folder, "773125288", changelog_path)
+    
+    #RHS Compat Commies - http://steamcommunity.com/sharedfiles/filedetails/?id=773131200
+    folder = buildCompatFolder("@ace_compat_rhs_usf3", ["ace_compat_rhs_usf3.*"])
+    publishFolder(folder, "773131200", changelog_path)
 
-    #RHS Compats - http://steamcommunity.com/sharedfiles/filedetails/?id=758436163
-    folder = buildCompatFolder("@ace_rhs_compat", ["ace_compat_rhs_afrf3.*", "ace_compat_rhs_usf3.*"])
-    publishFolder(folder, "758436163", changelog_path)
-
-
-    #ADR97 (p90)- ToDo
-    # folder = buildCompatFolder("@ace_adr97_compat", ["ace_compat_adr_97.*"])
-    # publishFolder(folder, "???", changelog_path)
+    #ADR97 (p90)- http://steamcommunity.com/sharedfiles/filedetails/?id=773136286
+    folder = buildCompatFolder("@ace_adr97_compat", ["ace_compat_adr_97.*"])
+    publishFolder(folder, "773136286", changelog_path)
 
 
 


### PR DESCRIPTION
This should lets us automate the publishing of ace to steam workshop.
It will let us upload each compatibility to separate mods

I believe next RHS will be available on steamworkshop, 
so this will let users get ACE, RHS and ACE's RHS compat all through steam.

This will take some final adjustments like actually creating the new mods on the workshop