### PR TITLE
Fix passanger interaction

### DIFF
--- a/addons/dogtags/config.cpp
+++ b/addons/dogtags/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common"};
+        requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"SzwedzikPL"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
Oddly #4446 broke passenger interaction because `ACE_Dogtag` ends up being before `MainActions`.
Adding requiredAddons will fix mod load order problems.

Should also take a look at making `ace_interaction_fnc_addPassengerAction` more robust.