### PR TITLE
Tweak overheating

### DIFF
--- a/addons/common/functions/fnc_interpolateFromArray.sqf
+++ b/addons/common/functions/fnc_interpolateFromArray.sqf
@@ -18,4 +18,4 @@ params ["_array", "_value"];
 private _min = _array select floor _value;
 private _max = _array select ceil _value;
 
-_min + (_max - _min) * (_value % 1) // return
+linearConversion [0, 1, _value % 1, _min, _max] // return

--- a/addons/overheating/functions/fnc_firedEH.sqf
+++ b/addons/overheating/functions/fnc_firedEH.sqf
@@ -94,7 +94,7 @@ if (GVAR(showParticleEffects) && {(CBA_missionTime > ((_unit getVariable [QGVAR(
 // Only compute jamming for the local player
 if (_unit != ACE_player) exitWith {END_COUNTER(firedEH);};
 
-_jamChance = _jamChance * ([[0.5, 1.5, 15, 150], 3 * _scaledTemperature] call EFUNC(common,interpolateFromArray));
+_jamChance = _jamChance * ([[0.5, 1, 2, 8, 20, 150], 5 * _scaledTemperature] call EFUNC(common,interpolateFromArray));
 
 // increase jam chance on dusty grounds if prone (and at ground level)
 if ((stance _unit == "PRONE") && {((getPosATL _unit) select 2) < 1}) then {

--- a/addons/overheating/functions/fnc_swapBarrelCallback.sqf
+++ b/addons/overheating/functions/fnc_swapBarrelCallback.sqf
@@ -31,7 +31,7 @@ if (_assistant isEqualTo _gunner) then {
 [localize LSTRING(SwappedBarrel), QPATHTOF(UI\spare_barrel_ca.paa)] call EFUNC(common,displayTextPicture);
 
 private _temp = _gunner getVariable [format [QGVAR(%1_temp), _weapon], 0];
-private _barrelMass = 0.50 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
+private _barrelMass = 0.55 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Instruct the server to load the coolest spare barrel into the weapon and
 // store the removed barrel with the former weapon temperature. The server

--- a/addons/overheating/functions/fnc_swapBarrelCallback.sqf
+++ b/addons/overheating/functions/fnc_swapBarrelCallback.sqf
@@ -31,7 +31,7 @@ if (_assistant isEqualTo _gunner) then {
 [localize LSTRING(SwappedBarrel), QPATHTOF(UI\spare_barrel_ca.paa)] call EFUNC(common,displayTextPicture);
 
 private _temp = _gunner getVariable [format [QGVAR(%1_temp), _weapon], 0];
-private _barrelMass = 0.55 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
+private _barrelMass = METAL_MASS_RATIO * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Instruct the server to load the coolest spare barrel into the weapon and
 // store the removed barrel with the former weapon temperature. The server

--- a/addons/overheating/functions/fnc_updateTemperature.sqf
+++ b/addons/overheating/functions/fnc_updateTemperature.sqf
@@ -27,7 +27,7 @@ private _timeVarName = format [QGVAR(%1_time), _weapon];
 private _temperature = _unit getVariable [_tempVarName, 0];
 private _lastTime = _unit getVariable [_timeVarName, 0];
 
-private _barrelMass = 0.55 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
+private _barrelMass = METAL_MASS_RATIO * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Calculate cooling
 _temperature = [_temperature, _barrelMass, CBA_missionTime - _lastTime] call FUNC(calculateCooling);

--- a/addons/overheating/functions/fnc_updateTemperature.sqf
+++ b/addons/overheating/functions/fnc_updateTemperature.sqf
@@ -27,7 +27,7 @@ private _timeVarName = format [QGVAR(%1_time), _weapon];
 private _temperature = _unit getVariable [_tempVarName, 0];
 private _lastTime = _unit getVariable [_timeVarName, 0];
 
-private _barrelMass = 0.50 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
+private _barrelMass = 0.55 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Calculate cooling
 _temperature = [_temperature, _barrelMass, CBA_missionTime - _lastTime] call FUNC(calculateCooling);

--- a/addons/overheating/script_component.hpp
+++ b/addons/overheating/script_component.hpp
@@ -17,6 +17,7 @@
 #include "\z\ace\addons\main\script_macros.hpp"
 
 #define TEMP_TOLERANCE 50
+#define METAL_MASS_RATIO 0.55
 
 #ifdef DEBUG_MODE_FULL
     #define TRACE_PROJECTILE_INFO(BULLET) _vdir = vectorNormalized velocity BULLET; _dir = (_vdir select 0) atan2 (_vdir select 1); _up = asin (_vdir select 2); _mv = vectorMagnitude velocity BULLET; TRACE_3("adjusted projectile",_dir,_up,_mv);


### PR DESCRIPTION
Small changes to overheating system
- Slightly reduce jam chance; mainly delaying the 150x multiplier
- Change barrel mass calc; this will effect heat buildup and cooldown rate
