### PR TITLE
dragging - Don't run animChanged event on all units

### DIFF
--- a/addons/dragging/CfgEventHandlers.hpp
+++ b/addons/dragging/CfgEventHandlers.hpp
@@ -48,14 +48,6 @@ class Extended_Killed_EventHandlers {
     };
 };
 
-class Extended_AnimChanged_EventHandlers {
-    class CAManBase {
-        class ADDON {
-            animChanged = QUOTE(_this call DFUNC(handleAnimChanged));
-        };
-    };
-};
-
 class Extended_DisplayLoad_EventHandlers {
     class RscDisplayMission {
         ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));

--- a/addons/dragging/XEH_postInit.sqf
+++ b/addons/dragging/XEH_postInit.sqf
@@ -20,9 +20,9 @@ if (isNil "ACE_maxWeightCarry") then {
 ["isNotCarrying", {!((_this select 0) getVariable [QGVAR(isCarrying), false])}] call EFUNC(common,addCanInteractWithCondition);
 
 // release object on player change. This does work when returning to lobby, but not when hard disconnecting.
-["unit", FUNC(handlePlayerChanged)] call CBA_fnc_addEventHandler;
-["vehicle", {[ACE_player, objNull] call FUNC(handlePlayerChanged)}] call CBA_fnc_addEventHandler;
-["weapon", FUNC(handlePlayerWeaponChanged)] call CBA_fnc_addEventHandler;
+["unit", FUNC(handlePlayerChanged)] call CBA_fnc_addPlayerEventHandler;
+["vehicle", {[ACE_player, objNull] call FUNC(handlePlayerChanged)}] call CBA_fnc_addPlayerEventHandler;
+["weapon", FUNC(handlePlayerWeaponChanged)] call CBA_fnc_addPlayerEventHandler;
 
 // handle waking up dragged unit and falling unconscious while dragging
 ["ace_unconscious", {_this call FUNC(handleUnconscious)}] call CBA_fnc_addEventHandler;

--- a/addons/dragging/functions/fnc_carryObject.sqf
+++ b/addons/dragging/functions/fnc_carryObject.sqf
@@ -56,6 +56,9 @@ _unit setVariable [QGVAR(ReleaseActionID), [
     {[_this select 0, (_this select 0) getVariable [QGVAR(carriedObject), objNull]] call FUNC(dropObject_carry)}
 ] call EFUNC(common,addActionEventHandler)];
 
+// add anim changed EH
+[_unit, "AnimChanged", FUNC(handleAnimChanged), [_unit]] call CBA_fnc_addBISEventHandler;
+
 // show mouse hint
 if (_target isKindOf "CAManBase") then {
     [localize LSTRING(Drop), "", ""] call EFUNC(interaction,showMouseHint);

--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -49,6 +49,9 @@ _unit setVariable [QGVAR(ReleaseActionID), [
     {[_this select 0, (_this select 0) getVariable [QGVAR(draggedObject), objNull]] call FUNC(dropObject)}
 ] call EFUNC(common,addActionEventHandler)];
 
+// add anim changed EH
+[_unit, "AnimChanged", FUNC(handleAnimChanged), [_unit]] call CBA_fnc_addBISEventHandler;
+
 // show mouse hint
 [localize LSTRING(Drop), ""] call EFUNC(interaction,showMouseHint);
 

--- a/addons/dragging/functions/fnc_handleAnimChanged.sqf
+++ b/addons/dragging/functions/fnc_handleAnimChanged.sqf
@@ -17,6 +17,13 @@
 #include "script_component.hpp"
 
 params ["_unit", "_anim"];
+_thisArgs params ["_realUnit"];
+TRACE_4("params",_unit,_anim,_realUnit,_thisID);
+
+if (_unit != _realUnit) exitWith {
+    TRACE_2("respawn (unit changed) - remove EH",_unit,_realUnit);
+    _unit removeEventHandler ["AnimChanged", _thisID];
+};
 
 if (_unit getVariable [QGVAR(isDragging), false]) then {
 
@@ -25,19 +32,25 @@ if (_unit getVariable [QGVAR(isDragging), false]) then {
         private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
 
         if (!isNull _draggedObject) then {
+            TRACE_2("stop drag",_unit,_draggedObject);
             [_unit, _draggedObject] call FUNC(dropObject);
         };
     };
-};
+} else {
 
-if (_unit getVariable [QGVAR(isCarrying), false]) then {
+    if (_unit getVariable [QGVAR(isCarrying), false]) then {
 
-    // drop carried object when not standing; also some exceptions when picking up crate
-    if (stance _unit != "STAND" && {_anim != "amovpercmstpsnonwnondnon"}) then {
-        private _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
+        // drop carried object when not standing; also some exceptions when picking up crate
+        if (stance _unit != "STAND" && {_anim != "amovpercmstpsnonwnondnon"}) then {
+            private _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
 
-        if (!isNull _carriedObject) then {
-            [_unit, _carriedObject] call FUNC(dropObject_carry);
+            if (!isNull _carriedObject) then {
+                TRACE_2("stop carry",_unit,_carriedObject);
+                [_unit, _carriedObject] call FUNC(dropObject_carry);
+            };
         };
+    } else {
+        TRACE_1("not drag/carry - remove EH",_unit);
+        _unit removeEventHandler ["AnimChanged", _thisID];
     };
 };


### PR DESCRIPTION
- Installs the animChanged EH on demand instead of having it running all the time for all units
- Also Fix CBA_fnc_addPlayerEventHandler

animChanged runs on all units (including non-local)
for units moving it fires about 1/second/unit
With 100+ units the overhead adds up (about 1 ms / second for 100 units on my system)

This installs the EH just for the unit that starts dragging/carrying