### PR TITLE
Fix isFeatureCameraActive for Spectator enhacements

### DIFF
--- a/addons/common/functions/fnc_isFeatureCameraActive.sqf
+++ b/addons/common/functions/fnc_isFeatureCameraActive.sqf
@@ -25,7 +25,7 @@
 
 !(
     isNull curatorCamera && // Curator
-    {isNull (GETMVAR(EGVAR(spectator,camera),objNull))} && // ACE Spectator
+    {isNull (GETMVAR(EGVAR(spectator,freeCamera),objNull))} && // ACE Spectator
     {isNull (GETUVAR(BIS_fnc_arsenal_cam, objNull))} && // Arsenal camera
     {isNull (GETMVAR(BIS_fnc_establishingShot_fakeUAV, objNull))} && // Establishing shot camera
     {isNull (GETMVAR(BIS_fnc_camera_cam, objNull))} && // Splendid camera

--- a/addons/common/functions/fnc_isFeatureCameraActive.sqf
+++ b/addons/common/functions/fnc_isFeatureCameraActive.sqf
@@ -25,7 +25,7 @@
 
 !(
     isNull curatorCamera && // Curator
-    {isNull (GETMVAR(EGVAR(spectator,freeCamera),objNull))} && // ACE Spectator
+    {GETMVAR(EGVAR(spectator,isSet),false)} && // ACE Spectator
     {isNull (GETUVAR(BIS_fnc_arsenal_cam, objNull))} && // Arsenal camera
     {isNull (GETMVAR(BIS_fnc_establishingShot_fakeUAV, objNull))} && // Establishing shot camera
     {isNull (GETMVAR(BIS_fnc_camera_cam, objNull))} && // Splendid camera


### PR DESCRIPTION
At the moment, isFeatureCameraActive does *not* detect ACE spectator mode, because `ace_spectator_camera` as a variable was removed in 77c2b99ee542e3825c4f25e7b5a399597fd436e2 .
spectator module initializes three separate cameras instead, of which for example `ace_spectator_freeCamera` could be used to check if spec mode is active.
