### PR TITLE
Switch Units - Remove use of BIS_fnc_addStackedEventHandler

### DIFF
--- a/addons/switchunits/functions/fnc_addMapFunction.sqf
+++ b/addons/switchunits/functions/fnc_addMapFunction.sqf
@@ -3,25 +3,21 @@
  * Adds a mapClick Eventhandler
  *
  * Arguments:
- * 0: unit <OBJECT>
- * 1: sides <ARRAY<OBJECT>>
+ * None
  *
  * Return Value:
  * None
  *
  * Example:
- * [_unit, _sides] call ace_switchunits_fnc_addMapFunction
+ * [] call ace_switchunits_fnc_addMapFunction
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_unit", "_sides"];
-
-["theMapClick", "onMapSingleClick", {
-    // IGNORE_PRIVATE_WARNING(_pos,_shift,_alt)
+addMissionEventHandler ["MapSingleClick", {
+    params ["", "_pos", "_alt", "_shift"];
     if (alive ACE_player && {GVAR(OriginalUnit) getVariable ["ACE_CanSwitchUnits", false]}) then {
-        [_this, _pos, _shift, _alt] call FUNC(handleMapClick);
+        [[GVAR(OriginalUnit), GVAR(switchableSides)], _pos, _shift, _alt] call FUNC(handleMapClick);
     };
-
-}, [_unit, _sides]] call BIS_fnc_addStackedEventHandler;
+}];

--- a/addons/switchunits/functions/fnc_initPlayer.sqf
+++ b/addons/switchunits/functions/fnc_initPlayer.sqf
@@ -27,6 +27,7 @@ if (vehicle _playerUnit == _playerUnit) then {
     GVAR(OriginalUnit) = _playerUnit;
     GVAR(OriginalName) = name _playerUnit;
     GVAR(OriginalGroup) = group _playerUnit;
+    GVAR(switchableSides) = _sides;
 
     // remove all starting gear of a player
     removeAllWeapons _playerUnit;
@@ -41,5 +42,5 @@ if (vehicle _playerUnit == _playerUnit) then {
 
     [_playerUnit, "forceWalk", "ACE_SwitchUnits", true] call EFUNC(common,statusEffect_set);
 
-    [_playerUnit, _sides] call FUNC(addMapFunction);
+    [] call FUNC(addMapFunction);
 };

--- a/addons/switchunits/functions/fnc_switchBack.sqf
+++ b/addons/switchunits/functions/fnc_switchBack.sqf
@@ -17,6 +17,7 @@
 #include "script_component.hpp"
 
 params ["_originalPlayerUnit"];
+TRACE_1("switchBack",_originalPlayerUnit);
 
 [_originalPlayerUnit] joinSilent GVAR(OriginalGroup);
 

--- a/addons/switchunits/functions/fnc_switchUnit.sqf
+++ b/addons/switchunits/functions/fnc_switchUnit.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_1("switchUnit",_unit);
 
 // don't switch to original player units
 if (!([_unit] call FUNC(isValidAi))) exitWith {};


### PR DESCRIPTION
BIS_fnc_addStackedEventHandler throws error on dev branch
they are now compiling the passed args.
also `_pos, _shift, _alt` are no longer present