### PR TITLE
Add Paradrop Time Coefficient Setting

### DIFF
--- a/addons/cargo/ACE_Settings.hpp
+++ b/addons/cargo/ACE_Settings.hpp
@@ -6,4 +6,11 @@ class ACE_Settings {
         value = 1;
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };
+    class GVAR(paradropTimeCoefficent) {
+        displayName = CSTRING(paradropTimeCoefficent);
+        description = CSTRING(paradropTimeCoefficent_description);
+        typeName = "SCALAR";
+        value = 2.5;
+        category = ECSTRING(OptionsMenu,CategoryLogistics);
+    };
 };

--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -26,6 +26,12 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 1;
             };
+            class paradropTimeCoefficent {
+                displayName = CSTRING(paradropTimeCoefficent);
+                description = CSTRING(paradropTimeCoefficent_description);
+                typeName = "SCALAR";
+                defaultValue = 2.5;
+            };
         };
 
         class ModuleDescription {

--- a/addons/cargo/functions/fnc_moduleSettings.sqf
+++ b/addons/cargo/functions/fnc_moduleSettings.sqf
@@ -24,5 +24,6 @@ params ["_logic", "", "_activated"];
 if (!_activated) exitWith {};
 
 [_logic, QGVAR(enable), "enable"] call EFUNC(common,readSettingFromModule);
+[_logic, QGVAR(paradropTimeCoefficent), "paradropTimeCoefficent"] call EFUNC(common,readSettingFromModule);
 
 INFO("Cargo Module Initialized.");

--- a/addons/cargo/functions/fnc_onMenuOpen.sqf
+++ b/addons/cargo/functions/fnc_onMenuOpen.sqf
@@ -44,7 +44,13 @@ if (GVAR(interactionParadrop)) then {
     lbClear _ctrl;
     {
         private _class = if (_x isEqualType "") then {_x} else {typeOf _x};
-        _ctrl lbAdd (getText(configfile >> "CfgVehicles" >> _class >> "displayName"));
+        private _displayName = getText(configfile >> "CfgVehicles" >> _class >> "displayName");
+        if (GVAR(interactionParadrop)) then {
+            _ctrl lbAdd format ["%1 (%2s)", _displayName, GVAR(paradropTimeCoefficent) * ([_class] call FUNC(getSizeItem))];
+        } else {
+            _ctrl lbAdd _displayName;
+        };
+
         true
     } count _loaded;
 

--- a/addons/cargo/functions/fnc_onMenuOpen.sqf
+++ b/addons/cargo/functions/fnc_onMenuOpen.sqf
@@ -44,7 +44,7 @@ if (GVAR(interactionParadrop)) then {
     lbClear _ctrl;
     {
         private _class = if (_x isEqualType "") then {_x} else {typeOf _x};
-        private _displayName = getText(configfile >> "CfgVehicles" >> _class >> "displayName");
+        private _displayName = getText (configfile >> "CfgVehicles" >> _class >> "displayName");
         if (GVAR(interactionParadrop)) then {
             _ctrl lbAdd format ["%1 (%2s)", _displayName, GVAR(paradropTimeCoefficent) * ([_class] call FUNC(getSizeItem))];
         } else {

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -90,6 +90,15 @@ _itemObject setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vecto
 
 }, 1, [_itemObject]] call CBA_fnc_addPerFrameHandler;
 
+[
+    [
+        LSTRING(UnloadedItem),
+        getText (configFile >> "CfgVehicles" >> typeOf _itemObject >> "displayName"),
+        getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName")
+    ],
+    3
+] call EFUNC(common,displayTextStructured);
+
 // Invoke listenable event
 ["ace_cargoUnloaded", [_item, _vehicle, "paradrop"]] call CBA_fnc_globalEvent;
 

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -37,7 +37,7 @@ if (GVAR(interactionParadrop)) exitWith {
         [
             [
                 LSTRING(UnloadedItem),
-                getText (configFile >> "CfgVehicles" >> ([_item, typeOf _item] select IS_STRING(_item)) >> "displayName"),
+                getText (configFile >> "CfgVehicles" >> ([typeOf _item, _item] select IS_STRING(_item)) >> "displayName"),
                 getText (configFile >> "CfgVehicles" >> typeOf GVAR(interactionVehicle) >> "displayName"),
             ],
             3

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -28,9 +28,22 @@ private _ctrl = _display displayCtrl 100;
 private _selected = (lbCurSel _ctrl) max 0;
 
 if (count _loaded <= _selected) exitWith {};
-private _item = _loaded select _selected; //This can be an object or a classname string
+private _item = _loaded select _selected; // This can be an object or a classname string
 
 if (GVAR(interactionParadrop)) exitWith {
+    // If drop time is 0 don't show a progress bar
+    if (GVAR(paradropTimeCoefficent) == 0) exitWith {
+        [QGVAR(paradropItem), [_item, GVAR(interactionVehicle)]] call CBA_fnc_localEvent;
+        [
+            [
+                LSTRING(UnloadedItem),
+                getText (configFile >> "CfgVehicles" >> ([_item, typeOf _item] select IS_STRING(_item)) >> "displayName"),
+                getText (configFile >> "CfgVehicles" >> typeOf GVAR(interactionVehicle) >> "displayName"),
+            ],
+            3
+        ] call EFUNC(common,displayTextStructured);
+    };
+
     // Start progress bar - paradrop
     private _size = [_item] call FUNC(getSizeItem);
     [

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -38,7 +38,7 @@ if (GVAR(interactionParadrop)) exitWith {
             [
                 LSTRING(UnloadedItem),
                 getText (configFile >> "CfgVehicles" >> ([typeOf _item, _item] select IS_STRING(_item)) >> "displayName"),
-                getText (configFile >> "CfgVehicles" >> typeOf GVAR(interactionVehicle) >> "displayName"),
+                getText (configFile >> "CfgVehicles" >> typeOf GVAR(interactionVehicle) >> "displayName")
             ],
             3
         ] call EFUNC(common,displayTextStructured);

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -34,7 +34,7 @@ if (GVAR(interactionParadrop)) exitWith {
     // Start progress bar - paradrop
     private _size = [_item] call FUNC(getSizeItem);
     [
-        2.5 * _size,
+        GVAR(paradropTimeCoefficent) * _size,
         [_item, GVAR(interactionVehicle), ACE_player],
         {
             (_this select 0) params ["_item", "_target", "_player"];

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -34,14 +34,6 @@ if (GVAR(interactionParadrop)) exitWith {
     // If drop time is 0 don't show a progress bar
     if (GVAR(paradropTimeCoefficent) == 0) exitWith {
         [QGVAR(paradropItem), [_item, GVAR(interactionVehicle)]] call CBA_fnc_localEvent;
-        [
-            [
-                LSTRING(UnloadedItem),
-                getText (configFile >> "CfgVehicles" >> ([typeOf _item, _item] select IS_STRING(_item)) >> "displayName"),
-                getText (configFile >> "CfgVehicles" >> typeOf GVAR(interactionVehicle) >> "displayName")
-            ],
-            3
-        ] call EFUNC(common,displayTextStructured);
     };
 
     // Start progress bar - paradrop

--- a/addons/cargo/stringtable.xml
+++ b/addons/cargo/stringtable.xml
@@ -251,5 +251,11 @@
             <Polish>Nierówny lot</Polish>
             <Korean>기체가 수평이 아닙니다</Korean>
         </Key>
+        <Key ID="STR_ACE_Cargo_paradropTimeCoefficent">
+            <English>Paradrop Time Coffecient</English>
+        </Key>
+        <Key ID="STR_ACE_Cargo_paradropTimeCoefficent_description">
+            <English>Modifier for how long it takes to paradrop a cargo item.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a new setting so it's possible to modify how long it takes for cargo to unload while paradropping. If the setting is 0 the progress bar is skipped and cargo is dropped immediately.
- Show how long it's going to take to unload something in the list dialog by it's name.

Counter point to any realism concerns people might have (even though it's a setting using the current value as default): IRL the aircraft's crew would have to unstrap the cargo container, slowly and safely move it to the ramp area, attach the drop hook etc... I know that. This setting is so _filthy casuals_ don't have to make 2 minutes of flight planning and fail the first attempt anyway because the random ammo box zeus chose that day took 17.8 seconds to drop, and there was no way for the pilot to know that.