### PR TITLE
Scopes - Adds simplified zeroing subsystem

### DIFF
--- a/addons/scopes/ACE_Settings.hpp
+++ b/addons/scopes/ACE_Settings.hpp
@@ -78,4 +78,12 @@ class ACE_Settings {
         displayName = CSTRING(useLegacyUI_displayName);
         description = CSTRING(useLegacyUI_description);
     };
+    
+    class GVAR(simplifiedZeroing) {
+        category = CSTRING(DisplayName);
+        typeName = "BOOL";
+        value = 0;
+        displayName = CSTRING(simplifiedZeroing_displayName);
+        description = CSTRING(simplifiedZeroing_description);
+    };
 };

--- a/addons/scopes/CfgVehicles.hpp
+++ b/addons/scopes/CfgVehicles.hpp
@@ -92,6 +92,12 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 0;
             };
+            class simplifiedZeroing {
+                displayName = CSTRING(simplifiedZeroing_displayName);
+                description = CSTRING(simplifiedZeroing_description);
+                typeName = "BOOL";
+                defaultValue = 0;
+            };
         };
         class ModuleDescription {
             description = CSTRING(Description);

--- a/addons/scopes/functions/fnc_adjustScope.sqf
+++ b/addons/scopes/functions/fnc_adjustScope.sqf
@@ -26,11 +26,10 @@ if (!GVAR(enabled)) exitWith {false};
 private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
 if (_weaponIndex < 0) exitWith {false};
 
-private _adjustment = _unit getVariable [QGVAR(Adjustment), [[0, 0, 0], [0, 0, 0], [0, 0, 0]]];
-
 if (!(GVAR(canAdjustElevation) select _weaponIndex) && (_turretAndDirection in [ELEVATION_UP, ELEVATION_DOWN])) exitWith {false};
 if (!(GVAR(canAdjustWindage) select _weaponIndex) && (_turretAndDirection in [WINDAGE_UP, WINDAGE_DOWN])) exitWith {false};
 
+private _adjustment = _unit getVariable [QGVAR(Adjustment), [[0, 0, 0], [0, 0, 0], [0, 0, 0]]];
 private _zeroing = _adjustment select _weaponIndex;
 _zeroing params ["_elevation", "_windage", "_zero"];
 

--- a/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
+++ b/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
@@ -33,14 +33,16 @@ playSound selectRandom ["ACE_Scopes_Click_1", "ACE_Scopes_Click_2", "ACE_Scopes_
 
 // slightly rotate the player if looking through optic
 if (cameraView == "GUNNER") then {
-    // Convert adjustmentDifference from mils to degrees
-    _adjustmentDifference = _adjustmentDifference apply {MRAD_TO_DEG(_x)};
-    _adjustmentDifference params ["_elevationDifference", "_windageDifference"];
-    private _pitchBankYaw = [_unit] call EFUNC(common,getPitchBankYaw);
-    _pitchBankYaw params ["_pitch", "_bank", "_yaw"];
-    _pitch = _pitch + _elevationDifference;
-    _yaw = _yaw + _windageDifference;
-    [_unit, _pitch, _bank, _yaw] call EFUNC(common,setPitchBankYaw);
+    if (!GVAR(simplifiedZeroing)) then {
+        // Convert adjustmentDifference from mils to degrees
+        _adjustmentDifference = _adjustmentDifference apply {MRAD_TO_DEG(_x)};
+        _adjustmentDifference params ["_elevationDifference", "_windageDifference"];
+        private _pitchBankYaw = [_unit] call EFUNC(common,getPitchBankYaw);
+        _pitchBankYaw params ["_pitch", "_bank", "_yaw"];
+        _pitch = _pitch + _elevationDifference;
+        _yaw = _yaw + _windageDifference;
+        [_unit, _pitch, _bank, _yaw] call EFUNC(common,setPitchBankYaw);
+    };
 } else {
     [] call FUNC(showZeroing);
 };

--- a/addons/scopes/functions/fnc_canAdjustZero.sqf
+++ b/addons/scopes/functions/fnc_canAdjustZero.sqf
@@ -19,6 +19,7 @@ params ["_unit"];
 
 if (cameraView == "GUNNER") exitWith {false};
 if (vehicle _unit != _unit) exitWith {false};
+if (GVAR(simplifiedZeroing)) exitWith {false};
 if (!(missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false])) exitWith {false};
 
 private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -30,7 +30,7 @@ TRACE_1("Adjusting With",_zeroing);
 // Convert zeroing from mils to degrees
 _zeroing = _zeroing vectorMultiply MRAD_TO_DEG(1);
 
-if (GVAR(correctZeroing)) then {
+if (GVAR(correctZeroing) || GVAR(simplifiedZeroing)) then {
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];
     private _baseAngle = GVAR(baseAngle) select _weaponIndex; 
     private _boreHeight = GVAR(boreHeight) select _weaponIndex;
@@ -40,7 +40,11 @@ if (GVAR(correctZeroing)) then {
     if (isNil "_zeroCorrection") then {
          _zeroCorrection = [_oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics] call FUNC(calculateZeroAngleCorrection);
     };
-    _zeroing = _zeroing vectorAdd [0, 0, _zeroCorrection - _baseAngle];
+    if (GVAR(simplifiedZeroing)) then {
+        _zeroing = [0, 0, _zeroCorrection - _baseAngle];
+    } else {
+        _zeroing = _zeroing vectorAdd [0, 0, _zeroCorrection - _baseAngle];
+    };
 #ifdef DISABLE_DISPERSION
     _projectile setVelocity (_unit weaponDirection currentWeapon _unit) vectorMultiply (vectorMagnitude (velocity _projectile));
 #endif

--- a/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
+++ b/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
@@ -21,6 +21,10 @@ if (!GVAR(enabled)) exitWith { currentZeroing _unit };
 
 private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
 if (_weaponIndex < 0) exitWith { currentZeroing _unit };
+if (GVAR(simplifiedZeroing)) exitWith {
+    private _adjustment = _unit getVariable [QGVAR(Adjustment), [[0, 0, 0], [0, 0, 0], [0, 0, 0]]];
+    ((_adjustment select _weaponIndex) select 0)
+};
 
 private _optic = GVAR(Optics) select _weaponIndex;
 private _opticConfig = if (_optic != "") then {

--- a/addons/scopes/functions/fnc_initModuleSettings.sqf
+++ b/addons/scopes/functions/fnc_initModuleSettings.sqf
@@ -30,7 +30,6 @@ if !(_activated) exitWith {};
 [_logic, QGVAR(zeroReferenceBarometricPressure), "zeroReferenceBarometricPressure"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(zeroReferenceHumidity), "zeroReferenceHumidity"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(deduceBarometricPressureFromTerrainAltitude), "deduceBarometricPressureFromTerrainAltitude"] call EFUNC(common,readSettingFromModule);
-
 GVAR(defaultZeroRange) = 0 max GVAR(defaultZeroRange) min 1000;
 GVAR(zeroReferenceTemperature) = -55 max GVAR(zeroReferenceTemperature) min 55;
 GVAR(zeroReferenceBarometricPressure) = 0 max GVAR(zeroReferenceBarometricPressure) min 1013.25;

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -25,32 +25,50 @@ private _newOptics = [_player] call FUNC(getOptics);
     if (_newOptics select _forEachIndex != _x) then {
         private _opticConfig = configFile >> "CfgWeapons" >> (_newOptics select _forEachIndex);
         private _opticType = getNumber(_opticConfig >> "ItemInfo" >> "opticType");
-        private _verticalIncrement = -1;
-        if (isNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement")) then {
-            _verticalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement");
-        };
-        private _horizontalIncrement = -1;
-        if (isNumber (_opticConfig >> "ACE_ScopeAdjust_HorizontalIncrement")) then {
-            _horizontalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_HorizontalIncrement");
-        };
         private _maxVertical = [];
-        if (isArray (_opticConfig >> "ACE_ScopeAdjust_Vertical")) then {
-            _maxVertical = getArray (_opticConfig >> "ACE_ScopeAdjust_Vertical");
-        };
+        private _verticalIncrement = -1;
         private _maxHorizontal = [];
-        if (isArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal")) then {
-            _maxHorizontal = getArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal");
-        };
-        if (GVAR(forceUseOfAdjustmentTurrets) && _opticType == 2) then {
-            if (_maxVertical   isEqualTo []) then { _maxVertical   = [-4, 30]; };
-            if (_maxHorizontal isEqualTo []) then { _maxHorizontal = [-6,  6]; };
-            if (_verticalIncrement   == -1) then { _verticalIncrement   = 0.1; };
-            if (_horizontalIncrement == -1) then { _horizontalIncrement = 0.1; };
+        private _horizontalIncrement = -1;
+        if (GVAR(simplifiedZeroing)) then {
+            private _maxDistanceZoomMax = 300;
+            private _maxDiscreteDistanceSize = 0;
+            {
+                _maxDistanceZoomMax = _maxDistanceZoomMax max (getNumber ( _x >> "distanceZoomMax"));
+                _maxDiscreteDistanceSize = _maxDiscreteDistanceSize max (count getArray (_x >> "discreteDistance"));
+            } forEach ("isArray (_x >> 'discreteDistance')" configClasses (_opticConfig >> "ItemInfo" >> "OpticsModes"));
+            if (_maxDiscreteDistanceSize < 2 && {getNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement") != 0}) then {
+                _maxVertical = [50, _maxDistanceZoomMax];
+                _verticalIncrement = 50;
+            } else {
+                _maxVertical = [0, 0];
+                _verticalIncrement = 0;
+            };
+            _maxHorizontal = [0, 0];
+            _horizontalIncrement = 0;
         } else {
-            if (_maxVertical   isEqualTo []) then { _maxVertical   = [0, 0]; };
-            if (_maxHorizontal isEqualTo []) then { _maxHorizontal = [0, 0]; };
-            if (_verticalIncrement   == -1) then { _verticalIncrement   = 0; };
-            if (_horizontalIncrement == -1) then { _horizontalIncrement = 0; };
+            if (isNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement")) then {
+                _verticalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_VerticalIncrement");
+            };
+            if (isNumber (_opticConfig >> "ACE_ScopeAdjust_HorizontalIncrement")) then {
+                _horizontalIncrement = getNumber (_opticConfig >> "ACE_ScopeAdjust_HorizontalIncrement");
+            };
+            if (isArray (_opticConfig >> "ACE_ScopeAdjust_Vertical")) then {
+                _maxVertical = getArray (_opticConfig >> "ACE_ScopeAdjust_Vertical");
+            };
+            if (isArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal")) then {
+                _maxHorizontal = getArray (_opticConfig >> "ACE_ScopeAdjust_Horizontal");
+            };
+            if (GVAR(forceUseOfAdjustmentTurrets) && _opticType == 2) then {
+                if (_maxVertical   isEqualTo []) then { _maxVertical   = [-4, 30]; };
+                if (_maxHorizontal isEqualTo []) then { _maxHorizontal = [-6,  6]; };
+                if (_verticalIncrement   == -1) then { _verticalIncrement   = 0.1; };
+                if (_horizontalIncrement == -1) then { _horizontalIncrement = 0.1; };
+            } else {
+                if (_maxVertical   isEqualTo []) then { _maxVertical   = [0, 0]; };
+                if (_maxHorizontal isEqualTo []) then { _maxHorizontal = [0, 0]; };
+                if (_verticalIncrement   == -1) then { _verticalIncrement   = 0; };
+                if (_horizontalIncrement == -1) then { _horizontalIncrement = 0; };
+            };
         };
         (GVAR(scopeAdjust) select _forEachIndex) set [0, _maxVertical];
         (GVAR(scopeAdjust) select _forEachIndex) set [1, _verticalIncrement];
@@ -70,20 +88,21 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
         if ((_newOptics select _x) == "") then {
             // Check if the weapon comes with an integrated optic     
             private _weaponConfig = configFile >> "CfgWeapons" >> (_newGuns select _x); 
-            private _verticalIncrement = 0;
-            if (isNumber (_weaponConfig >> "ACE_ScopeAdjust_VerticalIncrement")) then {
-                _verticalIncrement = getNumber (_weaponConfig >> "ACE_ScopeAdjust_VerticalIncrement");
-            };
-            private _horizontalIncrement = 0;
-            if (isNumber (_weaponConfig >> "ACE_ScopeAdjust_HorizontalIncrement")) then {
-                _horizontalIncrement = getNumber (_weaponConfig >> "ACE_ScopeAdjust_HorizontalIncrement");
-            };
             private _maxVertical = [0, 0];
-            if (isArray (_weaponConfig >> "ACE_ScopeAdjust_Vertical")) then {
-                _maxVertical = getArray (_weaponConfig >> "ACE_ScopeAdjust_Vertical");
-            };
+            private _verticalIncrement = 0;
             private _maxHorizontal = [0, 0];
-            if (isArray (_weaponConfig >> "ACE_ScopeAdjust_Horizontal")) then {
+            private _horizontalIncrement = 0;
+            if (GVAR(simplifiedZeroing)) then {
+                private _maxZeroing = 300 max (getNumber (_weaponConfig >> "maxZeroing"));
+                private _maxDiscreteDistanceSize = count getArray (configFile >> "CfgWeapons" >> (_newGuns select _x) >> "discreteDistance");
+                if (_maxDiscreteDistanceSize < 2 && {getNumber (_weaponConfig >> "ACE_ScopeAdjust_VerticalIncrement") != 0}) then {
+                    _maxVertical = [50, _maxZeroing];
+                    _verticalIncrement = 50;
+                };
+            } else {
+                _verticalIncrement = getNumber (_weaponConfig >> "ACE_ScopeAdjust_VerticalIncrement");
+                _horizontalIncrement = getNumber (_weaponConfig >> "ACE_ScopeAdjust_HorizontalIncrement");
+                _maxVertical = getArray (_weaponConfig >> "ACE_ScopeAdjust_Vertical");
                 _maxHorizontal = getArray (_weaponConfig >> "ACE_ScopeAdjust_Horizontal");
             };
             TRACE_5("",_newGuns select _x,_verticalIncrement,_horizontalIncrement,_maxVertical,_maxHorizontal);
@@ -101,8 +120,9 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
         if (!(_persistentZero isEqualType 0) || {_persistentZero < _minElevation || _persistentZero > _maxElevation}) then {
             _persistentZero = 0;
         };
-        if (!((_adjustment select _forEachIndex) isEqualTo [0, 0, _persistentZero])) then {
-            _adjustment set [_forEachIndex, [0, 0, _persistentZero]];
+        private _defaultElevation = [0, 300] select GVAR(simplifiedZeroing);
+        if (!((_adjustment select _forEachIndex) isEqualTo [_defaultElevation, 0, _persistentZero])) then {
+            _adjustment set [_forEachIndex, [_defaultElevation, 0, _persistentZero]];
             _updateAdjustment = true;
         };
     }

--- a/addons/scopes/functions/fnc_showZeroing.sqf
+++ b/addons/scopes/functions/fnc_showZeroing.sqf
@@ -35,26 +35,31 @@ private _zeroing = _adjustment select _weaponIndex;
 _zeroing params ["_elevation", "_windage"];
 private _vertical = _display displayCtrl 12;
 private _horizontal = _display displayCtrl 13;
-if (GVAR(useLegacyUI)) then {
-    _vertical ctrlSetText (str _elevation);
-    _horizontal ctrlSetText (str _windage);
+if (GVAR(simplifiedZeroing)) then {
+    _vertical ctrlSetText format["%1 m", round(_elevation)];
+    _horizontal ctrlSetText "";
 } else {
-    if (_elevation == 0) then {
-        _vertical ctrlSetText "0";
+    if (GVAR(useLegacyUI)) then {
+        _vertical ctrlSetText (str _elevation);
+        _horizontal ctrlSetText (str _windage);
     } else {
-        if (_elevation > 0) then {
-            _vertical ctrlSetText (str _elevation);
+        if (_elevation == 0) then {
+            _vertical ctrlSetText "0";
         } else {
-            _vertical ctrlSetText format[localize LSTRING(DisplayAdjustmentDown), abs(_elevation)];
+            if (_elevation > 0) then {
+                _vertical ctrlSetText (str _elevation);
+            } else {
+                _vertical ctrlSetText format[localize LSTRING(DisplayAdjustmentDown), abs(_elevation)];
+            };
         };
-    };
-    if (_windage == 0) then {
-        _horizontal ctrlSetText "0";
-    } else {
-        if (_windage > 0) then {
-            _horizontal ctrlSetText format[localize LSTRING(DisplayAdjustmentRight), abs(_windage)];
+        if (_windage == 0) then {
+            _horizontal ctrlSetText "0";
         } else {
-            _horizontal ctrlSetText format[localize LSTRING(DisplayAdjustmentLeft), abs(_windage)];
+            if (_windage > 0) then {
+                _horizontal ctrlSetText format[localize LSTRING(DisplayAdjustmentRight), abs(_windage)];
+            } else {
+                _horizontal ctrlSetText format[localize LSTRING(DisplayAdjustmentLeft), abs(_windage)];
+            };
         };
     };
 };

--- a/addons/scopes/stringtable.xml
+++ b/addons/scopes/stringtable.xml
@@ -224,6 +224,14 @@
             <Chinese>使用帶著標籤的數字顯示歸零遠近與風偏程度</Chinese>
             <Chinesesimp>使用带着标签的数字显示归零远近与风偏程度</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Scopes_simplifiedZeroing_displayName">
+            <English>Simplified zeroing</English>
+            <German>Vereinfachte Nullung</German>
+        </Key>
+        <Key ID="STR_ACE_Scopes_simplifiedZeroing_description">
+            <English>Replicates the vanilla zeroing system for riflescopes.</English>
+            <German>Repliziert das Vanilla-Zeroing-System für Zielfernrohre.</German>
+        </Key>
         <Key ID="STR_ACE_Scopes_AdjustUpMinor">
             <English>Minor adjustment up</English>
             <German>Kleine Korrektur hoch</German>


### PR DESCRIPTION
* Client side setting to choose the preferred zeroing method
* Replicates the behavior of the vanilla zeroing system

This allows you to zero your scope in 50 meter increments if you don't like the current adjustment turrets.