### PR TITLE
Linkingbelt refactoring

### DIFF
--- a/addons/reload/CfgVehicles.hpp
+++ b/addons/reload/CfgVehicles.hpp
@@ -6,7 +6,7 @@ class CfgVehicles {
                 class GVAR(LinkBelt) {
                     displayName = CSTRING(LinkBelt);
                     distance = 2.0;
-                    condition = QUOTE([ARR_2(_player, _target)] call FUNC(canLinkBelt));
+                    condition = QUOTE(([ARR_2(_player, _target)] call FUNC(getAmmoToLinkBelt)) > 0);
                     statement = QUOTE([ARR_2(_player, _target)] call FUNC(startLinkingBelt));
                 };
                 class GVAR(CheckAmmo) {

--- a/addons/reload/XEH_PREP.hpp
+++ b/addons/reload/XEH_PREP.hpp
@@ -1,6 +1,6 @@
 
 PREP(canCheckAmmo);
-PREP(canLinkBelt);
+PREP(getAmmoToLinkBelt);
 PREP(checkAmmo);
 PREP(displayAmmo);
 PREP(startLinkingBelt);

--- a/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
+++ b/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: esteldunedain
+ * Author: esteldunedain, phyma
  * Check if the target has an MG equiped with belt system that the player can link
  *
  * Arguments:
@@ -7,7 +7,7 @@
  * 1: Target <OBJECT>
  *
  * Return Value:
- * Can link belt<BOOL>
+ * Maximum ammo of magazine (-1 on error) <INT>
  *
  * Example:
  * [player, cursorObject] call ace_reload_fnc_canLinkBelt;
@@ -18,18 +18,18 @@
 
 params ["_player", "_target"];
 
-if (vehicle _target != _target) exitWith {false};
+if (vehicle _target != _target) exitWith {-1};
 
 private _magazineType = currentMagazine _target;
 private _magazineCfg = configFile >> "CfgMagazines" >> _magazineType;
 
-if (getNumber (_magazineCfg >> "ACE_isBelt") == 0) exitWith {false};
+if (getNumber (_magazineCfg >> "ACE_isBelt") == 0) exitWith {-1};
 
 // Check if the ammo is not empty or full
 private _ammoCount = _target ammo currentWeapon _target;
 
 // Exit if the belt is full or empty
-if (_ammoCount == 0 || getNumber (_magazineCfg >> "count") - _ammoCount == 0) exitWith {false};
+if (_ammoCount == 0 || getNumber (_magazineCfg >> "count") - _ammoCount == 0) exitWith {-1};
 
 // Check if the player has any of the same magazines
 // Calculate max ammo
@@ -39,4 +39,4 @@ private _maxAmmo = 0;
     _maxAmmo = _maxAmmo max (_x select 1);
 } forEach (magazinesAmmo _player select {_x select 0 == _magazineType});
 
-_maxAmmo > 0
+_maxAmmo

--- a/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
+++ b/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
@@ -7,10 +7,10 @@
  * 1: Target <OBJECT>
  *
  * Return Value:
- * Maximum ammo of magazine (-1 on error) <INT>
+ * Maximum ammo of magazine (-1 on error) <NUMBER>
  *
  * Example:
- * [player, cursorObject] call ace_reload_fnc_canLinkBelt;
+ * [player, cursorObject] call ace_reload_fnc_getAmmoToLinkBelt;
  *
  * Public: No
  */

--- a/addons/reload/functions/fnc_startLinkingBelt.sqf
+++ b/addons/reload/functions/fnc_startLinkingBelt.sqf
@@ -17,19 +17,11 @@ if (vehicle _target != _target) exitWith {false};
 
 private _magazineType = currentMagazine _target;
 
-private _canLink = [_player, _target] call FUNC(canLinkBelt);
 
-if ( !_canLink ) exitWith {} ;
+private _maxAmmo = [_player, _target] call FUNC(getAmmoToLinkBelt);
 
-// Check if the player has any of the same same magazines
-// Calculate max ammo it can link
-private _maxAmmo = 0;
-
-{
-    _maxAmmo = _maxAmmo max (_x select 1);
-} forEach (magazinesAmmo _player select {_x select 0 == _magazineType});
-
-if (_maxAmmo == 0) exitWith {};
+//if _maxAmmo is below 0 we quit
+if (_maxAmmo <= 0) exitWith {};
 
 // Condition to call each frame
 private _condition = {


### PR DESCRIPTION
Removed redundant code fnc_canLinkBelt now returns a value over  0 if success and -1 if error.
This is so there is no equal code in canLinkBelt and startLinkBelt.

Changes to config so it works.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/)
