### PR TITLE
Minor fixes for 1.78 RC

### DIFF
--- a/addons/aircraft/CfgWeapons.hpp
+++ b/addons/aircraft/CfgWeapons.hpp
@@ -105,10 +105,5 @@ class CfgWeapons {
             dispersion = 0.0064; //0.0023;
             multiplier = 1;
         };
-
-        class close: HighROF {};
-        class short: close {};
-        class medium: LowROF {};
-        class far: medium {};
     };
 };

--- a/addons/movement/functions/fnc_handleVirtualMass.sqf
+++ b/addons/movement/functions/fnc_handleVirtualMass.sqf
@@ -40,6 +40,7 @@ private _absLoad = getNumber (configFile >> "CfgInventoryGlobalVariable" >> "max
 private _loadCoef = _unit getVariable QGVAR(loadCoef);
 
 if (isNil "_loadCoef") then {
+    INFO("Note: getUnitTrait / loadCoef enum error can be ignored [present in ARMA 1.78 RC]");
     _loadCoef = _unit getUnitTrait "loadCoef";
     _unit setVariable [QGVAR(loadCoef), _loadCoef, true];
 };

--- a/addons/vehicles/CfgAmmo.hpp
+++ b/addons/vehicles/CfgAmmo.hpp
@@ -1,25 +1,7 @@
 
 class CfgAmmo {
-
-    class Missile_AGM_02_F;
-    class M_Mo_120mm_AT: Missile_AGM_02_F {
-        cost = 400000; // Stop it from aiming at FUCKING RABBITS.
-        weaponLockSystem = 2;
-    };
-
-    class M_Mo_120mm_AT_LG: M_Mo_120mm_AT {
-        cost = 400000;
-        weaponLockSystem = 4;
-    };
-
     class MissileBase;
     class M_Mo_82mm_AT: MissileBase {
-        cost = 400000;
-        weaponLockSystem = 2;
-    };
-
-    class M_Mo_82mm_AT_LG: M_Mo_82mm_AT {
-        cost = 400000;
-        weaponLockSystem = 4;
+        cost = 400000; // Stop it from aiming at FUCKING RABBITS.
     };
 };


### PR DESCRIPTION
Fix 
```
Updating base class M_Mo_82mm_AT->Missile_AGM_02_F, by z\ace\addons\vehicles\config.cpp/CfgAmmo/M_Mo_120mm_AT/ (original a3\weapons_f\config.bin)
Updating base class close->LowROF, by z\ace\addons\aircraft\config.cpp/CfgWeapons/M134_minigun/medium/ (original a3\weapons_f\config.bin)
Updating base class close->medium, by z\ace\addons\aircraft\config.cpp/CfgWeapons/M134_minigun/far/ (original a3\weapons_f\config.bin)
```


- aircraft - the inhertiance did nothing and can be removed
- movement - repoted here https://forums.bistudio.com/forums/topic/183856-release-candidate-branch-discussion/?do=findComment&comment=3251025
but I bet it will make it into final? doesn't hurt to print small warning in rpt.
- vehicles - weaponLockSystem was same as vanilla, I'm not even sure if we want the `cost` change still?