### PR TITLE
Fix multiple slideshows sub-actions, Add set name setting

### DIFF
--- a/addons/slideshow/CfgVehicles.hpp
+++ b/addons/slideshow/CfgVehicles.hpp
@@ -35,6 +35,12 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "";
             };
+            class SetName {
+                displayName = CSTRING(SetName_DisplayName);
+                description = CSTRING(SetName_Description);
+                typeName = "STRING";
+                defaultValue = "";
+            };
             class Duration {
                 displayName = CSTRING(Duration_DisplayName);
                 description = CSTRING(Duration_Description);

--- a/addons/slideshow/functions/fnc_createSlideshow.sqf
+++ b/addons/slideshow/functions/fnc_createSlideshow.sqf
@@ -19,7 +19,6 @@
  */
 #include "script_component.hpp"
 
-private ["_currentSlideshow", "_slidesAction", "_varString"];
 params [
     ["_objects", [], [[]] ],
     ["_controllers", [], [[]] ],
@@ -53,7 +52,7 @@ if (isServer) then {
     GVAR(slideshows) = GVAR(slideshows) + 1;
 };
 
-_currentSlideshow = GVAR(slideshows); // Local variable in case GVAR gets changed during execution of below code
+private _currentSlideshow = GVAR(slideshows); // Local variable in case GVAR gets changed during execution of below code
 
 // If interaction menu module is not present, set default duration value
 if !(["ace_interact_menu"] call EFUNC(common,isModLoaded)) then {
@@ -65,7 +64,17 @@ if !(["ace_interact_menu"] call EFUNC(common,isModLoaded)) then {
 if (_duration == 0) then {
     {
         // Add Slides sub-action and populate with images
-        _slidesAction = [QGVAR(Slides), localize LSTRING(Interaction), "", {}, {true}, {(_this select 2) call FUNC(addSlideActions)}, [_objects, _images, _names, _x, _currentSlideshow], [0, 0, 0], 2] call EFUNC(interact_menu,createAction);
+        private _slidesAction = [
+            format [QGVAR(Slides%1), _currentSlideshow],
+            localize LSTRING(Interaction),
+            "",
+            {},
+            {true},
+            {(_this select 2) call FUNC(addSlideActions)},
+            [_objects, _images, _names, _x, _currentSlideshow],
+            [0, 0, 0],
+            2
+        ] call EFUNC(interact_menu,createAction);
         [_x, 0, ["ACE_MainActions"], _slidesAction] call EFUNC(interact_menu,addActionToObject);
         nil
     } count _controllers;
@@ -73,7 +82,7 @@ if (_duration == 0) then {
     if !(isServer) exitWith {};
 
     // Formatted GVAR string (multiple modules support)
-    _varString = format [QGVAR(slideshow%1), _currentSlideshow];
+    private _varString = format [QGVAR(slideshow%1), _currentSlideshow];
     TRACE_1("Current Slide",_varString);
 
     // Set formatted GVAR to first slide

--- a/addons/slideshow/functions/fnc_createSlideshow.sqf
+++ b/addons/slideshow/functions/fnc_createSlideshow.sqf
@@ -8,12 +8,13 @@
  * 2: Image Paths <ARRAY>
  * 3: Action Names <ARRAY>
  * 4: Slide Duration <NUMBER> (0 disables automatic transitions)
+ * 5: Set Name <STRING> (default: localized "Slides")
  *
  * Return Value:
  * None
  *
  * Example:
- * [[object1, object2, object3], [controller1], ["images\image1.paa", "images\image2.paa"], ["Action1", "Action2"], 5] call ace_slideshow_fnc_createSlideshow
+ * [[object1, object2, object3], [controller1], ["images\image1.paa", "images\image2.paa"], ["Action1", "Action2"], 5, "My Slides"] call ace_slideshow_fnc_createSlideshow
  *
  * Public: Yes
  */
@@ -24,7 +25,8 @@ params [
     ["_controllers", [], [[]] ],
     ["_images", [], [[]] ],
     ["_names", [], [[]] ],
-    ["_duration", 0, [0]]
+    ["_duration", 0, [0]],
+    ["_setName", localize LSTRING(Interaction), [""]]
 ];
 
 // Verify data
@@ -40,7 +42,7 @@ if (_controllers isEqualTo []) then {
     _controllers = _objects;
 };
 
-TRACE_4("Information",_objects,_controllers,_images,_names);
+TRACE_5("Information",_objects,_controllers,_images,_names,_setName);
 
 if (isServer) then {
     // Default images on whiteboards (first image)
@@ -63,10 +65,14 @@ if !(["ace_interact_menu"] call EFUNC(common,isModLoaded)) then {
 // Add interactions if automatic transitions are disabled, else setup automatic transitions
 if (_duration == 0) then {
     {
+        if (_setName == "") then {
+            _setName = localize LSTRING(Interaction);
+        };
+
         // Add Slides sub-action and populate with images
         private _slidesAction = [
-            format [QGVAR(Slides%1), _currentSlideshow],
-            localize LSTRING(Interaction),
+            format [QGVAR(slideshow%1), _currentSlideshow],
+            _setName,
             "",
             {},
             {true},

--- a/addons/slideshow/functions/fnc_moduleInit.sqf
+++ b/addons/slideshow/functions/fnc_moduleInit.sqf
@@ -27,6 +27,7 @@ private _objects = [_logic getVariable ["Objects", ""], true, true] call EFUNC(c
 private _controllers = [_logic getVariable ["Controllers", ""], true, true] call EFUNC(common,parseList);
 private _images = [_logic getVariable ["Images", ""], false, false] call EFUNC(common,parseList);
 private _names = [_logic getVariable ["Names", ""], false, false] call EFUNC(common,parseList);
+private _setName = _logic getVariable ["SetName", ""];
 private _duration = _logic getVariable ["Duration", 0];
 
 // Objects synced to the module
@@ -36,6 +37,6 @@ private _duration = _logic getVariable ["Duration", 0];
 } count (synchronizedObjects _logic);
 
 // Prepare with actions
-[_objects, _controllers, _images, _names, _duration] call FUNC(createSlideshow);
+[_objects, _controllers, _images, _names, _duration, _setName] call FUNC(createSlideshow);
 
 INFO_1("Slideshow Module Initialized on %1 Objects", count _objects);

--- a/addons/slideshow/functions/fnc_moduleInit.sqf
+++ b/addons/slideshow/functions/fnc_moduleInit.sqf
@@ -17,18 +17,17 @@
 // Exit on Headless Client
 if (!hasInterface && !isDedicated) exitWith {};
 
-private ["_objects", "_controllers", "_images", "_names", "_duration"];
 params [["_logic", objNull, [objNull]], "_units", "_activated"];
 
 if !(_activated) exitWith {};
 if (isNull _logic) exitWith {};
 
 // Extract variables from logic
-_objects = [_logic getVariable ["Objects", ""], true, true] call EFUNC(common,parseList);
-_controllers = [_logic getVariable ["Controllers", ""], true, true] call EFUNC(common,parseList);
-_images = [_logic getVariable ["Images", ""], false, false] call EFUNC(common,parseList);
-_names = [_logic getVariable ["Names", ""], false, false] call EFUNC(common,parseList);
-_duration = _logic getVariable ["Duration", 0];
+private _objects = [_logic getVariable ["Objects", ""], true, true] call EFUNC(common,parseList);
+private _controllers = [_logic getVariable ["Controllers", ""], true, true] call EFUNC(common,parseList);
+private _images = [_logic getVariable ["Images", ""], false, false] call EFUNC(common,parseList);
+private _names = [_logic getVariable ["Names", ""], false, false] call EFUNC(common,parseList);
+private _duration = _logic getVariable ["Duration", 0];
 
 // Objects synced to the module
 {

--- a/addons/slideshow/stringtable.xml
+++ b/addons/slideshow/stringtable.xml
@@ -44,18 +44,18 @@
             <Korean>물체</Korean>
         </Key>
         <Key ID="STR_ACE_Slideshow_Objects_Description">
-            <English>Object names (can also be synchronized objects) slide-show will be displayed on, separated by commas if multiple. Reference INFO for object support.</English>
-            <German>Objektnamen (können auch synchronisierte Objekte sein) auf denen die Diavorführung abgepielt wird. Werden ggf. durch Kommata getrennt. Weiteres in der INFO für unterstützte Objekte.</German>
+            <English>Object names (can also be synchronized objects) slide-show will be displayed on, separated by commas if multiple.</English>
+            <German>Objektnamen (können auch synchronisierte Objekte sein) auf denen die Diavorführung abgepielt wird. Werden ggf. durch Kommata getrennt.</German>
             <French>Nom d'objets (peuvent aussi être des objets synchronisés) sur lesquels les diaporamas vont être affichées, séparation par virgule si plusieurs.</French>
-            <Polish>Nazwy obiektów (mogą to też być zsynchronizowane obiekty) na których pokaz slajdów zostanie pokazany, oddzielony przecinkiem jeżeli jest ich więcej niż 1. Sprawdź opis modułu aby dowiedzieć się jakie obiekty są wspierane przez moduł.</Polish>
-            <Hungarian>Objektum nevek (szinkronizált is lehet) amik a vetítésen megjelennek, több darab esetén vesszővel elválasztva. Objektumtámogatásért az INFO-t tekintsd meg.</Hungarian>
-            <Portuguese>Nomes dos objetos (também podem ser objetos sincronizados) em que a apresentação de slides será mostrada, separado por vírgulas se for mais de um. Referência INFO para suporte do objeto.</Portuguese>
-            <Russian>Имена объектов (так же могут использоваться синхронизированные объекты), на которых будет отображаться слайд-шоу, разделенные запятыми. Посмотрите описание, чтобы понять, какие объекты поддерживаются.</Russian>
-            <Spanish>Los nombres de objetos (también pueden ser objetos sincronizados) de diapositivas se mostrarán en, separados por comas. Referencia INFO para el soporte del objeto.</Spanish>
-            <Czech>Jména objektů (lze také použít synchronizované objekty) které se budou zobrazovat v prezentaci, oddělit čárkou pokud jich je více. Zkontrolujte POPIS abyste zjistili, zda je objekt podporován modulem.</Czech>
-            <Italian>Nomi di oggetti (possono anche essere oggetti sincronizzati) che verranno usati per la presentazione di diapositive, separato da virgole se più di uno. Fai riferimento ad INFO per gli oggetti supportati.</Italian>
+            <Polish>Nazwy obiektów (mogą to też być zsynchronizowane obiekty) na których pokaz slajdów zostanie pokazany, oddzielony przecinkiem jeżeli jest ich więcej niż 1.</Polish>
+            <Hungarian>Objektum nevek (szinkronizált is lehet) amik a vetítésen megjelennek, több darab esetén vesszővel elválasztva.</Hungarian>
+            <Portuguese>Nomes dos objetos (também podem ser objetos sincronizados) em que a apresentação de slides será mostrada, separado por vírgulas se for mais de um.</Portuguese>
+            <Russian>Имена объектов (так же могут использоваться синхронизированные объекты), на которых будет отображаться слайд-шоу, разделенные запятыми.</Russian>
+            <Spanish>Los nombres de objetos (también pueden ser objetos sincronizados) de diapositivas se mostrarán en, separados por comas.</Spanish>
+            <Czech>Jména objektů (lze také použít synchronizované objekty) které se budou zobrazovat v prezentaci, oddělit čárkou pokud jich je více.</Czech>
+            <Italian>Nomi di oggetti (possono anche essere oggetti sincronizzati) che verranno usati per la presentazione di diapositive, separato da virgole se più di uno.</Italian>
             <Japanese>スライドショーを表示するオブジェクト名 (オブジェクトとの同期も可)。複数ある場合はコンマで区切れます</Japanese>
-            <Korean>슬라이드 쇼가 보여질 물체(동기화 되는 물체도 가능합니다) 명칭, 다수의 경우 쉼표로 구분합니다. 자세한 물체목록은 INFO에서 확인하십시요.</Korean>
+            <Korean>슬라이드 쇼가 보여질 물체(동기화 되는 물체도 가능합니다) 명칭, 다수의 경우 쉼표로 구분합니다.</Korean>
         </Key>
         <Key ID="STR_ACE_Slideshow_Controllers_DisplayName">
             <English>Controllers</English>
@@ -138,6 +138,12 @@
             <German>Liste aller Namen, die für Interaktionseinträge genutzt werden. Mit Kommata getrennt, in Reihenfolge der Bilder.</German>
             <Japanese>画像を操作できるインタラクション エントリ名の一覧を入力してください。コンマで区切り複数を指定できます。</Japanese>
             <Korean>상호작용 메세지에 쓰일 명칭입니다, 쉼표로 구분합니다, 이미지의 순서입니다.</Korean>
+        </Key>
+        <Key ID="STR_ACE_Slideshow_SetName_DisplayName">
+            <English>Set Name</English>
+        </Key>
+        <Key ID="STR_ACE_Slideshow_SetName_Description">
+            <English>Name that will be used for main interaction entry (to distinguish multiple slideshows). Default: "Slides"</English>
         </Key>
         <Key ID="STR_ACE_Slideshow_Duration_DisplayName">
             <English>Slide Duration</English>

--- a/docs/wiki/feature/slideshow.md
+++ b/docs/wiki/feature/slideshow.md
@@ -13,14 +13,17 @@ version:
 ---
 
 ## 1. Overview
+
 This adds the ability to have images shown on some objects and have other objects being used as remotes.
 Please note that only objects with hiddenSelection 0 can be used to render images (whiteboard, TV, PC Screen being the most notable examples).
 
 ## 2. Usage
+
 Note that this sections is for users, for mission makers refer to [the entry in mission-tools](../missionmaker/mission-tools.html)
 Also if no remotes are defined the "screen" object itself becomes the remote.
 
 ### 2.1 Switching between images
+
 - Look at the object used as a remote and use the interaction menu <kbd>⊞&nbsp;Win</kbd> (ACE3 default).
 - Select the action that correspond to the image you want (the name of the action depends on the mission maker).
 

--- a/docs/wiki/framework/slideshow-framework.md
+++ b/docs/wiki/framework/slideshow-framework.md
@@ -47,6 +47,8 @@ Important notes:
 5  | Set Name | String | Optional (default: localized `"Slides"`)
 **R** | None | None | Return value
 
+_Note: Set Name argument added in 3.9.1._
+
 #### 2.1.1 Example
 
 `[[object1, object2], [controller1], ["images\image1.paa", "images\image2.paa"], ["Action1", "Action2"], 5, "My Slides"] call ace_slideshow_fnc_createSlideshow;`

--- a/docs/wiki/framework/slideshow-framework.md
+++ b/docs/wiki/framework/slideshow-framework.md
@@ -44,11 +44,12 @@ Important notes:
 2  | Image Paths | Array | Required (paths must use backslash `\`)
 3  | Action Names | Array | Required
 4  | Slide Duration | Number | Optional (default: `0`, `0` disables automatic transitions)
+5  | Set Name | String | Optional (default: localized `"Slides"`)
 **R** | None | None | Return value
 
 #### 2.1.1 Example
 
-`[[object1, object2], [controller1], ["images\image1.paa", "images\image2.paa"], ["Action1", "Action2"], 5] call ace_slideshow_fnc_createSlideshow;`
+`[[object1, object2], [controller1], ["images\image1.paa", "images\image2.paa"], ["Action1", "Action2"], 5, "My Slides"] call ace_slideshow_fnc_createSlideshow;`
 
    | Arguments | Explanation
 ---| --------- | -----------
@@ -57,3 +58,4 @@ Important notes:
 2  | `["images\image1.paa", "images\image2.paa"]` | Paths to images projected on screen objects
 3  | `["Action1", "Action2"]` | Action names for interaction menu if automatic transitions are not enabled
 4  | `5` | 5s slide duration before change to next image
+5  | `"My Slides"` | Main interaction point name, for easier distinguishing of multiple slideshow sets


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #4901 
- Use `private KEYWORD` instead of `private ARRAY`
- Add `Set Name` setting to allow distinguishing between multiple slideshow sets (#4901)
- Remove `Reference INFO for object support.` as there is no "INFO" in Eden
- Update documentation

![20170215162223_1](https://cloud.githubusercontent.com/assets/7935003/22980990/603fa4e4-f39b-11e6-823d-7fcf67b81a49.jpg)
![20170215162221_1](https://cloud.githubusercontent.com/assets/7935003/22980991/604491e8-f39b-11e6-9e58-04bfd9a4a49d.jpg)
