### PR TITLE
Deprecate isUnderwater (replaced by underwater command from 1.66)

### DIFF
--- a/addons/common/functions/fnc_isUnderwater.sqf
+++ b/addons/common/functions/fnc_isUnderwater.sqf
@@ -15,6 +15,8 @@
  */
 #include "script_component.hpp"
 
+ACE_DEPRECATED(QFUNC(isUnderwater),"3.13.0","underwater OBJECT");
+
 params [["_unit", objNull, [objNull]]];
 
 private _return = false;


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Both check if head is underwater, but from testing command is more precise. It was only made compatible with units in 1.66, so it makes sense why we used our own function before. It is not used anywhere in ACE3 though.