### PR TITLE
Match case for magazines in fillRightPanel (ACE Arsenal)

### DIFF
--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -86,7 +86,7 @@ private _compatibleMagazines = [[[], []], [[], []], [[], []]];
                     private _magArray = [_magazineGroups, _x] call CBA_fnc_hashGet;
                     {((_compatibleMagazines select _index) select _subIndex) pushBackUnique _x} forEach _magArray;
                 } else {
-                    ((_compatibleMagazines select _index) select _subIndex) pushBackUnique _x
+                    ((_compatibleMagazines select _index) select _subIndex) pushBackUnique (configName (configFile >> "CfgMagazines" >> _x))
                 }
             } foreach ([getArray (_weaponConfig >> _x >> "magazines"), getArray (_weaponConfig >> "magazines")] select (_x == "this"));
         } foreach getArray (_weaponConfig >> "muzzles");
@@ -216,7 +216,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgMagazines", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (((GVAR(virtualItems) select 2) apply {toLower _x}) arrayIntersect (_compatibleMagsPrimaryMuzzle apply {toLower _x}));
+            } foreach ((GVAR(virtualItems) select 2) arrayIntersect _compatibleMagsPrimaryMuzzle);
         };
     };
 
@@ -224,17 +224,17 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgMagazines", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (((GVAR(virtualItems) select 2) apply {toLower _x}) arrayIntersect (_compatibleMagsSecondaryMuzzle apply {toLower _x}));
+            } foreach ((GVAR(virtualItems) select 2) arrayIntersect _compatibleMagsSecondaryMuzzle);
         };
     };
 
     case IDC_buttonMag : {
         {
             ["CfgMagazines", _x, true] call _fnc_fill_right_Container;
-        } foreach (((GVAR(virtualItems) select 2) apply {toLower _x}) arrayIntersect (_allCompatibleMags apply {toLower _x}));
+        } foreach ((GVAR(virtualItems) select 2) arrayIntersect _allCompatibleMags);
         {
             ["CfgMagazines", _x, true, true] call _fnc_fill_right_Container;
-        } foreach (((GVAR(virtualItems) select 19) apply {toLower _x}) arrayIntersect (_allCompatibleMags apply {toLower _x}));
+        } foreach ((GVAR(virtualItems) select 19) arrayIntersect _allCompatibleMags);
     };
 
     case IDC_buttonMagALL : {

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -216,7 +216,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgMagazines", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach ((GVAR(virtualItems) select 2) arrayIntersect _compatibleMagsPrimaryMuzzle);
+            } foreach (((GVAR(virtualItems) select 2) apply {toLower _x}) arrayIntersect (_compatibleMagsPrimaryMuzzle apply {toLower _x}));
         };
     };
 
@@ -224,17 +224,17 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgMagazines", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach ((GVAR(virtualItems) select 2) arrayIntersect _compatibleMagsSecondaryMuzzle);
+            } foreach (((GVAR(virtualItems) select 2) apply {toLower _x}) arrayIntersect (_compatibleMagsSecondaryMuzzle apply {toLower _x}));
         };
     };
 
     case IDC_buttonMag : {
         {
             ["CfgMagazines", _x, true] call _fnc_fill_right_Container;
-        } foreach ((GVAR(virtualItems) select 2) arrayIntersect _allCompatibleMags);
+        } foreach (((GVAR(virtualItems) select 2) apply {toLower _x}) arrayIntersect (_allCompatibleMags apply {toLower _x}));
         {
             ["CfgMagazines", _x, true, true] call _fnc_fill_right_Container;
-        } foreach ((GVAR(virtualItems) select 19) arrayIntersect _allCompatibleMags);
+        } foreach (((GVAR(virtualItems) select 19) apply {toLower _x}) arrayIntersect (_allCompatibleMags apply {toLower _x}));
     };
 
     case IDC_buttonMagALL : {

--- a/addons/arsenal/ui/RscAttributes.hpp
+++ b/addons/arsenal/ui/RscAttributes.hpp
@@ -4,7 +4,6 @@
 class GVAR(display) {
     idd = IDD_ace_arsenal;
     enableSimulation=1;
-    closeOnMissionEnd = 1;
     onLoad = QUOTE([ARR_3('onLoad', _this, QQGVAR(display))] call FUNC(onArsenalOpen));
     onUnload = QUOTE([ARR_3('onUnload', _this, QQGVAR(display))] call FUNC(onArsenalClose));
     onKeyDown = QUOTE([ARR_3('onKeyDown', _this, QQGVAR(display))] call FUNC(onKeyDown));

--- a/addons/arsenal/ui/RscAttributes.hpp
+++ b/addons/arsenal/ui/RscAttributes.hpp
@@ -4,6 +4,7 @@
 class GVAR(display) {
     idd = IDD_ace_arsenal;
     enableSimulation=1;
+    closeOnMissionEnd = 1;
     onLoad = QUOTE([ARR_3('onLoad', _this, QQGVAR(display))] call FUNC(onArsenalOpen));
     onUnload = QUOTE([ARR_3('onUnload', _this, QQGVAR(display))] call FUNC(onArsenalClose));
     onKeyDown = QUOTE([ARR_3('onKeyDown', _this, QQGVAR(display))] call FUNC(onKeyDown));


### PR DESCRIPTION
**When merged this pull request will:**
- Match case for magazines in fillRightPanel.
 
For some reason you're able to have different case between the entry in the weapon magazines array and its actual configName, meaning that some mags won't show up in the currentMag and currentMag2 tabs even tho they should.