### PR TITLE
Fix virtual spectator breaking if template active

### DIFF
--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -26,15 +26,12 @@ if (isServer) then {
 
 [QGVAR(stageSpectator), FUNC(stageSpectator)] call CBA_fnc_addEventHandler;
 
-// Delay until local player (must not be ACE_Player) is fully initalized
-[
-    { !isNil { player } && { !isNull player } },
-    {
-        // Initalise virtual spectator players (must not be ACE_Player)
-        [QGVAR(virtual),"initpost",{
-            if !(GVAR(isSet)) then {
-                if (player == (_this select 0)) then { [true] call FUNC(setSpectator) };
-            };
-        },false,[],true] call CBA_fnc_addClassEventHandler;
-    },[]
-] call CBA_fnc_waitUntilAndExecute;
+// A virtual spectator cannot exist without an interface
+if (hasInterface) then {
+    // Local player (not ACE_Player) must be initalized to check
+    [
+        { !isNil { player } && { !isNull player } },
+        { if (player isKindOf QGVAR(virtual)) then { [true] call FUNC(setSpectator) }; },
+        []
+    ] call CBA_fnc_waitUntilAndExecute;
+};

--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -30,8 +30,9 @@ if (isServer) then {
 if (hasInterface) then {
     // Local player (not ACE_Player) must be initalized to check
     [
-        { !isNil { player } && { !isNull player } },
-        { if (player isKindOf QGVAR(virtual)) then { [true] call FUNC(setSpectator) }; },
-        []
+        { !isNull player },
+        {
+            if (player isKindOf QGVAR(virtual)) then { [true] call FUNC(setSpectator); };
+        }
     ] call CBA_fnc_waitUntilAndExecute;
 };

--- a/addons/spectator/functions/fnc_cam.sqf
+++ b/addons/spectator/functions/fnc_cam.sqf
@@ -28,7 +28,7 @@ if (_init) then {
     // Start tracking camera attributes if not pre-set by public function
     ISNILS(GVAR(camMode),MODE_FREE);
     ISNILS(GVAR(camVision),VISION_NORM);
-    ISNILS(GVAR(camTarget),objNull);
+    ISNILS(GVAR(camFocus),objNull);
 
     // Ticking related
     GVAR(camDeltaTime)          = 0;
@@ -79,7 +79,7 @@ if (_init) then {
     GVAR(camera) = _camera;
 
     // Create dummy target used for follow camera
-    GVAR(camDummy) = "Logic" createVehicleLocal getPosASLVisual GVAR(camTarget);
+    GVAR(camDummy) = "Logic" createVehicleLocal getPosASLVisual GVAR(camFocus);
 
     // Handle initial camera mode limitation
     if !(GVAR(camMode) in GVAR(availableModes)) then {
@@ -87,7 +87,7 @@ if (_init) then {
     };
 
     // If inital camera mode is not free cam and no focus, find initial focus
-    if (GVAR(camMode) != MODE_FREE && isNull GVAR(camTarget)) then {
+    if (GVAR(camMode) != MODE_FREE && isNull GVAR(camFocus)) then {
         [true] call FUNC(setFocus);
     };
 
@@ -126,7 +126,7 @@ if (_init) then {
     // Stop tracking everything
     GVAR(camMode)               = nil;
     GVAR(camVision)             = nil;
-    GVAR(camTarget)             = nil;
+    GVAR(camFocus)              = nil;
     GVAR(camDeltaTime)          = nil;
     GVAR(camLastTickTime)       = nil;
     GVAR(camHasTarget)          = nil;

--- a/addons/spectator/functions/fnc_cam_setCameraMode.sqf
+++ b/addons/spectator/functions/fnc_cam_setCameraMode.sqf
@@ -22,7 +22,7 @@ params ["_newMode"];
 
 private _oldMode = GVAR(camMode);
 private _modes = GVAR(availableModes);
-private _focus = GVAR(camTarget);
+private _focus = GVAR(camFocus);
 
 // If new mode isn't available then keep current (unless current also isn't)
 if !(_newMode in _modes) then {

--- a/addons/spectator/functions/fnc_cam_tick.sqf
+++ b/addons/spectator/functions/fnc_cam_tick.sqf
@@ -23,7 +23,7 @@
 
 BEGIN_COUNTER(camTick);
 private _cameraMode = GVAR(camMode);
-private _camTarget = GVAR(camTarget);
+private _camTarget = GVAR(camFocus);
 
 // UI mouse handler makes use of delta time between camera ticks
 private _currentTime = diag_tickTime;
@@ -56,7 +56,7 @@ if (_cameraMode != MODE_FREE) then {
 };
 
 // Refresh the local variable
-_camTarget = GVAR(camTarget);
+_camTarget = GVAR(camFocus);
 
 // Focus get in / out of vehicle state
 if !(isNull _camTarget) then {

--- a/addons/spectator/functions/fnc_getCameraAttributes.sqf
+++ b/addons/spectator/functions/fnc_getCameraAttributes.sqf
@@ -17,12 +17,12 @@
 #include "script_component.hpp"
 
 if !(isNil QGVAR(camera)) then {
-    [GVAR(camMode), GVAR(camTarget), GVAR(camVision), getPosATL GVAR(camera), getDirVisual GVAR(camera)]
+    [GVAR(camMode), GVAR(camFocus), GVAR(camVision), getPosATL GVAR(camera), getDirVisual GVAR(camera)]
 } else {
     // These values could be pre-set by function
     [
         GETMVAR(GVAR(camMode),0),
-        GETMVAR(GVAR(camTarget),objNull),
+        GETMVAR(GVAR(camFocus),objNull),
         GETMVAR(GVAR(camVision),-2),
         GETMVAR(GVAR(camPos),[ARR_3(0,0,0)]),
         GETMVAR(GVAR(camDir),0)

--- a/addons/spectator/functions/fnc_respawnTemplate.sqf
+++ b/addons/spectator/functions/fnc_respawnTemplate.sqf
@@ -31,6 +31,9 @@ if (_respawn in [0,1,4,5]) exitWith {
     if (typeOf _newCorpse == "seagull") then { deleteVehicle _newCorpse; };
 };
 
+// Virtual spectators should be ignored by the template (otherwise they break)
+if (_newCorpse isKindOf QGVAR(virtual)) exitWith {};
+
 // If player died while already in spectator, ignore
 if (!GVAR(isSet) || {alive _newCorpse}) then {
     // Negligible respawn delay can result in entering spectator after respawn

--- a/addons/spectator/functions/fnc_setCameraAttributes.sqf
+++ b/addons/spectator/functions/fnc_setCameraAttributes.sqf
@@ -55,7 +55,7 @@ if !(isNil QGVAR(camera)) then {
 
     if !(isNil "_mode") then {
         // If mode not free and no focus, find focus
-        if ((_mode != MODE_FREE) && {isNull GVAR(camTarget)}) then {
+        if ((_mode != MODE_FREE) && {isNull GVAR(camFocus)}) then {
             [true] call FUNC(setFocus);
         };
 
@@ -80,7 +80,7 @@ if !(isNil QGVAR(camera)) then {
             _focus = ([] call FUNC(getTargetEntities)) select 0;
         };
 
-        GVAR(camTarget) = _focus;
+        GVAR(camFocus) = _focus;
     };
 
     if !(isNil "_mode") then {

--- a/addons/spectator/functions/fnc_setFocus.sqf
+++ b/addons/spectator/functions/fnc_setFocus.sqf
@@ -37,8 +37,8 @@ if (_newFocus isEqualType true) then {
     };
 };
 
-if (_newFocus != GVAR(camTarget) && { !(isNull _newFocus && { isNull GVAR(camTarget) }) }) then {
-    GVAR(camTarget) = _newFocus;
+if (_newFocus != GVAR(camFocus) && { !(isNull _newFocus && { isNull GVAR(camFocus) }) }) then {
+    GVAR(camFocus) = _newFocus;
 
     if (isNull _newFocus) then {
         if (GVAR(camMode) == MODE_FREE) then {

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -34,9 +34,9 @@ GVAR(uiForced) = _force;
 if (_set isEqualTo GVAR(isSet)) exitWith {};
 
 // Delay if local player (must not be ACE_Player) is not fully initalized
-if (isNil { player } || { isNull player }) exitWith {
+if (isNull player) exitWith {
     [
-        { !isNil { player } && { !isNull player } },
+        { !isNull player },
         FUNC(setSpectator),
         _this
     ] call CBA_fnc_waitUntilAndExecute;

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -34,15 +34,6 @@ GVAR(uiForced) = _force;
 // Exit if no change (everything above this may need to be ran again)
 if (_set isEqualTo GVAR(isSet)) exitWith {};
 
-// Delay if the main display does not exist
-if (isNull MAIN_DISPLAY) exitWith {
-    [
-        { !isNull MAIN_DISPLAY },
-        FUNC(setSpectator),
-        _this
-    ] call CBA_fnc_waitUntilAndExecute;
-};
-
 // Delay if local player (must not be ACE_Player) does not exist
 if (isNull player) exitWith {
     [
@@ -66,8 +57,8 @@ if (_set) then {
     // Initalize the camera
     [true] call FUNC(cam);
 
-    // Create the display
-    [true] call FUNC(ui);
+    // Create the display when main display is ready
+    [{ !isNull MAIN_DISPLAY },{ [true] call FUNC(ui) }] call CBA_fnc_waitUntilAndExecute;
 
     // Cache current channel to switch back to on exit
     GVAR(channelCache) = currentChannel;
@@ -83,8 +74,8 @@ if (_set) then {
         EGVAR(nametags,showNamesForAI) = false;
     };
 } else {
-    // Kill the display
-    [false] call FUNC(ui);
+    // Kill the display (ensure main display exists, handles edge case where spectator turned off beforehand)
+    [{ !isNull MAIN_DISPLAY },{ [false] call FUNC(ui) }] call CBA_fnc_waitUntilAndExecute;
 
     // This variable doesn't matter anymore
     GVAR(uiForced) = nil;

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -22,6 +22,7 @@
 #include "script_component.hpp"
 
 params [["_set",true,[true]], ["_force",true,[true]], ["_hide",true,[true]]];
+TRACE_3("Params",_set,_force,_hide);
 
 // Only clients can be spectators
 if !(hasInterface) exitWith {};
@@ -33,7 +34,16 @@ GVAR(uiForced) = _force;
 // Exit if no change (everything above this may need to be ran again)
 if (_set isEqualTo GVAR(isSet)) exitWith {};
 
-// Delay if local player (must not be ACE_Player) is not fully initalized
+// Delay if the main display does not exist
+if (isNull MAIN_DISPLAY) exitWith {
+    [
+        { !isNull MAIN_DISPLAY },
+        FUNC(setSpectator),
+        _this
+    ] call CBA_fnc_waitUntilAndExecute;
+};
+
+// Delay if local player (must not be ACE_Player) does not exist
 if (isNull player) exitWith {
     [
         { !isNull player },
@@ -56,8 +66,8 @@ if (_set) then {
     // Initalize the camera
     [true] call FUNC(cam);
 
-    // Create the display when main display is ready
-    [{ !isNull MAIN_DISPLAY },{ [true] call FUNC(ui) }] call CBA_fnc_waitUntilAndExecute;
+    // Create the display
+    [true] call FUNC(ui);
 
     // Cache current channel to switch back to on exit
     GVAR(channelCache) = currentChannel;
@@ -73,8 +83,8 @@ if (_set) then {
         EGVAR(nametags,showNamesForAI) = false;
     };
 } else {
-    // Kill the display (ensure main display exists, handles edge case where spectator turned off before display exists)
-    [{ !isNull MAIN_DISPLAY },{ [false] call FUNC(ui) }] call CBA_fnc_waitUntilAndExecute;
+    // Kill the display
+    [false] call FUNC(ui);
 
     // This variable doesn't matter anymore
     GVAR(uiForced) = nil;

--- a/addons/spectator/functions/fnc_switchFocus.sqf
+++ b/addons/spectator/functions/fnc_switchFocus.sqf
@@ -18,7 +18,7 @@
 
 private _next = param [0, true];
 private _entities = [true] call FUNC(getTargetEntities);
-private _focus = GVAR(camTarget);
+private _focus = GVAR(camFocus);
 
 // No entities to switch to
 if ((_entities isEqualTo []) || (_entities isEqualTo [_focus])) exitWith {};

--- a/addons/spectator/functions/fnc_ui_draw3D.sqf
+++ b/addons/spectator/functions/fnc_ui_draw3D.sqf
@@ -18,7 +18,7 @@
 #define HEIGHT_OFFSET 1.5
 
 BEGIN_COUNTER(updateCursor);
-private _camTarget = GVAR(camTarget);
+private _camTarget = GVAR(camFocus);
 private _camTargetVeh = vehicle _camTarget;
 private _cursorObject = objNull;
 

--- a/addons/spectator/functions/fnc_ui_handleListClick.sqf
+++ b/addons/spectator/functions/fnc_ui_handleListClick.sqf
@@ -41,7 +41,7 @@ if !(isNull _object) then {
 
         _handled = true;
     } else {
-        if (_object != GVAR(camTarget)) then {
+        if (_object != GVAR(camFocus)) then {
             [_object] call FUNC(setFocus);
 
             _handled = true;

--- a/addons/spectator/functions/fnc_ui_handleMapClick.sqf
+++ b/addons/spectator/functions/fnc_ui_handleMapClick.sqf
@@ -23,7 +23,7 @@ params ["", "", "_x", "_y"];
 
 if (isNull GVAR(uiMapHighlighted)) then {
     // Give user feedback that camera is no longer focused
-    if !(isNull GVAR(camTarget)) then {
+    if !(isNull GVAR(camFocus)) then {
         playSound "ReadoutHideClick1";
     };
 

--- a/addons/spectator/functions/fnc_ui_handleMouseButtonDown.sqf
+++ b/addons/spectator/functions/fnc_ui_handleMouseButtonDown.sqf
@@ -28,7 +28,7 @@ params ["", "_button"];
 // Left click
 if (_button == 0) exitWith {
     if (isNull GVAR(cursorObject)) then {
-        if (GVAR(camMode) == MODE_FREE && { !isNull GVAR(camTarget) }) then {
+        if (GVAR(camMode) == MODE_FREE && { !isNull GVAR(camFocus) }) then {
             playSound "ReadoutHideClick1";
             [objNull] call FUNC(setFocus);
         };
@@ -45,7 +45,7 @@ if (_button == 0) exitWith {
 
 // Right click
 if (_button == 1) then {
-    if (GVAR(camMode) == MODE_FREE && { !isNull GVAR(camTarget) } && { !isNull (attachedTo GVAR(camDummy)) }) then {
+    if (GVAR(camMode) == MODE_FREE && { !isNull GVAR(camFocus) } && { !isNull (attachedTo GVAR(camDummy)) }) then {
         [] call FUNC(cam_resetTarget);
     };
     GVAR(holdingRMB) = true;

--- a/addons/spectator/functions/fnc_ui_updateHelp.sqf
+++ b/addons/spectator/functions/fnc_ui_updateHelp.sqf
@@ -26,7 +26,7 @@ if !(GVAR(uiHelpVisible)) exitWith {};
 
 private _cameraMode = GVAR(camMode);
 private _availableModes = GVAR(availableModes);
-private _hasTarget = !isNull GVAR(camTarget);
+private _hasTarget = !isNull GVAR(camFocus);
 
 private _controls = [];
 

--- a/addons/spectator/functions/fnc_ui_updateListFocus.sqf
+++ b/addons/spectator/functions/fnc_ui_updateListFocus.sqf
@@ -16,4 +16,4 @@
 
 #include "script_component.hpp"
 
-CTRL_LIST tvSetCurSel ([[GVAR(camTarget)] call BIS_fnc_objectVar] call FUNC(ui_getTreeDataIndex));
+CTRL_LIST tvSetCurSel ([[GVAR(camFocus)] call BIS_fnc_objectVar] call FUNC(ui_getTreeDataIndex));

--- a/addons/spectator/functions/fnc_ui_updateWidget.sqf
+++ b/addons/spectator/functions/fnc_ui_updateWidget.sqf
@@ -22,9 +22,9 @@
 #define IMG_UNARMED "" // TODO: Find suitable unarmed icon
 
 // Hide if no target or widget is toggled off
-if (!GVAR(uiWidgetVisible) || {isNull GVAR(camTarget)}) exitWith {CTRL_WIDGET ctrlShow false};
+if (!GVAR(uiWidgetVisible) || {isNull GVAR(camFocus)}) exitWith {CTRL_WIDGET ctrlShow false};
 
-private _focus = GVAR(camTarget);
+private _focus = GVAR(camFocus);
 
 private _name = ([_focus] call EFUNC(common,getName)) select [0, NAME_MAX_CHARACTERS];
 if !(isPlayer _focus) then { _name = format ["%1: %2", localize "str_player_ai", _name]; };

--- a/addons/spectator/functions/fnc_updateCameraModes.sqf
+++ b/addons/spectator/functions/fnc_updateCameraModes.sqf
@@ -49,7 +49,7 @@ if (_newModes isEqualTo []) then {
 // Update camera in case of change
 if !(isNil QGVAR(camera)) then {
     // If mode was free and no longer available, find a focus
-    if (!(MODE_FREE in _newModes) && {GVAR(camMode) == MODE_FREE} && {isNull GVAR(camTarget)}) then {
+    if (!(MODE_FREE in _newModes) && {GVAR(camMode) == MODE_FREE} && {isNull GVAR(camFocus)}) then {
         [true] call FUNC(setFocus);
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix virtual spectators exiting spectator when the respawn template is active (#5440)
- Simplify/optimise some of the code used for virtual spectators
- Rename the `GVAR(camTarget)` to `GVAR(camFocus)` to stop the linter complaining (probably bad practise to use script command in a variable name anyway)