### PR TITLE
Require CBA v3.2.1

### DIFF
--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -10,7 +10,7 @@
 
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.64
-#define REQUIRED_CBA_VERSION {3,2,0}
+#define REQUIRED_CBA_VERSION {3,2,1}
 
 #ifdef COMPONENT_BEAUTIFIED
     #define COMPONENT_NAME QUOTE(ACE3 - COMPONENT_BEAUTIFIED)


### PR DESCRIPTION
**When merged this pull request will:**
- Title

We only really require v3.2.0, but requiring v3.2.1 will prevent reports like #4949.