### PR TITLE
Handle changes to CBA_fnc_addPlayerEventHandler

### DIFF
--- a/addons/advanced_fatigue/XEH_postInit.sqf
+++ b/addons/advanced_fatigue/XEH_postInit.sqf
@@ -14,12 +14,15 @@ if (!hasInterface) exitWith {};
     // - GVAR updating and initialization -----------------------------------------
     ["unit", FUNC(handlePlayerChanged), true] call CBA_fnc_addPlayerEventHandler;
 
-    private _fnc_showStaminaBar = {
+    ["visibleMap", {
+        params ["", "_visableMap"]; // command visibleMap is updated one frame later
         private _staminaBarContainer = uiNamespace getVariable [QGVAR(staminaBarContainer), controlNull];
-        _staminaBarContainer ctrlShow ((!visibleMap) && {(vehicle ACE_player) == ACE_player});
-    };
-    ["visibleMap", _fnc_showStaminaBar, true] call CBA_fnc_addPlayerEventHandler;
-    ["vehicle", _fnc_showStaminaBar, true] call CBA_fnc_addPlayerEventHandler;
+        _staminaBarContainer ctrlShow ((!_visableMap) && {(vehicle ACE_player) == ACE_player});
+    }, true] call CBA_fnc_addPlayerEventHandler;
+    ["vehicle", {
+        private _staminaBarContainer = uiNamespace getVariable [QGVAR(staminaBarContainer), controlNull];
+        _staminaBarContainer ctrlShow ((!visableMap) && {(vehicle ACE_player) == ACE_player});
+    }, true] call CBA_fnc_addPlayerEventHandler;
 
     // - Duty factors -------------------------------------------------------------
     if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {

--- a/addons/advanced_fatigue/XEH_postInit.sqf
+++ b/addons/advanced_fatigue/XEH_postInit.sqf
@@ -15,13 +15,13 @@ if (!hasInterface) exitWith {};
     ["unit", FUNC(handlePlayerChanged), true] call CBA_fnc_addPlayerEventHandler;
 
     ["visibleMap", {
-        params ["", "_visableMap"]; // command visibleMap is updated one frame later
+        params ["", "_visibleMap"]; // command visibleMap is updated one frame later
         private _staminaBarContainer = uiNamespace getVariable [QGVAR(staminaBarContainer), controlNull];
-        _staminaBarContainer ctrlShow ((!_visableMap) && {(vehicle ACE_player) == ACE_player});
+        _staminaBarContainer ctrlShow ((!_visibleMap) && {(vehicle ACE_player) == ACE_player});
     }, true] call CBA_fnc_addPlayerEventHandler;
     ["vehicle", {
         private _staminaBarContainer = uiNamespace getVariable [QGVAR(staminaBarContainer), controlNull];
-        _staminaBarContainer ctrlShow ((!visableMap) && {(vehicle ACE_player) == ACE_player});
+        _staminaBarContainer ctrlShow ((!visibleMap) && {(vehicle ACE_player) == ACE_player});
     }, true] call CBA_fnc_addPlayerEventHandler;
 
     // - Duty factors -------------------------------------------------------------

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -67,8 +67,8 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
 }] call CBA_fnc_addPlayerEventhandler;
 
 ["visibleMap", {
-    params ["", "_visableMap"]; // command visibleMap is updated one frame later
-    if (_visableMap && {ACE_player getVariable [QGVAR(inHand), false]}) then {
+    params ["", "_visibleMap"]; // command visibleMap is updated one frame later
+    if (_visibleMap && {ACE_player getVariable [QGVAR(inHand), false]}) then {
         [ACE_player, "Opened Map"] call FUNC(exitThrowMode);
     };
 }] call CBA_fnc_addPlayerEventhandler;

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -67,7 +67,8 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
 }] call CBA_fnc_addPlayerEventhandler;
 
 ["visibleMap", {
-    if (visibleMap && {ACE_player getVariable [QGVAR(inHand), false]}) then {
+    params ["", "_visableMap"]; // command visibleMap is updated one frame later
+    if (_visableMap && {ACE_player getVariable [QGVAR(inHand), false]}) then {
         [ACE_player, "Opened Map"] call FUNC(exitThrowMode);
     };
 }] call CBA_fnc_addPlayerEventhandler;

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -282,11 +282,11 @@ enableCamShake true;
     params ["_newPlayer","_oldPlayer"];
 
     if (alive _newPlayer) then {
-        [_newPlayer] call FUNC(setName);
+        [FUNC(setName), [_newPlayer]] call CBA_fnc_execNextFrame;
     };
 
     if (alive _oldPlayer) then {
-        [_oldPlayer] call FUNC(setName);
+        [FUNC(setName), [_oldPlayer]] call CBA_fnc_execNextFrame;
     };
 }] call CBA_fnc_addPlayerEventHandler;
 

--- a/addons/common/functions/fnc_setName.sqf
+++ b/addons/common/functions/fnc_setName.sqf
@@ -13,6 +13,7 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_3("setName",_unit,alive _unit,name _unit);
 
 if (isNull _unit || {!alive _unit}) exitWith {};
 


### PR DESCRIPTION
Needed for CBA 3.2, but bwc with current.

"visibleMap" event is weird now: at the time the event runs the command `visibleMap` returns the previous value.
The fatigue bar was only showing on the map, but not in-game :smile: 

Similar problem with "unit", the command `name` would return the name of the previous AI.
Player reinforcements all had AI names on their nametags.