### PR TITLE
AdvancedBallistics - Utilize new 'parseSimpleArray' command

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_handleFirePFH.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFirePFH.sqf
@@ -33,7 +33,7 @@ private _aceTimeSecond = floor CBA_missionTime;
             drop ["\A3\data_f\ParticleEffects\Universal\Refract","","Billboard",1,0.1,getPos _bullet,[0,0,0],0,1.275,1,0,[0.02*_caliber,0.01*_caliber],[[0,0,0,0.65],[0,0,0,0.2]],[1,0],0,0,"","",""];
         };
 
-        call compile ("ace_advanced_ballistics" callExtension format["simulate:%1:%2:%3:%4:%5:%6:%7", _index, _bulletVelocity, _bulletPosition, ACE_wind, ASLToATL(_bulletPosition) select 2, _aceTimeSecond, CBA_missionTime - _aceTimeSecond]);
+        _bullet setVelocity (_bulletVelocity vectorAdd (parseSimpleArray ("ace_advanced_ballistics" callExtension format["simulate:%1:%2:%3:%4:%5:%6:%7", _index, _bulletVelocity, _bulletPosition, ACE_wind, ASLToATL(_bulletPosition) select 2, _aceTimeSecond, CBA_missionTime - _aceTimeSecond])));
     };
     nil
 } count +GVAR(allBullets);

--- a/extensions/advanced_ballistics/AdvancedBallistics.cpp
+++ b/extensions/advanced_ballistics/AdvancedBallistics.cpp
@@ -704,7 +704,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         velocityOffset[1] += accel[1] * deltaT;
         velocityOffset[2] += accel[2] * deltaT;
 
-        outputStr << "_bullet setVelocity (_bulletVelocity vectorAdd [" << velocityOffset[0] << "," << velocityOffset[1] << "," << velocityOffset[2] << "]);";
+        outputStr << "[" << velocityOffset[0] << "," << velocityOffset[1] << "," << velocityOffset[2] << "]";
         strncpy_s(output, outputSize, outputStr.str().c_str(), _TRUNCATE);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "set")) {


### PR DESCRIPTION
- Decent performance improvement compared to the old `call compile` approach
- Requires DLL rebuild.

![frametime_degradation](https://user-images.githubusercontent.com/9437207/30271143-7abbc44a-96ef-11e7-8f5d-ad223b9f429d.png)
