### PR TITLE
Hide duplicate weapon srifle_DMR_03_spotter_F

### DIFF
--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -233,6 +233,9 @@ class CfgWeapons {
     };
 
     class srifle_DMR_03_spotter_F: srifle_DMR_03_F {
+        // Weapon does not exist in base game, and parent srifle_DMR_03_F is scope 2
+        // Can remove entirely in 3.12
+        scope = 1;
         displayName = CSTRING(srifle_DMR_03_spotter); //NATO DMR (provisional) spotter;
     };
     class DMR_04_base_F: Rifle_Long_Base_F {


### PR DESCRIPTION
`srifle_DMR_03_spotter_F` does not exist in base game, and parent srifle_DMR_03_F is scope 2
So we were adding a duplicate weapon with only the name changed??

- Hide weapon for now via `scope = 1` to avoid breaking loadouts
- Can remove later
