### PR TITLE
AB: G.O.S N'Djenahoud latitude

### DIFF
--- a/addons/common/functions/fnc_getMapData.sqf
+++ b/addons/common/functions/fnc_getMapData.sqf
@@ -98,6 +98,7 @@ if (_map in ["pja308"]) exitWith { [36, 0] }; // G.O.S Gunkizli
 if (_map in ["pja310"]) exitWith { [36, 0] }; // G.O.S Al Rayak
 if (_map in ["pja312"]) exitWith { [16, 0] }; // G.O.S Song Bin Tanh
 if (_map in ["pja314"]) exitWith { [46, 0] }; // G.O.S Leskovets
+if (_map in ["pja319"]) exitWith { [20, 0] }; // G.O.S N'Djenahoud, Ennedi Massif (Republic of Chad)
 if (_map in ["plr_bulge"]) exitWith { [49, 0] }; // I44: Battle of the Bulge
 if (_map in ["porquerolles"]) exitWith { [43, 0] };
 if (_map in ["porto"]) exitWith { [40, 0] };


### PR DESCRIPTION
**G.O.S N'Djenahoud map with the Advanced Ballistics module enabled.**
- Ennedi Massif (Republic of Chad): positive latitude 20° N (default -20).