### PR TITLE
Decrease concertina "dismount" time

### DIFF
--- a/addons/concertina_wire/functions/fnc_dismount.sqf
+++ b/addons/concertina_wire/functions/fnc_dismount.sqf
@@ -23,7 +23,7 @@ if (uiNamespace getVariable [QEGVAR(interact_menu,cursorMenuOpened),false]) exit
 params ["_wire", "_unit"];
 
 private _config = (configFile >> "CfgVehicles" >> typeOf _unit);
-private _delay = [120, 60] select (getNumber (_config >> "engineer") == 1 || {getNumber (_config >> "canDeactivateMines") == 1});
+private _delay = [45, 30] select ([_unit] call EFUNC(common,isEngineer) || {[_unit] call EFUNC(common,isEOD)});
 
 // TODO: Animation?
 [


### PR DESCRIPTION
**When merged this pull request will:**
- Decrease concertina "dismount" time
  - IRL it’s just pushing them together again
- use ace checks to see if a unit is an engineer or an EOD
