### PR TITLE
Prevent fastroping teleport serverside

### DIFF
--- a/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
@@ -23,6 +23,12 @@ _rope params ["_attachmentPoint", "_ropeTop", "_ropeBottom", "_dummy", "_hook"];
 //Wait until the unit is actually outside of the helicopter
 if (vehicle _unit != _unit) exitWith {};
 
+//Prevent teleport if hook has been deleted due to rope cut
+if (isNull _hook) exitWith {
+    detach _unit; //Does not matter if unit was not attached yet
+    [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+};
+
 //Start fast roping
 if (getMass _dummy != 80) exitWith {
     //Fix for twitchyness


### PR DESCRIPTION
**When merged this pull request will:**
- Fix a specific case where fastroping could result in a teleport to [0, 0, -1]

A teleport would happen in the following situation:
- player starts fastrope
- player is moved out of the vehicle, attached to the dummy
- at the same time, rope gets cut, hook gets deleted
- server PFH just now arrives at `if (getMass _dummy != 80) exitWith {`, the dummy position gets set to 1m below nonexistant hook, teleport to [0, 0, -1] happens

See #5569.