### PR TITLE
Fix cars loaded as cargo taking water damage

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -50,6 +50,11 @@
 
     _item hideObjectGlobal false;
     _item setPosASL (AGLtoASL _emptyPosAGL);
+
+    if ((getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "carx") then {
+        TRACE_1("re-enabling car damage",_item);
+        [_item, "blockDamage", "ACE_cargo", false] call EFUNC(common,statusEffect_set);
+    };
 }] call CBA_fnc_addEventHandler;
 
 // Private events to handle adding actions globally via public functions

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -36,6 +36,12 @@ if (_item isEqualType objNull) then {
     detach _item;
     _item attachTo [_vehicle,[0,0,-100]];
     [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
+    
+    // Cars below water will take engine damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
+    if ((getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "carx") then {
+        TRACE_1("disabling car damage",_item);
+        [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
+    };
 };
 
 true

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -22,7 +22,7 @@
 ["forceWalk", false, ["ACE_SwitchUnits", "ACE_Attach", "ACE_dragging", "ACE_Explosives", "ACE_Ladder", "ACE_Sandbag", "ACE_refuel", "ACE_rearm", "ACE_dragging"]] call FUNC(statusEffect_addType);
 ["blockSprint", false, []] call FUNC(statusEffect_addType);
 ["setCaptive", true, [QEGVAR(captives,Handcuffed), QEGVAR(captives,Surrendered), "ace_unconscious"]] call FUNC(statusEffect_addType);
-["blockDamage", false, ["fixCollision"]] call FUNC(statusEffect_addType);
+["blockDamage", false, ["fixCollision", "ACE_cargo"]] call FUNC(statusEffect_addType);
 ["blockEngine", false, ["ACE_Refuel"]] call FUNC(statusEffect_addType);
 
 [QGVAR(forceWalk), {


### PR DESCRIPTION
Fix #5398

Seems like cars are hard-coded to take water damage,
`_item attachTo [_vehicle,[0,0,-100]];` can put the car below 0 ASL which triggers the effect
(tested on a 75m high hill, -70 was fine, -80 caused damage)

Once water logged the vehicle seems to be permently disabled (fixing HitEngine does not fix)

This just disables damage (`allowDamage`) on the car while in cargo