### PR TITLE
(spectator) unhide/unmute unit on exiting

### DIFF
--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -110,8 +110,13 @@ if (alive player) then {
     [player, _hidden, QGVAR(isSet), side group player] call EFUNC(common,switchToGroupSide);
 
     // Ghosts can't talk
-    [player, QGVAR(isSet)] call EFUNC(common,hideUnit);
-    [player, QGVAR(isSet)] call EFUNC(common,muteUnit);
+    if (_set) then {
+        [player, QGVAR(isSet)] call EFUNC(common,hideUnit);
+        [player, QGVAR(isSet)] call EFUNC(common,muteUnit);
+    } else {
+        [player, QGVAR(isSet)] call EFUNC(common,unhideUnit);
+        [player, QGVAR(isSet)] call EFUNC(common,unmuteUnit);
+    };
 };
 
 // Reset interruptions

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -110,7 +110,7 @@ if (alive player) then {
     [player, _hidden, QGVAR(isSet), side group player] call EFUNC(common,switchToGroupSide);
 
     // Ghosts can't talk
-    if (_set) then {
+    if (_hidden) then {
         [player, QGVAR(isSet)] call EFUNC(common,hideUnit);
         [player, QGVAR(isSet)] call EFUNC(common,muteUnit);
     } else {


### PR DESCRIPTION
**When merged this pull request will:**
- unmute/unhide player when exiting spectator

previously doing `[true] call ace_spectator_fnc_setSpectator` and then `[false] call ace_spectator_fnc_setSpectator` would result in a hidden player

I'm not entirely sure this is the best way. What if the player is dead when exiting?