### PR TITLE
Arsenal - Filter items with scopeArsenal = 0

### DIFF
--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -125,7 +125,7 @@ private _magazineGroups = [[],[]] call CBA_fnc_hashCreate;
             (_cargo select 17) pushBackUnique _className;
         };
     };
-} foreach configProperties [_configCfgWeapons, "isClass _x && {2 == (if (isNumber (_x >> 'scopeArsenal')) then {getNumber (_x >> 'scopeArsenal')} else {getNumber (_x >> 'scope')})} && {getNumber (_x >> 'ace_arsenal_hide') != 1}", true];
+} foreach configProperties [_configCfgWeapons, "isClass _x && {(if (isNumber (_x >> 'scopeArsenal')) then {getNumber (_x >> 'scopeArsenal')} else {getNumber (_x >> 'scope')}) == 2} && {getNumber (_x >> 'ace_arsenal_hide') != 1}", true];
 
 {
     private _className = configName _x;

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -125,7 +125,7 @@ private _magazineGroups = [[],[]] call CBA_fnc_hashCreate;
             (_cargo select 17) pushBackUnique _className;
         };
     };
-} foreach configProperties [_configCfgWeapons, "isClass _x && {getNumber (_x >> 'scope') == 2} && {getNumber (_x >> 'ace_arsenal_hide') != 1}", true];
+} foreach configProperties [_configCfgWeapons, "isClass _x && {2 == (if (isNumber (_x >> 'scopeArsenal')) then {getNumber (_x >> 'scopeArsenal')} else {getNumber (_x >> 'scope')})} && {getNumber (_x >> 'ace_arsenal_hide') != 1}", true];
 
 {
     private _className = configName _x;


### PR DESCRIPTION
Fix #5983

Uses same logic as bis's arsenal
`_scope = if (isnumber (_class >> "scopeArsenal")) then {getnumber (_class >> "scopeArsenal")} else {getnumber (_class >> "scope")};`


What gets filtered with my modset:
```
rhs_weap_ak74m_zenitco01_npz [2:0]
rhs_weap_ak74m_zenitco01_npz_grip1 [2:0]
rhs_weap_ak74m_zenitco01_npz_afg [2:0]
rhs_weap_ak105_zenitco01_npz [2:0]
rhs_weap_ak105_zenitco01_npz_grip1 [2:0]
rhs_weap_ak105_zenitco01_npz_afg [2:0]
rhs_weap_ak104_zenitco01_npz [2:0]
rhs_weap_ak104_zenitco01_npz_grip1 [2:0]
rhs_weap_ak104_zenitco01_npz_afg [2:0]
rhs_weap_ak103_zenitco01_npz [2:0]
rhs_weap_ak103_zenitco01_npz_grip1 [2:0]
rhs_weap_ak103_zenitco01_npz_afg [2:0]
rhs_weap_ak74m_dtk [2:0]
rhs_weap_ak105_pgs64 [2:0]
hlc_rifle_G36A1_CMAG [2:0]
hlc_rifle_G36A1AG36_CMAG [2:0]
hlc_rifle_MG36_30rnd [2:0]
hlc_rifle_G36KA1_CMAG [2:0]
hlc_rifle_G36c_CMAG [2:0]
hlc_rifle_G36E1_CMAG [2:0]
hlc_rifle_G36E1AG36_CMAG [2:0]
hlc_rifle_G36E1AG36_Romi_CMAG [2:0]
hlc_rifle_G36KE1_CMAG [2:0]
hlc_rifle_G36V_CMAG [2:0]
hlc_rifle_G36KV_CMAG [2:0]
hlc_rifle_G36cV_CMAG [2:0]
hlc_rifle_G36VAG36_CMAG [2:0]
hlc_rifle_G36KA1KSK_CMAG [2:0]
HLC_Rifle_G36KSKAG36_CMAG [2:0]
hlc_rifle_G36TAC_CMAG [2:0]
hlc_rifle_g36KTac_CMAG [2:0]
hlc_rifle_G36CTac_CMAG [2:0]
hlc_rifle_g3sg1_XMAG [2:0]
hlc_rifle_g3sg1ris_XMAG [2:0]
hlc_rifle_psg1_XMAG [2:0]
hlc_rifle_psg1A1_XMAG [2:0]
hlc_rifle_PSG1A1_RIS_XMAG [2:0]
hlc_rifle_g3a3_XMAG [2:0]
hlc_rifle_g3a3ris_XMAG [2:0]
hlc_rifle_g3a3v_XMAG [2:0]
hlc_rifle_g3a3vris_XMAG [2:0]
hlc_rifle_g3ka4_XMAG [2:0]
HLC_Rifle_g3ka4_GL_XMAG [2:0]
hlc_rifle_hk51_XMAG [2:0]
ACE_key_master [2:0]
ACE_key_lockpick [2:0]
ACE_key_west [2:0]
ACE_key_east [2:0]
ACE_key_indp [2:0]
ACE_key_civ [2:0]
CUP_U_B_GER_Ghillie [2:0]
CUP_U_B_GER_Fleck_Ghillie [2:0]
CUP_H_SLA_Pilot_Helmet [2:0]
CUP_U_O_TK_Ghillie [2:0]
CUP_U_B_USArmy_Ghillie [2:0]
CUP_U_B_USMC_Ghillie_WDL [2:0]
CUP_U_B_BAF_MTP_Ghillie [2:0]
```