### PR TITLE
Fix Advanced Throwing vanilla throw block for primed throwables

### DIFF
--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -63,7 +63,7 @@ private _power = linearConversion [0, 180, _phi - 30, 1, 0.3, true];
 ACE_player setVariable [QGVAR(throwSpeed), _throwSpeed * _power];
 
 #ifdef DEBUG_MODE_FULL
-hintSilent format ["Heading: %1\nPower: %2\nSpeed: %3\nThrowMag: %4", _phi, _power, _throwSpeed * _power, _throwableMag];
+hintSilent format ["Heading: %1\nPower: %2\nSpeed: %3\nThrowMag: %4\nMuzzle: %5", _phi, _power, _throwSpeed * _power, _throwableMag, ACE_player getVariable [QGVAR(activeMuzzle), ""]];
 #endif
 
 private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag >> "ammo");
@@ -71,25 +71,25 @@ private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag 
 if (!([ACE_player] call FUNC(canThrow)) && {!_primed}) exitWith {
     if (!isNull _activeThrowable) then {
         deleteVehicle _activeThrowable;
-        // Restore muzzle ammo to original
-        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", 0]]);
+        // Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
+        ACE_player setAmmo [ACE_player getVariable [QGVAR(activeMuzzle), ""], 1];
     };
 };
 
 if (isNull _activeThrowable || {(_throwableType != typeOf _activeThrowable) && {!_primed}}) then {
     if (!isNull _activeThrowable) then {
         deleteVehicle _activeThrowable;
-        // Restore muzzle ammo to original
-        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", 0]]);
+        // Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
+        ACE_player setAmmo [ACE_player getVariable [QGVAR(activeMuzzle), ""], 1];
     };
     _activeThrowable = _throwableType createVehicleLocal [0, 0, 0];
     _activeThrowable enableSimulation false;
     ACE_player setVariable [QGVAR(activeThrowable), _activeThrowable];
 
-    // Set muzzle ammo to 0 to block vanilla throwing, save to variable for later restoration
-    private _muzzle = _throwableType call FUNC(getMuzzle);
-    ACE_player setVariable [QGVAR(activeMuzzle), [_muzzle, ACE_player ammo _muzzle]];
+    // Set muzzle ammo to 0 to block vanilla throwing (can only be 0 or 1)
+    private _muzzle = _throwableMag call FUNC(getMuzzle);
     ACE_player setAmmo [_muzzle, 0];
+    ACE_player setVariable [QGVAR(activeMuzzle), _muzzle];
 };
 
 // Exit in case of explosion in hand

--- a/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
@@ -28,18 +28,19 @@ if !(_unit getVariable [QGVAR(inHand), false]) exitWith {};
 private _activeThrowable = _unit getVariable [QGVAR(activeThrowable), objNull];
 if !(_unit getVariable [QGVAR(primed), false]) then {
     deleteVehicle _activeThrowable;
-    // Set muzzle ammo to original
-    _unit setAmmo (_unit getVariable [QGVAR(activeMuzzle), ["", 0]]);
 } else {
     _unit setVariable [QGVAR(lastThrownTime), CBA_missionTime];
     // Fix floating for throwables without proper physics (eg. IR Grenade)
     _activeThrowable setVelocity [0, 0, -0.1];
 };
 
+// Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
+_unit setAmmo [_unit getVariable [QGVAR(activeMuzzle), ""], 1];
+
 _unit setVariable [QGVAR(inHand), false];
 _unit setVariable [QGVAR(primed), false];
 _unit setVariable [QGVAR(activeThrowable), objNull];
-_unit setVariable [QGVAR(activeMuzzle), ["", 0]];
+_unit setVariable [QGVAR(activeMuzzle), ""];
 _unit setVariable [QGVAR(throwType), THROW_TYPE_DEFAULT];
 _unit setVariable [QGVAR(throwSpeed), THROW_SPEED_DEFAULT];
 _unit setVariable [QGVAR(dropMode), false];

--- a/addons/advanced_throwing/functions/fnc_prepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_prepare.sqf
@@ -23,12 +23,15 @@ if (_unit getVariable [QGVAR(inHand), false]) exitWith {
     TRACE_1("inHand",_unit);
     if (!(_unit getVariable [QGVAR(primed), false])) then {
         TRACE_1("not primed",_unit);
+        // Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
+        // selectNextGrenade relies on muzzles array (setAmmo 0 removes the muzzle from the array and current can't be found, cycles between 0 and 1 muzzles)
+        ACE_player setAmmo [ACE_player getVariable [QGVAR(activeMuzzle), ""], 1];
         [_unit] call EFUNC(weaponselect,selectNextGrenade);
     };
 };
 
 // Try selecting next throwable if none currently selected
-if ((isNull (_unit getVariable [QGVAR(activeThrowable), objNull])) && {(currentThrowable _unit) isEqualTo []} && {!([_unit] call EFUNC(weaponselect,selectNextGrenade))}) exitWith {
+if (isNull (_unit getVariable [QGVAR(activeThrowable), objNull]) && {(currentThrowable _unit) isEqualTo []} && {!([_unit] call EFUNC(weaponselect,selectNextGrenade))}) exitWith {
     TRACE_1("no throwables",_unit);
 };
 

--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -26,7 +26,10 @@ private _throwableMag = (currentThrowable _unit) select 0;
 _unit removeItem _throwableMag;
 
 private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag >> "ammo");
-private _muzzle = (_unit getVariable [QGVAR(activeMuzzle), ["", 0]]) select 0;
+private _muzzle = _unit getVariable [QGVAR(activeMuzzle), ""];
+
+// Set muzzle ammo to 0 to block vanilla throwing (can only be 0 or 1), removeItem above resets it
+_unit setAmmo [_muzzle, 0];
 
 // Create actual throwable globally
 private _activeThrowableOld = _unit getVariable [QGVAR(activeThrowable), objNull];

--- a/addons/weaponselect/XEH_postInit.sqf
+++ b/addons/weaponselect/XEH_postInit.sqf
@@ -72,6 +72,8 @@ if (!hasInterface) exitWith {};
 ["ACE3 Weapons", QGVAR(SelectGrenadeFrag), localize LSTRING(SelectGrenadeFrag), {
     // Conditions: canInteract
     if !([ACE_player, ACE_player, ["isNotInside", "isNotEscorting"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    // Don't change mode or show hint if advanced throwing is active
+    if (ACE_player getVariable [QEGVAR(advanced_throwing,inHand), false]) exitWith {false};
 
     // Statement
     [ACE_player, 1] call FUNC(selectNextGrenade);
@@ -83,6 +85,8 @@ if (!hasInterface) exitWith {};
 ["ACE3 Weapons", QGVAR(SelectGrenadeOther), localize LSTRING(SelectGrenadeOther), {
     // Conditions: canInteract
     if !([ACE_player, ACE_player, ["isNotInside", "isNotEscorting"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    // Don't change mode or show hint if advanced throwing is active
+    if (ACE_player getVariable [QEGVAR(advanced_throwing,inHand), false]) exitWith {false};
 
     // Statement
     [ACE_player, 2] call FUNC(selectNextGrenade);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix vanilla throw block for primed throwables.
- Simplify muzzle ammo handling (can only be 0 or 1, setting it to 1 without an applicable throwable in the inventory won't have any impact).
- Fix select next grenade cycling between first 2 throwables due to `setAmmo` - fix #4375 

Sent to @alganthe for testing, he somehow keeps finding bugs with this magical _bugless_ throwing...