### PR TITLE
cargo - Improve interaction distance checks on very large vehicles.

### DIFF
--- a/addons/cargo/functions/fnc_addCargoVehiclesActions.sqf
+++ b/addons/cargo/functions/fnc_addCargoVehiclesActions.sqf
@@ -22,10 +22,11 @@ private _statement = {
     [_player, _target, _vehicle] call FUNC(startLoadIn);
 };
 
-private _vehicles = (nearestObjects [_target, GVAR(cargoHolderTypes), MAX_LOAD_DISTANCE]) select {
+private _vehicles = (nearestObjects [_target, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)]) select {
     private _hasCargoConfig = 1 == getNumber (configFile >> "CfgVehicles" >> typeOf _x >> QGVAR(hasCargo));
     private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];
-    (_hasCargoConfig || {_hasCargoPublic}) && {_x != _target}
+    (_hasCargoConfig || {_hasCargoPublic}) && {_x != _target} &&
+    {([_target, _x] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
 };
 
 [_vehicles, _statement, _target] call EFUNC(interact_menu,createVehiclesActions)

--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -34,7 +34,7 @@ if (_item  isEqualType "") then {
 } else {
     _validItem =
         (alive _item) &&
-        {(_item distance _vehicle) <= MAX_LOAD_DISTANCE};
+        {([_item, _vehicle] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE};
 };
 
 _validItem &&

--- a/addons/cargo/functions/fnc_initObject.sqf
+++ b/addons/cargo/functions/fnc_initObject.sqf
@@ -58,8 +58,9 @@ private _condition = {
             private _type = typeOf _x;
             private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];
             private _hasCargoConfig = getNumber (configFile >> "CfgVehicles" >> _type >> QGVAR(hasCargo)) == 1;
-            (_hasCargoPublic || _hasCargoConfig) && {_x != _target}
-        } count (nearestObjects [_player, GVAR(cargoHolderTypes), MAX_LOAD_DISTANCE])}
+            (_hasCargoPublic || _hasCargoConfig) && {_x != _target} &&
+            {([_target, _x] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
+        } count (nearestObjects [_player, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)])}
 };
 private _statement = {
     params ["_target", "_player"];

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -71,6 +71,7 @@ private _condition = {
     GVAR(enable) &&
     {(_target getVariable [QGVAR(hasCargo), getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(hasCargo)) == 1])} &&
     {locked _target < 2} &&
+    {([_player, _target] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE} &&
     {alive _target} &&
     {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)}
 };

--- a/addons/cargo/functions/fnc_onMenuOpen.sqf
+++ b/addons/cargo/functions/fnc_onMenuOpen.sqf
@@ -32,7 +32,7 @@ if (GVAR(interactionParadrop)) then {
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };
 
-    if (isNull GVAR(interactionVehicle) || {(ACE_player distance GVAR(interactionVehicle) >= 10) && {(vehicle ACE_player) != GVAR(interactionVehicle)}}) exitWith {
+    if (isNull GVAR(interactionVehicle) || {(([ACE_player, GVAR(interactionVehicle)] call EFUNC(interaction,getInteractionDistance)) >= MAX_LOAD_DISTANCE) && {(vehicle ACE_player) != GVAR(interactionVehicle)}}) exitWith {
         closeDialog 0;
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -24,7 +24,7 @@ private _vehicle = _cargoVehicle;
 if (isNull _vehicle) then {
     {
         if ([_object, _x] call FUNC(canLoadItemIn)) exitWith {_vehicle = _x};
-    } forEach (nearestObjects [_player, GVAR(cargoHolderTypes), MAX_LOAD_DISTANCE]);
+    } forEach (nearestObjects [_player, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)]);
 };
 
 if (isNull _vehicle) exitWith {

--- a/addons/cargo/script_component.hpp
+++ b/addons/cargo/script_component.hpp
@@ -16,7 +16,7 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
-#define MAX_LOAD_DISTANCE 10
+#define MAX_LOAD_DISTANCE 5
 
 #define GET_NUMBER(config,default) (if (isNumber (config)) then {getNumber (config)} else {default})
 

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -174,6 +174,7 @@ class CfgVehicles {
     };
 
     class rhsusf_CH53E_USMC: Helicopter_Base_H {
+        EGVAR(interaction,bodyWidth) = 3.5;
         EGVAR(map,vehicleLightColor)[] = {1,0,0,0.1};
         EGVAR(fastroping,enabled) = 1;
         EGVAR(fastroping,ropeOrigins)[] = {{0,-9.5,2.6}};


### PR DESCRIPTION
Close #5685 

Use getInteractionDistance, which approximately gets a distance to the outer hull of a vehicle
Great for very large aircraft as when near the rear you might be 12m from the center but 2m from the exit ramp.
