### PR TITLE
Scopes - Persistent zero adjustments (only with advanced ballistics)

### DIFF
--- a/addons/scopes/functions/fnc_adjustZero.sqf
+++ b/addons/scopes/functions/fnc_adjustZero.sqf
@@ -19,7 +19,8 @@ params ["_unit"];
 
 if (vehicle _unit != _unit) exitWith {false};
 
-private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
+private _weaponClass = currentWeapon _unit;
+private _weaponIndex = [_unit, _weaponClass] call EFUNC(common,getWeaponIndex);
 if (_weaponIndex < 0) exitWith {false};
 
 private _adjustment = _unit getVariable [QGVAR(Adjustment), [[0, 0, 0], [0, 0, 0], [0, 0, 0]]];
@@ -28,6 +29,13 @@ _zeroing params ["_elevation", "_windage", "_zero"];
 
 _zero = round((_zero + _elevation) * 10) / 10;
 _elevation = 0;
+
+private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex;
+if (_zero != 0) then {
+    profileNamespace setVariable [format["ACE_Scopes_PersistentZero_%1_%2", _weaponClass, _opticsClass], _zero];
+} else {
+    profileNamespace setVariable [format["ACE_Scopes_PersistentZero_%1_%2", _weaponClass, _opticsClass], nil];
+};
 
 [_unit, _elevation, _windage, _zero] call FUNC(applyScopeAdjustment);
 

--- a/addons/scopes/functions/fnc_adjustZero.sqf
+++ b/addons/scopes/functions/fnc_adjustZero.sqf
@@ -32,9 +32,9 @@ _elevation = 0;
 
 private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex;
 if (_zero != 0) then {
-    profileNamespace setVariable [format["ACE_Scopes_PersistentZero_%1_%2", _weaponClass, _opticsClass], _zero];
+    profileNamespace setVariable [format[QGVAR(PersistentZero_%1_%2), _weaponClass, _opticsClass], _zero];
 } else {
-    profileNamespace setVariable [format["ACE_Scopes_PersistentZero_%1_%2", _weaponClass, _opticsClass], nil];
+    profileNamespace setVariable [format[QGVAR(PersistentZero_%1_%2), _weaponClass, _opticsClass], nil];
 };
 
 [_unit, _elevation, _windage, _zero] call FUNC(applyScopeAdjustment);

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -64,13 +64,6 @@ private _newOptics = [_player] call FUNC(getOptics);
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
-        // The optic or the weapon changed, reset the adjustment
-        private _persistentZero = profileNamespace getVariable [format["ACE_Scopes_PersistentZero_%1_%2", _newGuns select _x, _newOptics select _x], 0];
-        if (!((_adjustment select _forEachIndex) isEqualTo [0, 0, _persistentZero])) then {
-            _adjustment set [_forEachIndex, [0, 0, _persistentZero]];
-            _updateAdjustment = true;
-        };
-
         GVAR(baseAngle) set [_x, [_player, _x] call FUNC(getBaseAngle)]; 
         GVAR(boreHeight) set [_x, [_player, _x] call FUNC(getBoreHeight)];
 
@@ -100,6 +93,17 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
             (GVAR(scopeAdjust) select _x) set [3, _horizontalIncrement];
             GVAR(canAdjustElevation) set [_x, (_verticalIncrement > 0) && !(_maxVertical isEqualTo [0, 0])];
             GVAR(canAdjustWindage) set [_x, (_horizontalIncrement > 0) && !(_maxHorizontal isEqualTo [0, 0])];
+        };
+        
+        // The optic or the weapon changed, reset the adjustment
+        private _persistentZero = profileNamespace getVariable [format[QGVAR(PersistentZero_%1_%2), _newGuns select _x, _newOptics select _x], 0];
+        ((GVAR(scopeAdjust) select _x) select 0) params ["_minElevation", "_maxElevation"];
+        if (!(_persistentZero isEqualType 0) || {_persistentZero < _minElevation || _persistentZero > _maxElevation}) then {
+            _persistentZero = 0;
+        };
+        if (!((_adjustment select _forEachIndex) isEqualTo [0, 0, _persistentZero])) then {
+            _adjustment set [_forEachIndex, [0, 0, _persistentZero]];
+            _updateAdjustment = true;
         };
     }
 } forEach [0, 1, 2];

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -64,9 +64,10 @@ private _newOptics = [_player] call FUNC(getOptics);
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
-        // The optic or the weapon changed, set adjustment to zero
-        if (!((_adjustment select _forEachIndex) isEqualTo [0, 0, 0])) then {
-            _adjustment set [_forEachIndex, [0, 0, 0]];
+        // The optic or the weapon changed, reset the adjustment
+        private _persistentZero = profileNamespace getVariable [format["ACE_Scopes_PersistentZero_%1_%2", _newGuns select _x, _newOptics select _x], 0];
+        if (!((_adjustment select _forEachIndex) isEqualTo [0, 0, _persistentZero])) then {
+            _adjustment set [_forEachIndex, [0, 0, _persistentZero]];
             _updateAdjustment = true;
         };
 


### PR DESCRIPTION
* Makes manual zero adjustments for each weapon & scope combination persistent across game restarts / mission restarts / weapon or scope changes.