### PR TITLE
Use selectRandomWeighted 1.76 command

### DIFF
--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -91,7 +91,7 @@ if (local _vehicle) then {
         } forEach _positions;
 
         if (isServer) then {
-            private _soundName = [QGVAR(Sound_low), 0.1, QGVAR(Sound_mid), 0.25, QGVAR(Sound_high), 0.65] call BIS_fnc_selectRandomWeighted; // TODO: replace with script Command in 1.74
+            private _soundName = selectRandomWeighted [QGVAR(Sound_low), 0.1, QGVAR(Sound_mid), 0.25, QGVAR(Sound_high), 0.65];
             // TODO - Players in the vehicle hear no sound (even after exiting the vehicle)
             private _sound = createSoundSource [_soundName, position _vehicle, [], 0];
 

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -9,7 +9,7 @@
 #define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 1.72
+#define REQUIRED_VERSION 1.76
 #define REQUIRED_CBA_VERSION {3,3,1}
 
 #ifdef COMPONENT_BEAUTIFIED


### PR DESCRIPTION
**When merged this pull request will:**
- Use [`selectRandomWeighted`](https://community.bistudio.com/wiki/selectRandomWeighted) command instead of function in `cookoff`
- Increase required Arma 3 version to 1.76 - `selectRandomWeighted` was added in 1.76