### PR TITLE
Added missing semicolon for ACE_Medcrate_Skeleton model.cfg

### DIFF
--- a/addons/medical/data/model.cfg
+++ b/addons/medical/data/model.cfg
@@ -11,7 +11,7 @@ class CfgSkeletons {
         skeletonBones[] = {
             "cover",""
         };
-    }
+    };
 };
 
 class CfgModels {


### PR DESCRIPTION
**When merged this pull request will:**
- Fixed missing semicolon in `model.cfg` for `ACE_Medcrate_Skeleton`
