### PR TITLE
add optionals meta.cpp files

### DIFF
--- a/optionals/compat_adr_97/meta.cpp
+++ b/optionals/compat_adr_97/meta.cpp
@@ -1,0 +1,2 @@
+protocol = 1;
+publishedid = 773136286;

--- a/optionals/compat_rhs_afrf3/meta.cpp
+++ b/optionals/compat_rhs_afrf3/meta.cpp
@@ -1,0 +1,2 @@
+protocol = 1;
+publishedid = 773131200;

--- a/optionals/compat_rhs_usf3/meta.cpp
+++ b/optionals/compat_rhs_usf3/meta.cpp
@@ -1,0 +1,2 @@
+protocol = 1;
+publishedid = 773125288;


### PR DESCRIPTION
**When merged this pull request will:**
- Add meta.cpp files to RHS and ADR optionals

Since those mods are now Steam Workshop it just makes sense, that they get their own meta.cpp

