### PR TITLE
R3F compat: dispersion overhaul & AtragMx presets

### DIFF
--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -176,52 +176,12 @@ class CfgWeapons {
     class R3F_HK416M_M203: R3F_HK416M {
         muzzles[] = {"this","Lance_Grenades"};
     };
-    class R3F_HK416M_HG: R3F_HK416M {};
-    class R3F_HK416S_HG: R3F_HK416M_HG {
+    class R3F_HK416S_HG: R3F_HK416M {
         ACE_barrelLength = 279.4;
-        class Single: Mode_SemiAuto {
-            sounds[] = {"StandardSound","SilencedSound"};
-            class BaseSoundModeType {
-                weaponSoundEffect = "DefaultRifle";
-                closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
-                closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
-                soundClosure[] = {"closure1",0.5,"closure2",0.5};
-            };
-            class StandardSound: BaseSoundModeType {
-                begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
-                begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
-                begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
-                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-            };
-            class SilencedSound: BaseSoundModeType {
-                begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
-                begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
-                begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
-                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-            };
+        class Single: Single {
             dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
         };
-        class FullAuto: Mode_FullAuto {
-            sounds[] = {"StandardSound","SilencedSound"};
-            class BaseSoundModeType {
-                weaponSoundEffect = "DefaultRifle";
-                closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
-                closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
-                soundClosure[] = {"closure1",0.5,"closure2",0.5};
-                soundContinuous = 0;
-            };
-            class StandardSound: BaseSoundModeType {
-                begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
-                begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
-                begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
-                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-            };
-            class SilencedSound: BaseSoundModeType {
-                begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
-                begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
-                begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
-                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-            };
+        class FullAuto: FullAuto {
             dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.005 (17.2 MOA)
         };
     };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -52,6 +52,7 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 5.14504;
         ACE_barrelTwist = 177.8; // 1:7"
         ACE_barrelLength = 450.0; // Beretta barrel
+        // Fix a ghost mag in the VA with the FAMAS FELIN: default magazines[]={...,"",...}
         magazines[] = {
 			"R3F_25Rnd_556x45_FAMAS",
 			"R3F_30Rnd_556x45_FAMAS",
@@ -113,7 +114,7 @@ class CfgWeapons {
     };
     class R3F_Minimi_HG: R3F_Minimi {
         class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.92); // 3.41 MOA*0.5621.92, R3F default value 0.0008 (2.75 MOA)
+            dispersion = MOA_TO_RAD(1.92); // 3.41 MOA*0.562, R3F default value 0.0008 (2.75 MOA)
         };
     };
     class R3F_Minimi_762: R3F_Minimi {
@@ -509,5 +510,27 @@ class CfgWeapons {
                 maxRangeProbabCoef = "1.0f";
             };
         };
+    };
+};
+class ACE_ATragMX_Presets {
+    class R3F_PGM_Hecate_II {
+        // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
+        preset[] = {"[R3F]PGM", 780, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15,753},{0,760},{10,767},{15,772},{25,786},{30,795},{35,806}}, {{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}}};
+    };
+    class R3F_M107 {
+        // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
+        preset[] = {"[R3F]M107", 850, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15,823},{0,830},{10,837},{15,842},{25,856},{30,865},{35,876}}, {{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}}};
+    };
+    class R3F_TAC50 {
+        // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
+        preset[] = {"[R3F]TAC50", 820, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15,793},{0,800},{10,807},{15,812},{25,826},{30,835},{35,846}}, {{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}}};
+    };
+    class R3F_FRF2 {
+        // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
+        preset[] = {"[R3F]FRF2", 850, 100, 0.0909184, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 29.46, 0.398, 1, "ICAO", {{-15,823},{0,830},{10,837},{15,842},{25,856},{30,865},{35,876}}, {{0, 0.399}, {810, 0.392}, {1030, 0.383}, {1120, 0.381}, {1270, 0.380}, {1410, 0.379}, {1530, 0.379}}};
+    };
+    class R3F_HK417L {
+        // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
+        preset[] = {"[R3F]HK417L", 820, 100, 0.0909184, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 29.46, 0.398, 1, "ICAO", {{-15,793},{0,800},{10,807},{15,812},{25,826},{30,835},{35,846}}, {{0, 0.399}, {810, 0.392}, {1030, 0.383}, {1120, 0.381}, {1270, 0.380}, {1410, 0.379}, {1530, 0.379}}};
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -1,4 +1,6 @@
 class Mode_SemiAuto;
+class Mode_Burst;
+class Mode_FullAuto;
 
 class CfgWeapons {
     class Pistol_Base_F;
@@ -8,6 +10,15 @@ class CfgWeapons {
         ACE_barrelTwist = 304.8; // 1:12"
         ACE_barrelLength = 488.0;
         muzzles[] = {"this"};
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+        };
+        class Burst: Mode_Burst {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.0035 (12 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+        };
     };
     class R3F_Famas_F1_M203: R3F_Famas_F1 {
         muzzles[] = {"this","Lance_Grenades"};
@@ -24,6 +35,15 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 10.1808;
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 488.0;
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+        };
+        class Burst: Mode_Burst {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.0035 (12 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+        };
     };
     class R3F_Famas_G2_M203: R3F_Famas_G2 {
         muzzles[] = {"this","Lance_Grenades"};
@@ -38,7 +58,7 @@ class CfgWeapons {
         ACE_barrelTwist = 294.6;
         ACE_barrelLength = 650.0;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; // 1 MOA, default 9.9999997e-005
+            dispersion = MOA_TO_RAD(0.73); // R3F default value 9.9999997e-005 (0.34 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -47,7 +67,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; // 1 MOA, default 0.00018
+            dispersion = MOA_TO_RAD(0.40); // R3F default value 0.00018 (0.62 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -56,7 +76,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; // 1 MOA, default 0.00030
+            dispersion = MOA_TO_RAD(0.45); // R3F default value 0.00030 (1.03 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -65,7 +85,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; // 1 MOA, default 0.00015
+            dispersion = MOA_TO_RAD(0.40); // R3F default value 0.00015 (0.52 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -75,32 +95,57 @@ class CfgWeapons {
         ACE_barrelLength = 347.98;
         muzzles[] = {"this"};
         initSpeed = 915; // R3F config
+        class manual: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(1.55); // R3F default value 0.0008 (2.75 MOA)
+        };
+    };
+    class R3F_Minimi_HG: R3F_Minimi {
+        class manual: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(1.55); // R3F default value 0.0008 (2.75 MOA)
+        };
     };
     class R3F_Minimi_762: R3F_Minimi {
         ACE_RailHeightAboveBore = 3.80834;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 502.92;
         initSpeed = 820; // R3F config
+        class manual: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(3.87); // R3F default value 0.002 (6.88 MOA)
+        };
     };
-    class R3F_SIG551: Rifle_Base_F {
-        ACE_RailHeightAboveBore = 3.95288;
-        ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 363.0;
-        muzzles[] = {"this"};
-    };
+    class R3F_Minimi_762_HG: R3F_Minimi_762 {
+        class manual: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(3.87); // R3F default value 0.002 (6.88 MOA)
+        };
+	};
     class R3F_HK417M: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.23377;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 406.0;
         muzzles[] = {"this"};
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.001 (3.44 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.0025 (8.6 MOA)
+        };
     };
     class R3F_HK417S_HG: R3F_HK417M {
         ACE_barrelLength = 305.0;
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.002 (6.88 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.007 (24.06 MOA)
+        };
     };
     class R3F_HK417L: R3F_HK417M {
         ACE_barrelLength = 508.0;
         class Single: Mode_SemiAuto {
-            dispersion = 0.00029; // 1 MOA, default 0.00020
+            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.0002 (0.69 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.0025 (8.6 MOA)
         };
     };
     class R3F_HK416M: Rifle_Base_F {
@@ -108,6 +153,12 @@ class CfgWeapons {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
         muzzles[] = {"this"};
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+        };
     };
     class R3F_HK416M_M203: R3F_HK416M {
         muzzles[] = {"this","Lance_Grenades"};
@@ -116,15 +167,39 @@ class CfgWeapons {
     class R3F_HK416S_HG: R3F_HK416M_HG {
         ACE_barrelLength = 279.4;
     };
+    class R3F_SIG551: Rifle_Base_F {
+        ACE_RailHeightAboveBore = 3.95288;
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 363.0;
+        muzzles[] = {"this"};
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+        };
+    };
     class R3F_MP5SD: Rifle_Base_F {
         ACE_RailHeightAboveBore = 4.21816;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 144.78;
         muzzles[] = {"this"};
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.004 (13.75 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.007 (24.06 MOA)
+        };
     };
     class R3F_MP5A5: R3F_MP5SD {
         ACE_barrelLength = 226.06;
         muzzles[] = {"this"};
+        class Single: Mode_SemiAuto {
+            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.004 (13.75 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.007 (24.06 MOA)
+        };
     };
     class R3F_M4S90: Rifle_Base_F {
         ACE_RailHeightAboveBore = 1.86213;
@@ -152,7 +227,7 @@ class CfgWeapons {
     class R3F_EOTECH: ItemCore {
         ACE_ScopeHeightAboveRail = 4.25923;
     };
-    class R3F_J4: ItemCore {
+    class R3F_J4: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Riflescope_LTE_J4_Datasheet_GB.pdf
         ACE_ScopeHeightAboveRail = 3.20641;
         ACE_ScopeAdjust_Vertical[] = {-8, 8};
         ACE_ScopeAdjust_Horizontal[] = {-8, 8};
@@ -173,7 +248,7 @@ class CfgWeapons {
     class R3F_FELIN_FRF2: ItemCore {
         ACE_ScopeHeightAboveRail = 4.28091;
     };
-    class R3F_J8: ItemCore {
+    class R3F_J8: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
         ACE_ScopeHeightAboveRail = 4.474;
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
@@ -202,7 +277,7 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_J10: ItemCore {
+    class R3F_J10: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
         ACE_ScopeZeroRange = 1400; // Inaccurate reticle, designed to work with the vanilla ballistic.
         ACE_ScopeHeightAboveRail = 4.474;
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
@@ -233,12 +308,12 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_ZEISS: ItemCore {
+    class R3F_ZEISS: ItemCore { // https://www.hensoldt.net/fileadmin/hensoldt/Datenbl%C3%A4tter/En/0714_SL_0817_9-6-24x72_6-24x56_EN_LoRes.pdf#page=2
         ACE_ScopeHeightAboveRail = 4.96547;
-        ACE_ScopeAdjust_Vertical[] = {0, 23};
-        ACE_ScopeAdjust_Horizontal[] = {-7, 7};
-        ACE_ScopeAdjust_VerticalIncrement = 0.1;
-        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        ACE_ScopeAdjust_Vertical[] = {0, 16};
+        ACE_ScopeAdjust_Horizontal[] = {-5, 5};
+        ACE_ScopeAdjust_VerticalIncrement = 0.05;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.05;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class ZEISS_MILDOT {
@@ -248,7 +323,7 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_NF: ItemCore {
+    class R3F_NF: ItemCore { // http://nightforceoptics.com/nxs/3-5-15x56
         ACE_ScopeHeightAboveRail = 4.30469;
         ACE_ScopeAdjust_Vertical[] = {0, 30};
         ACE_ScopeAdjust_Horizontal[] = {-11, 11};
@@ -263,10 +338,10 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_NF42: ItemCore {
+    class R3F_NF42: ItemCore { // http://nightforceoptics.com/nxs/12-42x56
         ACE_ScopeHeightAboveRail = 4.30469;
-        ACE_ScopeAdjust_Vertical[] = {0, 24};
-        ACE_ScopeAdjust_Horizontal[] = {-9, 9};
+        ACE_ScopeAdjust_Vertical[] = {0, 12};
+        ACE_ScopeAdjust_Horizontal[] = {-5, 5};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo: InventoryOpticsItem_Base_F {

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -11,13 +11,13 @@ class CfgWeapons {
         ACE_barrelLength = 488.0;
         muzzles[] = {"this"};
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
         };
         class Burst: Mode_Burst {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.0035 (12 MOA)
+            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.0035 (12 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.005 (17.2 MOA)
         };
     };
     class R3F_Famas_F1_M203: R3F_Famas_F1 {
@@ -36,13 +36,13 @@ class CfgWeapons {
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 488.0;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
         };
         class Burst: Mode_Burst {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.0035 (12 MOA)
+            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.0035 (12 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.005 (17.2 MOA)
         };
     };
     class R3F_Famas_G2_M203: R3F_Famas_G2 {
@@ -52,13 +52,25 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 5.14504;
         ACE_barrelTwist = 177.8; // 1:7"
         ACE_barrelLength = 450.0; // Beretta barrel
+        magazines[] = {
+			"R3F_25Rnd_556x45_FAMAS",
+			"R3F_30Rnd_556x45_FAMAS",
+			"R3F_25Rnd_556x45_TRACER_FAMAS",
+			"R3F_30Rnd_556x45_TRACER_FAMAS",
+			"R3F_30Rnd_556x45_HK416",
+			"R3F_30Rnd_556x45_tracer_hk416",
+			"30Rnd_556x45_Stanag",
+			"30Rnd_556x45_Stanag_Tracer_Red",
+			"30Rnd_556x45_Stanag_Tracer_Green",
+			"30Rnd_556x45_Stanag_Tracer_Yellow"
+		};
     };
     class R3F_FRF2: Rifle_Base_F {
         ACE_RailHeightAboveBore = 1.79013;
         ACE_barrelTwist = 294.6;
         ACE_barrelLength = 650.0;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.73); // R3F default value 9.9999997e-005 (0.34 MOA)
+            dispersion = MOA_TO_RAD(0.88); // 1.56 MOA*0.562, R3F default value 9.9999997e-005 (0.34 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -67,7 +79,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.40); // R3F default value 0.00018 (0.62 MOA)
+            dispersion = MOA_TO_RAD(0.58); // 1.04 MOA*0.562, R3F default value 0.00018 (0.62 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -76,7 +88,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.45); // R3F default value 0.00030 (1.03 MOA)
+            dispersion = MOA_TO_RAD(0.5); // 0.9 MOA*0.562, R3F default value 0.00030 (1.03 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -85,7 +97,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.40); // R3F default value 0.00015 (0.52 MOA)
+            dispersion = MOA_TO_RAD(0.53); // 0.95 MOA*0.562, R3F default value 0.00015 (0.52 MOA)
         };
         muzzles[] = {"this"};
     };
@@ -96,12 +108,12 @@ class CfgWeapons {
         muzzles[] = {"this"};
         initSpeed = 915; // R3F config
         class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.55); // R3F default value 0.0008 (2.75 MOA)
+            dispersion = MOA_TO_RAD(1.92); // 3.41 MOA*0.562, R3F default value 0.0008 (2.75 MOA)
         };
     };
     class R3F_Minimi_HG: R3F_Minimi {
         class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.55); // R3F default value 0.0008 (2.75 MOA)
+            dispersion = MOA_TO_RAD(1.92); // 3.41 MOA*0.5621.92, R3F default value 0.0008 (2.75 MOA)
         };
     };
     class R3F_Minimi_762: R3F_Minimi {
@@ -110,12 +122,12 @@ class CfgWeapons {
         ACE_barrelLength = 502.92;
         initSpeed = 820; // R3F config
         class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(3.87); // R3F default value 0.002 (6.88 MOA)
+            dispersion = MOA_TO_RAD(1.56); // 2.77 MOA*0.562, R3F default value 0.002 (6.88 MOA)
         };
     };
     class R3F_Minimi_762_HG: R3F_Minimi_762 {
         class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(3.87); // R3F default value 0.002 (6.88 MOA)
+            dispersion = MOA_TO_RAD(1.56); // 2.77 MOA*0.562, R3F default value 0.002 (6.88 MOA)
         };
 	};
     class R3F_HK417M: Rifle_Base_F {
@@ -124,28 +136,28 @@ class CfgWeapons {
         ACE_barrelLength = 406.0;
         muzzles[] = {"this"};
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.001 (3.44 MOA)
+            dispersion = MOA_TO_RAD(1.62); // 2.89 MOA*0.562, R3F default value 0.001 (3.44 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.0025 (8.6 MOA)
+            dispersion = MOA_TO_RAD(1.62); // 2.89 MOA*0.562, R3F default value 0.0025 (8.6 MOA)
         };
     };
     class R3F_HK417S_HG: R3F_HK417M {
         ACE_barrelLength = 305.0;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.002 (6.88 MOA)
+            dispersion = MOA_TO_RAD(1.9); // 3.4 MOA*0.562, R3F default value 0.002 (6.88 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.007 (24.06 MOA)
+            dispersion = MOA_TO_RAD(1.9); // 3.4 MOA*0.562, R3F default value 0.007 (24.06 MOA)
         };
     };
     class R3F_HK417L: R3F_HK417M {
         ACE_barrelLength = 508.0;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.0002 (0.69 MOA)
+            dispersion = MOA_TO_RAD(0.93); // 1.66 MOA*0.562, R3F default value 0.0002 (0.69 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81); // R3F default value 0.0025 (8.6 MOA)
+            dispersion = MOA_TO_RAD(0.93); // 1.66 MOA*0.562, R3F default value 0.0025 (8.6 MOA)
         };
     };
     class R3F_HK416M: Rifle_Base_F {
@@ -154,10 +166,10 @@ class CfgWeapons {
         ACE_barrelLength = 368.3;
         muzzles[] = {"this"};
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+            dispersion = MOA_TO_RAD(1.87); // 3.32 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+            dispersion = MOA_TO_RAD(1.87); // 3.32 MOA*0.562, R3F default value 0.005 (17.2 MOA)
         };
     };
     class R3F_HK416M_M203: R3F_HK416M {
@@ -166,6 +178,51 @@ class CfgWeapons {
     class R3F_HK416M_HG: R3F_HK416M {};
     class R3F_HK416S_HG: R3F_HK416M_HG {
         ACE_barrelLength = 279.4;
+        class Single: Mode_SemiAuto {
+            sounds[] = {"StandardSound","SilencedSound"};
+			class BaseSoundModeType {
+				weaponSoundEffect = "DefaultRifle";
+				closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
+				closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
+				soundClosure[] = {"closure1",0.5,"closure2",0.5};
+			};
+			class StandardSound: BaseSoundModeType {
+				begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
+				begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
+				begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
+				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+			};
+			class SilencedSound: BaseSoundModeType {
+				begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
+				begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
+				begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
+				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+			};
+            dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
+        };
+        class FullAuto: Mode_FullAuto {
+            sounds[] = {"StandardSound","SilencedSound"};
+			class BaseSoundModeType {
+				weaponSoundEffect = "DefaultRifle";
+				closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
+				closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
+				soundClosure[] = {"closure1",0.5,"closure2",0.5};
+				soundContinuous = 0;
+			};
+			class StandardSound: BaseSoundModeType {
+				begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
+				begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
+				begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
+				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+			};
+			class SilencedSound: BaseSoundModeType {
+				begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
+				begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
+				begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
+				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+			};
+            dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.005 (17.2 MOA)
+        };
     };
     class R3F_SIG551: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.95288;
@@ -173,10 +230,10 @@ class CfgWeapons {
         ACE_barrelLength = 363.0;
         muzzles[] = {"this"};
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.00087 (2.99 MOA)
+            dispersion = MOA_TO_RAD(1.88); // 3.34 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12); // R3F default value 0.005 (17.2 MOA)
+            dispersion = MOA_TO_RAD(1.88); // 3.34 MOA*0.562, R3F default value 0.005 (17.2 MOA)
         };
     };
     class R3F_MP5SD: Rifle_Base_F {
@@ -185,20 +242,20 @@ class CfgWeapons {
         ACE_barrelLength = 144.78;
         muzzles[] = {"this"};
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.004 (13.75 MOA)
+            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.004 (13.75 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.007 (24.06 MOA)
+            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.007 (24.06 MOA)
         };
     };
     class R3F_MP5A5: R3F_MP5SD {
         ACE_barrelLength = 226.06;
         muzzles[] = {"this"};
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.004 (13.75 MOA)
+            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.004 (13.75 MOA)
         };
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(7.73); // R3F default value 0.007 (24.06 MOA)
+            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.007 (24.06 MOA)
         };
     };
     class R3F_M4S90: Rifle_Base_F {
@@ -229,7 +286,7 @@ class CfgWeapons {
     };
     class R3F_J4: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Riflescope_LTE_J4_Datasheet_GB.pdf
         ACE_ScopeHeightAboveRail = 3.20641;
-        ACE_ScopeAdjust_Vertical[] = {-8, 8};
+        ACE_ScopeAdjust_Vertical[] = {0, 16};
         ACE_ScopeAdjust_Horizontal[] = {-8, 8};
         ACE_ScopeAdjust_VerticalIncrement = 0.2;
         ACE_ScopeAdjust_HorizontalIncrement = 0.2;
@@ -250,7 +307,7 @@ class CfgWeapons {
     };
     class R3F_J8: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
         ACE_ScopeHeightAboveRail = 4.474;
-        ACE_ScopeAdjust_Vertical[] = {-10, 10};
+        ACE_ScopeAdjust_Vertical[] = {0, 20};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
@@ -263,8 +320,8 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_J8_MILDOT: R3F_J8 { // Scope rail 30 MOA
-        ACE_ScopeAdjust_Vertical[] = {-2, 18};
+    class R3F_J8_MILDOT: R3F_J8 {
+        ACE_ScopeAdjust_Vertical[] = {0, 20};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
@@ -280,7 +337,7 @@ class CfgWeapons {
     class R3F_J10: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
         ACE_ScopeZeroRange = 1400; // Inaccurate reticle, designed to work with the vanilla ballistic.
         ACE_ScopeHeightAboveRail = 4.474;
-        ACE_ScopeAdjust_Vertical[] = {-10, 10};
+        ACE_ScopeAdjust_Vertical[] = {0, 20};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
@@ -293,9 +350,9 @@ class CfgWeapons {
             };
         };
     };
-    class R3F_J10_MILDOT: R3F_J10 { // Scope rail 30 MOA
+    class R3F_J10_MILDOT: R3F_J10 {
         ACE_ScopeZeroRange = 100;
-        ACE_ScopeAdjust_Vertical[] = {-2, 18};
+        ACE_ScopeAdjust_Vertical[] = {0, 20};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
@@ -311,7 +368,7 @@ class CfgWeapons {
     class R3F_ZEISS: ItemCore { // https://www.hensoldt.net/fileadmin/hensoldt/Datenbl%C3%A4tter/En/0714_SL_0817_9-6-24x72_6-24x56_EN_LoRes.pdf#page=2
         ACE_ScopeHeightAboveRail = 4.96547;
         ACE_ScopeAdjust_Vertical[] = {0, 16};
-        ACE_ScopeAdjust_Horizontal[] = {-5, 5};
+        ACE_ScopeAdjust_Horizontal[] = {-3.5, 3.5}; // {-5,5} for the Hensoldt but {-3.5,3.5} for the Zeiss according with the official documentation.
         ACE_ScopeAdjust_VerticalIncrement = 0.05;
         ACE_ScopeAdjust_HorizontalIncrement = 0.05;
         class ItemInfo: InventoryOpticsItem_Base_F {

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -130,7 +130,7 @@ class CfgWeapons {
         class manual: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.56); // 2.77 MOA*0.562, R3F default value 0.002 (6.88 MOA)
         };
-	};
+    };
     class R3F_HK417M: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.23377;
         ACE_barrelTwist = 279.4;

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -54,17 +54,17 @@ class CfgWeapons {
         ACE_barrelLength = 450.0; // Beretta barrel
         // Fix a ghost mag in the VA with the FAMAS FELIN: default magazines[]={...,"",...}
         magazines[] = {
-			"R3F_25Rnd_556x45_FAMAS",
-			"R3F_30Rnd_556x45_FAMAS",
-			"R3F_25Rnd_556x45_TRACER_FAMAS",
-			"R3F_30Rnd_556x45_TRACER_FAMAS",
-			"R3F_30Rnd_556x45_HK416",
-			"R3F_30Rnd_556x45_tracer_hk416",
-			"30Rnd_556x45_Stanag",
-			"30Rnd_556x45_Stanag_Tracer_Red",
-			"30Rnd_556x45_Stanag_Tracer_Green",
-			"30Rnd_556x45_Stanag_Tracer_Yellow"
-		};
+            "R3F_25Rnd_556x45_FAMAS",
+            "R3F_30Rnd_556x45_FAMAS",
+            "R3F_25Rnd_556x45_TRACER_FAMAS",
+            "R3F_30Rnd_556x45_TRACER_FAMAS",
+            "R3F_30Rnd_556x45_HK416",
+            "R3F_30Rnd_556x45_tracer_hk416",
+            "30Rnd_556x45_Stanag",
+            "30Rnd_556x45_Stanag_Tracer_Red",
+            "30Rnd_556x45_Stanag_Tracer_Green",
+            "30Rnd_556x45_Stanag_Tracer_Yellow"
+        };
     };
     class R3F_FRF2: Rifle_Base_F {
         ACE_RailHeightAboveBore = 1.79013;
@@ -181,47 +181,47 @@ class CfgWeapons {
         ACE_barrelLength = 279.4;
         class Single: Mode_SemiAuto {
             sounds[] = {"StandardSound","SilencedSound"};
-			class BaseSoundModeType {
-				weaponSoundEffect = "DefaultRifle";
-				closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
-				closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
-				soundClosure[] = {"closure1",0.5,"closure2",0.5};
-			};
-			class StandardSound: BaseSoundModeType {
-				begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
-				begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
-				begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
-				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-			};
-			class SilencedSound: BaseSoundModeType {
-				begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
-				begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
-				begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
-				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-			};
+            class BaseSoundModeType {
+                weaponSoundEffect = "DefaultRifle";
+                closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
+                closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
+                soundClosure[] = {"closure1",0.5,"closure2",0.5};
+            };
+            class StandardSound: BaseSoundModeType {
+                begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
+                begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
+                begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
+                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+            };
+            class SilencedSound: BaseSoundModeType {
+                begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
+                begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
+                begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
+                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+            };
             dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
         };
         class FullAuto: Mode_FullAuto {
             sounds[] = {"StandardSound","SilencedSound"};
-			class BaseSoundModeType {
-				weaponSoundEffect = "DefaultRifle";
-				closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
-				closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
-				soundClosure[] = {"closure1",0.5,"closure2",0.5};
-				soundContinuous = 0;
-			};
-			class StandardSound: BaseSoundModeType {
-				begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
-				begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
-				begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
-				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-			};
-			class SilencedSound: BaseSoundModeType {
-				begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
-				begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
-				begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
-				soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
-			};
+            class BaseSoundModeType {
+                weaponSoundEffect = "DefaultRifle";
+                closure1[] = {"A3\sounds_f\weapons\closure\closure_rifle_6",0.38999999,1,30};
+                closure2[] = {"A3\sounds_f\weapons\closure\closure_rifle_7",0.38999999,1,30};
+                soundClosure[] = {"closure1",0.5,"closure2",0.5};
+                soundContinuous = 0;
+            };
+            class StandardSound: BaseSoundModeType {
+                begin1[] = {"\r3f_armes\sons\hk416_1",3.5,1,1200};
+                begin2[] = {"\r3f_armes\sons\hk416_2",3.5,1,1200};
+                begin3[] = {"\r3f_armes\sons\hk416_3",3.5,1,1200};
+                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+            };
+            class SilencedSound: BaseSoundModeType {
+                begin1[] = {"A3\sounds_f\weapons\silenced\silent-18",0.80000001,1,300};
+                begin2[] = {"A3\sounds_f\weapons\silenced\silent-19",0.80000001,1,300};
+                begin3[] = {"A3\sounds_f\weapons\silenced\silent-11",0.80000001,1,300};
+                soundBegin[] = {"begin1",0.333,"begin2",0.333,"begin3",0.333};
+            };
             dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.005 (17.2 MOA)
         };
     };
@@ -512,6 +512,7 @@ class CfgWeapons {
         };
     };
 };
+
 class ACE_ATragMX_Presets {
     class R3F_PGM_Hecate_II {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation


### PR DESCRIPTION
- Dispersion overhaul for all R3F rifles :
    - Assuming that a dispersion depends of many, many parameters (rifle/ammo harmonisation, position, supports or not, shooter, etc ...).
    - Assuming that a dispersion is not a constant value but increases with the distance.
    - Assuming that a bipod is not a Bench Rest support.
    - Assuming that all muzzles velocities are correct with RL values.
    - According with https://github.com/acemod/ACE3/pull/5755 and the `0.562` value (should be increased a little bit imo).

For all rifles, I got the corresponding distance at the end of the supersonic domain (approximately Mach 1.2 or 408 m/s at the normal conditions) with Strelok Pro and applied a dispersion's square of 50/50 cm for the assault rifles, a dispersion's square of 30/30 cm for the Marksman and Sniper rifles.

By this way, i obtain a dispersion around 3 MOA for the assault rifles, 1.5 MOA for the Marksman rifles, 1 MOA for the Sniper rifles.

> Example with the added HK416 S (11" barrel) dispersion : 
408 m/s at the normal conditions = 455 meters, with a dispersion's square of 50/50 cm -> 3.78 MOA.
3.78 x 0.562 =  2.12 MOA, the effective dispersion in-game.

The goal isn't an utopian "real" dispersion but something coherent with military shooting and the (splendid) ArmA 3 dispersion system.

- AtragMx presets according with the [ATragMX Framework](https://ace3mod.com/wiki/framework/atragmx.html).
- Vertical and horizontal increments updated for the Zeiss scope.
- Fix a "ghost" magazine with the FAMAS FELIN.
- Minor changes for sniper scopes.
- And Space Wars ! 

*May the Force be with you !*
