### PR TITLE
AB compat rail/scope height update

### DIFF
--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -4,7 +4,7 @@ class CfgWeapons {
     class Pistol_Base_F;
     class Rifle_Base_F;
     class R3F_Famas_F1: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 10.6;
+        ACE_RailHeightAboveBore = 10.1796;
         ACE_barrelTwist = 304.8; // 1:12"
         ACE_barrelLength = 488.0;
         muzzles[] = {"this"};
@@ -13,7 +13,7 @@ class CfgWeapons {
         muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_Famas_surb: R3F_Famas_F1 {
-        ACE_RailHeightAboveBore = 5.4;
+        ACE_RailHeightAboveBore = 5.08219;
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 450.0; // Beretta barrel
     };
@@ -21,7 +21,7 @@ class CfgWeapons {
         muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_Famas_G2: R3F_Famas_F1 {
-        ACE_RailHeightAboveBore = 10.6;
+        ACE_RailHeightAboveBore = 10.1808;
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 488.0;
     };
@@ -29,12 +29,12 @@ class CfgWeapons {
         muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_Famas_felin: R3F_Famas_G2 {
-        ACE_RailHeightAboveBore = 5.4;
+        ACE_RailHeightAboveBore = 5.14504;
         ACE_barrelTwist = 177.8; // 1:7"
         ACE_barrelLength = 450.0; // Beretta barrel
     };
     class R3F_FRF2: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 2.2;
+        ACE_RailHeightAboveBore = 1.79013;
         ACE_barrelTwist = 294.6;
         ACE_barrelLength = 650.0;
         class Single: Mode_SemiAuto {
@@ -43,7 +43,7 @@ class CfgWeapons {
         muzzles[] = {"this"};
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 2.0;
+        ACE_RailHeightAboveBore = 1.84858;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
         class Single: Mode_SemiAuto {
@@ -52,7 +52,7 @@ class CfgWeapons {
         muzzles[] = {"this"};
     };
     class R3F_M107: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 3.6;
+        ACE_RailHeightAboveBore = 3.13099;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
@@ -61,7 +61,7 @@ class CfgWeapons {
         muzzles[] = {"this"};
     };
     class R3F_TAC50: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 3.2;
+        ACE_RailHeightAboveBore = 2.99563;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
@@ -70,45 +70,41 @@ class CfgWeapons {
         muzzles[] = {"this"};
     };
     class R3F_Minimi: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 4.0;
+        ACE_RailHeightAboveBore = 3.81385;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 347.98;
         muzzles[] = {"this"};
         initSpeed = 915; // R3F config
     };
     class R3F_Minimi_762: R3F_Minimi {
-        ACE_RailHeightAboveBore = 4.0;
+        ACE_RailHeightAboveBore = 3.80834;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 502.92;
         initSpeed = 820; // R3F config
     };
     class R3F_SIG551: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 4.2;
+        ACE_RailHeightAboveBore = 3.95288;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 363.0;
         muzzles[] = {"this"};
     };
     class R3F_HK417M: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 3.4;
+        ACE_RailHeightAboveBore = 3.23377;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 406.0;
         muzzles[] = {"this"};
     };
     class R3F_HK417S_HG: R3F_HK417M {
-        ACE_RailHeightAboveBore = 3.4;
-        ACE_barrelTwist = 279.4;
         ACE_barrelLength = 305.0;
     };
     class R3F_HK417L: R3F_HK417M {
-        ACE_RailHeightAboveBore = 3.4;
-        ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
         class Single: Mode_SemiAuto {
             dispersion = 0.00029; // 1 MOA, default 0.00020
         };
     };
     class R3F_HK416M: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 3.4;
+        ACE_RailHeightAboveBore = 2.84776;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
         muzzles[] = {"this"};
@@ -118,24 +114,20 @@ class CfgWeapons {
     };
     class R3F_HK416M_HG: R3F_HK416M {};
     class R3F_HK416S_HG: R3F_HK416M_HG {
-        ACE_RailHeightAboveBore = 3.4;
-        ACE_barrelTwist = 177.8;
         ACE_barrelLength = 279.4;
     };
     class R3F_MP5SD: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 4.5;
+        ACE_RailHeightAboveBore = 4.21816;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 144.78;
         muzzles[] = {"this"};
     };
     class R3F_MP5A5: R3F_MP5SD {
-        ACE_RailHeightAboveBore = 4.5;
-        ACE_barrelTwist = 254.0;
         ACE_barrelLength = 226.06;
         muzzles[] = {"this"};
     };
     class R3F_M4S90: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 2.2;
+        ACE_RailHeightAboveBore = 1.86213;
         ACE_twistDirection = 0;
         ACE_barrelTwist = 0;
         ACE_barrelLength = 144.78;
@@ -151,17 +143,17 @@ class CfgWeapons {
         ACE_barrelLength = 121.0;
         muzzles[] = {"this"};
         initSpeed = -1.0; // default 410
-    };   
+    };
     class ItemCore;
     class InventoryOpticsItem_Base_F;
     class R3F_AIMPOINT: ItemCore {
-        ACE_ScopeHeightAboveRail = 3.0;
+        ACE_ScopeHeightAboveRail = 3.1916;
     };
     class R3F_EOTECH: ItemCore {
-        ACE_ScopeHeightAboveRail = 3.8;
+        ACE_ScopeHeightAboveRail = 4.25923;
     };
     class R3F_J4: ItemCore {
-        ACE_ScopeHeightAboveRail = 3.0;
+        ACE_ScopeHeightAboveRail = 3.20641;
         ACE_ScopeAdjust_Vertical[] = {-8, 8};
         ACE_ScopeAdjust_Horizontal[] = {-8, 8};
         ACE_ScopeAdjust_VerticalIncrement = 0.2;
@@ -176,13 +168,13 @@ class CfgWeapons {
         };
     };
     class R3F_FELIN: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeHeightAboveRail = 8.13689;
     };
     class R3F_FELIN_FRF2: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.0;
+        ACE_ScopeHeightAboveRail = 4.28091;
     };
     class R3F_J8: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.4;
+        ACE_ScopeHeightAboveRail = 4.474;
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -197,7 +189,6 @@ class CfgWeapons {
         };
     };
     class R3F_J8_MILDOT: R3F_J8 { // Scope rail 30 MOA
-        ACE_ScopeHeightAboveRail = 4.4;
         ACE_ScopeAdjust_Vertical[] = {-2, 18};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -213,7 +204,7 @@ class CfgWeapons {
     };
     class R3F_J10: ItemCore {
         ACE_ScopeZeroRange = 1400; // Inaccurate reticle, designed to work with the vanilla ballistic.
-        ACE_ScopeHeightAboveRail = 4.4;
+        ACE_ScopeHeightAboveRail = 4.474;
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -229,7 +220,6 @@ class CfgWeapons {
     };
     class R3F_J10_MILDOT: R3F_J10 { // Scope rail 30 MOA
         ACE_ScopeZeroRange = 100;
-        ACE_ScopeHeightAboveRail = 4.4;
         ACE_ScopeAdjust_Vertical[] = {-2, 18};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -244,7 +234,7 @@ class CfgWeapons {
         };
     };
     class R3F_ZEISS: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.6;
+        ACE_ScopeHeightAboveRail = 4.96547;
         ACE_ScopeAdjust_Vertical[] = {0, 23};
         ACE_ScopeAdjust_Horizontal[] = {-7, 7};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -259,7 +249,7 @@ class CfgWeapons {
         };
     };
     class R3F_NF: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeHeightAboveRail = 4.30469;
         ACE_ScopeAdjust_Vertical[] = {0, 30};
         ACE_ScopeAdjust_Horizontal[] = {-11, 11};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -274,7 +264,7 @@ class CfgWeapons {
         };
     };
     class R3F_NF42: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.2;
+        ACE_ScopeHeightAboveRail = 4.30469;
         ACE_ScopeAdjust_Vertical[] = {0, 24};
         ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -289,7 +279,7 @@ class CfgWeapons {
         };
     };
     class R3F_OB50: ItemCore {
-        ACE_ScopeHeightAboveRail = 4.0;
+        ACE_ScopeHeightAboveRail = 4.13217;
     };
     class InventoryMuzzleItem_Base_F;
     class R3F_SILENCIEUX_HK416: ItemCore {

--- a/optionals/compat_rh_acc/CfgWeapons.hpp
+++ b/optionals/compat_rh_acc/CfgWeapons.hpp
@@ -5,15 +5,18 @@ class CfgWeapons {
     /* Scopes */
     class InventoryOpticsItem_Base_F;
 
-    // This would require MOA turrets
-    /*class RH_shortdot : ItemCore {
-        ACE_ScopeAdjust_Vertical[] = { -1, 25 };
-        ACE_ScopeAdjust_Horizontal[] = { -13, 13 };
-        ACE_ScopeAdjust_VerticalIncrement = 0.5;
-        ACE_ScopeAdjust_Unit = "MOA";
-    };*/
+    class RH_shortdot : ItemCore {
+        ACE_ScopeHeightAboveRail = 4.40511;
+        /* // This would require MOA turrets
+            ACE_ScopeAdjust_Vertical[] = { -1, 25 };
+            ACE_ScopeAdjust_Horizontal[] = { -13, 13 };
+            ACE_ScopeAdjust_VerticalIncrement = 0.5;
+            ACE_ScopeAdjust_Unit = "MOA";
+        */
+    };
 
     class RH_accupoint : ItemCore {
+        ACE_ScopeHeightAboveRail = 3.726;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -29,6 +32,7 @@ class CfgWeapons {
     };
 
     class RH_m3lr : ItemCore {
+        ACE_ScopeHeightAboveRail = 3.5751;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -44,6 +48,7 @@ class CfgWeapons {
     };
 
     class RH_leu_mk4 : ItemCore {
+        ACE_ScopeHeightAboveRail = 4.64216;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -59,6 +64,7 @@ class CfgWeapons {
     };
 
     class RH_c79 : ItemCore {
+        ACE_ScopeHeightAboveRail = 4.16731;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -74,6 +80,7 @@ class CfgWeapons {
     };
 
     class RH_c79_2d : ItemCore {
+        ACE_ScopeHeightAboveRail = 4.16731;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -89,6 +96,7 @@ class CfgWeapons {
     };
 
     class RH_anpvs10 : ItemCore {
+        ACE_ScopeHeightAboveRail = 2.64379;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -104,6 +112,7 @@ class CfgWeapons {
     };
 
     class RH_pas13cm : ItemCore {
+        ACE_ScopeHeightAboveRail = 10.601;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -119,6 +128,7 @@ class CfgWeapons {
     };
 
     class RH_pas13cmg : ItemCore {
+        ACE_ScopeHeightAboveRail = 10.601;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -134,6 +144,7 @@ class CfgWeapons {
     };
 
     class RH_pas13ch : ItemCore {
+        ACE_ScopeHeightAboveRail = 10.6017;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -65,10 +65,9 @@ class CfgWeapons {
     };
     class rhs_weap_orsis_Base_F;
     class rhs_weap_t5000: rhs_weap_orsis_Base_F { // http://en.orsis.com/production/catalog/19046/
-        ACE_RailHeightAboveBore = 2.12198;
         ACE_barrelTwist = 254.0; // 1:10"
         ACE_barrelLength = 698.5; // 27.5"
-        ACE_RailHeightAboveBore = 2.4;
+        ACE_RailHeightAboveBore = 2.12198;
     };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -12,26 +12,43 @@ class CfgWeapons {
     };
     class rhs_weap_ak74m_Base_F;
     class rhs_weap_ak74m: rhs_weap_ak74m_Base_F {
+        ACE_RailHeightAboveBore = -0.456233;
         ACE_barrelTwist = 199.898;
         ACE_barrelLength = 414.02;
     };
     class rhs_weap_akm: rhs_weap_ak74m {
+        ACE_RailHeightAboveBore = -0.456233;//from rhs_weap_akmn and rhs_weap_ak74m
         ACE_barrelTwist = 199.898;
         ACE_barrelLength = 414.02;
     };
     class rhs_weap_aks74;
     class rhs_weap_aks74u: rhs_weap_aks74 {
+        ACE_RailHeightAboveBore = -0.30262;
         ACE_barrelTwist = 160.02;
         ACE_barrelLength = 210.82;
     };
     class rhs_weap_svd: rhs_weap_ak74m {
+        ACE_RailHeightAboveBore = -0.617396;
         ACE_barrelTwist = 238.76;
         ACE_barrelLength = 619.76;
     };
     class rhs_weap_svdp;
+    class rhs_weap_svdp_npz: rhs_weap_svdp {
+        ACE_RailHeightAboveBore = 4.3348;
+    };
+    class rhs_weap_svdp_wd: rhs_weap_svdp {
+        ACE_RailHeightAboveBore = -0.617396;
+    };
+    class rhs_weap_svdp_wd_npz: rhs_weap_svdp_wd {
+        ACE_RailHeightAboveBore = 4.3348;
+    };
     class rhs_weap_svds: rhs_weap_svdp {
+        ACE_RailHeightAboveBore = -0.617396;
         ACE_barrelTwist = 238.76;
         ACE_barrelLength = 563.88;
+    };
+    class rhs_weap_svds_npz: rhs_weap_svds {
+        ACE_RailHeightAboveBore = 4.3348;
     };
     class rhs_pkp_base;
     class rhs_weap_pkp: rhs_pkp_base {
@@ -48,18 +65,21 @@ class CfgWeapons {
     };
     class rhs_weap_orsis_Base_F;
     class rhs_weap_t5000: rhs_weap_orsis_Base_F { // http://en.orsis.com/production/catalog/19046/
+        ACE_RailHeightAboveBore = 2.12198;
         ACE_barrelTwist = 254.0; // 1:10"
         ACE_barrelLength = 698.5; // 27.5"
         ACE_RailHeightAboveBore = 2.4;
     };
     class rhs_acc_sniper_base;
     class rhs_acc_pso1m2: rhs_acc_sniper_base {
+        ACE_ScopeHeightAboveRail = 4.41386;
         ACE_ScopeAdjust_Vertical[] = {0, 0};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.5;
         ACE_ScopeAdjust_HorizontalIncrement = 0.5;
     };
     class rhs_acc_pso1m21: rhs_acc_sniper_base {
+        ACE_ScopeHeightAboveRail = 7.75566;
         ACE_ScopeAdjust_Vertical[] = {0, 0};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.5;
@@ -68,7 +88,7 @@ class CfgWeapons {
     class ItemCore;
     class InventoryOpticsItem_Base_F;
     class rhs_acc_dh520x56: ItemCore { // http://nightvision.ru/catalog/4/item/35
-        ACE_ScopeHeightAboveRail = 4.6;
+        ACE_ScopeHeightAboveRail = 4.71476;
         ACE_ScopeAdjust_Vertical[] = {0, 33};
         ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -102,7 +122,7 @@ class CfgWeapons {
     class rhs_gssh18: H_HelmetB {
         HEARING_PROTECTION_EARMUFF
     };
-    
+
     class rhs_weap_d81;
     class rhs_weap_2a70: rhs_weap_d81 { // "Low pressure" 100mm cannon
         ace_overpressure_range = 15;

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -13,26 +13,27 @@ class CfgWeapons {
     class rhs_weap_M107_Base_F: GM6_base_F {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
-        ACE_RailHeightAboveBore = 3.8;
+        ACE_RailHeightAboveBore = 4.18639;
     };
     class rhs_weap_XM2010_Base_F: Rifle_Base_F {
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 609.6;
         ACE_Overheating_dispersion = 0.75;
-        ACE_RailHeightAboveBore = 3.6;
+        ACE_RailHeightAboveBore = 3.1028;
     };
     class rhs_weap_m24sws: rhs_weap_XM2010_Base_F {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 609.6;
-        ACE_RailHeightAboveBore = 1.8;
+        ACE_RailHeightAboveBore = 2.41891;
     };
     class rhs_weap_m40a5: rhs_weap_XM2010_Base_F {
         ACE_barrelTwist = 304.8; // 1:12"
         ACE_barrelLength = 635.0; // 25"
-        ACE_RailHeightAboveBore = 2.6;
+        ACE_RailHeightAboveBore = 2.46368;
     };
     class arifle_MX_Base_F;
     class rhs_weap_m4_Base: arifle_MX_Base_F {
+        ACE_RailHeightAboveBore = 2.56518;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
         class M203_GL: UGL_F {
@@ -42,6 +43,7 @@ class CfgWeapons {
     };
     class rhs_weap_m4a1;
     class rhs_weap_hk416d10: rhs_weap_m4a1 {
+        ACE_RailHeightAboveBore = 3.56139;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 254;
     };
@@ -50,31 +52,37 @@ class CfgWeapons {
         ACE_barrelLength = 368.3;
     };
     class rhs_weap_m27iar: rhs_weap_m4a1 {
+        ACE_RailHeightAboveBore = 3.56139;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 419.1;
     };
     class rhs_weap_m4a1_blockII;
     class rhs_weap_mk18: rhs_weap_m4a1_blockII {
+        ACE_RailHeightAboveBore = 2.6068;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 261.62;
     };
     class rhs_weap_m16a4: rhs_weap_m4_Base {
+        ACE_RailHeightAboveBore = 2.59324;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 508.0;
     };
     class rhs_weap_lmg_minimi_railed; // Rifle_Base_F - scope = private;
     class rhs_weap_m249_pip_S: rhs_weap_lmg_minimi_railed {
+        ACE_RailHeightAboveBore = 4.11044;
         ACE_barrelLength = 348;
         ACE_barrelTwist = 177.8;
         ACE_Overheating_allowSwapBarrel = 1;
     };
     class rhs_weap_m249_pip_L: rhs_weap_lmg_minimi_railed {
+        ACE_RailHeightAboveBore = 4.34899;
         ACE_barrelLength = 464.8;
         ACE_barrelTwist = 177.8;
         ACE_Overheating_allowSwapBarrel = 1;
     };
     class rhs_weap_m240_base; // Rifle_Long_Base_F
     class rhs_weap_m240B: rhs_weap_m240_base {
+        ACE_RailHeightAboveBore = 4.3987;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 629.92;
         ACE_Overheating_allowSwapBarrel = 1;
@@ -83,17 +91,17 @@ class CfgWeapons {
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 558.8;
         ACE_Overheating_dispersion = 0.75;
-        ACE_RailHeightAboveBore = 3.3;
+        ACE_RailHeightAboveBore = 3.08341;
     };
     class rhs_weap_sr25: rhs_weap_m14ebrri {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 609.6;
-        ACE_RailHeightAboveBore = 3.4;
+        ACE_RailHeightAboveBore = 3.13162;
     };
     class rhs_weap_sr25_ec: rhs_weap_sr25 {
         ACE_barrelTwist = 285.75;
         ACE_barrelLength = 508.0;
-        ACE_RailHeightAboveBore = 3.4;
+        ACE_RailHeightAboveBore = 3.13689;
     };
     class rhs_weap_M590_5RD: Rifle_Base_F {
         ACE_barrelTwist = 0.0;
@@ -107,6 +115,7 @@ class CfgWeapons {
     };
     class SMG_02_base_F;
     class rhsusf_weap_MP7A1_base_f: SMG_02_base_F {
+        ACE_RailHeightAboveBore = 5;
         ACE_barrelTwist = 160.0;
         ACE_barrelLength = 180.0;
     };
@@ -143,10 +152,10 @@ class CfgWeapons {
         };
     };
     class rhsusf_acc_LEUPOLDMK4: rhsusf_acc_sniper_base {
-        ACE_ScopeHeightAboveRail = 2.4;
+        ACE_ScopeHeightAboveRail = 2.62567;
     };
     class rhsusf_acc_LEUPOLDMK4_2: rhsusf_acc_sniper_base {
-        ACE_ScopeHeightAboveRail = 3.8;
+        ACE_ScopeHeightAboveRail = 3.86377;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class pso1_scope {
@@ -156,11 +165,8 @@ class CfgWeapons {
             };
         };
     };
-    class rhsusf_acc_LEUPOLDMK4_2_d: rhsusf_acc_LEUPOLDMK4_2 {
-        ACE_ScopeHeightAboveRail = 3.8;
-    };
     class rhsusf_acc_premier: rhsusf_acc_LEUPOLDMK4_2 {
-        ACE_ScopeHeightAboveRail = 5.4;
+        ACE_ScopeHeightAboveRail = 5.26066;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class pso1_scope {
@@ -171,10 +177,10 @@ class CfgWeapons {
         };
     };
     class rhsusf_acc_premier_low: rhsusf_acc_premier {
-        ACE_ScopeHeightAboveRail = 4.0;
+        ACE_ScopeHeightAboveRail = 3.90899;
     };
     class rhsusf_acc_premier_anpvs27: rhsusf_acc_premier {
-        ACE_ScopeHeightAboveRail = 5.4;
+        ACE_ScopeHeightAboveRail = 5.25066;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class pso1_nvg {
@@ -185,7 +191,7 @@ class CfgWeapons {
         };
     };
     class rhsusf_acc_M8541: rhsusf_acc_premier { // http://www.schmidtundbender.de/en/products/police-and-military-forces/3-12x50-pm-iilpmtc.html
-        ACE_ScopeHeightAboveRail = 4.0;
+        ACE_ScopeHeightAboveRail = 4.2235;
         ACE_ScopeAdjust_Vertical[] = {0, 22};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -200,7 +206,7 @@ class CfgWeapons {
         };
     };
     class rhsusf_acc_M8541_low: rhsusf_acc_M8541 {
-        ACE_ScopeHeightAboveRail = 3.0;
+        ACE_ScopeHeightAboveRail = 2.9789;
     };
     // RHS lauchers
     class rhs_weap_fgm148: launch_O_Titan_F {

--- a/optionals/compat_rksl_pm_ii/CfgWeapons.hpp
+++ b/optionals/compat_rksl_pm_ii/CfgWeapons.hpp
@@ -2,8 +2,9 @@
 class CfgWeapons {
     class ItemCore;
     class InventoryOpticsItem_Base_F;
-    
+
     class RKSL_optic_PMII_312 : ItemCore {
+        ACE_ScopeHeightAboveRail = 4.2235;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
@@ -19,6 +20,7 @@ class CfgWeapons {
     };
 
     class RKSL_optic_PMII_312_sunshade : ItemCore {
+        ACE_ScopeHeightAboveRail = 4.2235;
         ACE_ScopeAdjust_Vertical[] = { -4, 30 };
         ACE_ScopeAdjust_Horizontal[] = { -6, 6 };
         ACE_ScopeAdjust_VerticalIncrement = 0.1;


### PR DESCRIPTION
Compat variant of #5648
I only updated the weapons we already had in compat and only added new ones were really necessary.
I noticed we are missing all RHS AK variants with NPZ which have a different railheight that the non-NPZ ones.
If someone else want's to add the missing stuff here is a table of all rail heights: https://docs.google.com/spreadsheets/d/1d5O_nC0Cq26CWGI4sqjZU9jdhArV5pkSm-VMDT7uvM4/edit?usp=sharing