### PR TITLE
AB : compats RHS 4.2 updated 

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -46,7 +46,11 @@ class CfgWeapons {
         ACE_barrelTwist = 195.072;
         ACE_barrelLength = 589.28;
     };
-
+    class rhs_weap_orsis_Base_F;
+    class rhs_weap_t5000: rhs_weap_orsis_Base_F { // http://en.orsis.com/production/catalog/19046/
+        ACE_barrelTwist = 254.0; // 1:10"
+        ACE_barrelLength = 698.5; // 27.5"
+    };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {
         ACE_ScopeAdjust_Vertical[] = { 0, 0 };
@@ -60,7 +64,23 @@ class CfgWeapons {
         ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };
-
+    class ItemCore;
+    class InventoryOpticsItem_Base_F;
+    class rhs_acc_dh520x56: ItemCore { // http://nightvision.ru/catalog/4/item/35
+        ACE_ScopeHeightAboveRail = 4.0; // ?
+        ACE_ScopeAdjust_Vertical[] = {0, 33};
+        ACE_ScopeAdjust_Horizontal[] = {-9, 9};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo: InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class dedal_520 {
+                    discreteDistance[] = {100};
+                    discreteDistanceInitIndex = 0;
+                };
+            };
+        };
+    };
     class Launcher_Base_F;
     class rhs_weap_rpg7: Launcher_Base_F {
         ace_reloadlaunchers_enabled = 1;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -50,7 +50,7 @@ class CfgWeapons {
     class rhs_weap_t5000: rhs_weap_orsis_Base_F { // http://en.orsis.com/production/catalog/19046/
         ACE_barrelTwist = 254.0; // 1:10"
         ACE_barrelLength = 698.5; // 27.5"
-        ACE_RailHeightAboveBore = 2.4;
+        ACE_RailHeightAboveBore = 2.3;
     };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -53,14 +53,14 @@ class CfgWeapons {
     };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {
-        ACE_ScopeAdjust_Vertical[] = { 0, 0 };
-        ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
+        ACE_ScopeAdjust_Vertical[] = {0, 0};
+        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };
     class rhs_acc_pso1m21: rhs_acc_sniper_base {
-        ACE_ScopeAdjust_Vertical[] = { 0, 0 };
-        ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
+        ACE_ScopeAdjust_Vertical[] = {0, 0};
+        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -50,7 +50,7 @@ class CfgWeapons {
     class rhs_weap_t5000: rhs_weap_orsis_Base_F { // http://en.orsis.com/production/catalog/19046/
         ACE_barrelTwist = 254.0; // 1:10"
         ACE_barrelLength = 698.5; // 27.5"
-        ACE_RailHeightAboveBore = 2.3;
+        ACE_RailHeightAboveBore = 2.4;
     };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -50,6 +50,7 @@ class CfgWeapons {
     class rhs_weap_t5000: rhs_weap_orsis_Base_F { // http://en.orsis.com/production/catalog/19046/
         ACE_barrelTwist = 254.0; // 1:10"
         ACE_barrelLength = 698.5; // 27.5"
+        ACE_RailHeightAboveBore = 2.4;
     };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {
@@ -67,7 +68,7 @@ class CfgWeapons {
     class ItemCore;
     class InventoryOpticsItem_Base_F;
     class rhs_acc_dh520x56: ItemCore { // http://nightvision.ru/catalog/4/item/35
-        ACE_ScopeHeightAboveRail = 4.0; // ?
+        ACE_ScopeHeightAboveRail = 4.6;
         ACE_ScopeAdjust_Vertical[] = {0, 33};
         ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -31,7 +31,7 @@ class CfgAmmo {
         ACE_caliber = 7.823;
         ACE_bulletLength = 37.821;
         ACE_bulletMass = 14.256;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ammoTempMuzzleVelocityShifts[] = {-5.3, -5.1, -4.6, -4.2, -3.4, -2.6, -1.4, -0.3, 1.4, 3.0, 5.2};
         ACE_ballisticCoefficients[] = {0.310};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -13,15 +13,18 @@ class CfgWeapons {
     class rhs_weap_M107_Base_F: GM6_base_F {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
+        ACE_RailHeightAboveBore = 3.8;
     };
     class rhs_weap_XM2010_Base_F: Rifle_Base_F {
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 609.6;
         ACE_Overheating_dispersion = 0.75;
+        ACE_RailHeightAboveBore = 3.6;
     };
     class rhs_weap_m24sws: rhs_weap_XM2010_Base_F {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 609.6;
+        ACE_RailHeightAboveBore = 1.8;
     };
     class rhs_weap_m40a5: rhs_weap_XM2010_Base_F {
         ACE_barrelTwist = 304.8; // 1:12"
@@ -80,6 +83,7 @@ class CfgWeapons {
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 558.8;
         ACE_Overheating_dispersion = 0.75;
+        ACE_RailHeightAboveBore = 3.3;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri {
         ACE_barrelTwist = 285.75;
@@ -138,8 +142,11 @@ class CfgWeapons {
             };
         };
     };
-    class rhsusf_acc_LEUPOLDMK4: rhsusf_acc_sniper_base {};
+    class rhsusf_acc_LEUPOLDMK4: rhsusf_acc_sniper_base {
+        ACE_ScopeHeightAboveRail = 2.4;
+    };
     class rhsusf_acc_LEUPOLDMK4_2: rhsusf_acc_sniper_base {
+        ACE_ScopeHeightAboveRail = 3.8;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class pso1_scope {
@@ -149,8 +156,11 @@ class CfgWeapons {
             };
         };
     };
-    class rhsusf_acc_LEUPOLDMK4_2_d: rhsusf_acc_LEUPOLDMK4_2 {};
+    class rhsusf_acc_LEUPOLDMK4_2_d: rhsusf_acc_LEUPOLDMK4_2 {
+        ACE_ScopeHeightAboveRail = 3.8;
+    };
     class rhsusf_acc_premier: rhsusf_acc_LEUPOLDMK4_2 {
+        ACE_ScopeHeightAboveRail = 5.4;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class pso1_scope {
@@ -164,6 +174,7 @@ class CfgWeapons {
         ACE_ScopeHeightAboveRail = 4.0;
     };
     class rhsusf_acc_premier_anpvs27: rhsusf_acc_premier {
+        ACE_ScopeHeightAboveRail = 5.4;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class pso1_nvg {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -23,6 +23,10 @@ class CfgWeapons {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 609.6;
     };
+    class rhs_weap_m40a5: rhs_weap_XM2010_Base_F {
+        ACE_barrelTwist = 304.8; // 1:12"
+        ACE_barrelLength = 635.0; // 25"
+    };    
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F {
         ACE_barrelTwist = 177.8;
@@ -163,6 +167,24 @@ class CfgWeapons {
                 };
             };
         };
+    };
+    class rhsusf_acc_M8541: rhsusf_acc_premier { // http://www.schmidtundbender.de/en/products/police-and-military-forces/3-12x50-pm-iilpmtc.html
+        ACE_ScopeHeightAboveRail = 4.0; // ?
+        ACE_ScopeAdjust_Vertical[] = {0, 22};
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo: InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class Snip {
+                    discreteDistance[] = {100};
+                    discreteDistanceInitIndex = 0;
+                };    
+            };
+        };
+    };
+    class rhsusf_acc_M8541_low: rhsusf_acc_M8541 {
+        ACE_ScopeHeightAboveRail = 3.0; // ?
     };
     // RHS lauchers
     class rhs_weap_fgm148: launch_O_Titan_F {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -84,10 +84,12 @@ class CfgWeapons {
     class rhs_weap_sr25: rhs_weap_m14ebrri {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 609.6;
+        ACE_RailHeightAboveBore = 3.4;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25 {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 508.0;
+        ACE_RailHeightAboveBore = 3.4;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F {
         ACE_barrelTwist = 0.0;
@@ -158,7 +160,9 @@ class CfgWeapons {
             };
         };
     };
-    class rhsusf_acc_premier_low: rhsusf_acc_premier {};
+    class rhsusf_acc_premier_low: rhsusf_acc_premier {
+        ACE_ScopeHeightAboveRail = 4.0;
+    };
     class rhsusf_acc_premier_anpvs27: rhsusf_acc_premier {
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -26,6 +26,7 @@ class CfgWeapons {
     class rhs_weap_m40a5: rhs_weap_XM2010_Base_F {
         ACE_barrelTwist = 304.8; // 1:12"
         ACE_barrelLength = 635.0; // 25"
+        ACE_RailHeightAboveBore = 2.6;
     };    
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F {
@@ -169,7 +170,7 @@ class CfgWeapons {
         };
     };
     class rhsusf_acc_M8541: rhsusf_acc_premier { // http://www.schmidtundbender.de/en/products/police-and-military-forces/3-12x50-pm-iilpmtc.html
-        ACE_ScopeHeightAboveRail = 4.0; // ?
+        ACE_ScopeHeightAboveRail = 4.0;
         ACE_ScopeAdjust_Vertical[] = {0, 22};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -184,7 +185,7 @@ class CfgWeapons {
         };
     };
     class rhsusf_acc_M8541_low: rhsusf_acc_M8541 {
-        ACE_ScopeHeightAboveRail = 3.0; // ?
+        ACE_ScopeHeightAboveRail = 3.0;
     };
     // RHS lauchers
     class rhs_weap_fgm148: launch_O_Titan_F {


### PR DESCRIPTION
**Compat RHS afrf and usf updated with the new 4.2 sniper rifles and scopes**
- add M40A5 and S&B M8541
- add ORSIS T-5000 .338LM and Dedal DH 5-26x56 
- update all sniper scopes with the new Scopes Framework (except PSO scopes)
- update all sniper and marksman rifles with the new Scopes Framework (except SVD and VSS)
- fix the .300 WM TempMuzzleVelocityShifts according with the ACE_762x67_Ball_Mk248_Mod_1 (ballistics/CfgAmmo.hpp)