### PR TITLE
Refuel for non-AllVehicle objects

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -512,6 +512,19 @@ class CfgVehicles {
         GVAR(fuelCargo) = REFUEL_INFINITE_FUEL;
     };
 
+    // Helper object for non-AllVehicles objects
+    class GVAR(helper): Helicopter_Base_F {
+        scope = 1;
+        displayName = "Refuel Helper";
+        model = "\A3\Weapons_f\empty";
+        delete ACE_Actions;
+        damageEffect = "";
+        destrType = "";
+        class HitPoints {};
+        class Turrets {};
+        class TransportItems {};
+    };
+
     /* // Barrels found in config  \
         BarrelHelper: Misc_thing 100
         BarrelBase: BarrelHelper 100

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -517,7 +517,10 @@ class CfgVehicles {
         scope = 1;
         displayName = "Refuel Helper";
         model = "\A3\Weapons_f\empty";
-        delete ACE_Actions;
+        class ACE_Actions {};
+        class ACE_SelfActions {};
+        EGVAR(cargo,hasCargo) = 0;
+        EGVAR(cargo,space) = 0;
         damageEffect = "";
         destrType = "";
         class HitPoints {};

--- a/addons/refuel/functions/fnc_checkFuel.sqf
+++ b/addons/refuel/functions/fnc_checkFuel.sqf
@@ -21,7 +21,7 @@ params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
 private _fuel = [_target] call FUNC(getFuel);
 
 [
-    5,
+    REFUEL_PROGRESS_DURATION * 2.5,
     [_unit, _target, _fuel],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -72,7 +72,7 @@ _endPosTestOffset = _startingOffset vectorAdd (_closeInUnitVector vectorMultiply
 _endPosTestOffset set [2, (_startingOffset select 2)];
 
 [
-    2,
+    REFUEL_PROGRESS_DURATION,
     [_unit, _nozzle, _target, _endPosTestOffset],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
+++ b/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
@@ -49,7 +49,7 @@ if (_nozzle getVariable [QGVAR(jerryCan), false]) exitWith {};
                 if !(isNull _rope) then {
                     ropeDestroy _rope;
                 };
-                private _helper = _target getVariable [QGVAR(helper), objNull];
+                private _helper = _nozzle getVariable [QGVAR(helper), objNull];
                 if !(isNull _helper) then {
                     deleteVehicle _helper;
                 };

--- a/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
+++ b/addons/refuel/functions/fnc_maxDistanceDropNozzle.sqf
@@ -49,6 +49,10 @@ if (_nozzle getVariable [QGVAR(jerryCan), false]) exitWith {};
                 if !(isNull _rope) then {
                     ropeDestroy _rope;
                 };
+                private _helper = _target getVariable [QGVAR(helper), objNull];
+                if !(isNull _helper) then {
+                    deleteVehicle _helper;
+                };
                 deleteVehicle _nozzle;
             } else {
                 [LSTRING(Hint_TooFar), 2, _unit] call EFUNC(common,displayTextStructured);

--- a/addons/refuel/functions/fnc_readFuelCounter.sqf
+++ b/addons/refuel/functions/fnc_readFuelCounter.sqf
@@ -19,7 +19,7 @@
 params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
 
 [
-    2,
+    REFUEL_PROGRESS_DURATION,
     [_unit, _target],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_reset.sqf
+++ b/addons/refuel/functions/fnc_reset.sqf
@@ -31,7 +31,7 @@ if !(isNil "_nozzle") then {
     if !(isNull _rope) then {
         ropeDestroy _rope;
     };
-    private _helper = _target getVariable [QGVAR(helper), objNull];
+    private _helper = _nozzle getVariable [QGVAR(helper), objNull];
     if !(isNull _helper) then {
         deleteVehicle _helper;
     };

--- a/addons/refuel/functions/fnc_reset.sqf
+++ b/addons/refuel/functions/fnc_reset.sqf
@@ -31,6 +31,10 @@ if !(isNil "_nozzle") then {
     if !(isNull _rope) then {
         ropeDestroy _rope;
     };
+    private _helper = _target getVariable [QGVAR(helper), objNull];
+    if !(isNull _helper) then {
+        deleteVehicle _helper;
+    };
 
     {
         [QGVAR(resetLocal), [_x, _nozzle], _x] call CBA_fnc_targetEvent;

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -46,7 +46,7 @@ if (isNull _nozzle || {_source != _target}) exitWith {false};
         if !(isNull _rope) then {
             ropeDestroy _rope;
         };
-        private _helper = _target getVariable [QGVAR(helper), objNull];
+        private _helper = _nozzle getVariable [QGVAR(helper), objNull];
         if !(isNull _helper) then {
             deleteVehicle _helper;
         };

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -24,7 +24,7 @@ private _source = _nozzle getVariable QGVAR(source);
 if (isNull _nozzle || {_source != _target}) exitWith {false};
 
 [
-    2,
+    REFUEL_PROGRESS_DURATION,
     [_unit, _nozzle, _target],
     {
         params ["_args"];
@@ -45,6 +45,10 @@ if (isNull _nozzle || {_source != _target}) exitWith {false};
         private _rope = _nozzle getVariable [QGVAR(rope), objNull];
         if !(isNull _rope) then {
             ropeDestroy _rope;
+        };
+        private _helper = _target getVariable [QGVAR(helper), objNull];
+        if !(isNull _helper) then {
+            deleteVehicle _helper;
         };
         deleteVehicle _nozzle;
 

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -39,7 +39,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
         _endPosOffset = _endPosOffset select 0;
     };
     [
-        2,
+        REFUEL_PROGRESS_DURATION,
         [_unit, _target, _endPosOffset],
         {
             params ["_args"];
@@ -53,11 +53,22 @@ if (isNull _nozzle) then { // func is called on fuel truck
             _newNozzle attachTo [_unit, [-0.02,0.05,-0.12], "righthandmiddle1"];
             _unit setVariable [QGVAR(nozzle), _newNozzle, true];
 
-            if (_target isKindOf "AllVehicles") then {
-                // Currently ropeCreate requires its first parameter to be a real vehicle
-                private _rope = ropeCreate [_target, _endPosOffset, _newNozzle, [0, -0.20, 0.12], REFUEL_HOSE_LENGTH];
-                _newNozzle setVariable [QGVAR(rope), _rope, true];
+            private _ropeTarget = _target;
+            if (!(_target isKindOf "AllVehicles")) then {
+                private _helper = QGVAR(helper) createVehicle [0,0,0];
+                [QEGVAR(common,hideObjectGlobal), [_helper, true]] call CBA_fnc_serverEvent;
+                if ((getText (configFile >> "CfgVehicles" >> typeOf _target >> "simulation")) isEqualTo "thingX") then {
+                    _helper attachTo [_target, [0,0,0]];
+                } else {
+                    _helper setPosWorld (getPosWorld _target);
+                    _helper setDir (getDir _target);
+                    _helper setVectorUp (vectorUp _target);
+                };
+                _target setVariable [QGVAR(helper), _helper, true];
+                _ropeTarget = _helper;
             };
+            private _rope = ropeCreate [_ropeTarget, _endPosOffset, _newNozzle, [0, -0.20, 0.12], REFUEL_HOSE_LENGTH];
+            _newNozzle setVariable [QGVAR(rope), _rope, true];
             _newNozzle setVariable [QGVAR(attachPos), _endPosOffset, true];
             _newNozzle setVariable [QGVAR(source), _target, true];
 
@@ -93,7 +104,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
     ] call EFUNC(common,progressBar);
 } else { // func is called on muzzle either connected or on ground
     [
-        2,
+        REFUEL_PROGRESS_DURATION,
         [_unit, _nozzle],
         {
             params ["_args"];

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -64,7 +64,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
                     _helper setDir (getDir _target);
                     _helper setVectorUp (vectorUp _target);
                 };
-                _target setVariable [QGVAR(helper), _helper, true];
+                _newNozzle setVariable [QGVAR(helper), _helper, true];
                 _ropeTarget = _helper;
             };
             private _rope = ropeCreate [_ropeTarget, _endPosOffset, _newNozzle, [0, -0.20, 0.12], REFUEL_HOSE_LENGTH];

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -19,7 +19,7 @@
 params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 
 [
-    2,
+    REFUEL_PROGRESS_DURATION,
     [_unit, _nozzle],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -19,7 +19,7 @@
 params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 
 [
-    2,
+    REFUEL_PROGRESS_DURATION,
     [_unit, _nozzle],
     {
         params ["_args"];

--- a/addons/refuel/script_component.hpp
+++ b/addons/refuel/script_component.hpp
@@ -19,6 +19,7 @@
 #define REFUEL_INFINITE_FUEL -10
 #define REFUEL_ACTION_DISTANCE 7
 #define REFUEL_HOSE_LENGTH 12
+#define REFUEL_PROGRESS_DURATION 2
 
 #define REFUEL_HOLSTER_WEAPON \
     _unit setVariable [QGVAR(selectedWeaponOnRefuel), currentWeapon _unit]; \

--- a/addons/repair/CfgEventHandlers.hpp
+++ b/addons/repair/CfgEventHandlers.hpp
@@ -37,7 +37,7 @@ class Extended_InitPost_EventHandlers {
     class Helicopter {
         class ADDON {
             init = QUOTE(_this call DFUNC(addRepairActions));
-            exclude[] = {QEGVAR(fastroping,helper), "ACE_friesBase"};
+            exclude[] = {QEGVAR(fastroping,helper), "ACE_friesBase", QEGVAR(refuel,helper)};
         };
     };
     class Plane {


### PR DESCRIPTION
**When merged this pull request will:**
- Add helper.p3d from fastroping
- Create helper object for non-AllVehicles objects, allowing refuel to be configured for more stuff (sling-loadable barrels for example)
- Un-magic refuel progress timer value

This adds a workaround which makes it possible to have a fuel hose (an arma rope) coming from a non-physx object (limitation of ropeCreate) by using an invisible helper object which the rope is connected to instead - such that it looks like it connects to the actual object.

This has been used for sling-loadable fuel barrels for a number of weeks with no issues. These can be found here: https://github.com/uksf/modpack/blob/master/addons/vehicles/CfgVehicles.hpp#L102