### PR TITLE
Handle RHS impact grenades (RGN/RGO)

### DIFF
--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -31,6 +31,12 @@ private _muzzle = _unit getVariable [QGVAR(activeMuzzle), ""];
 // Set muzzle ammo to 0 to block vanilla throwing (can only be 0 or 1), removeItem above resets it
 _unit setAmmo [_muzzle, 0];
 
+// Handle weird scripted grenades (RHS) which could cause unexpected behaviour
+private _nonInheritedCfg = configProperties [configFile >> "CfgAmmo" >> _throwableType, 'configName _x == QGVAR(replaceWith)', false];
+if ((count _nonInheritedCfg) == 1) then {
+    _throwableType = getText (_nonInheritedCfg select 0);
+};
+
 // Create actual throwable globally
 private _activeThrowableOld = _unit getVariable [QGVAR(activeThrowable), objNull];
 private _activeThrowable = createVehicle [_throwableType, _activeThrowableOld, [], 0, "CAN_COLLIDE"];

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -163,6 +163,8 @@ class CfgAmmo {
         ace_frag_force = 1;
     };
     class rhs_ammo_rgn: rhs_ammo_rgn_base {
+        // RGN is scripted grenade that deletes itself, which will break advanced throwing, replace with it's base
+        ace_advanced_throwing_replaceWith = "rhs_ammo_rgn_base";
         ace_frag_enabled = 0;
         ace_frag_skip = 1;
         ace_frag_force = 0;


### PR DESCRIPTION
Quick version of how RHS impact grenades work:
- magazine ammo is type `rhs_ammo_rgn`
- after creation rhs's script deletes and recreates as `rhs_ammo_rgn_sub` with same position and velocity
- on impact, it's deleted again and recreated as `rhs_ammo_rgn_exp`

Even without manually priming, there is delay between "pulling the pin" and throwing.
In that time the ammo is deleted and replaced.
User throws nothing and a live grenade is dropped at their feet.

Adds a simple config `ace_advanced_throwing_replaceWith` that will replace one ammo with another.

Base grenade ammo works fine, but it loses the scripted impact.