### PR TITLE
Music compatibility  

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -28,6 +28,8 @@ GVAR(statusEffect_isGlobal) = [];
 
 GVAR(setHearingCapabilityMap) = [];
 
+GVAR(setMusicVolume) = true;
+
 //////////////////////////////////////////////////
 // Set up PlayerChanged eventhandler for pre init (EH is installed in postInit)
 //////////////////////////////////////////////////

--- a/addons/common/functions/fnc_setHearingCapability.sqf
+++ b/addons/common/functions/fnc_setHearingCapability.sqf
@@ -47,7 +47,9 @@ if (!_exists && _add) then {
 // in game sounds
 0 fadeSound _lowestVolume;
 0 fadeRadio _lowestVolume;
-0 fadeMusic _lowestVolume;
+if (GVAR(setMusicVolume)) then {
+    0 fadeMusic _lowestVolume;
+};
 
 // Set Radio mod variables.
 ACE_player setVariable ["tf_globalVolume", _lowestVolume];


### PR DESCRIPTION
This is a small change that adds the option to stop music volume being set. If  "ace_setMusicVolume" is false, music volume will not be set. Default value is true, so base functionality is unchanged. 
