### PR TITLE
fix the delay timing when a unit switch to Captive

### DIFF
--- a/addons/medical/functions/fnc_setUnconscious.sqf
+++ b/addons/medical/functions/fnc_setUnconscious.sqf
@@ -57,7 +57,7 @@ if (_unit == ACE_player) then {
 // if we have unconsciousness for AI disabled, we will kill the unit instead
 _isDead = false;
 if (!([_unit, GVAR(remoteControlledAI)] call EFUNC(common,isPlayer)) && !_force) then {
-    _enableUncon = _unit getVariable [QGVAR(enableUnconsciousnessAI), GVAR(enableUnconsciousnessAI)];
+    private _enableUncon = _unit getVariable [QGVAR(enableUnconsciousnessAI), GVAR(enableUnconsciousnessAI)];
     if (_enableUncon == 0 or {_enableUncon == 1 and (random 1) < 0.5}) then {
         [_unit, true] call FUNC(setDead);
         _isDead = true;
@@ -100,15 +100,19 @@ if (GVAR(moveUnitsFromGroupOnUnconscious)) then {
 if (GVAR(delayUnconCaptive) == 0) then {
     [_unit, "setCaptive", "ace_unconscious", true] call EFUNC(common,statusEffect_set);
 } else {
+    // when the Delay is so high that the unit can wake up and get uncon again we need to check if it is the correct wait that got executed
+    private _counter = _unit getVariable [QGVAR(unconsciousCounter), 0];
+    _counter = _counter + 1;
+    _unit setVariable [QGVAR(unconsciousCounter), _counter];
     [{
-        params ["_unit"];
-        if (_unit getVariable ["ACE_isUnconscious", false]) then {
+        params ["_unit", "_counter"];
+        if (_unit getVariable ["ACE_isUnconscious", false] && (_unit getVariable [QGVAR(unconsciousCounter), 0]) == _counter) then {
             [_unit, "setCaptive", "ace_unconscious", true] call EFUNC(common,statusEffect_set);
         };
-    },[_unit], GVAR(delayUnconCaptive)] call CBA_fnc_waitAndExecute;
+    },[_unit, _counter], GVAR(delayUnconCaptive)] call CBA_fnc_waitAndExecute;
 };
 
-_anim = [_unit] call EFUNC(common,getDeathAnim);
+private _anim = [_unit] call EFUNC(common,getDeathAnim);
 [_unit, _anim, 1, true] call EFUNC(common,doAnimation);
 [{
     params ["_unit", "_anim"];


### PR DESCRIPTION
**When merged this pull request will:**
- fix a timing issue that the setCaptive delay can be incorrect on a rapid switching of unconscious or long Captive Delays