### PR TITLE
Just warn for old compat pbos

### DIFF
--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -41,18 +41,28 @@ private _addons = "true" configClasses (configFile >> "CfgPatches");//
 _addons = _addons apply {toLower configName _x};//
 _addons = _addons select {_x find "ace_" == 0};
 
+private _oldCompats = [];
 {
     if (getText (configFile >> "CfgPatches" >> _x >> "versionStr") != _version) then {
         private _errorMsg = format ["File %1.pbo is outdated.", _x];
 
         ERROR(_errorMsg);
 
-        if (hasInterface) then {
-            ["[ACE] ERROR", _errorMsg, {findDisplay 46 closeDisplay 0}] call FUNC(errorMessage);
+        if ((_x select [0, 10]) != "ace_compat") then {
+            if (hasInterface) then {
+                ["[ACE] ERROR", _errorMsg, {findDisplay 46 closeDisplay 0}] call FUNC(errorMessage);
+            };
+        } else {
+            _oldCompats pushBack _x;  // Don't block game if it's just an old compat pbo
         };
     };
     false
 } count _addons;
+if (!(_oldCompats isEqualTo [])) then {
+    [{
+        systemChat format ["Warning: The Following ACE Compatiblity PBOs are Outdated %1", _this];
+    }, _oldCompats, 10] call CBA_fnc_waitAndExecute;
+};
 
 ///////////////
 // check dlls

--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -61,7 +61,7 @@ private _oldCompats = [];
 if (!(_oldCompats isEqualTo [])) then {
     [{
         // Lasts for ~10 seconds
-        ERROR_WITH_TITLE_1("The Following ACE Compatiblity PBOs are Outdated", "%1", _this);
+        ERROR_WITH_TITLE_1("The following ACE compatiblity PBOs are outdated", "%1", _this);
     }, _oldCompats, 1] call CBA_fnc_waitAndExecute;
 };
 

--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -60,8 +60,9 @@ private _oldCompats = [];
 } count _addons;
 if (!(_oldCompats isEqualTo [])) then {
     [{
-        systemChat format ["Warning: The Following ACE Compatiblity PBOs are Outdated %1", _this];
-    }, _oldCompats, 10] call CBA_fnc_waitAndExecute;
+        // Lasts for ~10 seconds
+        ERROR_WITH_TITLE_1("The Following ACE Compatiblity PBOs are Outdated", "%1", _this);
+    }, _oldCompats, 1] call CBA_fnc_waitAndExecute;
 };
 
 ///////////////


### PR DESCRIPTION
Having old compat pbos is less critical
Depending on how people update, they may get `@ace` way before `@ace_compat_X` and would be unable to play at all.