### PR TITLE
Fix grenade docs base url

### DIFF
--- a/docs/wiki/feature/grenades.md
+++ b/docs/wiki/feature/grenades.md
@@ -14,7 +14,7 @@ version:
 
 <div class="panel callout">
     <h5>Note:</h5>
-    <p>Check out the <a href="http://ace3mod.com/wiki/feature/advanced-throwing.html">Advanced Throwing</a> page for the new alternative system introduced in version 3.7.0.</p>
+    <p>Check out the <a href="{{ site.baseurl }}/wiki/feature/advanced-throwing.html">Advanced Throwing</a> page for the new alternative system introduced in version 3.7.0.</p>
 </div>
 
 ## 1. Overview


### PR DESCRIPTION
**When merged this pull request will:**
- Use Jekyll `baseurl` instead of hard coded url

See #4442