### PR TITLE
Generate isTracer array for magazines

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -52,6 +52,7 @@ PREP(fixCollision);
 PREP(fixFloating);
 PREP(fixLoweredRifleAnimation);
 PREP(fixPosition);
+PREP(generateIsTracerArray);
 PREP(getAllDefinedSetVariables);
 PREP(getDeathAnim);
 PREP(getDefaultAnim);

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -26,6 +26,8 @@ GVAR(statusEffect_isGlobal) = [];
 
 GVAR(setHearingCapabilityMap) = [];
 
+GVAR(isTracerNamespace) = [] call CBA_fnc_createNamespace;
+
 //////////////////////////////////////////////////
 // Set up PlayerChanged eventhandler for pre init (EH is installed in postInit)
 //////////////////////////////////////////////////

--- a/addons/common/functions/fnc_generateIsTracerArray.sqf
+++ b/addons/common/functions/fnc_generateIsTracerArray.sqf
@@ -1,0 +1,40 @@
+/*
+ * Author: PabstMirror
+ * Generates a array of which bullets are tracers for a given magazine.
+ * Note: it is zero indexed, so for a 30 round magazine, first shot will be 29, last will be 0
+ * Array will be empty if all rounds are tracers, use `_magTracers param [(_unit ammo _muzzle), true];`
+ *
+ * Arguments:
+ * 0: magazine classname <STRING>
+ *
+ * Return Value:
+ * Bools indicating if it is a tracer<ARRAY>
+ *
+ * Example:
+ * ["100Rnd_65x39_caseless_mag"] call ace_attach_fnc_attach;
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_magazine"];
+
+private _isTracerArray = [];
+private _count = getNumber(configFile >> "CfgMagazines" >> _magazine >> "count");
+private _tracersEvery = getNumber(configFile >> "CfgMagazines" >> _magazine >> "tracersEvery");
+private _lastRoundsTracer = getNumber(configFile >> "CfgMagazines" >> _magazine >> "lastRoundsTracer");
+TRACE_4("",_magazine,_count,_tracersEvery,_lastRoundsTracer);
+
+
+if (_tracersEvery != 1) then { // If every round will be a tracer just return an empty array
+    _isTracerArray resize _count;
+    for "_index" from 0 to (_count - 1) do {
+        private _ammoCount = _index + 1;
+        private _isTracer = (_ammoCount < _lastRoundsTracer) || {(_tracersEvery != 0) && {(_ammoCount - _lastRoundsTracer) % _tracersEvery == 0}};
+        _isTracerArray set [_index, _isTracer];
+    };
+};
+GVAR(isTracerNamespace) setVariable [_magazine, _isTracerArray];
+
+TRACE_1("return",_isTracerArray);
+_isTracerArray

--- a/addons/common/functions/fnc_generateIsTracerArray.sqf
+++ b/addons/common/functions/fnc_generateIsTracerArray.sqf
@@ -11,7 +11,7 @@
  * Bools indicating if it is a tracer<ARRAY>
  *
  * Example:
- * ["100Rnd_65x39_caseless_mag"] call ace_attach_fnc_attach;
+ * ["100Rnd_65x39_caseless_mag"] call ace_common_fnc_generateIsTracerArray;
  *
  * Public: No
  */

--- a/addons/winddeflection/functions/fnc_handleFired.sqf
+++ b/addons/winddeflection/functions/fnc_handleFired.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [clientFiredBIS-XEH] call ace_advanced_ballistics_fnc_handleFired
+ * [clientFiredBIS-XEH] call ace_winddeflection_fnc_handleFired
  *
  * Public: No
  */
@@ -25,10 +25,11 @@ if (_unit distance ACE_player > 2000) exitWith {false};
 
 private _abort = false;
 if (!local _unit && {_projectile isKindOf "BulletBase"}) then {
-    private _ammoCount = (_unit ammo _muzzle) + 1;
-    private _tracersEvery = getNumber(configFile >> "CfgMagazines" >> _magazine >> "tracersEvery");
-    private _lastRoundsTracer = getNumber(configFile >> "CfgMagazines" >> _magazine >> "lastRoundsTracer");
-    _abort = _ammoCount > _lastRoundsTracer && {_tracersEvery == 0 || {(_ammoCount - _lastRoundsTracer) % _tracersEvery != 0}};
+    private _magTracers = EGVAR(common,isTracerNamespace) getVariable _magazine;
+    if (isNil "_magTracers") then {
+        _magTracers = [_magazine] call EFUNC(common,generateIsTracerArray);
+    };
+    _abort = !(_magTracers param [(_unit ammo _muzzle), true]);
 };
 if (_abort) exitWith {false};
 


### PR DESCRIPTION
Minor optimization for determining if a shot is a tracer
Makes a array of bools for which shots are tracers `[true, false, true...]`
Performance gains are minor (0.0184 ms -> 0.0153 ms)

- [ ] Add to AB
- [ ] Add to new NVG after merge

Not thrilled with creating big arrays for the 2000 rnd mags, but it's really only going to be a few kilobytes. Could just cap count at ~500.
Most of those end up being all tracers, which are represented by an empty array.