### PR TITLE
Improve interaction position for air units.

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -263,6 +263,16 @@ class CfgVehicles {
         GVAR(hasCargo) = 0;
     };
 
+    class VTOL_Base_F;
+    class VTOL_01_base_F: VTOL_Base_F {
+        GVAR(space) = 4;
+        GVAR(hasCargo) = 1;
+    };
+    class VTOL_02_base_F: VTOL_Base_F {
+        GVAR(space) = 4;
+        GVAR(hasCargo) = 1;
+    };
+    
     // autonomus
     class UAV_01_base_F: Helicopter_Base_F {
         GVAR(space) = 0;

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -385,10 +385,11 @@ class CfgVehicles {
 
     class Air;
     class Helicopter: Air {
+        GVAR(bodyWidth) = 3;
         class ACE_Actions {
             class ACE_MainActions {
                 displayName = CSTRING(MainAction);
-                position = QUOTE(call DFUNC(getVehiclePos));
+                position = QUOTE([ARR_2(_target, EGVAR(interact_menu,cameraPosASL))] call DFUNC(getVehiclePosComplex));
                 selection = "";
                 distance = 4;
                 condition = "true";
@@ -415,6 +416,7 @@ class CfgVehicles {
         class ACE_Actions {
             class ACE_MainActions {
                 displayName = CSTRING(MainAction);
+                position = QUOTE([ARR_2(_target, EGVAR(interact_menu,cameraPosASL))] call DFUNC(getVehiclePosComplex));
                 selection = "";
                 distance = 4;
                 condition = "true";
@@ -435,6 +437,16 @@ class CfgVehicles {
                 insertChildren = QUOTE(_this call DFUNC(addPassengersActions));
             };
         };
+    };
+
+    class VTOL_Base_F;
+    class VTOL_01_base_F: VTOL_Base_F {
+        GVAR(bodyWidth) = 4;
+        GVAR(bodyLength) = 10;
+    };
+    class VTOL_02_base_F: VTOL_Base_F {
+        GVAR(bodyWidth) = 3;
+        GVAR(bodyLength) = 7;
     };
 
     class Ship;

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -3,6 +3,7 @@
 PREP(addPassengerActions);
 PREP(addPassengersActions);
 PREP(getVehiclePos);
+PREP(getVehiclePosComplex);
 PREP(getWeaponPos);
 PREP(moduleInteraction);
 

--- a/addons/interaction/functions/fnc_getVehiclePos.sqf
+++ b/addons/interaction/functions/fnc_getVehiclePos.sqf
@@ -19,9 +19,6 @@
 private _bb = boundingBoxReal _target;
 (_bb select 0) params ["_bbX", "_bbY", "_bbZ"];
 
-//Helicopter's rotors distort the bounding box, assume a max of 3 meters width for the body
-if (_target isKindOf "Helicopter") then {_bbX = (_bbx min 3) max -3;};
-
 private _relPos = _target worldToModelVisual ASLToAGL EGVAR(interact_menu,cameraPosASL);
 #ifdef DEBUG_MODE_FULL
     _relPos = _target worldToModelVisual ASLToAGL eyePos ACE_player;

--- a/addons/interaction/functions/fnc_getVehiclePosComplex.sqf
+++ b/addons/interaction/functions/fnc_getVehiclePosComplex.sqf
@@ -1,0 +1,59 @@
+/*
+ * Author: esteldunedain, PabstMirror
+ * Return a suitable position for the action point for the given target vehicle
+ *
+ * Arguments:
+ * 0: Target <OBJECT>
+ * 1: Player's Position ASL <ARRAY>
+ *
+ * Return value:
+ * Interaction point in model cords <ARRAY>
+ *
+ * Example:
+ * [cursorTarget, eyePos player] call ace_interaction_fnc_getVehiclePosComplex
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_target", "_cameraPosASL"];
+TRACE_2("params",_target,_cameraPosASL);
+
+private _bb = boundingBoxReal _target;
+(_bb select 0) params ["_bbX", "_bbY", "_bbZ"];
+
+private _config = configFile >> "CfgVehicles" >> (typeOf _target);
+if (isNumber (_config >> QGVAR(bodyWidth))) then {_bbX = getNumber (_config >> QGVAR(bodyWidth));};
+if (isNumber (_config >> QGVAR(bodyLength))) then {_bbY = getNumber (_config >> QGVAR(bodyLength));};
+
+private _relPos = _target worldToModelVisual ASLToAGL _cameraPosASL;
+_relPos params ["_dx", "_dy", "_dz"];
+
+private _ndx = (abs _dx) / ((abs (_bbx)) - 1);
+private _ndy = (abs _dy) / ((abs (_bbY)) - 1);
+private _ndz = (abs _dz) / ((abs (_bbZ)) - 1);
+
+
+private "_pos";
+if (_ndx > _ndy) then {
+    if (_ndx > _ndz) then {
+        // _ndx is greater, will colide with x plane first
+        _pos = _relPos vectorMultiply ((1 / _ndx) min 0.8);
+    } else {
+        // _ndz is greater, will colide with z plane first
+        _pos = _relPos vectorMultiply ((1 / _ndz) min 0.8);
+    };
+} else {
+    if (_ndy > _ndz) then {
+        // _ndy is greater, will colide with y plane first
+        _pos = _relPos vectorMultiply ((1 / _ndy) min 0.8);
+    } else {
+        // _ndz is greater, will colide with z plane first
+        _pos = _relPos vectorMultiply ((1 / _ndz) min 0.8);
+    };
+};
+
+//Set max height at player's eye level (prevent very high interactin point on choppers)
+_pos set [2, (_pos select 2) min _dz];
+
+_pos


### PR DESCRIPTION
Fix #4233

Adds a varient of getVehiclePos function that should work better for air units.
Allows us to define a custom bounding box for a vehicle to limit to the main hull of a air unit and ignore it's wings or rotors.

Example, green is boundingBoxReal, blue is the effective custom one:

![20160822213411_1](https://cloud.githubusercontent.com/assets/9376747/17878517/f466468a-68b0-11e6-9560-979c300f3672.jpg)

this function doesn't require higher scoped variables, so we can use it externally.
For example to get get the effective distance to a vehicle:

```
private _playerPosASL = eyePos _player;
private _targetInteractionPos = [_target, _playerPosASL] call FUNC(getVehiclePosComplex);
(ASLtoAGL _playerPosASL) distance (_target modelToWorld _targetInteractionPos)
```