### PR TITLE
Fix gforce avg on switching to aircraft

### DIFF
--- a/addons/gforces/functions/fnc_addPFEH.sqf
+++ b/addons/gforces/functions/fnc_addPFEH.sqf
@@ -14,7 +14,10 @@
 
 //Reset forces array
 GVAR(GForces) = [];
-for "_i" from 1 to 30 do {GVAR(GForces) pushBack 1}; // init array to full array of neutral g-forces
+// init array to full array of neutral g-forces
+GVAR(GForces) resize 30;
+GVAR(GForces) = GVAR(GForces) apply {1};
+
 GVAR(GForces_Index) = 0;
 
 // Setup ppEffect

--- a/addons/gforces/functions/fnc_addPFEH.sqf
+++ b/addons/gforces/functions/fnc_addPFEH.sqf
@@ -14,6 +14,7 @@
 
 //Reset forces array
 GVAR(GForces) = [];
+for "_i" from 1 to 30 do {GVAR(GForces) pushBack 1}; // init array to full array of neutral g-forces
 GVAR(GForces_Index) = 0;
 
 // Setup ppEffect
@@ -26,4 +27,4 @@ GVAR(GForces_CC) ppEffectCommit 0.4;
 GVAR(lastUpdateTime) = 0;
 GVAR(oldVel) = [0,0,0];
 
-GVAR(pfID) = [DFUNC(pfhUpdateGForces), 0, []] call CBA_fnc_addPerFrameHandler;
+GVAR(pfID) = [LINKFUNC(pfhUpdateGForces), 0, []] call CBA_fnc_addPerFrameHandler;

--- a/addons/gforces/functions/fnc_pfhUpdateGForces.sqf
+++ b/addons/gforces/functions/fnc_pfhUpdateGForces.sqf
@@ -27,7 +27,7 @@ private _accel = ((_newVel vectorDiff GVAR(oldVel)) vectorMultiply (1 / INTERVAL
 private _currentGForce = (((_accel vectorDotProduct vectorUp (vehicle ACE_player)) / 9.8) max -10) min 10;
 
 GVAR(GForces) set [GVAR(GForces_Index), _currentGForce];
-GVAR(GForces_Index) = (GVAR(GForces_Index) + 1) % round (AVERAGEDURATION / INTERVAL);
+GVAR(GForces_Index) = (GVAR(GForces_Index) + 1) % 30; // 30 = round (AVERAGEDURATION / INTERVAL);
 GVAR(oldVel) = _newVel;
 
 /* Source: https://github.com/KoffeinFlummi/AGM/issues/1774#issuecomment-70341573


### PR DESCRIPTION
Fix #4952
gforces averages the last 6 seconds
on zeus RC it would only use the last 0.2 seconds, so it could spike high