### PR TITLE
Cargo - Improve class initialization

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -569,16 +569,6 @@ class CfgVehicles {
         GVAR(size) = 50;
     };
 
-    class Ruins_F;
-    class Land_Cargo20_military_ruins_F: Ruins_F {
-        class EventHandlers {
-            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
-        };
-
-        GVAR(space) = 49;
-        GVAR(size) = 50;
-    };
-
     class Land_Cargo20_orange_F: Cargo_base_F {
         class EventHandlers {
             class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
@@ -677,15 +667,6 @@ class CfgVehicles {
         GVAR(size) = 100;
     };
     class Land_Cargo40_military_green_F: Cargo_base_F {
-        class EventHandlers {
-            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
-        };
-
-        GVAR(space) = 99;
-        GVAR(size) = 100;
-    };
-
-    class Land_Cargo40_military_ruins_F: Ruins_F {
         class EventHandlers {
             class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
         };

--- a/addons/cargo/functions/fnc_initObject.sqf
+++ b/addons/cargo/functions/fnc_initObject.sqf
@@ -41,38 +41,9 @@ if (_object getVariable [QGVAR(initObject),false]) exitWith {};
 if (_canLoadConfig) then {
     GVAR(initializedItemClasses) pushBack _type;
     TRACE_1("Adding load cargo action to class", _type);
+    [_type, 0, ["ACE_MainActions"], GVAR(objectAction)] call EFUNC(interact_menu,addActionToClass);
 } else {
     _object setVariable [QGVAR(initObject),true];
     TRACE_1("Adding load cargo action to object", _object);
+    [_object, 0, ["ACE_MainActions"], GVAR(objectAction)] call EFUNC(interact_menu,addActionToObject);
 };
-
-// Vehicles with passengers inside are prevented from being loaded in `fnc_canLoadItemIn`
-private _condition = {
-    //IGNORE_PRIVATE_WARNING ["_target", "_player"];
-    GVAR(enable) &&
-    {(_target getVariable [QGVAR(canLoad), getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(canLoad))]) in [true, 1]} &&
-    {locked _target < 2} &&
-    {alive _target} &&
-    {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)} &&
-    {0 < {
-            private _type = typeOf _x;
-            private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];
-            private _hasCargoConfig = getNumber (configFile >> "CfgVehicles" >> _type >> QGVAR(hasCargo)) == 1;
-            (_hasCargoPublic || _hasCargoConfig) && {_x != _target} &&
-            {([_target, _x] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
-        } count (nearestObjects [_player, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)])}
-};
-private _statement = {
-    params ["_target", "_player"];
-    [_player, _target] call FUNC(startLoadIn);
-};
-private _text = localize LSTRING(loadObject);
-private _icon = "a3\ui_f\data\IGUI\Cfg\Actions\loadVehicle_ca.paa";
-
-private _action = [QGVAR(load), _text, _icon, _statement, _condition, {call FUNC(addCargoVehiclesActions)}] call EFUNC(interact_menu,createAction);
-if (_canLoadConfig) then {
-    [_type, 0, ["ACE_MainActions"], _action] call EFUNC(interact_menu,addActionToClass);
-} else {
-    [_object, 0, ["ACE_MainActions"], _action] call EFUNC(interact_menu,addActionToObject);
-};
-

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -61,34 +61,11 @@ if (_vehicle getVariable [QGVAR(initVehicle),false]) exitWith {};
 if (_hasCargoConfig) then {
     GVAR(initializedVehicleClasses) pushBack _type;
     TRACE_1("Adding unload cargo action to class", _type);
+    [_type, 0, ["ACE_MainActions"], GVAR(vehicleAction)] call EFUNC(interact_menu,addActionToClass);
 } else {
     _vehicle setVariable [QGVAR(initVehicle),true];
     TRACE_1("Adding unload cargo action to object", _vehicle);
-};
-
-private _condition = {
-    //IGNORE_PRIVATE_WARNING ["_target", "_player"];
-    GVAR(enable) &&
-    {(_target getVariable [QGVAR(hasCargo), getNumber (configFile >> "CfgVehicles" >> (typeOf _target) >> QGVAR(hasCargo)) == 1])} &&
-    {locked _target < 2} &&
-    {([_player, _target] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE} &&
-    {alive _target} &&
-    {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)}
-};
-private _statement = {
-    //IGNORE_PRIVATE_WARNING ["_target", "_player"];
-    GVAR(interactionVehicle) = _target;
-    GVAR(interactionParadrop) = false;
-    createDialog QGVAR(menu);
-};
-private _text = localize LSTRING(openMenu);
-private _icon = "";
-
-private _action = [QGVAR(openMenu), _text, _icon, _statement, _condition] call EFUNC(interact_menu,createAction);
-if (_hasCargoConfig) then {
-    [_type, 0, ["ACE_MainActions"], _action] call EFUNC(interact_menu,addActionToClass);
-} else {
-    [_vehicle, 0, ["ACE_MainActions"], _action] call EFUNC(interact_menu,addActionToObject);
+    [_vehicle, 0, ["ACE_MainActions"], GVAR(vehicleAction)] call EFUNC(interact_menu,addActionToObject);
 };
 
 // Add the paradrop self interaction for planes and helicopters


### PR DESCRIPTION
**When merged this pull request will:**
- replace per-class cargo init with automatic init of all configured classes;
- fix `Static` classes not initialized properly;
- remove container ruins from config.

No more need to additionally init some classes in `XEH_postInit.sqf`. Just add config values.

Also placed in editor `Portable Light` ATM can't be loaded because it's kind of `Static` class and should be initialized accordingly. This PR fixes that.