### PR TITLE
Fix FCS Vehicle Init

### DIFF
--- a/addons/fcs/CfgEventHandlers.hpp
+++ b/addons/fcs/CfgEventHandlers.hpp
@@ -17,7 +17,7 @@ class Extended_PostInit_EventHandlers {
     };
 };
 
-class Extended_Init_EventHandlers {
+class Extended_InitPost_EventHandlers {
     class Tank {
         class ADDON {
             serverInit = QUOTE(_this call FUNC(vehicleInit));


### PR DESCRIPTION
Related to findings in https://github.com/CBATeam/CBA_A3/pull/628

vehicleInit.sqf runs several `setVariables [,,true]` that were not synced