### PR TITLE
Fix zeus RC units using player damage treshold

### DIFF
--- a/addons/medical/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical/functions/fnc_determineIfFatal.sqf
@@ -30,7 +30,7 @@ if (_part < 0 || _part > 5) exitWith {false};
 
 // Find the correct Damage threshold for unit.
 private _damageThreshold = [1,1,1];
-if ([_unit, true] call EFUNC(common,isPlayer)) then {
+if ([_unit, GVAR(remoteControlledAI)] call EFUNC(common,isPlayer)) then {
     _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(playerDamageThreshold), GVAR(playerDamageThreshold), GVAR(playerDamageThreshold) * 1.7]];
 } else {
     _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(AIDamageThreshold), GVAR(AIDamageThreshold), GVAR(AIDamageThreshold) * 1.7]];

--- a/addons/medical/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical/functions/fnc_determineIfFatal.sqf
@@ -30,7 +30,7 @@ if (_part < 0 || _part > 5) exitWith {false};
 
 // Find the correct Damage threshold for unit.
 private _damageThreshold = [1,1,1];
-if ([_unit] call EFUNC(common,IsPlayer)) then {
+if ([_unit, true] call EFUNC(common,isPlayer)) then {
     _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(playerDamageThreshold), GVAR(playerDamageThreshold), GVAR(playerDamageThreshold) * 1.7]];
 } else {
     _damageThreshold =_unit getVariable[QGVAR(unitDamageThreshold), [GVAR(AIDamageThreshold), GVAR(AIDamageThreshold), GVAR(AIDamageThreshold) * 1.7]];


### PR DESCRIPTION
Closes #5218

**When merged this pull request will:**
Use the boolean parameter for common_isPlayer to exclude remote controlled units
