### PR TITLE
Make attach/detach hint look uniform

### DIFF
--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -41,7 +41,7 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
     _attachedItem attachTo [_unit, [0.05, -0.09, 0.1], "leftshoulder"];
     if (!_silentScripted) then {
         _unit removeItem _itemClassname;  // Remove item
-        [_onAttachText] call EFUNC(common,displayTextStructured);
+        [_onAttachText, 2] call EFUNC(common,displayTextStructured);
     };
     _unit setVariable [QGVAR(attached), [[_attachedItem, _itemClassname]], true];
 } else {

--- a/addons/attach/functions/fnc_detach.sqf
+++ b/addons/attach/functions/fnc_detach.sqf
@@ -83,4 +83,4 @@ if (_itemDisplayName == "") then {
     _itemDisplayName = getText (configFile >> "CfgMagazines" >> _itemName >> "displayName");
 };
 
-[format [localize LSTRING(Item_Detached), _itemDisplayName]] call EFUNC(common,displayTextStructured);
+[format [localize LSTRING(Item_Detached), _itemDisplayName], 2] call EFUNC(common,displayTextStructured);

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -101,4 +101,4 @@ private _attachList = _attachToVehicle getVariable [QGVAR(attached), []];
 _attachList pushBack [_attachedObject, _itemClassname];
 _attachToVehicle setVariable [QGVAR(attached), _attachList, true];
 
-[_onAttachText] call EFUNC(common,displayTextStructured);
+[_onAttachText, 2] call EFUNC(common,displayTextStructured);


### PR DESCRIPTION
**When merged this pull request will:**
- Add space at the bottom of hint to make it look nicer
- Before: 
![attach_before](https://user-images.githubusercontent.com/34453221/33903360-279005ac-df46-11e7-94f5-073323ac8365.png)
- After:
![attach_after](https://user-images.githubusercontent.com/34453221/33903370-2baa44c2-df46-11e7-959c-64e59a9fe9e3.png)

