### PR TITLE
Allow loading fuel canister via ace_cargo

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -424,6 +424,12 @@ class CfgVehicles {
         GVAR(size) = 2; // 1 = small, 2 = large
     };
 
+    // Fuel Canister (ace_refuel)
+    class Land_CanisterFuel_F: Items_base_F {
+        GVAR(size) = 1;
+        GVAR(canLoad) = 1;
+    };
+
     // objects
     class Lamps_base_F;
     class RoadCone_F: ThingX {

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -108,6 +108,7 @@ private _attachPosModel = _sink worldToModel (ASLtoAGL _bestPosASL);
             };
         };
         [QEGVAR(common,setVectorDirAndUp), [_nozzle, _dirAndUp], _nozzle] call CBA_fnc_targetEvent;
+        if (_nozzle isKindOf "Land_CanisterFuel_F") then { _nozzle setVariable [QEGVAR(cargo,canLoad), false, true]; };
         _nozzle setVariable [QGVAR(sink), _sink, true];
         _nozzle setVariable [QGVAR(isConnected), true, true];
         _sink setVariable [QGVAR(nozzle), _nozzle, true];

--- a/addons/refuel/functions/fnc_disconnect.sqf
+++ b/addons/refuel/functions/fnc_disconnect.sqf
@@ -22,6 +22,7 @@ private _sink = _nozzle getVariable [QGVAR(sink), objNull];
 if (isNull _sink) exitWith {};
 
 _sink setVariable [QGVAR(nozzle), nil, true];
+if (_nozzle isKindOf "Land_CanisterFuel_F") then { _nozzle setVariable [QEGVAR(cargo,canLoad), true, true]; };
 _nozzle setVariable [QGVAR(sink), nil, true];
 _nozzle setVariable [QGVAR(isConnected), false, true];
 [objNull, _nozzle, true] call FUNC(dropNozzle);

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -43,6 +43,7 @@ if (_maxFuel == 0) then {
     if (!alive _source || {!alive _sink}) exitWith {
         [objNull, _nozzle] call FUNC(dropNozzle);
         _nozzle setVariable [QGVAR(isConnected), false, true];
+        if (_nozzle isKindOf "Land_CanisterFuel_F") then { _nozzle setVariable [QEGVAR(cargo,canLoad), true, true]; };
         _nozzle setVariable [QGVAR(sink), nil, true];
         _sink setVariable [QGVAR(nozzle), nil, true];
         [_pfID] call CBA_fnc_removePerFrameHandler;
@@ -54,6 +55,7 @@ if (_maxFuel == 0) then {
 
         [objNull, _nozzle] call FUNC(dropNozzle);
         _nozzle setVariable [QGVAR(isConnected), false, true];
+        if (_nozzle isKindOf "Land_CanisterFuel_F") then { _nozzle setVariable [QEGVAR(cargo,canLoad), true, true]; };
         _nozzle setVariable [QGVAR(sink), nil, true];
         _sink setVariable [QGVAR(nozzle), nil, true];
         [_pfID] call CBA_fnc_removePerFrameHandler;


### PR DESCRIPTION
Fix #5438
- Make canister loadable via cargo
- Also block cargo action when being used (attached to vehicle as a nozzle)

Don't need to make it drag/carrayble as that functionality is already handled by refuel