### PR TITLE
Modify JoinGroup action to show group name

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -116,6 +116,7 @@ class CfgVehicles {
                     displayName = CSTRING(JoinGroup);
                     condition = QUOTE(GVAR(EnableTeamManagement) && {[ARR_2(_player,_target)] call DFUNC(canJoinGroup)});
                     statement = QUOTE([_player] joinSilent group _target);
+                    modifierFunction = QUOTE(call FUNC(modifyJoinGroupAction));
                     showDisabled = 0;
                     priority = 2.6;
                     icon = QPATHTOF(UI\team\team_management_ca.paa);

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -17,6 +17,7 @@ PREP(canInteractWithCivilian);
 PREP(getDown);
 PREP(sendAway);
 PREP(canJoinGroup);
+PREP(modifyJoinGroupAction);
 PREP(canJoinTeam);
 PREP(joinTeam);
 PREP(canPassMagazine);

--- a/addons/interaction/functions/fnc_modifyJoinGroupAction.sqf
+++ b/addons/interaction/functions/fnc_modifyJoinGroupAction.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: PabstMirror
+ * Modifies the ACE_JoinGroup action to show group name.
+ *
+ * Arguments:
+ * 0: Target <OBJECT>
+ * 1: Player <OBJECT>
+ * 2: Args <Any>
+ * 3: Action Data <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject, player, [], []] call ace_repair_fnc_modifyInteraction;
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_target", "_player", "", "_actionData"];
+
+private _actionText = format ["%1: %2", localize LSTRING(JoinGroup), groupID group _target];
+TRACE_3("",_target,group _target,_actionText);
+_actionData set [1, _actionText];

--- a/addons/interaction/functions/fnc_modifyJoinGroupAction.sqf
+++ b/addons/interaction/functions/fnc_modifyJoinGroupAction.sqf
@@ -5,14 +5,14 @@
  * Arguments:
  * 0: Target <OBJECT>
  * 1: Player <OBJECT>
- * 2: Args <Any>
+ * 2: Args <ANY>
  * 3: Action Data <ARRAY>
  *
  * Return Value:
  * None
  *
  * Example:
- * [cursorObject, player, [], []] call ace_interaction_fnc_modifyJoinGroupAction;
+ * [cursorObject, player, [], []] call ace_interaction_fnc_modifyJoinGroupAction
  *
  * Public: No
  */

--- a/addons/interaction/functions/fnc_modifyJoinGroupAction.sqf
+++ b/addons/interaction/functions/fnc_modifyJoinGroupAction.sqf
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * [cursorObject, player, [], []] call ace_repair_fnc_modifyInteraction;
+ * [cursorObject, player, [], []] call ace_interaction_fnc_modifyJoinGroupAction;
  *
  * Public: No
  */
@@ -22,4 +22,5 @@ params ["_target", "_player", "", "_actionData"];
 
 private _actionText = format ["%1: %2", localize LSTRING(JoinGroup), groupID group _target];
 TRACE_3("",_target,group _target,_actionText);
+
 _actionData set [1, _actionText];


### PR DESCRIPTION
Shows group name in action menu.

![image](https://user-images.githubusercontent.com/9376747/27264137-17e59178-543e-11e7-8769-77ea260f2fcb.png)

Edit:
I see this as a small usability improvement. 
But I guess it does give some _meta_ information about the specific group a unit is part of??
There is an ace setting `GVAR(EnableTeamManagement)` that could disable the interaction if it's a problem.