### PR TITLE
Fix cargo find nearest vehicle

### DIFF
--- a/addons/cargo/functions/fnc_canLoad.sqf
+++ b/addons/cargo/functions/fnc_canLoad.sqf
@@ -21,7 +21,7 @@ TRACE_2("params",_player,_object);
 
 if (!([_player, _object, []] call EFUNC(common,canInteractWith))) exitWith {false};
 
-private _nearestVehicle = [_player] call FUNC(findNearestVehicle);
+private _nearestVehicle = [_player, _object] call FUNC(findNearestVehicle);
 
 if (_nearestVehicle isKindOf "Cargo_Base_F" || isNull _nearestVehicle) then {
     {

--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -19,7 +19,7 @@
 params [["_item", "", [objNull,""]], "_vehicle"];
 
 if (speed _vehicle > 1 || {((getPos _vehicle) select 2) > 3}) exitWith {TRACE_1("vehicle not stable",_vehicle); false};
-// TODO: use unitIsUAV command for uav check once out of devbuild
+
 if (_item isEqualType objNull && {{alive _x && {getText (configFile >> "CfgVehicles" >> typeOf _x >> "simulation") != "UAVPilot"}} count crew _item > 0}) exitWith {
     TRACE_1("item is occupied",_item);
     false

--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -19,6 +19,11 @@
 params [["_item", "", [objNull,""]], "_vehicle"];
 
 if (speed _vehicle > 1 || {((getPos _vehicle) select 2) > 3}) exitWith {TRACE_1("vehicle not stable",_vehicle); false};
+// TODO: use unitIsUAV command for uav check once out of devbuild
+if (_item isEqualType objNull && {{alive _x && {getText (configFile >> "CfgVehicles" >> typeOf _x >> "simulation") != "UAVPilot"}} count crew _item > 0}) exitWith {
+    TRACE_1("item is occupied",_item);
+    false
+};
 
 private _itemSize = [_item] call FUNC(getSizeItem);
 private _validItem = false;

--- a/addons/cargo/functions/fnc_findNearestVehicle.sqf
+++ b/addons/cargo/functions/fnc_findNearestVehicle.sqf
@@ -1,35 +1,41 @@
 /*
  * Author: Glowbal
- * Get nearest vehicle from unit, priority: Car-Air-Tank-Ship.
+ * Get nearest vehicle from unit that is not excluded, priority: Car-Air-Tank-Ship.
  *
  * Arguments:
  * 0: Unit <OBJECT>
+ * 1: Object to exclude <OBJECT>
  *
  * Return Value:
  * Vehicle in Distance <OBJECT>
  *
  * Example:
- * [unit] call ace_cargo_fnc_findNearestVehicle
+ * [unit, object] call ace_cargo_fnc_findNearestVehicle
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_unit"];
+params ["_unit","_object"];
 
-private _loadCar = nearestObject [_unit, "car"];
-if (_unit distance _loadCar <= MAX_LOAD_DISTANCE) exitWith {_loadCar};
+private _loadCar = nearestObjects [_unit, ["car"], MAX_LOAD_DISTANCE];
+_loadCar deleteAt (_loadCar find _object);
+if !(_loadCar isEqualTo []) exitWith {_loadCar select 0};
 
-private _loadHelicopter = nearestObject [_unit, "air"];
-if (_unit distance _loadHelicopter <= MAX_LOAD_DISTANCE) exitWith {_loadHelicopter};
+private _loadHelicopter = nearestObjects [_unit, ["air"], MAX_LOAD_DISTANCE];
+_loadHelicopter deleteAt (_loadHelicopter find _object);
+if !(_loadHelicopter isEqualTo []) exitWith {_loadHelicopter select 0};
 
-private _loadTank = nearestObject [_unit, "tank"];
-if (_unit distance _loadTank <= MAX_LOAD_DISTANCE) exitWith {_loadTank};
+private _loadTank = nearestObjects [_unit, ["tank"], MAX_LOAD_DISTANCE];
+_loadTank deleteAt (_loadTank find _object);
+if !(_loadTank isEqualTo []) exitWith {_loadTank select 0};
 
-private _loadShip = nearestObject [_unit, "ship"];
-if (_unit distance _loadShip <= MAX_LOAD_DISTANCE) exitWith {_loadShip};
+private _loadShip = nearestObjects [_unit, ["ship"], MAX_LOAD_DISTANCE];
+_loadShip deleteAt (_loadShip find _object);;
+if !(_loadShip isEqualTo []) exitWith {_loadShip select 0};
 
-private _loadContainer = nearestObject [_unit,"Cargo_base_F"];
-if (_unit distance _loadContainer <= MAX_LOAD_DISTANCE) exitWith {_loadContainer};
+private _loadContainer = nearestObjects [_unit, ["Cargo_base_F"], MAX_LOAD_DISTANCE];
+_loadContainer deleteAt (_loadContainer find _object);
+if !(_loadContainer isEqualTo []) exitWith {_loadContainer select 0};
 
 objNull

--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -19,7 +19,7 @@
 params ["_player", "_object"];
 TRACE_2("params",_player,_object);
 
-private _vehicle = [_player] call FUNC(findNearestVehicle);
+private _vehicle = [_player, _object] call FUNC(findNearestVehicle);
 
 if ((isNull _vehicle) || {_vehicle isKindOf "Cargo_Base_F"}) then {
     {


### PR DESCRIPTION
**When merged this pull request will:**
- Remaking of #4551 after a mess up in me trying to update my fork and being inexperienced with git 
- add the ability to exclude objects from the findNearestVehicle function. For situations like in the [image](https://camo.githubusercontent.com/e7201defd0e592011aca183596dc25bbed2ef8ce/687474703a2f2f692e696d6775722e636f6d2f42447571774c612e706e67) where a player might make an object like the quad loadable, and the findNearestVehicle is reporting the quad as still the closest even though im clipping into the truck.
- prevent object implosion. If a player decides to make an object capable of being cargo as well loadable.
- Added occupancy check when loading object.
- Update findNearestVehicle calls to pass new parameter.
