### PR TITLE
Allow goggle effects to be set locally per client

### DIFF
--- a/addons/goggles/ACE_Settings.hpp
+++ b/addons/goggles/ACE_Settings.hpp
@@ -5,6 +5,7 @@ class ACE_Settings {
         displayName = CSTRING(effects_displayName);
         typeName = "SCALAR";
         value = 2;
+        isClientSettable = 1;
         values[] = {ECSTRING(common,Disabled), CSTRING(effects_tintOnly), CSTRING(enabled_tintAndEffects)};
     };
     class GVAR(showInThirdPerson) {


### PR DESCRIPTION
From what I can see goggles are all handled locally and do not need to be globally enabled/disabled. If a group wants to force the setting, CBA provides optional force functionality.
