### PR TITLE
Moves cookoff probability to its configuration module

### DIFF
--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -24,4 +24,10 @@ class ACE_Settings {
         value = 1;
         typeName = "SCALAR";
     };
+    class GVAR(ammoCookoffProbability) {
+        displayName = CSTRING(ammoCookoffProbability_name);
+        description = CSTRING(ammoCookoffProbability_tooltip);
+        value = 0.7;
+        typeName = "SCALAR";
+    };
 };

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -64,9 +64,9 @@ if (_simulationType == "tank") exitWith {
         _hitpoint = "#subturret";
     };
 
-    // ammo was hit, high chance for cook-off
+    // ammo was hit, variable chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
-        if (_damage > 0.5 && {random 1 < 0.7}) then {
+        if (_damage > 0.5 && {random 1 < GVAR(ammoCookoffProbability)}) then {
             _vehicle call FUNC(cookOff);
         };
     } else {

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -104,5 +104,11 @@
             <Chinese>設定彈藥殉爆效果會持續多久時間 [輸入0來關閉殉爆效果]</Chinese>
             <Chinesesimp>设定弹药殉爆效果会持续多久时间 [输入0来关闭殉爆效果]</Chinesesimp>
         </Key>
+		<Key ID="STR_ACE_CookOff_ammoCookoffProbability_name">
+			<English>Ammunition cook off probability</English>
+		</Key>
+		<Key ID="STR_ACE_CookOff_ammoCookoffProbability_tooltip">
+			<English>Chance of a vehicle cooking off when its ammunition stores are hit, from 0.0 to 1.0</English>
+		</Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Move the probability of a vehicle cooking off to the configuration module, allowing it to be changed on a per-mission basis.

Note that this still needs to be tested. Working on setting everything up.
