### PR TITLE
Remove maximum distance of attach to vehicle action

### DIFF
--- a/addons/attach/CfgVehicles.hpp
+++ b/addons/attach/CfgVehicles.hpp
@@ -10,7 +10,6 @@
                 showDisabled = 0; \
                 priority = 0; \
                 icon = QPATHTOF(UI\attach_ca.paa); \
-                distance = 4.5; \
             }; \
             class GVAR(DetachVehicle) { \
                 displayName = CSTRING(Detach); \
@@ -20,7 +19,6 @@
                 showDisabled = 0; \
                 priority = 0.1; \
                 icon = QPATHTOF(UI\detach_ca.paa); \
-                distance = 4.5; \
             }; \
         }; \
     };

--- a/addons/attach/functions/fnc_canAttach.sqf
+++ b/addons/attach/functions/fnc_canAttach.sqf
@@ -27,7 +27,6 @@ _attachLimit = [6, 1] select (_player == _attachToVehicle);
 _attachedObjects = _attachToVehicle getVariable [QGVAR(attached), []];
 
 ((_player == _attachToVehicle) || {canStand _player}) &&
-{(_attachToVehicle distance _player) < 7} && 
-{alive _attachToVehicle} && 
-{(count _attachedObjects) < _attachLimit} && 
+{alive _attachToVehicle} &&
+{(count _attachedObjects) < _attachLimit} &&
 {_itemClassname in ((itemsWithMagazines _player) + [""])};

--- a/addons/attach/functions/fnc_canAttach.sqf
+++ b/addons/attach/functions/fnc_canAttach.sqf
@@ -27,6 +27,7 @@ _attachLimit = [6, 1] select (_player == _attachToVehicle);
 _attachedObjects = _attachToVehicle getVariable [QGVAR(attached), []];
 
 ((_player == _attachToVehicle) || {canStand _player}) &&
+{(_attachToVehicle distance _player) < 10} &&
 {alive _attachToVehicle} &&
 {(count _attachedObjects) < _attachLimit} &&
 {_itemClassname in ((itemsWithMagazines _player) + [""])};


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Max distance of 7 (4.5 in config had no impact) prevents attaching things to large vehicles such as VTOLs, unless you crawl under them. There is no real reason to have a max distance check here, as you can only attach to a vehicle you interacted with after picking the item to attach.