### PR TITLE
Add compat for RHS 0.4.3 new vehicles

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -59,22 +59,28 @@ class CfgVehicles {
     class rhs_a3spruttank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 400;
     };
+
+#define ERA(num) QUOTE(era_##num##_hitpoint)
+#define ERA_2_28 ERA(2), ERA(3), ERA(4), ERA(5), ERA(6), ERA(7), ERA(8), ERA(9), ERA(10), ERA(11), ERA(12), ERA(13), ERA(14), ERA(15), ERA(16), ERA(17), ERA(18), ERA(19), ERA(20), ERA(21), ERA(22), ERA(23), ERA(24), ERA(25), ERA(26), ERA(27), ERA(28)
+#define ERA_2_31 ERA_2_28, ERA(29), ERA(30), ERA(31)
+#define ERA_2_32 ERA_2_31, ERA(32)
+#define ERA_2_35 ERA_2_32, ERA(33), ERA(34), ERA(35)
+#define ERA_2_36 ERA_2_35, ERA(36)
+
     class rhs_a3t72tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 1200;
     };
     class rhs_t72bb_tv: rhs_a3t72tank_base {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_31}}};
     };
     class rhs_t72bc_tv: rhs_a3t72tank_base {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_32}}};
     };
     class rhs_t72bd_tv: rhs_a3t72tank_base {
-        class rhs_t72bd_tv: rhs_a3t72tank_base {
-            ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-            ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint"}}};
-        };
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_32}}};
     };
     class rhs_tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 1200;
@@ -179,8 +185,25 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 1100;
     };
     class rhs_t80bv: rhs_t80b {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_28}}};
+    };
+    class rhs_t80a: rhs_t80bv {};
+    class rhs_t80u: rhs_t80a {
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_35}}};
+    };
+    class rhs_t80uk: rhs_t80u {
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_36}}};
+    };
+    class rhs_t80ue1: rhs_t80a {
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_36}}};
+    };
+    class rhs_t80um: rhs_t80u {
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_36}}};
     };
 
     class Truck_F: Car_F {};
@@ -195,6 +218,10 @@ class CfgVehicles {
         transportFuel = 0;
         EGVAR(refuel,hooks)[] = {{-0.05,-3.6,-0.45}};
         EGVAR(refuel,fuelCargo) = 10000;
+    };
+    class RHS_Ural_Repair_MSV_01: RHS_Ural_Support_MSV_Base_01 {
+        transportRepair = 0;
+        EGVAR(repair,canRepair) = 1;
     };
 
     class rhs_truck: Truck_F {

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -44,22 +44,28 @@ class CfgVehicles {
         };
     };
 
+#define ERA(num) QUOTE(era_##num##_hitpoint)
+#define ERA_2_34 ERA(2), ERA(3), ERA(4), ERA(5), ERA(6), ERA(7), ERA(8), ERA(9), ERA(10), ERA(11), ERA(12), ERA(13), ERA(14), ERA(15), ERA(16), ERA(17), ERA(18), ERA(19), ERA(20), ERA(21), ERA(22), ERA(23), ERA(24), ERA(25), ERA(26), ERA(27), ERA(28), ERA(29), ERA(30), ERA(31), ERA(32), ERA(33), ERA(34)
+#define ERA_2_45 ERA_2_34, ERA(35), ERA(36), ERA(37), ERA(38), ERA(39), ERA(40), ERA(41), ERA(42), ERA(43), ERA(44), ERA(45)
+#define ERA_2_46 ERA_2_45, ERA(46)
+#define ERA_2_59 ERA_2_46, ERA(47), ERA(48), ERA(49), ERA(50), ERA(51), ERA(52), ERA(53), ERA(54), ERA(55), ERA(56), ERA(57), ERA(58), ERA(59)
+
     class MBT_01_base_F: Tank_F {};
     class rhsusf_m1a1tank_base: MBT_01_base_F {
         EGVAR(refuel,fuelCapacity) = 1909;
     };
     class rhsusf_m1a1aim_tuski_wd: rhsusf_m1a1tank_base {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint", "era_33_hitpoint", "era_34_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_34}}};
     };
     class rhsusf_m1a2tank_base;
     class rhsusf_m1a2sep1tuskid_usarmy: rhsusf_m1a2tank_base {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint", "era_33_hitpoint", "era_34_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_34}}};
     };
     class rhsusf_m1a2sep1tuskiiwd_usarmy: rhsusf_m1a2sep1tuskid_usarmy {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint", "era_20_hitpoint", "era_21_hitpoint", "era_22_hitpoint", "era_23_hitpoint", "era_24_hitpoint", "era_25_hitpoint", "era_26_hitpoint", "era_27_hitpoint", "era_28_hitpoint", "era_29_hitpoint", "era_30_hitpoint", "era_31_hitpoint", "era_32_hitpoint", "era_33_hitpoint", "era_34_hitpoint", "era_35_hitpoint", "era_36_hitpoint", "era_37_hitpoint", "era_38_hitpoint", "era_39_hitpoint", "era_40_hitpoint", "era_41_hitpoint", "era_42_hitpoint", "era_43_hitpoint", "era_44_hitpoint", "era_45_hitpoint", "era_46_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_46}}};
     };
 
     class Helicopter_Base_F: Helicopter {
@@ -226,24 +232,34 @@ class CfgVehicles {
     class rhsusf_fmtv_base: Truck_01_base_F {
         EGVAR(refuel,fuelCapacity) = 219;
     };
+    class rhsusf_M1078A1P2_B_M2_fmtv_usarmy;
+    class rhsusf_M1078A1R_SOV_M2_D_fmtv_socom: rhsusf_M1078A1P2_B_M2_fmtv_usarmy {
+        transportAmmo = 0;
+        EGVAR(rearm,defaultSupply) = 800;
+        transportFuel = 0;
+        EGVAR(refuel,hooks)[] = {{1.1,0.9,-1.2}};
+        EGVAR(refuel,fuelCargo) = 900; // 45 jerrycans
+        transportRepair = 0;
+        EGVAR(repair,canRepair) = 1;
+    };
 
     class rhsusf_HEMTT_A4_base: Truck_01_base_F {};
     class rhsusf_M977A4_usarmy_wd: rhsusf_HEMTT_A4_base {};
     class rhsusf_M977A4_AMMO_usarmy_wd: rhsusf_M977A4_usarmy_wd {
         transportAmmo = 0;
-        ace_rearm_defaultSupply = 1200;
+        EGVAR(rearm,defaultSupply) = 1200;
     };
 
     class rhsusf_M977A4_BKIT_usarmy_wd: rhsusf_M977A4_usarmy_wd {};
     class rhsusf_M977A4_AMMO_BKIT_usarmy_wd: rhsusf_M977A4_BKIT_usarmy_wd {
         transportAmmo = 0;
-        ace_rearm_defaultSupply = 1200;
+        EGVAR(rearm,defaultSupply) = 1200;
     };
 
     class rhsusf_M977A4_BKIT_M2_usarmy_wd: rhsusf_M977A4_usarmy_wd {};
     class rhsusf_M977A4_AMMO_BKIT_M2_usarmy_wd: rhsusf_M977A4_BKIT_M2_usarmy_wd {
         transportAmmo = 0;
-        ace_rearm_defaultSupply = 1200;
+        EGVAR(rearm,defaultSupply) = 1200;
     };
 
     class rhsusf_M978A4_usarmy_wd: rhsusf_M977A4_usarmy_wd {
@@ -282,7 +298,7 @@ class CfgVehicles {
     class rhsusf_m113_usarmy: rhsusf_m113tank_base {};
     class rhsusf_m113_usarmy_supply: rhsusf_m113_usarmy {
         transportAmmo = 0;
-        ace_rearm_defaultSupply = 1200;
+        EGVAR(rearm,defaultSupply) = 1200;
     };
 
     class APC_Tracked_03_base_F;
@@ -291,13 +307,17 @@ class CfgVehicles {
     };
     class RHS_M2A2: RHS_M2A2_Base {};
     class RHS_M2A2_BUSKI: RHS_M2A2 {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_45}}};
     };
     class RHS_M2A3: RHS_M2A2 {};
     class RHS_M2A3_BUSKI: RHS_M2A3 {
-        ace_repair_hitpointPositions[] = {{"era_1_hitpoint", {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{"era_1_hitpoint", {"era_2_hitpoint", "era_3_hitpoint", "era_4_hitpoint", "era_5_hitpoint", "era_6_hitpoint", "era_7_hitpoint", "era_8_hitpoint", "era_9_hitpoint", "era_10_hitpoint", "era_11_hitpoint", "era_12_hitpoint", "era_13_hitpoint", "era_14_hitpoint", "era_15_hitpoint", "era_16_hitpoint", "era_17_hitpoint", "era_18_hitpoint", "era_19_hitpoint"}}};
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_45}}};
+    };
+    class RHS_M2A3_BUSKIII: RHS_M2A3_BUSKI {
+        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
+        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_59}}};
     };
 
     class Plane_CAS_01_base_F;


### PR DESCRIPTION
**When merged this pull request will:**
- add Ural Repair and FMTV Rearm/Refuel/Repair;
- replace `era_*_hitpoint` elements with macros;
- fix `t72bd` ERA config;
- add missing T-80 and M2A2 ERA grouping configs.

It looks like it's better/simpler to create 1 big enough ERA grouping array (e.g. 100 elements) and not mess with exact ERA hitpoints count.

In fact `rhsusf_M1078A1R_SOV_M2_D_fmtv_socom` is not real refuel vehicle, so I made refuel hook at most appropriate (for me) place.