### PR TITLE
Tagging - For lastUsed setting, use random X tag if none selected yet

### DIFF
--- a/addons/tagging/functions/fnc_quickTag.sqf
+++ b/addons/tagging/functions/fnc_quickTag.sqf
@@ -22,19 +22,22 @@ if (GVAR(quickTag) == 0) exitWith {};
 params ["_unit"];
 
 private _possibleTags = [];
+private _useRandom = false;
 
 // Last Used
 if (GVAR(quickTag) == 1) then {
     private _lastUsedTagClass = _unit getVariable [QGVAR(lastUsedTag), nil];
 
-    if (!isNil "_lastUsedTagClass") then {
+    if (isNil "_lastUsedTagClass") then {
+        _useRandom = true;
+    } else {
         private _lastUsedTag = GVAR(cachedTags) select {(_x select 0) == _lastUsedTagClass};
         _possibleTags = _lastUsedTag;
     };
 };
 
 // Random X
-if (GVAR(quickTag == 2)) then {
+if ((GVAR(quickTag) == 2) || _useRandom) then {
     private _xTags = GVAR(cachedTags) select {(_x select 0) in ["ACE_XBlack", "ACE_XRed", "ACE_XGreen", "ACE_XBlue"]};
     _possibleTags = _xTags;
 };

--- a/addons/tagging/stringtable.xml
+++ b/addons/tagging/stringtable.xml
@@ -26,7 +26,7 @@
             <Chinese>定義噴漆系統預設設定</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_QuickTag">
-            <English>Quick Tag</English>
+            <English>Spray Paint - Quick Tag</English>
             <Russian>Быстрый маркер</Russian>
             <Japanese>クイック タグ</Japanese>
             <Polish>Szybkie tagowanie</Polish>


### PR DESCRIPTION
Close #5662

When using the "Last Used" setting, nothing would happen when hitting the hot key.
This changes it to just do a random X


`GVAR(quickTag == 2)` :smile: 