### PR TITLE
Arsenal - Add Missing semicolons

### DIFF
--- a/addons/arsenal/RscDisplayMain.hpp
+++ b/addons/arsenal/RscDisplayMain.hpp
@@ -17,12 +17,12 @@ class RscDisplayMain: RscStandardDisplay {
                     tooltip = CSTRING(Mission_tooltip);
                     y = "(3 *   1.5) *  (pixelH * pixelGrid * 2) +  (pixelH)";
                     onbuttonclick = QUOTE(playMission [ARR_2('','PATHTOF(missions\Arsenal.VR)')]);
-                    animTextureNormal = QPATHTOF(data\buttonMissionMainMenu_ca.paa)
-                    animTextureDisabled = QPATHTOF(data\buttonMissionMainMenu_ca.paa)
-                    animTextureOver = QPATHTOF(data\buttonMissionMainMenuHover_ca.paa)
-                    animTextureFocused = QPATHTOF(data\buttonMissionMainMenuHover_ca.paa)
-                    animTexturePressed = QPATHTOF(data\buttonMissionMainMenu_ca.paa)
-                    animTextureDefault = QPATHTOF(data\buttonMissionMainMenu_ca.paa)
+                    animTextureNormal = QPATHTOF(data\buttonMissionMainMenu_ca.paa);
+                    animTextureDisabled = QPATHTOF(data\buttonMissionMainMenu_ca.paa);
+                    animTextureOver = QPATHTOF(data\buttonMissionMainMenuHover_ca.paa);
+                    animTextureFocused = QPATHTOF(data\buttonMissionMainMenuHover_ca.paa);
+                    animTexturePressed = QPATHTOF(data\buttonMissionMainMenu_ca.paa);
+                    animTextureDefault = QPATHTOF(data\buttonMissionMainMenu_ca.paa);
                 };
                 class FieldManual: Bootcamp {
                     y = "(4 *   1.5) *  (pixelH * pixelGrid * 2) +  (pixelH)";


### PR DESCRIPTION
`File z\ace\addons\arsenal\RscDisplayMain.hpp, line 20: '/RscDisplayMain/controls/GroupTutorials/Controls/ace_arsenal_mission.animTextureNormal': Missing ';' at the end of line`

