### PR TITLE
Fix displayName of spectator respawn template

### DIFF
--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -21,7 +21,7 @@ class CfgPatches {
 
 class CfgRespawnTemplates {
     class ADDON {
-        displayName = CSTRING(Module_DisplayName);
+        displayName = CSTRING(Settings_DisplayName);
         onPlayerKilled = QFUNC(respawnTemplate);
         onPlayerRespawn = QFUNC(respawnTemplate);
         respawnTypes[] = {1,2,3,4,5};


### PR DESCRIPTION
**When merged this pull request will:**
- Revert the template display name back to "ACE Spectator" instead of "Spectator" (disambiguate from BI's "Spectator")
