### PR TITLE
add function to disable dogtags for factions, and disable for civilians

### DIFF
--- a/addons/dogtags/XEH_PREP.hpp
+++ b/addons/dogtags/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+
 PREP(addDogtagActions);
 PREP(addDogtagItem);
 PREP(bloodType);
@@ -11,3 +12,4 @@ PREP(sendDogtagData);
 PREP(showDogtag);
 PREP(ssn);
 PREP(takeDogtag);
+PREP(disableFactionDogtags);

--- a/addons/dogtags/XEH_postInit.sqf
+++ b/addons/dogtags/XEH_postInit.sqf
@@ -45,3 +45,6 @@ if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
         }] call CBA_fnc_addEventHandler;
     };
 };
+
+// disable dogtags for civilians
+"CIV_F" call FUNC(disableFactionDogtags);

--- a/addons/dogtags/XEH_preInit.sqf
+++ b/addons/dogtags/XEH_preInit.sqf
@@ -4,4 +4,6 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
+GVAR(disabledFactions) = [] call CBA_fnc_createNamespace;
+    
 ADDON = true;

--- a/addons/dogtags/functions/fnc_canCheckDogtag.sqf
+++ b/addons/dogtags/functions/fnc_canCheckDogtag.sqf
@@ -20,4 +20,7 @@ params ["_player", "_target"];
 
 if (isNull _target) exitWith {false};
 
+// check if disabled for faction
+if ([GVAR(disabledFactions) getVariable faction _target] param [0, false]) exitWith {false};
+
 (!alive _target) || {_target getVariable ["ACE_isUnconscious", false]}

--- a/addons/dogtags/functions/fnc_canTakeDogtag.sqf
+++ b/addons/dogtags/functions/fnc_canTakeDogtag.sqf
@@ -20,4 +20,7 @@ params ["_player", "_target"];
 
 if (isNull _target) exitWith {false};
 
+// check if disabled for faction
+if ([GVAR(disabledFactions) getVariable faction _target] param [0, false]) exitWith {false};
+
 (!alive _target) || {_target getVariable ["ACE_isUnconscious", false]}

--- a/addons/dogtags/functions/fnc_disableFactionDogtags.sqf
+++ b/addons/dogtags/functions/fnc_disableFactionDogtags.sqf
@@ -17,8 +17,4 @@
 
 params [["_faction", "", [""]]];
 
-if (isNil QGVAR(disabledFactions)) then {
-    GVAR(disabledFactions) = [] call CBA_fnc_createNamespace;
-};
-
 GVAR(disabledFactions) setVariable [_faction, true];

--- a/addons/dogtags/functions/fnc_disableFactionDogtags.sqf
+++ b/addons/dogtags/functions/fnc_disableFactionDogtags.sqf
@@ -1,0 +1,24 @@
+/*
+ * Author: commy2
+ * Disable this faction from using dogtags.
+ *
+ * Arguments:
+ * 0: Faction <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * "CIV_F" call ace_dogtags_fnc_disableFactionDogtags
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params [["_faction", "", [""]]];
+
+if (isNil QGVAR(disabledFactions)) then {
+    GVAR(disabledFactions) = [] call CBA_fnc_createNamespace;
+};
+
+GVAR(disabledFactions) setVariable [_faction, true];


### PR DESCRIPTION
**When merged this pull request will:**
- adds function to disable dogtags for certain factions (e.g. rebels)
- use it to disable dogtags for civilians
