### PR TITLE
Add brightness control when NV effects disabled

### DIFF
--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -26,11 +26,15 @@ GVAR(ppEffectCCMuzzleFlash) = -1;
 ["ace_settingsInitialized", {
     TRACE_3("settingsInitialized",GVAR(disableNVGsWithSights),GVAR(fogScaling),GVAR(effectScaling));
 
-    // Disable ALL effects if ace_nightvision_effectScaling is zero
-    if (GVAR(effectScaling) == 0) exitWith {};
+    ["visionMode", LINKFUNC(onVisionModeChanged), false] call CBA_fnc_addPlayerEventHandler;
+
+    // handle only brightness if effects are disabled
+    if (GVAR(effectScaling) == 0) exitWith {
+        GVAR(ppEffectNVGBrightness) = ppEffectCreate ["ColorCorrections", 1236];
+        GVAR(ppEffectNVGBrightness) ppEffectForceInNVG true;
+    };
 
     ["loadout", LINKFUNC(onLoadoutChanged), true] call CBA_fnc_addPlayerEventHandler;
-    ["visionMode", LINKFUNC(onVisionModeChanged), false] call CBA_fnc_addPlayerEventHandler;
     ["cameraView", LINKFUNC(onCameraViewChanged), true] call CBA_fnc_addPlayerEventHandler;
     ["vehicle", LINKFUNC(refreshGoggleType), false] call CBA_fnc_addPlayerEventHandler;
     ["turret", LINKFUNC(refreshGoggleType), true] call CBA_fnc_addPlayerEventHandler;

--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -32,7 +32,7 @@ GVAR(ppEffectCCMuzzleFlash) = -1;
     if (GVAR(effectScaling) == 0) exitWith {
         GVAR(ppEffectNVGBrightness) = ppEffectCreate ["ColorCorrections", 1236];
         GVAR(ppEffectNVGBrightness) ppEffectForceInNVG true;
-        GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (0+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
+        GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (-3+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
         GVAR(ppEffectNVGBrightness) ppEffectCommit 0;
     };
 

--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -32,6 +32,8 @@ GVAR(ppEffectCCMuzzleFlash) = -1;
     if (GVAR(effectScaling) == 0) exitWith {
         GVAR(ppEffectNVGBrightness) = ppEffectCreate ["ColorCorrections", 1236];
         GVAR(ppEffectNVGBrightness) ppEffectForceInNVG true;
+        GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (0+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
+        GVAR(ppEffectNVGBrightness) ppEffectCommit 0;
     };
 
     ["loadout", LINKFUNC(onLoadoutChanged), true] call CBA_fnc_addPlayerEventHandler;

--- a/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
+++ b/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
@@ -28,5 +28,11 @@ _player setVariable [QGVAR(NVGBrightness), _brightness, false];
 [format [(localize LSTRING(NVGBrightness)), _brightness]] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";
 
+// handle only brightness if effects are disabled
+if (GVAR(effectScaling) == 0) exitWith {
+    GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (_brightness+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
+    GVAR(ppEffectNVGBrightness) ppEffectCommit 0;
+};
+
 // Trigger full ppEffects update next time run in the PFEH:
 GVAR(nextEffectsUpdate) = -1;

--- a/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
+++ b/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
@@ -30,6 +30,7 @@ playSound "ACE_Sound_Click";
 
 // handle only brightness if effects are disabled
 if (GVAR(effectScaling) == 0) exitWith {
+    // here we take (-6; 0) _brightness range and alter it to (-1.6; 1.6)
     GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (_brightness+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
     GVAR(ppEffectNVGBrightness) ppEffectCommit 0;
 };

--- a/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
+++ b/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
@@ -30,7 +30,7 @@ playSound "ACE_Sound_Click";
 
 // handle only brightness if effects are disabled
 if (GVAR(effectScaling) == 0) exitWith {
-    // here we take (-6; 0) _brightness range and alter it to (-1.6; 1.6)
+    // here we take (-6; 0) _brightness range and alter it to (0.4; 1.6)
     GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (_brightness+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
     GVAR(ppEffectNVGBrightness) ppEffectCommit 0;
 };

--- a/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
+++ b/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
@@ -19,7 +19,8 @@
 params ["_player", "_changeInBrightness"];
 TRACE_2("changeNVGBrightness",_player,_changeInBrightness);
 
-private _brightness = _player getVariable [QGVAR(NVGBrightness), 0];
+private _areEffectsDisabled = GVAR(effectScaling) == 0;
+private _brightness = _player getVariable [QGVAR(NVGBrightness), [0, -3] select _areEffectsDisabled];
 
 _brightness = ((_brightness + _changeInBrightness) min 0) max -6;
 
@@ -29,7 +30,7 @@ _player setVariable [QGVAR(NVGBrightness), _brightness, false];
 playSound "ACE_Sound_Click";
 
 // handle only brightness if effects are disabled
-if (GVAR(effectScaling) == 0) exitWith {
+if (_areEffectsDisabled) exitWith {
     // here we take (-6; 0) _brightness range and alter it to (0.4; 1.6)
     GVAR(ppEffectNVGBrightness) ppEffectAdjust [1, (_brightness+3)/5 + 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
     GVAR(ppEffectNVGBrightness) ppEffectCommit 0;

--- a/addons/nightvision/functions/fnc_onVisionModeChanged.sqf
+++ b/addons/nightvision/functions/fnc_onVisionModeChanged.sqf
@@ -19,6 +19,11 @@
 params ["_unit", "_visionMode"];
 TRACE_2("onVisionModeChanged",_unit,_visionMode);
 
+// handle only brightness if effects are disabled
+if (GVAR(effectScaling) == 0) exitWith {
+    GVAR(ppEffectNVGBrightness) ppEffectEnable (_visionMode == 1);
+};
+
 // Start PFEH when entering night vision mode:
 if (_visionMode == 1) then {
     if (GVAR(PFID) == -1) then {


### PR DESCRIPTION
**When merged this pull request will:**
- get back brightness control from 3.11 when NV effects disabled with `ace_nightvision_effectScaling`==0.