### PR TITLE
Hide earplug actions if setting disabled

### DIFF
--- a/addons/hearing/CfgVehicles.hpp
+++ b/addons/hearing/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
             class ACE_Equipment {
                 class ACE_PutInEarplugs {
                     displayName = CSTRING(EarPlugs_On);
-                    condition = QUOTE( !([_player] call FUNC(hasEarPlugsIn)) && {'ACE_EarPlugs' in items _player} );
+                    condition = QUOTE(GVAR(EnableCombatDeafness) && {!([_player] call FUNC(hasEarPlugsIn)) && {'ACE_EarPlugs' in items _player}});
                     exceptions[] = {"isNotInside", "isNotSitting"};
                     statement = QUOTE( [_player] call FUNC(putInEarPlugs) );
                     showDisabled = 0;
@@ -14,7 +14,7 @@ class CfgVehicles {
                 };
                 class ACE_RemoveEarplugs {
                     displayName = CSTRING(EarPlugs_Off);
-                    condition = QUOTE( [_player] call FUNC(hasEarPlugsIn) );
+                    condition = QUOTE( GVAR(EnableCombatDeafness) && {[_player] call FUNC(hasEarPlugsIn)});
                     exceptions[] = {"isNotInside", "isNotSitting"};
                     statement = QUOTE( [_player] call FUNC(removeEarPlugs) );
                     showDisabled = 0;

--- a/addons/hearing/functions/fnc_putInEarplugs.sqf
+++ b/addons/hearing/functions/fnc_putInEarplugs.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_player"];
+
 if (!GVAR(EnableCombatDeafness)) exitWith {};
 
 // Plugs in inventory, putting them in

--- a/addons/hearing/functions/fnc_putInEarplugs.sqf
+++ b/addons/hearing/functions/fnc_putInEarplugs.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_player"];
+if (!GVAR(EnableCombatDeafness)) exitWith {};
 
 // Plugs in inventory, putting them in
 _player removeItem "ACE_EarPlugs";

--- a/addons/hearing/functions/fnc_removeEarplugs.sqf
+++ b/addons/hearing/functions/fnc_removeEarplugs.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_player"];
+
 if (!GVAR(EnableCombatDeafness)) exitWith {};
 
 if !(_player canAdd "ACE_EarPlugs") exitWith { // inventory full

--- a/addons/hearing/functions/fnc_removeEarplugs.sqf
+++ b/addons/hearing/functions/fnc_removeEarplugs.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_player"];
+if (!GVAR(EnableCombatDeafness)) exitWith {};
 
 if !(_player canAdd "ACE_EarPlugs") exitWith { // inventory full
     [localize LSTRING(Inventory_Full)] call EFUNC(common,displayTextStructured);


### PR DESCRIPTION
Fix #4912

Hides the actions if combat deafness setting is disabled.
Also add exits on the functions in case they are manually called by a script/mission