### PR TITLE
respawn - Replace unique acre radios with their baseclass

### DIFF
--- a/addons/respawn/functions/fnc_restoreGear.sqf
+++ b/addons/respawn/functions/fnc_restoreGear.sqf
@@ -4,7 +4,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: All Gear based on return value of ACE_common_fnc_getAllGear <ARRAY>
+ * 1: All Gear based on return value of getUnitLoadout <ARRAY>
  *
  * Return Value:
  * None
@@ -20,6 +20,22 @@ params ["_unit", "_allGear", "_activeWeaponAndMuzzle"];
 
 // restore all gear
 if (!isNil "_allGear") then {
+    // Handle Unique ACRE radios
+    {
+        private _container = _allGear select _x;
+        if (!(_container isEqualTo [])) then {
+            _container params ["","_itemsArray"];
+            {
+                _x params ["_itemClassname"];
+                if ((getNumber (configFile >> "CfgWeapons" >> _itemClassname >> "acre_isUnique")) > 0) then {
+                    private _newBase = getText (configFile >> "CfgWeapons" >> _itemClassname >> "acre_baseClass");
+                    INFO_2("replacing ACRE radio [%1] with base [%2]",_itemClassname,_newBase);
+                    _x set [0, _newBase];
+                };
+            } forEach _itemsArray;
+        };
+    } forEach [3,4,5]; // Uniform, Vest, Backpack
+
     _unit setUnitLoadout _allGear;
 };
 

--- a/addons/respawn/functions/fnc_restoreGear.sqf
+++ b/addons/respawn/functions/fnc_restoreGear.sqf
@@ -20,16 +20,24 @@ params ["_unit", "_allGear", "_activeWeaponAndMuzzle"];
 
 // restore all gear
 if (!isNil "_allGear") then {
-    // Handle Unique ACRE radios
     {
         private _container = _allGear select _x;
         if (!(_container isEqualTo [])) then {
             _container params ["","_itemsArray"];
             {
                 _x params ["_itemClassname"];
+
+                // Handle Unique ACRE radios
                 if ((getNumber (configFile >> "CfgWeapons" >> _itemClassname >> "acre_isUnique")) > 0) then {
                     private _newBase = getText (configFile >> "CfgWeapons" >> _itemClassname >> "acre_baseClass");
-                    INFO_2("replacing ACRE radio [%1] with base [%2]",_itemClassname,_newBase);
+                    ACE_LOGINFO_2("replacing ACRE radio [%1] with base [%2]",_itemClassname,_newBase);
+                    _x set [0, _newBase];
+                };
+
+                // Handle Unique TFAR radios
+                if ((getNumber (configFile >> "CfgWeapons" >> _itemClassname >> "tf_radio")) > 0) then {
+                    private _newBase = getText (configFile >> "CfgWeapons" >> _itemClassname >> "tf_parent");
+                    ACE_LOGINFO_2("replacing TFAR radio [%1] with base [%2]",_itemClassname,_newBase);
                     _x set [0, _newBase];
                 };
             } forEach _itemsArray;

--- a/addons/respawn/functions/fnc_showFriendlyFireMessage.sqf
+++ b/addons/respawn/functions/fnc_showFriendlyFireMessage.sqf
@@ -22,5 +22,7 @@ if (_unit != _killer && {side group _unit in [side group ACE_player, civilian]} 
     systemChat format ["%1 was killed by %2", [_unit, false, true] call EFUNC(common,getName), [_killer, false, true] call EFUNC(common,getName)];
 
     // Raise ACE globalEvent
-    ["ace_killedByFriendly", [_unit, _killer]] call CBA_fnc_globalEvent;
+    if (local _killer) then {
+        ["ace_killedByFriendly", [_unit, _killer]] call CBA_fnc_globalEvent;
+    };
 };


### PR DESCRIPTION
Fix #4441

- Should fix ACRE error
```
ACRE WARNING: Id object relation created independently of unique ID creation process (acre_prc343_id_2)
```
- Also fix `ace_killedByFriendly` global event inside global event