### PR TITLE
Movement - Fix climbing when over water

### DIFF
--- a/addons/movement/functions/fnc_handleClimb.sqf
+++ b/addons/movement/functions/fnc_handleClimb.sqf
@@ -24,4 +24,5 @@ private _pos = _unit modelToWorldVisual (_unit selectionPosition "camera");
 
 _pos = _pos vectorDiff (_unit selectionPosition "camera");
 
-_unit setPos _pos;
+_unit setPosASL (AGLtoASL _pos);
+TRACE_2("",AGLtoASL _pos,getPosASL _unit);


### PR DESCRIPTION
Fix #5795

```
Before: 
AGLtoASL _pos=[2452.95,6470.46,24.9426], getPosASL _unit=[2452.95,6470.46,49.5334] z\ace\addons\movement\functions\fnc_handleClimb.sqf:29

After: 
AGLtoASL _pos=[2453,6470.63,24.9413], getPosASL _unit=[2453,6470.63,24.9413] z\ace\addons\movement\functions\fnc_handleClimb.sqf:29
```
