### PR TITLE
Lock object while loading to cargo

### DIFF
--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -35,13 +35,17 @@ if (isNull _vehicle) exitWith {
 private _return = false;
 // Start progress bar
 if ([_object, _vehicle] call FUNC(canLoadItemIn)) then {
+    [_player, _object, true] call EFUNC(common,claim);
     private _size = [_object] call FUNC(getSizeItem);
 
     [
         5 * _size,
-        [_object,_vehicle],
-        {["ace_loadCargo", _this select 0] call CBA_fnc_localEvent},
-        {},
+        [_object, _vehicle],
+        {
+            [objNull, _this select 0 select 0, true] call EFUNC(common,claim);
+            ["ace_loadCargo", _this select 0] call CBA_fnc_localEvent;
+        },
+        {[objNull, _this select 0 select 0, true] call EFUNC(common,claim)},
         localize LSTRING(LoadingItem),
         {true},
         ["isNotSwimming"]

--- a/addons/common/functions/fnc_claim.sqf
+++ b/addons/common/functions/fnc_claim.sqf
@@ -30,10 +30,17 @@ _target setVariable [QGVAR(owner), _unit, true];
 
 // lock target object
 if (_lockTarget) then {
+    private _canBeDisassembled = !([] isEqualTo getArray (_target call CBA_fnc_getObjectConfig >> "assembleInfo" >> "dissasembleTo"));
     if (!isNull _unit) then {
         [QGVAR(lockVehicle), _target, _target] call CBA_fnc_targetEvent;
+        if (_canBeDisassembled) then {
+            _target enableWeaponDisassembly false;
+        };
     } else {
         [QGVAR(unlockVehicle), _target, _target] call CBA_fnc_targetEvent;
+        if (_canBeDisassembled) then {
+            _target enableWeaponDisassembly true;
+        };
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title;
- disable static weapon disassembling while it's claimed.

This will restrict interaction with static weapons which are being dragged/carried/(loaded to cargo).

I would also like to disable `Set-up the tripod` feature while it's claimed, but suddenly it's a vanilla feature and there are some troubles.