### PR TITLE
Advanced Fatigue swimming/diving/crawling tweaks

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_getAnimDuty.sqf
+++ b/addons/advanced_fatigue/functions/fnc_getAnimDuty.sqf
@@ -47,9 +47,15 @@ if (_animType in ["idl", "mov", "adj"]) then {
     };
 } else {
     // swimming and diving
-    if (_animType in ["swm", "ssw", "bsw", "dve", "sdv", "bdv"]) then {
-        _duty = 5;
-        GVAR(isSwimming) = true;
+    switch (true) do {
+        case (_animType in ["swm", "ssw", "bsw"]): {
+            _duty = 6.5;
+            GVAR(isSwimming) = true;
+        };
+        case (_animType in ["dve", "sdv", "bdv"]): {
+            _duty = 2.5;
+            GVAR(isSwimming) = true;
+        };
     };
 };
 

--- a/addons/advanced_fatigue/functions/fnc_getAnimDuty.sqf
+++ b/addons/advanced_fatigue/functions/fnc_getAnimDuty.sqf
@@ -28,7 +28,7 @@ if (_animType in ["idl", "mov", "adj"]) then {
             _duty = 1.5;
         };
         case ("pne"): {
-            _duty = 12;
+            _duty = 10;
         };
         default {
             _duty = 1;

--- a/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
@@ -58,7 +58,15 @@ if (GVAR(ppeBlackoutLast) == 1) then {
 
 // - Physical effects ---------------------------------------------------------
 if (GVAR(isSwimming)) exitWith {
-    _unit setAnimSpeedCoef (1 - _fatigue / 3);
+    _unit setAnimSpeedCoef linearConversion [0.7, 0.9, _fatigue, 1, 0.5, true];
+
+    if ((isSprintAllowed _unit) && {_fatigue > 0.7}) then {
+        [_unit, "blockSprint", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    } else {
+        if ((!isSprintAllowed _unit) && {_fatigue < 0.7}) then {
+            [_unit, "blockSprint", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        };
+    };
 };
 if ((getAnimSpeedCoef _unit) != 1) then {
     _unit setAnimSpeedCoef 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Allow you to crawl a bit further before getting fatigued
- Make swimming with normal clothes way harder than with a wetsuit 
- Steepen the animation slowdown in water to make it more noticable

Also see #4530.

This PR has a small somewhat unintended sideffect when wearing a wetsuit: Swimming on the surface is a bit slower than underwater and thus can consume no stamina. This creates a neat game mechanic where going to the surface is beneficial, but of course comes with the danger of getting discovered. I found that pretty interesting and left it in.
