### PR TITLE
Add note in options menu doc

### DIFF
--- a/docs/wiki/feature/optionsmenu.md
+++ b/docs/wiki/feature/optionsmenu.md
@@ -12,6 +12,11 @@ version:
   patch: 0
 ---
 
+<div class="panel callout">
+    <h5>Note:</h5>
+    <p>Deprecated and replaced with <a href="https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System">CBA Settings System</a> in 3.12.0!</p>
+</div>
+
 ## 1. Overview
 
 Adds the options menu used by other components.


### PR DESCRIPTION
**When merged this pull request will:**
- Add a note saying that the options menu is deprecated in the doc, the same that is in the ACE settings page.
