### PR TITLE
SQF Lint Cleanup Pass

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_readAmmoDataFromConfig.sqf
+++ b/addons/advanced_ballistics/functions/fnc_readAmmoDataFromConfig.sqf
@@ -26,7 +26,7 @@
 
 TRACE_1("Reading Ammo Config",_this);
 private ["_ammo", "_airFriction", "_caliber", "_bulletLength", "_bulletMass", "_transonicStabilityCoef", "_dragModel", "_ballisticCoefficients", "_velocityBoundaries", "_atmosphereModel", "_ammoTempMuzzleVelocityShifts", "_muzzleVelocityTable", "_barrelLengthTable", "_result"];
-_ammoConfig = configFile >> "CfgAmmo" >> _this;
+private _ammoConfig = configFile >> "CfgAmmo" >> _this;
 
 _airFriction = getNumber(_ammoConfig >> "airFriction");
 _caliber = getNumber(_ammoConfig >> "ACE_caliber");

--- a/addons/advanced_ballistics/functions/fnc_readWeaponDataFromConfig.sqf
+++ b/addons/advanced_ballistics/functions/fnc_readWeaponDataFromConfig.sqf
@@ -30,6 +30,6 @@ private _barrelLength = getNumber(_weaponConfig >> "ACE_barrelLength");
 
 private _result = [_barrelTwist, _twistDirection, _barrelLength];
 
-uiNamespace setVariable [format[QGVAR(%1), _weapon], _result];
+uiNamespace setVariable [format[QGVAR(%1), _this], _result];
 
 _result

--- a/addons/advanced_fatigue/functions/fnc_handlePlayerChanged.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handlePlayerChanged.sqf
@@ -54,7 +54,6 @@ GVAR(peakPower)       = VO2MAX_STRENGTH * GVAR(VO2MaxPower);
 
 GVAR(ae1PathwayPower) = GVAR(peakPower) / (13.3 + 16.7 + 113.3) * 13.3 * ANTPERCENT ^ 1.28 * 1.362;
 GVAR(ae2PathwayPower) = GVAR(peakPower) / (13.3 + 16.7 + 113.3) * 16.7 * ANTPERCENT ^ 1.28 * 1.362;
-GVAR(anPathwayPower)  = GVAR(peakPower) - _ae1PathwayPower - _ae2PathwayPower;
 
 GVAR(ppeBlackoutLast) = 100;
 GVAR(lastBreath)      = 0;

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -115,7 +115,7 @@ addMissionEventHandler ["Draw3D", { // Blue is predicted before throw, red is re
         drawIcon3D ["\a3\ui_f\data\gui\cfg\hints\icon_text\group_1_ca.paa", [0,0,1,1], _newTrajAGL, 1, 1, 0, "", 2];
     } forEach GVAR(predictedPath);
     {
-        _newTrajAGL = _x;
+        private _newTrajAGL = _x;
         drawIcon3D ["\a3\ui_f\data\gui\cfg\hints\icon_text\group_1_ca.paa", [1,0,0,1], _newTrajAGL, 1, 1, 0, "", 2];
     } forEach GVAR(flightPath)
 }];

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -115,8 +115,7 @@ addMissionEventHandler ["Draw3D", { // Blue is predicted before throw, red is re
         drawIcon3D ["\a3\ui_f\data\gui\cfg\hints\icon_text\group_1_ca.paa", [0,0,1,1], _newTrajAGL, 1, 1, 0, "", 2];
     } forEach GVAR(predictedPath);
     {
-        private _newTrajAGL = _x;
-        drawIcon3D ["\a3\ui_f\data\gui\cfg\hints\icon_text\group_1_ca.paa", [1,0,0,1], _newTrajAGL, 1, 1, 0, "", 2];
+        drawIcon3D ["\a3\ui_f\data\gui\cfg\hints\icon_text\group_1_ca.paa", [1,0,0,1], _x, 1, 1, 0, "", 2];
     } forEach GVAR(flightPath)
 }];
 #endif

--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -57,7 +57,6 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
     _actionID = _unit addAction [format ["<t color='#FF0000'>%1</t>", localize LSTRING(CancelAction)], {GVAR(placeAction) = PLACE_CANCEL}];
 
     //Display to show virtual object:
-    private [];
     _model = getText (configFile >> "CfgAmmo" >> _itemVehClass >> "model");
     if (_model == "") then {
         _model = getText (configFile >> "CfgVehicles" >> _itemVehClass >> "model");

--- a/addons/attach/functions/fnc_canDetach.sqf
+++ b/addons/attach/functions/fnc_canDetach.sqf
@@ -21,7 +21,7 @@ TRACE_2("params",_attachToVehicle,_unit);
 
 if ((vehicle _unit) != _unit) exitWith {false};
 
-_attachedList = _attachToVehicle getVariable [QGVAR(attached), []];
+private _attachedList = _attachToVehicle getVariable [QGVAR(attached), []];
 if ((count _attachedList) == 0) exitWith {false};
 
 private ["_inRange"];

--- a/addons/captives/functions/fnc_doEscortCaptive.sqf
+++ b/addons/captives/functions/fnc_doEscortCaptive.sqf
@@ -30,7 +30,7 @@ if (_state) then {
     _unit setVariable [QGVAR(escortedUnit), _target, true];
 
     //Add Actionmenu to release captive
-    _actionID = _unit addAction [format ["<t color='#FF0000'>%1</t>", localize LSTRING(StopEscorting)],
+    private _actionID = _unit addAction [format ["<t color='#FF0000'>%1</t>", localize LSTRING(StopEscorting)],
     {[(_this select 0), ((_this select 0) getVariable [QGVAR(escortedUnit), objNull]), false] call FUNC(doEscortCaptive);},
     nil, 20, false, true, "", QUOTE(!isNull (GETVAR(_target,QGVAR(escortedUnit),objNull)))];
 

--- a/addons/captives/functions/fnc_handleAnimChangedHandcuffed.sqf
+++ b/addons/captives/functions/fnc_handleAnimChangedHandcuffed.sqf
@@ -23,7 +23,7 @@ if (_unit == (vehicle _unit)) then {
         [_unit, "ACE_AmovPercMstpScapWnonDnon", 1] call EFUNC(common,doAnimation);
     };
 } else {
-    _turretPath = [];
+    private _turretPath = [];
     {
         _x params ["_xUnit", "", "", "_xTurretPath"];
         if (_unit == _xUnit) exitWith {_turretPath = _xTurretPath};

--- a/addons/captives/functions/fnc_handleGetIn.sqf
+++ b/addons/captives/functions/fnc_handleGetIn.sqf
@@ -31,7 +31,7 @@ if (local _unit) then {
 
     if (_unit getVariable [QGVAR(isHandcuffed), false]) then {
         //Need to force animation for FFV turrets
-        _turretPath = [];
+        private _turretPath = [];
         {
             _x params ["_xUnit", "", "", "_xTurretPath"];
             if (_unit == _xUnit) exitWith {_turretPath = _xTurretPath};

--- a/addons/captives/functions/fnc_handleRespawn.sqf
+++ b/addons/captives/functions/fnc_handleRespawn.sqf
@@ -46,7 +46,7 @@ if (_respawn > 3) then {
     };
     [_unit, "setCaptive", QGVAR(Surrendered), false] call EFUNC(common,statusEffect_set);
 
-    if (_oldUnit getVariable [QGVAR(isEscorting), false]) then {
-        _oldUnit setVariable [QGVAR(isEscorting), false, true];
+    if (_unit getVariable [QGVAR(isEscorting), false]) then {
+        _unit setVariable [QGVAR(isEscorting), false, true];
     };
 };

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -458,8 +458,8 @@ GVAR(deviceKeyCurrentIndex) = -1;
 ["ACE3 Equipment", QGVAR(cycleDevice), (localize "STR_ACE_Common_cycleHandheldDevices"), {
     [1] call FUNC(deviceKeyFindValidIndex);
     if (GVAR(deviceKeyCurrentIndex) == -1) exitWith {false};
-    _displayName = ((GVAR(deviceKeyHandlingArray) select GVAR(deviceKeyCurrentIndex)) select 0);
-    _iconImage = ((GVAR(deviceKeyHandlingArray) select GVAR(deviceKeyCurrentIndex)) select 1);
+    private _displayName = ((GVAR(deviceKeyHandlingArray) select GVAR(deviceKeyCurrentIndex)) select 0);
+    private _iconImage = ((GVAR(deviceKeyHandlingArray) select GVAR(deviceKeyCurrentIndex)) select 1);
     [_displayName, _iconImage] call FUNC(displayTextPicture);
     true
 },

--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -111,7 +111,7 @@ if (isMultiplayer) then {
 
             _addons = _addons - GVAR(ServerAddons);
             if !(_addons isEqualTo []) then {
-                _errorMsg = format ["Client/Server Addon Mismatch. Client has extra addons: %1.",_addons];
+                private _errorMsg = format ["Client/Server Addon Mismatch. Client has extra addons: %1.",_addons];
 
                 ERROR(_errorMsg);
 

--- a/addons/common/functions/fnc_deviceKeyFindValidIndex.sqf
+++ b/addons/common/functions/fnc_deviceKeyFindValidIndex.sqf
@@ -28,7 +28,7 @@ if (_searchOffsetOrName isEqualType "") then {
     } forEach GVAR(deviceKeyHandlingArray);
 } else {
     if (count GVAR(deviceKeyHandlingArray) > 0) then {
-        _baseIndex = [GVAR(deviceKeyCurrentIndex) + _searchOffsetOrName, 0] select (GVAR(deviceKeyCurrentIndex) == -1);
+        private _baseIndex = [GVAR(deviceKeyCurrentIndex) + _searchOffsetOrName, 0] select (GVAR(deviceKeyCurrentIndex) == -1);
 
         for "_offset" from _baseIndex to (count GVAR(deviceKeyHandlingArray) - 1 + _baseIndex) do {
             private _realIndex = _offset % (count GVAR(deviceKeyHandlingArray));

--- a/addons/common/functions/fnc_getDoorTurrets.sqf
+++ b/addons/common/functions/fnc_getDoorTurrets.sqf
@@ -23,7 +23,7 @@ private _doorTurrets = [];
 
     _config = [_config, _x] call FUNC(getTurretConfigPath);
 
-    if (getNumber (_config >> "isCopilot" == 0) && {count getArray (_config >> "weapons") > 0}) then {
+    if (((getNumber (_config >> "isCopilot")) == 0) && {count getArray (_config >> "weapons") > 0}) then {
         _doorTurrets pushBack _x;
     };
     false

--- a/addons/common/functions/fnc_getMGRSdata.sqf
+++ b/addons/common/functions/fnc_getMGRSdata.sqf
@@ -25,7 +25,7 @@ private _altitude =  getNumber (configFile >> "CfgWorlds" >> _map >> "elevationO
 private _mapData = _map call FUNC(getMapData);
 if (!(_mapData isEqualTo [])) then {
     _lat = _mapData select 0;
-    _alt = _mapData select 1;
+    _altitude = _mapData select 1;
 };
 TRACE_2("Latitude and Altitude",_lat,_alt);
 

--- a/addons/common/functions/fnc_getMGRSdata.sqf
+++ b/addons/common/functions/fnc_getMGRSdata.sqf
@@ -27,7 +27,7 @@ if (!(_mapData isEqualTo [])) then {
     _lat = _mapData select 0;
     _altitude = _mapData select 1;
 };
-TRACE_2("Latitude and Altitude",_lat,_alt);
+TRACE_2("Latitude and Altitude",_lat,_altitude);
 
 private _UTM = [_long, _lat] call BIS_fnc_posDegToUTM;
 private _easting = _UTM select 0;

--- a/addons/common/functions/fnc_getMapGridData.sqf
+++ b/addons/common/functions/fnc_getMapGridData.sqf
@@ -64,8 +64,8 @@ while {_startGrid == _originGrid} do {
 private _realOffsetY = (parseNumber (_originGrid select [count _formatX, count _formatY])) * _stepY + _heightOffset - 1;
 
 //Calculate MGRS 10digit step - they should both be 1 meter:
-_stepXat5 = _stepX * 10 ^ ((count _formatX) - 5);
-_stepYat5 = -1 * _stepY * 10 ^ ((count _formatY) - 5);
+private _stepXat5 = _stepX * 10 ^ ((count _formatX) - 5);
+private _stepYat5 = -1 * _stepY * 10 ^ ((count _formatY) - 5);
 
 if (_stepYat5 < 0) then {
     WARNING_1("Map Grid Warning (%1) - Northing is reversed.",worldName);

--- a/addons/common/functions/fnc_throttledPublicVariable.sqf
+++ b/addons/common/functions/fnc_throttledPublicVariable.sqf
@@ -27,7 +27,7 @@ if (isNil QGVAR(publishSchedId)) then {
     GVAR(publishSchedId) = [{
         if (diag_tickTime > GVAR(publishNextTime)) then {
             {
-                _x params [_unit, _varName];
+                _x params ["_unit", "_varName"];
                 _unit setVariable [_varName, _unit getVariable _varName, true];
                 false
             } count GVAR(publishVarNames);

--- a/addons/common/scripts/checkVersionNumber.sqf
+++ b/addons/common/scripts/checkVersionNumber.sqf
@@ -74,7 +74,7 @@ if (!isServer) then {
     } forEach _files;
 
     // display and log error messages
-    _fnc_cutComma = {
+    private _fnc_cutComma = {
         _string = _this;
         _string = toArray _string;
 

--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -53,7 +53,7 @@ if (isNil "_loudness") then {
         };
     } count _muzzles;
     {
-        _ammoType = getText(configFile >> "CfgMagazines" >> _x >> "ammo");
+        private _ammoType = getText(configFile >> "CfgMagazines" >> _x >> "ammo");
         _weaponMagazines set [_forEachIndex, [_x, _ammoType]];
     } forEach _weaponMagazines;
 

--- a/addons/magazinerepack/functions/fnc_magazineRepackProgress.sqf
+++ b/addons/magazinerepack/functions/fnc_magazineRepackProgress.sqf
@@ -18,7 +18,7 @@
  */
 #include "script_component.hpp"
 
-params ["_ars", "_elapsedTime", "_totalTime"];
+params ["_args", "_elapsedTime", "_totalTime"];
 _args params ["_magazineClassname", "_lastAmmoCount", "_simEvents"];
 
 if !((_simEvents select 0) params ["_nextEventTime", "_nextEventIsBullet", "_nextEventMags"]) exitWith { ERROR("No Event"); false };

--- a/addons/map/functions/fnc_compileFlashlightMenu.sqf
+++ b/addons/map/functions/fnc_compileFlashlightMenu.sqf
@@ -39,7 +39,7 @@ _unitLight params ["_flashlight", ""];
         {[_player, _this select 2] call FUNC(switchFlashlight)}
     };
 
-    _action = [_x, _displayName, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+    private _action = [_x, _displayName, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);
     _actions pushBack [_action, [], _player];
 } forEach _flashlightItems;
 

--- a/addons/minedetector/XEH_postInit.sqf
+++ b/addons/minedetector/XEH_postInit.sqf
@@ -27,7 +27,7 @@ addMissionEventHandler ["Draw3D", {
     GVAR(debugDetector) params ["_detectorPointAGL", "_mines"];
     drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", [0,0,1,1], _detectorPointAGL, 1, 1, 0, "detector", 1, 0.02, "PuristaMedium"];
     {
-        _name = format ["%1@%2", typeOf _x, (floor ((_x distance _detectorPointAGL) * 10)) / 10];
+        private _name = format ["%1@%2", typeOf _x, (floor ((_x distance _detectorPointAGL) * 10)) / 10];
         if ((getNumber (configFile >> "CfgVehicles" >> (typeOf _x) >> QGVAR(detectable))) == 1) then {
             drawIcon3D ["\A3\ui_f\data\map\markers\military\dot_CA.paa", [1,0,0,1], (ASLtoAGL (getPosASL _x)), 1, 1, 0, _name, 1, 0.02, "PuristaMedium"];
         } else {

--- a/addons/overpressure/functions/fnc_getDistance.sqf
+++ b/addons/overpressure/functions/fnc_getDistance.sqf
@@ -38,7 +38,7 @@ private _distance = 999;
 
         if (isNull _intersectObject) then {  //Terrain:
             // Calculate the angle between the terrain and the back blast direction
-            _angle = 90 - acos (- (_surfaceNormal vectorDotProduct _direction));
+            private _angle = 90 - acos (- (_surfaceNormal vectorDotProduct _direction));
             TRACE_3("Terrain Intersect",_surfaceNormal,_direction,_angle);
             // Angles is below 25deg, no backblast at all
             if (_angle < 25) exitWith {_distance = 999};

--- a/addons/refuel/functions/fnc_dropNozzle.sqf
+++ b/addons/refuel/functions/fnc_dropNozzle.sqf
@@ -33,7 +33,7 @@ private _posB = (getPosASL _nozzle) vectorAdd [0,0,-1000];
 private _intersections = lineIntersectsSurfaces [_posA, _posB, _unit, _nozzle, true, 1, "GEOM"];
 TRACE_1("",_intersections);
 if (_intersections isEqualTo []) then {
-    _groundPosition set [2, (getTerrainHeightASL _groundPosition) vectorAdd [0,0,0.005]];
+    _groundPosition set [2, (getTerrainHeightASL _groundPosition) + 0.005];
 } else {
     _groundPosition = ((_intersections select 0) select 0) vectorAdd [0,0,0.005];
 };

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -56,7 +56,7 @@ _processedHitpoints = [];
 
         // An action to remove the wheel is required
         _name = format ["Remove_%1_%2", _forEachIndex, _hitpoint];
-        _text = localize LSTRING(RemoveWheel);
+        private _text = localize LSTRING(RemoveWheel);
         _condition = {[_this select 1, _this select 0, _this select 2 select 0, "RemoveWheel"] call DFUNC(canRepair)};
         _statement = {[_this select 1, _this select 0, _this select 2 select 0, "RemoveWheel"] call DFUNC(repair)};
         _action = [_name, _text, _icon, _statement, _condition, {}, [_hitpoint], _position, 2] call EFUNC(interact_menu,createAction);

--- a/addons/tagging/functions/fnc_tag.sqf
+++ b/addons/tagging/functions/fnc_tag.sqf
@@ -77,7 +77,7 @@ private _v3 = _v2 vectorCrossProduct _v1;
 
 TRACE_3("Reference:", _v1, _v2, _v3);
 
-_fnc_isOk = {
+private _fnc_isOk = {
     params ["_rx", "_ry"];
     private _startPosASL2 = _touchingPoint vectorAdd (_v2 vectorMultiply _rx) vectorAdd (_v3 vectorMultiply _ry) vectorAdd (_v1 vectorMultiply (-0.06));
     private _endPosASL2   = _startPosASL2 vectorAdd (_v1 vectorMultiply (0.12));

--- a/tools/sqf_linter.py
+++ b/tools/sqf_linter.py
@@ -1,0 +1,63 @@
+﻿#!/usr/bin/env python3
+
+# Requires: https://github.com/LordGolias/sqf
+
+import fnmatch
+import os
+import sys
+import argparse
+from sqf.parser import parse
+import sqf.analyzer
+from sqf.exceptions import SQFParserError
+
+
+def analyze(filename, writer=sys.stdout):
+    with open(filename, 'r') as file:
+        code = file.read()
+        try:
+            result = parse(code)
+        except SQFParserError as e:
+            print("{}:".format(filename))
+            writer.write('    [%d,%d]:%s\n' % (e.position[0], e.position[1] - 1, e.message))
+            return -1
+
+        exceptions = sqf.analyzer.analyze(result).exceptions
+        if (exceptions): 
+            print("{}:".format(filename))
+            for e in exceptions:
+                writer.write('    [%d,%d]:%s\n' % (e.position[0], e.position[1] - 1, e.message))
+            return len(exceptions)
+    
+    return 0
+         
+def main():
+    print("#########################")
+    print("# Lint Check  #")
+    print("#########################")
+
+    sqf_list = []
+    all_warnings = 0
+    all_errors = 0
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m','--module', help='only search specified module addon folder', required=False, default=".")
+    args = parser.parse_args()
+ 
+    for root, dirnames, filenames in os.walk('../addons' + '/' + args.module):
+      for filename in fnmatch.filter(filenames, '*.sqf'):
+        sqf_list.append(os.path.join(root, filename))
+        
+    for filename in sqf_list:
+        ret = analyze(filename)
+        if (ret < 0):
+            all_errors = all_errors + 1
+        else:
+            all_warnings = all_warnings + ret
+    
+    print ("Parse Errors {0} - Warnings {1}".format(all_errors,all_warnings))
+
+    # return (all_errors + all_warnings)
+    return all_errors
+    
+if __name__ == "__main__":
+    main()

--- a/tools/sqf_linter.py
+++ b/tools/sqf_linter.py
@@ -21,16 +21,16 @@ def analyze(filename, writer=sys.stdout):
         except SQFParserError as e:
             print("{}:".format(filename))
             writer.write('    [%d,%d]:%s\n' % (e.position[0], e.position[1] - 1, e.message))
-            return 0, -1
+            return 0, 1
 
         exceptions = sqf.analyzer.analyze(result).exceptions
         if (exceptions): 
             print("{}:".format(filename))
             for e in exceptions:
                 if (e.message.startswith("error")):
-                    errors = errors + 1
+                    errors += 1
                 else:
-                    warnings = warnings + 1
+                    warnings += 1
                 writer.write('    [%d,%d]:%s\n' % (e.position[0], e.position[1] - 1, e.message))
     
     return warnings, errors
@@ -54,8 +54,8 @@ def main():
         
     for filename in sqf_list:
         warnings, errors = analyze(filename)
-        all_warnings = all_warnings + warnings
-        all_errors = all_errors + errors
+        all_warnings += warnings
+        all_errors += errors
     
     print ("Parse Errors {0} - Warnings {1}".format(all_errors,all_warnings))
 

--- a/tools/sqf_linter.py
+++ b/tools/sqf_linter.py
@@ -44,8 +44,8 @@ def main():
     args = parser.parse_args()
  
     for root, dirnames, filenames in os.walk('../addons' + '/' + args.module):
-      for filename in fnmatch.filter(filenames, '*.sqf'):
-        sqf_list.append(os.path.join(root, filename))
+        for filename in fnmatch.filter(filenames, '*.sqf'):
+            sqf_list.append(os.path.join(root, filename))
         
     for filename in sqf_list:
         ret = analyze(filename)


### PR DESCRIPTION
Did a quick pass with the SQF Lint tool. (https://github.com/LordGolias/sqf)

Most are just private cleanups which aren't a big deal, but it did find some actual errors.
- Fixed: getDoorTurrets (Not used, was broken, could drop?)
- Fixed: getMGRSdata (Was ignoring getMapData altitude)
- Fixed: throttledPublicVariable (Not used anywhere, should probably test if we use it in the future)
- Fixed: handleRespawn (Using bad var name, escort setVar would not be reset)
- Fixed dropNozzle
- magazineRepackProgress (magically not broken because progressbar uses same var name)
- readWeaponDataFromConfig (same thing, `_weapon` always existed from upper scope)
