### PR TITLE
Heal hitpoint after bandage sets bodyPartStatus

### DIFF
--- a/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_bandageLocal.sqf
@@ -108,8 +108,10 @@ if (GVAR(healHitPointAfterAdvBandage) || {GVAR(level) < 2}) then {
     // Tally of unbandaged wounds to each body part.
     private _headWounds = 0;
     private _bodyWounds = 0;
-    private _legsWounds = 0;
-    private _armWounds  = 0;
+    private _leftArmWounds = 0;
+    private _leftLegWounds = 0;
+    private _rightArmWounds = 0;
+    private _rightLegWounds = 0;
 
     // Loop through all current wounds and add up the number of unbandaged wounds on each body part.
     {
@@ -132,42 +134,52 @@ if (GVAR(healHitPointAfterAdvBandage) || {GVAR(level) < 2}) then {
 
             // Left Arm
             case 2: {
-                _armWounds = _armWounds + (_numOpenWounds * _bloodLoss);
+                _leftArmWounds = _leftArmWounds + (_numOpenWounds * _bloodLoss);
             };
 
             // Right Arm
             case 3: {
-                _armWounds = _armWounds + (_numOpenWounds * _bloodLoss);
+                _rightArmWounds = _rightArmWounds + (_numOpenWounds * _bloodLoss);
             };
 
             // Left Leg
             case 4: {
-                _legsWounds = _legsWounds + (_numOpenWounds * _bloodLoss);
+                _leftLegWounds = _leftLegWounds + (_numOpenWounds * _bloodLoss);
             };
 
             // Right Leg
             case 5: {
-                _legsWounds = _legsWounds + (_numOpenWounds * _bloodLoss);
+                _rightLegWounds = _rightLegWounds + (_numOpenWounds * _bloodLoss);
             };
         };
     } forEach _currentWounds;
 
+    // ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"]
+    private _bodyStatus = _target getVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0]];
+
     // Any body part that has no wounds is healed to full health
     if (_headWounds == 0) then {
-        _target setHitPointDamage ["hitHead",  0.0];
+        _bodyStatus set [0, 0];
     };
-
     if (_bodyWounds == 0) then {
-        _target setHitPointDamage ["hitBody",  0.0];
+        _bodyStatus set [1, 0];
+    };
+    if (_leftArmWounds == 0) then {
+        _bodyStatus set [2, 0];
+    };
+    if (_rightArmWounds == 0) then {
+        _bodyStatus set [3, 0];
+    };
+    if (_leftLegWounds == 0) then {
+        _bodyStatus set [4, 0];
+    };
+    if (_rightLegWounds == 0) then {
+        _bodyStatus set [5, 0];
     };
 
-    if (_armWounds == 0) then {
-        _target setHitPointDamage ["hitHands", 0.0];
-    };
+    _target setVariable [QGVAR(bodyPartStatus), _bodyStatus, true];
 
-    if (_legsWounds == 0) then {
-        _target setHitPointDamage ["hitLegs",  0.0];
-    };
+    [_target] call FUNC(handleDamage_advancedSetDamage);
 };
 
 true;


### PR DESCRIPTION
GVAR(healHitPointAfterAdvBandage) was only setting the hitpoint, but not changing the bodyPartStatus.
This caused later damage to always redamage the previously healed hitpoints because `FUNC(handleDamage_advancedSetDamage)` uses bodyPartStatus to set 4 hitpoints when taking new damage.

This changes advanced bandage to clear damage from bodyPartStatus when a hitpoint has been fully healed. It then calls `FUNC(handleDamage_advancedSetDamage)` to actually reset the damage.

Test case:
```
[] spawn { 
    [player, 0.8, "leg_r", "bullet"] call ace_medical_fnc_addDamageToUnit; 
    sleep 0.25; 
    [player, "bandage", "leg_r"] call ace_medical_fnc_treatmentAdvanced_bandageLocal; 
    sleep 0.25; 
    [player, 0.2, "body", "bullet"] call ace_medical_fnc_addDamageToUnit; 
};
```
Would leave the unit limping as the leg damage was healed, but was still on bodyPartStatus so it was reapplied when taking the later body damage.
