### PR TITLE
Fix Ambient Sounds

### DIFF
--- a/addons/missionmodules/functions/fnc_moduleAmbianceSound.sqf
+++ b/addons/missionmodules/functions/fnc_moduleAmbianceSound.sqf
@@ -49,7 +49,9 @@ if (_activated && local _logic) then {
             };
         } else {
             if (isClass (configFile >> "CfgSounds" >> _x)) then {
-                _ambianceSounds pushBack ((getArray(configFile >> "CfgSounds" >> _x >> "sound") select 0));
+                _soundPath = (getArray(configFile >> "CfgSounds" >> _x >> "sound")) param [0, ""];
+                if ((_soundPath select [0, 1]) == "\") then {_soundPath = _soundPath select [1];};
+                _ambianceSounds pushBack _soundPath;
             } else {
                 ACE_LOGERROR_1("Ambient Sounds: Sound ""%1"" not found.",_x);
             };
@@ -65,8 +67,9 @@ if (_activated && local _logic) then {
         };
     } forEach _ambianceSounds;
 
+    TRACE_1("",_ambianceSounds);
+
     [{
-        private ["_newPos", "_allUnits", "_targetUnit"];
         params ["_args", "_pfhHandle"];
         _args params ["_logic", "_ambianceSounds", "_minimalDistance", "_maximalDistance", "_minDelayBetweensounds", "_maxDelayBetweenSounds", "_volume", "_followPlayers", "_lastTimePlayed"];
 
@@ -77,39 +80,28 @@ if (_activated && local _logic) then {
         if (CBA_missionTime - _lastTimePlayed >= ((_minDelayBetweensounds + random(_maxDelayBetweenSounds)) min _maxDelayBetweenSounds)) then {
 
             // Find all players in session.
-            _allUnits = if (isMultiplayer) then {playableUnits} else {[ACE_player]};
+            private _allUnits = if (isMultiplayer) then {playableUnits} else {[ACE_player]};
 
             // Check if there are enough players to even start playing this sound.
             if (count _allUnits > 0) then {
-
-                // Select a target unit at random.
-                _targetUnit = _allUnits call BIS_fnc_selectRandom;
-
                 // find the position from which we are going to play this sound from.
-                _newPos = (getPos _targetUnit);
-                if (!_followPlayers) then {
-                    _newPos = getPos _logic;
-                };
-
-                // Randomize this position.
-                if (random(1) >= 0.5) then {
-                    if (random(1) >= 0.5) then {
-                        _newPos set [0, (_newPos select 0) + (_minimalDistance + random(_maximalDistance))];
-                    } else {
-                        _newPos set [0, (_newPos select 0) - (_minimalDistance + random(_maximalDistance))];
-                    };
+                private _newPosASL = if (_followPlayers) then {
+                    // Select a target unit at random.
+                    private _targetUnit = selectRandom _allUnits;
+                    AGLtoASL (_targetUnit getPos [random 360, _minimalDistance + random (_maximalDistance - _minimalDistance)]);
                 } else {
-                    if (random(1) >= 0.5) then {
-                        _newPos set [1, (_newPos select 1) + (_minimalDistance + random(_maximalDistance))];
-                    } else {
-                        _newPos set [1, (_newPos select 1) - (_minimalDistance + random(_maximalDistance))];
-                    };
+                    AGLtoASL (_logic getPos [random 360, _minimalDistance + random (_maximalDistance - _minimalDistance)]);
                 };
 
+                TRACE_1("",_newPosASL);
                 // If no unit is to close to this position, we will play the sound.
-                if ({(_newPos distance _x < (_minimalDistance / 2))}count _allUnits == 0) then {
-                    playSound3D [selectRandom _ambianceSounds, objNull,  false, _newPos, _volume, 1, 1000];
+                if ({(_newPosASL distance _x < (_minimalDistance / 2))}count _allUnits == 0) then {
+                    private _soundFile = selectRandom _ambianceSounds;
+                    TRACE_2("playing file",_soundFile,_newPosASL);
+                    playSound3D [_soundFile, objNull,  false, _newPosASL, _volume, 1, 1000];
                     _args set [8, CBA_missionTime];
+                } else {
+                    TRACE_1("pos is too close to a player",_newPosASL);
                 };
             };
         };


### PR DESCRIPTION
Fix #4418
- Remove leading `\` for configfile sounds
- Cleanup randomized location code

Config has leading slash, but playSound doesn't want it
`playSound3d ["\a3\Ui_f\data\Sound\CfgNotifications\scoreRemoved.wss", player];` // throws rpt error
`playSound3d ["a3\Ui_f\data\Sound\CfgNotifications\scoreRemoved.wss", player];` // works