### PR TITLE
Fix repair sound

### DIFF
--- a/addons/common/functions/fnc_playConfigSound3D.sqf
+++ b/addons/common/functions/fnc_playConfigSound3D.sqf
@@ -1,38 +1,43 @@
 /*
  * Author: esteldunedain
- * Plays a sound defined in CfgSounds using playSound3D, with global effect
+ * Plays a sound defined in CfgSounds using playSound3D, with global effect.
  *
  * Arguments:
  * 0: Sound class <STRING>
  * 1: Position ASL <ARRAY>
- * 2: Volume <NUMBER>
- * 3: Distance <NUMBER>
+ * 2: Volume <NUMBER> (default: from sound config)
+ * 3: Distance <NUMBER> (default: from sound config)
  *
  * Return Value:
  * None
  *
  * Example:
- * ["sound", [0,0,0], 5, 5] call ace_common_fnc_playConfigSound3D
+ * ["hint", getPosASL player, 5, 5] call ace_common_fnc_playConfigSound3D
  *
  * Public: Yes
  */
-// #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 params ["_soundClass", "_posASL", "_volume", "_distance"];
 
-private _cfgSound = configFile >> "CfgSounds" >> _soundClass;
-
-if (!isClass _cfgSound) exitWith {
-    ERROR_1("CfgSounds class [%1] does not exist", _soundClass);
+private _sound = getArray (configFile >> "CfgSounds" >> _soundClass >> "sound");
+if (_sound isEqualTo []) exitWith {
+    ERROR_1("CfgSounds class [%1] does not exist or contains empty sound array", _soundClass);
 };
+TRACE_2("sound",_soundClass,_sound);
 
-private _args = getArray (_cfgSound >> "sound");
-TRACE_1("playConfigSound3D args", _args);
-private _pitch = (_args select 2);
+_sound params ["_fileName", "_cfgVolume", "_pitch", ["_cfgDistance", 0]];
+
+ISNILS(_volume,_cfgVolume);
+ISNILS(_distance,_cfgDistance);
+
 // Strip the first \ from the filename
-private _fileName = _args select 0;
-_fileName = _fileName select [1, count _fileName - 1];
-TRACE_1("playConfigSound3D filename", _fileName);
+_fileName = _fileName select [1];
+
+// add file extension .wss as default
+if !(toLower (_fileName select [count _fileName - 4]) in [".wav", ".ogg", ".wss"]) then {
+    ADD(_fileName,".wss");
+};
+TRACE_5("vars",_fileName,_posASL,_volume,_pitch,_distance);
 
 playSound3D [_fileName, objNull, false, _posASL, _volume, _pitch, _distance];

--- a/addons/repair/CfgMoves.hpp
+++ b/addons/repair/CfgMoves.hpp
@@ -1,9 +1,9 @@
 class CfgMovesBasic;
 class CfgMovesMaleSdr: CfgMovesBasic {
-	class States {
-		class Campaign_Base;
-		class Acts_carFixingWheel: Campaign_Base {
-			soundOverride = "";
-		};
-	};
+    class States {
+        class Campaign_Base;
+        class Acts_carFixingWheel: Campaign_Base {
+            soundOverride = "";
+        };
+    };
 };

--- a/addons/repair/CfgMoves.hpp
+++ b/addons/repair/CfgMoves.hpp
@@ -1,0 +1,9 @@
+class CfgMovesBasic;
+class CfgMovesMaleSdr: CfgMovesBasic {
+	class States {
+		class Campaign_Base;
+		class Acts_carFixingWheel: Campaign_Base {
+			soundOverride = "";
+		};
+	};
+};

--- a/addons/repair/config.cpp
+++ b/addons/repair/config.cpp
@@ -16,7 +16,8 @@ class CfgPatches {
 
 #include "ACE_Repair.hpp"
 #include "ACE_Settings.hpp"
-#include "CfgEventHandlers.hpp"
 #include "CfgActions.hpp"
-#include "CfgVehicles.hpp"
 #include "CfgEden.hpp"
+#include "CfgEventHandlers.hpp"
+#include "CfgMoves.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/repair/functions/fnc_repair.sqf
+++ b/addons/repair/functions/fnc_repair.sqf
@@ -177,6 +177,9 @@ if (vehicle _caller == _caller && {_callerAnim != ""}) then {
     };
 };
 
+private _soundPosition = AGLToASL (_caller modelToWorldVisual (_caller selectionPosition "RightHand"));
+["Acts_carFixingWheel", _soundPosition, nil, 50] call EFUNC(common,playConfigSound3D);
+
 // Get repair time
 private _repairTime = [
     configFile >> "CfgVehicles" >> typeOf _target >> QGVAR(repairTimes) >> configName _config,


### PR DESCRIPTION
**When merged this pull request will:**
- remove sound from vanilla repair animation;
- add sound playback with `playSound3D` to repair function;
- improve `ace_common_fnc_playConfigSound3D` (doc, optional parameters, default file extension, etc);
- fix #5653.