### PR TITLE
AB : same values for the both 127x108 bullets

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -553,6 +553,10 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={820};
         ACE_barrelLengths[]={728.98};
     };
+    class B_127x108_APDS: B_127x108_Ball {
+        typicalSpeed = 820;
+        airFriction = -0.00065098;
+    };
     class B_45ACP_Ball : BulletBase {
         airFriction=-0.00081221;
         tracerScale = 0.6;

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -300,6 +300,9 @@ class CfgMagazines {
     };
 
     class 5Rnd_127x108_Mag;
+    class 5Rnd_127x108_APDS_Mag: 5Rnd_127x108_Mag {
+        initSpeed = 820;
+    };
     class ACE_5Rnd_127x99_Mag: 5Rnd_127x108_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "B_127x99_Ball";


### PR DESCRIPTION
Accord the `typicalSpeed`, `initSpeed` and `airFriction` for the both bullets due to the difference of the ballistic trajectory in-game :

- 127x108 : `typicalSpeed = 820;` /  `initSpeed = 820;` / `airFriction = -0.00065098;`

- APDS default values: `typicalSpeed = 1060;` / `initSpeed = 1060;` / `airFriction = -0.00036;`