### PR TITLE
Remove the unsupported option of disabling medical level

### DIFF
--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -5,7 +5,7 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_level_Description);
         value = 1;
         typeName = "SCALAR";
-        values[] = {"Disabled", "Basic", "Advanced"};
+        values[] = {"Basic", "Advanced"};
     };
     class GVAR(medicSetting) {
         category = CSTRING(Category_Medical);


### PR DESCRIPTION
Setting `Medical Level` to `0` (`Disabled`) in config entries (`serverconfig.hpp`) or mission parameters (`description.ext`) will unexpectedly default it to `1` (`Basic`), despite `Medical Level` under `ACE Options -> Export Menu` having a `Disabled` option. This is because only values `1` (`Basic`) and `2` (`Advanced`) are supported.

**When merged this pull request will:**
- Improve expectancy: In `ACE Options -> Export Menu` the `Medical Level` can now only be set to the supported options `Basic` or `Advanced` ([CfgVehicles.hpp](https://github.com/acemod/ACE3/blob/master/addons/medical/CfgVehicles.hpp#L31)).
- Improve consistency: In the `Medical Settings [ACE]` module the `Medical Level` can only be set to `Basic` or `Advanced` ([fnc_moduleMedicalSettings.sqf](https://github.com/acemod/ACE3/blob/master/addons/medical/functions/fnc_moduleMedicalSettings.sqf#L25)), as supported settings are read from [CfgVehicles.hpp](https://github.com/acemod/ACE3/blob/master/addons/medical/CfgVehicles.hpp).
- Fulfill design decisions: An option to disable `Medical Level` was previously considered invalid (https://github.com/acemod/ACE3/issues/2894).
- Not conflict with anyone's feature request (https://github.com/acemod/ACE3/issues/414) to be able to set `Medical Level` to `Disabled` (despite it not being supported).
- Not conflict with anyone's ACE settings or future implementation of being able to disable `Medical Level`. The alternative solution of changing the values of `normal` (`Basic`) and `full` (`Advanced`) from `1` and `2` to `0` and `1` in [CfgVehicles.hpp](https://github.com/acemod/ACE3/blob/master/addons/medical/CfgVehicles.hpp) as well, instead of only removing `Disabled`, would however cause conflict.