### PR TITLE
Handle laser targets from non-primaryGunner turrets

### DIFF
--- a/addons/laser/CfgVehicles.hpp
+++ b/addons/laser/CfgVehicles.hpp
@@ -10,23 +10,4 @@ class CfgVehicles {
             };
         };
     };
-
-    // laserTarget fails if the turret does not have "primaryGunner" config
-    // This only effects the indfor strider who's commander is not the primaryGunner
-    class LandVehicle;
-    class Car: LandVehicle {
-        class NewTurret;
-    };
-    class Car_F: Car {
-        class Turrets {
-            class MainTurret: NewTurret {};
-        };
-    };
-    class MRAP_03_base_F: Car_F {
-        class Turrets: Turrets {
-            class CommanderTurret: MainTurret {
-                primaryGunner = 1;
-            };
-        };
-    };
 };

--- a/addons/laser/functions/fnc_handleLaserTargetCreation.sqf
+++ b/addons/laser/functions/fnc_handleLaserTargetCreation.sqf
@@ -13,6 +13,7 @@
  *
  * Public: No
  */
+// #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 TRACE_1("params",_this);
@@ -34,5 +35,31 @@ TRACE_1("params",_this);
         [_targetObject, _owners select 0] call FUNC(addLaserTarget);
     };
 
-    TRACE_1("Laser target doesn't have owner", _targetObject);
+    // Vehicle based laser designators won't be linked via laserTarget if the turret has "primaryGunner = 0"
+    // This backup method just checks the player's vic - which should be reasonably safe as we know the laserTarget is local
+    private _foundSource = false;
+    private _vehicle = vehicle ACE_player;
+    TRACE_2("",_vehicle,typeOf _vehicle);
+    if ((alive ACE_player) && {_vehicle != ACE_player}) then {
+        private _turretPath = if (ACE_player == (driver _vehicle)) then {[-1]} else {ACE_player call CBA_fnc_turretPath};
+        TRACE_1("",_turretPath);
+        if (!(_turretPath isEqualTo [])) then {
+            private _currentWeapon = _vehicle currentWeaponTurret _turretPath;
+            TRACE_1("",_currentWeapon);
+            if ((getNumber (configFile >> "CfgWeapons" >> _currentWeapon >> "laser")) == 1) then {
+                #ifdef DEBUG_MODE_FULL
+                private _turretConfig = [_vehicle, _turretPath] call CBA_fnc_getTurret;
+                private _primaryGunner = getNumber (_turretConfig >> "primaryGunner");
+                TRACE_1("",_primaryGunner);
+                #endif
+                TRACE_2("Laser target owner [backup method]",_targetObject,_vehicle);
+                [_targetObject, _vehicle] call FUNC(addLaserTarget);
+                _foundSource = true;
+            };
+        };
+    };
+    if (!_foundSource) then {
+        WARNING_1("Laser target doesn't have owner", _targetObject);
+    };
+
 }, _this] call CBA_fnc_execNextFrame;


### PR DESCRIPTION
laserTarget fails if the turret does not have "primaryGunner" config
this adds a backup method that checks if the player's vehicle is a likely canidate for the laser's source

It effects the vanilla strider and indy hellcat chopper.
I think this is a better method than changing their configs