### PR TITLE
Fix Kestrel4500 wind speed calculation

### DIFF
--- a/addons/kestrel4500/functions/fnc_generateOutputData.sqf
+++ b/addons/kestrel4500/functions/fnc_generateOutputData.sqf
@@ -107,7 +107,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
         };
         case 2: { // Wind SPD
             if (!GVAR(MinAvgMax)) then {
-                _textCenterBig = Str(round(abs(_windSpeed) * 10) / 10);
+                _textCenterBig = Str(round(_windSpeed * 10) / 10);
             } else {
                 _textCenterLine1Left = "Max";
                 _textCenterLine2Left = "Avg";
@@ -134,7 +134,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
             if (!GVAR(MinAvgMax)) then {
                 if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {
                     _textCenterBig = Str(round(abs(sin(GVAR(RefHeading) - _playerDir) * _windSpeed) * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round((abs(cos(_playerDir - _windDir)) * _windSpeed) * 10) / 10, round(_playerDir)];
+                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_playerDir)];
                 } else {
                     _textCenterBig = Str(round(abs(sin(GVAR(RefHeading)) * _windSpeed) * 10) / 10);
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
@@ -166,7 +166,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
             if (!GVAR(MinAvgMax)) then {
                 if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {
                     _textCenterBig = Str(round(cos(GVAR(RefHeading) - _playerDir) * _windSpeed * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round((abs(cos(_playerDir - _windDir)) * _windSpeed) * 10) / 10, round(_playerDir)];
+                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_playerDir)];
                 } else {
                     _textCenterBig = Str(round(cos(GVAR(RefHeading)) * _windSpeed * 10) / 10);
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];


### PR DESCRIPTION
- `_windSpeed` is already an [absolute value](https://github.com/acemod/ACE3/blob/7b2d736ba35fb2c6808311ba61065076da4c9401/addons/kestrel4500/functions/fnc_measureWindSpeed.sqf#L21)
- `cos(_playerDir - _windDir)` is already applied in [`FUNC(measureWindSpeed)`](https://github.com/acemod/ACE3/blob/7b2d736ba35fb2c6808311ba61065076da4c9401/addons/kestrel4500/functions/fnc_measureWindSpeed.sqf#L26)

Closes: https://github.com/acemod/ACE3/pull/4552
