### PR TITLE
AB: update compat R3F v3.5

### DIFF
--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -25,7 +25,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
-    class R3F_762x51_Ball: BulletBase { // B_762x51_Ball, AtragMx GunList: 7.62x51mm M80 
+    class R3F_762x51_Ball: BulletBase { // B_762x51_Ball, AtragMx GunList: 7.62x51mm M80
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;

--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -1,100 +1,100 @@
 class CfgAmmo {
     class Default;
     class BulletBase;
-    class R3F_9x19_Ball: BulletBase {
-        ACE_caliber=9.017;
-        ACE_bulletLength=15.494;
-        ACE_bulletMass=8.0352;
-        ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
-        ACE_ballisticCoefficients[]={0.165};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={340, 370, 400};
-        ACE_barrelLengths[]={101.6, 127.0, 228.6};
+    class R3F_9x19_Ball: BulletBase { // ACE_9x19_Ball
+        ACE_caliber = 9.017;
+        ACE_bulletLength = 15.494;
+        ACE_bulletMass = 8.0352;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {0.165};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {340, 370, 400};
+        ACE_barrelLengths[] = {101.6, 127.0, 228.6};
     };
-    class R3F_556x45_Ball: BulletBase {
-        ACE_caliber=5.69;
-        ACE_bulletLength=23.012;
-        ACE_bulletMass=4.0176;
-        ACE_ammoTempMuzzleVelocityShifts[]={-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
-        ACE_ballisticCoefficients[]={0.151};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
-        ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
+    class R3F_556x45_Ball: BulletBase { // B_556x45_Ball, AtragMx GunList: 5.56x45mm M855
+        ACE_caliber = 5.69;
+        ACE_bulletLength = 23.012;
+        ACE_bulletMass = 4.0176;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
+        ACE_ballisticCoefficients[] = {0.151};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 7;
+        ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
+        ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
-    class R3F_762x51_Ball: BulletBase {
-        ACE_caliber=7.823;
-        ACE_bulletLength=28.956;
-        ACE_bulletMass=9.4608;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.2};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={700, 800, 820, 833, 845};
-        ACE_barrelLengths[]={254.0, 406.4, 508.0, 609.6, 660.4};
+    class R3F_762x51_Ball: BulletBase { // B_762x51_Ball, AtragMx GunList: 7.62x51mm M80 
+        ACE_caliber = 7.823;
+        ACE_bulletLength = 28.956;
+        ACE_bulletMass = 9.4608;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.2};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_dragModel = 7;
+        ACE_muzzleVelocities[] = {700, 800, 820, 833, 845};
+        ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
-    class R3F_127x99_Ball: BulletBase {
-        ACE_caliber=12.954;
-        ACE_bulletLength=58.674;
-        ACE_bulletMass=41.9256;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.670};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={700};
+    class R3F_127x99_Ball: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        ACE_caliber = 12.954;
+        ACE_bulletLength = 58.674;
+        ACE_bulletMass = 41.9256;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.670};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {900};
+        ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_PEI: R3F_127x99_Ball {
-        ACE_caliber=12.954;
-        ACE_bulletLength=58.674;
-        ACE_bulletMass=41.9256;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.670};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={700};
+    class R3F_127x99_PEI: R3F_127x99_Ball { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        ACE_caliber = 12.954;
+        ACE_bulletLength = 58.674;
+        ACE_bulletMass = 41.9256;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.670};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {900};
+        ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_Ball2: BulletBase {
-        ACE_caliber=12.954;
-        ACE_bulletLength=58.674;
-        ACE_bulletMass=41.9256;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.670};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={736.6};
+    class R3F_127x99_Ball2: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        ACE_caliber = 12.954;
+        ACE_bulletLength = 58.674;
+        ACE_bulletMass = 41.9256;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.670};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {900};
+        ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_PEI2: R3F_127x99_Ball2 {
-        ACE_caliber=12.954;
-        ACE_bulletLength=58.674;
-        ACE_bulletMass=41.9256;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.670};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={736.6};
+    class R3F_127x99_PEI2: R3F_127x99_Ball2 { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        ACE_caliber = 12.954;
+        ACE_bulletLength = 58.674;
+        ACE_bulletMass = 41.9256;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.670};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {900};
+        ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_Ball3: BulletBase {
-        ACE_caliber=12.954;
-        ACE_bulletLength=58.674;
-        ACE_bulletMass=41.9256;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.670};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={900};
-        ACE_barrelLengths[]={736.6};
+    class R3F_127x99_Ball3: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        ACE_caliber = 12.954;
+        ACE_bulletLength = 58.674;
+        ACE_bulletMass = 41.9256;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.670};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {900};
+        ACE_barrelLengths[] = {736.6};
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -9,7 +9,7 @@ class CfgWeapons {
     class R3F_Famas_surb: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 5.4;
         ACE_barrelTwist = 228.6; // 9"
-        ACE_barrelLength = 450.0;
+        ACE_barrelLength = 450.0; // Beretta barrel
     };
     class R3F_Famas_G2: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 10.6;
@@ -19,27 +19,39 @@ class CfgWeapons {
     class R3F_Famas_felin: R3F_Famas_G2 {
         ACE_RailHeightAboveBore = 5.4;
         ACE_barrelTwist = 177.8; // 7"
-        ACE_barrelLength = 450.0;
+        ACE_barrelLength = 450.0; // Beretta barrel
     };
     class R3F_FRF2: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.2;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 650.0;
+        class Single: Mode_SemiAuto {
+            dispersion = 0.00029; // 1 MOA
+        };
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.0;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
+        class Single: Mode_SemiAuto {
+            dispersion = 0.00029; 
+        };
     };
     class R3F_M107: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.6;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
+        class Single: Mode_SemiAuto {
+            dispersion = 0.00029;
+        };
     };
     class R3F_TAC50: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.2;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
+        class Single: Mode_SemiAuto {
+            dispersion = 0.00029;
+        };
     };
     class R3F_Minimi: Rifle_Base_F {
         ACE_RailHeightAboveBore = 4.0;
@@ -70,6 +82,9 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
+        class Single: Mode_SemiAuto {
+            dispersion = 0.00029;
+        };
     };
     class R3F_HK416M: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.4;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -135,7 +135,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-8, 8};
         ACE_ScopeAdjust_VerticalIncrement = 0.2;
         ACE_ScopeAdjust_HorizontalIncrement = 0.2;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J4 {
                     discreteDistance[] = {100};
@@ -156,7 +156,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J8 {
                     discreteDistance[] = {100};
@@ -171,7 +171,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J8_MILDOT {
                     discreteDistance[] = {100};
@@ -186,7 +186,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J10 {
                     discreteDistance[] = {100};
@@ -201,7 +201,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J10_MILDOT {
                     discreteDistance[] = {100};
@@ -216,7 +216,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-7, 7};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class ZEISS_MILDOT {
                     discreteDistance[] = {100};
@@ -231,7 +231,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-11, 11};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class NF_MILDOT {
                     discreteDistance[] = {100};
@@ -246,7 +246,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo : InventoryOpticsItem_Base_F {
+        class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class NF42_MILDOT {
                     discreteDistance[] = {100};

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -85,7 +85,7 @@ class CfgWeapons {
         ACE_ScopeHeightAboveRail = 3.0;
     };
     class R3F_EOTECH: ItemCore {
-        ACE_ScopeHeightAboveRail = 3.0;
+        ACE_ScopeHeightAboveRail = 3.8;
     };
     class R3F_J4: ItemCore {
         ACE_ScopeHeightAboveRail = 3.0;
@@ -101,6 +101,12 @@ class CfgWeapons {
                 };
             };
         };
+    };
+    class R3F_FELIN: ItemCore {
+        ACE_ScopeHeightAboveRail = 4.2;
+    };
+    class R3F_FELIN_FRF2: ItemCore {
+        ACE_ScopeHeightAboveRail = 4.0;
     };
     class R3F_J8: ItemCore {
         ACE_ScopeHeightAboveRail = 4.4;
@@ -208,6 +214,6 @@ class CfgWeapons {
         };
     };
     class R3F_OB50: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeHeightAboveRail = 4.0;
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -77,7 +77,7 @@ class CfgWeapons {
         ACE_barrelLength = 368.3;
     };
     class R3F_HK416M_HG: R3F_HK416M {};
-    class R3F_HK416S_HG: R3F_HK416M_HG
+    class R3F_HK416S_HG: R3F_HK416M_HG {
         ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 279.4;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -81,6 +81,12 @@ class CfgWeapons {
     };   
     class ItemCore;
     class InventoryOpticsItem_Base_F;
+    class R3F_AIMPOINT: ItemCore {
+        ACE_ScopeHeightAboveRail = 3.0;
+    };
+    class R3F_EOTECH: ItemCore {
+        ACE_ScopeHeightAboveRail = 3.0;
+    };
     class R3F_J4: ItemCore {
         ACE_ScopeHeightAboveRail = 3.0;
         ACE_ScopeAdjust_Vertical[] = {-8, 8};
@@ -200,5 +206,8 @@ class CfgWeapons {
                 };
             };
         };
+    };
+    class R3F_OB50: ItemCore {
+        ACE_ScopeHeightAboveRail = 4.2;
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -3,12 +3,22 @@ class CfgWeapons {
     class Rifle_Base_F;
     class R3F_Famas_F1: Rifle_Base_F {
         ACE_RailHeightAboveBore = 10.6;
-        ACE_barrelTwist = 304.8;
+        ACE_barrelTwist = 304.8; // 12"
         ACE_barrelLength = 488.0;
     };
     class R3F_Famas_surb: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 5.4;
-        ACE_barrelTwist = 304.8;
+        ACE_barrelTwist = 177.8; // 7"
+        ACE_barrelLength = 403.86;
+    };
+    class R3F_Famas_G2: R3F_Famas_F1 {
+        ACE_RailHeightAboveBore = 10.6;
+        ACE_barrelTwist = 228.6; // 9"
+        ACE_barrelLength = 488.0;
+    };
+    class R3F_Famas_felin: R3F_Famas_G2 {
+        ACE_RailHeightAboveBore = 5.4;
+        ACE_barrelTwist = 177.8; // 7"
         ACE_barrelLength = 403.86;
     };
     class R3F_FRF2: Rifle_Base_F {

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -2,71 +2,88 @@ class CfgWeapons {
     class Pistol_Base_F;
     class Rifle_Base_F;
     class R3F_Famas_F1: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 10.6;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 488.0;
     };
     class R3F_Famas_surb: R3F_Famas_F1 {
+        ACE_RailHeightAboveBore = 5.4;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 403.86;
     };
     class R3F_FRF2: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 2.2;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 650.0;
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 2.0;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
     };
     class R3F_M107: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 3.6;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
     };
     class R3F_TAC50: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 3.2;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
     };
     class R3F_Minimi: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 4.0;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 347.98;
     };
     class R3F_Minimi_762: R3F_Minimi {
+        ACE_RailHeightAboveBore = 4.0;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 502.92;
     };
     class R3F_SIG551: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 4.2;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 363.0;
     };
     class R3F_HK417M: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 406.0;
     };
     class R3F_HK417S_HG: R3F_HK417M {
+        ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 305.0;
     };
     class R3F_HK417L: R3F_HK417M {
+        ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
     };
     class R3F_HK416M: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
     };
     class R3F_HK416M_HG: R3F_HK416M {};
     class R3F_HK416S_HG: R3F_HK416M_HG
+        ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 279.4;
     };
     class R3F_MP5SD: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 4.5;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 144.78;
     };
     class R3F_MP5A5: R3F_MP5SD {
+        ACE_RailHeightAboveBore = 4.5;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 226.06;
     };
     class R3F_M4S90: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 2.2;
         ACE_twistDirection = 0;
         ACE_barrelTwist = 0;
         ACE_barrelLength = 144.78;
@@ -123,7 +140,7 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_J8_MILDOT: R3F_J8 { // Scope Mounting Rail 30 MOA
+    class R3F_J8_MILDOT: R3F_J8 { // Scope rail 30 MOA
         ACE_ScopeHeightAboveRail = 4.4;
         ACE_ScopeAdjust_Vertical[] = {-2, 18};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
@@ -153,7 +170,7 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_J10_MILDOT: R3F_J10 { // Scope Mounting Rail 30 MOA
+    class R3F_J10_MILDOT: R3F_J10 { // Scope rail 30 MOA
         ACE_ScopeHeightAboveRail = 4.4;
         ACE_ScopeAdjust_Vertical[] = {-2, 18};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -8,8 +8,8 @@ class CfgWeapons {
     };
     class R3F_Famas_surb: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 5.4;
-        ACE_barrelTwist = 177.8; // 7"
-        ACE_barrelLength = 403.86;
+        ACE_barrelTwist = 228.6; // 9"
+        ACE_barrelLength = 450.0;
     };
     class R3F_Famas_G2: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 10.6;
@@ -19,7 +19,7 @@ class CfgWeapons {
     class R3F_Famas_felin: R3F_Famas_G2 {
         ACE_RailHeightAboveBore = 5.4;
         ACE_barrelTwist = 177.8; // 7"
-        ACE_barrelLength = 403.86;
+        ACE_barrelLength = 450.0;
     };
     class R3F_FRF2: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.2;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -2,186 +2,200 @@ class CfgWeapons {
     class Pistol_Base_F;
     class Rifle_Base_F;
     class R3F_Famas_F1: Rifle_Base_F {
-        ACE_barrelTwist=304.8;
-        ACE_barrelLength=488;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 488.0;
     };
     class R3F_Famas_surb: R3F_Famas_F1 {
-        ACE_barrelTwist=304.8;
-        ACE_barrelLength=403.86;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 403.86;
     };
     class R3F_FRF2: Rifle_Base_F {
-        ACE_barrelTwist=304.8;
-        ACE_barrelLength=650;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 650.0;
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F {
-        ACE_barrelTwist=381.0;
-        ACE_barrelLength=700;
+        ACE_barrelTwist = 381.0;
+        ACE_barrelLength = 700.0;
     };
     class R3F_M107: Rifle_Base_F {
-        ACE_barrelTwist=381.0;
-        ACE_barrelLength=736.6;
+        ACE_barrelTwist = 381.0;
+        ACE_barrelLength = 736.6;
     };
-    class R3F_TAC50: Rifle_Base_F
-    {
-        ACE_barrelTwist=381.0;
-        ACE_barrelLength=736.6;
+    class R3F_TAC50: Rifle_Base_F {
+        ACE_barrelTwist = 381.0;
+        ACE_barrelLength = 736.6;
     };
     class R3F_Minimi: Rifle_Base_F {
-        ACE_barrelTwist=177.8;
-        ACE_barrelLength=347.98;
-    };
-    class R3F_Minimi_HG: R3F_Minimi {
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 347.98;
     };
     class R3F_Minimi_762: R3F_Minimi {
-        ACE_barrelTwist=304.8;
-        ACE_barrelLength=502.92;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 502.92;
     };
-    class R3F_Minimi_762_HG: R3F_Minimi_762 {
+    class R3F_SIG551: Rifle_Base_F {
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 363.0;
     };
     class R3F_HK417M: Rifle_Base_F {
-        ACE_barrelTwist=279.4;
-        ACE_barrelLength=406;
+        ACE_barrelTwist = 279.4;
+        ACE_barrelLength = 406.0;
     };
-    class R3F_HK417S_HG: R3F_HK417M
-    {
-        ACE_barrelTwist=279.4;
-        ACE_barrelLength=305;
+    class R3F_HK417S_HG: R3F_HK417M {
+        ACE_barrelTwist = 279.4;
+        ACE_barrelLength = 305.0;
     };
     class R3F_HK417L: R3F_HK417M {
-        ACE_barrelTwist=279.4;
-        ACE_barrelLength=508;
+        ACE_barrelTwist = 279.4;
+        ACE_barrelLength = 508.0;
     };
     class R3F_HK416M: Rifle_Base_F {
-        ACE_barrelTwist=177.8;
-        ACE_barrelLength=368.3;
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 368.3;
+    };
+    class R3F_HK416M_HG: R3F_HK416M {};
+    class R3F_HK416S_HG: R3F_HK416M_HG
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 279.4;
     };
     class R3F_MP5SD: Rifle_Base_F {
-        ACE_barrelTwist=254.0;
-        ACE_barrelLength=144.78;
+        ACE_barrelTwist = 254.0;
+        ACE_barrelLength = 144.78;
     };
     class R3F_MP5A5: R3F_MP5SD {
-        ACE_barrelTwist=254.0;
-        ACE_barrelLength=226.06;
+        ACE_barrelTwist = 254.0;
+        ACE_barrelLength = 226.06;
     };
     class R3F_M4S90: Rifle_Base_F {
-        ACE_twistDirection=0;
-        ACE_barrelTwist=0;
-        ACE_barrelLength=144.78;
+        ACE_twistDirection = 0;
+        ACE_barrelTwist = 0;
+        ACE_barrelLength = 144.78;
     };
     class R3F_PAMAS: Pistol_Base_F {
-        ACE_barrelTwist=248.92;
-        ACE_barrelLength=124.46;
+        ACE_barrelTwist = 250.0;
+        ACE_barrelLength = 125.0;
     };
-    
+    class R3F_HKUSP: Pistol_Base_F {
+        ACE_barrelTwist = 250.0;
+        ACE_barrelLength = 121.0;
+    };   
     class ItemCore;
     class InventoryOpticsItem_Base_F;
     class R3F_J4: ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { -8, 8 };
-        ACE_ScopeAdjust_Horizontal[] = { -8, 8 };
+        ACE_ScopeHeightAboveRail = 3.0;
+        ACE_ScopeAdjust_Vertical[] = {-8, 8};
+        ACE_ScopeAdjust_Horizontal[] = {-8, 8};
         ACE_ScopeAdjust_VerticalIncrement = 0.2;
         ACE_ScopeAdjust_HorizontalIncrement = 0.2;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J4 {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
     class R3F_J8: ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { -10, 10 };
-        ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
+        ACE_ScopeHeightAboveRail = 4.4;
+        ACE_ScopeAdjust_Vertical[] = {-10, 10};
+        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J8 {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
-    class R3F_J8_MILDOT: R3F_J8 {
-        ACE_ScopeAdjust_Vertical[] = { -10, 10 };
-        ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
+    class R3F_J8_MILDOT: R3F_J8 { // Scope Mounting Rail 30 MOA
+        ACE_ScopeHeightAboveRail = 4.4;
+        ACE_ScopeAdjust_Vertical[] = {-2, 18};
+        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J8_MILDOT {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
     class R3F_J10: ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { -10, 10 };
-        ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
+        ACE_ScopeHeightAboveRail = 4.4;
+        ACE_ScopeAdjust_Vertical[] = {-10, 10};
+        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J10 {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
-    class R3F_J10_MILDOT: R3F_J10 {
-        ACE_ScopeAdjust_Vertical[] = { -10, 10 };
-        ACE_ScopeAdjust_Horizontal[] = { -10, 10 };
+    class R3F_J10_MILDOT: R3F_J10 { // Scope Mounting Rail 30 MOA
+        ACE_ScopeHeightAboveRail = 4.4;
+        ACE_ScopeAdjust_Vertical[] = {-2, 18};
+        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J10_MILDOT {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
     class R3F_ZEISS: ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { 0, 23 };
-        ACE_ScopeAdjust_Horizontal[] = { -7, 7 };
+        ACE_ScopeHeightAboveRail = 4.6;
+        ACE_ScopeAdjust_Vertical[] = {0, 23};
+        ACE_ScopeAdjust_Horizontal[] = {-7, 7};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class ZEISS_MILDOT {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
     class R3F_NF: ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { -0.9, 34 };
-        ACE_ScopeAdjust_Horizontal[] = { -11, 11 };
-        ACE_ScopeAdjust_VerticalIncrement = 0.2;
+        ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeAdjust_Vertical[] = {0, 30};
+        ACE_ScopeAdjust_Horizontal[] = {-11, 11};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class NF_MILDOT {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };
         };
     };
     class R3F_NF42: ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { -27.3, 27.3 };
-        ACE_ScopeAdjust_Horizontal[] = { -27.3, 27.3};
+        ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeAdjust_Vertical[] = {0, 24};
+        ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class NF42_MILDOT {
-                    discreteDistance[] = { 100 };
+                    discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };
             };


### PR DESCRIPTION
**AB compat with the new R3F weapons pack v3.5**
- Add HK416S (barrel 11").
- Add SIG 551.
- Add HK USP Tactical.
- Update with the new Scopes Framework: reference BH=62mm with the PGM poly and the NF x42 scope.
Many thanks to Nanucq, R3F team.
- Add AtragMx GunList references for the bullets.
- Minor changes.
- Coherent dispersion for sniper and marksman rifles.