### PR TITLE
AdvFatigue - Remove setVar when removing eh

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_handlePlayerChanged.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handlePlayerChanged.sqf
@@ -11,10 +11,13 @@
  */
 #include "script_component.hpp"
 params ["_newUnit", "_oldUnit"];
+TRACE_2("unit changed",_newUnit,_oldUnit);
 
 if !(isNull _oldUnit) then {
     _oldUnit enableStamina true;
     _oldUnit removeEventHandler ["AnimChanged", _oldUnit getVariable [QGVAR(animHandler), -1]];
+    _oldUnit setVariable [QGVAR(animHandler), nil];
+    TRACE_1("remove old",_oldUnit getVariable QGVAR(animHandler));
 
     _oldUnit setVariable [QGVAR(ae1Reserve), GVAR(ae1Reserve)];
     _oldUnit setVariable [QGVAR(ae2Reserve), GVAR(ae2Reserve)];
@@ -30,6 +33,7 @@ if (_newUnit getVariable [QGVAR(animHandler), -1] == -1) then {
     private _animHandler = _newUnit addEventHandler ["AnimChanged", {
         GVAR(animDuty) = _this call FUNC(getAnimDuty);
     }];
+    TRACE_1("add new",_animHandler);
     _newUnit setVariable [QGVAR(animHandler), _animHandler];
 };
 


### PR DESCRIPTION
Removes the setVariable after removing the event handler.

Otherwise the EH would not be re-added when switching back to a previously controled unit.

Start Unit A - Add EH to A
Zeus Unit B - Remove from A, Add EH To B
Return to A - Remove from B, Would skip Adding to A because setVar was present