### PR TITLE
Faster, non movment blocking gesture for tap shoulder

### DIFF
--- a/addons/interaction/functions/fnc_tapShoulder.sqf
+++ b/addons/interaction/functions/fnc_tapShoulder.sqf
@@ -23,6 +23,6 @@ if (_unit == ACE_player) then {
     addCamShake [4, 0.5, 5];
 };
 
-[_unit, "PutDown"] call EFUNC(common,doGesture);
+[_unit, "gesturePoint"] call EFUNC(common,doGesture);
 
 [QGVAR(tapShoulder), [_target, _shoulderNum], [_target]] call CBA_fnc_targetEvent;


### PR DESCRIPTION
Close #4577

Doesn't block movement or makes camera look down like `putDown` does.