### PR TITLE
Fixed zero divisor when throwing Chemlight(IR)

### DIFF
--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -44,7 +44,7 @@ _unit setVariable [QGVAR(activeThrowable), _activeThrowable];
 deleteVehicle _activeThrowableOld;
 
 // Throw Fired XEH
-[QGVAR(throwFiredXEH), [
+[QFUNC(throwFiredXEH), [
     _unit, // unit
     "Throw", // weapon
     _muzzle, // muzzle


### PR DESCRIPTION
Fixed zero divisor when throwing Chemlight(IR).
Will fix zero divisor bug because the function throwFiredXEH was called with VAR instead of FUNC.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/)
