### PR TITLE
Add function command-line tool

### DIFF
--- a/tools/fnc.py
+++ b/tools/fnc.py
@@ -149,19 +149,19 @@ def renameFunction(addon, name, newName):
 def main():
     args = sys.argv
 
-    if "-cf" in args:
+    if "-c" in args:
         createFunction(args[2], args[3])
         sys.exit(2)
 
-    if "-df" in args:
+    if "-d" in args:
         deleteFunction(args[2], args[3])
         sys.exit(2)
 
-    if "-rf" in args:
+    if "-r" in args:
         renameFunction(args[2], args[3], args[4])
         sys.exit(2)
 
-    if "-mf" in args:
+    if "-m" in args:
         moveFunction(args[2], args[3], args[4])
         sys.exit(2)
 

--- a/tools/fnc.py
+++ b/tools/fnc.py
@@ -1,0 +1,169 @@
+import os
+import sys
+import re
+import glob
+import subprocess
+import textwrap
+
+PREFIX = 'ace'
+AUTHOR = ''
+ADDONS = '../addons/'
+PREP = 'XEH_PREP.hpp'
+EDITOR = 'C:/Program Files/Sublime Text 3/sublime_text.exe'
+
+def getFunctionPath(addon, name):
+    return "{}{}/functions/fnc_{}.sqf".format(ADDONS, addon, name)
+
+def getPrepPath(addon):
+    return "{}{}/{}".format(ADDONS, addon, PREP)
+
+def appendPrep(addon, name):
+    prepPath = getPrepPath(addon)
+    prep = open(prepPath, "a")
+    prep.write("PREP({});\n".format(name))
+    prep.close()
+
+def openFile(file):
+    subprocess.Popen([EDITOR, file])
+
+def replaceFunctionInCode(oldAddon, oldName, newAddon, newName):
+    for subdir, dirs, files in os.walk(ADDONS):
+        for addon in dirs:
+            files = glob.iglob('{0}{1}/**/*.*'.format(ADDONS, addon), recursive=True)
+            for file in files:
+                if ".sqf" in file or ".cpp" in file or ".hpp" in file:
+                    newContent = ''
+                    with open(file, 'r') as script:
+                        for line in script.readlines():
+                            if re.search(r'EFUNC\({0},[\s\S]*{1}\)'.format(oldAddon, oldName), line, re.IGNORECASE):
+                                newLine = re.sub(
+                                    r'EFUNC\({0},[\s\S]*{1}\)'.format(oldAddon, oldName),
+                                    "EFUNC({0}, {1})".format(newAddon, newName),
+                                    line,
+                                    flags=re.IGNORECASE
+                                )
+
+                                print("Replaced {0} with {1} in {2}".format(
+                                    "EFUNC({0}, {1})".format(oldAddon, oldName),
+                                    "EFUNC({0}, {1})".format(newAddon, newName),
+                                    file
+                                ))
+
+                                newContent += newLine
+                            else:
+                                if addon == newAddon and "func({0})".format(oldName.lower()) in line.lower():
+                                    newLine = line.replace(
+                                        "FUNC({0})".format(oldName),
+                                        "FUNC({0})".format(newName)
+                                    )
+
+                                    print("Replaced {0} with {1} in {2}".format(
+                                        "FUNC({0})".format(oldName),
+                                        "FUNC({0})".format(newName),
+                                        file
+                                    ))
+
+                                    newContent += newLine
+                                else:
+                                    newContent += line
+
+                    # Overwrite contents
+                    f = open(file, "w")
+                    f.write(newContent)
+                    f.close()
+        break
+
+def createFunction(addon, name, contents=''):
+    function = getFunctionPath(addon, name)
+
+    if os.path.exists(function):
+        print("Function already exists, exiting")
+        return
+
+    file = open(function, "w")
+
+    if contents == '':
+        file.write(textwrap.dedent('''\
+            /*
+             * Author: {0}
+             * 
+             *
+             * Arguments:
+             * 
+             *
+             * Return Value:
+             * 
+             *
+             * Example:
+             * [] call {3}_{1}_fnc_{2};
+             *
+             * Public: 
+             */
+
+            #include "script_component.hpp"
+            ''').format(AUTHOR, addon, name, PREFIX))
+    else:
+        file.write(contents)
+
+    file.close()
+
+    appendPrep(addon, name)
+    openFile(function)
+
+def deleteFunction(addon, name):
+    function = getFunctionPath(addon, name)
+
+    if not os.path.exists(function):
+        print("Function does not exist")
+        return
+
+    os.remove(function)
+
+    file = open(getPrepPath(addon), 'r+')
+    lines = file.readlines()
+    file.seek(0)
+
+    for line in lines:
+        if line != "PREP({0});\n".format(name):
+            file.write(line)
+
+    file.truncate()
+    file.close()
+
+def moveFunction(addon, name, newAddon):
+    contents = ''
+    with open(getFunctionPath(addon, name)) as file:
+        contents = file.read()
+    deleteFunction(addon, name)
+    createFunction(newAddon, name, contents)
+    replaceFunctionInCode(addon, name, newAddon, name)
+
+def renameFunction(addon, name, newName):
+    contents = ''
+    with open(getFunctionPath(addon, name)) as file:
+        contents = file.read()
+    deleteFunction(addon, name)
+    createFunction(addon, newName, contents)
+    replaceFunctionInCode(addon, name, addon, newName)
+
+def main():
+    args = sys.argv
+
+    if "-cf" in args:
+        createFunction(args[2], args[3])
+        sys.exit(2)
+
+    if "-df" in args:
+        deleteFunction(args[2], args[3])
+        sys.exit(2)
+
+    if "-rf" in args:
+        renameFunction(args[2], args[3], args[4])
+        sys.exit(2)
+
+    if "-mf" in args:
+        moveFunction(args[2], args[3], args[4])
+        sys.exit(2)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
**When merged this pull request will:**
- Add a Python command-line tool for functions

It's very basic at the moment and there are probably lots of ways to improve it, but I'm no Python guru. This tool makes it a lot easier and quicker to refactor since it will update the rest of the codebase with changes you make to function names and their addon.

-----------------------

### Options
**Create**
`fnc.py -c addon name` will create `fnc_name.sqf` in `addon\functions` with the function header and script_component included. It will also add `PREP(name);` to the PREP file and lastly open the file in the given editor (this may have to be changed to the default program for SQF files).

**Delete**
`fnc.py -d addon name` will delete `fnc_name.sqf` from `addon\functions` and also delete its PREP from the PREP file.

**Rename**
`fnc.py -r addon name newName` will rename `fnc_name.sqf` to `fnc_newName.sqf` in `addon\functions`. It will also rename the corresponding PREP. Lastly it will search through the rest of the codebase in `addons\` and update its name wherever used (`EFUNC` and `FUNC`).

**Move**
`fnc.py -m addon name newAddon` will move `fnc_name.sqf` in `addon\functions` to `newAddon\functions`, update the PREP files and update the rest of the codebase. It's almost identical to `-r`.