### PR TITLE
Add ammo box cookoff

### DIFF
--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -6,6 +6,12 @@ class ACE_Settings {
         value = 1;
         typeName = "BOOL";
     };
+    class GVAR(enableAmmobox) {
+        displayName = CSTRING(enableBoxCookoff_name);
+        description = CSTRING(enableBoxCookoff_tooltip);
+        value = 1;
+        typeName = "BOOL";
+    };
     class GVAR(enableAmmoCookoff) {
         displayName = CSTRING(enableAmmoCookoff_name);
         description = CSTRING(enableAmmoCookoff_tooltip);

--- a/addons/cookoff/XEH_PREP.hpp
+++ b/addons/cookoff/XEH_PREP.hpp
@@ -2,6 +2,7 @@
 PREP(handleDamage);
 PREP(engineFire);
 PREP(cookOff);
+PREP(cookOffBox);
 PREP(blowOffTurret);
 PREP(secondaryExplosions);
 PREP(detonateAmmunition);

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -2,6 +2,7 @@
 
 [QGVAR(engineFire), FUNC(engineFire)] call CBA_fnc_addEventHandler;
 [QGVAR(cookOff), FUNC(cookOff)] call CBA_fnc_addEventHandler;
+[QGVAR(cookOffBox), FUNC(cookOffBox)] call CBA_fnc_addEventHandler;
 
 GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
@@ -46,7 +47,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 ["ReammoBox_F", "init", {
     (_this select 0) addEventHandler ["HandleDamage", {
-        if (GVAR(enable)) then {
+        if (GVAR(enableAmmobox)) then {
             ["box", _this] call FUNC(handleDamage);
         };
     }];

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -44,17 +44,23 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     }];
 }, nil, ["Wheeled_APC_F"], true] call CBA_fnc_addClassEventHandler;
 
+["ReammoBox_F", "init", {
+    (_this select 0) addEventHandler ["HandleDamage", {
+        if (GVAR(enable)) then {
+            ["box", _this] call FUNC(handleDamage);
+        };
+    }];
+}, nil, nil, true] call CBA_fnc_addClassEventHandler;
+
 // secondary explosions
 ["AllVehicles", "killed", {
-    if ((_this select 0) isKindOf "StaticWeapon") exitWith {};
-        
     if (GVAR(enable)) then {
         (_this select 0) call FUNC(secondaryExplosions);
         if (GVAR(enableAmmoCookoff)) then {
             [(_this select 0), magazinesAmmo (_this select 0)] call FUNC(detonateAmmunition);
         };
     };
-}, nil, ["Man"]] call CBA_fnc_addClassEventHandler;
+}, nil, ["Man","StaticWeapon"]] call CBA_fnc_addClassEventHandler;
 
 // blow off turret effect
 ["Tank", "killed", {

--- a/addons/cookoff/functions/fnc_cookOffBox.sqf
+++ b/addons/cookoff/functions/fnc_cookOffBox.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: SilentSpike
+ * Author: KoffeinFlummi, commy2, SilentSpike
  * Start a cook-off in the given ammo box.
  *
  * Arguments:
@@ -20,8 +20,63 @@ params ["_box"];
 if (_box getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _box setVariable [QGVAR(isCookingOff), true];
 
-// Fire effect goes here, setDamage 1 at the end (boxes sink into ground so needs plenty of time for cookoff to occur)
+[QGVAR(cookOffBox), _box] call CBA_fnc_remoteEvent;
 
-// These functions are smart and do all the work
-_box call FUNC(secondaryExplosions);
-[_box, magazinesAmmo _box] call FUNC(detonateAmmunition);
+[{
+    params ["_box"];
+
+    // Box will start smoking
+    private _smoke = "#particlesource" createVehicleLocal [0,0,0];
+    _smoke setParticleClass "AmmoSmokeParticles2";
+    _smoke attachTo [_box, [0,0,0]];
+
+    private _effects = [_smoke];
+
+    if (isServer) then {
+        private _sound = createSoundSource ["Sound_Fire", position _box, [], 0];
+        _effects pushBack _sound;
+    };
+
+    // These functions are smart and do all the cooking off work
+    if (local _box) then {
+        _box call FUNC(secondaryExplosions);
+        [_box, magazinesAmmo _box] call FUNC(detonateAmmunition);
+    };
+
+    [{
+        params ["_box", "_effects"];
+
+        // This shit is busy being on fire, magazines aren't accessible/usable
+        if (local _box) then {
+            clearMagazineCargoGlobal _box;
+        };
+
+        private _light = "#lightpoint" createVehicleLocal [0,0,0];
+        _light setLightBrightness 0.7;
+        _light setLightAmbient [1,0.4,0.15];
+        _light setLightColor [1,0.4,0.15];
+        _light lightAttachObject [_box, [0,0,0]];
+
+        _effects pushBack _light;
+
+        // Light the fire
+        private _fire = "#particlesource" createVehicleLocal [0,0,0];
+        _fire setParticleClass "AmmoBulletCore";
+        _fire attachTo [_box, [0,0,0]];
+
+        _effects pushBack _fire;
+
+        [{
+            params ["_box", "_effects"];
+
+            {
+                deleteVehicle _x;
+            } forEach _effects;
+
+            if (local _box) then {
+                _box setDamage 1;
+            };
+        }, [_box, _effects], 60] call CBA_fnc_waitAndExecute; // Give signifcant time for ammo cookoff to occur (perhaps keep the box alive until all cooked off?)
+    }, [_box, _effects], 3 + random 15] call CBA_fnc_waitAndExecute;
+}, _box, 0.5 + random 5] call CBA_fnc_waitAndExecute;
+

--- a/addons/cookoff/functions/fnc_cookOffBox.sqf
+++ b/addons/cookoff/functions/fnc_cookOffBox.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: SilentSpike
+ * Start a cook-off in the given ammo box.
+ *
+ * Arguments:
+ * 0: Ammo box <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_box] call ace_cookoff_fnc_cookOffBox
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_box"];
+
+if (_box getVariable [QGVAR(isCookingOff), false]) exitWith {};
+_box setVariable [QGVAR(isCookingOff), true];
+
+// Fire effect goes here, setDamage 1 at the end (boxes sink into ground so needs plenty of time for cookoff to occur)
+
+// These functions are smart and do all the work
+_box call FUNC(secondaryExplosions);
+[_box, magazinesAmmo _box] call FUNC(detonateAmmunition);

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -58,12 +58,12 @@ if (_simulationType == "car") exitWith {
 
 if (_simulationType == "tank") exitWith {
     // determine ammo storage location
-    private _ammoLocationHitpoint = getText (_vehicle  call CBA_fnc_getObjectConfig >> QGVAR(ammoLocation));
+    private _ammoLocationHitpoint = getText (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(ammoLocation));
 
     if (_hitIndex in (GVAR(cacheTankDuplicates) getVariable (typeOf _vehicle))) then {
         _hitpoint = "#subturret";
     };
-    
+
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
         if (_damage > 0.5 && {random 1 < 0.7}) then {
@@ -77,6 +77,25 @@ if (_simulationType == "tank") exitWith {
 
     // prevent destruction, let cook-off handle it if necessary
     if (_hitpoint in ["hithull", "hitfuel", "#structural"]) then {
+        _damage min 0.89
+    } else {
+        _damage
+    };
+};
+
+if (_simulationType == "box") exitWith {
+    if (_hitpoint == "#structural" && {IS_EXPLOSIVE_AMMO(_ammo)}) then {
+        // High chance of cook-off when hit by an explosive
+        if (_damage > 0.5 && {random 1 < 0.7}) then {
+            _vehicle call FUNC(cookOffBox);
+        } else {
+            _hitpoint = "#death";
+            _damage = 1;
+        };
+    };
+
+    if (_hitpoint == "#structural") then {
+        // prevent destruction, let cook-off handle it if necessary
         _damage min 0.89
     } else {
         _damage

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -85,12 +85,9 @@ if (_simulationType == "tank") exitWith {
 
 if (_simulationType == "box") exitWith {
     if (_hitpoint == "#structural" && {IS_EXPLOSIVE_AMMO(_ammo)}) then {
-        // High chance of cook-off when hit by an explosive
-        if (_damage > 0.5 && {random 1 < 0.7}) then {
+        // Always catch fire when hit by an explosive
+        if (_damage > 0.5) then {
             _vehicle call FUNC(cookOffBox);
-        } else {
-            _hitpoint = "#death";
-            _damage = 1;
         };
     };
 

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="CookOff">
         <Key ID="STR_ACE_CookOff_enable_name">
@@ -12,6 +12,12 @@
             <German>Ermöglicht Cook-off und zugehörige Fahrzeug-Zerstörungseffekte.</German>
             <Czech>Povolí explozi munice a její následné ničivé efekty.</Czech>
             <Russian>Включает воспламенение и сопутствующие эффекты повреждения техники.</Russian>
+        </Key>
+        <Key ID="STR_ACE_CookOff_enable_name">
+            <English>Enable ammo box cook off</English>
+        </Key>
+        <Key ID="STR_ACE_CookOff_enable_tooltip">
+            <English>Enables cooking off of ammo boxes.</English>
         </Key>
         <Key ID="STR_ACE_CookOff_enableAmmoCookoff_name">
             <English>Enable Ammunition cook off</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add an option to enable ammo boxes to cook off using the new ammunition detination
- Currently only occurs when hit with explosive ammo, should look into things like tracers and the incendiary grenade
- Uses the vanilla ammo box particle effects for smooth transition to actual destruction and consistent look

Note that ammo boxes must be kept "alive" until cook off is finished, because their destruction simulation makes them sink and disappear. Hence cook off is initiated from the handle damage event - unlike vehicles where their cook off occurs after destruction has occurred.