### PR TITLE
Prevent switching to weapon while carrying fuel nozzle

### DIFF
--- a/addons/refuel/XEH_PREP.hpp
+++ b/addons/refuel/XEH_PREP.hpp
@@ -14,6 +14,7 @@ PREP(dropNozzle);
 PREP(getFuel);
 PREP(handleDisconnect);
 PREP(handleKilled);
+PREP(handlePlayerWeaponChanged);
 PREP(handleUnconscious);
 PREP(makeJerryCan);
 PREP(maxDistanceDropNozzle);

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
 ["ace_unconscious", {_this call FUNC(handleUnconscious)}] call CBA_fnc_addEventHandler;
+["weapon", FUNC(handlePlayerWeaponChanged)] call CBA_fnc_addPlayerEventHandler;
 
 if (isServer) then {
     addMissionEventHandler ["HandleDisconnect", {_this call FUNC(handleDisconnect)}];

--- a/addons/refuel/functions/fnc_handlePlayerWeaponChanged.sqf
+++ b/addons/refuel/functions/fnc_handlePlayerWeaponChanged.sqf
@@ -1,0 +1,29 @@
+/*
+ * Author: Jonpas
+ * Drops nozzle or jerry can when selecting a weapon.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Weapon <STRING> (unused)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_unit, "gun"] call ace_refuel_fnc_handlePlayerWeaponChanged;
+ *
+ * Public: No
+*/
+#include "script_component.hpp"
+
+params ["_unit"];
+
+// Drop nozzle/jerry can when selecting a non-primary weapon
+if (_unit getVariable [QGVAR(isRefueling), false]) then {
+    private _nozzle = _unit getVariable [QGVAR(nozzle), objNull];
+    if !(isNull _nozzle) then {
+        [_unit, _nozzle] call FUNC(dropNozzle);
+        _unit setVariable [QGVAR(selectedWeaponOnRefuel), nil];
+        [_unit, "forceWalk", "ACE_refuel", false] call EFUNC(common,statusEffect_set);
+    };
+};

--- a/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
+++ b/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
@@ -33,7 +33,8 @@ if (_nozzle getVariable [QGVAR(jerryCan), false]) exitWith {};
         ["_nozzle", (_args select 0) getVariable [QGVAR(nozzle), objNull], [objNull]]
     ];
 
-    if (_unit getVariable [QGVAR(isRefueling), false]) exitWith {
+    if (!(_unit getVariable [QGVAR(isRefueling), false])) exitWith {
+        TRACE_1("player not isRefueling",_unit);
         [_pfID] call CBA_fnc_removePerFrameHandler;
     };
 

--- a/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
+++ b/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
@@ -33,6 +33,10 @@ if (_nozzle getVariable [QGVAR(jerryCan), false]) exitWith {};
         ["_nozzle", (_args select 0) getVariable [QGVAR(nozzle), objNull], [objNull]]
     ];
 
+    if (_unit getVariable [QGVAR(isRefueling), false]) exitWith {
+        [_pfID] call CBA_fnc_removePerFrameHandler;
+    };
+
     if (isNull _source || {_unit distance (_source modelToWorld _endPosOffset) > (REFUEL_HOSE_LENGTH - 2)} || {!alive _source}) exitWith {
         if !(isNull _nozzle) then {
             [_unit, _nozzle] call FUNC(dropNozzle);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #4601 

Refuel should use a `canInteractWith` (like carrying does), but that will need a bigger rework. Because of it not using `canInteractWith` Advanced Throwing is possible while carrying a fuel nozzle or jerry can.

Aditionally vanilla throwing is possible both with refuel and carrying, a `setAmmo` framework for that would be nice, but have no time to work on it at the moment.