### PR TITLE
Refuel - change nozzle position calc

### DIFF
--- a/addons/common/functions/fnc_addLineToDebugDraw.sqf
+++ b/addons/common/functions/fnc_addLineToDebugDraw.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [[0,0,0], [1,1,0], [1,0,0,1]]] call ace_common_fnc_addLineToDebugDraw;
+ * [[0,0,0], [1,1,0], [1,0,0,1]] call ace_common_fnc_addLineToDebugDraw;
  *
  * Public: No
  */

--- a/addons/refuel/functions/fnc_checkFuel.sqf
+++ b/addons/refuel/functions/fnc_checkFuel.sqf
@@ -21,7 +21,7 @@ params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
 private _fuel = [_target] call FUNC(getFuel);
 
 [
-    REFUEL_PROGRESS_DURATION * 2.5,
+    TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION * 2),
     [_unit, _target, _fuel],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_connectNozzle.sqf
+++ b/addons/refuel/functions/fnc_connectNozzle.sqf
@@ -41,7 +41,6 @@ private _actionID = _unit addAction [format ["<t color='#FF0000'>%1</t>", locali
     if (cameraView == "EXTERNAL") then {
         _virtualPosASL = _virtualPosASL vectorAdd ((positionCameraToWorld [0.3,0,0]) vectorDiff (positionCameraToWorld [0,0,0]));
     };
-    private _virtualPos = _virtualPosASL call EFUNC(common,ASLToPosition);
     private _lineInterection = lineIntersects [eyePos ace_player, _virtualPosASL, ace_player];
 
     //Don't allow placing in a bad position:
@@ -57,7 +56,7 @@ private _actionID = _unit addAction [format ["<t color='#FF0000'>%1</t>", locali
         _unit removeAction _actionID;
 
         if (GVAR(placeAction) == PLACE_APPROVE) then {
-            [_unit, _target, _virtualPos, _nozzle] call FUNC(ConnectNozzleAction);
+            [_unit, _target, _virtualPosASL, _nozzle] call FUNC(ConnectNozzleAction);
         };
     }; // TODO add model like in attach/functions/fnc_attach
 }, 0, [_unit, _target, _nozzle, _actionID] ] call cba_fnc_addPerFrameHandler;

--- a/addons/refuel/functions/fnc_readFuelCounter.sqf
+++ b/addons/refuel/functions/fnc_readFuelCounter.sqf
@@ -19,7 +19,7 @@
 params [["_unit", objNull, [objNull]], ["_target", objNull, [objNull]]];
 
 [
-    REFUEL_PROGRESS_DURATION,
+    TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION),
     [_unit, _target],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -24,7 +24,7 @@ private _source = _nozzle getVariable QGVAR(source);
 if (isNull _nozzle || {_source != _target}) exitWith {false};
 
 [
-    REFUEL_PROGRESS_DURATION,
+    TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION),
     [_unit, _nozzle, _target],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -39,7 +39,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
         _endPosOffset = _endPosOffset select 0;
     };
     [
-        REFUEL_PROGRESS_DURATION,
+        TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION),
         [_unit, _target, _endPosOffset],
         {
             params ["_args"];
@@ -105,7 +105,7 @@ if (isNull _nozzle) then { // func is called on fuel truck
     ] call EFUNC(common,progressBar);
 } else { // func is called on muzzle either connected or on ground
     [
-        REFUEL_PROGRESS_DURATION,
+        TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION),
         [_unit, _nozzle],
         {
             params ["_args"];

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -19,7 +19,7 @@
 params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 
 [
-    REFUEL_PROGRESS_DURATION,
+    TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION),
     [_unit, _nozzle],
     {
         params ["_args"];

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -19,7 +19,7 @@
 params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 
 [
-    REFUEL_PROGRESS_DURATION,
+    TIME_PROGRESSBAR(REFUEL_PROGRESS_DURATION),
     [_unit, _nozzle],
     {
         params ["_args"];

--- a/addons/refuel/script_component.hpp
+++ b/addons/refuel/script_component.hpp
@@ -5,6 +5,7 @@
 // #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
+// #define FAST_PROGRESSBARS
 
 #ifdef DEBUG_ENABLED_REFUEL
     #define DEBUG_MODE_FULL
@@ -29,3 +30,9 @@
     _weaponSelect = _unit getVariable QGVAR(selectedWeaponOnRefuel); \
     _unit selectWeapon _weaponSelect; \
     _unit setVariable [QGVAR(selectedWeaponOnRefuel), nil];
+
+#ifdef FAST_PROGRESSBARS
+    #define TIME_PROGRESSBAR(X) ((X) * 0.075)
+#else
+    #define TIME_PROGRESSBAR(X) (X)
+#endif


### PR DESCRIPTION
Fix #5143

Removes the old binary search and now uses `lineIntersectsSurfaces`
Default is to aim at player's viewing angle (what you see is what you get) instead of using model center
