### PR TITLE
Remove superfluous requiredAddons in hearing

### DIFF
--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {"ACE_EarPlugs"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interaction", "A3_Characters_F", "A3_Characters_F_Kart"};
+        requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"KoffeinFlummi", "esteldunedain", "HopeJ", "commy2", "Rocko", "Rommel", "Ruthberg"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
**When merged this pull request will:**
- `"A3_Characters_F"` and `"A3_Characters_F_Kart"` are already required by `ACE_Main`

