### PR TITLE
make ammoCount ui element changeable despite ace_reload

### DIFF
--- a/addons/reload/ACE_UI.hpp
+++ b/addons/reload/ACE_UI.hpp
@@ -1,7 +1,0 @@
-class ACE_UI {
-    class ammoCount {
-        class conditions {
-            ADDON = "cameraOn == (getConnectedUAV ACE_player)";
-        };
-    };
-};

--- a/addons/reload/config.cpp
+++ b/addons/reload/config.cpp
@@ -19,4 +19,3 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgActions.hpp"
 #include "ACE_Settings.hpp"
-#include "ACE_UI.hpp"


### PR DESCRIPTION
I think making this not changeable when a component is present is unnecessarily confusing.