### PR TITLE
Fix ACE_ItemCore order

### DIFF
--- a/addons/trenches/CfgWeapons.hpp
+++ b/addons/trenches/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
-    class CBA_MiscItem_ItemInfo;
     class ACE_ItemCore;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_EntrenchingTool: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);

--- a/addons/vehiclelock/CfgWeapons.hpp
+++ b/addons/vehiclelock/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
-    class CBA_MiscItem_ItemInfo;
     class ACE_ItemCore;
+    class CBA_MiscItem_ItemInfo;
 
     class ACE_key_master: ACE_ItemCore {
         scopeArsenal = 0;


### PR DESCRIPTION
`ACE_ItemCore` is always above `CBA_MiscItem_ItemInfo` except here.

 <img src="https://upload.wikimedia.org/wikipedia/commons/4/4f/Autism_Awareness_Ribbon.png" width="60" height="80">