### PR TITLE
Scopes - Fix 'boreHeight' and 'baseAngle' MP synchronization

### DIFF
--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -32,8 +32,8 @@ _zeroing = _zeroing vectorMultiply MRAD_TO_DEG(1);
 
 if (GVAR(correctZeroing) || GVAR(simplifiedZeroing)) then {
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];
-    private _baseAngle = [_unit, _weaponIndex] call FUNC(getBaseAngle);
-    private _boreHeight = [_unit, _weaponIndex] call FUNC(getBoreHeight);
+    private _baseAngle = (_unit getVariable [QGVAR(baseAngle), [0,0,0]]) select _weaponIndex;
+    private _boreHeight = (_unit getVariable [QGVAR(boreHeight), [0,0,0]]) select _weaponIndex; 
     private _oldZeroRange = currentZeroing _unit;
     private _newZeroRange = [_unit] call FUNC(getCurrentZeroRange);
     private _zeroCorrection = missionNamespace getVariable format[QGVAR(%1_%2_%3_%4_%5_%6_%7), _oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics];

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -32,7 +32,7 @@ _zeroing = _zeroing vectorMultiply MRAD_TO_DEG(1);
 
 if (GVAR(correctZeroing) || GVAR(simplifiedZeroing)) then {
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];
-    private _baseAngle = [_unit, _weaponIndex] call FUNC(getBaseAngle); 
+    private _baseAngle = [_unit, _weaponIndex] call FUNC(getBaseAngle);
     private _boreHeight = [_unit, _weaponIndex] call FUNC(getBoreHeight);
     private _oldZeroRange = currentZeroing _unit;
     private _newZeroRange = [_unit] call FUNC(getCurrentZeroRange);

--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -32,8 +32,8 @@ _zeroing = _zeroing vectorMultiply MRAD_TO_DEG(1);
 
 if (GVAR(correctZeroing) || GVAR(simplifiedZeroing)) then {
     private _advancedBallistics = missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false];
-    private _baseAngle = GVAR(baseAngle) select _weaponIndex; 
-    private _boreHeight = GVAR(boreHeight) select _weaponIndex;
+    private _baseAngle = [_unit, _weaponIndex] call FUNC(getBaseAngle); 
+    private _boreHeight = [_unit, _weaponIndex] call FUNC(getBoreHeight);
     private _oldZeroRange = currentZeroing _unit;
     private _newZeroRange = [_unit] call FUNC(getCurrentZeroRange);
     private _zeroCorrection = missionNamespace getVariable format[QGVAR(%1_%2_%3_%4_%5_%6_%7), _oldZeroRange, _newZeroRange, _boreHeight, _weapon, _ammo, _magazine, _advancedBallistics];

--- a/addons/scopes/functions/fnc_getBaseAngle.sqf
+++ b/addons/scopes/functions/fnc_getBaseAngle.sqf
@@ -1,24 +1,27 @@
 /*
  * Author: Ruthberg
- * Gets the base angle of the currently used weapon & optic combination
+ * Gets the base angle of the weapon & optic combination with the given weapon index
  *
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: Weapon index <NUMBER>
- * 2: Weapon <CLASS>
- * 3: Optic <CLASS>
  *
  * Return Value:
  * base angle <NUMBER>
  *
  * Example:
- * [player, 0, "srifle_LRR_F", "optic_LRPS"] call ace_scopes_fnc_getBaseAngle
+ * [player, 0] call ace_scopes_fnc_getBaseAngle
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-params ["_player", "_weaponIndex", "_weaponClass", "_opticsClass"];
+params ["_unit", "_weaponIndex"];
+
+if (_weaponIndex < 0 || {_weaponIndex > 2}) exitWith { 0 }; 
+
+private _weaponClass = [primaryWeapon _unit, secondaryWeapon _unit, handgunWeapon _unit] select _weaponIndex; 
+private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex; 
 
 private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
 private _baseAngle = getNumber(_weaponConfig >> "ACE_IronSightBaseAngle");

--- a/addons/scopes/functions/fnc_getBaseAngle.sqf
+++ b/addons/scopes/functions/fnc_getBaseAngle.sqf
@@ -23,9 +23,6 @@ if (_weaponIndex < 0 || {_weaponIndex > 2}) exitWith { 0 };
 private _weaponClass = [primaryWeapon _unit, secondaryWeapon _unit, handgunWeapon _unit] select _weaponIndex; 
 private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex; 
 
-private _cachedResult = _unit getVariable format[QGVAR(%1_%2), _weaponClass, _opticsClass];
-if (!isNil "_cachedResult") exitWith { _cachedResult };
-
 private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
 private _baseAngle = getNumber(_weaponConfig >> "ACE_IronSightBaseAngle");
 
@@ -36,7 +33,5 @@ if (_opticsClass != "") then {
         _baseAngle = DEFAULT_RAIL_BASE_ANGLE;
     };
 };
-
-_unit setVariable [format[QGVAR(%1_%2), _weaponClass, _opticsClass], _baseAngle];
 
 _baseAngle

--- a/addons/scopes/functions/fnc_getBaseAngle.sqf
+++ b/addons/scopes/functions/fnc_getBaseAngle.sqf
@@ -23,6 +23,9 @@ if (_weaponIndex < 0 || {_weaponIndex > 2}) exitWith { 0 };
 private _weaponClass = [primaryWeapon _unit, secondaryWeapon _unit, handgunWeapon _unit] select _weaponIndex; 
 private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex; 
 
+private _cachedResult = _unit getVariable format[QGVAR(%1_%2), _weaponClass, _opticsClass];
+if (!isNil "_cachedResult") exitWith { _cachedResult };
+
 private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
 private _baseAngle = getNumber(_weaponConfig >> "ACE_IronSightBaseAngle");
 
@@ -33,5 +36,7 @@ if (_opticsClass != "") then {
         _baseAngle = DEFAULT_RAIL_BASE_ANGLE;
     };
 };
+
+_unit setVariable [format[QGVAR(%1_%2), _weaponClass, _opticsClass], _baseAngle];
 
 _baseAngle

--- a/addons/scopes/functions/fnc_getBoreHeight.sqf
+++ b/addons/scopes/functions/fnc_getBoreHeight.sqf
@@ -25,6 +25,9 @@ private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex;
 
 if (_opticsClass == "") then { _opticsClass = _weaponClass; };
 
+private _cachedResult = _unit getVariable format[QGVAR(%1_%2), _weaponClass, _opticsClass];
+if (!isNil "_cachedResult") exitWith { _cachedResult };
+
 // Determine rail height above bore
 private _railHeightAboveBore = 0;
 private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
@@ -54,4 +57,8 @@ if (isNumber (_opticConfig >> "ACE_ScopeHeightAboveRail")) then {
     };
 };
 
-(_railHeightAboveBore + _scopeHeightAboveRail)
+private _boreHeight = _railHeightAboveBore + _scopeHeightAboveRail;
+
+_unit setVariable [format[QGVAR(%1_%2), _weaponClass, _opticsClass], _boreHeight];
+
+_boreHeight

--- a/addons/scopes/functions/fnc_getBoreHeight.sqf
+++ b/addons/scopes/functions/fnc_getBoreHeight.sqf
@@ -25,9 +25,6 @@ private _opticsClass = ([_unit] call FUNC(getOptics)) select _weaponIndex;
 
 if (_opticsClass == "") then { _opticsClass = _weaponClass; };
 
-private _cachedResult = _unit getVariable format[QGVAR(%1_%2), _weaponClass, _opticsClass];
-if (!isNil "_cachedResult") exitWith { _cachedResult };
-
 // Determine rail height above bore
 private _railHeightAboveBore = 0;
 private _weaponConfig = configFile >> "CfgWeapons" >> _weaponClass;
@@ -57,8 +54,4 @@ if (isNumber (_opticConfig >> "ACE_ScopeHeightAboveRail")) then {
     };
 };
 
-private _boreHeight = _railHeightAboveBore + _scopeHeightAboveRail;
-
-_unit setVariable [format[QGVAR(%1_%2), _weaponClass, _opticsClass], _boreHeight];
-
-_boreHeight
+(_railHeightAboveBore + _scopeHeightAboveRail)

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -79,16 +79,14 @@ private _newOptics = [_player] call FUNC(getOptics);
     };
 } forEach GVAR(Optics);
 
-private _unitBaseAngleOld = _player getVariable [QGVAR(baseAngle), [0,0,0]];
-private _unitBaseAngleNew = +_unitBaseAngleOld;
-private _unitBoreHeightOld = _player getVariable [QGVAR(boreHeight), [0,0,0]];
-private _unitBoreHeightNew = +_unitBoreHeightOld;
+private _unitBaseAngle = +(_player getVariable [QGVAR(baseAngle), [0,0,0]]);
+private _unitBoreHeight = +(_player getVariable [QGVAR(boreHeight), [0,0,0]]);
 
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
-        _unitBaseAngleNew set [_x, [_player, _x] call FUNC(getBaseAngle)];
-        _unitBoreHeightNew set [_x, [_player, _x] call FUNC(getBoreHeight)];
+        _unitBaseAngle set [_x, [_player, _x] call FUNC(getBaseAngle)];
+        _unitBoreHeight set [_x, [_player, _x] call FUNC(getBoreHeight)];
         if ((_newOptics select _x) == "") then {
             // Check if the weapon comes with an integrated optic
             private _weaponConfig = configFile >> "CfgWeapons" >> (_newGuns select _x);
@@ -133,13 +131,13 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
 } forEach [0, 1, 2];
 
 if (GVAR(correctZeroing) || GVAR(simplifiedZeroing)) then {
-    if (!(_unitBaseAngleNew isEqualTo _unitBaseAngleOld)) then {
-        TRACE_2("syncing",_unitBaseAngleNew,_unitBaseAngleOld);
-        _unit setVariable [QGVAR(baseAngle), _unitBaseAngleNew, true];
+    if (!(_unitBaseAngle isEqualTo (_player getVariable [QGVAR(baseAngle), [0,0,0]]))) then {
+        TRACE_2("syncing",_unitBaseAngle,_player getVariable QGVAR(baseAngle));
+        _player setVariable [QGVAR(baseAngle), _unitBaseAngle, true];
     };
-    if (!(_unitBoreHeightNew isEqualTo _unitBoreHeightOld)) then {
-        TRACE_2("syncing",_unitBoreHeightNew,_unitBoreHeightOld);
-        _unit setVariable [QGVAR(boreHeight), _unitBoreHeightNew, true];
+    if (!(_unitBoreHeight isEqualTo (_player getVariable [QGVAR(boreHeight), [0,0,0]]))) then {
+        TRACE_2("syncing",_unitBoreHeight,_player getVariable QGVAR(boreHeight));
+        _player setVariable [QGVAR(boreHeight), _unitBoreHeight, true];
     };
 };
 

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -82,9 +82,6 @@ private _newOptics = [_player] call FUNC(getOptics);
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
-        GVAR(baseAngle) set [_x, [_player, _x] call FUNC(getBaseAngle)]; 
-        GVAR(boreHeight) set [_x, [_player, _x] call FUNC(getBoreHeight)];
-
         if ((_newOptics select _x) == "") then {
             // Check if the weapon comes with an integrated optic     
             private _weaponConfig = configFile >> "CfgWeapons" >> (_newGuns select _x); 

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -82,7 +82,7 @@ private _newOptics = [_player] call FUNC(getOptics);
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
-        GVAR(baseAngle) set [_x, [_player, _x, _newGuns select _x, _newOptics select _x] call FUNC(getBaseAngle)]; 
+        GVAR(baseAngle) set [_x, [_player, _x] call FUNC(getBaseAngle)]; 
         GVAR(boreHeight) set [_x, [_player, _x] call FUNC(getBoreHeight)];
 
         if ((_newOptics select _x) == "") then {

--- a/addons/scopes/functions/fnc_inventoryCheck.sqf
+++ b/addons/scopes/functions/fnc_inventoryCheck.sqf
@@ -79,12 +79,19 @@ private _newOptics = [_player] call FUNC(getOptics);
     };
 } forEach GVAR(Optics);
 
+private _unitBaseAngleOld = _player getVariable [QGVAR(baseAngle), [0,0,0]];
+private _unitBaseAngleNew = +_unitBaseAngleOld;
+private _unitBoreHeightOld = _player getVariable [QGVAR(boreHeight), [0,0,0]];
+private _unitBoreHeightNew = +_unitBoreHeightOld;
+
 private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapon _player];
 {
     if ((_newOptics select _x) != (GVAR(Optics) select _x) || (_newGuns select _x != GVAR(Guns) select _x)) then {
+        _unitBaseAngleNew set [_x, [_player, _x] call FUNC(getBaseAngle)];
+        _unitBoreHeightNew set [_x, [_player, _x] call FUNC(getBoreHeight)];
         if ((_newOptics select _x) == "") then {
-            // Check if the weapon comes with an integrated optic     
-            private _weaponConfig = configFile >> "CfgWeapons" >> (_newGuns select _x); 
+            // Check if the weapon comes with an integrated optic
+            private _weaponConfig = configFile >> "CfgWeapons" >> (_newGuns select _x);
             private _maxVertical = [0, 0];
             private _verticalIncrement = 0;
             private _maxHorizontal = [0, 0];
@@ -110,7 +117,7 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
             GVAR(canAdjustElevation) set [_x, (_verticalIncrement > 0) && !(_maxVertical isEqualTo [0, 0])];
             GVAR(canAdjustWindage) set [_x, (_horizontalIncrement > 0) && !(_maxHorizontal isEqualTo [0, 0])];
         };
-        
+
         // The optic or the weapon changed, reset the adjustment
         private _persistentZero = profileNamespace getVariable [format[QGVAR(PersistentZero_%1_%2), _newGuns select _x, _newOptics select _x], 0];
         ((GVAR(scopeAdjust) select _x) select 0) params ["_minElevation", "_maxElevation"];
@@ -124,6 +131,17 @@ private _newGuns = [primaryWeapon _player, secondaryWeapon _player, handgunWeapo
         };
     }
 } forEach [0, 1, 2];
+
+if (GVAR(correctZeroing) || GVAR(simplifiedZeroing)) then {
+    if (!(_unitBaseAngleNew isEqualTo _unitBaseAngleOld)) then {
+        TRACE_2("syncing",_unitBaseAngleNew,_unitBaseAngleOld);
+        _unit setVariable [QGVAR(baseAngle), _unitBaseAngleNew, true];
+    };
+    if (!(_unitBoreHeightNew isEqualTo _unitBoreHeightOld)) then {
+        TRACE_2("syncing",_unitBoreHeightNew,_unitBoreHeightOld);
+        _unit setVariable [QGVAR(boreHeight), _unitBoreHeightNew, true];
+    };
+};
 
 if (_updateAdjustment) then {
     [ACE_player, QGVAR(Adjustment), _adjustment, 0.5] call EFUNC(common,setVariablePublic);


### PR DESCRIPTION
* Unifies the 'getBaseAngle' & 'getBoreHeight' API
* Fixes the issue that the `boreHeight` and `baseAngle` information is always used from the local player

We should probably cache the calculation or use publicVariables instead at some point.