### PR TITLE
Nametag Changes (1)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -130,4 +130,5 @@ Valentin Torikian <valentin.torikian@gmail.com>
 voiper
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
+Whale (Whalen207) <quailsnap@gmail.com>
 zGuba

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -51,12 +51,18 @@ class ACE_Settings {
         values[] = {ECSTRING(common,Disabled), CSTRING(NameTagSettings), CSTRING(AlwaysShowAll)};
         category = CSTRING(Module_DisplayName);
     };
-    class GVAR(playerNamesViewDistance) {
+    class GVAR(playerNamesViewDistanceNearby) {
         value = 5;
         typeName = "SCALAR";
         isClientSettable = 0;
         category = CSTRING(Module_DisplayName);
     };
+	class GVAR(playerNamesViewDistanceCursor) {
+		value = 15;
+		typeName = "SCALAR";
+		isClientSettable = 0;
+		category = CSTRING(Module_DisplayName);
+	};
     class GVAR(playerNamesMaxAlpha) {
         value = 0.8;
         typeName = "SCALAR";

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -18,12 +18,13 @@
 // Determine flags from current settings
 private _drawName = true;
 private _enabledTagsNearby = false;
-private _enabledTagsCursor = false;
+private _enabledTagsCursor = true;
 
 switch (GVAR(showPlayerNames)) do {
     case 0: {
         // Player names Disabled [Note: this should be unreachable as the drawEH will be removed]
         _drawName = false;
+		_enableTagsCursor = false;
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
     };
     case 1: {
@@ -51,6 +52,7 @@ switch (GVAR(showPlayerNames)) do {
 };
 
 private _ambientBrightness = ((([] call EFUNC(common,ambientBrightness)) + ([0, 0.4] select ((currentVisionMode ace_player) != 0))) min 1) max 0;
-private _maxDistance = _ambientBrightness * GVAR(PlayerNamesViewDistance);
+private _maxDistanceNearby = _ambientBrightness * GVAR(playerNamesViewDistanceNearby);
+private _maxDistanceCursor = _ambientBrightness * GVAR(playerNamesViewDistanceCursor);
 
-[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_maxDistance]
+[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_maxDistanceNearby,_maxDistanceCursor]


### PR DESCRIPTION
**When merged this pull request will:**
> NAMETAGS
- Nametags under cursor can now be seen from further away.
- New GVAR added to settings to configure nametag cursor distance.
- Nametag alpha affected by distance from player to target instead of camera to target. This prevents players in third person from seeing fewer / fainter tags than players in first person. On the flip side, it should greatly increase the tags seen when, for instance, a player is in a truck full of people in third person.
> OTHER
- Added Whale to AUTHORS.txt
