### PR TITLE
[Compats] Fix classnames

### DIFF
--- a/optionals/compat_rh_acc/script_component.hpp
+++ b/optionals/compat_rh_acc/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT rh_acc_comp
+#define COMPONENT compat_rh_acc
 #define COMPONENT_BEAUTIFIED RH Accessories Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"

--- a/optionals/compat_rh_de/script_component.hpp
+++ b/optionals/compat_rh_de/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT rh_de_cfg_comp
+#define COMPONENT compat_rh_de
 #define COMPONENT_BEAUTIFIED RH Desert Eagle Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"

--- a/optionals/compat_rh_m4/script_component.hpp
+++ b/optionals/compat_rh_m4/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT rh_m4_cfg_comp
+#define COMPONENT compat_rh_m4
 #define COMPONENT_BEAUTIFIED RH M4 Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"

--- a/optionals/compat_rh_pdw/script_component.hpp
+++ b/optionals/compat_rh_pdw/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT rh_pdw_comp
+#define COMPONENT compat_rh_pdw
 #define COMPONENT_BEAUTIFIED RH PDW Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"

--- a/optionals/compat_rksl_pm_ii/script_component.hpp
+++ b/optionals/compat_rksl_pm_ii/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT RKSL_PMII_comp
+#define COMPONENT compat_rksl_pm_ii
 #define COMPONENT_BEAUTIFIED RKSL PMII Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"

--- a/optionals/compat_sma3_iansky/script_component.hpp
+++ b/optionals/compat_sma3_iansky/script_component.hpp
@@ -1,4 +1,4 @@
-#define COMPONENT sma3_iansky_comp
+#define COMPONENT compat_sma3_iansky
 #define COMPONENT_BEAUTIFIED Iansky Scope Mod Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Update compats `compat_rh_acc`, `compat_rh_de`, `compat_rh_m4`, `compat_rh_pdw`, `compat_rksl_pm_ii` and `compat_sma3_iansky` to correct classnames
- Fixes #5203
