### PR TITLE
Fix jerry can refuel interaction overlapping

### DIFF
--- a/addons/refuel/functions/fnc_makeJerryCan.sqf
+++ b/addons/refuel/functions/fnc_makeJerryCan.sqf
@@ -36,7 +36,7 @@ private _action = [QGVAR(Refuel),
     [],
     [0, 0, 0],
     REFUEL_ACTION_DISTANCE] call EFUNC(interact_menu,createAction);
-[_target, 0, [], _action] call EFUNC(interact_menu,addActionToObject);
+[_target, 0, ["ACE_MainActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
 // Add pickup
 _action = [QGVAR(PickUpNozzle),
@@ -48,7 +48,7 @@ _action = [QGVAR(PickUpNozzle),
     [],
     [0, 0, 0],
     REFUEL_ACTION_DISTANCE] call EFUNC(interact_menu,createAction);
-[_target, 0, [QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
+[_target, 0, ["ACE_MainActions", QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
 
 // Add turnOn
 _action = [QGVAR(TurnOn),
@@ -60,7 +60,7 @@ _action = [QGVAR(TurnOn),
     [],
     [0, 0, 0],
     REFUEL_ACTION_DISTANCE] call EFUNC(interact_menu,createAction);
-[_target, 0, [QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
+[_target, 0, ["ACE_MainActions", QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
 
 // Add turnOff
 _action = [QGVAR(TurnOff),
@@ -72,7 +72,7 @@ _action = [QGVAR(TurnOff),
     [],
     [0, 0, 0],
     REFUEL_ACTION_DISTANCE] call EFUNC(interact_menu,createAction);
-[_target, 0, [QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
+[_target, 0, ["ACE_MainActions", QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
 
 // Add disconnect
 _action = [QGVAR(Disconnect),
@@ -84,4 +84,4 @@ _action = [QGVAR(Disconnect),
     [],
     [0, 0, 0],
     REFUEL_ACTION_DISTANCE] call EFUNC(interact_menu,createAction);
-[_target, 0, [QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);
+[_target, 0, ["ACE_MainActions", QGVAR(Refuel)], _action] call EFUNC(interact_menu,addActionToObject);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #5106 
- Add jerry can actions under `"ACE_MainActions"`, mimicking the standard Refuel actions on vehicles.