### PR TITLE
Use getUnitTrait for medics, engineers and EOD

### DIFF
--- a/addons/common/functions/fnc_isEOD.sqf
+++ b/addons/common/functions/fnc_isEOD.sqf
@@ -20,4 +20,4 @@
 
 params ["_unit"];
 
-_unit getVariable ["ACE_isEOD", getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "canDeactivateMines") == 1] // return
+_unit getVariable ["ACE_isEOD", _unit getUnitTrait "explosiveSpecialist"] // return

--- a/addons/common/functions/fnc_isEngineer.sqf
+++ b/addons/common/functions/fnc_isEngineer.sqf
@@ -17,7 +17,7 @@
 
 params ["_unit"];
 
-private _isEngineer = _unit getVariable ["ACE_isEngineer", getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "engineer") == 1];
+private _isEngineer = _unit getVariable ["ACE_isEngineer", _unit getUnitTrait "engineer"];
 //Handle ace_repair modules setting this to a number
 if (_isEngineer isEqualType 0) then {_isEngineer = _isEngineer > 0};
 

--- a/addons/medical/functions/fnc_isMedic.sqf
+++ b/addons/medical/functions/fnc_isMedic.sqf
@@ -19,7 +19,7 @@
 
 params ["_unit", ["_medicN", 1]];
 
-private _class = _unit getVariable [QGVAR(medicClass), _unit getUnitTrait "medic"];
+private _class = _unit getVariable [QGVAR(medicClass), [0, 1] select (_unit getUnitTrait "medic")];
 
 if (_class >= _medicN min GVAR(medicSetting)) exitWith {true};
 if (!GVAR(increaseTrainingInLocations)) exitWith {false};

--- a/addons/medical/functions/fnc_isMedic.sqf
+++ b/addons/medical/functions/fnc_isMedic.sqf
@@ -19,7 +19,7 @@
 
 params ["_unit", ["_medicN", 1]];
 
-private _class = _unit getVariable [QGVAR(medicClass), getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "attendant")];
+private _class = _unit getVariable [QGVAR(medicClass), _unit getUnitTrait "medic"];
 
 if (_class >= _medicN min GVAR(medicSetting)) exitWith {true};
 if (!GVAR(increaseTrainingInLocations)) exitWith {false};

--- a/addons/repair/functions/fnc_isEngineer.sqf
+++ b/addons/repair/functions/fnc_isEngineer.sqf
@@ -20,7 +20,7 @@ params ["_unit", ["_engineerN", 1]];
 TRACE_2("params",_unit,_engineerN);
 
 private ["_class"];
-_class = _unit getVariable ["ACE_IsEngineer", getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "engineer")];
+_class = _unit getVariable ["ACE_IsEngineer", _unit getUnitTrait "engineer"];
 
 // This if statement is here for copmatability with the common variant of isEngineer, which requires a bool.
 // We cannot move this function to common because we require the GVAR(engineerSetting_Repair), which only makes sense to include in the repair module.


### PR DESCRIPTION
**When merged this pull request will:**
- Make the functions which check whether units are medics, engineers or explosive specialists use the newer `getUnitTrait` command which makes them compatible with use of `setUnitTrait` and not purely checking the config
