### PR TITLE
Improve cachedCall

### DIFF
--- a/addons/common/functions/fnc_cachedCall.sqf
+++ b/addons/common/functions/fnc_cachedCall.sqf
@@ -22,7 +22,7 @@ params ["_params", "_function", "_namespace", "_uid", "_duration", "_event"];
 private _cacheEntry = (_namespace getVariable [_uid, [-99999]]);
 
 if (_cacheEntry select 0 < diag_tickTime) then {
-	_cacheEntry = [diag_tickTime + _duration, _params call _function];
+    _cacheEntry = [diag_tickTime + _duration, _params call _function];
     _namespace setVariable [_uid, _cacheEntry];
 
     // Does the cache needs to be cleared on an event?
@@ -35,9 +35,9 @@ if (_cacheEntry select 0 < diag_tickTime) then {
             _cacheList = [];
             missionNamespace setVariable [_varName, _cacheList];
 
-			private _events = if (_event isEqualType []) then {_event} else {[_event]};
-			
-			{
+            private _events = if (_event isEqualType []) then {_event} else {[_event]};
+            
+            {
                 [_x, {
                     // _eventName is defined on the function that calls the event
                     #ifdef DEBUG_MODE_FULL
@@ -53,7 +53,7 @@ if (_cacheEntry select 0 < diag_tickTime) then {
                     // Empty the list
                     missionNamespace setVariable [_varName, []];
                 }] call CBA_fnc_addEventHandler;
-			} forEach _events;
+            } forEach _events;
         };
 
         // Add this cache to the list of the event

--- a/addons/common/functions/fnc_cachedCall.sqf
+++ b/addons/common/functions/fnc_cachedCall.sqf
@@ -35,21 +35,25 @@ if (_cacheEntry select 0 < diag_tickTime) then {
             _cacheList = [];
             missionNamespace setVariable [_varName, _cacheList];
 
-            [_event, {
-                // _eventName is defined on the function that calls the event
-                #ifdef DEBUG_MODE_FULL
-                    INFO_1("Clear cached variables on event: %1",_eventName);
-                #endif
-                // Get the list of caches to clear
-                private _varName = format [QGVAR(clearCache_%1), _eventName];
-                private _cacheList = missionNamespace getVariable [_varName, []];
-                // Erase all the cached results
-                {
-                    _x call FUNC(eraseCache);
-                } forEach _cacheList;
-                // Empty the list
-                missionNamespace setVariable [_varName, []];
-            }] call CBA_fnc_addEventHandler;
+			private _events = if (_event isEqualType []) then {_event} else {[_event]};
+			
+			{
+                [_x, {
+                    // _eventName is defined on the function that calls the event
+                    #ifdef DEBUG_MODE_FULL
+                        INFO_1("Clear cached variables on event: %1",_eventName);
+                    #endif
+                    // Get the list of caches to clear
+                    private _varName = format [QGVAR(clearCache_%1), _eventName];
+                    private _cacheList = missionNamespace getVariable [_varName, []];
+                    // Erase all the cached results
+                    {
+                        _x call FUNC(eraseCache);
+                    } forEach _cacheList;
+                    // Empty the list
+                    missionNamespace setVariable [_varName, []];
+                }] call CBA_fnc_addEventHandler;
+			} forEach _events;
         };
 
         // Add this cache to the list of the event

--- a/addons/common/functions/fnc_cachedCall.sqf
+++ b/addons/common/functions/fnc_cachedCall.sqf
@@ -19,8 +19,11 @@
 
 params ["_params", "_function", "_namespace", "_uid", "_duration", "_event"];
 
-if ((_namespace getVariable [_uid, [-99999]]) select 0 < diag_tickTime) then {
-    _namespace setVariable [_uid, [diag_tickTime + _duration, _params call _function]];
+private _cacheEntry = (_namespace getVariable [_uid, [-99999]]);
+
+if (_cacheEntry select 0 < diag_tickTime) then {
+	_cacheEntry = [diag_tickTime + _duration, _params call _function];
+    _namespace setVariable [_uid, _cacheEntry];
 
     // Does the cache needs to be cleared on an event?
     if (!isNil "_event") then {
@@ -61,4 +64,4 @@ if ((_namespace getVariable [_uid, [-99999]]) select 0 < diag_tickTime) then {
 
 };
 
-(_namespace getVariable _uid) select 1
+_cacheEntry select 1


### PR DESCRIPTION
- Remove the need for one getVariable call.
- Add the possibility to specify more than 1 Event to listen to.

The multi-event thingy will make it possible to Improve #4847 
One could also optimize out the setVariable. Because we are getting the Array as reference anyway so we could use 2x set's on the array instead of one setVariable. But I don't think that will provide a performance benefit.