### PR TITLE
Leave ACE_FCS off by default

### DIFF
--- a/addons/fcs/CfgVehicles.hpp
+++ b/addons/fcs/CfgVehicles.hpp
@@ -47,25 +47,19 @@ class CfgVehicles {
             };
         };
         class Turrets {
-            class MainTurret: NewTurret {
-                GVAR(Enabled) = 1; // all tracked vehicles get one by default
-            };
+            class MainTurret: NewTurret {};
         };
     };
 
     class Tank_F: Tank {
         class Turrets {
-            class MainTurret: NewTurret {
-                GVAR(Enabled) = 1; // all tracked vehicles get one by default
-            };
+            class MainTurret: NewTurret {};
         };
     };
 
     class APC_Tracked_01_base_F: Tank_F {
         class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
-            };
+            class MainTurret: MainTurret {};
         };
     };
 
@@ -86,14 +80,11 @@ class CfgVehicles {
 
     class APC_Tracked_02_base_F: Tank_F {
         class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
-            };
+            class MainTurret: MainTurret {};
         };
     };
 
     class O_APC_Tracked_02_base_F: APC_Tracked_02_base_F {};
-    
     class O_APC_Tracked_02_AA_F: O_APC_Tracked_02_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
@@ -103,38 +94,6 @@ class CfgVehicles {
                 discreteDistance[] = {};
                 discreteDistanceInitIndex = 0;
                 magazines[] += {"ACE_120Rnd_35mm_ABM_shells_Tracer_Green"};
-            };
-        };
-    };
-
-    class APC_Tracked_03_base_F: Tank_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
-            };
-        };
-    };
-
-    class MBT_01_base_F: Tank_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
-            };
-        };
-    };
-
-    class MBT_02_base_F: Tank_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
-            };
-        };
-    };
-    
-    class MBT_03_base_F: Tank_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 0;
             };
         };
     };

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -44,125 +44,23 @@ class CfgVehicles {
 
     class rhs_bmd_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 300;
-        class Turrets: Turrets {
-            class CommanderOptics: NewTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-            class GPMGTurret1: NewTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
     };
     class rhs_bmp1tank_base: Tank_F {
         EGVAR(map,vehicleLightColor)[] = {0,1,0,0.1};
         EGVAR(refuel,fuelCapacity) = 460;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-            class Com_BMP1: NewTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
-    };
-    class rhs_bmp_base: rhs_bmp1tank_base {};
-    class rhs_bmp1_vdv: rhs_bmp_base {};
-    class rhs_bmp2e_vdv : rhs_bmp1_vdv {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics : CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                };
-            };
-        };
     };
     class rhs_bmp3tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 460;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                };
-            };
-            class GPMGTurret1: NewTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
     };
     class rhs_btr_base: Wheeled_APC_F {
         EGVAR(map,vehicleLightColor)[] = {0,0,1,0.1};
         EGVAR(refuel,fuelCapacity) = 300;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret  {
-                EGVAR(fcs,enabled) = 0;
-            };
-            class CommanderOptics: CommanderOptics {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
     };
     class rhs_a3spruttank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 400;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics
-                    {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                };
-            };
-        };
-    };
-    class rhs_bmd4_vdv: rhs_a3spruttank_base {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
-            class GPMGTurret1: NewTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
-    };
-    class rhs_bmd4m_vdv: rhs_bmd4_vdv {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
-            class GPMGTurret1: GPMGTurret1 {};
-            class GPMGTurret2: GPMGTurret1 {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
     };
     class rhs_a3t72tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 1200;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                    class CommanderMG: CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                };
-            };
-        };
     };
     class rhs_t72bb_tv: rhs_a3t72tank_base {
         ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
@@ -178,43 +76,17 @@ class CfgVehicles {
             ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint"}}};
         };
     };
-    class rhs_t90_tv: rhs_t72bd_tv {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                };
-            };
-        };
-    };
     class rhs_tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 1200;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                    class CommanderMG: CommanderOptics {
-                        EGVAR(fcs,enabled) = 0;
-                    };
-                };
-            };
-        };
     };
 
     class rhs_infantry_msv_base;
-    class rhs_pilot_base : rhs_infantry_msv_base
-    {
+    class rhs_pilot_base: rhs_infantry_msv_base {
         ace_gforcecoef = 0.55;
     };
 
     class O_Plane_CAS_02_F;
-    class RHS_su25_base : O_Plane_CAS_02_F {
+    class RHS_su25_base: O_Plane_CAS_02_F {
         EGVAR(refuel,fuelCapacity) = 3600;
     };
 
@@ -222,7 +94,7 @@ class CfgVehicles {
         class EventHandlers;
     };
     class Heli_Light_02_base_F: Helicopter_Base_H {};
-    class RHS_Mi8_base : Heli_Light_02_base_F {
+    class RHS_Mi8_base: Heli_Light_02_base_F {
         EGVAR(map,vehicleLightColor)[] = {1,0,0,0.1};
         EGVAR(refuel,fuelCapacity) = 3700;
         EGVAR(fastroping,enabled) = 0;
@@ -277,33 +149,33 @@ class CfgVehicles {
     class rhs_mi28_base: Heli_Attack_02_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
+                EGVAR(fcs,enabled) = 0; // Note: This is still required because of inheritance from Heli_Attack_02_base_F
             };
         };
     };
 
-    class RHS_Ka52_base : Heli_Attack_02_base_F {
+    class RHS_Ka52_base: Heli_Attack_02_base_F {
         EGVAR(refuel,fuelCapacity) = 1870;
         EGVAR(fastroping,enabled) = 0;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
+                EGVAR(fcs,enabled) = 0; // Note: This is still required because of inheritance from Heli_Attack_02_base_F
             };
         };
     };
 
-    class RHS_Mi24_base : Heli_Attack_02_base_F {
+    class RHS_Mi24_base: Heli_Attack_02_base_F {
         EGVAR(map,vehicleLightColor)[] = {1,0,0,0.1};
         EGVAR(refuel,fuelCapacity) = 1851;
         EGVAR(fastroping,enabled) = 0;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
+                EGVAR(fcs,enabled) = 0; // Note: This is still required because of inheritance from Heli_Attack_02_base_F
             };
         };
     };
 
-    class rhs_t80b : rhs_tank_base {
+    class rhs_t80b: rhs_tank_base {
         EGVAR(refuel,fuelCapacity) = 1100;
     };
     class rhs_t80bv: rhs_t80b {
@@ -325,7 +197,7 @@ class CfgVehicles {
         EGVAR(refuel,fuelCargo) = 10000;
     };
 
-    class rhs_truck : Truck_F {
+    class rhs_truck: Truck_F {
         EGVAR(refuel,fuelCapacity) = 210;
     };
 
@@ -341,12 +213,12 @@ class CfgVehicles {
     };
 
     class MRAP_02_base_F;
-    class rhs_tigr_base : MRAP_02_base_F {
+    class rhs_tigr_base: MRAP_02_base_F {
         EGVAR(refuel,fuelCapacity) = 138;
     };
 
     class Offroad_01_base_f;
-    class RHS_UAZ_Base : Offroad_01_base_f {
+    class RHS_UAZ_Base: Offroad_01_base_f {
         EGVAR(refuel,fuelCapacity) = 78;
     };
 
@@ -356,38 +228,27 @@ class CfgVehicles {
         };
     };
 
-    class rhs_zsutank_base : APC_Tracked_02_base_F {
+    class rhs_zsutank_base: APC_Tracked_02_base_F {
         EGVAR(refuel,fuelCapacity) = 515;
-
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
     };
 
-    class rhs_btr60_base : rhs_btr_base {
+    class rhs_btr60_base: rhs_btr_base {
         EGVAR(refuel,fuelCapacity) = 290;
     };
-    class rhs_btr70_vmf : rhs_btr_base {
+    class rhs_btr70_vmf: rhs_btr_base {
         EGVAR(refuel,fuelCapacity) = 350;
     };
 
-    class rhs_btr70_msv : rhs_btr70_vmf {};
-    class rhs_btr80_msv : rhs_btr70_msv {
+    class rhs_btr70_msv: rhs_btr70_vmf {};
+    class rhs_btr80_msv: rhs_btr70_msv {
         EGVAR(refuel,fuelCapacity) = 300;
     };
 
-    class rhs_2s3tank_base : Tank_F {
+    class rhs_2s3tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 830;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0;
-            };
-        };
     };
 
-    class OTR21_Base : Truck_F {
+    class OTR21_Base: Truck_F {
         EGVAR(refuel,fuelCapacity) = 500;
     };
 };

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -47,19 +47,6 @@ class CfgVehicles {
     class MBT_01_base_F: Tank_F {};
     class rhsusf_m1a1tank_base: MBT_01_base_F {
         EGVAR(refuel,fuelCapacity) = 1909;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                ace_fcs_Enabled = 0;
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {
-                        ace_fcs_Enabled = 0;
-                    };
-                    class Loader: CommanderOptics {
-                        ace_fcs_Enabled = 0;
-                    };
-                };
-            };
-        };
     };
     class rhsusf_m1a1aim_tuski_wd: rhsusf_m1a1tank_base {
         ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
@@ -205,7 +192,7 @@ class CfgVehicles {
     class RHS_AH1Z: RHS_AH1Z_base {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                ace_fcs_Enabled = 0;
+                ace_fcs_Enabled = 0; // Note: This is still required because of inheritance from Heli_Attack_01_base_F
             };
         };
     };
@@ -215,7 +202,7 @@ class CfgVehicles {
     class RHS_AH64D: RHS_AH64_base {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                ace_fcs_Enabled = 0;
+                ace_fcs_Enabled = 0; // Note: This is still required because of inheritance from Heli_Attack_01_base_F
             };
         };
     };
@@ -289,11 +276,6 @@ class CfgVehicles {
     class rhsusf_m113tank_base: APC_Tracked_02_base_F {
         EGVAR(map,vehicleLightColor)[] = {0,1,0,0.1};
         EGVAR(refuel,fuelCapacity) = 360;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                ace_fcs_Enabled = 0;
-            };
-        };
     };
 
     class rhsusf_m113_usarmy: rhsusf_m113tank_base {};


### PR DESCRIPTION
Ref last FCS PR: #5152

Will no longer be enabled by default for `Tank_F`
Mod makers can still enable with `ace_fnc_enabled`