### PR TITLE
Add spare barrel to VA in 1.64

### DIFF
--- a/addons/overheating/CfgMagazines.hpp
+++ b/addons/overheating/CfgMagazines.hpp
@@ -2,6 +2,8 @@ class CfgMagazines {
     class CA_Magazine;
     class ACE_SpareBarrel: CA_Magazine {
         displayName = CSTRING(SpareBarrelName);
+        author = ECSTRING(common,ACETeam);
+        scope = 2; // Allows it to show up in Virtual Arsenal in 1.64
         descriptionshort = CSTRING(SpareBarrelDescription);
         picture = QUOTE(PATHTOF(UI\spare_barrel_ca.paa));
         count = 1;

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
         units[] = {};
-        weapons[] = {"ACE_SpareBarrel"};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);


### PR DESCRIPTION
Close #4325
Needs 1.64 to take effect, but should be fine on 1.62

![image](https://cloud.githubusercontent.com/assets/9376747/18233311/3e32aaa4-72a9-11e6-8c89-53c2c5570a02.png)
