### PR TITLE
Pylons - Fix old weapons not being removed

### DIFF
--- a/addons/pylons/XEH_postInit.sqf
+++ b/addons/pylons/XEH_postInit.sqf
@@ -28,14 +28,14 @@
     } forEach GVAR(aircraftWithPylons);
 
     [QGVAR(setPylonLoadOutEvent), {
-        params ["_aircraft", "_pylonIndex", "_pylon", "_turret", "_removeWeapon"];
-        TRACE_5("setPylonLoadOutEvent",_aircraft,_pylonIndex,_pylon,_turret,_removeWeapon);
+        params ["_aircraft", "_pylonIndex", "_pylon", "_turret", "_weaponToRemove"];
+        TRACE_5("setPylonLoadOutEvent",_aircraft,_pylonIndex,_pylon,_turret,_weaponToRemove);
         _aircraft setPylonLoadOut [_pylonIndex, _pylon, false, _turret];
-        if (_removeWeapon != "") then {
+        if (_weaponToRemove != "") then {
             {
                 if (_aircraft turretLocal _x) then {
-                    TRACE_3("removing",_aircraft,_x,_removeWeapon);
-                    _aircraft removeWeaponTurret [_removeWeapon, _x];
+                    TRACE_3("removing",_aircraft,_x,_weaponToRemove);
+                    _aircraft removeWeaponTurret [_weaponToRemove, _x];
                 };
             } forEach [[-1], [0]];
         };

--- a/addons/pylons/XEH_postInit.sqf
+++ b/addons/pylons/XEH_postInit.sqf
@@ -28,8 +28,17 @@
     } forEach GVAR(aircraftWithPylons);
 
     [QGVAR(setPylonLoadOutEvent), {
-        params ["_aircraft", "_pylonIndex", "_pylon", "_turret"];
+        params ["_aircraft", "_pylonIndex", "_pylon", "_turret", "_removeWeapon"];
+        TRACE_5("setPylonLoadOutEvent",_aircraft,_pylonIndex,_pylon,_turret,_removeWeapon);
         _aircraft setPylonLoadOut [_pylonIndex, _pylon, false, _turret];
+        if (_removeWeapon != "") then {
+            {
+                if (_aircraft turretLocal _x) then {
+                    TRACE_3("removing",_aircraft,_x,_removeWeapon);
+                    _aircraft removeWeaponTurret [_removeWeapon, [-1]];
+                };
+            } forEach [[-1], [0]];
+        };
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(setAmmoOnPylonEvent), {

--- a/addons/pylons/XEH_postInit.sqf
+++ b/addons/pylons/XEH_postInit.sqf
@@ -35,7 +35,7 @@
             {
                 if (_aircraft turretLocal _x) then {
                     TRACE_3("removing",_aircraft,_x,_removeWeapon);
-                    _aircraft removeWeaponTurret [_removeWeapon, [-1]];
+                    _aircraft removeWeaponTurret [_removeWeapon, _x];
                 };
             } forEach [[-1], [0]];
         };

--- a/addons/pylons/functions/fnc_configurePylons.sqf
+++ b/addons/pylons/functions/fnc_configurePylons.sqf
@@ -27,8 +27,10 @@ if (_currentPylon == count _pylonsToConfigure) exitWith {};
     {
         (_this select 0) params ["_pylonsToConfigure", "_currentPylon"];
         private _pylonIndex = _pylonsToConfigure select _currentPylon;
+        TRACE_2("",_currentPylon,_pylonIndex);
 
         // Remove the weapon of current pylon from aircraft IF weapon is only on this pylon
+        private _removeWeapon = "";
         private _currentPylonMagazine = (getPylonMagazines GVAR(currentAircraft)) select _pylonIndex;
         if (_currentPylonMagazine != "") then {
             private _allPylonWeapons = (getPylonMagazines GVAR(currentAircraft)) apply {
@@ -36,7 +38,8 @@ if (_currentPylon == count _pylonsToConfigure) exitWith {};
             };
             private _pylonWeapon = _allPylonWeapons select _pylonIndex;
             if (({_x == _pylonWeapon} count _allPylonWeapons) == 1) then {
-                GVAR(currentAircraft) removeWeaponGlobal _pylonWeapon;
+                TRACE_2("Removing unused weapon",_pylonWeapon,_allPylonWeapons);
+                _removeWeapon = _pylonWeapon;
             };
         };
 
@@ -47,7 +50,7 @@ if (_currentPylon == count _pylonsToConfigure) exitWith {};
 
         [
             QGVAR(setPylonLoadOutEvent),
-            [GVAR(currentAircraft), _pylonIndex + 1, _pylonMagazine, _turret]
+            [GVAR(currentAircraft), _pylonIndex + 1, _pylonMagazine, _turret, _removeWeapon]
         ] call CBA_fnc_globalEvent;
 
         private _count = if (GVAR(rearmNewPylons) || {GVAR(isCurator)}) then {

--- a/addons/pylons/functions/fnc_configurePylons.sqf
+++ b/addons/pylons/functions/fnc_configurePylons.sqf
@@ -30,7 +30,7 @@ if (_currentPylon == count _pylonsToConfigure) exitWith {};
         TRACE_2("",_currentPylon,_pylonIndex);
 
         // Remove the weapon of current pylon from aircraft IF weapon is only on this pylon
-        private _removeWeapon = "";
+        private _weaponToRemove = "";
         private _currentPylonMagazine = (getPylonMagazines GVAR(currentAircraft)) select _pylonIndex;
         if (_currentPylonMagazine != "") then {
             private _allPylonWeapons = (getPylonMagazines GVAR(currentAircraft)) apply {
@@ -39,7 +39,7 @@ if (_currentPylon == count _pylonsToConfigure) exitWith {};
             private _pylonWeapon = _allPylonWeapons select _pylonIndex;
             if (({_x == _pylonWeapon} count _allPylonWeapons) == 1) then {
                 TRACE_2("Removing unused weapon",_pylonWeapon,_allPylonWeapons);
-                _removeWeapon = _pylonWeapon;
+                _weaponToRemove = _pylonWeapon;
             };
         };
 
@@ -50,7 +50,7 @@ if (_currentPylon == count _pylonsToConfigure) exitWith {};
 
         [
             QGVAR(setPylonLoadOutEvent),
-            [GVAR(currentAircraft), _pylonIndex + 1, _pylonMagazine, _turret, _removeWeapon]
+            [GVAR(currentAircraft), _pylonIndex + 1, _pylonMagazine, _turret, _weaponToRemove]
         ] call CBA_fnc_globalEvent;
 
         private _count = if (GVAR(rearmNewPylons) || {GVAR(isCurator)}) then {

--- a/addons/pylons/functions/fnc_showDialog.sqf
+++ b/addons/pylons/functions/fnc_showDialog.sqf
@@ -149,7 +149,10 @@ if (!GVAR(isCurator)) then {
         isNull (GVAR(currentAircraft) getVariable [QGVAR(currentUser), objNull]) ||
         {(ace_player distanceSqr GVAR(currentAircraft)) > GVAR(searchDistanceSqr)}
     }, {
-        [localize LSTRING(TooFar), false, 5] call EFUNC(common,displayText);
+        TRACE_3("disconnect/far",GVAR(currentAircraft), ace_player distance GVAR(currentAircraft),GVAR(currentAircraft) getVariable QGVAR(currentUser));
+        if ((ace_player distanceSqr GVAR(currentAircraft)) > GVAR(searchDistanceSqr)) then {
+            [localize LSTRING(TooFar), false, 5] call EFUNC(common,displayText);
+        };
         call FUNC(onButtonClose);
     }] call CBA_fnc_waitUntilAndExecute;
 };

--- a/addons/pylons/functions/fnc_showDialog.sqf
+++ b/addons/pylons/functions/fnc_showDialog.sqf
@@ -149,7 +149,7 @@ if (!GVAR(isCurator)) then {
         isNull (GVAR(currentAircraft) getVariable [QGVAR(currentUser), objNull]) ||
         {(ace_player distanceSqr GVAR(currentAircraft)) > GVAR(searchDistanceSqr)}
     }, {
-        TRACE_3("disconnect/far",GVAR(currentAircraft), ace_player distance GVAR(currentAircraft),GVAR(currentAircraft) getVariable QGVAR(currentUser));
+        TRACE_3("disconnect/far",GVAR(currentAircraft),ace_player distance GVAR(currentAircraft),GVAR(currentAircraft) getVariable QGVAR(currentUser));
         if ((ace_player distanceSqr GVAR(currentAircraft)) > GVAR(searchDistanceSqr)) then {
             [localize LSTRING(TooFar), false, 5] call EFUNC(common,displayText);
         };


### PR DESCRIPTION
Fix  #6088
- Use removeWeaponTurret instead of removeWeaponGlobal
- Fix "Too Far" warning showing on completion

Tag @654wak654

I have no idea why `removeWeaponGlobal` doesn't work for pilot seat of some RHS helis, but `removeWeaponTurret` works just fine.