### PR TITLE
Add: Optional parameter to useEffects during setdamage/sethit

### DIFF
--- a/addons/repair/functions/fnc_setHitPointDamage.sqf
+++ b/addons/repair/functions/fnc_setHitPointDamage.sqf
@@ -7,6 +7,7 @@
  * 0: Local Vehicle to Damage <OBJECT>
  * 1: Selected hitpoint INDEX <NUMBER>
  * 2: Total Damage <NUMBER>
+ * 3: Skip destruction effects <BOOL>
  *
  * Return Value:
  * None
@@ -18,7 +19,7 @@
  */
 #include "script_component.hpp"
 
-params ["_vehicle", "_hitPointIndex", "_hitPointDamage"];
+params ["_vehicle", "_hitPointIndex", "_hitPointDamage", ["_useEffects", true]];
 TRACE_4("params",_vehicle,typeOf _vehicle,_hitPointIndex,_hitPointDamage);
 
 private ["_damageNew", "_damageOld", "_hitPointDamageRepaired", "_hitPointDamageSumOld", "_realHitpointCount", "_selectionName"];
@@ -63,14 +64,14 @@ if (_hitPointDamageSumOld > 0) then {
 TRACE_5("structuralDamage",_damageOld,_damageNew,_hitPointDamageRepaired,_hitPointDamageSumOld,_realHitpointCount);
 
 // set new structural damage value
-_vehicle setDamage _damageNew;
+_vehicle setDamage [_damageNew, _useEffects];
 
 //Repair the hitpoint in the damages array:
 _allHitPointDamages set [_hitPointIndex, _hitPointDamage];
 
 //Set the new damage for all hitpoints
 {
-    _vehicle setHitIndex [_forEachIndex, _x];
+    _vehicle setHitIndex [_forEachIndex, _x, _useEffects];
 } forEach _allHitPointDamages;
 
 // normalize hitpoints


### PR DESCRIPTION
Hello,
Since 1.67, you can  skip destruction effects if you want (see  : https://community.bistudio.com/wiki/setDamage and https://community.bistudio.com/wiki/setHitPointDamage https://community.bistudio.com/wiki/setHitIndex).
This is usefull in some cases where you don't want to see the vehicle explode and damage objects around (During a database loading for exemple).

This PR add an optional parameter  to ace_repair_fnc_setHitPointDamage to allow this new choice.

I would know if this change is possible ?
Thanks

**When merged this pull request will:**
- Add: Optional parameter `_useEffects`  to ace_repair_fnc_setHitPointDamage
- update the header
- change `params` with an optional param `"_useEffects"`
- `setDamage ` and `setHitIndex` have the new param `_useEffects`
-  https://community.bistudio.com/wiki/setDamage and https://community.bistudio.com/wiki/setHitPointDamage https://community.bistudio.com/wiki/setHitIndex
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/) --> tell me if anything is wrong
