### PR TITLE
Transfer old client settings to CBA

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -3,6 +3,7 @@ TRACE_1("",QUOTE(ADDON));
 PREP(cbaSettings);
 PREP(cbaSettings_loadFromConfig);
 PREP(cbaSettings_settingChanged);
+PREP(cbaSettings_transferUserSettings);
 
 PREP(actionKeysNamesConverted);
 PREP(addCanInteractWithCondition);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -180,8 +180,8 @@ private _previousVersion = profileNamespace getVariable ["ACE_VersionNumberStrin
 
 // check previous version number from profile
 if (_currentVersion != _previousVersion) then {
-    // do something
-
+    INFO_2("Updating ACE from [%1] to [%2]",_previousVersion,_currentVersion);
+    [_previousVersion] call FUNC(cbaSettings_transferUserSettings);
     profileNamespace setVariable ["ACE_VersionNumberString", _currentVersion];
 };
 

--- a/addons/common/functions/fnc_cbaSettings_transferUserSettings.sqf
+++ b/addons/common/functions/fnc_cbaSettings_transferUserSettings.sqf
@@ -36,9 +36,6 @@ private _aceSettings = configProperties [configFile >> "ACE_Settings", "isClass 
             private _ret = [_settingName, _profileVar, 0, "client", true] call CBA_settings_fnc_set;
             INFO_3("Transfering setting [%1: %2] returned %3", _settingName, _profileVar, _ret);
         };
-
-        // Cleanup old profileNamespace
-        // profileNamespace setVariable [_settingName, nil];
     };
 } forEach _aceSettings;
 

--- a/addons/common/functions/fnc_cbaSettings_transferUserSettings.sqf
+++ b/addons/common/functions/fnc_cbaSettings_transferUserSettings.sqf
@@ -1,0 +1,45 @@
+/*
+ * Author: PabstMirror
+ * Transfers a client's old ace settings to cba
+ *
+ * Arguments:
+ * 0: Old Version <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["3.11.0"] call ace_common_fnc_cbaSettings_transferUserSettings
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+params [["_lastVersion", "", [""]]];
+
+if ((parseNumber _lastVersion) >= 3.12) exitWith {};
+
+INFO("-Transfering old ACE_Settings to CBA-");
+
+private _aceSettings = configProperties [configFile >> "ACE_Settings", "isClass _x"];
+{
+    private _settingName = configName _x;
+    private _isClientSettable = (getNumber (_x >> "isClientSettable")) > 0;
+    private _profileVar = profileNamespace getVariable _settingName;
+
+    if (!isNil "_profileVar") then {
+        private _currentValue = [_settingName, "client"] call CBA_settings_fnc_get;
+        if (_isClientSettable && {!(_currentValue isEqualTo _profileVar)}) then {
+            // CBA_settings_fnc_set will do type checking for the old profile var
+            private _ret = [_settingName, _profileVar, 0, "client", true] call CBA_settings_fnc_set;
+            INFO_3("Transfering setting [%1: %2] returned %3", _settingName, _profileVar, _ret);
+        };
+
+        // Cleanup old profileNamespace
+        // profileNamespace setVariable [_settingName, nil];
+    };
+} forEach _aceSettings;
+
+INFO("-Finished Transfering-");


### PR DESCRIPTION
Transfer old ace setting to the cba setting profile var
Should make the conversion smoother for normal users.

Example output:
```
[ACE] (common) INFO: -Transfering old ACE_Settings to CBA-
[ACE] (common) INFO: Transfering setting [ace_interact_menu_alwaysUseCursorSelfInteraction: true] returned true
[ACE] (common) INFO: Transfering setting [ace_interact_menu_menuBackground: 2] returned true
``
