### PR TITLE
Fix Full Repair menu not shown when damage returns 0

### DIFF
--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -72,7 +72,7 @@ class ACE_Repair {
             requiredEngineer = QGVAR(engineerSetting_fullRepair);
             repairLocations[] = {QGVAR(fullRepairLocation)};
             repairingTime = 30;
-            condition = "damage _target > 0";
+            condition = "0 < ({_x>0} count (getAllHitPointsDamage _target param [2,[]]))";
             callbackSuccess = QUOTE(call FUNC(doFullRepair));
             itemConsumed = QGVAR(consumeItem_ToolKit);
         };


### PR DESCRIPTION
Sometimes [damage command](https://community.bistudio.com/wiki/damage) returns 0 even if vehicle is almost fully destroyed. It's mentioned in Notes section on that wiki page. I found it can easily reproduced with HMG fire at Hunter.
damage can be replaced with [getAllHitPointsDamage](https://community.bistudio.com/wiki/getAllHitPointsDamage).

damage is also used for vehicles in [fnc_normalizeHitPoints.sqf](../blob/e60df02758e9dd997fb591ba8dfcbe2876c3b6ea/addons/repair/functions/fnc_normalizeHitPoints.sqf#L50) and  [fnc_setHitPointDamage.sqf](../blob/e60df02758e9dd997fb591ba8dfcbe2876c3b6ea/addons/repair/functions/fnc_setHitPointDamage.sqf#L37), but I didn't managed to understand the sense.