### PR TITLE
[Medical Rewrite] Fixing zeus remote controll unnconsious problem

### DIFF
--- a/addons/medical_ui/XEH_postInit.sqf
+++ b/addons/medical_ui/XEH_postInit.sqf
@@ -15,3 +15,10 @@ GVAR(heartBeatEffectRunning) = false;
     [_unconscious, 1] call FUNC(effectUnconscious);
     ["unconscious", _unconscious] call EFUNC(common,setDisableUserInputStatus);
 }] call CBA_fnc_addEventHandler;
+
+["unit", {
+    params ["_new", "_old"];
+    private _status = _new getVariable ["ace_unconscious", false];
+    [_status, 0] call FUNC(effectUnconscious);
+    ["unconscious", _status] call EFUNC(common,setDisableUserInputStatus);
+}] call CBA_fnc_addPlayerEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Fixing a bug where zeus would receive the unnconsious effect and the input block when his remote controlled unit becomes unnconsious.

This will not work by now as the `unit` player eventhandler is still broken for zeus leaving a remote controlled unit. Fixed with [this commit](https://github.com/CBATeam/CBA_A3/commit/2f37af3110ac8b03d4b397d7db2a9b9f751de964) in cba.
