### PR TITLE
Wind Deflection - Only track remote bullets if they are tracers

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -55,11 +55,7 @@ if (_abort) then {
         };
     };
 };
-if (_abort) exitWith {
-    if (missionNamespace getVariable [QEGVAR(windDeflection,enabled), false]) then {
-        EGVAR(windDeflection,trackedBullets) pushBack [_projectile, getNumber(configFile >> "CfgAmmo" >> _ammo >> "airFriction")];
-    };
-};
+if (_abort) exitWith {};
 
 // Get Weapon and Ammo Configurations
 private _AmmoCacheEntry = uiNamespace getVariable format[QGVAR(%1), _ammo];

--- a/addons/winddeflection/functions/fnc_handleFired.sqf
+++ b/addons/winddeflection/functions/fnc_handleFired.sqf
@@ -18,9 +18,18 @@
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
 TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile, _vehicle, _gunner, _turret);
 
-if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false] && {_projectile isKindOf "BulletBase"} && {_unit isKindOf "Man"}) exitWith {false};
+if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false] && {_projectile isKindOf "BulletBase" && {_unit isKindOf "Man"}}) exitWith {false};
 
 if (!((_projectile isKindOf "BulletBase") || {_projectile isKindOf "GrenadeBase"})) exitWith {false};
 if (_unit distance ACE_player > GVAR(simulationRadius)) exitWith {false};
+
+private _abort = false;
+if (!local _unit && {_projectile isKindOf "BulletBase"}) then {
+    private _ammoCount = (_unit ammo _muzzle) + 1;
+    private _tracersEvery = getNumber(configFile >> "CfgMagazines" >> _magazine >> "tracersEvery");
+    private _lastRoundsTracer = getNumber(configFile >> "CfgMagazines" >> _magazine >> "lastRoundsTracer");
+    _abort = _ammoCount > _lastRoundsTracer && {_tracersEvery == 0 || {(_ammoCount - _lastRoundsTracer) % _tracersEvery != 0}};
+};
+if (_abort) exitWith {false};
 
 GVAR(trackedBullets) pushBack [_projectile, getNumber(configFile >> "CfgAmmo" >> _ammo >> "airFriction")];


### PR DESCRIPTION
* Do not run the PFH for remote projectiles unless they are tracers
