### PR TITLE
Add RHS MELB fastrope, add 3d debuging of mem points

### DIFF
--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -16,3 +16,24 @@
         false
     };
 }, {false}] call CBA_fnc_addKeybind;
+
+
+
+#ifdef DRAW_FASTROPE_INFO
+addMissionEventHandler ["Draw3D", {
+    if (!(cursorObject isKindOf "Helicopter")) exitWith {};
+    private _config = configFile >> "CfgVehicles" >> (typeOf cursorObject);
+    private _enabled = getNumber (_config >> QGVAR(enabled));
+    drawIcon3D ["", [.5,.5,1,1], (ASLtoAGL getPosASL cursorObject), 0.5, 0.5, 0, format ["%1 = %2", typeOf cursorObject, _enabled], 0.5, 0.025, "TahomaB"];
+    if (_enabled > 0) then {
+        {
+            private _hookAttachment = cursorObject getVariable [QGVAR(FRIES), cursorObject];
+            private _ropeOrigin = if (_x isEqualType []) then {_x} else {_hookAttachment selectionPosition _x};
+            drawIcon3D ["", [1,.5,.5,1], (_hookAttachment modelToWorld _ropeOrigin), 0.5, 0.5, 0, format ["Rope: %1", _forEachIndex], 0.5, 0.025, "TahomaB"];
+        } forEach (getArray (_config >> QGVAR(ropeOrigins)));
+    };
+    if (_enabled == 2) then {
+        drawIcon3D ["", [.5,1,.5,1], (cursorObject modelToWorld getArray (_config >> QGVAR(friesAttachmentPoint))), 0.5, 0.5, 0, format ["Fries: %1", getText (_config >> QGVAR(friesType))], 0.5, 0.025, "TahomaB"];
+    };
+}];
+#endif

--- a/addons/fastroping/script_component.hpp
+++ b/addons/fastroping/script_component.hpp
@@ -2,6 +2,7 @@
 #define COMPONENT_BEAUTIFIED Fastroping
 #include "\z\ace\addons\main\script_mod.hpp"
 
+// #define DRAW_FASTROPE_INFO
 // #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -196,6 +196,15 @@ class CfgVehicles {
         class Eventhandlers;
     };
     class Heli_Transport_01_base_F: Helicopter_Base_H {};
+    
+    class RHS_MELB_base: Helicopter_Base_H {};
+    class RHS_MELB_MH6M: RHS_MELB_base {
+        EGVAR(fastroping,enabled) = 1;
+        EGVAR(fastroping,onCut) = QFUNC(onCut);
+        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
+        EGVAR(fastroping,ropeOrigins)[] = {{1.166, 0.79, -0.01}, {-1.166, 0.79, -0.01}};
+    };
+
     class RHS_UH60_Base: Heli_Transport_01_base_F {
         EGVAR(refuel,fuelCapacity) = 1360;
     };

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -200,8 +200,6 @@ class CfgVehicles {
     class RHS_MELB_base: Helicopter_Base_H {};
     class RHS_MELB_MH6M: RHS_MELB_base {
         EGVAR(fastroping,enabled) = 1;
-        EGVAR(fastroping,onCut) = QFUNC(onCut);
-        EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
         EGVAR(fastroping,ropeOrigins)[] = {{1.166, 0.79, -0.01}, {-1.166, 0.79, -0.01}};
     };
 

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor"};
+        requiredAddons[] = {"ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor", "rhsusf_c_melb"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
Close #4683
Config from @Whigital - thanks!

This is for the `RHS_MELB_MH6M` variant, which already has the rope bars in the model.
Also added a little visual debugging for the memory points.