### PR TITLE
End path drawing when passing through Geom/Fire

### DIFF
--- a/addons/advanced_throwing/functions/fnc_drawArc.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawArc.sqf
@@ -47,11 +47,15 @@ for "_i" from 0.05 to 1.45 step 0.1 do {
 
     if (_newTrajASL distance (getPosASLVisual ACE_player) <= 20) then {
         if ((ASLToATL _newTrajASL) select 2 <= 0) then {
-            _cross = 1
+            _cross = 1; // 1: Distance Limit (Green)
         } else {
             // Even vanilla throwables go through glass, only "GEOM" LOD will stop it but that will also stop it when there is glass in a window
-            if (lineIntersects [_prevTrajASL, _newTrajASL]) then {
-                _cross = 2;
+            if (lineIntersects [_prevTrajASL, _newTrajASL]) then { // Checks the "VIEW" LOD
+                _cross = 2; // 2: View LOD Block (Red)
+            } else {
+                if (!((lineIntersectsSurfaces [_prevTrajASL, _newTrajASL, _activeThrowable, ACE_player, true, 1, "GEOM", "FIRE"]) isEqualTo [])) then {
+                    _cross = 3; // 3: GEOM/FIRE LOD Block (Yellow) - pass a3 bulding glass, but blocked on some CUP glass
+                };
             };
         };
 
@@ -60,7 +64,7 @@ for "_i" from 0.05 to 1.45 step 0.1 do {
         private _movePerc = linearConversion [3, 0, vectorMagnitude (velocity ACE_player), 0, 1, true];
         _alpha = _alpha * _movePerc;
 
-        private _col = [ [1, 1, 1, _alpha], [0, 1, 0, _alpha], [1, 0, 0, _alpha] ] select _cross;
+        private _col = [ [1, 1, 1, _alpha], [0, 1, 0, _alpha], [1, 0, 0, _alpha], [1, 1, 0, _alpha] ] select _cross;
 
         if (_cross != 2 && {lineIntersects [eyePos ACE_player, _newTrajASL]}) then {
             _col set [3, 0.1]

--- a/docs/wiki/feature/advanced-throwing.md
+++ b/docs/wiki/feature/advanced-throwing.md
@@ -27,11 +27,24 @@ After cooking a grenade any mode can be used to throw it further or it can simpl
 
 Grenade will be thrown where you are currently looking at, free-look (including TrackIR) is fully supported. However, the further to the side and back you are looking, the lower the throw power will be.
 
-### 1.2 Rethrowing
+### 1.2 Indicators
+
+When enabled, an arc of colored filled circles will indicate the path grenade will fly through.
+
+Color | Meaning
+----- | --------
+White | Flight path
+Green | Collision with ground surface
+Red | Collision with object
+Yellow | Possible collision
+
+Possible collisions are collisions that might happen, but there is also a chance that the grenade will not collide with that object. It is impossible to predict in many cases due to different object configurations.
+
+### 1.3 Rethrowing
 
 Advanced Throwing allows you to pick up grenades that have already been thrown. You have to be very close to it to effectively pick it up. Useful for rethrowing smoke grenades or repositioning chemlights. Frag grenades can also be thrown back, for example out of the house, however doing so is extremely risky.
 
-### 1.3 Settings
+### 1.4 Settings
 
 Various settings can be set according to your likeness. Next to global toggle to disable Advanced Throwing there are settings to hide the throw arc indicating approximate throw distance and the arc it will fly through and hide mouse controls. Additionally for server administrators and mission makers, picking up grenades can be entirely disabled, as well as a setting to enable picking up attached items such as chemlights attached to vehicles or other player's shoulder.
 


### PR DESCRIPTION
Ends grenade arc drawing when throw will collide with the GEOM or FIRE LOD.

Unfortunately many CUP buildings have bulletproof windows that do not pass grenades.
There are also other cases where we could show a throw as being safe when it will be blocked such as A3 Gratings.
However this also could introduce warnings when the shot will be fine.

But I believe the worst thing we can do is to tell the user that a shot will be safe when it could fail and kill their team.  Warning about a "false negative" is far less critical.

- Neither of these shots are possible, but would have been shown as safe:
![20160912203918_1](https://cloud.githubusercontent.com/assets/9376747/18458972/8f55c816-792b-11e6-9671-3d8ff2480875.jpg)

- This shot is actually fine, but we still show a warning:
![20160912205522_1](https://cloud.githubusercontent.com/assets/9376747/18459007/bb38ac5a-792b-11e6-86da-883392af0619.jpg)
