### PR TITLE
Illumination Flares

### DIFF
--- a/optionals/flares/$PBOPREFIX$
+++ b/optionals/flares/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\flares

--- a/optionals/flares/CfgAmmo.hpp
+++ b/optionals/flares/CfgAmmo.hpp
@@ -1,0 +1,15 @@
+class CfgAmmo {
+    class FlareCore;
+    class FlareBase: FlareCore {};
+
+    class F_40mm_White: FlareBase {
+        intensity = 1000000; // vanilla: 10000
+        timeToLive = 40; // vanilla: 25
+        coefGravity = 0.25; // vanilla: undefined (would be 1)
+        // Makes the ammo fall the ground slower
+    };
+
+    class Flare_82mm_AMOS_White: FlareCore {
+        intensity = 1500000; // vanilla: 10000
+    };
+};

--- a/optionals/flares/README.md
+++ b/optionals/flares/README.md
@@ -1,0 +1,11 @@
+ace_flares
+============
+
+Increasing light from flares making them suitable for illumination instead of just signaling.
+Based on the M583 (burning for 40 seconds, parachute slowing decent to 2 Meters/Sec).
+
+## Maintainers
+
+The people responsible for merging changes to this component or answering potential questions.
+
+- [PabstMirror](https://github.com/PabstMirror)

--- a/optionals/flares/config.cpp
+++ b/optionals/flares/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_common", "ace_grenades"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"PabstMirror"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgAmmo.hpp"

--- a/optionals/flares/script_component.hpp
+++ b/optionals/flares/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT flares
+#define COMPONENT_BEAUTIFIED Flares
+#include "\z\ace\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_FLARES
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_FLARES
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_FLARES
+#endif
+
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
Ref #2901
- GL and Mortar flares provide illumination
- Slows decent on GL flare (simulating a parachute)

Since 1.60/62 lighting changes arma can get very dark and flares offer almost no lighting until they are almost at ground level. Really only useful for signaling.

This make the flare provide a mild amount of  illumination.
It also slows their decent by simulating a parachute, but no change in model (based on M583's stats).

Two questions: 
Realistically- How much illumination would these types of flares produce?
Best way to implement the changes?
- Create a brand new magazine type with the changes. Would be a real pain with `magazines[]` configs on weapons.
- Add this to an existing ace addon (like grenades which already touches the intensity)
- Add it to a new optional addon, if people do not want the illumination changes.