### PR TITLE
Deprecate common function numberToDigitsString

### DIFF
--- a/addons/common/functions/fnc_numberToDigits.sqf
+++ b/addons/common/functions/fnc_numberToDigits.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: commy2
+ * Author: commy2, SilentSpike
  * Transforms a number to an array of the correspondending digits.
  *
  * Arguments:
@@ -18,24 +18,6 @@
 
 params ["_number", "_minLength"];
 
-_number = _number min 999999;
-_number = str _number;
+_number = [_number min 999999, _minLength] call CBA_fnc_formatNumber;
 
-private _length = count _number;
-
-if (isNil "_minLength") then {_minLength = _length};
-
-_minLength = _minLength min 6;
-
-while {_length < _minLength} do {
-    _number = "0" + _number;
-    _length = _length + 1;
-};
-
-private _digits = [];
-
-for "_x" from 0 to (_length - 1) do {
-    _digits pushBack parseNumber (_number select [_x, 1]);
-};
-
-_digits
+(_number splitString "") apply { parseNumber _x }

--- a/addons/common/functions/fnc_numberToDigitsString.sqf
+++ b/addons/common/functions/fnc_numberToDigitsString.sqf
@@ -16,6 +16,6 @@
  */
 #include "script_component.hpp"
 
-ACE_DEPRECATED(QFUNC(numberToDigitsString),"3.14.0",CBA_fnc_formatNumber);
+ACE_DEPRECATED(QFUNC(numberToDigitsString),"3.14.0","CBA_fnc_formatNumber");
 
 _this call CBA_fnc_formatNumber

--- a/addons/common/functions/fnc_numberToDigitsString.sqf
+++ b/addons/common/functions/fnc_numberToDigitsString.sqf
@@ -16,20 +16,6 @@
  */
 #include "script_component.hpp"
 
-params ["_number", "_minLength"];
+ACE_DEPRECATED(QFUNC(numberToDigitsString),"3.14.0",CBA_fnc_formatNumber);
 
-_number = _number min 999999;
-_number = str _number;
-
-private _length = count _number;
-
-if (isNil "_minLength") then {_minLength = _length};
-
-_minLength = _minLength min 6;
-
-while {_length < _minLength} do {
-    _number = "0" + _number;
-    _length = _length + 1;
-};
-
-_number
+_this call CBA_fnc_formatNumber

--- a/addons/parachute/functions/fnc_showAltimeter.sqf
+++ b/addons/parachute/functions/fnc_showAltimeter.sqf
@@ -40,7 +40,7 @@ GVAR(AltimeterActive) = true;
     private _timeDiff = _curTime - _prevTime;
     private _descentRate = if (_timeDiff > 0) then {floor((_oldHeight - _height) / _timeDiff)} else {0};
 
-    _TimeText ctrlSetText (format ["%1:%2",[_hour, 2] call EFUNC(common,numberToDigitsString),[_minute, 2] call EFUNC(common,numberToDigitsString)]);
+    _TimeText ctrlSetText (format ["%1:%2", [_hour, 2] call CBA_fnc_formatNumber, [_minute, 2] call CBA_fnc_formatNumber]);
     _HeightText ctrlSetText (format ["%1", floor _height]);
     _DecendRate ctrlSetText (format ["%1", _descentRate max 0]);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Deprecate common function `numberToDigitsString` in favour of `CBA_fnc_formatNumber`
- Optimise common function `numberToDigits`
