### PR TITLE
Add seperate setting for NVG noise intensity

### DIFF
--- a/addons/nightvision/ACE_Settings.hpp
+++ b/addons/nightvision/ACE_Settings.hpp
@@ -14,6 +14,14 @@ class ACE_Settings {
         value = 1;
         sliderSettings[] = {0, 2, 1, 1};
     };
+    class GVAR(noiseScaling) {
+        category = CSTRING(Category);
+        displayName = CSTRING(noiseScaling_DisplayName);
+        description = CSTRING(noiseScaling_Description);
+        typeName = "SCALAR";
+        value = 1;
+        sliderSettings[] = {0, 2, 1, 1};
+    };
     class GVAR(effectScaling) {
         category = CSTRING(Category);
         displayName = CSTRING(effectScaling_DisplayName);

--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -23,7 +23,7 @@ GVAR(ppeffectBlur) = -1;
 
 
 ["ace_settingsInitialized", {
-    TRACE_3("settingsInitialized",GVAR(disableNVGsWithSights),GVAR(fogScaling),GVAR(effectScaling));
+    TRACE_4("settingsInitialized",GVAR(disableNVGsWithSights),GVAR(fogScaling),GVAR(noiseScaling),GVAR(effectScaling));
 
     ["visionMode", LINKFUNC(onVisionModeChanged), false] call CBA_fnc_addPlayerEventHandler;
 

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -92,13 +92,14 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
         if (currentWeapon ACE_player == handgunWeapon ACE_player) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_PISTOL]}; // Pistols aren't so bad
     };
 
-    // Scale effects based on ace_nightvision_effectScaling setting
-    _grainIntensityFinal = _grainIntensityFinal * GVAR(effectScaling);
-    _noiseSharpnessFinal = linearConversion [0, 1, GVAR(effectScaling), 2.5, _noiseSharpnessFinal];
+    // Scale general effects based on ace_nightvision_effectScaling setting
     private _radialBlurPower = 0.0025 * GVAR(effectScaling);
     _brightFinal = linearConversion [0, 1, GVAR(effectScaling), 1, _brightFinal];
     _contrastFinal = linearConversion [0, 1, GVAR(effectScaling), 1, _contrastFinal];
 
+    // Scale grain effects based on ace_nightvision_noiseScaling setting
+    _grainIntensityFinal = _grainIntensityFinal * GVAR(noiseScaling);
+    _noiseSharpnessFinal = linearConversion [0, 1, GVAR(noiseScaling), 2.5, _noiseSharpnessFinal];
 
     // Setup all effects
     // This is hacky but... works. This prevents the effects from being cancelled by various things - alt-tabbing, resizing, going into AT sights, etc. A nicer method would be welcome but I don't have time to spend on it. TODO.
@@ -152,7 +153,18 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
 
     #ifdef DEBUG_MODE_FULL
     private _aceAmbient = [] call EFUNC(common,ambientBrightness);
-    hintSilent format ["EffectiveLight %1\nLight: %2\nACE Ambient: %3\nBrightness: %4\nContrast: %5\nGrain: %6\nBlur: %7\nFog: %8\nScaling %9", _effectiveLight, _lightFinal, _aceAmbient, _brightFinal, _contrastFinal, [_grainIntensityFinal, _noiseSharpnessFinal, _grainFinal], _blurFinal, _fogApply, [GVAR(effectScaling),GVAR(fogScaling)]];
+    hintSilent format [
+        "EffectiveLight %1\nLight: %2\nACE Ambient: %3\nBrightness: %4\nContrast: %5\nGrain: %6\nBlur: %7\nFog: %8\nScaling %9",
+        _effectiveLight,
+        _lightFinal,
+        _aceAmbient,
+        _brightFinal,
+        _contrastFinal,
+        [_grainIntensityFinal, _noiseSharpnessFinal, _grainFinal],
+        _blurFinal,
+        _fogApply,
+        [GVAR(effectScaling), GVAR(fogScaling), GVAR(noiseScaling)]
+    ];
     #endif
 
     END_COUNTER(updateAllEffects);

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -258,13 +258,21 @@
             <Italian>Effetto livello NVG</Italian>
         </Key>
         <Key ID="STR_ACE_NightVision_effectScaling_Description">
-            <English>Blur, grain and brightness effects [Setting to 0 will disable ALL nightvision effects]</English>
+            <English>Blur and brightness effects [Setting to 0 will disable ALL nightvision effects]</English>
             <Japanese>ぼかしと粒子、明度効果 [0 に設定で全効果を無効化します]</Japanese>
-            <Italian>Effetti di sfocatura, sgranatura e luminosità [Importare a 0 disabiliterà TUTTI gli effetti della visione notturna]</Italian>
+            <Italian>Effetti di sfocatura e luminosità [Importare a 0 disabiliterà TUTTI gli effetti della visione notturna]</Italian>
         </Key>
         <Key ID="STR_ACE_NightVision_aimDownSightsBlur_DisplayName">
             <English>Aim Down Sights Blur</English>
             <Japanese>照準器を使用時にぼかし</Japanese>
+        </Key>
+        <Key ID="STR_ACE_NightVision_noiseScaling_DisplayName">
+            <English>NVG Noise Scale</English>
+            <German>Intensität des Bildrauschens</German>
+        </Key>
+        <Key ID="STR_ACE_NightVision_noiseScaling_Description">
+            <English>Image noise intensity when wearing NVGs</English>
+            <German>Intensität des Bildrauschens im Nachtsichtgerät</German>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a seperate setting for NVG noise intensity

A seperate setting for this makes sense as it can cause headaches with long time use. The other effects do not cause this issue. Was also requested in #3594 by @ghost.