### PR TITLE
Use correct TransportX type for ace items

### DIFF
--- a/addons/grenades/CfgVehicles.hpp
+++ b/addons/grenades/CfgVehicles.hpp
@@ -12,8 +12,8 @@ class CfgVehicles {
     class EAST_Box_Base;
     class Box_East_Grenades_F: EAST_Box_Base {
         class TransportMagazines {
-            MACRO_ADDMAGAZINE(ACE_HandFlare_White,12);
-            MACRO_ADDMAGAZINE(ACE_HandFlare_Green,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Yellow,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Red,12);
             MACRO_ADDMAGAZINE(ACE_M84,12);
         };
     };
@@ -21,7 +21,7 @@ class CfgVehicles {
     class IND_Box_Base;
     class Box_IND_Grenades_F: IND_Box_Base {
         class TransportMagazines {
-            MACRO_ADDMAGAZINE(ACE_HandFlare_White,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Yellow,12);
             MACRO_ADDMAGAZINE(ACE_HandFlare_Green,12);
             MACRO_ADDMAGAZINE(ACE_M84,12);
         };

--- a/addons/grenades/CfgVehicles.hpp
+++ b/addons/grenades/CfgVehicles.hpp
@@ -2,40 +2,40 @@
 class CfgVehicles {
     class NATO_Box_Base;
     class Box_NATO_Grenades_F: NATO_Box_Base {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_HandFlare_White,12);
-            MACRO_ADDITEM(ACE_HandFlare_Green,12);
-            MACRO_ADDITEM(ACE_M84,12);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_HandFlare_White,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Green,12);
+            MACRO_ADDMAGAZINE(ACE_M84,12);
         };
     };
 
     class EAST_Box_Base;
     class Box_East_Grenades_F: EAST_Box_Base {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_HandFlare_Yellow,12);
-            MACRO_ADDITEM(ACE_HandFlare_Red,12);
-            MACRO_ADDITEM(ACE_M84,12);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_HandFlare_White,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Green,12);
+            MACRO_ADDMAGAZINE(ACE_M84,12);
         };
     };
 
     class IND_Box_Base;
     class Box_IND_Grenades_F: IND_Box_Base {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_HandFlare_Yellow,12);
-            MACRO_ADDITEM(ACE_HandFlare_Green,12);
-            MACRO_ADDITEM(ACE_M84,12);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_HandFlare_White,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Green,12);
+            MACRO_ADDMAGAZINE(ACE_M84,12);
         };
     };
 
     class Box_NATO_Support_F;
     class ACE_Box_Misc: Box_NATO_Support_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_HandFlare_White,12);
-            MACRO_ADDITEM(ACE_HandFlare_Red,12);
-            MACRO_ADDITEM(ACE_HandFlare_Green,12);
-            MACRO_ADDITEM(ACE_HandFlare_Yellow,12);
-            MACRO_ADDITEM(ACE_M84,12);
-            MACRO_ADDITEM(ACE_M14,12);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_HandFlare_White,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Red,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Green,12);
+            MACRO_ADDMAGAZINE(ACE_HandFlare_Yellow,12);
+            MACRO_ADDMAGAZINE(ACE_M84,12);
+            MACRO_ADDMAGAZINE(ACE_M14,12);
         };
     };
 };

--- a/addons/minedetector/CfgVehicles.hpp
+++ b/addons/minedetector/CfgVehicles.hpp
@@ -1,9 +1,9 @@
 class CfgVehicles {
     class Box_NATO_Support_F;
     class ACE_Box_Misc: Box_NATO_Support_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_VMM3,4);
-            MACRO_ADDITEM(ACE_VMH3,4);
+        class TransportWeapons {
+            MACRO_ADDWEAPON(ACE_VMM3,4);
+            MACRO_ADDWEAPON(ACE_VMH3,4);
         };
     };
 

--- a/addons/mx2a/CfgVehicles.hpp
+++ b/addons/mx2a/CfgVehicles.hpp
@@ -6,15 +6,15 @@ class CfgVehicles {
         scopeCurator = 2;
         displayName = CSTRING(DisplayName);
         vehicleClass = "Items";
-        class TransportWeapons {
-            MACRO_ADDWEAPON(ACE_MX2A,1);
+        class TransportItems {
+            MACRO_ADDITEM(ACE_MX2A,1);
         };
     };
 
     class Box_NATO_Support_F;
     class ACE_Box_Misc: Box_NATO_Support_F {
-        class TransportWeapons {
-            MACRO_ADDWEAPON(ACE_MX2A,6);
+        class TransportItems {
+            MACRO_ADDITEM(ACE_MX2A,6);
         };
     };
 };

--- a/addons/overheating/CfgVehicles.hpp
+++ b/addons/overheating/CfgVehicles.hpp
@@ -68,62 +68,62 @@ class CfgVehicles {
     class FIA_Box_Base_F;
 
     class Box_NATO_Support_F: NATO_Box_Base {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class B_supplyCrate_F: ReammoBox_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class Box_East_Support_F: EAST_Box_Base {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class O_supplyCrate_F: B_supplyCrate_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class Box_IND_Support_F: IND_Box_Base {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class Box_FIA_Support_F: FIA_Box_Base_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class I_supplyCrate_F: B_supplyCrate_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class IG_supplyCrate_F: ReammoBox_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class C_supplyCrate_F: ReammoBox_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,2);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,2);
         };
     };
 
     class ACE_Box_Misc: Box_NATO_Support_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_SpareBarrel,6);
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(ACE_SpareBarrel,6);
         };
     };
 };

--- a/addons/vector/CfgVehicles.hpp
+++ b/addons/vector/CfgVehicles.hpp
@@ -6,15 +6,15 @@ class CfgVehicles {
         scopeCurator = 2;
         displayName = CSTRING(VectorName);
         vehicleClass = "Items";
-        class TransportWeapons {
-            MACRO_ADDWEAPON(ACE_Vector,1);
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Vector,1);
         };
     };
 
     class Box_NATO_Support_F;
     class ACE_Box_Misc: Box_NATO_Support_F {
-        class TransportWeapons {
-            MACRO_ADDWEAPON(ACE_Vector,6);
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Vector,6);
         };
     };
 };

--- a/addons/yardage450/CfgVehicles.hpp
+++ b/addons/yardage450/CfgVehicles.hpp
@@ -6,15 +6,15 @@ class CfgVehicles {
         scopeCurator = 2;
         displayName = CSTRING(DisplayName);
         vehicleClass = "Items";
-        class TransportWeapons {
-            MACRO_ADDWEAPON(ACE_Yardage450,1);
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Yardage450,1);
         };
     };
 
     class Box_NATO_Support_F;
     class ACE_Box_Misc: Box_NATO_Support_F {
-        class TransportWeapons {
-            MACRO_ADDWEAPON(ACE_Yardage450,4);
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Yardage450,4);
         };
     };
 };


### PR DESCRIPTION
Fix #5068

As far as I can tell arma can handle the wrong entries.
This does seem to put he mine detectors at the top of the "misc items" box, but I noticed no other changes.