### PR TITLE
Revert slideshow module to scope = 2

### DIFF
--- a/addons/slideshow/CfgVehicles.hpp
+++ b/addons/slideshow/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
         category = "ACE_missionModules";
         displayName = CSTRING(DisplayName);
         function = QFUNC(moduleInit);
-        scope = 1;
+        scope = 2;
         isGlobal = 1;
         isTriggerActivated = 0;
         isDisposable = 0;


### PR DESCRIPTION
Slideshow is mission utility not setting

**When merged this pull request will:**
- Change ace_slideshow_module.scope from 1 to 2
