### PR TITLE
Make.py Mikero tools detection fix

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -228,57 +228,31 @@ def find_bi_tools(work_drive):
         raise Exception("BadTools","Arma 3 Tools are not installed correctly or the P: drive needs to be created.")
 
 
-def find_depbo_tools(regKey):
+def find_depbo_tools():
     """Use registry entries to find DePBO-based tools."""
-    stop = False
+    requiredToolPaths = {"pboProject": None,"rapify": None,"MakePbo": None}
+    failed = False
 
-    if regKey == "HKCU":
-        reg = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
-        stop = True
-    else:
-        reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
-
-    try:
+    for tool in requiredToolPaths:
         try:
-            k = winreg.OpenKey(reg, r"Software\Wow6432Node\Mikero\pboProject")
+            k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Mikero\{}".format(tool))
         except FileNotFoundError:
-            k = winreg.OpenKey(reg, r"Software\Mikero\pboProject")
+            k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"Software\Mikero\{}".format(tool))
         try:
-            pboproject_path = winreg.QueryValueEx(k, "exe")[0]
-            winreg.CloseKey(k)
-            print("Found pboproject.")
+            path = winreg.QueryValueEx(k, "exe")[0]
+            #Strip any quotations from the path due to a MikeRo tool bug which leaves a trailing space in some of its registry paths.
+            requiredToolPaths[tool] = path.strip('"')
+            print_green("Found {}.".format(tool))
         except:
-            print_error("Could not find pboProject.")
-
-        try:
-            k = winreg.OpenKey(reg, r"Software\Wow6432Node\Mikero\rapify")
-        except FileNotFoundError:
-            k = winreg.OpenKey(reg, r"Software\Mikero\rapify")
-        try:
-            rapify_path = winreg.QueryValueEx(k, "exe")[0]
+            print_error("Could not find {}".format(tool))
+            failed = True
+        finally:
             winreg.CloseKey(k)
-            print("Found rapify.")
-        except:
-            print_error("Could not find rapify.")
 
-        try:
-            k = winreg.OpenKey(reg, r"Software\Wow6432Node\Mikero\MakePbo")
-        except FileNotFoundError:
-            k = winreg.OpenKey(reg, r"Software\Mikero\MakePbo")
-        try:
-            makepbo_path = winreg.QueryValueEx(k, "exe")[0]
-            winreg.CloseKey(k)
-            print("Found makepbo.")
-        except:
-            print_error("Could not find makepbo.")
-    except:
-        if stop == True:
-            raise Exception("BadDePBO", "DePBO tools not installed correctly")
-        return -1
+    if failed > 0:
+        raise Exception("BadDePBO", "DePBO tools not installed correctly")
 
-
-    #Strip any quotations from the path due to a MikeRo tool bug which leaves a trailing space in some of its registry paths.
-    return [pboproject_path.strip('"'),rapify_path.strip('"'),makepbo_path.strip('"')]
+    return requiredToolPaths
 
 
 def color(color):
@@ -1037,12 +1011,11 @@ See the make.cfg file for additional build options.
 
     if build_tool == "pboproject":
         try:
-            depbo_tools = find_depbo_tools("HKLM")
-            if depbo_tools == -1:
-                depbo_tools = find_depbo_tools("HKCU")
-            pboproject = depbo_tools[0]
-            rapifyTool = depbo_tools[1]
-            makepboTool = depbo_tools[2]
+            depbo_tools = find_depbo_tools()
+
+            pboproject = depbo_tools["pboProject"]
+            rapifyTool = depbo_tools["rapify"]
+            makepboTool = depbo_tools["MakePbo"]
         except:
             raise
             print_error("Could not find dePBO tools. Download the needed tools from: https://dev.withsix.com/projects/mikero-pbodll/files")

--- a/tools/make.py
+++ b/tools/make.py
@@ -230,7 +230,7 @@ def find_bi_tools(work_drive):
 
 def find_depbo_tools():
     """Use registry entries to find DePBO-based tools."""
-    requiredToolPaths = {"pboProject": None,"rapify": None,"MakePbo": None}
+    requiredToolPaths = {"pboProject": None, "rapify": None, "MakePbo": None}
     failed = False
 
     for tool in requiredToolPaths:

--- a/tools/make.py
+++ b/tools/make.py
@@ -249,7 +249,7 @@ def find_depbo_tools():
         finally:
             winreg.CloseKey(k)
 
-    if failed > 0:
+    if failed:
         raise Exception("BadDePBO", "DePBO tools not installed correctly")
 
     return requiredToolPaths


### PR DESCRIPTION
**When merged this pull request will:**
- Changes the find_depbo_tools function to look inside both root keys for each tool individually instead of as a group.
    - Allowing for situations where some keys for the tools would be in different root keys 

Maybe an edge case issue but I don't see a reason not to fix it.
_Will also be making PR to project template_