### PR TITLE
Add parentheses to GETVAR macros

### DIFF
--- a/addons/captives/XEH_postInit.sqf
+++ b/addons/captives/XEH_postInit.sqf
@@ -52,6 +52,6 @@ if (!hasInterface) exitWith {};
 {false},
 [DIK_F1, [true, false, false]], true] call CBA_fnc_addKeybind; // Shift + F1
 
-["isNotEscorting", {!(GETVAR(_this select 0,GVAR(isEscorting),false))}] call EFUNC(common,addCanInteractWithCondition);
-["isNotHandcuffed", {!(GETVAR(_this select 0,GVAR(isHandcuffed),false))}] call EFUNC(common,addCanInteractWithCondition);
-["isNotSurrendering", {!(GETVAR(_this select 0,GVAR(isSurrendering),false))}] call EFUNC(common,addCanInteractWithCondition);
+["isNotEscorting", {!GETVAR(_this select 0,GVAR(isEscorting),false)}] call EFUNC(common,addCanInteractWithCondition);
+["isNotHandcuffed", {!GETVAR(_this select 0,GVAR(isHandcuffed),false)}] call EFUNC(common,addCanInteractWithCondition);
+["isNotSurrendering", {!GETVAR(_this select 0,GVAR(isSurrendering),false)}] call EFUNC(common,addCanInteractWithCondition);

--- a/addons/captives/functions/fnc_doEscortCaptive.sqf
+++ b/addons/captives/functions/fnc_doEscortCaptive.sqf
@@ -32,7 +32,7 @@ if (_state) then {
     //Add Actionmenu to release captive
     private _actionID = _unit addAction [format ["<t color='#FF0000'>%1</t>", localize LSTRING(StopEscorting)],
     {[(_this select 0), ((_this select 0) getVariable [QGVAR(escortedUnit), objNull]), false] call FUNC(doEscortCaptive);},
-    nil, 20, false, true, "", QUOTE(!isNull (GETVAR(_target,QGVAR(escortedUnit),objNull)))];
+    nil, 20, false, true, "", QUOTE(!isNull GETVAR(_target,QGVAR(escortedUnit),objNull))];
 
     [{
         params ["_args", "_pfID"];

--- a/addons/common/functions/fnc_errorMessage.sqf
+++ b/addons/common/functions/fnc_errorMessage.sqf
@@ -38,7 +38,7 @@ if (_textMessage isEqualType "") then {
     _textMessage = parseText _textMessage;
 };
 
-(ARR_SELECT(_this,4,call BIS_fnc_displayMission)) createDisplay "RscDisplayCommonMessagePause";
+ARR_SELECT(_this,4,call BIS_fnc_displayMission) createDisplay "RscDisplayCommonMessagePause";
 
 private _display = uiNamespace getVariable "RscDisplayCommonMessage_display";
 private _ctrlRscMessageBox =          _display displayCtrl 2351;

--- a/addons/common/functions/fnc_isFeatureCameraActive.sqf
+++ b/addons/common/functions/fnc_isFeatureCameraActive.sqf
@@ -26,11 +26,11 @@
 
 !(
     isNull curatorCamera && // Curator
-    {!(GETMVAR(EGVAR(spectator,isSet),false))} && // ACE Spectator
-    {isNull (GETMVAR(BIS_EGSpectatorCamera_camera, objNull))} && // BIS Nexus Spectator
-    {isNull (GETUVAR(BIS_fnc_arsenal_cam, objNull))} && // Arsenal camera
-    {isNull (GETMVAR(BIS_fnc_establishingShot_fakeUAV, objNull))} && // Establishing shot camera
-    {isNull (GETMVAR(BIS_fnc_camera_cam, objNull))} && // Splendid camera
-    {isNull (GETUVAR(BIS_fnc_animViewer_cam, objNull))} && // Animation viewer camera
-    {isNull (GETMVAR(BIS_DEBUG_CAM, objNull))} // Classic camera
+    {!GETMVAR(EGVAR(spectator,isSet),false)} && // ACE Spectator
+    {isNull GETMVAR(BIS_EGSpectatorCamera_camera, objNull)} && // BIS Nexus Spectator
+    {isNull GETUVAR(BIS_fnc_arsenal_cam, objNull)} && // Arsenal camera
+    {isNull GETMVAR(BIS_fnc_establishingShot_fakeUAV, objNull)} && // Establishing shot camera
+    {isNull GETMVAR(BIS_fnc_camera_cam, objNull)} && // Splendid camera
+    {isNull GETUVAR(BIS_fnc_animViewer_cam, objNull)} && // Animation viewer camera
+    {isNull GETMVAR(BIS_DEBUG_CAM, objNull)} // Classic camera
 ) // return

--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -4,7 +4,7 @@ if (!hasInterface) exitWith {};
 
 ["ACE3 Common", QGVAR(wipeGlasses), localize LSTRING(WipeGlasses), {
     if (GVAR(effects) != 2) exitWith {false}; //Can only wipe if full effects setting is set
-    if (!(GETVAR(ace_player,ACE_isUnconscious,false))) exitWith {
+    if (!GETVAR(ace_player,ACE_isUnconscious,false)) exitWith {
         call FUNC(clearGlasses);
         true
     };

--- a/addons/goggles/script_component.hpp
+++ b/addons/goggles/script_component.hpp
@@ -37,6 +37,6 @@
 #define DBULLETS 2
 #define DAMOUNT 3
 
-#define GLASSDISPLAY (GETUVAR(GVAR(Display),displayNull))
+#define GLASSDISPLAY GETUVAR(GVAR(Display),displayNull)
 
 #define CLAMP(x,low,high) (if(x > high)then{high}else{if(x < low)then{low}else{x}})

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -20,11 +20,11 @@
 #define SETPVAR_SYS(var1,var2) setVariable [ARR_3(QUOTE(var1),var2,true)]
 
 #undef GETVAR
-#define GETVAR(var1,var2,var3) var1 GETVAR_SYS(var2,var3)
-#define GETMVAR(var1,var2) missionNamespace GETVAR_SYS(var1,var2)
-#define GETUVAR(var1,var2) uiNamespace GETVAR_SYS(var1,var2)
-#define GETPRVAR(var1,var2) profileNamespace GETVAR_SYS(var1,var2)
-#define GETPAVAR(var1,var2) parsingNamespace GETVAR_SYS(var1,var2)
+#define GETVAR(var1,var2,var3) (var1 GETVAR_SYS(var2,var3))
+#define GETMVAR(var1,var2) (missionNamespace GETVAR_SYS(var1,var2))
+#define GETUVAR(var1,var2) (uiNamespace GETVAR_SYS(var1,var2))
+#define GETPRVAR(var1,var2) (profileNamespace GETVAR_SYS(var1,var2))
+#define GETPAVAR(var1,var2) (parsingNamespace GETVAR_SYS(var1,var2))
 
 #undef SETVAR
 #define SETVAR(var1,var2,var3) var1 SETVAR_SYS(var2,var3)
@@ -37,7 +37,7 @@
 #define GETGVAR(var1,var2) GETMVAR(GVAR(var1),var2)
 #define GETEGVAR(var1,var2,var3) GETMVAR(EGVAR(var1,var2),var3)
 
-#define ARR_SELECT(ARRAY,INDEX,DEFAULT) if (count ARRAY > INDEX) then {ARRAY select INDEX} else {DEFAULT}
+#define ARR_SELECT(ARRAY,INDEX,DEFAULT) (if (count ARRAY > INDEX) then {ARRAY select INDEX} else {DEFAULT})
 
 
 #define MACRO_ADDWEAPON(WEAPON,COUNT) class _xx_##WEAPON { \

--- a/addons/parachute/functions/fnc_handleReserve.sqf
+++ b/addons/parachute/functions/fnc_handleReserve.sqf
@@ -25,7 +25,7 @@ if (
     {GETVAR(_unit,GVAR(hasReserve),false)}
 ) then {
     // Case where unit has just opened parachute and reserve should be added
-    _unit addBackpackGlobal (GETVAR(_unit,GVAR(backpackClass),"ACE_NonSteerableReserveParachute"));
+    _unit addBackpackGlobal GETVAR(_unit,GVAR(backpackClass),"ACE_NonSteerableReserveParachute");
     SETVAR(vehicle _unit,GVAR(canCut),true); // Mark the parachute cuttable since reserve is present
 } else {
     // Case where inventory has changed otherwise (including when reserve is added)

--- a/addons/tacticalladder/functions/fnc_handleInteractMenuOpened.sqf
+++ b/addons/tacticalladder/functions/fnc_handleInteractMenuOpened.sqf
@@ -17,6 +17,6 @@
 
 params ["_unit"];
 
-if (!isNull (GETMVAR(GVAR(ladder),objNull)) && {GVAR(ladder) in attachedObjects _unit}) then {
+if (!isNull GETMVAR(GVAR(ladder),objNull) && {GVAR(ladder) in attachedObjects _unit}) then {
     [_unit, GVAR(ladder)] call FUNC(cancelTLdeploy);
 };

--- a/addons/tacticalladder/functions/fnc_handleKilled.sqf
+++ b/addons/tacticalladder/functions/fnc_handleKilled.sqf
@@ -17,6 +17,6 @@
 
 params ["_unit"];
 
-if (!isNull (GETMVAR(ladder,objNull)) && {GVAR(ladder) in attachedObjects _unit}) then {
+if (!isNull GETMVAR(ladder,objNull) && {GVAR(ladder) in attachedObjects _unit}) then {
     [_unit, GVAR(ladder)] call FUNC(cancelTLdeploy);
 };

--- a/addons/tacticalladder/functions/fnc_handlePlayerChanged.sqf
+++ b/addons/tacticalladder/functions/fnc_handlePlayerChanged.sqf
@@ -16,7 +16,7 @@
 */
 #include "script_component.hpp"
 
-if (isNull (GETGVAR(ladder,objNull))) exitWith {};
+if (isNull GETGVAR(ladder,objNull)) exitWith {};
 
 params ["_newPlayer", "_oldPlayer"];
 

--- a/addons/tacticalladder/functions/fnc_handleUnconscious.sqf
+++ b/addons/tacticalladder/functions/fnc_handleUnconscious.sqf
@@ -19,6 +19,6 @@ params ["_unit"];
 
 if (!local _unit) exitWith {};
 
-if (!isNull (GETMVAR(ladder,objNull)) && {GVAR(ladder) in attachedObjects _unit}) then {
+if (!isNull GETMVAR(ladder,objNull) && {GVAR(ladder) in attachedObjects _unit}) then {
     [_unit, GVAR(ladder)] call FUNC(cancelTLdeploy);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- add parentheses to `GETVAR` and `ARR_SELECT` macros;
- remove superfluous parentheses in some scripts.