### PR TITLE
Disallow radio usage on captivity and surrender

### DIFF
--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -41,6 +41,11 @@ if ((_unit getVariable [QGVAR(isHandcuffed), false]) isEqualTo _state) exitWith 
 if (_state) then {
     _unit setVariable [QGVAR(isHandcuffed), true, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
+    call FUNC(endRadioTransmission);
+    //TFAR disallow radio usage
+    _unit setVariable ["tf_unable_to_use_radio", true];
+    //ACRE disallow radio usage
+    _unit setVariable ["acre_sys_core_isDisabled", true, true];
 
     if (_unit getVariable [QGVAR(isSurrendering), false]) then {  //If surrendering, stop
         [_unit, false] call FUNC(setSurrendered);
@@ -81,6 +86,10 @@ if (_state) then {
 } else {
     _unit setVariable [QGVAR(isHandcuffed), false, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), false] call EFUNC(common,statusEffect_set);
+    //TFAR allow radio usage
+    _unit setVariable ["tf_unable_to_use_radio", false];
+    //ACRE allow radio usage
+    _unit setVariable ["acre_sys_core_isDisabled", false, true];
 
     //remove AnimChanged EH
     private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -41,7 +41,7 @@ if ((_unit getVariable [QGVAR(isHandcuffed), false]) isEqualTo _state) exitWith 
 if (_state) then {
     _unit setVariable [QGVAR(isHandcuffed), true, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
-    call FUNC(endRadioTransmission);
+    call EFUNC(common,endRadioTransmission);
     //TFAR disallow radio usage
     _unit setVariable ["tf_unable_to_use_radio", true];
     //ACRE disallow radio usage

--- a/addons/captives/functions/fnc_setSurrendered.sqf
+++ b/addons/captives/functions/fnc_setSurrendered.sqf
@@ -45,6 +45,11 @@ if (_state) then {
     _unit setVariable [QGVAR(isSurrendering), true, true];
 
     [_unit, "setCaptive", QGVAR(Surrendered), true] call EFUNC(common,statusEffect_set);
+    call EFUNC(common,endRadioTransmission);
+    //TFAR disallow radio usage
+    _unit setVariable ["tf_unable_to_use_radio", true];
+    //ACRE disallow radio usage
+    _unit setVariable ["acre_sys_core_isDisabled", true, true];
 
     if (_unit == ACE_player) then {
         ["captive", [false, false, false, false, false, false, false, false]] call EFUNC(common,showHud);
@@ -71,6 +76,10 @@ if (_state) then {
 } else {
     _unit setVariable [QGVAR(isSurrendering), false, true];
     [_unit, "setCaptive", QGVAR(Surrendered), false] call EFUNC(common,statusEffect_set);
+    //TFAR allow radio usage
+    _unit setVariable ["tf_unable_to_use_radio", false];
+    //ACRE allow radio usage
+    _unit setVariable ["acre_sys_core_isDisabled", false, true];
 
     //remove AnimChanged EH
     private _animChangedEHID = _unit getVariable [QGVAR(surrenderAnimEHID), -1];

--- a/addons/captives/functions/fnc_setSurrendered.sqf
+++ b/addons/captives/functions/fnc_setSurrendered.sqf
@@ -45,7 +45,6 @@ if (_state) then {
     _unit setVariable [QGVAR(isSurrendering), true, true];
 
     [_unit, "setCaptive", QGVAR(Surrendered), true] call EFUNC(common,statusEffect_set);
-    call EFUNC(common,endRadioTransmission);
     //TFAR disallow radio usage
     _unit setVariable ["tf_unable_to_use_radio", true];
     //ACRE disallow radio usage


### PR DESCRIPTION
**When merged this pull request will:**
- end the current radio transmission on captivity and surrender
- for both TFAR and ACRE disallow radio usage on captivity and surrender
- allow radio usage again on release/cancel surrender
