### PR TITLE
1.70 FCS - Remove ACE_FCS from most vics

### DIFF
--- a/addons/fcs/CfgOptics.hpp
+++ b/addons/fcs/CfgOptics.hpp
@@ -11,110 +11,13 @@
         h = 0; \
     };
 
+class RscText;
 class RscControlsGroup;
 class RscMapControl;
 
 class RscInGameUI {
     class RscUnitInfo;
-    class RscUnitInfo_AH64D_gunner {
-        controls[] = {"CA_Distance","ACE_CA_Distance"};
-        MACRO_RANGEFINDER
-    };
-    class RscWeaponRangeFinder {
-        controls[] = {"CA_Distance","ACE_CA_Distance"};
-        MACRO_RANGEFINDER
-    };
 
-    class RscWeaponRangeFinderPAS13 {
-        MACRO_RANGEFINDER
-    };
-    class RscOptics_Rangefinder: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscWeaponRangeFinderMAAWS {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscWeaponRangeFinderAbramsCom {
-        controls[] = {"CA_Distance","ACE_CA_Distance"};
-        MACRO_RANGEFINDER
-    };
-    class RscWeaponRangeFinderAbramsGun {
-        controls[] = {"CA_Distance","ACE_CA_Distance"};
-        MACRO_RANGEFINDER
-    };
-    class RscWeaponRangeFinderStrykerMGSGun {
-        controls[] = {"CA_Distance","ACE_CA_Distance"};
-        MACRO_RANGEFINDER
-    };
-    class RscOptics_crows: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_strider_commander {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-
-    class RscWeaponRangeZeroing: RscUnitInfo {
-        controls[] = {"CA_Zeroing", "CA_DistanceText", "CA_Distance","ACE_CA_Distance", "ACE_Rangehelper"};
-        MACRO_RANGEFINDER
-    };
-    class RscOptics_sos: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_nightstalker: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_tws: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_punisher {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_tws_sniper: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_SDV_periscope {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
     class RscOptics_Heli_Attack_02_gunner: RscUnitInfo {
         class CA_IGUI_elements_group: RscControlsGroup {
             class controls {
@@ -122,7 +25,7 @@ class RscInGameUI {
             };
         };
     };
-     class Rsc_ACE_Helo_UI_Turret: RscUnitInfo {
+    class Rsc_ACE_Helo_UI_Turret: RscUnitInfo { // RscOptics_Heli_Attack_01_gunner
         onLoad = "[""onLoad"",_this,""RscUnitInfo"",'IGUI'] call    (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable ['ACE_dlgRangefinder', _this select 0]; ((_this select 0) displayCtrl 151) ctrlSetTextColor [0, 0, 0, 0];";
         class CA_IGUI_elements_group: RscControlsGroup {
             class controls {
@@ -130,103 +33,30 @@ class RscInGameUI {
             };
         };
     };
-    class RscOptics_Heli_Attack_01_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_UAV_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_UGV_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
+
     class RscOptics_APC_Tracked_01_gunner: RscUnitInfo {
         class CA_IGUI_elements_group: RscControlsGroup {
             class controls {
-                MACRO_RANGEFINDER
+                class CA_Distance: RscText {};
             };
         };
     };
-    class RscOptics_APC_Tracked_03_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_APC_Wheeled_01_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_APC_Wheeled_03_commander: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_APC_Wheeled_03_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_MBT_01_commander: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_MBT_01_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_MBT_02_commander: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_MBT_02_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-    class RscOptics_MBT_03_gunner: RscUnitInfo {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
-            };
-        };
-    };
-
-    // marksmen
-    class RscOptics_LaserDesignator_02 {
-        class CA_IGUI_elements_group: RscControlsGroup {
-            class controls {
-                MACRO_RANGEFINDER
+    class ACE_RscOptics_APC_Tracked_01_gunner: RscOptics_APC_Tracked_01_gunner {
+        class CA_IGUI_elements_group: CA_IGUI_elements_group {
+            class controls: controls {
+                // MACRO_RANGEFINDER + modify IDC of CA_Distance
+                class CA_Distance: CA_Distance {
+                    idc = 151;
+                };
+                class ACE_CA_Distance: CA_Distance {
+                    idc = 1713151;
+                    text = "----";
+                };
+                class ACE_Rangehelper: RscMapControl {
+                    onDraw = "((ctrlParent (_this select 0)) displayCtrl 1713151) ctrlShow (cameraView == 'GUNNER');";
+                    w = 0;
+                    h = 0;
+                };
             };
         };
     };

--- a/addons/fcs/CfgVehicles.hpp
+++ b/addons/fcs/CfgVehicles.hpp
@@ -49,9 +49,6 @@ class CfgVehicles {
         class Turrets {
             class MainTurret: NewTurret {
                 GVAR(Enabled) = 1; // all tracked vehicles get one by default
-                class Turrets {
-                    class CommanderOptics;
-                };
             };
         };
     };
@@ -60,231 +57,52 @@ class CfgVehicles {
         class Turrets {
             class MainTurret: NewTurret {
                 GVAR(Enabled) = 1; // all tracked vehicles get one by default
-                class Turrets {
-                    class CommanderOptics;//: CommanderOptics {};
-                };
             };
         };
-    };
-
-    class Car_F: Car {
-        class Turrets {
-            class MainTurret;
-        };
-    };
-
-    class Wheeled_APC_F: Car_F {
-        class Turrets {
-            class MainTurret: NewTurret {
-                class Turrets {
-                    class CommanderOptics;//: CommanderOptics {};
-                };
-            };
-        };
-    };
-
-    class MRAP_01_base_F: Car_F {};
-
-    class MRAP_01_gmg_base_F: MRAP_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
-
-    class MRAP_01_hmg_base_F: MRAP_01_gmg_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
-    };
-
-    class B_MRAP_01_F: MRAP_01_base_F {
-        class Turrets;
-    };
-
-    class MRAP_02_base_F: Car_F {};
-
-    class MRAP_02_hmg_base_F: MRAP_02_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
-
-    class MRAP_02_gmg_base_F: MRAP_02_hmg_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
-    };
-
-    class O_MRAP_02_F: MRAP_02_base_F {
-        class Turrets;
-    };
-
-    class MRAP_03_base_F: Car_F {
-        class Turrets: Turrets {
-            class CommanderTurret: MainTurret {
-                GVAR(Enabled) = 0;
-            };
-        };
-    };
-
-    class MRAP_03_hmg_base_F: MRAP_03_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-            class CommanderTurret: CommanderTurret {
-                GVAR(Enabled) = 0;
-            };
-        };
-    };
-
-    class MRAP_03_gmg_base_F: MRAP_03_hmg_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-            class CommanderTurret: CommanderTurret {};
-        };*/
-    };
-
-    class APC_Wheeled_01_base_F: Wheeled_APC_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
-        };*/
-    };
-
-    class B_APC_Wheeled_01_base_F: APC_Wheeled_01_base_F {};
-
-    class B_APC_Wheeled_01_cannon_F: B_APC_Wheeled_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
-
-    class APC_Wheeled_02_base_F: Wheeled_APC_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-
-            // class CommanderOptics: CommanderOptics {};
-        };
-    };
-
-    class APC_Wheeled_03_base_F: Wheeled_APC_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-
-                /*class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };*/
-            };
-        };
-    };
-
-    class I_APC_Wheeled_03_base_F: APC_Wheeled_03_base_F {};
-
-    class I_APC_Wheeled_03_cannon_F: I_APC_Wheeled_03_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
     };
 
     class APC_Tracked_01_base_F: Tank_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets;
-            };
-        };*/
-    };
-
-    class B_APC_Tracked_01_base_F: APC_Tracked_01_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
-    };
-
-    class B_APC_Tracked_01_rcws_F: B_APC_Tracked_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MaxDistance) = 2000;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
+                GVAR(Enabled) = 0;
             };
-            class CommanderOptics: CommanderOptics {};
         };
     };
 
-    class B_APC_Tracked_01_CRV_F: B_APC_Tracked_01_base_F {
-        //GVAR(Enabled) = 0; @todo
-    };
+    class B_APC_Tracked_01_base_F: APC_Tracked_01_base_F {};
 
     class B_APC_Tracked_01_AA_F: B_APC_Tracked_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
+                GVAR(Enabled) = 1;
+                turretinfotype = "ACE_RscOptics_APC_Tracked_01_gunner";
+                GVAR(MaxDistance) = 2000;
                 discreteDistance[] = {};
                 discreteDistanceInitIndex = 0;
                 magazines[] += {"ACE_120Rnd_35mm_ABM_shells_Tracer_Red"};
-
-                /*class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };*/
             };
         };
     };
 
     class APC_Tracked_02_base_F: Tank_F {
-        /*class Turrets: Turrets {
+        class Turrets: Turrets {
             class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
+                GVAR(Enabled) = 0;
             };
-        };*/
+        };
     };
 
     class O_APC_Tracked_02_base_F: APC_Tracked_02_base_F {};
-
-    class O_APC_Tracked_02_cannon_F: O_APC_Tracked_02_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
-    };
-
+    
     class O_APC_Tracked_02_AA_F: O_APC_Tracked_02_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
+                GVAR(Enabled) = 1;
+                turretinfotype = "ACE_RscOptics_APC_Tracked_01_gunner";
+                GVAR(MaxDistance) = 2000;
+                discreteDistance[] = {};
+                discreteDistanceInitIndex = 0;
                 magazines[] += {"ACE_120Rnd_35mm_ABM_shells_Tracer_Green"};
-
-                /*class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };*/
             };
         };
     };
@@ -292,12 +110,7 @@ class CfgVehicles {
     class APC_Tracked_03_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-
-                /*class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };*/
+                GVAR(Enabled) = 0;
             };
         };
     };
@@ -305,59 +118,7 @@ class CfgVehicles {
     class MBT_01_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-
-                /*class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };*/
-            };
-        };
-    };
-
-    class B_MBT_01_base_F: MBT_01_base_F {};
-
-    class B_MBT_01_cannon_F: B_MBT_01_base_F {};
-
-    class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        GVAR(Enabled) = 1;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
-                    };
-                };
-            };
-        };
-    };
-
-    class MBT_01_arty_base_F: MBT_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
                 GVAR(Enabled) = 0;
-
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        GVAR(Enabled) = 1;
-                        GVAR(MaxDistance) = 2000;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
-                    };
-                };
-            };
-        };
-    };
-
-    class MBT_01_mlrs_base_F: MBT_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
-                //class Turrets;
             };
         };
     };
@@ -365,78 +126,15 @@ class CfgVehicles {
     class MBT_02_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        GVAR(Enabled) = 1;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
-                    };
-                };
-            };
-        };
-    };
-
-    class MBT_02_arty_base_F: MBT_02_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
                 GVAR(Enabled) = 0;
-
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        GVAR(Enabled) = 1;
-                        GVAR(MaxDistance) = 2000;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
-                    };
-                };
             };
         };
     };
-
+    
     class MBT_03_base_F: Tank_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        GVAR(Enabled) = 1;
-                        discreteDistance[] = {};
-                        discreteDistanceInitIndex = 0;
-                    };
-                };
-            };
-        };
-    };
-
-    // SHIPS
-    class Ship: AllVehicles {
-        class Turrets {
-            class MainTurret;
-        };
-    };
-
-    class Ship_F: Ship {};
-
-    class Boat_F: Ship_F {};
-
-    class Boat_Armed_01_base_F: Boat_F {
-        class Turrets: Turrets {
-            class FrontTurret: NewTurret {
-                GVAR(enabled) = 1;
-                GVAR(minDistance) = 100;
-                GVAR(maxDistance) = 2000;
-                GVAR(distanceInterval) = 5;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-            class RearTurret: FrontTurret {
-                discreteDistance[] = {100,200,300,400,600,800,1000,1200};  // Originally inherited from FrontTurret
-                discreteDistanceInitIndex = 4;
+                GVAR(Enabled) = 0;
             };
         };
     };
@@ -450,51 +148,7 @@ class CfgVehicles {
         };
     };
 
-    class Plane: Air {};
-
-    class Helicopter_Base_F: Helicopter {
-        class Turrets: Turrets {
-            class CopilotTurret;
-        };
-    };
-
-    class Helicopter_Base_H: Helicopter_Base_F {
-        class Turrets: Turrets {
-            class CopilotTurret;
-        };
-    };
-
-    class Heli_Light_01_base_F: Helicopter_Base_H {
-        /*class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {};
-        };*/
-    };
-
-    class Heli_Light_01_unarmed_base_F: Heli_Light_01_base_F {};
-
-    class B_Heli_Light_01_F: Heli_Light_01_unarmed_base_F {
-        /*class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {};
-        };*/
-    };
-
-    class Heli_Light_01_armed_base_F: Heli_Light_01_base_F {
-        /*class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {};
-        };*/
-    };
-
-    class Heli_Light_02_base_F: Helicopter_Base_H {
-        /*class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {};
-        };*/
-    };
-
-    class Plane_Base_F: Plane {
-        class Turrets {
-            class CopilotTurret;
-        };
-    };
+    class Helicopter_Base_F: Helicopter {};
 
     class Heli_Attack_01_base_F: Helicopter_Base_F {
         class Turrets: Turrets {
@@ -510,82 +164,6 @@ class CfgVehicles {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
                 GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
-
-    class Heli_Transport_01_base_F: Helicopter_Base_H {
-        /*class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {};
-            class MainTurret: MainTurret {};
-            class RightDoorGun: MainTurret {};
-        };*/
-    };
-
-    class Heli_Transport_02_base_F: Helicopter_Base_H {
-        /*class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {};
-        };*/
-    };
-
-    class Heli_light_03_base_F;
-    class I_Heli_light_03_base_F: Heli_light_03_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
-    };
-    class I_Heli_light_03_F: Heli_light_03_base_F {
-        /*class Turrets: Turrets {
-            class MainTurret: MainTurret {};
-        };*/
-    };
-
-    class Plane_CAS_01_base_F: Plane_Base_F {
-        class Turrets;
-    };
-
-    class Plane_CAS_02_base_F: Plane_Base_F {
-        class Turrets;
-    };
-
-    class Plane_Fighter_03_base_F: Plane_Base_F {
-        class Turrets;
-    };
-
-    // static weapons.
-    class StaticWeapon: LandVehicle {
-        class Turrets {
-            class MainTurret; //: NewTurret {};
-        };
-    };
-
-    class StaticMGWeapon: StaticWeapon {};
-
-    class HMG_01_base_F: StaticMGWeapon {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MinDistance) = 200;
-                GVAR(MaxDistance) = 2000;
-                GVAR(DistanceInterval) = 5;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
-
-    class StaticGrenadeLauncher: StaticWeapon {};
-    class GMG_TriPod: StaticGrenadeLauncher {};
-
-    class GMG_01_base_F: GMG_TriPod {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                GVAR(MinDistance) = 200;
-                GVAR(MaxDistance) = 2000;
-                GVAR(DistanceInterval) = 5;
                 discreteDistance[] = {};
                 discreteDistanceInitIndex = 0;
             };

--- a/addons/fcs/CfgWeapons.hpp
+++ b/addons/fcs/CfgWeapons.hpp
@@ -1,15 +1,6 @@
 
 class CfgWeapons {
-    // disable locking, so it doesn't interfere with our system
     class CannonCore;
-    class cannon_120mm: CannonCore {
-        canLock = 0;
-        ballisticsComputer = 0;
-    };
-    class autocannon_Base_F: CannonCore {
-        canLock = 0;
-        ballisticsComputer = 0;
-    };
     class autocannon_35mm: CannonCore {
         canLock = 0;
         ballisticsComputer = 4; //was "4 + 2", 2 is for manual zeroing, 4 is for the lead indicator - https://community.bistudio.com/wiki/A3_Locking_Review#ballisticsComputer

--- a/addons/fcs/XEH_postInit.sqf
+++ b/addons/fcs/XEH_postInit.sqf
@@ -21,3 +21,7 @@ if (!hasInterface) exitWith {};
 
 // Register event for global updates
 [QGVAR(forceUpdate), {[ACE_player] call FUNC(onForceUpdate)}] call CBA_fnc_addEventHandler;
+
+#ifdef DEBUG_MODE_FULL
+call compile preprocessFileLineNumbers QPATHTOF(functions\dev_debugConfigs.sqf);
+#endif

--- a/addons/fcs/functions/dev_debugConfigs.sqf
+++ b/addons/fcs/functions/dev_debugConfigs.sqf
@@ -35,6 +35,11 @@ private _problemUIs = [];
                 if (_fcsMsg != "") then {diag_log text format ["%1: %2", _vehicleType, _fcsMsg];};
             };
 
+            if (_vanillaFCS) then {
+                private _dd = getArray (_config >> "discreteDistance");
+                if (_dd isEqualTo []) exitWith {diag_log format ["%1->%2: discreteDistance with vanillaFCS [%3]", _vehicleType, _turret, _config];};
+            };
+
             if (true) then {
                 private _turretInfo = getText (_config >> "turretInfoType");
                 private _infoConfig = configFile >> "RscInGameUI" >> _turretInfo;

--- a/addons/fcs/functions/dev_debugConfigs.sqf
+++ b/addons/fcs/functions/dev_debugConfigs.sqf
@@ -1,0 +1,83 @@
+// PabstMirror
+#include "script_component.hpp"
+
+diag_log text format ["[ACE_FCS] ---------------"];
+private _vehicles = configProperties [configFile >> "CfgVehicles", "(isClass _x) && {2 == getNumber (_x >> 'scope')}", true];
+private _problemUIs = [];
+{
+    private _vehicleType = configName _x;
+    {
+        private _turret = _x;
+        private _config = [_vehicleType, _turret] call CBA_fnc_getTurret;
+        if (!isNull _config) then {
+            private _aceFCS = (getNumber (_config >> "ACE_FCS_Enabled")) == 1;
+
+            private _vanillaFCS = false;
+            private _weapons = getArray (_config >> "weapons");
+            {
+                private _weapon = _x;
+                private _ballisticComputer = getNumber (configFile >> "CfgWeapons" >> _weapon >> "ballisticsComputer");
+                _ballisticComputer = [_ballisticComputer, 5] call ace_common_fnc_toBin;
+                if ((_ballisticComputer select [(count _ballisticComputer) - 5, 1]) == "1") then {
+                    _vanillaFCS = true;
+                    if (_aceFCS) then {diag_log text format ["%1 -> %2:  ACE FCS Enabled CONFLICTS with vanilla FCS [%3]", _vehicleType, _weapon, _ballisticComputer];};
+                };
+            } forEach _weapons;
+
+            if (!(_weapons isEqualTo [])) then {
+                private _fcsMsg = switch (true) do {
+                // case ((!_vanillaFCS) && {!_aceFCS}): {"No FCS"};
+                // case ((_vanillaFCS) && {_aceFCS}): {"CONFLICT FCS"};
+                // case (_vanillaFCS): {"Vanilla FCS"};
+                // case (_aceFCS): {"ACE FCS"};
+                default {""};
+                };
+                if (_fcsMsg != "") then {diag_log text format ["%1: %2", _vehicleType, _fcsMsg];};
+            };
+
+            if (true) then {
+                private _turretInfo = getText (_config >> "turretInfoType");
+                private _infoConfig = configFile >> "RscInGameUI" >> _turretInfo;
+                if (!isNull _infoConfig) then {
+                    private _idcList = [];
+
+                    private _fncGetIDCS = {
+                        params ["_subConfig"];
+                        if (!isClass _subConfig) exitWith {diag_log "err";};
+                        private _controlsArray = getArray (_subConfig >> "controls");
+                        {
+                            [_subConfig >> _x] call _fncGetIDCS;
+                        } forEach _controlsArray;
+                        private _controlsConfig = configProperties [(_subConfig >> "controls"), "isClass _x", true];
+                        {
+                            [_x] call _fncGetIDCS;
+                        } forEach _controlsConfig;
+                        _idcList pushBack getNumber (_subConfig >> "idc");
+                    };
+                    [_infoConfig] call _fncGetIDCS;
+
+                    if (_aceFCS && {!(1713151 in _idcList)}) then {
+                        _problemUIs pushBackUnique format ["%1: ACE_FCS, but missing ACE_CA_DIST", _turretInfo];
+                    };
+                    if (_aceFCS && {(198 in _idcList)}) then {
+                        _problemUIs pushBackUnique format ["%1: ACE_FCS, but NEW Lazr CA_DIST", _turretInfo, _vehicleType];
+                    };
+                    if ((!_aceFCS) && {(1713151 in _idcList)}) then {
+                        _problemUIs pushBackUnique format ["%1: Not ACE but has ACE_CA_DIST", _turretInfo, _vehicleType];
+                    };
+                    if (_vanillaFCS && {!(198 in _idcList)}) then {
+                        _problemUIs pushBackUnique format ["%1: vanillaFCS but missing NEW Lazr CA_DIST [just a warning]", _turretInfo, _vehicleType];
+                    };
+                };
+            };
+        };
+    } forEach [[0],[0,0]];
+} forEach _vehicles;
+
+_problemUIs sort true;
+
+diag_log text format ["[ACE_FCS] ------- Problem UIs --------"];
+{
+    diag_log text format ["- %1", _x];
+} forEach _problemUIs;
+diag_log text format ["[ACE_FCS] ---------------"];

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -451,6 +451,11 @@ class CfgVehicles {
 
     class rhs_2s3tank_base : Tank_F {
         EGVAR(refuel,fuelCapacity) = 830;
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                EGVAR(fcs,enabled) = 0;
+            };
+        };
     };
 
     class OTR21_Base : Truck_F {


### PR DESCRIPTION
Right now 1.70 RC has the new FCS system
In some quick testing it's fairly close to ace's system.
New "Laze Target" button 
- just like ace you now have to hit the button to get a range in most things like the handheld RangeFinder
- Their moving target calculations seem to be using some magic based off of looking at the velocity of the cursorTarget instead of using real relative movement of the aim point like ace does, but it's not that bad imho.

There is a major conflict from fcs doing
```
discreteDistance[] = {};
discreteDistanceInitIndex = 0;
```
which seems to mess up their FCS and delete the projectile and cause some bizarre script errors in overpressure and winddeflection.
```
getPosASL _projectile=[2492.92,5692.51,-1.#IND], vectorDir _projectile=[-1.#IND,-1.#IND,-1.#IND]
```

This PR removes ace_fcs from all vanilla vics that have the new system.
The only 4 left that don't are the 2 AA canons and 2 attack choppers.

The other option is disabling vanilla FCS on vanilla weapons and keeping ace's fcs, but that cause more compatibility issues.