### PR TITLE
Lower minimum speed limiter speed to 5 km/h

### DIFF
--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -28,7 +28,7 @@ if (GVAR(isSpeedLimiter)) exitWith {
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;
 
-private _maxSpeed = speed _vehicle;
+private _maxSpeed = speed _vehicle max 3;
 
 [{
     params ["_args", "_idPFH"];

--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -28,7 +28,7 @@ if (GVAR(isSpeedLimiter)) exitWith {
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;
 
-private _maxSpeed = speed _vehicle; // "max 10" entfernt, da kein Grund mehr für Mindestgeschwindigkeit 10 km/h besteht
+private _maxSpeed = speed _vehicle;
 
 [{
     params ["_args", "_idPFH"];

--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -28,7 +28,7 @@ if (GVAR(isSpeedLimiter)) exitWith {
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;
 
-private _maxSpeed = speed _vehicle max 10;
+private _maxSpeed = speed _vehicle; // "max 10" entfernt, da kein Grund mehr für Mindestgeschwindigkeit 10 km/h besteht
 
 [{
     params ["_args", "_idPFH"];

--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -28,7 +28,7 @@ if (GVAR(isSpeedLimiter)) exitWith {
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;
 
-private _maxSpeed = speed _vehicle max 3;
+private _maxSpeed = speed _vehicle max 5;
 
 [{
     params ["_args", "_idPFH"];


### PR DESCRIPTION
Minimum speed limit of 10 km/h was needed in the past due to engine limitations. Multiple user tests have shown that the minimum speed is not needed anymore. The new minimum of 0 km/h allows for example setting walking speed for vehicles (<10 km/h).