### PR TITLE
Fix 3rd party air and sea vehicle fuel capacity

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -196,7 +196,6 @@ class CfgVehicles {
 
     class Ship_F: Ship {
         MACRO_CONNECT_ACTIONS
-        GVAR(fuelCapacity) = 2000;
         GVAR(flowRate) = 4;
     };
 
@@ -368,19 +367,6 @@ class CfgVehicles {
         GVAR(fuelCapacity) = 830;
     };
 
-    class Heli_Attack_01_base_F: Helicopter_Base_F {
-        // Commanche
-    };
-
-    class Heli_Attack_02_base_F: Helicopter_Base_F {
-        // Mi-48 Kajman
-    };
-
-    class Heli_Light_01_base_F: Helicopter_Base_H {
-        // MH-6
-        GVAR(fuelCapacity) = 242;
-    };
-
     class Heli_Light_02_base_F: Helicopter_Base_H {
         // Ka-60 Kasatka
         GVAR(fuelCapacity) = 1450;
@@ -432,11 +418,6 @@ class CfgVehicles {
     class UAV_02_base_F: UAV {
         // Assuming similar YAHBON-R2
         GVAR(fuelCapacity) = 270;
-    };
-
-    class UGV_01_base_F: Car_F {
-        // Stomper
-        GVAR(fuelCapacity) = 100;
     };
 
     class Plane_Fighter_03_base_F: Plane_Base_F {

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -180,18 +180,13 @@ class CfgVehicles {
 
     class Helicopter: Air {
         MACRO_CONNECT_ACTIONS
-        GVAR(fuelCapacity) = 1500;
     };
 
     class Helicopter_Base_F: Helicopter {};
-
-    class Helicopter_Base_H: Helicopter_Base_F {
-        GVAR(fuelCapacity) = 3000;
-    };
+    class Helicopter_Base_H: Helicopter_Base_F {};
 
     class Plane: Air {
         MACRO_CONNECT_ACTIONS
-        GVAR(fuelCapacity) = 2000;
         GVAR(flowRate) = 16;
     };
 

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -18,8 +18,16 @@
 
 params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]], ["_nozzle", objNull, [objNull]], ["_connectToPoint", [0,0,0], [[]], 3]];
 
-private _rate =  getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(flowRate)) * GVAR(rate);
-private _maxFuel = getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(fuelCapacity));
+private _config = configFile >> "CfgVehicles" >> typeOf _target;
+
+private _rate =  getNumber (_config >> QGVAR(flowRate)) * GVAR(rate);
+private _maxFuel = getNumber (_config >> QGVAR(fuelCapacity));
+
+// Fall back to vanilla fuelCapacity value (only air vehicles don't have this defined by default by us)
+// Air vehicles have that value properly defined in liters, unlike ground vehicles which is is formula of (range * tested factor) - different fuel consumption system than ground vehicles
+if (_maxFuel == 0) then {
+    _maxFuel = getNumber (_config >> "fuelCapacity");
+};
 
 [{
     params ["_args", "_pfID"];

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -23,8 +23,8 @@ private _config = configFile >> "CfgVehicles" >> typeOf _target;
 private _rate =  getNumber (_config >> QGVAR(flowRate)) * GVAR(rate);
 private _maxFuel = getNumber (_config >> QGVAR(fuelCapacity));
 
-// Fall back to vanilla fuelCapacity value (only air vehicles don't have this defined by default by us)
-// Air vehicles have that value properly defined in liters, unlike ground vehicles which is is formula of (range * tested factor) - different fuel consumption system than ground vehicles
+// Fall back to vanilla fuelCapacity value (only air and sea vehicles don't have this defined by default by us)
+// Air and sea vehicles have that value properly defined in liters, unlike ground vehicles which is is formula of (range * tested factor) - different fuel consumption system than ground vehicles
 if (_maxFuel == 0) then {
     _maxFuel = getNumber (_config >> "fuelCapacity");
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix wrong fuel capacity for 3rd party helicopters/planes/ships by removing base class ACE3 fuel capacity config entry and fall-back to vanilla `fuelCapacity`.
- Not fix wrong fuel capacity for other ground vehicles, that is due to those using a different fuel consumption system (apparently at least) and require `fuelCapacity` to be `range * fuel factor`.
- Remove empty classes in refuel.

Previously MELB (modded) was being refueled slowly with 3000 liters (instead of expected 463 or 242) due to default helicopter `ace_refuel_fuelCapacity` config entry for example. That is not friendly to any mod, however sadly we can't do a fall-back to vanilla `fuelCapacity` for ground vehicles because they have a different fuel consumption system (formulated as above).