### PR TITLE
Cook-off probability and cook-off tweaks

### DIFF
--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -24,10 +24,10 @@ class ACE_Settings {
         value = 1;
         typeName = "SCALAR";
     };
-    class GVAR(probability) {
-        displayName = CSTRING(probability_name);
-        description = CSTRING(probability_tooltip);
-        value = 0.4;
+    class GVAR(probabilityCoef) {
+        displayName = CSTRING(probabilityCoef_name);
+        description = CSTRING(probabilityCoef_tooltip);
+        value = 1;
         typeName = "SCALAR";
     };
 };

--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -24,9 +24,9 @@ class ACE_Settings {
         value = 1;
         typeName = "SCALAR";
     };
-    class GVAR(cookoffProbability) {
-        displayName = CSTRING(cookoffProbability_name);
-        description = CSTRING(cookoffProbability_tooltip);
+    class GVAR(probability) {
+        displayName = CSTRING(probability_name);
+        description = CSTRING(probability_tooltip);
         value = 0.4;
         typeName = "SCALAR";
     };

--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -24,4 +24,10 @@ class ACE_Settings {
         value = 1;
         typeName = "SCALAR";
     };
+    class GVAR(cookoffProbability) {
+        displayName = CSTRING(cookoffProbability_name);
+        description = CSTRING(cookoffProbability_tooltip);
+        value = 0.4;
+        typeName = "SCALAR";
+    };
 };

--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -37,6 +37,7 @@ class CfgVehicles {
     class Tank_F: Tank {
         GVAR(ammoLocation) = "HitHull";
         GVAR(cookoffSelections)[] = {"poklop_gunner","poklop_commander"};
+        GVAR(cookoffProbability) = 0.5;
     };
     class MBT_02_base_F: Tank_F {
         GVAR(ammoLocation) = "HitTurret";
@@ -46,6 +47,7 @@ class CfgVehicles {
     class Wheeled_APC_F: Car_F {
         GVAR(ammoLocation) = "HitHull";
         GVAR(cookoffSelections)[] = {"poklop_gunner","poklop_commander"};
+        GVAR(cookoffProbability) = 0.8;
 
         // big explosions for wheeled APCs (same as for tanks)
         explosionEffect = "FuelExplosionBig";

--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -37,7 +37,7 @@ class CfgVehicles {
     class Tank_F: Tank {
         GVAR(ammoLocation) = "HitHull";
         GVAR(cookoffSelections)[] = {"poklop_gunner","poklop_commander"};
-        GVAR(cookoffProbability) = 0.5;
+        GVAR(probability) = 0.5;
     };
     class MBT_02_base_F: Tank_F {
         GVAR(ammoLocation) = "HitTurret";
@@ -47,7 +47,7 @@ class CfgVehicles {
     class Wheeled_APC_F: Car_F {
         GVAR(ammoLocation) = "HitHull";
         GVAR(cookoffSelections)[] = {"poklop_gunner","poklop_commander"};
-        GVAR(cookoffProbability) = 0.8;
+        GVAR(probability) = 0.8;
 
         // big explosions for wheeled APCs (same as for tanks)
         explosionEffect = "FuelExplosionBig";

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -69,7 +69,7 @@ if (_simulationType == "tank") exitWith {
         // get cookoff probability for vehicle
         private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", 0.7] call CBA_fnc_getConfigEntry;
         // probability multiplied by coef for global probability control (higher coef = more probable cookoff)
-        if (_damage > 0.1 && {random 1 < (_probability * GVAR(probabilityCoef))}) then {
+        if (_damage > 0.5 && {random 1 < (_probability * GVAR(probabilityCoef))}) then {
             _vehicle call FUNC(cookOff);
         };
     } else {

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -67,7 +67,7 @@ if (_simulationType == "tank") exitWith {
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
         // get cookoff probability for vehicle (default to global setting if not found)
-        private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(cookoffProbability), "number", GVAR(cookoffProbability)] call CBA_fnc_getConfigEntry;
+        private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", GVAR(probability)] call CBA_fnc_getConfigEntry;
         if (_damage > 0.1 && {random 1 < _probability}) then {
             _vehicle call FUNC(cookOff);
         };

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -66,17 +66,18 @@ if (_simulationType == "tank") exitWith {
 
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
-        // get cookoff probability for vehicle
-        private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", 0.7] call CBA_fnc_getConfigEntry;
-        // probability multiplied by coef for global probability control (higher coef = more probable cookoff)
-        if (GVAR(probabilityCoef) > 1) then {
-            _probability = 1 - (1 - _probability) / GVAR(probabilityCoef);
-        } else {
-            _probability = _probability * GVAR(probabilityCoef);
-        };
-
-        if (_damage > 0.5 && {random 1 < _probability}) then {
-            _vehicle call FUNC(cookOff);
+        if (_damage > 0.5) then {
+            // get cookoff probability for vehicle
+            private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", 0.7] call CBA_fnc_getConfigEntry;
+            // probability multiplied by coef for global probability control (higher coef = more probable cookoff)
+            if (GVAR(probabilityCoef) > 1) then {
+                _probability = 1 - (1 - _probability) / GVAR(probabilityCoef);
+            } else {
+                _probability = _probability * GVAR(probabilityCoef);
+            };
+            if (random 1 < _probability) then {
+                _vehicle call FUNC(cookOff);
+            };
         };
     } else {
         if (_hitpoint in ["hithull", "hitturret", "#structural"] && {_newDamage > 0.8 + random 0.2}) then {

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -46,7 +46,7 @@ private _newDamage = _damage - _oldDamage;
 // because the config version ignores the return value completely
 if (_simulationType == "car") exitWith {
     // prevent destruction, let cook-off handle it if necessary
-    if (_hitpoint in ["hithull", "hitfuel", "#structural"] && {!IS_EXPLOSIVE_AMMO(_ammo)}) then {
+    if (_hitpoint in ["hithull", "#structural"] && {!IS_EXPLOSIVE_AMMO(_ammo)}) then {
         _damage min 0.89
     } else {
         if (_hitpoint isEqualTo "hitengine" && {_damage > 0.9}) then {
@@ -66,17 +66,23 @@ if (_simulationType == "tank") exitWith {
 
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
-        if (_damage > 0.5 && {random 1 < 0.7}) then {
+        // get cookoff probability for vehicle (default to global setting)
+        private _probability = if (isNumber (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(cookoffProbability))) then {
+            getNumber (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(cookoffProbability))
+        } else {
+            GVAR(cookoffProbability)
+        };
+        if (_damage > 0.1 && {random 1 < _probability}) then {
             _vehicle call FUNC(cookOff);
         };
     } else {
-        if (_hitpoint in ["hithull", "hitturret", "#structural"] && {_newDamage > 0.6 + random 0.3}) then {
-            _vehicle call FUNC(cookOff);
+        if (_hitpoint in ["hithull", "hitturret", "#structural"] && {_newDamage > 0.8 + random 0.2}) then {
+            _vehicle setDamage 1;
         };
     };
 
     // prevent destruction, let cook-off handle it if necessary
-    if (_hitpoint in ["hithull", "hitfuel", "#structural"]) then {
+    if (_hitpoint in ["hithull", "#structural"]) then {
         _damage min 0.89
     } else {
         _damage

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -69,7 +69,13 @@ if (_simulationType == "tank") exitWith {
         // get cookoff probability for vehicle
         private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", 0.7] call CBA_fnc_getConfigEntry;
         // probability multiplied by coef for global probability control (higher coef = more probable cookoff)
-        if (_damage > 0.5 && {random 1 < (_probability * GVAR(probabilityCoef))}) then {
+        if (GVAR(probabilityCoef) > 1) then {
+            _probability = 1 - (1 - _probability) / GVAR(probabilityCoef);
+        } else {
+            _probability = _probability * GVAR(probabilityCoef);
+        };
+
+        if (_damage > 0.5 && {random 1 < _probability}) then {
             _vehicle call FUNC(cookOff);
         };
     } else {

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -46,7 +46,7 @@ private _newDamage = _damage - _oldDamage;
 // because the config version ignores the return value completely
 if (_simulationType == "car") exitWith {
     // prevent destruction, let cook-off handle it if necessary
-    if (_hitpoint in ["hithull", "#structural"] && {!IS_EXPLOSIVE_AMMO(_ammo)}) then {
+    if (_hitpoint in ["hithull", "hitfuel", "#structural"] && {!IS_EXPLOSIVE_AMMO(_ammo)}) then {
         _damage min 0.89
     } else {
         if (_hitpoint isEqualTo "hitengine" && {_damage > 0.9}) then {
@@ -79,7 +79,7 @@ if (_simulationType == "tank") exitWith {
     };
 
     // prevent destruction, let cook-off handle it if necessary
-    if (_hitpoint in ["hithull", "#structural"]) then {
+    if (_hitpoint in ["hithull", "hitfuel", "#structural"]) then {
         _damage min 0.89
     } else {
         _damage

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -66,12 +66,8 @@ if (_simulationType == "tank") exitWith {
 
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
-        // get cookoff probability for vehicle (default to global setting)
-        private _probability = if (isNumber (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(cookoffProbability))) then {
-            getNumber (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(cookoffProbability))
-        } else {
-            GVAR(cookoffProbability)
-        };
+        // get cookoff probability for vehicle (default to global setting if not found)
+        private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(cookoffProbability), "number", GVAR(cookoffProbability)] call CBA_fnc_getConfigEntry;
         if (_damage > 0.1 && {random 1 < _probability}) then {
             _vehicle call FUNC(cookOff);
         };

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -66,9 +66,10 @@ if (_simulationType == "tank") exitWith {
 
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
-        // get cookoff probability for vehicle (default to global setting if not found)
-        private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", GVAR(probability)] call CBA_fnc_getConfigEntry;
-        if (_damage > 0.1 && {random 1 < _probability}) then {
+        // get cookoff probability for vehicle
+        private _probability = [_vehicle call CBA_fnc_getObjectConfig >> QGVAR(probability), "number", 0.7] call CBA_fnc_getConfigEntry;
+        // probability multiplied by coef for global probability control (higher coef = more probable cookoff)
+        if (_damage > 0.1 && {random 1 < (_probability * GVAR(probabilityCoef))}) then {
             _vehicle call FUNC(cookOff);
         };
     } else {

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -106,6 +106,12 @@
             <Chinese>設定彈藥殉爆效果會持續多久時間 [輸入0來關閉殉爆效果]</Chinese>
             <Chinesesimp>设定弹药殉爆效果会持续多久时间 [输入0来关闭殉爆效果]</Chinesesimp>
             <Korean>쿡오프 지속 시간의 배수 [0 이면 비활성]</Korean>
-        </Key>
+        </Key>        
+		<Key ID="STR_ACE_CookOff_cookoffProbability_name">
+			<English>Cook off probability</English>
+		</Key>
+		<Key ID="STR_ACE_CookOff_cookoffProbability_tooltip">
+			<English>Chance of a vehicle cooking off when hit, from 0.0 to 1.0</English>
+		</Key>
     </Package>
 </Project>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -107,11 +107,11 @@
             <Chinesesimp>设定弹药殉爆效果会持续多久时间 [输入0来关闭殉爆效果]</Chinesesimp>
             <Korean>쿡오프 지속 시간의 배수 [0 이면 비활성]</Korean>
         </Key>        
-		<Key ID="STR_ACE_CookOff_probability_name">
-			<English>Cook off probability</English>
+		<Key ID="STR_ACE_CookOff_probabilityCoef_name">
+			<English>Cook-off probability coefficient</English>
 		</Key>
-		<Key ID="STR_ACE_CookOff_probability_tooltip">
-			<English>Chance of a vehicle cooking off when hit, from 0.0 to 1.0</English>
+		<Key ID="STR_ACE_CookOff_probabilityCoef_tooltip">
+			<English>Multiplier for cook-off probability. Higher value results in higher cook-off probability</English>
 		</Key>
     </Package>
 </Project>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -107,10 +107,10 @@
             <Chinesesimp>设定弹药殉爆效果会持续多久时间 [输入0来关闭殉爆效果]</Chinesesimp>
             <Korean>쿡오프 지속 시간의 배수 [0 이면 비활성]</Korean>
         </Key>        
-		<Key ID="STR_ACE_CookOff_cookoffProbability_name">
+		<Key ID="STR_ACE_CookOff_probability_name">
 			<English>Cook off probability</English>
 		</Key>
-		<Key ID="STR_ACE_CookOff_cookoffProbability_tooltip">
+		<Key ID="STR_ACE_CookOff_probability_tooltip">
 			<English>Chance of a vehicle cooking off when hit, from 0.0 to 1.0</English>
 		</Key>
     </Package>

--- a/docs/wiki/framework/cookoff-framework.md
+++ b/docs/wiki/framework/cookoff-framework.md
@@ -27,3 +27,17 @@ Likewise, cook off can also be disabled for a specific vehicle:
 ```
 VEHICLE setVariable ["ace_cookoff_enable", false, true];
 ```
+
+## 2. Cook off probability
+
+You can set the probability of cook off for individual vehicle types by changing the `ace_cookoff_probability` value in the vehicle's config:
+
+```
+class MyVehicle {
+    ace_cookoff_probability = 0.6;
+};
+```
+
+Global cook off probability can also be adjusted with the `ace_cookoff_probabilityCoef` mission setting.
+
+Higher values will make cook-off more probable, whilst lower values will make cook-off less probable.


### PR DESCRIPTION
**When merged this pull request will:**
- Add cook-off probability for vehicles. Configurable via config value `ace_cookoff_cookoffProbability` for tanks and APCs. ACE setting `ace_cookoff_probabilityCoef ` is used as a multiplier for the probability. Higher values mean cook-off is more likely.
- Probability values (up for discussion, figured tanks less likely to cook-off):
  - `Tank_F: 0.5 (50%)`
  - `Wheeled_APC_F: 0.8 (80%)`
  - `ace_cookoff_probabilityCoef 1 (multiplier)`
- Tweak the way cook-off works somewhat (major impact on end-effect)
  - Increased damage threshold for other hit locations on tanks, but a high enough hit will cause instant destruction. This means high-damage munitions (Javelin, Hellfire, GBU, etc) are capable of instantly destroying heavy armour like they should be able to.