### PR TITLE
Map - Add Camping Light support

### DIFF
--- a/addons/common/functions/fnc_lightIntensityFromObject.sqf
+++ b/addons/common/functions/fnc_lightIntensityFromObject.sqf
@@ -79,6 +79,21 @@ if (_lightSource isKindOf "CAManBase") then {
 
     } forEach _lights;
 
+    if (isCollisionLightOn _lightSource) then {
+        private _markerLights = [
+            _lightSource,
+            {configProperties [configFile >> "CfgVehicles" >> typeOf _this >> "MarkerLights", "isClass _x", true]},
+            uiNamespace,
+            format [QEGVAR(cache,MarkerLights_%1), typeOf _lightSource],
+            1E11
+        ] call FUNC(cachedCall);
+        {
+            private _position = _lightSource modelToWorld (_lightSource selectionPosition getText (_x >> "name"));
+            private _distance = _unitPos distance _position;
+            _lightLevel = _lightLevel max (linearConversion [0, 10, _distance, 1, 0, true]);
+        } forEach _markerLights;
+    };
+
     // handle campfires
     if (inflamed _lightSource) then {
         private _distance = _unitPos distance position _lightSource;


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Camping Light and some other vehicles have `MarkerLights` config instead of `Reflectors` with hitpoints. Their lights should be considered when determining map light.

Unfortunately I don't know how to consider `blinking` parameter. So blinking lights will light a map like continuous light. Not a big deal I think.