### PR TITLE
Update laser code if laser is already on

### DIFF
--- a/addons/laser/XEH_postInit.sqf
+++ b/addons/laser/XEH_postInit.sqf
@@ -17,6 +17,16 @@
     };
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(updateCode), {
+    params ["_uuid", "_newCode"];
+    TRACE_2("ace_laser_updateCode eh",_uuid,_newCode);
+    if ([GVAR(laserEmitters), _uuid] call CBA_fnc_hashHasKey) then {
+        private _laserArray = [GVAR(laserEmitters), _uuid] call CBA_fnc_hashGet;
+        TRACE_2("updating",_newCode,_laserArray select 4);
+        _laserArray set [4, _newCode];
+    };
+}] call CBA_fnc_addEventHandler;
+
 // Shows detector and mine posistions in 3d when debug is on
 #ifdef DRAW_LASER_INFO
 addMissionEventHandler ["Draw3D", {_this call FUNC(dev_drawVisibleLaserTargets)}];

--- a/addons/laser/functions/fnc_addLaserTarget.sqf
+++ b/addons/laser/functions/fnc_addLaserTarget.sqf
@@ -50,7 +50,7 @@ private _methodArgs = [_vehicleSourceSelection];
 TRACE_6("Laser on:",_vehicle,_laserMethod,_waveLength,_laserCode,_beamSpread,_methodArgs);
 private _laserUuid = [_vehicle, _vehicle, _laserMethod, _waveLength, _laserCode, _beamSpread, _methodArgs] call FUNC(laserOn);
 
-GVAR(trackedLaserTargets) pushBack [_targetObject, _vehicle, _laserUuid];
+GVAR(trackedLaserTargets) pushBack [_targetObject, _vehicle, _laserUuid, _laserCode];
 TRACE_1("",GVAR(trackedLaserTargets));
 
 if (GVAR(pfehID) == -1) then {

--- a/addons/laser/functions/fnc_laserTargetPFH.sqf
+++ b/addons/laser/functions/fnc_laserTargetPFH.sqf
@@ -18,7 +18,7 @@
 params ["", "_pfhuid"];
 
 GVAR(trackedLaserTargets) = GVAR(trackedLaserTargets) select {
-    _x params ["_targetObject", "_owner", "_laserUuid"];
+    _x params ["_targetObject", "_owner", "_laserUuid", "_laserCode"];
     if ((isNull _targetObject) ||
             {!(alive _targetObject)} ||
             {isNull _owner} ||
@@ -29,6 +29,12 @@ GVAR(trackedLaserTargets) = GVAR(trackedLaserTargets) select {
         TRACE_1("Laser off:", _laserUuid);
         false
     } else {
+        private _newCode = _owner getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
+        if (_laserCode != _newCode) then {
+            TRACE_2("code change",_newCode,_laserCode);
+            [QGVAR(updateCode), [_laserUuid, _newCode]] call CBA_fnc_globalEvent;
+            _x set [3, _newCode];
+        };
         true
     };
 };


### PR DESCRIPTION
This makes it possible to change code while laser is on.
Before it would have no effect until turning off and on again.