### PR TITLE
fix Kestrel without adv. ballistics

### DIFF
--- a/addons/kestrel4500/functions/fnc_generateOutputData.sqf
+++ b/addons/kestrel4500/functions/fnc_generateOutputData.sqf
@@ -132,13 +132,8 @@ if (GVAR(referenceHeadingMenu) == 0) then {
         };
         case 3: { // CROSSWIND
             if (!GVAR(MinAvgMax)) then {
-                if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {
-                    _textCenterBig = Str(round(abs(sin(GVAR(RefHeading) - _playerDir) * _windSpeed) * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round((abs(cos(_playerDir - _windDir)) * _windSpeed) * 10) / 10, round(_playerDir)];
-                } else {
-                    _textCenterBig = Str(round(abs(sin(GVAR(RefHeading)) * _windSpeed) * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
-                };
+                _textCenterBig = Str(round(abs(sin(GVAR(RefHeading) - _playerDir) * _windSpeed) * 10) / 10);
+                _textInfoLine1 = format["%1 m/s @ %2", round((abs(cos(_playerDir - _windDir)) * _windSpeed) * 10) / 10, round(_playerDir)];
                 _textInfoLine2 = "- set heading";
             } else {
                 _textCenterLine1Left = "Max";
@@ -164,13 +159,8 @@ if (GVAR(referenceHeadingMenu) == 0) then {
         };
         case 4: { // HEADWIND
             if (!GVAR(MinAvgMax)) then {
-                if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {
-                    _textCenterBig = Str(round(cos(GVAR(RefHeading) - _playerDir) * _windSpeed * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round((abs(cos(_playerDir - _windDir)) * _windSpeed) * 10) / 10, round(_playerDir)];
-                } else {
-                    _textCenterBig = Str(round(cos(GVAR(RefHeading)) * _windSpeed * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
-                };
+                _textCenterBig = Str(round(cos(GVAR(RefHeading) - _playerDir) * _windSpeed * 10) / 10);
+                _textInfoLine1 = format["%1 m/s @ %2", round((abs(cos(_playerDir - _windDir)) * _windSpeed) * 10) / 10, round(_playerDir)];
                 _textInfoLine2 = "- set heading";
             } else {
                 _textCenterLine1Left = "Max";


### PR DESCRIPTION
**When merged this pull request will:**
- IDK why it uses different formulas depending on whether adv. ballisitcs is enabled or not. It clearly says "Head wind" and "Cross wind", so it makes no sense that both tabs report the same with "basic wind"

