### PR TITLE
 Advanced Ballistics - Removed all unnecessary settings

### DIFF
--- a/addons/advanced_ballistics/ACE_Settings.hpp
+++ b/addons/advanced_ballistics/ACE_Settings.hpp
@@ -6,43 +6,6 @@ class ACE_Settings {
         typeName = "BOOL";
         value = 0;
     };
-    class GVAR(simulateForSnipers) {
-        category = CSTRING(DisplayName);
-        displayName = CSTRING(simulateForSnipers_DisplayName);
-        description = CSTRING(simulateForSnipers_Description);
-        typeName = "BOOL";
-        value = 1;
-    };
-    class GVAR(simulateForGroupMembers) {
-        category = CSTRING(DisplayName);
-        displayName = CSTRING(simulateForGroupMembers_DisplayName);
-        description = CSTRING(simulateForGroupMembers_Description);
-        typeName = "BOOL";
-        value = 0;
-    };
-    class GVAR(simulateForEveryone) {
-        category = CSTRING(DisplayName);
-        displayName = CSTRING(simulateForEveryone_DisplayName);
-        description = CSTRING(simulateForEveryone_Description);
-        typeName = "BOOL";
-        value = 0;
-    };
-    class GVAR(disabledInFullAutoMode) {
-        category = CSTRING(DisplayName);
-        displayName = CSTRING(disabledInFullAutoMod_DisplayName);
-        description = CSTRING(disabledInFullAutoMod_Description);
-        typeName = "BOOL";
-        value = 0;
-    };
-    /* // TODO: We currently do not have firedEHs on vehicles
-    class GVAR(vehicleGunnerEnabled) {
-        category = CSTRING(DisplayName);
-        displayName = "Enabled For Vehicle Gunners";
-        description = "Enables advanced ballistics for vehicle gunners";
-        typeName = "BOOL";
-        value = 0;
-    };
-    */
     class GVAR(muzzleVelocityVariationEnabled) {
         category = CSTRING(DisplayName);
         displayName = CSTRING(muzzleVelocityVariationEnabled_DisplayName);
@@ -78,13 +41,5 @@ class ACE_Settings {
         typeName = "SCALAR";
         value = 0.05;
         sliderSettings[] = {0, 0.2, 0.05, 1};
-    };
-    class GVAR(simulationRadius) {
-        category = CSTRING(DisplayName);
-        displayName = CSTRING(simulationRadius_DisplayName);
-        description = CSTRING(simulationRadius_Description);
-        typeName = "SCALAR";
-        value = 3000;
-        sliderSettings[] = {0, 3000, 3000, 0};
     };
 };

--- a/addons/advanced_ballistics/CfgVehicles.hpp
+++ b/addons/advanced_ballistics/CfgVehicles.hpp
@@ -17,38 +17,6 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 0;
             };
-            class simulateForSnipers {
-                displayName = CSTRING(simulateForSnipers_DisplayName);
-                description = CSTRING(simulateForSnipers_Description);
-                typeName = "BOOL";
-                defaultValue = 1;
-            };
-            class simulateForGroupMembers {
-                displayName = CSTRING(simulateForGroupMembers_DisplayName);
-                description = CSTRING(simulateForGroupMembers_Description);
-                typeName = "BOOL";
-                defaultValue = 0;
-            };
-            class simulateForEveryone {
-                displayName = CSTRING(simulateForEveryone_DisplayName);
-                description = CSTRING(simulateForEveryone_Description);
-                typeName = "BOOL";
-                defaultValue = 0;
-            };
-            class disabledInFullAutoMode {
-                displayName = CSTRING(disabledInFullAutoMod_DisplayName);
-                description = CSTRING(disabledInFullAutoMod_Description);
-                typeName = "BOOL";
-                defaultValue = 0;
-            };
-            /* // TODO: We currently do not have firedEHs on vehicles
-            class vehicleGunnerEnabled {
-                displayName = "Enabled For Vehicle Gunners";
-                description = "Enables advanced ballistics for vehicle gunners";
-                typeName = "BOOL";
-                defaultValue = 0;
-            };
-            */
             class muzzleVelocityVariationEnabled {
                 displayName = CSTRING(muzzleVelocityVariationEnabled_DisplayName);
                 description = CSTRING(muzzleVelocityVariationEnabled_Description);
@@ -78,12 +46,6 @@ class CfgVehicles {
                 description = CSTRING(simulationInterval_Description);
                 typeName = "NUMBER";
                 defaultValue = 0.05;
-            };
-            class simulationRadius {
-                displayName = CSTRING(simulationRadius_DisplayName);
-                description = CSTRING(simulationRadius_Description);
-                typeName = "NUMBER";
-                defaultValue = 3000;
             };
         };
         class ModuleDescription {

--- a/addons/advanced_ballistics/functions/fnc_handleFirePFH.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFirePFH.sqf
@@ -24,7 +24,7 @@
         private _bulletVelocity = velocity _bullet;
         private _bulletPosition = getPosASL _bullet;
 
-        if (_bulletTraceVisible && {vectorMagnitude _bulletVelocity > 500}) then {
+        if (_bulletTraceVisible && {vectorMagnitude _bulletVelocity > BULLET_TRACE_MIN_VELOCITY}) then {
             drop ["\A3\data_f\ParticleEffects\Universal\Refract","","Billboard",1,0.1,getPos _bullet,[0,0,0],0,1.275,1,0,[0.02*_caliber,0.01*_caliber],[[0,0,0,0.65],[0,0,0,0.2]],[1,0],0,0,"","",""];
         };
 

--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -21,22 +21,45 @@ TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectil
 
 if (!(_ammo isKindOf "BulletBase")) exitWith {};
 if (!alive _projectile) exitWith {};
-if (_unit distance ACE_player > GVAR(simulationRadius)) exitWith {};
 if (underwater _unit) exitWith {};
 
-private _abort = GVAR(disabledInFullAutoMode) && {getNumber(configFile >> "CfgWeapons" >> _weapon >> _mode >> "autoFire") == 1};
-if (!local _unit && {!_abort && !GVAR(simulateForEveryone)}) then {
-    // The shooter is non local -> abort unless we match an exception rule        
-    _abort = !GVAR(simulateForGroupMembers) || {group ACE_player != group _unit};
-    if (_abort && GVAR(simulateForSnipers)) then {
-        if (currentWeapon _unit == primaryWeapon _unit && count primaryWeaponItems _unit > 2) then {
-            private _opticsName = (primaryWeaponItems _unit) select 2;
+private _abort = !local _unit;
+if (_abort) then {
+    private _bulletVelocity = velocity _projectile;
+    private _muzzleVelocity = vectorMagnitude _bulletVelocity;
+    
+    private _maxRange = uiNamespace getVariable format[QGVAR(maxRange_%1), _ammo];
+    if (isNil "_maxRange") then {
+        private _airFriction = getNumber(configFile >> "CfgAmmo" >> _ammo >> "airFriction");
+        private _maxTime = ((_muzzleVelocity - BULLET_TRACE_MIN_VELOCITY) / (BULLET_TRACE_MIN_VELOCITY * -_airFriction * _muzzleVelocity)) max getNumber(configFile >> "CfgAmmo" >> _ammo >> "tracerEndTime");
+        private _maxRange = if (_airFriction < 0) then {
+            -ln(1 - _airFriction * _muzzleVelocity * _maxTime) / _airFriction
+        } else {
+            _muzzleVelocity * _maxTime
+        };
+        uiNamespace setVariable [format[QGVAR(maxRange_%1), _ammo], _maxRange];
+    };
+    if (ACE_player distance _unit > _maxRange && {ACE_player distance ((getPosASL _unit) vectorAdd ((vectorNormalized _bulletVelocity) vectorMultiply _maxRange)) > _maxRange}) exitWith {};
+    
+    private _ammoCount = (_unit ammo _muzzle) + 1;
+    private _tracersEvery = getNumber(configFile >> "CfgMagazines" >> _magazine >> "tracersEvery");
+    private _lastRoundsTracer = getNumber(configFile >> "CfgMagazines" >> _magazine >> "lastRoundsTracer");
+    if (_ammoCount <= _lastRoundsTracer || {_tracersEvery > 0 && {(_ammoCount - _lastRoundsTracer) % _tracersEvery == 0}}) exitWith { _abort = false };
+    
+    if (GVAR(bulletTraceEnabled) && {_muzzleVelocity > BULLET_TRACE_MIN_VELOCITY} && {cameraView == "GUNNER"}) then {
+        if (currentWeapon ACE_player == binocular ACE_player) exitWith { _abort = false };
+        if (currentWeapon ACE_player == primaryWeapon ACE_player && {count primaryWeaponItems ACE_player > 2}) then {
+            private _opticsName = (primaryWeaponItems ACE_player) select 2;
             private _opticType = getNumber(configFile >> "CfgWeapons" >> _opticsName >> "ItemInfo" >> "opticType");
-            _abort = _opticType != 2; // We only abort if the non local shooter is not a sniper
+            if (_opticType == 2) exitWith { _abort = false };
         };
     };
 };
-//if (!GVAR(vehicleGunnerEnabled) && !(_unit isKindOf "Man")) then { _abort = true; }; // We currently do not have firedEHs on vehicles
+if (_abort) exitWith {
+    if (missionNamespace getVariable [QEGVAR(windDeflection,enabled), false]) then {
+        EGVAR(windDeflection,trackedBullets) pushBack [_projectile, getNumber(configFile >> "CfgAmmo" >> _ammo >> "airFriction")];
+    };
+};
 
 // Get Weapon and Ammo Configurations
 private _AmmoCacheEntry = uiNamespace getVariable format[QGVAR(%1), _ammo];
@@ -54,7 +77,6 @@ _WeaponCacheEntry params ["_barrelTwist", "_twistDirection", "_barrelLength"];
 private _temperature = nil; // We need the variable in this scope. So we need to init it here.
 
 private _ammoCount = _unit ammo _muzzle;
-
 private _bulletVelocity = velocity _projectile;
 private _muzzleVelocity = vectorMagnitude _bulletVelocity;
 
@@ -78,14 +100,8 @@ if (GVAR(muzzleVelocityVariationEnabled)) then {
 _bulletVelocity = (vectorNormalized _bulletVelocity) vectorMultiply _muzzleVelocity;
 _projectile setVelocity _bulletVelocity;
 
-if (_abort) exitWith {
-    if (missionNamespace getVariable [QEGVAR(windDeflection,enabled), false]) then {
-        EGVAR(windDeflection,trackedBullets) pushBack [_projectile, getNumber(configFile >> "CfgAmmo" >> _ammo >> "airFriction")];
-    };
-};
-
 private _bulletTraceVisible = false;
-if (GVAR(bulletTraceEnabled) && cameraView == "GUNNER") then {
+if (GVAR(bulletTraceEnabled) && {_muzzleVelocity > BULLET_TRACE_MIN_VELOCITY} && {cameraView == "GUNNER"}) then {
     if (currentWeapon ACE_player == binocular ACE_player) then {
         _bulletTraceVisible = true;
     } else {

--- a/addons/advanced_ballistics/functions/fnc_initModuleSettings.sqf
+++ b/addons/advanced_ballistics/functions/fnc_initModuleSettings.sqf
@@ -26,11 +26,6 @@ if !(_activated) exitWith {};
 [_logic, QGVAR(ammoTemperatureEnabled), "ammoTemperatureEnabled"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(barrelLengthInfluenceEnabled), "barrelLengthInfluenceEnabled"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(bulletTraceEnabled), "bulletTraceEnabled"] call EFUNC(common,readSettingFromModule);
-[_logic, QGVAR(simulateForEveryone), "simulateForEveryone"] call EFUNC(common,readSettingFromModule);
-[_logic, QGVAR(disabledInFullAutoMode), "disabledInFullAutoMode"] call EFUNC(common,readSettingFromModule);
-[_logic, QGVAR(simulateForSnipers), "simulateForSnipers"] call EFUNC(common,readSettingFromModule);
-[_logic, QGVAR(simulateForGroupMembers), "simulateForGroupMembers"] call EFUNC(common,readSettingFromModule);
 [_logic, QGVAR(simulationInterval), "simulationInterval"] call EFUNC(common,readSettingFromModule);
-[_logic, QGVAR(simulationRadius), "simulationRadius"] call EFUNC(common,readSettingFromModule);
 
 GVAR(simulationInterval) = 0 max GVAR(simulationInterval) min 0.2;

--- a/addons/advanced_ballistics/script_component.hpp
+++ b/addons/advanced_ballistics/script_component.hpp
@@ -31,4 +31,6 @@
  // Standard deviation of the default muzzle velocity variation (0.3%)
 #define DEFAULT_MUZZLE_VELOCITY_VARIATION_SD 0.003
 
+#define BULLET_TRACE_MIN_VELOCITY 500
+
 #define EXTENSION_REQUIRED_VERSION "1.0"

--- a/addons/advanced_ballistics/stringtable.xml
+++ b/addons/advanced_ballistics/stringtable.xml
@@ -81,166 +81,6 @@
             <Chinese>啟用先進彈道系統</Chinese>
             <Chinesesimp>启用先进弹道系统</Chinesesimp>
         </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_simulateForSnipers_DisplayName">
-            <English>Enabled For Snipers</English>
-            <Spanish>Activada para francotiradores</Spanish>
-            <Polish>Akt. dla snajperów</Polish>
-            <German>Für Scharfschützen aktiviert</German>
-            <Czech>Povoleno pro odstřelovače</Czech>
-            <Portuguese>Ativar para caçadores</Portuguese>
-            <French>Activé pour les snipers</French>
-            <Hungarian>Mesterlövészeknek engedélyezve</Hungarian>
-            <Russian>Включена для снайперов</Russian>
-            <Italian>Abilita per Tiratori Scelti</Italian>
-            <Japanese>狙撃手へ有効化</Japanese>
-            <Korean>저격수만 적용</Korean>
-            <Chinese>啟用給狙擊手</Chinese>
-            <Chinesesimp>启用给狙击手</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_simulateForSnipers_Description">
-            <English>Enables advanced ballistics for non local snipers (when using high power optics)</English>
-            <Spanish>Activa la balística avanzada para francotiradores no locales (cuando se usa una mira telescópica)</Spanish>
-            <Polish>Aktywuje zaawansowaną balistykę dla nielokalnych snajperów (kiedy używają optyki)</Polish>
-            <German>Aktiviert die erweiterte Ballistik für nicht lokale Scharfschützen (bei Benutzung von Optiken mit starker Vergrößerung)</German>
-            <Czech>Aktivuje pokročilou balistiku pro nelokální odstřelovače (při použití optiky)</Czech>
-            <Portuguese>Ativa balística avançada para caçadores não locais (quando usando miras telescópicas)</Portuguese>
-            <French>Active la balistique avancée pour les snipers non locaux (en utilisant les optiques avancées)</French>
-            <Hungarian>Engedélyezi a fejlett ballisztikát nem-helyi mesterlövészeknek (nagy-teljesítményű optika használatakor)</Hungarian>
-            <Russian>Включает продвинутую баллистику для нелокальных снайперов (при использовании мощной оптики)</Russian>
-            <Italian>Abilita Balistica Avanzata per Tiratori Scelti non locali (con ottiche ad alto potenziale)</Italian>
-            <Japanese>非ローカルの狙撃手 (高倍率スコープを使っている場合)へアドバンスド バリスティックスを有効化します</Japanese>
-            <Korean>고급 탄도학을 비-저격수 인원에게도 적용합니다(고성능 조준경을 사용시)</Korean>
-            <Chinese>啟用先進彈道系統給非本地狙擊手(當使用高倍率光學瞄鏡時)</Chinese>
-            <Chinesesimp>启用先进弹道系统给非本地狙击手(当使用高倍率光学瞄镜时)</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_simulateForGroupMembers_DisplayName">
-            <English>Enabled For Group Members</English>
-            <Spanish>Activada para miembros de grupo</Spanish>
-            <Polish>Akt. dla czł. grupy</Polish>
-            <German>Für Gruppenmitglieder aktiviert</German>
-            <Czech>Povoleno pro členy skupiny</Czech>
-            <Portuguese>Ativada para membros do grupo</Portuguese>
-            <French>Activé pour les membres groupés</French>
-            <Hungarian>Csoporttagoknak engedélyezve</Hungarian>
-            <Russian>Включена для группы</Russian>
-            <Italian>Abilita per Membri del Gruppo</Italian>
-            <Japanese>グループ メンバーへ有効化</Japanese>
-            <Korean>그룹 멤버도 적용</Korean>
-            <Chinese>啟用給小隊成員</Chinese>
-            <Chinesesimp>启用给小队成员</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_simulateForGroupMembers_Description">
-            <English>Enables advanced ballistics for non local group members</English>
-            <Spanish>Activada la balística avanzada para miembros de grupo no locales</Spanish>
-            <Polish>Aktywuje zaawansowaną balistykę dla nielokalnych członków grupy</Polish>
-            <German>Aktiviert die erweiterte Ballistik für nicht lokale Gruppenmitglieder</German>
-            <Czech>Aktivuje pokročilou balistiku pro nelokální členy skupiny</Czech>
-            <Portuguese>Ativa balística avançada para membros de grupo não locais</Portuguese>
-            <French>Active la balistique avancée pour les membres du groupe non locaux</French>
-            <Hungarian>Engedélyezi a fejlett ballisztikát nem-helyi csoporttagoknak</Hungarian>
-            <Russian>Включает продвинутую баллистику для нелокальных членов группы</Russian>
-            <Italian>Abilita Balistica Avanzata per Membri non locali del Gruppo</Italian>
-            <Japanese>非ローカルのグループ メンバーへアドバンスド バリスティックスを有効化します</Japanese>
-            <Korean>고급 탄도학을 비-그룹멤버에게도 적용합니다</Korean>
-            <Chinese>啟用先進彈道系統給非本地小隊成員</Chinese>
-            <Chinesesimp>启用先进弹道系统给非本地小队成员</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_simulateForEveryone_DisplayName">
-            <English>Enabled For Everyone</English>
-            <Spanish>Activada para todos</Spanish>
-            <Polish>Akt. dla wszystkich</Polish>
-            <German>Für jeden aktiviert</German>
-            <Czech>Povoleno pro všechny</Czech>
-            <Portuguese>Ativada para todos</Portuguese>
-            <French>Activé pour tout le monde</French>
-            <Hungarian>Mindenkinek engedélyezve</Hungarian>
-            <Russian>Включена для всех</Russian>
-            <Italian>Abilita per tutti</Italian>
-            <Japanese>全員に有効化</Japanese>
-            <Korean>모두에게 적용</Korean>
-            <Chinese>啟用給所有人</Chinese>
-            <Chinesesimp>启用给所有人</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_simulateForEveryone_Description">
-            <English>Enables advanced ballistics for all non local players (enabling this may degrade performance during heavy firefights in multiplayer)</English>
-            <Spanish>Activada la balística avanzada para todos los jugadores no locales (activarlo puede degradar el rendimiento durante grandes tiroteos en multijugador).</Spanish>
-            <Polish>Aktywuje zaawansowaną balistykę dla wszystkich nielokalnych graczy (aktywacja tej opcji może spodowować spory spadek wydajności podczas ciężkiej wymiany ognia)</Polish>
-            <German>Aktiviert die erweiterte Ballistik für alle nicht lokalen Spieler (das Aktivieren dieser Funktion kann zur Beeinträchtigung des Spielerlebnisses im Multiplayer führen)</German>
-            <Czech>Aktivuje pokročilou balistiku pro všechny nelokální hráče (aktivace této možnosti způsobuje pokles FPS během velké přestřelky v multiplayeru)</Czech>
-            <Portuguese>Ativa balística avançada para todos os jogadores não locais (ativando isso pode degradar a performance durante troca de tiros intensas no multiplayer)</Portuguese>
-            <French>Active la balistique avancée pour tous les joueurs non locaux (activer cette option peut avoir un impact sur les performance en multi durant les grands échanges de tirs)</French>
-            <Hungarian>Engedélyezi a fejlett ballisztikát az összes nem-helyi játékosnak (ez a funkció leronthatja a teljesítményt intenzív többjátékos tűzharcok alatt)</Hungarian>
-            <Russian>Включает продвинутую баллистику для всех нелокальных игроков (включение этой опции может снизить производительность при массовых перестрелках в мультиплеере)</Russian>
-            <Italian>Abilita Balistica Avanzata per tutti i giocatori non locali (abilitare questo parametro potrebbe ridurre le prestazioni durante scontri intensi in multiplayer)</Italian>
-            <Japanese>非ローカルの全プレイヤーへアドバンスド バリスティックスを有効化します (マルチプレイで大規模な銃撃戦がおこなわれると、動作の低下を招きます)</Japanese>
-            <Korean>고급 탄도학을 모든 비-로컬그룹에게도 적용합니다(적용 후 대규모 전투시 성능하락을 유발할 수 있습니다)</Korean>
-            <Chinese>啟用先進彈道系統給所有非本地玩家 (啟用此功能後,在多人連線大量交火時可能會降低效能)</Chinese>
-            <Chinesesimp>启用先进弹道系统给所有非本地玩家 (启用此功能后,在多人连线大量交火时可能会降低效能)</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_alwaysSimulateForGroupMembers_DisplayName">
-            <English>Always Enabled For Group Members</English>
-            <Polish>Zawsze akt. dla czł. grupy</Polish>
-            <Spanish>Siempre activada para miembros de grupo</Spanish>
-            <German>Für Gruppenmitglieder immer aktiviert</German>
-            <Czech>Vždy povoleno pro členy skupiny</Czech>
-            <Portuguese>Sempre ativada para membros do grupo</Portuguese>
-            <French>Toujours activer pour les membres du groupe</French>
-            <Hungarian>Mindig engedélyezve csoporttagoknak</Hungarian>
-            <Russian>Всегда включена для членов группы</Russian>
-            <Italian>Sempre abilitato per Membri del Gruppo</Italian>
-            <Japanese>常にグループ メンバーへ有効化</Japanese>
-            <Korean>그룹 멤버에게 항상 적용</Korean>
-            <Chinese>永遠啟用給小隊成員</Chinese>
-            <Chinesesimp>永远启用给小队成员</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_alwaysSimulateForGroupMembers_Description">
-            <English>Always enables advanced ballistics when a group member fires</English>
-            <Polish>Aktywuje zaawansowaną balistykę dla wszystkich członków grupy</Polish>
-            <Spanish>Activada la balística avanzada siempre cuando miembros de grupo disparan</Spanish>
-            <German>Aktiviert die erweiterte Ballistik immer, wenn ein Gruppenmitglied schießt</German>
-            <Czech>Aktivuje pokročilou balistiku pro členy skupiny</Czech>
-            <Portuguese>Sempre ative balística avançada quando um membro do grupo disparar</Portuguese>
-            <French>Active tout le temps la balistique avancée quand un membre du groupe ouvre le feu</French>
-            <Hungarian>Mindig engedélyezi a fejlett ballisztikát, ha egy csoporttag tüzel</Hungarian>
-            <Russian>Всегда включает продвинутую баллистику когда стреляет член группы</Russian>
-            <Italian>Abilita sempre Balistica Avanzata quando un membro del gruppo spara</Italian>
-            <Japanese>グループ メンバーが射撃した時、常にアドバンスド バリスティックスを有効化します</Japanese>
-            <Korean>그룹 멤버가 발사시 항상 고급 탄도학을 적용합니다</Korean>
-            <Chinese>當小隊成員開火時,永遠啟用先進彈道系統</Chinese>
-            <Chinesesimp>当小队成员开火时,永远启用先进弹道系统</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_disabledInFullAutoMod_DisplayName">
-            <English>Disabled In FullAuto Mode</English>
-            <Polish>Wył. podczas ognia auto.</Polish>
-            <Spanish>Desactivada en modo automático</Spanish>
-            <German>Beim vollautomatischen Feuern deaktiviert</German>
-            <Czech>Zakázáno v automatickém režimu střelby</Czech>
-            <Portuguese>Desabilitar no modo automático</Portuguese>
-            <French>Désactiver en mode automatique</French>
-            <Hungarian>Automata módban letiltva</Hungarian>
-            <Russian>Выкл. для автомат. режима</Russian>
-            <Italian>Disabilita in modalità di fuoco automatico</Italian>
-            <Japanese>フルオートでは無効化</Japanese>
-            <Korean>조정간 자동시 비활성화</Korean>
-            <Chinese>在全自動模式時關閉</Chinese>
-            <Chinesesimp>在全自动模式时关闭</Chinesesimp>
-        </Key>
-        <Key ID="STR_ACE_Advanced_Ballistics_disabledInFullAutoMod_Description">
-            <English>Disables the advanced ballistics during full auto fire</English>
-            <Polish>Dezaktywuje zaawansowaną balistykę podczas ognia automatycznego</Polish>
-            <Spanish>Desactivada la balística avanzada durante el fuego automático</Spanish>
-            <German>Deaktiviert die erweiterte Ballistik beim vollautomatischen Feuern</German>
-            <Czech>Zákáže pokročilou balistiku během střelby v režimu automat</Czech>
-            <Portuguese>Desabilitar a balística avançada durante fogo automático</Portuguese>
-            <French>Désactive la balistique avancée pour les tirs en automatique</French>
-            <Hungarian>Letiltja a fejlett ballisztikát automata tüzelés folyamán</Hungarian>
-            <Russian>Выключает продвинутую баллистику при стрельбе в полностью автоматическом режиме</Russian>
-            <Italian>Disabilita Balistica Avanzata durante fuoco automatico</Italian>
-            <Japanese>フルオートで射撃中ではアドバンスド バリスティックスを無効化します</Japanese>
-            <Korean>조정간 자동시 고급 탄도학을 비활성화 합니다</Korean>
-            <Chinese>在全自動模式開火時,關閉先進彈道系統</Chinese>
-            <Chinesesimp>在全自动模式开火时,关闭先进弹道系统</Chinesesimp>
-        </Key>
         <Key ID="STR_ACE_Advanced_Ballistics_muzzleVelocityVariationEnabled_DisplayName">
             <English>Enable Muzzle Velocity Variation</English>
             <German>Variation der Mündungsgeschwindigkeit aktivieren</German>
@@ -362,10 +202,10 @@
             <Chinesesimp>模拟间隔</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Advanced_Ballistics_simulationInterval_Description">
-            <English>Defines the interval between every calculation step</English>
+            <English>Defines the interval between each calculation step</English>
             <Polish>Określa interwał pomiędzy każdym krokiem kalkulacji</Polish>
             <Spanish>Define el intervalo entre cada cálculo</Spanish>
-            <German>Legt das Intervall zwischen den Berechnungsschritten fest</German>
+            <German>Definiert das Intervall zwischen den einzelnen Simulationsschritten</German>
             <Czech>Určuje interval mezi každým výpočtem</Czech>
             <Portuguese>Define o intervalo entre cada cálculo</Portuguese>
             <French>Définit un intervalle de calcul entre deux simulations</French>


### PR DESCRIPTION
Replaced `simulateForSnipers`, `simulateForGroupMembers`, `simulateForEveryone`, `disabledInFullAutoMode` and `simulationRadius` with some automagic.

Advanced Ballistics is now only running if:
a) The projectile is local
b) The projectile is a tracer (or has a visible bullet trace effect) and is reasonably close to the player