### PR TITLE
hide 1.71 mine detector actions

### DIFF
--- a/addons/common/CfgActions.hpp
+++ b/addons/common/CfgActions.hpp
@@ -1,0 +1,12 @@
+
+// hide mine detector actions
+class CfgActions {
+    class None;
+    class NextModeRightVehicleDisplay: None {
+        show = 0;
+    };
+
+    class ListRightVehicleDisplay: None {
+        show = 0;
+    };
+};

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -22,6 +22,7 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 #include "CfgMagazines.hpp"
 
+#include "CfgActions.hpp"
 #include "CfgMoves.hpp"
 #include "CfgVoice.hpp"
 #include "CfgUnitInsignia.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Alternative to #5147. Hide the actions instead.