### PR TITLE
Fix ammo cook off with certain explosives

### DIFF
--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -11,7 +11,7 @@ class Cfg3DEN {
                         tooltip = CSTRING(enable_tooltip);
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
-                        condition = "objectVehicle";
+                        condition = "objectVehicle + objectHasInventoryCargo";
                         defaultValue = "(true)"; // fix pbo project preprocessing bug
                     };
                 };

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -11,7 +11,7 @@ class Cfg3DEN {
                         tooltip = CSTRING(enable_tooltip);
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
-                        condition = "objectVehicle + objectHasInventoryCargo";
+                        condition = "objectHasInventoryCargo";
                         defaultValue = "(true)"; // fix pbo project preprocessing bug
                     };
                 };

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -71,7 +71,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 ["ReammoBox_F", "init", {
     (_this select 0) addEventHandler ["HandleDamage", {
-        if (GVAR(enableAmmobox)) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enableAmmobox)]) then {
             ["box", _this] call FUNC(handleDamage);
         };
     }];

--- a/addons/cookoff/functions/fnc_detonateAmmunition.sqf
+++ b/addons/cookoff/functions/fnc_detonateAmmunition.sqf
@@ -37,7 +37,7 @@ if (_amountOfMagazines > 0) exitWith {
     _timeBetweenAmmoDetonation = _timeBetweenAmmoDetonation max 0.1;
 
     private _ammo = getText (configFile >> "CfgMagazines" >> _magazineClassname >> "ammo");
-    private _ammoCfg = (configFile >> "CfgAmmo" >> _ammo);
+    private _ammoCfg = configFile >> "CfgAmmo" >> _ammo;
 
     private _speedOfAmmo = getNumber (configFile >> "CfgMagazines" >> _magazineClassname >> "initSpeed");
     private _simulationTime = getNumber (_ammoCfg >> "simulation");
@@ -53,8 +53,8 @@ if (_amountOfMagazines > 0) exitWith {
         if (_spawnPos select 2 < 0) then {
             _spawnPos set [2, 0];
         };
-        private _projectile = _ammo createVehicle [0,0,0];
-        _projectile setPos _spawnPos;
+
+        private _projectile = createVehicle [_ammo, _spawnPos, [], 0, "CAN_COLLIDE"];
         if (_flyAway) then {
             private _vectorAmmo = [(-1 + (random 2)), (-1 + (random 2)), -0.2 + (random 1)];
             private _velVec = _vectorAmmo vectorMultiply _speed;
@@ -99,7 +99,7 @@ if (_amountOfMagazines > 0) exitWith {
 
             [_vehicle, _ammo, _speed, random 1 < 0.3] call _spawnProjectile;
         } else {
-            "ACE_ammoExplosionLarge" createvehicle (_vehicle modelToWorld _effect2pos);
+            createvehicle ["ACE_ammoExplosionLarge", (_vehicle modelToWorld _effect2pos), [], 0 , "CAN_COLLIDE"];
         };
     };
     if (toLower _simType in ["shotdirectionalbomb", "shotmine"]) then {
@@ -114,7 +114,7 @@ if (_amountOfMagazines > 0) exitWith {
             if (_ammo != "") then {
                 [_vehicle, _ammo, 0, false] call _spawnProjectile;
             } else {
-                "SmallSecondary" createvehicle (_vehicle modelToWorld _effect2pos);
+                createvehicle ["SmallSecondary", (_vehicle modelToWorld _effect2pos), [], 0 , "CAN_COLLIDE"];
             };
         };
     };

--- a/addons/cookoff/functions/fnc_detonateAmmunition.sqf
+++ b/addons/cookoff/functions/fnc_detonateAmmunition.sqf
@@ -33,15 +33,16 @@ if (_amountOfMagazines > 0) exitWith {
     } else {
         _magazine set [1, _newMagCount]; // clear out the magazine
     };
-    private _ammo = getText (configFile >> "CfgMagazines" >> _magazineClassname >> "ammo");
-
     private _timeBetweenAmmoDetonation = (random 7) * (1 / random (_amountOfMagazines)) min MAX_TIME_BETWEEN_AMMO_DET;
     _timeBetweenAmmoDetonation = _timeBetweenAmmoDetonation max 0.1;
 
+    private _ammo = getText (configFile >> "CfgMagazines" >> _magazineClassname >> "ammo");
+    private _ammoCfg = (configFile >> "CfgAmmo" >> _ammo);
+
     private _speedOfAmmo = getNumber (configFile >> "CfgMagazines" >> _magazineClassname >> "initSpeed");
-    private _simulationTime = getNumber (configFile >> "CfgAmmo" >> _ammo >> "simulation");
-    private _caliber = getNumber (configFile >> "CfgAmmo" >> _ammo >> "caliber");
-    private _simType = getText (configFile >> "CfgAmmo" >> _ammo >> "simulation");
+    private _simulationTime = getNumber (_ammoCfg >> "simulation");
+    private _caliber = getNumber (_ammoCfg >> "caliber");
+    private _simType = getText (_ammoCfg >> "simulation");
 
     private _effect2pos = _vehicle selectionPosition "destructionEffect2";
 
@@ -91,7 +92,7 @@ if (_amountOfMagazines > 0) exitWith {
         };
         [_vehicle, _ammo, _speed, random 1 < 0.5] call _spawnProjectile;
     };
-    if (toLower _simType == "shotrocket" || {toLower _simType == "shotmissile"}) then {
+    if (toLower _simType in ["shotrocket", "shotmissile", "shotsubmunitions"]) then {
         if (random 1 < 0.1) then {
             private _sound = selectRandom [QUOTE(PATHTO_R(sounds\cannon_crack_close.wss)), QUOTE(PATHTO_R(sounds\cannon_crack_close_filtered.wss))];
             playSound3D [_sound, objNull, false, (getPosASL _vehicle), 3, 1, 1600];
@@ -101,9 +102,25 @@ if (_amountOfMagazines > 0) exitWith {
             "ACE_ammoExplosionLarge" createvehicle (_vehicle modelToWorld _effect2pos);
         };
     };
-    if (toLower _simType in ["shotdirectionalbomb", "shotilluminating", "shotmine"]) then {
+    if (toLower _simType in ["shotdirectionalbomb", "shotmine"]) then {
         if (random 1 < 0.5) then {
-            [_vehicle, _ammo, 0, false] call _spawnProjectile;
+            // Not all explosives detonate on destruction, some have scripted alternatives
+            private _scripted = getNumber (_ammoCfg >> "triggerWhenDestroyed") == 1;
+            if !(_scripted) then {
+                _ammo = getText (_ammoCfg >> "ace_explosives_Explosive");
+            };
+
+            // If a scripted alternative doesn't exist use generic explosion
+            if (_ammo != "") then {
+                [_vehicle, _ammo, 0, false] call _spawnProjectile;
+            } else {
+                "SmallSecondary" createvehicle (_vehicle modelToWorld _effect2pos);
+            };
+        };
+    };
+    if (toLower _simType == "shotilluminating") then {
+        if (random 1 < 0.15) then {
+            [_vehicle, _ammo, _speed, random 1 < 0.3] call _spawnProjectile;
         };
     };
 

--- a/addons/cookoff/functions/fnc_secondaryExplosions.sqf
+++ b/addons/cookoff/functions/fnc_secondaryExplosions.sqf
@@ -44,7 +44,7 @@ private _fnc_secondaryExplosion = {
     private _position = _vehicle modelToWorld (_vehicle selectionPosition "destructionEffect2");
 
     // these CfgAmmo objects are always global
-    "SmallSecondary" createVehicle _position;
+    createVehicle ["SmallSecondary", _position, [], 0, "CAN_COLLIDE"];
 
     DEC(_amount);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add a toggle to ammo boxes in 3den to disable their cook off individually
- Fix some explosives not working as part of ammo detonation
- Include shots of simulation type `shotsubmunitions` in ammo detonation