### PR TITLE
Add uiNamespace variable to spectator display

### DIFF
--- a/addons/spectator/functions/fnc_ui_handleKeyDown.sqf
+++ b/addons/spectator/functions/fnc_ui_handleKeyDown.sqf
@@ -147,20 +147,20 @@ if (_key == DIK_F1) exitWith {
 };
 
 // Handle toggle focus info widget
-if (_key == DIK_P) exitWith {
+if (_key == DIK_I) exitWith {
     GVAR(uiWidgetVisible) = !GVAR(uiWidgetVisible);
     [] call FUNC(ui_updateWidget);
     true
 };
 
 // Handle toggling projectile drawing
-if (_key == DIK_O) exitWith {
+if (_key == DIK_P) exitWith {
     GVAR(drawProjectiles) = !GVAR(drawProjectiles);
     true
 };
 
 // Handle toggling unit drawing
-if (_key == DIK_I) exitWith {
+if (_key == DIK_O) exitWith {
     GVAR(drawUnits) = !GVAR(drawUnits);
     true
 };

--- a/addons/spectator/ui.hpp
+++ b/addons/spectator/ui.hpp
@@ -17,6 +17,8 @@ class GVAR(display) {
     enableSimulation = 1;
     movingEnable = 0;
     closeOnMissionEnd = 1;
+    
+    onLoad = QUOTE(SETUVAR(GVAR(display),_this select 0));
 
     onKeyDown = QUOTE(_this call FUNC(ui_handleKeyDown));
     onKeyUp = QUOTE(_this call FUNC(ui_handleKeyUp));


### PR DESCRIPTION
**When merged this pull request will:**
- Store the spectator display in a uiNamespace variable (so external scripts can access it #5469)
- Update the toggle hotkeys to match the docs branch waiting to be merged after release
