### PR TITLE
Update publish.py for RHS Gref Compat

### DIFF
--- a/tools/publish.py
+++ b/tools/publish.py
@@ -107,7 +107,7 @@ def main(argv):
 
             
     #ACE Main - http://steamcommunity.com/sharedfiles/filedetails/?id=463939057
-    # publishFolder(ace_release_dir, "463939057", changelog_path)
+    # Note: command line publisher doesn't like our file structure, just upload this one manually
 
     
     
@@ -115,9 +115,13 @@ def main(argv):
     folder = buildCompatFolder("@ace_compat_rhs_usf3", ["ace_compat_rhs_usf3.*"])
     publishFolder(folder, "773125288", changelog_path)
     
-    #RHS Compat Commies - http://steamcommunity.com/sharedfiles/filedetails/?id=773131200
+    #RHS Compat Russians - http://steamcommunity.com/sharedfiles/filedetails/?id=773131200
     folder = buildCompatFolder("@ace_compat_rhs_afrf3", ["ace_compat_rhs_afrf3.*"])
     publishFolder(folder, "773131200", changelog_path)
+
+    #RHS Compat GREF - http://steamcommunity.com/sharedfiles/filedetails/?id=884966711
+    folder = buildCompatFolder("@ace_compat_rhs_gref3", ["ace_compat_rhs_gref3.*"])
+    publishFolder(folder, "884966711", changelog_path)
 
     #ADR97 (p90)- http://steamcommunity.com/sharedfiles/filedetails/?id=773136286
     folder = buildCompatFolder("@ace_adr97_compat", ["ace_compat_adr_97.*"])


### PR DESCRIPTION
New compat mod is published but set as private until 3.9.1 is out