### PR TITLE
Grenades - Make flashbang reaction more authentic

### DIFF
--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -135,6 +135,7 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
     };
 
     // Make player flinch
+    if (_strength <= 0.2) exitWith {};
     private _minFlinch = linearConversion [0.2, 1, _strength, 0, 60, true];
     private _maxFlinch = linearConversion [0.2, 1, _strength, 0, 95, true];
     private _flinch    = (_minFlinch + random (_maxFlinch - _minFlinch)) * selectRandom [-1, 1];

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -46,7 +46,7 @@ private _affected = (ASLtoAGL _grenadePosASL) nearEntities ["CAManBase", 20];
 _affected = _affected - [ACE_player];
 {
     if (local _x && {alive _x}) then {
-        private _strength = 1 - (((getPosASL _x) vectorDistance _grenadePosASL) min 20) / 20;
+        private _strength = 1 - (((eyePos _x) vectorDistance _grenadePosASL) min 20) / 20;
 
         TRACE_3("FlashBangEffect Start",_x,((getPosASL _x) vectorDistance _grenadePosASL),_strength);
 
@@ -54,9 +54,9 @@ _affected = _affected - [ACE_player];
 
         _x setSkill (skill _x / 50);
 
-        if (_strength > 0.2) then {
-            _x setVectorDir ((getPosASL _x) vectorDiff _grenadePosASL);
-        };
+        // Make AI try to look away
+        private _dirToFlash = _x getDir _grenadePosASL;
+        _x setDir (_dirToFlash + linearConversion [0.2, 1, _strength, 40, 135] * selectRandom [-1, 1]);
 
         [{
             params ["_unit"];
@@ -134,8 +134,10 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
         }, [], 17 * _strength] call CBA_fnc_waitAndExecute;
     };
 
-    if (_strength > 0.2) then {
-        ACE_player setVectorDir (_eyePos vectorDiff _grenadePosASL);
-    };
+    // Make player flinch
+    private _minFlinch = linearConversion [0.2, 1, _strength, 0, 45, true];
+    private _maxFlinch = linearConversion [0.2, 1, _strength, 0, 90, true];
+    private _flinch    = (_minFlinch + random (_maxFlinch - _minFlinch)) * selectRandom [-1, 1];
+    ACE_player setDir (getDir ACE_player + _flinch);
 };
 true

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -135,8 +135,8 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
     };
 
     // Make player flinch
-    private _minFlinch = linearConversion [0.2, 1, _strength, 0, 45, true];
-    private _maxFlinch = linearConversion [0.2, 1, _strength, 0, 90, true];
+    private _minFlinch = linearConversion [0.2, 1, _strength, 0, 60, true];
+    private _maxFlinch = linearConversion [0.2, 1, _strength, 0, 95, true];
     private _flinch    = (_minFlinch + random (_maxFlinch - _minFlinch)) * selectRandom [-1, 1];
     ACE_player setDir (getDir ACE_player + _flinch);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Make players flinch and AI try to look away as a reaction to a flashbang explosion - previously both players and AI turned 180° away from the explosion, making it very confusing and weird for players to be suddenly turned around
- Improve effect strength calculation for AI using eye position instead of ground position