### PR TITLE
Allow checking dogtags inside vehicles and when sitting

### DIFF
--- a/addons/dogtags/CfgVehicles.hpp
+++ b/addons/dogtags/CfgVehicles.hpp
@@ -34,6 +34,7 @@ class CfgVehicles {
                     displayName = CSTRING(checkItem);
                     condition = "true";
                     statement = "";
+                    exceptions[] = {"isNotInside", "isNotSitting"};
                     insertChildren = QUOTE(_this call DFUNC(addDogtagActions));
                 };
             };

--- a/addons/dogtags/functions/fnc_addDogtagActions.sqf
+++ b/addons/dogtags/functions/fnc_addDogtagActions.sqf
@@ -32,7 +32,7 @@ private _unitDogtagIDs = [];
 //Create action children for all dogtags
 private _actions = [];
 {
-    private _displayName = format ["%1", getText (configFile >> "CfgWeapons" >> _x >> "displayName")];
+    private _displayName = getText (configFile >> "CfgWeapons" >> _x >> "displayName");
     private _picture = getText (configFile >> "CfgWeapons" >> _x >> "picture");
 
     private _action = [_x, _displayName, _picture, {_this call FUNC(checkDogtagItem)}, {true}, {}, _x] call EFUNC(interact_menu,createAction);


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Remove redundant `format`

I also think we should display the name in the interaction menu, currently it's only `Dog Tag, Dog Tag, Dog Tag, ...` when checking dog tags you have taken. Doesn't seem to be as easy as it is communicated from the server rather than kept on client that has it. Reverting #4558 might be preferable in that case, simply to distinguish them (maybe that was the original idea anyways?).