### PR TITLE
Kestrel4500 - Fixed head- and crosswind calculation

### DIFF
--- a/addons/kestrel4500/functions/fnc_generateOutputData.sqf
+++ b/addons/kestrel4500/functions/fnc_generateOutputData.sqf
@@ -136,7 +136,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
                     _textCenterBig = Str(round(abs(sin(GVAR(RefHeading) - _playerDir) * _windSpeed) * 10) / 10);
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_playerDir)];
                 } else {
-                    _textCenterBig = Str(round(abs(sin(GVAR(RefHeading)) * _windSpeed) * 10) / 10);
+                    _textCenterBig = Str(round(abs(sin(GVAR(RefHeading) - _windDir) * _windSpeed) * 10) / 10);
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
                 };
                 _textInfoLine2 = "- set heading";
@@ -168,7 +168,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
                     _textCenterBig = Str(round(cos(GVAR(RefHeading) - _playerDir) * _windSpeed * 10) / 10);
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_playerDir)];
                 } else {
-                    _textCenterBig = Str(round(cos(GVAR(RefHeading)) * _windSpeed * 10) / 10);
+                    _textCenterBig = Str(round(-cos(GVAR(RefHeading) - _windDir) * _windSpeed * 10) / 10);
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
                 };
                 _textInfoLine2 = "- set heading";

--- a/addons/kestrel4500/functions/fnc_generateOutputData.sqf
+++ b/addons/kestrel4500/functions/fnc_generateOutputData.sqf
@@ -137,7 +137,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_playerDir)];
                 } else {
                     _textCenterBig = Str(round(abs(sin(GVAR(RefHeading) - _windDir) * _windSpeed) * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
+                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(180 + _windDir)];
                 };
                 _textInfoLine2 = "- set heading";
             } else {
@@ -169,7 +169,7 @@ if (GVAR(referenceHeadingMenu) == 0) then {
                     _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_playerDir)];
                 } else {
                     _textCenterBig = Str(round(-cos(GVAR(RefHeading) - _windDir) * _windSpeed * 10) / 10);
-                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(_windDir)];
+                    _textInfoLine1 = format["%1 m/s @ %2", round(_windSpeed * 10) / 10, round(180 + _windDir)];
                 };
                 _textInfoLine2 = "- set heading";
             } else {


### PR DESCRIPTION
- The wind direction was not taken into account when calculating head- and crosswinds.
- The output of the wind direction was formatted incorrectly.
- Those changes are only relevant when AdvancedBallistics is disabled.
- Fixes #5181