### PR TITLE
Add setUniqueEventHandler

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -145,6 +145,7 @@ PREP(setPitchBankYaw);
 PREP(setProne);
 PREP(setSetting);
 PREP(setSettingFromConfig);
+PREP(setUniqueEventHandler);
 PREP(setVariableJIP);
 PREP(setVariablePublic);
 PREP(setVolume);

--- a/addons/common/functions/fnc_setUniqueEventHandler.sqf
+++ b/addons/common/functions/fnc_setUniqueEventHandler.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: PabstMirror
+ * Adds a unique event handler with a unique string handle.
+ * Only stays on for the current unit and will be removed on repawn.
+ * Pass emtpy code {} to remove.
+ *
+ * Arguments:
+ * 0: Object (designed for units that can respawn) <OBJECT>
+ * 1: Unique ID <STRING>
+ * 2: Event Type <STRING>
+ * 3: Event Handler <CODE>
+ *
+ * Return Value:
+ * Added EH ID <NUMBER>
+ *
+ * Example:
+ * [player, "firedTest", "FiredNear", {systemChat str _this}] call ace_common_fnc_setUniqueEventHandler;
+ *
+ * Public: Yes
+ */
+// #define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+params [["_unit", objNull, [objNull]], ["_uniqueID", "", [""]], ["_eventType", "", [""]], ["_code", {}, [{}]]];
+TRACE_4("params",_unit,_uniqueID,_eventType,(_code isEqualTo {}));
+
+if (isNull _unit) exitWith {-2};
+
+private _varName = format [QGVAR(uniqueEH_%1_%2), _eventType, _uniqueID];
+TRACE_1("",_varName);
+
+// Remove old ID if it exists (regardless of unit)
+private _ehID = (_unit getVariable _varName) param [3, -1];
+if (_ehID != -1) then {
+    _unit removeEventHandler [_eventType, _ehID];
+    TRACE_2("Removed EH",_eventType,_ehID);
+};
+
+if (_code isEqualTo {}) then {
+    _unit setVariable [_varName, nil];
+    TRACE_1("empty code, clearing var",_varName);
+    -1
+} else {
+    // Add event handler
+
+    private _fnc_eh = {
+        _thisArgs params ["_realUnit", "_ehFunc", "_uniqueID"];
+        TRACE_5("event",_realUnit,_thisId,_uniqueID,_thisType,_this); // we get some of these variables from CBA
+        if ((_this select 0) == _realUnit) then {
+            _this call _ehFunc;
+        } else {
+            // Unit must have respawned, remove this EH
+            [(_this select 0), _uniqueID, _thisType, {}] call FUNC(setUniqueEventHandler);
+        };
+    };
+    private _ehArgs = [_unit, _code, _uniqueID];
+    _ehID = [_unit, _eventType, _fnc_eh, _ehArgs] call CBA_fnc_addBISEventHandler;
+    _ehArgs pushBack _ehID;
+
+    TRACE_2("Added EH",_eventType,_ehID);
+
+    _unit setVariable [_varName, _ehArgs];
+    _ehID
+};

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -31,11 +31,9 @@ GVAR(lastPlayerVehicle) = objNull;
         params ["", "_vehicle"];
         if (!isNull GVAR(lastPlayerVehicle)) then {
             [GVAR(lastPlayerVehicle), QUOTE(ADDON), "FiredNear", {}] call EFUNC(common,setUniqueEventHandler);
-            [GVAR(lastPlayerVehicle), QUOTE(ADDON), "Explosion", {}] call EFUNC(common,setUniqueEventHandler);
         };
         if ((!isNull _vehicle) && {ace_player != _vehicle}) then {
             [_vehicle, QUOTE(ADDON), "FiredNear", FUNC(firedNear)] call EFUNC(common,setUniqueEventHandler);
-            [_vehicle, QUOTE(ADDON), "Explosion", FUNC(explosionNear)] call EFUNC(common,setUniqueEventHandler);
             GVAR(lastPlayerVehicle) = _vehicle;
         };
     }] call CBA_fnc_addPlayerEventHandler;

--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -24,8 +24,6 @@
 
 params ["_object", "_firer", "_distance", "_weapon", "", "", "_ammo"];
 
-//Only run if firedNear object is player or player's vehicle:
-if ((ACE_player != _object) && {(vehicle ACE_player) != _object}) exitWith {};
 if (_weapon in ["Throw", "Put"]) exitWith {};
 if (_distance > 50) exitWith {};
 


### PR DESCRIPTION
`setUniqueEventHandler` allows adding a event handler to a unit via a string ID which will handle cleanup if the unit respawns. It's based on `CBA_fnc_addBISEventHandler`

@BaerMitUmlaut this should fix the problem with the fatgigue anim eh (https://github.com/acemod/ACE3/blob/advanced-fatigue/addons/advanced_fatigue/functions/fnc_handlePlayerChanged.sqf#L17)

Why we need this:
Lets say there is player object `A` with AnimChanged event handler ID: 0
If `A` dies and respawns in to object `B`, all of `A`'s variables and event handlers will be copied as well.
Removing the event handler from the dead body `A` will not remove it from `B`

Added to hearing as an example:
We can replace the XEH running on every unit, and skip having to check every shot if the unit affected is the player. FiredNear can happen a lot (5 people in a fireteam each shoot once is 25 events)

Downsides to this method:
- Slightly more code; both addBISEventHandler and this add some overhead. But we can eliminate almost the amount from firedEH as we don't have to check the unit.
- Scripted event handlers could be removed via mission/other addon.
