### PR TITLE
Repair - Handle depends = "0"

### DIFF
--- a/addons/repair/dev/draw_showRepairInfo.sqf
+++ b/addons/repair/dev/draw_showRepairInfo.sqf
@@ -1,0 +1,69 @@
+// PabstMirror
+// [] execVM "\z\ace\addons\repair\dev\draw_showRepairInfo.sqf";
+
+#include "\z\ace\addons\repair\script_component.hpp"
+
+addMissionEventHandler ["Draw3D", {
+    if !((cursorObject isKindOf "Car") || (cursorObject isKindOf "Tank") || (cursorObject isKindOf "Air")) exitWith {};
+    private _config = configFile >> "CfgVehicles" >> (typeOf cursorObject);
+
+    private _hitpointPositions = getArray (_config >> QGVAR(hitpointPositions));
+    private _hitpointGroups = getArray (_config >> QGVAR(hitpointGroups));
+
+    (getAllHitPointsDamage cursorObject) params [["_hitPoints", []], ["_hitSelections", []]];
+    ([cursorObject] call FUNC(getWheelHitPointsWithSelections)) params ["_wheelHitPoints", "_wheelHitSelections"];
+
+    private _output = [];
+    
+    {
+        private _selection = _x;
+        private _hitpoint = _hitPoints select _forEachIndex;
+
+        if ((_selection != "") && {_hitPoint != ""}) then {
+            if (((toLower _hitPoint) find "glass") != -1) exitWith {};
+
+            private _info = "";
+            private _color = [1,0,0,1];
+            if (_selection in _wheelHitSelections) then {
+                _info = _info + "[Wheel]";
+                _color = [0,1,0,1];
+            };
+            if (!((getText (_config>> "HitPoints" >> _hitpoint >> "depends")) in ["", "0"])) then {
+                _info = _info + format ["[depends: %1]", getText (_config>> "HitPoints" >> _hitpoint >> "depends")];
+                _color = [0,0,1,1]
+            };
+
+            private _position = cursorObject selectionPosition [_selection, "HitPoints"];
+            {
+                _x params ["_hit", "_pos"];
+                if (_hitpoint == _hit) exitWith {
+                    _info = _info + format ["[hitPos: %1]", _pos];
+                    if (_pos isEqualType []) exitWith {
+                        _position = _pos;
+                    };
+                    if (_pos isEqualType "") exitWith {
+                        _position = cursorObject selectionPosition [_pos, "HitPoints"];
+                    };
+                };
+            } forEach _hitpointPositions;
+
+            private _parentHitpoint = "";
+            {
+                private _xParent = _x select 0;
+                {
+                    if (_hitpoint == _x) exitWith {
+                        _info = _info + format ["[Parent: %1]", _xParent];
+                        _parentHitpoint = _xParent;
+                    };
+                } forEach (_x select 1);
+            } forEach _hitpointGroups;
+
+            if (_parentHitpoint == "") then {
+                drawIcon3D ["", _color, (cursorObject modelToWorld _position), 0.5, 0.5, 0, format ["%1 [%2]", _hitpoint, _selection], 0.5, 0.025, "TahomaB"];
+            };
+            _output pushBack format ["%1: %2[%3] = %4", _forEachIndex, _hitPoint, _selection, cursorObject getHitIndex _forEachIndex];
+            _output pushBack format ["- %1 -",_info];
+        };
+    } forEach _hitPoints;
+    hintSilent (_output joinString "\n");
+}];

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -79,7 +79,7 @@ _processedHitpoints = [];
         if (_selection isEqualTo "") exitWith { TRACE_3("Selection Empty",_hitpoint,_forEachIndex,_selection); };
         if (_hitpoint isEqualTo "") exitWith { TRACE_3("Hitpoint Empty",_hitpoint,_forEachIndex,_selection); };
         //Depends hitpoints shouldn't be modified directly (will be normalized)
-        // >Clearing 'depends' in case of inheritance cannot be an empty string (rpt warnings), but rather a "0" value.
+        // Biki: Clearing 'depends' in case of inheritance cannot be an empty string (rpt warnings), but rather a "0" value.
         if (!((getText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _hitpoint >> "depends")) in ["", "0"])) exitWith {
             TRACE_3("Skip Depends",_hitpoint,_forEachIndex,_selection);
         };

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -79,7 +79,8 @@ _processedHitpoints = [];
         if (_selection isEqualTo "") exitWith { TRACE_3("Selection Empty",_hitpoint,_forEachIndex,_selection); };
         if (_hitpoint isEqualTo "") exitWith { TRACE_3("Hitpoint Empty",_hitpoint,_forEachIndex,_selection); };
         //Depends hitpoints shouldn't be modified directly (will be normalized)
-        if (isText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _hitpoint >> "depends")) exitWith {
+        // >Clearing 'depends' in case of inheritance cannot be an empty string (rpt warnings), but rather a "0" value.
+        if (!((getText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _hitpoint >> "depends")) in ["", "0"])) exitWith {
             TRACE_3("Skip Depends",_hitpoint,_forEachIndex,_selection);
         };
 

--- a/addons/repair/functions/fnc_normalizeHitPoints.sqf
+++ b/addons/repair/functions/fnc_normalizeHitPoints.sqf
@@ -33,7 +33,7 @@ private _dependentHitPointScripts = [];
 {
     if ((_x != "") && {isClass (_config >> _x)} && {!(_x in _realHitPoints)}) then {
         _realHitPoints pushBack _x;
-        if (isText (_config >> _x >> "depends")) then {
+        if (!((getText (_config >> _x >> "depends")) in ["", "0"])) then {
             _dependentHitPoints pushBack _x;
             _dependentHitPointScripts pushBack compile getText (_config >> _x >> "depends");
         };

--- a/addons/repair/functions/fnc_setHitPointDamage.sqf
+++ b/addons/repair/functions/fnc_setHitPointDamage.sqf
@@ -45,7 +45,7 @@ _hitPointDamageRepaired = 0; //positive for repairs : newSum = (oldSum - repaire
     if ((!isNil {_vehicle getHit _selectionName}) && {_x != ""}) then {
         _realHitpointCount = _realHitpointCount + 1;
 
-        if ((((toLower _x) find "glass") == -1) && {!isText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "HitPoints" >> _x >> "depends")}) then {
+        if ((((toLower _x) find "glass") == -1) && {(getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "HitPoints" >> _x >> "depends")) in ["", "0"]}) then {
             _hitPointDamageSumOld = _hitPointDamageSumOld + (_allHitPointDamages select _forEachIndex);
             if (_forEachIndex == _hitPointIndex) then {
                 _hitPointDamageRepaired = (_allHitPointDamages select _forEachIndex) - _hitPointDamage;


### PR DESCRIPTION
Close #5180
Depends can be `"0"` and still haven no effect

https://community.bistudio.com/wiki/Arma_3_Jets_Hitpoint_Configuration
>depends - simple expressions for creating dependencies between hitpoints. Clearing 'depends' in case of inheritance cannot be an empty string (rpt warnings), but rather a "0" value. It can be used for more detailed damage model.