### PR TITLE
Medical AI

### DIFF
--- a/addons/medical_ai/$PBOPREFIX$
+++ b/addons/medical_ai/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\medical_ai

--- a/addons/medical_ai/CfgEventHandlers.hpp
+++ b/addons/medical_ai/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/medical_ai/CfgEventHandlers.hpp
+++ b/addons/medical_ai/CfgEventHandlers.hpp
@@ -9,3 +9,9 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/medical_ai/README.md
+++ b/addons/medical_ai/README.md
@@ -1,0 +1,10 @@
+ace_medical_ai
+==========
+
+Makes AI units heal themselves and each other.
+
+## Maintainers
+
+The people responsible for merging changes to this component or answering potential questions.
+
+- [BaerMitUmlaut](https://github.com/BaerMitUmlaut)

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -1,4 +1,4 @@
-class ACE_Medical_AI_StateMachine {
+class GVAR(stateMachine) {
     list = "allUnits select {(!isPlayer _x) && {local _x}}";
 
     class Initial {
@@ -44,10 +44,12 @@ class ACE_Medical_AI_StateMachine {
         onStateLeaving = QUOTE(_this setVariable [QGVAR(treatmentOverAt), nil]);
 
         class Initial {
+            // Go back to initial state when done healing
             targetState = "Initial";
             condition = QUOTE(!(call FUNC(isInjured)));
         };
         class Injured {
+            // Stop treating when it's no more safe
             targetState = "Injured";
             condition = QUOTE(!(call FUNC(isSafe)));
         };
@@ -57,8 +59,14 @@ class ACE_Medical_AI_StateMachine {
         onState = QUOTE(call FUNC(healUnit));
 
         class Initial {
+            // Go back to initial state when done healing or it's no more safe to treat
             targetState = "Initial";
             condition = QUOTE(!(call FUNC(wasRequestedAsMedic || {call FUNC(isSafe)})));
+        };
+        class Injured {
+            // Treating yourself has priority
+            targetState = "Injured";
+            condition = QUOTE(!(call FUNC(isInjured)));
         };
     };
 };

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -1,0 +1,59 @@
+class ACE_Medical_AI_StateMachine {
+    list = "allUnits select {!isPlayer _x}";
+
+    class Initial {
+        class Injured {
+            targetState = "Injured";
+            condition = QUOTE(call FUNC(isInjured));
+        };
+        class HealUnit {
+            targetState = "HealUnit";
+            condition = QUOTE((call FUNC(isSafe)) && {call FUNC(wasRequested)});
+        };
+    };
+
+    class Injured {
+        #ifdef DEBUG_MODE_FULL
+            onState = "systemChat format [""%1 is injured"", _this]";
+        #endif
+
+        class InSafety {
+            targetState = "Safe";
+            condition = QUOTE(call FUNC(isSafe));
+        };
+    };
+
+    class Safe {
+        #ifdef DEBUG_MODE_FULL
+            onState = "systemChat format [""%1 is injured, but safe"", _this]";
+        #endif
+
+        class RequestMedic {
+            targetState = "HealSelf";
+            condition = QUOTE(call FUNC(canRequestMedic));
+            onTransition = QUOTE(call FUNC(requestMedic));
+        };
+        class HealSelf {
+            targetState = "HealSelf";
+            condition = "true";
+        };
+    };
+
+    class HealSelf {
+        onState = QUOTE(call FUNC(healSelf));
+
+        class Initial {
+            targetState = "Initial";
+            condition = QUOTE(!(call FUNC(isInjured)));
+        };
+    };
+
+    class HealUnit {
+        onState = QUOTE(call FUNC(healUnit));
+
+        class Initial {
+            targetState = "Initial";
+            condition = QUOTE(!(call FUNC(wasRequestedAsMedic)));
+        };
+    };
+};

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -1,5 +1,5 @@
 class ACE_Medical_AI_StateMachine {
-    list = "allUnits select {!isPlayer _x}";
+    list = "allUnits select {(!isPlayer _x) && {local _x}}";
 
     class Initial {
         class Injured {
@@ -46,6 +46,10 @@ class ACE_Medical_AI_StateMachine {
             targetState = "Initial";
             condition = QUOTE(!(call FUNC(isInjured)));
         };
+        class Injured {
+            targetState = "Injured";
+            condition = QUOTE(!(call FUNC(isSafe)));
+        };
     };
 
     class HealUnit {
@@ -53,7 +57,7 @@ class ACE_Medical_AI_StateMachine {
 
         class Initial {
             targetState = "Initial";
-            condition = QUOTE(!(call FUNC(wasRequestedAsMedic)));
+            condition = QUOTE(!(call FUNC(wasRequestedAsMedic || {call FUNC(isSafe)})));
         };
     };
 };

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -41,6 +41,7 @@ class ACE_Medical_AI_StateMachine {
 
     class HealSelf {
         onState = QUOTE(call FUNC(healSelf));
+        onStateLeaving = QUOTE(_this setVariable [QGVAR(treatmentOverAt), nil]);
 
         class Initial {
             targetState = "Initial";

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -1,5 +1,6 @@
 class GVAR(stateMachine) {
     list = "allUnits select {(!isPlayer _x) && {local _x}}";
+    skipNull = 1;
 
     class Initial {
         class Injured {

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -41,32 +41,45 @@ class GVAR(stateMachine) {
 
     class HealSelf {
         onState = QUOTE(call FUNC(healSelf));
-        onStateLeaving = QUOTE(_this setVariable [QGVAR(treatmentOverAt), nil]);
+        onStateLeaving = QUOTE(_this setVariable [ARR_2(QUOTE(QGVAR(treatmentOverAt)),nil)]);
 
         class Initial {
             // Go back to initial state when done healing
             targetState = "Initial";
-            condition = QUOTE(!(call FUNC(isInjured)));
+            condition = QUOTE( \
+                !(call FUNC(isInjured)) \
+                && {_this getVariable [ARR_2(QUOTE(QGVAR(treatmentOverAt)),CBA_missionTime)] <= CBA_missionTime} \
+            );
         };
         class Injured {
             // Stop treating when it's no more safe
             targetState = "Injured";
-            condition = QUOTE(!(call FUNC(isSafe)));
+            condition = QUOTE( \
+                !(call FUNC(isSafe)) \
+                && {_this getVariable [ARR_2(QUOTE(QGVAR(treatmentOverAt)),CBA_missionTime)] <= CBA_missionTime} \
+            );
         };
     };
 
     class HealUnit {
         onState = QUOTE(call FUNC(healUnit));
+        onStateLeaving = QUOTE(_this setVariable [ARR_2(QUOTE(QGVAR(treatmentOverAt)),nil)]);
 
         class Initial {
             // Go back to initial state when done healing or it's no more safe to treat
             targetState = "Initial";
-            condition = QUOTE(!(call FUNC(wasRequestedAsMedic || {call FUNC(isSafe)})));
+            condition = QUOTE( \
+                !((call FUNC(wasRequested)) && {call FUNC(isSafe)}) \
+                && {_this getVariable [ARR_2(QUOTE(QGVAR(treatmentOverAt)),CBA_missionTime)] <= CBA_missionTime} \
+            );
         };
         class Injured {
             // Treating yourself has priority
             targetState = "Injured";
-            condition = QUOTE(!(call FUNC(isInjured)));
+            condition = QUOTE( \
+                (call FUNC(isInjured)) \
+                && {_this getVariable [ARR_2(QUOTE(QGVAR(treatmentOverAt)),CBA_missionTime)] <= CBA_missionTime} \
+            );
         };
     };
 };

--- a/addons/medical_ai/StateMachine.hpp
+++ b/addons/medical_ai/StateMachine.hpp
@@ -1,5 +1,5 @@
 class GVAR(stateMachine) {
-    list = "allUnits select {(!isPlayer _x) && {local _x}}";
+    list = "allUnits select {local _x}";
     skipNull = 1;
 
     class Initial {

--- a/addons/medical_ai/XEH_PREP.hpp
+++ b/addons/medical_ai/XEH_PREP.hpp
@@ -3,5 +3,6 @@ PREP(healSelf);
 PREP(healUnit);
 PREP(isInjured);
 PREP(isSafe);
+PREP(playTreatmentAnim);
 PREP(requestMedic);
 PREP(wasRequested);

--- a/addons/medical_ai/XEH_PREP.hpp
+++ b/addons/medical_ai/XEH_PREP.hpp
@@ -1,0 +1,7 @@
+PREP(canRequestMedic);
+PREP(healSelf);
+PREP(healUnit);
+PREP(isInjured);
+PREP(isSafe);
+PREP(requestMedic);
+PREP(wasRequested);

--- a/addons/medical_ai/XEH_postInit.sqf
+++ b/addons/medical_ai/XEH_postInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+["ace_firedNonPlayer", {
+    _unit setVariable [QGVAR(lastFired), CBA_missionTime];
+}] call CBA_fnc_addEventHandler;
+
+GVAR(statemachine) = [configFile >> "ACE_Medical_AI_StateMachine"] call CBA_statemachine_fnc_createFromConfig;

--- a/addons/medical_ai/XEH_postInit.sqf
+++ b/addons/medical_ai/XEH_postInit.sqf
@@ -1,7 +1,31 @@
 #include "script_component.hpp"
 
-["ace_firedNonPlayer", {
-    _unit setVariable [QGVAR(lastFired), CBA_missionTime];
-}] call CBA_fnc_addEventHandler;
+["ace_settingsInitialized", {
+    // Only run for AI that does not have to deal with advanced medical
+    if (EGVAR(medical,enableFor) == 1 || {hasInterface && {EGVAR(medical,level) == 2}}) exitWith {};
 
-GVAR(statemachine) = [configFile >> "ACE_Medical_AI_StateMachine"] call CBA_statemachine_fnc_createFromConfig;
+    ["ace_firedNonPlayer", {
+        _unit setVariable [QGVAR(lastFired), CBA_missionTime];
+    }] call CBA_fnc_addEventHandler;
+
+    if (hasInterface) then {
+        ["ace_unconscious", {
+            params ["_unit", "_unconscious"];
+            if (!_unconscious || {_unit != ACE_player}) exitWith {};
+
+            private _medic = objNull;
+            {
+                if ((!isPlayer _x) && {[_x] call EFUNC(medical,isMedic)}) exitWith {
+                    _medic = _x;
+                };
+            } forEach (units _unit);
+            if (isNull _medic) exitWith {};
+
+            private _healQueue = _medic getVariable [QGVAR(healQueue), []];
+            _healQueue pushBack _unit;
+            _medic setVariable [QGVAR(healQueue), _healQueue];
+        }] call CBA_fnc_addEventHandler;
+    };
+
+    GVAR(statemachine) = [configFile >> "ACE_Medical_AI_StateMachine"] call CBA_statemachine_fnc_createFromConfig;
+}] call CBA_fnc_addEventHandler;

--- a/addons/medical_ai/XEH_preInit.sqf
+++ b/addons/medical_ai/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/addons/medical_ai/XEH_preStart.sqf
+++ b/addons/medical_ai/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/medical_ai/config.cpp
+++ b/addons/medical_ai/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_common"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"BaerMitUmlaut"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/medical_ai/config.cpp
+++ b/addons/medical_ai/config.cpp
@@ -15,3 +15,4 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
+#include "StateMachine.hpp"

--- a/addons/medical_ai/config.cpp
+++ b/addons/medical_ai/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common"};
+        requiredAddons[] = {"ace_medical"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"BaerMitUmlaut"};
         url = ECSTRING(main,URL);

--- a/addons/medical_ai/functions/fnc_canRequestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_canRequestMedic.sqf
@@ -15,6 +15,9 @@
 // Note: Although an unconscious unit cannot call for a medic itself,
 //   we ignore this here. We need to "notice" the medic that he should
 //   treat other units, or else he won't do anything on his own.
+
+if ([_this] call EFUNC(medical,isMedic)) exitWith {false};
+
 {
     if ([_x] call EFUNC(medical,isMedic)) exitWith {
         _this setVariable [QGVAR(assignedMedic), _x];

--- a/addons/medical_ai/functions/fnc_canRequestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_canRequestMedic.sqf
@@ -16,7 +16,7 @@
 //   we ignore this here. We need to "notice" the medic that he should
 //   treat other units, or else he won't do anything on his own.
 
-if ([_this] call EFUNC(medical,isMedic)) exitWith {false};
+if ([_this] call EFUNC(medical,isMedic) || {vehicle _this != _this}) exitWith {false};
 
 {
     if ([_x] call EFUNC(medical,isMedic)) exitWith {

--- a/addons/medical_ai/functions/fnc_canRequestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_canRequestMedic.sqf
@@ -12,6 +12,9 @@
  */
 #include "script_component.hpp"
 
+// Note: Although an unconscious unit cannot call for a medic itself,
+//   we ignore this here. We need to "notice" the medic that he should
+//   treat other units, or else he won't do anything on his own.
 {
     if ([_x] call EFUNC(medical,isMedic)) exitWith {
         _this setVariable [QGVAR(assignedMedic), _x];

--- a/addons/medical_ai/functions/fnc_canRequestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_canRequestMedic.sqf
@@ -1,13 +1,21 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Checks if there is a medic available in the unit's group.
  *
  * Arguments:
  * None
  *
  * Return Value:
- * Nothing
+ * Can request medic <BOOL>
  *
  * Public: No
  */
 #include "script_component.hpp"
+
+{
+    if ([_x] call EFUNC(medical,isMedic)) exitWith {
+        _this setVariable [QGVAR(assignedMedic), _x];
+        true
+    };
+    false
+} forEach (units _this);

--- a/addons/medical_ai/functions/fnc_canRequestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_canRequestMedic.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -15,10 +15,10 @@
 // Can't heal self when unconscious
 if (_this getVariable ["ACE_isUnconscious", false]) exitWith {};
 // Check if we're still treating
-if ((_this getVariable [QGVAR(treatmentOverAt), CBA_missionTime]) >= CBA_missionTime) exitWith {};
+if ((_this getVariable [QGVAR(treatmentOverAt), CBA_missionTime]) > CBA_missionTime) exitWith {};
 
 private _needsBandaging   = ([_this] call EFUNC(medical,getBloodLoss)) > 0;
-private _needsMorphine    = (_this getVariable [QEGVAR(medical,pain), 0]) > 0.5;
+private _needsMorphine    = (_this getVariable [QEGVAR(medical,pain), 0]) > 0.2;
 // Advanced only?
 // private _needsEpinephrine = (_this getVariable [QEGVAR(medical,heartRate), 70]) < 40;
 
@@ -31,7 +31,11 @@ switch (true) do {
         } forEach _bodyPartStatus;
         private _selection = ["head","body","hand_l","hand_r","leg_l","leg_r"] select _partIndex;
         [_this, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
-        
+
+        #ifdef DEBUG_MODE_FULL
+            systemChat systemChat format ["%1 is bandaging selection %2", _this, _selection];
+        #endif
+
         // Play animation
         [_this, true, true] call FUNC(playTreatmentAnim);
         _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 5];
@@ -40,5 +44,9 @@ switch (true) do {
         [_this] call EFUNC(medical,treatmentBasic_morphineLocal);
         [_this, false, true] call FUNC(playTreatmentAnim);
         _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 2];
+
+        #ifdef DEBUG_MODE_FULL
+            systemChat systemChat format ["%1 is giving himself morphine", _this];
+        #endif
     };
 };

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -11,3 +11,20 @@
  * Public: No
  */
 #include "script_component.hpp"
+
+// Can't heal self when unconscious
+if (_this getVariable ["ACE_isUnconscious", false]) exitWith {};
+// Check if we're still treating
+if ((_this getVariable [QGVAR(treatmentOverAt), CBA_missionTime]) >= CBA_missionTime) exitWith {};
+
+private _needsBandaging   = ([_this] call EFUNC(medical,getBloodLoss)) > 0;
+private _needsMorphine    = (_this getVariable [QEGVAR(medical,pain), 0]) > 0.5;
+private _needsEpinephrine = (_this getVariable [QEGVAR(medical,heartRate), 70]) < 40;
+
+switch (true) do {
+    case _needsBandaging: {
+        private _selection = "";
+        [_this, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
+        _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 5];
+    };
+};

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Makes the unit heal itself.
  *
  * Arguments:
  * None

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -19,12 +19,26 @@ if ((_this getVariable [QGVAR(treatmentOverAt), CBA_missionTime]) >= CBA_mission
 
 private _needsBandaging   = ([_this] call EFUNC(medical,getBloodLoss)) > 0;
 private _needsMorphine    = (_this getVariable [QEGVAR(medical,pain), 0]) > 0.5;
-private _needsEpinephrine = (_this getVariable [QEGVAR(medical,heartRate), 70]) < 40;
+// Advanced only?
+// private _needsEpinephrine = (_this getVariable [QEGVAR(medical,heartRate), 70]) < 40;
 
 switch (true) do {
     case _needsBandaging: {
-        private _selection = "";
+        // Find injured body part and bandage it
+        private _bodyPartStatus = _this getVariable [QEGVAR(medical,bodyPartStatus), [0,0,0,0,0,0]];
+        private _partIndex = {
+            if (_x > 0) exitWith {_forEachIndex};
+        } forEach _bodyPartStatus;
+        private _selection = ["head","body","hand_l","hand_r","leg_l","leg_r"] select _partIndex;
         [_this, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
+        
+        // Play animation
+        [_this, true, true] call FUNC(playTreatmentAnim);
         _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 5];
+    };
+    case _needsMorphine: {
+        [_this] call EFUNC(medical,treatmentBasic_morphineLocal);
+        [_this, false, true] call FUNC(playTreatmentAnim);
+        _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 2];
     };
 };

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -19,20 +19,21 @@ if (_this getVariable ["ACE_isUnconscious", false]) exitWith {};
 // Check if we're still treating
 if ((_this getVariable [QGVAR(treatmentOverAt), CBA_missionTime]) > CBA_missionTime) exitWith {};
 
-private _needsBandaging   = ([_this] call EFUNC(medical,getBloodLoss)) > 0;
-private _needsMorphine    = (_this getVariable [QEGVAR(medical,pain), 0]) > 0.2;
-// Advanced only?
-// private _needsEpinephrine = (_this getVariable [QEGVAR(medical,heartRate), 70]) < 40;
+private _needsBandaging = ([_this] call EFUNC(medical,getBloodLoss)) > 0;
+private _needsMorphine  = (_this getVariable [QEGVAR(medical,pain), 0]) > 0.2;
 
 switch (true) do {
     case _needsBandaging: {
-        // Find injured body part and bandage it
-        private _bodyPartStatus = _this getVariable [QEGVAR(medical,bodyPartStatus), [0,0,0,0,0,0]];
+        // Select first wound and bandage it
+        private _openWounds = _this getVariable [QEGVAR(medical,openWounds), []];
         private _partIndex = {
-            if (_x > 0) exitWith {_forEachIndex};
-        } forEach _bodyPartStatus;
+            _x params ["", "", "_index", "_amount", "_percentage"];
+            if (_amount * _percentage > 0) exitWith {
+                _index
+            };
+        } forEach _openWounds;
         private _selection = ["head","body","hand_l","hand_r","leg_l","leg_r"] select _partIndex;
-        [_this, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
+        [_this, "Bandage", _selection] call EFUNC(medical,treatmentAdvanced_bandageLocal);
 
         #ifdef DEBUG_MODE_FULL
             systemChat format ["%1 is bandaging selection %2", _this, _selection];

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -12,6 +12,8 @@
  */
 #include "script_component.hpp"
 
+// Player will have to do this manually of course
+if (isPlayer _this) exitWith {};
 // Can't heal self when unconscious
 if (_this getVariable ["ACE_isUnconscious", false]) exitWith {};
 // Check if we're still treating

--- a/addons/medical_ai/functions/fnc_healSelf.sqf
+++ b/addons/medical_ai/functions/fnc_healSelf.sqf
@@ -33,7 +33,7 @@ switch (true) do {
         [_this, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
 
         #ifdef DEBUG_MODE_FULL
-            systemChat systemChat format ["%1 is bandaging selection %2", _this, _selection];
+            systemChat format ["%1 is bandaging selection %2", _this, _selection];
         #endif
 
         // Play animation
@@ -46,7 +46,7 @@ switch (true) do {
         _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 2];
 
         #ifdef DEBUG_MODE_FULL
-            systemChat systemChat format ["%1 is giving himself morphine", _this];
+            systemChat format ["%1 is giving himself morphine", _this];
         #endif
     };
 };

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Makes a medic heal the next unit that needs treatment.
  *
  * Arguments:
  * None

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -27,6 +27,8 @@ if (isNull _target || {!alive _target} || {!(_target call FUNC(isInjured))}) exi
     _healQueue deleteAt 0;
     _this getVariable [QGVAR(healQueue), _healQueue];
     _this forceSpeed -1;
+    // return to formation instead of going where the injured unit was if it healed itself in the mean time
+    _this moveTo getPosATL _this;
 
     #ifdef DEBUG_MODE_FULL
         systemChat systemChat format ["%1 finished healing %2", _this, _target];

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -11,3 +11,52 @@
  * Public: No
  */
 #include "script_component.hpp"
+
+// Can't heal other units when unconscious
+if (_this getVariable ["ACE_isUnconscious", false]) exitWith {};
+// Check if we're still treating
+if ((_this getVariable [QGVAR(treatmentOverAt), CBA_missionTime]) >= CBA_missionTime) exitWith {};
+
+// Find next unit to treat
+private _healQueue = _this getVariable [QGVAR(healQueue), []];
+private _target = _healQueue select 0;
+
+// If unit died or was healed, be lazy and wait for the next tick
+if (isNull _target || {!(_target call FUNC(isInjured))}) exitWith {
+    _target forceSpeed -1;
+    _healQueue deleteAt 0;
+    _this getVariable [QGVAR(healQueue), _healQueue];
+    _this forceSpeed -1;
+};
+
+// Move to target...
+if (_this distance _target > 2) exitWith {
+    _this doMove _target;
+};
+// ...and make sure medic and target don't move
+_this forceSpeed 0;
+_target forceSpeed 0;
+
+private _needsBandaging   = ([_target] call EFUNC(medical,getBloodLoss)) > 0;
+private _needsMorphine    = (_target getVariable [QEGVAR(medical,pain), 0]) > 0.5;
+
+switch (true) do {
+    case _needsBandaging: {
+        // Find injured body part and bandage it
+        private _bodyPartStatus = _target getVariable [QEGVAR(medical,bodyPartStatus), [0,0,0,0,0,0]];
+        private _partIndex = {
+            if (_x > 0) exitWith {_forEachIndex};
+        } forEach _bodyPartStatus;
+        private _selection = ["head","body","hand_l","hand_r","leg_l","leg_r"] select _partIndex;
+        [_target, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
+        
+        // Play animation
+        [_this, true, false] call FUNC(playTreatmentAnim);
+        _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 5];
+    };
+    case _needsMorphine: {
+        [_target] call EFUNC(medical,treatmentBasic_morphineLocal);
+        [_this, false, false] call FUNC(playTreatmentAnim);
+        _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 2];
+    };
+};

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -28,7 +28,7 @@ if (isNull _target || {!alive _target} || {!(_target call FUNC(isInjured))}) exi
     _this getVariable [QGVAR(healQueue), _healQueue];
     _this forceSpeed -1;
     // return to formation instead of going where the injured unit was if it healed itself in the mean time
-    _this moveTo getPosATL _this;
+    _this doFollow leader _this;
 
     #ifdef DEBUG_MODE_FULL
         systemChat format ["%1 finished healing %2", _this, _target];

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -36,7 +36,7 @@ if (isNull _target || {!alive _target} || {!(_target call FUNC(isInjured))}) exi
 };
 
 // Move to target...
-if (_this distance _target > 1.5) exitWith {
+if (_this distance _target > 2) exitWith {
     // This is necessary to force the unit to move ._.
     _this forceSpeed 0;
     _this forceSpeed -1;

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -42,22 +42,26 @@ if (_this distance _target > 2) exitWith {
     _this forceSpeed -1;
     _this doMove getPosATL _target;
 };
+
 // ...and make sure medic and target don't move
 _this forceSpeed 0;
 _target forceSpeed 0;
 
-private _needsBandaging   = ([_target] call EFUNC(medical,getBloodLoss)) > 0;
-private _needsMorphine    = (_target getVariable [QEGVAR(medical,pain), 0]) > 0.2;
+private _needsBandaging = ([_target] call EFUNC(medical,getBloodLoss)) > 0;
+private _needsMorphine  = (_target getVariable [QEGVAR(medical,pain), 0]) > 0.2;
 
 switch (true) do {
     case _needsBandaging: {
-        // Find injured body part and bandage it
-        private _bodyPartStatus = _target getVariable [QEGVAR(medical,bodyPartStatus), [0,0,0,0,0,0]];
+        // Select first wound and bandage it
+        private _openWounds = _target getVariable [QEGVAR(medical,openWounds), []];
         private _partIndex = {
-            if (_x > 0) exitWith {_forEachIndex};
-        } forEach _bodyPartStatus;
+            _x params ["", "", "_index", "_amount", "_percentage"];
+            if (_amount * _percentage > 0) exitWith {
+                _index
+            };
+        } forEach _openWounds;
         private _selection = ["head","body","hand_l","hand_r","leg_l","leg_r"] select _partIndex;
-        [_target, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
+        [_target, "Bandage", _selection] call EFUNC(medical,treatmentAdvanced_bandageLocal);
 
         #ifdef DEBUG_MODE_FULL
             systemChat format ["%1 is bandaging selection %2 on %3", _this, _selection, _target];

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -37,11 +37,12 @@ if (isNull _target || {!alive _target} || {!(_target call FUNC(isInjured))}) exi
 
 // Move to target...
 if (_this distance _target > 2) exitWith {
-    // This is necessary to force the unit to move ._.
-    _this forceSpeed 0;
-    _this forceSpeed -1;
-    _this doMove getPosATL _target;
+    if !(_this getVariable [QGVAR(movingToInjured), false]) then {
+        _this setVariable [QGVAR(movingToInjured), true];
+        _this doMove getPosATL _target;
+    };
 };
+_this setVariable [QGVAR(movingToInjured), false];
 
 // ...and make sure medic and target don't move
 _this forceSpeed 0;

--- a/addons/medical_ai/functions/fnc_healUnit.sqf
+++ b/addons/medical_ai/functions/fnc_healUnit.sqf
@@ -31,7 +31,7 @@ if (isNull _target || {!alive _target} || {!(_target call FUNC(isInjured))}) exi
     _this moveTo getPosATL _this;
 
     #ifdef DEBUG_MODE_FULL
-        systemChat systemChat format ["%1 finished healing %2", _this, _target];
+        systemChat format ["%1 finished healing %2", _this, _target];
     #endif
 };
 
@@ -60,7 +60,7 @@ switch (true) do {
         [_target, _selection] call EFUNC(medical,treatmentBasic_bandageLocal);
 
         #ifdef DEBUG_MODE_FULL
-            systemChat systemChat format ["%1 is bandaging selection %2 on %3", _this, _selection, _target];
+            systemChat format ["%1 is bandaging selection %2 on %3", _this, _selection, _target];
         #endif
 
         // Play animation
@@ -73,7 +73,7 @@ switch (true) do {
         _this setVariable [QGVAR(treatmentOverAt), CBA_missionTime + 2];
 
         #ifdef DEBUG_MODE_FULL
-            systemChat systemChat format ["%1 is giving %2 morphine", _this, _target];
+            systemChat format ["%1 is giving %2 morphine", _this, _target];
         #endif
     };
 };

--- a/addons/medical_ai/functions/fnc_isInjured.sqf
+++ b/addons/medical_ai/functions/fnc_isInjured.sqf
@@ -17,4 +17,4 @@ private _pain      = _this getVariable [QEGVAR(medical,pain), 0];
 // Advanced only?
 // private _heartRate = _this getVariable [QEGVAR(medical,heartRate), 70];
 
-(_bloodLoss > 0) || {_pain > 0.5} // || {_heartRate > 100} || {_heartRate < 40}
+(_bloodLoss > 0) || {_pain > 0.2} // || {_heartRate > 100} || {_heartRate < 40}

--- a/addons/medical_ai/functions/fnc_isInjured.sqf
+++ b/addons/medical_ai/functions/fnc_isInjured.sqf
@@ -14,6 +14,7 @@
 
 private _bloodLoss = [_this] call EFUNC(medical,getBloodLoss);
 private _pain      = _this getVariable [QEGVAR(medical,pain), 0];
-private _heartRate = _this getVariable [QEGVAR(medical,heartRate), 70];
+// Advanced only?
+// private _heartRate = _this getVariable [QEGVAR(medical,heartRate), 70];
 
-(_bloodLoss > 0) || {_pain > 0.5} || {_heartRate > 100} || {_heartRate < 40}
+(_bloodLoss > 0) || {_pain > 0.5} // || {_heartRate > 100} || {_heartRate < 40}

--- a/addons/medical_ai/functions/fnc_isInjured.sqf
+++ b/addons/medical_ai/functions/fnc_isInjured.sqf
@@ -1,13 +1,19 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Checks if a unit needs treatment.
  *
  * Arguments:
  * None
  *
  * Return Value:
- * Nothing
+ * Does unit need treatment <BOOL>
  *
  * Public: No
  */
 #include "script_component.hpp"
+
+private _bloodLoss = [_this] call EFUNC(medical,getBloodLoss);
+private _pain      = _this getVariable [QEGVAR(medical,pain), 0];
+private _heartRate = _this getVariable [QEGVAR(medical,heartRate), 70];
+
+(_bloodLoss > 0) || {_pain > 0.5} || {_heartRate > 100} || {_heartRate < 40}

--- a/addons/medical_ai/functions/fnc_isInjured.sqf
+++ b/addons/medical_ai/functions/fnc_isInjured.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/fnc_isInjured.sqf
+++ b/addons/medical_ai/functions/fnc_isInjured.sqf
@@ -12,6 +12,8 @@
  */
 #include "script_component.hpp"
 
+if !(alive _this) exitWith {false};
+
 private _bloodLoss = [_this] call EFUNC(medical,getBloodLoss);
 private _pain      = _this getVariable [QEGVAR(medical,pain), 0];
 // Advanced only?

--- a/addons/medical_ai/functions/fnc_isSafe.sqf
+++ b/addons/medical_ai/functions/fnc_isSafe.sqf
@@ -1,13 +1,15 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Checks if a unit is currently considered safe enough to treat itself.
  *
  * Arguments:
  * None
  *
  * Return Value:
- * Nothing
+ * Is unit safe enough <BOOL>
  *
  * Public: No
  */
 #include "script_component.hpp"
+
+(getSuppression _this == 0) && {CBA_missionTime - (_this getVariable [QGVAR(lastFired), -60]) > 60}

--- a/addons/medical_ai/functions/fnc_isSafe.sqf
+++ b/addons/medical_ai/functions/fnc_isSafe.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/fnc_isSafe.sqf
+++ b/addons/medical_ai/functions/fnc_isSafe.sqf
@@ -12,4 +12,4 @@
  */
 #include "script_component.hpp"
 
-(getSuppression _this == 0) && {CBA_missionTime - (_this getVariable [QGVAR(lastFired), -60]) > 60}
+(getSuppression _this == 0) && {CBA_missionTime - (_this getVariable [QGVAR(lastFired), -30]) > 30}

--- a/addons/medical_ai/functions/fnc_playTreatmentAnim.sqf
+++ b/addons/medical_ai/functions/fnc_playTreatmentAnim.sqf
@@ -1,0 +1,38 @@
+/*
+ * Author: BaerMitUmlaut
+ * Plays the corresponding treatment animation.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Is bandage <BOOL>
+ * 2: Is self treatment <BOOL>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+params ["_unit", "_isBandage", "_isSelfTreatment"];
+
+if (vehicle _unit != _unit) exitWith {};
+
+private _animConfig = if (_isBandage) then {
+    configFile >> "ACE_Medical_Actions" >> "Basic" >> "Bandage";
+} else {
+    configFile >> "ACE_Medical_Actions" >> "Basic" >> "Morphine";
+};
+
+private _configProperty = "animationCaller";
+if (_isSelfTreatment) then {
+    _configProperty = _configProperty + "Self";
+};
+if (stance _unit == "PRONE") then {
+    _configProperty = _configProperty + "Prone";
+};
+
+private _anim = getText (_animConfig >> _configProperty);
+private _wpn = ["non", "rfl", "pst"] select (1 + ([primaryWeapon _unit, handgunWeapon _unit] find (currentWeapon _unit)));
+_anim = [_anim, "[wpn]", _wpn] call CBA_fnc_replace;
+
+[_unit, _anim] call EFUNC(common,doAnimation);

--- a/addons/medical_ai/functions/fnc_requestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_requestMedic.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Sends a request to the units assigned medic to heal it.
  *
  * Arguments:
  * None
@@ -11,3 +11,8 @@
  * Public: No
  */
 #include "script_component.hpp"
+
+private _assignedMedic = _this getVariable QGVAR(assignedMedic);
+private _healQueue = _assignedMedic getVariable [QGVAR(healQueue), []];
+_healQueue pushBack _this;
+_assignedMedic setVariable [QGVAR(healQueue), _healQueue];

--- a/addons/medical_ai/functions/fnc_requestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_requestMedic.sqf
@@ -16,3 +16,7 @@ private _assignedMedic = _this getVariable QGVAR(assignedMedic);
 private _healQueue = _assignedMedic getVariable [QGVAR(healQueue), []];
 _healQueue pushBack _this;
 _assignedMedic setVariable [QGVAR(healQueue), _healQueue];
+
+#ifdef DEBUG_MODE_FULL
+    systemChat systemChat format ["%1 requested %2 for medical treatment", _this, _assignedMedic];
+#endif

--- a/addons/medical_ai/functions/fnc_requestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_requestMedic.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/fnc_requestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_requestMedic.sqf
@@ -18,5 +18,5 @@ _healQueue pushBack _this;
 _assignedMedic setVariable [QGVAR(healQueue), _healQueue];
 
 #ifdef DEBUG_MODE_FULL
-    systemChat systemChat format ["%1 requested %2 for medical treatment", _this, _assignedMedic];
+    systemChat format ["%1 requested %2 for medical treatment", _this, _assignedMedic];
 #endif

--- a/addons/medical_ai/functions/fnc_wasRequested.sqf
+++ b/addons/medical_ai/functions/fnc_wasRequested.sqf
@@ -12,5 +12,5 @@
  */
 #include "script_component.hpp"
 
-private _healQueue = _assignedMedic getVariable [QGVAR(healQueue), []];
+private _healQueue = _this getVariable [QGVAR(healQueue), []];
 !(_healQueue isEqualTo [])

--- a/addons/medical_ai/functions/fnc_wasRequested.sqf
+++ b/addons/medical_ai/functions/fnc_wasRequested.sqf
@@ -1,13 +1,16 @@
 /*
  * Author: BaerMitUmlaut
- *
+ * Checks if the unit was requested to treat another unit.
  *
  * Arguments:
  * None
  *
  * Return Value:
- * Nothing
+ * Was requested <BOOL>
  *
  * Public: No
  */
 #include "script_component.hpp"
+
+private _healQueue = _assignedMedic getVariable [QGVAR(healQueue), []];
+!(_healQueue isEqualTo [])

--- a/addons/medical_ai/functions/fnc_wasRequested.sqf
+++ b/addons/medical_ai/functions/fnc_wasRequested.sqf
@@ -1,0 +1,13 @@
+/*
+ * Author: BaerMitUmlaut
+ *
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#include "script_component.hpp"

--- a/addons/medical_ai/functions/script_component.hpp
+++ b/addons/medical_ai/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\ace\addons\medical_ai\script_component.hpp"

--- a/addons/medical_ai/script_component.hpp
+++ b/addons/medical_ai/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Medical AI
 #include "\z\ace\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_ENABLED_MEDICAL_AI
+#define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/medical_ai/script_component.hpp
+++ b/addons/medical_ai/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Medical AI
 #include "\z\ace\addons\main\script_mod.hpp"
 
-#define DEBUG_ENABLED_MEDICAL_AI
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_ENABLED_MEDICAL_AI
+// #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/medical_ai/script_component.hpp
+++ b/addons/medical_ai/script_component.hpp
@@ -1,0 +1,18 @@
+#define COMPONENT medical_ai
+#define COMPONENT_BEAUTIFIED Medical AI
+#include "\z\ace\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define CBA_DEBUG_SYNCHRONOUS
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_MEDICAL_AI
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_MEDICAL_AI
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_MEDICAL_AI
+#endif
+
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Make AI units heal themselves, each other and players in their group
- This only works when the AI units have to deal with basic medical (they won't do anything when the player is using advanced medical or advanced medical is enabled for AI units) due to the complexity of advanced medical

Some details on the implementation:
- This uses a CBA state machine, so performance will not be an issue at all, no matter the amount of AI
- AI units will treat themselves when not suppressed and not having shot at enemies since 30 seconds
- Only medic units will heal other units in their group, and only when they are not injured or under fire themselves
- Since AI units usually don't get custom loadouts with a balanced medical equipment they do not consume bandages or syringes at all