### PR TITLE
Grenades - disable throw mode / keybind if advThrow

### DIFF
--- a/addons/grenades/XEH_postInit.sqf
+++ b/addons/grenades/XEH_postInit.sqf
@@ -15,6 +15,8 @@ GVAR(flashbangPPEffectCC) ppEffectForceInNVG true;
     if !([ACE_player, objNull, ["isNotEscorting"]] call EFUNC(common,canInteractWith)) exitWith {false};
     // Conditions: specific
     if (!([ACE_player] call CBA_fnc_canUseWeapon)) exitWith {false};
+    // Don't change mode or show hint if advanced throwing is active
+    if (ACE_player getVariable [QEGVAR(advanced_throwing,inHand), false]) exitWith {false};
 
     // Statement
     [] call FUNC(nextMode);

--- a/addons/grenades/functions/fnc_throwGrenade.sqf
+++ b/addons/grenades/functions/fnc_throwGrenade.sqf
@@ -61,6 +61,7 @@ if (getNumber (_config >> QGVAR(incendiary)) == 1) then {
 
 // handle throw modes
 if (_unit != ACE_player) exitWith {};
+if (_unit getVariable [QEGVAR(advanced_throwing,primed), false]) exitWith {LOG("advanced_throwing throw");};
 
 private _mode = missionNamespace getVariable [QGVAR(currentThrowMode), 0];
 


### PR DESCRIPTION
Neither of these should have really caused any problems, 
but this should make things cleaner when using advanced throwing.