### PR TITLE
Add manual reload for vehicle weapons

### DIFF
--- a/addons/reload/CfgVehicles.hpp
+++ b/addons/reload/CfgVehicles.hpp
@@ -34,5 +34,43 @@ class CfgVehicles {
                 };
             };
         };
+        class ACE_SelfActions {
+            class GVAR(reloadTurret) {
+                displayName = "$STR_controls_tooltips_RELOAD_MAGAZINE";
+                condition = QUOTE(call FUNC(canSwapTurretMagazine));
+                statement = QUOTE(call FUNC(swapTurretMagazine));
+            };
+        };
+    };
+
+    class Tank: LandVehicle {
+        class ACE_SelfActions {
+            class GVAR(reloadTurret) {
+                displayName = "$STR_controls_tooltips_RELOAD_MAGAZINE";
+                condition = QUOTE(call FUNC(canSwapTurretMagazine));
+                statement = QUOTE(call FUNC(swapTurretMagazine));
+            };
+        };
+    };
+
+    class Car: LandVehicle {
+        class ACE_SelfActions {
+            class GVAR(reloadTurret) {
+                displayName = "$STR_controls_tooltips_RELOAD_MAGAZINE";
+                condition = QUOTE(call FUNC(canSwapTurretMagazine));
+                statement = QUOTE(call FUNC(swapTurretMagazine));
+            };
+        };
+    };
+
+    class Air;
+    class Helicopter: Air {
+        class ACE_SelfActions {
+            class GVAR(reloadTurret) {
+                displayName = "$STR_controls_tooltips_RELOAD_MAGAZINE";
+                condition = QUOTE(call FUNC(canSwapTurretMagazine));
+                statement = QUOTE(call FUNC(swapTurretMagazine));
+            };
+        };
     };
 };

--- a/addons/reload/XEH_PREP.hpp
+++ b/addons/reload/XEH_PREP.hpp
@@ -1,6 +1,8 @@
 
 PREP(canCheckAmmo);
+PREP(canSwapTurretMagazine);
 PREP(getAmmoToLinkBelt);
 PREP(checkAmmo);
 PREP(displayAmmo);
 PREP(startLinkingBelt);
+PREP(swapTurretMagazine);

--- a/addons/reload/functions/fnc_canSwapTurretMagazine.sqf
+++ b/addons/reload/functions/fnc_canSwapTurretMagazine.sqf
@@ -1,0 +1,50 @@
+/*
+ * Author: PabstMirror
+ * Check if the player can reload their vehicles magazine to one with more ammo
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ * 1: Player <OBJECT>
+ *
+ * Return Value:
+ * <BOOL> 
+ *
+ * Example:
+ * [vehicle player, player] call ace_reload_fnc_canSwapTurretMagazine
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_vehicle", "_player"];
+TRACE_2("canSwapTurretMagazine",_vehicle,_player);
+
+private _turretPath = _player call CBA_fnc_turretPath;
+if (_turretPath isEqualTo []) exitWith {false}; // skip driver / cargo
+if (!(_vehicle turretLocal _turretPath)) exitWith {false}; // just to be safe
+
+(weaponState [_vehicle, _turretPath]) params ["_weapon", "_muzzle", "", "_magazine", "_ammoCount"];
+TRACE_5("",_weapon,_muzzle,_magazine,_ammoCount,typeOf _vehicle);
+
+if ((_weapon == "") || {_weapon != _muzzle}) exitWith {false}; // skip multi-muzzle (he/ap auto-cannons)
+if (_magazine == "") exitWith {false};
+if (isText (configFile >> "CfgMagazines" >> _magazine >> "pylonWeapon")) exitWith {false};
+
+private _maxAmmo = getNumber (configFile >> "CfgMagazines" >> _magazine >> "count");
+if ((_ammoCount == 0) || {_ammoCount == _maxAmmo}) exitWith {false};
+
+private _magAmmoCounts = [];
+{
+    _x params ["_xMag", "_xTurret", "_xAmmo"];
+    if ((_xMag == _magazine) && {_xTurret isEqualTo _turretPath}) then {
+        _magAmmoCounts pushBack _xAmmo;
+    };
+} forEach (magazinesAllTurrets _vehicle);
+
+_magAmmoCounts sort false;
+TRACE_1("",_magAmmoCounts);
+
+if ((count _magAmmoCounts) < 2) exitWith {false};
+if ((_magAmmoCounts select 0) <= _ammoCount) exitWith {false}; // what we have is already the best
+
+true

--- a/addons/reload/functions/fnc_swapTurretMagazine.sqf
+++ b/addons/reload/functions/fnc_swapTurretMagazine.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: PabstMirror
+ * Check if the player can 
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ * 1: Player <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [vehicle player, player] call ace_reload_fnc_swapTurretMagazine
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_vehicle", "_player"];
+TRACE_2("swapTurretMagazine",_vehicle,_player);
+
+private _turretPath = _player call CBA_fnc_turretPath;
+(weaponState [_vehicle, _turretPath]) params ["_weapon", "", "", "_magazine"];
+TRACE_3("",_weapon,_magazine,typeOf _vehicle);
+
+private _weaponMagazines = (getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines")) apply {toLower _x};
+
+private _magAmmoCounts = [];  // ammo counts for the magazine type currently loaded
+private _otherMagazines = []; // mag type and ammo count for magazines that also fit into the weapon
+private _magazinesToRemove = [_magazine];
+{
+    _x params ["_xMag", "_xTurret", "_xAmmo"];
+    if ((_xTurret isEqualTo _turretPath) && {_xAmmo > 0}) then {
+        if (_xMag == _magazine) then {
+            _magAmmoCounts pushBack _xAmmo;
+        } else {
+            if ((toLower _xMag) in _weaponMagazines) then {
+                _magazinesToRemove pushBackUnique _xMag;
+                _otherMagazines pushBack [_xMag, _xTurret, _xAmmo];
+            };
+        };
+    };
+} forEach (magazinesAllTurrets _vehicle);
+
+TRACE_1("Remove all magazines that could fit into the current weapon",_magazinesToRemove);
+{  
+    _vehicle removeMagazinesTurret [_x, _turretPath];
+} forEach _magazinesToRemove;
+
+_magAmmoCounts sort false; // sort mags in decending order
+
+TRACE_2("Re-add the previously loaded magazines",_magazine,_magAmmoCounts);
+{
+    _vehicle addMagazineTurret [_magazine, _turretPath, _x];
+} forEach _magAmmoCounts;
+
+TRACE_1("Re-add other magazines",_otherMagazines);
+{
+    _vehicle addMagazineTurret _x;
+} forEach _otherMagazines;
+
+TRACE_1("done",weaponState [ARR_2(_vehicle, _turretPath)]);
+
+nil

--- a/addons/reload/functions/fnc_swapTurretMagazine.sqf
+++ b/addons/reload/functions/fnc_swapTurretMagazine.sqf
@@ -1,6 +1,7 @@
 /*
  * Author: PabstMirror
- * Check if the player can 
+ * Reloads a vehicles turret to a new magazine.
+ * Just removes all magazines and then re-adds them, reloading animation happens automaticaly by engine.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>


### PR DESCRIPTION
Adds ability to reload vehicle weapons (swapping to a fuller magazine)
I'm not sure why this isn't in the base game

Example:
HMG gunner on car, have 10 rounds left;
before you would have to mag dump to do a tactical reload
