### PR TITLE
Fix pick up delay and IR chemlights, prevent picking up GL and mortar smoke shells

### DIFF
--- a/addons/advanced_throwing/CfgVehicles.hpp
+++ b/addons/advanced_throwing/CfgVehicles.hpp
@@ -58,7 +58,7 @@ class CfgVehicles {
         class ACE_Actions {
             class GVAR(pickUp) {
                 displayName = CSTRING(PickUp);
-                condition = QUOTE(_player call FUNC(canPrepare));
+                condition = QUOTE([ARR_2(_player,true)] call FUNC(canPrepare));
                 statement = QUOTE(_this call FUNC(pickUp));
                 distance = 1.8; // Requires >1.7 to work when standing with weapon on back
                 icon = "\a3\ui_f\data\igui\cfg\actions\obsolete\ui_action_takemine_ca.paa";

--- a/addons/advanced_throwing/functions/fnc_canPrepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_canPrepare.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
+ * 1: Pick Up <BOOL> (default: false)
  *
  * Return Value:
  * Can Prepare <BOOL>
@@ -15,12 +16,12 @@
  */
 #include "script_component.hpp"
 
-params ["_unit"];
+params ["_unit", ["_pickUp", false]];
 
 GVAR(enabled) &&
 
 #ifndef DEBUG_MODE_FULL
-{_unit getVariable [QGVAR(lastThrownTime), CBA_missionTime - 3] < CBA_missionTime - 2} && // Prevent throwing in quick succession
+{_pickUp || {_unit getVariable [QGVAR(lastThrownTime), CBA_missionTime - 3] < CBA_missionTime - 2}} && // Prevent throwing in quick succession
 #else
 {true} &&
 #endif

--- a/addons/advanced_throwing/functions/fnc_canPrepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_canPrepare.sqf
@@ -18,12 +18,17 @@
 
 params ["_unit", ["_pickUp", false]];
 
+// Don't delay when picking up
+if (_pickUp) then {
+    _unit setVariable [QGVAR(lastThrownTime), -1];
+};
+
 GVAR(enabled) &&
 
-#ifndef DEBUG_MODE_FULL
-{_pickUp || {_unit getVariable [QGVAR(lastThrownTime), CBA_missionTime - 3] < CBA_missionTime - 2}} && // Prevent throwing in quick succession
-#else
+#ifdef ALLOW_QUICK_THROW
 {true} &&
+#else
+{_unit getVariable [QGVAR(lastThrownTime), CBA_missionTime - 3] < CBA_missionTime - 2} && // Prevent throwing in quick succession
 #endif
 
 {!(call EFUNC(common,isFeatureCameraActive))} &&

--- a/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
+++ b/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
@@ -31,7 +31,10 @@
             _nearThrowables append (ACE_player nearObjects ["ACE_Chemlight_IR_Dummy", PICK_UP_DISTANCE]);
 
             {
-                if (!(_x in _throwablesHelped) && {GVAR(enablePickUpAttached) || {!GVAR(enablePickUpAttached) && {isNull (attachedTo _x)}}}) then {
+                if (!(_x in _throwablesHelped) &&
+                    {!(_x isKindOf "SmokeShellArty")} && {!(_x isKindOf "G_40mm_Smoke")} && // All smokes inherit from "GrenadeHand" >> "SmokeShell"
+                    {GVAR(enablePickUpAttached) || {!GVAR(enablePickUpAttached) && {isNull (attachedTo _x)}}}
+                ) then {
                     TRACE_2("Making PickUp Helper",_x,typeOf _x);
                     private _pickUpHelper = QGVAR(pickUpHelper) createVehicleLocal [0, 0, 0];
 

--- a/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
+++ b/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
@@ -22,11 +22,12 @@
 
     // isNull is necessarry to prevent rare error when ending mission with interact key down
     if (EGVAR(interact_menu,keyDown) && {!isNull ACE_player}) then {
-        // Rescan when player moved >5 meters from last pos, nearObjects is costly
+        // Rescan when player moved >5 meters from last pos, nearObjects can be costly with a lot of objects around
         if ((getPosASL ACE_player) distance _setPosition > 5) then {
-             // IR throwbles inherit from GrenadeCore, others from GrenadeHand, IR Chemlights are special snowflakes
+             // Grenades inherit from GrenadeHand, IR throwbles from IRStrobeBase, IR Chemlights are special snowflakes
+             // nearEntities does not see throwables
             _nearThrowables = ACE_player nearObjects ["GrenadeHand", PICK_UP_DISTANCE];
-            _nearThrowables append (ACE_player nearObjects ["GrenadeCore", PICK_UP_DISTANCE]);
+            _nearThrowables append (ACE_player nearObjects ["IRStrobeBase", PICK_UP_DISTANCE]);
             _nearThrowables append (ACE_player nearObjects ["ACE_Chemlight_IR_Dummy", PICK_UP_DISTANCE]);
 
             {

--- a/addons/advanced_throwing/script_component.hpp
+++ b/addons/advanced_throwing/script_component.hpp
@@ -3,6 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DRAW_THROW_PATH
+// #define ALLOW_QUICK_THROW
 // #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS

--- a/addons/chemlights/functions/fnc_throwEH.sqf
+++ b/addons/chemlights/functions/fnc_throwEH.sqf
@@ -27,8 +27,8 @@ if (isNull _projectile) then {
 
 if (local _unit) then {
     if ([_ammo] call FUNC(isIRClass)) then {
-        // Handle advancedThrowing:
-        if ((ace_player getVariable [QEGVAR(advancedThrowing,activeThrowable), objNull]) == _projectile) then {
+        // Handle Advanced Throwing
+        if ((ACE_player getVariable [QEGVAR(advanced_throwing,activeThrowable), objNull]) == _projectile) then {
             [_projectile, _ammo, true] call FUNC(throwIR); // direct call if we are priming with adv throw
         } else {
             [{_this call FUNC(throwIR)}, [_projectile, _ammo]] call CBA_fnc_execNextFrame;

--- a/addons/chemlights/functions/fnc_throwIR.sqf
+++ b/addons/chemlights/functions/fnc_throwIR.sqf
@@ -32,5 +32,5 @@ _dummy setPosATL _pos;
 _dummy setVelocity _velocity;
 
 if (_replaceAdvThrowable) then {
-    ace_player setVariable [QEGVAR(advancedThrowing,activeThrowable), _dummy];
+    ACE_player setVariable [QEGVAR(advanced_throwing,activeThrowable), _dummy];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Initially this was meant to fix mortar shells from being picked up, but they inherit from `GrenadeBase` as well, would be small overhead to filter them. However, it seems only smoke shell is the problem, with which I don't really have a problem with being picked up and thrown further.