### PR TITLE
Virtual units goggles hearing

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -295,18 +295,10 @@ enableCamShake true;
 // Set up numerous eventhanders for player controlled units
 //////////////////////////////////////////////////
 
-// It is possible that CBA_fnc_addPlayerEventHandler has allready been called and run
-// We will NOT get any events for the initial state, so manually set ACE_player
-if (!isNull (missionNamespace getVariable ["cba_events_oldUnit", objNull])) then {
-    // INFO("CBA_fnc_addPlayerEventHandler has already run - manually setting ace_player"); //ToDo CBA 3.1
-    diag_log text "[ACE-Common - CBA_fnc_addPlayerEventHandler has already run - manually setting ace_player";
-    ACE_player = cba_events_oldUnit;
-};
-
-// "playerChanged" event
+TRACE_1("adding unit playerEH to set ace_player",isNull cba_events_oldUnit);
 ["unit", {
     ACE_player = (_this select 0);
-}] call CBA_fnc_addPlayerEventHandler;
+}, true] call CBA_fnc_addPlayerEventHandler;
 
 GVAR(OldIsCamera) = false;
 

--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -20,7 +20,7 @@ if (!hasInterface) exitWith {};
     if (GVAR(effects) == 0) exitWith {};
 
     // ---Add the TINT Effect---
-    
+
     // make sure to stack effect layers in correct order
     GVAR(GogglesEffectsLayer) = QGVAR(GogglesEffectsLayer) call BIS_fnc_RSCLayer;
     GVAR(GogglesLayer) = QGVAR(GogglesLayer) call BIS_fnc_RSCLayer;
@@ -28,6 +28,26 @@ if (!hasInterface) exitWith {};
     if (isNil QGVAR(UsePP)) then {
         GVAR(UsePP) = true;
     };
+
+    // init pp effects
+    GVAR(PostProcess) = ppEffectCreate ["ColorCorrections", 1995];
+    GVAR(EffectsActive) = false;
+
+    // add glasses eventhandlers
+    ["ace_glassesChanged", {
+        params ["_unit", "_glasses"];
+        TRACE_2("ace_glassesChanged eh",_unit,_glasses);
+
+        SETGLASSES(_unit,GLASSESDEFAULT);
+
+        if (call FUNC(ExternalCamera)) exitWith {call FUNC(RemoveGlassesEffect)};
+
+        if ([_unit] call FUNC(isGogglesVisible)) then {
+            [_unit, _glasses] call FUNC(applyGlassesEffect);
+        } else {
+            call FUNC(removeGlassesEffect);
+        };
+    }] call CBA_fnc_addEventHandler;
 
     // init GlassesChanged eventhandler
     GVAR(OldGlasses) = "<null>";
@@ -40,12 +60,9 @@ if (!hasInterface) exitWith {};
             ["ace_glassesChanged", [_unit, _currentGlasses]] call CBA_fnc_localEvent;
             GVAR(OldGlasses) = _currentGlasses;
         };
-    }] call CBA_fnc_addPlayerEventHandler;
+    }, true] call CBA_fnc_addPlayerEventHandler;
 
 
-    // init pp effects
-    GVAR(PostProcess) =     ppEffectCreate ["ColorCorrections", 1995];
-    GVAR(EffectsActive) = false;
 
     // check goggles
     private _fnc_checkGoggles = {
@@ -57,7 +74,7 @@ if (!hasInterface) exitWith {};
             };
         } else {
             if (!(call FUNC(externalCamera)) && {[_unit] call FUNC(isGogglesVisible)}) then {
-                [goggles _unit] call FUNC(applyGlassesEffect);
+                [_unit, goggles _unit] call FUNC(applyGlassesEffect);
             };
         };
     };
@@ -65,21 +82,6 @@ if (!hasInterface) exitWith {};
     ["cameraView", _fnc_checkGoggles] call CBA_fnc_addPlayerEventHandler;
     ["ace_activeCameraChanged", _fnc_checkGoggles] call CBA_fnc_addEventHandler;
 
-
-    // add glasses eventhandlers
-    ["ace_glassesChanged", {
-        params ["_unit", "_glasses"];
-
-        SETGLASSES(_unit,GLASSESDEFAULT);
-
-        if (call FUNC(ExternalCamera)) exitWith {call FUNC(RemoveGlassesEffect)};
-
-        if ([_unit] call FUNC(isGogglesVisible)) then {
-            _glasses call FUNC(applyGlassesEffect);
-        } else {
-            call FUNC(removeGlassesEffect);
-        };
-    }] call CBA_fnc_addEventHandler;
 
 
     // // ---Add the Dust/Dirt/Rain Effects---
@@ -96,7 +98,7 @@ if (!hasInterface) exitWith {};
         GVAR(PostProcessEyes) ppEffectCommit 0;
         GVAR(PostProcessEyes) ppEffectEnable false;
         GVAR(PostProcessEyes_Enabled) = false;
-        
+
         GVAR(FrameEvent) = [false, [false, 20]];
         GVAR(DustHandler) = -1;
         GVAR(RainDrops) = objNull;

--- a/addons/goggles/functions/fnc_applyGlassesEffect.sqf
+++ b/addons/goggles/functions/fnc_applyGlassesEffect.sqf
@@ -5,22 +5,28 @@
  * Sets dirt/rain overlay for glasses.
  *
  * Arguments:
- * 0: Glasses classname to be applied <STRING>
+ * 0: Player <OBJECT>
+ * 1: Glasses classname to be applied <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [goggles ace_player] call ace_goggles_fnc_applyGlassesEffect
+ * [ace_player, goggles ace_player] call ace_goggles_fnc_applyGlassesEffect
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_glasses"];
+params ["_player", "_glasses"];
+TRACE_2("applyGlassesEffect",_player,_glasses);
 
 // remove old effect
 call FUNC(removeGlassesEffect);
+
+if ((getNumber (configFile >> "CfgVehicles" >> (typeOf _player) >> "isPlayableLogic")) == 1) exitWith {
+    TRACE_1("skipping playable logic",typeOf _player); // VirtualMan_F (placeable logic zeus / spectator)
+};
 
 private ["_config", "_postProcessColour", "_postProcessTintAmount", "_imagePath"];
 

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -48,7 +48,7 @@ GVAR(lastPlayerVehicle) = objNull;
     ["unit", {
         params ["_player", "_oldPlayer"];
         TRACE_2("unit change",_player,_oldPlayer);
-        
+
         if (!isNull _oldPlayer) then {
             private _firedEH = _oldPlayer getVariable [QGVAR(firedEH), -1];
             _oldPlayer removeEventHandler ["FiredNear", _firedEH];
@@ -60,6 +60,9 @@ GVAR(lastPlayerVehicle) = objNull;
         };
         // Don't add a new EH if the unit respawned
         if ((_player getVariable [QGVAR(firedEH), -1]) == -1) then {
+            if ((getNumber (configFile >> "CfgVehicles" >> (typeOf _player) >> "isPlayableLogic")) == 1) exitWith {
+                TRACE_1("skipping playable logic",typeOf _player); // VirtualMan_F (placeable logic zeus / spectator)
+            };
             private _firedEH = _player addEventHandler ["FiredNear", {call FUNC(firedNear)}];
             _player setVariable [QGVAR(firedEH), _firedEH];
             private _explosionEH = _player addEventHandler ["Explosion", {call FUNC(explosionNear)}];
@@ -69,7 +72,6 @@ GVAR(lastPlayerVehicle) = objNull;
 
         GVAR(deafnessDV) = 0;
         GVAR(deafnessPrior) = 0;
-        ACE_player setVariable [QGVAR(deaf), false];
         GVAR(time3) = 0;
         [] call FUNC(updateHearingProtection);
     }, true] call CBA_fnc_addPlayerEventHandler;

--- a/addons/map/XEH_postInitClient.sqf
+++ b/addons/map/XEH_postInitClient.sqf
@@ -116,12 +116,13 @@ call FUNC(determineZoom);
 GVAR(hasWatch) = true;
 
 ["loadout", {
-    if (isNull (_this select 0)) exitWith {
+    params ["_unit"];
+    if (isNull _unit) exitWith {
         GVAR(hasWatch) = true;
     };
     GVAR(hasWatch) = false;
     {
         if (_x isKindOf ["ItemWatch", configFile >> "CfgWeapons"]) exitWith {GVAR(hasWatch) = true;};
         false
-    } count (assignedItems ACE_player);
-}] call CBA_fnc_addPlayerEventHandler;
+    } count (assignedItems _unit);
+}, true] call CBA_fnc_addPlayerEventHandler;


### PR DESCRIPTION
- 	Disable goggles and hearing fx for virtual units
- Fix goggles not always showing at mission start (loadout EH added after loadout was set)
- 	Cleanup some other CBA_fnc_addPlayerEventHandler (common, map)
- Should fix #4986

Virtual Units are things like spectator and permanent zeus "logics", not VR guys.