### PR TITLE
Add persistent laserpointer

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -165,6 +165,7 @@ PREP(statusEffect_sendEffects);
 PREP(statusEffect_set);
 PREP(stringCompare);
 PREP(stringToColoredText);
+PREP(switchPersistentLaser);
 PREP(switchToGroupSide);
 PREP(throttledPublicVariable);
 PREP(toBin);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -446,9 +446,4 @@ GVAR(deviceKeyCurrentIndex) = -1;
 {false},
 [0xC7, [true, false, false]], false] call CBA_fnc_addKeybind;  //SHIFT + Home Key
 
-
-// init persistent laser
-if (GVAR(persistentLaserEnabled)) then {true call FUNC(switchPersistentLaser)};
-
-
 GVAR(commonPostInited) = true;

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -446,4 +446,9 @@ GVAR(deviceKeyCurrentIndex) = -1;
 {false},
 [0xC7, [true, false, false]], false] call CBA_fnc_addKeybind;  //SHIFT + Home Key
 
+
+// init persistent laser
+if (GVAR(persistentLaserEnabled)) then {true call FUNC(switchPersistentLaser)};
+
+
 GVAR(commonPostInited) = true;

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -40,4 +40,14 @@ isHC = !hasInterface && !isDedicated; // deprecated because no tag
 missionNamespace setVariable ["ACE_isHC", ACE_isHC];
 uiNamespace setVariable ["ACE_isHC", ACE_isHC];
 
+[
+    QGVAR(persistentLaserEnabled),
+    "CHECKBOX",
+    [localize LSTRING(SettingPersistentLaserName), localize LSTRING(SettingPersistentLaserDesc)],
+    localize LSTRING(ACEKeybindCategoryWeapons),
+    false,
+    false,
+    LINKFUNC(switchPersistentLaser)
+] call CBA_settings_fnc_init;
+
 ADDON = true;

--- a/addons/common/functions/fnc_switchPersistentLaser.sqf
+++ b/addons/common/functions/fnc_switchPersistentLaser.sqf
@@ -18,6 +18,7 @@
 params ["_enabled"];
 
 if (!_enabled) exitWith {
+    if (isNil QGVAR(laserKeyDownEH)) exitWith {};
     ["KeyDown", GVAR(laserKeyDownEH)] call CBA_fnc_removeDisplayHandler;
     ["weapon", GVAR(laserWeaponEH)] call CBA_fnc_removePlayerEventHandler;
     ["turret", GVAR(laserTurretEH)] call CBA_fnc_removePlayerEventHandler;

--- a/addons/common/functions/fnc_switchPersistentLaser.sqf
+++ b/addons/common/functions/fnc_switchPersistentLaser.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: Dystopian
+ * Controls persistent laser state.
+ *
+ * Arguments:
+ * 0: Enabled <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * true call ace_common_fnc_switchPersistentLaser
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_enabled"];
+
+if (!_enabled) exitWith {
+    ["KeyDown", GVAR(laserKeyDownEH)] call CBA_fnc_removeDisplayHandler;
+    ["weapon", GVAR(laserWeaponEH)] call CBA_fnc_removePlayerEventHandler;
+    ["turret", GVAR(laserTurretEH)] call CBA_fnc_removePlayerEventHandler;
+    ["vehicle", GVAR(laserVehicleEH)] call CBA_fnc_removePlayerEventHandler;
+};
+
+GVAR(laserKeyDownEH) = ["KeyDown", {
+    if !((_this select 1) in actionKeys "headlights") exitWith {false};
+    private _weapon = currentWeapon ACE_player;
+    [
+        {
+            params ["_weapon", "_laserWasEnabled"];
+            private _laserEnabled = ACE_player isIRLaserOn _weapon || {ACE_player isFlashlightOn _weapon};
+            if (_laserEnabled && {_laserWasEnabled} || {!_laserEnabled && {!_laserWasEnabled}}) exitWith {};
+            private _weaponIndex = [ACE_player, _weapon] call FUNC(getWeaponIndex);
+            ACE_player setVariable [QGVAR(laserEnabled_) + str _weaponIndex, [nil, true] select _laserEnabled];
+        },
+        [_weapon, ACE_player isIRLaserOn _weapon || {ACE_player isFlashlightOn _weapon}]
+    ] call CBA_fnc_execNextFrame;
+    false
+}] call CBA_fnc_addDisplayHandler;
+
+private _laserEH = {
+    if (sunOrMoon > 0.5) exitWith {};
+    params ["_player"];
+    private _weaponIndex = [_player, currentWeapon _player] call FUNC(getWeaponIndex);
+    if (
+        !(_player getVariable [QGVAR(laserEnabled_) + str _weaponIndex, false])
+        || {_weaponIndex > 0 && {"" != primaryWeapon _player}} // Arma switches to primary weapon if exists
+        || {!(_player call CBA_fnc_canUseWeapon)} // ignore in vehicle except FFV
+    ) exitWith {};
+    [
+        // wait for weapon in "ready to fire" direction
+        {0.01 > getCameraViewDirection _this vectorDistance (_this weaponDirection currentWeapon _this)},
+        {{_this action [_x, _this]} forEach ["GunLightOn", "IRLaserOn"]},
+        _player,
+        3,
+        {{_this action [_x, _this]} forEach ["GunLightOn", "IRLaserOn"]}
+    ] call CBA_fnc_waitUntilAndExecute;
+};
+
+GVAR(laserWeaponEH) = ["weapon", _laserEH] call CBA_fnc_addPlayerEventHandler;
+GVAR(laserTurretEH) = ["turret", _laserEH] call CBA_fnc_addPlayerEventHandler;
+GVAR(laserVehicleEH) = ["vehicle", _laserEH] call CBA_fnc_addPlayerEventHandler;

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -619,6 +619,14 @@
             <Chinese>設定ACE提示文字的顏色。若提示字體並無指定其他顏色，將會自動選用ACE系統的預設顏色。</Chinese>
             <Chinesesimp>设定ACE提示文字的颜色。若提示字体并无指定其他颜色，将会自动选用ACE系统的预设颜色。</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Common_SettingPersistentLaserName">
+            <English>Persistent weapon laserpointer/flashlight</English>
+            <Russian>Автоматический ЛЦУ/тактический фонарь</Russian>
+        </Key>
+        <Key ID="STR_ACE_Common_SettingPersistentLaserDesc">
+            <English>Enable gunlight after weapon switch or vehicle enter/exit if it was previously enabled.</English>
+            <Russian>Включать ЛЦУ/тактический фонарь после смены оружия или входа/выхода из машины, если он был до этого включен.</Russian>
+        </Key>
         <Key ID="STR_ACE_Common_bananaDisplayName">
             <English>Banana</English>
             <German>Banane</German>


### PR DESCRIPTION
**When merged this pull request will:**
- add automatically enabled laserpointer/flashlight after weapon switch or vehicle enter/exit.

It's very useful in coop modes (where laserpointer are used IMO) when you often have to switch to launcher or enter/exit vehicles. In vanilla laserpointer is disabled after these actions and you have to switch it on each time.

Option is added to `ACE Weapons` category (after #5815), which I plan to extend with some uncategorized settings.