### PR TITLE
Usage of BIS HandleDamage Array

### DIFF
--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -16,7 +16,7 @@
 #include "script_component.hpp"
 
 params ["_simulationType", "_thisHandleDamage"];
-_thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIndex", "_shooter", "_hitPoint"];
+_thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIndex", "_shooter", "_hitLoc"];
 
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
@@ -25,7 +25,7 @@ if (damage _vehicle >= 1) exitWith {};
 private _hitpoint = "#structural";
 
 if (_hitIndex != -1) then {
-    _hitpoint = toLower (_hitPoint);
+    _hitpoint = toLower (_hitLoc);
 };
 
 // get change in damage

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -16,21 +16,15 @@
 #include "script_component.hpp"
 
 params ["_simulationType", "_thisHandleDamage"];
-_thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIndex", "_shooter", "_hitLoc"];
+_thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIndex", "_shooter", "_hitpoint", "_oldDamage"];
 
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
 
 // set default value
-private _hitpoint = "#structural";
-
-if (_hitIndex != -1) then {
-    _hitpoint = toLower (_hitLoc);
-};
+_hitpoint = ["#structural", toLower _hitpoint] select (_hitIndex != -1);
 
 // get change in damage
-private "_oldDamage";
-
 if (_hitpoint isEqualTo "#structural") then {
     _oldDamage = damage _vehicle;
 } else {

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -21,11 +21,11 @@ _thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIn
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
 
-// To lower name
-_hitpoint = toLower (_hitPoint);
+// set default value
+private _hitpoint = "#structural";
 
 if (_hitIndex != -1) then {
-    _hitpoint = toLower ((getAllHitPointsDamage _vehicle param [0, []]) select _hitIndex);
+    _hitpoint = toLower (_hitPoint);
 };
 
 // get change in damage

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -16,13 +16,13 @@
 #include "script_component.hpp"
 
 params ["_simulationType", "_thisHandleDamage"];
-_thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIndex", "_shooter"];
+_thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIndex", "_shooter", "_hitPoint"];
 
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
 
-// get hitpoint name
-private _hitpoint = "#structural";
+// To lower name
+_hitpoint = toLower (_hitPoint);
 
 if (_hitIndex != -1) then {
     _hitpoint = toLower ((getAllHitPointsDamage _vehicle param [0, []]) select _hitIndex);


### PR DESCRIPTION
https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#HandleDamage
Has hitPoint as a input so use that instead of try and find it by ourself.

This changed the behaviour of damage pretty hard, more insta explosions and only cook off some of the time more than i expected so please try and verify if this is proper behaviour.

Test mission was RHS Launchers and RHS vehicles.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/)
