### PR TITLE
Add slider settings

### DIFF
--- a/addons/advanced_ballistics/ACE_Settings.hpp
+++ b/addons/advanced_ballistics/ACE_Settings.hpp
@@ -40,6 +40,6 @@ class ACE_Settings {
         description = CSTRING(simulationInterval_Description);
         typeName = "SCALAR";
         value = 0.05;
-        sliderSettings[] = {0, 0.2, 0.05, 1};
+        sliderSettings[] = {0, 0.2, 0.05, 2};
     };
 };

--- a/addons/advanced_fatigue/ACE_Settings.hpp
+++ b/addons/advanced_fatigue/ACE_Settings.hpp
@@ -20,7 +20,7 @@ class ACE_Settings {
         description = CSTRING(PerformanceFactor_Description);
         typeName = "SCALAR";
         value = 1;
-        sliderSettings[] = {0, 10, 1, 1};
+        sliderSettings[] = {0, 5, 1, 1};
     };
     class GVAR(recoveryFactor) {
         category = CSTRING(DisplayName);
@@ -28,7 +28,7 @@ class ACE_Settings {
         description = CSTRING(RecoveryFactor_Description);
         typeName = "SCALAR";
         value = 1;
-        sliderSettings[] = {0, 10, 1, 1};
+        sliderSettings[] = {0, 5, 1, 1};
     };
     class GVAR(loadFactor) {
         category = CSTRING(DisplayName);
@@ -36,7 +36,7 @@ class ACE_Settings {
         description = CSTRING(LoadFactor_Description);
         typeName = "SCALAR";
         value = 1;
-        sliderSettings[] = {0, 10, 1, 1};
+        sliderSettings[] = {0, 5, 1, 1};
     };
     class GVAR(terrainGradientFactor) {
         category = CSTRING(DisplayName);
@@ -44,6 +44,6 @@ class ACE_Settings {
         description = CSTRING(TerrainGradientFactor_Description);
         typeName = "SCALAR";
         value = 1;
-        sliderSettings[] = {0, 10, 1, 1};
+        sliderSettings[] = {0, 5, 1, 1};
     };
 };

--- a/addons/advanced_fatigue/ACE_Settings.hpp
+++ b/addons/advanced_fatigue/ACE_Settings.hpp
@@ -20,6 +20,7 @@ class ACE_Settings {
         description = CSTRING(PerformanceFactor_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 10, 1, 1};
     };
     class GVAR(recoveryFactor) {
         category = CSTRING(DisplayName);
@@ -27,6 +28,7 @@ class ACE_Settings {
         description = CSTRING(RecoveryFactor_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 10, 1, 1};
     };
     class GVAR(loadFactor) {
         category = CSTRING(DisplayName);
@@ -34,6 +36,7 @@ class ACE_Settings {
         description = CSTRING(LoadFactor_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 10, 1, 1};
     };
     class GVAR(terrainGradientFactor) {
         category = CSTRING(DisplayName);
@@ -41,5 +44,6 @@ class ACE_Settings {
         description = CSTRING(TerrainGradientFactor_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 10, 1, 1};
     };
 };

--- a/addons/cargo/ACE_Settings.hpp
+++ b/addons/cargo/ACE_Settings.hpp
@@ -12,5 +12,6 @@ class ACE_Settings {
         typeName = "SCALAR";
         value = 2.5;
         category = ECSTRING(OptionsMenu,CategoryLogistics);
+        sliderSettings[] = {0, 10, 2.5, 1};
     };
 };

--- a/addons/common/functions/fnc_cbaSettings_loadFromConfig.sqf
+++ b/addons/common/functions/fnc_cbaSettings_loadFromConfig.sqf
@@ -61,7 +61,7 @@ case ("SCALAR"): { // ACE's Scalar can be a float or an index for a list
             _cbaValueInfo = if (isArray (_config >> "sliderSettings")) then {
                 getArray (_config >> "sliderSettings");
             } else {
-                WARNING_1("Using auto min/max for [%1]",_varName);
+                INFO_1("Using auto min/max for [%1]",_varName);
                 [-1, 5000, 0, 1]
             };
             _cbaValueInfo set [2, getNumber (_config >> "value")];

--- a/addons/common/functions/fnc_cbaSettings_loadFromConfig.sqf
+++ b/addons/common/functions/fnc_cbaSettings_loadFromConfig.sqf
@@ -61,6 +61,7 @@ case ("SCALAR"): { // ACE's Scalar can be a float or an index for a list
             _cbaValueInfo = if (isArray (_config >> "sliderSettings")) then {
                 getArray (_config >> "sliderSettings");
             } else {
+                WARNING_1("Using auto min/max for [%1]",_varName);
                 [-1, 5000, 0, 1]
             };
             _cbaValueInfo set [2, getNumber (_config >> "value")];

--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -27,6 +27,7 @@ class ACE_Settings {
         description = CSTRING(ammoCookoffDuration_tooltip);
         value = 1;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 5, 1, 1};
     };
     class GVAR(probabilityCoef) {
         category = CSTRING(displayName);
@@ -34,5 +35,6 @@ class ACE_Settings {
         description = CSTRING(probabilityCoef_tooltip);
         value = 1;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 5, 1, 1};
     };
 };

--- a/addons/finger/ACE_Settings.hpp
+++ b/addons/finger/ACE_Settings.hpp
@@ -11,6 +11,7 @@ class ACE_Settings {
         typeName = "SCALAR";
         displayName = CSTRING(maxRange_displayName);
         description = CSTRING(maxRange_description);
+        sliderSettings[] = {0, 50, 4, 1};
     };
     class GVAR(indicatorForSelf) {
         category = CSTRING(DisplayName);

--- a/addons/frag/ACE_Settings.hpp
+++ b/addons/frag/ACE_Settings.hpp
@@ -26,6 +26,7 @@ class ACE_Settings {
         description = CSTRING(MaxTrack_Desc);
         typeName = "SCALAR";
         value = 10;
+        sliderSettings[] = {0, 50, 10, -1};
     };
     class GVAR(maxTrackPerFrame) {
         category = CSTRING(Module_DisplayName);
@@ -33,5 +34,6 @@ class ACE_Settings {
         description = CSTRING(MaxTrackPerFrame_Desc);
         typeName = "SCALAR";
         value = 10;
+        sliderSettings[] = {0, 50, 10, -1};
     };
 };

--- a/addons/hearing/ACE_Settings.hpp
+++ b/addons/hearing/ACE_Settings.hpp
@@ -10,11 +10,13 @@ class ACE_Settings {
         category = CSTRING(Module_DisplayName);
         value = 0.5;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 1, 0.5, 1};
     };
     class GVAR(unconsciousnessVolume) {
         category = CSTRING(Module_DisplayName);
         value = 0.4;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 1, 0.4, 1};
     };
     class GVAR(disableEarRinging) {
         category = CSTRING(Module_DisplayName);

--- a/addons/hitreactions/ACE_Settings.hpp
+++ b/addons/hitreactions/ACE_Settings.hpp
@@ -5,5 +5,6 @@ class ACE_Settings {
         typeName = "SCALAR";
         value = 0.1;
         displayName = CSTRING(minDamageToTrigger_displayName);
+        sliderSettings[] = {-1, 1, 0.1, 1};
     };
 };

--- a/addons/laser/ACE_Settings.hpp
+++ b/addons/laser/ACE_Settings.hpp
@@ -3,5 +3,6 @@ class ACE_Settings {
         value = 2;
         typeName = "SCALAR";
         displayName = CSTRING(dispersionCount_displayName);
+        sliderSettings[] = {0, 5, 2, -1};
     };
 };

--- a/addons/map/ACE_Settings.hpp
+++ b/addons/map/ACE_Settings.hpp
@@ -5,6 +5,7 @@ class ACE_Settings {
         typeName = "SCALAR";
         displayName = CSTRING(BFT_Interval_DisplayName);
         description = CSTRING(BFT_Interval_Description);
+        sliderSettings[] = {0, 30, 1, 1};
     };
     class GVAR(BFT_Enabled) {
         category = CSTRING(Module_DisplayName);
@@ -68,5 +69,6 @@ class ACE_Settings {
         typeName = "SCALAR";
         displayName = CSTRING(DefaultChannel_DisplayName);
         description = CSTRING(DefaultChannel_Description);
+        sliderSettings[] = {-1, 5, -1, -1};
     };
 };

--- a/addons/map_gestures/ACE_Settings.hpp
+++ b/addons/map_gestures/ACE_Settings.hpp
@@ -12,6 +12,7 @@ class ACE_Settings {
         category = CSTRING(mapGestures_category);
         typeName = "SCALAR";
         value = 7;
+        sliderSettings[] = {0, 50, 7, 1};
     };
     class GVAR(interval) {
         displayName = CSTRING(interval_displayName);
@@ -19,6 +20,7 @@ class ACE_Settings {
         category = CSTRING(mapGestures_category);
         typeName = "SCALAR";
         value = 0.03;
+        sliderSettings[] = {0, 1, 0.03, 2};
     };
     class GVAR(nameTextColor) {
         displayName = CSTRING(nameTextColor_displayName);

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -41,6 +41,7 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_bleedingCoefficient_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 25, 1, 1};
     };
     class GVAR(painCoefficient) {
         category = CSTRING(Category_Medical);
@@ -48,6 +49,7 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_painCoefficient_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 25, 1, 1};
     };
     class GVAR(enableAdvancedWounds) {
         category = CSTRING(Category_Medical);
@@ -76,6 +78,7 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_playerDamageThreshold_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 25, 1, 1};
     };
     class GVAR(AIDamageThreshold) {
         category = CSTRING(Category_Medical);
@@ -83,6 +86,7 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_AIDamageThreshold_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 25, 1, 1};
     };
     class GVAR(enableUnconsciousnessAI) {
         category = CSTRING(Category_Medical);
@@ -120,6 +124,7 @@ class ACE_Settings {
         description = CSTRING(ReviveSettings_maxReviveTime_Description);
         typeName = "SCALAR";
         value = 120;
+        sliderSettings[] = {0, 1200, 120, 0};
     };
     class GVAR(amountOfReviveLives) {
         category = CSTRING(Category_Medical);
@@ -127,6 +132,7 @@ class ACE_Settings {
         description = CSTRING(ReviveSettings_amountOfReviveLives_Description);
         typeName = "SCALAR";
         value = -1;
+        sliderSettings[] = {-1, 25, -1, -1};
     };
     class GVAR(allowDeadBodyMovement) {
         category = CSTRING(Category_Medical);
@@ -156,6 +162,7 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_litterCleanUpDelay_Description);
         typeName = "SCALAR";
         value = 0;
+        sliderSettings[] = {-1, 3600, 0, 0};
     };
     class GVAR(medicSetting_basicEpi) {
         category = CSTRING(Category_Medical);
@@ -291,5 +298,6 @@ class ACE_Settings {
         description = CSTRING(MedicalSettings_delayUnconCaptive_Description);
         typeName = "SCALAR";
         value = 3;
+        sliderSettings[] = {0, 30, 3, 0};
     };
 };

--- a/addons/medical_menu/ACE_Settings.hpp
+++ b/addons/medical_menu/ACE_Settings.hpp
@@ -29,5 +29,6 @@ class ACE_Settings {
         value = 3;
         typeName = "SCALAR";
         category = ECSTRING(medical,Category_Medical);
+        sliderSettings[] = {0, 10, 3, 1};
     };
 };

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -56,12 +56,14 @@ class ACE_Settings {
         typeName = "SCALAR";
         isClientSettable = 0;
         category = CSTRING(Module_DisplayName);
+        sliderSettings[] = {0, 50, 5, 1};
     };
     class GVAR(playerNamesMaxAlpha) {
         value = 0.8;
         typeName = "SCALAR";
         isClientSettable = 0;
         category = CSTRING(Module_DisplayName);
+        sliderSettings[] = {0, 1, 0.8, 2};
     };
     class GVAR(tagSize) {
         value = 2;

--- a/addons/nightvision/ACE_Settings.hpp
+++ b/addons/nightvision/ACE_Settings.hpp
@@ -12,6 +12,7 @@ class ACE_Settings {
         description = CSTRING(fogScaling_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 2, 1, 1};
     };
     class GVAR(effectScaling) {
         category = CSTRING(Category);
@@ -19,5 +20,6 @@ class ACE_Settings {
         description = CSTRING(effectScaling_Description);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {0, 2, 1, 1};
     };
 };

--- a/addons/overheating/ACE_Settings.hpp
+++ b/addons/overheating/ACE_Settings.hpp
@@ -43,6 +43,7 @@ class ACE_Settings {
         value = 0.1;
         displayName = CSTRING(unJamFailChance_displayName);
         description = CSTRING(unJamFailChance_description);
+        sliderSettings[] = {0, 1, 0.1, 2};
     };
     class GVAR(enabled) {
         category = CSTRING(DisplayName);

--- a/addons/overpressure/ACE_Settings.hpp
+++ b/addons/overpressure/ACE_Settings.hpp
@@ -4,5 +4,6 @@ class ACE_Settings {
         description = CSTRING(distanceCoefficient_toolTip);
         typeName = "SCALAR";
         value = 1;
+        sliderSettings[] = {-1, 10, 5, 1};
     };
 };

--- a/addons/pylons/ACE_Settings.hpp
+++ b/addons/pylons/ACE_Settings.hpp
@@ -19,6 +19,7 @@ class ACE_Settings {
         description = CSTRING(SearchDistance_description);
         value = 15;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 50, 15, 1};
     };
     class GVAR(timePerPylon) {
         category = CSTRING(Category_Pylons);
@@ -26,6 +27,7 @@ class ACE_Settings {
         description = CSTRING(TimePerPylon_description);
         value = 5;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 10, 5, 1};
     };
     class GVAR(requireEngineer) {
         category = CSTRING(Category_Pylons);

--- a/addons/refuel/ACE_Settings.hpp
+++ b/addons/refuel/ACE_Settings.hpp
@@ -5,11 +5,13 @@ class ACE_Settings {
         description = CSTRING(RefuelSettings_speed_Description);
         value = 1;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 25, 1, 1};
     };
     class GVAR(hoseLength) {
         category = ECSTRING(OptionsMenu,CategoryLogistics);
         displayName = CSTRING(RefuelSettings_hoseLength_DisplayName);
         value = 12;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 50, 12, 1};
     };
 };

--- a/addons/repair/ACE_Settings.hpp
+++ b/addons/repair/ACE_Settings.hpp
@@ -29,6 +29,7 @@ class ACE_Settings {
         typeName = "SCALAR";
         value = 0.6;
         category = ECSTRING(OptionsMenu,CategoryLogistics);
+        sliderSettings[] = {0, 1, 0.6, 2};
     };
     class GVAR(repairDamageThreshold_engineer) {
         displayName = CSTRING(repairDamageThreshold_Engineer_name);
@@ -36,6 +37,7 @@ class ACE_Settings {
         typeName = "SCALAR";
         value = 0.4;
         category = ECSTRING(OptionsMenu,CategoryLogistics);
+        sliderSettings[] = {0, 1, 0.4, 2};
     };
     class GVAR(consumeItem_toolKit) {
         displayName = CSTRING(consumeItem_ToolKit_name);

--- a/addons/respawn/ACE_Settings.hpp
+++ b/addons/respawn/ACE_Settings.hpp
@@ -14,10 +14,11 @@ class ACE_Settings {
         value = 1;
         typeName = "BOOL";
     };
-    class GVAR(bodyRemoveTimer) {
-        category = CSTRING(DisplayName);
-        displayName = CSTRING(DeadBodyRemoveTimer);
-        value = 0;
-        typeName = "SCALAR";
-    };
+    // Not used anywhere???
+    // class GVAR(bodyRemoveTimer) {
+        // category = CSTRING(DisplayName);
+        // displayName = CSTRING(DeadBodyRemoveTimer);
+        // value = 0;
+        // typeName = "SCALAR";
+    // };
 };

--- a/addons/scopes/ACE_Settings.hpp
+++ b/addons/scopes/ACE_Settings.hpp
@@ -48,7 +48,7 @@ class ACE_Settings {
         value = 15;
         displayName = CSTRING(zeroReferenceTemperature_displayName);
         description = CSTRING(zeroReferenceTemperature_description);
-        sliderSettings[] = {-55, 55, 15, 1};
+        sliderSettings[] = {-55, 55, 15, 0};
     };
     class GVAR(zeroReferenceBarometricPressure) {
         category = CSTRING(DisplayName);

--- a/addons/scopes/ACE_Settings.hpp
+++ b/addons/scopes/ACE_Settings.hpp
@@ -38,6 +38,7 @@ class ACE_Settings {
         value = 100;
         displayName = CSTRING(defaultZeroRange_displayName);
         description = CSTRING(defaultZeroRange_description);
+        sliderSettings[] = {0, 1000, 100, 0};
     };
     
     // Only relevant when advanced ballistics is enabled
@@ -47,6 +48,7 @@ class ACE_Settings {
         value = 15;
         displayName = CSTRING(zeroReferenceTemperature_displayName);
         description = CSTRING(zeroReferenceTemperature_description);
+        sliderSettings[] = {-55, 55, 15, 1};
     };
     class GVAR(zeroReferenceBarometricPressure) {
         category = CSTRING(DisplayName);
@@ -54,6 +56,7 @@ class ACE_Settings {
         value = 1013.25;
         displayName = CSTRING(zeroReferenceBarometricPressure_displayName);
         description = CSTRING(zeroReferenceBarometricPressure_description);
+        sliderSettings[] = {0, 1013.25, 1013.25, 2};
     };
     class GVAR(zeroReferenceHumidity) {
         category = CSTRING(DisplayName);
@@ -61,6 +64,7 @@ class ACE_Settings {
         value = 0.0;
         displayName = CSTRING(zeroReferenceHumidity_displayName);
         description = CSTRING(zeroReferenceHumidity_description);
+        sliderSettings[] = {0, 1, 0, 2};
     };
     class GVAR(deduceBarometricPressureFromTerrainAltitude) {
         category = CSTRING(DisplayName);

--- a/addons/switchunits/ACE_Settings.hpp
+++ b/addons/switchunits/ACE_Settings.hpp
@@ -45,5 +45,6 @@ class ACE_Settings {
         description = CSTRING(SafeZoneRadius_Description);
         value = 100;
         typeName = "SCALAR";
+        sliderSettings[] = {0, 1000, 100, 0};
     };
 };

--- a/addons/vehiclelock/ACE_Settings.hpp
+++ b/addons/vehiclelock/ACE_Settings.hpp
@@ -5,6 +5,7 @@ class ACE_Settings {
         description = CSTRING(DefaultLockpickStrength_Description);
         value = 10;
         typeName = "SCALAR";
+        sliderSettings[] = {-1, 60, 5, 1};
     };
     class GVAR(lockVehicleInventory) {
         category = CSTRING(DisplayName);
@@ -19,5 +20,6 @@ class ACE_Settings {
         description = CSTRING(VehicleStartingLockState_Description);
         value = -1;
         typeName = "SCALAR";
+        sliderSettings[] = {-1, 2, -1, -1}; // ToDo: Make this a list?
     };
 };

--- a/addons/viewdistance/ACE_Settings.hpp
+++ b/addons/viewdistance/ACE_Settings.hpp
@@ -39,6 +39,7 @@ class ACE_Settings {
         value = 10000; // Value, NOT index. 10000 is the maximum in A3
         displayName = CSTRING(limit_DisplayName);
         description = CSTRING(limit_setting);
+        sliderSettings[] = {500, 12000, 10000, 0};
     };
     class GVAR(objectViewDistanceCoeff) {
         category = CSTRING(Module_DisplayName);

--- a/addons/winddeflection/ACE_Settings.hpp
+++ b/addons/winddeflection/ACE_Settings.hpp
@@ -19,6 +19,6 @@ class ACE_Settings {
         description = CSTRING(simulationInterval_Description);
         typeName = "SCALAR";
         value = 0.05;
-        sliderSettings[] = {0, 0.2, 0.05, 1};
+        sliderSettings[] = {0, 0.2, 0.05, 2};
     };
 };


### PR DESCRIPTION
Adds proper min/max for slider settings
Without it would use `[-1, 5000, 0, 1]` because it needed to handle long distances, but that's pretty bad for settings in the 0-1 range.

These values were a little tricky to come up with, some of them are a little subjective.
I tried to give plenty of room for the min/max as they are hard limits.
e.g. medical_bleedingCoefficient has max of 25, which I think should be ok

There also are some special cases where -1 means something else, I tried to check everything, but this could use a thorough review.