### PR TITLE
Use createSimpleObject for medical litter

### DIFF
--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -159,8 +159,6 @@ class ACE_Settings {
         value = 3;
         values[] = {"Off", "Low", "Medium", "High", "Ultra"};
         _values[] = { 0, 50, 100, 1000, 5000 };
-
-        isClientSettable = 1;
     };
     class GVAR(litterCleanUpDelay) {
         category = CSTRING(Category_Medical);

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -27,8 +27,11 @@ GVAR(heartBeatSounds_Slow) = ["ACE_heartbeat_slow_1", "ACE_heartbeat_slow_2"];
 [QGVAR(treatmentTourniquetLocal), DFUNC(treatmentTourniquetLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(actionPlaceInBodyBag), FUNC(actionPlaceInBodyBag)] call CBA_fnc_addEventHandler;
 
-//Handle Deleting Bodies on Server:
-if (isServer) then {["ace_placedInBodyBag", FUNC(serverRemoveBody)] call CBA_fnc_addEventHandler;};
+//Handle Deleting Bodies and creating litter on Server:
+if (isServer) then {
+    ["ace_placedInBodyBag", FUNC(serverRemoveBody)] call CBA_fnc_addEventHandler;
+    [QGVAR(createLitterServer), FUNC(handleCreateLitter)] call CBA_fnc_addEventHandler;
+};
 
 ["ace_unconscious", {
     params ["_unit", "_status"];
@@ -267,9 +270,6 @@ GVAR(lastHeartBeatSound) = CBA_missionTime;
 };
 
 ["ace_settingsInitialized", {
-    // Networked litter (need to wait for GVAR(litterCleanUpDelay) to be set)
-    [QGVAR(createLitter), FUNC(handleCreateLitter), GVAR(litterCleanUpDelay)] call EFUNC(common,addSyncedEventHandler);
-
     [
         {(((_this select 0) getVariable [QGVAR(bloodVolume), 100]) < 65)},
         {(((_this select 0) getVariable [QGVAR(pain), 0]) - ((_this select 0) getVariable [QGVAR(painSuppress), 0])) > 0.9},

--- a/addons/medical/functions/fnc_createLitter.sqf
+++ b/addons/medical/functions/fnc_createLitter.sqf
@@ -22,21 +22,22 @@
 #define MIN_ENTRIES_LITTER_CONFIG 3
 
 params ["_caller", "_target", "_selectionName", "_className", "", "_usersOfItems", "_bloodLossOnSelection"];
+TRACE_6("params",_caller,_target,_selectionName,_className,_usersOfItems,_bloodLossOnSelection);
 
 //Ensures comptibilty with other possible medical treatment configs
 private _previousDamage = _bloodLossOnSelection;
 
 if !(GVAR(allowLitterCreation)) exitwith {};
-if (vehicle _caller != _caller || vehicle _target != _target) exitwith {};
+if (vehicle _caller != _caller || {vehicle _target != _target}) exitwith {};
 
 private _config = if (GVAR(level) >= 2) then {
     (configFile >> "ACE_Medical_Actions" >> "Advanced" >> _className);
 } else {
     (configFile >> "ACE_Medical_Actions" >> "Basic" >> _className)
 };
-if !(isClass _config) exitwith {false};
+if !(isClass _config) exitwith {TRACE_1("No action config", _className);};
 
-if !(isArray (_config >> "litter")) exitwith {};
+if !(isArray (_config >> "litter")) exitwith {TRACE_1("No litter config", _className);};
 private _litter = getArray (_config >> "litter");
 
 private _createLitter = {
@@ -53,7 +54,8 @@ private _createLitter = {
 
     // Create the litter, and timeout the event based on the cleanup delay
     // The cleanup delay for events in MP is handled by the server side
-    [QGVAR(createLitter), [_litterClass, _position, _direction], 0] call EFUNC(common,syncedEvent);
+    TRACE_3("Creating Litter on server",_litterClass,_position,_direction);
+    [QGVAR(createLitterServer), [_litterClass, _position, _direction]] call CBA_fnc_serverEvent;
 
     true
 };

--- a/addons/medical/functions/fnc_handleCreateLitter.sqf
+++ b/addons/medical/functions/fnc_handleCreateLitter.sqf
@@ -14,10 +14,9 @@
  */
 #include "script_component.hpp"
 
-if(!hasInterface) exitWith { false };
-
 params ["_litterClass", "_position", "_direction"];
-private["_litterObject", "_maxLitterCount"];
+TRACE_3("params",_litterClass,_position,_direction);
+
 //IGNORE_PRIVATE_WARNING(_values);
 
 if (isNil QGVAR(allCreatedLitter)) then {
@@ -25,17 +24,22 @@ if (isNil QGVAR(allCreatedLitter)) then {
     GVAR(litterPFHRunning) = false;
 };
 
-_litterObject = _litterClass createVehicleLocal _position;
+private _p3dFile = getText (configFile >> "CfgVehicles" >> _litterClass >> "model");
+if (_p3dFile == "") exitWith {TRACE_2("no model",_litterClass,_p3dFile)};
+// createSimpleObject expects a path without the leading slash
+if ((_p3dFile select [0,1]) == "\") then {_p3dFile = _p3dFile select [1];};
+
+private _litterObject = createSimpleObject [_p3dFile, [0,0,0]];
+TRACE_2("created",_litterClass,_litterObject);
 _litterObject setDir _direction;
 _litterObject setPosATL _position;
 // Move the litter next frame to get rid of HORRIBLE spacing, fixes #1112
 [{ params ["_object", "_pos"]; _object setPosATL _pos; }, [_litterObject, _position]] call CBA_fnc_execNextFrame;
 
-_maxLitterCount = getArray (configFile >> "ACE_Settings" >> QGVAR(litterSimulationDetail) >> "_values") select GVAR(litterSimulationDetail);
-if((count GVAR(allCreatedLitter)) > _maxLitterCount ) then {
+private _maxLitterCount = getArray (configFile >> "ACE_Settings" >> QGVAR(litterSimulationDetail) >> "_values") select GVAR(litterSimulationDetail);
+if ((count GVAR(allCreatedLitter)) > _maxLitterCount) then {
     // gank the first litter object, and spawn ours.
-    private["_oldLitter"];
-    _oldLitter = GVAR(allCreatedLitter) deleteAt 0;
+    private _oldLitter = GVAR(allCreatedLitter) deleteAt 0;
     {
         deleteVehicle _x;
     } forEach (_oldLitter select 1);

--- a/addons/medical/functions/fnc_litterCleanupLoop.sqf
+++ b/addons/medical/functions/fnc_litterCleanupLoop.sqf
@@ -15,17 +15,18 @@
 
 {
     _x params ["_time", "_objects"];
-    if (CBA_missionTime - _time >= GVAR(litterCleanUpDelay)) then {
-        {
-            deleteVehicle _x;
-        } forEach _objects;
-        GVAR(allCreatedLitter) set[_forEachIndex, objNull];
-    };
+    //Older elements are always at the begining of the array:
+    if ((CBA_missionTime - _time) < GVAR(litterCleanUpDelay)) exitWith {};
+    TRACE_2("deleting",_time,_objects);
+    {
+        deleteVehicle _x;
+    } forEach _objects;
+    GVAR(allCreatedLitter) set [_forEachIndex, objNull];
 } forEach GVAR(allCreatedLitter);
 GVAR(allCreatedLitter) = GVAR(allCreatedLitter) - [objNull];
 
 // If no more litter remaining, exit the loop
-if ( (count GVAR(allCreatedLitter)) == 0) exitWith {
+if (GVAR(allCreatedLitter) isEqualTo []) exitWith {
     GVAR(litterPFHRunning) = false;
 };
 


### PR DESCRIPTION
Ref discussion in #3537

- Uses `createSimpleObject` for medical litter
- ace_medical_litterSimulationDetail is now a server setting with global effects

Benifits:
- creation and cleanup loop code only runs on server
- no physX
- Objects do not show up in `(entities "")` - e.g. CBA xeh fallback won't waste time on them!

Drawbacks:
- @Glowbal mentioned that clients lose the ability to set their own litter levels.

```
_start = diag_tickTime;
_created = 0;
for "_xPos" from -25 to 25 do { 
    for "_yPos" from 0 to 25 do { 
        _position = getPosATL player; 
        _position = _position vectorAdd [_xPos, _yPos, 0]; 
        
        // _litterObject = createSimpleObject ["z\ace\addons\medical\data\littergeneric_bandages1.p3d", [0,0,0]]; 
        _litterObject = "ACE_MedicalLitter_bandage1" createVehicleLocal [0,0,0];

        _litterObject setDir random 360; 
        _litterObject setPosATL _position; 
        _created = _created + 1;
    }; 
};
systemChat format ["took %1 to make %2", (diag_tickTime - _start), _created];
```

`createSimpleObject` had much less effect on FPS
`createVehicleLocal` also created terrible lag for about 5 second (2-4 FPS) while the objects danced around and tried to stabilize on the ground