### PR TITLE
Added config params for white/blacklisting digging

### DIFF
--- a/addons/common/functions/fnc_canDig.sqf
+++ b/addons/common/functions/fnc_canDig.sqf
@@ -24,8 +24,11 @@ if ((getPosATL _unit) select 2 > 0.05 || // Walking on objects, such as building
 ) exitWith {false};
 
 private _surfaceClass = (surfaceType _posASL) select [1];
-private _surfaceType = getText (configFile >> "CfgSurfaces" >> _surfaceClass >> "soundEnviron");
-private _surfaceDust = getNumber (configFile >> "CfgSurfaces" >> _surfaceClass >> "dust");
+private _config = configFile >> "CfgSurfaces" >> _surfaceClass;
+private _surfaceType = getText (_config >> "soundEnviron");
+private _surfaceDust = getNumber (_config >> "dust");
+private _isWhitelisted = getNumber (_config >> "ACE_digWhitelisted") == 1;
+private _isBlacklisted = getNumber (_config >> "ACE_digBlacklisted") == 1;
 TRACE_2("Surface",_surfaceType,_surfaceDust);
 
-!(_surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_surfaceType in DIG_SURFACE_WHITELIST}}
+!(_isBlacklisted || _surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_isWhitelisted} || {_surfaceType in DIG_SURFACE_WHITELIST}}

--- a/addons/common/functions/fnc_canDig.sqf
+++ b/addons/common/functions/fnc_canDig.sqf
@@ -27,7 +27,11 @@ private _surfaceClass = (surfaceType _posASL) select [1];
 private _config = configFile >> "CfgSurfaces" >> _surfaceClass;
 private _surfaceType = getText (_config >> "soundEnviron");
 private _surfaceDust = getNumber (_config >> "dust");
-private _canDig = getNumber (_config >> "ACE_canDig") == 1;
+
 TRACE_2("Surface",_surfaceType,_surfaceDust);
 
-_canDig || !{(_surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_surfaceType in DIG_SURFACE_WHITELIST}}}
+if (isNumber (_config >> "ACE_canDig")) then {
+    getNumber (_config >> "ACE_canDig") // return
+} else {
+    !(_surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_surfaceType in DIG_SURFACE_WHITELIST}} // return
+};

--- a/addons/common/functions/fnc_canDig.sqf
+++ b/addons/common/functions/fnc_canDig.sqf
@@ -27,8 +27,7 @@ private _surfaceClass = (surfaceType _posASL) select [1];
 private _config = configFile >> "CfgSurfaces" >> _surfaceClass;
 private _surfaceType = getText (_config >> "soundEnviron");
 private _surfaceDust = getNumber (_config >> "dust");
-private _isWhitelisted = getNumber (_config >> "ACE_digWhitelisted") == 1;
-private _isBlacklisted = getNumber (_config >> "ACE_digBlacklisted") == 1;
+private _canDig = getNumber (_config >> "ACE_canDig") == 1;
 TRACE_2("Surface",_surfaceType,_surfaceDust);
 
-!(_isBlacklisted || _surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_isWhitelisted} || {_surfaceType in DIG_SURFACE_WHITELIST}}
+_canDig || !{(_surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_surfaceType in DIG_SURFACE_WHITELIST}}}

--- a/addons/trenches/README.md
+++ b/addons/trenches/README.md
@@ -5,18 +5,15 @@ Adds item 'ACE_entrenchingtool'
 Adds 2 trenches; Envelope - Small & Envelop - Big
 
 ### Whitelist surfaces for digging
-Single surfaces can be whitelisted by adding `ACE_digWhitelisted = 1` into `CfgSurfaces`.  
+Single surfaces can be whitelisted by adding `ACE_canDig = 1` into `CfgSurfaces`.
 Example: 
 ```cpp
 class CfgSurfaces {
     class myAwesomeSurface {
-        ACE_digWhitelisted = 1;
+        ACE_canDig = 1;
     };
 };
 ```
-
-### Blacklist surfaces for digging
-Same as above but use `ACE_digBlacklisted = 1`.
 
 ## Maintainers
 

--- a/addons/trenches/README.md
+++ b/addons/trenches/README.md
@@ -4,6 +4,19 @@ ace_trenches
 Adds item 'ACE_entrenchingtool'
 Adds 2 trenches; Envelope - Small & Envelop - Big
 
+### Whitelist surfaces for digging
+Single surfaces can be whitelisted by adding `ACE_digWhitelisted = 1` into `CfgSurfaces`.  
+Example: 
+```cpp
+class CfgSurfaces {
+    class myAwesomeSurface {
+        ACE_digWhitelisted = 1;
+    };
+};
+```
+
+### Blacklist surfaces for digging
+Same as above but use `ACE_digBlacklisted = 1`.
 
 ## Maintainers
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add config switches to allow 3rd party mods to white/blacklist single surfaces for digging.

Current black/whitelist macros could be preserved otherwise a lot of config entries have to be made. Plus some maps could be misconfigured.
