### PR TITLE
Add trip flare to Put muzzle

### DIFF
--- a/addons/explosives/CfgWeapons.hpp
+++ b/addons/explosives/CfgWeapons.hpp
@@ -1,4 +1,13 @@
 class CfgWeapons {
+    class Default;
+    class Put: Default {
+        muzzles[] += {QGVAR(muzzle)};
+        class PutMuzzle: Default{};
+        class GVAR(muzzle): PutMuzzle {
+            magazines[] = {"ACE_FlareTripMine_Mag"};
+        };
+    };
+
     class ACE_ItemCore;
     class CBA_MiscItem_ItemInfo;
 


### PR DESCRIPTION
Muzzle won't be used because explosives has a custom placing engine.
But arsenal needs this to categorize it as an "explosive"

Close #5563
