### PR TITLE
Scopes - Rifle zeroing improvements

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -111,6 +111,8 @@
 
 #define GRAVITY 9.8066
 
+#define SD_TO_MIN_MAX(d) ((d) * 3.371) // Standard deviation -> min / max of random [min, mid, max]
+
 // Angular unit conversion
 #define MRAD_TO_MOA(d) ((d) * 3.43774677) // Conversion factor: 54 / (5 * PI)
 #define MOA_TO_MRAD(d) ((d) * 0.29088821) // Conversion factor: (5 * PI) / 54

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -119,5 +119,6 @@
 #define DEG_TO_MRAD(d) ((d) * 17.45329252) // Conversion factor: (50 * PI) / 9
 #define MRAD_TO_DEG(d) ((d) / 17.45329252) // Conversion factor: 9 / (50 * PI)
 #define MOA_TO_RAD(d) ((d) * 0.00029088) // Conversion factor: PI / 10800
+#define RAD_TO_DEG(d) ((d) * 57.29577951) // Conversion factor: 180 / PI
 
 #include "script_debug.hpp"

--- a/addons/overheating/XEH_postInit.sqf
+++ b/addons/overheating/XEH_postInit.sqf
@@ -48,12 +48,15 @@ if (hasInterface) then {
     //Add Take EH (for reload)
     ["CAManBase", "Take", {_this call FUNC(handleTakeEH);}] call CBA_fnc_addClassEventHandler;
 
-    // Register fire event handler
-    ["ace_firedPlayer", DFUNC(firedEH)] call CBA_fnc_addEventHandler;
-    // Only add eh to non local players if dispersion is enabled
-    if (GVAR(overheatingDispersion)) then {
-        ["ace_firedPlayerNonLocal", DFUNC(firedEH)] call CBA_fnc_addEventHandler;
-    };
+    // Make sure these run after the firedEH in the scopes module
+    [{
+        // Register fire event handler
+        ["ace_firedPlayer", DFUNC(firedEH)] call CBA_fnc_addEventHandler;
+        // Only add eh to non local players if dispersion is enabled
+        if (GVAR(overheatingDispersion)) then {
+            ["ace_firedPlayerNonLocal", DFUNC(firedEH)] call CBA_fnc_addEventHandler;
+        };
+    }, []] call CBA_fnc_execNextFrame;
 
     // Schedule cool down calculation of player weapons at (infrequent) regular intervals
     [] call FUNC(updateTemperatureThread);

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -306,7 +306,7 @@ class CfgWeapons {
     };
 
     class SMG_01_Base: Rifle_Short_Base_F {
-        ACE_RailHeightAboveBore = 8.85355;
+        ACE_RailHeightAboveBore = 4.85355;
     };
     class SMG_02_base_F: Rifle_Short_Base_F  {
         ACE_RailHeightAboveBore = 4.41831;
@@ -362,13 +362,13 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 2.83284;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
-        ACE_RailHeightAboveBore = 4.43913;
+        ACE_RailHeightAboveBore = 3.43913;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
         ACE_RailHeightAboveBore = 4.0795;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
-        ACE_RailHeightAboveBore = 5.38022;
+        ACE_RailHeightAboveBore = 2.38022;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         ACE_RailHeightAboveBore = 3.91334;

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -255,6 +255,7 @@ class CfgWeapons {
 
     class pdw2000_base_F: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 3.08883;
+        ACE_RailBaseAngle = 0.019366;
     };
 
     class arifle_AKS_base_F: Rifle_Base_F {
@@ -307,12 +308,15 @@ class CfgWeapons {
 
     class SMG_01_Base: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 4.85355;
+        ACE_RailBaseAngle = 0.0250956;
     };
     class SMG_02_base_F: Rifle_Short_Base_F  {
         ACE_RailHeightAboveBore = 4.41831;
+        ACE_RailBaseAngle = 0.0217724;
     };
     class SMG_05_base_F: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 4.05169;
+        ACE_RailBaseAngle = 0.019366;
     };
 
     class Tavor_base_F: Rifle_Base_F {};
@@ -369,6 +373,7 @@ class CfgWeapons {
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         ACE_RailHeightAboveBore = 2.38022;
+        ACE_RailBaseAngle = 0.019366;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         ACE_RailHeightAboveBore = 3.91334;

--- a/addons/scopes/XEH_PREP.hpp
+++ b/addons/scopes/XEH_PREP.hpp
@@ -2,9 +2,10 @@
 PREP(adjustScope);
 PREP(adjustZero);
 PREP(applyScopeAdjustment);
-PREP(calculateZeroAngleCorrection);
+PREP(calculateZeroAngle);
 PREP(canAdjustZero);
 PREP(firedEH);
+PREP(getBaseAngle);
 PREP(getBoreHeight);
 PREP(getCurrentZeroRange);
 PREP(getOptics);

--- a/addons/scopes/XEH_postInit.sqf
+++ b/addons/scopes/XEH_postInit.sqf
@@ -14,6 +14,7 @@ GVAR(Guns) = ["", "", ""];
 GVAR(canAdjustElevation) = [false, false, false];
 GVAR(canAdjustWindage) = [false, false, false];
 GVAR(boreHeight) = [0, 0, 0];
+GVAR(baseAngle) = [0, 0, 0];
 GVAR(scopeAdjust) = [[[0,0],0,[0,0],0], [[0,0],0,[0,0],0], [[0,0],0,[0,0],0]];
 
 ["ace_settingsInitialized", {

--- a/addons/scopes/functions/fnc_calculateZeroAngle.sqf
+++ b/addons/scopes/functions/fnc_calculateZeroAngle.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: Ruthberg
- * Calculates the zero angle correction for the new zero range based on current zero range and bore height (distance between bore- and sight axis)
+ * Calculates the required zero angle for the given zero range with respect to the bore height (distance between bore- and sight axis)
  *
  * Arguments:
  * 0: Zero range <NUMBER>
@@ -14,13 +14,13 @@
  * zeroAngleCorrection <NUMBER>
  *
  * Example:
- * [5, 6, gun, ammo, magazine, true] call ace_scopes_fnc_calculateZeroAngleCorrection
+ * [5, 6, gun, ammo, magazine, true] call ace_scopes_fnc_calculateZeroAngle
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_oldZeroRange", "_newZeroRange", "_boreHeight"/*in cm*/, "_weapon", "_ammo", "_magazine", "_advancedBallistics"];
+params ["_zeroRange", "_boreHeight"/*in cm*/, "_weapon", "_ammo", "_magazine", "_advancedBallistics"];
 
 private _airFriction = getNumber (configFile >> "CfgAmmo" >> _ammo >> "airFriction");
 private _initSpeed = getNumber(configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
@@ -32,11 +32,8 @@ if (_initSpeedCoef < 0) then {
     _initSpeed = _initSpeed * (-1 * _initSpeedCoef);
 };
 
-private _zeroAngle = "ace_advanced_ballistics" callExtension format ["zeroAngleVanilla:%1:%2:%3:%4", _oldZeroRange, _initSpeed, _airFriction, 0];
-private _vanillaZero = parseNumber _zeroAngle;
-
 private _trueZero = if (!_advancedBallistics) then {
-    _zeroAngle = "ace_advanced_ballistics" callExtension format ["zeroAngleVanilla:%1:%2:%3:%4", _newZeroRange, _initSpeed, _airFriction, _boreHeight];
+    private _zeroAngle = "ace_advanced_ballistics" callExtension format ["zeroAngleVanilla:%1:%2:%3:%4", _zeroRange, _initSpeed, _airFriction, _boreHeight];
     (parseNumber _zeroAngle)
 } else {
     // Get Weapon and Ammo Configurations
@@ -66,8 +63,6 @@ private _trueZero = if (!_advancedBallistics) then {
     (parseNumber _zeroAngle)
 };
 
-private _zeroAngleCorrection = _trueZero - _vanillaZero;
+missionNamespace setVariable [format[QGVAR(%1_%2_%3_%4_%5_%6), _zeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics], _trueZero];
 
-missionNamespace setVariable [format[QGVAR(%1_%2_%3_%4_%5_%6_%7), _oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics], _zeroAngleCorrection];
-
-_zeroAngleCorrection
+_trueZero

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -36,7 +36,7 @@ if (GVAR(correctZeroing)) then {
     private _railDirection = _unit weaponDirection _weapon;
     _projectile setVelocity (_railDirection vectorMultiply _muzzleVelocity);
     // Add dispersion (Bivariate normal distribution - calculate variance by solving the Rayleigh CDF for sigma at x ~ 0.6827)
-    private _dispersion = SD_TO_MIN_MAX(0.659991 * sqrt((RAD_TO_DEG(getNumber(configFile >> "CfgWeapons" >> _weapon >> "Single" >> "dispersion")) / 2) ^ 2));
+    private _dispersion = SD_TO_MIN_MAX(0.66 * RAD_TO_DEG(getNumber(configFile >> "CfgWeapons" >> _weapon >> "Single" >> "dispersion")) / 2);
     _zeroing = _zeroing vectorAdd [random [-_dispersion, 0, _dispersion], random [-_dispersion, 0, _dispersion], 0];
     // Calculate correct zero angle
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -31,15 +31,20 @@ TRACE_1("Adjusting With",_zeroing);
 _zeroing = _zeroing vectorMultiply MRAD_TO_DEG(1);
 
 if (GVAR(correctZeroing)) then {
+    // Override all previously applied corrections
+    private _muzzleVelocity = vectorMagnitude (velocity _projectile);
+    private _railDirection = _unit weaponDirection _weapon;
+    _projectile setVelocity (_railDirection vectorMultiply _muzzleVelocity);
+    // Calculate correct zero angle
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];
     private _boreHeight = GVAR(boreHeight) select _weaponIndex;
-    private _oldZeroRange = currentZeroing _unit;
-    private _newZeroRange = [_unit] call FUNC(getCurrentZeroRange);
-    private _zeroCorrection = missionNamespace getVariable format[QGVAR(%1_%2_%3_%4_%5_%6_%7), _oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics];
+    private _baseAngle = GVAR(baseAngle) select _weaponIndex;
+    private _zeroRange = [_unit] call FUNC(getCurrentZeroRange);
+    private _zeroAngle = missionNamespace getVariable format[QGVAR(%1_%2_%3_%4_%5_%6), _zeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics];
     if (isNil "_zeroCorrection") then {
-         _zeroCorrection = [_oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics] call FUNC(calculateZeroAngleCorrection);
+         _zeroAngle = [_zeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics] call FUNC(calculateZeroAngle);
     };
-    _zeroing = _zeroing vectorAdd [0, 0, _zeroCorrection];
+    _zeroing = _zeroing vectorAdd [0, 0, _zeroAngle - _baseAngle];
 };
 
 if (_zeroing isEqualTo [0, 0, 0]) exitWith {};

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -36,7 +36,7 @@ if (GVAR(correctZeroing)) then {
     private _railDirection = _unit weaponDirection _weapon;
     _projectile setVelocity (_railDirection vectorMultiply _muzzleVelocity);
     // Add dispersion (Bivariate normal distribution - calculate variance by solving the Rayleigh CDF for sigma at x ~ 0.6827)
-    private _dispersion = 0.659991 * sqrt((RAD_TO_DEG(getNumber(configFile >> "CfgWeapons" >> _weapon >> "Single" >> "dispersion")) / 2) ^ 2);
+    private _dispersion = SD_TO_MIN_MAX(0.659991 * sqrt((RAD_TO_DEG(getNumber(configFile >> "CfgWeapons" >> _weapon >> "Single" >> "dispersion")) / 2) ^ 2));
     _zeroing = _zeroing vectorAdd [random [-_dispersion, 0, _dispersion], random [-_dispersion, 0, _dispersion], 0];
     // Calculate correct zero angle
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -35,15 +35,18 @@ if (GVAR(correctZeroing)) then {
     private _muzzleVelocity = vectorMagnitude (velocity _projectile);
     private _railDirection = _unit weaponDirection _weapon;
     _projectile setVelocity (_railDirection vectorMultiply _muzzleVelocity);
+    // Add dispersion (Bivariate normal distribution - calculate variance by solving the Rayleigh CDF for sigma at x ~ 0.6827)
+    private _dispersion = 0.659991 * sqrt((RAD_TO_DEG(getNumber(configFile >> "CfgWeapons" >> _weapon >> "Single" >> "dispersion")) / 2) ^ 2);
+    _zeroing = _zeroing vectorAdd [random [-_dispersion, 0, _dispersion], random [-_dispersion, 0, _dispersion], 0];
     // Calculate correct zero angle
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];
     private _boreHeight = GVAR(boreHeight) select _weaponIndex;
-    private _baseAngle = GVAR(baseAngle) select _weaponIndex;
     private _zeroRange = [_unit] call FUNC(getCurrentZeroRange);
     private _zeroAngle = missionNamespace getVariable format[QGVAR(%1_%2_%3_%4_%5_%6), _zeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics];
     if (isNil "_zeroCorrection") then {
          _zeroAngle = [_zeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics] call FUNC(calculateZeroAngle);
     };
+    private _baseAngle = GVAR(baseAngle) select _weaponIndex;
     _zeroing = _zeroing vectorAdd [0, 0, _zeroAngle - _baseAngle];
 };
 

--- a/addons/scopes/functions/fnc_getBaseAngle.sqf
+++ b/addons/scopes/functions/fnc_getBaseAngle.sqf
@@ -1,0 +1,31 @@
+/*
+ * Author: Ruthberg
+ * Gets the base angle of the rail on the weapon with the given weapon index
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Weapon index <NUMBER>
+ *
+ * Return Value:
+ * rail base angle <NUMBER>
+ *
+ * Example:
+ * [player, 0] call ace_scopes_fnc_getBaseAngle
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params ["_player", "_weaponIndex"];
+
+if (_weaponIndex < 0 || {_weaponIndex > 2}) exitWith { 0 };
+
+private _weaponClass = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] select _weaponIndex;
+
+private _baseAngle = DEFAULT_RAIL_BASE_ANGLE;
+private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
+if (isNumber (_weaponConfig >> "ACE_RailBaseAngle")) then {
+    _baseAngle = getNumber(_weaponConfig >> "ACE_RailBaseAngle");
+};
+
+_baseAngle

--- a/addons/scopes/functions/fnc_getBoreHeight.sqf
+++ b/addons/scopes/functions/fnc_getBoreHeight.sqf
@@ -10,7 +10,7 @@
  * bore height <NUMBER>
  *
  * Example:
- * [player] call ace_scopes_fnc_getBoreHeight
+ * [player, 0] call ace_scopes_fnc_getBoreHeight
  *
  * Public: Yes
  */

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -69,9 +69,10 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
             _adjustment set [_forEachIndex, [0, 0, 0]];
             _updateAdjustment = true;
         };
-        
+
         GVAR(boreHeight) set [_x, [_player, _x] call FUNC(getBoreHeight)];
-                
+        GVAR(baseAngle) set [_x, [_player, _x] call FUNC(getBaseAngle)];
+
         if ((_newOptics select _x) == "") then {
             // Check if the weapon comes with an integrated optic     
             private _weaponConfig = configFile >> "CfgWeapons" >> (_newGuns select _x); 

--- a/addons/scopes/script_component.hpp
+++ b/addons/scopes/script_component.hpp
@@ -14,6 +14,8 @@
 #define MINOR_INCREMENT false
 #define MAJOR_INCREMENT true
 
+#define DEFAULT_RAIL_BASE_ANGLE 0.00802141
+
 #ifdef DEBUG_ENABLED_SCOPES
     #define DEBUG_MODE_FULL
 #endif

--- a/extensions/advanced_ballistics/AdvancedBallistics.cpp
+++ b/extensions/advanced_ballistics/AdvancedBallistics.cpp
@@ -253,7 +253,7 @@ double calculateZeroAngle(double zeroRange, double muzzleVelocity, double boreHe
         double offset = -std::atan(y / zeroRange);
         zeroAngle += offset;
 
-        if (std::abs(offset) < 0.0001f) {
+        if (std::abs(offset) < 0.00001f) {
             break;
         }
     }


### PR DESCRIPTION
* Fixed vertical point of impact shift with different initSpeeds / airFrictions (vanilla bug)
* Rifle/Ammo precision is now following a bivariate normal distribution

| Vanilla | ACE3 |
| -------- | -------- |
| ![dispersion_vanilla](https://user-images.githubusercontent.com/9437207/32676869-7ad6229e-c65c-11e7-8ff2-9ceef3f50f94.png) | ![dispersion_ace3](https://user-images.githubusercontent.com/9437207/32676866-794a09d6-c65c-11e7-87b9-eb9f2fd2377a.png) |

Instead of trying to undo the vanilla zeroing we now overwrite the velocity vector of the projectile with the current `weaponDirection` and apply an angular offset (`ACE_RailBaseAngle`).

*TODO:*
- [ ] Make the `dispersion` config lookup more robust
- [ ] Figure out how to handle non local units
- [ ] Test with 3rd party rifles
- [ ] Rebuild AB DLLs
