### PR TITLE
AdvThrow - Handle bugged currentThrowable

### DIFF
--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -36,6 +36,11 @@ if (_throwable isEqualTo [] && {!_primed}) exitWith {
 
 private _throwableMag = _throwable param [0, "#none"];
 
+// If not primed, double check we actually have the magazine in inventory
+if ((!_primed) && {!(_throwableMag in (magazines ACE_player))}) exitWith {
+    [ACE_player, "No valid throwable (glitched currentThrowable)"] call FUNC(exitThrowMode);
+};
+
 // Get correct throw power for primed grenade
 if (_primed) then {
     private _ammoType = typeOf _activeThrowable;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/9376747/26537775/c577431e-4407-11e7-9d8a-3e0c3fbf2b0c.png)

`currentThrowable` can get glitched and show a magazine that you don't have in inventory
Advanced throwing lets you throw unlimited grenades.
Effects vanilla throw as well, although there you can only do a single throw of a `x0` grenade.

This also breaks `ace_weaponselect_fnc_selectNextGrenade` because removing has no effect