### PR TITLE
Use common icon function for vehicle actions

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -9,6 +9,7 @@ PREP_RECOMPILE_END;
 
 GVAR(syncedEvents) = [] call CBA_fnc_hashCreate;
 GVAR(showHudHash) = [] call CBA_fnc_hashCreate;
+GVAR(vehicleIconCache) = call CBA_fnc_createNamespace; // for getVehicleIcon
 
 GVAR(settingsInitFinished) = false;
 GVAR(runAtSettingsInitialized) = [];

--- a/addons/common/functions/fnc_getVehicleIcon.sqf
+++ b/addons/common/functions/fnc_getVehicleIcon.sqf
@@ -21,8 +21,6 @@ params [["_object", objNull, [objNull, ""]]];
 
 if ((_object isEqualType objNull && {isNull _object}) || {_object isEqualType "" && {_object == ""}}) exitWith { DEFAULT_TEXTURE };
 
-ISNILS(GVAR(vehicleIconCache),call CBA_fnc_createNamespace);
-
 private _objectType = if (_object isEqualType objNull) then {
     typeOf _object
 } else {

--- a/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
+++ b/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
@@ -21,13 +21,13 @@
 params ["_vehicles", "_statement", "_target"];
 
 _vehicles apply {
-    private _config = configFile >> "CfgVehicles" >> typeOf _x;
-    private _name = getText (_config >> "displayName");
+    private _type = typeOf _x;
+    private _name = getText (configFile >> "CfgVehicles" >> _type >> "displayName");
     private _ownerName = [_x, true] call EFUNC(common,getName);
     if ("" != _ownerName) then {
         _name = format ["%1 (%2)", _name, _ownerName];
     };
-    private _icon = (getText (_config >> "icon")) call BIS_fnc_textureVehicleIcon;
+    private _icon = [_type] call EFUNC(common,getVehicleIcon);
     private _action = [format ["%1", _x], _name, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);
     [_action, [], _target]
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Make `interact_menu` function `createVehiclesActions` (used by `cargo`) use `common` function `getVehicleIcon` which utilises caching (used by `spectator` currently).
- Consequently remove a dependence on external BI function `BIS_fnc_textureVehicleIcon`