### PR TITLE
Scope stats and ballistic stats improvement

### DIFF
--- a/addons/ballistics/ACE_Arsenal_Stats.hpp
+++ b/addons/ballistics/ACE_Arsenal_Stats.hpp
@@ -34,6 +34,7 @@ class EGVAR(arsenal,stats) {
         displayName= CSTRING(statBallisticCoef);
         showText= 1;
         textStatement = QUOTE(params[ARR_2('_stat', '_config')]; private _ammoCfg = (configFile >> 'CfgAmmo' >> (getText (_config >> 'ammo'))); private _ballisticCoef = getArray (_ammoCfg >> _stat select 1); _ballisticCoef sort false; format [ARR_4('%1 G%2 (%3)', _ballisticCoef select 0 ,getNumber (_ammoCfg >> _stat select 0), getText (_ammoCfg >> _stat select 2))]);
+        condition = QUOTE(params[ARR_2('_stat', '_config')]; private _ammoCfg = (configFile >> 'CfgAmmo' >> (getText (_config >> 'ammo'))); !(getArray (_ammoCfg >> _stat select 1) isEqualTo []));
         tabs[] ={{}, {4}};
     };
     class ACE_bulletMass: statBase {
@@ -43,6 +44,7 @@ class EGVAR(arsenal,stats) {
         displayName = CSTRING(statBulletMass);
         showText = 1;
         textStatement = QUOTE(params[ARR_2('_stat', '_config')]; private _ammoWeight = getNumber (configFile >> 'CfgAmmo' >> (getText (_config >> 'ammo')) >> _stat select 0); format [ARR_3('%1g (%2gr)', _ammoWeight toFixed 1, (_ammoWeight * 15.43) toFixed 1)]);
+        condition = QUOTE(params[ARR_2('_stat', '_config')]; getNumber (configFile >> 'CfgAmmo' >> (getText (_config >> 'ammo')) >> _stat select 0) > 0);
         tabs[] = {{}, {4}};
     };
     class ACE_magMuzzleVelocity: statBase {
@@ -52,6 +54,7 @@ class EGVAR(arsenal,stats) {
         displayName= CSTRING(statMuzzleVelocity);
         showText= 1;
         textStatement = QUOTE(params[ARR_2('_stat', '_config')]; private _initSpeed = getNumber (_config >> _stat select 0); format [ARR_3('%1 m/s (%2 ft/s)', _initSpeed, (_initSpeed * 3.28084) toFixed 0)]);
+        condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
         tabs[] = {{}, {4}};
     };
     class ACE_weaponMuzzleVelocity: statBase {

--- a/addons/scopes/ACE_Arsenal_Stats.hpp
+++ b/addons/scopes/ACE_Arsenal_Stats.hpp
@@ -1,0 +1,18 @@
+class EGVAR(arsenal,stats) {
+    class statBase;
+    class ACE_scopeHorizontalLimits: statBase {
+        scope = 2;
+        priority = 3;
+        stats[] = {"ACE_ScopeAdjust_Horizontal", "ACE_ScopeAdjust_HorizontalIncrement"};
+        displayName = CSTRING(statHorizontalLimits);
+        showText = 1;
+        textStatement = QUOTE(params[ARR_2('_stat','_config')]; private _limits = getArray (_config >> _stat select 0); format [ARR_4('%1 / %2 MIL (∆ %3 MIL)', _limits select 0, _limits select 1, getNumber (_config >> _stat select 1))]);
+        condition = QUOTE(params[ARR_2('_stat', '_config')]; !((getArray (_config >> _stat select 0)) isEqualTo []));
+        tabs[] = {{}, {0}};
+    };
+    class ACE_scopeVerticalLimits: ACE_scopeHorizontalLimits {
+        stats[] = {"ACE_ScopeAdjust_Vertical", "ACE_ScopeAdjust_VerticalIncrement"};
+        priority = 2;
+        displayName = CSTRING(statVerticalLimits);
+    };
+};

--- a/addons/scopes/config.cpp
+++ b/addons/scopes/config.cpp
@@ -20,3 +20,4 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 #include "RscTitles.hpp"
 #include "ACE_Settings.hpp"
+#include "ACE_Arsenal_Stats.hpp"

--- a/addons/scopes/stringtable.xml
+++ b/addons/scopes/stringtable.xml
@@ -440,5 +440,13 @@
             <Japanese>%1R</Japanese>
             <Korean>%1R</Korean>
         </Key>
+        <Key ID="STR_ACE_Scopes_statHorizontalLimits">
+            <English>Horizontal limits</English>
+            <Chinese>Limites horizontales</Chinese>
+        </Key>
+        <Key ID="STR_ACE_Scopes_statVerticalLimits">
+            <English>Vertical limits</English>
+            <Chinese>Limites verticales</Chinese>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Hide some ballistics stats if the config entries they use aren't defined (ballistic coef / bullet mass / mag muzzle velocity) to avoid "weird" looking stats in the GL tab.
- Add scope horizontal and vertical limits stats.

![scope stats](https://i.imgur.com/BmklWz2.png)