### PR TITLE
Clear reviveState when calling setUnconscious

### DIFF
--- a/addons/medical/functions/fnc_setUnconscious.sqf
+++ b/addons/medical/functions/fnc_setUnconscious.sqf
@@ -34,6 +34,9 @@ if (_set isEqualTo (_unit getVariable ["ACE_isUnconscious", false])) exitWith {}
 
 if !(_set) exitWith {
     _unit setVariable ["ACE_isUnconscious", false, true];
+    if (_unit getVariable [QGVAR(inReviveState), false]) then {
+        _unit setVariable [QGVAR(inReviveState), nil, true];
+    };
 };
 
 if !(!(isNull _unit) && {(_unit isKindOf "CAManBase") && ([_unit] call EFUNC(common,isAwake))}) exitWith{};

--- a/addons/medical/functions/fnc_treatmentBasic_epipen.sqf
+++ b/addons/medical/functions/fnc_treatmentBasic_epipen.sqf
@@ -18,7 +18,3 @@
 params ["_caller", "_target","_className"];
 
 [_target, false] call FUNC(setUnconscious);
-
-if (_target getVariable [QGVAR(inReviveState), false]) then {
-    _target setVariable [QGVAR(inReviveState), nil, true];
-};


### PR DESCRIPTION
Should fix #4250 

Manual calls to `FUNC(setUnconscious)` with set = false will clear the `inReviveState` var.
Only things calling the function like this are the epiPen and the zeus module.