### PR TITLE
Fix broken fonts for map gps display

### DIFF
--- a/addons/maptools/MapGpsUI.hpp
+++ b/addons/maptools/MapGpsUI.hpp
@@ -40,7 +40,8 @@ class RscTitles {
                 colorBackground[] = {0,0,0,0};
                 colorText[] = {0.247,0.251,0.157,1};
                 shadowColo[] = {0,0,0,0};
-                font = "EtelkaNarrowMediumPro";
+                // EtelkaNarrowMediumPro broke with 1.72 hotfix, can revert back to that font if fixed (following 3 uses of PuristaSemibold)
+                font = "PuristaSemibold"; 
                 shadow = 0;
                 sizeEx = 0.042;
             };
@@ -55,7 +56,7 @@ class RscTitles {
                 colorBackground[] = {0,0,0,0};
                 colorText[] = {0.247,0.251,0.157,1};
                 shadowColo[] = {0,0,0,0};
-                font = "EtelkaNarrowMediumPro";
+                font = "PuristaSemibold";
                 shadow = 0;
                 sizeEx = 0.042;
             };
@@ -70,7 +71,7 @@ class RscTitles {
                 colorBackground[] = {0,0,0,0};
                 colorText[] = {0.247,0.251,0.157,1};
                 shadowColo[] = {0,0,0,0};
-                font = "EtelkaNarrowMediumPro";
+                font = "PuristaSemibold";
                 shadow = 0;
                 sizeEx = 0.1;
             };


### PR DESCRIPTION
EtelkaNarrowMediumPro broke with 1.72 hotfix

![image](https://user-images.githubusercontent.com/9376747/27937978-8dc564c2-6280-11e7-9ac0-dbb6223df991.png)

