### PR TITLE
Fix Chemlight Shield Green and Red descriptions

### DIFF
--- a/addons/chemlights/CfgWeapons.hpp
+++ b/addons/chemlights/CfgWeapons.hpp
@@ -6,27 +6,27 @@ class CfgWeapons {
         muzzles[] += {"ACE_Chemlight_OrangeMuzzle","ACE_Chemlight_WhiteMuzzle","ACE_Chemlight_HiRedMuzzle","ACE_Chemlight_HiYellowMuzzle","ACE_Chemlight_HiOrangeMuzzle","ACE_Chemlight_HiWhiteMuzzle","ACE_Chemlight_IRMuzzle"};
 
         class ThrowMuzzle;
-        
+
         class ACE_Chemlight_OrangeMuzzle: ThrowMuzzle {
             magazines[] = {"ACE_Chemlight_Orange"};
         };
-        
+
         class ACE_Chemlight_WhiteMuzzle: ThrowMuzzle {
             magazines[] = {"ACE_Chemlight_White"};
         };
-        
+
         class ACE_Chemlight_HiRedMuzzle: ThrowMuzzle {
             magazines[] = {"ACE_Chemlight_HiRed"};
         };
-        
+
         class ACE_Chemlight_HiYellowMuzzle: ThrowMuzzle {
             magazines[] = {"ACE_Chemlight_HiYellow"};
         };
-        
+
         class ACE_Chemlight_HiOrangeMuzzle: ThrowMuzzle {
             magazines[] = {"ACE_Chemlight_HiOrange"};
         };
-        
+
         class ACE_Chemlight_HiWhiteMuzzle: ThrowMuzzle {
             magazines[] = {"ACE_Chemlight_HiWhite"};
         };
@@ -34,10 +34,10 @@ class CfgWeapons {
             magazines[] = {"ACE_Chemlight_IR"};
         };
     };
-    
+
     class ACE_ItemCore;
     class InventoryItem_Base_F;
-    
+
     class ACE_Chemlight_Shield: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(Shield_Empty_DisplayName);
@@ -49,12 +49,12 @@ class CfgWeapons {
             mass = 1;
         };
     };
-    
+
     class ACE_Chemlight_Shield_Green: ACE_ItemCore {
         ACE_Chemlight = "Chemlight_green";
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(Shield_Green_DisplayName);
-        descriptionShort = CSTRING(Shield_Empty_DescriptionShort);
+        descriptionShort = CSTRING(Shield_Green_DescriptionShort);
         model = "\A3\weapons_F\ammo\mag_univ.p3d";
         picture = QPATHTOF(UI\ace_chemlight_shield_green_x_ca.paa);
         scope = 1;
@@ -67,11 +67,11 @@ class CfgWeapons {
             };
         };
     };
-    
+
     class ACE_Chemlight_Shield_Red: ACE_Chemlight_Shield_Green {
         ACE_Chemlight = "Chemlight_red";
         displayName = CSTRING(Shield_Red_DisplayName);
-        descriptionShort = CSTRING(Shield_Green_DescriptionShort);
+        descriptionShort = CSTRING(Shield_Red_DescriptionShort);
         picture = QPATHTOF(UI\ace_chemlight_shield_red_x_ca.paa);
         class ItemInfo: InventoryItem_Base_F {
             mass = 1;
@@ -97,7 +97,7 @@ class CfgWeapons {
             };
         };
     };
-    
+
     class ACE_Chemlight_Shield_Yellow: ACE_Chemlight_Shield_Green {
         ACE_Chemlight = "Chemlight_yellow";
         displayName = CSTRING(Shield_Yellow_DisplayName);
@@ -112,7 +112,7 @@ class CfgWeapons {
             };
         };
     };
-    
+
     class ACE_Chemlight_Shield_Orange: ACE_Chemlight_Shield_Green {
         ACE_Chemlight = "ACE_Chemlight_Orange";
         displayName = CSTRING(Shield_Orange_DisplayName);


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Apparently also remove excessive whitespace

![20160831220700_1](https://cloud.githubusercontent.com/assets/7935003/18146569/bf28d6dc-6fd0-11e6-8297-76a6a5095b83.jpg)
![20160831220702_1](https://cloud.githubusercontent.com/assets/7935003/18146570/bf2bd9e0-6fd0-11e6-9fd4-cdd026541e29.jpg)
