### PR TITLE
Add getInteractionDistance and fix VTOL refuel/arm

### DIFF
--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -2,6 +2,7 @@
 // interaction menu
 PREP(addPassengerActions);
 PREP(addPassengersActions);
+PREP(getInteractionDistance);
 PREP(getVehiclePos);
 PREP(getVehiclePosComplex);
 PREP(getWeaponPos);

--- a/addons/interaction/functions/fnc_getInteractionDistance.sqf
+++ b/addons/interaction/functions/fnc_getInteractionDistance.sqf
@@ -1,0 +1,33 @@
+/*
+ * Author: PabstMirror
+ * Gets effective interaction distance (handles very large vehicles)
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ * 0: Target Vehicle <OBJECT>
+ *
+ * Return value:
+ * Distance to interaction point <NUMBER>
+ *
+ * Example:
+ * [player, cursorObject] call ace_interaction_fnc_getInteractionDistance
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit", "_target"];
+TRACE_3("getInteractionDistance",_unit,_target,typeOf _target);
+
+// Handle Man, Crate
+if (!((_target isKindOf "Car") || {_target isKindOf "Tank"} || {_target isKindOf "Helicopter"} || {_target isKindOf "Plane"} || {_target isKindOf "Ship_F"})) exitWith {
+    _unit distance _target
+};
+
+private _unitEyeASL = eyePos _unit;
+private _targetModelPos = [_target, _unitEyeASL] call FUNC(getVehiclePosComplex);
+private _distance = _unitEyeASL distance (AGLtoASL (_target modelToWorld _targetModelPos));
+
+TRACE_2("",_targetModelPos,_distance);
+
+_distance

--- a/addons/rearm/functions/fnc_canRearm.sqf
+++ b/addons/rearm/functions/fnc_canRearm.sqf
@@ -19,7 +19,7 @@
 private ["_dummy","_magazineClass"];
 params [["_target", objNull, [objNull]], ["_unit", objNull, [objNull]]];
 
-if (GVAR(level) == 0 || {isNull _unit} || {!(_unit isKindOf "CAManBase")} || {!local _unit} || {_target distance _unit > REARM_ACTION_DISTANCE} || {_target getVariable [QGVAR(disabled), false]}) exitWith {false};
+if (GVAR(level) == 0 || {isNull _unit} || {!(_unit isKindOf "CAManBase")} || {!local _unit} || {([_unit, _target] call EFUNC(interaction,getInteractionDistance)) > REARM_ACTION_DISTANCE} || {_target getVariable [QGVAR(disabled), false]}) exitWith {false};
 
 _dummy = _unit getVariable [QGVAR(dummy), objNull];
 if (isNull _dummy) exitwith {false};

--- a/addons/refuel/functions/fnc_canCheckFuel.sqf
+++ b/addons/refuel/functions/fnc_canCheckFuel.sqf
@@ -22,5 +22,5 @@ params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
     {!(_unit isKindOf "CAManBase")} ||
     {!local _unit} ||
     {!alive _target} ||
-    {(_target distance _unit) > REFUEL_ACTION_DISTANCE} ||
+    {([_unit, _target] call EFUNC(interaction,getInteractionDistance)) > REFUEL_ACTION_DISTANCE} ||
     {(_target call FUNC(getFuel) == REFUEL_INFINITE_FUEL)})

--- a/addons/refuel/functions/fnc_canConnectNozzle.sqf
+++ b/addons/refuel/functions/fnc_canConnectNozzle.sqf
@@ -27,5 +27,5 @@ if (_target isKindOf "AllVehicles") then {
 
 !(isNull _nozzle ||
     {_engine} ||
-    {(_target distance _unit) > REFUEL_ACTION_DISTANCE} ||
+    {([_unit, _target] call EFUNC(interaction,getInteractionDistance)) > REFUEL_ACTION_DISTANCE} ||
     {!isNull (_target getVariable [QGVAR(nozzle), objNull])})

--- a/addons/refuel/functions/fnc_canReturnNozzle.sqf
+++ b/addons/refuel/functions/fnc_canReturnNozzle.sqf
@@ -21,5 +21,5 @@ params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
 private _nozzle = _unit getVariable [QGVAR(nozzle), objNull];
 
 (!isNull _nozzle) &&
-{_target distance _unit < REFUEL_ACTION_DISTANCE} &&
+{([_unit, _target] call EFUNC(interaction,getInteractionDistance)) < REFUEL_ACTION_DISTANCE} &&
 {_target == (_nozzle getVariable [QGVAR(source), objNull])}

--- a/addons/refuel/functions/fnc_canTakeNozzle.sqf
+++ b/addons/refuel/functions/fnc_canTakeNozzle.sqf
@@ -23,6 +23,6 @@ if (isNull _unit ||
     {!local _unit} ||
     {!alive _target} ||
     {!isNull (_unit getVariable [QGVAR(nozzle), objNull])} ||
-    {(_target distance _unit) > REFUEL_ACTION_DISTANCE}) exitWith {false};
+    {([_unit, _target] call EFUNC(interaction,getInteractionDistance)) > REFUEL_ACTION_DISTANCE}) exitWith {false};
 
 !(_target getVariable [QGVAR(isConnected), false]) && {!(_unit getVariable [QGVAR(isRefueling), false])}


### PR DESCRIPTION
Fix #4784

`ace_interaction_fnc_getInteractionDistance` should return something closer to the distance to the exterior of the vehicle. 

With the giant VTOL you could be standing right next to the hull and `distance` would be 7.5, which is further than the rearm/refuel actions allowed.

Could also look at integrating this into ace_cargo at some point.