### PR TITLE
Fix throwing from map screen - global XEH

### DIFF
--- a/addons/advanced_throwing/CfgEventHandlers.hpp
+++ b/addons/advanced_throwing/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_FILE(XEH_postInitClient));
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -1,5 +1,8 @@
 #include "script_component.hpp"
 
+// Fired XEH
+[QGVAR(throwFiredXEH), FUNC(throwFiredXEH)] call CBA_fnc_addEventHandler;
+
 // Exit on HC
 if (!hasInterface) exitWith {};
 
@@ -63,6 +66,13 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
     [_this select 1, "Player changed"] call FUNC(exitThrowMode);
 }] call CBA_fnc_addPlayerEventhandler;
 
+["visiblemap", {
+    if (visibleMap && {ACE_player getVariable [QGVAR(inHand), false]}) then {
+        [ACE_player, "Opened Map"] call FUNC(exitThrowMode);
+    };
+}] call CBA_fnc_addPlayerEventhandler;
+
+
 ["ace_interactMenuOpened", {
     // Exit if advanced throwing is disabled (pick up only supports advanced throwing)
     if (!GVAR(enabled)) exitWith {};
@@ -79,9 +89,6 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
     };
 }] call CBA_fnc_addEventHandler;
 
-
-// Fired XEH
-[QGVAR(throwFiredXEH), FUNC(throwFiredXEH)] call CBA_fnc_addEventHandler;
 
 // Set last thrown time on Vanilla Throwing and Advanced Throwing
 ["ace_firedPlayer", {

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -66,7 +66,7 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
     [_this select 1, "Player changed"] call FUNC(exitThrowMode);
 }] call CBA_fnc_addPlayerEventhandler;
 
-["visiblemap", {
+["visibleMap", {
     if (visibleMap && {ACE_player getVariable [QGVAR(inHand), false]}) then {
         [ACE_player, "Opened Map"] call FUNC(exitThrowMode);
     };


### PR DESCRIPTION
Fixes 2 minor issues with advanced throwing
- If advanced throwing is up, and player brings up map; clicking on the map would throw a grenaded
 Now exits throw mode

- Custom firedXeh event handler was only run on clients
Renamed to XEH_postInit and moved to above the `!hasInterface` line.