### PR TITLE
Fix typo in Eden Options

### DIFF
--- a/addons/medical/CfgEden.hpp
+++ b/addons/medical/CfgEden.hpp
@@ -22,7 +22,7 @@ class Cfg3DEN {
                     rows = 1;
                     columns = 4;
                     strings[] = {"$STR_3DEN_Attributes_Lock_Default_text", CSTRING(AssignMedicRoles_role_none), CSTRING(AssignMedicRoles_role_medic), CSTRING(AssignMedicRoles_role_doctorShort)};
-                    onToolboxSelChanged = "missionnamespace setvariable ['ace_isMeidc_temp',_this select 1];";
+                    onToolboxSelChanged = "missionnamespace setvariable ['ace_isMedic_temp',_this select 1];";
                 };
             };
         };

--- a/addons/medical/CfgEden.hpp
+++ b/addons/medical/CfgEden.hpp
@@ -10,7 +10,7 @@ class Cfg3DEN {
         };
         class GVAR(isMedicControl): Title {
             attributeLoad = "(_this controlsGroupCtrl 100) lbsetcursel (((_value + 1) min 3) max 0);";
-            attributeSave = "(missionnamespace getvariable ['ace_isMeidc_temp',0]) - 1;";
+            attributeSave = "(missionnamespace getvariable ['ace_isMedic_temp',0]) - 1;";
             class Controls: Controls {
                 class Title: Title{};
                 class Value: ctrlToolbox {


### PR DESCRIPTION
**When merged this pull request will:**

This fixes a typo in line 25, `ace_isMeidc_temp` to `ace_isMedic_temp`
