### PR TITLE
ACE rearm/refuel/repair actions for RHS vehicles

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -1,3 +1,77 @@
+#define MACRO_REARM_TRUCK_ACTIONS \
+        class ACE_Actions: ACE_Actions { \
+            class ACE_MainActions: ACE_MainActions { \
+                class EGVAR(rearm,TakeAmmo) { \
+                    displayName = ECSTRING(rearm,TakeAmmo); \
+                    distance = 7; \
+                    condition = QUOTE(_this call EFUNC(rearm,canTakeAmmo)); \
+                    insertChildren = QUOTE(_target call EFUNC(rearm,addRearmActions)); \
+                    exceptions[] = {"isNotInside"}; \
+                    showDisabled = 0; \
+                    priority = 2; \
+                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                }; \
+                class EGVAR(rearm,StoreAmmo) { \
+                    displayName = ECSTRING(rearm,StoreAmmo); \
+                    distance = 7; \
+                    condition = QUOTE(_this call EFUNC(rearm,canStoreAmmo)); \
+                    statement = QUOTE(_this call EFUNC(rearm,storeAmmo)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                }; \
+            }; \
+        };
+
+#define MACRO_REFUEL_ACTIONS \
+    class ACE_Actions: ACE_Actions { \
+        class ACE_MainActions: ACE_MainActions { \
+            class EGVAR(refuel,Refuel) { \
+                displayName = ECSTRING(refuel,Refuel); \
+                distance = 7; \
+                condition = "true"; \
+                statement = ""; \
+                showDisabled = 0; \
+                priority = 2; \
+                icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                class EGVAR(refuel,TakeNozzle) { \
+                    displayName = ECSTRING(refuel,TakeNozzle); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canTakeNozzle)); \
+                    statement = QUOTE([ARR_3(_player,_target,objNull)] call EFUNC(refuel,TakeNozzle)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,CheckFuelCounter) { \
+                    displayName = ECSTRING(refuel,CheckFuelCounter); \
+                    condition = "true"; \
+                    statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,readFuelCounter)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,CheckFuel) { \
+                    displayName = ECSTRING(refuel,CheckFuel); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canCheckFuel)); \
+                    statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,checkFuel)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,Connect) { \
+                    displayName = ECSTRING(refuel,Connect); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canConnectNozzle)); \
+                    statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,connectNozzle)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,Return) { \
+                    displayName = ECSTRING(refuel,Return); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canReturnNozzle)); \
+                    statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,returnNozzle)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+            }; \
+        }; \
+    };
+
 class CfgVehicles {
     class LandVehicle;
     class Tank: LandVehicle {
@@ -280,8 +354,27 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 360;
     };
 
+    class RHS_Ural_Support_MSV_Base_01;
+    class RHS_Ural_Fuel_MSV_01 : RHS_Ural_Support_MSV_Base_01 {
+        transportFuel = 0;
+        MACRO_REFUEL_ACTIONS
+        EGVAR(refuel,hooks)[] = {{-0.05,-3.6,-0.45}};
+        EGVAR(refuel,fuelCargo) = 10000;
+    };
+
     class rhs_truck : Truck_F {
         EGVAR(refuel,fuelCapacity) = 210;
+    };
+
+    class rhs_gaz66_vmf;
+    class rhs_gaz66_repair_base: rhs_gaz66_vmf {
+        transportRepair = 0;
+        EGVAR(repair,canRepair) = 1;
+    };
+
+    class rhs_gaz66_ammo_base: rhs_gaz66_vmf {
+        transportAmmo = 0;
+        MACRO_REARM_TRUCK_ACTIONS
     };
 
     class MRAP_02_base_F;

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -9,7 +9,7 @@
                     exceptions[] = {"isNotInside"}; \
                     showDisabled = 0; \
                     priority = 2; \
-                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                    icon = QPATHTOEF(rearm,ui\icon_rearm_interact.paa); \
                 }; \
                 class EGVAR(rearm,StoreAmmo) { \
                     displayName = ECSTRING(rearm,StoreAmmo); \
@@ -17,7 +17,7 @@
                     condition = QUOTE(_this call EFUNC(rearm,canStoreAmmo)); \
                     statement = QUOTE(_this call EFUNC(rearm,storeAmmo)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                    icon = QPATHTOEF(rearm,ui\icon_rearm_interact.paa); \
                 }; \
             }; \
         };
@@ -32,41 +32,41 @@
                 statement = ""; \
                 showDisabled = 0; \
                 priority = 2; \
-                icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 class EGVAR(refuel,TakeNozzle) { \
                     displayName = ECSTRING(refuel,TakeNozzle); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canTakeNozzle)); \
                     statement = QUOTE([ARR_3(_player,_target,objNull)] call EFUNC(refuel,TakeNozzle)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,CheckFuelCounter) { \
                     displayName = ECSTRING(refuel,CheckFuelCounter); \
                     condition = "true"; \
                     statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,readFuelCounter)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,CheckFuel) { \
                     displayName = ECSTRING(refuel,CheckFuel); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canCheckFuel)); \
                     statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,checkFuel)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,Connect) { \
                     displayName = ECSTRING(refuel,Connect); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canConnectNozzle)); \
                     statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,connectNozzle)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,Return) { \
                     displayName = ECSTRING(refuel,Return); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canReturnNozzle)); \
                     statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,returnNozzle)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
             }; \
         }; \

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_2s3", "rhs_c_rva"};
+        requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_trucks", "rhs_c_2s3", "rhs_c_rva"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "commy2", "Skengman2"};
         url = ECSTRING(main,URL);

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_trucks", "rhs_c_2s3", "rhs_c_rva"};
+        requiredAddons[] = {"ace_rearm", "ace_refuel", "ace_repair", "rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_trucks", "rhs_c_2s3", "rhs_c_rva"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "commy2", "Skengman2"};
         url = ECSTRING(main,URL);

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -11,6 +11,80 @@
     }; \
 }
 
+#define MACRO_REARM_TRUCK_ACTIONS \
+        class ACE_Actions: ACE_Actions { \
+            class ACE_MainActions: ACE_MainActions { \
+                class EGVAR(rearm,TakeAmmo) { \
+                    displayName = ECSTRING(rearm,TakeAmmo); \
+                    distance = 7; \
+                    condition = QUOTE(_this call EFUNC(rearm,canTakeAmmo)); \
+                    insertChildren = QUOTE(_target call EFUNC(rearm,addRearmActions)); \
+                    exceptions[] = {"isNotInside"}; \
+                    showDisabled = 0; \
+                    priority = 2; \
+                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                }; \
+                class EGVAR(rearm,StoreAmmo) { \
+                    displayName = ECSTRING(rearm,StoreAmmo); \
+                    distance = 7; \
+                    condition = QUOTE(_this call EFUNC(rearm,canStoreAmmo)); \
+                    statement = QUOTE(_this call EFUNC(rearm,storeAmmo)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                }; \
+            }; \
+        };
+
+#define MACRO_REFUEL_ACTIONS \
+    class ACE_Actions: ACE_Actions { \
+        class ACE_MainActions: ACE_MainActions { \
+            class EGVAR(refuel,Refuel) { \
+                displayName = ECSTRING(refuel,Refuel); \
+                distance = 7; \
+                condition = "true"; \
+                statement = ""; \
+                showDisabled = 0; \
+                priority = 2; \
+                icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                class EGVAR(refuel,TakeNozzle) { \
+                    displayName = ECSTRING(refuel,TakeNozzle); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canTakeNozzle)); \
+                    statement = QUOTE([ARR_3(_player,_target,objNull)] call EFUNC(refuel,TakeNozzle)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,CheckFuelCounter) { \
+                    displayName = ECSTRING(refuel,CheckFuelCounter); \
+                    condition = "true"; \
+                    statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,readFuelCounter)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,CheckFuel) { \
+                    displayName = ECSTRING(refuel,CheckFuel); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canCheckFuel)); \
+                    statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,checkFuel)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,Connect) { \
+                    displayName = ECSTRING(refuel,Connect); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canConnectNozzle)); \
+                    statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,connectNozzle)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+                class EGVAR(refuel,Return) { \
+                    displayName = ECSTRING(refuel,Return); \
+                    condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canReturnNozzle)); \
+                    statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,returnNozzle)); \
+                    exceptions[] = {"isNotInside"}; \
+                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                }; \
+            }; \
+        }; \
+    };
+
 class CfgVehicles {
     class LandVehicle;
     class Tank: LandVehicle {
@@ -196,6 +270,53 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 219;
     };
 
+    class rhsusf_M977A4_usarmy_wd;
+    class rhsusf_M977A4_AMMO_usarmy_wd: rhsusf_M977A4_usarmy_wd {
+        transportAmmo = 0;
+        MACRO_REARM_TRUCK_ACTIONS
+    };
+
+    class rhsusf_M977A4_BKIT_usarmy_wd;
+    class rhsusf_M977A4_AMMO_BKIT_usarmy_wd: rhsusf_M977A4_BKIT_usarmy_wd {
+        transportAmmo = 0;
+        MACRO_REARM_TRUCK_ACTIONS
+    };
+
+    class rhsusf_M977A4_BKIT_M2_usarmy_wd;
+    class rhsusf_M977A4_AMMO_BKIT_M2_usarmy_wd: rhsusf_M977A4_BKIT_M2_usarmy_wd {
+        transportAmmo = 0;
+        MACRO_REARM_TRUCK_ACTIONS
+    };
+
+    class rhsusf_M978A4_usarmy_wd: rhsusf_M977A4_usarmy_wd {
+        transportFuel = 0;
+        MACRO_REFUEL_ACTIONS
+        EGVAR(refuel,hooks)[] = {{-0.44,-4.87,0}, {0.5,-4.87,0}};
+        EGVAR(refuel,fuelCargo) = 10000;
+    };
+
+    class rhsusf_M978A4_BKIT_usarmy_wd: rhsusf_M977A4_usarmy_wd {
+        transportFuel = 0;
+        MACRO_REFUEL_ACTIONS
+        EGVAR(refuel,hooks)[] = {{-0.44,-4.87,0}, {0.5,-4.87,0}};
+        EGVAR(refuel,fuelCargo) = 10000;
+    };
+
+    class rhsusf_M977A4_REPAIR_usarmy_wd: rhsusf_M977A4_usarmy_wd {
+        transportRepair = 0;
+        EGVAR(repair,canRepair) = 1;
+    };
+
+    class rhsusf_M977A4_REPAIR_BKIT_usarmy_wd: rhsusf_M977A4_BKIT_usarmy_wd {
+        transportRepair = 0;
+        EGVAR(repair,canRepair) = 1;
+    };
+
+    class rhsusf_M977A4_REPAIR_BKIT_M2_usarmy_wd: rhsusf_M977A4_BKIT_M2_usarmy_wd {
+        transportRepair = 0;
+        EGVAR(repair,canRepair) = 1;
+    };
+
     class APC_Tracked_02_base_F: Tank_F {};
     class rhsusf_m113_tank_base: APC_Tracked_02_base_F {
         EGVAR(refuel,fuelCapacity) = 360;
@@ -204,6 +325,12 @@ class CfgVehicles {
                 ace_fcs_Enabled = 0;
             };
         };
+    };
+
+    class rhsusf_m113_usarmy;
+    class rhsusf_m113_usarmy_supply: rhsusf_m113_usarmy {
+        transportAmmo = 0;
+        MACRO_REARM_TRUCK_ACTIONS
     };
 
     class APC_Tracked_03_base_F;

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -22,7 +22,7 @@
                     exceptions[] = {"isNotInside"}; \
                     showDisabled = 0; \
                     priority = 2; \
-                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                    icon = QPATHTOEF(rearm,ui\icon_rearm_interact.paa); \
                 }; \
                 class EGVAR(rearm,StoreAmmo) { \
                     displayName = ECSTRING(rearm,StoreAmmo); \
@@ -30,7 +30,7 @@
                     condition = QUOTE(_this call EFUNC(rearm,canStoreAmmo)); \
                     statement = QUOTE(_this call EFUNC(rearm,storeAmmo)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(rearm,ui\icon_rearm_interact.paa); \
+                    icon = QPATHTOEF(rearm,ui\icon_rearm_interact.paa); \
                 }; \
             }; \
         };
@@ -45,41 +45,41 @@
                 statement = ""; \
                 showDisabled = 0; \
                 priority = 2; \
-                icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 class EGVAR(refuel,TakeNozzle) { \
                     displayName = ECSTRING(refuel,TakeNozzle); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canTakeNozzle)); \
                     statement = QUOTE([ARR_3(_player,_target,objNull)] call EFUNC(refuel,TakeNozzle)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,CheckFuelCounter) { \
                     displayName = ECSTRING(refuel,CheckFuelCounter); \
                     condition = "true"; \
                     statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,readFuelCounter)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,CheckFuel) { \
                     displayName = ECSTRING(refuel,CheckFuel); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canCheckFuel)); \
                     statement = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,checkFuel)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,Connect) { \
                     displayName = ECSTRING(refuel,Connect); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canConnectNozzle)); \
                     statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,connectNozzle)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
                 class EGVAR(refuel,Return) { \
                     displayName = ECSTRING(refuel,Return); \
                     condition = QUOTE([ARR_2(_player,_target)] call EFUNC(refuel,canReturnNozzle)); \
                     statement = QUOTE([ARR_2(_player,_target)] call DEFUNC(refuel,returnNozzle)); \
                     exceptions[] = {"isNotInside"}; \
-                    icon = PATHTOEF(refuel,ui\icon_refuel_interact.paa); \
+                    icon = QPATHTOEF(refuel,ui\icon_refuel_interact.paa); \
                 }; \
             }; \
         }; \

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_javelin", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
+        requiredAddons[] = {"ace_javelin", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
         url = ECSTRING(main,URL);

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_javelin", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
+        requiredAddons[] = {"ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
**When merged this pull request will:**
- Add rearm/refuel/repair actions for the applicable RHS AFRF vehicles (GAZ-66s, Urals)
- Add rearm/refuel/repair actions for the applicable RHS USF vehicles (M113 supply vehicle, HEMTT A4s)

So macros are a strange and new experience for me, full of wonder and amazement. I've never really worked with them before and while I think I've done it without screwing it up, someone should look them over before this is approved.

Also because setting up those three also requires disabling the vanilla equivalent system, should I add them to the requiredAddons?