### PR TITLE
Fix cookoff desynch

### DIFF
--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -132,6 +132,6 @@ if (local _vehicle) then {
             if (local _vehicle) then {
                 _vehicle setDamage 1;
             };
-        }, [_vehicle, _effects], 4 + random 20] call CBA_fnc_waitAndExecute;
-    }, [_vehicle, _effects, _positions], 3 + random 15] call CBA_fnc_waitAndExecute;
-}, _vehicle, 0.5 + random 5] call CBA_fnc_waitAndExecute;
+        }, [_vehicle, _effects], 14] call CBA_fnc_waitAndExecute;
+    }, [_vehicle, _effects, _positions], 10.5] call CBA_fnc_waitAndExecute;
+}, _vehicle, 3] call CBA_fnc_waitAndExecute;

--- a/addons/cookoff/functions/fnc_cookOffBox.sqf
+++ b/addons/cookoff/functions/fnc_cookOffBox.sqf
@@ -71,6 +71,6 @@ if (local _box) then {
             if (local _box) then {
                 _box setDamage 1;
             };
-        }, [_box, _effects], 45 + random 75] call CBA_fnc_waitAndExecute; // Give signifcant time for ammo cookoff to occur (perhaps keep the box alive until all cooked off?)
-    }, [_box, _effects], 3 + random 15] call CBA_fnc_waitAndExecute;
-}, _box, 0.5 + random 5] call CBA_fnc_waitAndExecute;
+        }, [_box, _effects], 82.5] call CBA_fnc_waitAndExecute; // Give signifcant time for ammo cookoff to occur (perhaps keep the box alive until all cooked off?)
+    }, [_box, _effects], 10.5] call CBA_fnc_waitAndExecute;
+}, _box, 3] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- fix #4900

Randomness would be calculated on every machine, but only vehicle explosion and sound are done by the server. Smoke, light and fire sfx are done by each client.
