### PR TITLE
fix fatigue when diving while sprinting

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
+++ b/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
@@ -15,6 +15,12 @@ if (!alive ACE_player) exitWith { // Dead people don't breath, Will also handle 
 
 private _currentWork = REE;
 private _currentSpeed = (vectorMagnitude (velocity ACE_player)) min 6;
+
+// fix #4481. Diving to the ground is recorded as PRONE stance with running speed velocity. Cap maximum speed to fix.
+if (stance ACE_player == "PRONE") then {
+    _currentSpeed = _currentSpeed min 1.5;
+};
+
 if ((vehicle ACE_player == ACE_player) && {_currentSpeed > 0.1} && {isTouchingGround ACE_player || {underwater ACE_player}}) then {
     _currentWork = [ACE_player, _currentSpeed] call FUNC(getMetabolicCosts);
     _currentWork = _currentWork max REE;


### PR DESCRIPTION
**When merged this pull request will:**
- Caps assumed max speed while prone.
- This ensures that moves like diving to the ground while sprinting are not calculated as crawling with running speed.
- fixes #4481

the max speed I could do while crawling is 1.33_ with rifle. Don't think there is anything faster than 1.5 aside from the transitions we try to fix here ofc.