### PR TITLE
Rallypoints- Don't modify setVar if already set

### DIFF
--- a/addons/respawn/functions/fnc_handleInitPostServer.sqf
+++ b/addons/respawn/functions/fnc_handleInitPostServer.sqf
@@ -39,7 +39,9 @@ _leaderVarName = _groupUnit getVariable [QGVAR(leaderVarName), ""];
 if (_leaderVarName != "") exitWith {
     // assign JIP unit as rallypoint leader
     if (str _unit == _leaderVarName) then {
-        _unit setVariable ["ACE_canMoveRallypoint", true, true];
+        if (isNil {_unit getVariable "ACE_canMoveRallypoint"}) then {
+            _unit setVariable ["ACE_canMoveRallypoint", true, true];
+        };
     };
 };
 
@@ -61,4 +63,6 @@ if (_leaderVarName == "") then {
 // prevent group from getting multiple leaders; use this to assign rallypoint moving ability on JIP
 _groupUnit setVariable [QGVAR(leaderVarName), _leaderVarName];
 
-_unit setVariable ["ACE_canMoveRallypoint", true, true];
+if (isNil {_unit getVariable "ACE_canMoveRallypoint"}) then {
+    _unit setVariable ["ACE_canMoveRallypoint", true, true];
+};


### PR DESCRIPTION
From slack, user was using `this setVariable ["ACE_canMoveRallypoint", false, true];` 
to block ability to move rally points.

ACE's initPost XEH runs after unit's init and changed it to true

This will prevent ace from modifying that variable if it's already defined