### PR TITLE
DLEGION-medical-handleDamageAdvanced

### DIFF
--- a/addons/medical/functions/fnc_handleDamage_advanced.sqf
+++ b/addons/medical/functions/fnc_handleDamage_advanced.sqf
@@ -65,7 +65,13 @@ private _typeOfDamage = [_typeOfProjectile] call FUNC(getTypeOfDamage);
 
 if (alive _unit && {!(_unit getVariable ["ACE_isUnconscious", false])}) then {
     // If it reaches this, we can assume that the hit did not kill this unit, as this function is called 3 frames after the damage has been passed.
-    if ([_unit, _part, if (_part > 1) then {_newDamage * 1.3} else {_newDamage * 2}] call FUNC(determineIfFatal)) then {
+    if ([_unit, _part, if (_part > 1) then {_newDamage * 4.9} else {_newDamage * 2}] call FUNC(determineIfFatal)) then {
         [_unit] call FUNC(setUnconscious);
     };
+        
+        _pain = _unit getVariable [QGVAR(pain), 0];
+        _pain = _pain + (_newDamage * 6) * (1 - (_unit getVariable [QGVAR(morphine), 0]));
+        _unit setVariable [QGVAR(pain), _pain min 5, true];
+
+
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](http://ace3mod.com/wiki/development/)

this changes are part of a bigger "fix" for the trouble of "18 shot to limbs and soldier still alive and conscious".
other fixes will include 2 other files : ace_settings.hpp and fnc_determineIfFatalsqf .
this will set the medical system so that a shot to an arm or a leg will make you fall unconscious in pain. you can still be saved, but you need help. small / weak calibers can still injure you without causing unconsciousness.

this is FOR SURE not the best solution, but is all i can make (i hope the great ACE3 devs fix this), anyway the result is actually realistic...a wounded soldier, hit by 2-3 glancing shots will still be able to fight (despite bleeding and in pain), but a well placed hit, even on a 9mm handgun, will make you fall unconscious in pain, needing for help.
