### PR TITLE
Fix missing word in gibot comment

### DIFF
--- a/.gibot.yml
+++ b/.gibot.yml
@@ -11,7 +11,7 @@ stages:
        - marked for cleanup
      comment:
        - 'Hello @{author}! There has been no activity on this ticket for over a period of {days} days. I am automatically replying to let you know we will close this ticket within 1 week due to inactivity and consider this resolved.'
-       - 'If you believe this in error, please reply with the requested information.'
+       - 'If you believe this is in error, please reply with the requested information.'
        - 'Thank you. :robot:'
      action:
        close: false


### PR DESCRIPTION
**When merged this pull request will:**
- Add missing `is` to allow gibot to make its comments the right way!