### PR TITLE
Add dev macro to quickly recompile functions

### DIFF
--- a/addons/advanced_ballistics/XEH_preInit.sqf
+++ b/addons/advanced_ballistics/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/advanced_fatigue/XEH_preInit.sqf
+++ b/addons/advanced_fatigue/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 //#include "initSettings.sqf"
 
 GVAR(staminaBarWidth) = 10 * (((safezoneW / safezoneH) min 1.2) / 40);

--- a/addons/advanced_throwing/XEH_preInit.sqf
+++ b/addons/advanced_throwing/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/atragmx/XEH_preInit.sqf
+++ b/addons/atragmx/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/attach/XEH_preInit.sqf
+++ b/addons/attach/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/backpacks/XEH_preInit.sqf
+++ b/addons/backpacks/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/captives/XEH_preInit.sqf
+++ b/addons/captives/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(captivityEnabled) = false;
 

--- a/addons/cargo/XEH_preInit.sqf
+++ b/addons/cargo/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(initializedItemClasses) = [];
 GVAR(initializedVehicleClasses) = [];

--- a/addons/chemlights/XEH_preInit.sqf
+++ b/addons/chemlights/XEH_preInit.sqf
@@ -3,6 +3,8 @@
 ADDON = false;
 LOG(MSG_INIT);
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -3,7 +3,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(syncedEvents) = [] call CBA_fnc_hashCreate;
 GVAR(showHudHash) = [] call CBA_fnc_hashCreate;

--- a/addons/concertina_wire/XEH_preInit.sqf
+++ b/addons/concertina_wire/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/cookoff/XEH_preInit.sqf
+++ b/addons/cookoff/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/dagr/XEH_preInit.sqf
+++ b/addons/dagr/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/disarming/XEH_preInit.sqf
+++ b/addons/disarming/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/disposable/XEH_preInit.sqf
+++ b/addons/disposable/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/dogtags/XEH_preInit.sqf
+++ b/addons/dogtags/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(disabledFactions) = [] call CBA_fnc_createNamespace;
     

--- a/addons/dragging/XEH_preInit.sqf
+++ b/addons/dragging/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -17,7 +17,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 if (isServer) then {
     GVAR(explosivesOrientations) = []

--- a/addons/fastroping/XEH_preInit.sqf
+++ b/addons/fastroping/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/fcs/XEH_preInit.sqf
+++ b/addons/fcs/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/finger/XEH_preInit.sqf
+++ b/addons/finger/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/frag/XEH_preInit.sqf
+++ b/addons/frag/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(replacedBisArtyWrapper) = true;
 GVAR(blackList) = [];

--- a/addons/gestures/XEH_preInit.sqf
+++ b/addons/gestures/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/gforces/XEH_preInit.sqf
+++ b/addons/gforces/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(GForces) = [];
 GVAR(GForces_Index) = 0;

--- a/addons/goggles/XEH_preInit.sqf
+++ b/addons/goggles/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/grenades/XEH_preInit.sqf
+++ b/addons/grenades/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // restore gunbag info after respawn
 ["CAManBase", "respawn", {

--- a/addons/hearing/XEH_preInit.sqf
+++ b/addons/hearing/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/hitreactions/XEH_preInit.sqf
+++ b/addons/hitreactions/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/huntir/XEH_preInit.sqf
+++ b/addons/huntir/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(ActNamespace) = [] call CBA_fnc_createNamespace;
 GVAR(ActSelfNamespace) = [] call CBA_fnc_createNamespace;

--- a/addons/interaction/XEH_preInit.sqf
+++ b/addons/interaction/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/inventory/XEH_preInit.sqf
+++ b/addons/inventory/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/javelin/XEH_preInit.sqf
+++ b/addons/javelin/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(isLockKeyDown) = false;
 GVAR(pfehID) = -1;

--- a/addons/kestrel4500/XEH_preInit.sqf
+++ b/addons/kestrel4500/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/laser/XEH_preInit.sqf
+++ b/addons/laser/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // Laser default variables
 ACE_DEFAULT_LASER_CODE = 1111;

--- a/addons/laserpointer/XEH_preInit.sqf
+++ b/addons/laserpointer/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/logistics_uavbattery/XEH_preInit.sqf
+++ b/addons/logistics_uavbattery/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/logistics_wirecutter/XEH_preInit.sqf
+++ b/addons/logistics_wirecutter/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/magazinerepack/XEH_preInit.sqf
+++ b/addons/magazinerepack/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/main/script_debug.hpp
+++ b/addons/main/script_debug.hpp
@@ -1,4 +1,21 @@
 /**
+Fast Recompiling via function
+**/
+// #define DISABLE_COMPILE_CACHE
+// To Use: [] call ACE_PREP_RECOMPILE;
+
+#ifdef DISABLE_COMPILE_CACHE
+    #define LINKFUNC(x) {_this call FUNC(x)}
+    #define PREP_RECOMPILE_START    if (isNil "ACE_PREP_RECOMPILE") then {ACE_RECOMPILES = []; ACE_PREP_RECOMPILE = {{call _x} forEach ACE_RECOMPILES;}}; private _recomp = {
+    #define PREP_RECOMPILE_END      }; call _recomp; ACE_RECOMPILES pushBack _recomp;
+#else
+    #define LINKFUNC(x) FUNC(x)
+    #define PREP_RECOMPILE_START /* */
+    #define PREP_RECOMPILE_END /* */
+#endif
+
+
+/**
 STACK TRACING
 **/
 //#define ENABLE_CALLSTACK
@@ -23,6 +40,7 @@ STACK TRACING
 PERFORMANCE COUNTERS SECTION
 **/
 //#define ENABLE_PERFORMANCE_COUNTERS
+// To Use: [] call ace_common_fnc_dumpPerformanceCounters; 
 
 #ifdef ENABLE_PERFORMANCE_COUNTERS
     #define CBA_fnc_addPerFrameHandler { _ret = [(_this select 0), (_this select 1), (_this select 2), #function] call CBA_fnc_addPerFrameHandler; if(isNil "ACE_PFH_COUNTER" ) then { ACE_PFH_COUNTER=[]; }; ACE_PFH_COUNTER pushBack [[_ret, __FILE__, __LINE__], [(_this select 0), (_this select 1), (_this select 2)]];  _ret }

--- a/addons/map/XEH_preInit.sqf
+++ b/addons/map/XEH_preInit.sqf
@@ -3,6 +3,8 @@
 ADDON = false;
 LOG(MSG_INIT);
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/map_gestures/XEH_preInit.sqf
+++ b/addons/map_gestures/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(GroupColorCfgMappingNew) = call CBA_fnc_createNamespace;
 

--- a/addons/maptools/XEH_preInit.sqf
+++ b/addons/maptools/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/markers/XEH_preInit.sqf
+++ b/addons/markers/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // init marker types
 if (isNil QGVAR(MarkersCache)) then {

--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(injuredUnitCollection) = [];
 

--- a/addons/medical_ai/XEH_preInit.sqf
+++ b/addons/medical_ai/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/medical_blood/XEH_preInit.sqf
+++ b/addons/medical_blood/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // blood object model namespace
 GVAR(models) = [] call CBA_fnc_createNamespace;

--- a/addons/medical_menu/XEH_preInit.sqf
+++ b/addons/medical_menu/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(INTERACTION_TARGET) = objNull;
 GVAR(actionsOther) = [];

--- a/addons/microdagr/XEH_preInit.sqf
+++ b/addons/microdagr/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 //Functions that are called for each draw of the map:
 GVAR(miniMapDrawHandlers) = [];

--- a/addons/minedetector/XEH_preInit.sqf
+++ b/addons/minedetector/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/missionmodules/XEH_preInit.sqf
+++ b/addons/missionmodules/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/mk6mortar/XEH_preInit.sqf
+++ b/addons/mk6mortar/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/modules/XEH_preInit.sqf
+++ b/addons/modules/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(moduleInitCollection) = [];
 

--- a/addons/movement/XEH_preInit.sqf
+++ b/addons/movement/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/nametags/XEH_preInit.sqf
+++ b/addons/nametags/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/nightvision/XEH_preInit.sqf
+++ b/addons/nightvision/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/optionsmenu/XEH_preInit.sqf
+++ b/addons/optionsmenu/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(clientSideOptions) = [];
 GVAR(clientSideColors) = [];

--- a/addons/overheating/XEH_preInit.sqf
+++ b/addons/overheating/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/overpressure/XEH_preInit.sqf
+++ b/addons/overpressure/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/parachute/XEH_preInit.sqf
+++ b/addons/parachute/XEH_preInit.sqf
@@ -17,6 +17,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/rangecard/XEH_preInit.sqf
+++ b/addons/rangecard/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/rearm/XEH_preInit.sqf
+++ b/addons/rearm/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/recoil/XEH_preInit.sqf
+++ b/addons/recoil/XEH_preInit.sqf
@@ -3,6 +3,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/refuel/XEH_preInit.sqf
+++ b/addons/refuel/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/reload/XEH_preInit.sqf
+++ b/addons/reload/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/reloadlaunchers/XEH_preInit.sqf
+++ b/addons/reloadlaunchers/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/repair/XEH_preInit.sqf
+++ b/addons/repair/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ["ACE_RepairItem_Base", "killed", {
     params ["_object"];

--- a/addons/respawn/XEH_preInit.sqf
+++ b/addons/respawn/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/safemode/XEH_preInit.sqf
+++ b/addons/safemode/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/sandbag/XEH_preInit.sqf
+++ b/addons/sandbag/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/scopes/XEH_preInit.sqf
+++ b/addons/scopes/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/slideshow/XEH_preInit.sqf
+++ b/addons/slideshow/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(slideshows) = 0;
 

--- a/addons/spectator/XEH_preInit.sqf
+++ b/addons/spectator/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // Reset the stored display
 SETUVAR(GVAR(interface),displayNull);

--- a/addons/spottingscope/XEH_preInit.sqf
+++ b/addons/spottingscope/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/switchunits/XEH_preInit.sqf
+++ b/addons/switchunits/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/tacticalladder/XEH_preInit.sqf
+++ b/addons/tacticalladder/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/tagging/XEH_preInit.sqf
+++ b/addons/tagging/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(cachedTags) = [];
 GVAR(cachedRequiredItems) = [];

--- a/addons/trenches/XEH_preInit.sqf
+++ b/addons/trenches/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/tripod/XEH_preInit.sqf
+++ b/addons/tripod/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 GVAR(interfaceInitialized) = false;
 

--- a/addons/vector/XEH_preInit.sqf
+++ b/addons/vector/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/vehiclelock/XEH_preInit.sqf
+++ b/addons/vehiclelock/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/vehicles/XEH_preInit.sqf
+++ b/addons/vehicles/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/viewdistance/XEH_preInit.sqf
+++ b/addons/viewdistance/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/weaponselect/XEH_preInit.sqf
+++ b/addons/weaponselect/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // collect frag and other grenades separately
 GVAR(GrenadesAll) = [];

--- a/addons/weather/XEH_preInit.sqf
+++ b/addons/weather/XEH_preInit.sqf
@@ -3,7 +3,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 // Make sure this data is read before client/server postInit
 call FUNC(getMapData);

--- a/addons/winddeflection/XEH_preInit.sqf
+++ b/addons/winddeflection/XEH_preInit.sqf
@@ -12,6 +12,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/yardage450/XEH_preInit.sqf
+++ b/addons/yardage450/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 ADDON = true;

--- a/addons/zeus/XEH_preInit.sqf
+++ b/addons/zeus/XEH_preInit.sqf
@@ -2,7 +2,9 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
 
 if (isServer) then {
     [QGVAR(zeusUnitAssigned), FUNC(handleZeusUnitAssigned)] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
Only effects dev enviroment

If you have `DISABLE_COMPILE_CACHE` macro set, this will add the code from `xeh_prep.hpp` to an array, which can easily be called mid mission.

So you can add a addAction/keybind/pfeh that runs 
`[] call ACE_PREP_RECOMPILE;` 
and all functions will be recompiled mid-mission.

Also adds `#define LINKFUNC(x)` which acts just like `FUNC(x)` normally, but when used with `DISABLE_COMPILE_CACHE` will become `{_this call FUNC(x)}`.
This acts sort of like "pass by reference", and will be updated with each recompile.

E.G. `player addEventHandler ["Fired", LINKFUNC(firedEH)];`
Will run updated code after each recompile.

No need to restart missions.  Save code, recompile, test.