### PR TITLE
Fix refuel framework page build failure

### DIFF
--- a/docs/wiki/framework/refuel-framework.md
+++ b/docs/wiki/framework/refuel-framework.md
@@ -14,6 +14,7 @@ version:
 
 ## 1. Config Values
 
+{% raw %}
 ```cpp
 class CfgVehicles {
     class MyFuelTruck {
@@ -28,6 +29,7 @@ class CfgVehicles {
     };
 };
 ```
+{% endraw %}
 
 <div class="panel callout">
     <h5>Note:</h5>


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Jekyll thinks `{{ something }}` is a variable in code blocks too. 