### PR TITLE
Add ability to set aiming coefficient for mission scripting.

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
@@ -90,12 +90,12 @@ if (_overexhausted) then {
 
 switch (stance _unit) do {
     case ("CROUCH"): {
-        _unit setCustomAimCoef (1.0 + _fatigue ^ 2 * 0.1);
+        [_unit, QUOTE(ADDON), 1.0 + _fatigue ^ 2 * 0.1] call EFUNC(common,setAimCoef);
     };
     case ("PRONE"): {
-        _unit setCustomAimCoef (1.0 + _fatigue ^ 2 * 2.0);
+        [_unit, QUOTE(ADDON), 1.0 + _fatigue ^ 2 * 2.0] call EFUNC(common,setAimCoef);
     };
     default {
-        _unit setCustomAimCoef (1.5 + _fatigue ^ 2 * 3.0);
+        [_unit, QUOTE(ADDON), 1.5 + _fatigue ^ 2 * 3.0] call EFUNC(common,setAimCoef);
     };
 };

--- a/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
@@ -90,12 +90,12 @@ if (_overexhausted) then {
 
 switch (stance _unit) do {
     case ("CROUCH"): {
-        [_unit, QUOTE(ADDON), 1.0 + _fatigue ^ 2 * 0.1] call EFUNC(common,setAimCoef);
+        [_unit, QUOTE(ADDON), (1.0 + _fatigue ^ 2 * 0.1) * GVAR(swayFactor)] call EFUNC(common,setAimCoef);
     };
     case ("PRONE"): {
-        [_unit, QUOTE(ADDON), 1.0 + _fatigue ^ 2 * 2.0] call EFUNC(common,setAimCoef);
+        [_unit, QUOTE(ADDON), (1.0 + _fatigue ^ 2 * 2.0) * GVAR(swayFactor)] call EFUNC(common,setAimCoef);
     };
     default {
-        [_unit, QUOTE(ADDON), 1.5 + _fatigue ^ 2 * 3.0] call EFUNC(common,setAimCoef);
+        [_unit, QUOTE(ADDON), (1.5 + _fatigue ^ 2 * 3.0) * GVAR(swayFactor)] call EFUNC(common,setAimCoef);
     };
 };

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -142,6 +142,7 @@ PREP(runTests);
 PREP(sanitizeString);
 PREP(sendRequest);
 PREP(serverLog);
+PREP(setAimCoef);
 PREP(setApproximateVariablePublic);
 PREP(setDefinedVariable);
 PREP(setDisableUserInputStatus);

--- a/addons/common/functions/fnc_setAimCoef.sqf
+++ b/addons/common/functions/fnc_setAimCoef.sqf
@@ -1,0 +1,50 @@
+/*
+ * Author: xrufix, Glowbal
+ * Handle set AimCoef calls. Will use highest available setting.
+ *
+ * Arguments:
+ * 0: id <STRING>
+ * 1: settings <NUMBER>
+ * 2: add [true] OR remove [false] (default: true) <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player,"ace_advanced_fatigue", 1, true] call ace_common_fnc_setAimCoef
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params ["_unit","_id", "_setting", ["_add", true]];
+
+private _exists = false;
+private _highestCoef = 1;
+private _map = _unit getVariable [QGVAR(setAimCoefMap), []];
+
+_map = _map select {
+    _x params ["_xID", "_xSetting"];
+    if (_id == _xID) then {
+        _exists = true;
+        if (_add) then {
+            _x set [1, _setting];
+            _highestCoef = _highestCoef max _setting;
+            true
+        } else {
+            false
+        };
+    } else {
+        _highestCoef = _highestCoef max _xSetting;
+        true
+    };
+};
+
+if (!exists && _add) then {
+	_highestCoef = _highestCoef max _setting;
+	_map pushBack [_id, _setting];
+};
+
+// Update the value
+_unit setVariable [QGVAR(setAimCoefMap), _map];
+_unit setCustomAimCoef _highestCoef;

--- a/addons/common/functions/fnc_setAimCoef.sqf
+++ b/addons/common/functions/fnc_setAimCoef.sqf
@@ -18,7 +18,7 @@
  */
 #include "script_component.hpp"
 
-params ["_unit","_id", "_setting", ["_add", true]];
+params ["_unit", "_id", "_setting", ["_add", true]];
 
 private _exists = false;
 private _highestCoef = 1;

--- a/addons/common/functions/fnc_setAimCoef.sqf
+++ b/addons/common/functions/fnc_setAimCoef.sqf
@@ -42,8 +42,8 @@ _map = _map select {
 };
 
 if (!_exists && _add) then {
-	_highestCoef = _highestCoef max _setting;
-	_map pushBack [_id, _setting];
+    _highestCoef = _highestCoef max _setting;
+    _map pushBack [_id, _setting];
 };
 
 // Update the value

--- a/addons/common/functions/fnc_setAimCoef.sqf
+++ b/addons/common/functions/fnc_setAimCoef.sqf
@@ -1,18 +1,18 @@
 /*
  * Author: xrufix, Glowbal
- * Handle set AimCoef calls. Will use highest available setting.
+ * Handle set AimCoef calls. Will use the highest available setting.
  *
  * Arguments:
- * 0: unit <OBJECT>
- * 1: id <STRING>
- * 2: settings <NUMBER>
- * 3: add [true] OR remove [false] (default: true) <BOOL>
+ * 0: Unit <OBJECT>
+ * 1: Unique ID <STRING>
+ * 2: Aim coefficient (a higher value causes more shaking) <NUMBER>
+ * 3: Add (true) or remove (false) <BOOL> (default: true)
  *
  * Return Value:
  * None
  *
  * Example:
- * [player,"ace_advanced_fatigue", 1, true] call ace_common_fnc_setAimCoef
+ * [player, "ace_advanced_fatigue", 1, true] call ace_common_fnc_setAimCoef
  *
  * Public: Yes
  */

--- a/addons/common/functions/fnc_setAimCoef.sqf
+++ b/addons/common/functions/fnc_setAimCoef.sqf
@@ -3,9 +3,10 @@
  * Handle set AimCoef calls. Will use highest available setting.
  *
  * Arguments:
- * 0: id <STRING>
- * 1: settings <NUMBER>
- * 2: add [true] OR remove [false] (default: true) <BOOL>
+ * 0: unit <OBJECT>
+ * 1: id <STRING>
+ * 2: settings <NUMBER>
+ * 3: add [true] OR remove [false] (default: true) <BOOL>
  *
  * Return Value:
  * None
@@ -40,7 +41,7 @@ _map = _map select {
     };
 };
 
-if (!exists && _add) then {
+if (!_exists && _add) then {
 	_highestCoef = _highestCoef max _setting;
 	_map pushBack [_id, _setting];
 };

--- a/addons/common/functions/fnc_setHearingCapability.sqf
+++ b/addons/common/functions/fnc_setHearingCapability.sqf
@@ -3,9 +3,9 @@
  * Handle set volume calls. Will use the lowest available volume setting.
  *
  * Arguments:
- * 0: id <STRING>
- * 1: settings <NUMBER>
- * 2: add [true] OR remove [false] (default: true) <BOOL>
+ * 0: ID <STRING>
+ * 1: Settings <NUMBER>
+ * 2: Add (true) or remove (false) <BOOL> (default: true)
  *
  * Return Value:
  * None


### PR DESCRIPTION
**When merged this pull request will:**
- Add function **ace_common_fnc_setAimCoef**. This is a partial copy of the [setHearingCapability](https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_setHearingCapability.sqf) function and allows for scripts to raise the aiming coefficient (weapon sway) above the current value. The highest value set will be applied. It is designed so that scripts can simulate stress, fear, suppression and other mental or physical conditions that will likely reduce a soldier's ability to aim correctly.
- Make ace_advanced_fatigue_fnc_handleEffects use the above-mentioned function instead of `setCustomAimCoef`.

I would however prefer a framework for similar functionality (having a max/min setting that can be set by different functions/scripts).