### PR TITLE
Realisticweights: Updated cyrus weight

### DIFF
--- a/addons/realisticweights/CfgWeapons.hpp
+++ b/addons/realisticweights/CfgWeapons.hpp
@@ -289,6 +289,16 @@ class CfgWeapons {
         };
     };
 
+    // - Cyrus ------------------------------------------------------
+    class DMR_05_base_F: Rifle_Long_Base_F {
+        class WeaponSlotsInfo;
+    };
+    class srifle_DMR_05_blk_F: DMR_05_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 140;
+        };
+    };
+
     // - SIG 556 --------------------------------------------------------------
     class DMR_03_base_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo;


### PR DESCRIPTION
Cyrus was set to weigh 300 units (~30lb?). The NATO equivalent, the Noreen
Bad News (or MAR-10) weighed 130, or 13lbs, equivalent to it's real life
counterpart. This just changes the weight to 140, similar to that of the
SVDK, a possible real-life counterpart for this rifle.

Fixes #4732 