### PR TITLE
FIX: ace_common_fnc_loadPerson don't detect Taru pod with place for crew

### DIFF
--- a/addons/common/functions/fnc_loadPerson.sqf
+++ b/addons/common/functions/fnc_loadPerson.sqf
@@ -24,7 +24,7 @@ private _vehicle = objNull;
 
 if (!([_caller, _unit, ["isNotDragging", "isNotCarrying"]] call FUNC(canInteractWith)) || {_caller == _unit}) exitWith {_vehicle};
 
-private _nearVehicles = nearestObjects [_unit, ["Car", "Air", "Tank", "Ship_F"], 10];
+private _nearVehicles = nearestObjects [_unit, ["Car", "Air", "Tank", "Ship_F","Pod_Heli_Transport_04_crewed_base_F"], 10];
 
 {
     TRACE_1("",_x);


### PR DESCRIPTION
Hello,

Should fix https://github.com/acemod/ACE3/issues/5456

When you load somebody inside a vehicle the [`ace_common_fnc_loadPerson`](https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_loadPerson.sqf) is used. This fonction actually search `nearestObjects` of type `["Car","Air", "Tank", "Ship_F"]` to put player inside. 

Infortunatly, the taru family with crew position (exemple:` "Land_Pod_Heli_Transport_04_medevac_black_F"`) are not detected because the corresponding parents class of `"Land_Pod_Heli_Transport_04_medevac_black_F"` is : `["Land_Pod_Heli_Transport_04_medevac_F","Pod_Heli_Transport_04_crewed_base_F","StaticWeapon","LandVehicle","Land","AllVehicles","All"]`. To avoid this, the `"Pod_Heli_Transport_04_crewed_base_F"` parent class should also be search by nearestobjects.  **This will detect all Taru pod with crew place available.**

**When merged this pull request will:**
- [`ace_common_fnc_loadPerson`](https://github.com/acemod/ACE3/compare/master...Vdauphin:FIX-Taru_pod_loadperson?expand=1#diff-d8b1b6c6184a03ad9a6c117cab5f6abfR27) now search also kind of `"Pod_Heli_Transport_04_crewed_base_F"` vehicles with crew place available.
- Added `"Pod_Heli_Transport_04_crewed_base_F"` to the `nearestObjects` searching array.
- Documentation : [`nearestObjects`](https://community.bistudio.com/wiki/nearestObjects)
- [Development Guidelines](https://ace3mod.com/wiki/development/), tel me if anything is wrong.
