### PR TITLE
Medical AI: Filter player medics

### DIFF
--- a/addons/medical_ai/functions/fnc_canRequestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_canRequestMedic.sqf
@@ -19,7 +19,7 @@
 if ([_this] call EFUNC(medical,isMedic) || {vehicle _this != _this}) exitWith {false};
 
 {
-    if ([_x] call EFUNC(medical,isMedic)) exitWith {
+    if ([_x] call EFUNC(medical,isMedic) && {!([_x] call EFUNC(common,isPlayer))}) exitWith {
         _this setVariable [QGVAR(assignedMedic), _x];
         true
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Filter player medics for Medical AI, so players will never become the assigned medic of a unit (in case there is both an AI and a player medic in the group)
