### PR TITLE
Don't show dogtag ID in action menu

### DIFF
--- a/addons/dogtags/functions/fnc_addDogtagActions.sqf
+++ b/addons/dogtags/functions/fnc_addDogtagActions.sqf
@@ -32,8 +32,7 @@ private _unitDogtagIDs = [];
 //Create action children for all dogtags
 private _actions = [];
 {
-    private _tagID = _unitDogtagIDs select _forEachIndex;
-    private _displayName = format ["%1 #%2", getText (configFile >> "CfgWeapons" >> _x >> "displayName"), _tagID];
+    private _displayName = format ["%1", getText (configFile >> "CfgWeapons" >> _x >> "displayName")];
     private _picture = getText (configFile >> "CfgWeapons" >> _x >> "picture");
 
     private _action = [_x, _displayName, _picture, {_this call FUNC(checkDogtagItem)}, {true}, {}, _x] call EFUNC(interact_menu,createAction);


### PR DESCRIPTION
Fix #4476

The internal tag IDs were still visiable from action menu
![image](https://cloud.githubusercontent.com/assets/9376747/19423363/3ad1b578-93e5-11e6-805d-a3694524ea51.png)
