### PR TITLE
fix tripflares script error

### DIFF
--- a/addons/explosives/functions/fnc_spawnFlare.sqf
+++ b/addons/explosives/functions/fnc_spawnFlare.sqf
@@ -21,3 +21,5 @@ TRACE_3("Params",_posX,_posY,_posZ);
 private _flare = "ACE_TripFlare_FlareEffect" createVehicle [_posX,_posY,_posZ];
 
 TRACE_1("",_flare);
+
+nil


### PR DESCRIPTION
**When merged this pull request will:**
- this function is called via `directCall` which internally uses the assignment operator on the called functions return value.
https://github.com/acemod/ACE3/blob/98da86b74d4089bc3403d0b0c0074e6a46ce35d8/addons/explosives/scripts/TripflareEffect.sqf#L20
- this function itself ends with an assignment operator too unless the `TRACE()` is resolved in debug mode. The assignment operator is bugged in the SQF engine. It's the only "command" that reports `void` instead of e.g. `GameValueNil` in C++ land. Using the assignment operator on `void` causes the following script error:
```
 0:33:15 Error in expression <ate "_CBA_return";

isNil {
_CBA_return = _CBA_arguments call _CBA_code;
};

if >
 0:33:15   Error position: <= _CBA_arguments call _CBA_code;
};

if >
 0:33:15   Error Generic error in expression
 0:33:15 File x\cba\addons\common\fnc_directCall.sqf, line 9
```

- can be replicated by using:
```sqf
_var1 = call {
    _var2 = "";
};
```

Note again: this error does not happen in debug mode, due to the different way how `TRACE()` is resolved.