### PR TITLE
Fix draw3D in specator free camera when perma-dead

### DIFF
--- a/addons/spectator/functions/fnc_cam.sqf
+++ b/addons/spectator/functions/fnc_cam.sqf
@@ -79,6 +79,10 @@ if (_init) then {
     // Store camera
     GVAR(camera) = _camera;
 
+    // Create agent used to fix draw3D in free camera for case where player is perma-dead
+    GVAR(camAgentFree) = createAgent [QGVAR(virtual), [0,0,0], [], 0, "NONE"];
+    GVAR(camAgentFree) enableSimulation false; // Prevent falling into water
+
     // Create dummy target used for follow camera
     GVAR(camDummy) = "Logic" createVehicleLocal getPosASLVisual GVAR(camFocus);
 
@@ -120,8 +124,12 @@ if (_init) then {
     // Remove camera variable
     GVAR(camera) = nil;
 
+    // Destroy free camera agent
+    deleteVehicle GVAR(camAgentFree);
+    GVAR(camAgentFree) = nil;
+
     // Destroy dummy target
-    deleteVehicle (GVAR(camDummy));
+    deleteVehicle GVAR(camDummy);
     GVAR(camDummy) = nil;
 
     // Stop tracking everything

--- a/addons/spectator/functions/fnc_cam_setCameraMode.sqf
+++ b/addons/spectator/functions/fnc_cam_setCameraMode.sqf
@@ -62,7 +62,7 @@ if (!isNull _focus || _newMode == MODE_FREE) then {
 
     if (_newMode == MODE_FREE) then {
         _camera cameraEffect ["Internal", "BACK"];
-        player switchCamera "INTERNAL";
+        switchCamera GVAR(camAgentFree); // Fix draw3D while in free camera for case where player is perma-dead
         _camera setDir getDirVisual _camera;
 
         if (!isNull _focus) then {


### PR DESCRIPTION
This is a weird engine behaviour where draw3D doesn't work if the current camera unit is not alive (or going to respawn), so we switch to a temporary agent unit while in free camera to work around this edge case.

Closes #5856 