### PR TITLE
Cache Nametags onDraw3D flags.

### DIFF
--- a/addons/nametags/XEH_PREP.hpp
+++ b/addons/nametags/XEH_PREP.hpp
@@ -2,6 +2,7 @@
 PREP(canShow);
 PREP(doShow);
 PREP(drawNameTagIcon);
+PREP(getCachedFlags);
 PREP(getVehicleData);
 PREP(initIsSpeaking);
 PREP(moduleNameTags);

--- a/addons/nametags/XEH_postInit.sqf
+++ b/addons/nametags/XEH_postInit.sqf
@@ -15,7 +15,7 @@ GVAR(showNamesTime) = -10;
 
     // Statement
     GVAR(showNamesTime) = CBA_missionTime;
-    if (call FUNC(canShow)) then{ call FUNC(doShow); };
+    // if (call FUNC(canShow)) then{ call FUNC(doShow); }; // This code doesn't work (canShow has a nil / has never worked??)
     // Return false so it doesn't block other actions
     false
 },
@@ -34,6 +34,13 @@ GVAR(showNamesTime) = -10;
     if (_name == QGVAR(showPlayerNames)) then {
         call FUNC(updateSettings);
     };
+    // Reset nametag flag cache on setting change:
+    ACE_player setVariable [QGVAR(flagsCache), nil];
+}] call CBA_fnc_addEventHandler;
+
+["cba_events_visionModeEvent", {
+    // Reset nametag flag cache on vision mode change:
+    ACE_player setVariable [QGVAR(flagsCache), nil];
 }] call CBA_fnc_addEventHandler;
 
 // civilians don't use military ranks

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: <N/A>
+ * Get's flags used for onDraw3D that can be cached
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * [_drawName,_drawRank,_enabledTagsNearby,_enabledTagsCursor,_onKeyPressAlphaMax,_maxDistance]
+ *
+ * Example:
+ * call ace_nametags_fnc_getCachedFlags
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+
+// Determine flags from current settings
+private _drawName = true;
+private _enabledTagsNearby = false;
+private _enabledTagsCursor = false;
+private _onKeyPressAlphaMax = 1;
+
+switch (GVAR(showPlayerNames)) do {
+    case 0: {
+        // Player names Disabled
+        _drawName = false;
+        _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
+        _enabledTagsCursor = false;
+    };
+    case 1: {
+        // Player names Enabled
+        _enabledTagsNearby = true;
+        _enabledTagsCursor = false;
+    };
+    case 2: {
+        // Player names Only cursor
+        _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
+        _enabledTagsCursor = true;
+    };
+    case 3: {
+        // Player names Only Keypress
+        _onKeyPressAlphaMax = 2 + (GVAR(showNamesTime) - CBA_missionTime);
+        _enabledTagsNearby = (_onKeyPressAlphaMax) > 0 || (GVAR(showSoundWaves) == 2);
+        _enabledTagsCursor = false;
+    };
+    case 4: {
+        // Player names Only Cursor and Keypress
+        _onKeyPressAlphaMax = 2 + (GVAR(showNamesTime) - CBA_missionTime);
+        _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
+        _enabledTagsCursor = _onKeyPressAlphaMax > 0;
+    };
+    case 5: {
+        // Fade on border
+        _enabledTagsNearby = true;
+        _enabledTagsCursor = false;
+    };
+};
+
+private _ambientBrightness = ((([] call EFUNC(common,ambientBrightness)) + ([0, 0.4] select ((currentVisionMode ace_player) != 0))) min 1) max 0;
+private _maxDistance = _ambientBrightness * GVAR(PlayerNamesViewDistance);
+
+[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_onKeyPressAlphaMax,_maxDistance]

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -15,24 +15,20 @@
  */
 #include "script_component.hpp"
 
-
 // Determine flags from current settings
 private _drawName = true;
 private _enabledTagsNearby = false;
 private _enabledTagsCursor = false;
-private _onKeyPressAlphaMax = 1;
 
 switch (GVAR(showPlayerNames)) do {
     case 0: {
-        // Player names Disabled
+        // Player names Disabled [Note: this should be unreachable as the drawEH will be removed]
         _drawName = false;
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = false;
     };
     case 1: {
         // Player names Enabled
         _enabledTagsNearby = true;
-        _enabledTagsCursor = false;
     };
     case 2: {
         // Player names Only cursor
@@ -41,24 +37,20 @@ switch (GVAR(showPlayerNames)) do {
     };
     case 3: {
         // Player names Only Keypress
-        _onKeyPressAlphaMax = 2 + (GVAR(showNamesTime) - CBA_missionTime);
-        _enabledTagsNearby = (_onKeyPressAlphaMax) > 0 || (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = false;
+        _enabledTagsNearby = GVAR(showSoundWaves) == 2; // non-cached: || _onKeyPressAlphaMax) > 0
     };
     case 4: {
         // Player names Only Cursor and Keypress
-        _onKeyPressAlphaMax = 2 + (GVAR(showNamesTime) - CBA_missionTime);
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = _onKeyPressAlphaMax > 0;
+        // non-cached: _enabledTagsCursor = _onKeyPressAlphaMax > 0;
     };
     case 5: {
         // Fade on border
         _enabledTagsNearby = true;
-        _enabledTagsCursor = false;
     };
 };
 
 private _ambientBrightness = ((([] call EFUNC(common,ambientBrightness)) + ([0, 0.4] select ((currentVisionMode ace_player) != 0))) min 1) max 0;
 private _maxDistance = _ambientBrightness * GVAR(PlayerNamesViewDistance);
 
-[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_onKeyPressAlphaMax,_maxDistance]
+[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_maxDistance]

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -6,7 +6,7 @@
  * None
  *
  * Return Value:
- * [_drawName,_drawRank,_enabledTagsNearby,_enabledTagsCursor,_onKeyPressAlphaMax,_maxDistance]
+ * [_drawName,_drawRank,_enabledTagsNearby,_enabledTagsCursor,_maxDistance]
  *
  * Example:
  * call ace_nametags_fnc_getCachedFlags

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -15,57 +15,14 @@
  */
 #include "script_component.hpp"
 
-private ["_defaultIcon", "_distance", "_alpha", "_icon", "_targets", "_relPos", "_projDist", "_target"];
-
 BEGIN_COUNTER(GVAR(onDraw3d));
 
 // Don't show nametags in spectator or if RscDisplayMPInterrupt is open
 if ((isNull ACE_player) || {!alive ACE_player} || {!isNull (findDisplay 49)}) exitWith {};
 
-// Determine flags from current settings
-private _drawName = true;
-private _drawRank = GVAR(showPlayerRanks);
-private _enabledTagsNearby = false;
-private _enabledTagsCursor = false;
-private _onKeyPressAlphaMax = 1;
-switch (GVAR(showPlayerNames)) do {
-    case 0: {
-        // Player names Disabled
-        _drawName = false;
-        _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = false;
-    };
-    case 1: {
-        // Player names Enabled
-        _enabledTagsNearby = true;
-        _enabledTagsCursor = false;
-    };
-    case 2: {
-        // Player names Only cursor
-        _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = true;
-    };
-    case 3: {
-        // Player names Only Keypress
-        _onKeyPressAlphaMax = 2 + (GVAR(showNamesTime) - CBA_missionTime);
-        _enabledTagsNearby = (_onKeyPressAlphaMax) > 0 || (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = false;
-    };
-    case 4: {
-        // Player names Only Cursor and Keypress
-        _onKeyPressAlphaMax = 2 + (GVAR(showNamesTime) - CBA_missionTime);
-        _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
-        _enabledTagsCursor = _onKeyPressAlphaMax > 0;
-    };
-    case 5: {
-        // Fade on border
-        _enabledTagsNearby = true;
-        _enabledTagsCursor = false;
-    };
-};
+private _flags = [[], DFUNC(getCachedFlags), ACE_player, QGVAR(flagsCache), 2, "cba_events_visionModeEvent"] call EFUNC(common,cachedCall);
 
-private _ambientBrightness = ((([] call EFUNC(common,ambientBrightness)) + ([0, 0.4] select ((currentVisionMode ace_player) != 0))) min 1) max 0;
-private _maxDistance = _ambientBrightness * GVAR(PlayerNamesViewDistance);
+_flags params ["_drawName", "_drawRank", "_enabledTagsNearby", "_enabledTagsCursor", "_onKeyPressAlphaMax","_maxDistance"];
 
 private _camPosAGL = positionCameraToWorld [0, 0, 0];
 if !((_camPosAGL select 0) isEqualType 0) exitWith {}; // handle RHS / bugged vehicle slots
@@ -75,7 +32,7 @@ private _vecy = (AGLtoASL positionCameraToWorld [0, 0, 1]) vectorDiff _camPosASL
 
 // Show nametag for the unit behind the cursor or its commander
 if (_enabledTagsCursor) then {
-    _target = cursorTarget;
+    private _target = cursorTarget;
     if !(_target isKindOf "CAManBase") then {
         // When cursorTarget is on a vehicle show the nametag for the commander.
         if !(_target in allUnitsUAV) then {
@@ -92,7 +49,7 @@ if (_enabledTagsCursor) then {
         {lineIntersectsSurfaces [_camPosASL, eyePos _target, ACE_player, _target] isEqualTo []} &&
         {!isObjectHidden _target}) then {
 
-        _distance = ACE_player distance _target;
+        private _distance = ACE_player distance _target;
 
         private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
         // Alpha:


### PR DESCRIPTION
This will cache the Nametag Flags and _maxDistance for 2 seconds instead of reparsing them every Frame.
This will take about 0.0621ms of load from eachFrame and cache it.
After caching the load will be about 0.0323ms per frame.
0.03ms improvement call me crazy if you want.
This will also remove the unused privates from fnc_onDraw3d.

This will create lag from changing Nametag settings to them being visible. Sadly cachedCall can only use 1 Event and I used `cba_events_visionModeEvent` to be also able to cache the _maxDistance variable.
Calculating the _maxDistance variable takes 0.0267 ms so it's very worthwhile to be cached.
