### PR TITLE
Serialize spectator help control variable

### DIFF
--- a/addons/spectator/functions/fnc_ui_updateHelp.sqf
+++ b/addons/spectator/functions/fnc_ui_updateHelp.sqf
@@ -115,6 +115,7 @@ if (count _controls > MAX_CONTROLS_HELP_ENTRIES) then {
     _controls resize MAX_CONTROLS_HELP_ENTRIES;
 };
 
+disableSerialization; // This function could run scheduled as a result of public API
 private _help = CTRL_HELP;
 
 _help ctrlEnable false;


### PR DESCRIPTION
Could result in an on-screen error if the spectator API was used in a scheduled environment.

