### PR TITLE
Ballistics - Cleanup

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -79,28 +79,6 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={735, 883, 892};
         ACE_barrelLengths[]={206.5, 414.02, 508.0};
     };
-    class ACE_545x39_Ball_7N6M : B_545x39_Ball_F {
-    };
-    class B_556x45_Ball_Tracer_Green;
-    class ACE_545x39_Ball_7T3M : B_556x45_Ball_Tracer_Green {
-        airFriction=-0.00116278;
-        caliber=0.6;
-        deflecting=18;
-        hit=7;
-        typicalSpeed=883;
-        tracerStartTime=0.073;  // 7T3M tracer burns out to 850m
-        tracerEndTime=1.70236;  // Time in seconds calculated with ballistics calculator
-        ACE_caliber=5.588;
-        ACE_bulletLength=21.59;
-        ACE_bulletMass=3.22704;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.168};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={740, 886, 897};
-        ACE_barrelLengths[]={206.5, 414.02, 508.0};
-    };
     class B_56x15_dual: BulletBase {
         tracerScale = 0.5;
     };
@@ -271,54 +249,6 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={305, 325, 335, 340};
         ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
-    class ACE_30_06_M1_Ball : B_762x51_Ball {
-        airFriction=-0.00080900;
-        typicalSpeed=800;
-        caliber=2.0;
-        hit=10;
-        ACE_caliber=7.823;
-        ACE_bulletLength=30.734;
-        ACE_bulletMass=11.2752;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.494};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={700, 785, 800, 830, 840};
-        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
-    };
-    class ACE_7_Remington_Magnum_Ball : B_762x51_Ball {
-        airFriction=-0.00056738;
-        typicalSpeed=820;
-        caliber=2.1;
-        hit=8;
-        ACE_caliber=7.214;
-        ACE_bulletLength=38.837;
-        ACE_bulletMass=11.664;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.345};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={720, 780, 812, 822, 830};
-        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
-    };
-    class ACE_243_Winchester_Ball : B_762x51_Ball {
-        airFriction=-0.00067875;
-        typicalSpeed=915;
-        caliber=2.3;
-        hit=6;
-        ACE_caliber=6.172;
-        ACE_bulletLength=32.563;
-        ACE_bulletMass=11.664;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.278};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={830, 875, 900, 915, 920};
-        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
-    };
     class ACE_762x67_Ball_Mk248_Mod_0 : B_762x51_Ball {
         airFriction=-0.00070530;
         caliber=1.8;
@@ -380,22 +310,6 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={700, 800, 820, 833};
         ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
-    class ACE_762x54_Ball_7N14 : B_762x51_Ball {
-        airFriction=-0.00100023;
-        caliber=1.5;
-        hit=15;
-        typicalSpeed=820;
-        ACE_caliber=7.925;
-        ACE_bulletLength=28.956;
-        ACE_bulletMass=9.8496;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.4};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
-    };
     class B_762x54_Tracer_Green;
     class ACE_762x54_Ball_7T2 : B_762x54_Tracer_Green {
         airFriction=-0.00103989;
@@ -415,47 +329,11 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={680, 750, 798, 800};
         ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
     };
-    class ACE_762x35_Ball : B_762x51_Ball {
-        airFriction=-0.00128942;
-        caliber=1.5;
-        hit=11;
-        typicalSpeed=790;
-        ACE_caliber=7.823;
-        ACE_bulletLength=29.286;
-        ACE_bulletMass=8.1;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.349, 0.338, 0.330, 0.310};
-        ACE_velocityBoundaries[]={792, 610, 488};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={620, 655, 675};
-        ACE_barrelLengths[]={228.6, 406.4, 508.0};
-    };
     class B_762x39_Ball_F : BulletBase {
         airFriction=-0.00151621;
         ACE_caliber=7.823;
         ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.275};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={650, 716, 750};
-        ACE_barrelLengths[]={254.0, 414.02, 508.0};
-    };
-    class ACE_762x39_Ball : B_762x39_Ball_F {
-    };
-    class ACE_762x39_Ball_57N231P : B_762x54_Tracer_Green {
-        airFriction=-0.00151621;
-        hit=12;
-        caliber=1.5;
-        typicalSpeed=716;
-        tracerStartTime = 0.073;            //57N231P tracer burns out to 800m
-        tracerEndTime = 2.082;              //Time in seconds calculated with ballistics calculator
-        ACE_caliber=7.823;
-        ACE_bulletLength=28.956;
-        ACE_bulletMass=7.5816;
         ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[]={0.275};
         ACE_velocityBoundaries[]={};
@@ -481,21 +359,6 @@ class CfgAmmo {
     class B_9x21_Ball_Tracer_Green: B_9x21_Ball {
         tracerScale = 0.5;
     };
-    class ACE_9x18_Ball_57N181S : B_9x21_Ball {
-        hit=5;
-        airFriction=-0.00190333;
-        typicalSpeed=298;
-        ACE_caliber=9.271;
-        ACE_bulletLength=15.494;
-        ACE_bulletMass=6.00048;
-        ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
-        ACE_ballisticCoefficients[]={0.125};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={298, 330, 350};
-        ACE_barrelLengths[]={96.52, 127.0, 228.6};
-    };
     class ACE_9x19_Ball : B_9x21_Ball {
         airFriction=-0.0019835;
         typicalSpeed=370;
@@ -510,51 +373,6 @@ class CfgAmmo {
         ACE_dragModel=1;
         ACE_muzzleVelocities[]={340, 370, 400};
         ACE_barrelLengths[]={101.6, 127.0, 228.6};
-    };
-    class ACE_10x25_Ball : B_9x21_Ball {
-        airFriction=-0.00181928;
-        typicalSpeed=425;
-        hit=7;
-        ACE_caliber=12.7;
-        ACE_bulletLength=19.406;
-        ACE_bulletMass=10.692;
-        ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
-        ACE_ballisticCoefficients[]={0.189};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={360, 400, 430};
-        ACE_barrelLengths[]={101.6, 117.094, 228.6};
-    };
-    class ACE_765x17_Ball: B_9x21_Ball {
-        airFriction=-0.00163356;
-        typicalSpeed=282;
-        hit=7;
-        ACE_caliber=7.938;
-        ACE_bulletLength=15.494;
-        ACE_bulletMass=4.212;
-        ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
-        ACE_ballisticCoefficients[]={0.118};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={282, 300, 320};
-        ACE_barrelLengths[]={101.6, 127.0, 228.6};
-    };
-    class ACE_303_Ball : ACE_762x51_Ball_M118LR {
-        airFriction=-0.0008349;
-        typicalSpeed=761;
-        caliber=2.0;
-        ACE_caliber=7.899;
-        ACE_bulletLength=31.166;
-        ACE_bulletMass=11.2752;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.499, 0.493, 0.48};
-        ACE_velocityBoundaries[]={671, 549};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={748, 761, 765};
-        ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00108571;
@@ -600,20 +418,6 @@ class CfgAmmo {
         ACE_standardAtmosphere="ICAO";
         ACE_dragModel=7;
         ACE_muzzleVelocities[]={1067};
-        ACE_barrelLengths[]={736.6};
-    };
-    class ACE_106x83mm_Ball : B_408_Ball {
-        timeToLive=10;
-        airFriction=-0.00052047;
-        ACE_caliber=10.566;
-        ACE_bulletLength=53.061;
-        ACE_bulletMass=25.7904;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.72};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={960};
         ACE_barrelLengths[]={736.6};
     };
     class B_338_Ball : BulletBase {

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -8,8 +8,6 @@ class CfgAmmo {
 
     class B_556x45_Ball : BulletBase {
         airFriction=-0.00126466;
-        hit=8;
-        typicalSpeed=750;
         tracerScale = 1;
         tracerStartTime=0.073;  // M856 tracer burns out to 800m
         tracerEndTime=1.57123;  // Time in seconds calculated with ballistics calculator
@@ -26,10 +24,6 @@ class CfgAmmo {
     };
     class ACE_556x45_Ball_Mk262 : B_556x45_Ball {
         airFriction=-0.00109563;
-        caliber=0.8;
-        deflecting=18;
-        hit=11;
-        typicalSpeed=836;
         ACE_caliber=5.69;
         ACE_bulletLength=23.012;
         ACE_bulletMass=4.9896;
@@ -43,10 +37,6 @@ class CfgAmmo {
     };
     class ACE_556x45_Ball_Mk318 : B_556x45_Ball {
         airFriction=-0.00123318;
-        caliber=0.8;
-        deflecting=18;
-        hit=9;
-        typicalSpeed=886;
         ACE_caliber=5.69;
         ACE_bulletLength=23.012;
         ACE_bulletMass=4.0176;
@@ -61,9 +51,6 @@ class CfgAmmo {
     class ACE_556x45_Ball_M995_AP : B_556x45_Ball {
         airFriction=-0.00123272;
         caliber=1.6;
-        deflecting=18;
-        hit=6;
-        typicalSpeed=869;
         ACE_caliber=5.69;
         ACE_bulletLength=23.012;
         ACE_bulletMass=4.5359237;
@@ -81,10 +68,6 @@ class CfgAmmo {
     };
     class B_545x39_Ball_F : BulletBase {
         airFriction=-0.00116278;
-        caliber=0.6;
-        deflecting=18;
-        hit=7;
-        typicalSpeed=880;
         ACE_caliber=5.588;
         ACE_bulletLength=21.59;
         ACE_bulletMass=3.42792;
@@ -123,7 +106,6 @@ class CfgAmmo {
     };
     class B_580x42_Ball_F: BulletBase {
         airFriction=-0.00117956;
-        typicalSpeed=930;
         ACE_caliber=5.9944;
         ACE_bulletLength=24.2;
         ACE_bulletMass=4.15;
@@ -137,7 +119,6 @@ class CfgAmmo {
     };
     class B_65x39_Caseless : BulletBase {
         airFriction=-0.00075308;
-        typicalSpeed=800;
         tracerScale = 1.1; //1.0;
         ACE_caliber=6.706;
         ACE_bulletLength=32.893;
@@ -160,7 +141,6 @@ class CfgAmmo {
     };
     class ACE_65x47_Ball_Scenar: B_65x39_Caseless {
         airFriction=-0.00067037;
-        typicalSpeed=820 ;
         caliber=0.9;
         ACE_caliber=6.706;
         ACE_bulletLength=34.646;
@@ -175,7 +155,6 @@ class CfgAmmo {
     };
     class ACE_65_Creedmor_Ball: B_65x39_Caseless {
         airFriction=-0.00060887;
-        typicalSpeed=860 ;
         caliber=1.1;
         ACE_caliber=6.706;
         ACE_bulletLength=36.22;
@@ -194,8 +173,6 @@ class CfgAmmo {
     };
     class B_762x51_Ball : BulletBase {
         airFriction=-0.00100957;
-        typicalSpeed=833;
-        hit=9;
         tracerScale = 1.2; //0.6;
         tracerStartTime=0.073;  // Based on the British L5A1 which burns out to 1000m 
         tracerEndTime=2.15957;  // Time in seconds calculated with ballistics calculator
@@ -392,7 +369,6 @@ class CfgAmmo {
     };
     class B_762x54_Ball: B_762x51_Ball {
         airFriction=-0.00100023;
-        typicalSpeed=820;
         ACE_caliber=7.925;
         ACE_bulletLength=28.956;
         ACE_bulletMass=9.8496;
@@ -457,9 +433,6 @@ class CfgAmmo {
     };
     class B_762x39_Ball_F : BulletBase {
         airFriction=-0.00151621;
-        hit=12;
-        caliber=1.5;
-        typicalSpeed=716;
         ACE_caliber=7.823;
         ACE_bulletLength=28.956;
         ACE_bulletMass=7.9704;
@@ -493,9 +466,7 @@ class CfgAmmo {
     };
     class B_9x21_Ball : BulletBase {
         airFriction=-0.00208292;
-        typicalSpeed=390;
         tracerScale = 0.5;
-        hit=6;
         ACE_caliber=9.042;
         ACE_bulletLength=15.494;
         ACE_bulletMass=7.452;
@@ -587,7 +558,6 @@ class CfgAmmo {
     };
     class B_93x64_Ball : BulletBase {
         airFriction=-0.00108571;
-        typicalSpeed=880;
         ACE_caliber=9.296;
         ACE_bulletLength=34.29;
         ACE_bulletMass=14.904;
@@ -602,7 +572,6 @@ class CfgAmmo {
     class B_408_Ball : BulletBase {
         timeToLive=10;
         airFriction=-0.00044958;
-        typicalSpeed=867;
         tracerScale = 1.3;
         ACE_caliber=10.363;
         ACE_bulletLength=55.1942;
@@ -650,7 +619,6 @@ class CfgAmmo {
     class B_338_Ball : BulletBase {
         timeToLive=10;
         airFriction=-0.00059133;
-        typicalSpeed=915;
         ACE_caliber=8.585;
         ACE_bulletLength=39.573;
         ACE_bulletMass=16.2;
@@ -664,7 +632,6 @@ class CfgAmmo {
     };
     class B_338_NM_Ball : BulletBase {
         airFriction=-0.00052201;
-        typicalSpeed=820;
         ACE_caliber=8.585;
         ACE_bulletLength=43.18;
         ACE_bulletMass=19.44;
@@ -712,7 +679,6 @@ class CfgAmmo {
     };
     class B_127x54_Ball : BulletBase {
         airFriction=-0.00019268;
-        typicalSpeed=300;
         tracerScale = 1.3;//
         ACE_caliber=12.954;
         ACE_bulletLength=64.516;
@@ -728,7 +694,6 @@ class CfgAmmo {
     class B_127x99_Ball : BulletBase {
         timeToLive=10;
         airFriction=-0.00057503;
-        typicalSpeed=900;
         tracerScale = 1.3; //1.2;
         ACE_caliber=12.954;
         ACE_bulletLength=58.674;
@@ -778,7 +743,6 @@ class CfgAmmo {
     class B_127x108_Ball : BulletBase {
         timeToLive=10;
         airFriction=-0.00063800;
-        typicalSpeed=820;
         tracerScale = 1.3; //1.5;
         ACE_caliber=12.979;
         ACE_bulletLength=64.008;
@@ -793,7 +757,6 @@ class CfgAmmo {
     };
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.00081221;
-        typicalSpeed=250;
         tracerScale = 0.6;
         ACE_caliber=11.481;
         ACE_bulletLength=17.272;
@@ -808,7 +771,6 @@ class CfgAmmo {
     };
     class B_50BW_Ball_F : BulletBase {
         airFriction=-0.00202645;
-        typicalSpeed=550;
         ACE_caliber=12.7;
         ACE_bulletLength=24.13;
         ACE_bulletMass=21.7076;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -313,8 +313,6 @@ class CfgAmmo {
     class B_762x54_Tracer_Green;
     class ACE_762x54_Ball_7T2 : B_762x54_Tracer_Green {
         airFriction=-0.00103989;
-        caliber=1.5;
-        hit=15;
         typicalSpeed=800;
         tracerStartTime=0.073;  // Based on the 7T2 which burns three seconds
         tracerEndTime=3;
@@ -361,8 +359,6 @@ class CfgAmmo {
     };
     class ACE_9x19_Ball : B_9x21_Ball {
         airFriction=-0.0019835;
-        typicalSpeed=370;
-        hit=6;
         ACE_caliber=9.017;
         ACE_bulletLength=15.494;
         ACE_bulletMass=8.0352;
@@ -510,10 +506,9 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={900};
         ACE_barrelLengths[]={736.6};
     };
-    class ACE_127x99_API : BulletBase {
+    class ACE_127x99_API : B_127x99_Ball {
         timeToLive=10;
         airFriction=-0.00057503;
-        typicalSpeed=900;
         tracerScale = 1.3;//
         hit=25;
         caliber=4.0;
@@ -531,7 +526,6 @@ class CfgAmmo {
     class ACE_127x99_Ball_AMAX : B_127x99_Ball {
         timeToLive=10;
         airFriction=-0.00036645;
-        typicalSpeed=860;
         caliber=3.0;
         ACE_caliber=12.954;
         ACE_bulletLength=64.516;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove all `caliber`, `hit` and `typicalSpeed` config entries form the vanilla ammo classes
 (as discussed in https://ace3public.slack.com/messages/medical/)
- Remove all unused ammo classes

Related: #2931