### PR TITLE
FCS with no compat pbo required

### DIFF
--- a/addons/fcs/functions/fnc_calculateSolution.sqf
+++ b/addons/fcs/functions/fnc_calculateSolution.sqf
@@ -17,6 +17,7 @@
 params ["_vehicle","_turret","_distance","_angleTarget"];
 TRACE_4("params",_vehicle,_turret,_distance,_angleTarget);
 
+private _FCSInitSpeed = [];
 private _FCSMagazines = [];
 private _FCSElevation = [];
 private _turretConfig = [configFile >> "CfgVehicles" >> typeOf _vehicle, _turret] call EFUNC(common,getTurretConfigPath);
@@ -64,6 +65,7 @@ private _turretConfig = [configFile >> "CfgVehicles" >> typeOf _vehicle, _turret
         private _offset = "ace_fcs" callExtension format ["%1,%2,%3,%4", _initSpeed, _airFriction, _angleTarget, _distance];
         _offset = parseNumber _offset;
 
+        _FCSInitSpeed pushBack _initSpeed;
         _FCSMagazines pushBack _magazine;
         _FCSElevation pushBack _offset;
     };
@@ -71,5 +73,6 @@ private _turretConfig = [configFile >> "CfgVehicles" >> typeOf _vehicle, _turret
 } count (_vehicle magazinesTurret _turret);
 
 [_vehicle, format ["%1_%2", QGVAR(Distance),  _turret],     _distance] call EFUNC(common,setVariablePublic);
+[_vehicle, format ["%1_%2", QGVAR(InitSpeed), _turret], _FCSInitSpeed] call EFUNC(common,setVariablePublic);
 [_vehicle, format ["%1_%2", QGVAR(Magazines), _turret], _FCSMagazines] call EFUNC(common,setVariablePublic);
 [_vehicle, format ["%1_%2", QGVAR(Elevation), _turret], _FCSElevation] call EFUNC(common,setVariablePublic);

--- a/addons/fcs/functions/fnc_firedEH.sqf
+++ b/addons/fcs/functions/fnc_firedEH.sqf
@@ -19,14 +19,16 @@ private _FCSMagazines = _vehicle getVariable [format ["%1_%2", QGVAR(Magazines),
 
 if !(_magazine in _FCSMagazines) exitWith {};
 
+private _FCSInitSpeed = _vehicle getVariable format ["%1_%2", QGVAR(InitSpeed), _turret];
 private _FCSElevation = _vehicle getVariable format ["%1_%2", QGVAR(Elevation), _turret];
 
-// GET ELEVATION OFFSET OF CURRENT MAGAZINE
+// GET ELEVATION OFFSET AND INITSPEED OF CURRENT MAGAZINE
 private _offset = 0;
-
+private _initSpeed = 0;
 {
     if (_x == _magazine) exitWith {
         _offset = _FCSElevation select _forEachIndex;
+        _initSpeed = _FCSInitSpeed select _forEachIndex;
     };
 } forEach _FCSMagazines;
 
@@ -35,9 +37,6 @@ private _zeroDistance = currentZeroing _gunner;
 if (_zeroDistance > 0) then {
     private _weaponCombo = [_weapon, _magazine, _ammo, _zeroDistance];
     if !(_weaponCombo isEqualTo (_gunner getVariable [QGVAR(lastWeaponCombo), []])) then {
-        // Hackish way of getting initSpeed. @todo: replace it by correct calculation and caching
-        private _initSpeed = vectorMagnitude velocity _projectile;
-
         private _airFriction = getNumber (configFile >> "CfgAmmo" >> _ammo >> "airFriction");
         private _antiOffset = "ace_fcs" callExtension format ["%1,%2,%3,%4", _initSpeed, _airFriction, 0, _zeroDistance];
         _antiOffset = parseNumber _antiOffset;

--- a/addons/fcs/functions/fnc_firedEH.sqf
+++ b/addons/fcs/functions/fnc_firedEH.sqf
@@ -30,6 +30,27 @@ private _offset = 0;
     };
 } forEach _FCSMagazines;
 
+// Calculate the correction due to vanilla zeroing
+private _zeroDistance = currentZeroing _gunner;
+if (_zeroDistance > 0) then {
+    private _weaponCombo = [_weapon, _magazine, _ammo, _zeroDistance];
+    if !(_weaponCombo isEqualTo (_gunner getVariable [QGVAR(lastWeaponCombo), []])) then {
+        // Hackish way of getting initSpeed. @todo: replace it by correct calculation and caching
+        private _initSpeed = vectorMagnitude velocity _projectile;
+
+        private _airFriction = getNumber (configFile >> "CfgAmmo" >> _ammo >> "airFriction");
+        private _antiOffset = "ace_fcs" callExtension format ["%1,%2,%3,%4", _initSpeed, _airFriction, 0, _zeroDistance];
+        _antiOffset = parseNumber _antiOffset;
+
+        _gunner setVariable [QGVAR(lastWeaponCombo), _weaponCombo];
+        _gunner setVariable [QGVAR(lastAntiOffset), _antiOffset];
+    };
+    private _antiOffset = _gunner getVariable QGVAR(lastAntiOffset);
+
+    _offset = _offset - _antiOffset;
+    TRACE_4("fired",_gunner, currentZeroing _gunner, _antiOffset, _offset);
+};
+
 [_projectile, (_vehicle getVariable format ["%1_%2", QGVAR(Azimuth), _turret]), _offset, 0] call EFUNC(common,changeProjectileDirection);
 
 // Remove the platform velocity

--- a/addons/fcs/functions/fnc_firedEH.sqf
+++ b/addons/fcs/functions/fnc_firedEH.sqf
@@ -64,7 +64,7 @@ if (vectorMagnitude velocity _vehicle > 2) then {
 if (!local _gunner) exitWith {};
 
 if (getNumber (configFile >> "CfgAmmo" >> _ammo >> QGVAR(Airburst)) == 1) then {
-    private _zeroing = _vehicle getVariable [format ["%1_%2", QGVAR(Distance), _turret], currentZeroing _vehicle];
+    private _zeroing = _vehicle getVariable [format ["%1_%2", QGVAR(Distance), _turret], currentZeroing _gunner];
 
     if (_zeroing < 50) exitWith {};
     if (_zeroing > 1500) exitWith {};


### PR DESCRIPTION
Reincarnation of https://github.com/acemod/ACE3/pull/3561

**When merged this pull request will:**
* Add a correction to ACE_FCS to account for vanilla zeroing
* Allow ACE_FCS to work without requiring a compatibility PBO

**TODO** 
~~Think about hiding the vanilla zeroing control if necessary (**Edit:** I don't think that we should hide it)~~

Closes: https://github.com/acemod/ACE3/pull/3561