### PR TITLE
Add Ctrl+F search shortcut for ACE Arsenal

### DIFF
--- a/addons/arsenal/functions/fnc_onKeyDown.sqf
+++ b/addons/arsenal/functions/fnc_onKeyDown.sqf
@@ -46,6 +46,10 @@ if (!GVAR(leftSearchbarFocus) && {!GVAR(rightSearchbarFocus)}) then {
         case (_keyPressed == DIK_V && {_ctrlState}): {
             [_display] call FUNC(buttonImport);
         };
+        // Search fields
+        case (_keyPressed == DIK_F && {_ctrlState}): {
+            ctrlSetFocus (_display displayCtrl IDC_leftSearchbar);
+        };
         // Switch vision mode
         case (_keyPressed in (actionkeys "nightvision")): {
             if (isNil QGVAR(visionMode)) then {
@@ -98,6 +102,14 @@ if (!GVAR(leftSearchbarFocus) && {!GVAR(rightSearchbarFocus)}) then {
         };
         case (_keyPressed == DIK_V && {_ctrlState}): {
             _return = false;
+        };
+        // Search fields
+        case (_keyPressed == DIK_F && {_ctrlState}): {
+            if (GVAR(rightSearchbarFocus)) then {
+                ctrlSetFocus (_display displayCtrl IDC_leftSearchbar);
+            } else {
+                ctrlSetFocus (_display displayCtrl IDC_rightSearchbar);
+            };
         };
     };
 };

--- a/addons/arsenal/functions/fnc_onKeyDown.sqf
+++ b/addons/arsenal/functions/fnc_onKeyDown.sqf
@@ -103,6 +103,12 @@ if (!GVAR(leftSearchbarFocus) && {!GVAR(rightSearchbarFocus)}) then {
         case (_keyPressed == DIK_V && {_ctrlState}): {
             _return = false;
         };
+        case (_keyPressed == DIK_A && {_ctrlState}): {
+            _return = false;
+        };
+        case (_keyPressed == DIK_X && {_ctrlState}): {
+            _return = false;
+        };
         // Search fields
         case (_keyPressed == DIK_F && {_ctrlState}): {
             if (GVAR(rightSearchbarFocus)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Add Ctrl+F, Ctrl+A, and Ctrl+X support for ACE Arsenal

Pressing it while no search field are in focus: select left field
Pressing it while a search field is in focus: select the other field.
