### PR TITLE
add BlueForceTracking filtering via an object variable

### DIFF
--- a/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
+++ b/addons/map/functions/fnc_blueForceTrackingUpdate.sqf
@@ -27,7 +27,7 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
     };
 
     if (GVAR(BFT_ShowPlayerNames)) then {
-        _playersToDrawMarkers = allPlayers select {side _x == _playerSide};
+        _playersToDrawMarkers = allPlayers select {side _x == _playerSide && {!(_x getVariable [QGVAR(hideBlueForceMarker), false])}};
 
         {
             private _markerType = [_x] call EFUNC(common,getMarkerType);
@@ -47,6 +47,8 @@ if (GVAR(BFT_Enabled) and {(!isNil "ACE_player") and {alive ACE_player}}) then {
             } count units _x > 0;
         };
     };
+
+    _groupsToDrawMarkers = _groupsToDrawMarkers select {!(_x getVariable [QGVAR(hideBlueForceMarker), false])};
 
     {
         private _markerType = [_x] call EFUNC(common,getMarkerType);


### PR DESCRIPTION
add BlueForceTracking filtering via an object variable

There's no good workaround for this:

 * creating a dummy unit on [0,0,0] and making it leader prevents
   grp members from entering vehicles
 * joining group of a different side prevents grp members from seeing
   blueforce tracking markers of their original side

Usage (_obj can be group or unit, depending on BFT_ShowPlayerNames):

    _obj setVariable ["ACE_map_hideBlueForceMarker", true];