### PR TITLE
Fix spotting rifle loudness

### DIFF
--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -74,6 +74,8 @@ if (isNil "_loudness") then {
         private _initSpeed = getNumber(configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
         private _caliber = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_caliber");
         _caliber = call {
+            // If explicilty defined, use ACE_caliber
+            if ((count configProperties [(configFile >> "CfgAmmo" >> _ammo), "configName _x == 'ACE_caliber'", false]) == 1) exitWith {_caliber};
             if (_ammo isKindOf ["ShellBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
             if (_ammo isKindOf ["RocketBase", (configFile >> "CfgAmmo")]) exitWith { 200 };
             if (_ammo isKindOf ["MissileBase", (configFile >> "CfgAmmo")]) exitWith { 600 };

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -271,4 +271,7 @@ class CfgAmmo {
         ace_frag_skip = 0;
         ace_frag_force = 1;
     };
+    class rhs_ammo_smaw_SR: RocketBase {
+        ACE_caliber = 9;
+    };
 };


### PR DESCRIPTION
Fix loudness of spotting rifle on the SMAW
Because of how launchers in Arma work the ammo needs to be type `RocketBase`
Which fired near would set as caliber 200 when it should be 9mm

Replaces joko's #2371 . 
This uses existing config entry `ACE_caliber` which should make things simpler.
