### PR TITLE
Fade nametags towards screen border

### DIFF
--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -12,7 +12,7 @@ class ACE_Settings {
         isClientSettable = 1;
         displayName = CSTRING(ShowPlayerNames);
         description = CSTRING(ShowPlayerNames_Desc);
-        values[] = {ECSTRING(common,Disabled), ECSTRING(common,Enabled), CSTRING(OnlyCursor), CSTRING(OnlyKeypress), CSTRING(OnlyCursorAndKeypress)};
+        values[] = {ECSTRING(common,Disabled), ECSTRING(common,Enabled), CSTRING(OnlyCursor), CSTRING(OnlyKeypress), CSTRING(OnlyCursorAndKeypress), CSTRING(FadeOnBorder)};
         category = CSTRING(Module_DisplayName);
     };
     class GVAR(showPlayerRanks) {

--- a/addons/nametags/CfgVehicles.hpp
+++ b/addons/nametags/CfgVehicles.hpp
@@ -28,6 +28,10 @@ class CfgVehicles {
                         name = CSTRING(ForceShow);
                         value = 1;
                     };
+                    class ForceShowFadeOnBorder {
+                        name = CSTRING(FadeOnBorder);
+                        value = 5;
+                    };
                     class ForceShowOnlyCursor {
                         name = CSTRING(ForceShowOnlyCursor);
                         value = 2;

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -57,6 +57,11 @@ switch (GVAR(showPlayerNames)) do {
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
         _enabledTagsCursor = _onKeyPressAlphaMax > 0;
     };
+    case 5: {
+        // Fade on border
+        _enabledTagsNearby = true;
+        _enabledTagsCursor = false;
+    };
 };
 
 private _ambientBrightness = ((([] call EFUNC(common,ambientBrightness)) + ([0, 0.4] select ((currentVisionMode ace_player) != 0))) min 1) max 0;
@@ -133,13 +138,16 @@ if (_enabledTagsNearby) then {
             private _relPos = (visiblePositionASL _target) vectorDiff _camPosASL;
             private _distance = vectorMagnitude _relPos;
 
-            private _screenPos = worldToScreen (_target modelToWorld (_target selectionPosition "head"));
-            private _centerOffsetFactor = if !(_screenPos isEqualTo []) then {
-                // Distance from center / half of screen width
-                1 - ((_screenPos distance2D [0.5, 0.5]) / (safezoneW / 3))
-            } else {
-                // Target outside of screen
-                0
+            // Fade on border
+            private _centerOffsetFactor = 1;
+            if (GVAR(showPlayerNames) == 5) then {
+                private _screenPos = worldToScreen (_target modelToWorld (_target selectionPosition "head"));
+                if !(_screenPos isEqualTo []) then {
+                    // Distance from center / half of screen width
+                    _centerOffsetFactor = 1 - ((_screenPos distance2D [0.5, 0.5]) / (safezoneW / 3));
+                } else {
+                    _centerOffsetFactor = 0;
+                };
             };
 
             private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -132,7 +132,16 @@ if (_enabledTagsNearby) then {
         if !(isNull _target) then {
             private _relPos = (visiblePositionASL _target) vectorDiff _camPosASL;
             private _distance = vectorMagnitude _relPos;
-            private _projDist = _relPos vectorDistance (_vecy vectorMultiply (_relPos vectorDotProduct _vecy));
+
+            private _screenPos = worldToScreen (_target modelToWorld (_target selectionPosition "head"));
+            if (_screenPos isEqualTo []) then {
+                // Target outside of screen
+                _screenPos = [1000, 1000];
+            };
+            _screenPos pushBack 0;
+
+            // Distance from center / half of screen width
+            private _centerOffsetFactor = 1 - ((vectorMagnitude (_screenPos vectorDiff [0.5, 0.5, 0])) / (safezoneW / 3));
 
             private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
             private _alphaMax = _onKeyPressAlphaMax;
@@ -146,7 +155,7 @@ if (_enabledTagsNearby) then {
             // - decreases when _distance > _maxDistance
             // - increases when the unit is speaking
             // - it's clamped by the value of _onKeyPressAlphaMax unless soundwaves are forced on and the unit is talking
-            private _alpha = (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistance)) min 1) * GVAR(playerNamesMaxAlpha)) min _alphaMax;
+            private _alpha = (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistance)) min 1) * GVAR(playerNamesMaxAlpha) * _centerOffsetFactor) min _alphaMax;
 
             if (_alpha > 0) then {
                 [ACE_player, _target, _alpha, _distance * 0.026, _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -138,10 +138,9 @@ if (_enabledTagsNearby) then {
                 // Target outside of screen
                 _screenPos = [1000, 1000];
             };
-            _screenPos pushBack 0;
 
             // Distance from center / half of screen width
-            private _centerOffsetFactor = 1 - ((vectorMagnitude (_screenPos vectorDiff [0.5, 0.5, 0])) / (safezoneW / 3));
+            private _centerOffsetFactor = 1 - ((_screenPos distance2D [0.5, 0.5]) / (safezoneW / 3));
 
             private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
             private _alphaMax = _onKeyPressAlphaMax;

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -134,13 +134,13 @@ if (_enabledTagsNearby) then {
             private _distance = vectorMagnitude _relPos;
 
             private _screenPos = worldToScreen (_target modelToWorld (_target selectionPosition "head"));
-            if (_screenPos isEqualTo []) then {
+            private _centerOffsetFactor = if !(_screenPos isEqualTo []) then {
+                // Distance from center / half of screen width
+                1 - ((_screenPos distance2D [0.5, 0.5]) / (safezoneW / 3))
+            } else {
                 // Target outside of screen
-                _screenPos = [1000, 1000];
+                0
             };
-
-            // Distance from center / half of screen width
-            private _centerOffsetFactor = 1 - ((_screenPos distance2D [0.5, 0.5]) / (safezoneW / 3));
 
             private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
             private _alphaMax = _onKeyPressAlphaMax;

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -396,5 +396,9 @@
             <Russian>Масштабирование размера текста и иконок</Russian>
             <Italian>Proporzione Dimensioni Testo ed Icone</Italian>
         </Key>
+        <Key ID="STR_ACE_NameTags_FadeOnBorder">
+            <English>Fade on screen border</English>
+            <German>Am Bildschirmrand ausblenden</German>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Make nametags fade depending on distance to the screens center

![20160901212255_1](https://cloud.githubusercontent.com/assets/9693842/18181319/fd155cd0-708a-11e6-95d6-1619ececd5a0.jpg)

PS: This component needs some cleanup.
