### PR TITLE
Center spectator map correctly in FPP

### DIFF
--- a/addons/spectator/functions/fnc_ui_toggleMap.sqf
+++ b/addons/spectator/functions/fnc_ui_toggleMap.sqf
@@ -32,7 +32,8 @@ if (GVAR(uiMapVisible)) then {
     CTRL_MAP_TITLE ctrlSetText (getMissionConfigValue ["onLoadName", getMissionConfigValue ["briefingName", localize ELSTRING(common,unknown)]]);
     CTRL_MAP_SPEC_NUM ctrlSetText str ({GETVAR(_x,GVAR(isSet),false)} count allPlayers);
 
-    CTRL_MAP ctrlMapAnimAdd [0, 0.05, getPosASLVisual GVAR(camera)];
+    // Center on camera position (accounts for first person)
+    CTRL_MAP ctrlMapAnimAdd [0, 0.05, positionCameraToWorld [0,0,0]];
     ctrlMapAnimCommit CTRL_MAP;
 
     // Disable camera input while map is open


### PR DESCRIPTION
Instead of centering on the camera object use `positionCameraToWorld` to
get the actual viewpoint