### PR TITLE
Scopes - Fixed iron sight zeroing

### DIFF
--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -220,6 +220,7 @@ class CfgWeapons {
 
     class DMR_07_base_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 5.07109;
+        ACE_IronSightBaseAngle = -0.00160721;
     };
     
     class arifle_MX_Base_F: Rifle_Base_F {
@@ -228,119 +229,150 @@ class CfgWeapons {
     };
     class arifle_MX_SW_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.40874;
+        ACE_IronSightBaseAngle = 0.216372;
     };
     class arifle_MXM_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.40323;
+        ACE_IronSightBaseAngle = 0.157545;
     };
 
     class arifle_SPAR_01_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.20768;
+        ACE_IronSightBaseAngle = -0.166678;
     };
     class arifle_SPAR_02_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.22175;
+        ACE_IronSightBaseAngle = -0.184641;
     };
     class arifle_SPAR_03_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.71491;
+        ACE_IronSightBaseAngle = -0.134908;
     };
 
     class LMG_Mk200_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 2.68925;
+        ACE_IronSightBaseAngle = 0.0182228;
     };
     class LMG_Zafir_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 0.996651;
+        ACE_IronSightBaseAngle = 0.19812212;
     };
     class LMG_03_base_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 4.24282;
+        ACE_IronSightBaseAngle = 0.00181939;
     };
 
     class pdw2000_base_F: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 3.08883;
         ACE_RailBaseAngle = 0.019366;
+        ACE_IronSightBaseAngle = 0.0399664;
     };
 
     class arifle_AKS_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 0;
+        ACE_IronSightBaseAngle = 0.00574991;
     };
     class arifle_AKM_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 0;
+        ACE_IronSightBaseAngle = 0.006273;
     };
     class arifle_AK12_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.82508;
+        ACE_IronSightBaseAngle = 0.0276926;
     };
     class arifle_CTAR_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 6.07588;
+        ACE_IronSightBaseAngle = 0.0151815;
     };
     class arifle_CTARS_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 6.0787;
+        ACE_IronSightBaseAngle = 0.0125245;
     };
     class arifle_ARX_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.81635;
+        ACE_IronSightBaseAngle = 0.113024;
     };
 
     class arifle_katiba_Base_F: Rifle_Base_F {};
     
     class arifle_Katiba_F: arifle_katiba_Base_F {
         ACE_RailHeightAboveBore = 5.75468;
+        ACE_IronSightBaseAngle = 0.0863227;
     };
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
         ACE_RailHeightAboveBore = 5.75468;
+        ACE_IronSightBaseAngle = 0.083419;
     };
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
         ACE_RailHeightAboveBore = 5.75468;
+        ACE_IronSightBaseAngle = 0.0863227;
     };
     
     class arifle_MX_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.80201;
+        ACE_IronSightBaseAngle = 0.19502;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.80201;
+        ACE_IronSightBaseAngle = 0.17142857;
     };
 
     class arifle_MXC_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.40874;
+        ACE_IronSightBaseAngle = 0.0154129;
     };
 
     class SDAR_base_F: Rifle_Base_F {};
     
     class arifle_SDAR_F: SDAR_base_F {
         ACE_RailHeightAboveBore = 0;
+        ACE_IronSightBaseAngle = -0.0237516;
     };
 
     class SMG_01_Base: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 4.85355;
         ACE_RailBaseAngle = 0.0250956;
+        ACE_IronSightBaseAngle = -0.159239;
     };
     class SMG_02_base_F: Rifle_Short_Base_F  {
         ACE_RailHeightAboveBore = 4.41831;
         ACE_RailBaseAngle = 0.0217724;
+        ACE_IronSightBaseAngle = 0.434847;
     };
     class SMG_05_base_F: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 4.05169;
         ACE_RailBaseAngle = 0.019366;
+        ACE_IronSightBaseAngle = -0.122823;
     };
 
     class Tavor_base_F: Rifle_Base_F {};
 
     class arifle_TRG20_F: Tavor_base_F {
         ACE_RailHeightAboveBore = 4.30954;
+        ACE_IronSightBaseAngle = 0.0338428;
     };
     class arifle_TRG21_F: Tavor_base_F {
         ACE_RailHeightAboveBore = 4.30954;
+        ACE_IronSightBaseAngle = 0.0317759;
     };
     class arifle_TRG21_GL_F: arifle_TRG21_F {
         ACE_RailHeightAboveBore = 4.30954;
+        ACE_IronSightBaseAngle = -0.03428571;
     };
 
     class mk20_base_F: Rifle_Base_F {};
 
     class arifle_Mk20_F: mk20_base_F {
         ACE_RailHeightAboveBore = 4.57255;
+        ACE_IronSightBaseAngle = -0.153292;
     };
     class arifle_Mk20C_F: mk20_base_F {
         ACE_RailHeightAboveBore = 4.41539;
+        ACE_IronSightBaseAngle = -0.137835;
     };
     class arifle_Mk20_GL_F: mk20_base_F {
         ACE_RailHeightAboveBore = 4.41539;
+        ACE_IronSightBaseAngle = -0.1532926;
     };
 
     class EBR_base_F: Rifle_Long_Base_F {};
@@ -355,31 +387,39 @@ class CfgWeapons {
 
     class srifle_EBR_F: EBR_base_F {
         ACE_RailHeightAboveBore = 1.98812;
+        ACE_IronSightBaseAngle = -0.00601782;
     };
     class srifle_LRR_F: LRR_base_F {
         ACE_RailHeightAboveBore = 3.20864;
+        ACE_IronSightBaseAngle = -0.0302847;
     };
     class srifle_GM6_F: GM6_base_F {
         ACE_RailHeightAboveBore = 4.75572;
+        ACE_IronSightBaseAngle = -0.165062;
     };
     class srifle_DMR_01_F: DMR_01_base_F {
         ACE_RailHeightAboveBore = 2.83284;
+        ACE_IronSightBaseAngle = 0.234393;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
         ACE_RailHeightAboveBore = 3.43913;
+        ACE_IronSightBaseAngle = 0.013878;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
         ACE_RailHeightAboveBore = 4.0795;
+        ACE_IronSightBaseAngle = 0.0138099;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         ACE_RailHeightAboveBore = 2.38022;
-        ACE_RailBaseAngle = 0.019366;
+        ACE_RailBaseAngle = 0.0171842;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         ACE_RailHeightAboveBore = 3.91334;
+        ACE_IronSightBaseAngle = 0.0123425;
     };
     class srifle_DMR_06_camo_F: DMR_06_base_F {
         ACE_RailHeightAboveBore = 3.27488;
+        ACE_IronSightBaseAngle = 0.018227;
     };
 
     class MMG_01_base_F;
@@ -387,8 +427,10 @@ class CfgWeapons {
 
     class MMG_01_hex_F: MMG_01_base_F {
         ACE_RailHeightAboveBore = 4.73961;
+        ACE_IronSightBaseAngle = -0.0101613;
     };    
     class MMG_02_camo_F: MMG_02_base_F {
         ACE_RailHeightAboveBore = 5.01913;
+        ACE_IronSightBaseAngle = 0.0136377;
     };
 };

--- a/addons/scopes/functions/fnc_calculateZeroAngleCorrection.sqf
+++ b/addons/scopes/functions/fnc_calculateZeroAngleCorrection.sqf
@@ -35,6 +35,10 @@ if (_initSpeedCoef < 0) then {
 private _zeroAngle = "ace_advanced_ballistics" callExtension format ["replicateVanillaZero:%1:%2:%3", _oldZeroRange, _initSpeed, _airFriction];
 private _vanillaZero = parseNumber _zeroAngle;
 
+#ifdef DISABLE_DISPERSION
+    _vanillaZero = 0;
+#endif
+
 private _trueZero = if (!_advancedBallistics) then {
     _zeroAngle = "ace_advanced_ballistics" callExtension format ["calcZero:%1:%2:%3:%4", _newZeroRange, _initSpeed, _airFriction, _boreHeight];
     (parseNumber _zeroAngle)

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -41,6 +41,9 @@ if (GVAR(correctZeroing)) then {
          _zeroCorrection = [_oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics] call FUNC(calculateZeroAngleCorrection);
     };
     _zeroing = _zeroing vectorAdd [0, 0, _zeroCorrection - _baseAngle];
+#ifdef DISABLE_DISPERSION
+    _projectile setVelocity (_unit weaponDirection currentWeapon _unit) vectorMultiply (vectorMagnitude (velocity _projectile));
+#endif
 };
 
 if (_zeroing isEqualTo [0, 0, 0]) exitWith {};

--- a/addons/scopes/functions/fnc_getBaseAngle.sqf
+++ b/addons/scopes/functions/fnc_getBaseAngle.sqf
@@ -1,31 +1,34 @@
 /*
  * Author: Ruthberg
- * Gets the base angle of the rail on the weapon with the given weapon index
+ * Gets the base angle of the currently used weapon & optic combination
  *
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: Weapon index <NUMBER>
+ * 2: Weapon <CLASS>
+ * 3: Optic <CLASS>
  *
  * Return Value:
  * base angle <NUMBER>
  *
  * Example:
- * [player, 0] call ace_scopes_fnc_getBaseAngle
+ * [player, 0, "srifle_LRR_F", "optic_LRPS"] call ace_scopes_fnc_getBaseAngle
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-params ["_player", "_weaponIndex"];
+params ["_player", "_weaponIndex", "_weaponClass", "_opticsClass"];
 
-if (_weaponIndex < 0 || {_weaponIndex > 2}) exitWith { 0 };
-
-private _weaponClass = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] select _weaponIndex;
-
-private _baseAngle = DEFAULT_RAIL_BASE_ANGLE;
 private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
-if (isNumber (_weaponConfig >> "ACE_RailBaseAngle")) then {
-    _baseAngle = getNumber(_weaponConfig >> "ACE_RailBaseAngle");
+private _baseAngle = getNumber(_weaponConfig >> "ACE_IronSightBaseAngle");
+
+if (_opticsClass != "") then {
+    if (isNumber (_weaponConfig >> "ACE_RailBaseAngle")) then {
+        _baseAngle = getNumber(_weaponConfig >> "ACE_RailBaseAngle");
+    } else {
+        _baseAngle = DEFAULT_RAIL_BASE_ANGLE;
+    };
 };
 
 _baseAngle

--- a/addons/scopes/functions/fnc_getBoreHeight.sqf
+++ b/addons/scopes/functions/fnc_getBoreHeight.sqf
@@ -1,27 +1,24 @@
 /*
  * Author: Ruthberg
- * Gets the bore height of the weapon & optic combination with the given weapon index
+ * Gets the bore height of the currently used weapon & optic combination
  *
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: Weapon index <NUMBER>
+ * 2: Weapon <CLASS>
+ * 3: Optic <CLASS>
  *
  * Return Value:
  * bore height <NUMBER>
  *
  * Example:
- * [player, 0] call ace_scopes_fnc_getBoreHeight
+ * [player, 0, "srifle_LRR_F", "optic_LRPS"] call ace_scopes_fnc_getBoreHeight
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-params ["_player", "_weaponIndex"];
-
-if (_weaponIndex < 0 || {_weaponIndex > 2}) exitWith { 0 };
-
-private _weaponClass = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player] select _weaponIndex;
-private _opticsClass = ([_player] call FUNC(getOptics)) select _weaponIndex;
+params ["_player", "_weaponIndex", "_weaponClass", "_opticsClass"];
 
 if (_opticsClass == "") then { _opticsClass = _weaponClass; };
 
@@ -47,8 +44,8 @@ if (isNumber (_opticConfig >> "ACE_ScopeHeightAboveRail")) then {
         case 2: { _scopeHeightAboveRail = 4.0; }; // High power scope
         default {
             switch (_weaponIndex) do {
-                case 0: { _scopeHeightAboveRail = 0.5; }; // Rifle iron sights
-                case 2: { _scopeHeightAboveRail = 0.3; }; // Pistol iron sights
+                case 0: { _scopeHeightAboveRail = 2.0; }; // Rifle iron sights
+                case 2: { _scopeHeightAboveRail = 1.0; }; // Pistol iron sights
             };
         };
     };

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -64,8 +64,8 @@ private _newOptics = [_player] call FUNC(getOptics);
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
-        GVAR(baseAngle) set [_x, [_player, _x] call FUNC(getBaseAngle)]; 
-        GVAR(boreHeight) set [_x, [_player, _x] call FUNC(getBoreHeight)];
+        GVAR(baseAngle) set [_x, [_player, _x, _newGuns select _x, _newOptics select _x] call FUNC(getBaseAngle)]; 
+        GVAR(boreHeight) set [_x, [_player, _x, _newGuns select _x, _newOptics select _x] call FUNC(getBoreHeight)];
 
         if ((_newOptics select _x) == "") then {
             // Check if the weapon comes with an integrated optic     

--- a/addons/scopes/script_component.hpp
+++ b/addons/scopes/script_component.hpp
@@ -16,6 +16,8 @@
 
 #define DEFAULT_RAIL_BASE_ANGLE 0.0086
 
+// #define DISABLE_DISPERSION
+
 #ifdef DEBUG_ENABLED_SCOPES
     #define DEBUG_MODE_FULL
 #endif


### PR DESCRIPTION
* Added new config entry `ACE_IronSightBaseAngle` to fix the iron sight zeroing
* Added `DISABLE_DISPERSION` helper flag which allows you to disable any vanilla dispersion for testing purposes