### PR TITLE
Use Python 3.5 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
    - release
 language: python
 python:
-- '3.4'
+- '3.5'
 before_script:
 - if [ -n "${GH_TOKEN}" ] && [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
     pip install pygithub;


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Python 3.5 is pre-installed on Trusty environment:
>  This job ran on our Trusty environment, which is gradually becoming our default Linux environment. Read all about this [in our blog: Trusty as a default Linux is coming](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default) and take note that you can add `dist: precise` in your .travis.yml file to continue using Precise.

This will just speed up the build as it won't need to download another Python version.