### PR TITLE
Add object attribute to disable cookoff for individual vehicles

### DIFF
--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -1,0 +1,21 @@
+
+class Cfg3DEN {
+    class Object {
+        class AttributeCategories {
+            class ace_attributes {
+                class Attributes {
+                    class GVAR(enable) {
+                        property = QGVAR(enable);
+                        control = "CheckboxInverted";
+                        displayName = CSTRING(enable_name);
+                        tooltip = CSTRING(enable_tooltip);
+                        expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
+                        typeName = "BOOL";
+                        condition = "objectVehicle";
+                        defaultValue = "(true)"; // fix pbo project preprocessing bug
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -6,7 +6,7 @@ class Cfg3DEN {
                 class Attributes {
                     class GVAR(enable) {
                         property = QGVAR(enable);
-                        control = "CheckboxInverted";
+                        control = "Checkbox";
                         displayName = CSTRING(enable_name);
                         tooltip = CSTRING(enable_tooltip);
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -22,7 +22,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     };
 
     _vehicle addEventHandler ["HandleDamage", {
-        if (GVAR(enable)) then {
+        if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
@@ -30,7 +30,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 ["Wheeled_APC_F", "init", {
     (_this select 0) addEventHandler ["HandleDamage", {
-        if (GVAR(enable)) then {
+        if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
@@ -38,7 +38,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 ["Car", "init", {
     (_this select 0) addEventHandler ["HandleDamage", {
-        if (GVAR(enable)) then {
+        if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
             ["car", _this] call FUNC(handleDamage);
         };
     }];
@@ -46,14 +46,14 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // secondary explosions
 ["AllVehicles", "killed", {
-    if (GVAR(enable)) then {
+    if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
         (_this select 0) call FUNC(secondaryExplosions);
     };
 }, nil, ["Man"]] call CBA_fnc_addClassEventHandler;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if (GVAR(enable)) then {
+    if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
         (_this select 0) call FUNC(blowOffTurret);
     };
 }] call CBA_fnc_addClassEventHandler;

--- a/addons/cookoff/config.cpp
+++ b/addons/cookoff/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches {
 };
 
 #include "ACE_Settings.hpp"
+#include "CfgEden.hpp"
 #include "CfgEventHandlers.hpp"
 
 #include "CfgCloudlets.hpp"

--- a/docs/wiki/framework/cookoff-framework.md
+++ b/docs/wiki/framework/cookoff-framework.md
@@ -1,0 +1,29 @@
+---
+layout: wiki
+title: Cook Off Framework
+description: Explains the Cook off system for developers & mission makers.
+group: framework
+order: 5
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 7
+  patch: 0
+---
+
+## 1. Disabling / Enabling Cook off for individual vehicles
+
+You can dynamically enable and/or disable vehicle cook off for individual vehicles by using `setVariable`:
+
+```
+VEHICLE setVariable ["ace_cookoff_enable", true, true];
+```
+
+The above will enable cook off for that specific vehicle, no matter the mission settings.
+
+Likewise, cook off can also be disabled for a specific vehicle:
+
+```
+VEHICLE setVariable ["ace_cookoff_enable", false, true];
+```


### PR DESCRIPTION
When a vehicle is destroyed / killed, it will start secondairy explosives. If a mission has a single vehicle that the misson maker wishes to be destroyed, right now it will start secondairy explosives (with ammo cook off (#4376) it becomes a real party). This PR allows mission makers to disable cook off for individual vehicles.

This PR also adds initial framework documentation for cook off.