### PR TITLE
add setting to hide freefall altimeter, ref #5596

### DIFF
--- a/addons/parachute/XEH_preInit.sqf
+++ b/addons/parachute/XEH_preInit.sqf
@@ -21,4 +21,12 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+[
+    QGVAR(hideAltimeter),
+    "CHECKBOX",
+    [LSTRING(HideAltimeter), LSTRING(HideAltimeter_tooltip)],
+    format ["ACE %1", localize ELSTRING(common,DisplayName)],
+    true
+] call cba_settings_fnc_init; 
+
 ADDON = true;

--- a/addons/parachute/XEH_preInit.sqf
+++ b/addons/parachute/XEH_preInit.sqf
@@ -26,7 +26,9 @@ PREP_RECOMPILE_END;
     "CHECKBOX",
     [LSTRING(HideAltimeter), LSTRING(HideAltimeter_tooltip)],
     format ["ACE %1", localize ELSTRING(common,DisplayName)],
-    true
+    true,
+    false,
+    {[QGVAR(hideAltimeter), _this, false] call EFUNC(common,cbaSettings_settingChanged)}
 ] call cba_settings_fnc_init; 
 
 ADDON = true;

--- a/addons/parachute/functions/fnc_handleInfoDisplayChanged.sqf
+++ b/addons/parachute/functions/fnc_handleInfoDisplayChanged.sqf
@@ -18,7 +18,7 @@
 params ["_dialog", "_type"];
 
 // don't do anything in noob mode
-if (cadetMode) exitWith {};
+if (!GVAR(hideAltimeter)) exitWith {};
 
 switch (_type) do {
     case ("Parachute"): {

--- a/addons/parachute/stringtable.xml
+++ b/addons/parachute/stringtable.xml
@@ -97,5 +97,13 @@
             <Chinesesimp>备用降落伞</Chinesesimp>
             <Chinese>備用降落傘</Chinese>
         </Key>
+        <Key ID="STR_ACE_Parachute_HideAltimeter">
+            <English>Hide Freefall Altimeter</English>
+            <German>Freifall-Höhenmesser verstecken</German>
+        </Key>
+        <Key ID="STR_ACE_Parachute_HideAltimeter_tooltip">
+            <English>Hides the altitude and speed shown while free falling or parachuting.</English>
+            <German>Blendet den Höhen- und Geschwindigkeitsmesser während des Fallschirmspringens aus.</German>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Currently broken, because `cadetMode` is synonymous with `true` now
- solves part of #5596