### PR TITLE
Remove submuntion ammo changes to A-10

### DIFF
--- a/addons/aircraft/CfgAmmo.hpp
+++ b/addons/aircraft/CfgAmmo.hpp
@@ -36,4 +36,23 @@ class CfgAmmo {
         caliber = 1.6;
         deflecting = 15;
     };
+
+    // also adjust tracer, "muh lightshow"; also adjust splash damage radius
+    class Gatling_30mm_HE_Plane_CAS_01_F: BulletBase {
+        hit = 80; // default: 180
+        indirectHit = 12; // default: 4
+        indirectHitRange = 3; // default: 3
+        caliber = 1.4; // default: 5
+        deflecting = 3; // default: 5
+        fuseDistance = 3; // default: 10
+        tracerStartTime = 0.02; // default: 0.1
+        timeToLive = 40; // default: 6
+    };
+
+    // adjust damage and splash damage, closer to bluefor gatling with same caliber
+    class Cannon_30mm_HE_Plane_CAS_02_F: Gatling_30mm_HE_Plane_CAS_01_F {
+        hit = 70; // default: 150
+        indirectHit = 11; // default: 4
+        indirectHitRange = 3; // default: 3
+    };
 };

--- a/addons/aircraft/CfgAmmo.hpp
+++ b/addons/aircraft/CfgAmmo.hpp
@@ -36,32 +36,4 @@ class CfgAmmo {
         caliber = 1.6;
         deflecting = 15;
     };
-
-    // also adjust tracer, "muh lightshow"; also adjust splash damage radius
-    class Gatling_30mm_HE_Plane_CAS_01_F: BulletBase {
-        hit = 80;
-        indirectHit = 12;
-        indirectHitRange = 3; //2;
-        caliber = 1.4;
-        deflecting = 3;
-        fuseDistance = 3;
-        tracerStartTime = 0.02;
-        timeToLive = 40;
-    };
-
-    // helper projectiles to simulate a rof > fps
-    class ACE_Gatling_30mm_HE_Plane_CAS_01_Deploy: Gatling_30mm_HE_Plane_CAS_01_F {
-        simulation = "shotSubmunitions";
-        triggerTime = 0;
-        submunitionAmmo = "ACE_Gatling_30mm_HE_Plane_CAS_01_Sub";
-        submunitionConeType[] = {"custom", {{0,0}, {0,0}, {0,0}} };
-    };
-    class ACE_Gatling_30mm_HE_Plane_CAS_01_Sub: Gatling_30mm_HE_Plane_CAS_01_F {};
-
-    // adjust damage and splash damage, closer to bluefor gatling with same caliber
-    class Cannon_30mm_HE_Plane_CAS_02_F: Gatling_30mm_HE_Plane_CAS_01_F {
-        hit = 70; //40;
-        indirectHit = 11; //14;
-        indirectHitRange = 3;
-    };
 };

--- a/addons/aircraft/CfgMagazines.hpp
+++ b/addons/aircraft/CfgMagazines.hpp
@@ -2,7 +2,6 @@ class CfgMagazines {
     // shoot helper object to tripple rof
     class VehicleMagazine;
     class 1000Rnd_Gatling_30mm_Plane_CAS_01_F: VehicleMagazine {
-        ammo = "ACE_Gatling_30mm_HE_Plane_CAS_01_Deploy";
         count = 1170;
     };
 

--- a/addons/aircraft/CfgWeapons.hpp
+++ b/addons/aircraft/CfgWeapons.hpp
@@ -111,22 +111,4 @@ class CfgWeapons {
         class medium: LowROF {};
         class far: medium {};
     };
-
-    class Gatling_30mm_Plane_CAS_01_F: CannonCore {
-        autoFire = 1;
-        burst = 1;
-
-        class LowROF: Mode_FullAuto {
-            autoFire = 0;
-            burst = 22; //65;
-            reloadTime = 0.0462; //0.0154; //0.034;
-            multiplier = 3;
-        };
-
-        class close: LowROF {};
-        class near: close {};
-        class short: close {};
-        class medium: close {};
-        class far: close {};
-    };
 };


### PR DESCRIPTION
Fix #5221
Removes the submunition (`Deploy`) ammo type for the a-10 cannon
Ref PR #5197