### PR TITLE
DLEGION-medical-determineIFfatal

### DIFF
--- a/addons/medical/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical/functions/fnc_determineIfFatal.sqf
@@ -31,9 +31,9 @@ if (_part < 0 || _part > 5) exitWith {false};
 // Find the correct Damage threshold for unit.
 private _damageThreshold = [1,1,1];
 if ([_unit] call EFUNC(common,IsPlayer)) then {
-    _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(playerDamageThreshold), GVAR(playerDamageThreshold), GVAR(playerDamageThreshold) * 1.7]];
+    _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(playerDamageThreshold), GVAR(playerDamageThreshold), GVAR(playerDamageThreshold) * 1]];
 } else {
-    _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(AIDamageThreshold), GVAR(AIDamageThreshold), GVAR(AIDamageThreshold) * 1.7]];
+    _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(AIDamageThreshold), GVAR(AIDamageThreshold), GVAR(AIDamageThreshold) * 1]];
 };
 _damageThreshold params ["_thresholdHead", "_thresholdTorso",  "_thresholdLimbs"];
 
@@ -52,5 +52,5 @@ if (_part == 1) exitWith {
 };
 // Check if damage to body part is higher as damage limbs
 // We use a slightly lower decrease for limbs, as we want any injuries done to those to be less likely to be fatal compared to head shots or torso.
-private _chanceFatal = CHANGE_FATAL_LIMB + ((INCREASE_CHANGE_LIMB * (_damageBodyPart - _thresholdLimbs)) * 10);
-(_damageBodyPart >= _thresholdLimbs && {(_chanceFatal >= random(1))});
+private _chanceFatal = CHANGE_FATAL_LIMB + ((INCREASE_CHANGE_LIMB * (_damageBodyPart - _thresholdLimbs)) * 199);
+(_damageBodyPart >= _thresholdLimbs);


### PR DESCRIPTION
**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](http://ace3mod.com/wiki/development/)

this changes are part of a bigger "fix" for the trouble of "18 shot to limbs and soldier still alive and conscious".
other fixes will include 2 other files : ace_settings.hpp and fnc_handleDamage_Advanced.sqf .
this will set the medical system so that a shot to an arm or a leg will make you fall unconscious in pain. you can still be saved, but you need help. small / weak calibers can still injure you without causing unconsciousness.

this is FOR SURE not the best solution, but is all i can make (i hope the great ACE3 devs fix this), anyway the result is actually realistic...a wounded soldier, hit by 2-3 glancing shots will still be able to fight (despite bleeding and in pain), but a well placed hit, even on a 9mm handgun, will make you fall unconscious in pain, needing for help.
