### PR TITLE
improve dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,7 +2,10 @@
 # docker build -t ace3mod/jekyll .
 #
 # Run:
-# docker run -p 4000:4000 -it ace3mod/jekyll
+# docker run -it -p 4000:4000 -v $(pwd):/usr/src/app ace3mod/jekyll
+# 
+# Run with --incremental flag:
+# docker run -it -p 4000:4000 -v $(pwd):/usr/src/app ace3mod/jekyll --incremental
 
 FROM starefossen/github-pages:latest
 MAINTAINER bux
@@ -11,4 +14,4 @@ COPY . /usr/src/app
 
 VOLUME "/usr/src/app"
 
-CMD ["jekyll", "serve", "--future", "--incremental", "--config", "_config_dev.yml", "-H", "0.0.0.0", "-P", "4000"]
+ENTRYPOINT ["jekyll", "serve", "--future", "--config", "_config_dev.yml", "-H", "0.0.0.0", "-P", "4000"]


### PR DESCRIPTION
**When merged this pull request will:**
- fix the dockerfile to use a proper entrypoint
- remove "--incremental" but by using an entrypoint a user could simply add the "--incremental" flag

```
# Build:
# docker build -t ace3mod/jekyll .
#
# Run:
# docker run -it -p 4000:4000 -v $(pwd):/usr/src/app ace3mod/jekyll
# 
# Run with --incremental flag:
# docker run -it -p 4000:4000 -v $(pwd):/usr/src/app ace3mod/jekyll --incremental
```