### PR TITLE
Arsenal - Pass arsenal dispay to displayOpened event

### DIFF
--- a/addons/arsenal/functions/fnc_onArsenalOpen.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalOpen.sqf
@@ -172,7 +172,7 @@ GVAR(currentWeaponType) = switch true do {
     default {-1};
 };
 
-[QGVAR(displayOpened), []] call CBA_fnc_localEvent;
+[QGVAR(displayOpened), [_display]] call CBA_fnc_localEvent;
 
 //--------------- Fade out unused elements
 private _mouseBlockCtrl = _display displayCtrl IDC_mouseBlock;


### PR DESCRIPTION
Tag @Alganthe
This pretty much matches the args passed by the vanilla event:
```
[missionnamespace,"arsenalOpened",[_display,_toggleSpace]] call bis_fnc_callscriptedeventhandler;
```

e.g. we add extra buttons to allow exporting gear to the format we want