### PR TITLE
Disable RHS openable doors

### DIFF
--- a/addons/quickmount/XEH_PREP.hpp
+++ b/addons/quickmount/XEH_PREP.hpp
@@ -1,2 +1,3 @@
+PREP(exportNoDoorsConfig);
 PREP(getInNearest);
 PREP(moduleInit);

--- a/addons/quickmount/functions/fnc_exportNoDoorsConfig.sqf
+++ b/addons/quickmount/functions/fnc_exportNoDoorsConfig.sqf
@@ -1,0 +1,61 @@
+/*
+ * Author: BaerMitUmlaut, 654wak654, Dystopian
+ * Generates the CfgVehicles config to disable openable driver and cargo doors.
+ * Based on nouniformrestrictions export script.
+ *
+ * Arguments:
+ * 0: Mod folder (default: any) <STRING>
+ *
+ * Return Value:
+ * CfgVehicles Content <STRING>
+ *
+ * Example:
+ * ["@rhs_afrf3"] call ace_quickmount_fnc_exportNoDoorsConfig
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params [["_modFolder", ""]];
+
+private _modifyClasses = [];
+private _baseClasses = [];
+{
+    if (
+        (_modFolder == "" || {_modFolder in configSourceModList _x})
+        && (
+            !isNull (_x >> "driverDoor")
+            && {(_x >> "driverDoor") in (configProperties [_x, "true", false])}
+            && {"" != getText (_x >> "driverDoor")}
+            || {
+                !isNull (_x >> "cargoDoors")
+                && {(_x >> "cargoDoors") in (configProperties [_x, "true", false])}
+                && {!([] isEqualTo getArray (_x >> "cargoDoors"))}
+            }
+        )
+    ) then {
+        private _baseClass = inheritsFrom _x;
+        _modifyClasses pushBackUnique [_x, _baseClass];
+        if !(_baseClass in (_modifyClasses apply {_x select 0})) then {
+            _baseClasses pushBackUnique _baseClass;
+        };
+    };
+    false
+} count ("true" configClasses (configFile >> "CfgVehicles"));
+
+private _nl = toString [13, 10];
+private _output = "class CfgVehicles {" + _nl;
+{
+    ADD(_output,format [ARR_3("    class %1;%2",configName _x,_nl)]);
+    false
+} count _baseClasses;
+ADD(_output,_nl);
+{
+    _x params ["_class", "_parent"];
+    ADD(_output,format [ARR_4("    class %1: %2 {%3        driverDoor = """";%3        cargoDoors[] = {};%3    };%3",configName _class,configName _parent,_nl)]);
+    false
+} count _modifyClasses;
+ADD(_output,"};");
+
+copyToClipboard _output;
+_output;

--- a/optionals/compat_rhs_afrf3/nodoors/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/nodoors/CfgVehicles.hpp
@@ -1,0 +1,112 @@
+class CfgVehicles {
+    class MRAP_02_base_F;
+    class Offroad_01_base_F;
+    class Truck_F;
+    class O_Truck_02_covered_F;
+    class Heli_Attack_02_base_F;
+    class RHS_Mi8_base;
+    class RHS_Mi8mt_vvs;
+    class RHS_Mi8MTV3_vvs;
+    class Tank_F;
+    class rhs_bmp1_vdv;
+    class rhs_bmp2_vdv;
+    class Wheeled_APC_F;
+    class APC_Tracked_02_base_F;
+
+    class rhs_tigr_base: MRAP_02_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_UAZ_Base: Offroad_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_uaz_open_Base: RHS_UAZ_Base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_Ural_BaseTurret: Truck_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_kamaz5350: O_Truck_02_covered_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_Mi24_base: Heli_Attack_02_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_mi8amt_base: RHS_Mi8_base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_Mi8mt_Cargo_vvs: RHS_Mi8mt_vvs {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_Mi8mtv3_Cargo_vvs: RHS_Mi8MTV3_vvs {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_Ka52_base: Heli_Attack_02_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_mi28_base: Heli_Attack_02_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_truck: Truck_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_2s3tank_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_bmd_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_bmp3tank_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_bmp1tank_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_bmp2e_vdv: rhs_bmp1_vdv {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_bmp2k_vdv: rhs_bmp2_vdv {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_btr_base: Wheeled_APC_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_pts_base: APC_Tracked_02_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_a3spruttank_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_a3t72tank_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_tank_base: Tank_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhs_btr60_base: rhs_btr_base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+};

--- a/optionals/compat_rhs_afrf3/nodoors/config.cpp
+++ b/optionals/compat_rhs_afrf3/nodoors/config.cpp
@@ -1,0 +1,18 @@
+#include "\z\ace\addons\compat_rhs_afrf3\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT compat_rhs_afrf3_nodoors
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_compat_rhs_afrf3"};
+        author = ECSTRING(common,ACETeam);
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_gref3/nodoors/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/nodoors/CfgVehicles.hpp
@@ -1,0 +1,8 @@
+class CfgVehicles {
+    class Wheeled_APC_F;
+
+    class rhsgref_BRDM2: Wheeled_APC_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+};

--- a/optionals/compat_rhs_gref3/nodoors/config.cpp
+++ b/optionals/compat_rhs_gref3/nodoors/config.cpp
@@ -1,0 +1,18 @@
+#include "\z\ace\addons\compat_rhs_gref3\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT compat_rhs_gref3_nodoors
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_compat_rhs_gref3"};
+        author = ECSTRING(common,ACETeam);
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -217,6 +217,16 @@ class CfgVehicles {
     class rhsusf_hmmwe_base: MRAP_01_base_F {
         EGVAR(refuel,fuelCapacity) = 95;
     };
+    class rhsusf_m998_w_4dr_halftop;
+    class rhsusf_m998_w_4dr_fulltop: rhsusf_m998_w_4dr_halftop {
+        class UserActions;
+    };
+    class rhsusf_m1025_w: rhsusf_m998_w_4dr_fulltop {
+        class UserActions: UserActions {
+            // this action is incompatible with nodoors config
+            delete door_action;
+        };
+    };
 
     class rhsusf_rg33_base: MRAP_01_base_F {
         EGVAR(refuel,fuelCapacity) = 302;

--- a/optionals/compat_rhs_usf3/nodoors/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/nodoors/CfgVehicles.hpp
@@ -1,0 +1,107 @@
+class CfgVehicles {
+    class RHS_AH1Z_base;
+    class RHS_UH60_Base;
+    class RHS_UH60M;
+    class RHS_UH1_Base;
+    class RHS_C130J_Base;
+    class APC_Tracked_03_base_F;
+    class Truck_01_base_F;
+    class rhsusf_M1078A1P2_B_fmtv_usarmy;
+    class rhsusf_M1083A1P2_B_fmtv_usarmy;
+    class rhsusf_m998_w_2dr;
+    class rhsusf_m998_w_4dr;
+    class MBT_01_arty_base_F;
+    class Wheeled_APC_F;
+    class APC_Tracked_02_base_F;
+    class MBT_01_base_F;
+    class MRAP_01_base_F;
+
+    class RHS_AH1Z: RHS_AH1Z_base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_UH60M_base: RHS_UH60_Base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_UH60M_MEV: RHS_UH60M {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_UH1Y_base: RHS_UH1_Base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_C130J: RHS_C130J_Base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_M2A2_Base: APC_Tracked_03_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_M2A2: RHS_M2A2_Base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class RHS_M6: RHS_M2A2_Base {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_caiman_base: Truck_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_fmtv_base: Truck_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_M1078A1P2_B_M2_fmtv_usarmy: rhsusf_M1078A1P2_B_fmtv_usarmy {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_M1083A1P2_B_M2_fmtv_usarmy: rhsusf_M1083A1P2_B_fmtv_usarmy {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_HEMTT_A4_base: Truck_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_m998_w_2dr_halftop: rhsusf_m998_w_2dr {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_m998_w_4dr_halftop: rhsusf_m998_w_4dr {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_m109tank_base: MBT_01_arty_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_M1117_base: Wheeled_APC_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_m113tank_base: APC_Tracked_02_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_m1a1tank_base: MBT_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_mtvr_base: Truck_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_rg33_base: MRAP_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+    class rhsusf_RG33L_base: MRAP_01_base_F {
+        driverDoor = "";
+        cargoDoors[] = {};
+    };
+};

--- a/optionals/compat_rhs_usf3/nodoors/config.cpp
+++ b/optionals/compat_rhs_usf3/nodoors/config.cpp
@@ -1,0 +1,18 @@
+#include "\z\ace\addons\compat_rhs_usf3\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT compat_rhs_usf3_nodoors
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_compat_rhs_usf3"};
+        author = ECSTRING(common,ACETeam);
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- add function for exporting CfgVehicles config;
- add separate configs for driver and cargo openable doors disabling to RHS compats.

Some RHS vehicles have configured `driverDoor` and `cargoDoors` parameters. If use `GetIn*` actions on them (like `GetInGunner` or `GetInCargo`) the driver door (hatch) is opened. It's especially bad in MP with driver in.

`cargoDoors` parameter gives sometimes (I don't really know when) bug with `GetInCargo`: unit gets stuck in standing animation and can't move anymore until mission restart.

It looks like it's BI's fault, maybe that's why they don't have any vehicles with configured openable doors.

ACE quickmount uses exactly those actions. So we have to disable bugged openable doors to use quickmount.

CUP already removed those parameters from their vehicles (see http://dev.cup-arma3.org/T2200).