### PR TITLE
Refuel nozzle taking, disconnecting, connecting and returning interaction fixes

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -77,7 +77,7 @@
             class GVAR(PickUpNozzle) { \
                 displayName = CSTRING(TakeNozzle); \
                 condition = QUOTE([ARR_2(_player,_target)] call FUNC(canTakeNozzle)); \
-                statement = QUOTE([ARR_3(_player,objNull,_target)] call FUNC(TakeNozzle)); \
+                statement = QUOTE([ARR_3(_player,objNull,_target)] call FUNC(takeNozzle)); \
                 exceptions[] = {"isNotInside"}; \
                 icon = QPATHTOF(ui\icon_refuel_interact.paa); \
             }; \
@@ -322,7 +322,7 @@ class CfgVehicles {
     class I_G_Van_01_fuel_F: Van_01_fuel_base_F {
         transportFuel = 0; //1k
     };
-    
+
     class Tank_F: Tank {
         GVAR(fuelCapacity) = 1200;
     };

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -31,13 +31,6 @@
                     exceptions[] = {"isNotInside"}; \
                     icon = QPATHTOF(ui\icon_refuel_interact.paa); \
                 }; \
-                class GVAR(Connect) { \
-                    displayName = CSTRING(Connect); \
-                    condition = QUOTE([ARR_2(_player,_target)] call FUNC(canConnectNozzle)); \
-                    statement = QUOTE([ARR_2(_player,_target)] call DFUNC(connectNozzle)); \
-                    exceptions[] = {"isNotInside"}; \
-                    icon = QPATHTOF(ui\icon_refuel_interact.paa); \
-                }; \
                 class GVAR(Return) { \
                     displayName = CSTRING(Return); \
                     condition = QUOTE([ARR_2(_player,_target)] call FUNC(canReturnNozzle)); \

--- a/addons/refuel/functions/fnc_canConnectNozzle.sqf
+++ b/addons/refuel/functions/fnc_canConnectNozzle.sqf
@@ -28,4 +28,4 @@ if (_target isKindOf "AllVehicles") then {
 !(isNull _nozzle ||
     {_engine} ||
     {(_target distance _unit) > REFUEL_ACTION_DISTANCE} ||
-    {!isNull (_target getVariable [QGVAR(nozzle), objNull])}) // TODO verify cant connect multiple fuel lines
+    {!isNull (_target getVariable [QGVAR(nozzle), objNull])})

--- a/addons/refuel/functions/fnc_canDisconnect.sqf
+++ b/addons/refuel/functions/fnc_canDisconnect.sqf
@@ -22,6 +22,7 @@ if (isNull _unit ||
     {isNull _nozzle} ||
     {!(_unit isKindOf "CAManBase")} ||
     {!local _unit} ||
+    {!isNull (_unit getVariable [QGVAR(nozzle), objNull])} ||
     {(_nozzle distance _unit) > REFUEL_ACTION_DISTANCE}) exitWith {false};
 
 private _sink = _nozzle getVariable [QGVAR(sink), objNull];

--- a/addons/refuel/functions/fnc_canReturnNozzle.sqf
+++ b/addons/refuel/functions/fnc_canReturnNozzle.sqf
@@ -18,6 +18,8 @@
 
 params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
 
-private _nozzle = _unit getVariable QGVAR(nozzle);
+private _nozzle = _unit getVariable [QGVAR(nozzle), objNull];
 
-(_this call FUNC(canConnectNozzle)) && {_target == (_nozzle getVariable [QGVAR(source), objNull])}
+(!isNull _nozzle) &&
+{_target distance _unit < REFUEL_ACTION_DISTANCE} &&
+{_target == (_nozzle getVariable [QGVAR(source), objNull])}

--- a/addons/refuel/functions/fnc_canTakeNozzle.sqf
+++ b/addons/refuel/functions/fnc_canTakeNozzle.sqf
@@ -22,6 +22,7 @@ if (isNull _unit ||
     {!(_unit isKindOf "CAManBase")} ||
     {!local _unit} ||
     {!alive _target} ||
+    {!isNull (_unit getVariable [QGVAR(nozzle), objNull])} ||
     {(_target distance _unit) > REFUEL_ACTION_DISTANCE}) exitWith {false};
 
 !(_target getVariable [QGVAR(isConnected), false]) && {!(_unit getVariable [QGVAR(isRefueling), false])}


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent taking or disconnecting a nozzle if already carrying one - fix #4332 
- Allow returning a nozzle into a refuel vehicle which has a nozzle attached - fix #4332 
- Remove duplicate nozzle connect action