### PR TITLE
Jerry Can - only set global var on server

### DIFF
--- a/addons/refuel/functions/fnc_makeJerryCan.sqf
+++ b/addons/refuel/functions/fnc_makeJerryCan.sqf
@@ -22,7 +22,9 @@ if (isNull _target ||
     {_target isKindOf "AllVehicles"} ||
     {_target getVariable [QGVAR(jerryCan), false]}) exitWith {};
 
-[_target, _fuelAmount] call FUNC(setFuel);
+if (isServer) then {
+    [_target, _fuelAmount] call FUNC(setFuel);  // has global effects
+};
 _target setVariable [QGVAR(jerryCan), true];
 _target setVariable [QGVAR(source), _target];
 


### PR DESCRIPTION
makeJerryCan needs to run on all machines, because the interaction actions are local effects.
FUNC(setFuel) has global effects


so if someone jips, it would reset the fuel var