### PR TITLE
Improve cook off settings UX

### DIFF
--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -11,6 +11,16 @@ class Cfg3DEN {
                         tooltip = CSTRING(enable_tooltip);
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
+                        condition = "objectVehicle";
+                        defaultValue = "(true)"; // fix pbo project preprocessing bug
+                    };
+                    class GVAR(enableAmmoCookoff) {
+                        property = QGVAR(enableAmmoCookoff);
+                        control = "Checkbox";
+                        displayName = CSTRING(enableAmmoCookoff_name);
+                        tooltip = CSTRING(enableAmmoCookoff_tooltip);
+                        expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
+                        typeName = "BOOL";
                         condition = "objectHasInventoryCargo";
                         defaultValue = "(true)"; // fix pbo project preprocessing bug
                     };

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -12,7 +12,7 @@ class Cfg3DEN {
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
                         condition = "objectVehicle";
-                        defaultValue = "(true)"; // fix pbo project preprocessing bug
+                        defaultValue = QUOTE(GETMVAR(QGVAR(enable),true));
                     };
                     class GVAR(enableAmmoCookoff) {
                         property = QGVAR(enableAmmoCookoff);
@@ -22,7 +22,7 @@ class Cfg3DEN {
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
                         condition = "objectHasInventoryCargo";
-                        defaultValue = "(true)"; // fix pbo project preprocessing bug
+                        defaultValue = QUOTE(if (_this isKindOf 'ReammoBox_F') then { GETMVAR(QGVAR(enableAmmobox),true) } else { GETMVAR(QGVAR(enableAmmoCookoff),true) };);
                     };
                 };
             };

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -71,7 +71,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 ["ReammoBox_F", "init", {
     (_this select 0) addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enableAmmobox)]) then {
+        if ((_this select 0) getVariable [QGVAR(enableAmmoCookoff), GVAR(enableAmmobox)]) then {
             ["box", _this] call FUNC(handleDamage);
         };
     }];

--- a/addons/cookoff/functions/fnc_cookOffBox.sqf
+++ b/addons/cookoff/functions/fnc_cookOffBox.sqf
@@ -44,11 +44,9 @@ if (local _box) then {
 
         // These functions are smart and do all the cooking off work
         if (local _box) then {
-            if (_box getVariable [QGVAR(enableAmmoCookoff), GVAR(enableAmmoCookoff)]) then {
-                if (GVAR(ammoCookoffDuration) == 0) exitWith {};
-                ([_box] call FUNC(getVehicleAmmo)) params ["_mags", "_total"];
-                [_box, _mags, _total] call FUNC(detonateAmmunition);
-            };
+            if (GVAR(ammoCookoffDuration) == 0) exitWith {};
+            ([_box] call FUNC(getVehicleAmmo)) params ["_mags", "_total"];
+            [_box, _mags, _total] call FUNC(detonateAmmunition);
 
             // This shit is busy being on fire, magazines aren't accessible/usable
             clearMagazineCargoGlobal _box;

--- a/addons/grenades/functions/fnc_incendiary.sqf
+++ b/addons/grenades/functions/fnc_incendiary.sqf
@@ -169,7 +169,10 @@ if (isServer) then {
             _x setDamage 1;
         };
         if (_x isKindOf "ReammoBox_F") then {
-            if ("ace_cookoff" call EFUNC(common,isModLoaded) && {EGVAR(cookoff,enable)}) then {
+            if (
+                "ace_cookoff" call EFUNC(common,isModLoaded) &&
+                {GETVAR(_x,EGVAR(cookoff,enableAmmoCookoff),EGVAR(cookoff,enableAmmobox))}
+            ) then {
                 _x call EFUNC(cookoff,cookOffBox);
             } else {
                 _x setDamage 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Add second eden attribute to boxes/vehicles to toggle the ammunition cook off independently
- Remove the general cook off toggle from boxes (only ammunition cook off is relevant)
- Remove the `GVAR(enableAmmoCookoff)` setting condition from boxes as they already have their own setting `GVAR(enableAmmobox)`
- Make the eden default values respect the ace_setting value

The aim here is to change the way boxes respect cook off settings and make the UX cleaner.

Old behaviour:
Boxes are sharing both possible attributes vehicles use to toggle their individual cook off components (`GVAR(enableAmmoCookoff)` and `GVAR(enable)`) as well as the global setting for `GVAR(enableAmmoCookoff)` and their own setting `GVAR(enableAmmobox)`.

New behaviour:
Boxes only care about the global box setting `GVAR(enableAmmobox)` and the attribute `GVAR(enableAmmoCookoff)`.

We probably want to do this alongside the change to CBA settings for 3.11.0.