### PR TITLE
Fix track repair selection placement

### DIFF
--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -132,9 +132,9 @@ _processedHitpoints = [];
             // Tracks should always be unique
             if (_hitpoint in _processedHitpoints) exitWith {TRACE_3("Duplicate Track",_hitpoint,_forEachIndex,_selection);};
             if (_hitpoint == "HitLTrack") then {
-                _position = [-1.75, 0, -1.75];
+                _position = compile format ["private _return = _target selectionPosition ['%1', 'HitPoints']; _return set [1, 0]; _return", _selection];
             } else {
-                _position = [1.75, 0, -1.75];
+                _position = compile format ["private _return = _target selectionPosition ['%1', 'HitPoints']; _return set [1, 0]; _return", _selection];
             };
             TRACE_4("Adding RepairTrack",_hitpoint,_forEachIndex,_selection,_text);
             _condition = {[_this select 1, _this select 0, _this select 2 select 0, "RepairTrack"] call DFUNC(canRepair)};


### PR DESCRIPTION
This tweaks the placement of repair track actions.
The BW Leopard model center is at ground level so -1.75 below that is no good.

The hitpoint selection is usually pretty good in Z and X axis, but the Y is usually no good.
This uses the selection position and just sets the Y to 0.


Using this to test placement (red = old position, blue = selection, green = new):

![x](https://cloud.githubusercontent.com/assets/9376747/17315188/38fa4414-582f-11e6-849a-09c26b79dc9f.jpg)


```
addMissionEventHandler ["Draw3D", {
    _selPos = cursorTarget modelToWorldVisual [-1.75, 0, -1.75];
    drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", [1,0,0,1], _selPos, 1, 1, 0, "1.75", 1, 0.02, "PuristaMedium"];
    _selPos = cursorTarget modelToWorldVisual [1.75, 0, -1.75];
    drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", [1,0,0,1], _selPos, 1, 1, 0, "1.75", 1, 0.02, "PuristaMedium"];
    {
        _selection = getText (configFile >> "CfgVehicles" >> (typeOf cursorTarget )>> "HitPoints" >> _x >> "name");

        _hitPosM = cursorTarget selectionPosition [_selection, "HitPoints"];
        _selPos = cursorTarget modelToWorldVisual _hitPosM;
        drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", [0,0,1,1], _selPos, 1, 1, 0, _x, 1, 0.02, "PuristaMedium"];

        _hitPosM = cursorTarget selectionPosition [_selection, "HitPoints"];
        _hitPosM set [1, 0];
        _selPos = cursorTarget modelToWorldVisual _hitPosM;
        drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", [0,1,0,1], _selPos, 1, 1, 0, _x, 1, 0.02, "PuristaMedium"];
    } forEach ["HitLTrack", "HitRTrack"];
}];
```

Tested with a variety of Vanilla, RHS and BW tracked vehicles and it seemed like an improvement on most. For vanilla it is moved inwards slightly, but still fully accessible.