### PR TITLE
incendiary and cookoff improvements

### DIFF
--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -53,4 +53,16 @@ class CfgVehicles {
     class O_MBT_02_cannon_F: O_MBT_02_base_F {
         GVAR(turret)[] = {QGVAR(Turret_MBT_02),{0,-1,0}};
     };
+
+    class MRAP_01_base_F: Car_F {
+        GVAR(engineSmokeOffset)[] = {0,-4,2};
+    };
+
+    class MRAP_02_base_F: Car_F {
+        GVAR(engineSmokeOffset)[] = {0,-4,2};
+    };
+
+    class MRAP_03_base_F: Car_F {
+        GVAR(engineSmokeOffset)[] = {0,-4,2};
+    };
 };

--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -55,14 +55,18 @@ class CfgVehicles {
     };
 
     class MRAP_01_base_F: Car_F {
-        GVAR(engineSmokeOffset)[] = {0,-4,2};
+        GVAR(engineSmokeOffset)[] = {0,-2,0};
     };
 
     class MRAP_02_base_F: Car_F {
-        GVAR(engineSmokeOffset)[] = {0,-4,2};
+        GVAR(engineSmokeOffset)[] = {0,-2,0};
     };
 
     class MRAP_03_base_F: Car_F {
-        GVAR(engineSmokeOffset)[] = {0,-4,2};
+        GVAR(engineSmokeOffset)[] = {0,-2,0};
+    };
+
+    class Quadbike_01_base_F: Car_F {
+        GVAR(engineSmokeOffset)[] = {0,1,0};
     };
 };

--- a/addons/cookoff/functions/fnc_engineFire.sqf
+++ b/addons/cookoff/functions/fnc_engineFire.sqf
@@ -24,11 +24,17 @@ if (local _vehicle) then {
     [QGVAR(engineFire), _vehicle] call CBA_fnc_remoteEvent;
 };
 
+private _offset = getArray (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(engineSmokeOffset));
+
+if (_offset isEqualTo []) then {
+    _offset = [0,-2,2];
+};
+
 private _position = [
     0,
-    (boundingBoxReal _vehicle select 1 select 1) - 4,
-    (boundingBoxReal _vehicle select 0 select 2) + 2
-];
+    (boundingBoxReal _vehicle select 1 select 1),
+    (boundingBoxReal _vehicle select 0 select 2)
+] vectorAdd _offset;
 
 private _smoke = "#particlesource" createVehicleLocal [0,0,0];
 _smoke setParticleClass "ObjectDestructionSmoke1_2Smallx";

--- a/addons/cookoff/functions/fnc_engineFire.sqf
+++ b/addons/cookoff/functions/fnc_engineFire.sqf
@@ -27,13 +27,13 @@ if (local _vehicle) then {
 private _offset = getArray (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(engineSmokeOffset));
 
 if (_offset isEqualTo []) then {
-    _offset = [0,-2,2];
+    _offset = [0,0,0];
 };
 
 private _position = [
     0,
-    (boundingBoxReal _vehicle select 1 select 1),
-    (boundingBoxReal _vehicle select 0 select 2)
+    (boundingBoxReal _vehicle select 1 select 1) - 2,
+    (boundingBoxReal _vehicle select 0 select 2) + 2
 ] vectorAdd _offset;
 
 private _smoke = "#particlesource" createVehicleLocal [0,0,0];

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -70,7 +70,7 @@ if (_simulationType == "tank") exitWith {
             _vehicle call FUNC(cookOff);
         };
     } else {
-        if (_hitpoint in ["hitbody", "hitturret", "#structural"] && {_newDamage > 0.6 + random 0.3}) then {
+        if (_hitpoint in ["hithull", "hitturret", "#structural"] && {_newDamage > 0.6 + random 0.3}) then {
             _vehicle call FUNC(cookOff);
         };
     };

--- a/addons/grenades/functions/fnc_incendiary.sqf
+++ b/addons/grenades/functions/fnc_incendiary.sqf
@@ -169,6 +169,7 @@ private _config = _vehicle call CBA_fnc_getObjectConfig;
 private _fnc_isWheelHitPoint = {
     params ["_selectionName"];
 
+    // wheels must use a selection named "wheel_X_Y_steering" for PhysX to work
     _selectionName select [0, 6] == "wheel_" && {
         _selectionName select [count _selectionName - 9] == "_steering"
     } // return
@@ -177,7 +178,6 @@ private _fnc_isWheelHitPoint = {
 {
     private _wheelSelection = getText (_config >> "HitPoints" >> _x >> "name");
 
-    // wheels must use a selection named "wheel_X_Y_steering"
     if (_wheelSelection call _fnc_isWheelHitPoint) then {
         private _wheelPosition = _vehicle modelToWorld (_vehicle selectionPosition _wheelSelection);
 

--- a/addons/grenades/functions/fnc_incendiary.sqf
+++ b/addons/grenades/functions/fnc_incendiary.sqf
@@ -144,7 +144,7 @@ if (isServer) then {
         //systemChat format ["burn: %1", _x];
 
         // --- destroy nearby static weapons and ammo boxes
-        if (_x isKindOf "StaticWeapon" || {_x isKindOf "ReammoBox_F"}) then {
+        if (_x isKindOf "StaticWeapon" || {_x isKindOf "ReammoBox_F"} || {_x isKindOf "ACE_RepairItem_Base"}) then {
             _x setDamage 1;
         };
 
@@ -158,11 +158,39 @@ if (isServer) then {
     };
 } forEach (_position nearObjects EFFECT_SIZE);
 
-// --- burn car engine
+// --- damage local vehicle
 private _vehicle = _position nearestObject "Car";
-if (!local _vehicle || {_vehicle isKindOf "Wheeled_APC_F"}) exitWith {};
 
-private _engineSelection = getText (_vehicle call CBA_fnc_getObjectConfig >> "HitPoints" >> "HitEngine" >> "name");
+if (!local _vehicle) exitWith {};
+
+private _config = _vehicle call CBA_fnc_getObjectConfig;
+
+// --- burn tyres
+private _fnc_isWheelHitPoint = {
+    params ["_selectionName"];
+
+    _selectionName select [0, 6] == "wheel_" && {
+        _selectionName select [count _selectionName - 9] == "_steering"
+    } // return
+};
+
+{
+    private _wheelSelection = getText (_config >> "HitPoints" >> _x >> "name");
+
+    // wheels must use a selection named "wheel_X_Y_steering"
+    if (_wheelSelection call _fnc_isWheelHitPoint) then {
+        private _wheelPosition = _vehicle modelToWorld (_vehicle selectionPosition _wheelSelection);
+
+        if (_position distance _wheelPosition < EFFECT_SIZE * 2) then {
+            _vehicle setHit [_wheelSelection, 1];
+        };
+    };
+} forEach (getAllHitPointsDamage _vehicle param [0, []]);
+
+// --- burn car engine
+if (_vehicle isKindOf "Wheeled_APC_F") exitWith {};
+
+private _engineSelection = getText (_config >> "HitPoints" >> "HitEngine" >> "name");
 private _enginePosition = _vehicle modelToWorld (_vehicle selectionPosition _engineSelection);
 
 if (_position distance _enginePosition < EFFECT_SIZE * 2) then {

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -15,7 +15,7 @@
         }; \
     };
 
-class CBA_Extended_EventHandlers;
+class CBA_Extended_EventHandlers_base;
 
 class CfgVehicles {
     class ACE_Module;
@@ -311,14 +311,14 @@ class CfgVehicles {
     class ThingX;
     class ACE_RepairItem_Base: ThingX {
         class EventHandlers {
-            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers_base {};
         };
 
         icon = "iconObject_circle";
         mapSize = 0.7;
         accuracy = 0.2;
         vehicleClass = "ACE_Logistics_Items";
-        destrType = "DestructBuilding";
+        destrType = "DesturctNo"; // scripted delayed destruction
     };
 
     class ACE_Track: ACE_RepairItem_Base {

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -318,7 +318,7 @@ class CfgVehicles {
         mapSize = 0.7;
         accuracy = 0.2;
         vehicleClass = "ACE_Logistics_Items";
-        destrType = "DesturctNo";
+        destrType = "DestructBuilding";
     };
 
     class ACE_Track: ACE_RepairItem_Base {

--- a/addons/repair/XEH_preInit.sqf
+++ b/addons/repair/XEH_preInit.sqf
@@ -4,4 +4,10 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
+["ACE_RepairItem_Base", "killed", {
+    params ["_object"];
+
+    [{deleteVehicle _this}, _object, 5] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addClassEventHandler;
+
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- destroyable wheels (including spare wheels)
- `GVAR(engineSmokeOffset)` for smoke effect
- fix `hithull` vs `hitbody` mixup
- delete destroyed `ACE_RepairItem` objects (after 5 seconds)

todo:
- [x] fix spare item destruction effect
- [x] quad smoke offset