### PR TITLE
Replace Helicopter eject configs with universal scripted action

### DIFF
--- a/addons/aircraft/CfgEventHandlers.hpp
+++ b/addons/aircraft/CfgEventHandlers.hpp
@@ -1,4 +1,3 @@
-
 class Extended_PreStart_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preStart));

--- a/addons/aircraft/CfgEventHandlers.hpp
+++ b/addons/aircraft/CfgEventHandlers.hpp
@@ -1,0 +1,18 @@
+
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        clientInit = QUOTE(call COMPILE_FILE(XEH_postInitClient));
+    };
+};

--- a/addons/aircraft/CfgVehicles.hpp
+++ b/addons/aircraft/CfgVehicles.hpp
@@ -37,11 +37,9 @@ class CfgVehicles {
 
     class Heli_Light_01_base_F: Helicopter_Base_H {
         incomingMissileDetectionSystem = 16; // Vanilla: 0
-        driverCanEject = 1;
 
         class Turrets: Turrets {
             class CopilotTurret: CopilotTurret {
-                canEject = 1;
                 showHMD = 1;
             };
         };
@@ -49,22 +47,13 @@ class CfgVehicles {
 
     class Heli_Light_01_armed_base_F: Heli_Light_01_base_F {
         incomingMissileDetectionSystem = 16; // Vanilla: 0
-        driverCanEject = 1;
-
-        class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {
-                canEject = 1;
-            };
-        };
     };
     class Heli_Light_02_base_F: Helicopter_Base_H {
-        driverCanEject = 1;
         incomingMissileDetectionSystem = 16; // Vanilla: 24
         magazines[] = {"2000Rnd_762x51_Belt_T_Green", "12Rnd_PG_missiles", "168Rnd_CMFlare_Chaff_Magazine"}; // Switch gun magazine to 7.62mm from 6.5mm
 
         class Turrets: Turrets {
             class CopilotTurret: CopilotTurret {
-                canEject = 1;
                 showHMD = 1;
             };
         };
@@ -80,44 +69,31 @@ class CfgVehicles {
 
     class Heli_Attack_02_base_F: Helicopter_Base_F {
         incomingMissileDetectionSystem = 16; // Vanilla: 24
-        driverCanEject = 1;
-
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                canEject = 1;
-            };
-        };
     };
 
     class Heli_Transport_01_base_F: Helicopter_Base_H {
         incomingMissileDetectionSystem = 16; // Vanilla: 24
-        driverCanEject = 1;
 
         class Turrets: Turrets {
             class CopilotTurret: CopilotTurret {
-                canEject = 1;
                 showHMD = 1;
             };
 
             class MainTurret: MainTurret {
                 magazines[] = {"2000Rnd_762x51_Belt_T_Red"}; // Switch gun magazine to 7.62mm from 6.5mm
-                canEject = 1;
             };
 
             class RightDoorGun: MainTurret {
                 magazines[] = {"2000Rnd_762x51_Belt_T_Red"}; // Switch gun magazine to 7.62mm from 6.5mm
-                canEject = 1;
             };
         };
     };
 
     class Heli_Transport_02_base_F: Helicopter_Base_H {
         incomingMissileDetectionSystem = 16; // Vanilla: 24
-        driverCanEject = 1;
 
         class Turrets: Turrets {
             class CopilotTurret: CopilotTurret {
-                canEject = 1;
                 showHMD = 1;
             };
         };
@@ -126,11 +102,9 @@ class CfgVehicles {
     class Heli_light_03_base_F: Helicopter_Base_F {
         lockDetectionSystem = 0; // Vanilla: 12
         incomingMissileDetectionSystem = 16; // Vanilla: 24
-        driverCanEject = 1;
 
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                canEject = 1;
                 showHMD = 1;
                 weapons[] = {"Laserdesignator_mounted"}; // Add Laser Designator
                 magazines[] = {"Laserbatteries"};
@@ -166,26 +140,8 @@ class CfgVehicles {
 
     class Heli_Transport_03_base_F: Helicopter_Base_H {
         incomingMissileDetectionSystem = 16; // Vanilla: 24
-        driverCanEject = 1;
-
-        class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {
-                canEject = 1;
-            };
-        };
     };
     class Heli_Transport_04_base_F: Helicopter_Base_H {
         incomingMissileDetectionSystem = 16; // Vanilla: 24
-        driverCanEject = 1;
-
-        class Turrets: Turrets {
-            class CopilotTurret: CopilotTurret {
-                canEject = 1;
-            };
-
-            class LoadmasterTurret: MainTurret {
-                canEject = 1;
-            };
-        };
     };
 };

--- a/addons/aircraft/Heli_Attack_01_base_F.hpp
+++ b/addons/aircraft/Heli_Attack_01_base_F.hpp
@@ -1,6 +1,5 @@
 class Heli_Attack_01_base_F: Helicopter_Base_F {
     incomingMissileDetectionSystem = 16; // Vanilla: 24
-    driverCanEject = 1;
 
     class Turrets: Turrets {
         class MainTurret: MainTurret {

--- a/addons/aircraft/XEH_PREP.hpp
+++ b/addons/aircraft/XEH_PREP.hpp
@@ -1,3 +1,2 @@
-
 PREP(initEjectAction);
 PREP(canShowEject);

--- a/addons/aircraft/XEH_PREP.hpp
+++ b/addons/aircraft/XEH_PREP.hpp
@@ -1,0 +1,3 @@
+
+PREP(initEjectAction);
+PREP(canShowEject);

--- a/addons/aircraft/XEH_postInitClient.sqf
+++ b/addons/aircraft/XEH_postInitClient.sqf
@@ -20,7 +20,7 @@ GVAR(ejectActionParams) = [
         false,
         true,
         getText (_cfgAction >> "shortcut"),
-        QUOTE([ARR_2(_this,_target)] call DFUNC(canShowEject))
+        '[_this, _target] call DFUNC(canShowEject)'
     ],
     getText (_cfgAction >> "text"),
     getText (_cfgAction >> "textDefault")

--- a/addons/aircraft/XEH_postInitClient.sqf
+++ b/addons/aircraft/XEH_postInitClient.sqf
@@ -20,7 +20,7 @@ GVAR(ejectActionParams) = [
         false,
         true,
         getText (_cfgAction >> "shortcut"),
-        QUOTE([ARR_2(_this,_target)] call FUNC(canShowEject))
+        QUOTE([ARR_2(_this,_target)] call DFUNC(canShowEject))
     ],
     getText (_cfgAction >> "text"),
     getText (_cfgAction >> "textDefault")

--- a/addons/aircraft/XEH_postInitClient.sqf
+++ b/addons/aircraft/XEH_postInitClient.sqf
@@ -6,7 +6,15 @@ private _cfgAction = configFile >> "CfgActions" >> "Eject";
 GVAR(ejectActionParams) = [
     [
         "", // will be set with setUserActionText
-        {moveOut (_this select 1)},
+        {
+            params ["_vehicle", "_unit"];
+            private _preserveEngineOn = (_unit == driver _vehicle) && {isEngineOn _vehicle};
+            moveOut _unit;
+            if (_preserveEngineOn) then {
+                // vehicle is local to last driver, no need to care
+                _vehicle engineOn true;
+            };
+        },
         nil,
         getNumber (_cfgAction >> "priority"),
         false,

--- a/addons/aircraft/XEH_postInitClient.sqf
+++ b/addons/aircraft/XEH_postInitClient.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+private _cfgAction = configFile >> "CfgActions" >> "Eject";
+GVAR(ejectActionParams) = [
+    [
+        "", // will be set with setUserActionText
+        {moveOut (_this select 1)},
+        nil,
+        getNumber (_cfgAction >> "priority"),
+        false,
+        true,
+        getText (_cfgAction >> "shortcut"),
+        QUOTE([ARR_2(_this,_target)] call FUNC(canShowEject))
+    ],
+    getText (_cfgAction >> "text"),
+    getText (_cfgAction >> "textDefault")
+];
+
+["Helicopter", "initPost", LINKFUNC(initEjectAction)] call CBA_fnc_addClassEventHandler;

--- a/addons/aircraft/XEH_preInit.sqf
+++ b/addons/aircraft/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/aircraft/XEH_preStart.sqf
+++ b/addons/aircraft/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/aircraft/config.cpp
+++ b/addons/aircraft/config.cpp
@@ -18,6 +18,7 @@ class CfgPatches {
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/aircraft/functions/fnc_canShowEject.sqf
+++ b/addons/aircraft/functions/fnc_canShowEject.sqf
@@ -16,21 +16,15 @@
  */
 #include "script_component.hpp"
 
-params [["_unit", objNull, [objNull]], ["_vehicle", objNull, [objNull]]];
+params ["_unit", "_vehicle"];
 
 _vehicle == vehicle _unit
-&& {_vehicle getVariable [
-    // handle race when unit gets out of vehicle
-    call {
-        private _return = {
-            _x params ["_owner", "_role", "", "_turretPath"];
-            if (_unit == _owner) exitWith {
-                format ["%1_%2_%3", QGVAR(ejectAction), _role, _turretPath]
-            };
-            false
-        } count fullCrew _vehicle;
-        // getVariable ["", ...] returns default value
-        ["", _return] select (_return isEqualType "")
-    },
-    false
-]}
+&& {
+    private _ejectVarName = "";
+    {
+        if (_unit == _x select 0) exitWith {
+            _ejectVarName = format [QGVAR(ejectAction_%1), _x select 3];
+        };
+    } count fullCrew _vehicle;
+    _vehicle getVariable [_ejectVarName, false]
+}

--- a/addons/aircraft/functions/fnc_canShowEject.sqf
+++ b/addons/aircraft/functions/fnc_canShowEject.sqf
@@ -16,14 +16,18 @@
  */
 #include "script_component.hpp"
 
+#define FULLCREW_UNIT       0
+#define FULLCREW_ROLE       1
+#define FULLCREW_TURRETPATH 3
+
 params ["_unit", "_vehicle"];
 
 _vehicle == vehicle _unit
 && {
     private _ejectVarName = "";
     {
-        if (_unit == _x select 0) exitWith {
-            _ejectVarName = format [QGVAR(ejectAction_%1), _x select 3];
+        if (_unit == _x select FULLCREW_UNIT) exitWith {
+            _ejectVarName = format [QGVAR(ejectAction_%1_%2), _x select FULLCREW_ROLE, _x select FULLCREW_TURRETPATH];
         };
     } count fullCrew _vehicle;
     _vehicle getVariable [_ejectVarName, false]

--- a/addons/aircraft/functions/fnc_canShowEject.sqf
+++ b/addons/aircraft/functions/fnc_canShowEject.sqf
@@ -1,0 +1,36 @@
+/*
+ * Author: Dystopian
+ * Check if Eject action can be shown.
+ *
+ * Arguments:
+ * 0: Unit who calls action <OBJECT>
+ * 1: Vehicle which action is attached to <OBJECT>
+ *
+ * Return Value:
+ * Can show <BOOL>
+ *
+ * Example:
+ * [player, vehicle player] call ace_aircraft_fnc_canShowEject
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params [["_unit", objNull, [objNull]], ["_vehicle", objNull, [objNull]]];
+
+_vehicle == vehicle _unit
+&& {_vehicle getVariable [
+    // handle race when unit gets out of vehicle
+    call {
+        private _return = {
+            _x params ["_owner", "_role", "", "_turretPath"];
+            if (_unit == _owner) exitWith {
+                format ["%1_%2_%3", QGVAR(ejectAction), _role, _turretPath]
+            };
+            false
+        } count fullCrew _vehicle;
+        // getVariable ["", ...] returns default value
+        ["", _return] select (_return isEqualType "")
+    },
+    false
+]}

--- a/addons/aircraft/functions/fnc_initEjectAction.sqf
+++ b/addons/aircraft/functions/fnc_initEjectAction.sqf
@@ -30,7 +30,7 @@ if (0 == getNumber (_config >> "driverCanEject")) then {
 
 {
     _x params ["", "_role", "", "_turretPath"];
-    if (0 == getNumber (([_vehicle, _turretPath] call CBA_fnc_getTurret) >> "canEject")) then {
+    if (0 == getNumber (([_config, _turretPath] call CBA_fnc_getTurret) >> "canEject")) then {
         _vehicle setVariable [format ["%1_%2_%3", QGVAR(ejectAction), _role, _turretPath], true];
         _addAction = true;
     };

--- a/addons/aircraft/functions/fnc_initEjectAction.sqf
+++ b/addons/aircraft/functions/fnc_initEjectAction.sqf
@@ -1,0 +1,44 @@
+/*
+ * Author: Dystopian
+ * Add Eject action to vehicle if needed.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * _vehicle call ace_aircraft_fnc_initEjectAction
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_vehicle"];
+
+if (unitIsUAV _vehicle) exitWith {};
+
+private _config = configFile >> "CfgVehicles" >> (typeOf _vehicle);
+
+private _addAction = false;
+
+if (0 == getNumber (_config >> "driverCanEject")) then {
+    _vehicle setVariable [QUOTE(DOUBLES(GVAR(ejectAction),driver_[])), true];
+    _addAction = true;
+};
+
+{
+    _x params ["", "_role", "", "_turretPath"];
+    if (0 == getNumber (([_vehicle, _turretPath] call CBA_fnc_getTurret) >> "canEject")) then {
+        _vehicle setVariable [format ["%1_%2_%3", QGVAR(ejectAction), _role, _turretPath], true];
+        _addAction = true;
+    };
+} forEach (fullCrew [_vehicle, "gunner", true] + fullCrew [_vehicle, "turret", true]);
+
+if (!_addAction) exitWith {};
+
+GVAR(ejectActionParams) params ["_params", "_text", "_picture"];
+private _actionID = _vehicle addAction _params;
+_vehicle setUserActionText [_actionID, _text, "", _picture];
+_vehicle setVariable [QGVAR(ejectAction), _actionID];

--- a/addons/aircraft/functions/fnc_initEjectAction.sqf
+++ b/addons/aircraft/functions/fnc_initEjectAction.sqf
@@ -25,16 +25,16 @@ private _addAction = false;
 
 if (0 == getNumber (_config >> "driverCanEject")) then {
     TRACE_2("eject action",typeOf _vehicle,"driver");
-    _vehicle setVariable [QGVAR(ejectAction_[]), true];
+    _vehicle setVariable [QGVAR(ejectAction_driver_[]), true];
     _addAction = true;
 };
 
 {
     {
-        private _turretPath = _x select 3;
+        _x params ["", "_role", "", "_turretPath"];
         if (0 == getNumber (([_config, _turretPath] call CBA_fnc_getTurret) >> "canEject")) then {
             TRACE_2("eject action",typeOf _vehicle,_turretPath);
-            _vehicle setVariable [format [QGVAR(ejectAction_%1), _turretPath], true];
+            _vehicle setVariable [format [QGVAR(ejectAction_%1_%2), _role, _turretPath], true];
             _addAction = true;
         };
     } forEach fullCrew [_vehicle, _x, true];

--- a/addons/aircraft/functions/fnc_initEjectAction.sqf
+++ b/addons/aircraft/functions/fnc_initEjectAction.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * _vehicle call ace_aircraft_fnc_initEjectAction
+ * [cursorObject] call ace_aircraft_fnc_initEjectAction
  *
  * Public: No
  */
@@ -19,22 +19,26 @@ params ["_vehicle"];
 
 if (unitIsUAV _vehicle) exitWith {};
 
-private _config = configFile >> "CfgVehicles" >> (typeOf _vehicle);
+private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
 
 private _addAction = false;
 
 if (0 == getNumber (_config >> "driverCanEject")) then {
-    _vehicle setVariable [QUOTE(DOUBLES(GVAR(ejectAction),driver_[])), true];
+    TRACE_2("eject action",typeOf _vehicle,"driver");
+    _vehicle setVariable [QGVAR(ejectAction_[]), true];
     _addAction = true;
 };
 
 {
-    _x params ["", "_role", "", "_turretPath"];
-    if (0 == getNumber (([_config, _turretPath] call CBA_fnc_getTurret) >> "canEject")) then {
-        _vehicle setVariable [format ["%1_%2_%3", QGVAR(ejectAction), _role, _turretPath], true];
-        _addAction = true;
-    };
-} forEach (fullCrew [_vehicle, "gunner", true] + fullCrew [_vehicle, "turret", true]);
+    {
+        private _turretPath = _x select 3;
+        if (0 == getNumber (([_config, _turretPath] call CBA_fnc_getTurret) >> "canEject")) then {
+            TRACE_2("eject action",typeOf _vehicle,_turretPath);
+            _vehicle setVariable [format [QGVAR(ejectAction_%1), _turretPath], true];
+            _addAction = true;
+        };
+    } forEach fullCrew [_vehicle, _x, true];
+} forEach ["gunner", "commander", "turret"];
 
 if (!_addAction) exitWith {};
 

--- a/addons/aircraft/functions/script_component.hpp
+++ b/addons/aircraft/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\ace\addons\aircraft\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- remove `*canEject` config entries;
- add Eject action with vanilla `addAction` command to appropriate helicopters.

This is replacement of #4749.

- [x] I would like to wait for CBA 3.4.1, there is a little change in `CBA_fnc_getTurret`. But not if it's later then next ACE minor release.

There may be another approach with getIn/getOut EH, but I decided it's more difficult.

~Question: can it happen that initPost EH fires more then once? If yes, many actions will be added.~ OK

Problems with used `moveOut` comand:
1. ~It stops engine while vanilla `Eject` doesn't (driver only).~ Fixed
1. AI subordinate just really moves out by order while with vanilla AI unit doesn't do it until he has a parachute and then he moves out.