### PR TITLE
Spectator - Fix BIS_fnc_lerp causing crash in 3rd person spectator

### DIFF
--- a/addons/spectator/functions/fnc_cam.sqf
+++ b/addons/spectator/functions/fnc_cam.sqf
@@ -39,7 +39,7 @@ if (_init) then {
 
     // Follow camera related
     GVAR(camDistance)           = 0;
-    GVAR(camDistanceTemp)       = 0;
+    GVAR(camDistanceTrue)       = 0;
     GVAR(camYaw)                = 0;
     GVAR(camPitch)              = 0;
 
@@ -133,7 +133,7 @@ if (_init) then {
     GVAR(camHasTarget)          = nil;
     GVAR(camTargetInVehicle)    = nil;
     GVAR(camDistance)           = nil;
-    GVAR(camDistanceTemp)       = nil;
+    GVAR(camDistanceTrue)       = nil;
     GVAR(camYaw)                = nil;
     GVAR(camPitch)              = nil;
     GVAR(camSlow)               = nil;

--- a/addons/spectator/functions/fnc_cam_prepareTarget.sqf
+++ b/addons/spectator/functions/fnc_cam_prepareTarget.sqf
@@ -18,6 +18,7 @@
 #include "script_component.hpp"
 
 private _focus = vehicle (param [0, objNull, [objNull]]);
+TRACE_1("cam_prepareTarget",_focus);
 
 if !(isNull _focus) then {
     // Interpolate zoom
@@ -25,8 +26,19 @@ if !(isNull _focus) then {
     private _zoomTemp = GVAR(camDistanceTemp);
 
     if (_zoomTemp != _zoom) then {
-        _zoomTemp = [_zoomTemp, _zoom, 10, GVAR(camDeltaTime)] call BIS_fnc_lerp;
+        _zoomTemp = [_zoomTemp, _zoom, 10, GVAR(camDeltaTime)] call {
+            // BIS_fnc_lerp was broken in 1.78, this is the previous version from a3\functions_f_exp_a\math
+            params [["_a", 0.0, [0.0]], ["_b", 0.0, [0.0]], ["_speed", 1.0, [0.0]], ["_deltaTime", 0.0, [0.0]]];
+            private "_result";
+            _result = 0.0;
+            if (_a != _b) then
+            {
+                _result = (_a * (1.0 - _deltaTime * _speed)) + (_b * _deltaTime * _speed);
+            };
+            _result;
+        };
         GVAR(camDistanceTemp) = _zoomTemp;
+        TRACE_2("new zoom",GVAR(camDeltaTime),_zoomTemp);
     };
 
     // The distance at which to place camera from the focus pivot

--- a/addons/spectator/functions/fnc_cam_prepareTarget.sqf
+++ b/addons/spectator/functions/fnc_cam_prepareTarget.sqf
@@ -21,29 +21,21 @@ private _focus = vehicle (param [0, objNull, [objNull]]);
 TRACE_1("cam_prepareTarget",_focus);
 
 if !(isNull _focus) then {
-    // Interpolate zoom
+    // Zooming takes place smoothly over multiple frames
+    // _zoom is target set by user, _zoomTrue is actual value each frame
     private _zoom = [0, GVAR(camDistance)] select (GVAR(camMode) == MODE_FOLLOW);
-    private _zoomTemp = GVAR(camDistanceTemp);
+    private _zoomTrue = GVAR(camDistanceTrue);
 
-    if (_zoomTemp != _zoom) then {
-        _zoomTemp = [_zoomTemp, _zoom, 10, GVAR(camDeltaTime)] call {
-            // BIS_fnc_lerp was broken in 1.78, this is the previous version from a3\functions_f_exp_a\math
-            params [["_a", 0.0, [0.0]], ["_b", 0.0, [0.0]], ["_speed", 1.0, [0.0]], ["_deltaTime", 0.0, [0.0]]];
-            private "_result";
-            _result = 0.0;
-            if (_a != _b) then
-            {
-                _result = (_a * (1.0 - _deltaTime * _speed)) + (_b * _deltaTime * _speed);
-            };
-            _result;
-        };
-        GVAR(camDistanceTemp) = _zoomTemp;
-        TRACE_2("new zoom",GVAR(camDeltaTime),_zoomTemp);
+    // Interpolate zoom each frame until desired zoom is reached
+    if (_zoomTrue != _zoom) then {
+        _zoomTrue = (_zoomTrue * (1 - GVAR(camDeltaTime) * 10)) + (_zoom * GVAR(camDeltaTime) * 10);
+        GVAR(camDistanceTrue) = _zoomTrue;
+        TRACE_2("new zoom",GVAR(camDeltaTime),_zoomTrue);
     };
 
     // The distance at which to place camera from the focus pivot
     private _bbd = [_focus] call BIS_fnc_getObjectBBD;
-    private _distance = (_bbd select 1) + _zoomTemp;
+    private _distance = (_bbd select 1) + _zoomTrue;
 
     // The pivot on the target vehicle
     private _isMan = _focus isKindOf "Man";


### PR DESCRIPTION
Using 3rd person follow in spectator caused hard game crash.
It pushed camera out to infinity

```
TRACE: 9649 pre1: _zoom=1, _zoomTemp=-3.48678e+009 z\ace\addons\spectator\functions\fnc_cam_prepareTarget.sqf:28
TRACE: 9649 pre2: ace_spectator_camDistance=1, ace_spectator_camDistanceTemp=-3.48678e+009 z\ace\addons\spectator\functions\fnc_cam_prepareTarget.sqf:29
TRACE: 9649 new: ace_spectator_camDeltaTime=0.171005, _zoomTemp=3.13811e+010 z\ace\addons\spectator\functions\fnc_cam_prepareTarget.sqf:34
TRACE: 9649 x: _bbd=[1.6,2.2,2], _distance=3.13811e+010 z\ace\addons\spectator\functions\fnc_cam_prepareTarget.sqf:40
```

1.78 changed BIS_fnc_lerp, both files still exist but the one that gets used has changed.

Current (a3\functions_f\animation\interp)
```
params [["_a", 0.0, [0.0]], ["_b", 0.0, [0.0]], ["_alpha", 0.0, [0.0]]];

_a + _alpha * (_b - _a);
```
Prior (a3\functions_f_exp_a\math)
```
params [["_a", 0.0, [0.0]], ["_b", 0.0, [0.0]], ["_speed", 1.0, [0.0]], ["_deltaTime", 0.0, [0.0]]];

private "_result";
_result = 0.0;

if (_a != _b) then
{
    _result = (_a * (1.0 - _deltaTime * _speed)) + (_b * _deltaTime * _speed);
};

_result;
```