### PR TITLE
AB - Revert default simulation interval

### DIFF
--- a/addons/advanced_ballistics/ACE_Settings.hpp
+++ b/addons/advanced_ballistics/ACE_Settings.hpp
@@ -69,7 +69,7 @@ class ACE_Settings {
         displayName = CSTRING(simulationInterval_DisplayName);
         description = CSTRING(simulationInterval_Description);
         typeName = "SCALAR";
-        value = 0.05;
+        value = 0.0;
     };
     class GVAR(simulationRadius) {
         category = CSTRING(DisplayName);

--- a/addons/advanced_ballistics/CfgVehicles.hpp
+++ b/addons/advanced_ballistics/CfgVehicles.hpp
@@ -71,7 +71,7 @@ class CfgVehicles {
                 displayName = CSTRING(simulationInterval_DisplayName);
                 description = CSTRING(simulationInterval_Description);
                 typeName = "NUMBER";
-                defaultValue = 0.05;
+                defaultValue = 0.0;
             };
             class simulationRadius {
                 displayName = CSTRING(simulationRadius_DisplayName);


### PR DESCRIPTION
* Point of impact shifts measurably (at long ranges) if we skip frames in our velocity update routine
* New players might never touch the config and suffer from less than perfect accuracy without knowing why
* Reverts: #4707