### PR TITLE
Fix the captive module from creating attributes when not needed

### DIFF
--- a/addons/captives/CfgEden.hpp
+++ b/addons/captives/CfgEden.hpp
@@ -11,7 +11,7 @@ class Cfg3DEN {
                         expression = QUOTE(if (_value) then {[ARR_3(objNull,[_this],true)] call FUNC(moduleHandcuffed)});
                         typeName = "BOOL";
                         condition = "objectBrain";
-                        defaultValue = "false";
+                        defaultValue = "(false)";
                     };
                     class ace_isSurrendered {
                         property = QUOTE(ace_isSurrendered);
@@ -21,7 +21,7 @@ class Cfg3DEN {
                         expression = QUOTE(if (_value) then {[ARR_3(objNull,[_this],true)] call FUNC(moduleSurrender)});
                         typeName = "BOOL";
                         condition = "objectBrain";
-                        defaultValue = "false";
+                        defaultValue = "(false)";
                     };
                 };
             };

--- a/addons/captives/CfgEden.hpp
+++ b/addons/captives/CfgEden.hpp
@@ -11,7 +11,7 @@ class Cfg3DEN {
                         expression = QUOTE(if (_value) then {[ARR_3(objNull,[_this],true)] call FUNC(moduleHandcuffed)});
                         typeName = "BOOL";
                         condition = "objectBrain";
-                        defaultValue = false;
+                        defaultValue = "false";
                     };
                     class ace_isSurrendered {
                         property = QUOTE(ace_isSurrendered);
@@ -21,7 +21,7 @@ class Cfg3DEN {
                         expression = QUOTE(if (_value) then {[ARR_3(objNull,[_this],true)] call FUNC(moduleSurrender)});
                         typeName = "BOOL";
                         condition = "objectBrain";
-                        defaultValue = false;
+                        defaultValue = "false";
                     };
                 };
             };


### PR DESCRIPTION
Fix default values, so we don't get two custom attributes per unit, even when the unit is not handcuffed/surrendered

Pretty simple fix, saves a lot of space when dealing with large framework scale SQMs