### PR TITLE
Handle ace_cargo_canLoad set to scalar

### DIFF
--- a/addons/cargo/functions/fnc_initObject.sqf
+++ b/addons/cargo/functions/fnc_initObject.sqf
@@ -21,10 +21,13 @@ TRACE_2("params",_object,_type);
 
 // If object had size given to it via eden/public then override config canLoad setting
 private _canLoadPublic = _object getVariable [QGVAR(canLoad), false];
+if (!(_canLoadPublic isEqualType false)) then {
+    WARNING_4("%1[%2] - Variable %3 is %4 - Should be bool",_object,_type,QGVAR(canLoad),_canLoadPublic);
+};
 private _canLoadConfig = getNumber (configFile >> "CfgVehicles" >> _type >> QGVAR(canLoad)) == 1;
 
 // Nothing to do here if object can't be loaded
-if !(_canLoadConfig || _canLoadPublic) exitWith {};
+if !(_canLoadConfig || {_canLoadPublic in [true, 1]}) exitWith {};
 
 // Servers and HCs do not require action menus (beyond this point)
 if !(hasInterface) exitWith {};
@@ -47,7 +50,7 @@ if (_canLoadConfig) then {
 private _condition = {
     //IGNORE_PRIVATE_WARNING ["_target", "_player"];
     GVAR(enable) &&
-    {(_target getVariable [QGVAR(canLoad), getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(canLoad)) == 1])} &&
+    {(_target getVariable [QGVAR(canLoad), getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(canLoad))]) in [true, 1]} &&
     {locked _target < 2} &&
     {alive _target} &&
     {[_player, _target, []] call EFUNC(common,canInteractWith)} &&


### PR DESCRIPTION
var `ace_cargo_canLoad` used to be 0/1
some addons are still setting to scalar

e.g. r3f-logistics does
```
		_object setVariable ['ace_dragging_canCarry', false];
		_object setVariable ['ace_dragging_canDrag', false];
		_object setVariable ['ace_cargo_canLoad', 0];
```

Throws error
```
  Error ||: Type Number, expected Bool,code
 File z\ace\addons\cargo\functions\fnc_initObject.sqf, line 13
```