### PR TITLE
Add Pentolite Gurney constant to wiki

### DIFF
--- a/docs/wiki/framework/frag-framework.md
+++ b/docs/wiki/framework/frag-framework.md
@@ -70,6 +70,7 @@ LX-14           | 2970 m/s
 Octol 75/25     | 2800 m/s
 PBX 9404        | 2900 m/s
 PBX 9502        | 2377 m/s
+Pentolite       | 2750 m/s
 PETN            | 2930 m/s
 RDX             | 2830 m/s
 Tetryl          | 2500 m/s


### PR DESCRIPTION
Hard to find a reference for this, but figure it is useful to others as it's fairly common in older HEAT shells (WW2 stuff is why this even came to my attention) and modern fast-acting explosives.

It's a bit of an approximation as I had to interpolate the value of the first reference so that it was correct relative to the other values on our wiki (by using two other explosives common to both tables). The second reference in fps converts to roughly the same value in m/s so I'm content to call it good.

References:
http://axpro.mines.edu/documents/MNGN%20444_Fragmentation%20and%20Safety%20Distances%20_Examples.pdf, p.3
http://dtic.mil/dtic/tr/fulltext/u2/783941.pdf, p.25