### PR TITLE
Unify settings and keybinds categories prefix

### DIFF
--- a/addons/common/functions/fnc_cbaSettings_loadFromConfig.sqf
+++ b/addons/common/functions/fnc_cbaSettings_loadFromConfig.sqf
@@ -90,8 +90,8 @@ if (_category == "") then {
     // WARNING_1("Setting [%1] - no category",_varName);
     _category = "Uncategorized";
 };
-if (((_varName select [0, 4]) == "ACE_") && {(_category select [0, 3]) != "ACE"}) then {_category = format ["ACE - %1", _category];};
-if (((_varName select [0, 5]) == "ACEX_") && {(_category select [0, 4]) != "ACEX"}) then {_category = format ["ACEX - %1", _category];};
+if (((_varName select [0, 4]) == "ACE_") && {(_category select [0, 3]) != "ACE"}) then {_category = format ["ACE %1", _category];};
+if (((_varName select [0, 5]) == "ACEX_") && {(_category select [0, 4]) != "ACEX"}) then {_category = format ["ACEX %1", _category];};
 
 private _code = compile format ['["%1", _this] call FUNC(cbaSettings_settingChanged)', _varName];
 

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -999,94 +999,94 @@
             <Chinesesimp>不要强行</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryEquipment">
-            <English>ACE3 Equipment</English>
-            <German>ACE-Ausrüstung</German>
-            <Polish>ACE3 Wyposażenie</Polish>
-            <Portuguese>Equipamentos ACE3</Portuguese>
-            <Russian>ACE3 Снаряжение</Russian>
-            <Czech>ACE3 Vybavení</Czech>
-            <Spanish>ACE3 Equipo</Spanish>
-            <Italian>Equipaggiamento ACE3</Italian>
-            <French>ACE3 Equipement</French>
-            <Japanese>ACE3 装備</Japanese>
-            <Korean>ACE3 장비</Korean>
-            <Chinese>ACE3 裝備按鍵</Chinese>
-            <Chinesesimp>ACE3 装备按键</Chinesesimp>
+            <English>ACE Equipment</English>
+            <German>ACE Ausrüstung</German>
+            <Polish>ACE Wyposażenie</Polish>
+            <Portuguese>ACE Equipamentos</Portuguese>
+            <Russian>ACE Снаряжение</Russian>
+            <Czech>ACE Vybavení</Czech>
+            <Spanish>ACE Equipo</Spanish>
+            <Italian>ACE Equipaggiamento</Italian>
+            <French>ACE Equipement</French>
+            <Japanese>ACE 装備</Japanese>
+            <Korean>ACE 장비</Korean>
+            <Chinese>ACE 裝備按鍵</Chinese>
+            <Chinesesimp>ACE 装备按键</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryCommon">
-            <English>ACE3 Common</English>
-            <German>ACE3 Allgemein</German>
-            <Polish>ACE3 Ogólne</Polish>
-            <Portuguese>Comum ACE3</Portuguese>
-            <Russian>ACE3 Общие</Russian>
-            <Spanish>ACE3 Común</Spanish>
-            <Czech>ACE3 Obecné</Czech>
-            <Italian>Comune ACE3</Italian>
-            <French>ACE3 Commun</French>
-            <Japanese>ACE3 全般</Japanese>
-            <Korean>ACE3 일반</Korean>
-            <Chinese>ACE3 通用按鍵</Chinese>
-            <Chinesesimp>ACE3 通用按键</Chinesesimp>
+            <English>ACE Common</English>
+            <German>ACE Allgemein</German>
+            <Polish>ACE Ogólne</Polish>
+            <Portuguese>ACE Comum</Portuguese>
+            <Russian>ACE Общие</Russian>
+            <Spanish>ACE Común</Spanish>
+            <Czech>ACE Obecné</Czech>
+            <Italian>ACE Comune</Italian>
+            <French>ACE Commun</French>
+            <Japanese>ACE 全般</Japanese>
+            <Korean>ACE 일반</Korean>
+            <Chinese>ACE 通用按鍵</Chinese>
+            <Chinesesimp>ACE 通用按键</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryWeapons">
-            <English>ACE3 Weapons</English>
-            <German>ACE3 Waffen</German>
-            <Polish>ACE3 Broń</Polish>
-            <Portuguese>Armamento ACE3</Portuguese>
-            <Russian>ACE3 Оружие</Russian>
-            <Czech>ACE3 Zbraně</Czech>
-            <Spanish>ACE3 Armas</Spanish>
-            <Italian>Armi ACE3</Italian>
-            <French>ACE3 Armes</French>
-            <Japanese>ACE3 武器</Japanese>
-            <Korean>ACE3 무기</Korean>
-            <Chinese>ACE3 武器按鍵</Chinese>
-            <Chinesesimp>ACE3 武器按键</Chinesesimp>
+            <English>ACE Weapons</English>
+            <German>ACE Waffen</German>
+            <Polish>ACE Broń</Polish>
+            <Portuguese>ACE Armamento</Portuguese>
+            <Russian>ACE Оружие</Russian>
+            <Czech>ACE Zbraně</Czech>
+            <Spanish>ACE Armas</Spanish>
+            <Italian>ACE Armi</Italian>
+            <French>ACE Armes</French>
+            <Japanese>ACE 武器</Japanese>
+            <Korean>ACE 무기</Korean>
+            <Chinese>ACE 武器按鍵</Chinese>
+            <Chinesesimp>ACE 武器按键</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryMovement">
-            <English>ACE3 Movement</English>
-            <German>ACE3 Bewegung</German>
-            <Polish>ACE3 Ruch</Polish>
-            <Portuguese>Movimento ACE3</Portuguese>
-            <Russian>ACE3 Перемещение</Russian>
-            <Spanish>ACE3 Movimiento</Spanish>
-            <Czech>ACE3 Pohyb</Czech>
-            <Italian>Movimento ACE3</Italian>
-            <French>ACE3 Mouvement</French>
-            <Japanese>ACE3 移動</Japanese>
-            <Korean>ACE3 움직임</Korean>
-            <Chinese>ACE3 動作按鍵</Chinese>
-            <Chinesesimp>ACE3 动作按键</Chinesesimp>
+            <English>ACE Movement</English>
+            <German>ACE Bewegung</German>
+            <Polish>ACE Ruch</Polish>
+            <Portuguese>ACE Movimento</Portuguese>
+            <Russian>ACE Перемещение</Russian>
+            <Spanish>ACE Movimiento</Spanish>
+            <Czech>ACE Pohyb</Czech>
+            <Italian>ACE Movimento</Italian>
+            <French>ACE Mouvement</French>
+            <Japanese>ACE 移動</Japanese>
+            <Korean>ACE 움직임</Korean>
+            <Chinese>ACE 動作按鍵</Chinese>
+            <Chinesesimp>ACE 动作按键</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryScopeAdjustment">
-            <English>ACE3 Scope Adjustment</English>
-            <German>ACE3 Visiereinstellung</German>
-            <Polish>ACE3 Regulacja optyki</Polish>
-            <Portuguese>Ajuste de luneta ACE3</Portuguese>
-            <Russian>ACE3 Прицелы</Russian>
-            <Czech>ACE3 Nastavení optiky</Czech>
-            <Spanish>ACE3 Ajuste de miras</Spanish>
-            <Italian>Regolazione Ottiche ACE3</Italian>
-            <French>ACE3 Ajustement de la lunette </French>
-            <Japanese>ACE3 スコープ調節</Japanese>
-            <Korean>ACE3 조준경 조정</Korean>
-            <Chinese>ACE3 瞄準鏡調節按鍵</Chinese>
-            <Chinesesimp>ACE3 瞄准镜调节按键</Chinesesimp>
+            <English>ACE Scope Adjustment</English>
+            <German>ACE Visiereinstellung</German>
+            <Polish>ACE Regulacja optyki</Polish>
+            <Portuguese>ACE Ajuste de luneta</Portuguese>
+            <Russian>ACE Прицелы</Russian>
+            <Czech>ACE Nastavení optiky</Czech>
+            <Spanish>ACE Ajuste de miras</Spanish>
+            <Italian>ACE Regolazione Ottiche</Italian>
+            <French>ACE Ajustement de la lunette </French>
+            <Japanese>ACE スコープ調節</Japanese>
+            <Korean>ACE 조준경 조정</Korean>
+            <Chinese>ACE 瞄準鏡調節按鍵</Chinese>
+            <Chinesesimp>ACE 瞄准镜调节按键</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_ACEKeybindCategoryVehicles">
-            <English>ACE3 Vehicles</English>
-            <German>ACE3 Fahrzeuge</German>
-            <Polish>ACE3 Pojazdy</Polish>
-            <Portuguese>Veículos ACE3</Portuguese>
-            <Russian>ACE3 Транспорт</Russian>
-            <Czech>ACE3 Vozidla</Czech>
-            <Spanish>ACE3 Vehículos</Spanish>
-            <Italian>Veicoli ACE3</Italian>
-            <French>ACE3 Vehicules</French>
-            <Japanese>ACE3 車両</Japanese>
-            <Korean>ACE3 차량</Korean>
-            <Chinese>ACE3 載具按鍵</Chinese>
-            <Chinesesimp>ACE3 载具按键</Chinesesimp>
+            <English>ACE Vehicles</English>
+            <German>ACE Fahrzeuge</German>
+            <Polish>ACE Pojazdy</Polish>
+            <Portuguese>ACE Veículos</Portuguese>
+            <Russian>ACE Транспорт</Russian>
+            <Czech>ACE Vozidla</Czech>
+            <Spanish>ACE Vehículos</Spanish>
+            <Italian>ACE Veicoli</Italian>
+            <French>ACE Vehicules</French>
+            <Japanese>ACE 車両</Japanese>
+            <Korean>ACE 차량</Korean>
+            <Chinese>ACE 載具按鍵</Chinese>
+            <Chinesesimp>ACE 载具按键</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Common_NoRoomToUnload">
             <English>No Room to unload</English>

--- a/addons/gestures/stringtable.xml
+++ b/addons/gestures/stringtable.xml
@@ -2,20 +2,20 @@
 <Project name="ACE">
     <Package name="Gestures">
         <Key ID="STR_ACE_Gestures_ACEKeybindCategoryGestures">
-            <English>ACE3 Gestures</English>
-            <German>ACE3 Gesten</German>
-            <Polish>ACE3 Gesty</Polish>
-            <Czech>ACE3 Posunky</Czech>
-            <French>ACE3 Gestes</French>
-            <Hungarian>ACE3 Kézjelek</Hungarian>
-            <Italian>Gesti ACE3</Italian>
-            <Portuguese>ACE3 Gestos</Portuguese>
-            <Russian>ACE3 Жесты</Russian>
-            <Spanish>ACE3 Gestos</Spanish>
-            <Japanese>ACE3 ジェスチャー</Japanese>
-            <Korean>ACE3 수신호</Korean>
-            <Chinesesimp>ACE3 手势</Chinesesimp>
-            <Chinese>ACE3 手勢</Chinese>
+            <English>ACE Gestures</English>
+            <German>ACE Gesten</German>
+            <Polish>ACE Gesty</Polish>
+            <Czech>ACE Posunky</Czech>
+            <French>ACE Gestes</French>
+            <Hungarian>ACE Kézjelek</Hungarian>
+            <Italian>ACE Gesti</Italian>
+            <Portuguese>ACE Gestos</Portuguese>
+            <Russian>ACE Жесты</Russian>
+            <Spanish>ACE Gestos</Spanish>
+            <Japanese>ACE ジェスチャー</Japanese>
+            <Korean>ACE 수신호</Korean>
+            <Chinesesimp>ACE 手势</Chinesesimp>
+            <Chinese>ACE 手勢</Chinese>
         </Key>
         <Key ID="STR_ACE_Gestures_Name">
             <English>ACE Gestures</English>
@@ -24,7 +24,7 @@
             <Czech>ACE Posunky</Czech>
             <French>ACE Gestes</French>
             <Hungarian>ACE Kézjelek</Hungarian>
-            <Italian>Gesti ACE</Italian>
+            <Italian>ACE Gesti</Italian>
             <Portuguese>ACE Gestos</Portuguese>
             <Russian>ACE Жесты</Russian>
             <Spanish>ACE Gestos</Spanish>

--- a/addons/noradio/XEH_preInit.sqf
+++ b/addons/noradio/XEH_preInit.sqf
@@ -27,7 +27,7 @@ if (hasInterface) then {
     }, true] call CBA_fnc_addPlayerEventHandler;
 };
 
-[QGVAR(enabled), "CHECKBOX", [LSTRING(setting), LSTRING(setting_tooltip)], format ["ACE - %1", localize ELSTRING(common,DisplayName)], true, true, {
+[QGVAR(enabled), "CHECKBOX", [LSTRING(setting), LSTRING(setting_tooltip)], format ["ACE %1", localize ELSTRING(common,DisplayName)], true, true, {
     params ["_enabled"];
 
     if (_enabled) then {

--- a/addons/optionsmenu/XEH_preInit.sqf
+++ b/addons/optionsmenu/XEH_preInit.sqf
@@ -7,8 +7,8 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 if (hasInterface) then {
-    [[format ["ACE3 %1", localize LSTRING(DumpDebug)], localize LSTRING(DumpDebugTooltip)], QGVAR(MainMenuHelperDumpDebug)] call CBA_fnc_addPauseMenuOption;
-    [[format ["ACE3 %1", localize LSTRING(headBugFix)], localize LSTRING(headBugFixTooltip)], QGVAR(MainMenuHelperHeadBugFix)] call CBA_fnc_addPauseMenuOption;
+    [[format ["ACE %1", localize LSTRING(DumpDebug)], localize LSTRING(DumpDebugTooltip)], QGVAR(MainMenuHelperDumpDebug)] call CBA_fnc_addPauseMenuOption;
+    [[format ["ACE %1", localize LSTRING(headBugFix)], localize LSTRING(headBugFixTooltip)], QGVAR(MainMenuHelperHeadBugFix)] call CBA_fnc_addPauseMenuOption;
 };
 
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- replace `ACE3 ` and `ACE -` prefixes and suffixes with `ACE ` prefix, as discussed in Slack.
