### PR TITLE
Changed hellfire interaction check & added N variant

### DIFF
--- a/addons/hellfire/CfgAmmo.hpp
+++ b/addons/hellfire/CfgAmmo.hpp
@@ -19,7 +19,7 @@ class CfgAmmo {
         laserLock = 0;
         manualControl = 0;
         maxSpeed = 450;
-        
+
         thrustTime = 2.5; // motor burn 2-3 sec
         thrust = 250;
         timeToLive = 40;
@@ -63,5 +63,8 @@ class CfgAmmo {
         indirectHit = 200;
         indirectHitRange = 10;
         explosionEffects = "BombExplosion";
+        class ace_missileguidance: ace_missileguidance {
+            enabled = 1; // Missile Guidance must be explicitly enabled
+        };
     };
 };

--- a/addons/hellfire/CfgAmmo.hpp
+++ b/addons/hellfire/CfgAmmo.hpp
@@ -54,4 +54,14 @@ class CfgAmmo {
             attackProfiles[] = {"hellfire", "hellfire_hi", "hellfire_lo"};
         };
     };
+    class ACE_Hellfire_AGM114N: ACE_Hellfire_AGM114K {
+        displayName = "AGM-114N";
+        displayNameShort = "AGM-114N";
+        description = "AGM-114N";
+        descriptionShort = "AGM-114N";
+        hit = 1100;
+        indirectHit = 200;
+        indirectHitRange = 10;
+        explosionEffects = "BombExplosion";
+    };
 };

--- a/addons/hellfire/CfgMagazines.hpp
+++ b/addons/hellfire/CfgMagazines.hpp
@@ -1,6 +1,7 @@
 class CfgMagazines {
     class 12Rnd_PG_missiles;
     
+    // Kilo - tandem shaped charge HEAT (anti-tank)
     class 6Rnd_ACE_Hellfire_AGM114K: 12Rnd_PG_missiles { // Old style vehicle magazine
         count = 6;
         ammo = "ACE_Hellfire_AGM114K";
@@ -43,5 +44,36 @@ class CfgMagazines {
         hardpoints[] = {"UNI_SCALPEL"};
         model = "\A3\Weapons_F\DynamicLoadout\PylonPod_4x_Missile_LG_scalpel_F.p3d";
         mirrorMissilesIndexes[] = {2, 1, 4, 3};
+    };
+
+    // November - Metal augmented charge (Thermobaric) (Enclosures, ships, urban targets, air defense units)
+    class 6Rnd_ACE_Hellfire_AGM114N: 6Rnd_ACE_Hellfire_AGM114K { // Old style vehicle magazine
+        count = 6;
+        ammo = "ACE_Hellfire_AGM114K";
+        displayName = "AGM-114K [ACE]";
+        displayNameShort = "AGM-114K";
+        descriptionShort = "AGM-114K";
+    };
+
+    // 1.70 pylon magazines:
+    class PylonMissile_1Rnd_ACE_Hellfire_AGM114N: PylonMissile_1Rnd_ACE_Hellfire_AGM114K { // Bare missle
+        displayName = "1x AGM-114N [ACE]";
+        ammo = "ACE_Hellfire_AGM114N";
+        pylonWeapon = QGVAR(launcher_N);
+    };
+    class PylonRack_1Rnd_ACE_Hellfire_AGM114N: PylonRack_1Rnd_ACE_Hellfire_AGM114K { // 1x Launcher Support Rack
+        displayName = "1x AGM-114N [ACE]";
+        ammo = "ACE_Hellfire_AGM114N";
+        pylonWeapon = QGVAR(launcher_N);
+    };
+    class PylonRack_3Rnd_ACE_Hellfire_AGM114N: PylonRack_3Rnd_ACE_Hellfire_AGM114K { // 3x Launcher Support Rack
+        displayName = "3x AGM-114N [ACE]";
+        ammo = "ACE_Hellfire_AGM114N";
+        pylonWeapon = QGVAR(launcher_N);
+    };
+    class PylonRack_4Rnd_ACE_Hellfire_AGM114N: PylonRack_4Rnd_ACE_Hellfire_AGM114K { // 4x Launcher Support Rack
+        displayName = "4x AGM-114N [ACE]";
+        ammo = "ACE_Hellfire_AGM114N";
+        pylonWeapon = QGVAR(launcher_N);
     };
 };

--- a/addons/hellfire/CfgMagazines.hpp
+++ b/addons/hellfire/CfgMagazines.hpp
@@ -49,30 +49,38 @@ class CfgMagazines {
     // November - Metal augmented charge (Thermobaric) (Enclosures, ships, urban targets, air defense units)
     class 6Rnd_ACE_Hellfire_AGM114N: 6Rnd_ACE_Hellfire_AGM114K { // Old style vehicle magazine
         count = 6;
-        ammo = "ACE_Hellfire_AGM114K";
+        ammo = "ACE_Hellfire_AGM114N";
         displayName = "AGM-114K [ACE]";
-        displayNameShort = "AGM-114K";
-        descriptionShort = "AGM-114K";
+        displayNameShort = "AGM-114N";
+        descriptionShort = "AGM-114N";
     };
 
     // 1.70 pylon magazines:
     class PylonMissile_1Rnd_ACE_Hellfire_AGM114N: PylonMissile_1Rnd_ACE_Hellfire_AGM114K { // Bare missle
         displayName = "1x AGM-114N [ACE]";
+        displayNameShort = "AGM-114N";
+        descriptionShort = "AGM-114N";
         ammo = "ACE_Hellfire_AGM114N";
         pylonWeapon = QGVAR(launcher_N);
     };
     class PylonRack_1Rnd_ACE_Hellfire_AGM114N: PylonRack_1Rnd_ACE_Hellfire_AGM114K { // 1x Launcher Support Rack
         displayName = "1x AGM-114N [ACE]";
+        displayNameShort = "AGM-114N";
+        descriptionShort = "AGM-114N";
         ammo = "ACE_Hellfire_AGM114N";
         pylonWeapon = QGVAR(launcher_N);
     };
     class PylonRack_3Rnd_ACE_Hellfire_AGM114N: PylonRack_3Rnd_ACE_Hellfire_AGM114K { // 3x Launcher Support Rack
         displayName = "3x AGM-114N [ACE]";
+        displayNameShort = "AGM-114N";
+        descriptionShort = "AGM-114N";
         ammo = "ACE_Hellfire_AGM114N";
         pylonWeapon = QGVAR(launcher_N);
     };
     class PylonRack_4Rnd_ACE_Hellfire_AGM114N: PylonRack_4Rnd_ACE_Hellfire_AGM114K { // 4x Launcher Support Rack
         displayName = "4x AGM-114N [ACE]";
+        displayNameShort = "AGM-114N";
+        descriptionShort = "AGM-114N";
         ammo = "ACE_Hellfire_AGM114N";
         pylonWeapon = QGVAR(launcher_N);
     };

--- a/addons/hellfire/CfgMagazines.hpp
+++ b/addons/hellfire/CfgMagazines.hpp
@@ -50,7 +50,7 @@ class CfgMagazines {
     class 6Rnd_ACE_Hellfire_AGM114N: 6Rnd_ACE_Hellfire_AGM114K { // Old style vehicle magazine
         count = 6;
         ammo = "ACE_Hellfire_AGM114N";
-        displayName = "AGM-114K [ACE]";
+        displayName = "AGM-114N [ACE]";
         displayNameShort = "AGM-114N";
         descriptionShort = "AGM-114N";
     };

--- a/addons/hellfire/CfgWeapons.hpp
+++ b/addons/hellfire/CfgWeapons.hpp
@@ -10,4 +10,8 @@ class CfgWeapons {
         lockingTargetSound[] = {"",0,1};
         lockedTargetSound[] = {"",0,1};
     };
+    class GVAR(launcher_N): GVAR(launcher) {
+        displayName = "AGM-114N Hellfire II";
+        magazines[] = {"6Rnd_ACE_Hellfire_AGM114N", "PylonMissile_1Rnd_ACE_Hellfire_AGM114N", "PylonRack_1Rnd_ACE_Hellfire_AGM114N", "PylonRack_3Rnd_ACE_Hellfire_AGM114N", "PylonRack_4Rnd_ACE_Hellfire_AGM114N"};
+    };
 };

--- a/addons/hellfire/CfgWeapons.hpp
+++ b/addons/hellfire/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 class CfgWeapons {
     class missiles_SCALPEL;
     class GVAR(launcher): missiles_SCALPEL {
-        displayName = CSTRING(Hellfire);
+        displayName = "AGM-114K Hellfire II";
         GVAR(enabled) = 1; // show attack profile / lock on hud
         EGVAR(laser,canSelect) = 1; // can ace_laser lock (allows switching laser code)
         canLock = 0;

--- a/addons/hellfire/functions/fnc_setupVehicle.sqf
+++ b/addons/hellfire/functions/fnc_setupVehicle.sqf
@@ -61,7 +61,7 @@ private _fnc_condition = {
     params ["_target", "_player", "_attackProfile"];
     
     private _turretPath = if (ACE_player == (driver _target)) then {[-1]} else {ACE_player call CBA_fnc_turretPath};
-    private _hasWeapon = ({QGVAR(launcher) == _x} count (_target weaponsTurret _turretPath)) > 0;
+    private _hasWeapon = ({(isNumber (configFile >> "CfgWeapons" >> _x >> QGVAR(enabled))) && {getNumber (configFile >> "CfgWeapons" >> _x >> QGVAR(enabled)) > 0}} count (_target weaponsTurret _turretPath)) > 0;
 
     (_hasWeapon) &&
     {(_target getVariable [QEGVAR(missileguidance,attackProfile), "hellfire"]) != _attackProfile};

--- a/addons/hellfire/stringtable.xml
+++ b/addons/hellfire/stringtable.xml
@@ -1,19 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Hellfire">
-        <Key ID="STR_ACE_Hellfire_Hellfire">
-            <English>Hellfire</English>
-            <Spanish>Hellfire</Spanish>
-            <French>Hellfire</French>
-            <Polish>Hellfire</Polish>
-            <German>Hellfire</German>
-            <Czech>Hellfire</Czech>
-            <Italian>Hellfire</Italian>
-            <Portuguese>Hellfire</Portuguese>
-            <Hungarian>Hellfire</Hungarian>
-            <Russian>Hellfire</Russian>
-            <Japanese>ヘルファイア</Japanese>
-        </Key>
         <Key ID="STR_ACE_Hellfire_hellfireModeAction">
             <English>Set Hellfire mode</English>
             <Italian>Imposta modalità Hellfire</Italian>


### PR DESCRIPTION
**When merged this pull request will:**
- Change the check in the interaction condition to check for `ace_hellfire_enabled` config value instead of just the raw `ace_hellfire_launcher` weapon.
- This allows other launchers to be made and be compatible (for example, N-variant hellfires)
- Added November (Thermobaric) hellfire ammo, magazines, and weapon. (https://en.wikipedia.org/wiki/AGM-114_Hellfire#Variants) Have used the settings committed for some time with no balance issue. Not as good against tanks, better against infantry and bunkers etc.
