### PR TITLE
Fix missing HE magazine for Blackfish Autocannon.

### DIFF
--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -546,6 +546,16 @@ class CfgWeapons {
         };
     };
 
+    class autocannon_40mm_VTOL_01: autocannon_40mm_CTWS {
+        displayName = "L/60 Bofors Autocannon";
+        class AP: AP {
+            displayName = "L/60 Bofors Autocannon";
+        };
+        class HE: AP {
+            displayName = "L/60 Bofors Autocannon";
+        };
+    };
+
     class autocannon_30mm_CTWS: autocannon_Base_F {
         displayName = "Mk44 Bushmaster II";
         class AP: autocannon_Base_F {

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -46,29 +46,6 @@ class CfgWeapons {
         class far: close {};
     };
 
-    class autocannon_Base_F;
-    class autocannon_30mm_CTWS: autocannon_Base_F {
-        class AP: autocannon_Base_F {
-            magazines[] = {"60Rnd_30mm_APFSDS_shells","60Rnd_30mm_APFSDS_shells_Tracer_Red","60Rnd_30mm_APFSDS_shells_Tracer_Green","60Rnd_30mm_APFSDS_shells_Tracer_Yellow","140Rnd_30mm_MP_shells","140Rnd_30mm_MP_shells_Tracer_Red","140Rnd_30mm_MP_shells_Tracer_Green","140Rnd_30mm_MP_shells_Tracer_Yellow"};
-            magazineReloadTime = 0;
-        };
-
-        muzzles[] = {"AP"};
-    };
-    class autocannon_40mm_CTWS: autocannon_Base_F {
-        class AP: autocannon_Base_F {
-            magazines[] = {"40Rnd_40mm_APFSDS_shells","40Rnd_40mm_APFSDS_Tracer_Red_shells","40Rnd_40mm_APFSDS_Tracer_Green_shells","40Rnd_40mm_APFSDS_Tracer_Yellow_shells","60Rnd_40mm_GPR_shells","60Rnd_40mm_GPR_Tracer_Red_shells","60Rnd_40mm_GPR_Tracer_Green_shells","60Rnd_40mm_GPR_Tracer_Yellow_shells"};
-            magazineReloadTime = 0;
-        };
-
-        muzzles[] = {"AP"};
-    };
-    class autocannon_40mm_VTOL_01: autocannon_40mm_CTWS {
-        class AP: AP {
-            magazines[] = {"160Rnd_40mm_APFSDS_Tracer_Red_shells", "40Rnd_40mm_APFSDS_shells", "40Rnd_40mm_APFSDS_Tracer_Red_shells", "40Rnd_40mm_APFSDS_Tracer_Green_shells", "40Rnd_40mm_APFSDS_Tracer_Yellow_shells","240Rnd_40mm_GPR_Tracer_Red_shells", "60Rnd_40mm_GPR_shells", "60Rnd_40mm_GPR_Tracer_Red_shells", "60Rnd_40mm_GPR_Tracer_Green_shells", "60Rnd_40mm_GPR_Tracer_Yellow_shells"};
-        };
-    };
-
     // make static weapons compatible with 100rnd mag variants
     class HMG_static: HMG_01 {
         magazines[] = {"500Rnd_127x99_mag","500Rnd_127x99_mag_Tracer_Red","500Rnd_127x99_mag_Tracer_Green","500Rnd_127x99_mag_Tracer_Yellow","200Rnd_127x99_mag","200Rnd_127x99_mag_Tracer_Red","200Rnd_127x99_mag_Tracer_Green","200Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Yellow"};

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -63,6 +63,11 @@ class CfgWeapons {
 
         muzzles[] = {"AP"};
     };
+    class autocannon_40mm_VTOL_01: autocannon_40mm_CTWS {
+        class AP: AP {
+            magazines[] = {"160Rnd_40mm_APFSDS_Tracer_Red_shells", "40Rnd_40mm_APFSDS_shells", "40Rnd_40mm_APFSDS_Tracer_Red_shells", "40Rnd_40mm_APFSDS_Tracer_Green_shells", "40Rnd_40mm_APFSDS_Tracer_Yellow_shells","240Rnd_40mm_GPR_Tracer_Red_shells", "60Rnd_40mm_GPR_shells", "60Rnd_40mm_GPR_Tracer_Red_shells", "60Rnd_40mm_GPR_Tracer_Green_shells", "60Rnd_40mm_GPR_Tracer_Yellow_shells"};
+        };
+    };
 
     // make static weapons compatible with 100rnd mag variants
     class HMG_static: HMG_01 {


### PR DESCRIPTION
**When merged this pull request will:**
- ~~Adds magazine from HE muzzle to AP muzzle for Blackfish Autocannon (`autocannon_40mm_VTOL_01`)~~
- Removes muzzle tweak from all autocannons in ace_vehicles to fix problems with inheriting from autocannon classes.
- Fixes #5847
- Changes displayName to `"L/60 Bofors Autocannon"`. See reason below.