### PR TITLE
Optimise spectator loops

### DIFF
--- a/addons/spectator/functions/fnc_respawnTemplate.sqf
+++ b/addons/spectator/functions/fnc_respawnTemplate.sqf
@@ -12,7 +12,7 @@
  * 3: Respawn Delay <NUMBER>
  *
  * Return Value:
- * None <NIL>
+ * None
  *
  * Example:
  * [bob, kevin, 3, 6] call ace_spectator_fnc_respawnTemplate

--- a/addons/spectator/functions/fnc_ui_draw3D.sqf
+++ b/addons/spectator/functions/fnc_ui_draw3D.sqf
@@ -72,8 +72,6 @@ if !(GVAR(uiMapVisible)) then {
 
             // Draw icon
             drawIcon3D _icon;
-
-            nil // Speed loop
         } count GVAR(iconsToDraw);
         END_COUNTER(drawTags);
     };
@@ -119,13 +117,9 @@ if !(GVAR(uiMapVisible)) then {
                         drawLine3D [_oldLoc, _locNew, _colorNew];
                     };
                     _oldLoc = _locNew;
-
-                    nil // Speed loop
                 } count _segments;
             };
-
-            nil // Speed loop
-        } count GVAR(projectilesToDraw);
+        } forEach GVAR(projectilesToDraw);
         GVAR(projectilesToDraw) = _projectilesNew;
 
         {
@@ -138,9 +132,7 @@ if !(GVAR(uiMapVisible)) then {
                 // Store grenade for next frame
                 _grenadesNew pushBack _x;
             };
-
-            nil // Speed loop
-        } count GVAR(grenadesToDraw);
+        } forEach GVAR(grenadesToDraw);
 
         GVAR(grenadesToDraw) = _grenadesNew;
         END_COUNTER(drawTracers);

--- a/addons/spectator/functions/fnc_ui_draw3D.sqf
+++ b/addons/spectator/functions/fnc_ui_draw3D.sqf
@@ -72,7 +72,7 @@ if !(GVAR(uiMapVisible)) then {
 
             // Draw icon
             drawIcon3D _icon;
-        } count GVAR(iconsToDraw);
+        } forEach GVAR(iconsToDraw);
         END_COUNTER(drawTags);
     };
 
@@ -117,7 +117,7 @@ if !(GVAR(uiMapVisible)) then {
                         drawLine3D [_oldLoc, _locNew, _colorNew];
                     };
                     _oldLoc = _locNew;
-                } count _segments;
+                } forEach _segments;
             };
         } forEach GVAR(projectilesToDraw);
         GVAR(projectilesToDraw) = _projectilesNew;

--- a/addons/spectator/functions/fnc_ui_handleMapDraw.sqf
+++ b/addons/spectator/functions/fnc_ui_handleMapDraw.sqf
@@ -64,7 +64,7 @@ private _handledVehicles = [];
 
         _map drawIcon [_vehicleTexture, _sideColor, getPosASLVisual _vehicle, 24, 24, getDirVisual _vehicle, _text, 1, 0.04, "TahomaB", "right"];
     };
-} count ([] call FUNC(getTargetEntities));
+} forEach ([] call FUNC(getTargetEntities));
 
 // Set highlighted unit
 private _text = if (isNull _nearestEntity) then {

--- a/addons/spectator/functions/fnc_ui_handleMapDraw.sqf
+++ b/addons/spectator/functions/fnc_ui_handleMapDraw.sqf
@@ -64,7 +64,6 @@ private _handledVehicles = [];
 
         _map drawIcon [_vehicleTexture, _sideColor, getPosASLVisual _vehicle, 24, 24, getDirVisual _vehicle, _text, 1, 0.04, "TahomaB", "right"];
     };
-    nil // Speed loop
 } count ([] call FUNC(getTargetEntities));
 
 // Set highlighted unit

--- a/addons/spectator/functions/fnc_ui_updateIconsToDraw.sqf
+++ b/addons/spectator/functions/fnc_ui_updateIconsToDraw.sqf
@@ -139,9 +139,7 @@ private _camPos = AGLToASL positionCameraToWorld [0,0,0];
             SETVAR(_vehicle,GVAR(firedEH),_vehicle addEventHandler [ARR_2("Fired",{_this call FUNC(handleFired)})]);
         };
     };
-
-    nil // Speed loop
-} count ([] call FUNC(getTargetEntities));
+} forEach ([] call FUNC(getTargetEntities));
 
 GVAR(iconsToDraw) = _iconsToDraw;
 GVAR(entitiesToDraw) = _entitiesToDraw;

--- a/addons/spectator/functions/fnc_ui_updateListEntities.sqf
+++ b/addons/spectator/functions/fnc_ui_updateListEntities.sqf
@@ -51,8 +51,7 @@ private _entities = [true] call FUNC(getTargetEntities);
                     alive _x && { NEEDS_REVIVE(_x) },
                     _name
                 ];
-                nil // Speed loop
-            } count _entitiesGroup;
+            } forEach _entitiesGroup;
 
             // Cache the info of the group itself
             private _groupTexture = [_group] call FUNC(getGroupIcon);
@@ -80,8 +79,7 @@ private _entities = [true] call FUNC(getTargetEntities);
             ((_newList select _sideIndex) select 4) pushBack [_groupInfo, _unitsInfo];
         };
     };
-    nil // Speed loop
-} count allGroups;
+} forEach allGroups;
 
 // Whether an update to the list is required (really only if something changed)
 if !(GVAR(curList) isEqualTo _newList) then {
@@ -207,12 +205,9 @@ if !(GVAR(curList) isEqualTo _newList) then {
                     _ctrl tvSetPictureColor [_path, _sideColor];
                     _ctrl tvSetTooltip [_path, _tooltip];
                 };
-                nil // Speed loop
             } count _nestedUnitData;
-            nil // Speed loop
-        } count _nestedGroupData;
-        nil // Speed loop
-    } count _newList;
+        } forEach _nestedGroupData;
+    } forEach _newList;
 
     // Store the new list as the current list
     GVAR(curList) = _newList;

--- a/addons/spectator/functions/fnc_ui_updateListEntities.sqf
+++ b/addons/spectator/functions/fnc_ui_updateListEntities.sqf
@@ -205,7 +205,7 @@ if !(GVAR(curList) isEqualTo _newList) then {
                     _ctrl tvSetPictureColor [_path, _sideColor];
                     _ctrl tvSetTooltip [_path, _tooltip];
                 };
-            } count _nestedUnitData;
+            } forEach _nestedUnitData;
         } forEach _nestedGroupData;
     } forEach _newList;
 


### PR DESCRIPTION
`count` is only quicker than `forEach` when the final command returns a
boolean or nil. `forEach` is quicker if the final command returns any
other data type.
