### PR TITLE
AdvFatigue - Fix unarmed sprint->prone + minor perf improvments

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_getAnimDuty.sqf
+++ b/addons/advanced_fatigue/functions/fnc_getAnimDuty.sqf
@@ -21,6 +21,7 @@ private _duty = 1;
 private _animType = _animName select [1, 3];
 
 GVAR(isSwimming) = false;
+GVAR(isProne) = (stance _unit) == "PRONE";
 
 if (_animType in ["idl", "mov", "adj"]) then {
     switch (_animName select [5, 3]) do {
@@ -29,6 +30,7 @@ if (_animType in ["idl", "mov", "adj"]) then {
         };
         case ("pne"): {
             _duty = 10;
+            GVAR(isProne) = true; // #4880 - Unarmed sprint->prone has wrong `stance`
         };
         default {
             _duty = 1;

--- a/addons/advanced_fatigue/functions/fnc_getMetabolicCosts.sqf
+++ b/addons/advanced_fatigue/functions/fnc_getMetabolicCosts.sqf
@@ -18,18 +18,8 @@
 #include "script_component.hpp"
 params ["_unit", "_velocity"];
 
-private _virtualLoad = 0;
-{
-    _virtualLoad = _virtualLoad + (_x getVariable [QEGVAR(movement,vLoad), 0]);
-} forEach [
-    _unit,
-    uniformContainer _unit,
-    vestContainer _unit,
-    backpackContainer _unit
-];
+private _gearMass = ((_unit getVariable [QEGVAR(movement,totalLoad), loadAbs _unit]) / 22.046) * GVAR(loadFactor);
 
-private _gearMass = ((loadAbs _unit + _virtualLoad) * 0.1 / 2.2046) * GVAR(loadFactor);
-private _terrainFactor = 1;
 private _terrainAngle = asin (1 - ((surfaceNormal getPosASL _unit) select 2));
 private _terrainGradient = (_terrainAngle / 45 min 1) * 5 * GVAR(terrainGradientFactor);
 private _duty = GVAR(animDuty);
@@ -50,12 +40,12 @@ if (_velocity > 2) then {
     (
         2.10 * SIM_BODYMASS
         + 4 * (SIM_BODYMASS + _gearMass) * ((_gearMass / SIM_BODYMASS) ^ 2)
-        + _terrainFactor * (SIM_BODYMASS + _gearMass) * (0.90 * (_velocity ^ 2) + 0.66 * _velocity * _terrainGradient)
+        + (SIM_BODYMASS + _gearMass) * (0.90 * (_velocity ^ 2) + 0.66 * _velocity * _terrainGradient)
     ) * 0.23 * _duty
 } else {
     (
         1.05 * SIM_BODYMASS
         + 4 * (SIM_BODYMASS + _gearMass) * ((_gearMass / SIM_BODYMASS) ^ 2)
-        + _terrainFactor * (SIM_BODYMASS + _gearMass) * (1.15 * (_velocity ^ 2) + 0.66 * _velocity * _terrainGradient)
+        + (SIM_BODYMASS + _gearMass) * (1.15 * (_velocity ^ 2) + 0.66 * _velocity * _terrainGradient)
     ) * 0.23 * _duty
 };

--- a/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
+++ b/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
@@ -20,7 +20,7 @@ private _currentWork = REE;
 private _currentSpeed = (vectorMagnitude (velocity ACE_player)) min 6;
 
 // fix #4481. Diving to the ground is recorded as PRONE stance with running speed velocity. Cap maximum speed to fix.
-if (stance ACE_player == "PRONE") then {
+if (GVAR(isProne)) then {
     _currentSpeed = _currentSpeed min 1.5;
 };
 
@@ -32,11 +32,11 @@ if ((vehicle ACE_player == ACE_player) && {_currentSpeed > 0.1} && {isTouchingGr
 // Calculate muscle damage increase
 // Note: Muscle damage recovery is ignored as it takes multiple days
 GVAR(muscleDamage) = GVAR(muscleDamage) + (_currentWork / GVAR(peakPower)) ^ 3.2 * 0.00004;
-private _muscleIntegrity = 1 - GVAR(muscleDamage);
+private _muscleIntegritySqrt = sqrt (1 - GVAR(muscleDamage));
 
 // Calculate available power
-private _ae1PathwayPowerFatigued = GVAR(ae1PathwayPower) * sqrt (GVAR(ae1Reserve) / AE1_MAXRESERVE) * OXYGEN * sqrt _muscleIntegrity;
-private _ae2PathwayPowerFatigued = GVAR(ae2PathwayPower) * sqrt (GVAR(ae2Reserve) / AE2_MAXRESERVE) * OXYGEN * sqrt _muscleIntegrity;
+private _ae1PathwayPowerFatigued = GVAR(ae1PathwayPower) * sqrt (GVAR(ae1Reserve) / AE1_MAXRESERVE) * OXYGEN * _muscleIntegritySqrt;
+private _ae2PathwayPowerFatigued = GVAR(ae2PathwayPower) * sqrt (GVAR(ae2Reserve) / AE2_MAXRESERVE) * OXYGEN * _muscleIntegritySqrt;
 
 // Calculate how much power is consumed from each reserve
 private _ae1Power = _currentWork min _ae1PathwayPowerFatigued;

--- a/addons/movement/functions/fnc_handleVirtualMass.sqf
+++ b/addons/movement/functions/fnc_handleVirtualMass.sqf
@@ -28,6 +28,8 @@ private _virtualLoad = 0;
     backpackContainer _unit
 ];
 
+_unit setVariable [QGVAR(totalLoad), (loadAbs _unit + _virtualLoad)];
+
 // get absolute vanilla load
 private _absLoad = getNumber (configFile >> "CfgInventoryGlobalVariable" >> "maxSoldierLoad");
 


### PR DESCRIPTION
Fix #4880 - Adds `GVAR(isProne)` which is set in getAnimDuty
Minor performance improvements; 
main one is setting total virtual load in movement (on `loadout` EH) so we can skip forEach loop