### PR TITLE
Allow inheritance for addActionToClass

### DIFF
--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -8,7 +8,7 @@
  * 1: Type of action, 0 for actions, 1 for self-actions <NUMBER>
  * 2: Parent path of the new action <ARRAY>
  * 3: Action <ARRAY>
- * 4: Use Inheritance (Default: False) <BOOL><OPTIONAL>
+ * 4: Use Inheritance <BOOL> (default: false)
  *
  * Return Value:
  * The entry full path, which can be used to remove the entry, or add children entries <ARRAY>.

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -8,6 +8,7 @@
  * 1: Type of action, 0 for actions, 1 for self-actions <NUMBER>
  * 2: Parent path of the new action <ARRAY>
  * 3: Action <ARRAY>
+ * 4: Use Inheritance (Default: False) <BOOL><OPTIONAL>
  *
  * Return Value:
  * The entry full path, which can be used to remove the entry, or add children entries <ARRAY>.
@@ -15,12 +16,28 @@
  * Example:
  * [typeOf cursorTarget, 0, ["ACE_TapShoulderRight"],VulcanPinchAction] call ace_interact_menu_fnc_addActionToClass;
  *
- * Public: No
+ * Public: Yes
  */
 #include "script_component.hpp"
 
 if (!params [["_objectType", "", [""]], ["_typeNum", 0, [0]], ["_parentPath", [], [[]]], ["_action", [], [[]], 11]]) exitWith {
     ERROR("Bad Params");
+};
+TRACE_4("params",_objectType,_typeNum,_parentPath,_action);
+
+if (param [4, false, [false]]) exitwith {
+    if (isNil QGVAR(inheritedActions)) then {GVAR(inheritedActions) = [];};
+    private _index = GVAR(inheritedActions) pushBack [[], _typeNum, _parentPath, _action];
+    private _initEH = compile format ['
+        params ["_object"];
+        private _typeOf = typeOf _object;
+        (GVAR(inheritedActions) select %1) params ["_addedClasses", "_typeNum", "_parentPath", "_action"];
+        if (_typeOf in _addedClasses) exitWith {};
+        _addedClasses pushBack _typeOf;
+        [_typeOf, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+    ', _index];
+    TRACE_2("Added inheritable action",_objectType,_index);
+    [_objectType, "init", _initEH, true, [], true] call CBA_fnc_addClassEventHandler;
 };
 
 // Ensure the config menu was compiled first

--- a/addons/interact_menu/functions/fnc_createAction.sqf
+++ b/addons/interact_menu/functions/fnc_createAction.sqf
@@ -22,7 +22,7 @@
  * Example:
  * ["VulcanPinch","Vulcan Pinch","",{_target setDamage 1;},{true},{},[parameters], [0,0,0], 100] call ace_interact_menu_fnc_createAction;
  *
- * Public: No
+ * Public: Yes
  */
 #include "script_component.hpp"
 

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -138,11 +138,11 @@ _action = ["Open RDF","Radio Direction Finder","pabst\RDF.jpg",_statement,_condi
 [(typeOf _unit), 1, ["ACE_SelfActions"], _action] call ace_interact_menu_fnc_addActionToClass;
 ```
 
-Using addActionToClass inheritance:
+Using `addActionToClass` inheritance:
 
 ```cpp
 // Adds action to check fuel levels for all land vehicles
-_action = ["CheckFuel","Check Fuel","",{hint format["Fuel: %1", fuel _target]},{true}] call ace_interact_menu_fnc_createAction;
+_action = ["CheckFuel", "Check Fuel", "", {hint format ["Fuel: %1", fuel _target]}, {true}] call ace_interact_menu_fnc_createAction;
 ["LandVehicle", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
 // Adds action to check external fuel levels on tanks.  Will be a sub action of the previous action.

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -97,8 +97,10 @@ Important: `ace_common_fnc_canInteractWith` is not automatically checked and nee
  * 1: Type of action, 0 for actions, 1 for self-actions <NUMBER>
  * 2: Parent path of the new action <ARRAY>
  * 3: Action <ARRAY>
+ * 4: Use Inheritance (Default: False) <BOOL><OPTIONAL>
  */
 ```
+By default this function will not use inheritance, so actions will only be added to the specific class.
 
 ### 2.3 fnc_addActionToObject
 
@@ -134,6 +136,18 @@ _statement = {
 };
 _action = ["Open RDF","Radio Direction Finder","pabst\RDF.jpg",_statement,_condition] call ace_interact_menu_fnc_createAction;
 [(typeOf _unit), 1, ["ACE_SelfActions"], _action] call ace_interact_menu_fnc_addActionToClass;
+```
+
+Using addActionToClass inheritance:
+
+```cpp
+// Adds action to check fuel levels for all land vehicles
+_action = ["CheckFuel","Check Fuel","",{hint format["Fuel: %1", fuel _target]},{true}] call ace_interact_menu_fnc_createAction;
+["LandVehicle", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
+
+// Adds action to check external fuel levels on tanks.  Will be a sub action of the previous action.
+_action = ["CheckExtTank","Check External Tank","",{hint format ["Ext Tank: %1", 5]},{true}] call ace_interact_menu_fnc_createAction;
+["Tank_F", 0, ["ACE_MainActions", "CheckFuel"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 ```
 
 ### 2.5 Advanced Example


### PR DESCRIPTION
Handles the mess of adding actions to all units.
E.G. can add class actions to `CaManBase`.