### PR TITLE
Add keybind to toggle interaction menu

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -940,6 +940,20 @@
             <Portuguese>Sem espaço para descarregar</Portuguese>
             <Russian>Нет места для выгрузки</Russian>
             <Japanese>降ろすための空間がありません</Japanese>
+        </Key>       
+        <Key ID="STR_ACE_Common_KeybindToggle">
+            <English>Toggle</English>
+            <Polish>переключить</Polish>
+            <Russian>переключить</Russian>
+            <French>Basculer</French>
+            <Spanish>Cambiar</Spanish>
+            <Italian>camb.</Italian>
+            <German>Umschalten</German>
+            <Hungarian>pecek</Hungarian>
+            <Czech>přep.</Czech>
+            <Portuguese>alternar</Portuguese>
+            <Japanese>トグル</Japanese>
+            <Korean>토글</Korean>
         </Key>
     </Package>
 </Project>

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -42,6 +42,27 @@ GVAR(ParsedTextCached) = [];
 [219, [false, true, false]], false] call CBA_fnc_addKeybind; //Left Windows Key + Ctrl/Strg
 
 
+["ACE3 Common", QGVAR(InteractKey_Toggle),
+format ["%1 (%2)", (localize LSTRING(InteractKey)), localize ELSTRING(common,KeybindToggle)],
+{
+    if (GVAR(openedMenuType) != 0) then {
+        [0] call FUNC(keyDown)
+    } else {
+        [0,false] call FUNC(keyUp)
+    };
+}, {}, [-1, [false, false, false]], false] call CBA_fnc_addKeybind; // UNBOUND
+
+["ACE3 Common", QGVAR(SelfInteractKey_Toggle),
+format ["%1 (%2)", (localize LSTRING(SelfInteractKey)), localize ELSTRING(common,KeybindToggle)],
+{
+    if (GVAR(openedMenuType) != 1) then {
+        [1] call FUNC(keyDown)
+    } else {
+        [1, false] call FUNC(keyUp)
+    };
+}, {}, [-1, [false, false, false]], false] call CBA_fnc_addKeybind; // UNBOUND
+
+
 // Listens for the falling unconscious event, just in case the menu needs to be closed
 ["ace_unconscious", {
     // If no menu is open just quit


### PR DESCRIPTION
@HeadTraumaZA
Ref https://github.com/acemod/ACE3/issues/3594#issuecomment-296169526

Adds seperate keybind that just toggles the interaction menu.
When combined with the "Do action when releasing key: No" setting, it should be much easier to use.


Should we add new keybinds, or just add a setting to change behaviour of the existing keybinds?