### PR TITLE
Fix fuel nozzle disconnect at maximum hose distance

### DIFF
--- a/addons/refuel/XEH_PREP.hpp
+++ b/addons/refuel/XEH_PREP.hpp
@@ -16,6 +16,7 @@ PREP(handleDisconnect);
 PREP(handleKilled);
 PREP(handleUnconscious);
 PREP(makeJerryCan);
+PREP(maxDistanceDropNozzle);
 PREP(moduleRefuelSettings);
 PREP(readFuelCounter);
 PREP(refuel);

--- a/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
+++ b/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
@@ -1,0 +1,54 @@
+/*
+ * Author: GitHawk, Jonpas
+ * Drops the nozzle at maximum hose distance.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Fuel Truck <OBJECT>
+ * 2: End Pos Offset <ARRAY>
+ * 3: Nozzle <OBJECT> (optional)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, fuelTruck, [0, 0, 0], nozzle] call ace_refuel_fnc_maxDistanceDropNozzle
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit", "_source", "_endPosOffset", "_nozzle"];
+
+// Exit if jerry can (no maximum distance there as it's not connected to anything)
+if (_nozzle getVariable [QGVAR(jerryCan), false]) exitWith {};
+
+// Check distance periodically to drop it at maximum hose length
+[{
+    params ["_args", "_pfID"];
+    _args params [
+        ["_unit", player, [objNull]],
+        ["_source", objNull, [objNull]],
+        ["_endPosOffset", [0, 0, 0], [[]], 3],
+        ["_nozzle", (_args select 0) getVariable [QGVAR(nozzle), objNull], [objNull]]
+    ];
+
+    if (isNull _source || {_unit distance (_source modelToWorld _endPosOffset) > (REFUEL_HOSE_LENGTH - 2)} || {!alive _source}) exitWith {
+        if !(isNull _nozzle) then {
+            [_unit, _nozzle] call FUNC(dropNozzle);
+            REFUEL_UNHOLSTER_WEAPON
+
+            [_unit, "forceWalk", "ACE_refuel", false] call EFUNC(common,statusEffect_set);
+            if (isNull _source || {!alive _source}) then {
+                private _rope = _nozzle getVariable [QGVAR(rope), objNull];
+                if !(isNull _rope) then {
+                    ropeDestroy _rope;
+                };
+                deleteVehicle _nozzle;
+            } else {
+                [LSTRING(Hint_TooFar), 2, _unit] call EFUNC(common,displayTextStructured);
+            };
+        };
+        [_pfID] call CBA_fnc_removePerFrameHandler;
+    };
+}, 0, [_unit, _target, _endPosOffset, _nozzle]] call CBA_fnc_addPerFrameHandler;

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -82,6 +82,9 @@ if (isNull _nozzle) then { // func is called on fuel truck
                 '!isNull (_target getVariable [QGVAR(nozzle), objNull])'
             ];
             _unit setVariable [QGVAR(ReleaseActionID), _actionID];
+
+            // Drop nozzle at maximum hose distance
+            [_unit, _target, _endPosOffset, _nozzle] call FUNC(maxDistanceDropNozzle);
         },
         "",
         localize LSTRING(TakeNozzleAction),
@@ -123,43 +126,15 @@ if (isNull _nozzle) then { // func is called on fuel truck
                 '!isNull (_target getVariable [QGVAR(nozzle), objNull])'
             ];
             _unit setVariable [QGVAR(ReleaseActionID), _actionID];
+
+            // Drop nozzle at maximum hose distance
+            private _target = _nozzle getVariable QGVAR(source);
+            private _endPosOffset = _nozzle getVariable QGVAR(attachPos);
+            [_unit, _target, _endPosOffset, _nozzle] call FUNC(maxDistanceDropNozzle);
         },
         "",
         localize LSTRING(TakeNozzleAction),
         {true},
         ["isnotinside"]
     ] call EFUNC(common,progressBar);
-
-    _target = _nozzle getVariable QGVAR(source);
-    _endPosOffset = _nozzle getVariable QGVAR(attachPos);
-};
-if !(_nozzle getVariable [QGVAR(jerryCan), false]) then {
-    [{
-        params ["_args", "_pfID"];
-        _args params [
-            ["_unit", player, [objNull]],
-            ["_source", objNull, [objNull]],
-            ["_endPosOffset", [0, 0, 0], [[]], 3],
-            ["_nozzle", _unit getVariable [QGVAR(nozzle), objNull], [objNull]]
-        ];
-
-        if (isNull _source || {_unit distance (_source modelToWorld _endPosOffset) > (REFUEL_HOSE_LENGTH - 2)} || {!alive _source}) exitWith {
-            if !(isNull _nozzle) then {
-                [_unit, _nozzle] call FUNC(dropNozzle);
-                REFUEL_UNHOLSTER_WEAPON
-
-                [_unit, "forceWalk", "ACE_refuel", false] call EFUNC(common,statusEffect_set);
-                if (isNull _source || {!alive _source}) then {
-                    private _rope = _nozzle getVariable [QGVAR(rope), objNull];
-                    if !(isNull _rope) then {
-                        ropeDestroy _rope;
-                    };
-                    deleteVehicle _nozzle;
-                } else {
-                    [LSTRING(Hint_TooFar), 2, _unit] call EFUNC(common,displayTextStructured);
-                };
-            };
-            [_pfID] call cba_fnc_removePerFrameHandler;
-        };
-    }, 0, [_unit, _target, _endPosOffset]] call cba_fnc_addPerFrameHandler;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #4523 
- Move drop PFH into separate function that gets added on progress bar success, it was getting added before and was exiting too fast in case of picking up from a direction that made the rope even longer.