### PR TITLE
Pass functions by "reference" to bis event handlers

### DIFF
--- a/addons/concertina_wire/XEH_init.sqf
+++ b/addons/concertina_wire/XEH_init.sqf
@@ -1,3 +1,3 @@
 #include "script_component.hpp"
 params ["_wire"];
-_wire addEventHandler ["HandleDamage", FUNC(handleDamage)];
+_wire addEventHandler ["HandleDamage", {call FUNC(handleDamage)}];

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -35,7 +35,7 @@ GVAR(lastPlayerVehicle) = objNull;
             TRACE_2("removed veh eh",_firedEH,GVAR(lastPlayerVehicle));
         };
         if ((!isNull _vehicle) && {_player != _vehicle}) then {
-            private _firedEH = _vehicle addEventHandler ["FiredNear", {call (firedNear)}];
+            private _firedEH = _vehicle addEventHandler ["FiredNear", {call FUNC(firedNear)}];
             _vehicle setVariable [QGVAR(firedEH), _firedEH];
             GVAR(lastPlayerVehicle) = _vehicle;
             TRACE_2("added veh eh",_firedEH,GVAR(lastPlayerVehicle));
@@ -60,9 +60,9 @@ GVAR(lastPlayerVehicle) = objNull;
         };
         // Don't add a new EH if the unit respawned
         if ((_player getVariable [QGVAR(firedEH), -1]) == -1) then {
-            private _firedEH = _player addEventHandler ["FiredNear", {call (firedNear)}];
+            private _firedEH = _player addEventHandler ["FiredNear", {call FUNC(firedNear)}];
             _player setVariable [QGVAR(firedEH), _firedEH];
-            private _explosionEH = _player addEventHandler ["Explosion", {call (explosionNear)}];
+            private _explosionEH = _player addEventHandler ["Explosion", {call FUNC(explosionNear)}];
             _player setVariable [QGVAR(explosionEH), _explosionEH];
             TRACE_3("added unit eh",_player,_firedEH,_explosionEH);
         };

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -35,7 +35,7 @@ GVAR(lastPlayerVehicle) = objNull;
             TRACE_2("removed veh eh",_firedEH,GVAR(lastPlayerVehicle));
         };
         if ((!isNull _vehicle) && {_player != _vehicle}) then {
-            private _firedEH = _vehicle addEventHandler ["FiredNear", LINKFUNC(firedNear)];
+            private _firedEH = _vehicle addEventHandler ["FiredNear", {call (firedNear)}];
             _vehicle setVariable [QGVAR(firedEH), _firedEH];
             GVAR(lastPlayerVehicle) = _vehicle;
             TRACE_2("added veh eh",_firedEH,GVAR(lastPlayerVehicle));
@@ -60,9 +60,9 @@ GVAR(lastPlayerVehicle) = objNull;
         };
         // Don't add a new EH if the unit respawned
         if ((_player getVariable [QGVAR(firedEH), -1]) == -1) then {
-            private _firedEH = _player addEventHandler ["FiredNear", LINKFUNC(firedNear)];
+            private _firedEH = _player addEventHandler ["FiredNear", {call (firedNear)}];
             _player setVariable [QGVAR(firedEH), _firedEH];
-            private _explosionEH = _player addEventHandler ["Explosion", LINKFUNC(explosionNear)];
+            private _explosionEH = _player addEventHandler ["Explosion", {call (explosionNear)}];
             _player setVariable [QGVAR(explosionEH), _explosionEH];
             TRACE_3("added unit eh",_player,_firedEH,_explosionEH);
         };

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -21,7 +21,7 @@ GVAR(ParsedTextCached) = [];
     //Setup text/shadow/size/color settings matrix
     [] call FUNC(setupTextColors);
     // Install the render EH on the main display
-    addMissionEventHandler ["Draw3D", DFUNC(render)];
+    addMissionEventHandler ["Draw3D", {call FUNC(render)}];
 }] call CBA_fnc_addEventHandler;
 
 //Add Actions to Houses:

--- a/addons/laserpointer/XEH_postInit.sqf
+++ b/addons/laserpointer/XEH_postInit.sqf
@@ -77,5 +77,5 @@ GVAR(greenLaserUnits) = [];
         _unit call _fnc_processUnit;
     }, 0.1, _fnc_processUnit] call CBA_fnc_addPerFrameHandler;
 
-    addMissionEventHandler ["Draw3D", FUNC(onDraw)];
+    addMissionEventHandler ["Draw3D", {call FUNC(onDraw)}];
 }] call CBA_fnc_addEventHandler;

--- a/addons/spectator/functions/fnc_handleInterface.sqf
+++ b/addons/spectator/functions/fnc_handleInterface.sqf
@@ -34,7 +34,7 @@ switch (toLower _mode) do {
         [FUNC(handleUnits), 9, _display] call CBA_fnc_addPerFrameHandler;
 
         // Handle 3D unit icons
-        GVAR(iconHandler) = addMissionEventHandler ["Draw3D",FUNC(handleIcons)];
+        GVAR(iconHandler) = addMissionEventHandler ["Draw3D", {call FUNC(handleIcons)}];
 
         // Populate the help window
         private _help = (_display displayCtrl IDC_HELP) controlsGroupCtrl IDC_HELP_LIST;

--- a/docs/wiki/development/coding-guidelines.md
+++ b/docs/wiki/development/coding-guidelines.md
@@ -590,6 +590,15 @@ Event handlers in ACE3 are implemented through the CBA event system (ACE3's own 
 
 More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events){:target="_blank"} pages.
 
+<div class="panel info">
+    <h5>Warning about BIS event handlers:</h5>
+    <p>BIS's event handlers (`addEventHandler`, `addMissionEventHandler`) are slow when passing a large code variable. Use a short code block that calls the function you want.</p>
+    ```js
+    player addEventHandler ["Fired", FUNC(handleFired)]; // bad
+    player addEventHandler ["Fired", {call FUNC(handleFired)}]; // good
+    ```
+</div>
+
 ### 7.4 Hashes
 
 When a key value pair is required, make use of the hash implementation from ACE3.


### PR DESCRIPTION
Thanks to a discovery from @dedmen  (ref https://github.com/CBATeam/CBA_A3/pull/588)

Passing a large code function to a BIS EH has a significant performance cost.

Using interact_menu as an example.
```
addMissionEventHandler ["Draw3D", {x3 = diag_tickTime}];
for "_index" from 1 to 2000 do {
    // addMissionEventHandler ["Draw3D", FUNC(render)]; // (660 ms / 2000) = .33 ms
    addMissionEventHandler ["Draw3D", {call FUNC(render)}]; // (28 ms / 2000) = 0.014 ms
};
addMissionEventHandler ["Draw3D", {diag_log text format ["2000 calls took %1 ms", 1000 * (diag_tickTime - x3)]}];
```

So an extra processing time of ~0.3 ms when passing the entire function vs passing a short bit of code that calls the function. 
