### PR TITLE
Nametag Changes

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -130,5 +130,5 @@ Valentin Torikian <valentin.torikian@gmail.com>
 voiper
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
-Whale (Whalen207) <quailsnap@gmail.com>
+Whale (Quailsnap) <quailsnap@gmail.com>
 zGuba

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -130,4 +130,5 @@ Valentin Torikian <valentin.torikian@gmail.com>
 voiper
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
+Whale (Whalen207) <quailsnap@gmail.com>
 zGuba

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -51,12 +51,18 @@ class ACE_Settings {
         values[] = {ECSTRING(common,Disabled), CSTRING(NameTagSettings), CSTRING(AlwaysShowAll)};
         category = CSTRING(Module_DisplayName);
     };
-    class GVAR(playerNamesViewDistance) {
+    class GVAR(playerNamesViewDistanceNearby) {
         value = 5;
         typeName = "SCALAR";
         isClientSettable = 0;
         category = CSTRING(Module_DisplayName);
     };
+	class GVAR(playerNamesViewDistanceCursor) {
+		value = 15;
+		typeName = "SCALAR";
+		isClientSettable = 0;
+		category = CSTRING(Module_DisplayName);
+	};
     class GVAR(playerNamesMaxAlpha) {
         value = 0.8;
         typeName = "SCALAR";

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -57,12 +57,12 @@ class ACE_Settings {
         isClientSettable = 0;
         category = CSTRING(Module_DisplayName);
     };
-	class GVAR(playerNamesViewDistanceCursor) {
-		value = 15;
-		typeName = "SCALAR";
-		isClientSettable = 0;
-		category = CSTRING(Module_DisplayName);
-	};
+    class GVAR(playerNamesViewDistanceCursor) {
+        value = 15;
+        typeName = "SCALAR";
+        isClientSettable = 0;
+        category = CSTRING(Module_DisplayName);
+    };
     class GVAR(playerNamesMaxAlpha) {
         value = 0.8;
         typeName = "SCALAR";

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -79,7 +79,7 @@ _fnc_parameters = {
 };
 
 private _parameters = [_this, _fnc_parameters, _target, QGVAR(drawParameters), 0.1] call EFUNC(common,cachedCall);
-_parameters set [2, _target modelToWorldVisual ((_target selectionPosition "pilot") vectorAdd [0,0,(_heightOffset + .25)])];
+_parameters set [2, _target modelToWorldVisual ((_target selectionPosition "pilot") vectorAdd [0,0,((_heightOffset * (_parameters select 4)) + 0.2)])]; //.25
 
 
 drawIcon3D _parameters;

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -31,10 +31,10 @@ _fnc_parameters = {
 
     //Set Icon:
     private _icon = "";
-    private _size = 0;
+	// W- _size normalized to 1 to avoid height fluctations
+    private _size = 1;
     if (_drawSoundwave) then {
         _icon = format [QPATHTOF(UI\soundwave%1.paa), floor random 10];
-        _size = 1;
     } else {
         if (_drawRank && {rank _target != ""}) then {
             _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
@@ -43,7 +43,6 @@ _fnc_parameters = {
             } else {
                 _icon = format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target];
             };
-            _size = 1;
         };
     };
 
@@ -80,7 +79,7 @@ _fnc_parameters = {
 };
 
 private _parameters = [_this, _fnc_parameters, _target, QGVAR(drawParameters), 0.1] call EFUNC(common,cachedCall);
-_parameters set [2, _target modelToWorldVisual ((_target selectionPosition "pilot") vectorAdd [0,0,(_heightOffset + .3)])];
+_parameters set [2, _target modelToWorldVisual ((_target selectionPosition "pilot") vectorAdd [0,0,(_heightOffset + .25)])];
 
 
 drawIcon3D _parameters;

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -31,7 +31,7 @@ _fnc_parameters = {
 
     //Set Icon:
     private _icon = "";
-	// W- _size normalized to 1 to avoid height fluctations
+    // W- _size normalized to 1 to avoid height fluctations
     private _size = 1;
     if (_drawSoundwave) then {
         _icon = format [QPATHTOF(UI\soundwave%1.paa), floor random 10];

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -18,12 +18,13 @@
 // Determine flags from current settings
 private _drawName = true;
 private _enabledTagsNearby = false;
-private _enabledTagsCursor = false;
+private _enabledTagsCursor = true;
 
 switch (GVAR(showPlayerNames)) do {
     case 0: {
         // Player names Disabled [Note: this should be unreachable as the drawEH will be removed]
         _drawName = false;
+		_enableTagsCursor = false;
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
     };
     case 1: {
@@ -51,6 +52,7 @@ switch (GVAR(showPlayerNames)) do {
 };
 
 private _ambientBrightness = ((([] call EFUNC(common,ambientBrightness)) + ([0, 0.4] select ((currentVisionMode ace_player) != 0))) min 1) max 0;
-private _maxDistance = _ambientBrightness * GVAR(PlayerNamesViewDistance);
+private _maxDistanceNearby = _ambientBrightness * GVAR(playerNamesViewDistanceNearby);
+private _maxDistanceCursor = _ambientBrightness * GVAR(playerNamesViewDistanceCursor);
 
-[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_maxDistance]
+[_drawName, GVAR(showPlayerRanks),_enabledTagsNearby,_enabledTagsCursor,_maxDistanceNearby,_maxDistanceCursor]

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -24,7 +24,7 @@ switch (GVAR(showPlayerNames)) do {
     case 0: {
         // Player names Disabled [Note: this should be unreachable as the drawEH will be removed]
         _drawName = false;
-        _enableTagsCursor = false;
+        _enabledTagsCursor = false;
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
     };
     case 1: {

--- a/addons/nametags/functions/fnc_getCachedFlags.sqf
+++ b/addons/nametags/functions/fnc_getCachedFlags.sqf
@@ -24,7 +24,7 @@ switch (GVAR(showPlayerNames)) do {
     case 0: {
         // Player names Disabled [Note: this should be unreachable as the drawEH will be removed]
         _drawName = false;
-		_enableTagsCursor = false;
+        _enableTagsCursor = false;
         _enabledTagsNearby = (GVAR(showSoundWaves) == 2);
     };
     case 1: {

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -108,8 +108,8 @@ if (_enabledTagsNearby) then {
             // W-
             private _alpha = 
             (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistanceNearby)) min 1) * GVAR(playerNamesMaxAlpha) * _centerOffsetFactor) min _alphaMax;
-			//= ((linearConversion[_maxDistanceNearby/1.3,_maxDistanceNearby,_distance,_alphaMax,0,true] + ([0,0.2] select _drawSoundWave)) min _alphaMax);
-			
+            //= ((linearConversion[_maxDistanceNearby/1.3,_maxDistanceNearby,_distance,_alphaMax,0,true] + ([0,0.2] select _drawSoundWave)) min _alphaMax);
+            
             if (_alpha > 0) then {
                 [ACE_player, _target, _alpha, (_distance * 0.05), _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
             };

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -108,9 +108,10 @@ if (_enabledTagsNearby) then {
             // W-
             private _alpha = 
             (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistanceNearby)) min 1) * GVAR(playerNamesMaxAlpha) * _centerOffsetFactor) min _alphaMax;
-
+			//= ((linearConversion[_maxDistanceNearby/1.3,_maxDistanceNearby,_distance,_alphaMax,0,true] + ([0,0.2] select _drawSoundWave)) min _alphaMax);
+			
             if (_alpha > 0) then {
-                [ACE_player, _target, _alpha, _distance * 0.026, _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
+                [ACE_player, _target, _alpha, (_distance * 0.05), _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
             };
         };
         nil
@@ -152,7 +153,7 @@ if (_enabledTagsCursor) then {
         private _alpha = (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistanceCursor)) min 1) * GVAR(playerNamesMaxAlpha)) min _onKeyPressAlphaMax;
 
         if (_alpha > 0) then {
-            [ACE_player, _target, _alpha, _distance * 0.026, _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
+            [ACE_player, _target, _alpha, (_distance * 0.05), _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon); // 0.026
         };
     };
 };

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -45,7 +45,7 @@ if (_enabledTagsNearby) then {
         private _nearMen = _camPosAGL nearObjects ["CAManBase", _maxDistanceNearby + 7];
         _nearMen = _nearMen select {
             _x != ACE_player &&
-			{!_enabledTagsCursor || {!(_x isEqualTo cursorTarget)}} &&
+            {!_enabledTagsCursor || {!(_x isEqualTo cursorTarget)}} &&
             {(side group _x) == (side group ACE_player)} &&
             {GVAR(showNamesForAI) || {[_x] call EFUNC(common,isPlayer)}} &&
             {lineIntersectsSurfaces [_camPosASL, eyePos _x, ACE_player, _x] isEqualTo []} &&
@@ -70,14 +70,14 @@ if (_enabledTagsNearby) then {
         if !(isNull _target) then {
             private _drawSoundwave = (GVAR(showSoundWaves) > 0) && {[_target] call FUNC(isSpeaking)};
             
-			// W- disabled below
-			//if (_enabledTagsCursor && {!_drawSoundwave}) exitWith {}; 
-			// (Cursor Only && showSoundWaves==2) - quick exit
+            // W- disabled below
+            //if (_enabledTagsCursor && {!_drawSoundwave}) exitWith {}; 
+            // (Cursor Only && showSoundWaves==2) - quick exit
 
-			private _distance = ACE_Player distance _target;
-			
-			// W- Changed distance to be absolute distance from player to target.
-			// This prevents players seeing less tags (or fainter ones) in third person.
+            private _distance = ACE_Player distance _target;
+            
+            // W- Changed distance to be absolute distance from player to target.
+            // This prevents players seeing less tags (or fainter ones) in third person.
             //private _relPos = (visiblePositionASL _target) vectorDiff _camPosASL;
             //private _distance = vectorMagnitude _relPos;
 
@@ -104,10 +104,10 @@ if (_enabledTagsNearby) then {
             // - decreases when _distance > _maxDistance
             // - increases when the unit is speaking
             // - it's clamped by the value of _onKeyPressAlphaMax unless soundwaves are forced on and the unit is talking
-			
-			// W-
+            
+            // W-
             private _alpha = 
-			(((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistanceNearby)) min 1) * GVAR(playerNamesMaxAlpha) * _centerOffsetFactor) min _alphaMax;
+            (((1 + ([0, 0.2] select _drawSoundwave) - 0.2 * (_distance - _maxDistanceNearby)) min 1) * GVAR(playerNamesMaxAlpha) * _centerOffsetFactor) min _alphaMax;
 
             if (_alpha > 0) then {
                 [ACE_player, _target, _alpha, _distance * 0.026, _drawName, _drawRank, _drawSoundwave] call FUNC(drawNameTagIcon);
@@ -122,11 +122,11 @@ if (_enabledTagsNearby) then {
 if (_enabledTagsCursor) then {
 
     private _target = cursorTarget;
-	
-	// W- exit to prevent double tagging.
-	if (_enabledTagsNearby && {_target in _nearMen}) exitWith {};
-	
-	// W- Adding cursorTarget if within distance
+    
+    // W- exit to prevent double tagging.
+    if (_enabledTagsNearby && {_target in _nearMen}) exitWith {};
+    
+    // W- Adding cursorTarget if within distance
     if !(_target isKindOf "CAManBase") then {
         // When cursorTarget is on a vehicle show the nametag for the commander.
         if ( !(_target in allUnitsUAV) && {((ACE_Player distance _target) < (_maxDistanceCursor))} ) then {
@@ -140,7 +140,7 @@ if (_enabledTagsCursor) then {
     if (_target != ACE_player &&
         {(side group _target) == (side group ACE_player)} &&
         {GVAR(showNamesForAI) || {[_target] call EFUNC(common,isPlayer)}} &&
-		// Necessary? Can't see cursorTarget through walls.
+        // Necessary? Can't see cursorTarget through walls.
         {lineIntersectsSurfaces [_camPosASL, eyePos _target, ACE_player, _target] isEqualTo []} &&
         {!isObjectHidden _target}) then {
 

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -122,10 +122,7 @@ if (_enabledTagsNearby) then {
 if (_enabledTagsCursor) then {
 
     private _target = cursorTarget;
-    
-    // W- exit to prevent double tagging.
-    if (_enabledTagsNearby && {_target in _nearMen}) exitWith {};
-    
+
     // W- Adding cursorTarget if within distance
     if !(_target isKindOf "CAManBase") then {
         // When cursorTarget is on a vehicle show the nametag for the commander.


### PR DESCRIPTION
**Eventual Goals of Nametag Update:**

Currently many units use STUI Nametags and ACE nametags together, which ends up creating many ugly redundancies I *dislike*. People use ACE for 3D nearby tags that display voice, and STUI for checking identities at a distance and recognizing groups. To reduce the necessity for STUI nametags, features of ACE nametags will have to be brought up to par with the script I created [here](https://github.com/Quailsnap/WH-NT). That means:
- Nametags under cursor can be seen from further away.
- Nametags under cursor now feature the name of the target's group.
- Nametags under cursor fade slowly when you mouse away.
- Properly displaying nametags in/on vehicles -- or at least the tags for vehicle commanders. This will require using different location functions if targets are mounted.
- Distance fading starts later but falls off faster (using linearConversion). Barely-visible "squinty" levels of transparency are to be avoided, since you can't 'half-recognize' a face. You either recognize it or you don't.
- Change the default font color to not something that blends in with so much of Arma's palette.
- Change the default font weight OR size to be more legible without squinting.
- Prevent tags from changing position if there's an icon displayed above (ie: rank or soundwaves).
- (?Maybe) Zoom level (e.g. holding right click, or looking through a scope) can affect how far you can see nametags under cursor.
- (? Maybe) Zoom level affects nametag spacing (to maintain consistency) and font size.
- (? Maybe) Targets under cursor display their role and/or allow custom text.
- (? Maybe) Give players an option to display tags above target heads (as it is right now) or on their torsos (ala F3, looks better at very close or very far ranges).
- (? Maybe) Let players customize the font (in font sets), color (in color sets), and size (with precision) of the nametag text.
- (??Maybe) Display vehicle name and available seating info on mouseover.
Also, maybe:
https://github.com/acemod/ACE3/issues/3594#issuecomment-314247005

<hr>

**When merged this pull request will:**
> NAMETAGS

1 
- Nametags for cursorTarget can be seen further away (3x) default.
- A new setting (playerNamesViewDistanceCursor) has been added to accomodate that.
- The existing setting is now (playerNamesViewDistanceNearby).
- Distance checks have been changed to be between player and target instead of camera and target. This means players in third person will no longer see fewer / fainter tags than players in first person. This also means that players riding in full trucks in third person will see lots and lots of tags.

2 
- Prevent height from changing when soundwaves or ranks are in use.
> OTHER
- Added Whale to AUTHORS.txt
- Remember not to use any TABS
