### PR TITLE
Fix typos in missile guidance framework wiki page

### DIFF
--- a/docs/wiki/framework/missile-guidance-framework.md
+++ b/docs/wiki/framework/missile-guidance-framework.md
@@ -88,8 +88,8 @@ class CfgAmmo {
 ### 4.2 Custom Seeker Types
 
 ```cpp
-class ace_missileguidance_attackProfiles {
-    class MyAttackProfile {
+class ace_missileguidance_seekerTypes {
+    class MySeekerType {
         name = "";  // Name
         visualName = "";  // Visual name
         description = "";  // Description
@@ -102,8 +102,8 @@ class ace_missileguidance_attackProfiles {
 ### 4.3 Custom Attack Profiles
 
 ```cpp
-class ace_missileguidance_seekerTypes {
-    class MySeekerType {
+class ace_missileguidance_attackProfiles {
+    class MyAttackProfile {
         name = "";  // Name
         visualName = "";  // Visual name
         description = "";  // Description


### PR DESCRIPTION
**When merged this pull request will:**
- In the code examples for seeker types and attack profiles config, class names were switched between both.