### PR TITLE
Correct typos ("enginer" to "engineer")

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -40,6 +40,7 @@ Aleksey EpMAK Yermakov <epmak777@gmail.com>
 Alganthe <alganthe@live.fr>
 Andrea "AtixNeon" Verano <veranoandrea88@gmail.com>
 Anthariel <Contact@storm-simulation.com>
+Anton
 Arkhir <wonsz666@gmail.com >
 Asgar Serran <piechottaf@web.de>
 BaerMitUmlaut

--- a/addons/repair/ACE_Settings.hpp
+++ b/addons/repair/ACE_Settings.hpp
@@ -8,16 +8,16 @@ class ACE_Settings {
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };
     class GVAR(engineerSetting_repair) {
-        displayName = CSTRING(enginerSetting_Repair_name);
-        description = CSTRING(enginerSetting_Repair_description);
+        displayName = CSTRING(engineerSetting_Repair_name);
+        description = CSTRING(engineerSetting_Repair_description);
         typeName = "SCALAR";
         value = 1;
         values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_AdvancedOnly)};
         category = ECSTRING(OptionsMenu,CategoryLogistics);
     };
     class GVAR(engineerSetting_wheel) {
-        displayName = CSTRING(enginerSetting_Wheel_name);
-        description = CSTRING(enginerSetting_Wheel_description);
+        displayName = CSTRING(engineerSetting_Wheel_name);
+        description = CSTRING(engineerSetting_Wheel_description);
         typeName = "SCALAR";
         value = 0;
         values[] = {CSTRING(engineerSetting_anyone), CSTRING(engineerSetting_EngineerOnly), CSTRING(engineerSetting_AdvancedOnly)};

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -32,8 +32,8 @@ class CfgVehicles {
         author = ECSTRING(Common,ACETeam);
         class Arguments {
             class engineerSetting_Repair {
-                displayName = CSTRING(enginerSetting_Repair_name);
-                description = CSTRING(enginerSetting_Repair_description);
+                displayName = CSTRING(engineerSetting_Repair_name);
+                description = CSTRING(engineerSetting_Repair_description);
                 typeName = "NUMBER";
                 class values {
                     class anyone { name = CSTRING(engineerSetting_anyone); value = 0; };
@@ -42,8 +42,8 @@ class CfgVehicles {
                 };
             };
             class engineerSetting_Wheel {
-                displayName = CSTRING(enginerSetting_Wheel_name);
-                description = CSTRING(enginerSetting_Wheel_description);
+                displayName = CSTRING(engineerSetting_Wheel_name);
+                description = CSTRING(engineerSetting_Wheel_description);
                 typeName = "NUMBER";
                 class values {
                     class anyone { name = CSTRING(engineerSetting_anyone); value = 0; default = 1; };

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1103,7 +1103,7 @@
             <Chinesesimp>只有维修专精兵</Chinesesimp>
             <Chinese>只有維修專精兵</Chinese>
         </Key>
-        <Key ID="STR_ACE_Repair_enginerSetting_Wheel_name">
+        <Key ID="STR_ACE_Repair_engineerSetting_Wheel_name">
             <English>Allow Wheel</English>
             <German>Erlaube Radwechsel</German>
             <Polish>Wymiana kół</Polish>
@@ -1118,7 +1118,7 @@
             <Chinesesimp>允许轮胎</Chinesesimp>
             <Chinese>允許輪胎</Chinese>
         </Key>
-        <Key ID="STR_ACE_Repair_enginerSetting_Wheel_description">
+        <Key ID="STR_ACE_Repair_engineerSetting_Wheel_description">
             <English>Who can remove and replace wheels?</English>
             <German>Wer kann Radwechsel durchführern?</German>
             <Polish>Kto może zdejmować i zmieniać koła?</Polish>
@@ -1133,7 +1133,7 @@
             <Chinesesimp>谁可维修轮胎?</Chinesesimp>
             <Chinese>誰可維修輪胎?</Chinese>
         </Key>
-        <Key ID="STR_ACE_Repair_enginerSetting_Repair_name">
+        <Key ID="STR_ACE_Repair_engineerSetting_Repair_name">
             <English>Allow Repair</English>
             <German>Erlaube Reperatur</German>
             <Polish>Możliwość naprawy</Polish>
@@ -1148,7 +1148,7 @@
             <Chinesesimp>允许维修</Chinesesimp>
             <Chinese>允許維修</Chinese>
         </Key>
-        <Key ID="STR_ACE_Repair_enginerSetting_Repair_description">
+        <Key ID="STR_ACE_Repair_engineerSetting_Repair_description">
             <English>Who can perform repair actions?</English>
             <German>Wer kann eine Reperatur durchführen?</German>
             <Polish>Kto może wykonywać czynności związane z naprawą pojazdów?</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- Correct typos ("enginer" to "engineer").