### PR TITLE
Fix makeJerryCan locality issues

### DIFF
--- a/addons/refuel/functions/fnc_makeJerryCan.sqf
+++ b/addons/refuel/functions/fnc_makeJerryCan.sqf
@@ -23,8 +23,8 @@ if (isNull _target ||
     {_target getVariable [QGVAR(jerryCan), false]}) exitWith {};
 
 [_target, _fuelAmount] call FUNC(setFuel);
-_target setVariable [QGVAR(jerryCan), true, true];
-_target setVariable [QGVAR(source), _target, true];
+_target setVariable [QGVAR(jerryCan), true];
+_target setVariable [QGVAR(source), _target];
 
 // Main Action
 private _action = [QGVAR(Refuel),


### PR DESCRIPTION
**When merged this pull request will:**
- Fix makeJerryCan locality issues

The jerry can object was marked as such globally, but the interaction points were only added locally. The function will work when the object namespace variable wasn't synched yet, but once the first player has synched it the function will simply exit without adding the interaction points.