### PR TITLE
Add ace_common_fnc_getPylonTurret func

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -67,6 +67,7 @@ PREP(getMGRSdata);
 PREP(getName);
 PREP(getNumberMagazinesIn);
 PREP(getPitchBankYaw);
+PREP(getPylonTurret);
 PREP(getSettingData);
 PREP(getStaminaBarControl);
 PREP(getTargetAzimuthAndInclination);

--- a/addons/common/functions/fnc_getPylonTurret.sqf
+++ b/addons/common/functions/fnc_getPylonTurret.sqf
@@ -1,13 +1,13 @@
 /*
  * Author: PabstMirror
- * Finds turret owner of a pylon
+ * Finds turret owner of a pylon.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
  * 1: Pylon Index (starting at 0) <NUMBER>
  *
  * Return Value:
- * <ARRAY> (turret Index, either [-1] or [0])
+ * * Turret index (either [-1] or [0]) <ARRAY>
  *
  * Example:
  * [cursorObject, 0] call ace_common_fnc_getPylonTurret
@@ -24,13 +24,13 @@ private _pylonTurrets = _vehicle getVariable ["ace_pylonTurrets", []];
 private _returnValue = _pylonTurrets param [_pylonIndex, []];
 
 if (!(_returnValue isEqualTo [])) then {
-    TRACE_1("Using ace_pylonTurrets value",_savedValue);
+    TRACE_1("Using ace_pylonTurrets value",_returnValue);
 } else {
     // Attempt to determine turret owner based on magazines in the vehicle
     private _pyMags = getPylonMagazines _vehicle;
     private _pylonConfigs = configProperties [configFile >> "CfgVehicles" >> typeOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"];
-    if (_pylonIndex >= (count _pyMags)) exitWith {ERROR("out of bounds"); []};
-    if (_pylonIndex >= (count _pylonConfigs)) exitWith {ERROR("out of bounds"); []};
+    if (_pylonIndex >= (count _pyMags)) exitWith {ERROR("out of bounds");};
+    if (_pylonIndex >= (count _pylonConfigs)) exitWith {ERROR("out of bounds");};
 
     private _targetMag = _pyMags select _pylonIndex;
     private _inPilot = _targetMag in (_vehicle magazinesTurret [-1]);

--- a/addons/common/functions/fnc_getPylonTurret.sqf
+++ b/addons/common/functions/fnc_getPylonTurret.sqf
@@ -14,7 +14,7 @@
  *
  * Public: No
  */
-#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 params ["_vehicle", "_pylonIndex"];

--- a/addons/common/functions/fnc_getPylonTurret.sqf
+++ b/addons/common/functions/fnc_getPylonTurret.sqf
@@ -1,0 +1,65 @@
+/*
+ * Author: PabstMirror
+ * Finds turret owner of a pylon
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ * 1: Pylon Index (starting at 0) <NUMBER>
+ *
+ * Return Value:
+ * <ARRAY> (turret Index, either [-1] or [0])
+ *
+ * Example:
+ * [cursorObject, 0] call ace_common_fnc_getPylonTurret
+ *
+ * Public: No
+ */
+#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+params ["_vehicle", "_pylonIndex"];
+
+// See if index is in ace_pylonTurrets setVar on vehicle
+private _pylonTurrets = _vehicle getVariable ["ace_pylonTurrets", []];
+private _returnValue = _pylonTurrets param [_pylonIndex, []];
+
+if (!(_returnValue isEqualTo [])) then {
+    TRACE_1("Using ace_pylonTurrets value",_savedValue);
+} else {
+    // Attempt to determine turret owner based on magazines in the vehicle
+    private _pyMags = getPylonMagazines _vehicle;
+    private _pylonConfigs = configProperties [configFile >> "CfgVehicles" >> typeOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"];
+    if (_pylonIndex >= (count _pyMags)) exitWith {ERROR("out of bounds"); []};
+    if (_pylonIndex >= (count _pylonConfigs)) exitWith {ERROR("out of bounds"); []};
+
+    private _targetMag = _pyMags select _pylonIndex;
+    private _inPilot = _targetMag in (_vehicle magazinesTurret [-1]);
+    private _inGunner = _targetMag in (_vehicle magazinesTurret [0]);
+
+    [];
+    if (_inPilot) then {
+        if (_inGunner) then {
+            TRACE_3("ambiguous - in both",_targetMag,_inPilot,_inGunner);
+        } else {
+            TRACE_3("Pilot Mag",_targetMag,_inPilot,_inGunner);
+            _returnValue = [-1];
+        };
+    } else {
+        if (_inGunner) then {
+            TRACE_3("Gunner Mag",_targetMag,_inPilot,_inGunner);
+            _returnValue = [0];
+        } else {
+            TRACE_3("ambiguous - in neither",_targetMag,_inPilot,_inGunner);
+        };
+    };
+
+    if (_returnValue isEqualTo []) then { // If not sure, just use config value
+        _returnValue = getArray ((_pylonConfigs select _pylonIndex) >> "turret");
+        if (_returnValue isEqualTo []) then {
+            _returnValue = [-1];
+        };
+    };
+};
+
+TRACE_3("",_vehicle,_pylonIndex,_returnValue);
+_returnValue

--- a/addons/common/functions/fnc_getPylonTurret.sqf
+++ b/addons/common/functions/fnc_getPylonTurret.sqf
@@ -36,7 +36,6 @@ if (!(_returnValue isEqualTo [])) then {
     private _inPilot = _targetMag in (_vehicle magazinesTurret [-1]);
     private _inGunner = _targetMag in (_vehicle magazinesTurret [0]);
 
-    [];
     if (_inPilot) then {
         if (_inGunner) then {
             TRACE_3("ambiguous - in both",_targetMag,_inPilot,_inGunner);


### PR DESCRIPTION
Needed for ace_pylons and rearm
It can fail if aircraft is configured with same weapon on pilot and gunner but those configurations don't really make any sense and probably won't be an issue.