### PR TITLE
Update CBA_DEBUG_SYNCHRONOUS macro for new CBA

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -1,3 +1,11 @@
+// BWC for CBA's DEBUG_SYNCHRONOUS - https://github.com/CBATeam/CBA_A3/pull/466/
+#ifdef CBA_DEBUG_SYNCHRONOUS
+    // For New CBA:
+    #define DEBUG_SYNCHRONOUS
+    // For Old CBA:
+    #define CBA_fnc_log { params ["_file","_lineNum","_message"]; diag_log [diag_frameNo, diag_tickTime, time,  _file + ":"+str(_lineNum + 1), _message]; }
+#endif
+
 #include "\x\cba\addons\main\script_macros_common.hpp"
 #include "\x\cba\addons\xeh\script_xeh.hpp"
 
@@ -96,11 +104,6 @@
 #define ACE_isHC (!hasInterface && !isDedicated)
 
 #define IDC_STAMINA_BAR 193
-
-//By default CBA's TRACE/LOG/WARNING spawn a buffer, which can cause messages to be logged out of order:
-#ifdef CBA_DEBUG_SYNCHRONOUS
-    #define CBA_fnc_log { params ["_file","_lineNum","_message"]; diag_log [diag_frameNo, diag_tickTime, time,  _file + ":"+str(_lineNum + 1), _message]; }
-#endif
 
 #define ACE_LOG(module,level,message) diag_log text ACE_LOGFORMAT(module,level,message)
 #define ACE_LOGFORMAT(module,level,message) FORMAT_2(QUOTE([ACE] (module) %1: %2),level,message)


### PR DESCRIPTION
ref https://github.com/CBATeam/CBA_A3/pull/466/

This is safe to merge now and something we want soon as sync TRACE is broken with current CBA master.
It is backwards compatible with last CBA 3.0 release for developers without dev CBA.

Whenever we switch to CBA 3.1 we can clean this up (and all modules script components).