### PR TITLE
Fix global bool behavior for add / remove virtual items

### DIFF
--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -5,6 +5,9 @@ GVAR(EH_ID) = 0;
 GVAR(lastSearchTextLeft) = "";
 GVAR(lastSearchTextRight) = "";
 
+[QGVAR(addVirtualItems), {_this call FUNC(addVirtualItems)}] call CBA_fnc_addEventHandler;
+[QGVAR(removeVirtualItems), {_this call FUNC(removeVirtualItems)}] call CBA_fnc_addEventHandler;
+
 [QGVAR(initBox), {_this call FUNC(initBox)}] call CBA_fnc_addEventHandler;
 [QGVAR(removeBox), {_this call FUNC(removeBox)}] call CBA_fnc_addEventHandler;
 

--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -24,200 +24,206 @@ params [["_object", objNull, [objNull]], ["_items", [], [true, []]], ["_global",
 if (_object == objNull) exitWith {};
 if (_items isEqualType [] && {count _items == 0}) exitWith {};
 
-private _cargo = _object getVariable [QGVAR(virtualItems), [
-    [[], [], []], // Weapons 0, primary, secondary, handgun
-    [[], [], [], []], // WeaponAccessories 1, optic,side,muzzle,bipod
-    [ ], // Magazines 2
-    [ ], // Headgear 3
-    [ ], // Uniform 4
-    [ ], // Vest 5
-    [ ], // Backpacks 6
-    [ ], // Goggles 7
-    [ ], // NVGs 8
-    [ ], // Binoculars 9
-    [ ], // Map 10
-    [ ], // Compass 11
-    [ ], // Radio slot 12
-    [ ], // Watch slot  13
-    [ ], // Comms slot 14
-    [ ], // WeaponThrow 15
-    [ ], // WeaponPut 16
-    [ ] // InventoryItems 17
-]];
-
-private _configCfgWeapons = configFile >> "CfgWeapons"; //Save this lookup in variable for perf improvement
-
-if (_items isEqualType true && {_items}) then {
-    private _configItems = uiNamespace getVariable QGVAR(configItems);
-
-    {
-        (_x select 0) append (_x select 1);
-        (_x select 2) set [(_x select 3), (_x select 0) arrayIntersect (_x select 0)];
-    } forEach [
-        [(_cargo select 0 select 0),(_configItems select 0 select 0), _cargo select 0, 0],
-        [(_cargo select 0 select 1),(_configItems select 0 select 1), _cargo select 0, 1],
-        [(_cargo select 0 select 2),(_configItems select 0 select 2), _cargo select 0, 2],
-        [(_cargo select 1 select 0),(_configItems select 1 select 0), _cargo select 1, 0],
-        [(_cargo select 1 select 1),(_configItems select 1 select 1), _cargo select 1, 1],
-        [(_cargo select 1 select 2),(_configItems select 1 select 2), _cargo select 1, 2],
-        [(_cargo select 1 select 3),(_configItems select 1 select 3), _cargo select 1, 3]
-    ];
-
-    for "_index" from 2 to 17 do {
-        (_cargo select _index) append (_configItems select _index);
-        _cargo set [_index, (_cargo select _index) arrayIntersect (_cargo select _index)];
-    };
+if (_global && {isMultiplayer}) then {
+    [QGVAR(addVirtualItems), [_object, _items, false]] call CBA_fnc_globalEvent;
 
 } else {
-    {
-        if (_x isEqualType "") then {
-            private _configItemInfo = _configCfgWeapons >> _x >> "ItemInfo";
-            private _simulationType = getText (_configCfgWeapons >> _x >> "simulation");
-            switch true do {
-                case (isClass (_configCfgWeapons >> _x)): {
-                    switch true do {
-                        /* Weapon acc */
-                        case (
-                                isClass (_configItemInfo) &&
-                                {(getNumber (_configItemInfo >> "type")) in [101, 201, 301, 302]} &&
-                                {!(_x isKindOf ["CBA_MiscItem", (_configCfgWeapons)])}
-                            ): {
-                            switch (getNumber (_configItemInfo >> "type")) do {
-                                case 201: {
-                                    (_cargo select 1) select 0 pushBackUnique _x;
-                                };
-                                case 301: {
-                                    (_cargo select 1) select 1 pushBackUnique _x;
-                                };
-                                case 101: {
-                                    (_cargo select 1) select 2 pushBackUnique _x;
-                                };
-                                case 302: {
-                                    (_cargo select 1) select 3 pushBackUnique _x;
-                                };
-                            };
-                        };
-                        /* Headgear */
-                        case (isClass (_configItemInfo) &&
-                            {getNumber (_configItemInfo >> "type") == 605}): {
-                            (_cargo select 3) pushBackUnique _x;
-                        };
-                        /* Uniform */
-                        case (isClass (_configItemInfo) &&
-                            {getNumber (_configItemInfo >> "type") == 801}): {
-                            (_cargo select 4) pushBackUnique _x;
-                        };
-                        /* Vest */
-                        case (isClass (_configItemInfo) &&
-                            {getNumber (_configItemInfo >> "type") == 701}): {
-                            (_cargo select 5) pushBackUnique _x;
-                        };
-                        /* NVgs */
-                        case (_simulationType == "NVGoggles"): {
-                            (_cargo select 8) pushBackUnique _x;
-                        };
-                        /* Binos */
-                        case (_simulationType == "Binocular" ||
-                            {(_simulationType == 'Weapon') && {(getNumber (_configCfgWeapons >> _x >> 'type') == 4096)}}): {
-                            (_cargo select 9) pushBackUnique _x;
-                        };
-                        /* Map */
-                        case (_simulationType == "ItemMap"): {
-                            (_cargo select 10) pushBackUnique _x;
-                        };
-                        /* Compass */
-                        case (_simulationType == "ItemCompass"): {
-                            (_cargo select 11) pushBackUnique _x;
-                        };
-                        /* Radio */
-                        case (_simulationType == "ItemRadio"): {
-                            (_cargo select 12) pushBackUnique _x;
-                        };
-                        /* Watch */
-                        case (_simulationType == "ItemWatch"): {
-                            (_cargo select 13) pushBackUnique _x;
-                        };
-                        /* GPS */
-                        case (_simulationType == "ItemGPS"): {
-                            (_cargo select 14) pushBackUnique _x;
-                        };
-                        /* UAV terminals */
-                        case (isClass (_configItemInfo) &&
-                            {getNumber (_configItemInfo >> "type") == 621}): {
-                            (_cargo select 14) pushBackUnique _x;
-                        };
-                        /* Weapon, at the bottom to avoid adding binos */
-                        case (isClass (_configCfgWeapons >> _x >> "WeaponSlotsInfo") &&
-                            {getNumber (_configCfgWeapons >> _x >> 'type') != 4096}): {
-                            switch (getNumber (_configCfgWeapons >> _x >> "type")) do {
-                                case 1: {
-                                    (_cargo select 0) select 0 pushBackUnique  ([_x] call bis_fnc_baseWeapon);
-                                };
-                                case 2: {
-                                    (_cargo select 0) select 2 pushBackUnique ([_x] call bis_fnc_baseWeapon);
-                                };
-                                case 4: {
-                                    (_cargo select 0) select 1 pushBackUnique ([_x] call bis_fnc_baseWeapon);
-                                };
-                            };
-                        };
-                        /* Misc items */
-                        case (
-                                isClass (_configItemInfo) &&
-                                ((getNumber (_configItemInfo >> "type")) in [101, 201, 301, 302] &&
-                                {(_x isKindOf ["CBA_MiscItem", (_configCfgWeapons)])}) ||
-                                {(getNumber (_configItemInfo >> "type")) in [401, 619, 620]} ||
-                                {(getText (_configCfgWeapons >> _x >> "simulation")) == "ItemMineDetector"}
-                            ): {
-                            (_cargo select 17) pushBackUnique _x;
-                        };
-                    };
-                };
-                case (isClass (configFile >> "CfgMagazines" >> _x)): {
-                    // Lists to check against
-                    private _grenadeList = [];
-                    {
-                        _grenadeList append getArray (_configCfgWeapons >> "Throw" >> _x >> "magazines");
-                        false
-                    } count getArray (_configCfgWeapons >> "Throw" >> "muzzles");
+    private _cargo = _object getVariable [QGVAR(virtualItems), [
+        [[], [], []], // Weapons 0, primary, secondary, handgun
+        [[], [], [], []], // WeaponAccessories 1, optic,side,muzzle,bipod
+        [ ], // Magazines 2
+        [ ], // Headgear 3
+        [ ], // Uniform 4
+        [ ], // Vest 5
+        [ ], // Backpacks 6
+        [ ], // Goggles 7
+        [ ], // NVGs 8
+        [ ], // Binoculars 9
+        [ ], // Map 10
+        [ ], // Compass 11
+        [ ], // Radio slot 12
+        [ ], // Watch slot  13
+        [ ], // Comms slot 14
+        [ ], // WeaponThrow 15
+        [ ], // WeaponPut 16
+        [ ] // InventoryItems 17
+    ]];
 
-                    private _putList = [];
-                    {
-                        _putList append getArray (_configCfgWeapons >> "Put" >> _x >> "magazines");
-                        false
-                    } count getArray (_configCfgWeapons >> "Put" >> "muzzles");
+    private _configCfgWeapons = configFile >> "CfgWeapons"; //Save this lookup in variable for perf improvement
 
-                    // Check what the magazine actually is
-                    switch true do {
-                        // Rifle, handgun, secondary weapons mags
-                        case (
-                                (getNumber (configFile >> "CfgMagazines" >> _x >> "type") in [256,512,1536,16]) &&
-                                {!(_x in _grenadeList)} &&
-                                {!(_x in _putList)}
-                            ): {
-                            (_cargo select 2) pushBackUnique _x;
-                        };
-                        // Grenades
-                        case (_x in _grenadeList): {
-                            (_cargo select 15) pushBackUnique _x;
-                        };
-                        // Put
-                        case (_x in _putList): {
-                            (_cargo select 16) pushBackUnique _x;
-                        };
-                    };
-                };
-                case (isClass (configFile >> "CfgVehicles" >> _x)): {
-                    if (getText (configFile >> "CfgVehicles" >> _x >> "vehicleClass") == "Backpacks") then {
-                        (_cargo select 6) pushBackUnique _x;
-                    };
-                };
-                case (isClass (configFile >> "CfgGlasses" >> _x)): {
-                    (_cargo select 7) pushBackUnique _x;
-                };
+    if (_items isEqualType true) then {
+        if (_items) then {
+            private _configItems = uiNamespace getVariable QGVAR(configItems);
+
+            {
+                (_x select 0) append (_x select 1);
+                (_x select 2) set [(_x select 3), (_x select 0) arrayIntersect (_x select 0)];
+            } forEach [
+                [(_cargo select 0 select 0),(_configItems select 0 select 0), _cargo select 0, 0],
+                [(_cargo select 0 select 1),(_configItems select 0 select 1), _cargo select 0, 1],
+                [(_cargo select 0 select 2),(_configItems select 0 select 2), _cargo select 0, 2],
+                [(_cargo select 1 select 0),(_configItems select 1 select 0), _cargo select 1, 0],
+                [(_cargo select 1 select 1),(_configItems select 1 select 1), _cargo select 1, 1],
+                [(_cargo select 1 select 2),(_configItems select 1 select 2), _cargo select 1, 2],
+                [(_cargo select 1 select 3),(_configItems select 1 select 3), _cargo select 1, 3]
+            ];
+
+            for "_index" from 2 to 17 do {
+                (_cargo select _index) append (_configItems select _index);
+                _cargo set [_index, (_cargo select _index) arrayIntersect (_cargo select _index)];
             };
         };
-    } foreach _items;
-};
+    } else {
+        {
+            if (_x isEqualType "") then {
+                private _configItemInfo = _configCfgWeapons >> _x >> "ItemInfo";
+                private _simulationType = getText (_configCfgWeapons >> _x >> "simulation");
+                switch true do {
+                    case (isClass (_configCfgWeapons >> _x)): {
+                        switch true do {
+                            /* Weapon acc */
+                            case (
+                                    isClass (_configItemInfo) &&
+                                    {(getNumber (_configItemInfo >> "type")) in [101, 201, 301, 302]} &&
+                                    {!(_x isKindOf ["CBA_MiscItem", (_configCfgWeapons)])}
+                                ): {
+                                switch (getNumber (_configItemInfo >> "type")) do {
+                                    case 201: {
+                                        (_cargo select 1) select 0 pushBackUnique _x;
+                                    };
+                                    case 301: {
+                                        (_cargo select 1) select 1 pushBackUnique _x;
+                                    };
+                                    case 101: {
+                                        (_cargo select 1) select 2 pushBackUnique _x;
+                                    };
+                                    case 302: {
+                                        (_cargo select 1) select 3 pushBackUnique _x;
+                                    };
+                                };
+                            };
+                            /* Headgear */
+                            case (isClass (_configItemInfo) &&
+                                {getNumber (_configItemInfo >> "type") == 605}): {
+                                (_cargo select 3) pushBackUnique _x;
+                            };
+                            /* Uniform */
+                            case (isClass (_configItemInfo) &&
+                                {getNumber (_configItemInfo >> "type") == 801}): {
+                                (_cargo select 4) pushBackUnique _x;
+                            };
+                            /* Vest */
+                            case (isClass (_configItemInfo) &&
+                                {getNumber (_configItemInfo >> "type") == 701}): {
+                                (_cargo select 5) pushBackUnique _x;
+                            };
+                            /* NVgs */
+                            case (_simulationType == "NVGoggles"): {
+                                (_cargo select 8) pushBackUnique _x;
+                            };
+                            /* Binos */
+                            case (_simulationType == "Binocular" ||
+                                {(_simulationType == 'Weapon') && {(getNumber (_configCfgWeapons >> _x >> 'type') == 4096)}}): {
+                                (_cargo select 9) pushBackUnique _x;
+                            };
+                            /* Map */
+                            case (_simulationType == "ItemMap"): {
+                                (_cargo select 10) pushBackUnique _x;
+                            };
+                            /* Compass */
+                            case (_simulationType == "ItemCompass"): {
+                                (_cargo select 11) pushBackUnique _x;
+                            };
+                            /* Radio */
+                            case (_simulationType == "ItemRadio"): {
+                                (_cargo select 12) pushBackUnique _x;
+                            };
+                            /* Watch */
+                            case (_simulationType == "ItemWatch"): {
+                                (_cargo select 13) pushBackUnique _x;
+                            };
+                            /* GPS */
+                            case (_simulationType == "ItemGPS"): {
+                                (_cargo select 14) pushBackUnique _x;
+                            };
+                            /* UAV terminals */
+                            case (isClass (_configItemInfo) &&
+                                {getNumber (_configItemInfo >> "type") == 621}): {
+                                (_cargo select 14) pushBackUnique _x;
+                            };
+                            /* Weapon, at the bottom to avoid adding binos */
+                            case (isClass (_configCfgWeapons >> _x >> "WeaponSlotsInfo") &&
+                                {getNumber (_configCfgWeapons >> _x >> 'type') != 4096}): {
+                                switch (getNumber (_configCfgWeapons >> _x >> "type")) do {
+                                    case 1: {
+                                        (_cargo select 0) select 0 pushBackUnique  ([_x] call bis_fnc_baseWeapon);
+                                    };
+                                    case 2: {
+                                        (_cargo select 0) select 2 pushBackUnique ([_x] call bis_fnc_baseWeapon);
+                                    };
+                                    case 4: {
+                                        (_cargo select 0) select 1 pushBackUnique ([_x] call bis_fnc_baseWeapon);
+                                    };
+                                };
+                            };
+                            /* Misc items */
+                            case (
+                                    isClass (_configItemInfo) &&
+                                    ((getNumber (_configItemInfo >> "type")) in [101, 201, 301, 302] &&
+                                    {(_x isKindOf ["CBA_MiscItem", (_configCfgWeapons)])}) ||
+                                    {(getNumber (_configItemInfo >> "type")) in [401, 619, 620]} ||
+                                    {(getText (_configCfgWeapons >> _x >> "simulation")) == "ItemMineDetector"}
+                                ): {
+                                (_cargo select 17) pushBackUnique _x;
+                            };
+                        };
+                    };
+                    case (isClass (configFile >> "CfgMagazines" >> _x)): {
+                        // Lists to check against
+                        private _grenadeList = [];
+                        {
+                            _grenadeList append getArray (_configCfgWeapons >> "Throw" >> _x >> "magazines");
+                            false
+                        } count getArray (_configCfgWeapons >> "Throw" >> "muzzles");
 
-_object setVariable [QGVAR(virtualItems), _cargo, _global];
+                        private _putList = [];
+                        {
+                            _putList append getArray (_configCfgWeapons >> "Put" >> _x >> "magazines");
+                            false
+                        } count getArray (_configCfgWeapons >> "Put" >> "muzzles");
+
+                        // Check what the magazine actually is
+                        switch true do {
+                            // Rifle, handgun, secondary weapons mags
+                            case (
+                                    (getNumber (configFile >> "CfgMagazines" >> _x >> "type") in [256,512,1536,16]) &&
+                                    {!(_x in _grenadeList)} &&
+                                    {!(_x in _putList)}
+                                ): {
+                                (_cargo select 2) pushBackUnique _x;
+                            };
+                            // Grenades
+                            case (_x in _grenadeList): {
+                                (_cargo select 15) pushBackUnique _x;
+                            };
+                            // Put
+                            case (_x in _putList): {
+                                (_cargo select 16) pushBackUnique _x;
+                            };
+                        };
+                    };
+                    case (isClass (configFile >> "CfgVehicles" >> _x)): {
+                        if (getText (configFile >> "CfgVehicles" >> _x >> "vehicleClass") == "Backpacks") then {
+                            (_cargo select 6) pushBackUnique _x;
+                        };
+                    };
+                    case (isClass (configFile >> "CfgGlasses" >> _x)): {
+                        (_cargo select 7) pushBackUnique _x;
+                    };
+                };
+            };
+        } foreach _items;
+    };
+
+    _object setVariable [QGVAR(virtualItems), _cargo];
+};

--- a/addons/arsenal/functions/fnc_removeVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_removeVirtualItems.sqf
@@ -23,58 +23,65 @@ params [ ["_object", objNull, [objNull]], ["_items", [], [true, [""]]], ["_globa
 if (_object == objNull) exitWith {};
 if (_items isEqualType [] && {count _items == 0}) exitWith {};
 
-private _cargo = _object getVariable [QGVAR(virtualItems), [
-    [[], [], []], // Weapons 0, primary, handgun, secondary
-    [[], [], [], []], // WeaponAccessories 1, optic,side,muzzle,bipod
-    [ ], // Magazines 2
-    [ ], // Headgear 3
-    [ ], // Uniform 4
-    [ ], // Vest 5
-    [ ], // Backpacks 6
-    [ ], // Goggles 7
-    [ ], // NVGs 8
-    [ ], // Binoculars 9
-    [ ], // Map 10
-    [ ], // Compass 11
-    [ ], // Radio slot 12
-    [ ], // Watch slot  13
-    [ ], // Comms slot 14
-    [ ], // WeaponThrow 15
-    [ ], // WeaponPut 16
-    [ ] // InventoryItems 17
-]];
+if (_global && {isMultiplayer}) then {
+    [QGVAR(removeVirtualItems), [_object, _items, false]] call CBA_fnc_globalEvent;
 
-if (_items isEqualType true && {_items}) then {
-    [_object, _global] call FUNC(removeBox);
-    _object setVariable [QGVAR(virtualItems), nil, _global];
 } else {
+    private _cargo = _object getVariable [QGVAR(virtualItems), [
+        [[], [], []], // Weapons 0, primary, handgun, secondary
+        [[], [], [], []], // WeaponAccessories 1, optic,side,muzzle,bipod
+        [ ], // Magazines 2
+        [ ], // Headgear 3
+        [ ], // Uniform 4
+        [ ], // Vest 5
+        [ ], // Backpacks 6
+        [ ], // Goggles 7
+        [ ], // NVGs 8
+        [ ], // Binoculars 9
+        [ ], // Map 10
+        [ ], // Compass 11
+        [ ], // Radio slot 12
+        [ ], // Watch slot  13
+        [ ], // Comms slot 14
+        [ ], // WeaponThrow 15
+        [ ], // WeaponPut 16
+        [ ] // InventoryItems 17
+    ]];
 
-    // Make sure all items are in string form
-    _items = _items select {_x isEqualType "" && {_x != ""}};
-
-    {
-        if (_forEachIndex isEqualTo 0) then {
-            _cargo set [_forEachIndex, [(_x select 0) - _items, (_x select 1) - _items, (_x select 2) - _items]];
-        } else {
-            if (_forEachIndex isEqualTo 1) then {
-                _cargo set [_forEachIndex, [(_x select 0) - _items, (_x select 1) - _items, (_x select 2) - _items, (_x select 3) - _items]];
-            } else {
-                _cargo set [_cargo find _x, _x - _items];
-            };
+    if (_items isEqualType true) then {
+        if (_items) then {
+            [_object, _global] call FUNC(removeBox);
+                _object setVariable [QGVAR(virtualItems), nil, _global];
         };
-    } foreach _cargo;
-
-    private _itemCount = {
-        if (_x isEqualTo (_cargo select 0) || {_x isEqualTo (_cargo select 1)}) then {
-            !(_x isEqualTo [[],[],[]] || {_x isEqualTo [[],[],[],[]]})
-        } else {
-            !(_x isEqualTo [])
-        };
-    } count _cargo;
-
-    if (_itemCount == 0) then {
-        [_object, _global] call FUNC(removeBox);
     } else {
-        _object setVariable [QGVAR(virtualItems), _cargo, _global];
+
+        // Make sure all items are in string form
+        _items = _items select {_x isEqualType "" && {_x != ""}};
+
+        {
+            if (_forEachIndex isEqualTo 0) then {
+                _cargo set [_forEachIndex, [(_x select 0) - _items, (_x select 1) - _items, (_x select 2) - _items]];
+            } else {
+                if (_forEachIndex isEqualTo 1) then {
+                    _cargo set [_forEachIndex, [(_x select 0) - _items, (_x select 1) - _items, (_x select 2) - _items, (_x select 3) - _items]];
+                } else {
+                    _cargo set [_cargo find _x, _x - _items];
+                };
+            };
+        } foreach _cargo;
+
+        private _itemCount = {
+            if (_x isEqualTo (_cargo select 0) || {_x isEqualTo (_cargo select 1)}) then {
+                !(_x isEqualTo [[],[],[]] || {_x isEqualTo [[],[],[],[]]})
+            } else {
+                !(_x isEqualTo [])
+            };
+        } count _cargo;
+
+        _object setVariable [QGVAR(virtualItems), _cargo];
+
+        if (_itemCount == 0) then {
+            [_object, false] call FUNC(removeBox);
+        };
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Previously adding / removing virtual items would do:
`_object setVariable [QGVAR(virtualItems), _cargo, _global];`
which is not the intended behavior, now the func is re-ran on every machine locally to avoid overriding local changes every time you add / remove an item.

- Also add support for passing false as second argument for both of those functions, previously it would error out.
