### PR TITLE
Add GitHub Changelog Generator configuration file

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,22 @@
+# No issues and PRs without labels
+issues=false
+pr-wo-labels=false
+
+# Issues are disabled, don't fetch them
+max-issues=0
+
+# Label filters
+exclude-labels=by design,can't reproduce,duplicate,question,invalid,wontfix,translation,ignore changelog
+bug-labels=conflict,bug,critical bug
+enhancement-labels=enhancement,feature request,Focus Feature
+
+# Tag is created before generating changelog for release candidates
+unreleased=false
+
+# No section labels, we only want a list of merged PRs (label separation only works for Issues)
+simple-list=true
+
+# Misc
+author=false
+compare-link=false
+header-label=## Change Log Summary

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ texHeaders.bin
 *.swo
 *.biprivatekey
 Thumbs.db
+CHANGELOG.md


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Add generated `CHANGELOG.md` to `.gitignore` as change logs are posted on release pages

Change Log Generation:
- Install https://github.com/skywinder/github-changelog-generator (Ruby gem)
- Generate GitHub token if you don't have it yet (to allow more than 50 API calls)
- Run in ACE3 clone root: `github_changelog_generator -t <token> --between-tags <tag>`
  - Example: `github_changelog_generator -t 0000000000 --between-tags v3.8.2-rc1`
- Replace linked PR numbers (GitHub automatically links them)
  - Regex: `"\[\\(.+?)\].*\)"` -> `"($1)"`
- Sort into sections and prettify accordingly