### PR TITLE
Fix being unable to throw last mag

### DIFF
--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -37,7 +37,7 @@ if (_throwable isEqualTo [] && {!_primed}) exitWith {
 private _throwableMag = _throwable param [0, "#none"];
 
 // If not primed, double check we actually have the magazine in inventory
-if ((!_primed) && {!(_throwableMag in (magazines ACE_player))}) exitWith {
+if ((!_primed) && {!((_throwableMag in (uniformItems ACE_player)) || {_throwableMag in (vestItems ACE_player)} || {_throwableMag in (backpackItems ACE_player)})}) exitWith {
     [ACE_player, "No valid throwable (glitched currentThrowable)"] call FUNC(exitThrowMode);
 };
 


### PR DESCRIPTION
Ref https://github.com/acemod/ACE3/pull/5216

Fixes bug from last PR that prevents throwing last grenade
I didn't account for the fact that ` ACE_player setAmmo [_muzzle, 0];` seems to remove the magazines from `magazines` command
But they still show with the `xItems` commands.