### PR TITLE
Add setting to disable Vehicle Freelook in aircraft

### DIFF
--- a/addons/aircraft/XEH_PREP.hpp
+++ b/addons/aircraft/XEH_PREP.hpp
@@ -1,2 +1,3 @@
-PREP(initEjectAction);
 PREP(canShowEject);
+PREP(initEjectAction);
+PREP(switchVehicleFreelook);

--- a/addons/aircraft/XEH_preInit.sqf
+++ b/addons/aircraft/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/aircraft/functions/fnc_switchVehicleFreelook.sqf
+++ b/addons/aircraft/functions/fnc_switchVehicleFreelook.sqf
@@ -22,6 +22,8 @@
 
 params ["_player", "_vehicle"];
 
+if (!hasInterface) exitWith {};
+
 disableSerialization;
 private _displayMission = DISPLAY(IDD_MISSION);
 if (isNull _displayMission) exitWith { // wait for mission start

--- a/addons/aircraft/functions/fnc_switchVehicleFreelook.sqf
+++ b/addons/aircraft/functions/fnc_switchVehicleFreelook.sqf
@@ -22,6 +22,12 @@
 
 params ["_player", "_vehicle"];
 
+disableSerialization;
+private _displayMission = DISPLAY(IDD_MISSION);
+if (isNull _displayMission) exitWith { // wait for mission start
+    [{!isNull DISPLAY(IDD_MISSION)}, FUNC(switchVehicleFreelook), [_player, _vehicle]] call CBA_fnc_waitUntilAndExecute;
+};
+
 private _disableFreelook = 
     _vehicle isKindOf "Air"
     && {!(_vehicle isKindOf "ParachuteBase")}
@@ -32,11 +38,10 @@ private _disableFreelook =
 ;
 if (_disableFreelook isEqualTo GVAR(isVehicleFreelookDisabled)) exitWith {};
 
-disableSerialization;
 private _displayInterrupt = DISPLAY(IDD_INTERRUPT);
 // exit if in aircraft when option becomes enabled - otherwise arma crashes on ctrlActivate
 if (!isNull _displayInterrupt) exitWith {};
-_displayInterrupt = DISPLAY(IDD_MISSION) createDisplay "RscDisplayInterrupt";
+_displayInterrupt = _displayMission createDisplay "RscDisplayInterrupt";
 if (isNil "_displayInterrupt" || {isNull _displayInterrupt}) exitWith {hint "no Interrupt display"};
 
 private _buttonGame = _displayInterrupt displayCtrl IDC_OPTIONS_GAMEOPTIONS;

--- a/addons/aircraft/functions/fnc_switchVehicleFreelook.sqf
+++ b/addons/aircraft/functions/fnc_switchVehicleFreelook.sqf
@@ -1,0 +1,62 @@
+/*
+ * Author: Dystopian
+ * Controls Vehicle Freelook state. Called from vehicle player EH.
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, vehicle player] call ace_aircraft_fnc_switchVehicleFreelook
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+#include "\a3\ui_f\hpp\defineResincl.inc"
+#define LB_FREELOOK_DISABLED 0
+#define LB_FREELOOK_ENABLED  1
+
+params ["_player", "_vehicle"];
+
+private _disableFreelook = 
+    _vehicle isKindOf "Air"
+    && {!(_vehicle isKindOf "ParachuteBase")}
+    && { // check if pilot or copilot
+        _player == driver _vehicle
+        || {1 == getNumber (([_vehicle, _player call CBA_fnc_turretPath] call CBA_fnc_getTurret) >> "isCopilot")}
+    }
+;
+if (_disableFreelook isEqualTo GVAR(isVehicleFreelookDisabled)) exitWith {};
+
+disableSerialization;
+private _displayInterrupt = DISPLAY(IDD_INTERRUPT);
+// exit if in aircraft when option becomes enabled - otherwise arma crashes on ctrlActivate
+if (!isNull _displayInterrupt) exitWith {};
+_displayInterrupt = DISPLAY(IDD_MISSION) createDisplay "RscDisplayInterrupt";
+if (isNil "_displayInterrupt" || {isNull _displayInterrupt}) exitWith {hint "no Interrupt display"};
+
+private _buttonGame = _displayInterrupt displayCtrl IDC_OPTIONS_GAMEOPTIONS;
+if (isNull _buttonGame || "ButtonGame" != ctrlClassName _buttonGame) then {
+    hint "no Game button";
+} else {
+    ctrlActivate _buttonGame;
+    private _displayGameOptions = DISPLAY(IDD_GAMEOPTIONS);
+    if (isNull _displayGameOptions) then {
+        hint "no GameOptions display";
+    } else {
+        private _lbFreelook = _displayGameOptions displayCtrl IDC_OPTIONS_VEHICLEFREELOOK;
+        if (isNull _lbFreelook || "ValueVehicleFreelook" != ctrlClassName _lbFreelook) then {
+            hint "no VehicleFreelook listbox";
+        } else {
+            _lbFreelook lbSetCurSel ([LB_FREELOOK_ENABLED, LB_FREELOOK_DISABLED] select _disableFreelook);
+            GVAR(isVehicleFreelookDisabled) = _disableFreelook;
+        };
+        _displayGameOptions closeDisplay 0;
+    };
+};
+
+_displayInterrupt closeDisplay 0;

--- a/addons/aircraft/initSettings.sqf
+++ b/addons/aircraft/initSettings.sqf
@@ -1,0 +1,17 @@
+[
+    QGVAR(disableVehicleFreelook),
+    "CHECKBOX",
+    [LSTRING(SettingDisableVehicleFreelookName), LSTRING(SettingDisableVehicleFreelookDesc)],
+    "ACE Uncategorized",
+    false,
+    false,
+    {
+        params ["_enabled"];
+        if (!_enabled) exitWith {
+            if (isNil QGVAR(vehicleFreelookEH)) exitWith {};
+            ["vehicle", GVAR(vehicleFreelookEH)] call CBA_fnc_removePlayerEventHandler;
+        };
+        GVAR(isVehicleFreelookDisabled) = false;
+        GVAR(vehicleFreelookEH) = ["vehicle", LINKFUNC(switchVehicleFreelook), true] call CBA_fnc_addPlayerEventHandler;
+    }
+] call CBA_settings_fnc_init;

--- a/addons/aircraft/stringtable.xml
+++ b/addons/aircraft/stringtable.xml
@@ -49,5 +49,13 @@
             <Chinese>關閉貨艙門</Chinese>
             <Chinesesimp>关闭货舱门</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Aircraft_SettingDisableVehicleFreelookName">
+            <English>Disable Vehicle Freelook in aircraft</English>
+            <Russian>Откл. Свободный обзор в возд. технике</Russian>
+        </Key>
+        <Key ID="STR_ACE_Aircraft_SettingDisableVehicleFreelookDesc">
+            <English>Disable "Vehicle Freelook" game option when pilot aircraft</English>
+            <Russian>Отключать игровую опцию "Свободный обзор в технике" во время пилотирования воздушной техники</Russian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- add setting to disable `Vehicle Freelook` game option when pilot an aircraft.

In vanilla `Vehicle Freelook` game option can be only enabled or disabled. There are some tickets at BI tracker asking to disable it for air vehicles because it's more comfortable to control them with mouse than with keyboard.

This setting goes the most hackish way: opens Esc-menu, presses `Game` button, then switches `Vehicle Freelook` value and closes both displays. I tried to create just `Game options` display without Esc-menu but it opened with empty values. I will be glad if anyone suggest better solution.

During game this looks like small delay when enter/exit air vehicle.

I moved the setting to `ACE Uncategorized` category which should be changed to some subcategory when CBA 3.6 is released.

To use this feature you have to re-enter the vehicle when:
- pilot and activate the setting;
- get in not as pilot and then change seat to pilot.

It does work when start mission in pilot seat.

Bug: if you end mission in pilot seat, option will remain disabled until you manually enable it or enter/exit aircraft in next mission.
Also I don't know how it will go if some other display/dialog is opened and player enters/exits aircraft.

There are really many checks in code to avoid possible problems if BI changes some classes/values. Error messages are not localized because of very small probability of errors.

I will not be sorry if you say this PR doesn't suit ACE by any reason :)