### PR TITLE
Increase blood bag flow rate for basic medical

### DIFF
--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -5,7 +5,6 @@ ADDON = false;
 #include "XEH_PREP.hpp"
 
 GVAR(injuredUnitCollection) = [];
-GVAR(IVBags) = [];
 
 private _versionEx = "ace_medical" callExtension "version";
 DFUNC(handleDamage_assignWounds) = if (_versionEx == "") then {

--- a/addons/medical/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical/functions/fnc_displayPatientInformation.sqf
@@ -68,12 +68,11 @@ if (_show) then {
         };
 
         private _totalIvVolume = 0;
+        private _bloodBags = _unit getVariable [QGVAR(bloodbags), []];
         {
-            private _value = _target getVariable _x;
-            if !(isnil "_value") then {
-                _totalIvVolume = _totalIvVolume + (_target getVariable [_x, 0]);
-            };
-        } foreach GVAR(IVBags);
+            _x params ["_bagVolumeRemaining"];
+            _totalIvVolume = _totalIvVolume + _bagVolumeRemaining;
+        } foreach _bloodBags;
 
         if (_totalIvVolume >= 1) then {
             _genericMessages pushback [format[localize LSTRING(receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];

--- a/addons/medical/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical/functions/fnc_displayPatientInformation.sqf
@@ -68,7 +68,7 @@ if (_show) then {
         };
 
         private _totalIvVolume = 0;
-        private _bloodBags = _unit getVariable [QGVAR(bloodbags), []];
+        private _bloodBags = _unit getVariable [QGVAR(ivBags), []];
         {
             _x params ["_bagVolumeRemaining"];
             _totalIvVolume = _totalIvVolume + _bagVolumeRemaining;

--- a/addons/medical/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/medical/functions/fnc_getBloodVolumeChange.sqf
@@ -4,9 +4,10 @@
  *
  * Arguments:
  * 0: The Unit <OBJECT>
+ * 1: Global Sync Values (bloodbags) <BOOL>
  *
  * ReturnValue:
- * Current cardiac output <NUMBER>
+ * Blood volume change (in % total) <NUMBER>
  *
  * Public: No
  */
@@ -16,40 +17,38 @@
 /*
     IV Change per second calculation:
     250ml should take 60 seconds to fill. 250/60 = 4.166.
-*/
-#define IV_CHANGE_PER_SECOND         -4.166
+    Basic medical is 10x (will take 6 seconds for 250ml)
+ */
+#define IV_CHANGE_PER_SECOND         ([41.66, 4.166] select (GVAR(level) >= 2))
 
-/*
-    Blood Change per second calculation for IVs:
-    250ml should take 60 seconds to fill in. Total blood volume is 7000ml = 100%.
-    7000/100 = 70 = 1%
-    250 / 70 = 3.571428571%
-    3.571428571 / 60 = 0.0595% per second.
-*/
-#define BLOOD_CHANGE_PER_SECOND        0.0595
-
-#define EMPTY_IV_BAG_VALUE 0
-#define IV_VOLUME (_unit getVariable [_x, EMPTY_IV_BAG_VALUE]) + IV_CHANGE_PER_SECOND
-
-private ["_bloodVolume", "_bloodVolumeChange", "_ivVolume"];
-params ["_unit"];
+params ["_unit", "_syncValues"];
 
 private _bloodVolume = _unit getVariable [QGVAR(bloodVolume), 100];
 private _bloodVolumeChange = -([_unit] call FUNC(getBloodLoss));
 
-if (_bloodVolume < 100) then {
-    {
-        if ((_unit getVariable [_x, EMPTY_IV_BAG_VALUE]) > EMPTY_IV_BAG_VALUE) then {
-            _bloodVolumeChange = _bloodVolumeChange + BLOOD_CHANGE_PER_SECOND;
-            _unit setVariable [_x, IV_VOLUME];
+if (!isNil {_unit getVariable QGVAR(bloodbags)}) then {
+    if (_bloodVolume < 100) then {
+        private _bloodBags = _unit getVariable [QGVAR(bloodbags), []];
+        _bloodBags = _bloodBags apply {
+            _x params ["_bagVolumeRemaining"];
+            private _bagChange = IV_CHANGE_PER_SECOND min _bagVolumeRemaining; // absolute value of the change in miliLiters
+            _bagVolumeRemaining = _bagVolumeRemaining - _bagChange;
+            _bloodVolumeChange = _bloodVolumeChange + (_bagChange / 70); // ((bag change in ml) / (body total:7000ml)) out of 100 percent
+            if (_bagVolumeRemaining < 0.01) then {
+                []
+            } else {
+                [_bagVolumeRemaining];
+            };
         };
-    } forEach GVAR(IVBags);
-} else {
-    {
-        if ((_unit getVariable [_x, EMPTY_IV_BAG_VALUE]) > EMPTY_IV_BAG_VALUE) then {
-            _unit setVariable [_x, EMPTY_IV_BAG_VALUE]; // lets get rid of exessive IV volume
+        _bloodBags = _bloodBags - [[]]; // remove empty bags
+        if (_bloodBags isEqualTo []) then {
+            _unit setVariable [QGVAR(bloodBags), nil, true]; // no bags left - clear variable (always globaly sync this)
+        } else {
+            _unit setVariable [QGVAR(bloodBags), _bloodBags, _syncValues];
         };
-    } forEach GVAR(IVBags);
+    } else {
+        _unit setVariable [QGVAR(bloodBags), nil, true]; // blood volume = 100% - clear variable (always globaly sync this)
+    };
 };
 
 _bloodVolumeChange;

--- a/addons/medical/functions/fnc_getBloodVolumeChange.sqf
+++ b/addons/medical/functions/fnc_getBloodVolumeChange.sqf
@@ -26,9 +26,9 @@ params ["_unit", "_syncValues"];
 private _bloodVolume = _unit getVariable [QGVAR(bloodVolume), 100];
 private _bloodVolumeChange = -([_unit] call FUNC(getBloodLoss));
 
-if (!isNil {_unit getVariable QGVAR(bloodbags)}) then {
+if (!isNil {_unit getVariable QGVAR(ivBags)}) then {
     if (_bloodVolume < 100) then {
-        private _bloodBags = _unit getVariable [QGVAR(bloodbags), []];
+        private _bloodBags = _unit getVariable [QGVAR(ivBags), []];
         _bloodBags = _bloodBags apply {
             _x params ["_bagVolumeRemaining"];
             private _bagChange = IV_CHANGE_PER_SECOND min _bagVolumeRemaining; // absolute value of the change in miliLiters
@@ -42,12 +42,12 @@ if (!isNil {_unit getVariable QGVAR(bloodbags)}) then {
         };
         _bloodBags = _bloodBags - [[]]; // remove empty bags
         if (_bloodBags isEqualTo []) then {
-            _unit setVariable [QGVAR(bloodBags), nil, true]; // no bags left - clear variable (always globaly sync this)
+            _unit setVariable [QGVAR(ivBags), nil, true]; // no bags left - clear variable (always globaly sync this)
         } else {
-            _unit setVariable [QGVAR(bloodBags), _bloodBags, _syncValues];
+            _unit setVariable [QGVAR(ivBags), _bloodBags, _syncValues];
         };
     } else {
-        _unit setVariable [QGVAR(bloodBags), nil, true]; // blood volume = 100% - clear variable (always globaly sync this)
+        _unit setVariable [QGVAR(ivBags), nil, true]; // blood volume = 100% - clear variable (always globaly sync this)
     };
 };
 

--- a/addons/medical/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical/functions/fnc_handleUnitVitals.sqf
@@ -23,7 +23,7 @@ if (_syncValues) then {
     _unit setVariable [QGVAR(lastMomentValuesSynced), CBA_missionTime];
 };
 
-private _bloodVolume = (_unit getVariable [QGVAR(bloodVolume), 100]) + ([_unit] call FUNC(getBloodVolumeChange));
+private _bloodVolume = (_unit getVariable [QGVAR(bloodVolume), 100]) + ([_unit, _syncValues] call FUNC(getBloodVolumeChange));
 _bloodVolume = _bloodVolume max 0;
 
 _unit setVariable  [QGVAR(bloodVolume), _bloodVolume, _syncValues];
@@ -140,17 +140,5 @@ if (GVAR(level) >= 2) then {
         if (_heartRate > 200 || (_heartRate < 20)) then {
             [_unit] call FUNC(setCardiacArrest);
         };
-    };
-
-    // syncing any remaining values
-    if (_syncValues) then {
-        TRACE_3("ACE_DEBUG_IVBAGS_SYNC",GVAR(IVBags),_syncValues,_unit);
-        {
-            private "_value";
-            _value = _unit getVariable _x;
-            if !(isNil "_value") then {
-                _unit setVariable [_x,(_unit getVariable [_x, 0]), true];
-            };
-        } forEach GVAR(IVBags);
     };
 };

--- a/addons/medical/functions/fnc_init.sqf
+++ b/addons/medical/functions/fnc_init.sqf
@@ -47,9 +47,7 @@ _unit setVariable [QGVAR(triageLevel), 0, true];
 _unit setVariable [QGVAR(triageCard), [], true];
 
 // IVs
-_unit setVariable [QGVAR(salineIVVolume), 0, true];
-_unit setVariable [QGVAR(plasmaIVVolume), 0, true];
-_unit setVariable [QGVAR(bloodIVVolume), 0, true];
+_unit setVariable [QGVAR(ivBags), nil, true];
 
 // damage storage
 _unit setVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0], true];

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf
@@ -36,9 +36,7 @@ if (alive _target) exitWith {
     _target setVariable [QGVAR(fractures), []];
 
     // IVs
-    _target setVariable [QGVAR(salineIVVolume), 0];
-    _target setVariable [QGVAR(plasmaIVVolume), 0];
-    _target setVariable [QGVAR(bloodIVVolume), 0];
+    _target setVariable [QGVAR(ivBags), nil, true];
 
     // damage storage
     _target setVariable [QGVAR(bodyPartStatus), [0,0,0,0,0,0], true];

--- a/addons/medical/functions/fnc_treatmentIVLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentIVLocal.sqf
@@ -33,10 +33,6 @@ if (isClass (_config >> _treatmentClassname)) then {
     ERROR("IV Treatment Classname not found");
 };
 
-private _varName = format["ACE_Medical_IVVolume_%1",_typeOf];
-_target setVariable [_varName, (_target getVariable [_varName, 0]) + _volumeAdded, true];
-
-if !(_varName in GVAR(IVBags)) then {
-    GVAR(IVBags) pushBack _varName;
-    publicVariable QGVAR(IVBags);
-};
+private _bloodBags = _target getVariable [QGVAR(bloodbags), []];
+_bloodBags pushBack [_volumeAdded]; // Future BagType: [_volumeAdded, _typeOf]
+_target setVariable [QGVAR(bloodBags), _bloodBags, true];

--- a/addons/medical/functions/fnc_treatmentIVLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentIVLocal.sqf
@@ -33,6 +33,6 @@ if (isClass (_config >> _treatmentClassname)) then {
     ERROR("IV Treatment Classname not found");
 };
 
-private _bloodBags = _target getVariable [QGVAR(bloodbags), []];
+private _bloodBags = _target getVariable [QGVAR(ivBags), []];
 _bloodBags pushBack [_volumeAdded]; // Future BagType: [_volumeAdded, _typeOf]
-_target setVariable [QGVAR(bloodBags), _bloodBags, true];
+_target setVariable [QGVAR(ivBags), _bloodBags, true];


### PR DESCRIPTION
- Increase flow rate for basic medical (41ml/sec in an arm vein probably doesn't feel great :smile: )
- Don't queue bags - (2 bags flow twice as fast, instead of just doubling the total to add)

Uses a single unit variable `QGVAR(ivBags)` to hold all bag info.
We can skip calculations and syncing if the value is nil (no bags) which should be the common case.