### PR TITLE
Sanatize damage value used for blood creation

### DIFF
--- a/addons/medical_blood/functions/fnc_spurt.sqf
+++ b/addons/medical_blood/functions/fnc_spurt.sqf
@@ -23,6 +23,7 @@
 #define OFFSET 0.25
 
 params ["_unit", "_dir", "_damage"];
+_damage = _damage min 1;
 
 private _distanceBetweenDrops = DISTANCE_BETWEEN_DROPS * _damage;
 private _offset = OFFSET + _distanceBetweenDrops;


### PR DESCRIPTION
Fix #4571
```
[ACE] (medical_blood) TRACE: 16374 hit: _unit=bob, _causedBy=B Alpha 1-1:1 (Pabst Mirror), _damage=154523 z\ace\addons\medical_blood\functions\fnc_hit.sqf:18
```
`_damage=154523` 
So it was trying to create 618094 blood objects :smile: 

RPG-32 was doing about 27k damage hit.