### PR TITLE
Simplify config crawling in nouniformrestrictions

### DIFF
--- a/optionals/nouniformrestrictions/functions/fnc_exportConfig.sqf
+++ b/optionals/nouniformrestrictions/functions/fnc_exportConfig.sqf
@@ -18,19 +18,15 @@
 private _modifyClasses = [];
 private _baseClasses = [];
 {
-    if ((_x >> "modelSides") in (configProperties [_x, "true", false])) then {
-        private _modifyClass = {
-            if (!isNull (_x >> "modelSides")) exitWith {_x};
-        } forEach (configHierarchy _x);
-        private _baseClass = inheritsFrom _modifyClass;
-        _modifyClasses pushBackUnique [_modifyClass, _baseClass];
-        if !(_baseClass in (_modifyClasses apply {_x select 0})) then {
-            _baseClasses pushBackUnique _baseClass;
-        };
+    private _baseClass = inheritsFrom _x;
+    _modifyClasses pushBackUnique [_x, _baseClass];
+    if !(_baseClass in (_modifyClasses apply {_x select 0})) then {
+        _baseClasses pushBackUnique _baseClass;
     };
     false
 } count (
     ("!isNull (_x >> 'modelSides') &&" +
+    "{(_x >> 'modelSides') in (configProperties [_x, 'true', false])} &&" +
     "{!(getArray (_x >> 'modelSides') isEqualTo [6])} &&" +
     "{!(getArray (_x >> 'modelSides') isEqualTo [0,1,2,3])}")
     configClasses (configFile >> "CfgVehicles")


### PR DESCRIPTION
I know it's not important for performance, but it's a good example script (e.g. for me) and I want it to be more perfect.