### PR TITLE
Overpressure - Don't add backblast damage if blocked

### DIFF
--- a/addons/overpressure/functions/fnc_firedEHBB.sqf
+++ b/addons/overpressure/functions/fnc_firedEHBB.sqf
@@ -54,6 +54,8 @@ if (_distance < _backblastRange) then {
     if (isClass (configFile >> "CfgPatches" >> "ACE_Medical") && {([_unit] call EFUNC(medical,hasMedicalEnabled))}) then {
         [_unit, _damage, "body", "backblast"] call EFUNC(medical,addDamageToUnit);
     } else {
+        TRACE_1("",isDamageAllowed _x);
+        if (!isDamageAllowed _x) exitWith {}; // Skip damage if not allowed
         _unit setDamage (damage _unit + _damage);
     };
 };

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -59,6 +59,8 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
             if (isClass (configFile >> "CfgPatches" >> "ACE_Medical") && {([_x] call EFUNC(medical,hasMedicalEnabled))}) then {
                 [_x, _damage, "body", "backblast"] call EFUNC(medical,addDamageToUnit);
             } else {
+                TRACE_1("",isDamageAllowed _x);
+                if (!isDamageAllowed _x) exitWith {}; // Skip damage if not allowed
                 _x setDamage (damage _x + _damage);
             };
 


### PR DESCRIPTION
@Neviothr 

Blocks backblast damage if not using ace medical AND damage is disabled via `allowDamage`