### PR TITLE
Advanced Ballistics - New default simulation interval

### DIFF
--- a/addons/advanced_ballistics/ACE_Settings.hpp
+++ b/addons/advanced_ballistics/ACE_Settings.hpp
@@ -69,7 +69,7 @@ class ACE_Settings {
         displayName = CSTRING(simulationInterval_DisplayName);
         description = CSTRING(simulationInterval_Description);
         typeName = "SCALAR";
-        value = 0.0;
+        value = 0.05;
     };
     class GVAR(simulationRadius) {
         category = CSTRING(DisplayName);

--- a/addons/advanced_ballistics/CfgVehicles.hpp
+++ b/addons/advanced_ballistics/CfgVehicles.hpp
@@ -71,7 +71,7 @@ class CfgVehicles {
                 displayName = CSTRING(simulationInterval_DisplayName);
                 description = CSTRING(simulationInterval_Description);
                 typeName = "NUMBER";
-                defaultValue = 0.0;
+                defaultValue = 0.05;
             };
             class simulationRadius {
                 displayName = CSTRING(simulationRadius_DisplayName);


### PR DESCRIPTION
**When merged this pull request will:**
- Change the default simulation interval to 0.05s