### PR TITLE
Fix tagging model cache

### DIFF
--- a/addons/tagging/XEH_postInit.sqf
+++ b/addons/tagging/XEH_postInit.sqf
@@ -16,7 +16,7 @@ for "_index" from 0 to (_countOptions - 1) do {
             private _model = getText (_cfgClass >> "model");
             if (_model != "") then {
                 private _array = _model splitString "\";
-                GVAR(cacheStaticModels) setVariable [toLower (_array select ((count _array) - 2)), _cfgClass];
+                GVAR(cacheStaticModels) setVariable [(_array select ((count _array) - 1)), true];
             };
         };
     };
@@ -32,7 +32,7 @@ for "_index" from 0 to (_countOptions - 1) do {
             private _model = getText (_cfgClass >> "model");
             if (_model != "") then {
                 private _array = _model splitString "\";
-                GVAR(cacheStaticModels) setVariable [toLower (_array select ((count _array) - 2)), _cfgClass];
+                GVAR(cacheStaticModels) setVariable [(_array select ((count _array) - 1)), true];
             };
         };
     };

--- a/addons/tagging/functions/fnc_checkTaggable.sqf
+++ b/addons/tagging/functions/fnc_checkTaggable.sqf
@@ -9,16 +9,14 @@
  * Is surface taggable <BOOL>
  *
  * Example:
- * [unit] call ace_tagging_fnc_checkTaggable
+ * [player] call ace_tagging_fnc_checkTaggable
  *
  * Public: No
  */
 
 #include "script_component.hpp"
 
-params ["_unit"];
-
-[[_unit], {
+[_this, {
     params ["_unit"];
 
     // Exit if no required item in inventory
@@ -45,15 +43,11 @@ params ["_unit"];
         if (_object isKindOf "Static") exitWith {false};
 
         // If the class is not categorized correctly search the cache
-        private _array = str(_object) splitString " ";
-        private _str = toLower (_array select 1);
-        TRACE_1("Object:",_str);
-        private _objClass = GVAR(cacheStaticModels) getVariable _str;
+        private _modelName = (getModelInfo _object) select 0;
+        private _isStatic = GVAR(cacheStaticModels) getVariable [_modelName, false];
+        TRACE_2("Object:",_modelName,_isStatic);
         // If the class in not on the cache, exit
-        if (isNil "_objClass") exitWith {
-            false
-        };
-        true
+        (!_isStatic)
     }) exitWith {
         TRACE_1("Pointed object is non static",_object);
         false

--- a/addons/tagging/functions/fnc_tag.sqf
+++ b/addons/tagging/functions/fnc_tag.sqf
@@ -49,15 +49,11 @@ if ((!isNull _object) && {
     if (_object isKindOf "Static") exitWith {false};
 
     // If the class is not categorized correctly search the cache
-    private _array = str(_object) splitString " ";
-    private _str = toLower (_array select 1);
-    TRACE_1("Object:",_str);
-    private _objClass = GVAR(cacheStaticModels) getVariable _str;
+    private _modelName = (getModelInfo _object) select 0;
+    private _isStatic = GVAR(cacheStaticModels) getVariable [_modelName, false];
+    TRACE_2("Object:",_modelName,_isStatic);
     // If the class in not on the cache, exit
-    if (isNil "_objClass") exitWith {
-        false
-    };
-    true
+    (!_isStatic)
 }) exitWith {
     TRACE_1("Pointed object is non static",_object);
     false


### PR DESCRIPTION
- postInit wasn't saving p3d name to cache (wrong index)
- other functions had inverted logic for exitWith (so it still worked)
- config class isn't used, so just save bool

Could possibly cause array bounds error if a building had an odd model path (see #5035)
```
 7:25:43 Error in expression <aticModels setVariable [toLower (_array select ((count _array) - 2)), _cfgClass]>
 7:25:43   Error position: <select ((count _array) - 2)), _cfgClass]>
 7:25:43   Error Zero divisor
```
If array only had 1 element you could get something like `["x"] select -1`