### PR TITLE
Cleanup use of ACE_HashLocation

### DIFF
--- a/addons/common/CfgLocationTypes.hpp
+++ b/addons/common/CfgLocationTypes.hpp
@@ -4,7 +4,7 @@
 class CfgLocationTypes {
     class ACE_HashLocation {
         color[] = {0,0,0,0};
-        drawStyle = "bananas";
+        drawStyle = "WARNING-ACE_HashLocation_is_deprecated"; // Replaced by CBA_fnc_createNamespace
         font = "RobotoCondensed";
         importance = 5;
         name = "HashLocation";

--- a/addons/tagging/XEH_postInit.sqf
+++ b/addons/tagging/XEH_postInit.sqf
@@ -3,8 +3,7 @@
 
 
 // Cache for static objects
-GVAR(cacheStaticModels) = createLocation ["ACE_HashLocation", [-10000,-10000,-10000], 0, 0];
-GVAR(cacheStaticModels) setText QGVAR(cacheStaticModels);
+GVAR(cacheStaticModels) = [false] call CBA_fnc_createNamespace;
 
 // Consider static everything vehicle that inherit from Static
 // This include houses (which we don't need), but also walls, that we do


### PR DESCRIPTION
Needed due to changes on profiling/dev:

Keep old type in case someone else was using, profiling branch will now print:
`Wrong location draw style - "WARNING-ACE_HashLocation_is_deprecated"`
