### PR TITLE
fixing typo in ace_interaction_fnc_getDoorAnimations

### DIFF
--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -36,7 +36,7 @@ _index = [
     "door_11",
     "door_12",
     "door_13",
-    "Door_14",
+    "door_14",
     "door_15",
     "door_16",
     "door_17",


### PR DESCRIPTION
**When merged this pull request will:**
- Fix a typo in ace_interaction_fnc_getDoorAnimations
