### PR TITLE
AdvThrow - Fix torque script error for IR strobes

### DIFF
--- a/addons/advanced_throwing/CfgAmmo.hpp
+++ b/addons/advanced_throwing/CfgAmmo.hpp
@@ -4,4 +4,8 @@ class CfgAmmo {
         GVAR(torqueDirection)[] = {1, 1, 0};
         GVAR(torqueMagnitude) = "(50 + random 100) * selectRandom [1, -1]";
     };
+    class GrenadeCore: Default {
+        GVAR(torqueDirection)[] = {1, 1, 0};
+        GVAR(torqueMagnitude) = "(50 + random 100) * selectRandom [1, -1]";
+    };
 };

--- a/addons/advanced_throwing/functions/fnc_throw.sqf
+++ b/addons/advanced_throwing/functions/fnc_throw.sqf
@@ -50,7 +50,8 @@ if (!(_unit getVariable [QGVAR(primed), false])) then {
     };
 
     private _config = configFile >> "CfgAmmo" >> typeOf _activeThrowable;
-    private _torqueDir = vectorNormalized (getArray (_config >> QGVAR(torqueDirection)));
+    private _torqueDir = getArray (_config >> QGVAR(torqueDirection));
+    _torqueDir = if (_torqueDir isEqualTypeArray [0,0,0]) then { vectorNormalized _torqueDir } else { [0,0,0] };
     private _torqueMag = getNumber (_config >> QGVAR(torqueMagnitude));
     private _torque = _torqueDir vectorMultiply _torqueMag;
 


### PR DESCRIPTION
Close #5835
- Add config to GrenadeCore (IRStrobeBase: GrenadeCore)
- Verify array is valid 3d vector in throw.sqf
