### PR TITLE
Repair specialist rename, fixes #3186

### DIFF
--- a/addons/repair/ACE_Settings.hpp
+++ b/addons/repair/ACE_Settings.hpp
@@ -12,7 +12,7 @@ class ACE_Settings {
         description = CSTRING(enginerSetting_Repair_description);
         typeName = "SCALAR";
         value = 1;
-        values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_RepairSpecialistOnly)};
+        values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_AdvancedOnly)};
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };
     class GVAR(engineerSetting_wheel) {
@@ -20,7 +20,7 @@ class ACE_Settings {
         description = CSTRING(enginerSetting_Wheel_description);
         typeName = "SCALAR";
         value = 0;
-        values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_RepairSpecialistOnly)};
+        values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_AdvancedOnly)};
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };
     class GVAR(repairDamageThreshold) {
@@ -58,7 +58,7 @@ class ACE_Settings {
         description = CSTRING(engineerSetting_fullRepair_description);
         typeName = "SCALAR";
         value = 2;
-        values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_RepairSpecialistOnly)};
+        values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_AdvancedOnly)};
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };
     class GVAR(addSpareParts) {

--- a/addons/repair/CfgEden.hpp
+++ b/addons/repair/CfgEden.hpp
@@ -21,7 +21,7 @@ class Cfg3DEN {
                     h = "5 * (pixelH * pixelGrid * 0.50)";
                     rows = 1;
                     columns = 4;
-                    strings[] = {"$STR_3DEN_Attributes_Lock_Default_text", CSTRING(AssignEngineerRole_role_none), CSTRING(AssignEngineerRole_role_engineer), CSTRING(AssignEngineerRole_role_specialist)};
+                    strings[] = {"$STR_3DEN_Attributes_Lock_Default_text", CSTRING(AssignEngineerRole_role_none), CSTRING(AssignEngineerRole_role_engineer), CSTRING(AssignEngineerRole_role_advanced)};
                 };
             };
         };

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -38,7 +38,7 @@ class CfgVehicles {
                 class values {
                     class anyone { name = CSTRING(engineerSetting_anyone); value = 0; };
                     class Engineer { name = CSTRING(engineerSetting_EngineerOnly); value = 1; default = 1; };
-                    class Special { name = CSTRING(engineerSetting_RepairSpecialistOnly); value = 2; };
+                    class Advanced { name = CSTRING(engineerSetting_AdvancedOnly); value = 2; };
                 };
             };
             class engineerSetting_Wheel {
@@ -48,7 +48,7 @@ class CfgVehicles {
                 class values {
                     class anyone { name = CSTRING(engineerSetting_anyone); value = 0; default = 1; };
                     class Engineer { name = CSTRING(engineerSetting_EngineerOnly); value = 1; };
-                    class Special { name = CSTRING(engineerSetting_RepairSpecialistOnly); value = 2; };
+                    class Advanced { name = CSTRING(engineerSetting_AdvancedOnly); value = 2; };
                 };
             };
             class repairDamageThreshold {
@@ -91,7 +91,7 @@ class CfgVehicles {
                 class values {
                     class anyone { name = CSTRING(engineerSetting_anyone); value = 0; };
                     class Engineer { name = CSTRING(engineerSetting_EngineerOnly); value = 1; };
-                    class Special { name = CSTRING(engineerSetting_RepairSpecialistOnly); value = 2; default = 1;};
+                    class Advanced { name = CSTRING(engineerSetting_AdvancedOnly); value = 2; default = 1;};
                 };
             };
             class addSpareParts {
@@ -150,7 +150,7 @@ class CfgVehicles {
                         default = 1;
                     };
                     class doctor {
-                        name = CSTRING(AssignEngineerRole_role_specialist);
+                        name = CSTRING(AssignEngineerRole_role_advanced);
                         value = 2;
                     };
                 };

--- a/addons/repair/functions/fnc_getPostRepairDamage.sqf
+++ b/addons/repair/functions/fnc_getPostRepairDamage.sqf
@@ -22,7 +22,7 @@ TRACE_1("params",_unit);
 if (([_unit] call FUNC(isInRepairFacility) || {[_unit] call FUNC(isNearRepairVehicle)})) exitWith {0};
 
 private _class = _unit getVariable ["ACE_IsEngineer", getNumber (configFile >> "CfgVehicles" >> typeOf _unit >> "engineer")];
-//If specialist or more qualified than min, then use engineer threshold:
+//If advanced or more qualified than min, then use engineer threshold:
 if ((_class isEqualTo 2) || {[_unit, GVAR(engineerSetting_Repair) + 1] call FUNC(isEngineer)}) exitWith {
     (GVAR(repairDamageThreshold_Engineer) min GVAR(repairDamageThreshold))
 };

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -955,17 +955,17 @@
             <Korean>오직 정비공만</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_engineerSetting_RepairSpecialistOnly">
-            <English>Repair Specialist only</English>
-            <German>Nur Reparaturspezialist</German>
+            <English>Advanced Engineer only</English>
+            <German>Nur Ingenieur</German>
             <Polish>Tylko inżynierowie</Polish>
-            <Portuguese>Somente especialista em reparos</Portuguese>
-            <Russian>Только ремонтные специалисты</Russian>
-            <Czech>Pouze specialista na opravování</Czech>
-            <Spanish>Solo especialista en reparación</Spanish>
-            <Italian>Solo Specialista Riparazioni</Italian>
-            <French>Spécialistes de réparation seulement</French>
-            <Japanese>専門兵のみ</Japanese>
-            <Korean>오직 정비 특기만</Korean>
+            <Portuguese>Somente engenheiro avançado</Portuguese>
+            <Russian>Только продвинутый инженер</Russian>
+            <Czech>Pokročilý inženýr pouze</Czech>
+            <Spanish>Solo Ingeniero avanzado</Spanish>
+            <Italian>Solo Ingegnere avanzato</Italian>
+            <French>Ingénieur Avancé seulement</French>
+            <Japanese>高度なエンジニアのみ</Japanese>
+            <Korean>고급 엔지니어 전용</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_enginerSetting_Wheel_name">
             <English>Allow Wheel</English>
@@ -1241,17 +1241,17 @@
             <Korean>정비공</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_role_specialist">
-            <English>Specialist</English>
-            <German>Reparaturspezialist</German>
-            <Polish>Inżynier</Polish>
-            <Portuguese>Especialista</Portuguese>
-            <Russian>Специалист</Russian>
-            <Czech>Specialista</Czech>
-            <Spanish>Especialista</Spanish>
-            <Italian>Specialista Riparazioni</Italian>
-            <French>Spécialiste</French>
-            <Japanese>工兵として単体、複数ユニットを割り当てます。</Japanese>
-            <Korean>정비 특기</Korean>
+            <English>Advanced Engineer</English>
+            <German>Ingenieur</German>
+            <Polish>inżynierowie</Polish>
+            <Portuguese>engenheiro avançado</Portuguese>
+            <Russian>продвинутый инженер</Russian>
+            <Czech>Pokročilý inženýr</Czech>
+            <Spanish>Ingeniero avanzado</Spanish>
+            <Italian>Ingegnere avanzato</Italian>
+            <French>Ingénieur Avancé</French>
+            <Japanese>上級エンジニア</Japanese>
+            <Korean>고급 엔지니어</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_Module_Description">
             <English>Assign one or multiple units as an engineer</English>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="repair">
         <Key ID="STR_ACE_Repair_SpareTrack">
@@ -943,7 +943,7 @@
         </Key>
         <Key ID="STR_ACE_Repair_engineerSetting_EngineerOnly">
             <English>Engineer only</English>
-            <German>Pionier</German>
+            <German>Nur pionier</German>
             <Polish>Tylko mechanicy</Polish>
             <Portuguese>Somente engenheiro</Portuguese>
             <Russian>Только инженеры</Russian>
@@ -956,14 +956,14 @@
         </Key>
         <Key ID="STR_ACE_Repair_engineerSetting_RepairSpecialistOnly">
             <English>Advanced Engineer only</English>
-            <German>Nur Ingenieur</German>
+            <German>Nur ingenieur</German>
             <Polish>Tylko inżynierowie</Polish>
             <Portuguese>Somente engenheiro avançado</Portuguese>
             <Russian>Только продвинутый инженер</Russian>
             <Czech>Pokročilý inženýr pouze</Czech>
-            <Spanish>Solo Ingeniero avanzado</Spanish>
-            <Italian>Solo Ingegnere avanzato</Italian>
-            <French>Ingénieur Avancé seulement</French>
+            <Spanish>Solo ingeniero avanzado</Spanish>
+            <Italian>Solo ingegnere avanzato</Italian>
+            <French>Ingénieur avancé seulement</French>
             <Japanese>高度なエンジニアのみ</Japanese>
             <Korean>고급 엔지니어 전용</Korean>
         </Key>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -954,7 +954,7 @@
             <Japanese>工兵のみ</Japanese>
             <Korean>오직 정비공만</Korean>
         </Key>
-        <Key ID="STR_ACE_Repair_engineerSetting_RepairSpecialistOnly">
+        <Key ID="STR_ACE_Repair_engineerSetting_AdvancedOnly">
             <English>Advanced Engineer only</English>
         </Key>
         <Key ID="STR_ACE_Repair_enginerSetting_Wheel_name">
@@ -1230,8 +1230,9 @@
             <Japanese>専門兵</Japanese>
             <Korean>정비공</Korean>
         </Key>
-        <Key ID="STR_ACE_Repair_AssignEngineerRole_role_specialist">
-            <English>Adv. Engineer</English> <!-- Advanced Engineer is to long for some fields so it it shorted to Adv. -->
+        <Key ID="STR_ACE_Repair_AssignEngineerRole_role_advanced">
+            <!-- Advanced Engineer is to long for some fields so it it shorted to Adv. -->
+            <English>Adv. Engineer</English>
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_Module_Description">
             <English>Assign one or multiple units as an engineer</English>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -943,7 +943,7 @@
         </Key>
         <Key ID="STR_ACE_Repair_engineerSetting_EngineerOnly">
             <English>Engineer only</English>
-            <German>Nur pionier</German>
+            <German>Pionier</German>
             <Polish>Tylko mechanicy</Polish>
             <Portuguese>Somente engenheiro</Portuguese>
             <Russian>Только инженеры</Russian>
@@ -956,16 +956,6 @@
         </Key>
         <Key ID="STR_ACE_Repair_engineerSetting_RepairSpecialistOnly">
             <English>Advanced Engineer only</English>
-            <German>Nur ingenieur</German>
-            <Polish>Tylko inżynierowie</Polish>
-            <Portuguese>Somente engenheiro avançado</Portuguese>
-            <Russian>Только продвинутый инженер</Russian>
-            <Czech>Pokročilý inženýr pouze</Czech>
-            <Spanish>Solo ingeniero avanzado</Spanish>
-            <Italian>Solo ingegnere avanzato</Italian>
-            <French>Ingénieur avancé seulement</French>
-            <Japanese>高度なエンジニアのみ</Japanese>
-            <Korean>고급 엔지니어 전용</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_enginerSetting_Wheel_name">
             <English>Allow Wheel</English>
@@ -1242,16 +1232,6 @@
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_role_specialist">
             <English>Advanced Engineer</English>
-            <German>Ingenieur</German>
-            <Polish>inżynierowie</Polish>
-            <Portuguese>engenheiro avançado</Portuguese>
-            <Russian>продвинутый инженер</Russian>
-            <Czech>Pokročilý inženýr</Czech>
-            <Spanish>Ingeniero avanzado</Spanish>
-            <Italian>Ingegnere avanzato</Italian>
-            <French>Ingénieur Avancé</French>
-            <Japanese>上級エンジニア</Japanese>
-            <Korean>고급 엔지니어</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_Module_Description">
             <English>Assign one or multiple units as an engineer</English>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1231,7 +1231,7 @@
             <Korean>정비공</Korean>
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_role_specialist">
-            <English>Advanced Engineer</English>
+            <English>Adv. Engineer</English> <!-- Advanced Engineer is to long for some fields so it it shorted to Adv. -->
         </Key>
         <Key ID="STR_ACE_Repair_AssignEngineerRole_Module_Description">
             <English>Assign one or multiple units as an engineer</English>

--- a/docs/team.md
+++ b/docs/team.md
@@ -110,6 +110,7 @@ tpM | ACSE Dev Lead - Sounds, SME
 * OnkelDisMaster
 * oscarmolinadev
 * PaxJaromeMalues
+* Phyma
 * pokertour
 * Professor
 * rakowozz


### PR DESCRIPTION
**When merged this pull request will:**
- Will change the translation from Repair specialist to Advanced Engineer. See picture.
- Translation on other languages than English might be weird so  if its your native language and wrong then please review.

Did not have time to look through all stringtables in ACE so if you know there is a mention of ACE repair specialist somewhere else than repair then please say so. Should not be mentioned anywhere else.

http://steamcommunity.com/sharedfiles/filedetails/?id=940226455

Fixes #3186 

