### PR TITLE
Chemlights cleanup

### DIFF
--- a/addons/chemlights/XEH_postInit.sqf
+++ b/addons/chemlights/XEH_postInit.sqf
@@ -2,6 +2,6 @@
 
 if (!hasInterface) exitWith {};
 
-["firedPlayer", DFUNC(throwEH)] call EFUNC(common,addEventHandler);
-["firedPlayerNonLocal", DFUNC(throwEH)] call EFUNC(common,addEventHandler);
-["firedNonPlayer", DFUNC(throwEH)] call EFUNC(common,addEventHandler);
+["ace_firedPlayer", DFUNC(throwEH)] call CBA_fnc_addEventHandler;
+// ["ace_firedPlayerNonLocal", DFUNC(throwEH)] call CBA_fnc_addEventHandler;
+// ["ace_firedNonPlayer", DFUNC(throwEH)] call CBA_fnc_addEventHandler;

--- a/addons/chemlights/functions/fnc_compileChemlightMenu.sqf
+++ b/addons/chemlights/functions/fnc_compileChemlightMenu.sqf
@@ -5,7 +5,7 @@
  * Arguments:
  * 0: Vehicle <OBJECT>
  * 1: Player <OBJECT>
- * 3: Parameters <ARRAY>
+ * 2: Parameters <ARRAY>
  *
  * Return value:
  * None

--- a/addons/chemlights/functions/fnc_isIRClass.sqf
+++ b/addons/chemlights/functions/fnc_isIRClass.sqf
@@ -3,7 +3,7 @@
  * Check if an ammo classname is an IR chemlight.
  *
  * Arguments:
- * 1: Projectile or ammo classname <OBJECT> or <STRING>
+ * 0: Projectile or ammo classname <OBJECT> or <STRING>
  *
  * Return Value:
  * Is IR chemlight? <BOOL>

--- a/addons/chemlights/functions/fnc_removeIR.sqf
+++ b/addons/chemlights/functions/fnc_removeIR.sqf
@@ -3,8 +3,8 @@
  * Kill chemlight and any dummy objects attached to it.
  *
  * Arguments:
- * 1: Chemlight object <OBJECT>
- * 2: Light marker vehicle <OBJECT>
+ * 0: Chemlight object <OBJECT>
+ * 1: Light marker vehicle <OBJECT>
  *
  * Return Value:
  * None

--- a/addons/chemlights/functions/fnc_throwEH.sqf
+++ b/addons/chemlights/functions/fnc_throwEH.sqf
@@ -16,7 +16,7 @@
 
 #include "script_component.hpp"
 
-params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
+params ["_unit", "_weapon", "", "", "_ammo", "", "_projectile"];
 
 if ((_weapon != "Throw") || {!(_ammo isKindOf ["Chemlight_base", configFile >> "CfgAmmo"])}) exitWith {};
 
@@ -27,6 +27,11 @@ if (isNull _projectile) then {
 
 if (local _unit) then {
     if ([_ammo] call FUNC(isIRClass)) then {
-        [{_this call FUNC(throwIR)}, [_projectile, _ammo]] call CBA_fnc_execNextFrame;
+        // Handle advancedThrowing:
+        if ((ace_player getVariable [QEGVAR(advancedThrowing,activeThrowable), objNull]) == _projectile) then {
+            [_projectile, _ammo, true] call FUNC(throwIR); // direct call if we are priming with adv throw
+        } else {
+            [{_this call FUNC(throwIR)}, [_projectile, _ammo]] call CBA_fnc_execNextFrame;
+        };
     };
 };

--- a/addons/chemlights/functions/fnc_throwIR.sqf
+++ b/addons/chemlights/functions/fnc_throwIR.sqf
@@ -3,8 +3,9 @@
  * Create and throw IR chemlight.
  *
  * Arguments:
- * 1: Original throw projectile <OBJECT>
- * 2: Class of projectile <STRING>
+ * 0: Original throw projectile <OBJECT>
+ * 1: Class of projectile <STRING>
+ * 2: Adv throw (default: false) <BOOL><OPTIONAL>
  *
  * Return Value:
  * None
@@ -17,7 +18,7 @@
 
 #include "script_component.hpp"
 
-params ["_projectile", "_ammo"];
+params ["_projectile", "_ammo", ["_replaceAdvThrowable", false]];
 
 private _config = configFile >> "CfgAmmo" >> _ammo;
 private _dummyClass = getText (_config >> "ACE_Chemlight_IR");
@@ -29,3 +30,7 @@ private _dummy = _dummyClass createVehicle _pos;
 _dummy setPosATL _pos;
 [_dummy, 90, 0] call BIS_fnc_setPitchBank;
 _dummy setVelocity _velocity;
+
+if (_replaceAdvThrowable) then {
+    ace_player setVariable [QEGVAR(advancedThrowing,activeThrowable), _dummy];
+};


### PR DESCRIPTION
Minor cleanup of @voiperr 's chemlights

For the fired event handlers:
`FUNC(throwEH)` only does anything for local units so we can remove `firedPlayerNonLocal`; 
and I don't think AI have any idea how to use chemlights so I think we can skip `firedNonPlayer` as well?

Add support for handling primed IR grenades for advanced throwing (@jonpas)
