### PR TITLE
Fix Advanced Throwing floating IR grenades and block vanilla throwing

### DIFF
--- a/addons/advanced_throwing/XEH_postInitClient.sqf
+++ b/addons/advanced_throwing/XEH_postInitClient.sqf
@@ -83,6 +83,13 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
 // Fired XEH
 [QGVAR(throwFiredXEH), FUNC(throwFiredXEH)] call CBA_fnc_addEventHandler;
 
+// Set last thrown time on Vanilla Throwing and Advanced Throwing
+["ace_firedPlayer", {
+    if (_weapon == "Throw") then {
+        _unit setVariable [QGVAR(lastThrownTime), CBA_missionTime];
+    };
+}] call CBA_fnc_addEventHandler;
+
 
 // Display handlers
 ["KeyDown", {_this call FUNC(onKeyDown)}] call CBA_fnc_addDisplayHandler;

--- a/addons/advanced_throwing/functions/fnc_canPrepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_canPrepare.sqf
@@ -4,7 +4,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: Pick Up <BOOL> (default: false)
+ * 1: Ignore Last Thrown Time <BOOL> (default: false)
  *
  * Return Value:
  * Can Prepare <BOOL>
@@ -16,10 +16,10 @@
  */
 #include "script_component.hpp"
 
-params ["_unit", ["_pickUp", false]];
+params ["_unit", ["_ignoreLastThrownTime", false]];
 
 // Don't delay when picking up
-if (_pickUp) then {
+if (_ignoreLastThrownTime) then {
     _unit setVariable [QGVAR(lastThrownTime), -1];
 };
 

--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -71,16 +71,25 @@ private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag 
 if (!([ACE_player] call FUNC(canThrow)) && {!_primed}) exitWith {
     if (!isNull _activeThrowable) then {
         deleteVehicle _activeThrowable;
+        // Restore muzzle ammo to original
+        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", 0]]);
     };
 };
 
 if (isNull _activeThrowable || {(_throwableType != typeOf _activeThrowable) && {!_primed}}) then {
     if (!isNull _activeThrowable) then {
         deleteVehicle _activeThrowable;
+        // Restore muzzle ammo to original
+        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", 0]]);
     };
     _activeThrowable = _throwableType createVehicleLocal [0, 0, 0];
     _activeThrowable enableSimulation false;
     ACE_player setVariable [QGVAR(activeThrowable), _activeThrowable];
+
+    // Set muzzle ammo to 0 to block vanilla throwing, save to variable for later restoration
+    private _muzzle = _throwableType call FUNC(getMuzzle);
+    ACE_player setVariable [QGVAR(activeMuzzle), [_muzzle, ACE_player ammo _muzzle]];
+    ACE_player setAmmo [_muzzle, 0];
 };
 
 // Exit in case of explosion in hand

--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-if (dialog || {!(ACE_player getVariable [QGVAR(inHand), false])} || {!([ACE_player] call FUNC(canPrepare))}) exitWith {
+if (dialog || {!(ACE_player getVariable [QGVAR(inHand), false])} || {!([ACE_player, true] call FUNC(canPrepare))}) exitWith {
     [ACE_player, "In dialog or no throwable in hand or cannot prepare throwable"] call FUNC(exitThrowMode);
 };
 

--- a/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
@@ -28,6 +28,8 @@ if !(_unit getVariable [QGVAR(inHand), false]) exitWith {};
 private _activeThrowable = _unit getVariable [QGVAR(activeThrowable), objNull];
 if !(_unit getVariable [QGVAR(primed), false]) then {
     deleteVehicle _activeThrowable;
+    // Set muzzle ammo to original
+    _unit setAmmo (_unit getVariable [QGVAR(activeMuzzle), ["", 0]]);
 } else {
     // Fix floating for throwables without proper physics (eg. IR Grenade)
     _activeThrowable setVelocity [0, 0, -0.1];
@@ -36,6 +38,7 @@ if !(_unit getVariable [QGVAR(primed), false]) then {
 _unit setVariable [QGVAR(inHand), false];
 _unit setVariable [QGVAR(primed), false];
 _unit setVariable [QGVAR(activeThrowable), objNull];
+_unit setVariable [QGVAR(activeMuzzle), ["", 0]];
 _unit setVariable [QGVAR(throwType), THROW_TYPE_DEFAULT];
 _unit setVariable [QGVAR(throwSpeed), THROW_SPEED_DEFAULT];
 _unit setVariable [QGVAR(dropMode), false];

--- a/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
@@ -25,8 +25,12 @@ if !(_unit getVariable [QGVAR(inHand), false]) exitWith {};
     systemChat format ["Exit Throw Mode: %1", _reason];
 #endif
 
+private _activeThrowable = _unit getVariable [QGVAR(activeThrowable), objNull];
 if !(_unit getVariable [QGVAR(primed), false]) then {
-    deleteVehicle (_unit getVariable [QGVAR(activeThrowable), objNull]);
+    deleteVehicle _activeThrowable;
+} else {
+    // Fix floating for throwables without proper physics (eg. IR Grenade)
+    _activeThrowable setVelocity [0, 0, -0.1];
 };
 
 _unit setVariable [QGVAR(inHand), false];

--- a/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
@@ -31,6 +31,7 @@ if !(_unit getVariable [QGVAR(primed), false]) then {
     // Set muzzle ammo to original
     _unit setAmmo (_unit getVariable [QGVAR(activeMuzzle), ["", 0]]);
 } else {
+    _unit setVariable [QGVAR(lastThrownTime), CBA_missionTime];
     // Fix floating for throwables without proper physics (eg. IR Grenade)
     _activeThrowable setVelocity [0, 0, -0.1];
 };

--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -26,7 +26,7 @@ private _throwableMag = (currentThrowable _unit) select 0;
 _unit removeItem _throwableMag;
 
 private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag >> "ammo");
-private _muzzle = _throwableMag call FUNC(getMuzzle);
+private _muzzle = (_unit getVariable [QGVAR(activeMuzzle), ["", 0]]) select 0;
 
 // Create actual throwable globally
 private _activeThrowableOld = _unit getVariable [QGVAR(activeThrowable), objNull];

--- a/addons/advanced_throwing/functions/fnc_throw.sqf
+++ b/addons/advanced_throwing/functions/fnc_throw.sqf
@@ -54,8 +54,6 @@ if (!(_unit getVariable [QGVAR(primed), false])) then {
         _activeThrowable setVelocity _newVelocity;
     };
 
-    _unit setVariable [QGVAR(lastThrownTime), CBA_missionTime];
-
     // Invoke listenable event
     ["ace_throwableThrown", [_unit, _activeThrowable]] call CBA_fnc_localEvent;
 }, [


### PR DESCRIPTION
**When merged this pull request will:**
- Fix floating primed IR grenades on exiting throw mode without throwing - fix #4362
- Block vanilla throwing while a throwable is prepared with Advanced Throwing - fix #4363
- Add last thrown time support for vanilla throwing
- Add last thrown time support for dropping primed throwable

Author should really be @BaerMitUmlaut here, I may have abused him and stole all his time by making him do the research. :worried: 