### PR TITLE
Remove rain, lightnings and wind sync

### DIFF
--- a/addons/weather/ACE_Settings.hpp
+++ b/addons/weather/ACE_Settings.hpp
@@ -11,12 +11,6 @@ class ACE_Settings {
         typeName = "BOOL";
         value = 1;
     };
-    class GVAR(syncRain) {
-        displayName = CSTRING(syncRain_DisplayName);
-        description = CSTRING(syncRain_Description);
-        typeName = "BOOL";
-        value = 1;
-    };
     class GVAR(syncWind) {
         displayName = CSTRING(syncWind_DisplayName);
         description = CSTRING(syncWind_Description);

--- a/addons/weather/CfgVehicles.hpp
+++ b/addons/weather/CfgVehicles.hpp
@@ -24,12 +24,6 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 1;
             };
-            class syncRain {
-                displayName = CSTRING(syncRain_DisplayName);
-                description = CSTRING(syncRain_Description);
-                typeName = "BOOL";
-                defaultValue = 1;
-            };
             class syncWind {
                 displayName = CSTRING(syncWind_DisplayName);
                 description = CSTRING(syncWind_Description);

--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -12,13 +12,12 @@ if (!isServer) then {
     "ACE_MISC_PARAMS" addPublicVariableEventHandler {
         TRACE_1("MISC PARAMS PVEH",ACE_MISC_PARAMS);
         if (GVAR(syncMisc)) then {
-            30 setLightnings (ACE_MISC_PARAMS select 0);
-            30 setRainbow    (ACE_MISC_PARAMS select 1);
-            30 setFog        (ACE_MISC_PARAMS select 2);
+            30 setRainbow    (ACE_MISC_PARAMS select 0);
+            30 setFog        (ACE_MISC_PARAMS select 1);
         };
-        GVAR(temperatureShift) = (ACE_MISC_PARAMS select 3);
-        GVAR(badWeatherShift)  = (ACE_MISC_PARAMS select 4);
-        GVAR(humidityShift)    = (ACE_MISC_PARAMS select 5);
+        GVAR(temperatureShift) = (ACE_MISC_PARAMS select 2);
+        GVAR(badWeatherShift)  = (ACE_MISC_PARAMS select 3);
+        GVAR(humidityShift)    = (ACE_MISC_PARAMS select 4);
         call FUNC(updateTemperature);
         call FUNC(updateHumidity);
     };

--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -6,14 +6,10 @@ GVAR(badWeatherShift) = (random 1) ^ 2 * 10;
 GVAR(humidityShift) = (5 - random 10) / 100;
 
 GVAR(wind_period_start_time) = CBA_missionTime;
-GVAR(rain_period_start_time) = CBA_missionTime;
-
-GVAR(ACE_rain) = rain;
 
 "ACE_WIND_PARAMS" addPublicVariableEventHandler { GVAR(wind_period_start_time) = CBA_missionTime; };
-"ACE_RAIN_PARAMS" addPublicVariableEventHandler { GVAR(rain_period_start_time) = CBA_missionTime; };
-"ACE_MISC_PARAMS" addPublicVariableEventHandler {
-    if (!isServer) then {
+if (!isServer) then {
+    "ACE_MISC_PARAMS" addPublicVariableEventHandler {
         TRACE_1("MISC PARAMS PVEH",ACE_MISC_PARAMS);
         if (GVAR(syncMisc)) then {
             30 setLightnings (ACE_MISC_PARAMS select 0);
@@ -62,25 +58,13 @@ simulWeatherSync;
 ["ace_settingsInitialized",{
     TRACE_1("ace_settingsInitialized eh",GVAR(syncRain));
 
-    // update rain every frame:
-    if (GVAR(syncRain)) then {
-        addMissionEventHandler ["EachFrame", {0 setRain GVAR(ACE_rain)}];
-    };
-
-    //Create a 1 sec delay PFEH to update wind/rain/temp/humidity:
-
-    //If we don't sync rain, set next time to infinity
-    GVAR(nextUpdateRain) = if (GVAR(syncRain)) then {0} else {1e99};
+    // Create a 1 sec delay PFEH to update wind/temp/humidity
     GVAR(nextUpdateTempAndHumidity) = 0;
     [{
         BEGIN_COUNTER(weatherPFEH);
 
         [] call FUNC(updateWind); //Every 1 second
 
-        if (CBA_missionTime >= GVAR(nextUpdateRain)) then {
-            [] call FUNC(updateRain); //Every 2 seconds
-            GVAR(nextUpdateRain) = 2 + CBA_missionTime;
-        };
         if (CBA_missionTime >= GVAR(nextUpdateTempAndHumidity)) then {
             [] call FUNC(updateTemperature); //Every 20 seconds
             [] call FUNC(updateHumidity); //Every 20 seconds

--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -55,8 +55,6 @@ simulWeatherSync;
 
 
 ["ace_settingsInitialized",{
-    TRACE_1("ace_settingsInitialized eh",GVAR(syncRain));
-
     // Create a 1 sec delay PFEH to update wind/temp/humidity
     GVAR(nextUpdateTempAndHumidity) = 0;
     [{

--- a/addons/weather/XEH_postServerInit.sqf
+++ b/addons/weather/XEH_postServerInit.sqf
@@ -5,6 +5,8 @@ GVAR(rain_next_period) = -1;
 GVAR(rain_period_count) = 0;
 GVAR(current_rain) = 0;
 GVAR(rain_current_range) = -1+(random 2);
+GVAR(rain_period_start_time) = CBA_missionTime;
+GVAR(ACE_rain) = rain;
 
 // Wind
 call FUNC(initWind);
@@ -14,5 +16,23 @@ call FUNC(initWind);
 
     if (GVAR(enableServerController)) then {
         [FUNC(serverController), GVAR(serverUpdateInterval)] call CBA_fnc_addPerFrameHandler;
+    };
+
+    if (GVAR(useACEWeather)) then {
+        // Update rain every frame
+        addMissionEventHandler ["EachFrame", {0 setRain GVAR(ACE_rain)}];
+
+        // Create a 1 sec delay PFEH to update rain
+        [{
+            BEGIN_COUNTER(weatherPFEHserver);
+
+            GVAR(nextUpdateRain) = 0;
+            if (CBA_missionTime >= GVAR(nextUpdateRain)) then {
+                [] call FUNC(updateRain); // Every 2 seconds
+                GVAR(nextUpdateRain) = 2 + CBA_missionTime;
+            };
+
+            END_COUNTER(weatherPFEHserver);
+        }, 1, []] call CBA_fnc_addPerFrameHandler;
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/weather/functions/fnc_initModuleSettings.sqf
+++ b/addons/weather/functions/fnc_initModuleSettings.sqf
@@ -29,9 +29,8 @@ if !(_activated) exitWith {};
 [_logic, QGVAR(useACEWeather), "useACEWeather"] call EFUNC(common,readSettingFromModule);
 
 // Control client side weather effects
-[_logic, QGVAR(syncRain), "syncRain"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(syncWind), "syncWind"] call EFUNC(common,readSettingFromModule); // Wind, Gusts, Waves
-[_logic, QGVAR(syncMisc), "syncMisc"] call EFUNC(common,readSettingFromModule); // Lightnings, Rainbow, Fog
+[_logic, QGVAR(syncMisc), "syncMisc"] call EFUNC(common,readSettingFromModule); // Rainbow, Fog
 
 // Server weather update interval
 [_logic, QGVAR(serverUpdateInterval), "serverUpdateInterval"] call EFUNC(common,readSettingFromModule);

--- a/addons/weather/functions/fnc_serverController.sqf
+++ b/addons/weather/functions/fnc_serverController.sqf
@@ -20,10 +20,6 @@ if (GVAR(useACEWeather)) then {
     [] call FUNC(updateAceWeather);
 } else {
     // Simply replicate the server weather on the clients
-    if (GVAR(syncRain)) then {
-        ACE_RAIN_PARAMS = [rain, rain, GVAR(serverUpdateInterval)];
-        publicVariable "ACE_RAIN_PARAMS";
-    };
     if (GVAR(syncWind)) then {
         //Wind _dir is the "source" of the wind [eg: "northerly wind": _dir = 0 -> wind = [0,-1,0];]
         private _windDir = ((((wind select 0) atan2 (wind select 1)) + 180) % 360);

--- a/addons/weather/functions/fnc_serverController.sqf
+++ b/addons/weather/functions/fnc_serverController.sqf
@@ -27,7 +27,7 @@ if (GVAR(useACEWeather)) then {
         publicVariable "ACE_WIND_PARAMS";
     };
     if (GVAR(syncMisc)) then {
-        ACE_MISC_PARAMS = [lightnings, rainbow, fogParams, GVAR(temperatureShift), GVAR(badWeatherShift), GVAR(humidityShift)];
+        ACE_MISC_PARAMS = [rainbow, fogParams, GVAR(temperatureShift), GVAR(badWeatherShift), GVAR(humidityShift)];
         publicVariable "ACE_MISC_PARAMS";
     };
 };

--- a/addons/weather/functions/fnc_updateAceWeather.sqf
+++ b/addons/weather/functions/fnc_updateAceWeather.sqf
@@ -99,7 +99,7 @@ if (GVAR(syncWind) && {GVAR(wind_period_count) > GVAR(wind_next_period)}) then {
 
 
 if (GVAR(syncMisc)) then {
-    ACE_MISC_PARAMS = [lightnings, rainbow, fogParams, GVAR(temperatureShift), GVAR(badWeatherShift), GVAR(humidityShift)];
+    ACE_MISC_PARAMS = [rainbow, fogParams, GVAR(temperatureShift), GVAR(badWeatherShift), GVAR(humidityShift)];
     publicVariable "ACE_MISC_PARAMS";
 };
 

--- a/addons/weather/functions/fnc_updateAceWeather.sqf
+++ b/addons/weather/functions/fnc_updateAceWeather.sqf
@@ -18,7 +18,7 @@
 private _overcastMultiplier = 1 max (2* overcast) min 2; // 0 (@ overcast 0), 2 (@ overcast 1)
 
 // Rain simulation
-if (GVAR(syncRain) && {GVAR(rain_period_count) > GVAR(rain_next_period)}) then {
+if (GVAR(rain_period_count) > GVAR(rain_next_period)) then {
 
     GVAR(rain_next_period) = ceil((1 + (random 10)) / _overcastMultiplier);
     GVAR(rain_period_count) = 0;
@@ -49,7 +49,6 @@ if (GVAR(syncRain) && {GVAR(rain_period_count) > GVAR(rain_next_period)}) then {
     TRACE_4("",_lastRain,_rainOverCast,_transitionTime,overcast);
 
     GVAR(rain_period_start_time) = CBA_missionTime;
-    publicVariable "ACE_RAIN_PARAMS";
 };
 
 // Wind simulation

--- a/addons/weather/functions/fnc_updateAceWeather.sqf
+++ b/addons/weather/functions/fnc_updateAceWeather.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: ACE2 Team, esteldunedain, ruthberg
- * Updates the wind and rain evolution on the server. Broadcasts the current and next values to the clients
+ * Updates the wind and rain evolution on the server. Broadcasts the current and next values to the clients where needed.
  *
  * Arguments:
  * None

--- a/addons/weather/functions/fnc_updateWind.sqf
+++ b/addons/weather/functions/fnc_updateWind.sqf
@@ -18,7 +18,12 @@
 if (!GVAR(syncWind)) exitWith { ACE_wind = wind };
 
 ACE_wind = [] call FUNC(getWind);
-setWind [ACE_wind select 0, ACE_wind select 1, true];
+
+// setWind correctly replicates to clients
+if (isServer) then {
+    setWind [ACE_wind select 0, ACE_wind select 1, true];
+};
+
 2 setGusts 0;
 
 // Set waves: 0 when no wind, 1 when wind >= 16 m/s

--- a/addons/weather/init3DEN.sqf
+++ b/addons/weather/init3DEN.sqf
@@ -7,8 +7,6 @@
 // we have to auto set these settings manually - on mission creation
 add3DENEventHandler ["onMissionNew", {
     set3DENMissionAttributes [
-        ["Intel", "IntelRainIsForced", true],
-        ["Intel", "IntelLightningIsForced", true],
         ["Intel", "IntelWavesIsForced", true],
         ["Intel", "IntelWindIsForced", true]
     ];

--- a/addons/weather/stringtable.xml
+++ b/addons/weather/stringtable.xml
@@ -129,38 +129,6 @@
             <Chinesesimp>使ACE天气覆盖预设的天气 (编辑任务设置)</Chinesesimp>
             <Chinese>使ACE天氣覆蓋預設的天氣 (編輯任務設置)</Chinese>
         </Key>
-        <Key ID="STR_ACE_Weather_syncRain_DisplayName">
-            <English>Sync Rain</English>
-            <Polish>Synchronizuj deszcz</Polish>
-            <Spanish>Sincronizar lluvia</Spanish>
-            <German>Regen synchronisieren</German>
-            <Czech>Synchronizuj déšť</Czech>
-            <Portuguese>Sincronizar chuva</Portuguese>
-            <French>Synchronisation de la pluie</French>
-            <Hungarian>Eső szinkronizálása</Hungarian>
-            <Russian>Синхрониз. дождь</Russian>
-            <Italian>Sincronizza Pioggia</Italian>
-            <Japanese>降雨の同期</Japanese>
-            <Korean>비 동기화</Korean>
-            <Chinesesimp>同步雨</Chinesesimp>
-            <Chinese>同步雨</Chinese>
-        </Key>
-        <Key ID="STR_ACE_Weather_syncRain_Description">
-            <English>Synchronizes rain</English>
-            <Polish>Synchronizuje deszcz</Polish>
-            <Spanish>Sincroniza la lluvia</Spanish>
-            <German>Synchronisiert den Regen</German>
-            <Czech>Synchronizace deště</Czech>
-            <Portuguese>Sincroniza a chuva</Portuguese>
-            <French>Synchronise la pluie</French>
-            <Hungarian>Szinkronizálja az esőt</Hungarian>
-            <Russian>Синхронизирует дождь</Russian>
-            <Italian>Sincronizza Pioggia</Italian>
-            <Japanese>降雨の同期</Japanese>
-            <Korean>비를 동기화 합니다</Korean>
-            <Chinesesimp>同步雨</Chinesesimp>
-            <Chinese>同步雨</Chinese>
-        </Key>
         <Key ID="STR_ACE_Weather_syncWind_DisplayName">
             <English>Sync Wind</English>
             <Polish>Synchronizuj wiatr</Polish>
@@ -210,20 +178,7 @@
             <Chinese>同步雜項</Chinese>
         </Key>
         <Key ID="STR_ACE_Weather_syncMisc_Description">
-            <English>Synchronizes lightnings, rainbow, fog,...</English>
-            <Polish>Synchronizuje pioruny, tęcze, mgłę,...</Polish>
-            <Spanish>Sincroniza relampagos, arcoiris, niebla...</Spanish>
-            <German>Synchronisiert Blitze, Regenbögen, Nebel,...</German>
-            <Czech>Synchronizace blesků, duhy, mlhy,...</Czech>
-            <Portuguese>Sincroniza relâmpagos, arco-íris, neblina...</Portuguese>
-            <French>Synchronise les éclairs, les arcs en ciel, le brouillard,...</French>
-            <Hungarian>Szinkronizálja a villámokat, szivárványokat, ködöt,...</Hungarian>
-            <Russian>Синхронизирует молнии, радугу, туман,...</Russian>
-            <Italian>Sincronizza lampi, arcobaleni, nebbia,...</Italian>
-            <Japanese>ライティングや虹、霧などを同期</Japanese>
-            <Korean>번개라던가, 무지개, 안개등을 동기화 합니다</Korean>
-            <Chinesesimp>同步闪电, 彩虹, 雾等等...</Chinesesimp>
-            <Chinese>同步閃電, 彩虹, 霧等等...</Chinese>
+            <English>Synchronizes rainbow, fog, temperature and humidity</English>
         </Key>
         <Key ID="STR_ACE_Weather_serverUpdateInterval_DisplayName">
             <English>Update Interval</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Close #5465 
- Move `setRain` to server (correctly synced in vanilla), we still want proper map data calculation
- Removed lightnings sync (synced correctly in vanilla), we didn't do anything else with it
- Moved `setWind` to only execute on server (correctly synced in vanilla), `FUNC(updateWind)` runs globally (I think), we still need to sync gusts and waves

This should resolve extreme wind bug (assuming it works). Completely untested.