### PR TITLE
fix broken ace menu in main menu

### DIFF
--- a/addons/optionsmenu/CfgEventHandlers.hpp
+++ b/addons/optionsmenu/CfgEventHandlers.hpp
@@ -20,8 +20,5 @@ class Extended_PostInit_EventHandlers {
 class Extended_DisplayLoad_EventHandlers {
     class RscDisplayMain {
         GVAR(loadMainMenuBox) = QUOTE(_this call COMPILE_FILE(init_loadMainMenuBox));
-
-        //Hide the button if there is no world (-world=empty)
-        GVAR(hideButtonEmptyWorld) = "((_this select 0) displayCtrl 80085) ctrlShow (missionName != '');";
     };
 };

--- a/addons/optionsmenu/gui/pauseMenu.hpp
+++ b/addons/optionsmenu/gui/pauseMenu.hpp
@@ -102,14 +102,6 @@ class RscDisplayMovieInterrupt: RscStandardDisplay {
 };
 class RscDisplayMain: RscStandardDisplay {
     class controls {
-        class ACE_Open_settingsMenu_Btn : ACE_Open_SettingsMenu_BtnBase {
-            action = "if (missionName != '') then {createDialog 'ACE_settingsMenu';};";
-            x = "safezoneX";
-            y = "safezoneY";
-            idc = 80085;
-        };
-
-
         class ACE_news_apex: RscControlsGroupNoHScrollbars {
             idc = 80090;
             x = "safezoneX + safezoneW - 10 * (pixelW * pixelGrid * 2) - (4 * pixelH)";


### PR DESCRIPTION
**When merged this pull request will:**
- Currently the ACE menu is not shown in the main menu, no matter if you have `-world=empty` or not
- This is because BI changed some things around in 3den. And now the mission does not exist before the Main display is created
- therefore there is no way to check if the main menu mission is enabled
- there is a weird bug that causes the main menu to reload when you confirm the menu where you change your avatar with `OK`
- this makes the ACE menu button show up, but only if you have the main menu mission enabled
- turns out it's pretty bugged though. You can click all the other buttons which interfers with our menu
- this happens even when you manually hide the "spotlight" thingies in the middle with some additional scripting
- I therefore decided to completely remove the ACE menu from the main menu to fix this bug

![https://i.gyazo.com/7e89506cebdcefe9e5b70f0ad5375957.gif](https://i.gyazo.com/7e89506cebdcefe9e5b70f0ad5375957.gif)