### PR TITLE
Wirecutter - Add global event when cutting fences

### DIFF
--- a/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
@@ -56,6 +56,6 @@ private _progressCheck = {
     ((!isNull _fenceObject) && {(damage _fenceObject) < 1} && {("ACE_wirecutter" in (items _unit))})
 };
 
-["ace_wireCuttingStarted", [_unit, _fenceObject]] call CBA_fnc_globalEvent;
-
 [_timeToCut, [_fenceObject,0,_unit], _onCompletion, _onFail, localize LSTRING(CuttingFence), _progressCheck, ["isNotSwimming"]] call EFUNC(common,progressBar);
+
+["ace_wireCuttingStarted", [_unit, _fenceObject]] call CBA_fnc_globalEvent;

--- a/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
@@ -56,6 +56,6 @@ private _progressCheck = {
     ((!isNull _fenceObject) && {(damage _fenceObject) < 1} && {("ACE_wirecutter" in (items _unit))})
 };
 
-["ace_wireCutStart", [_unit, _fenceObject]] call CBA_fnc_globalEvent;
+["ace_wireCuttingStarted", [_unit, _fenceObject]] call CBA_fnc_globalEvent;
 
 [_timeToCut, [_fenceObject,0,_unit], _onCompletion, _onFail, localize LSTRING(CuttingFence), _progressCheck, ["isNotSwimming"]] call EFUNC(common,progressBar);

--- a/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
@@ -56,4 +56,6 @@ private _progressCheck = {
     ((!isNull _fenceObject) && {(damage _fenceObject) < 1} && {("ACE_wirecutter" in (items _unit))})
 };
 
+["ace_wireCutStart", [_unit, _fenceObject]] call CBA_fnc_globalEvent;
+
 [_timeToCut, [_fenceObject,0,_unit], _onCompletion, _onFail, localize LSTRING(CuttingFence), _progressCheck, ["isNotSwimming"]] call EFUNC(common,progressBar);


### PR DESCRIPTION
This hook could be used to script things happening when player 'touches' fence when wirecutting. Would reduce overhead if you want to script electric fences (no need for distance checks).

**When merged this pull request will:**
- add global event to wirecut start
