### PR TITLE
Prevent taking nozzle if already carried

### DIFF
--- a/addons/refuel/functions/fnc_canTakeNozzle.sqf
+++ b/addons/refuel/functions/fnc_canTakeNozzle.sqf
@@ -23,6 +23,7 @@ if (isNull _unit ||
     {!local _unit} ||
     {!alive _target} ||
     {!isNull (_unit getVariable [QGVAR(nozzle), objNull])} ||
+    {typeOf _target == QGVAR(fuelNozzle) && {!isNull (attachedTo _target)}} || // Not carried by someone else
     {([_unit, _target] call EFUNC(interaction,getInteractionDistance)) > REFUEL_ACTION_DISTANCE}) exitWith {false};
 
 !(_target getVariable [QGVAR(isConnected), false]) && {!(_unit getVariable [QGVAR(isRefueling), false])}


### PR DESCRIPTION
**When merged this pull request will:**
- Title

If allowed, it caused the unit that carried it to completely glitch out, as it was still "carrying" it, just unable to do anything. Not something you'd want to do due to it being a logistical thing (not in combat), so this fix should be enough.