### PR TITLE
Add endRadioTransmissions Event

### DIFF
--- a/addons/common/functions/fnc_endRadioTransmission.sqf
+++ b/addons/common/functions/fnc_endRadioTransmission.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: commy2
  *
- * End radio transmissions of addons TFAR and ACRE2. TFAR v0.9.7, ACRE Public Beta 2.0.3.571
+ * End radio transmissions of addons TFAR and ACRE2. TFAR v0.9.x, ACRE Public Beta 2.0.3.571
  *
  * Arguments:
  * None
@@ -15,6 +15,8 @@
  * Public: No
  */
 #include "script_component.hpp"
+
+[QGVAR(endRadioTransmissions)] call CBA_fnc_localEvent;
 
 // ACRE
 if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {

--- a/addons/common/functions/fnc_endRadioTransmission.sqf
+++ b/addons/common/functions/fnc_endRadioTransmission.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-[QGVAR(endRadioTransmissions)] call CBA_fnc_localEvent;
+["ace_endRadioTransmissions"] call CBA_fnc_localEvent;
 
 // ACRE
 if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {


### PR DESCRIPTION
Add's ACE_endRadioTransmissions Event that can be hooked by other Radio mods.

The TFAR code causes Problems in combination with spectator. TFAR 1.0 has a new function that handles that but I don't want to keep adding a TFAR 1.0 check into here and modify this everytime something changes. So I just added one Event for all Radio mods.

Also calling `TFAR_fnc_onDDTangentReleased` will throw a deprecation warning with 1.0. So the old code should be removed once the new version is released and properly gained traction.