### PR TITLE
Fix Load Patient/Captive actions

### DIFF
--- a/addons/captives/CfgEventHandlers.hpp
+++ b/addons/captives/CfgEventHandlers.hpp
@@ -63,3 +63,11 @@ class Extended_Local_EventHandlers {
         };
     };
 };
+
+class Extended_Killed_EventHandlers {
+    class CAManBase {
+        class ADDON {
+            killed = QUOTE(_this call FUNC(handleKilled));
+        };
+    };
+};

--- a/addons/captives/XEH_PREP.hpp
+++ b/addons/captives/XEH_PREP.hpp
@@ -1,4 +1,3 @@
-
 PREP(canApplyHandcuffs);
 PREP(canEscortCaptive);
 PREP(canFriskPerson);
@@ -18,6 +17,7 @@ PREP(handleAnimChangedHandcuffed);
 PREP(handleAnimChangedSurrendered);
 PREP(handleGetIn);
 PREP(handleGetOut);
+PREP(handleKilled);
 PREP(handleLocal);
 PREP(handleOnUnconscious);
 PREP(handlePlayerChanged);

--- a/addons/captives/functions/fnc_canLoadCaptive.sqf
+++ b/addons/captives/functions/fnc_canLoadCaptive.sqf
@@ -19,6 +19,9 @@
 
 params ["_unit", "_target","_vehicle"];
 
+// Don't show "Load Captive" if unit is unconscious (already has "Load Patient")
+if (_target getVariable ["ACE_isUnconscious", false]) exitWith {false};
+
 if ((isNull _target) && {_unit getVariable [QGVAR(isEscorting), false]}) then {
     //Looking at a vehicle while escorting, get target from attached objects:
     {

--- a/addons/captives/functions/fnc_canUnloadCaptive.sqf
+++ b/addons/captives/functions/fnc_canUnloadCaptive.sqf
@@ -18,4 +18,5 @@
 
 params ["_player", "_unit"];
 
-((vehicle _unit) != _unit) && {_unit getVariable [QGVAR(isHandcuffed), false]}
+// Don't show "Unload Captive" if unit is unconscious (already has "Unload Patient")
+(vehicle _unit != _unit) && {_unit getVariable [QGVAR(isHandcuffed), false]} && {!(_unit getVariable ["ACE_isUnconscious", false])}

--- a/addons/captives/functions/fnc_canUnloadCaptive.sqf
+++ b/addons/captives/functions/fnc_canUnloadCaptive.sqf
@@ -19,4 +19,4 @@
 params ["_player", "_unit"];
 
 // Don't show "Unload Captive" if unit is unconscious (already has "Unload Patient")
-(vehicle _unit != _unit) && {_unit getVariable [QGVAR(isHandcuffed), false]} && {!(_unit getVariable ["ACE_isUnconscious", false])}
+(vehicle _unit != _unit) && {vehicle _player == _player} && {_unit getVariable [QGVAR(isHandcuffed), false]} && {!(_unit getVariable ["ACE_isUnconscious", false])}

--- a/addons/captives/functions/fnc_handleKilled.sqf
+++ b/addons/captives/functions/fnc_handleKilled.sqf
@@ -1,0 +1,23 @@
+/*
+ * Author: Jonpas
+ * Called when a unit dies.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [bob] call ace_captives_fnc_handleKilled
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit"];
+
+// Remove handcuffs on a dead unit, removing them after unit goes into ragdoll causes a stand-up twitch and restarts the ragdoll
+if (_unit getVariable [QGVAR(isHandcuffed), false]) then {
+    [_unit, false] call FUNC(setHandcuffed);
+};

--- a/addons/captives/functions/fnc_handleKilled.sqf
+++ b/addons/captives/functions/fnc_handleKilled.sqf
@@ -16,6 +16,7 @@
 #include "script_component.hpp"
 
 params ["_unit"];
+TRACE_1("handleKilled",_unit);
 
 // Remove handcuffs on a dead unit, removing them after unit goes into ragdoll causes a stand-up twitch and restarts the ragdoll
 if (_unit getVariable [QGVAR(isHandcuffed), false]) then {

--- a/addons/captives/functions/fnc_handleRespawn.sqf
+++ b/addons/captives/functions/fnc_handleRespawn.sqf
@@ -17,6 +17,7 @@
 #include "script_component.hpp"
 
 params ["_unit","_dead"];
+TRACE_2("handleRespawn",_unit,_dead);
 
 if (!local _unit) exitWith {};
 

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -545,8 +545,8 @@ class CfgVehicles {
                 class GVAR(loadPatient) {
                     displayName = CSTRING(LoadPatient);
                     distance = 5;
-                    condition = QUOTE(_target getVariable[ARR_2(QUOTE(QUOTE(ACE_isUnconscious)),false)] && vehicle _target == _target);
-                    statement = QUOTE([ARR_2(_player, _target)] call DFUNC(actionLoadUnit));
+                    condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {alive _target} && {vehicle _target == _target});
+                    statement = QUOTE(call DFUNC(actionLoadUnit));
                     showDisabled = 0;
                     priority = 2;
                     icon = QPATHTOF(UI\icons\medical_cross.paa);
@@ -555,8 +555,8 @@ class CfgVehicles {
                 class GVAR(UnLoadPatient) {
                     displayName = CSTRING(UnloadPatient);
                     distance = 5;
-                    condition = QUOTE(_target getVariable[ARR_2(QUOTE(QUOTE(ACE_isUnconscious)),false)] && vehicle _target != _target);
-                    statement = QUOTE([ARR_2(_player, _target)] call DFUNC(actionUnloadUnit));
+                    condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {alive _target} && {vehicle _target != _target});
+                    statement = QUOTE(call DFUNC(actionUnloadUnit));
                     showDisabled = 0;
                     priority = 2;
                     icon = QPATHTOF(UI\icons\medical_cross.paa);

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -555,7 +555,7 @@ class CfgVehicles {
                 class GVAR(UnLoadPatient) {
                     displayName = CSTRING(UnloadPatient);
                     distance = 5;
-                    condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {vehicle _target != _target});
+                    condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {vehicle _target != _target} && {vehicle _player == _player});
                     statement = QUOTE([ARR_2(_player, _target)] call DFUNC(actionUnloadUnit));
                     showDisabled = 0;
                     priority = 2;

--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -546,7 +546,7 @@ class CfgVehicles {
                     displayName = CSTRING(LoadPatient);
                     distance = 5;
                     condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {alive _target} && {vehicle _target == _target});
-                    statement = QUOTE(call DFUNC(actionLoadUnit));
+                    statement = QUOTE([ARR_2(_player, _target)] call DFUNC(actionLoadUnit));
                     showDisabled = 0;
                     priority = 2;
                     icon = QPATHTOF(UI\icons\medical_cross.paa);
@@ -555,8 +555,8 @@ class CfgVehicles {
                 class GVAR(UnLoadPatient) {
                     displayName = CSTRING(UnloadPatient);
                     distance = 5;
-                    condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {alive _target} && {vehicle _target != _target});
-                    statement = QUOTE(call DFUNC(actionUnloadUnit));
+                    condition = QUOTE(_target getVariable [ARR_2(QUOTE(QUOTE(ACE_isUnconscious)), false)] && {vehicle _target != _target});
+                    statement = QUOTE([ARR_2(_player, _target)] call DFUNC(actionUnloadUnit));
                     showDisabled = 0;
                     priority = 2;
                     icon = QPATHTOF(UI\icons\medical_cross.paa);


### PR DESCRIPTION
**When merged this pull request will:**
- Disable "Load Patient" action if unit is dead but was unconscious before (we don't want loading of dead units do their weirdness) - `ACE_isUnconscious` flag doesn't get reset on death
- Remove handcuffs on death to prevent ability to remove them later which causes the unit to stand up and run the ragdoll again (looks quite hilarious though)
- Change "Load Captive" to show only if unit is not unconscious ("Load Patient" and "Load Captive" do the same thing and it's easier to notice someone is unconscious)
- Disable "Unload Patient" action when inside a vehicle - fix #5525 (more of a bandaid, but it makes more sense anyways)