### PR TITLE
RHS CH-47 - use animationSourcePhase

### DIFF
--- a/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
+++ b/optionals/compat_rhs_usf3/functions/fnc_canCloseDoor.sqf
@@ -18,7 +18,13 @@
 #include "script_component.hpp"
 params ["_vehicle", "_door"];
 
-(_vehicle doorPhase _door > 0) &&
+(
+    if (_vehicle isKindOf "RHS_CH_47F") then {
+        (_vehicle animationSourcePhase _door) > 0
+    } else {
+        (_vehicle doorPhase _door) > 0
+    }
+) &&
 {alive _vehicle} &&
 {!(_vehicle getVariable [QEGVAR(fastroping,doorsLocked),false])} &&
 {


### PR DESCRIPTION
Fix #5196
Matches their config for ch47:
```
condition = "this animationSourcePhase 'ramp_anim' > 0
```
Other vehicles still use `doorPhase`