### PR TITLE
Fix ab module strings

### DIFF
--- a/addons/advanced_ballistics/CfgVehicles.hpp
+++ b/addons/advanced_ballistics/CfgVehicles.hpp
@@ -50,8 +50,8 @@ class CfgVehicles {
             };
             */
             class muzzleVelocityVariationEnabled {
-                displayName = CSTRING(muzzleVelocityVariation_DisplayName);
-                description = CSTRING(muzzleVelocityVariation_Description);
+                displayName = CSTRING(muzzleVelocityVariationEnabled_DisplayName);
+                description = CSTRING(muzzleVelocityVariationEnabled_Description);
                 typeName = "BOOL";
                 defaultValue = 1;
             };


### PR DESCRIPTION
really doesn't matter because it's deprecated

```
String STR_ace_advanced_ballistics_muzzleVelocityVariation_DisplayName not found
String STR_ace_advanced_ballistics_muzzleVelocityVariation_Description not found
```