### PR TITLE
fix bug which would cause unecessary echo network traffic

### DIFF
--- a/addons/cookoff/functions/fnc_engineFire.sqf
+++ b/addons/cookoff/functions/fnc_engineFire.sqf
@@ -20,7 +20,9 @@ params ["_vehicle"];
 if (_vehicle getVariable [QGVAR(isEngineSmoking), false]) exitWith {};
 _vehicle setVariable [QGVAR(isEngineSmoking), true];
 
-[QGVAR(engineFire), _vehicle] call CBA_fnc_remoteEvent;
+if (local _vehicle) then {
+    [QGVAR(engineFire), _vehicle] call CBA_fnc_remoteEvent;
+};
 
 private _position = [
     0,


### PR DESCRIPTION
**When merged this pull request will:**
The funtion would call itself on other machines, where it would rebound to all other machines again. n^2
It's not infinite thanks to the `exitWith` above, but still unecessary.