### PR TITLE
NVG - Fix grain and color effects

### DIFF
--- a/addons/nightvision/CfgEventHandlers.hpp
+++ b/addons/nightvision/CfgEventHandlers.hpp
@@ -13,3 +13,10 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };
+
+// In SP-Editor, opening escape menu will break nvg grain effect
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayInterrupt {
+        GVAR(resetGrain) = QUOTE(if (GVAR(ppeffectGrain) > -1) then {ppEffectDestroy GVAR(ppeffectGrain);};);
+    };
+};

--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -20,7 +20,6 @@ GVAR(ppeffectGrain) = -1;
 GVAR(ppeffectRadialBlur) = -1;
 GVAR(ppeffectColorCorrect) = -1;
 GVAR(ppeffectBlur) = -1;
-GVAR(ppEffectCCMuzzleFlash) = -1;
 
 
 ["ace_settingsInitialized", {

--- a/addons/nightvision/functions/fnc_onFiredPlayer.sqf
+++ b/addons/nightvision/functions/fnc_onFiredPlayer.sqf
@@ -55,12 +55,7 @@ TRACE_1("final", _visibleFire);
 if (_visibleFire <= 1.5) exitWith {};
 if ((random (linearConversion [1, 4, GVAR(nvgGeneration), 10, 20])) > _visibleFire) exitWith {};
 
-GVAR(ppEffectCCMuzzleFlash) = ppEffectCreate ["ColorCorrections", 1237];
-GVAR(ppEffectCCMuzzleFlash) ppEffectEnable true;
-GVAR(ppEffectCCMuzzleFlash) ppEffectForceInNVG true;
-
-GVAR(ppEffectCCMuzzleFlash) ppEffectAdjust [1, 1, -1, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
-GVAR(ppEffectCCMuzzleFlash) ppEffectCommit 0;
-
-GVAR(ppEffectCCMuzzleFlash) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]];
-GVAR(ppEffectCCMuzzleFlash) ppEffectCommit 0.07;
+QGVAR(cutoff) cutText ["", "BLACK", .1];
+[{
+   QGVAR(cutoff) cutText ["", "PLAIN", 0];
+}, [], 0.07] call CBA_fnc_waitAndExecute;

--- a/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
+++ b/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
@@ -71,7 +71,3 @@ if (GVAR(ppeffectColorCorrect) != -1) then {
     ppEffectDestroy GVAR(ppeffectColorCorrect);
     GVAR(ppeffectColorCorrect) = -1;
 };
-if (GVAR(ppEffectCCMuzzleFlash) != -1) then {
-    ppEffectDestroy GVAR(ppEffectCCMuzzleFlash);
-    GVAR(ppEffectCCMuzzleFlash) = -1;
-};


### PR DESCRIPTION
Fix #6017 - Delete grain effect when opening escape menu in SP
Fix #5961 - Just use `cutText`