### PR TITLE
Spectator - Use ACRE2 add display passthrough keys API

### DIFF
--- a/addons/spectator/XEH_PREP.hpp
+++ b/addons/spectator/XEH_PREP.hpp
@@ -17,6 +17,7 @@ PREP(ui_handleChildDestroyed);
 PREP(ui_handleKeyDown);
 PREP(ui_handleKeyUp);
 PREP(ui_handleListClick);
+PREP(ui_handleLoad);
 PREP(ui_handleMapClick);
 PREP(ui_handleMapDraw);
 PREP(ui_handleMouseButtonDblClick);

--- a/addons/spectator/functions/fnc_ui_handleKeyDown.sqf
+++ b/addons/spectator/functions/fnc_ui_handleKeyDown.sqf
@@ -197,13 +197,4 @@ if ((_key in (actionKeys "CuratorInterface")) && {!isNull (getAssignedCuratorLog
     true
 };
 
-// Handle acre spectate headset down (if present)
-if (
-    ["acre_sys_radio"] call EFUNC(common,isModLoaded) &&
-    { [_key, [_shift, _ctrl, _alt]] isEqualTo ((["ACRE2", "HeadSet"] call CBA_fnc_getKeybind) select 5) }
-) exitWith {
-    [] call acre_sys_core_fnc_toggleHeadset;
-    true
-};
-
 false // default to unhandled

--- a/addons/spectator/functions/fnc_ui_handleLoad.sqf
+++ b/addons/spectator/functions/fnc_ui_handleLoad.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: SilentSpike, Jonpas
+ * Function used to handle load event.
+ *
+ * Arguments:
+ * 0: Spectator display <DISPLAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * _this call ace_spectator_fnc_ui_handleLoad
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_display"];
+
+uiNamespace setVariable [QGVAR(display), _display];
+
+// Handle ACRE2 Toggle Spectator (if present)
+if (["acre_sys_radio"] call EFUNC(common,isModLoaded)) then {
+    [_display] call acre_api_fnc_addDisplayPassthroughKeys;
+};

--- a/addons/spectator/functions/fnc_ui_handleLoad.sqf
+++ b/addons/spectator/functions/fnc_ui_handleLoad.sqf
@@ -20,6 +20,6 @@ params ["_display"];
 uiNamespace setVariable [QGVAR(display), _display];
 
 // Handle ACRE2 Toggle Spectator (if present)
-if (["acre_sys_radio"] call EFUNC(common,isModLoaded)) then {
+if (!isNil "acre_api_fnc_addDisplayPassthroughKeys") then {
     [_display] call acre_api_fnc_addDisplayPassthroughKeys;
 };

--- a/addons/spectator/ui.hpp
+++ b/addons/spectator/ui.hpp
@@ -17,8 +17,8 @@ class GVAR(display) {
     enableSimulation = 1;
     movingEnable = 0;
     closeOnMissionEnd = 1;
-    
-    onLoad = QUOTE(with uiNameSpace do {GVAR(display) = _this select 0};);
+
+    onLoad = QUOTE(_this call FUNC(ui_handleLoad));
 
     onKeyDown = QUOTE(_this call FUNC(ui_handleKeyDown));
     onKeyUp = QUOTE(_this call FUNC(ui_handleKeyUp));


### PR DESCRIPTION
**When merged this pull request will:**
- ACRE2 v2.5.1 will have `acre_api_fnc_addDisplayPassthroughKeys` function (https://github.com/IDI-Systems/acre2/pull/437) for better compatibility with all spectator systems. It will hook all required buttons (only "Mute Spectators" as of this time) and also support CBA's new multiple keybinds.