### PR TITLE
Escape jekyll code in documentation guidelines page

### DIFF
--- a/docs/wiki/development/documentation-guidelines-and-tips.md
+++ b/docs/wiki/development/documentation-guidelines-and-tips.md
@@ -66,7 +66,7 @@ Short description of sub-feature 2.
 
 ## 3. Dependencies
 
-{% include dependencies_list.md component="ace_something" %}
+{% raw %}{% include dependencies_list.md component="ace_something" %}{% endraw %}
 
 ## 4. Guides
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix large white space due to Jekyll code being parsed inside markdown code block.