### PR TITLE
Change key items mass from 0 to 0.1

### DIFF
--- a/addons/vehiclelock/CfgWeapons.hpp
+++ b/addons/vehiclelock/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\keyBlack.paa);
         scope = 2;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 0;
+            mass = 0.1;
         };
     };
     class ACE_key_lockpick: ACE_key_master {


### PR DESCRIPTION
**When merged this pull request will:**
- Change ace keys and lockpick to have 0.1 mass instead of 0.
