### PR TITLE
Fix adv. throw key handling when reloading

### DIFF
--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -21,6 +21,7 @@ GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
 ["ACE3 Weapons", QGVAR(prepare), localize LSTRING(Prepare), {
     // Condition
     if (!([ACE_player] call FUNC(canPrepare))) exitWith {false};
+    if (EGVAR(common,isReloading)) exitWith {true};
 
     // Statement
     [ACE_player] call FUNC(prepare);

--- a/addons/advanced_throwing/functions/fnc_canPrepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_canPrepare.sqf
@@ -32,6 +32,5 @@ GVAR(enabled) &&
 #endif
 
 {!(call EFUNC(common,isFeatureCameraActive))} &&
-{!EGVAR(common,isReloading)} &&
 {[_unit, objNull, ["isNotInside", "isNotSitting"/*, "isNotOnLadder"*/]] call EFUNC(common,canInteractWith)} && // Ladder needs positioning fixes on throw
 {_unit call CBA_fnc_canUseWeapon} // Disable in non-FFV seats due to surface detection issues

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -374,11 +374,8 @@ GVAR(isReloading) = false;
 
         if (_weapon != "") then {
             private _muzzle = currentMuzzle ACE_player;
-            private _gesture = if (_weapon isEqualTo _muzzle) then {
-                getText (configfile >> "CfgWeapons" >> _weapon >> "reloadAction");
-            } else {
-                getText (configfile >> "CfgWeapons" >> _weapon >> _muzzle >> "reloadAction");
-            };
+            private _wpnConfig = configFile >> "CfgWeapons" >> _weapon;
+            private _gesture = getText ([_wpnConfig >> _muzzle, _wpnConfig] select (_weapon isEqualTo _muzzle) >> "reloadAction");
             if (_gesture == "") exitWith {}; //Ignore weapons with no reload gesture (binoculars)
             private _isLauncher = _weapon isKindOf ["Launcher", configFile >> "CfgWeapons"];
             private _config = ["CfgGesturesMale", "CfgMovesMaleSdr"] select _isLauncher;

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -374,11 +374,10 @@ GVAR(isReloading) = false;
 
         if (_weapon != "") then {
             private _muzzle = currentMuzzle ACE_player;
-            private ["_gesture"];
-            if(_weapon isEqualTo _muzzle) then {
-                _gesture  = getText (configfile >> "CfgWeapons" >> _weapon >> "reloadAction");
+            private _gesture = if (_weapon isEqualTo _muzzle) then {
+                getText (configfile >> "CfgWeapons" >> _weapon >> "reloadAction");
             } else {
-                _gesture  = getText (configfile >> "CfgWeapons" >> _weapon >> _muzzle >> "reloadAction");
+                getText (configfile >> "CfgWeapons" >> _weapon >> _muzzle >> "reloadAction");
             };
             if (_gesture == "") exitWith {}; //Ignore weapons with no reload gesture (binoculars)
             private _isLauncher = _weapon isKindOf ["Launcher", configFile >> "CfgWeapons"];

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -373,7 +373,13 @@ GVAR(isReloading) = false;
         private _weapon = currentWeapon ACE_player;
 
         if (_weapon != "") then {
-            private _gesture  = getText (configfile >> "CfgWeapons" >> _weapon >> "reloadAction");
+            private _muzzle = currentMuzzle ACE_player;
+            private ["_gesture"];
+            if(_weapon isEqualTo _muzzle) then {
+                _gesture  = getText (configfile >> "CfgWeapons" >> _weapon >> "reloadAction");
+            } else {
+                _gesture  = getText (configfile >> "CfgWeapons" >> _weapon >> _muzzle >> "reloadAction");
+            };
             if (_gesture == "") exitWith {}; //Ignore weapons with no reload gesture (binoculars)
             private _isLauncher = _weapon isKindOf ["Launcher", configFile >> "CfgWeapons"];
             private _config = ["CfgGesturesMale", "CfgMovesMaleSdr"] select _isLauncher;


### PR DESCRIPTION
I use one key for vanilla and ACE throwing (if ACE is loaded adv. one is used, if not - vanilla one).
If current weapon reloading time is not correctly calculated, you can suddenly throw vanilla way instead of ACE. This can be easily reproduced with `MX_3GL` or `KH2002 Sama 3GL` UGL reloading because UGL reloading time is less than calculated one.
This PR adds UGL reloading time considering to `ace_common_isReloading` var calculating.
Also this PR adds blocking of adv. throwing key when reloading (if once another reloading time is not correctly calculated).