### PR TITLE
[compat_rhs_usf3] Reload Launchers and Overpressure

### DIFF
--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -212,7 +212,17 @@ class CfgWeapons {
         lockedTargetSound[] = {"",0,1};
     };
 
-
+    class Launcher_Base_F;
+    class rhs_weap_smaw: Launcher_Base_F {
+        ace_reloadlaunchers_enabled = 1;
+        ace_overpressure_angle = 45;
+    };
+    class rhs_weap_maaws: Launcher_Base_F {
+        ace_reloadlaunchers_enabled = 1;
+        ace_overpressure_range = 15;
+        ace_overpressure_angle = 70;
+        ace_overpressure_damage = 0.75;
+    };
 
     #define HEARING_PROTECTION_VICCREW EGVAR(hearing,protection) = 0.85; EGVAR(hearing,lowerVolume) = 0.6;
     #define HEARING_PROTECTION_EARMUFF EGVAR(hearing,protection) = 0.75; EGVAR(hearing,lowerVolume) = 0.5;


### PR DESCRIPTION
**When merged this pull request will:**
* Add ace_reloadlaunchers capability and ace_overpressure config to Mk 153 SMAW launcher
* Add ace_reloadlaunchers capability and ace_overpressure config to M3 MWAAS launcher

Overpressure for the Gustaf based on the vanilla `launch_RPG32_F` values and increased a bit. SMAW got default inherited values from `Launcher_Base_F`, but with a narrower cone angle.

Let me know if the values are unacceptable and i'll scale them back a bit.