### PR TITLE
Fix Javelin for AI

### DIFF
--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -69,7 +69,7 @@ class CfgAmmo {
     class M_Titan_AT: MissileBase {};
 
     class ACE_Javelin_FGM148: M_Titan_AT {
-        irLock = 0;
+        irLock = 1;
         laserLock = 0;
         airLock = 0;
 


### PR DESCRIPTION
Fix #4856

Ammo seems to need this config or AI just take their launcher out and then put them away.
Missile is still guided by script
