### PR TITLE
Use CBA Misc Items

### DIFF
--- a/addons/atragmx/CfgWeapons.hpp
+++ b/addons/atragmx/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_ATragMX: ACE_ItemCore {
         author = "Ruthberg";
@@ -13,7 +13,7 @@ class CfgWeapons {
         icon = "iconObject_circle";
         mapSize = 0.034;
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 2;
         };
     };

--- a/addons/attach/CfgWeapons.hpp
+++ b/addons/attach/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_IR_Strobe_Item: ACE_ItemCore {
         ACE_attachable = "ACE_IR_Strobe_Effect";
@@ -11,7 +11,7 @@ class CfgWeapons {
         model = QPATHTOF(data\ace_IRStrobe.p3d);
         picture = QPATHTOF(UI\irstrobe_item.paa);
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/captives/CfgWeapons.hpp
+++ b/addons/captives/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_CableTie: ACE_ItemCore {
         displayName = CSTRING(CableTie);
@@ -8,7 +8,7 @@ class CfgWeapons {
         model = QPATHTOF(models\ace_cabletie.p3d);
         picture = QPATHTOF(UI\ace_cabletie_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/chemlights/CfgWeapons.hpp
+++ b/addons/chemlights/CfgWeapons.hpp
@@ -36,7 +36,7 @@ class CfgWeapons {
     };
 
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_Chemlight_Shield: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
@@ -45,7 +45,7 @@ class CfgWeapons {
         model = "\A3\weapons_F\ammo\mag_univ.p3d";
         picture = QPATHTOF(UI\ace_chemlight_shield_x_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -58,7 +58,7 @@ class CfgWeapons {
         model = "\A3\weapons_F\ammo\mag_univ.p3d";
         picture = QPATHTOF(UI\ace_chemlight_shield_green_x_ca.paa);
         scope = 1;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "green";
@@ -73,7 +73,7 @@ class CfgWeapons {
         displayName = CSTRING(Shield_Red_DisplayName);
         descriptionShort = CSTRING(Shield_Red_DescriptionShort);
         picture = QPATHTOF(UI\ace_chemlight_shield_red_x_ca.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "red";
@@ -88,7 +88,7 @@ class CfgWeapons {
         displayName = CSTRING(Shield_Blue_DisplayName);
         descriptionShort = CSTRING(Shield_Blue_DescriptionShort);
         picture = QPATHTOF(UI\ace_chemlight_shield_blue_x_ca.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "blue";
@@ -103,7 +103,7 @@ class CfgWeapons {
         displayName = CSTRING(Shield_Yellow_DisplayName);
         descriptionShort = CSTRING(Shield_Yellow_DescriptionShort);
         picture = QPATHTOF(UI\ace_chemlight_shield_yellow_x_ca.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "yellow";
@@ -118,7 +118,7 @@ class CfgWeapons {
         displayName = CSTRING(Shield_Orange_DisplayName);
         descriptionShort = CSTRING(Shield_Orange_DescriptionShort);
         picture = QPATHTOF(UI\ace_chemlight_shield_orange_x_ca.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "orange";
@@ -133,7 +133,7 @@ class CfgWeapons {
         displayName = CSTRING(Shield_White_DisplayName);
         descriptionShort = CSTRING(Shield_White_DescriptionShort);
         picture = QPATHTOF(UI\ace_chemlight_shield_white_x_ca.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "white";

--- a/addons/common/CfgWeapons.hpp
+++ b/addons/common/CfgWeapons.hpp
@@ -1,11 +1,8 @@
 
 class CfgWeapons {
-    class ItemCore;
-    class ACE_ItemCore: ItemCore {
-        type = 4096;//4;
-        detectRange = -1;
-        simulation = "ItemMineDetector";
-    };
+    class CBA_MiscItem;
+    class CBA_MiscItem_ItemInfo;
+    class ACE_ItemCore: CBA_MiscItem {};
 
     class Rifle;
     class Rifle_Base_F: Rifle {
@@ -28,7 +25,6 @@ class CfgWeapons {
         };
     };
 
-    class InventoryItem_Base_F;
     class ACE_Banana: ACE_ItemCore {
         author = CSTRING(ACETeam);
         scope = 2;
@@ -38,7 +34,7 @@ class CfgWeapons {
         picture = QPATHTOF(data\icon_banana_ca.paa);
         icon = "iconObject_circle";
         mapSize = 0.034;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/dagr/CfgWeapons.hpp
+++ b/addons/dagr/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_DAGR: ACE_ItemCore {
         author[] = {$STR_ACE_Common_ACETeam, "Ruthberg"};
@@ -12,7 +12,7 @@ class CfgWeapons {
         picture = QPATHTOF(UI\DAGR_Icon.paa);
         icon = "iconObject_circle";
         mapSize = 0.034;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };

--- a/addons/disarming/CfgWeapons.hpp
+++ b/addons/disarming/CfgWeapons.hpp
@@ -1,13 +1,13 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_DebugPotato: ACE_ItemCore {
         displayName = "ACE Potato (debug)";
         descriptionShort = "Glorious Potato<br/>If you see this in game it means someone fucked up";
         picture = QPATHTOF(UI\potato_ca.paa);
         scope = 1;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/dogtags/CfgWeapons.hpp
+++ b/addons/dogtags/CfgWeapons.hpp
@@ -10,7 +10,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_dogtag: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
@@ -18,7 +18,7 @@ class CfgWeapons {
         displayName = CSTRING(itemName);
         model = QUOTE(PATHTOF(data\ace_dogtag.p3d));
         picture = QUOTE(PATHTOF(data\dogtagSingle.paa));
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 0; //too small to for 1 ?
         };
     };

--- a/addons/explosives/CfgWeapons.hpp
+++ b/addons/explosives/CfgWeapons.hpp
@@ -1,8 +1,8 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_f;
+    class CBA_MiscItem_ItemInfo;
 
-    class ACE_ExplosiveItem: InventoryItem_Base_f {
+    class ACE_ExplosiveItem: CBA_MiscItem_ItemInfo {
         allowedSlots[] = {801,701,901};
         //type = 201;
     };

--- a/addons/flashlights/CfgWeapons.hpp
+++ b/addons/flashlights/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 class CfgWeapons {
 
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_Flashlight_MX991: ACE_ItemCore {
         displayName = CSTRING(MX991_DisplayName);
@@ -9,7 +9,7 @@ class CfgWeapons {
         model = QPATHTOF(data\MX_991.p3d);
         picture = QPATHTOF(UI\mx991_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "red";
@@ -26,7 +26,7 @@ class CfgWeapons {
         model = QPATHTOF(data\KSF_1.p3d);
         picture = QPATHTOF(UI\ksf1_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "red";
@@ -43,7 +43,7 @@ class CfgWeapons {
         model = QPATHTOF(data\Maglight.p3d);
         picture = QPATHTOF(UI\xl50_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
             class FlashLight {
                 ACE_Flashlight_Colour = "white";

--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_EarPlugs: ACE_ItemCore {
         displayName = CSTRING(EarPlugs_Name);
@@ -8,7 +8,7 @@ class CfgWeapons {
         model = QPATHTOF(data\ace_earplugs.p3d);
         picture = QPATHTOF(UI\ACE_earplugs_x_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/huntir/CfgWeapons.hpp
+++ b/addons/huntir/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_HuntIR_monitor: ACE_ItemCore {
         scope = 2;
@@ -10,7 +10,7 @@ class CfgWeapons {
         descriptionShort = CSTRING(monitor_displayName);
         model = QPATHTOF(data\ace_huntir_monitor.p3d);
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 20;
         };
     };

--- a/addons/logistics_uavbattery/CfgWeapons.hpp
+++ b/addons/logistics_uavbattery/CfgWeapons.hpp
@@ -1,5 +1,5 @@
 class CfgWeapons {
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
     class ACE_ItemCore;
 
     class ACE_UAVBattery: ACE_ItemCore {
@@ -8,7 +8,7 @@ class CfgWeapons {
         descriptionShort = CSTRING(Battery_Description);
         model = QPATHTOF(data\ace_battery.p3d);
         picture = QPATHTOF(ui\UAV_battery_ca.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 20;
         };
     };

--- a/addons/logistics_wirecutter/CfgWeapons.hpp
+++ b/addons/logistics_wirecutter/CfgWeapons.hpp
@@ -1,5 +1,5 @@
 class CfgWeapons {
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
     class ACE_ItemCore;
 
     class ACE_wirecutter: ACE_ItemCore {
@@ -9,7 +9,7 @@ class CfgWeapons {
         model = QPATHTOF(data\ace_wirecutter.p3d);
         picture = QPATHTOF(ui\item_wirecutter_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 25;
         };
     };

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -10,7 +10,7 @@
 
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.76
-#define REQUIRED_CBA_VERSION {3,3,1}
+#define REQUIRED_CBA_VERSION {3,4,1}
 
 #ifdef COMPONENT_BEAUTIFIED
     #define COMPONENT_NAME QUOTE(ACE3 - COMPONENT_BEAUTIFIED)

--- a/addons/maptools/CfgWeapons.hpp
+++ b/addons/maptools/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_MapTools: ACE_ItemCore {
         displayName = CSTRING(Name);
@@ -8,7 +8,7 @@ class CfgWeapons {
         model = QPATHTOF(data\ace_MapTools.p3d);
         picture = QPATHTOF(UI\maptool_item.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/medical/CfgWeapons.hpp
+++ b/addons/medical/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
     class InventoryFirstAidKitItem_Base_F;
     class MedikitItem;
 
@@ -27,7 +27,7 @@ class CfgWeapons {
         displayName = CSTRING(Bandage_Basic_Display);
         descriptionShort = CSTRING(Bandage_Basic_Desc_Short);
         descriptionUse = CSTRING(Bandage_Basic_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -38,7 +38,7 @@ class CfgWeapons {
         model = QPATHTOF(data\packingbandage.p3d);
         descriptionShort = CSTRING(Packing_Bandage_Desc_Short);
         descriptionUse = CSTRING(Packing_Bandage_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -49,7 +49,7 @@ class CfgWeapons {
         model = "\A3\Structures_F_EPA\Items\Medical\Bandage_F.p3d";
         descriptionShort = CSTRING(Bandage_Elastic_Desc_Short);
         descriptionUse = CSTRING(Bandage_Elastic_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -60,7 +60,7 @@ class CfgWeapons {
         model = QPATHTOF(data\tourniquet.p3d);
         descriptionShort = CSTRING(Tourniquet_Desc_Short);
         descriptionUse = CSTRING(Tourniquet_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -71,7 +71,7 @@ class CfgWeapons {
         model = QPATHTOF(data\morphine.p3d);
         descriptionShort = CSTRING(Morphine_Desc_Short);
         descriptionUse = CSTRING(Morphine_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -82,7 +82,7 @@ class CfgWeapons {
         model = QPATHTOF(data\adenosine.p3d);
         descriptionShort = CSTRING(adenosine_Desc_Short);
         descriptionUse = CSTRING(adenosine_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -93,7 +93,7 @@ class CfgWeapons {
         model = QPATHTOF(data\atropine.p3d);
         descriptionShort = CSTRING(Atropine_Desc_Short);
         descriptionUse = CSTRING(Atropine_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -104,7 +104,7 @@ class CfgWeapons {
         model = QPATHTOF(data\epinephrine.p3d);
         descriptionShort = CSTRING(Epinephrine_Desc_Short);
         descriptionUse = CSTRING(Epinephrine_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -118,7 +118,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\items\plasmaIV_x_ca.paa);
         descriptionShort = CSTRING(Plasma_IV_Desc_Short);
         descriptionUse = CSTRING(Plasma_IV_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };
@@ -126,7 +126,7 @@ class CfgWeapons {
         displayName = CSTRING(Plasma_IV_500);
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_plasma_500ml_ca.paa) };
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 5;
         };
     };
@@ -134,7 +134,7 @@ class CfgWeapons {
         displayName = CSTRING(Plasma_IV_250);
         model = QPATHTOF(data\IVBag_250ml.p3d);
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_plasma_250ml_ca.paa) };
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 2.5;
         };
     };
@@ -147,7 +147,7 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_blood_1000ml_ca.paa) };
         descriptionShort = CSTRING(Blood_IV_Desc_Short);
         descriptionUse = CSTRING(Blood_IV_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };
@@ -155,7 +155,7 @@ class CfgWeapons {
         displayName = CSTRING(Blood_IV_500);
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_blood_500ml_ca.paa) };
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 5;
         };
     };
@@ -163,7 +163,7 @@ class CfgWeapons {
         displayName = CSTRING(Blood_IV_250);
         model = QPATHTOF(data\IVBag_250ml.p3d);
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_blood_250ml_ca.paa) };
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 2.5;
         };
     };
@@ -176,7 +176,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\items\salineIV_x_ca.paa);
         descriptionShort = CSTRING(Saline_IV_Desc_Short);
         descriptionUse = CSTRING(Saline_IV_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };
@@ -184,7 +184,7 @@ class CfgWeapons {
         displayName = CSTRING(Saline_IV_500);
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_saline_500ml_ca.paa) };
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 5;
         };
     };
@@ -192,7 +192,7 @@ class CfgWeapons {
         displayName = CSTRING(Saline_IV_250);
         model = QPATHTOF(data\IVBag_250ml.p3d);
         hiddenSelectionsTextures[] = { QPATHTOF(data\IVBag_saline_250ml_ca.paa) };
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 2.5;
         };
     };
@@ -203,7 +203,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\items\quickclot_x_ca.paa);
         descriptionShort = CSTRING(QuikClot_Desc_Short);
         descriptionUse = CSTRING(QuikClot_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };
@@ -213,7 +213,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\items\personal_aid_kit_x_ca.paa);
         descriptionShort = CSTRING(Aid_Kit_Desc_Short);
         descriptionUse = CSTRING(Aid_Kit_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };
@@ -224,7 +224,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\items\surgicalKit_x_ca.paa);
         descriptionShort = CSTRING(SurgicalKit_Desc_Short);
         descriptionUse = CSTRING(SurgicalKit_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 15;
         };
     };
@@ -235,7 +235,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\items\bodybag_x_ca.paa);
         descriptionShort = CSTRING(Bodybag_Desc_Short);
         descriptionUse = CSTRING(Bodybag_Desc_Use);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 7;
         };
     };

--- a/addons/microdagr/CfgWeapons.hpp
+++ b/addons/microdagr/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_microDAGR: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
@@ -9,7 +9,7 @@ class CfgWeapons {
         descriptionShort = CSTRING(itemDescription);
         model = QPATHTOF(data\MicroDAGR.p3d);
         picture = QPATHTOF(images\microDAGR_item.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 2;
         };
     };

--- a/addons/mk6mortar/CfgWeapons.hpp
+++ b/addons/mk6mortar/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_RangeTable_82mm: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
@@ -8,7 +8,7 @@ class CfgWeapons {
         displayName = CSTRING(rangetable_name);
         descriptionShort = CSTRING(rangetable_description);
         picture = QPATHTOF(UI\icon_rangeTable.paa);
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 0.5;
         };
     };

--- a/addons/overheating/CfgWeapons.hpp
+++ b/addons/overheating/CfgWeapons.hpp
@@ -1,7 +1,4 @@
 class CfgWeapons {
-    class ACE_ItemCore;
-    class InventoryItem_Base_F;
-
     class RifleCore;
     class Rifle: RifleCore {
         //Mean Rounds Between Stoppages (this will be scaled based on the barrel temp)

--- a/addons/rangecard/CfgWeapons.hpp
+++ b/addons/rangecard/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_RangeCard: ACE_ItemCore {
         author[] = {"Ruthberg"};
@@ -12,7 +12,7 @@ class CfgWeapons {
         icon = "iconObject_circle";
         mapSize = 0.034;
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
     };

--- a/addons/sandbag/CfgWeapons.hpp
+++ b/addons/sandbag/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_Sandbag_empty: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
@@ -10,7 +10,7 @@ class CfgWeapons {
         model = QPATHTOF(data\ace_sandbag_m.p3d);
         picture = QPATHTOF(data\m_sandbag_ca.paa);
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 8;
         };
     };
@@ -22,7 +22,7 @@ class CfgWeapons {
         model = QPATHTOF(data\ace_sandbag_build.p3d);
         picture = QPATHTOF(data\m_sandbag_ca.paa);
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 160;
         };
     };

--- a/addons/spottingscope/CfgWeapons.hpp
+++ b/addons/spottingscope/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_SpottingScope: ACE_ItemCore {
         scope = 2;
@@ -10,7 +10,7 @@ class CfgWeapons {
         picture = QPATHTOF(UI\w_spottingscope_ca.paa);
         model = QPATHTOF(data\ace_spottingscope.p3d);
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 40;
         };
     };

--- a/addons/tagging/CfgWeapons.hpp
+++ b/addons/tagging/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_SpraypaintBlack : ACE_ItemCore {
         author = "jokoho48";
@@ -11,7 +11,7 @@ class CfgWeapons {
         scope = 2;
         hiddenSelections[] = {"camo"};
         hiddenSelectionsTextures[] = {QPATHTOF(data\spraycanBlack_co.paa)};
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };

--- a/addons/trenches/CfgWeapons.hpp
+++ b/addons/trenches/CfgWeapons.hpp
@@ -1,5 +1,5 @@
 class CfgWeapons {
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
     class ACE_ItemCore;
 
     class ACE_EntrenchingTool: ACE_ItemCore {
@@ -9,7 +9,7 @@ class CfgWeapons {
         model = QPATHTOEF(apl,ace_entrchtool.p3d);
         picture = QPATHTOF(ui\w_entrchtool_ca.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
     };

--- a/addons/tripod/CfgWeapons.hpp
+++ b/addons/tripod/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
     class ACE_ItemCore;
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_Tripod: ACE_ItemCore {
         author[] = {"Rocko", "Scubaman3D"};
@@ -10,7 +10,7 @@ class CfgWeapons {
         model = QPATHTOF(data\w_sniper_tripod.p3d);
         picture = QPATHTOF(UI\w_sniper_tripod_ca.paa);
 
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 40;
         };
     };

--- a/addons/vehiclelock/CfgWeapons.hpp
+++ b/addons/vehiclelock/CfgWeapons.hpp
@@ -1,5 +1,5 @@
 class CfgWeapons {
-    class InventoryItem_Base_F;
+    class CBA_MiscItem_ItemInfo;
     class ACE_ItemCore;
 
     class ACE_key_master: ACE_ItemCore {
@@ -10,7 +10,7 @@ class CfgWeapons {
         model = "\A3\weapons_F\ammo\mag_univ.p3d";
         picture = QPATHTOF(ui\keyBlack.paa);
         scope = 2;
-        class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 0;
         };
     };


### PR DESCRIPTION
For https://github.com/CBATeam/CBA_A3/pull/744

```
class ACE_ItemCore: CBA_MiscItem {};
```
Should we keep `ACE_ItemCore` or just drop it and use the CBA item base for everything?
