### PR TITLE
RHS 3.4 Goggles and AB Ammo compat update

### DIFF
--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -25,7 +25,7 @@ class CfgAmmo {
         ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {900};
         ACE_barrelLengths[] = {736.6};
-    };    
+    };
     class B_762x54_Ball;
     class rhsusf_B_300winmag: B_762x54_Ball { // ACE_762x67_Ball_Mk248_Mod_1 (ballistics/CfgAmmo.hpp)
         ACE_caliber = 7.823;
@@ -40,7 +40,19 @@ class CfgAmmo {
         ACE_barrelLengths[] = {508.0, 609.6, 660.4};
     };
     class B_556x45_Ball;
-    class rhs_ammo_556x45_M855A1_Ball: B_556x45_Ball { // B_556x45_Ball (ballistics/CfgAmmo.hpp) 
+    class rhs_ammo_556x45_M855_Ball: B_556x45_Ball { // B_556x45_Ball (ballistics/CfgAmmo.hpp)
+        ACE_caliber = 5.69;
+        ACE_bulletLength = 23.012;
+        ACE_bulletMass = 4.0176;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
+        ACE_ballisticCoefficients[] = {0.151};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 7;
+        ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
+        ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
+    };
+    class rhs_ammo_556x45_M855A1_Ball: B_556x45_Ball { // B_556x45_Ball (ballistics/CfgAmmo.hpp)
         ACE_caliber = 5.69;
         ACE_bulletLength = 23.012;
         ACE_bulletMass = 4.0176;
@@ -154,8 +166,8 @@ class CfgAmmo {
         ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {680};
         ACE_barrelLengths[] = {180};
-    };        
-    class rhs_ammo_45ACP_MHP: BulletBase { // B_45ACP_Ball (ballistics/CfgAmmo.hpp) 
+    };
+    class rhs_ammo_45ACP_MHP: BulletBase { // B_45ACP_Ball (ballistics/CfgAmmo.hpp)
         ACE_caliber = 11.481;
         ACE_bulletLength = 17.272;
         ACE_bulletMass = 14.904;
@@ -222,13 +234,13 @@ class CfgAmmo {
             seekerMaxRange = 2500;      // Range from the missile which the seeker can visually search
 
             seekLastTargetPos = 1;      // seek last target position [if seeker loses LOS of target, continue to last known pos]
-            
+
             // Attack profile type selection
             defaultAttackProfile = "JAV_TOP";
             attackProfiles[] = { "JAV_TOP", "JAV_DIR" };
         };
     };
-    
+
     class GrenadeHand;
     class rhs_ammo_mk3a2: GrenadeHand {
         ace_frag_enabled = 0;

--- a/optionals/compat_rhs_usf3/CfgGlasses.hpp
+++ b/optionals/compat_rhs_usf3/CfgGlasses.hpp
@@ -1,6 +1,16 @@
 
 class CfgGlasses {
     class G_Combat;
+    class rhs_ess_black: G_Combat {
+        ACE_Color[] = {0,0,0};
+        ACE_TintAmount = 16.0;
+        ACE_Overlay = "";
+        ACE_OverlayDirt = "A3\Ui_f\data\igui\rsctitles\HealthTextures\dust_upper_ca.paa";
+        ACE_OverlayCracked = QPATHTOEF(goggles,textures\HUD\Cracked.paa);
+        ACE_Resistance = 1;
+        ACE_Protection = 0;
+        ACE_DustPath = QPATHTOEF(goggles,textures\fx\dust\%1.paa);
+    };
     class rhs_googles_black: G_Combat {
         ACE_Color[] = {0,0,0};
         ACE_TintAmount = 16.0;
@@ -60,5 +70,21 @@ class CfgGlasses {
     class rhsusf_oakley_goggles_ylw: rhsusf_oakley_goggles_base {
         ACE_Color[] = {0,0,-1.5};
         ACE_TintAmount = 8.0;
+    };
+    class rhsusf_shemagh_gogg_base: G_Combat {
+        ACE_Overlay = "";
+        ACE_OverlayDirt = "A3\Ui_f\data\igui\rsctitles\HealthTextures\dust_upper_ca.paa";
+        ACE_OverlayCracked = QPATHTOEF(goggles,textures\HUD\Cracked.paa);
+        ACE_Resistance = 1;
+        ACE_Protection = 0;
+        ACE_DustPath = QPATHTOEF(goggles,textures\fx\dust\%1.paa);
+    };
+    class rhsusf_shemagh2_gogg_base: G_Combat {
+        ACE_Overlay = "";
+        ACE_OverlayDirt = "A3\Ui_f\data\igui\rsctitles\HealthTextures\dust_upper_ca.paa";
+        ACE_OverlayCracked = QPATHTOEF(goggles,textures\HUD\Cracked.paa);
+        ACE_Resistance = 1;
+        ACE_Protection = 0;
+        ACE_DustPath = QPATHTOEF(goggles,textures\fx\dust\%1.paa);
     };
 };

--- a/optionals/compat_rhs_usf3/CfgGlasses.hpp
+++ b/optionals/compat_rhs_usf3/CfgGlasses.hpp
@@ -41,4 +41,24 @@ class CfgGlasses {
         ACE_Protection = 0;
         ACE_DustPath = QPATHTOEF(goggles,textures\fx\dust\%1.paa);
     };
+    class rhsusf_oakley_goggles_base: G_Combat {
+        ACE_Overlay = "";
+        ACE_OverlayDirt = "A3\Ui_f\data\igui\rsctitles\HealthTextures\dust_upper_ca.paa";
+        ACE_OverlayCracked = QPATHTOEF(goggles,textures\HUD\Cracked.paa);
+        ACE_Resistance = 1;
+        ACE_Protection = 0;
+        ACE_DustPath = QPATHTOEF(goggles,textures\fx\dust\%1.paa);
+    };
+    class rhsusf_oakley_goggles_blk: rhsusf_oakley_goggles_base {
+        ACE_Color[] = {0,0,0};
+        ACE_TintAmount = 16.0;
+    };
+    class rhsusf_oakley_goggles_clr: rhsusf_oakley_goggles_base {
+        ACE_Color[] = {0,0,0};
+        ACE_TintAmount = 0;
+    };
+    class rhsusf_oakley_goggles_ylw: rhsusf_oakley_goggles_base {
+        ACE_Color[] = {0,0,-1.5};
+        ACE_TintAmount = 8.0;
+    };
 };


### PR DESCRIPTION
Adds the new Oakley SI Ballistics googles and the googles integrated into the new shemags.
Also add's M855 Ammo which is the same as M855A1 because our A1 data is incorrect. But it doesn't matter that it's incorrect. The difference is too small to matter for such a short-range round.
The `rhs_ess_black` is not new in 3.4 as far as I can see. But it was missing.