### PR TITLE
remove civilian rank icons from nametags

### DIFF
--- a/addons/nametags/XEH_postInit.sqf
+++ b/addons/nametags/XEH_postInit.sqf
@@ -35,3 +35,6 @@ GVAR(showNamesTime) = -10;
         call FUNC(updateSettings);
     };
 }] call CBA_fnc_addEventHandler;
+
+// civilians don't use military ranks
+["CIV_F", ["","","","","","",""]] call FUNC(setFactionRankIcons);


### PR DESCRIPTION
**When merged this pull request will:**
- Civs shouldn't use these.
