### PR TITLE
Fix ACE arsenal missing string and unused code in buttonHide

### DIFF
--- a/addons/arsenal/functions/fnc_buttonHide.sqf
+++ b/addons/arsenal/functions/fnc_buttonHide.sqf
@@ -17,10 +17,6 @@ params ["_display"];
 
 private _showToggle = !ctrlShown (_display displayCtrl IDC_menuBar);
 
-if (_showToggle) then {
-    [_display, _display displayCtrl GVAR(currentLeftPanel)] call FUNC(populatePanel)
-};
-
 {
     private _ctrl = _display displayctrl _x;
     _ctrl ctrlshow _showToggle;

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -318,5 +318,10 @@
             <French>Enregistre les objets manquants / indisponibles dans le RPT</French>
             <Polish>Rejestruj brakujące / niedostępne przedmioty do pliku RPT</Polish>
         </Key>
+        <Key ID="STR_ACE_Arsenal_CantOpenDisplay">
+            <English>Unable to open ACE arsenal</English>
+            <French>Impossible d'ouvrir ACE arsenal</French>
+            <German>Kann ACE Arsenal nicht anzeigen</German>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Said string was lost while merging the german translation a while back, it has been added back.
- The unused code in buttonHide can be safely removed, it's a remnant from when I was designing the left panel a month ago.