### PR TITLE
Fix FRIES attach point for unarmed wildcat

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -217,7 +217,7 @@ class CfgVehicles {
         GVAR(enabled) = 2;
         GVAR(ropeOrigins)[] = {"ropeOriginRight", "ropeOriginLeft"};
         GVAR(friesType) = "ACE_friesGantry";
-        GVAR(friesAttachmentPoint)[] = {-1.07, 3.26, -0.5};
+        GVAR(friesAttachmentPoint)[] = {1.07, 2.5, -0.5};
         EQUIP_FRIES_ATTRIBUTE;
     };
     class Heli_Transport_04_base_F: Helicopter_Base_H {


### PR DESCRIPTION
Close #4490

I'm not sure if something changed on the wildcat or on our model??

I had done the reverse for the armed version: d7b0bde1ca3e6c455d63538f773733a615bc9b0b
Changing x-offset from positive to negative, which is the opposite of what this one needed,