### PR TITLE
Fix null ace_player from early call to addPlayerEH

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -295,6 +295,13 @@ enableCamShake true;
 // Set up numerous eventhanders for player controlled units
 //////////////////////////////////////////////////
 
+// It is possible that CBA_fnc_addPlayerEventHandler has allready been called and run
+// We will NOT get any events for the initial state, so manually set ACE_player
+if (!isNull (missionNamespace getVariable ["cba_events_oldUnit", objNull])) then {
+    INFO("CBA_fnc_addPlayerEventHandler has already run - manually setting ace_player");
+    ACE_player = cba_events_oldUnit;
+};
+
 // "playerChanged" event
 ["unit", {
     ACE_player = (_this select 0);

--- a/addons/noradio/XEH_postInit.sqf
+++ b/addons/noradio/XEH_postInit.sqf
@@ -10,6 +10,11 @@ if (isServer) then {
 
 if (!hasInterface) exitWith {};
 
+// Handle early CBA_fnc_addPlayerEventHandler
+if (!isNull ace_player) then {
+    [ace_player, "isPlayer"] call EFUNC(common,muteUnit);
+};
+
 // mutes/unmutes units when the player changes
 ["unit", {
     params ["_newPlayer", "_oldPlayer"];


### PR DESCRIPTION
It is possible that `CBA_fnc_addPlayerEventHandle`r has already been called and run,
We will NOT get any events for the initial state, so manually set ACE_player

e.g. in preInit or SP mission init.sqf do
```
["loadout", {
    diag_log text format ["%1 - Loadout change - %2", time, _this];
}] call CBA_fnc_addPlayerEventHandler;
```
and `ace_player` will never bet set because the event has already happened.

Skimmed our use of the function and fixed noradio as well, everything else seemed ok.