### PR TITLE
Add category for laserpointer and reload settings

### DIFF
--- a/addons/laserpointer/ACE_Settings.hpp
+++ b/addons/laserpointer/ACE_Settings.hpp
@@ -1,5 +1,6 @@
 class ACE_Settings {
     class GVAR(enabled) {
+        category = ECSTRING(common,ACEKeybindCategoryWeapons);
         displayName = CSTRING(DisplayName);
         typeName = "BOOL";
         value = 1;

--- a/addons/reload/ACE_Settings.hpp
+++ b/addons/reload/ACE_Settings.hpp
@@ -1,5 +1,6 @@
 class ACE_Settings {
     class GVAR(displayText) {
+        category = ECSTRING(common,ACEKeybindCategoryWeapons);
         typeName = "BOOL";
         isClientSettable = 1;
         value = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- move uncategorized `Laser Pointer` and `Check ammo on weapon reload` settings to `ACE Weapons` category. `Display text on grenade throw` will be moved there after #5581 (when?).

Should these uncategorized settings be moved to `ACE Vehicles`?
- `Cook-off probability coefficient`
- `Gforces Effects`
- `Overpressure Distance Coefficient`