### PR TITLE
Don't compile action menu for playable logics

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -99,6 +99,11 @@ private _recurseFnc = {
     _actions
 };
 
+if ((getNumber (configFile >> "CfgVehicles" >> _objectType >> "isPlayableLogic")) == 1) exitWith {
+    TRACE_1("skipping playable logic",_objectType);
+    _namespace setVariable [_objectType, []];
+};
+
 private _actionsCfg = configFile >> "CfgVehicles" >> _objectType >> "ACE_Actions";
 
 TRACE_1("Building ACE_Actions",_objectType);


### PR DESCRIPTION
Fix #4664

playableLogic seems to be `VirtualMan_F` and it's children
`HeadlessClient_F`
`VirtualCurator_F`
`VirtualSpectator_F`