### PR TITLE
Adjusted dig surface whitelist for jungle maps

### DIFF
--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -33,4 +33,4 @@
     "wood", "wood_int", "int_wood", "softwood_exp", "int_softwood_exp", "int_solidwood_exp" \
 ]
 
-#define DIG_SURFACE_WHITELIST ["grass"]
+#define DIG_SURFACE_WHITELIST ["grass", "grasstall_exp"]

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -33,4 +33,4 @@
     "wood", "wood_int", "int_wood", "softwood_exp", "int_softwood_exp", "int_solidwood_exp" \
 ]
 
-#define DIG_SURFACE_WHITELIST ["grass", "grasstall_exp"]
+#define DIG_SURFACE_WHITELIST ["grass", "grasstall_exp", "forest_exp"]


### PR DESCRIPTION
**When merged this pull request will:**
- Allow digging trenches on some jungle maps (e.g. Prei Khmaoch Luong)


Probably this whitelist and blacklist should be included in CfgSurfaces to allow 3rd party mods to whitelist their surfaces on purpose.