### PR TITLE
Improvments for advanced throwing branch

### DIFF
--- a/addons/advancedthrowing/CfgVehicles.hpp
+++ b/addons/advancedthrowing/CfgVehicles.hpp
@@ -50,7 +50,7 @@ class CfgVehicles {
 
     class Items_base_F;
     class GVAR(pickUpHelper): Items_base_F {
-        author = ECSTRING(common,Author);
+        author = ECSTRING(common,ACETeam);
         displayName = "ACE Throwable Pick Up Helper";
         model = "\a3\weapons_f\dummyweapon.p3d";
         scope = 1;

--- a/addons/advancedthrowing/XEH_postInitClient.sqf
+++ b/addons/advancedthrowing/XEH_postInitClient.sqf
@@ -3,6 +3,15 @@
 // Exit on HC
 if (!hasInterface) exitWith {};
 
+GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
+{
+    {
+        private _ammo = getText (configFile >> "CfgMagazines" >> _x >> "ammo");
+        GVAR(ammoMagLookup) setVariable [_ammo, _x];
+    } count (getArray (configFile >> "CfgWeapons" >> "Throw" >> _x >> "magazines"));
+    nil
+} count getArray (configFile >> "CfgWeapons" >> "Throw" >> "muzzles");
+
 
 // Add keybinds
 ["ACE3 Weapons", QGVAR(prepare), localize LSTRING(Prepare), {

--- a/addons/advancedthrowing/functions/fnc_drawArc.sqf
+++ b/addons/advancedthrowing/functions/fnc_drawArc.sqf
@@ -62,7 +62,7 @@ for "_i" from 0.05 to 1.45 step 0.1 do {
 
         private _col = [ [1, 1, 1, _alpha], [0, 1, 0, _alpha], [1, 0, 0, _alpha] ] select _cross;
 
-        if (_cross != 2 && lineIntersects [eyePos ACE_player, _newTrajASL]) then {
+        if (_cross != 2 && {lineIntersects [eyePos ACE_player, _newTrajASL]}) then {
             _col set [3, 0.1]
         };
 

--- a/addons/advancedthrowing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advancedthrowing/functions/fnc_exitThrowMode.sqf
@@ -17,6 +17,7 @@
 #include "script_component.hpp"
 
 params ["_unit", "_reason"];
+TRACE_2("params",_unit,_reason);
 
 if !(_unit getVariable [QGVAR(inHand), false]) exitWith {};
 

--- a/addons/advancedthrowing/functions/fnc_pickUp.sqf
+++ b/addons/advancedthrowing/functions/fnc_pickUp.sqf
@@ -10,17 +10,18 @@
  * None
  *
  * Example:
- * [unit, throwable] call ace_advancedthrowing_fnc_pickUp
+ * [helper, player] call ace_advancedthrowing_fnc_pickUp
  *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_helper", "_unit"];
+TRACE_2("params",_helper,_unit);
 
-_activeThrowable = _helper getVariable [QGVAR(throwable), objNull];
+private _activeThrowable = _helper getVariable [QGVAR(throwable), objNull];
 
-if (isNull _activeThrowable) exitWith {};
+if (isNull _activeThrowable) exitWith {TRACE_2("throwable is null",_helper,_activeThrowable);};
 
 // Detach if attached (to vehicle for example or another player)
 private _attachedTo = attachedTo _activeThrowable;
@@ -30,7 +31,7 @@ if (!isNull _attachedTo) then {
 
 // Change locality for manipulation (some commands require local object, such as setVelocity)
 if (!local _activeThrowable) then {
-    ["ace_setOwner", [_activeThrowable, clientOwner]] call CBA_fnc_serverEvent;
+    ["ace_setOwner", [_activeThrowable, CBA_clientID]] call CBA_fnc_serverEvent;
 };
 
 // Invoke listenable event

--- a/addons/advancedthrowing/functions/fnc_pickUp.sqf
+++ b/addons/advancedthrowing/functions/fnc_pickUp.sqf
@@ -26,6 +26,15 @@ if (isNull _activeThrowable) exitWith {TRACE_2("throwable is null",_helper,_acti
 // Detach if attached (to vehicle for example or another player)
 private _attachedTo = attachedTo _activeThrowable;
 if (!isNull _attachedTo) then {
+    private _attachedList = _attachedTo getVariable [QEGVAR(attach,attached), []];
+    {
+        _x params ["_xObject"];
+        if (_activeThrowable == _xObject) exitWith {
+            TRACE_2("removing from ace_attach",_attachedTo,_attachedList);
+            _attachedList deleteAt _forEachIndex;
+            _attachedTo setVariable [QEGVAR(attach,attached), _attachedList, true];
+        };
+    } forEach _attachedList;
     detach _activeThrowable;
 };
 

--- a/addons/advancedthrowing/functions/fnc_prepare.sqf
+++ b/addons/advancedthrowing/functions/fnc_prepare.sqf
@@ -16,16 +16,21 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_1("params",_unit);
 
 // Select next throwable if one already in hand
 if (_unit getVariable [QGVAR(inHand), false]) exitWith {
+    TRACE_1("inHand",_unit);
     if (!(_unit getVariable [QGVAR(primed), false])) then {
+        TRACE_1("not primed",_unit);
         [_unit] call EFUNC(weaponselect,selectNextGrenade);
     };
 };
 
 // Try selecting next throwable if none currently selected
-if ((currentThrowable _unit) isEqualTo [] && {!([_unit] call EFUNC(weaponselect,selectNextGrenade))}) exitWith {};
+if ((isNull (_unit getVariable [QGVAR(activeThrowable), objNull])) && {(currentThrowable _unit) isEqualTo []} && {!([_unit] call EFUNC(weaponselect,selectNextGrenade))}) exitWith {
+    TRACE_1("no throwables",_unit);
+};
 
 
 _unit setVariable [QGVAR(inHand), true];

--- a/addons/advancedthrowing/functions/fnc_prime.sqf
+++ b/addons/advancedthrowing/functions/fnc_prime.sqf
@@ -17,6 +17,7 @@
 #include "script_component.hpp"
 
 params ["_unit", ["_showHint", false]];
+TRACE_2("params",_unit,_showHint);
 
 _unit setVariable [QGVAR(primed), true];
 

--- a/addons/advancedthrowing/functions/fnc_throw.sqf
+++ b/addons/advancedthrowing/functions/fnc_throw.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_1("params",_unit);
 
 // Prime the throwable if it hasn't been cooking already
 // Next to proper simulation this also has to happen before delay for orientation of the throwable to be set
@@ -28,6 +29,7 @@ if (!(_unit getVariable [QGVAR(primed), false])) then {
 // Pass position to reset later because animation may change it in certain stances
 [{
     params ["_unit", "_activeThrowable", "_posThrown", "_throwType", "_throwSpeed", "_dropMode"];
+    TRACE_6("delayParams",_unit,_activeThrowable,_posThrown,_throwType,_throwSpeed,_dropMode);
 
     // Reset position in case animation changed it
     _activeThrowable setPosASL _posThrown;

--- a/addons/advancedthrowing/functions/fnc_updateControlsHint.sqf
+++ b/addons/advancedthrowing/functions/fnc_updateControlsHint.sqf
@@ -1,4 +1,4 @@
-    /*
+/*
  * Author: Jonpas
  * Updates controls hints based on current state.
  *


### PR DESCRIPTION
For PR #3477
- FUNC(drawThrowable): Fix issue getting correct `_throwableMag` when you have a primed grenade. If you had nothing in inventory it would end up being nil otherwise it would use the wrong grenade type's initSpeed. This was a little messy to fix because we just have the ammo type and there could possibly be multiple magazines that use the same ammo. Uses a lookup hash that gets generated at the start.

- FUNC(prepare): When you have no grenades in inventory and picking up a live grenade it would fail because selectNextGrenade returned true.

- Handle detaching from ace_attach.
