### PR TITLE
Bundle fire damage into larger chunks

### DIFF
--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -9,9 +9,6 @@
  * 3: Shooter <OBJECT>
  * 4: Projectile <STRING>
  * 5: Hit part index of the hit point <NUMBER>
- * 6: Current damage to be returned <NUMBER>
- *
- * //On 1.63 dev:
  * 6: Shooter? <OBJECT>
  * 7: Current damage to be returned <NUMBER>
  *
@@ -23,12 +20,23 @@
 
 #include "script_component.hpp"
 
-params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfProjectile", "_hitPointNumber", "_newDamage"];
+params ["_unit", "_selectionName", "_amountOfDamage", "_sourceOfDamage", "_typeOfProjectile", "_hitPointNumber", "", "_newDamage"];
 
-//Temp fix for 1.63 handleDamage changes
-if (_newDamage isEqualType objNull) then {
-    _newDamage = _this select 7;
-};
+// For burning damage we will get a ton of very small hits of damage; they are too small to create any wounds
+// Save them up in a variable and run when it is over a noticable amount
+
+if ((_typeOfProjectile == "") && {_newDamage < 0.15} && {
+    _newDamage = _newDamage + (_unit getVariable [QGVAR(trivialDamage), 0]);
+    if (_newDamage > 0.15) then { 
+        // if the new sum is large enough, reset variable and continue with it added in
+        _unit setVariable [QGVAR(trivialDamage), 0];
+        false 
+    } else {
+        // otherwise just save the new sum into the variable and exit
+        _unit setVariable [QGVAR(trivialDamage), _newDamage];
+        true // exit
+    };
+}) exitWith {};
 
 private _part = [_selectionName] call FUNC(selectionNameToNumber);
 if (_part < 0) exitWith {};

--- a/addons/medical/functions/fnc_handleDamage_wounds.sqf
+++ b/addons/medical/functions/fnc_handleDamage_wounds.sqf
@@ -20,6 +20,8 @@
 params ["_unit", "_selectionName", "_damage", "_typeOfProjectile", "_typeOfDamage"];
 TRACE_6("ACE_DEBUG: HandleDamage Called",_unit, _selectionName, _damage, _shooter, _typeOfProjectile,_typeOfDamage);
 
+if (_typeOfDamage == "") then {_typeOfDamage = "unknown";};
+
 // Administration for open wounds and ids
 private _openWounds = _unit getVariable[QGVAR(openWounds), []];
 private _woundID = _unit getVariable[QGVAR(lastUniqueWoundID), 1];


### PR DESCRIPTION
Ref #4206

Fire damage comes in as a continuous stream, but each bit is lower than the threshold to trigger unknown damage. This saves the little chunks until together they addup to something that would be enough to trigger a wound from the extension.

Without this we add damage to `bodyPartStatus` but never create any wounds, so the damage would not be removable when in basic medical or healAfterBandage.

This also makes damage type `""` into `unknown` which is consistent with the non-dll wound code.