### PR TITLE
Add RH Acc Surefire flashlight map compatibility

### DIFF
--- a/optionals/compat_rh_acc/CfgWeapons.hpp
+++ b/optionals/compat_rh_acc/CfgWeapons.hpp
@@ -1,18 +1,18 @@
 
 class CfgWeapons {
     class ItemCore;
+
+    /* Scopes */
     class InventoryOpticsItem_Base_F;
-    
-    /*
+
     // This would require MOA turrets
-    class RH_shortdot : ItemCore {
+    /*class RH_shortdot : ItemCore {
         ACE_ScopeAdjust_Vertical[] = { -1, 25 };
         ACE_ScopeAdjust_Horizontal[] = { -13, 13 };
         ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_Unit = "MOA";
-    };
-    */
-    
+    };*/
+
     class RH_accupoint : ItemCore {
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
@@ -144,6 +144,20 @@ class CfgWeapons {
                     discreteDistance[] = { 100 };
                     discreteDistanceInitIndex = 0;
                 };
+            };
+        };
+    };
+
+    /* Flashlights */
+    class InventoryFlashLightItem_Base_F;
+
+    class RH_SFM952V: ItemCore {
+        class ItemInfo: InventoryFlashLightItem_Base_F {
+            class FlashLight {
+                ACE_Flashlight_Colour = "white";
+                ACE_Flashlight_Beam = QPATHTOEF(map,UI\Flashlight_beam_white_ca.paa);
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Enable map flashlight for RH Acc's Surefire flashlight

![20170121191905_1](https://cloud.githubusercontent.com/assets/7935003/22176609/c001a800-e00e-11e6-90ea-cba123ba2570.jpg)
