### PR TITLE
Use getPosASLVisual for icons and camera position.

### DIFF
--- a/addons/spectator/functions/fnc_handleCamera.sqf
+++ b/addons/spectator/functions/fnc_handleCamera.sqf
@@ -64,7 +64,7 @@ if (GVAR(camMode) == 0) then {
     _vector = _vector vectorAdd [0,0,_distance*sin(-_tilt)];
 
     // Update the position of the target camera (used for smooth unit tracking)
-    _target camSetPos ((_unit modelToWorldVisual [0,0,0]) vectorAdd [0,0,1.5]);
+    _target camSetPos ((ASLToAGL getPosASLVisual _unit) vectorAdd [0,0,1.5]);
     _target camCommit 0;
 
     // Update the relative position of the unit camera

--- a/addons/spectator/functions/fnc_handleIcons.sqf
+++ b/addons/spectator/functions/fnc_handleIcons.sqf
@@ -29,7 +29,7 @@ _drawVehicles = [];
         _color = GETVAR(_x,GVAR(gColor),[ARR_4(0,0,0,0)]);
         _txt = groupID _x;
 
-        drawIcon3D ["\A3\ui_f\data\map\markers\nato\b_inf.paa", _color, _leader modelToWorldVisual [0,0,30], 1, 1, 0, _txt, 2, 0.02];
+        drawIcon3D ["\A3\ui_f\data\map\markers\nato\b_inf.paa", _color, ASLToAGL getPosASLVisual _leader, 1, 1, 0, _txt, 2, 0.02];
     } else {
         _drawVehicles append (units _x);
     };
@@ -41,6 +41,6 @@ _drawVehicles = [];
     _color = GETVAR((group _x),GVAR(gColor),[ARR_4(0,0,0,0)]);
     _txt = ["", GETVAR(_x,GVAR(uName),"")] select (isPlayer _x);
 
-    drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", _color, _x modelToWorldVisual [0,0,3], 0.7, 0.7, 0, _txt, 1, 0.02];
+    drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", _color, ASLToAGL getPosASLVisual _x, 0.7, 0.7, 0, _txt, 1, 0.02];
     false
 } count (_drawVehicles arrayIntersect GVAR(unitList));

--- a/addons/spectator/functions/fnc_handleIcons.sqf
+++ b/addons/spectator/functions/fnc_handleIcons.sqf
@@ -29,7 +29,7 @@ _drawVehicles = [];
         _color = GETVAR(_x,GVAR(gColor),[ARR_4(0,0,0,0)]);
         _txt = groupID _x;
 
-        drawIcon3D ["\A3\ui_f\data\map\markers\nato\b_inf.paa", _color, ASLToAGL getPosASLVisual _leader, 1, 1, 0, _txt, 2, 0.02];
+        drawIcon3D ["\A3\ui_f\data\map\markers\nato\b_inf.paa", _color, (_leader modelToWorldVisual (_leader selectionPosition "Head")) vectorAdd [0,0,1.5], 1, 1, 0, _txt, 2, 0.02];
     } else {
         _drawVehicles append (units _x);
     };
@@ -41,6 +41,6 @@ _drawVehicles = [];
     _color = GETVAR((group _x),GVAR(gColor),[ARR_4(0,0,0,0)]);
     _txt = ["", GETVAR(_x,GVAR(uName),"")] select (isPlayer _x);
 
-    drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", _color, ASLToAGL getPosASLVisual _x, 0.7, 0.7, 0, _txt, 1, 0.02];
+    drawIcon3D ["a3\Ui_f\data\GUI\Rsc\RscDisplayEGSpectator\UnitIcon_ca.paa", _color, (_x modelToWorldVisual (_x selectionPosition "Head")) vectorAdd [0,0,1.5], 0.7, 0.7, 0, _txt, 1, 0.02];
     false
 } count (_drawVehicles arrayIntersect GVAR(unitList));


### PR DESCRIPTION
**When merged this pull request will:**
- Fix stuttering of the camera and icons when camera is following the unit.
- Moves icons directly to the unit position.

It uses ```getPosASLVisual``` and ```ASLToAGL``` which simulates what ```modelToWorldVisual``` does but it updates properly. Tested this in the spectator we use in my community, works properly for any surface (water, underwater, above ground).

Example video.
Old - https://youtu.be/j7L0hg4POtY?t=0
New - https://youtu.be/j7L0hg4POtY?t=16
