### PR TITLE
Added drag and Cargo ability to Orange crates

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -425,6 +425,7 @@ class CfgVehicles {
     };
 
     // objects
+    class Lamps_base_F;
     class RoadCone_F: ThingX {
         GVAR(size) = 1;
         GVAR(canLoad) = 1;
@@ -432,7 +433,11 @@ class CfgVehicles {
     class RoadBarrier_F: RoadCone_F {
         GVAR(size) = 2;
     };
-
+    class Land_PortableLight_single_F: Lamps_base_F {
+        GVAR(size) = 1;
+        GVAR(canLoad) = 1;
+    };
+    
     class Scrapyard_base_F;
     class Land_PaperBox_closed_F: Scrapyard_base_F {
         class EventHandlers {
@@ -742,7 +747,7 @@ class CfgVehicles {
         GVAR(size) = 100;
     };
 
-    // small
+    // Small
     class Land_CargoBox_V1_F: ThingX {
         class EventHandlers {
             class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
@@ -763,10 +768,39 @@ class CfgVehicles {
             };
         };
     };
-
-    class Lamps_base_F;
-    class Land_PortableLight_single_F: Lamps_base_F {
+    class Land_PaperBox_01_small_closed_base_F: Items_base_F {
         GVAR(size) = 1;
+        GVAR(canLoad) = 1;
+        
+        maximumLoad = 1000;
+        transportMaxBackpacks = 12;
+        transportMaxMagazines = 64;
+        transportMaxWeapons = 12;
+    };
+    class Box_UAV_06_base_F: Items_base_F {
+        GVAR(size) = 1;
+        GVAR(canLoad) = 1;
+    };
+
+    // Aid items
+    class Land_FoodSack_01_full_base_F: Items_base_F {
+        GVAR(size) = 1;
+        GVAR(canLoad) = 1;
+    };
+    class Land_FoodSack_01_cargo_base_F: Items_base_F {
+        GVAR(size) = 7;
+        GVAR(canLoad) = 1;
+    };
+    class Land_FoodSack_01_large_base_F: Items_base_F {
+        GVAR(size) = 7;
+        GVAR(canLoad) = 1;
+    };
+    class Land_WaterBottle_01_stack_F: Items_base_F {
+        GVAR(size) = 7;
+        GVAR(canLoad) = 1;
+    };
+    class Land_PaperBox_01_small_stacked_F: Items_base_F {
+        GVAR(size) = 7;
         GVAR(canLoad) = 1;
     };
 };

--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -795,11 +795,27 @@ class CfgVehicles {
         GVAR(size) = 7;
         GVAR(canLoad) = 1;
     };
-    class Land_WaterBottle_01_stack_F: Items_base_F {
+    class Land_FoodSack_01_small_base_F: Items_base_F {
+        GVAR(size) = 2;
+        GVAR(canLoad) = 1;
+    };
+    class Land_PaperBox_01_open_boxes_F: Items_base_F {
+        GVAR(size) = 7;
+        GVAR(canLoad) = 1;
+    };
+    class Land_PaperBox_01_open_water_F: Items_base_F {
+        GVAR(size) = 7;
+        GVAR(canLoad) = 1;
+    };
+    class Land_PaperBox_01_open_empty_F: Items_base_F {
         GVAR(size) = 7;
         GVAR(canLoad) = 1;
     };
     class Land_PaperBox_01_small_stacked_F: Items_base_F {
+        GVAR(size) = 7;
+        GVAR(canLoad) = 1;
+    };
+    class Land_WaterBottle_01_stack_F: Items_base_F {
         GVAR(size) = 7;
         GVAR(canLoad) = 1;
     };

--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -207,6 +207,15 @@ class CfgVehicles {
         GVAR(dragPosition[]) = {0,1.5,0};
         GVAR(dragDirection) = 90;
     };
+    class Land_PaperBox_01_small_closed_base_F: Items_base_F {
+        GVAR(canCarry) = 1;
+        GVAR(carryPosition[]) = {0,1,1};
+        GVAR(carryDirection) = 0;
+
+        GVAR(canDrag) = 1;
+        GVAR(dragPosition[]) = {0,1.5,0};
+        GVAR(dragDirection) = 90;
+    };
 
     class ACE_RepairItem_Base: ThingX {};
 

--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -216,7 +216,15 @@ class CfgVehicles {
         GVAR(dragPosition[]) = {0,1.5,0};
         GVAR(dragDirection) = 90;
     };
+    class Box_UAV_06_base_F: Items_base_F {
+        GVAR(canCarry) = 1;
+        GVAR(carryPosition[]) = {0,1,1};
+        GVAR(carryDirection) = 0;
 
+        GVAR(canDrag) = 1;
+        GVAR(dragPosition[]) = {0,1.5,0};
+        GVAR(dragDirection) = 0;
+    };
     class ACE_RepairItem_Base: ThingX {};
 
     class ACE_Track: ACE_RepairItem_Base {


### PR DESCRIPTION
**When merged this pull request will:**
- Added cargo to pallet food stacks crate
- Added cargo to water stacks crate
- Added cargo to Paper Box stacks
- Added cargo to Paper Box
- Added cargo to UAV box
- Added dragging and carry to Paper Box
- Added dragging and carry to UAV box
- Moved Land_PortableLight_single_F up to objects category
