### PR TITLE
Fix javelin fire block not being removed

### DIFF
--- a/addons/javelin/XEH_pre_init.sqf
+++ b/addons/javelin/XEH_pre_init.sqf
@@ -7,4 +7,28 @@ ADDON = false;
 GVAR(isLockKeyDown) = false;
 GVAR(pfehID) = -1;
 
+DFUNC(disableFire) = {
+    params ["_firedEH"];
+
+    if(_firedEH < 0 && {difficulty > 0}) then {
+        _firedEH = [ACE_player, "DefaultAction", {true}, {
+            _canFire = (_this select 1) getVariable["ace_missileguidance_target", nil];
+            if(!isNil "_canFire") exitWith { false };
+            true
+        }] call EFUNC(common,addActionEventHandler);
+        TRACE_1("added",_firedEH);
+
+    };
+    _firedEH
+};
+DFUNC(enableFire) = {
+    params ["_firedEH"];
+
+    if(_firedEH >= 0 && {difficulty > 0}) then {
+        TRACE_1("removing",_firedEH);
+        [ACE_player, "DefaultAction", _firedEH] call EFUNC(common,removeActionEventHandler);
+    };
+    -1
+};
+
 ADDON = true;

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -146,27 +146,6 @@ if((call CBA_fnc_getFoV) select 1 > 9) then {
     __JavelinIGUIWFOV ctrlSetTextColor __ColorGreen;
 };
 
-FUNC(disableFire) = {
-    _firedEH = _this select 0;
-
-    if(_firedEH < 0 && difficulty > 0) then {
-        _firedEH = [ACE_player, "DefaultAction", {true}, {
-            _canFire = (_this select 1) getVariable["ace_missileguidance_target", nil];
-            if(!isNil "_canFire") exitWith { false };
-            true
-        }] call EFUNC(common,addActionEventHandler);
-    };
-    _firedEH
-};
-FUNC(enableFire) = {
-    _firedEH = _this select 0;
-
-    if(_firedEH > 0 && difficulty > 0) then {
-        [ACE_player, "DefaultAction", _firedEH] call EFUNC(common,removeActionEventHandler);
-    };
-    -1
-};
-
 if (isNull _newTarget) then {
     // No targets found
     _currentTarget = objNull;


### PR DESCRIPTION
Releated to #4079 , javelin can be the first thing to add the addActionEventHandler and get index 0.

- Only real change is in FUNC(enableFire): `_firedEH > 0` would fail if index is 0
- moved func defines to preInit