### PR TITLE
Fix spectator onLoad

### DIFF
--- a/addons/spectator/ui.hpp
+++ b/addons/spectator/ui.hpp
@@ -18,7 +18,7 @@ class GVAR(display) {
     movingEnable = 0;
     closeOnMissionEnd = 1;
     
-    onLoad = QUOTE(SETUVAR(GVAR(display),_this select 0));
+    onLoad = QUOTE(with uiNameSpace do {GVAR(display) = _this select 0};);
 
     onKeyDown = QUOTE(_this call FUNC(ui_handleKeyDown));
     onKeyUp = QUOTE(_this call FUNC(ui_handleKeyUp));


### PR DESCRIPTION
Fix crash on start
```
 File z\ace\addons\spectator\ui.hpp, line 20: '/ace_spectator_display.onLoad': Missing ';' at the end of line
 Error context , _this select 0]";
ErrorMessage: File z\ace\addons\spectator\ui.hpp, line 20: '/ace_spectator_display.ace_spectator_display': '"' encountered instead of '='
```

I guess the macro doesn't like being in a quote macro