### PR TITLE
Short R3F compat update according with the new AB drag models

### DIFF
--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -3,7 +3,7 @@ class CfgAmmo {
     class BulletBase;
     class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L360
         typicalSpeed = 350; // R3F config
-        airFriction = -0.0019835001; // ACE3 value, default -0.001413
+        airFriction = -0.00201185; // ACE3 value, default -0.001413
         ACE_caliber = 9.017;
         ACE_bulletLength = 15.494;
         ACE_bulletMass = 8.0352;
@@ -17,57 +17,57 @@ class CfgAmmo {
     };
     class R3F_556x45_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L9
         typicalSpeed = 930; // R3F config
-        airFriction = -0.00126466; // ACE3 value, default -0.001625
+        airFriction = -0.00130094; // ACE3 value, default -0.001625
         ACE_caliber = 5.69;
         ACE_bulletLength = 23.012;
         ACE_bulletMass = 4.0176;
         ACE_ammoTempMuzzleVelocityShifts[] = {-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
-        ACE_ballisticCoefficients[] = {0.302}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.151};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
-        ACE_dragModel = 1;
+        ACE_dragModel = 7;
         ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
     class R3F_762x51_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 820; // R3F config
-        airFriction = -0.00100957; // ACE3 value, default -0.001625
+        airFriction = -0.00103711; // ACE3 value, default -0.00095
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.398}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.2};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
-        ACE_dragModel = 1;
+        ACE_dragModel = 7;
         ACE_muzzleVelocities[] = {700, 800, 820, 833, 845};
         ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
     class R3F_762x51_Ball2: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00100957; // ACE3 value, default -0.001625
+        airFriction = -0.00103711; // ACE3 value, default -0.00095
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.398}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.2};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
-        ACE_dragModel = 1;
+        ACE_dragModel = 7;
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {650};
     };
     class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
-        airFriction = -0.00100957; // ACE3 value, default -0.002000
+        airFriction = -0.00103711; // ACE3 value, default -0.002000
     };
     class R3F_127x99_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
-        airFriction = -0.00057503; // ACE3 value, default -0.00086
+        airFriction = -0.00058679; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -76,12 +76,12 @@ class CfgAmmo {
     };
     class R3F_127x99_PEI: R3F_127x99_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 780; // R3F config
-        airFriction = -0.00057503; // ACE3 value, default -0.00086
+        airFriction = -0.00058679; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -90,12 +90,12 @@ class CfgAmmo {
     };
     class R3F_127x99_Ball2: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00057503; // ACE3 value, default -0.00086
+        airFriction = -0.00058679; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -104,12 +104,12 @@ class CfgAmmo {
     };
     class R3F_127x99_PEI2: R3F_127x99_Ball2 { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00057503; // ACE3 value, default -0.00086
+        airFriction = -0.00058679; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
@@ -118,12 +118,12 @@ class CfgAmmo {
     };
     class R3F_127x99_Ball3: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
         typicalSpeed = 820; // R3F config
-        airFriction = -0.00057503; // ACE3 value, default -0.00086
+        airFriction = -0.00058679; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[] = {0.670}; // AtragMx G1 BC
+        ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;


### PR DESCRIPTION
- Revert to the default G7 drag model for the 5.56x45 and 7.62x51 bullets.
- Update all `airFriction ` according with the new ACE3's ones.