### PR TITLE
Fix Large IED defuse distance

### DIFF
--- a/addons/explosives/CfgAmmo.hpp
+++ b/addons/explosives/CfgAmmo.hpp
@@ -27,10 +27,13 @@ class CfgAmmo {
     class PipeBombCore: TimeBombCore;
     class PipeBombBase: PipeBombCore;
     */
+    // GVAR(size) = 0; is small size
+    // GVAR(size) = 1; is large size
     class DirectionalBombBase;
     class ClaymoreDirectionalMine_Remote_Ammo: DirectionalBombBase {
         GVAR(magazine) = "ClaymoreDirectionalMine_Remote_Mag";
         GVAR(Explosive) = "ClaymoreDirectionalMine_Remote_Ammo_Scripted";
+        GVAR(size) = 0;
         GVAR(defuseObjectPosition)[] = {0, 0, 0.038};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
@@ -39,6 +42,7 @@ class CfgAmmo {
 
     class APERSTripMine_Wire_Ammo: DirectionalBombBase {
         GVAR(defuseObjectPosition)[] = {-1.415, 0, 0.12};
+        GVAR(size) = 0;
     };
 
     class ACE_FlareTripMine_Wire_Ammo: APERSTripMine_Wire_Ammo {
@@ -58,16 +62,18 @@ class CfgAmmo {
             distance = 0;
         };
     };
-    
+
     class F_20mm_Red;
     class ACE_TripFlare_FlareEffect: F_20mm_Red {
         triggerTime = 0.1;
+        GVAR(size) = 0;
     };
 
     class SLAMDirectionalMine_Wire_Ammo: DirectionalBombBase {
         indirectHitRange = 20;
         GVAR(explodeOnDefuseChance) = 1;
         GVAR(magazine) = "SLAMDirectionalMine_Wire_Mag";
+        GVAR(size) = 0;
     };
     class ACE_SLAMDirectionalMine_Command_Ammo: SLAMDirectionalMine_Wire_Ammo {
         mineTrigger = "RemoteTrigger";
@@ -89,6 +95,7 @@ class CfgAmmo {
     class DemoCharge_Remote_Ammo: PipeBombBase {
         GVAR(magazine) = "DemoCharge_Remote_Mag";
         GVAR(Explosive) = "DemoCharge_Remote_Ammo_Scripted";
+        GVAR(size) = 0;
         GVAR(defuseObjectPosition)[] = {0.07, 0, 0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
@@ -99,6 +106,7 @@ class CfgAmmo {
     class SatchelCharge_Remote_Ammo: PipeBombBase {
         GVAR(magazine) = "SatchelCharge_Remote_Mag";
         GVAR(Explosive) = "SatchelCharge_Remote_Ammo_Scripted";
+        GVAR(size) = 0;
         GVAR(defuseObjectPosition)[] = {0.1, 0.1, 0.05};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
@@ -110,6 +118,7 @@ class CfgAmmo {
         triggerWhenDestroyed = 1;
         GVAR(explodeOnDefuseChance) = 0.02;
         GVAR(magazine) = "IEDUrbanBig_Remote_Mag";
+        GVAR(size) = 1;
         soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};
     };
     class ACE_IEDUrbanBig_Command_Ammo: IEDUrbanBig_Remote_Ammo {
@@ -123,6 +132,7 @@ class CfgAmmo {
         triggerWhenDestroyed = 1;
         GVAR(explodeOnDefuseChance) = 0.02;
         GVAR(magazine) = "IEDUrbanSmall_Remote_Mag";
+        GVAR(size) = 0;
         soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};
     };
     class ACE_IEDUrbanSmall_Command_Ammo: IEDUrbanSmall_Remote_Ammo {
@@ -136,6 +146,7 @@ class CfgAmmo {
         triggerWhenDestroyed = 1;
         GVAR(explodeOnDefuseChance) = 0.02;
         GVAR(magazine) = "IEDLandBig_Remote_Mag";
+        GVAR(size) = 1;
         soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};
     };
     class ACE_IEDLandBig_Command_Ammo: IEDLandBig_Remote_Ammo {
@@ -149,6 +160,7 @@ class CfgAmmo {
         triggerWhenDestroyed = 1;
         GVAR(explodeOnDefuseChance) = 0.02;
         GVAR(magazine) = "IEDLandSmall_Remote_Mag";
+        GVAR(size) = 0;
         soundTrigger[] = {"A3\Sounds_F\weapons\mines\mech_trigger_1", 0.8, 1, 40};
     };
     class ACE_IEDLandSmall_Command_Ammo: IEDLandSmall_Remote_Ammo {

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -60,11 +60,11 @@ class CfgVehicles {
                 icon = QPATHTOF(UI\Defuse_ca.paa);
             };
         };
-    };    
+    };
     class ACE_DefuseObject_Large: ACE_DefuseObject {
         class ACE_Actions: ACE_Actions {
             class ACE_Defuse: ACE_Defuse {
-                distance = 1.5;
+                distance = 2;
             };
         };
     };

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -42,22 +42,16 @@ if (!("ACE_DefusalKit" in (items ACE_player))) exitWith {};
         if (((getPosASL ace_player) distance _setPosition) > 5) then {
             {
                 if (((_x distance ACE_player) < 15) && {!(_x in _minesHelped)}) then {
-                    TRACE_3("Making Defuse Helper",(_x),(typeOf _x),(_x isKindOf "UnderwaterMine_Range_Ammo"));
-                    /*private _defuseHelper = if (_x isKindOf "UnderwaterMine_Range_Ammo") then {
-                        "ACE_DefuseObject_Large" createVehicleLocal (getPos _x);
-                    } else {
-                        "ACE_DefuseObject" createVehicleLocal (getPos _x);
-                    };*/
+
+                    private _config = configFile >> "CfgAmmo" >> typeOf _x;
+                    private _size = getNumber (_config >> QGVAR(size));
+                    TRACE_3("Making Defuse Helper",(_x),(typeOf _x),(_size == 1);
                     private ["_defuseHelper"];
-                    private _magazine = getText ((_x call CBA_fnc_getObjectConfig) >> "ace_explosives_magazine");
-                    if ((_magazine == "IEDLandBig_Remote_Mag") || (_magazine == "IEDUrbanBig_Remote_Mag")) then {
+                    if (_size == 1) then {
                         _defuseHelper = "ACE_DefuseObject_Large" createVehicleLocal (getPos _x);
                     } else {
                         _defuseHelper = "ACE_DefuseObject" createVehicleLocal (getPos _x);
                     };
-
-
-                    private _config = configFile >> "CfgAmmo" >> typeOf _x;
 
                     private _defuseObjectPosition = getArray (_config >> QGVAR(defuseObjectPosition));
                     if (_defuseObjectPosition isEqualTo []) then {

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -43,11 +43,19 @@ if (!("ACE_DefusalKit" in (items ACE_player))) exitWith {};
             {
                 if (((_x distance ACE_player) < 15) && {!(_x in _minesHelped)}) then {
                     TRACE_3("Making Defuse Helper",(_x),(typeOf _x),(_x isKindOf "UnderwaterMine_Range_Ammo"));
-                    private _defuseHelper = if (_x isKindOf "UnderwaterMine_Range_Ammo") then {
+                    /*private _defuseHelper = if (_x isKindOf "UnderwaterMine_Range_Ammo") then {
                         "ACE_DefuseObject_Large" createVehicleLocal (getPos _x);
                     } else {
                         "ACE_DefuseObject" createVehicleLocal (getPos _x);
+                    };*/
+                    private ["_defuseHelper"];
+                    private _magazine = getText ((_x call CBA_fnc_getObjectConfig) >> "ace_explosives_magazine");
+                    if ((_magazine == "IEDLandBig_Remote_Mag") || (_magazine == "IEDUrbanBig_Remote_Mag")) then {
+                        _defuseHelper = "ACE_DefuseObject_Large" createVehicleLocal (getPos _x);
+                    } else {
+                        _defuseHelper = "ACE_DefuseObject" createVehicleLocal (getPos _x);
                     };
+
 
                     private _config = configFile >> "CfgAmmo" >> typeOf _x;
 

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -45,7 +45,7 @@ if (!("ACE_DefusalKit" in (items ACE_player))) exitWith {};
 
                     private _config = configFile >> "CfgAmmo" >> typeOf _x;
                     private _size = getNumber (_config >> QGVAR(size));
-                    TRACE_3("Making Defuse Helper",(_x),(typeOf _x),(_size == 1);
+                    TRACE_3("Making Defuse Helper",(_x),(typeOf _x),(_size == 1));
                     private ["_defuseHelper"];
                     if (_size == 1) then {
                         _defuseHelper = "ACE_DefuseObject_Large" createVehicleLocal (getPos _x);

--- a/docs/wiki/feature/explosives.md
+++ b/docs/wiki/feature/explosives.md
@@ -41,7 +41,7 @@ Enables attaching explosives to vehicles.
 - Select `Disarm`.
 - You are safe to pick it up after the action has completed.
 
-**Tip:** To increase the success rate when defusing, make sure you crawl to the IED.
+**Tip:** To increase the success rate when defusing, make sure you crawl up to the IED.
 
 ## 3. Dependencies
 

--- a/docs/wiki/feature/explosives.md
+++ b/docs/wiki/feature/explosives.md
@@ -41,6 +41,8 @@ Enables attaching explosives to vehicles.
 - Select `Disarm`.
 - You are safe to pick it up after the action has completed.
 
+**Tip:** To increase the success rate when defusing, make sure you crawl to the IED.
+
 ## 3. Dependencies
 
 {% include dependencies_list.md component="explosives" %}

--- a/docs/wiki/framework/explosives-framework.md
+++ b/docs/wiki/framework/explosives-framework.md
@@ -54,6 +54,7 @@ class CfgAmmo {
         triggerWhenDestroyed = 1;  // (Optional) Explode when the object is shot and destroyed (after being placed) (0-disabled, 1-enabled).
         ACE_explodeOnDefuse = 0.02;  // (Optional) Add a chance for the explosive to detonate after being disarmed (in percent)
         ACE_explosives_defuseObjectPosition[] = {-1.415, 0, 0.12}; // (Optional) The position relative to the model where the defuse helper object will be attached and thus the interaction point will be rendered
+        ACE_explosives_size = 0; // (Optional) Setting to 1 will use a defusal action with a larger radius (useful for large mines or mines with a wide pressure plane trigger area)
     };
 };
 ```


### PR DESCRIPTION
**When merged this pull request will:**
- IED will get size variable. 0 for small, 1 for large.
- This size will determine how far the defuse range should be, might be used for other things aswell.
- Increase defusal range for large IEDs to replicate behaviour of small IEDs, you can now crouch to big IEDs but be aware!
- Will add Tip on wiki about defusing 
- Will fix #5258 

PS I know _size == 1 might be redundant but its how I write because _size is formally a number not a bool then you have to compare it and not just if (_size)

