### PR TITLE
Don't cookoff when commander turret is hit

### DIFF
--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -3,9 +3,25 @@
 [QGVAR(engineFire), FUNC(engineFire)] call CBA_fnc_addEventHandler;
 [QGVAR(cookOff), FUNC(cookOff)] call CBA_fnc_addEventHandler;
 
+GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
+
 // cookoff and burning engine
 ["Tank", "init", {
-    (_this select 0) addEventHandler ["HandleDamage", {
+    params ["_vehicle"];
+    private _typeOf = typeOf _vehicle;
+    if (isNil {GVAR(cacheTankDuplicates) getVariable _typeOf}) then {
+        private _hitpoints = (getAllHitPointsDamage _vehicle param [0, []]) apply {toLower _x};
+        private _duplicateHitpoints = [];
+        {
+            if ((_x != "") && {_x in (_hitpoints select [0,_forEachIndex])}) then {
+                _duplicateHitpoints pushBack _forEachIndex;
+            };
+        } forEach _hitpoints;
+        TRACE_2("dupes",_typeOf,_duplicateHitpoints);
+        GVAR(cacheTankDuplicates) setVariable [_typeOf, _duplicateHitpoints];
+    };
+
+    _vehicle addEventHandler ["HandleDamage", {
         if (GVAR(enable)) then {
             ["tank", _this] call FUNC(handleDamage);
         };

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -60,6 +60,10 @@ if (_simulationType == "tank") exitWith {
     // determine ammo storage location
     private _ammoLocationHitpoint = getText (_vehicle  call CBA_fnc_getObjectConfig >> QGVAR(ammoLocation));
 
+    if (_hitIndex in (GVAR(cacheTankDuplicates) getVariable (typeOf _vehicle))) then {
+        _hitpoint = "#subturret";
+    };
+    
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
         if (_damage > 0.5 && {random 1 < 0.7}) then {


### PR DESCRIPTION
Prevents the tank from cooking off when the commander turret takes damage.

Subturrets often have the same hitpoint name: (2x HitTurret)
`["HitHull","HitEngine","HitLTrack","HitRTrack","","","","","HitTurret","HitGun","HitTurret","HitGun"]`

The commander's turret was matching the `ammoLocation` and the tank was cooking off with 2 12.7mm shots to it.

![20160821160349_1](https://cloud.githubusercontent.com/assets/9376747/17839804/5006401a-67b9-11e6-8bb0-78a4c685f4ed.jpg)

I did some quick testing with the RHS BMD-1s which have 8 HitTurret hitpoints and it seemed to be ok, but this does assume that the main HitTurret will be listed first.