### PR TITLE
1.70 CMs - Remove countermeasure mode switching

### DIFF
--- a/addons/aircraft/CfgWeapons.hpp
+++ b/addons/aircraft/CfgWeapons.hpp
@@ -1,5 +1,3 @@
-class Mode_SemiAuto;
-class Mode_Burst;
 class Mode_FullAuto;
 
 class CfgWeapons {
@@ -16,20 +14,6 @@ class CfgWeapons {
         burst = 0;
         reloadTime = 0.01;
         magazineReloadTime = 0.1;
-    };
-
-    // Manual Switching Of Flare Mode
-    class SmokeLauncher;
-    class CMFlareLauncher: SmokeLauncher {
-        modes[] = {"Single", "Burst", "AIBurst"};
-
-        class Single: Mode_SemiAuto {
-            reloadTime = 0.1;
-        };
-
-        class Burst: Mode_Burst {
-            displayName = CSTRING(CMFlareLauncher_Burst_Name);
-        };
     };
 
     // bigger mag for comanche

--- a/addons/aircraft/stringtable.xml
+++ b/addons/aircraft/stringtable.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Aircraft">
-        <Key ID="STR_ACE_Aircraft_CMFlareLauncher_Burst_Name">
-            <English>Burst</English>
-            <German>Feuerstoß</German>
-            <Spanish>Ráfaga</Spanish>
-            <Polish>Seria</Polish>
-            <Czech>Dávka</Czech>
-            <French>Rafale</French>
-            <Russian>Очередь</Russian>
-            <Hungarian>Sorozat</Hungarian>
-            <Portuguese>Rajada</Portuguese>
-            <Italian>Raffica</Italian>
-            <Japanese>バースト</Japanese>
-            <Korean>점사</Korean>
-        </Key>
         <Key ID="STR_ACE_Aircraft_gatling_20mm_Name">
             <English>XM301</English>
             <German>XM301</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Remove our version of countermeasure mode switching (burst - single) as vanilla will have it in 1.70.