### PR TITLE
Fix Spotting Scope Interaction Point

### DIFF
--- a/addons/spottingscope/CfgVehicles.hpp
+++ b/addons/spottingscope/CfgVehicles.hpp
@@ -43,7 +43,7 @@ class CfgVehicles {
 
         class ACE_Actions: ACE_Actions{
             class ACE_MainActions: ACE_MainActions {
-                selection = "main_gun";
+                selection = "main_turret_axis";
                 class ACE_Pickup {
                     selection = "";
                     displayName = CSTRING(PickUp);


### PR DESCRIPTION
Close #5128
Spotting scope was using rear glass as interaction point.
New point is right on the main pivot near the center.