### PR TITLE
Remove unit from laser pointer list if laser removed

### DIFF
--- a/addons/laserpointer/XEH_postInit.sqf
+++ b/addons/laserpointer/XEH_postInit.sqf
@@ -41,9 +41,16 @@ GVAR(greenLaserUnits) = [];
         params ["_unit"];
 
         private _weapon = currentWeapon _unit;
+        if (!(_unit isFlashlightOn _weapon)) exitWith {
+            GVAR(redLaserUnits) deleteAt (GVAR(redLaserUnits) find _unit);
+            GVAR(greenLaserUnits) deleteAt (GVAR(greenLaserUnits) find _unit);
+        };
+        
         private _laser = [(_unit weaponAccessories _weapon) select 1] param [0, ""];
-
-        if (_laser isEqualTo "") exitWith {};
+        if (_laser isEqualTo "") exitWith {
+            GVAR(redLaserUnits) deleteAt (GVAR(redLaserUnits) find _unit);
+            GVAR(greenLaserUnits) deleteAt (GVAR(greenLaserUnits) find _unit);
+        };
 
         private _laserID = GVAR(laserClassesCache) getVariable _laser;
 
@@ -51,20 +58,16 @@ GVAR(greenLaserUnits) = [];
             _laserID = getNumber (configFile >> "CfgWeapons" >> _laser >> "ACE_laserpointer");
             GVAR(laserClassesCache) setVariable [_laser, _laserID];
         };
+        TRACE_3("",_weapon,_laser,_laserID);
 
-        if (_unit isFlashlightOn _weapon) then {
-            if (_laserID isEqualTo 1) exitWith {
-                GVAR(redLaserUnits) pushBackUnique _unit;
-                GVAR(greenLaserUnits) deleteAt (GVAR(greenLaserUnits) find _unit);
-            };
-
-            if (_laserID isEqualTo 2) exitWith {
-                GVAR(greenLaserUnits) pushBackUnique _unit;
-                GVAR(redLaserUnits) deleteAt (GVAR(redLaserUnits) find _unit);
-            };
-        } else {
-            GVAR(redLaserUnits) deleteAt (GVAR(redLaserUnits) find _unit);
+        if (_laserID isEqualTo 1) exitWith {
+            GVAR(redLaserUnits) pushBackUnique _unit;
             GVAR(greenLaserUnits) deleteAt (GVAR(greenLaserUnits) find _unit);
+        };
+
+        if (_laserID isEqualTo 2) exitWith {
+            GVAR(greenLaserUnits) pushBackUnique _unit;
+            GVAR(redLaserUnits) deleteAt (GVAR(redLaserUnits) find _unit);
         };
     };
 

--- a/addons/laserpointer/functions/fnc_getNearUnits.sqf
+++ b/addons/laserpointer/functions/fnc_getNearUnits.sqf
@@ -6,7 +6,7 @@
  * None
  *
  * Return Value:
- * None
+ * Near Units <ARRAY>
  *
  * Public: No
  */
@@ -15,7 +15,7 @@
 private _camPosAGL = positionCameraToWorld [0, 0, 0];
 
 // handle RHS / bugged vehicle slots
-if !((_camPosAGL select 0) isEqualType 0) exitWith {};
+if !((_camPosAGL select 0) isEqualType 0) exitWith { [] };
 
 private _nearUnits = [];
 


### PR DESCRIPTION
Fix #5189

`if (_laser isEqualTo "") exitWith {};` - never removed people from laser lists
I slightly reordered to exitWith early if `!isFlashlightOn` as I think that should common case