### PR TITLE
Overpressure changes

### DIFF
--- a/addons/common/functions/fnc_addLineToDebugDraw.sqf
+++ b/addons/common/functions/fnc_addLineToDebugDraw.sqf
@@ -7,11 +7,17 @@
  * 1: End point ASL <ARRAY>
  * 2: Color <ARRAY>
  *
- * None
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [[0,0,0], [1,1,0], [1,0,0,1]]] call ace_common_fnc_addLineToDebugDraw;
  *
  * Public: No
  */
 #include "script_component.hpp"
+
+params ["_startASL", "_endASL", "_color"];
 
 if (isNil QGVAR(debugLines)) then {
     GVAR(debugLines) = [];
@@ -19,30 +25,23 @@ if (isNil QGVAR(debugLines)) then {
 };
 
 if (count GVAR(debugLines) < 100) then {
-    GVAR(debugLines) pushBack _this;
+    GVAR(debugLines) pushBack [ASLtoAGL _startASL, ASLtoAGL _endASL, _color];
     GVAR(debugLinesIndex) = 0;
 } else {
-    GVAR(debugLines) set [GVAR(debugLinesIndex), _this];
+    GVAR(debugLines) set [GVAR(debugLinesIndex), [ASLtoAGL _startASL, ASLtoAGL _endASL, _color]];
     GVAR(debugLinesIndex) = (GVAR(debugLinesIndex) + 1) mod 100;
 };
 
 if (isNil QGVAR(debugDrawHandler)) then {
     GVAR(debugDrawHandler) = addMissionEventHandler ["Draw3D", {
-        if (count GVAR(debugLines) == 0) exitWith {
+        if (GVAR(debugLines) isEqualTo []) exitWith {
             removeMissionEventHandler ["Draw3D", GVAR(debugDrawHandler)];
             GVAR(debugDrawHandler) = nil;
         };
 
         {
-            _p0 = _x select 0;
-            if (!surfaceIsWater _p0) then {
-                _p0 = ASLtoATL _p0;
-            };
-            _p1 = _x select 1;
-            if (!surfaceIsWater _p1) then {
-                _p1 = ASLtoATL _p1;
-            };
-            drawLine3D [_p0, _p1, _x select 2];
+            _x params ["_start", "_end", "_color"];
+            drawLine3D [_start, _end, _color];
         } forEach GVAR(debugLines);
     }];
 };

--- a/addons/overpressure/ACE_Settings.hpp
+++ b/addons/overpressure/ACE_Settings.hpp
@@ -1,0 +1,8 @@
+class ACE_Settings {
+    class GVAR(distanceCoefficient) {
+        displayName = CSTRING(distanceCoefficient_displayName);
+        description = CSTRING(distanceCoefficient_toolTip);
+        typeName = "SCALAR";
+        value = 1;
+    };
+};

--- a/addons/overpressure/XEH_postInit.sqf
+++ b/addons/overpressure/XEH_postInit.sqf
@@ -1,7 +1,12 @@
 #include "script_component.hpp"
 
-["ace_overpressure", FUNC(overpressureDamage)] call CBA_fnc_addEventHandler;
+["ace_settingsInitialized", {
+    TRACE_1("settingsInit eh",GVAR(distanceCoefficient));
+    if (GVAR(distanceCoefficient) <= 0) exitWith {};
 
-// Register fire event handler
-["ace_firedPlayer", DFUNC(firedEHBB)] call CBA_fnc_addEventHandler;
-["ace_firedPlayerVehicle", DFUNC(firedEHOP)] call CBA_fnc_addEventHandler;
+    ["ace_overpressure", LINKFUNC(overpressureDamage)] call CBA_fnc_addEventHandler;
+
+    // Register fire event handler
+    ["ace_firedPlayer", LINKFUNC(firedEHBB)] call CBA_fnc_addEventHandler;
+    ["ace_firedPlayerVehicle", LINKFUNC(firedEHOP)] call CBA_fnc_addEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/overpressure/config.cpp
+++ b/addons/overpressure/config.cpp
@@ -14,5 +14,6 @@ class CfgPatches {
     };
 };
 
+#include "ACE_Settings.hpp"
 #include "CfgEventHandlers.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -46,7 +46,7 @@ TRACE_1("ConfigPath",_config);
 // get the Variables out of the Configes and create a array with then
 private _return = [
     (getNumber (_config >> QGVAR(angle))),
-    (getNumber (_config >> QGVAR(range))),
+    (getNumber (_config >> QGVAR(range))) * GVAR(distanceCoefficient),
     (getNumber (_config >> QGVAR(damage)))
 ];
 

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -51,6 +51,7 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
             private _beta = sqrt (1 - _angle / _overpressureAngle);
 
             private _damage = _alpha * _beta * _overpressureDamage;
+            TRACE_1("",_damage);
 
             // If the target is the ACE_player
             if (_x == ACE_player) then {[_damage * 100] call BIS_fnc_bloodEffect};

--- a/addons/overpressure/stringtable.xml
+++ b/addons/overpressure/stringtable.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACE">
+    <Package name="overpressure">
+        <Key ID="STR_ACE_overpressure_distanceCoefficient_displayName">
+            <English>Overpressure Distance Coefficient</English>
+        </Key>
+        <Key ID="STR_ACE_overpressure_distanceCoefficient_toolTip">
+            <English>Scales the overpressure effect [Default: 1]</English>
+        </Key>
+    </Package>
+</Project>

--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -213,7 +213,7 @@ class CfgAmmo {
     class rhs_g_vg40sz: rhs_g_vog25 { //Flashbang
         ace_frag_force = 0;
     };
-    class rhs_GDM40: rhs_g_vog25 { //Smoke
+    class rhs_g_gdm40: rhs_g_vog25 { //Smoke
         ace_frag_force = 0;
     };
     class rhs_g_vg40md_white: rhs_g_vog25 { //Smoke

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -85,4 +85,10 @@ class CfgWeapons {
         ace_hearing_protection = 0.5;
         ace_hearing_lowerVolume = 0.60;
     };
+    
+    class rhs_weap_d81;
+    class rhs_weap_2a70: rhs_weap_d81 { // "Low pressure" 100mm cannon
+        ace_overpressure_range = 15;
+        ace_overpressure_damage = 0.5;
+    };
 };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -91,6 +91,7 @@ class CfgWeapons {
         ace_overpressure_range = 15;
         ace_overpressure_damage = 0.5;
     };
+    class cannon_120mm;
     class rhs_weap_2a28_base: cannon_120mm { // "Low pressure"
         ace_overpressure_range = 15;
         ace_overpressure_damage = 0.5;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -91,4 +91,8 @@ class CfgWeapons {
         ace_overpressure_range = 15;
         ace_overpressure_damage = 0.5;
     };
+    class rhs_weap_2a28_base: cannon_120mm { // "Low pressure"
+        ace_overpressure_range = 15;
+        ace_overpressure_damage = 0.5;
+    };
 };

--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_rearm", "ace_refuel", "ace_repair", "rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_trucks", "rhs_c_2s3", "rhs_c_rva"};
+        requiredAddons[] = {"ace_rearm", "ace_refuel", "ace_repair", "rhs_c_weapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_trucks", "rhs_c_2s3", "rhs_c_rva", "rhs_c_heavyweapons"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "commy2", "Skengman2"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
Close #4691

- Add ace_setting for overpressure distance
- Change overpressure config on 2a70 (used on the bmp-3/bmd-4; it has a very low muzzle velocity)
- fix rhs gl smoke causing frag
- improve debug line drawing