### PR TITLE
Use new private syntax for winddeflection PFH

### DIFF
--- a/addons/winddeflection/functions/fnc_updateTrajectoryPFH.sqf
+++ b/addons/winddeflection/functions/fnc_updateTrajectoryPFH.sqf
@@ -18,34 +18,32 @@
 
 [{
     // BEGIN_COUNTER(pfeh);
-    private ["_accel", "_accelRef", "_bulletSpeed", "_bulletVelocity", "_deleted", "_deltaT", "_drag", "_dragRef", "_isWind", "_trueSpeed", "_trueVelocity"];
 
     params ["_args"];
     _args params ["_lastTime"];
-    _deltaT = CBA_missionTime - _lastTime;
+    private _deltaT = CBA_missionTime - _lastTime;
     _args set [0, CBA_missionTime];
-    _deleted = 0;
-    _isWind = (vectorMagnitude ACE_wind > 0);
+    private _isWind = (vectorMagnitude ACE_wind > 0);
 
     {
         _x params ["_bullet", "_airFriction"];
 
-        _bulletVelocity = velocity _bullet;
-        _bulletSpeed = vectorMagnitude _bulletVelocity;
+        private _bulletVelocity = velocity _bullet;
+        private _bulletSpeed = vectorMagnitude _bulletVelocity;
 
         if ((!alive _bullet) || {(_bullet isKindOf "BulletBase") && {_bulletSpeed < 100}}) then {
             GVAR(trackedBullets) deleteAt (GVAR(trackedBullets) find _x);
         } else {
             if (_isWind) then {
-                _trueVelocity = _bulletVelocity vectorDiff ACE_wind;
-                _trueSpeed = vectorMagnitude _trueVelocity;
+                private _trueVelocity = _bulletVelocity vectorDiff ACE_wind;
+                private _trueSpeed = vectorMagnitude _trueVelocity;
 
-                _dragRef = _deltaT * _airFriction * _bulletSpeed * _bulletSpeed;
-                _accelRef = (vectorNormalized _bulletVelocity) vectorMultiply (_dragRef);
+                private _dragRef = _deltaT * _airFriction * _bulletSpeed * _bulletSpeed;
+                private _accelRef = (vectorNormalized _bulletVelocity) vectorMultiply (_dragRef);
                 _bulletVelocity = _bulletVelocity vectorDiff _accelRef;
 
-                _drag = _deltaT * _airFriction * _trueSpeed;
-                _accel = _trueVelocity vectorMultiply (_drag);
+                private _drag = _deltaT * _airFriction * _trueSpeed;
+                private _accel = _trueVelocity vectorMultiply (_drag);
                 _bulletVelocity = _bulletVelocity vectorAdd _accel;
             };
             _bullet setVelocity _bulletVelocity;


### PR DESCRIPTION
`private _var` is about double as fast as `private [array]` and this is a PFH so its kinda important
0.0196ms for the 
```
private ["_accel", "_accelRef", "_bulletSpeed", "_bulletVelocity", "_deleted", "_deltaT", "_drag", "_dragRef", "_isWind", "_trueSpeed", "_trueVelocity"];
_accel                  = 0; 
_accelRef             = 0; 
_bulletSpeed        = 0; 
_bulletVelocity      = 0; 
_deleted               = 0; 
_deltaT                = 0; 
_drag                   = 0; 
_dragRef              = 0; 
_isWind                = 0; 
_trueSpeed          = 0; 
_trueVelocity        = 0; 
```
vs 0.0129ms for
```
private _accel                  = 0; 
private _accelRef             = 0; 
private _bulletSpeed        = 0; 
private _bulletVelocity      = 0; 
private _deleted               = 0; 
private _deltaT                = 0; 
private _drag                   = 0; 
private _dragRef              = 0; 
private _isWind                = 0; 
private _trueSpeed          = 0; 
private _trueVelocity        = 0; 
```
also `_deleted` variable was unused