### PR TITLE
Spectator - Fix script error in ui_draw3d

### DIFF
--- a/addons/spectator/functions/fnc_cam.sqf
+++ b/addons/spectator/functions/fnc_cam.sqf
@@ -17,6 +17,7 @@
 #include "script_component.hpp"
 
 params ["_init"];
+TRACE_1("cam",_init);
 
 // No change
 if (_init isEqualTo !isNil QGVAR(camera)) exitWith {};

--- a/addons/spectator/functions/fnc_respawnTemplate.sqf
+++ b/addons/spectator/functions/fnc_respawnTemplate.sqf
@@ -23,6 +23,7 @@
 #include "script_component.hpp"
 
 params [["_newCorpse",objNull,[objNull]], ["_oldKiller",objNull,[objNull]], ["_respawn",0,[0]], ["_respawnDelay",0,[0]]];
+TRACE_4("respawnTemplate",_newCorpse,_oldKiller,_respawn,_respawnDelay);
 
 // Compatibility handled via spectator display XEH
 if (_respawn in [0,1,4,5]) exitWith {

--- a/addons/spectator/functions/fnc_setSpectator.sqf
+++ b/addons/spectator/functions/fnc_setSpectator.sqf
@@ -101,6 +101,7 @@ if (_set) then {
 // Hide/Unhide the player if enabled and alive
 if (alive player) then {
     private _hidden = (_hide && _set);
+    TRACE_1("",_hidden);
 
     // Ignore damage (vanilla and ace_medical)
     player allowDamage !_hidden;

--- a/addons/spectator/functions/fnc_ui.sqf
+++ b/addons/spectator/functions/fnc_ui.sqf
@@ -17,6 +17,7 @@
 #include "script_component.hpp"
 
 params ["_init"];
+TRACE_1("ui",_init);
 
 // No change
 if (_init isEqualTo !isNull SPEC_DISPLAY) exitWith {};

--- a/addons/spectator/functions/fnc_ui_draw3D.sqf
+++ b/addons/spectator/functions/fnc_ui_draw3D.sqf
@@ -18,7 +18,7 @@
 #define HEIGHT_OFFSET 1.5
 
 BEGIN_COUNTER(updateCursor);
-private _camTarget = GVAR(camFocus);
+private _camTarget = missionNamespace getVariable [QGVAR(camFocus), objNull];
 private _camTargetVeh = vehicle _camTarget;
 private _cursorObject = objNull;
 


### PR DESCRIPTION
```
[ACE] (spectator) TRACE: 85515 respawnTemplate: _newCorpse=unit1, _oldKiller=unit1, _respawn=3, _respawnDelay=10 z\ace\addons\spectator\functions\fnc_respawnTemplate.sqf:26
[ACE] (spectator) TRACE: 85515 Params: _set=false, _force=true, _hide=true z\ace\addons\spectator\functions\fnc_setSpectator.sqf:25
[ACE] (spectator) TRACE: 85515 cam: _init=false z\ace\addons\spectator\functions\fnc_cam.sqf:20
[ACE] (spectator) TRACE: 85515 : player=unit1, _hidden=false z\ace\addons\spectator\functions\fnc_setSpectator.sqf:107
Error in expression <30625 ) then {
private _intersections = lineIntersectsSurfaces [_start, _end, _c>
  Error position: <lineIntersectsSurfaces [_start, _end, _c>
  Error Type Any, expected Object
File z\ace\addons\spectator\functions\fnc_ui_draw3D.sqf, line 18
[ACE] (spectator) TRACE: 85516 ui: _init=false z\ace\addons\spectator\functions\fnc_ui.sqf:20
```

FUNC(cam) sets `GVAR(camFocus)              = nil;`
draw EH is removed a frame later in FUNC(ui) because it's delayed with
`[{ !isNull MAIN_DISPLAY },{ [false] call FUNC(ui) }] call CBA_fnc_waitUntilAndExecute;`

 this just uses `getVariable` to prevent nil error
