### PR TITLE
Use single queue for blood cleanup

### DIFF
--- a/addons/medical_blood/XEH_PREP.hpp
+++ b/addons/medical_blood/XEH_PREP.hpp
@@ -3,4 +3,5 @@ PREP(handleWoundReceived);
 PREP(isBleeding);
 PREP(onBleeding);
 PREP(createBlood);
+PREP(serverCleanupBlood);
 PREP(spurt);

--- a/addons/medical_blood/functions/fnc_serverCleanupBlood.sqf
+++ b/addons/medical_blood/functions/fnc_serverCleanupBlood.sqf
@@ -1,0 +1,23 @@
+/*
+ * Author: PabstMirror
+ * Loop that cleans up blood
+ *
+ * Arguments:
+ * None
+ *
+ * ReturnValue:
+ * None
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+        
+(GVAR(bloodDrops) deleteAt 0) params ["", "_deletedBloodDrop"];
+deleteVehicle _deletedBloodDrop;
+
+// If we cleaned out the array, exit loop
+if (GVAR(bloodDrops) isEqualTo []) exitWith {};
+
+// Wait until the next blood drop in the queue will expire
+(GVAR(bloodDrops) select 0) params ["_expireTime"];
+[FUNC(serverCleanupBlood), [], (_expireTime - CBA_missionTime)] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
Using a single ordered queue for blood drop cleanup 
instead of having every drop (up to 500) on a `waitAndExecute`

Every call to `CBA_fnc_waitAndExecute` does a `sort`, so it's best to keep the array small.
