### PR TITLE
Updates to realisticnames

### DIFF
--- a/addons/maverick/stringtable.xml
+++ b/addons/maverick/stringtable.xml
@@ -12,31 +12,31 @@
                 <Korean>AGM-65 Maverick L, 레이저 유도 대지 미사일</Korean>
             </Key>
             <Key ID="str_ace_maverick_l_mag_x1">
-                <English>AGM-65 Maverick L x1</English>
-                <German>AGM-65 Maverick L x1</German>
-                <Italian>AGM-65 Maverick L x1</Italian>
-                <Japanese>AGM-65 マーベリック L x1</Japanese>
-                <Chinese>AGM-65"小牛"飛彈L型 x1</Chinese>
-                <Chinesesimp>AGM-65"小牛"飞弹L型 x1</Chinesesimp>
-                <Korean>AGM-65 Maverick L x1</Korean>
+                <English>AGM-65 Maverick L [ACE]</English>
+                <German>AGM-65 Maverick L [ACE]</German>
+                <Italian>AGM-65 Maverick L [ACE]</Italian>
+                <Japanese>AGM-65 マーベリック L [ACE]</Japanese>
+                <Chinese>AGM-65"小牛"飛彈L型 [ACE]</Chinese>
+                <Chinesesimp>AGM-65"小牛"飞弹L型 [ACE]</Chinesesimp>
+                <Korean>AGM-65 Maverick L [ACE]</Korean>
             </Key>
             <Key ID="str_ace_maverick_l_mag_x2">
-                <English>AGM-65 Maverick L x2</English>
-                <German>AGM-65 Maverick L x2</German>
-                <Italian>AGM-65 Maverick L x2</Italian>
-                <Japanese>AGM-65 マーベリック L x2</Japanese>
-                <Chinese>AGM-65"小牛"飛彈L型 x2</Chinese>
-                <Chinesesimp>AGM-65"小牛"飞弹L型 x2</Chinesesimp>
-                <Korean>AGM-65 Maverick L x2</Korean>
+                <English>2x AGM-65 Maverick L [ACE]</English>
+                <German>2x AGM-65 Maverick L [ACE]</German>
+                <Italian>2x AGM-65 Maverick L [ACE]</Italian>
+                <Japanese>2x AGM-65 マーベリック L [ACE]</Japanese>
+                <Chinese>2x AGM-65"小牛"飛彈L型 [ACE]</Chinese>
+                <Chinesesimp>2x AGM-65"小牛"飞弹L型 [ACE]</Chinesesimp>
+                <Korean>2x AGM-65 Maverick L [ACE]</Korean>
             </Key>
             <Key ID="str_ace_maverick_l_mag_x3">
-                <English>AGM-65 Maverick L x3</English>
-                <German>AGM-65 Maverick L x3</German>
-                <Italian>AGM-65 Maverick L x3</Italian>
-                <Japanese>AGM-65 マーベリック L x3</Japanese>
-                <Chinese>AGM-65"小牛"飛彈L型 x3</Chinese>
-                <Chinesesimp>AGM-65"小牛"飞弹L型 x3</Chinesesimp>
-                <Korean>AGM-65 Maverick L x3</Korean>
+                <English>3x AGM-65 Maverick L [ACE]</English>
+                <German>3x AGM-65 Maverick L [ACE]</German>
+                <Italian>3x AGM-65 Maverick L [ACE]</Italian>
+                <Japanese>3x AGM-65 マーベリック L [ACE]</Japanese>
+                <Chinese>3x AGM-65"小牛"飛彈L型 [ACE]</Chinese>
+                <Chinesesimp>3x AGM-65"小牛"飞弹L型 [ACE]</Chinesesimp>
+                <Korean>3x AGM-65 Maverick L [ACE]</Korean>
             </Key>
             <Key ID="str_ace_maverick_l_mag_short">
                 <English>Laser Guided</English>

--- a/addons/realisticnames/CfgMagazines.hpp
+++ b/addons/realisticnames/CfgMagazines.hpp
@@ -472,7 +472,7 @@ class CfgMagazines {
     };
     class 12Rnd_missiles;
     class PylonRack_12Rnd_missiles: 12Rnd_missiles {
-        displayName = "Hydra 70"; // [vanilla: DAR - missiles_DAR]
+        displayName = "Hydra 70 12x HE"; // [vanilla: DAR - missiles_DAR]
     };
     class PylonRack_20Rnd_Rocket_03_HE_F: 20Rnd_Rocket_03_HE_F {
         displayName = "S-8 20x HE"; // [vanilla: Tratnyr 20x HE - Rocket_03_HE_Plane_CAS_02_F]

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -406,6 +406,11 @@ class CfgVehicles {
         displayName = CSTRING(Plane_Fighter_03_Name);
     };
 
+    class Plane_Fighter_04_Base_F;
+    class I_Plane_Fighter_04_F : Plane_Fighter_04_Base_F {
+        displayName = CSTRING(Plane_Fighter_04_Name);
+    };
+
     // uavs
     class UAV_02_base_F;
     class B_UAV_02_F: UAV_02_base_F {

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -314,6 +314,9 @@ class CfgVehicles {
     class Heli_Light_01_civil_base_F: Heli_Light_01_unarmed_base_F {
         displayName = CSTRING(Heli_Light_01_civil_Name);
     };
+    class I_C_Heli_Light_01_civil_F: Heli_Light_01_civil_base_F {
+        displayName = CSTRING(Heli_Light_01_civil_Name);
+    };
 
     class Heli_Light_01_armed_base_F;
     class B_Heli_Light_01_armed_F: Heli_Light_01_armed_base_F {
@@ -727,6 +730,9 @@ class CfgVehicles {
     class C_Offroad_02_unarmed_F: Offroad_02_unarmed_base_F {
         displayName = CSTRING(C_Offroad_02_unarmed);
     };
+    class I_C_Offroad_02_unarmed_F: Offroad_02_unarmed_base_F {
+        displayName = CSTRING(C_Offroad_02_unarmed);
+    };
     class C_Offroad_02_unarmed_F_black: C_Offroad_02_unarmed_F {
         displayName = CSTRING(C_Offroad_02_unarmed_black);
     };
@@ -747,6 +753,9 @@ class CfgVehicles {
     };
     class C_Plane_Civil_01_racing_F: Plane_Civil_01_base_F {
         displayName = CSTRING(C_Plane_Civil_01_racing);
+    };
+    class I_C_Plane_Civil_01_F: Plane_Civil_01_base_F {
+        displayName = CSTRING(C_Plane_Civil_01);
     };
 
     // Burraq

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -66,14 +66,23 @@ class CfgVehicles {
     class O_MRAP_02_F: MRAP_02_base_F {
         displayName = CSTRING(MRAP_02_Name);
     };
+    class O_T_MRAP_02_ghex_F: MRAP_02_base_F {
+        displayName = CSTRING(MRAP_02_Name);
+    };
 
     class MRAP_02_hmg_base_F: MRAP_02_base_F {};
     class O_MRAP_02_hmg_F: MRAP_02_hmg_base_F {
         displayName = CSTRING(MRAP_02_hmg_Name);
     };
+    class O_T_MRAP_02_hmg_ghex_F: MRAP_02_hmg_base_F {
+        displayName = CSTRING(MRAP_02_hmg_Name);
+    };
 
     class MRAP_02_gmg_base_F: MRAP_02_hmg_base_F {};
     class O_MRAP_02_gmg_F: MRAP_02_gmg_base_F {
+        displayName = CSTRING(MRAP_02_gmg_Name);
+    };
+    class O_T_MRAP_02_gmg_ghex_F: MRAP_02_gmg_base_F {
         displayName = CSTRING(MRAP_02_gmg_Name);
     };
 

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -740,4 +740,26 @@ class CfgVehicles {
     class O_T_UAV_04_CAS_F: UAV_04_base_F {
         displayName = CSTRING(O_T_UAV_04_CAS);
     };
+
+    // Polaris DAGOR (Prowler)
+    class LSV_01_base_F;
+    class LSV_01_armed_base_F : LSV_01_base_F {
+        displayName = CSTRING(lsv_01_armed);
+    };
+    class LSV_01_unarmed_base_F : LSV_01_base_F {
+        displayName = CSTRING(lsv_01_unarmed);
+    };
+    class LSV_01_light_base_F : LSV_01_base_F {
+        displayName = CSTRING(lsv_01_light);
+    };
+
+    // Light Strike Vehicle Mk. II (Qilin)
+    class LSV_02_base_F;
+    class LSV_02_armed_base_F : LSV_02_base_F {
+        displayName = CSTRING(lsv_02_armed);
+    };
+    class LSV_02_unarmed_base_F : LSV_02_base_F {
+        displayName = CSTRING(lsv_02_unarmed);
+    };
+
 };

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -173,8 +173,8 @@ class CfgVehicles {
         displayName = CSTRING(APC_Wheeled_01_cannon_Name);
     };
 
-    class O_APC_Wheeled_02_base_F;
-    class O_APC_Wheeled_02_rcws_F: O_APC_Wheeled_02_base_F {
+    class APC_Wheeled_02_base_F;
+    class O_APC_Wheeled_02_base_F : APC_Wheeled_02_base_F {
         displayName = CSTRING(APC_Wheeled_02_rcws_Name);
     };
 

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2929,20 +2929,20 @@
             <Chinesesimp>GM6"天猫"反器材狙击步枪 (绿色数位蜂巢迷彩)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_LMG_03">
-            <English>M249 SPW</English>
-            <German>M249 SPW</German>
-            <Spanish>M249 SPW</Spanish>
-            <Polish>M249 SPW</Polish>
-            <Czech>M249 SPW</Czech>
-            <French>M249 SPW</French>
-            <Russian>M249 SPW</Russian>
-            <Portuguese>M249 SPW</Portuguese>
-            <Hungarian>M249 SPW</Hungarian>
-            <Italian>M249 SPW</Italian>
-            <Japanese>M249 SPW</Japanese>
-            <Korean>M249 SPW</Korean>
-            <Chinese>M249班用自動機槍</Chinese>
-            <Chinesesimp>M249班用自动机枪</Chinesesimp>
+            <English>FN Minimi SPW</English>
+            <German>FN Minimi SPW</German>
+            <Spanish>FN Minimi SPW</Spanish>
+            <Polish>FN Minimi SPW</Polish>
+            <Czech>FN Minimi SPW</Czech>
+            <French>FN Minimi SPW</French>
+            <Russian>FN Minimi SPW</Russian>
+            <Portuguese>FN Minimi SPW</Portuguese>
+            <Hungarian>FN Minimi SPW</Hungarian>
+            <Italian>FN Minimi SPW</Italian>
+            <Japanese>FN Minimi SPW</Japanese>
+            <Korean>FN Minimi SPW</Korean>
+            <Chinese>FN Minimi班用自動機槍</Chinese>
+            <Chinesesimp>FN Minimi班用自动机枪</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_srifle_LRR_tna">
             <English>M200 Intervention (Tropic)</English>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2166,7 +2166,7 @@
             <French>Noreen "Bad News" ULR (Camo)</French>
             <Spanish>Noreen "Bad News" ULR (Camuflaje)</Spanish>
             <Russian>Noreen "Bad News" ULR (Камо)</Russian>
-            <German>Noreen "Bad News" ULR (Camo)</German>
+            <German>Noreen "Bad News" ULR (Tarnmuster)</German>
             <Polish>Noreen "Bad News" ULR (kamuflaż)</Polish>
             <Italian>Noreen "Bad News" ULR (Camo)</Italian>
             <Hungarian>Noreen "Bad News"ULR (Terepmintás)</Hungarian>
@@ -2182,7 +2182,7 @@
             <French>Noreen "Bad News" ULR (Beige)</French>
             <Spanish>Noreen "Bad News" ULR (Arena)</Spanish>
             <Russian>Noreen "Bad News" ULR (Песочный)</Russian>
-            <German>Noreen "Bad News" ULR (Sand)</German>
+            <German>Noreen "Bad News" ULR (Sandfarben)</German>
             <Polish>Noreen "Bad News" ULR (piaskowy)</Polish>
             <Italian>Noreen "Bad News" ULR (Sabbia)</Italian>
             <Hungarian>Noreen "Bad News"ULR (Homok)</Hungarian>
@@ -2247,7 +2247,7 @@
             <Spanish>SIG 556 (Arena)</Spanish>
             <Russian>SIG 556 (Песочный)</Russian>
             <Polish>SIG 556 (piaskowy)</Polish>
-            <German>SIG 556 (Sand)</German>
+            <German>SIG 556 (Sandfarben)</German>
             <Italian>SIG 556 (Sabbia)</Italian>
             <Hungarian>SIG 556 (Homok)</Hungarian>
             <Portuguese>SIG 556 (Deserto)</Portuguese>
@@ -2263,7 +2263,7 @@
             <Spanish>SIG 556 (Camuflaje)</Spanish>
             <Russian>SIG 556 (Камо)</Russian>
             <Polish>SIG 556 (kamuflaż)</Polish>
-            <German>SIG 556 (Camo)</German>
+            <German>SIG 556 (Wüstentarn)</German>
             <Italian>SIG 556 (Camo)</Italian>
             <Hungarian>SIG 556 (Terepmintás)</Hungarian>
             <Portuguese>SIG 556 (Camuflagem)</Portuguese>
@@ -2279,7 +2279,7 @@
             <Spanish>SIG 556 (Bosque)</Spanish>
             <Russian>SIG 556 (Лесной)</Russian>
             <Polish>SIG 556 (leśny)</Polish>
-            <German>SIG 556 (Woodland)</German>
+            <German>SIG 556 (Grünes Tarnmuster)</German>
             <Italian>SIG 556 (Woodland)</Italian>
             <Hungarian>SIG 556 (Erdőmintás)</Hungarian>
             <Portuguese>SIG 556 (Floresta)</Portuguese>
@@ -2423,7 +2423,7 @@
             <Spanish>M14 (Camuflaje)</Spanish>
             <Russian>M14 (Камо)</Russian>
             <Polish>M14 (kamuflaż)</Polish>
-            <German>M14 (Camo)</German>
+            <German>M14 (Tarnmuster)</German>
             <Italian>M14 (Camo)</Italian>
             <Hungarian>M14 (Terepmintás)</Hungarian>
             <Portuguese>M14 (Camuflagem)</Portuguese>
@@ -2439,7 +2439,7 @@
             <Spanish>M14 (Oliva)</Spanish>
             <Russian>M14 (Олива)</Russian>
             <Polish>M14 (oliwkowy)</Polish>
-            <German>M14 (Olive)</German>
+            <German>M14 (Olivgrün)</German>
             <Italian>M14 (Olive)</Italian>
             <Hungarian>M14 (Olíva)</Hungarian>
             <Portuguese>M14 (Oliva)</Portuguese>
@@ -2551,7 +2551,7 @@
             <Spanish>LWMMG (Arena)</Spanish>
             <Russian>LWMMG (Песочный)</Russian>
             <Polish>LWMMG (piaskowy)</Polish>
-            <German>LWMMG (Sand)</German>
+            <German>LWMMG (Sandfarben)</German>
             <Italian>LWMMG (Sabbia)</Italian>
             <Hungarian>LWMMG (Homok)</Hungarian>
             <Portuguese>LWMMG (Deserto)</Portuguese>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2277,7 +2277,7 @@
             <Spanish>SIG 556 (Camuflaje)</Spanish>
             <Russian>SIG 556 (Камо)</Russian>
             <Polish>SIG 556 (kamuflaż)</Polish>
-            <German>SIG 556 (Wüstentarn)</German>
+            <German>SIG 556 (Tarnmuster)</German>
             <Italian>SIG 556 (Camo)</Italian>
             <Hungarian>SIG 556 (Terepmintás)</Hungarian>
             <Portuguese>SIG 556 (Camuflagem)</Portuguese>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -755,7 +755,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_APC_Tracked_02_AA_Name">
             <English>ZSU-35 Tigris</English>
-            <German>SSU-35 Tigris</German>
+            <German>ZSU-35 Tigris</German>
             <Spanish>ZSU-35 Tigris</Spanish>
             <Polish>ZSU-35 Tigris</Polish>
             <Czech>ZSU-35 Tigris</Czech>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -563,7 +563,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_transport_Name">
             <English>KamAZ Transport</English>
-            <German>KamAZ Transport</German>
+            <German>KamAS Transport</German>
             <Spanish>KamAZ de transporte</Spanish>
             <Polish>KamAZ transportowy</Polish>
             <Czech>KamAZ (valník)</Czech>
@@ -579,7 +579,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_covered_Name">
             <English>KamAZ Transport (covered)</English>
-            <German>KamAZ Transport (bedeckt)</German>
+            <German>KamAS Transport (bedeckt)</German>
             <Spanish>KamAZ de transporte (cubierto)</Spanish>
             <Polish>KamAZ Transportowy (zakryty)</Polish>
             <Czech>KamAZ (valník-krytý)</Czech>
@@ -595,7 +595,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_ammo_Name">
             <English>KamAZ Ammo</English>
-            <German>KamAZ Munition</German>
+            <German>KamAS Munition</German>
             <Spanish>KamAZ de munición</Spanish>
             <Polish>KamAZ Amunicyjny</Polish>
             <Czech>KamAZ (muniční)</Czech>
@@ -611,7 +611,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_fuel_Name">
             <English>KamAZ Fuel</English>
-            <German>KamAZ Treibstoff</German>
+            <German>KamAS Treibstoff</German>
             <Spanish>KamAZ de combustible</Spanish>
             <Polish>KamAZ cysterna</Polish>
             <Czech>KamAZ (cisterna)</Czech>
@@ -627,7 +627,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_box_Name">
             <English>KamAZ Repair</English>
-            <German>KamAZ Instandsetzung</German>
+            <German>KamAS Instandsetzung</German>
             <Spanish>KamAZ de reparación</Spanish>
             <Polish>KamAZ Naprawczy</Polish>
             <Czech>KamAZ (opravárenský)</Czech>
@@ -643,7 +643,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_medical_Name">
             <English>KamAZ Medical</English>
-            <German>KamAZ Sanitäter</German>
+            <German>KamAS Sanitäter</German>
             <Spanish>KamAZ médico</Spanish>
             <Polish>KamAZ Medyczny</Polish>
             <Czech>KamAZ (zdravotnický)</Czech>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3216,5 +3216,85 @@
             <Chinese>"馬卡洛夫"手槍</Chinese>
             <Chinesesimp>"马卡洛夫"手枪</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_01_armed">
+            <English>Polaris DAGOR (XM312)</English>
+            <German>Polaris DAGOR (XM312)</German>
+            <Spanish>Polaris DAGOR (XM312)</Spanish>
+            <Polish>Polaris DAGOR (XM312)</Polish>
+            <Czech>Polaris DAGOR (XM312)</Czech>
+            <French>Polaris DAGOR (XM312)</French>
+            <Russian>Polaris DAGOR (XM312)</Russian>
+            <Portuguese>Polaris DAGOR (XM312)</Portuguese>
+            <Hungarian>Polaris DAGOR (XM312)</Hungarian>
+            <Italian>Polaris DAGOR (XM312)</Italian>
+            <Japanese>Polaris DAGOR (XM312)</Japanese>
+            <Korean>Polaris DAGOR (XM312)</Korean>
+            <Chinese>Polaris DAGOR (XM312)</Chinese>
+            <Chinesesimp>Polaris DAGOR (XM312)</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_01_unarmed">
+            <English>Polaris DAGOR</English>
+            <German>Polaris DAGOR</German>
+            <Spanish>Polaris DAGOR</Spanish>
+            <Polish>Polaris DAGOR</Polish>
+            <Czech>Polaris DAGOR</Czech>
+            <French>Polaris DAGOR</French>
+            <Russian>Polaris DAGOR</Russian>
+            <Portuguese>Polaris DAGOR</Portuguese>
+            <Hungarian>Polaris DAGOR</Hungarian>
+            <Italian>Polaris DAGOR</Italian>
+            <Japanese>Polaris DAGOR</Japanese>
+            <Korean>Polaris DAGOR</Korean>
+            <Chinese>Polaris DAGOR</Chinese>
+            <Chinesesimp>Polaris DAGOR</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_01_light">
+            <English>Polaris DAGOR (light)</English>
+            <German>Polaris DAGOR (leicht)</German>
+            <Spanish>Polaris DAGOR (light)</Spanish>
+            <Polish>Polaris DAGOR (light)</Polish>
+            <Czech>Polaris DAGOR (light)</Czech>
+            <French>Polaris DAGOR (light)</French>
+            <Russian>Polaris DAGOR (light)</Russian>
+            <Portuguese>Polaris DAGOR (light)</Portuguese>
+            <Hungarian>Polaris DAGOR (light)</Hungarian>
+            <Italian>Polaris DAGOR (light)</Italian>
+            <Japanese>Polaris DAGOR (light)</Japanese>
+            <Korean>Polaris DAGO (light)</Korean>
+            <Chinese>Polaris DAGOR (light)</Chinese>
+            <Chinesesimp>Polaris DAGOR (light)</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_02_armed">
+            <English>LSV Mk. II (M134)</English>
+            <German>LSV Mk. II (M134)</German>
+            <Spanish>LSV Mk. II (M134)</Spanish>
+            <Polish>LSV Mk. II (M134)</Polish>
+            <Czech>LSV Mk. II (M134)</Czech>
+            <French>LSV Mk. II (M134)</French>
+            <Russian>LSV Mk. II (M134)</Russian>
+            <Portuguese>LSV Mk. II (M134)</Portuguese>
+            <Hungarian>LSV Mk. II (M134)</Hungarian>
+            <Italian>LSV Mk. II (M134)</Italian>
+            <Japanese>LSV Mk. II (M134)</Japanese>
+            <Korean>LSV Mk. II (M134)</Korean>
+            <Chinese>LSV Mk. II (M134)</Chinese>
+            <Chinesesimp>LSV Mk. II (M134)</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_02_unarmed">
+            <English>LSV Mk. II</English>
+            <German>LSV Mk. II</German>
+            <Spanish>LSV Mk. II</Spanish>
+            <Polish>LSV Mk. II</Polish>
+            <Czech>LSV Mk. II</Czech>
+            <French>LSV Mk. II</French>
+            <Russian>LSV Mk. II</Russian>
+            <Portuguese>LSV Mk. II</Portuguese>
+            <Hungarian>LSV Mk. II</Hungarian>
+            <Italian>LSV Mk. II</Italian>
+            <Japanese>LSV Mk. II</Japanese>
+            <Korean>LSV Mk. II</Korean>
+            <Chinese>LSV Mk. II</Chinese>
+            <Chinesesimp>LSV Mk. II</Chinesesimp>
+        </Key>
     </Package>
 </Project>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -179,7 +179,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_01_hmg_Name">
             <English>M-ATV (HMG)</English>
-            <German>M-ATV (SMG)</German>
+            <German>M-ATV (sMG)</German>
             <Spanish>M-ATV (HMG)</Spanish>
             <Polish>M-ATV (CKM)</Polish>
             <Czech>M-ATV (HMG)</Czech>
@@ -483,7 +483,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_03_hmg_Name">
             <English>Fennek (HMG)</English>
-            <German>Fennek (SMG)</German>
+            <German>Fennek (sMG)</German>
             <Spanish>Fennek (HMG)</Spanish>
             <Polish>Fennek (CKM)</Polish>
             <Czech>Fennek (HMG)</Czech>
@@ -675,7 +675,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_02_hmg_Name">
             <English>Punisher (HMG)</English>
-            <German>Punisher (SMG)</German>
+            <German>Punisher (sMG)</German>
             <Spanish>Punisher (HMG)</Spanish>
             <Polish>Punisher (CKM)</Polish>
             <Czech>Punisher (HMG)</Czech>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -658,50 +658,50 @@
             <Chinesesimp>"卡玛斯"卡车 (医疗)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_02_Name">
-            <English>Punisher</English>
-            <German>Punisher</German>
-            <Spanish>Punisher</Spanish>
-            <Polish>Punisher</Polish>
-            <Czech>Punisher</Czech>
-            <French>Punisher</French>
+            <English>Karatel</English>
+            <German>Karatel</German>
+            <Spanish>Karatel</Spanish>
+            <Polish>Karatel</Polish>
+            <Czech>Karatel</Czech>
+            <French>Karatel</French>
             <Russian>Kаратель</Russian>
-            <Portuguese>Punisher</Portuguese>
-            <Hungarian>Punisher</Hungarian>
-            <Italian>Punisher</Italian>
+            <Portuguese>Karatel</Portuguese>
+            <Hungarian>Karatel</Hungarian>
+            <Italian>Karatel</Italian>
             <Japanese>パニッシャー</Japanese>
-            <Korean>Punisher</Korean>
+            <Korean>Karatel</Korean>
             <Chinese>"懲罰者"防地雷反伏擊車</Chinese>
             <Chinesesimp>"惩罚者"防地雷反伏击车</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_02_hmg_Name">
-            <English>Punisher (HMG)</English>
-            <German>Punisher (sMG)</German>
-            <Spanish>Punisher (HMG)</Spanish>
-            <Polish>Punisher (CKM)</Polish>
-            <Czech>Punisher (HMG)</Czech>
-            <French>Punisher (HMG)</French>
+            <English>Karatel (HMG)</English>
+            <German>Karatel (sMG)</German>
+            <Spanish>Karatel (HMG)</Spanish>
+            <Polish>Karatel (CKM)</Polish>
+            <Czech>Karatel (HMG)</Czech>
+            <French>Karatel (HMG)</French>
             <Russian>Kаратель (Пулемёт)</Russian>
-            <Portuguese>Punisher (HMG)</Portuguese>
-            <Hungarian>Punisher (nehézgéppuska)</Hungarian>
-            <Italian>Punisher (HMG)</Italian>
+            <Portuguese>Karatel (HMG)</Portuguese>
+            <Hungarian>Karatel (nehézgéppuska)</Hungarian>
+            <Italian>Karatel (HMG)</Italian>
             <Japanese>パニッシャー (HMG)</Japanese>
-            <Korean>Punisher (HMG)</Korean>
+            <Korean>Karatel (HMG)</Korean>
             <Chinese>"懲罰者"防地雷反伏擊車 (重機槍)</Chinese>
             <Chinesesimp>"惩罚者"防地雷反伏击车 (重机枪)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_02_gmg_Name">
-            <English>Punisher (GMG)</English>
-            <German>Punisher (GMW)</German>
-            <Spanish>Punisher (GMG)</Spanish>
-            <Polish>Punisher (GMG)</Polish>
-            <Czech>Punisher (GMG)</Czech>
-            <French>Punisher (GMG)</French>
+            <English>Karatel (GMG)</English>
+            <German>Karatel (GMW)</German>
+            <Spanish>Karatel (GMG)</Spanish>
+            <Polish>Karatel (GMG)</Polish>
+            <Czech>Karatel (GMG)</Czech>
+            <French>Karatel (GMG)</French>
             <Russian>Kаратель (Гранатомёт)</Russian>
-            <Portuguese>Punisher (GMG)</Portuguese>
-            <Hungarian>Punisher (gránátgéppuska)</Hungarian>
-            <Italian>Punisher (GMG)</Italian>
+            <Portuguese>Karatel (GMG)</Portuguese>
+            <Hungarian>Karatel (gránátgéppuska)</Hungarian>
+            <Italian>Karatel (GMG)</Italian>
             <Japanese>パニッシャー (GMG)</Japanese>
-            <Korean>Punisher (GMG)</Korean>
+            <Korean>Karatel (GMG)</Korean>
             <Chinese>"懲罰者"防地雷反伏擊車 (榴彈機槍)</Chinese>
             <Chinesesimp>"惩罚者"防地雷反伏击车 (榴弹机枪)</Chinesesimp>
         </Key>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2960,7 +2960,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_srifle_LRR_tna">
             <English>M200 Intervention (Tropic)</English>
-            <German>M200 Intervention (Tropentarn)</German>
+            <German>M200 Intervention (Tropisch)</German>
             <Czech>M200 Intervention (Tropická kamufláž)</Czech>
             <Polish>M200 Intervention (zwrotnik)</Polish>
             <French>M200 Intervention (Tropique)</French>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2198,7 +2198,7 @@
             <French>Noreen "Bad News" ULR (Beige)</French>
             <Spanish>Noreen "Bad News" ULR (Arena)</Spanish>
             <Russian>Noreen "Bad News" ULR (Песочный)</Russian>
-            <German>Noreen "Bad News" ULR (Sandfarben)</German>
+            <German>Noreen "Bad News" ULR (sandfarben)</German>
             <Polish>Noreen "Bad News" ULR (piaskowy)</Polish>
             <Italian>Noreen "Bad News" ULR (Sabbia)</Italian>
             <Hungarian>Noreen "Bad News"ULR (Homok)</Hungarian>
@@ -2263,7 +2263,7 @@
             <Spanish>SIG 556 (Arena)</Spanish>
             <Russian>SIG 556 (Песочный)</Russian>
             <Polish>SIG 556 (piaskowy)</Polish>
-            <German>SIG 556 (Sandfarben)</German>
+            <German>SIG 556 (sandfarben)</German>
             <Italian>SIG 556 (Sabbia)</Italian>
             <Hungarian>SIG 556 (Homok)</Hungarian>
             <Portuguese>SIG 556 (Deserto)</Portuguese>
@@ -2567,7 +2567,7 @@
             <Spanish>LWMMG (Arena)</Spanish>
             <Russian>LWMMG (Песочный)</Russian>
             <Polish>LWMMG (piaskowy)</Polish>
-            <German>LWMMG (Sandfarben)</German>
+            <German>LWMMG (sandfarben)</German>
             <Italian>LWMMG (Sabbia)</Italian>
             <Hungarian>LWMMG (Homok)</Hungarian>
             <Portuguese>LWMMG (Deserto)</Portuguese>
@@ -3030,7 +3030,7 @@
             <French>HK416A5 11" (Beige)</French>
             <Spanish>HK416A5 11" (Arena)</Spanish>
             <Russian>HK416A5 11" (Песочный)</Russian>
-            <German>HK416A5 11" (Sandfarben)</German>
+            <German>HK416A5 11" (sandfarben)</German>
             <Polish>HK416A5 11" (piaskowy)</Polish>
             <Italian>HK416A5 11" (Sabbia)</Italian>
             <Hungarian>HK416A5 11" (Homok)</Hungarian>
@@ -3078,7 +3078,7 @@
             <French>HK416A5 11" GL (Beige)</French>
             <Spanish>HK416A5 11" GL (Arena)</Spanish>
             <Russian>HK416A5 11" GL (Песочный)</Russian>
-            <German>HK416A5 11" GL (Sandfarben)</German>
+            <German>HK416A5 11" GL (sandfarben)</German>
             <Polish>HK416A5 11" GL (piaskowy)</Polish>
             <Italian>HK416A5 11" GL (Sabbia)</Italian>
             <Hungarian>HK416A5 11" GL (Homok)</Hungarian>
@@ -3126,7 +3126,7 @@
             <French>HK416A5 14.5" (Beige)</French>
             <Spanish>HK416A5 14.5" (Arena)</Spanish>
             <Russian>HK416A5 14.5" (Песочный)</Russian>
-            <German>HK416A5 14.5" (Sandfarben)</German>
+            <German>HK416A5 14.5" (sandfarben)</German>
             <Polish>HK416A5 14.5" (piaskowy)</Polish>
             <Italian>HK416A5 14.5" (Sabbia)</Italian>
             <Hungarian>HK416A5 14.5" (Homok)</Hungarian>
@@ -3174,7 +3174,7 @@
             <French>HK417A2 20" (Beige)</French>
             <Spanish>HK417A2 20" (Arena)</Spanish>
             <Russian>HK417A2 20" (Песочный)</Russian>
-            <German>HK417A2 20" (Sandfarben)</German>
+            <German>HK417A2 20" (sandfarben)</German>
             <Polish>HK417A2 20" (piaskowy)</Polish>
             <Italian>HK417A2 20" (Sabbia)</Italian>
             <Hungarian>HK417A2 20" (Homok)</Hungarian>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1089,6 +1089,22 @@
             <Chinese>L-159先進輕型戰鬥機 (空對空)</Chinese>
             <Chinesesimp>L-159先进轻型战斗机 (空对空)</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_Plane_Fighter_04_Name">
+            <English>JAS 39 Gripen</English>
+            <German>JAS 39 Gripen</German>
+            <Spanish>JAS 39 Gripen</Spanish>
+            <Polish>JAS 39 Gripen</Polish>
+            <Czech>JAS 39 Gripen</Czech>
+            <French>JAS 39 Gripen</French>
+            <Russian>JAS 39 Gripen</Russian>
+            <Portuguese>JAS 39 Gripen</Portuguese>
+            <Hungarian>JAS 39 Gripen</Hungarian>
+            <Italian>JAS 39 Gripen</Italian>
+            <Japanese>JAS 39 Gripen</Japanese>
+            <Korean>JAS 39 Gripen</Korean>
+            <Chinese>JAS 39 Gripen</Chinese>
+            <Chinesesimp>JAS 39 Gripen</Chinesesimp>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_Heli_Light_02_Name">
             <English>Ka-60 Kasatka</English>
             <German>Ka-60 Kasatka</German>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -755,7 +755,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_APC_Tracked_02_AA_Name">
             <English>ZSU-35 Tigris</English>
-            <German>ZSU-35 Tigris</German>
+            <German>SSU-35 Tigris</German>
             <Spanish>ZSU-35 Tigris</Spanish>
             <Polish>ZSU-35 Tigris</Polish>
             <Czech>ZSU-35 Tigris</Czech>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1096,14 +1096,12 @@
             <Polish>JAS 39 Gripen</Polish>
             <Czech>JAS 39 Gripen</Czech>
             <French>JAS 39 Gripen</French>
-            <Russian>JAS 39 Gripen</Russian>
+            <Russian>JAS 39 Грипен</Russian>
             <Portuguese>JAS 39 Gripen</Portuguese>
-            <Hungarian>JAS 39 Gripen</Hungarian>
             <Italian>JAS 39 Gripen</Italian>
-            <Japanese>JAS 39 Gripen</Japanese>
-            <Korean>JAS 39 Gripen</Korean>
-            <Chinese>JAS 39 Gripen</Chinese>
-            <Chinesesimp>JAS 39 Gripen</Chinesesimp>
+            <Japanese>サーブ 39 グリペン</Japanese>
+            <Korean>JAS 39 그리펜</Korean>
+            <Chinese>JAS 39 獅鷲戰鬥機</Chinese>
         </Key>
         <Key ID="STR_ACE_RealisticNames_Heli_Light_02_Name">
             <English>Ka-60 Kasatka</English>
@@ -3235,82 +3233,22 @@
         <Key ID="STR_ACE_RealisticNames_lsv_01_armed">
             <English>Polaris DAGOR (XM312)</English>
             <German>Polaris DAGOR (XM312)</German>
-            <Spanish>Polaris DAGOR (XM312)</Spanish>
-            <Polish>Polaris DAGOR (XM312)</Polish>
-            <Czech>Polaris DAGOR (XM312)</Czech>
-            <French>Polaris DAGOR (XM312)</French>
-            <Russian>Polaris DAGOR (XM312)</Russian>
-            <Portuguese>Polaris DAGOR (XM312)</Portuguese>
-            <Hungarian>Polaris DAGOR (XM312)</Hungarian>
-            <Italian>Polaris DAGOR (XM312)</Italian>
-            <Japanese>Polaris DAGOR (XM312)</Japanese>
-            <Korean>Polaris DAGOR (XM312)</Korean>
-            <Chinese>Polaris DAGOR (XM312)</Chinese>
-            <Chinesesimp>Polaris DAGOR (XM312)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_01_unarmed">
             <English>Polaris DAGOR</English>
             <German>Polaris DAGOR</German>
-            <Spanish>Polaris DAGOR</Spanish>
-            <Polish>Polaris DAGOR</Polish>
-            <Czech>Polaris DAGOR</Czech>
-            <French>Polaris DAGOR</French>
-            <Russian>Polaris DAGOR</Russian>
-            <Portuguese>Polaris DAGOR</Portuguese>
-            <Hungarian>Polaris DAGOR</Hungarian>
-            <Italian>Polaris DAGOR</Italian>
-            <Japanese>Polaris DAGOR</Japanese>
-            <Korean>Polaris DAGOR</Korean>
-            <Chinese>Polaris DAGOR</Chinese>
-            <Chinesesimp>Polaris DAGOR</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_01_light">
             <English>Polaris DAGOR (light)</English>
             <German>Polaris DAGOR (leicht)</German>
-            <Spanish>Polaris DAGOR (light)</Spanish>
-            <Polish>Polaris DAGOR (light)</Polish>
-            <Czech>Polaris DAGOR (light)</Czech>
-            <French>Polaris DAGOR (light)</French>
-            <Russian>Polaris DAGOR (light)</Russian>
-            <Portuguese>Polaris DAGOR (light)</Portuguese>
-            <Hungarian>Polaris DAGOR (light)</Hungarian>
-            <Italian>Polaris DAGOR (light)</Italian>
-            <Japanese>Polaris DAGOR (light)</Japanese>
-            <Korean>Polaris DAGO (light)</Korean>
-            <Chinese>Polaris DAGOR (light)</Chinese>
-            <Chinesesimp>Polaris DAGOR (light)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_02_armed">
             <English>LSV Mk. II (M134)</English>
             <German>LSV Mk. II (M134)</German>
-            <Spanish>LSV Mk. II (M134)</Spanish>
-            <Polish>LSV Mk. II (M134)</Polish>
-            <Czech>LSV Mk. II (M134)</Czech>
-            <French>LSV Mk. II (M134)</French>
-            <Russian>LSV Mk. II (M134)</Russian>
-            <Portuguese>LSV Mk. II (M134)</Portuguese>
-            <Hungarian>LSV Mk. II (M134)</Hungarian>
-            <Italian>LSV Mk. II (M134)</Italian>
-            <Japanese>LSV Mk. II (M134)</Japanese>
-            <Korean>LSV Mk. II (M134)</Korean>
-            <Chinese>LSV Mk. II (M134)</Chinese>
-            <Chinesesimp>LSV Mk. II (M134)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_02_unarmed">
             <English>LSV Mk. II</English>
             <German>LSV Mk. II</German>
-            <Spanish>LSV Mk. II</Spanish>
-            <Polish>LSV Mk. II</Polish>
-            <Czech>LSV Mk. II</Czech>
-            <French>LSV Mk. II</French>
-            <Russian>LSV Mk. II</Russian>
-            <Portuguese>LSV Mk. II</Portuguese>
-            <Hungarian>LSV Mk. II</Hungarian>
-            <Italian>LSV Mk. II</Italian>
-            <Japanese>LSV Mk. II</Japanese>
-            <Korean>LSV Mk. II</Korean>
-            <Chinese>LSV Mk. II</Chinese>
-            <Chinesesimp>LSV Mk. II</Chinesesimp>
         </Key>
     </Package>
 </Project>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2946,7 +2946,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_srifle_LRR_tna">
             <English>M200 Intervention (Tropic)</English>
-            <German>M200 Intervention (Tropisch)</German>
+            <German>M200 Intervention (Tropentarn)</German>
             <Czech>M200 Intervention (Tropická kamufláž)</Czech>
             <Polish>M200 Intervention (zwrotnik)</Polish>
             <French>M200 Intervention (Tropique)</French>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1921,20 +1921,20 @@
             <Chinesesimp>CTAR-21卡宾步枪</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_arifle_TRG21_GL_Name">
-            <English>TAR-21 EGLM</English>
-            <German>TAR-21 EGLM</German>
-            <Czech>TAR-21 EGLM</Czech>
-            <Polish>TAR-21 EGLM</Polish>
-            <French>TAR-21 EGLM</French>
-            <Hungarian>TAR-21 EGLM</Hungarian>
-            <Spanish>TAR-21 EGLM</Spanish>
-            <Russian>TAR-21 EGLM</Russian>
-            <Portuguese>TAR-21 EGLM</Portuguese>
-            <Italian>TAR-21 EGLM</Italian>
-            <Japanese>TAR-21 EGLM</Japanese>
-            <Korean>TAR-21 EGLM</Korean>
-            <Chinese>TAR-21突擊步槍 (榴彈)</Chinese>
-            <Chinesesimp>TAR-21突击步枪 (榴弹)</Chinesesimp>
+            <English>GTAR-21 EGLM</English>
+            <German>GTAR-21 EGLM</German>
+            <Czech>GTAR-21 EGLM</Czech>
+            <Polish>GTAR-21 EGLM</Polish>
+            <French>GTAR-21 EGLM</French>
+            <Hungarian>GTAR-21 EGLM</Hungarian>
+            <Spanish>GTAR-21 EGLM</Spanish>
+            <Russian>GTAR-21 EGLM</Russian>
+            <Portuguese>GTAR-21 EGLM</Portuguese>
+            <Italian>GTAR-21 EGLM</Italian>
+            <Japanese>GTAR-21 EGLM</Japanese>
+            <Korean>GTAR-21 EGLM</Korean>
+            <Chinese>GTAR-21突擊步槍 (榴彈)</Chinese>
+            <Chinesesimp>GTAR-21突击步枪 (榴弹)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_SMG_01_Name">
             <English>Vector SMG</English>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1250,7 +1250,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_SmokeShell_Name">
             <English>M83 Smoke Grenade (White)</English>
-            <German>M83 Rauchgranate (Weiss)</German>
+            <German>M83 Rauchgranate (Weiß)</German>
             <Spanish>Granada de humo M83 (Blanco)</Spanish>
             <Polish>Granat dymny M83 (Biały)</Polish>
             <Czech>M83 Kouřový Granát (Bílý)</Czech>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3014,7 +3014,7 @@
             <French>HK416A5 11" (Beige)</French>
             <Spanish>HK416A5 11" (Arena)</Spanish>
             <Russian>HK416A5 11" (Песочный)</Russian>
-            <German>HK416A5 11" (Sand)</German>
+            <German>HK416A5 11" (Sandfarben)</German>
             <Polish>HK416A5 11" (piaskowy)</Polish>
             <Italian>HK416A5 11" (Sabbia)</Italian>
             <Hungarian>HK416A5 11" (Homok)</Hungarian>
@@ -3062,7 +3062,7 @@
             <French>HK416A5 11" GL (Beige)</French>
             <Spanish>HK416A5 11" GL (Arena)</Spanish>
             <Russian>HK416A5 11" GL (Песочный)</Russian>
-            <German>HK416A5 11" GL (Sand)</German>
+            <German>HK416A5 11" GL (Sandfarben)</German>
             <Polish>HK416A5 11" GL (piaskowy)</Polish>
             <Italian>HK416A5 11" GL (Sabbia)</Italian>
             <Hungarian>HK416A5 11" GL (Homok)</Hungarian>
@@ -3110,7 +3110,7 @@
             <French>HK416A5 14.5" (Beige)</French>
             <Spanish>HK416A5 14.5" (Arena)</Spanish>
             <Russian>HK416A5 14.5" (Песочный)</Russian>
-            <German>HK416A5 14.5" (Sand)</German>
+            <German>HK416A5 14.5" (Sandfarben)</German>
             <Polish>HK416A5 14.5" (piaskowy)</Polish>
             <Italian>HK416A5 14.5" (Sabbia)</Italian>
             <Hungarian>HK416A5 14.5" (Homok)</Hungarian>
@@ -3158,7 +3158,7 @@
             <French>HK417A2 20" (Beige)</French>
             <Spanish>HK417A2 20" (Arena)</Spanish>
             <Russian>HK417A2 20" (Песочный)</Russian>
-            <German>HK417A2 20" (Sand)</German>
+            <German>HK417A2 20" (Sandfarben)</German>
             <Polish>HK417A2 20" (piaskowy)</Polish>
             <Italian>HK417A2 20" (Sabbia)</Italian>
             <Hungarian>HK417A2 20" (Homok)</Hungarian>


### PR DESCRIPTION
## When merged this pull request will:
### ace_realisticnames
* Use "sMG" instead of "SMG" as abbreviation for German "schweres Maschinengewehr".
* Rename "Punisher" to "Karatel". It seems odd to me to use translations for names. **Discussion requested**.
* Rename "KamAZ" to "KamAS" and "ZSU-35 Tigris" to "SSU-35 Tigris" in German translations. The Cyrillic letter `з` is transcribed as `s` in German.
* Use `ß` instead of `ss` in all German strings where applicable.
* Rename "TAR-21 EGLM" to "GTAR-21 EGLM". 
* Corrected some German translations for camo variants of rifles.
* Rename "M249" to "FN Minimi". M249 is the American designation, but given the Syndicat which uses it is francophone and Tanoa is not in any way connected to the US, i would prefer using the producer's name. **Discussion requested**.
* Rename "Hydra 70" pylon magazine to "Hydra 70 12x HE".
* Add realistic names of Apex-DLC LSVs:
  * Renamed "Prowler" to "Polaris DAGOR".
  * Renamed "Qilin" to "LSV Mk. II".
* Add missing Chinese CSAT vehicles not inheriting their displayNames from Iranian CSAT vehicles or base classes (Otokar Arma, Karatel).
* Rename "A-149 Gryphon" to "JAS 39 Gripen".
* Add missing Syndicat vehicles not inheriting their displayNames from Civilian vehicles (MD 500, Cessna, Jeep).

### ace_maverick
* Add `[ACE]` tag to pylon magazines displayNames.