### PR TITLE
Laser seeker range improvements

### DIFF
--- a/addons/hellfire/functions/fnc_showHud.sqf
+++ b/addons/hellfire/functions/fnc_showHud.sqf
@@ -91,9 +91,12 @@ GVAR(pfID) = [{
     private _ctrlIcon = (uiNamespace getVariable [QGVAR(display), displayNull]) displayCtrl IDC_LASERICON;
 
     // Do Laser Scan:
+    private _ammo = getText (configFile >> "CfgMagazines" >> _vehicle currentMagazineTurret _turretPath >> "ammo");
     private _laserSource = AGLtoASL (_vehicle modelToWorld (_vehicle selectionPosition _seekerSource));
     private _laserCode = _vehicle getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
-    private _laserResult = [_laserSource, vectorDir _vehicle, 70, 5000, [ACE_DEFAULT_LASER_WAVELENGTH,ACE_DEFAULT_LASER_WAVELENGTH], _laserCode, _vehicle] call EFUNC(laser,seekerFindLaserSpot);
+    private _seekerAngle = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ace_missileguidance" >> "seekerAngle");
+    private _seekerMaxRange = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ace_missileguidance" >> "seekerMaxRange");
+    private _laserResult = [_laserSource, vectorDir _vehicle, _seekerAngle, _seekerMaxRange, [ACE_DEFAULT_LASER_WAVELENGTH,ACE_DEFAULT_LASER_WAVELENGTH], _laserCode, _vehicle] call EFUNC(laser,seekerFindLaserSpot);
     private _foundTargetPos = _laserResult select 0;
     private _haveLock = !isNil "_foundTargetPos";
 

--- a/addons/laser/functions/fnc_seekerFindLaserSpot.sqf
+++ b/addons/laser/functions/fnc_seekerFindLaserSpot.sqf
@@ -25,15 +25,15 @@
 
 BEGIN_COUNTER(seekerFindLaserSpot);
 
-params ["_posASL", "_dir", "_seekerFov", "_seekerMaxDistnace", "_seekerWavelengths", "_seekerCode", ["_ignoreObj1", objNull]];
+params ["_posASL", "_dir", "_seekerFov", "_seekerMaxDistance", "_seekerWavelengths", "_seekerCode", ["_ignoreObj1", objNull]];
 
 _dir = vectorNormalized _dir;
 _seekerWavelengths params ["_seekerWavelengthMin", "_seekerWavelengthMax"];
 
 private _seekerCos = cos _seekerFov;
-private _seekerMaxDistSq = _seekerMaxDistnace ^ 2;
+private _seekerMaxDistSq = _seekerMaxDistance ^ 2;
 
-TRACE_6("",_posASL,_dir,_seekerFov,_seekerMaxDistnace,_seekerWavelengths,_seekerCode);
+TRACE_6("",_posASL,_dir,_seekerFov,_seekerMaxDistance,_seekerWavelengths,_seekerCode);
 
 private _spots = [];
 private _finalPos = nil;

--- a/addons/laser/functions/fnc_shootRay.sqf
+++ b/addons/laser/functions/fnc_shootRay.sqf
@@ -31,9 +31,9 @@ private _intersects = lineIntersectsSurfaces [_posASL, _farPoint, _ignoreVehicle
 // workaround for lineIntersectsSurfaces using a hardcoded max distance of 5000m. New max distance 15000m
 if (_intersects isEqualTo []) then {
     _intersects = lineIntersectsSurfaces [_posASL vectorAdd (_dir vectorMultiply 5000), _farPoint vectorAdd (_dir vectorMultiply 5000), _ignoreVehicle1, _ignoreVehicle2];
-};
-if (_intersects isEqualTo []) then {
-    _intersects = lineIntersectsSurfaces [_posASL vectorAdd (_dir vectorMultiply 10000), _farPoint vectorAdd (_dir vectorMultiply 10000), _ignoreVehicle1, _ignoreVehicle2];
+    if (_intersects isEqualTo []) then {
+        _intersects = lineIntersectsSurfaces [_posASL vectorAdd (_dir vectorMultiply 10000), _farPoint vectorAdd (_dir vectorMultiply 10000), _ignoreVehicle1, _ignoreVehicle2];
+    };
 };
 
 if (!(_intersects isEqualTo [])) then {

--- a/addons/laser/functions/fnc_shootRay.sqf
+++ b/addons/laser/functions/fnc_shootRay.sqf
@@ -28,6 +28,13 @@ private _resultPos = nil;
 
 private _farPoint = _posASL vectorAdd (_dir vectorMultiply 10000);
 private _intersects = lineIntersectsSurfaces [_posASL, _farPoint, _ignoreVehicle1, _ignoreVehicle2];
+// workaround for lineIntersectsSurfaces using a hardcoded max distance of 5000m. New max distance 15000m
+if (_intersects isEqualTo []) then {
+    _intersects = lineIntersectsSurfaces [_posASL vectorAdd (_dir vectorMultiply 5000), _farPoint vectorAdd (_dir vectorMultiply 5000), _ignoreVehicle1, _ignoreVehicle2];
+};
+if (_intersects isEqualTo []) then {
+    _intersects = lineIntersectsSurfaces [_posASL vectorAdd (_dir vectorMultiply 10000), _farPoint vectorAdd (_dir vectorMultiply 10000), _ignoreVehicle1, _ignoreVehicle2];
+};
 
 if (!(_intersects isEqualTo [])) then {
     (_intersects select 0) params ["_intersectPosASL", "", "_intersectObject"];


### PR DESCRIPTION
**When merged this pull request will:**
- Add a workaround for the max hardcoded range of `lineIntersectsSurfaces` (5000m). Simply attempts another ray from the end of the previous ray. It does this twice, so the new max range is 15000m, which is overcompensating.
- Change hellfire HUD seeker call to use values of current ammunition
- Fix spelling of distance in `fnc_seekerFindLaserSpot`
