### PR TITLE
Simplify huntIR configs using +=

### DIFF
--- a/addons/huntir/CfgWeapons.hpp
+++ b/addons/huntir/CfgWeapons.hpp
@@ -19,11 +19,5 @@ class CfgWeapons {
     class UGL_F: GrenadeLauncher {
         magazines[] += {"ACE_HuntIR_M203"};
     };
-    class Rifle_Base_F;
-    class arifle_MX_Base_F: Rifle_Base_F {
-        class GL_3GL_F: UGL_F {
-            //magazines[] += {"ACE_HuntIR_M203"};
-            magazines[] = {"1Rnd_HE_Grenade_shell","UGL_FlareWhite_F","UGL_FlareGreen_F","UGL_FlareRed_F","UGL_FlareYellow_F","UGL_FlareCIR_F","1Rnd_Smoke_Grenade_shell","1Rnd_SmokeRed_Grenade_shell","1Rnd_SmokeGreen_Grenade_shell","1Rnd_SmokeYellow_Grenade_shell","1Rnd_SmokePurple_Grenade_shell","1Rnd_SmokeBlue_Grenade_shell","1Rnd_SmokeOrange_Grenade_shell","3Rnd_HE_Grenade_shell","3Rnd_UGL_FlareWhite_F","3Rnd_UGL_FlareGreen_F","3Rnd_UGL_FlareRed_F","3Rnd_UGL_FlareYellow_F","3Rnd_UGL_FlareCIR_F","3Rnd_Smoke_Grenade_shell","3Rnd_SmokeRed_Grenade_shell","3Rnd_SmokeGreen_Grenade_shell","3Rnd_SmokeYellow_Grenade_shell","3Rnd_SmokePurple_Grenade_shell","3Rnd_SmokeBlue_Grenade_shell","3Rnd_SmokeOrange_Grenade_shell","ACE_HuntIR_M203"};
-        };
-    };
+    // Added to the GL_3GL_F in subconfig
 };

--- a/addons/huntir/subConfig/config.cpp
+++ b/addons/huntir/subConfig/config.cpp
@@ -1,0 +1,26 @@
+#include "\z\ace\addons\huntir\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT huntirSubConfig
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_huntir"};
+        author = ECSTRING(common,ACETeam);
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+class CfgWeapons {
+    class UGL_F;
+    class Rifle_Base_F;
+    class arifle_MX_Base_F: Rifle_Base_F {
+        class GL_3GL_F: UGL_F {
+            magazines[] += {"ACE_HuntIR_M203"};
+        };
+    };
+};

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -5,7 +5,7 @@ class CfgWeapons {
     class srifle_EBR_F;
     class launch_O_Titan_F;
     class UGL_F;
-    
+
     class GM6_base_F;
     class rhs_weap_M107_Base_F: GM6_base_F {
         ACE_barrelTwist = 381.0;
@@ -16,7 +16,7 @@ class CfgWeapons {
         ACE_barrelLength = 609.6;
         ACE_Overheating_dispersion = 0.75;
     };
-    class rhs_weap_m24sws : rhs_weap_XM2010_Base_F {
+    class rhs_weap_m24sws: rhs_weap_XM2010_Base_F {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 609.6;
     };
@@ -25,97 +25,9 @@ class CfgWeapons {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
         class M203_GL: UGL_F {
-            magazines[] = {
-                "rhs_mag_M441_HE",
-                "rhs_mag_M433_HEDP",
-                "rhs_mag_M4009",
-                "rhs_mag_m576",
-                "rhs_mag_M585_white",
-                "rhs_mag_M661_green",
-                "rhs_mag_M662_red",
-                "rhs_mag_M713_red",
-                "rhs_mag_M714_white",
-                "rhs_mag_M715_green",
-                "rhs_mag_M716_yellow",
-
-                // bis compatibility
-                "1Rnd_HE_Grenade_shell",
-                "UGL_FlareWhite_F",
-                "UGL_FlareGreen_F",
-                "UGL_FlareRed_F",
-                "UGL_FlareYellow_F",
-                "UGL_FlareCIR_F",
-                "1Rnd_Smoke_Grenade_shell",
-                "1Rnd_SmokeRed_Grenade_shell",
-                "1Rnd_SmokeGreen_Grenade_shell",
-                "1Rnd_SmokeYellow_Grenade_shell",
-                "1Rnd_SmokePurple_Grenade_shell",
-                "1Rnd_SmokeBlue_Grenade_shell",
-                "1Rnd_SmokeOrange_Grenade_shell",
-                "3Rnd_HE_Grenade_shell",
-                "3Rnd_UGL_FlareWhite_F",
-                "3Rnd_UGL_FlareGreen_F",
-                "3Rnd_UGL_FlareRed_F",
-                "3Rnd_UGL_FlareYellow_F",
-                "3Rnd_UGL_FlareCIR_F",
-                "3Rnd_Smoke_Grenade_shell",
-                "3Rnd_SmokeRed_Grenade_shell",
-                "3Rnd_SmokeGreen_Grenade_shell",
-                "3Rnd_SmokeYellow_Grenade_shell",
-                "3Rnd_SmokePurple_Grenade_shell",
-                "3Rnd_SmokeBlue_Grenade_shell",
-                "3Rnd_SmokeOrange_Grenade_shell",
-
-                // ACE3 Compatibility
-                "ACE_HuntIR_M203"
-            };
+            magazines[] += {"ACE_HuntIR_M203"};
         };
-        class M320_GL : M203_GL {
-            magazines[] = {
-                "rhs_mag_M441_HE",
-                "rhs_mag_M433_HEDP",
-                "rhs_mag_M4009",
-                "rhs_mag_m576",
-                "rhs_mag_M585_white",
-                "rhs_mag_M661_green",
-                "rhs_mag_M662_red",
-                "rhs_mag_M713_red",
-                "rhs_mag_M714_white",
-                "rhs_mag_M715_green",
-                "rhs_mag_M716_yellow",
-
-                // bis compatibility
-                "1Rnd_HE_Grenade_shell",
-                "UGL_FlareWhite_F",
-                "UGL_FlareGreen_F",
-                "UGL_FlareRed_F",
-                "UGL_FlareYellow_F",
-                "UGL_FlareCIR_F",
-                "1Rnd_Smoke_Grenade_shell",
-                "1Rnd_SmokeRed_Grenade_shell",
-                "1Rnd_SmokeGreen_Grenade_shell",
-                "1Rnd_SmokeYellow_Grenade_shell",
-                "1Rnd_SmokePurple_Grenade_shell",
-                "1Rnd_SmokeBlue_Grenade_shell",
-                "1Rnd_SmokeOrange_Grenade_shell",
-                "3Rnd_HE_Grenade_shell",
-                "3Rnd_UGL_FlareWhite_F",
-                "3Rnd_UGL_FlareGreen_F",
-                "3Rnd_UGL_FlareRed_F",
-                "3Rnd_UGL_FlareYellow_F",
-                "3Rnd_UGL_FlareCIR_F",
-                "3Rnd_Smoke_Grenade_shell",
-                "3Rnd_SmokeRed_Grenade_shell",
-                "3Rnd_SmokeGreen_Grenade_shell",
-                "3Rnd_SmokeYellow_Grenade_shell",
-                "3Rnd_SmokePurple_Grenade_shell",
-                "3Rnd_SmokeBlue_Grenade_shell",
-                "3Rnd_SmokeOrange_Grenade_shell",
-
-                // ACE3 Compatibility
-                "ACE_HuntIR_M203"
-            };
-        };
+        // Added to the M320_GL in subconfig
     };
     class rhs_weap_m4a1;
     class rhs_weap_hk416d10: rhs_weap_m4a1 {
@@ -141,7 +53,7 @@ class CfgWeapons {
     };
     class rhs_weap_lmg_minimi_railed; // Rifle_Base_F - scope = private;
     class rhs_weap_m249_pip_S: rhs_weap_lmg_minimi_railed {
-        ACE_barrelLength = 348; 
+        ACE_barrelLength = 348;
         ACE_barrelTwist = 177.8;
         ACE_Overheating_allowSwapBarrel = 1;
     };
@@ -180,9 +92,9 @@ class CfgWeapons {
         ACE_barrelLength = 508.0;
     };
     class SMG_01_F;
-    class rhsusf_weap_MP7A1_base_f : SMG_01_F {
+    class rhsusf_weap_MP7A1_base_f: SMG_01_F {
         ACE_barrelTwist = 160.0;
-        ACE_barrelLength = 180.0;     
+        ACE_barrelLength = 180.0;
     };
     // RHS pistols
     class hgun_ACPC2_F;
@@ -227,7 +139,7 @@ class CfgWeapons {
             };
         };
     };
-    class rhsusf_acc_LEUPOLDMK4_2_d : rhsusf_acc_LEUPOLDMK4_2 {};
+    class rhsusf_acc_LEUPOLDMK4_2_d: rhsusf_acc_LEUPOLDMK4_2 {};
     class rhsusf_acc_premier: rhsusf_acc_LEUPOLDMK4_2 {
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
@@ -238,7 +150,7 @@ class CfgWeapons {
             };
         };
     };
-    class rhsusf_acc_premier_low : rhsusf_acc_premier {};
+    class rhsusf_acc_premier_low: rhsusf_acc_premier {};
     class rhsusf_acc_premier_anpvs27: rhsusf_acc_premier {
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -6,6 +6,9 @@ class CfgWeapons {
     class launch_O_Titan_F;
     class UGL_F;
 
+    class rhs_weap_M320_Base_F: Pistol_Base_F { // Standalone M320 (pistol slot)
+        magazines[] += {"ACE_HuntIR_M203"};
+    };
     class GM6_base_F;
     class rhs_weap_M107_Base_F: GM6_base_F {
         ACE_barrelTwist = 381.0;
@@ -27,7 +30,7 @@ class CfgWeapons {
         class M203_GL: UGL_F {
             magazines[] += {"ACE_HuntIR_M203"};
         };
-        // Added to the M320_GL in subconfig
+        // Added to the M320_GL in subConfig
     };
     class rhs_weap_m4a1;
     class rhs_weap_hk416d10: rhs_weap_m4a1 {

--- a/optionals/compat_rhs_usf3/subConfig/config.cpp
+++ b/optionals/compat_rhs_usf3/subConfig/config.cpp
@@ -1,6 +1,6 @@
-#include "\z\ace\addons\huntir\script_component.hpp"
+#include "\z\ace\addons\compat_rhs_usf3\script_component.hpp"
 #undef COMPONENT
-#define COMPONENT huntir_sub
+#define COMPONENT compat_rhs_usf3_sub
 
 class CfgPatches {
     class ADDON {
@@ -8,7 +8,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_huntir"};
+        requiredAddons[] = {"ace_compat_rhs_usf3"};
         author = ECSTRING(common,ACETeam);
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
@@ -16,10 +16,10 @@ class CfgPatches {
 };
 
 class CfgWeapons {
-    class UGL_F;
-    class Rifle_Base_F;
-    class arifle_MX_Base_F: Rifle_Base_F {
-        class GL_3GL_F: UGL_F {
+    class arifle_MX_Base_F;
+    class rhs_weap_m4_Base: arifle_MX_Base_F {
+        class M203_GL;
+        class M320_GL: M203_GL {
             magazines[] += {"ACE_HuntIR_M203"};
         };
     };


### PR DESCRIPTION
Close #4199

Based on work by @robalo https://github.com/toadie2k/NIArms/commit/365a10dcd8a51d3de358e8be2f82aacc3b84c32d

`+=` fails on inheritance in a single config; 
but it can work if done in separate configs
and we can include multiple config.cpp in a single pbo

Allows us to simplify our configs, and should help with compatibility with other mods using similar techniques.
Also will allows us to add multiple gl magazines without creating conflicts.  (ref #4506)
