### PR TITLE
Introduce small variation to length of cardiac arrest

### DIFF
--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -53,7 +53,7 @@ GVAR(STATE_MACHINE) = (configFile >> "ACE_Medical_StateMachine") call CBA_statem
 [
     QGVAR(cardiacArrestTime),
     "SLIDER",
-    ["Cardiac Arrest Time", "Sets how long cardiac arrest will last for (in minutes)."], //@todo
+    ["Cardiac Arrest Time", "Sets how long cardiac arrest will last for on average (in minutes)."], //@todo
     "ACE Medical", // @todo
     [0, 30, 2, 0],
     true

--- a/addons/medical/functions/fnc_conditionCardiacArrestTimer.sqf
+++ b/addons/medical/functions/fnc_conditionCardiacArrestTimer.sqf
@@ -14,5 +14,6 @@
 params ["_unit"];
 
 private _startTime = _unit getVariable [QGVAR(cardiacArrestStart), CBA_missionTime];
+private _lifeTime = _unit getVariable [QGVAR(cardiacArrestTime), GVAR(cardiacArrestTime)];
 
-(CBA_missionTime - _startTime) > (GVAR(cardiacArrestTime) * 60)
+(CBA_missionTime - _startTime) > (_lifeTime * 60)

--- a/addons/medical/functions/fnc_enteredStateCardiacArrest.sqf
+++ b/addons/medical/functions/fnc_enteredStateCardiacArrest.sqf
@@ -13,4 +13,8 @@
 #include "script_component.hpp"
 params ["_unit"];
 
+private _time = GVAR(cardiacArrestTime);
+_time = _time + random [_time*-0.1, 0, _time*0.1];
+
+_unit setVariable [QGVAR(cardiacArrestTime), _time];
 _unit setVariable [QGVAR(cardiacArrestStart), CBA_missionTime];


### PR DESCRIPTION
**When merged this pull request will:**
- Add some minor variation to the length of cardiac arrest, can only vary up to 10% of the setting value with a Gaussian distribution that favours the setting itself
