### PR TITLE
Interaction - Add Smash Windshield action

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -365,6 +365,11 @@ class CfgVehicles {
                 statement = "";
                 insertChildren = QUOTE(_this call DFUNC(addPassengersActions));
             };
+            class GVAR(smashWindshield) {
+                displayName = CSTRING(SmashWindshield);
+                condition = QUOTE(_player == driver _target && {private _damage = _target getHitPointDamage 'HitGlass1'; _damage > 0.5 && {_damage < 1}});
+                statement = QUOTE(playSound3D [ARR_2('A3\Sounds_F\weapons\hits\glass_2.wss',_target)]; _target setHitPointDamage [ARR_2('HitGlass1',1)];);
+            };
         };
     };
 

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -1084,5 +1084,14 @@
             <Chinese>拿出屍體</Chinese>
             <Chinesesimp>拿出尸体</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Interaction_SmashWindshield">
+            <English>Smash windshield</English>
+            <German>Frontscheibe einschlagen</German>
+            <French>Dégager le pare-brise</French>
+            <Czech>Vyrazit čelní sklo</Czech>
+            <Russian>Выбить лобовое стекло</Russian>
+            <Polish>Wyłam szybę</Polish>
+            <Hungarian>Szélvédő széttörése</Hungarian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
When windshield is partly damaged it becomes less clear so you may want to break it entirely.

Strings are copied from ACE2, I don't know if they are correct.