### PR TITLE
Scopes - Fixes various minor issues

### DIFF
--- a/addons/scopes/ACE_Settings.hpp
+++ b/addons/scopes/ACE_Settings.hpp
@@ -20,6 +20,13 @@ class ACE_Settings {
         displayName = CSTRING(correctZeroing_displayName);
         description = CSTRING(correctZeroing_description);
     };
+    // Enables the use of the 'defaultZeroRange' setting to overwrite the discreteDistance[] config
+    class GVAR(overwriteZeroRange) {
+        typeName = "BOOL";
+        value = 0;
+        displayName = CSTRING(overwriteZeroRange_displayName);
+        description = CSTRING(overwriteZeroRange_description);
+    };
     // Only affects scopes with elevation adjustment turrets (ACE_ScopeAdjust_Vertical != [0,0])
     class GVAR(defaultZeroRange) {
         typeName = "SCALAR";

--- a/addons/scopes/CfgVehicles.hpp
+++ b/addons/scopes/CfgVehicles.hpp
@@ -46,6 +46,12 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 1;
             };
+            class overwriteZeroRange {
+                displayName = CSTRING(overwriteZeroRange_DisplayName);
+                description = CSTRING(overwriteZeroRange_Description);
+                typeName = "BOOL";
+                defaultValue = 0;
+            };
             class defaultZeroRange {
                 displayName = CSTRING(defaultZeroRange_DisplayName);
                 description = CSTRING(defaultZeroRange_Description);

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -52,16 +52,50 @@ class CfgWeapons {
     
     class optic_Nightstalker : ItemCore {
         ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo : InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class NCTALKEP {
+                    discreteDistance[] = {200};
+                    discreteDistanceInitIndex = 0;
+                };
+            };
+        };
     };
     
     class optic_NVS : ItemCore {
         ACE_ScopeHeightAboveRail = 4.2;
-        ACE_ScopeAdjust_Vertical[] = {0, 0};
-        ACE_ScopeAdjust_Horizontal[] = {0, 0};
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo : InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class NVS {
+                    discreteDistance[] = {300};
+                    discreteDistanceInitIndex = 0;
+                };
+            };
+        };
     };
     
     class optic_TWS : ItemCore {
         ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo : InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class TWS {
+                    discreteDistance[] = {300};
+                    discreteDistanceInitIndex = 0;
+                };
+            };
+        };
     };
     
     class optic_LRPS : ItemCore {

--- a/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
+++ b/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
@@ -23,11 +23,14 @@ private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponI
 if (_weaponIndex < 0) exitWith { currentZeroing _unit };
 
 private _optic = GVAR(Optics) select _weaponIndex;
-private _opticConfig = configFile >> "CfgWeapons" >> _optic;
-private _opticType = getNumber(_opticConfig >> "ItemInfo" >> "opticType");
+private _opticConfig = if (_optic != "") then {
+    (configFile >> "CfgWeapons" >> _optic)
+} else {
+    (configFile >> "CfgWeapons" >> (GVAR(Guns) select _weaponIndex))
+};
 
 private _zeroRange = currentZeroing _unit;
-if (_opticType == 2 && {(GVAR(canAdjustElevation) select _weaponIndex) || GVAR(forceUseOfAdjustmentTurrets)}) then {
+if (GVAR(canAdjustElevation) select _weaponIndex) then {
     _zeroRange = GVAR(defaultZeroRange);
 };
 if (isNumber (_opticConfig >> "ACE_ScopeZeroRange")) then {

--- a/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
+++ b/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
@@ -30,7 +30,7 @@ private _opticConfig = if (_optic != "") then {
 };
 
 private _zeroRange = currentZeroing _unit;
-if (GVAR(canAdjustElevation) select _weaponIndex) then {
+if (GVAR(overwriteZeroRange) && {GVAR(canAdjustElevation) select _weaponIndex}) then {
     _zeroRange = GVAR(defaultZeroRange);
 };
 if (isNumber (_opticConfig >> "ACE_ScopeZeroRange")) then {

--- a/addons/scopes/functions/fnc_initModuleSettings.sqf
+++ b/addons/scopes/functions/fnc_initModuleSettings.sqf
@@ -21,6 +21,7 @@ if !(_activated) exitWith {};
 [_logic, QGVAR(enabled), "enabled"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(forceUseOfAdjustmentTurrets), "forceUseOfAdjustmentTurrets"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(correctZeroing), "correctZeroing"] call EFUNC(common,readSettingFromModule);
+[_logic, QGVAR(overwriteZeroRange), "overwriteZeroRange"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(defaultZeroRange), "defaultZeroRange"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(zeroReferenceTemperature), "zeroReferenceTemperature"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(zeroReferenceBarometricPressure), "zeroReferenceBarometricPressure"] call EFUNC(common,readSettingFromModule);

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -23,7 +23,8 @@ private _updateAdjustment = false;
 private _newOptics = [_player] call FUNC(getOptics);
 {
     if (_newOptics select _forEachIndex != _x) then {
-        private _opticConfig = configFile >> "CfgWeapons" >> (_newOptics select _forEachIndex);        
+        private _opticConfig = configFile >> "CfgWeapons" >> (_newOptics select _forEachIndex);
+        private _opticType = getNumber(_opticConfig >> "ItemInfo" >> "opticType");
         private _verticalIncrement = -1;
         if (isNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement")) then {
             _verticalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement");
@@ -40,7 +41,7 @@ private _newOptics = [_player] call FUNC(getOptics);
         if (isArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal")) then {
             _maxHorizontal = getArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal");
         };
-        if (GVAR(forceUseOfAdjustmentTurrets)) then {
+        if (GVAR(forceUseOfAdjustmentTurrets) && _opticType == 2) then {
             if (_maxVertical   isEqualTo []) then { _maxVertical   = [-4, 30]; };
             if (_maxHorizontal isEqualTo []) then { _maxHorizontal = [-6,  6]; };
             if (_verticalIncrement   == -1) then { _verticalIncrement   = 0.1; };

--- a/addons/scopes/stringtable.xml
+++ b/addons/scopes/stringtable.xml
@@ -22,6 +22,12 @@
         <Key ID="STR_ACE_Scopes_correctZeroing_description">
             <English>Corrects the zeroing of all small arms sights</English>
         </Key>
+        <Key ID="STR_ACE_Scopes_overwriteZeroRange_displayName">
+            <English>Overwrite zero distance</English>
+        </Key>
+        <Key ID="STR_ACE_Scopes_overwriteZeroRange_Description">
+            <English>Uses the 'defaultZeroRange' setting to overwrite the zero range of high power scopes</English>
+        </Key>
         <Key ID="STR_ACE_Scopes_defaultZeroRange_displayName">
             <English>Default zero distance</English>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
* Fix `forceUseOfAdjustmentTurrets` setting affecting all scopes including iron sights
* Fix `ACE_ScopeZeroRange` config being ignored when placed in a weapon class
* Rework the `optic_Nightstalker`, `optic_NVS` and `optic_TWS` config settings
* Add a new `overwriteZeroRange` setting to have more control over the enforced overwriting of the zero range

**Rationale:**
* Different scopes should be able to have different zero ranges
* Some scopes come with red dot or iron sights on top of it which should be able to have different zero ranges

Both of which are not possible when we overwrite the zero range in code.