### PR TITLE
Fix FRIES being applied when attribute unchecked

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -4,7 +4,7 @@
         control = "Checkbox"; \
         displayName = CSTRING(Eden_equipFRIES); \
         tooltip = CSTRING(Eden_equipFRIES_Tooltip); \
-        expression = QUOTE([_this] call FUNC(equipFRIES)); \
+        expression = QUOTE(if (_value) then {[_this] call FUNC(equipFRIES)}); \
         typeName = "BOOL"; \
         condition = "objectVehicle"; \
         defaultValue = false; \


### PR DESCRIPTION
Attributes that are specific to objects are saved even when the default value is set, so the helicopters using this one would always be equipped with FRIES if the checkbox had ever been toggled.
