### PR TITLE
fix RHS air vehicles eject like in ace_aircraft

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -287,7 +287,7 @@ class CfgVehicles {
     class Heli_Light_02_base_F: Helicopter_Base_H {
         class Turrets: Turrets {
                 class CopilotTurret;
-                class MainTurret;
+                class MainTurret; // from RHS, not in vanilla
         };
     };
     class RHS_Mi8_base : Heli_Light_02_base_F {

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -282,13 +282,27 @@ class CfgVehicles {
     class Helicopter_Base_F;
     class Helicopter_Base_H: Helicopter_Base_F {
         class EventHandlers;
+        class Turrets;
     };
-    class Heli_Light_02_base_F: Helicopter_Base_H {};
+    class Heli_Light_02_base_F: Helicopter_Base_H {
+        class Turrets: Turrets {
+                class CopilotTurret;
+                class MainTurret;
+        };
+    };
     class RHS_Mi8_base : Heli_Light_02_base_F {
         EGVAR(refuel,fuelCapacity) = 3700;
         EGVAR(fastroping,enabled) = 0;
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers;
+        };
+        class Turrets: Turrets {
+            class CopilotTurret: CopilotTurret {
+                canEject = 1;
+            };
+            class MainTurret: MainTurret {
+                canEject = 1;
+            };
         };
     };
 

--- a/optionals/compat_rhs_gref/$PBOPREFIX$
+++ b/optionals/compat_rhs_gref/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_rhs_gref

--- a/optionals/compat_rhs_gref/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref/CfgVehicles.hpp
@@ -1,0 +1,14 @@
+class CfgVehicles {
+    class Plane;
+    class Plane_Base_F: Plane {
+        class Turrets;
+    };
+    class RHS_AN2_Base: Plane_Base_F {
+        class NewTurret;
+        class Turrets: Turrets {
+            class MainTurret: NewTurret {
+                canEject = 1;
+            };
+        };
+    };
+};

--- a/optionals/compat_rhs_gref/config.cpp
+++ b/optionals/compat_rhs_gref/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"rhsgref_c_air"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Dystopian"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_gref/script_component.hpp
+++ b/optionals/compat_rhs_gref/script_component.hpp
@@ -1,0 +1,6 @@
+#define COMPONENT compat_rhs_gref
+#define COMPONENT_BEAUTIFIED RHS GREF Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+
+#include "\z\ace\addons\main\script_macros.hpp"

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -167,6 +167,16 @@ class CfgVehicles {
         EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
         EGVAR(fastroping,ropeOrigins)[] = {"ropeOriginLeft", "ropeOriginRight"};
 
+        driverCanEject = 1;
+        class Turrets: Turrets {
+            class CopilotTurret: MainTurret {
+                canEject = 1;
+            };
+            class MainTurret: MainTurret {
+                canEject = 1;
+            };
+        };
+
         class UserActions;
         class EventHandlers: EventHandlers {
             class RHSUSF_EventHandlers;
@@ -194,10 +204,20 @@ class CfgVehicles {
 
     class Helicopter_Base_H: Helicopter_Base_F {
         class Eventhandlers;
+        class Turrets: Turrets {
+            class CopilotTurret;
+        };
     };
     class Heli_Transport_01_base_F: Helicopter_Base_H {};
     
-    class RHS_MELB_base: Helicopter_Base_H {};
+    class RHS_MELB_base: Helicopter_Base_H {
+        driverCanEject = 1;
+        class Turrets: Turrets {
+            class CopilotTurret: CopilotTurret {
+                canEject = 1;
+            };
+        };
+    };
     class RHS_MELB_MH6M: RHS_MELB_base {
         EGVAR(fastroping,enabled) = 1;
         EGVAR(fastroping,ropeOrigins)[] = {{1.166, 0.79, -0.01}, {-1.166, 0.79, -0.01}};
@@ -216,6 +236,16 @@ class CfgVehicles {
         EGVAR(fastroping,onCut) = QFUNC(onCut);
         EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
         EGVAR(fastroping,ropeOrigins)[] = {"ropeOriginLeft", "ropeOriginRight"};
+
+        driverCanEject = 1;
+        class Turrets: Turrets {
+            class CopilotTurret: CopilotTurret {
+                canEject = 1;
+            };
+            class MainTurret: MainTurret {
+                canEject = 1;
+            };
+        };
 
         class UserActions {
             class OpenCargoDoor;
@@ -247,7 +277,7 @@ class CfgVehicles {
         EQUIP_FRIES_ATTRIBUTE;
     };
 
-    class Heli_Transport_02_base_F;
+    class Heli_Transport_02_base_F: Helicopter_Base_H{};
     class RHS_CH_47F_base: Heli_Transport_02_base_F {
         EGVAR(refuel,fuelCapacity) = 3914;
     };
@@ -258,12 +288,26 @@ class CfgVehicles {
         EGVAR(fastroping,onCut) = QFUNC(onCut);
         EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
 
+        driverCanEject = 1;
+        class Turrets: Turrets {
+            class CopilotTurret: CopilotTurret {
+                canEject = 1;
+            };
+            class MainTurret: MainTurret {
+                canEject = 1;
+            };
+        };
+
         class UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
                 condition = QUOTE([ARR_2(this,'ramp_anim')] call FUNC(canCloseDoor));
             };
         };
+    };
+
+    class rhsusf_CH53E_USMC: Helicopter_Base_H {
+        driverCanEject = 1;
     };
 
     class Heli_Attack_01_base_F: Helicopter_Base_F {};
@@ -273,6 +317,7 @@ class CfgVehicles {
     };
 
     class RHS_AH1Z: RHS_AH1Z_base {
+        driverCanEject = 1;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 ace_fcs_Enabled = 0;
@@ -283,6 +328,7 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 1420;
     };
     class RHS_AH64D: RHS_AH64_base {
+        driverCanEject = 1;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 ace_fcs_Enabled = 0;
@@ -399,5 +445,14 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 25704;
         EGVAR(cargo,space) = 4;
         EGVAR(cargo,hasCargo) = 1;
+        class Turrets;
+    };
+    class RHS_C130J: RHS_C130J_Base {
+        class Turrets: Turrets {
+            class MainTurret;
+            class CopilotTurret: MainTurret {
+                canEject = 1;
+            };
+        };
     };
 };

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor", "rhsusf_c_melb"};
+        requiredAddons[] = {"ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor", "rhsusf_c_melb", "rhsusf_c_ch53"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
- also RHS GREF compatibility addon created

Sometimes class inheritance looks like a kind of magic for me, so there can be errors.
I used modified fnc_exportConfig script from `nouniformrestrictions` to find all not ejectable classes.