### PR TITLE
French translation missing

### DIFF
--- a/addons/cargo/stringtable.xml
+++ b/addons/cargo/stringtable.xml
@@ -259,7 +259,7 @@
             <English>Paradrop Time Coffecient</English>
             <Japanese>空中投下までの時間係数</Japanese>
             <Italian>Coefficente Tempo Lancio Paracadute</Italian>
-            <French>Coefficient Temps de larguage de cargaison</French>
+            <French>Coefficient Temps de largage de cargaison</French>
         </Key>
         <Key ID="STR_ACE_Cargo_paradropTimeCoefficent_description">
             <English>Modifier for how long it takes to paradrop a cargo item.</English>

--- a/addons/cargo/stringtable.xml
+++ b/addons/cargo/stringtable.xml
@@ -259,11 +259,13 @@
             <English>Paradrop Time Coffecient</English>
             <Japanese>空中投下までの時間係数</Japanese>
             <Italian>Coefficente Tempo Lancio Paracadute</Italian>
+            <French>Coefficient Temps de larguage de cargaison</French>
         </Key>
         <Key ID="STR_ACE_Cargo_paradropTimeCoefficent_description">
             <English>Modifier for how long it takes to paradrop a cargo item.</English>
             <Japanese>カーゴ アイテムを空中投下するまでの時間を変更します。</Japanese>
             <Italian>Modificato per quanto tempo ci impiega a paracadutare un oggetto cargo.</Italian>
+            <French>Modifier le temps qu'il faut pour larguer la cargaison.</French>
         </Key>
     </Package>
 </Project>

--- a/addons/spectator/stringtable.xml
+++ b/addons/spectator/stringtable.xml
@@ -5,6 +5,7 @@
             <English>ACE Spectator</English>
             <Japanese>ACE スペクテイター</Japanese>
             <Italian>Spettatore ACE</Italian>
+            <French>Spectateur ACE</French>
         </Key>
         <Key ID="STR_ACE_Spectator_Settings_DisplayName">
             <English>Spectator Settings</English>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -865,6 +865,7 @@
         <Key ID="STR_ACE_Zeus_ModuleSuppressiveFire_DisplayName">
             <English>Suppressive Fire</English>
             <Italian>Fuoco di Soppressione</Italian>
+            <French>Tir de suppression</French>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Hello,

- Add french translation to Cargo, spectator and Zeus
- Cargo : 
-- Add on : <Key ID="STR_ACE_Cargo_paradropTimeCoefficent">
--- <French>Coefficient Temps de larguage de cargaison</French>
-- Add on : <Key ID="STR_ACE_Cargo_paradropTimeCoefficent_description">
-- <French>Modifier le temps qu'il faut pour larguer la cargaison.</French>

- Spectator :
-- Add on : <Key ID="STR_ACE_Spectator_DisplayName">
--- <French>Spectateur ACE</French>

- Zeus : 
-- Add on : <Key ID="STR_ACE_Zeus_ModuleSuppressiveFire_DisplayName">
--- <French>Tir de suppression</French>


