### PR TITLE
lower wirecutter item mass

### DIFF
--- a/addons/logistics_wirecutter/CfgWeapons.hpp
+++ b/addons/logistics_wirecutter/CfgWeapons.hpp
@@ -10,7 +10,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\item_wirecutter_ca.paa);
         scope = 2;
         class ItemInfo: InventoryItem_Base_F {
-            mass = 65;
+            mass = 25;
         };
     };
 };


### PR DESCRIPTION
The current mass makes it take a LOT of inventory space (~half of
an assault pack) which makes it impractical to carry around as a tool.

Lower it to use the same mass as the entrenching tool.
