### PR TITLE
Functions to perform arithmetic ops on sets

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -7,6 +7,8 @@ PREP(addToInventory);
 PREP(assignedItemFix);
 PREP(assignObjectsInList);
 PREP(ambientBrightness);
+PREP(arithmeticGetResult);
+PREP(arithmeticSetSource);
 PREP(ASLToPosition);
 PREP(binarizeNumber);
 PREP(blurScreen);

--- a/addons/common/functions/fnc_arithmeticGetResult.sqf
+++ b/addons/common/functions/fnc_arithmeticGetResult.sqf
@@ -1,0 +1,69 @@
+/*
+ * Author: PabstMirror
+ * Gets arithmetic resultfrom a set.
+ *
+ * Arguments:
+ * 0: Namespace <OBJECT><LOCATION><MISSIONNAMESPACE>
+ * 1: Number Set ID <STRING>
+ * 2: Operation (sum, product, min, max, avg) <STRING>
+ *
+ * Return Value:
+ * <NUMBER>
+ *
+ * Example:
+ * [ace_player, "ace_aimCoefficents", "product"] call ace_common_fnc_arithmeticGetResult
+ * [missionNameSpace, "ace_hearing", "min"] call ace_common_fnc_arithmeticGetResult
+ *
+ * Public: Yes
+ */
+// #define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+params ["_namespace", "_setID", "_op"];
+TRACE_3("params",_namespace,_setID,_op);
+
+private _data = (_namespace getVariable _setID) param [2, []];
+
+switch (_op) do {
+    case ("sum"): {
+        private _result = 0;
+        {
+            _result = _result + (call _x);
+            nil
+        } count _data;
+        _result // return
+    };
+    case ("product"): {
+        private _result = 1;
+        {
+            _result = _result * (call _x);
+            nil
+        } count _data;
+        _result // return
+    };
+    case ("min"): {
+        private _result = 1e99;
+        {
+            _result = _result min (call _x);
+            nil
+        } count _data;
+        _result // return
+    };
+    case ("max"): {
+        private _result = -1e99;
+        {
+            _result = _result max (call _x);
+            nil
+        } count _data;
+        _result // return
+    };
+    case ("avg"): {
+        private _result = 0;
+        {
+            _result = _result + (call _x);
+            nil
+        } count _data;
+        _result / (count _data); // return
+    };
+    default {3735928559};
+};

--- a/addons/common/functions/fnc_arithmeticGetResult.sqf
+++ b/addons/common/functions/fnc_arithmeticGetResult.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: PabstMirror
- * Gets arithmetic resultfrom a set.
+ * Gets arithmetic result from a set.
  *
  * Arguments:
  * 0: Namespace <OBJECT><LOCATION><MISSIONNAMESPACE>

--- a/addons/common/functions/fnc_arithmeticSetSource.sqf
+++ b/addons/common/functions/fnc_arithmeticSetSource.sqf
@@ -1,0 +1,39 @@
+/*
+ * Author: PabstMirror
+ * Adds or removes a source to an arithmetic set.
+ *
+ * Arguments:
+ * 0: Namespace <OBJECT><LOCATION><MISSIONNAMESPACE>
+ * 1: Number Set ID <STRING>
+ * 2: Source <STRING>
+ * 3: Code that returns a number (can access var _namespace) [use {} to remove] <CODE>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [missionNameSpace, "ace_hearing", "myMission", {0.5}] call ace_common_fnc_arithmeticSetSource
+ * [ace_player, "ace_aimCoefficents", "ace_medical", {linearConversion [0,1,(_namespace getVariable "ace_medical_pain",1,0.2,true]}] call ace_common_fnc_arithmeticSetSource
+ *
+ * Public: Yes
+ */
+// #define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+params ["_namespace", "_setID", "_source", "_variable"];
+TRACE_4("params",_namespace,_setID,_source,_variable);
+
+private _hash = _namespace getVariable _setID;
+if (isNil "_hash") then {
+    _hash = [] call CBA_fnc_hashCreate;
+    _namespace setVariable [_setID, _hash];
+};
+if (_variable isEqualTo {}) then {
+    TRACE_1("removing",_source);
+    [_hash, _source] call CBA_fnc_hashRem;
+} else {
+    TRACE_2("adding",_source,_variable);
+    [_hash, _source, _variable] call CBA_fnc_hashSet;
+};
+
+nil


### PR DESCRIPTION
Allows add/removing blocks of code that return numbers.
And performing arithmetic operations on those sets.

Allows a variable number of sources to provide input into a final calcuation. Like Aim Coefficent or possibly `fadeSound`)

Inspired by Baer's AF duty system.

Example:
```
[missionNamespace, "ace_AimCoef", "ace_medical", {
    linearConversion [0,1,(ace_player getVariable "ace_medical_pain"),1,0.2,true]
}] call ace_common_fnc_arithmeticSetSource;

[missionNamespace, "ace_AimCoef", "ace_advancedFat", {
    (1.0 + _fatigue ^ 2 * 0.1);
}] call ace_common_fnc_arithmeticSetSource;

[missionNamespace, "ace_AimCoef", "min"] call ace_common_fnc_arithmeticGetResult;
```

First arg can be any type of namespace (object, location, `missionNamespace`)
Can use the namespace in the code block:
```
[player, "test", "a1", {_namespace getVariable "a1"}] call ace_common_fnc_arithmeticSetSource;
```