### PR TITLE
Map - Don't shake map when player is dead

### DIFF
--- a/addons/map/functions/fnc_updateMapEffects.sqf
+++ b/addons/map/functions/fnc_updateMapEffects.sqf
@@ -35,7 +35,7 @@ if (GVAR(mapShake)) then {
 
     // Only shake map while moving on foot
     private _speed = 0;
-    if (vehicle ACE_player == ACE_player) then {
+    if ((alive ACE_player) && {vehicle ACE_player == ACE_player}) then {
         _speed = vectorMagnitude (velocity ACE_player);
     };
 


### PR DESCRIPTION
Close #5830

Dead player had very small velocity (0.001) for a bit after dying, maybe from ragdoll
Caused mapshake to trigger on respawn screen (which I guess uses the same map)