### PR TITLE
Cargo - Remove excess lower empty space in menu

### DIFF
--- a/addons/cargo/menu.hpp
+++ b/addons/cargo/menu.hpp
@@ -17,7 +17,7 @@ class GVAR(menu) {
         };
         class CenterBackground: HeaderBackground {
             y = "2.1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) + (safezoneY + (safezoneH - (((safezoneW / safezoneH) min 1.2) / 1.2))/2)";
-            h = "14 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+            h = "13.1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
             text = "#(argb,8,8,3)color(0,0,0,0.8)";
             colorText[] = {0, 0, 0, "(profilenamespace getVariable ['GUI_BCG_RGB_A',0.9])"};
             colorBackground[] = {0,0,0,"(profilenamespace getVariable ['GUI_BCG_RGB_A',0.9])"};


### PR DESCRIPTION
**When merged this pull request will:**
- Small change to make the cargo menu a little nicer (remove lower empty space)
- Before: 
![cargo_before](https://user-images.githubusercontent.com/34453221/35702601-989ea44e-0767-11e8-92e3-e3fee512879a.png)
- After: 
![cargo_after](https://user-images.githubusercontent.com/34453221/35702632-a3dbeae2-0767-11e8-9f87-563d082fbab0.png)


