### PR TITLE
Add support for Tanoa and Malden Fuel Pumps, Flexible Tanks and Fuel Canister

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -7,6 +7,19 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
+            "A3_Data_F_Loadorder",
+            "A3_Data_F_Curator_Loadorder",
+            "A3_Data_F_Kart_Loadorder",
+            "A3_Data_F_Bootcamp_Loadorder",
+            "A3_Data_F_Heli_Loadorder",
+            "A3_Data_F_Mark_Loadorder",
+            "A3_Data_F_Exp_A_Loadorder",
+            "A3_Data_F_Exp_B_Loadorder",
+            "A3_Data_F_Exp_Loadorder",
+            "A3_Data_F_Jets_Loadorder",
+            "A3_Data_F_Argo_Loadorder",
+            "A3_Data_F_Patrol_Loadorder",
+
             // Vanilla
             "a3_3den",
             "a3_3den_language",

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -9,7 +9,7 @@
 #define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 1.70
+#define REQUIRED_VERSION 1.72
 #define REQUIRED_CBA_VERSION {3,3,1}
 
 #ifdef COMPONENT_BEAUTIFIED

--- a/addons/refuel/CfgEventHandlers.hpp
+++ b/addons/refuel/CfgEventHandlers.hpp
@@ -1,4 +1,3 @@
-
 class Extended_PreStart_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preStart));
@@ -29,6 +28,14 @@ class Extended_Killed_EventHandlers {
     class CAManBase {
         class ADDON {
             killed = QUOTE(_this call FUNC(handleKilled));
+        };
+    };
+};
+
+class Extended_InitPost_EventHandlers {
+    class Land_CanisterFuel_F {
+        class ADDON {
+            init = QUOTE(_this call DFUNC(makeJerryCan));
         };
     };
 };

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -539,6 +539,12 @@ class CfgVehicles {
         GVAR(hooks)[] = {{0, 0.4, -0.5}, {0, -0.4, -0.5}};
         GVAR(fuelCargo) = REFUEL_INFINITE_FUEL;
     };
+    class Land_FuelStation_01_pump_malevil_F: House_F {
+        transportFuel = 0; //50k
+        MACRO_REFUEL_ACTIONS
+        GVAR(hooks)[] = {{0, 0.4, -0.5}, {0, -0.4, -0.5}};
+        GVAR(fuelCargo) = REFUEL_INFINITE_FUEL;
+    };
 
     // Helper object for non-AllVehicles objects
     class GVAR(helper): Helicopter_Base_F {

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -146,9 +146,7 @@ class CfgVehicles {
     class NonStrategic: Building {};
     class HouseBase: NonStrategic {};
     class House: HouseBase {};
-    class House_F: House {};
-
-    class House_Small_F: House_F {
+    class House_F: House {
         class ACE_Actions {
             class ACE_MainActions {
                 displayName = ECSTRING(interaction,MainAction);
@@ -158,6 +156,7 @@ class CfgVehicles {
             };
         };
     };
+    class House_Small_F: House_F {};
 
     class AllVehicles: All {
         GVAR(flowRate) = 1;
@@ -480,7 +479,7 @@ class CfgVehicles {
         GVAR(fuelCargo) = 10000;
     };
 
-
+    // Vanilla fuel objects
     class StorageBladder_base_F: NonStrategic {
         class ACE_Actions {
             class ACE_MainActions {
@@ -496,10 +495,27 @@ class CfgVehicles {
             class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
         };
 
-        MACRO_REFUEL_ACTIONS
         transportFuel = 0; //60k
+        MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{-3.35,2.45,0.17}};
         GVAR(fuelCargo) = 60000;
+    };
+
+    class FlexibleTank_base_F: ThingX {
+        class ACE_Actions {
+            class ACE_MainActions {
+                displayName = ECSTRING(interaction,MainAction);
+                position = "[0, 0, 0.5]";
+                distance = 4;
+                condition = "true";
+            };
+        };
+    };
+    class Land_FlexibleTank_01_F: FlexibleTank_base_F {
+        transportFuel = 0; //300
+        MACRO_REFUEL_ACTIONS
+        GVAR(hooks)[] = {{0, 0, 0.5}};
+        GVAR(fuelCargo) = 300;
     };
 
     // Vanilla buildings
@@ -514,6 +530,13 @@ class CfgVehicles {
         transportFuel = 0; //50k
         MACRO_REFUEL_ACTIONS
         GVAR(hooks)[] = {{-0.4,0.022,-.23}};
+        GVAR(fuelCargo) = REFUEL_INFINITE_FUEL;
+    };
+
+    class Land_FuelStation_01_pump_F: House_F {
+        transportFuel = 0; //50k
+        MACRO_REFUEL_ACTIONS
+        GVAR(hooks)[] = {{0, 0.4, -0.5}, {0, -0.4, -0.5}};
         GVAR(fuelCargo) = REFUEL_INFINITE_FUEL;
     };
 

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -37,3 +37,14 @@ private _fuelTrucks = configProperties [configFile >> "CfgVehicles", "(isClass _
     };
 } forEach _fuelTrucks;
 #endif
+
+#ifdef DRAW_HOOKS_POS
+addMissionEventHandler ["Draw3D", { // Blue is predicted before throw, red is real
+    private _target = cursorObject;
+    private _cfgPos = getArray (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hooks));
+    private _dynPos = _target getVariable [QGVAR(dev_hooks), []];
+    {
+        drawIcon3D ["\a3\ui_f\data\gui\cfg\hints\icon_text\group_1_ca.paa", [1,1,1,1], _target modelToWorldVisual _x, 1, 1, 0, format ["Hook %1", _forEachIndex]];
+    } forEach ([_dynPos, _cfgPos] select (_dynPos isEqualTo []));
+}];
+#endif

--- a/addons/refuel/XEH_postInit.sqf
+++ b/addons/refuel/XEH_postInit.sqf
@@ -39,7 +39,7 @@ private _fuelTrucks = configProperties [configFile >> "CfgVehicles", "(isClass _
 #endif
 
 #ifdef DRAW_HOOKS_POS
-addMissionEventHandler ["Draw3D", { // Blue is predicted before throw, red is real
+addMissionEventHandler ["Draw3D", {
     private _target = cursorObject;
     private _cfgPos = getArray (configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(hooks));
     private _dynPos = _target getVariable [QGVAR(dev_hooks), []];

--- a/addons/refuel/script_component.hpp
+++ b/addons/refuel/script_component.hpp
@@ -2,10 +2,11 @@
 #define COMPONENT_BEAUTIFIED Refuel
 #include "\z\ace\addons\main\script_mod.hpp"
 
+// #define FAST_PROGRESSBARS
+// #define DRAW_HOOKS_POS
 // #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
-// #define FAST_PROGRESSBARS
 
 #ifdef DEBUG_ENABLED_REFUEL
     #define DEBUG_MODE_FULL


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Make Fuel Canister automatically set as a Jerry Can
- Add debug drawing of refuel hooks

Changed interactions to `House_F` to support that pump, unsure if this effects performance a lot.