### PR TITLE
Fix medical AI activation

### DIFF
--- a/addons/medical_ai/XEH_postInit.sqf
+++ b/addons/medical_ai/XEH_postInit.sqf
@@ -4,9 +4,9 @@
     TRACE_1("settingsInitialized", GVAR(enabledFor));
     if (GVAR(enabledFor) == 0) exitWith {}; // 0: disabled
     if ((GVAR(enabledFor) == 1) && {!isServer} && {hasInterface}) exitWith {}; // 1: Don't Run on non-hc Clients
-    
+
     // Only run for AI that does not have to deal with advanced medical
-    if (EGVAR(medical,enableFor) == 1 || {hasInterface && {EGVAR(medical,level) == 2}}) exitWith {};
+    if (EGVAR(medical,level) == 2 && {EGVAR(medical,enableFor) == 1 || hasInterface}) exitWith {};
 
     ["ace_firedNonPlayer", {
         _unit setVariable [QGVAR(lastFired), CBA_missionTime];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix medical AI not being enabled when the medical `enableFor` setting was set to 1 with basic medical

The `enableFor` should have no effect when used with basic medical. Fixes #6020, #6073.