### PR TITLE
ATragMX - Allow one decimal place for the bullet mass

### DIFF
--- a/addons/atragmx/functions/fnc_update_gun.sqf
+++ b/addons/atragmx/functions/fnc_update_gun.sqf
@@ -24,7 +24,7 @@ if (GVAR(currentUnit) != 2) then {
 if (GVAR(currentUnit) != 2) then {
     ctrlSetText [110, Str(Round((GVAR(workingMemory) select 12) * 15.4323584))];
 } else {
-    ctrlSetText [110, Str(Round(GVAR(workingMemory) select 12))];
+    ctrlSetText [110, Str(Round((GVAR(workingMemory) select 12) * 10) / 10)];
 };
 if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {
     ctrlSetText [120, Str(Round((GVAR(workingMemory) select 15) * 1000) / 1000)];

--- a/addons/atragmx/functions/fnc_update_gun_ammo_data.sqf
+++ b/addons/atragmx/functions/fnc_update_gun_ammo_data.sqf
@@ -25,7 +25,7 @@ if (GVAR(currentUnit) != 2) then {
 if (GVAR(currentUnit) != 2) then {
     ctrlSetText [120010, Str(Round((GVAR(workingMemory) select 12) * 15.4323584))];
 } else {
-    ctrlSetText [120010, Str(Round(GVAR(workingMemory) select 12))];
+    ctrlSetText [120010, Str(Round((GVAR(workingMemory) select 12) * 10) / 10)];
 };
 if (GVAR(currentUnit) != 2) then {
     ctrlSetText [120020, Str(Round((GVAR(workingMemory) select 13) / 10 / 2.54 * 1000) / 1000)];


### PR DESCRIPTION
The bullet mass (in [grains](https://en.wikipedia.org/wiki/Grain_(unit))) is still going to be limited to integers.

Closes: #6040

  