### PR TITLE
Disable Debug Define

### DIFF
--- a/addons/common/functions/fnc_playConfigSound3D.sqf
+++ b/addons/common/functions/fnc_playConfigSound3D.sqf
@@ -16,7 +16,7 @@
  *
  * Public: Yes
  */
-#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 params ["_soundClass", "_posASL", "_volume", "_distance"];


### PR DESCRIPTION
**Comments out Debug define that was left enabled in release version.**
- Fixes Traces getting logged to rpt especially when using mine detector.

The file [fnc_diagnoseWeapons](https://github.com/acemod/ACE3/blob/master/addons/advanced_ballistics/functions/fnc_diagnoseWeapons.sqf) also contains a debug define that is not commented out but it appears to be intentional. Unless I am mistaken by my assumption.