### PR TITLE
Scopes - Auto convert rifle/ammo precision to dispersion

### DIFF
--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -15,14 +15,14 @@ class CfgWeapons {
     // GM6 Lynx
     class GM6_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
     };
 
     // M200 Intervention
     class LRR_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.7);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(0.7));
         };
     };
 
@@ -41,65 +41,65 @@ class CfgWeapons {
     // M14
     class DMR_06_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
     };
 
     // Cyrus
     class DMR_05_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
     };
 
     // ASP-1 Kir
     class DMR_04_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
     };
 
     // SIG 556
     class DMR_03_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.1);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.1));
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.1);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.1));
         };
     };
 
     // Noreen "Bad News" ULR
     class DMR_02_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.9);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(0.9));
         };
     };
 
     // VS-121
     class DMR_01_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.375);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.375));
         };
     };
 
     // Mk14 Mod 1 EBR
     class EBR_base_F: Rifle_Long_Base_F {
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.0));
         };
     };
 
@@ -137,11 +137,11 @@ class CfgWeapons {
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 457.2;
         class Single: Single {
-            dispersion = MOA_TO_RAD(1.5);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.5));
         };
 
         class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(1.5);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(1.5));
         };
     };
     
@@ -218,15 +218,15 @@ class CfgWeapons {
     class SDAR_base_F: Rifle_Base_F {
         initSpeed = -1.211;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(3.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(3.0));
         };
 
         class Burst: Mode_Burst {
-            dispersion = MOA_TO_RAD(3.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(3.0));
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(3.0);
+            dispersion = PRECISION_TO_DISPERSION(MOA_TO_RAD(3.0));
         };
     };
 

--- a/addons/scopes/script_component.hpp
+++ b/addons/scopes/script_component.hpp
@@ -16,6 +16,12 @@
 
 #define DEFAULT_RAIL_BASE_ANGLE 0.0086
 
+// Converts rifle/ammo precision (a) into dispersion config values (b)
+// Meets the following criteria:
+// 68.3 % of the shots land within a circle of diameter (1a)
+// 99.6 % of the shots land within a circle of diameter (2a)
+#define PRECISION_TO_DISPERSION(d) ((d) * 0.562) // empirical data
+
 #ifdef DEBUG_ENABLED_SCOPES
     #define DEBUG_MODE_FULL
 #endif


### PR DESCRIPTION
Converts rifle/ammo precision (a) into dispersion config values (b).

Meets the following criteria:
* 68.3 % of the shots land within a circle of diameter (0.5 * a)
* 99.6 % of the shots land within a circle of diameter (1.0 * a)

- [ ] Needs discussion since it might impact gameplay for some people.

| Vanilla | ACE3 |
| -------- | -------- |
| ![dispersion_vanilla](https://user-images.githubusercontent.com/9437207/32723593-57291e6e-c86e-11e7-89c1-d5a7f87a4067.png) | ![dispersion_ace3](https://user-images.githubusercontent.com/9437207/32723596-588d8f7e-c86e-11e7-8919-04fe7c8db562.png) |
| ![dispersion_vanilla](https://user-images.githubusercontent.com/9437207/32723741-e3ba2f62-c86e-11e7-91c8-f7896970f8d7.png) | ![dispersion_ace3](https://user-images.githubusercontent.com/9437207/32723739-e2e63b94-c86e-11e7-8575-186ef64a4dee.png) |