### PR TITLE
HuntIR - Fix connecting when ammo is null

### DIFF
--- a/addons/huntir/CfgVehicles.hpp
+++ b/addons/huntir/CfgVehicles.hpp
@@ -7,7 +7,7 @@ class CfgVehicles {
                 class GVAR(open) {
                     displayName = CSTRING(activateMonitor);
                     condition = QUOTE([ARR_2(ACE_player,'ACE_HuntIR_monitor')] call EFUNC(common,hasItem));
-                    statement = QUOTE(call FUNC(huntir));
+                    statement = QUOTE([FUNC(huntir)] call CBA_fnc_execNextFrame;);
                     showDisabled = 0;
                     priority = 2;
                     icon = QPATHTOF(UI\w_huntir_monitor_ca.paa);

--- a/addons/huntir/functions/fnc_huntir.sqf
+++ b/addons/huntir/functions/fnc_huntir.sqf
@@ -49,6 +49,14 @@ createDialog QGVAR(cam_dialog_off);
             private _elapsedTime = CBA_missionTime - GVAR(startTime);
             private _nearestHuntIRs = ACE_player nearEntities ["ACE_HuntIR", HUNTIR_MAX_TRANSMISSION_RANGE];
 
+            if ((GVAR(state) in ["connecting", "connected"]) && {_nearestHuntIRs isEqualTo []}) then {
+                TRACE_1("reseting back to search because no valid ammo exists anymore",GVAR(state));
+                GVAR(state) = "searching";
+                GVAR(done) = false;
+                GVAR(message) = [];
+                GVAR(connectionDelay) = 5;
+            };
+
             if ((!dialog) || GVAR(done)) exitWith {
                 [_this select 1] call CBA_fnc_removePerFrameHandler;
 


### PR DESCRIPTION
Fix #6093

`[_nearestHuntIRs select 0] call FUNC(cam);` would pass nill
Also delay opening GUI for a frame to prevent issue with interaction menu
