### PR TITLE
(spectator) set correct state on unit

### DIFF
--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -119,6 +119,6 @@ GVAR(interrupts) = [];
 
 // Mark spectator state for reference
 GVAR(isSet) = _set;
-player setVariable [QGVAR(isSet), true, true];
+player setVariable [QGVAR(isSet), _set, true];
 
 ["ace_spectatorSet", [_set, player]] call CBA_fnc_globalEvent;


### PR DESCRIPTION
This looks incorrect.

**When merged this pull request will:**
- Set the spectator state using `_set` variable instead of `true`