### PR TITLE
Fix missing refuel menu on static fuel stations

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -144,13 +144,11 @@ class CfgVehicles {
     class House_F: House {};
 
     class House_Small_F: House_F {
-        class EventHandlers;
-
         class ACE_Actions {
             class ACE_MainActions {
                 displayName = ECSTRING(interaction,MainAction);
                 selection = "";
-                distance = 10;
+                distance = 5;
                 condition = "true";
             };
         };
@@ -501,10 +499,6 @@ class CfgVehicles {
 
     // Vanilla buildings
     class Land_Fuelstation_Feed_F: House_Small_F {
-        class EventHandlers {
-            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
-        };
-
         transportFuel = 0; //50k
         MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{0,0,-0.5}};
@@ -512,10 +506,6 @@ class CfgVehicles {
     };
 
     class Land_fs_feed_F: House_Small_F {
-        class EventHandlers {
-            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
-        };
-
         transportFuel = 0; //50k
         MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{-0.4,0.022,-.23}};

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -19,7 +19,8 @@ if (hasInterface) then {
             {isClass (_x >> "ACE_Actions" >> "ACE_MainActions" >> QGVAR(Refuel))} &&
             {getNumber (_x >> "scope") == 2}
         ) then {
-            deleteVehicle (configName _x createVehicleLocal [0,0,0]);
+            TRACE_1("Compiling menu",configName _x);
+            [configName _x] call EFUNC(interact_menu,compileMenu);
         };
     } count ('true' configClasses (configFile >> "CfgVehicles"));
 };

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -11,6 +11,19 @@ if (isServer) then {
     _this call FUNC(resetLocal);
 }] call CBA_fnc_addEventHandler;
 
+// workaround for static fuel stations
+if (hasInterface) then {
+    {
+        if (
+            configName _x isKindOf "Building" &&
+            {isClass (_x >> "ACE_Actions" >> "ACE_MainActions" >> QGVAR(Refuel))} &&
+            {getNumber (_x >> "scope") == 2}
+        ) then {
+            deleteVehicle (configName _x createVehicleLocal [0,0,0]);
+        };
+    } count ('true' configClasses (configFile >> "CfgVehicles"));
+};
+
 
 #ifdef DEBUG_MODE_FULL
 diag_log text format ["[ACE-refuel] Showing CfgVehicles with vanilla transportFuel"];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix missing refuel menu on static fuel stations.

I think it would fix #4077.

I found that:
- to fix missing refuel menu it's enough to create vehicle of the same class (it can be deleted at once);
- it's much faster to check conditions in if-then condition inside `'true' configClasses` loop than to check conditions in configClasses parameter.

Save/load, respawn, jip compatible.
