### PR TITLE
Hearing - player only event handlers

### DIFF
--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -11,35 +11,69 @@ GVAR(playerVehAttenuation) = 1;
 GVAR(time3) = 0;
 GVAR(damageCoefficent) = 1;
 GVAR(volumeAttenuation) = 1;
+GVAR(lastPlayerVehicle) = objNull;
 
 ["ace_settingsInitialized", {
     TRACE_1("settingInit",GVAR(EnableCombatDeafness));
     // Only run PFEH and install event handlers if combat deafness is enabled
     if (!GVAR(EnableCombatDeafness)) exitWith {};
 
-    //Add XEH:
-    ["CAManBase", "FiredNear", FUNC(firedNear)] call CBA_fnc_addClassEventHandler;
-    ["CAManBase", "Explosion", FUNC(explosionNear)] call CBA_fnc_addClassEventHandler;
-
-    // Update hearing protection now:
-    [] call FUNC(updateHearingProtection);
-
     // Spawn volume updating process
-    [FUNC(updateVolume), 1, [false]] call CBA_fnc_addPerFrameHandler;
+    [LINKFUNC(updateVolume), 1, [false]] call CBA_fnc_addPerFrameHandler;
 
     // Update veh attunation when player veh changes
-    ["vehicle", FUNC(updatePlayerVehAttenuation)] call CBA_fnc_addPlayerEventHandler;
-    ["turret", FUNC(updatePlayerVehAttenuation)] call CBA_fnc_addPlayerEventHandler;
+    ["vehicle", {
+        params ["_player", "_vehicle"];
+        TRACE_2("vehicle change",_player,_vehicle);
+        _this call FUNC(updatePlayerVehAttenuation);
+
+        if (!isNull GVAR(lastPlayerVehicle)) then {
+            private _firedEH = GVAR(lastPlayerVehicle) getVariable [QGVAR(firedEH), -1];
+            GVAR(lastPlayerVehicle) removeEventHandler ["FiredNear", _firedEH];
+            GVAR(lastPlayerVehicle) setVariable [QGVAR(firedEH), nil];
+            GVAR(lastPlayerVehicle) = objNull;
+            TRACE_2("removed veh eh",_firedEH,GVAR(lastPlayerVehicle));
+        };
+        if ((!isNull _vehicle) && {_player != _vehicle}) then {
+            private _firedEH = _vehicle addEventHandler ["FiredNear", LINKFUNC(firedNear)];
+            _vehicle setVariable [QGVAR(firedEH), _firedEH];
+            GVAR(lastPlayerVehicle) = _vehicle;
+            TRACE_2("added veh eh",_firedEH,GVAR(lastPlayerVehicle));
+        };
+    }, true] call CBA_fnc_addPlayerEventHandler;
+    ["turret", LINKFUNC(updatePlayerVehAttenuation), false] call CBA_fnc_addPlayerEventHandler;
+
 
     // Reset deafness on respawn (or remote control player switch)
     ["unit", {
+        params ["_player", "_oldPlayer"];
+        TRACE_2("unit change",_player,_oldPlayer);
+        
+        if (!isNull _oldPlayer) then {
+            private _firedEH = _oldPlayer getVariable [QGVAR(firedEH), -1];
+            _oldPlayer removeEventHandler ["FiredNear", _firedEH];
+            _oldPlayer setVariable [QGVAR(firedEH), nil];
+            private _explosionEH = _oldPlayer getVariable [QGVAR(explosionEH), -1];
+            _oldPlayer removeEventHandler ["Explosion", _explosionEH];
+            _oldPlayer setVariable [QGVAR(explosionEH), nil];
+            TRACE_3("removed unit eh",_oldPlayer,_firedEH,_explosionEH);
+        };
+        // Don't add a new EH if the unit respawned
+        if ((_player getVariable [QGVAR(firedEH), -1]) == -1) then {
+            private _firedEH = _player addEventHandler ["FiredNear", LINKFUNC(firedNear)];
+            _player setVariable [QGVAR(firedEH), _firedEH];
+            private _explosionEH = _player addEventHandler ["Explosion", LINKFUNC(explosionNear)];
+            _player setVariable [QGVAR(explosionEH), _explosionEH];
+            TRACE_3("added unit eh",_player,_firedEH,_explosionEH);
+        };
+
         GVAR(deafnessDV) = 0;
         GVAR(deafnessPrior) = 0;
         ACE_player setVariable [QGVAR(deaf), false];
         GVAR(time3) = 0;
         [] call FUNC(updateHearingProtection);
-    }] call CBA_fnc_addPlayerEventHandler;
+    }, true] call CBA_fnc_addPlayerEventHandler;
 
     // Update protection on possible helmet change
-    ["loadout", FUNC(updateHearingProtection)] call CBA_fnc_addPlayerEventHandler;
+    ["loadout", LINKFUNC(updateHearingProtection), false] call CBA_fnc_addPlayerEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/hearing/functions/fnc_explosionNear.sqf
+++ b/addons/hearing/functions/fnc_explosionNear.sqf
@@ -18,8 +18,6 @@
 
 params ["_unit", "_damage"];
 
-if (_unit != ACE_player) exitWith {};
-
 TRACE_2("explosion near player",_unit,_damage);
 
 private ["_strength"];

--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -24,8 +24,6 @@
 
 params ["_object", "_firer", "_distance", "_weapon", "", "", "_ammo"];
 
-//Only run if firedNear object is player or player's vehicle:
-if ((ACE_player != _object) && {(vehicle ACE_player) != _object}) exitWith {};
 if (_weapon in ["Throw", "Put"]) exitWith {};
 if (_distance > 50) exitWith {};
 

--- a/addons/hearing/functions/fnc_updatePlayerVehAttenuation.sqf
+++ b/addons/hearing/functions/fnc_updatePlayerVehAttenuation.sqf
@@ -15,20 +15,17 @@
  */
 #include "script_component.hpp"
 
-private ["_effectType", "_newAttenuation", "_turretConfig", "_turretPath", "_vehicle"];
-
-_vehicle = vehicle ACE_player;
+private _vehicle = vehicle ACE_player;
 
 if (isNull _vehicle) exitWith {};
 
-_newAttenuation = 1;
+private _newAttenuation = 1;
 if (ACE_player != _vehicle) then {
-    _effectType = "";
-    _turretPath = [ACE_player] call EFUNC(common,getTurretIndex);
-    _effectType = getText (configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "attenuationEffectType");
+    private _turretPath = [ACE_player] call EFUNC(common,getTurretIndex);
+    private _effectType = getText (configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "attenuationEffectType");
 
     if (!(_turretPath isEqualTo [])) then {
-        _turretConfig = [(configFile >> "CfgVehicles" >> (typeOf _vehicle)), _turretPath] call EFUNC(common,getTurretConfigPath);
+        private _turretConfig = [(configFile >> "CfgVehicles" >> (typeOf _vehicle)), _turretPath] call EFUNC(common,getTurretConfigPath);
 
         if ((getNumber (_turretConfig >> "disableSoundAttenuation")) == 1) then {
             _effectType = "";
@@ -41,8 +38,10 @@ if (ACE_player != _vehicle) then {
 
     _newAttenuation = switch (true) do {
         case (_effectType == ""): {1};
-        case (_effectType == "CarAttenuation"): {0.5};
-        case (_effectType == "RHS_CarAttenuation"): {0.5};
+        case (_effectType == "CarAttenuation");
+        case (_effectType == "RHS_CarAttenuation"): { // Increase protection for armored cars
+            private _armor = getNumber (configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitBody" >> "armor");
+            linearConversion [2, 8, _armor, 0.5, 0.3, true];};
         case (_effectType == "OpenCarAttenuation"): {1};
         case (_effectType == "TankAttenuation"): {0.1};
         case (_effectType == "HeliAttenuation"): {0.3};


### PR DESCRIPTION
Replaces #4278 (no event overhead with this method)
Fixes #2627 - Increase vehicle protection for MRAPs

Switches to dynamically adding `firedNear` event handlers via code based on Advanced Fatigue.

firedNear can trigger many times for a single shot;
filtering by player isn't that expensive, but will run a lot
only running the EH on the player/vic will be even faster.