### PR TITLE
Fastrope animations and in-line privatization

### DIFF
--- a/addons/fastroping/functions/fnc_canDeployRopes.sqf
+++ b/addons/fastroping/functions/fnc_canDeployRopes.sqf
@@ -17,11 +17,10 @@
 
 #include "script_component.hpp"
 params ["_unit", "_vehicle"];
-private ["_config", "_enabled", "_deploymentStage"];
 
-_config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-_enabled = getNumber (_config >> QGVAR(enabled));
-_deploymentStage = _vehicle getVariable [QGVAR(deploymentStage), 0];
+private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
+private _enabled = getNumber (_config >> QGVAR(enabled));
+private _deploymentStage = _vehicle getVariable [QGVAR(deploymentStage), 0];
 
 (driver _vehicle != _unit) &&
 {getPos _vehicle select 2 > 2} &&

--- a/addons/fastroping/functions/fnc_cutRopes.sqf
+++ b/addons/fastroping/functions/fnc_cutRopes.sqf
@@ -16,9 +16,8 @@
 
 #include "script_component.hpp"
 params ["_vehicle"];
-private ["_deployedRopes", "_config", "_waitTime"];
 
-_deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
+private _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
 {
     _x params ["", "_ropeTop", "_ropeBottom", "_dummy", "_hook", "_occupied"];
 
@@ -42,8 +41,8 @@ _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
 _vehicle setVariable [QGVAR(deployedRopes), [], true];
 _vehicle setVariable [QGVAR(deploymentStage), 1, true];
 
-_config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-_waitTime = 0;
+private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
+private _waitTime = 0;
 if (isText (_config >> QGVAR(onCut))) then {
     _waitTime = [_vehicle] call (missionNamespace getVariable (getText (_config >> QGVAR(onCut))));
 };

--- a/addons/fastroping/functions/fnc_deployAI.sqf
+++ b/addons/fastroping/functions/fnc_deployAI.sqf
@@ -18,7 +18,6 @@
 
 #include "script_component.hpp"
 params [["_vehicle", objNull, [objNull]], ["_deploySpecial", false, [true]], ["_createDeploymentGroup", true, [true]]];
-private ["_config", "_configEnabled", "_deployTime", "_unitsToDeploy", "_deployGroup"];
 
 if (isNull _vehicle || {!(_vehicle isKindOf "Helicopter")}) exitWith {
     if (hasInterface) then {
@@ -28,8 +27,8 @@ if (isNull _vehicle || {!(_vehicle isKindOf "Helicopter")}) exitWith {
     ERROR('FUNC(deployAI): deployAI was called with an invalid or non-existant vehicle.');
 };
 
-_config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-_configEnabled = getNumber (_config >> QGVAR(enabled));
+private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
+private _configEnabled = getNumber (_config >> QGVAR(enabled));
 if (_configEnabled == 0) exitWith {
     if (hasInterface) then {
         [format ["You cannot fast rope from a ""%1"" helicopter.", getText (_config >> "DisplayName")], QFUNC(deployAI)] spawn BIS_fnc_guiMessage;
@@ -44,7 +43,7 @@ if (_configEnabled == 2 && {isNull (_vehicle getVariable [QGVAR(FRIES), objNull]
     ERROR_1('FUNC(deployAI): "%1" requires a FRIES for fastroping but has not been equipped with one.',getText (_config >> "DisplayName"));
 };
 
-_unitsToDeploy = crew _vehicle;
+private _unitsToDeploy = crew _vehicle;
 if (_deploySpecial) then {
     _unitsToDeploy deleteAt (_unitsToDeploy find driver _vehicle);
 } else {
@@ -56,11 +55,11 @@ if (_unitsToDeploy isEqualTo []) exitWith {
 };
 
 if (_createDeploymentGroup) then {
-    _deployGroup = createGroup side (_unitsToDeploy select 0);
+    private _deployGroup = createGroup side (_unitsToDeploy select 0);
     _unitsToDeploy joinSilent _deployGroup;
 };
 
-_deployTime = 0;
+private  _deployTime = 0;
 if (getText (_config >> QGVAR(onPrepare)) != "") then {
     _deployTime = [_vehicle] call (missionNamespace getVariable (getText (_config >> QGVAR(onPrepare))));
 };

--- a/addons/fastroping/functions/fnc_deployAIWaypoint.sqf
+++ b/addons/fastroping/functions/fnc_deployAIWaypoint.sqf
@@ -7,7 +7,7 @@
  * 1: Waypoint position <ARRAY>
  *
  * Return Value:
- * true <BOOLEAN>
+ * true <BOOL>
  *
  * Example:
  * [_group, [6560, 12390, 0]] call ace_fastroping_fnc_deployAIWayoint
@@ -17,11 +17,10 @@
 
 #include "script_component.hpp"
 params [["_group", grpNull, [grpNull]], ["_position", [0, 0, 0], [[]], 3]];
-private ["_vehicle", "_commander", "_speedMode"];
 
-_vehicle = vehicle leader _group;
-_commander = effectiveCommander _vehicle;
-_speedMode = speedMode _group;
+private _vehicle = vehicle leader _group;
+private _commander = effectiveCommander _vehicle;
+private _speedMode = speedMode _group;
 
 // - Approach -----------------------------------------------------------------
 if (_vehicle distance2D _position > 50) then {

--- a/addons/fastroping/functions/fnc_equipFRIES.sqf
+++ b/addons/fastroping/functions/fnc_equipFRIES.sqf
@@ -18,12 +18,12 @@
 params ["_vehicle"];
 private ["_config", "_fries"];
 
-_config = configFile >> "CfgVehicles" >> typeOf _vehicle;
+private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
 if !(isNumber (_config >> QGVAR(enabled))) then {
     ["%1 has not been configured for ACE_Fastroping.", getText (_config >> "DisplayName")] call BIS_fnc_error;
 } else {
     if (getNumber (_config >> QGVAR(enabled)) == 2) then {
-        _fries = (getText (_config >> QGVAR(friesType))) createVehicle [0, 0, 0];
+        private _fries = (getText (_config >> QGVAR(friesType))) createVehicle [0, 0, 0];
         _fries attachTo [_vehicle, (getArray (_config >> QGVAR(friesAttachmentPoint)))];
         _vehicle setVariable [QGVAR(FRIES), _fries, true];
         _vehicle addEventHandler ["Killed", {

--- a/addons/fastroping/functions/fnc_fastRope.sqf
+++ b/addons/fastroping/functions/fnc_fastRope.sqf
@@ -17,12 +17,11 @@
 
 #include "script_component.hpp"
 params ["_unit", "_vehicle"];
-private ["_deployedRopes", "_usableRope", "_usableRopeIndex"];
 
 //Select unoccupied rope
-_deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
-_usableRope = _deployedRopes select 0;
-_usableRopeIndex = 0;
+private _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
+private _usableRope = _deployedRopes select 0;
+private _usableRopeIndex = 0;
 {
     if !(_x select 5) exitWith {
         _usableRope = _x;

--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -17,9 +17,8 @@
 
 #include "script_component.hpp"
 params ["_arguments", "_pfhHandle"];
-_arguments params ["_unit", "_vehicle", "_rope", "_ropeIndex", "_timeToPlayRopeSound"];
-_rope params ["_attachmentPoint", "_ropeTop", "_ropeBottom", "_dummy", "_hook", "_occupied"];
-private ["_vectorUp", "_vectorDir", "_origin"];
+_arguments params ["_unit", "", "_rope", "", "_timeToPlayRopeSound"];
+_rope params ["", "", "", "_dummy"];
 
 //Wait until the unit is actually outside of the helicopter
 if (vehicle _unit != _unit) exitWith {};

--- a/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
@@ -18,8 +18,7 @@
 #include "script_component.hpp"
 params ["_arguments", "_pfhHandle"];
 _arguments params ["_unit", "_vehicle", "_rope", "_ropeIndex", "_hasBeenAttached"];
-_rope params ["_attachmentPoint", "_ropeTop", "_ropeBottom", "_dummy", "_hook", "_occupied"];
-private ["_vectorUp", "_vectorDir", "_origin"];
+_rope params ["_attachmentPoint", "_ropeTop", "_ropeBottom", "_dummy", "_hook"];
 
 //Wait until the unit is actually outside of the helicopter
 if (vehicle _unit != _unit) exitWith {};
@@ -29,7 +28,7 @@ if (getMass _dummy != 80) exitWith {
     //Fix for twitchyness
     _dummy setMass 80;
     _dummy setCenterOfMass [0, 0, -2];
-    _origin = getPosASL _hook;
+    private _origin = getPosASL _hook;
     _dummy setPosASL (_origin vectorAdd [0, 0, -2]);
     _dummy setVectorUp [0, 0, 1];
 
@@ -65,7 +64,7 @@ if (
     deleteVehicle _ropeTop;
     deleteVehicle _ropeBottom;
 
-    _origin = getPosASL _hook;
+    private _origin = getPosASL _hook;
     _dummy setPosASL (_origin vectorAdd [0, 0, -1]);
 
     //Restore original mass and center of mass
@@ -79,7 +78,7 @@ if (
     _ropeBottom addEventHandler ["RopeBreak", {[_this, "bottom"] call FUNC(onRopeBreak)}];
 
     //Update deployedRopes array
-    _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
+    private _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
     _deployedRopes set [_ropeIndex, [_attachmentPoint, _ropeTop, _ropeBottom, _dummy, _hook, false]];
     _vehicle setVariable [QGVAR(deployedRopes), _deployedRopes, true];
 

--- a/addons/fastroping/functions/fnc_onCutCommon.sqf
+++ b/addons/fastroping/functions/fnc_onCutCommon.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: BaerMitUmlaut
- * Function for opening doors and extending the hook for most vanilla helos.
+ * Function for closing doors and retracting the hook for most vanilla and older Arma helos.
  *
  * Arguments:
  * 0: Helicopter <OBJECT>
@@ -19,28 +19,17 @@ params ["_vehicle"];
 
 private _fries = _vehicle getVariable [QGVAR(FRIES), objNull];
 if !(isNull _fries) then {
-    _fries animate ["extendHookRight", 0];
-    _fries animate ["extendHookLeft", 0];
+    {_fries animate [_x, 0]} forEach ANIMS_HOOK;
     [{
-        _this animateDoor ["door_R", 0];
-        _this animateDoor ["door_L", 0];
-        _this animateDoor ["CargoRamp_Open", 0];
-        _this animateDoor ["Door_rear_source", 0];
-        _this animateDoor ["Door_6_source", 0];
-        _this animate ["dvere1_posunZ", 0];
-        _this animate ["dvere2_posunZ", 0];
+        {_vehicle animateDoor [_x, 0]} forEach ANIMS_DOOR;
+        {_vehicle animate [_x, 0]} forEach ANIMS;
         _this setVariable [QGVAR(doorsLocked), false, true];
     }, _vehicle, 2] call CBA_fnc_waitAndExecute;
 
     4
 } else {
-    _vehicle animateDoor ["door_R", 0];
-    _vehicle animateDoor ["door_L", 0];
-    _vehicle animateDoor ["CargoRamp_Open", 0];
-    _vehicle animateDoor ["Door_rear_source", 0];
-    _vehicle animateDoor ["Door_6_source", 0];
-    _vehicle animate ["dvere1_posunZ", 0];
-    _vehicle animate ["dvere2_posunZ", 0];
+    {_vehicle animateDoor [_x, 0]} forEach ANIMS_DOOR;
+    {_vehicle animate [_x, 0]} forEach ANIMS;
     _vehicle setVariable [QGVAR(doorsLocked), false, true];
 
     2

--- a/addons/fastroping/functions/fnc_onCutCommon.sqf
+++ b/addons/fastroping/functions/fnc_onCutCommon.sqf
@@ -21,8 +21,8 @@ private _fries = _vehicle getVariable [QGVAR(FRIES), objNull];
 if !(isNull _fries) then {
     {_fries animate [_x, 0]} forEach ANIMS_HOOK;
     [{
-        {_vehicle animateDoor [_x, 0]} forEach ANIMS_ANIMATEDOOR;
-        {_vehicle animate [_x, 0]} forEach ANIMS_ANIMATE;
+        {_this animateDoor [_x, 0]} forEach ANIMS_ANIMATEDOOR;
+        {_this animate [_x, 0]} forEach ANIMS_ANIMATE;
         _this setVariable [QGVAR(doorsLocked), false, true];
     }, _vehicle, 2] call CBA_fnc_waitAndExecute;
 

--- a/addons/fastroping/functions/fnc_onCutCommon.sqf
+++ b/addons/fastroping/functions/fnc_onCutCommon.sqf
@@ -21,15 +21,15 @@ private _fries = _vehicle getVariable [QGVAR(FRIES), objNull];
 if !(isNull _fries) then {
     {_fries animate [_x, 0]} forEach ANIMS_HOOK;
     [{
-        {_vehicle animateDoor [_x, 0]} forEach ANIMS_DOOR;
-        {_vehicle animate [_x, 0]} forEach ANIMS;
+        {_vehicle animateDoor [_x, 0]} forEach ANIMS_ANIMATEDOOR;
+        {_vehicle animate [_x, 0]} forEach ANIMS_ANIMATE;
         _this setVariable [QGVAR(doorsLocked), false, true];
     }, _vehicle, 2] call CBA_fnc_waitAndExecute;
 
     4
 } else {
-    {_vehicle animateDoor [_x, 0]} forEach ANIMS_DOOR;
-    {_vehicle animate [_x, 0]} forEach ANIMS;
+    {_vehicle animateDoor [_x, 0]} forEach ANIMS_ANIMATEDOOR;
+    {_vehicle animate [_x, 0]} forEach ANIMS_ANIMATE;
     _vehicle setVariable [QGVAR(doorsLocked), false, true];
 
     2

--- a/addons/fastroping/functions/fnc_onPrepareCommon.sqf
+++ b/addons/fastroping/functions/fnc_onPrepareCommon.sqf
@@ -19,8 +19,8 @@ params ["_vehicle"];
 
 private _waitTime = 2;
 
-{_vehicle animateDoor [_x, 1]} forEach ANIMS_DOOR;
-{_vehicle animate [_x, 1]} forEach ANIMS;
+{_vehicle animateDoor [_x, 1]} forEach ANIMS_ANIMATEDOOR;
+{_vehicle animate [_x, 1]} forEach ANIMS_ANIMATE;
 
 _vehicle setVariable [QGVAR(doorsLocked), true, true];
 

--- a/addons/fastroping/functions/fnc_onPrepareCommon.sqf
+++ b/addons/fastroping/functions/fnc_onPrepareCommon.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: BaerMitUmlaut
- * Function for closing doors and retracting the hook for most vanilla helos.
+ * Function for opening doors and extending the hook for most vanilla and older Arma helos.
  *
  * Arguments:
  * 0: Helicopter <OBJECT>
@@ -16,25 +16,18 @@
 
 #include "script_component.hpp"
 params ["_vehicle"];
-private ["_fries", "_waitTime"];
 
-_waitTime = 2;
+private _waitTime = 2;
 
-_vehicle animateDoor ["door_R", 1];
-_vehicle animateDoor ["door_L", 1];
-_vehicle animateDoor ["CargoRamp_Open", 1];
-_vehicle animateDoor ["Door_rear_source", 1];
-_vehicle animateDoor ["Door_6_source", 1];
-_vehicle animate ["dvere1_posunZ", 1];
-_vehicle animate ["dvere2_posunZ", 1];
+{_vehicle animateDoor [_x, 1]} forEach ANIMS_DOOR;
+{_vehicle animate [_x, 1]} forEach ANIMS;
 
 _vehicle setVariable [QGVAR(doorsLocked), true, true];
 
-_fries = _vehicle getVariable [QGVAR(FRIES), objNull];
+private _fries = _vehicle getVariable [QGVAR(FRIES), objNull];
 if !(isNull _fries) then {
     [{
-        _this animate ["extendHookRight", 1];
-        _this animate ["extendHookLeft", 1];
+        {_this animate [_x, 1]} forEach ANIMS_HOOK;
     }, _fries, 2] call CBA_fnc_waitAndExecute;
     _waitTime = 4;
 };

--- a/addons/fastroping/functions/fnc_prepareFRIES.sqf
+++ b/addons/fastroping/functions/fnc_prepareFRIES.sqf
@@ -16,13 +16,12 @@
 
 #include "script_component.hpp"
 params ["_vehicle"];
-private ["_config", "_waitTime"];
 
 //Stage indicator: 0 - travel mode; 1 - preparing FRIES; 2 - FRIES ready; 3 - ropes deployed
 _vehicle setVariable [QGVAR(deploymentStage), 1, true];
 
-_config = configFile >> "CfgVehicles" >> typeOf _vehicle;
-_waitTime = 0;
+private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
+private _waitTime = 0;
 if (isText (_config >> QGVAR(onPrepare))) then {
     _waitTime = [_vehicle] call (missionNamespace getVariable (getText (_config >> QGVAR(onPrepare))));
 };

--- a/addons/fastroping/script_component.hpp
+++ b/addons/fastroping/script_component.hpp
@@ -16,3 +16,8 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+
+
+#define ANIMS_HOOK ["extendHookRight", "extendHookLeft"]
+#define ANIMS_DOOR ["door_R", "door_L", "CargoRamp_Open", "Door_rear_source", "Door_6_source", "CargoDoorR", "CargoDoorL"]
+#define ANIMS ["dvere1_posunZ", "dvere2_posunZ", "doors"]

--- a/addons/fastroping/script_component.hpp
+++ b/addons/fastroping/script_component.hpp
@@ -19,5 +19,5 @@
 
 
 #define ANIMS_HOOK ["extendHookRight", "extendHookLeft"]
-#define ANIMS_DOOR ["door_R", "door_L", "CargoRamp_Open", "Door_rear_source", "Door_6_source", "CargoDoorR", "CargoDoorL"]
-#define ANIMS ["dvere1_posunZ", "dvere2_posunZ", "doors"]
+#define ANIMS_ANIMATEDOOR ["door_R", "door_L", "CargoRamp_Open", "Door_rear_source", "Door_6_source", "CargoDoorR", "CargoDoorL"]
+#define ANIMS_ANIMATE ["dvere1_posunZ", "dvere2_posunZ", "doors"]


### PR DESCRIPTION
**When merged this pull request will:**
- Add animations from older Arma games (support for eg. CUP which are still using those - not including any special new animations like fancy ramps)
- Macroize animations names
- Change to in-line privatization
- Fix inverted comments for public `onPrepare(/Cut)Common` functions