### PR TITLE
AB : update R3F compat

### DIFF
--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -67,7 +67,7 @@ class CfgAmmo {
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670};
+        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -81,7 +81,7 @@ class CfgAmmo {
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670};
+        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -95,7 +95,7 @@ class CfgAmmo {
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670};
+        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -109,7 +109,7 @@ class CfgAmmo {
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670};
+        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -123,7 +123,7 @@ class CfgAmmo {
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670};
+        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;

--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -1,7 +1,7 @@
 class CfgAmmo {
     class Default;
     class BulletBase;
-    class R3F_9x19_Ball: BulletBase { // ACE_9x19_Ball
+    class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L360
         typicalSpeed = 350; // R3F config
         airFriction = -0.0019835001; // ACE3 value
         ACE_caliber = 9.017;
@@ -15,7 +15,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {340, 370, 400};
         ACE_barrelLengths[] = {101.6, 127.0, 228.6};
     };
-    class R3F_556x45_Ball: BulletBase { // B_556x45_Ball, AtragMx GunList: 5.56x45mm M855
+    class R3F_556x45_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L9
         typicalSpeed = 930; // R3F config
         airFriction = -0.00126466; // ACE3 value
         ACE_caliber = 5.69;
@@ -29,7 +29,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
-    class R3F_762x51_Ball: BulletBase { // B_762x51_Ball, AtragMx GunList: 7.62x51mm M80
+    class R3F_762x51_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 820; // R3F config
         airFriction = -0.00100957; // ACE3 value
         ACE_caliber = 7.823;
@@ -43,7 +43,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {700, 800, 820, 833, 845};
         ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
-    class R3F_762x51_Ball2: R3F_762x51_Ball { // FRF2 bullet
+    class R3F_762x51_Ball2: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 850; // R3F config
         airFriction = -0.00100957; // ACE3 value
 		ACE_caliber = 7.823;
@@ -57,10 +57,10 @@ class CfgAmmo {
 		ACE_muzzleVelocities[] = {850};
 		ACE_barrelLengths[] = {650};
 	};
-    class R3F_762x51_Minimi_Ball: R3F_762x51_Ball {
+    class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         airFriction = -0.00100957; // ACE3 value
 	};
-    class R3F_127x99_Ball: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+    class R3F_127x99_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
         airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
@@ -74,7 +74,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_PEI: R3F_127x99_Ball { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+    class R3F_127x99_PEI: R3F_127x99_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
         airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
@@ -88,7 +88,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_Ball2: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+    class R3F_127x99_Ball2: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 850; // R3F config
         airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
@@ -102,7 +102,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_PEI2: R3F_127x99_Ball2 { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+    class R3F_127x99_PEI2: R3F_127x99_Ball2 { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 850; // R3F config
         airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
@@ -116,7 +116,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_Ball3: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+    class R3F_127x99_Ball3: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 820; // R3F config
         airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;

--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -46,20 +46,20 @@ class CfgAmmo {
     class R3F_762x51_Ball2: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 850; // R3F config
         airFriction = -0.00100957; // ACE3 value, default -0.001625
-		ACE_caliber = 7.823;
-		ACE_bulletLength = 28.956;
-		ACE_bulletMass = 9.4608;
-		ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-		ACE_ballisticCoefficients[] = {0.398}; // AtragMx G1 BC
-		ACE_velocityBoundaries[] = {};
-		ACE_standardAtmosphere = "ICAO";
-		ACE_dragModel = 1;
-		ACE_muzzleVelocities[] = {850};
-		ACE_barrelLengths[] = {650};
-	};
+        ACE_caliber = 7.823;
+        ACE_bulletLength = 28.956;
+        ACE_bulletMass = 9.4608;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.398}; // AtragMx G1 BC
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {850};
+        ACE_barrelLengths[] = {650};
+    };
     class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         airFriction = -0.00100957; // ACE3 value, default -0.002000
-	};
+    };
     class R3F_127x99_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
         airFriction = -0.00057503; // ACE3 value, default -0.00086

--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -2,6 +2,8 @@ class CfgAmmo {
     class Default;
     class BulletBase;
     class R3F_9x19_Ball: BulletBase { // ACE_9x19_Ball
+        typicalSpeed = 350; // R3F config
+        airFriction = -0.0019835001; // ACE3 value
         ACE_caliber = 9.017;
         ACE_bulletLength = 15.494;
         ACE_bulletMass = 8.0352;
@@ -14,30 +16,53 @@ class CfgAmmo {
         ACE_barrelLengths[] = {101.6, 127.0, 228.6};
     };
     class R3F_556x45_Ball: BulletBase { // B_556x45_Ball, AtragMx GunList: 5.56x45mm M855
+        typicalSpeed = 930; // R3F config
+        airFriction = -0.00126466; // ACE3 value
         ACE_caliber = 5.69;
         ACE_bulletLength = 23.012;
         ACE_bulletMass = 4.0176;
         ACE_ammoTempMuzzleVelocityShifts[] = {-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
-        ACE_ballisticCoefficients[] = {0.151};
+        ACE_ballisticCoefficients[] = {0.302}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
-        ACE_dragModel = 7;
+        ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class R3F_762x51_Ball: BulletBase { // B_762x51_Ball, AtragMx GunList: 7.62x51mm M80
+        typicalSpeed = 820; // R3F config
+        airFriction = -0.00100957; // ACE3 value
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.2};
+        ACE_ballisticCoefficients[] = {0.398}; // AtragMx G1 BC
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
-        ACE_dragModel = 7;
+        ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {700, 800, 820, 833, 845};
         ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
+    class R3F_762x51_Ball2: R3F_762x51_Ball { // FRF2 bullet
+        typicalSpeed = 850; // R3F config
+        airFriction = -0.00100957; // ACE3 value
+		ACE_caliber = 7.823;
+		ACE_bulletLength = 28.956;
+		ACE_bulletMass = 9.4608;
+		ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+		ACE_ballisticCoefficients[] = {0.398}; // AtragMx G1 BC
+		ACE_velocityBoundaries[] = {};
+		ACE_standardAtmosphere = "ICAO";
+		ACE_dragModel = 1;
+		ACE_muzzleVelocities[] = {850};
+		ACE_barrelLengths[] = {650};
+	};
+    class R3F_762x51_Minimi_Ball: R3F_762x51_Ball {
+        airFriction = -0.00100957; // ACE3 value
+	};
     class R3F_127x99_Ball: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        typicalSpeed = 780; // R3F config
+        airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -46,10 +71,12 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {900};
+        ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
     class R3F_127x99_PEI: R3F_127x99_Ball { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        typicalSpeed = 780; // R3F config
+        airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -58,10 +85,12 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {900};
+        ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
     class R3F_127x99_Ball2: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        typicalSpeed = 850; // R3F config
+        airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -70,10 +99,12 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {900};
+        ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
     class R3F_127x99_PEI2: R3F_127x99_Ball2 { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        typicalSpeed = 850; // R3F config
+        airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -82,10 +113,12 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {900};
+        ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
     class R3F_127x99_Ball3: BulletBase { // B_127x99_Ball, AtragMx GunList: 12.7x99mm
+        typicalSpeed = 820; // R3F config
+        airFriction = -0.00057503; // ACE3 value
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -94,7 +127,7 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {900};
+        ACE_muzzleVelocities[] = {820};
         ACE_barrelLengths[] = {736.6};
     };
 };

--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -3,7 +3,7 @@ class CfgAmmo {
     class BulletBase;
     class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L360
         typicalSpeed = 350; // R3F config
-        airFriction = -0.0019835001; // ACE3 value
+        airFriction = -0.0019835001; // ACE3 value, default -0.001413
         ACE_caliber = 9.017;
         ACE_bulletLength = 15.494;
         ACE_bulletMass = 8.0352;
@@ -17,7 +17,7 @@ class CfgAmmo {
     };
     class R3F_556x45_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L9
         typicalSpeed = 930; // R3F config
-        airFriction = -0.00126466; // ACE3 value
+        airFriction = -0.00126466; // ACE3 value, default -0.001625
         ACE_caliber = 5.69;
         ACE_bulletLength = 23.012;
         ACE_bulletMass = 4.0176;
@@ -31,7 +31,7 @@ class CfgAmmo {
     };
     class R3F_762x51_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 820; // R3F config
-        airFriction = -0.00100957; // ACE3 value
+        airFriction = -0.00100957; // ACE3 value, default -0.001625
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;
@@ -45,7 +45,7 @@ class CfgAmmo {
     };
     class R3F_762x51_Ball2: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00100957; // ACE3 value
+        airFriction = -0.00100957; // ACE3 value, default -0.001625
 		ACE_caliber = 7.823;
 		ACE_bulletLength = 28.956;
 		ACE_bulletMass = 9.4608;
@@ -58,11 +58,11 @@ class CfgAmmo {
 		ACE_barrelLengths[] = {650};
 	};
     class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
-        airFriction = -0.00100957; // ACE3 value
+        airFriction = -0.00100957; // ACE3 value, default -0.002000
 	};
     class R3F_127x99_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
-        airFriction = -0.00057503; // ACE3 value
+        airFriction = -0.00057503; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -76,7 +76,7 @@ class CfgAmmo {
     };
     class R3F_127x99_PEI: R3F_127x99_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
-        airFriction = -0.00057503; // ACE3 value
+        airFriction = -0.00057503; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -90,7 +90,7 @@ class CfgAmmo {
     };
     class R3F_127x99_Ball2: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00057503; // ACE3 value
+        airFriction = -0.00057503; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -104,7 +104,7 @@ class CfgAmmo {
     };
     class R3F_127x99_PEI2: R3F_127x99_Ball2 { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00057503; // ACE3 value
+        airFriction = -0.00057503; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
@@ -118,7 +118,7 @@ class CfgAmmo {
     };
     class R3F_127x99_Ball3: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 820; // R3F config
-        airFriction = -0.00057503; // ACE3 value
+        airFriction = -0.00057503; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;

--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -1,59 +1,59 @@
 class CfgMagazines {
     class CA_magazine;
     class R3F_securite_mag: CA_magazine {
-		scope = 0; // default 2
+        scope = 0; // default 2
     };
     class R3F_15Rnd_9x19_PAMAS: CA_magazine {
-		initSpeed = 350; // R3F config
-	};
-	class R3F_15Rnd_9x19_HKUSP: CA_magazine {
-		initSpeed = 350; // R3F config
-	};
-	class R3F_30Rnd_9x19_MP5: CA_magazine {
-		initSpeed = 400; // R3F config
-	};
-	class R3F_25Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 960; // R3F config
-	};
-	class R3F_25Rnd_556x45_TRACER_FAMAS: R3F_25Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
-	class R3F_30Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 925; // R3F config
-	};
-	class R3F_30Rnd_556x45_TRACER_FAMAS: R3F_30Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
-	class R3F_30Rnd_556x45_HK416: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 850; // R3F config
-	};
-	class R3F_30Rnd_556x45_TRACER_HK416: R3F_30Rnd_556x45_HK416 {}; // AtragMx GunList: 5.56x45mm M855
-	class R3F_30Rnd_556x45_SIG551: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 850; // R3F config
-	};
-	class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {}; // AtragMx GunList: 5.56x45mm M855
-	class R3F_10Rnd_762x51_FRF2: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 850; // R3F config
-	};
-	class R3F_200Rnd_556x45_MINIMI: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 915; // R3F config
-	};
-	class R3F_100Rnd_762x51_MINIMI: CA_magazine { // AtragMx GunList: 7.62x51mm M80
-		initSpeed = 820; // R3F config
-	};
-	class R3F_20Rnd_762x51_HK417: CA_magazine { // AtragMx GunList: 7.62x51mm M80
-		initSpeed = 820; // R3F config
-	};
-	class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80
-	class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-		initSpeed = 780; // R3F config
-	};
-	class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: 12.7x99mm
-		initSpeed = 780; // R3F config
-	};
-	class R3F_10Rnd_127x99_M107: CA_magazine { // AtragMx GunList: 12.7x99mm
-		initSpeed = 850; // R3F config
-	};
-	class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 { // AtragMx GunList: 12.7x99mm
-		initSpeed = 850; // R3F config
-	};
-	class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: 12.7x99mm
-		initSpeed = 820; // R3F config
-	};
+        initSpeed = 350; // R3F config
+    };
+    class R3F_15Rnd_9x19_HKUSP: CA_magazine {
+        initSpeed = 350; // R3F config
+    };
+    class R3F_30Rnd_9x19_MP5: CA_magazine {
+        initSpeed = 400; // R3F config
+    };
+    class R3F_25Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 960; // R3F config
+    };
+    class R3F_25Rnd_556x45_TRACER_FAMAS: R3F_25Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
+    class R3F_30Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 925; // R3F config
+    };
+    class R3F_30Rnd_556x45_TRACER_FAMAS: R3F_30Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
+    class R3F_30Rnd_556x45_HK416: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 850; // R3F config
+    };
+    class R3F_30Rnd_556x45_TRACER_HK416: R3F_30Rnd_556x45_HK416 {}; // AtragMx GunList: 5.56x45mm M855
+    class R3F_30Rnd_556x45_SIG551: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 850; // R3F config
+    };
+    class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {}; // AtragMx GunList: 5.56x45mm M855
+    class R3F_10Rnd_762x51_FRF2: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 850; // R3F config
+    };
+    class R3F_200Rnd_556x45_MINIMI: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 915; // R3F config
+    };
+    class R3F_100Rnd_762x51_MINIMI: CA_magazine { // AtragMx GunList: 7.62x51mm M80
+        initSpeed = 820; // R3F config
+    };
+    class R3F_20Rnd_762x51_HK417: CA_magazine { // AtragMx GunList: 7.62x51mm M80
+        initSpeed = 820; // R3F config
+    };
+    class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80
+    class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+        initSpeed = 780; // R3F config
+    };
+    class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: 12.7x99mm
+        initSpeed = 780; // R3F config
+    };
+    class R3F_10Rnd_127x99_M107: CA_magazine { // AtragMx GunList: 12.7x99mm
+        initSpeed = 850; // R3F config
+    };
+    class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 { // AtragMx GunList: 12.7x99mm
+        initSpeed = 850; // R3F config
+    };
+    class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: 12.7x99mm
+        initSpeed = 820; // R3F config
+    };
 };

--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -12,48 +12,48 @@ class CfgMagazines {
 	class R3F_30Rnd_9x19_MP5: CA_magazine {
 		initSpeed = 400; // R3F config
 	};
-	class R3F_25Rnd_556x45_FAMAS: CA_magazine {
+	class R3F_25Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 960; // R3F config
 	};
-	class R3F_25Rnd_556x45_TRACER_FAMAS: R3F_25Rnd_556x45_FAMAS {};
-	class R3F_30Rnd_556x45_FAMAS: CA_magazine {
+	class R3F_25Rnd_556x45_TRACER_FAMAS: R3F_25Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
+	class R3F_30Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 925; // R3F config
 	};
-	class R3F_30Rnd_556x45_TRACER_FAMAS: R3F_30Rnd_556x45_FAMAS {};
-	class R3F_30Rnd_556x45_HK416: CA_magazine {
+	class R3F_30Rnd_556x45_TRACER_FAMAS: R3F_30Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
+	class R3F_30Rnd_556x45_HK416: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 850; // R3F config
 	};
-	class R3F_30Rnd_556x45_TRACER_HK416: R3F_30Rnd_556x45_HK416 {};
-	class R3F_30Rnd_556x45_SIG551: CA_magazine {
+	class R3F_30Rnd_556x45_TRACER_HK416: R3F_30Rnd_556x45_HK416 {}; // AtragMx GunList: 5.56x45mm M855
+	class R3F_30Rnd_556x45_SIG551: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 850; // R3F config
 	};
-	class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {};
-	class R3F_10Rnd_762x51_FRF2: CA_magazine {
+	class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {}; // AtragMx GunList: 5.56x45mm M855
+	class R3F_10Rnd_762x51_FRF2: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 850; // R3F config
 	};
-	class R3F_200Rnd_556x45_MINIMI: CA_magazine {
+	class R3F_200Rnd_556x45_MINIMI: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 915; // R3F config
 	};
-	class R3F_100Rnd_762x51_MINIMI: CA_magazine {
+	class R3F_100Rnd_762x51_MINIMI: CA_magazine { // AtragMx GunList: 7.62x51mm M80
 		initSpeed = 820; // R3F config
 	};
-	class R3F_20Rnd_762x51_HK417: CA_magazine {
+	class R3F_20Rnd_762x51_HK417: CA_magazine { // AtragMx GunList: 7.62x51mm M80
 		initSpeed = 820; // R3F config
 	};
-	class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {};
-	class R3F_7Rnd_127x99_PGM: CA_magazine {
+	class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80
+	class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: 5.56x45mm M855
 		initSpeed = 780; // R3F config
 	};
-	class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM {
+	class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: 12.7x99mm
 		initSpeed = 780; // R3F config
 	};
-	class R3F_10Rnd_127x99_M107: CA_magazine {
+	class R3F_10Rnd_127x99_M107: CA_magazine { // AtragMx GunList: 12.7x99mm
 		initSpeed = 850; // R3F config
 	};
-	class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 {
+	class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 { // AtragMx GunList: 12.7x99mm
 		initSpeed = 850; // R3F config
 	};
-	class R3F_5Rnd_127x99_TAC50: CA_magazine {
+	class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: 12.7x99mm
 		initSpeed = 820; // R3F config
 	};
 };

--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -1,0 +1,6 @@
+class CfgMagazines {
+    class CA_magazine;
+    class R3F_securite_mag: CA_magazine {
+		scope = 0;
+    };
+};

--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -41,7 +41,7 @@ class CfgMagazines {
         initSpeed = 820; // R3F config
     };
     class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80
-    class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+    class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: 12.7x99mm
         initSpeed = 780; // R3F config
     };
     class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: 12.7x99mm

--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -1,6 +1,59 @@
 class CfgMagazines {
     class CA_magazine;
     class R3F_securite_mag: CA_magazine {
-		scope = 0;
+		scope = 0; // default 2
     };
+    class R3F_15Rnd_9x19_PAMAS: CA_magazine {
+		initSpeed = 350; // R3F config
+	};
+	class R3F_15Rnd_9x19_HKUSP: CA_magazine {
+		initSpeed = 350; // R3F config
+	};
+	class R3F_30Rnd_9x19_MP5: CA_magazine {
+		initSpeed = 400; // R3F config
+	};
+	class R3F_25Rnd_556x45_FAMAS: CA_magazine {
+		initSpeed = 960; // R3F config
+	};
+	class R3F_25Rnd_556x45_TRACER_FAMAS: R3F_25Rnd_556x45_FAMAS {};
+	class R3F_30Rnd_556x45_FAMAS: CA_magazine {
+		initSpeed = 925; // R3F config
+	};
+	class R3F_30Rnd_556x45_TRACER_FAMAS: R3F_30Rnd_556x45_FAMAS {};
+	class R3F_30Rnd_556x45_HK416: CA_magazine {
+		initSpeed = 850; // R3F config
+	};
+	class R3F_30Rnd_556x45_TRACER_HK416: R3F_30Rnd_556x45_HK416 {};
+	class R3F_30Rnd_556x45_SIG551: CA_magazine {
+		initSpeed = 850; // R3F config
+	};
+	class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {};
+	class R3F_10Rnd_762x51_FRF2: CA_magazine {
+		initSpeed = 850; // R3F config
+	};
+	class R3F_200Rnd_556x45_MINIMI: CA_magazine {
+		initSpeed = 915; // R3F config
+	};
+	class R3F_100Rnd_762x51_MINIMI: CA_magazine {
+		initSpeed = 820; // R3F config
+	};
+	class R3F_20Rnd_762x51_HK417: CA_magazine {
+		initSpeed = 820; // R3F config
+	};
+	class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {};
+	class R3F_7Rnd_127x99_PGM: CA_magazine {
+		initSpeed = 780; // R3F config
+	};
+	class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM {
+		initSpeed = 780; // R3F config
+	};
+	class R3F_10Rnd_127x99_M107: CA_magazine {
+		initSpeed = 850; // R3F config
+	};
+	class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 {
+		initSpeed = 850; // R3F config
+	};
+	class R3F_5Rnd_127x99_TAC50: CA_magazine {
+		initSpeed = 820; // R3F config
+	};
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -298,9 +298,9 @@ class CfgWeapons {
             };
 
             class AmmoCoef {
-                hit = 1.0;
+                hit = 1.0; // default "0.8"
                 visibleFire = 0.5;
-                audibleFire = 0.1;
+                audibleFire = 0.1; // default "0.3"
                 visibleFireTime = 0.5;
                 audibleFireTime = 0.5;
                 cost = 1.0;
@@ -309,11 +309,11 @@ class CfgWeapons {
             };
 
             class MuzzleCoef {
-                dispersionCoef = "0.95f";
+                dispersionCoef = "0.95f"; // default "0.8f"
                 artilleryDispersionCoef = "1.0f";
-                fireLightCoef = "0.5f";
-                recoilCoef = "0.95f";
-                recoilProneCoef = "0.95f";
+                fireLightCoef = "0.5f"; // default "0.1f"
+                recoilCoef = "0.95f"; // default "1.0f"
+                recoilProneCoef = "0.95f"; // default "1.0f"
                 minRangeCoef = "1.0f";
                 minRangeProbabCoef = "1.0f";
                 midRangeCoef = "1.0f";

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -142,13 +142,13 @@ class CfgWeapons {
         ACE_barrelTwist = 250.0;
         ACE_barrelLength = 125.0;
         muzzles[] = {"this"};
-        initSpeed = 350; // default 410
+        initSpeed = -1.0; // default 410
     };
     class R3F_HKUSP: Pistol_Base_F {
         ACE_barrelTwist = 250.0;
         ACE_barrelLength = 121.0;
         muzzles[] = {"this"};
-        initSpeed = 350; // default 410
+        initSpeed = -1.0; // default 410
     };   
     class ItemCore;
     class InventoryOpticsItem_Base_F;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -74,11 +74,13 @@ class CfgWeapons {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 347.98;
         muzzles[] = {"this"};
+        initSpeed = 915; // R3F config
     };
     class R3F_Minimi_762: R3F_Minimi {
         ACE_RailHeightAboveBore = 4.0;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 502.92;
+        initSpeed = 820; // R3F config
     };
     class R3F_SIG551: Rifle_Base_F {
         ACE_RailHeightAboveBore = 4.2;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -10,23 +10,23 @@ class CfgWeapons {
         muzzles[] = {"this"};
     };
     class R3F_Famas_F1_M203: R3F_Famas_F1 {
-		muzzles[] = {"this","Lance_Grenades"};
-	};
+        muzzles[] = {"this","Lance_Grenades"};
+    };
     class R3F_Famas_surb: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 5.4;
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 450.0; // Beretta barrel
     };
     class R3F_Famas_surb_M203: R3F_Famas_surb {
-		muzzles[] = {"this","Lance_Grenades"};
-	};
+        muzzles[] = {"this","Lance_Grenades"};
+    };
     class R3F_Famas_G2: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 10.6;
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 488.0;
     };
     class R3F_Famas_G2_M203: R3F_Famas_G2 {
-		muzzles[] = {"this","Lance_Grenades"};
+        muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_Famas_felin: R3F_Famas_G2 {
         ACE_RailHeightAboveBore = 5.4;
@@ -114,8 +114,8 @@ class CfgWeapons {
         muzzles[] = {"this"};
     };
     class R3F_HK416M_M203: R3F_HK416M {
-		muzzles[] = {"this","Lance_Grenades"};
-	};
+        muzzles[] = {"this","Lance_Grenades"};
+    };
     class R3F_HK416M_HG: R3F_HK416M {};
     class R3F_HK416S_HG: R3F_HK416M_HG {
         ACE_RailHeightAboveBore = 3.4;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -5,60 +5,75 @@ class CfgWeapons {
     class Rifle_Base_F;
     class R3F_Famas_F1: Rifle_Base_F {
         ACE_RailHeightAboveBore = 10.6;
-        ACE_barrelTwist = 304.8; // 12"
+        ACE_barrelTwist = 304.8; // 1:12"
         ACE_barrelLength = 488.0;
+        muzzles[] = {"this"};
     };
+    class R3F_Famas_F1_M203: R3F_Famas_F1 {
+		muzzles[] = {"this","Lance_Grenades"};
+	};
     class R3F_Famas_surb: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 5.4;
-        ACE_barrelTwist = 228.6; // 9"
+        ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 450.0; // Beretta barrel
     };
+    class R3F_Famas_surb_M203: R3F_Famas_surb {
+		muzzles[] = {"this","Lance_Grenades"};
+	};
     class R3F_Famas_G2: R3F_Famas_F1 {
         ACE_RailHeightAboveBore = 10.6;
-        ACE_barrelTwist = 228.6; // 9"
+        ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 488.0;
+    };
+    class R3F_Famas_G2_M203: R3F_Famas_G2 {
+		muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_Famas_felin: R3F_Famas_G2 {
         ACE_RailHeightAboveBore = 5.4;
-        ACE_barrelTwist = 177.8; // 7"
+        ACE_barrelTwist = 177.8; // 1:7"
         ACE_barrelLength = 450.0; // Beretta barrel
     };
     class R3F_FRF2: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.2;
-        ACE_barrelTwist = 304.8;
+        ACE_barrelTwist = 294.6;
         ACE_barrelLength = 650.0;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; // 1 MOA
+            dispersion = 0.00029; // 1 MOA, default 9.9999997e-005
         };
+        muzzles[] = {"this"};
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.0;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; 
+            dispersion = 0.00029; // 1 MOA, default 0.00018
         };
+        muzzles[] = {"this"};
     };
     class R3F_M107: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.6;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029;
+            dispersion = 0.00029; // 1 MOA, default 0.00030
         };
+        muzzles[] = {"this"};
     };
     class R3F_TAC50: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.2;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029;
+            dispersion = 0.00029; // 1 MOA, default 0.00015
         };
+        muzzles[] = {"this"};
     };
     class R3F_Minimi: Rifle_Base_F {
         ACE_RailHeightAboveBore = 4.0;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 347.98;
+        muzzles[] = {"this"};
     };
     class R3F_Minimi_762: R3F_Minimi {
         ACE_RailHeightAboveBore = 4.0;
@@ -69,11 +84,13 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 4.2;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 363.0;
+        muzzles[] = {"this"};
     };
     class R3F_HK417M: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 406.0;
+        muzzles[] = {"this"};
     };
     class R3F_HK417S_HG: R3F_HK417M {
         ACE_RailHeightAboveBore = 3.4;
@@ -85,14 +102,18 @@ class CfgWeapons {
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029;
+            dispersion = 0.00029; // 1 MOA, default 0.00020
         };
     };
     class R3F_HK416M: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.4;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
+        muzzles[] = {"this"};
     };
+    class R3F_HK416M_M203: R3F_HK416M {
+		muzzles[] = {"this","Lance_Grenades"};
+	};
     class R3F_HK416M_HG: R3F_HK416M {};
     class R3F_HK416S_HG: R3F_HK416M_HG {
         ACE_RailHeightAboveBore = 3.4;
@@ -103,11 +124,13 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 4.5;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 144.78;
+        muzzles[] = {"this"};
     };
     class R3F_MP5A5: R3F_MP5SD {
         ACE_RailHeightAboveBore = 4.5;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 226.06;
+        muzzles[] = {"this"};
     };
     class R3F_M4S90: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.2;
@@ -118,10 +141,14 @@ class CfgWeapons {
     class R3F_PAMAS: Pistol_Base_F {
         ACE_barrelTwist = 250.0;
         ACE_barrelLength = 125.0;
+        muzzles[] = {"this"};
+        initSpeed = 350; // default 410
     };
     class R3F_HKUSP: Pistol_Base_F {
         ACE_barrelTwist = 250.0;
         ACE_barrelLength = 121.0;
+        muzzles[] = {"this"};
+        initSpeed = 350; // default 410
     };   
     class ItemCore;
     class InventoryOpticsItem_Base_F;
@@ -183,6 +210,7 @@ class CfgWeapons {
         };
     };
     class R3F_J10: ItemCore {
+        ACE_ScopeZeroRange = 1400; // Inaccurate reticle, designed to work with the vanilla ballistic.
         ACE_ScopeHeightAboveRail = 4.4;
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
@@ -259,5 +287,102 @@ class CfgWeapons {
     };
     class R3F_OB50: ItemCore {
         ACE_ScopeHeightAboveRail = 4.0;
+    };
+    class InventoryMuzzleItem_Base_F;
+    class R3F_SILENCIEUX_HK416: ItemCore {
+        class ItemInfo: InventoryMuzzleItem_Base_F {
+            class MagazineCoef {
+                initSpeed = 1.0;
+            };
+
+            class AmmoCoef {
+                hit = 1.0;
+                visibleFire = 0.5;
+                audibleFire = 0.1;
+                visibleFireTime = 0.5;
+                audibleFireTime = 0.5;
+                cost = 1.0;
+                typicalSpeed = 1.0;
+                airFriction = 1.0;
+            };
+
+            class MuzzleCoef {
+                dispersionCoef = "0.95f";
+                artilleryDispersionCoef = "1.0f";
+                fireLightCoef = "0.5f";
+                recoilCoef = "0.95f";
+                recoilProneCoef = "0.95f";
+                minRangeCoef = "1.0f";
+                minRangeProbabCoef = "1.0f";
+                midRangeCoef = "1.0f";
+                midRangeProbabCoef = "1.0f";
+                maxRangeCoef = "1.0f";
+                maxRangeProbabCoef = "1.0f";
+            };
+        };
+    };
+    class R3F_SILENCIEUX_HK417: ItemCore {
+        class ItemInfo: InventoryMuzzleItem_Base_F {
+            class MagazineCoef {
+                initSpeed = 1.0;
+            };
+
+            class AmmoCoef {
+                hit = 1.0;
+                visibleFire = 0.5;
+                audibleFire = 0.1;
+                visibleFireTime = 0.5;
+                audibleFireTime = 0.5;
+                cost = 1.0;
+                typicalSpeed = 1.0;
+                airFriction = 1.0;
+            };
+
+            class MuzzleCoef {
+                dispersionCoef = "0.95f";
+                artilleryDispersionCoef = "1.0f";
+                fireLightCoef = "0.5f";
+                recoilCoef = "0.95f";
+                recoilProneCoef = "0.95f";
+                minRangeCoef = "1.0f";
+                minRangeProbabCoef = "1.0f";
+                midRangeCoef = "1.0f";
+                midRangeProbabCoef = "1.0f";
+                maxRangeCoef = "1.0f";
+                maxRangeProbabCoef = "1.0f";
+            };
+        };
+    };
+    class R3F_SILENCIEUX_FRF2: ItemCore {
+        class ItemInfo: InventoryMuzzleItem_Base_F {
+            class MagazineCoef {
+                initSpeed = 1.0;
+            };
+
+            class AmmoCoef {
+                hit = 1.0;
+                visibleFire = 0.5;
+                audibleFire = 0.1;
+                visibleFireTime = 0.5;
+                audibleFireTime = 0.5;
+                cost = 1.0;
+                typicalSpeed = 1.0;
+                airFriction = 1.0;
+            };
+
+            class MuzzleCoef {
+                dispersionCoef = "0.95f";
+                artilleryDispersionCoef = "1.0f";
+                fireLightCoef = "0.5f";
+                recoilCoef = "0.95f";
+                recoilProneCoef = "0.95f";
+                minRangeCoef = "1.0f";
+                minRangeProbabCoef = "1.0f";
+                midRangeCoef = "1.0f";
+                midRangeProbabCoef = "1.0f";
+                maxRangeCoef = "1.0f";
+                maxRangeProbabCoef = "1.0f";
+            };
+        };
     };
 };

--- a/optionals/compat_r3f/config.cpp
+++ b/optionals/compat_r3f/config.cpp
@@ -15,4 +15,5 @@ class CfgPatches {
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"

--- a/optionals/compat_r3f/script_component.hpp
+++ b/optionals/compat_r3f/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT compat_r3f
-#define COMPONENT_BEAUTIFIED R3F Compatibilty
+#define COMPONENT_BEAUTIFIED R3F Compatibility
 
 #include "\z\ace\addons\main\script_mod.hpp"
 


### PR DESCRIPTION
- Change to G1 BC (AtragMx values) for the 5.56x45 and 7.62x51 bullets (G7 BC).
- Remove the R3F safety and the ghost "R3F_securite_mag", redondant with the ACE3 Safe Mode.
- ACE3 values for all RF3 suppressors.
- Adjustment between R3F `typicalSpeed`, `initSpeed` and ACE3 `airFriction` (playability for all players : AB and non-AB users and ballistically better).
- Minors updates.
