### PR TITLE
Fix Pylons' Combo Box Cut off When There Are Too Many Magazines to List

### DIFF
--- a/addons/pylons/functions/fnc_showDialog.sqf
+++ b/addons/pylons/functions/fnc_showDialog.sqf
@@ -57,7 +57,7 @@ if (["ace_fastroping"] call EFUNC(common,isModLoaded) && {_hasFRIES > 1}) then {
 
 GVAR(comboBoxes) = [];
 {
-    private _combo = _display ctrlCreate ["ctrlCombo", -1];
+    private _combo = _display ctrlCreate [QGVAR(CtrlCombo), -1];
     private _picturePos = ctrlPosition (_display displayCtrl ID_PICTURE_AIRCRAFT);
     private _uiPos = getArray (_x >> "UIposition");
     _combo ctrlSetPosition [

--- a/addons/pylons/menu.hpp
+++ b/addons/pylons/menu.hpp
@@ -1,3 +1,11 @@
+// combo box that looks good + doesn't get cut off
+class RscCombo;
+class GVAR(CtrlCombo): RscCombo {
+    arrowEmpty = "\a3\3DEN\Data\Controls\ctrlCombo\arrowEmpty_ca.paa";
+    arrowFull = "\a3\3DEN\Data\Controls\ctrlCombo\arrowFull_ca.paa";
+    colorSelectBackground[] = {"(profileNamespace getVariable ['GUI_BCG_RGB_R', 0.13])","(profileNamespace getVariable ['GUI_BCG_RGB_G', 0.54])","(profileNamespace getVariable ['GUI_BCG_RGB_B', 0.21])",1};
+};
+
 class IGUIBack;
 class RscCheckBox;
 class RscListBox;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix combo boxes cutting off. Goodbye #5649 
- 😢 

Using the old `RscCombo` type but making it look like `ctrlCombo` looks like the ideal way to get a proper combo box that doesn't cut off at an arbitrary control height limit.