### PR TITLE
CBA Settings Conversion - Fix movedToSQF

### DIFF
--- a/addons/common/functions/fnc_cbaSettings.sqf
+++ b/addons/common/functions/fnc_cbaSettings.sqf
@@ -85,17 +85,18 @@ for "_index" from 0 to (_countOptions - 1) do {
     };
 };
 
-_settingsConfig = missionConfigFile >> "ACE_Settings";
-_countOptions = count _settingsConfig;
+private _missionSettingsConfig = missionConfigFile >> "ACE_Settings";
+_countOptions = count _missionSettingsConfig;
 TRACE_1("Reading settings from missionConfigFile",_countOptions);
 for "_index" from 0 to (_countOptions - 1) do {
-    private _optionEntry = _settingsConfig select _index;
+    private _optionEntry = _missionSettingsConfig select _index;
     private _settingName = configName _optionEntry;
     if ((toLower _settingName) in GVAR(cbaSettings_forcedSettings)) then {
         WARNING_1("Setting [%1] - Already Forced - ignoring missionConfig",_varName);
     } else {
         if ((isNil _settingName) && {(getNumber (_settingsConfig >> _settingName >> "movedToSQF")) == 0}) then {
             // New setting, that was first defined in missionConfigFile
+            INFO_1("Creating new CBA setting for ace_setting from mission config [%1]",_settingName);
             [_optionEntry] call FUNC(cbaSettings_loadFromConfig);
         } else {
             private _value = (_optionEntry >> "value") call BIS_fnc_getCfgData;


### PR DESCRIPTION
`_settingsConfig >> _settingName >> "movedToSQF"`

_settingsConfig was the missionConfig, not main config