### PR TITLE
Move handle on carrier doors

### DIFF
--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -83,7 +83,7 @@ GVAR(isOpeningDoor) = false;
     call EFUNC(interaction,openDoor);
     true
 }, {
-    //Probably don't want any condidtions here, so variable never gets locked down
+    //Probably don't want any conditions here, so variable never gets locked down
     // Statement
     GVAR(isOpeningDoor) = false;
     true

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -31,7 +31,7 @@ if (_animations isEqualTo []) exitWith {};
 
 private _lockedVariable = format ["bis_disabled_%1", _door];
 
-//Check if the door can be locked aka have locked variable, otherwhise cant lock it
+// Check if the door can be locked aka have locked variable, otherwhise cant lock it
 if ((_house animationPhase (_animations select 0) <= 0) && {_house getVariable [_lockedVariable, 0] == 1}) exitWith {
     private _lockedAnimation = format ["%1_locked_source", _door];
     TRACE_3("locked",_house,_lockedAnimation,isClass (configfile >> "CfgVehicles" >> (typeOf _house) >> "AnimationSources" >> _lockedAnimation));
@@ -39,6 +39,13 @@ if ((_house animationPhase (_animations select 0) <= 0) && {_house getVariable [
         // from: a3\structures_f\scripts\fn_door.sqf: - wiggles the door handle (A3 buildings)
         _house animateSource [_lockedAnimation, (1 - (_house animationSourcePhase _lockedAnimation))];
     };
+};
+
+// Add handle on carrier
+if (typeOf _house == "Land_Carrier_01_island_01_F") then {
+    private _handle = format ["door_handle_%1_rot_1", (_animations select 0) select [5, 1]];
+    TRACE_1("carrier handle",_handle);
+    _animations pushBack _handle;
 };
 
 playSound "ACE_Sound_Click"; // @todo replace with smth. more fitting


### PR DESCRIPTION
**When merged this pull request will:**
- Title

There are 3 animations for carrier doors:
```
"door_1_rot","door_handle_1_rot_1","door_handle_1_rot_2"
```
`rot_2` does not seem to be used with normal action menu opening at all, so using `animationSource` does not work, because it will activate both of those animations as well and handle will end up in original position (and also be broken for action menu usage).

I didn't find any other good way to extract those handle animations, so it's just checking for the USS Freedom carrier directly and adding the handle based on the door number.

https://i.imgur.com/HzJZ058.gifv