### PR TITLE
Open glass and CUP doors

### DIFF
--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -30,6 +30,7 @@ PREP(pardon);
 
 // interaction with doors
 PREP(getDoor);
+PREP(getGlassDoor);
 PREP(getDoorAnimations);
 PREP(handleScrollWheel);
 PREP(openDoor);

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -39,9 +39,9 @@ _door = _intersections select 0 select 0;
 
 //Check if door is glass because then we need to find the proper location of the door so we can use it
 if (["glass", _door] call BIS_fnc_inString) then {
-	_glassDoor = [_house, _door] call FUNC(getGlassDoor);
-	_house = _glassDoor select 0;
-	_door = _glassDoor select 1;
+    _glassDoor = [_house, _door] call FUNC(getGlassDoor);
+    _house = _glassDoor select 0;
+    _door = _glassDoor select 1;
 };
 
 if (isNil "_door") exitWith {[_house, ""]};

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -41,7 +41,7 @@ if (isNil "_door") exitWith {[_house, ""]};
 
 //Check if door is glass because then we need to find the proper location of the door so we can use it
 if ((_door find "glass") != -1) then {
-    _door = [_distance, _house, _door] call FUNC(getGlassDoor);   
+    _door = [_distance, _house, _door] call FUNC(getGlassDoor);
 };
 
 if (isNil "_door") exitWith {[_house, ""]};

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: commy2
+ * Author: commy2, Phyma
  * Find door.
  *
  * Arguments:
@@ -36,6 +36,50 @@ if (typeOf _house == "") exitWith {[objNull, ""]};
 _intersections = [_house, "GEOM"] intersect [_position0, _position1];
 
 _door = _intersections select 0 select 0;
+
+private _doorParts = [];
+
+//Check if door is glass because then we need to find the proper location of the door so we can use it
+if (["glass", _door] call BIS_fnc_inString) then {
+
+	private ["_animName", "_splitStr", "_newString", "_dist", "_animate"];
+	private _config = _house call CBA_fnc_getObjectConfig;	
+	
+	private _animate = configProperties [_config >> "AnimationSources", "true", false];
+	
+	// calculate all animation names so we know what is there	
+	{			
+		_animName = configName _x;
+		if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {			
+			_splitStr = _animName splitString "_";			
+			_doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
+		};
+	} forEach _animate;	
+	
+	private _glassDoor = _door splitString "_";	
+	private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);	
+	
+	private _doorPos = [];
+	{
+		_doorPos pushBack (_house selectionPosition [_x, "Memory"]);
+	} forEach _doorParts;
+	
+	private _lowestDistance = 0;	
+	{		
+		private _dist = _glassPos distance  _x;
+		if (_lowestDistance == 0) then {
+			_lowestDistance = _dist;
+			_newString = (_doorParts select _forEachIndex) splitString "_";			
+			_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");
+		} else {
+			if (_dist < _lowestDistance) then {
+				_lowestDistance = _dist;
+				_newString = (_doorParts select _forEachIndex) splitString "_";			
+				_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");				
+			};			
+		};							
+	} forEach _doorPos;		
+};
 
 if (isNil "_door") exitWith {[_house, ""]};
 

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -35,15 +35,15 @@ if (typeOf _house == "") exitWith {[objNull, ""]};
 
 _intersections = [_house, "GEOM"] intersect [_position0, _position1];
 
-_door = _intersections select 0 select 0;
+_door = toLower (_intersections select 0 select 0);
 
 if (isNil "_door") exitWith {[_house, ""]};
 
 //Check if door is glass because then we need to find the proper location of the door so we can use it
-if (["glass", _door] call BIS_fnc_inString) then {
+if ((_door find "glass") != -1) then {
     _door = [_distance, _house, _door] call FUNC(getGlassDoor);   
 };
 
-if (isNil "_door") exitWith {systemChat "Wrong"; [_house, ""]};
+if (isNil "_door") exitWith {[_house, ""]};
 
 [_house, _door]

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -38,6 +38,8 @@ _intersections = [_house, "GEOM"] intersect [_position0, _position1];
 _door = _intersections select 0 select 0;
 
 //Check if door is glass because then we need to find the proper location of the door so we can use it
+if (isNil "_door") exitWith {[_house, ""]};
+
 if (["glass", _door] call BIS_fnc_inString) then {
     _glassDoor = [_house, _door] call FUNC(getGlassDoor);
     _house = _glassDoor select 0;

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -19,7 +19,7 @@
 
 params ["_distance"];
 
-private ["_position0", "_position1", "_intersections", "_house", "_door"];
+private ["_position0", "_position1", "_intersections", "_house", "_door", "_glassDoor"];
 
 _position0 = positionCameraToWorld [0, 0, 0];
 _position1 = positionCameraToWorld [0, 0, _distance];
@@ -37,48 +37,11 @@ _intersections = [_house, "GEOM"] intersect [_position0, _position1];
 
 _door = _intersections select 0 select 0;
 
-private _doorParts = [];
-
 //Check if door is glass because then we need to find the proper location of the door so we can use it
 if (["glass", _door] call BIS_fnc_inString) then {
-
-	private ["_animName", "_splitStr", "_newString", "_dist", "_animate"];
-	private _config = _house call CBA_fnc_getObjectConfig;	
-	
-	private _animate = configProperties [_config >> "AnimationSources", "true", false];
-	
-	// calculate all animation names so we know what is there	
-	{			
-		_animName = configName _x;
-		if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {			
-			_splitStr = _animName splitString "_";			
-			_doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
-		};
-	} forEach _animate;	
-	
-	private _glassDoor = _door splitString "_";	
-	private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);	
-	
-	private _doorPos = [];
-	{
-		_doorPos pushBack (_house selectionPosition [_x, "Memory"]);
-	} forEach _doorParts;
-	
-	private _lowestDistance = 0;	
-	{		
-		private _dist = _glassPos distance  _x;
-		if (_lowestDistance == 0) then {
-			_lowestDistance = _dist;
-			_newString = (_doorParts select _forEachIndex) splitString "_";			
-			_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");
-		} else {
-			if (_dist < _lowestDistance) then {
-				_lowestDistance = _dist;
-				_newString = (_doorParts select _forEachIndex) splitString "_";			
-				_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");				
-			};			
-		};							
-	} forEach _doorPos;		
+	_glassDoor = [_house, _door] call FUNC(getGlassDoor);
+	_house = _glassDoor select 0;
+	_door = _glassDoor select 1;
 };
 
 if (isNil "_door") exitWith {[_house, ""]};

--- a/addons/interaction/functions/fnc_getDoor.sqf
+++ b/addons/interaction/functions/fnc_getDoor.sqf
@@ -19,7 +19,7 @@
 
 params ["_distance"];
 
-private ["_position0", "_position1", "_intersections", "_house", "_door", "_glassDoor"];
+private ["_position0", "_position1", "_intersections", "_house", "_door"];
 
 _position0 = positionCameraToWorld [0, 0, 0];
 _position1 = positionCameraToWorld [0, 0, _distance];
@@ -37,15 +37,13 @@ _intersections = [_house, "GEOM"] intersect [_position0, _position1];
 
 _door = _intersections select 0 select 0;
 
-//Check if door is glass because then we need to find the proper location of the door so we can use it
 if (isNil "_door") exitWith {[_house, ""]};
 
+//Check if door is glass because then we need to find the proper location of the door so we can use it
 if (["glass", _door] call BIS_fnc_inString) then {
-    _glassDoor = [_house, _door] call FUNC(getGlassDoor);
-    _house = _glassDoor select 0;
-    _door = _glassDoor select 1;
+    _door = [_distance, _house, _door] call FUNC(getGlassDoor);   
 };
 
-if (isNil "_door") exitWith {[_house, ""]};
+if (isNil "_door") exitWith {systemChat "Wrong"; [_house, ""]};
 
 [_house, _door]

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: commy2
+ * Author: commy2, Phyma
  * Get door animations. @todo rewrite for better custom building support
  *
  * Arguments:
@@ -22,102 +22,21 @@ params ["_house", "_door"];
 
 private ["_index", "_animations", "_lockedVariable"];
 
-_index = [
-    "door_1",
-    "door_2",
-    "door_3",
-    "door_4",
-    "door_5",
-    "door_6",
-    "door_7",
-    "door_8",
-    "door_9",
-    "door_10",
-    "door_11",
-    "door_12",
-    "door_13",
-    "door_14",
-    "door_15",
-    "door_16",
-    "door_17",
-    "door_18",
-    "door_19",
-    "door_20",
-    "door_21",
-    "door_22",
+private _config = _house call CBA_fnc_getObjectConfig;
+private _animate = getArray(_config >> "SimpleObject" >> "animate");
 
-    "hatch_1",
-    "hatch_2",
-    "hatch_3",
-    "hatch_4",
-    "hatch_5",
-    "hatch_6"
-] find toLower _door;
+_animations = [];
+_lockedVariable = [];
 
-if (_index == -1) exitWith {[[],""]};
-
-_animations = [
-    ["Door_1_rot",  "Door_Handle_1_rot_1",  "Door_Handle_1_rot_2"],
-    ["Door_2_rot",  "Door_Handle_2_rot_1",  "Door_Handle_2_rot_2"],
-    ["Door_3_rot",  "Door_Handle_3_rot_1",  "Door_Handle_3_rot_2"],
-    ["Door_4_rot",  "Door_Handle_4_rot_1",  "Door_Handle_4_rot_2"],
-    ["Door_5_rot",  "Door_Handle_5_rot_1",  "Door_Handle_5_rot_2"],
-    ["Door_6_rot",  "Door_Handle_6_rot_1",  "Door_Handle_6_rot_2"],
-    ["Door_7_rot",  "Door_Handle_7_rot_1",  "Door_Handle_7_rot_2"],
-    ["Door_8_rot",  "Door_Handle_8_rot_1",  "Door_Handle_8_rot_2"],
-    ["Door_9_rot",  "Door_Handle_9_rot_1",  "Door_Handle_9_rot_2"],
-    ["Door_10_rot", "Door_Handle_10_rot_1", "Door_Handle_10_rot_2"],
-    ["Door_11_rot", "Door_Handle_11_rot_1", "Door_Handle_11_rot_2"],
-    ["Door_12_rot", "Door_Handle_12_rot_1", "Door_Handle_12_rot_2"],
-    ["Door_13_rot", "Door_Handle_13_rot_1", "Door_Handle_13_rot_2"],
-    ["Door_14_rot", "Door_Handle_14_rot_1", "Door_Handle_14_rot_2"],
-    ["Door_15_rot", "Door_Handle_15_rot_1", "Door_Handle_15_rot_2"],
-    ["Door_16_rot", "Door_Handle_16_rot_1", "Door_Handle_16_rot_2"],
-    ["Door_17_rot", "Door_Handle_17_rot_1", "Door_Handle_17_rot_2"],
-    ["Door_18_rot", "Door_Handle_18_rot_1", "Door_Handle_18_rot_2"],
-    ["Door_19_rot", "Door_Handle_19_rot_1", "Door_Handle_19_rot_2"],
-    ["Door_20_rot", "Door_Handle_20_rot_1", "Door_Handle_20_rot_2"],
-    ["Door_21_rot", "Door_Handle_21_rot_1", "Door_Handle_21_rot_2"],
-    ["Door_22_rot", "Door_Handle_22_rot_1", "Door_Handle_22_rot_2"],
-
-    ["Hatch_1_rot"],
-    ["Hatch_2_rot"],
-    ["Hatch_3_rot"],
-    ["Hatch_4_rot"],
-    ["Hatch_5_rot"],
-    ["Hatch_6_rot"]
-] select _index;
-
-_lockedVariable = [
-    ["BIS_Disabled_Door_1",  "Door_Handle_1_rot_1",  "Door_Locked_1_rot"],
-    ["BIS_Disabled_Door_2",  "Door_Handle_2_rot_1",  "Door_Locked_2_rot"],
-    ["BIS_Disabled_Door_3",  "Door_Handle_3_rot_1",  "Door_Locked_3_rot"],
-    ["BIS_Disabled_Door_4",  "Door_Handle_4_rot_1",  "Door_Locked_4_rot"],
-    ["BIS_Disabled_Door_5",  "Door_Handle_5_rot_1",  "Door_Locked_5_rot"],
-    ["BIS_Disabled_Door_6",  "Door_Handle_6_rot_1",  "Door_Locked_6_rot"],
-    ["BIS_Disabled_Door_7",  "Door_Handle_7_rot_1",  "Door_Locked_7_rot"],
-    ["BIS_Disabled_Door_8",  "Door_Handle_8_rot_1",  "Door_Locked_8_rot"],
-    ["BIS_Disabled_Door_9",  "Door_Handle_9_rot_1",  "Door_Locked_9_rot"],
-    ["BIS_Disabled_Door_10", "Door_Handle_10_rot_1", "Door_Locked_10_rot"],
-    ["BIS_Disabled_Door_11", "Door_Handle_11_rot_1", "Door_Locked_11_rot"],
-    ["BIS_Disabled_Door_12", "Door_Handle_12_rot_1", "Door_Locked_12_rot"],
-    ["BIS_Disabled_Door_13", "Door_Handle_13_rot_1", "Door_Locked_13_rot"],
-    ["BIS_Disabled_Door_14", "Door_Handle_14_rot_1", "Door_Locked_14_rot"],
-    ["BIS_Disabled_Door_15", "Door_Handle_15_rot_1", "Door_Locked_15_rot"],
-    ["BIS_Disabled_Door_16", "Door_Handle_16_rot_1", "Door_Locked_16_rot"],
-    ["BIS_Disabled_Door_17", "Door_Handle_17_rot_1", "Door_Locked_17_rot"],
-    ["BIS_Disabled_Door_18", "Door_Handle_18_rot_1", "Door_Locked_18_rot"],
-    ["BIS_Disabled_Door_19", "Door_Handle_19_rot_1", "Door_Locked_19_rot"],
-    ["BIS_Disabled_Door_20", "Door_Handle_20_rot_1", "Door_Locked_20_rot"],
-    ["BIS_Disabled_Door_21", "Door_Handle_21_rot_1", "Door_Locked_21_rot"],
-    ["BIS_Disabled_Door_22", "Door_Handle_22_rot_1", "Door_Locked_22_rot"],
-
-    ["", ""],
-    ["", ""],
-    ["", ""],
-    ["", ""],
-    ["", ""],
-    ["", ""]
-] select _index;
+{
+	_animName = _x select 0;
+	if ([toLower _door, _animName] call BIS_fnc_inString) then {
+		if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then{
+			_LockedVariable pushBack _animName;
+		} else {
+			_animations pushBack _animName;
+		};
+	};
+} forEach _animate;
 
 [_animations, _lockedVariable]

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -25,8 +25,8 @@ private _animations = [];
 private _lockedVariable = [];
 
 {
-    private _animName = toLower _x;    
-    if ((_animName find (toLower _door)) != -1) then {        
+    private _animName = toLower _x;
+    if ((_animName find (toLower _door)) != -1) then {
         if (((_animName find "disabled") != -1) || ((_animName find "locked") != -1)) then {
             _lockedVariable pushBack _animName;
         } else {

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -28,14 +28,14 @@ private _animations = [];
 private _lockedVariable = [];
 
 {
-	_animName = _x select 0;
-	if ([toLower _door, _animName] call BIS_fnc_inString) then {
-		if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then {
-			_LockedVariable pushBack _animName;
-		} else {
-			_animations pushBack _animName;
-		};
-	};
+    _animName = _x select 0;
+    if ([toLower _door, _animName] call BIS_fnc_inString) then {
+        if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then {
+            _LockedVariable pushBack _animName;
+        } else {
+            _animations pushBack _animName;
+        };
+    };
 } forEach _animate;
 
 [_animations, _lockedVariable]

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: commy2, Phyma
- * Get door animations. @todo rewrite for better custom building support
+ * Get door animations. @todo rewrite for better custom building support could look in animationsources instead of animate
  *
  * Arguments:
  * 0: House <OBJECT>
@@ -24,14 +24,13 @@ private ["_index", "_animations", "_lockedVariable"];
 
 private _config = _house call CBA_fnc_getObjectConfig;
 private _animate = getArray(_config >> "SimpleObject" >> "animate");
-
-_animations = [];
-_lockedVariable = [];
+private _animations = [];
+private _lockedVariable = [];
 
 {
 	_animName = _x select 0;
 	if ([toLower _door, _animName] call BIS_fnc_inString) then {
-		if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then{
+		if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then {
 			_LockedVariable pushBack _animName;
 		} else {
 			_animations pushBack _animName;

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -20,17 +20,15 @@
 
 params ["_house", "_door"];
 
-private ["_index", "_animations", "_lockedVariable"];
-
 private _animate = animationNames _house;
 private _animations = [];
 private _lockedVariable = [];
 
 {
-    _animName = _x;
-    if ([toLower _door, _animName] call BIS_fnc_inString) then {
-        if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then {
-            _LockedVariable pushBack _animName;
+    private _animName = toLower _x;    
+    if ((_animName find (toLower _door)) != -1) then {        
+        if (((_animName find "disabled") != -1) || ((_animName find "locked") != -1)) then {
+            _lockedVariable pushBack _animName;
         } else {
             _animations pushBack _animName;
         };

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: commy2, Phyma
- * Get door animations. @todo rewrite for better custom building support could look in animationsources instead of animate
+ * Get door animations.
  *
  * Arguments:
  * 0: House <OBJECT>

--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -22,13 +22,12 @@ params ["_house", "_door"];
 
 private ["_index", "_animations", "_lockedVariable"];
 
-private _config = _house call CBA_fnc_getObjectConfig;
-private _animate = getArray(_config >> "SimpleObject" >> "animate");
+private _animate = animationNames _house;
 private _animations = [];
 private _lockedVariable = [];
 
 {
-    _animName = _x select 0;
+    _animName = _x;
     if ([toLower _door, _animName] call BIS_fnc_inString) then {
         if (["disabled", _animName] call BIS_fnc_inString || ["locked", _animName] call BIS_fnc_inString) then {
             _LockedVariable pushBack _animName;

--- a/addons/interaction/functions/fnc_getGlassDoor.sqf
+++ b/addons/interaction/functions/fnc_getGlassDoor.sqf
@@ -1,0 +1,60 @@
+/*
+ * Author: Phyma
+ * Find glass door.
+ *
+ * Arguments:
+ * 0: House <OBJECT>
+ * 1: Door name <STRING>
+ *
+ * Return Value:
+ * House objects and door <ARRAY>
+ * 0: House <OBJECT>
+ * 1: Door Name <STRING>
+ *
+ * Example:
+ * [player, target] call ace_interaction_fnc_getGlassDoor
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_house", "_door"]; 
+
+private ["_animName", "_splitStr", "_newString", "_dist", "_animate"];
+private _doorParts = [];
+private _doorPos = [];
+private _config = _house call CBA_fnc_getObjectConfig;	
+private _animate = configProperties [_config >> "AnimationSources", "true", false];
+private _glassDoor = _door splitString "_";	
+private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);	
+
+// calculate all animation names so we know what is there	
+{			
+	_animName = configName _x;
+	if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {			
+		_splitStr = _animName splitString "_";			
+		_doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
+	};
+} forEach _animate;	
+
+{
+	_doorPos pushBack (_house selectionPosition [_x, "Memory"]);
+} forEach _doorParts;
+
+private _lowestDistance = 0;	
+{		
+	private _dist = _glassPos distance  _x;
+	if (_lowestDistance == 0) then {
+		_lowestDistance = _dist;
+		_newString = (_doorParts select _forEachIndex) splitString "_";			
+		_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");
+	} else {
+		if (_dist < _lowestDistance) then {
+			_lowestDistance = _dist;
+			_newString = (_doorParts select _forEachIndex) splitString "_";			
+			_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");				
+		};			
+	};							
+} forEach _doorPos;
+
+[_house, _door]

--- a/addons/interaction/functions/fnc_getGlassDoor.sqf
+++ b/addons/interaction/functions/fnc_getGlassDoor.sqf
@@ -32,11 +32,15 @@ private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_g
 {           
     _animName = configName _x;
     if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {         
-        _splitStr = _animName splitString "_"; 
-        // Get the pos of all the door componetnts
-        _doorPos pushBack (_house selectionPosition [((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger"), "Memory"]);
+        _splitStr = _animName splitString "_";             
+        _doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
     };
 } forEach _animate; 
+
+// Get the pos of all the door components and save the parts
+{
+    _doorPos pushBack (_house selectionPosition [_x, "Memory"]);
+} forEach _doorParts;
 
 // Calculate what door that is closest to the glass door
 private _lowestDistance = 0;    

--- a/addons/interaction/functions/fnc_getGlassDoor.sqf
+++ b/addons/interaction/functions/fnc_getGlassDoor.sqf
@@ -7,7 +7,7 @@
  * 1: House <OBJECT>
  * 2: Door name <STRING>
  *
- * Return Value: 
+ * Return Value:
  * 0: Door Name <STRING>
  *
  * Example:
@@ -17,21 +17,22 @@
  */
 #include "script_component.hpp"
 
-params ["_distance", "_house", "_door"]; 
+params ["_distance", "_house", "_door"];
 
 private _doorParts = [];
 private _doorPos = [];
 private _animate = animationNames _house;
-private _glassDoor = _door splitString "_"; 
-private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);     
-// Calculate all animation names so we know what is there   
-{           
+private _glassDoor = _door splitString "_";
+private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);
+// Calculate all animation names so we know what is there
+{
     private _animName = toLower _x;
-    if (((_animName find "door") != -1) && ((_animName find "locked") == -1) && ((_animName find "disabled") == -1) && ((_animName find "handle") == -1)) then {         
-        private _splitStr = _animName splitString "_";             
+    if (((_animName find "door") != -1) && ((_animName find "locked") == -1) && ((_animName find "disabled") == -1) && ((_animName find "handle") == -1)) then {
+        private _splitStr = _animName splitString "_";
         _doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
     };
-} forEach _animate; 
+} forEach _animate;
+
 
 // Get the pos of all the door components and save the parts
 {
@@ -39,24 +40,24 @@ private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_g
 } forEach _doorParts;
 
 // Calculate what door that is closest to the glass door
-private _lowestDistance = 0;    
-{       
-    private _objDist = _glassPos distance  _x;   
+private _lowestDistance = 0;
+{
+    private _objDist = _glassPos distance  _x;
     //Make sure we dont take another door by mistake
-    if (_objDist <= _distance) then {    
+    if (_objDist <= _distance) then {
         //Need to set the value in the beginning
         if (_lowestDistance == 0) then {
             _lowestDistance = _objDist;
-            private _splitStr = (_doorParts select _forEachIndex) splitString "_";         
+            private _splitStr = (_doorParts select _forEachIndex) splitString "_";
             _door = (_splitStr select 0) + "_" + (_splitStr select 1);
         } else {
-            if (_objDist < _lowestDistance) then {               
+            if (_objDist < _lowestDistance) then {
                 _lowestDistance = _objDist;
-                private _splitStr = (_doorParts select _forEachIndex) splitString "_";         
-                _door = (_splitStr select 0) + "_" + (_splitStr select 1); 
-            };          
+                private _splitStr = (_doorParts select _forEachIndex) splitString "_";
+                _door = (_splitStr select 0) + "_" + (_splitStr select 1);
+            };
         };
-    };        
+    };
 } forEach _doorPos;
 
 // Check if we have a door or if it is the glass part

--- a/addons/interaction/functions/fnc_getGlassDoor.sqf
+++ b/addons/interaction/functions/fnc_getGlassDoor.sqf
@@ -19,7 +19,6 @@
 
 params ["_distance", "_house", "_door"]; 
 
-private ["_animName", "_splitStr", "_newString", "_objDist", "_animate"];
 private _doorParts = [];
 private _doorPos = [];
 private _animate = animationNames _house;
@@ -27,9 +26,9 @@ private _glassDoor = _door splitString "_";
 private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);     
 // Calculate all animation names so we know what is there   
 {           
-    _animName = _x;
-    if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {         
-        _splitStr = _animName splitString "_";             
+    private _animName = toLower _x;
+    if (((_animName find "door") != -1) && ((_animName find "locked") == -1) && ((_animName find "disabled") == -1) && ((_animName find "handle") == -1)) then {         
+        private _splitStr = _animName splitString "_";             
         _doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
     };
 } forEach _animate; 
@@ -42,26 +41,26 @@ private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_g
 // Calculate what door that is closest to the glass door
 private _lowestDistance = 0;    
 {       
-    private _objDist = _glassPos distance  _x;
-    
+    private _objDist = _glassPos distance  _x;   
+    //Make sure we dont take another door by mistake
     if (_objDist <= _distance) then {    
         //Need to set the value in the beginning
         if (_lowestDistance == 0) then {
             _lowestDistance = _objDist;
-            _newString = (_doorParts select _forEachIndex) splitString "_";         
-            _door = (_newString select 0) + "_" + (_newString select 1);
+            private _splitStr = (_doorParts select _forEachIndex) splitString "_";         
+            _door = (_splitStr select 0) + "_" + (_splitStr select 1);
         } else {
             if (_objDist < _lowestDistance) then {               
                 _lowestDistance = _objDist;
-                _newString = (_doorParts select _forEachIndex) splitString "_";         
-                _door = (_newString select 0) + "_" + (_newString select 1); 
+                private _splitStr = (_doorParts select _forEachIndex) splitString "_";         
+                _door = (_splitStr select 0) + "_" + (_splitStr select 1); 
             };          
         };
     };        
 } forEach _doorPos;
 
 // Check if we have a door or if it is the glass part
-if (isNil "_door"|| (["glass", _door] call BIS_fnc_inString)) exitWith {};
+if ((isNil "_door") || ((_door find "glass") != -1)) exitWith {};
 
 _door
 

--- a/addons/interaction/functions/fnc_getGlassDoor.sqf
+++ b/addons/interaction/functions/fnc_getGlassDoor.sqf
@@ -23,38 +23,38 @@ params ["_house", "_door"];
 private ["_animName", "_splitStr", "_newString", "_dist", "_animate"];
 private _doorParts = [];
 private _doorPos = [];
-private _config = _house call CBA_fnc_getObjectConfig;	
+private _config = _house call CBA_fnc_getObjectConfig;  
 private _animate = configProperties [_config >> "AnimationSources", "true", false];
-private _glassDoor = _door splitString "_";	
-private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);	
+private _glassDoor = _door splitString "_"; 
+private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);    
 
-// calculate all animation names so we know what is there	
-{			
-	_animName = configName _x;
-	if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {			
-		_splitStr = _animName splitString "_";			
-		_doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
-	};
-} forEach _animate;	
+// calculate all animation names so we know what is there   
+{           
+    _animName = configName _x;
+    if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {         
+        _splitStr = _animName splitString "_";          
+        _doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
+    };
+} forEach _animate; 
 
 {
-	_doorPos pushBack (_house selectionPosition [_x, "Memory"]);
+    _doorPos pushBack (_house selectionPosition [_x, "Memory"]);
 } forEach _doorParts;
 
-private _lowestDistance = 0;	
-{		
-	private _dist = _glassPos distance  _x;
-	if (_lowestDistance == 0) then {
-		_lowestDistance = _dist;
-		_newString = (_doorParts select _forEachIndex) splitString "_";			
-		_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");
-	} else {
-		if (_dist < _lowestDistance) then {
-			_lowestDistance = _dist;
-			_newString = (_doorParts select _forEachIndex) splitString "_";			
-			_door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");				
-		};			
-	};							
+private _lowestDistance = 0;    
+{       
+    private _dist = _glassPos distance  _x;
+    if (_lowestDistance == 0) then {
+        _lowestDistance = _dist;
+        _newString = (_doorParts select _forEachIndex) splitString "_";         
+        _door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");
+    } else {
+        if (_dist < _lowestDistance) then {
+            _lowestDistance = _dist;
+            _newString = (_doorParts select _forEachIndex) splitString "_";         
+            _door = ((_newString select 0) + "_" + (_newString select 1) + "_rot");             
+        };          
+    };                          
 } forEach _doorPos;
 
 [_house, _door]

--- a/addons/interaction/functions/fnc_getGlassDoor.sqf
+++ b/addons/interaction/functions/fnc_getGlassDoor.sqf
@@ -28,22 +28,22 @@ private _animate = configProperties [_config >> "AnimationSources", "true", fals
 private _glassDoor = _door splitString "_"; 
 private _glassPos = (_house selectionPosition [(_glassDoor select 0) + "_" + (_glassDoor select 1) + "_effects", "Memory"]);    
 
-// calculate all animation names so we know what is there   
+// Calculate all animation names so we know what is there   
 {           
     _animName = configName _x;
     if ((["door", _animName] call BIS_fnc_inString) && !(["locked", _animName] call BIS_fnc_inString) && !(["disabled", _animName] call BIS_fnc_inString) && !(["handle", _animName] call BIS_fnc_inString)) then {         
-        _splitStr = _animName splitString "_";          
-        _doorParts pushBack ((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger");
+        _splitStr = _animName splitString "_"; 
+        // Get the pos of all the door componetnts
+        _doorPos pushBack (_house selectionPosition [((_splitStr select 0) + "_" + (_splitStr select 1) + "_trigger"), "Memory"]);
     };
 } forEach _animate; 
 
-{
-    _doorPos pushBack (_house selectionPosition [_x, "Memory"]);
-} forEach _doorParts;
-
+// Calculate what door that is closest to the glass door
 private _lowestDistance = 0;    
 {       
     private _dist = _glassPos distance  _x;
+    
+    //Need to set the value in the beginning
     if (_lowestDistance == 0) then {
         _lowestDistance = _dist;
         _newString = (_doorParts select _forEachIndex) splitString "_";         

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -66,5 +66,5 @@ GVAR(usedScrollWheel) = false;
         GVAR(usedScrollWheel) = true;
     };
     // do incremental door opening
-    {_house animate [_x, GVAR(doorTargetPhase)];  false} count _animations;
+    {_house animate [_x, GVAR(doorTargetPhase)]; false} count _animations;
 }, 0.1, [_house, _animations, getPosASL ACE_player, CBA_missionTime + 0.2, diag_frameno + 2]] call CBA_fnc_addPerFrameHandler;

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -28,9 +28,12 @@ _getDoorAnimations params ["_animations", "_lockedVariable"];
 
 if (_animations isEqualTo []) exitWith {};
 
-if (_house animationPhase (_animations select 0) <= 0 && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
-    _lockedVariable set [0, _house];
-    _lockedVariable call BIS_fnc_LockedDoorOpen;
+//Check if the door can be locked aka have locked variable, otherwhise cant lock it
+if(!isNil(_lockedVariable select 0)) then {
+	if (_house animationPhase (_animations select 0) <= 0 && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
+		_lockedVariable set [0, _house];
+		_lockedVariable call BIS_fnc_LockedDoorOpen;
+	};
 };
 
 playSound "ACE_Sound_Click"; // @todo replace with smth. more fitting
@@ -62,7 +65,6 @@ GVAR(usedScrollWheel) = false;
     if (CBA_missionTime > _time && {diag_frameno > _frame}) then {
         GVAR(usedScrollWheel) = true;
     };
-
     // do incremental door opening
-    {_house animate [_x, GVAR(doorTargetPhase)]; false} count _animations;
+    {_house animate [_x, GVAR(doorTargetPhase)];  false} count _animations;
 }, 0.1, [_house, _animations, getPosASL ACE_player, CBA_missionTime + 0.2, diag_frameno + 2]] call CBA_fnc_addPerFrameHandler;

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -30,7 +30,7 @@ if (_animations isEqualTo []) exitWith {};
 
 //Check if the door can be locked aka have locked variable, otherwhise cant lock it
 if (!(isNil (_lockedVariable select 0))) then {
-    if (_house animationPhase (_animations select 0) <= 0 && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
+    if ((_house animationPhase (_animations select 0) <= 0) && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
         _lockedVariable set [0, _house];
         _lockedVariable call BIS_fnc_LockedDoorOpen;
     };

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -30,10 +30,10 @@ if (_animations isEqualTo []) exitWith {};
 
 //Check if the door can be locked aka have locked variable, otherwhise cant lock it
 if(!isNil(_lockedVariable select 0)) then {
-	if (_house animationPhase (_animations select 0) <= 0 && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
-		_lockedVariable set [0, _house];
-		_lockedVariable call BIS_fnc_LockedDoorOpen;
-	};
+    if (_house animationPhase (_animations select 0) <= 0 && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
+        _lockedVariable set [0, _house];
+        _lockedVariable call BIS_fnc_LockedDoorOpen;
+    };
 };
 
 playSound "ACE_Sound_Click"; // @todo replace with smth. more fitting

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -29,7 +29,7 @@ _getDoorAnimations params ["_animations", "_lockedVariable"];
 if (_animations isEqualTo []) exitWith {};
 
 //Check if the door can be locked aka have locked variable, otherwhise cant lock it
-if(!isNil(_lockedVariable select 0)) then {
+if (!(isNil (_lockedVariable select 0))) then {
     if (_house animationPhase (_animations select 0) <= 0 && {_house getVariable [_lockedVariable select 0, 0] == 1}) exitWith {
         _lockedVariable set [0, _house];
         _lockedVariable call BIS_fnc_LockedDoorOpen;


### PR DESCRIPTION
Will make sure that you can Ace slow open glass doors.
Also a bit flexible animation gathering instead of fixed strings.
CUP houses now works to incremental open!

The reason behind getGlassDoor is that if you do the regular door check you will get the hide and unhide of the glass pane. So you then need to find the closest doorobject because thats the door.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/)
