### PR TITLE
Fix the issue that SFX variants are not global 

### DIFF
--- a/addons/cookoff/CfgSFX.hpp
+++ b/addons/cookoff/CfgSFX.hpp
@@ -1,12 +1,26 @@
 
 class CfgSFX {
-    class GVAR(CookOff) {
-        name = QGVAR(cookoff);
+    class GVAR(CookOff_low) {
+        name = QGVAR(cookoff_low);
         // Index 4 is percentage chance to play, in theory high pressure is way more likely
-        variant0[] = {PATHTOF(sounds\cookoff_low_pressure.ogg),6,1,400,0.1,0,0,0};
-        variant1[] = {PATHTOF(sounds\cookoff_mid_pressure.ogg),6,1,400,0.25,0,0,0};
-        variant2[] = {PATHTOF(sounds\cookoff_high_pressure.ogg),6,1,400,0.65,0,0,0};
-        sounds[] = {"variant0","variant1","variant2"};
+        sound[] = {QPATHTOF(sounds\cookoff_low_pressure.ogg),6,1,400,1,0,0,0};
+        sounds[] = {"sound"};
+        titles[] = {};
+        empty[] = {"",0,0,0,0,0,0,0};
+    };
+    class GVAR(CookOff_mid) {
+        name = QGVAR(cookoff_mid);
+        // Index 4 is percentage chance to play, in theory high pressure is way more likely
+        sound[] = {QPATHTOF(sounds\cookoff_mid_pressure.ogg),6,1,400,1,0,0,0};
+        sounds[] = {"sound"};
+        titles[] = {};
+        empty[] = {"",0,0,0,0,0,0,0};
+    };
+    class GVAR(CookOff_high) {
+        name = QGVAR(cookoff_high);
+        // Index 4 is percentage chance to play, in theory high pressure is way more likely
+        sound[] = {QPATHTOF(sounds\cookoff_high_pressure.ogg),6,1,400,1,0,0,0};
+        sounds[] = {"sound"};
         titles[] = {};
         empty[] = {"",0,0,0,0,0,0,0};
     };

--- a/addons/cookoff/CfgSFX.hpp
+++ b/addons/cookoff/CfgSFX.hpp
@@ -2,26 +2,17 @@
 class CfgSFX {
     class GVAR(CookOff_low) {
         name = QGVAR(cookoff_low);
-        // Index 4 is percentage chance to play, in theory high pressure is way more likely
         sound[] = {QPATHTOF(sounds\cookoff_low_pressure.ogg),6,1,400,1,0,0,0};
         sounds[] = {"sound"};
         titles[] = {};
         empty[] = {"",0,0,0,0,0,0,0};
     };
-    class GVAR(CookOff_mid) {
+    class GVAR(CookOff_mid): GVAR(CookOff_low) {
         name = QGVAR(cookoff_mid);
-        // Index 4 is percentage chance to play, in theory high pressure is way more likely
         sound[] = {QPATHTOF(sounds\cookoff_mid_pressure.ogg),6,1,400,1,0,0,0};
-        sounds[] = {"sound"};
-        titles[] = {};
-        empty[] = {"",0,0,0,0,0,0,0};
     };
-    class GVAR(CookOff_high) {
+    class GVAR(CookOff_high): GVAR(CookOff_low) {
         name = QGVAR(cookoff_high);
-        // Index 4 is percentage chance to play, in theory high pressure is way more likely
         sound[] = {QPATHTOF(sounds\cookoff_high_pressure.ogg),6,1,400,1,0,0,0};
-        sounds[] = {"sound"};
-        titles[] = {};
-        empty[] = {"",0,0,0,0,0,0,0};
     };
 };

--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -1,11 +1,18 @@
 
 class CfgVehicles {
     class Sound;
-    class GVAR(Sound): Sound {
+    class GVAR(Sound_low): Sound {
         author = ECSTRING(common,ACETeam);
         _generalMacro = QGVAR(Sound);
         scope = 1;
-        sound = QGVAR(CookOff);
+        sound = QGVAR(CookOff_low);
+    };
+
+    class GVAR(Sound_mid): GVAR(Sound_low) {
+        sound = QGVAR(CookOff_mid);
+    };
+    class GVAR(Sound_high): GVAR(Sound_low) {
+        sound = QGVAR(CookOff_high);
     };
 
     class ThingX;

--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -91,8 +91,9 @@ if (local _vehicle) then {
         } forEach _positions;
 
         if (isServer) then {
+            private _soundName = [QGVAR(Sound_low), 0.1, QGVAR(Sound_mid), 0.25, QGVAR(Sound_high), 0.65] call BIS_fnc_selectRandomWeighted;
             // TODO - Players in the vehicle hear no sound (even after exiting the vehicle)
-            private _sound = createSoundSource [QGVAR(Sound), position _vehicle, [], 0];
+            private _sound = createSoundSource [_soundName, position _vehicle, [], 0];
 
             _effects pushBack _sound;
         };

--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -91,7 +91,7 @@ if (local _vehicle) then {
         } forEach _positions;
 
         if (isServer) then {
-            private _soundName = [QGVAR(Sound_low), 0.1, QGVAR(Sound_mid), 0.25, QGVAR(Sound_high), 0.65] call BIS_fnc_selectRandomWeighted;
+            private _soundName = [QGVAR(Sound_low), 0.1, QGVAR(Sound_mid), 0.25, QGVAR(Sound_high), 0.65] call BIS_fnc_selectRandomWeighted; // TODO: replace with script Command in 1.74
             // TODO - Players in the vehicle hear no sound (even after exiting the vehicle)
             private _sound = createSoundSource [_soundName, position _vehicle, [], 0];
 


### PR DESCRIPTION
what means that different players can get different pressure Cookoff sounds

to prevent that I split up the sounds in 3 types and used a Weighted select to have the before used values back

