### PR TITLE
auto add blown off turrets to curator

### DIFF
--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -11,15 +11,17 @@ class CfgVehicles {
     class ThingX;
     class GVAR(Turret_MBT_01): ThingX {
         author = ECSTRING(common,ACETeam);
-        _generalMacro = QGVAR(TurretDummy);
+        _generalMacro = QGVAR(Turret_MBT_01);
         scope = 1;
+        displayName = CSTRING(generic_turret_wreck);
         model = "\A3\Structures_F\Wrecks\Wreck_Slammer_turret_F.p3d";
         icon = "\A3\armor_f_gamma\MBT_01\Data\ui\map_slammer_mk4_ca.paa";
     };
     class GVAR(Turret_MBT_02): ThingX {
         author = ECSTRING(common,ACETeam);
-        _generalMacro = QGVAR(TurretDummy);
+        _generalMacro = QGVAR(Turret_MBT_02);
         scope = 1;
+        displayName = CSTRING(generic_turret_wreck);
         model = "\A3\Structures_F\Wrecks\Wreck_T72_turret_F.p3d";
         icon = "\A3\armor_f_gamma\MBT_02\Data\UI\map_MBT_02_ca.paa";
     };

--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -14,12 +14,14 @@ class CfgVehicles {
         _generalMacro = QGVAR(TurretDummy);
         scope = 1;
         model = "\A3\Structures_F\Wrecks\Wreck_Slammer_turret_F.p3d";
+        icon = "\A3\armor_f_gamma\MBT_01\Data\ui\map_slammer_mk4_ca.paa";
     };
     class GVAR(Turret_MBT_02): ThingX {
         author = ECSTRING(common,ACETeam);
         _generalMacro = QGVAR(TurretDummy);
         scope = 1;
         model = "\A3\Structures_F\Wrecks\Wreck_T72_turret_F.p3d";
+        icon = "\A3\armor_f_gamma\MBT_02\Data\UI\map_MBT_02_ca.paa";
     };
 
     class Tank;

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -8,37 +8,45 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 // cookoff and burning engine
 ["Tank", "init", {
     params ["_vehicle"];
+
     private _typeOf = typeOf _vehicle;
+
     if (isNil {GVAR(cacheTankDuplicates) getVariable _typeOf}) then {
         private _hitpoints = (getAllHitPointsDamage _vehicle param [0, []]) apply {toLower _x};
         private _duplicateHitpoints = [];
+
         {
             if ((_x != "") && {_x in (_hitpoints select [0,_forEachIndex])}) then {
                 _duplicateHitpoints pushBack _forEachIndex;
             };
         } forEach _hitpoints;
+
         TRACE_2("dupes",_typeOf,_duplicateHitpoints);
         GVAR(cacheTankDuplicates) setVariable [_typeOf, _duplicateHitpoints];
     };
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
 }, nil, nil, true] call CBA_fnc_addClassEventHandler;
 
 ["Wheeled_APC_F", "init", {
-    (_this select 0) addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
+    params ["_vehicle"];
+
+    _vehicle addEventHandler ["HandleDamage", {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
 }, nil, nil, true] call CBA_fnc_addClassEventHandler;
 
 ["Car", "init", {
-    (_this select 0) addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
+    params ["_vehicle"];
+
+    _vehicle addEventHandler ["HandleDamage", {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
             ["car", _this] call FUNC(handleDamage);
         };
     }];
@@ -46,14 +54,31 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // secondary explosions
 ["AllVehicles", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
-        (_this select 0) call FUNC(secondaryExplosions);
+    params ["_vehicle"];
+
+    if (_vehicle getVariable [QGVAR(enable), GVAR(enable)]) then {
+        _vehicle call FUNC(secondaryExplosions);
     };
 }, nil, ["Man"]] call CBA_fnc_addClassEventHandler;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
-        (_this select 0) call FUNC(blowOffTurret);
+    params ["_vehicle"];
+
+    if (_vehicle getVariable [QGVAR(enable), GVAR(enable)]) then {
+        _vehicle call FUNC(blowOffTurret);
     };
 }] call CBA_fnc_addClassEventHandler;
+
+// event to add a turret to a curator if the vehicle already belonged to that curator
+if (isServer) then {
+    [QGVAR(addTurretToEditable), {
+        params ["_vehicle", "_turret"];
+
+        {
+            if (_vehicle in curatorEditableObjects _x) then {
+                _x addCuratorEditableObjects [[_turret], false];
+            };
+        } forEach allCurators;
+    }] call CBA_fnc_addEventHandler;
+};

--- a/addons/cookoff/functions/fnc_blowOffTurret.sqf
+++ b/addons/cookoff/functions/fnc_blowOffTurret.sqf
@@ -30,4 +30,7 @@
 
     _turret setVectorUp [random 1, random 1, 1];
     _turret setVelocity [random 7, random 7, 8 + random 5];
+
+    // add turret to all curators that already own the wreck
+    [QGVAR(addTurretToEditable), [_vehicle, _turret]] call CBA_fnc_serverEvent;
 }, _this, 1] call CBA_fnc_waitAndExecute;

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -13,5 +13,19 @@
             <Czech>Povolí explozi munice a její následné ničivé efekty.</Czech>
             <Russian>Включает воспламенение и сопутствующие эффекты повреждения техники.</Russian>
         </Key>
+        <Key ID="STR_ACE_CookOff_generic_turret_wreck">
+          <Original>Wreck (Turret)</Original>
+          <French>Épave (tourelle)</French>
+          <Spanish>Restos (torreta)</Spanish>
+          <Italian>Rottami (torretta)</Italian>
+          <Polish>Wrak (wieżyczka)</Polish>
+          <Russian>Обломки (башня)</Russian>
+          <German>Wrack (Geschützturm)</German>
+          <Czech>Vrak (věž)</Czech>
+          <English>Wreck (Turret)</English>
+          <Portuguese>Ruínas (torre)</Portuguese>
+          <Korean>잔해(포탑)</Korean>
+          <Japanese>残骸（タレット）</Japanese>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- make it so that blown off turrets are added to all curators that own the wreck
- it also adds icons to the turrets. those huge ass question marks would be annoying, so I just use the corresponding tanks icon
- also OCD formatting

![http://i.imgur.com/8REyLfo.png](http://i.imgur.com/8REyLfo.png)
