### PR TITLE
AB and ACE3 ballistic : compat r3f updated

### DIFF
--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -47,13 +47,13 @@ class CfgAmmo {
         typicalSpeed = 850; // R3F config
         airFriction = -0.00110718; // ACE3 value, default -0.00095
         ACE_caliber = 7.823;
-        ACE_bulletLength = 28.956;
-        ACE_bulletMass = 9.4608;
+        ACE_bulletLength = 31.496;
+        ACE_bulletMass = 8.22946157;
         ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
-        ACE_ballisticCoefficients[] = {0.2};
+        ACE_ballisticCoefficients[] = {0.359};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
-        ACE_dragModel = 7;
+        ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {650};
     };

--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -1,7 +1,7 @@
 class CfgAmmo {
     class Default;
     class BulletBase;
-    class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L360
+    class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L370
         typicalSpeed = 350; // R3F config
         airFriction = -0.00201185; // ACE3 value, default -0.001413
         ACE_caliber = 9.017;
@@ -15,13 +15,13 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {340, 370, 400};
         ACE_barrelLengths[] = {101.6, 127.0, 228.6};
     };
-    class R3F_556x45_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L9
+    class R3F_556x45_Ball: BulletBase { // M855 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L9
         typicalSpeed = 930; // R3F config
         airFriction = -0.00130094; // ACE3 value, default -0.001625
         ACE_caliber = 5.69;
         ACE_bulletLength = 23.012;
         ACE_bulletMass = 4.0176;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-27.20, -26.44, -23.76, -21.00, -17.54, -13.10, -7.95, -1.62, 6.24, 15.48, 27.75};
+        ACE_ammoTempMuzzleVelocityShifts[] = {-19.25, -18.49, -15.81, -13.05, -9.59, -5.15, 0, 6.33, 14.19, 23.43, 35.70};
         ACE_ballisticCoefficients[] = {0.151};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
@@ -29,13 +29,13 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
-    class R3F_762x51_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
+    class R3F_762x51_Ball: BulletBase { // M80 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L155
         typicalSpeed = 820; // R3F config
         airFriction = -0.00103711; // ACE3 value, default -0.00095
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.2};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
@@ -43,13 +43,13 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {700, 800, 820, 833, 845};
         ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
-    class R3F_762x51_Ball2: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
+    class R3F_762x51_Ball2: R3F_762x51_Ball { // M993 AP https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L226
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00103711; // ACE3 value, default -0.00095
+        airFriction = -0.00110718; // ACE3 value, default -0.00095
         ACE_caliber = 7.823;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.4608;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.2};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
@@ -57,17 +57,17 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {650};
     };
-    class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L152
+    class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // M80 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L155
         airFriction = -0.00103711; // ACE3 value, default -0.002000
     };
-    class R3F_127x99_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
+    class R3F_127x99_Ball: BulletBase { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
         typicalSpeed = 780; // R3F config
-        airFriction = -0.00058679; // ACE3 value, default -0.00086
+        airFriction = -0.00062115; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD=0.35;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_muzzleVelocityVariationSD = 0.35;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
@@ -75,14 +75,14 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_PEI: R3F_127x99_Ball { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
+    class R3F_127x99_PEI: R3F_127x99_Ball { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
         typicalSpeed = 780; // R3F config
-        airFriction = -0.00058679; // ACE3 value, default -0.00086
+        airFriction = -0.00062115; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD=0.4;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_muzzleVelocityVariationSD = 0.4;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
@@ -90,14 +90,14 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_Ball2: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
+    class R3F_127x99_Ball2: BulletBase { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00058679; // ACE3 value, default -0.00086
+        airFriction = -0.000601; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD=0.35;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_muzzleVelocityVariationSD = 0.35;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
@@ -105,14 +105,14 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_PEI2: R3F_127x99_Ball2 { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
+    class R3F_127x99_PEI2: R3F_127x99_Ball2 { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
         typicalSpeed = 850; // R3F config
-        airFriction = -0.00058679; // ACE3 value, default -0.00086
+        airFriction = -0.000601; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD=0.4;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_muzzleVelocityVariationSD = 0.4;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
@@ -120,14 +120,14 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_Ball3: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L494
+    class R3F_127x99_Ball3: BulletBase { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
         typicalSpeed = 820; // R3F config
-        airFriction = -0.00058679; // ACE3 value, default -0.00086
+        airFriction = -0.00060964; // ACE3 value, default -0.00086
         ACE_caliber = 12.954;
         ACE_bulletLength = 58.674;
         ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD=0.35;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_muzzleVelocityVariationSD = 0.35;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -476,22 +476,22 @@ class CfgWeapons {
 class ACE_ATragMX_Presets {
     class R3F_PGM_Hecate_II {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"[R3F]PGM", 780, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15,753},{0,760},{10,767},{15,772},{25,786},{30,795},{35,806}}, {{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}}};
+        preset[] = {"R3F PGM M33", 780, 100, 0.0879633, -0.00062115, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_M107 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"[R3F]M107", 850, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15,823},{0,830},{10,837},{15,842},{25,856},{30,865},{35,876}}, {{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}}};
+        preset[] = {"R3F M107 M33", 850, 100, 0.0879633, -0.000601, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_TAC50 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"[R3F]TAC50", 820, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15,793},{0,800},{10,807},{15,812},{25,826},{30,835},{35,846}}, {{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}}};
+        preset[] = {"R3F TAC50 M33", 820, 100, 0.0879633, -0.00060964, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_FRF2 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"[R3F]FRF2", 850, 100, 0.0909184, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 29.46, 0.398, 1, "ICAO", {{-15,823},{0,830},{10,837},{15,842},{25,856},{30,865},{35,876}}, {{0, 0.399}, {810, 0.392}, {1030, 0.383}, {1120, 0.381}, {1270, 0.380}, {1410, 0.379}, {1530, 0.379}}};
+        preset[] = {"R3F FRF2 M993", 850, 100, 0.0803840, -0.00110718, 6.35, 0, 2, 10, 120, 0, 0, 8.230, 7.82, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
     };
     class R3F_HK417L {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"[R3F]HK417L", 820, 100, 0.0909184, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 29.46, 0.398, 1, "ICAO", {{-15,793},{0,800},{10,807},{15,812},{25,826},{30,835},{35,846}}, {{0, 0.399}, {810, 0.392}, {1030, 0.383}, {1120, 0.381}, {1270, 0.380}, {1410, 0.379}, {1530, 0.379}}};
+        preset[] = {"R3F HK417L M80", 820, 100, 0.0909184, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 27.94, 0.398, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- update all `airFriction` for the Marksman and Sniper ammos with the [generate_airfriction tool](https://github.com/acemod/ACE3/blob/master/tools/generate_airfriction_config.py) by @ulteq.
Many thanks Ruthberb. :)
- update 5.56, 7.62 and 12.7 `ACE_ammoTempMuzzleVelocityShifts` for a zero MV shift at 15°C.
(same `ACE_muzzleVelocities` and `initSpeed` in-game for a better BDC reticle compatibility between the both ballistics).
- update the `R3F_762x51_Ball2` with the `ACE_762x51_Ball_M993_AP` [values](https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L226).
- update the AtragMx presets' airFrictions, MV vs. T°C tables and minor fixes.