### PR TITLE
Nightvision improvements (White Phosphor tubes support)

### DIFF
--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -9,6 +9,7 @@ class CfgWeapons {
         colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
     };
     class NVGoggles_WP: NVGoggles { // White Phosphor version for example
+        author = "JDT & AleM";
         displayName = "NV Goggles (Gen3 WP tubes, Sand)";
         descriptionShort = "3rd Generation NVD /w White Phosphor tubes";
         colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}}; // White Phosphor tube Preset (JDT & AleM)

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -5,6 +5,13 @@ class CfgWeapons {
         modelOptics = "";
         GVAR(border) = QPATHTOF(data\nvg_mask_binos_4096.paa);
         GVAR(bluRadius) = 0.15;
+        // It's should prevent from main classes incorrectly work (Set Color Correction Params) / Original ACE3's Green (JDT & AleM)
+        colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
+    };
+    class NVGoggles_WP: NVGoggles { // White Phosphor version for example
+        displayName = "NV Goggles (Gen3 WP tubes, Sand)";
+        descriptionShort = "3rd Generation NVD /w White Phosphor tubes";
+        colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}}; // White Phosphor tube Preset (JDT & AleM)
     };
     class O_NVGoggles_hex_F: NVGoggles { // APEX NVG with multiple lenses (spider eyes)
         modelOptics = "";

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -5,14 +5,13 @@ class CfgWeapons {
         modelOptics = "";
         GVAR(border) = QPATHTOF(data\nvg_mask_binos_4096.paa);
         GVAR(bluRadius) = 0.15;
-        // It's should prevent from main classes incorrectly work (Set Color Correction Params) / Original ACE3's Green (JDT & AleM)
-        colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
+        colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}; // Green color (by default)
     };
-    class NVGoggles_WP: NVGoggles { // White Phosphor version for example
+    class NVGoggles_WP: NVGoggles { // White Phosphor version (example)
         author = "JDT & AleM";
         displayName = "NV Goggles (Gen3 WP tubes, Sand)";
         descriptionShort = "3rd Generation NVD /w White Phosphor tubes";
-        colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}}; // White Phosphor tube Preset (JDT & AleM)
+        colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}}; // White Phosphor tube Preset
     };
     class O_NVGoggles_hex_F: NVGoggles { // APEX NVG with multiple lenses (spider eyes)
         modelOptics = "";

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -127,7 +127,8 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     // ColorCorrections - Changes brightness, contrast and "green" color of nvg
     // Params: [brightness(0..2), contrast(0..inf), offset(-x..+x), blendArray, colorizeArray, weightArray]
     GVAR(ppeffectColorCorrect) = ppEffectCreate ["ColorCorrections", 2003];
-    GVAR(ppeffectColorCorrect) ppEffectAdjust [_brightFinal, _contrastFinal, 0, [0.0, 0.0, 0.0, 0.0], [1.3, 1.2, 0.0, 0.9], [6, 1, 1, 0.0]];
+    // 4 last Params now operated by Global variables / Watch fnc_refreshGoggleType.sqf fo more clarification / Required for WP supporting (JDT & AleM)
+    GVAR(ppeffectColorCorrect) ppEffectAdjust [_brightFinal, _contrastFinal, GVAR(nvgOffset), GVAR(nvgBlend), GVAR(nvgColorize), GVAR(nvgWeight)];
     GVAR(ppeffectColorCorrect) ppEffectCommit 0;
     GVAR(ppeffectColorCorrect) ppEffectForceInNVG true;
     GVAR(ppeffectColorCorrect) ppEffectEnable true;

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -127,7 +127,7 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     // ColorCorrections - Changes brightness, contrast and "green" color of nvg
     // Params: [brightness(0..2), contrast(0..inf), offset(-x..+x), blendArray, colorizeArray, weightArray]
     GVAR(ppeffectColorCorrect) = ppEffectCreate ["ColorCorrections", 2003];
-    // 4 last Params now operated by Global variables / Watch fnc_refreshGoggleType.sqf fo more clarification / Required for WP supporting (JDT & AleM)
+    // 4 last Params now operated by Global variables / Required for WP supporting
     GVAR(ppeffectColorCorrect) ppEffectAdjust [_brightFinal, _contrastFinal, GVAR(nvgOffset), GVAR(nvgBlend), GVAR(nvgColorize), GVAR(nvgWeight)];
     GVAR(ppeffectColorCorrect) ppEffectCommit 0;
     GVAR(ppeffectColorCorrect) ppEffectForceInNVG true;

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -26,6 +26,15 @@ private _hideHex = true;
 private _nvgGen = 3;
 private _blurRadius = -1;
 
+// Privated NVD's PP Effects (ColorCorrection) Params / Contains original ACE3's (ST's) by default. (JDT & AleM)
+private _offset = 0;
+private _blend = [0.0, 0.0, 0.0, 0.0];
+private _colorize = [1.3, 1.2, 0.0, 0.9];
+private _weight = [6, 1, 1, 0.0];
+// Adds Array of Params / Original ACE3's (ST's) by default. (JDT & AleM)
+private _preset = [0, [0.0, 0.0, 0.0, 0.0], [1.3, 1.2, 0.0, 0.9], [6, 1, 1, 0.0]];
+
+
 if (alive ACE_player) then {
     if (((vehicle ACE_player) == ACE_player) || {
         // Test if we are using player's nvg or if sourced from vehicle:
@@ -60,6 +69,14 @@ if (alive ACE_player) then {
             TRACE_1("souce: binocular",binocular ACE_player); // Source is from player's binocular (Rangefinder/Vector21bNite)
             private _config = configFile >> "CfgWeapons" >> (binocular ACE_player);
             if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
+            // Gets proper Params' Array from CfgWeapons (JDT & AleM)
+            if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
+            // Selection from Array (JDT & AleM)
+            _offset = _preset select 0;
+      		_blend = _preset select 1;
+      		_colorize = _preset select 2;
+      		_weight = _preset select 3;
+
         };
 
         TRACE_1("source: hmd",GVAR(playerHMD)); // Source is player's HMD (or possibly a NVG scope, but no good way to detect that)
@@ -74,6 +91,13 @@ if (alive ACE_player) then {
             if (isNumber (_config >> QGVAR(bluRadius))) then {_blurRadius = getNumber (_config >> QGVAR(bluRadius));};
         };
         if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
+        // Same as above (JDT & AleM)
+        if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
+        // Same as above (JDT & AleM)
+        _offset = _preset select 0;
+        _blend = _preset select 1;
+      	_colorize = _preset select 2;
+      	_weight = _preset select 3;
 
     } else {
         TRACE_1("source: vehicle - defaults",typeOf vehicle ACE_player);
@@ -87,6 +111,11 @@ systemChat format ["EyeCups: %1, HideHex %2, NVGen: %3, BluRadius: %4", _eyeCups
 
 GVAR(nvgBlurRadius) = _blurRadius;
 GVAR(nvgGeneration) = _nvgGen;
+// Additional Global variables for Params transfer & supporting (JDT & AleM)
+GVAR(nvgOffset) = _offset;
+GVAR(nvgBlend) = _blend;
+GVAR(nvgColorize) = _colorize;
+GVAR(nvgWeight) = _weight;
 
 // Setup border and hex image based on NVG config:
 private _scale = (call EFUNC(common,getZoom)) * 1.12513;

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -100,7 +100,7 @@ systemChat format ["EyeCups: %1, HideHex %2, NVGen: %3, BluRadius: %4", _eyeCups
 #endif
 
 // Selection cancelled, params added
-_preset params ["_offset", "_blend", "_colorize", "_weight"]?
+_preset params ["_offset", "_blend", "_colorize", "_weight"];
 
 GVAR(nvgBlurRadius) = _blurRadius;
 GVAR(nvgGeneration) = _nvgGen;

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -73,9 +73,9 @@ if (alive ACE_player) then {
             if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
             // Selection from Array (JDT & AleM)
             _offset = _preset select 0;
-      		_blend = _preset select 1;
-      		_colorize = _preset select 2;
-      		_weight = _preset select 3;
+            _blend = _preset select 1;
+            _colorize = _preset select 2;
+            _weight = _preset select 3;
 
         };
 
@@ -96,8 +96,8 @@ if (alive ACE_player) then {
         // Same as above (JDT & AleM)
         _offset = _preset select 0;
         _blend = _preset select 1;
-      	_colorize = _preset select 2;
-      	_weight = _preset select 3;
+        _colorize = _preset select 2;
+        _weight = _preset select 3;
 
     } else {
         TRACE_1("source: vehicle - defaults",typeOf vehicle ACE_player);

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -26,12 +26,12 @@ private _hideHex = true;
 private _nvgGen = 3;
 private _blurRadius = -1;
 
-// Privated NVD's PP Effects (ColorCorrection) Params / Contains original ACE3's (ST's) by default. (JDT & AleM)
+// Privated NVD's PP Effects (ColorCorrection) Params / Contains original ACE3's (ST's) by default.
 private _offset = 0;
 private _blend = [0.0, 0.0, 0.0, 0.0];
 private _colorize = [1.3, 1.2, 0.0, 0.9];
 private _weight = [6, 1, 1, 0.0];
-// Adds Array of Params / Original ACE3's (ST's) by default. (JDT & AleM)
+// Adds Array of Params / Original ACE3's (ST's) by default.
 private _preset = [0, [0.0, 0.0, 0.0, 0.0], [1.3, 1.2, 0.0, 0.9], [6, 1, 1, 0.0]];
 
 
@@ -69,13 +69,8 @@ if (alive ACE_player) then {
             TRACE_1("souce: binocular",binocular ACE_player); // Source is from player's binocular (Rangefinder/Vector21bNite)
             private _config = configFile >> "CfgWeapons" >> (binocular ACE_player);
             if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
-            // Gets proper Params' Array from CfgWeapons (JDT & AleM)
+            // Gets proper Params' Array from CfgWeapons
             if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
-            // Selection from Array (JDT & AleM)
-            _offset = _preset select 0;
-            _blend = _preset select 1;
-            _colorize = _preset select 2;
-            _weight = _preset select 3;
 
         };
 
@@ -93,11 +88,6 @@ if (alive ACE_player) then {
         if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
         // Same as above (JDT & AleM)
         if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
-        // Same as above (JDT & AleM)
-        _offset = _preset select 0;
-        _blend = _preset select 1;
-        _colorize = _preset select 2;
-        _weight = _preset select 3;
 
     } else {
         TRACE_1("source: vehicle - defaults",typeOf vehicle ACE_player);
@@ -109,9 +99,12 @@ systemChat format ["NVG Refresh - Border: %1", _borderImage];
 systemChat format ["EyeCups: %1, HideHex %2, NVGen: %3, BluRadius: %4", _eyeCups, _hideHex, _nvgGen, _blurRadius];
 #endif
 
+// Selection cancelled, params added
+_preset params ["_offset", "_blend", "_colorize", "_weight"]?
+
 GVAR(nvgBlurRadius) = _blurRadius;
 GVAR(nvgGeneration) = _nvgGen;
-// Additional Global variables for Params transfer & supporting (JDT & AleM)
+// Additional Global variables for Params transfer & supporting
 GVAR(nvgOffset) = _offset;
 GVAR(nvgBlend) = _blend;
 GVAR(nvgColorize) = _colorize;

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -86,7 +86,7 @@ if (alive ACE_player) then {
             if (isNumber (_config >> QGVAR(bluRadius))) then {_blurRadius = getNumber (_config >> QGVAR(bluRadius));};
         };
         if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
-        // Same as above (JDT & AleM)
+        // Same as at line 72
         if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
 
     } else {

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -71,7 +71,6 @@ if (alive ACE_player) then {
             if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
             // Gets proper Params' Array from CfgWeapons
             if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
-
         };
 
         TRACE_1("source: hmd",GVAR(playerHMD)); // Source is player's HMD (or possibly a NVG scope, but no good way to detect that)

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -6,10 +6,24 @@ class CfgWeapons {
         EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_4096.paa);
         EGVAR(nightvision,bluRadius) = 0.13;
     };
+    // White Phosphor version (JDT & AleM)
+    class rhsusf_ANPVS_14_WP: rhsusf_ANPVS_14 {
+        author = "JDT & AleM"
+        displayName = "AN/PVS-14 (Gen3, WP tube)";
+        descriptionShort = "AN/PVS-14 Monocular NVD /w White Phosphor tube";
+        colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}};
+    };
     class rhsusf_ANPVS_15: rhsusf_ANPVS_14 { // Binocular (same as base)
         modelOptics = "";        
         EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_binos_4096.paa);
         EGVAR(nightvision,bluRadius) = 0.15;
+    };
+    // White Phosphor version (JDT & AleM)
+    class rhsusf_ANPVS_15_WP: rhsusf_ANPVS_15 {
+        author = "JDT & AleM"
+        displayName = "AN/PVS-15 (Gen3, WP tube)";
+        descriptionShort = "3rd Generation Binocular NVD /w White Phosphor tubes";
+        colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}};
     };
 
     class Pistol_Base_F;

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -6,7 +6,7 @@ class CfgWeapons {
         EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_4096.paa);
         EGVAR(nightvision,bluRadius) = 0.13;
     };
-    // White Phosphor version (JDT & AleM)
+    // White Phosphor version
     class rhsusf_ANPVS_14_WP: rhsusf_ANPVS_14 {
         author = "JDT & AleM"
         displayName = "AN/PVS-14 (Gen3, WP tube)";
@@ -18,7 +18,7 @@ class CfgWeapons {
         EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_binos_4096.paa);
         EGVAR(nightvision,bluRadius) = 0.15;
     };
-    // White Phosphor version (JDT & AleM)
+    // White Phosphor version
     class rhsusf_ANPVS_15_WP: rhsusf_ANPVS_15 {
         author = "JDT & AleM"
         displayName = "AN/PVS-15 (Gen3, WP tube)";

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -8,7 +8,7 @@ class CfgWeapons {
     };
     // White Phosphor version
     class rhsusf_ANPVS_14_WP: rhsusf_ANPVS_14 {
-        author = "JDT & AleM"
+        author = "JDT & AleM";
         displayName = "AN/PVS-14 (Gen3, WP tube)";
         descriptionShort = "AN/PVS-14 Monocular NVD /w White Phosphor tube";
         colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}};
@@ -20,7 +20,7 @@ class CfgWeapons {
     };
     // White Phosphor version
     class rhsusf_ANPVS_15_WP: rhsusf_ANPVS_15 {
-        author = "JDT & AleM"
+        author = "JDT & AleM";
         displayName = "AN/PVS-15 (Gen3, WP tube)";
         descriptionShort = "3rd Generation Binocular NVD /w White Phosphor tubes";
         colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {0.7, 0.3, 1.3, 0.9}, {1, 1, 6, 0.0}};


### PR DESCRIPTION
**When merged this pull request will:**

- Adds possibility to set Color Correction Params (PP Effects) to classes.
- Adds 'supporting' elements in fnc_RefreshGoggleType & minor changes in fnc_pfeh which do same ('support').
- Adds example class in CfgWeapons & 2 classes for RHSUSAF compat. patch.

**Description**

Just added few improvements for fnc_pfeh & fnc_refreshGoggleType (ace_nightvision) to support different Color Correction presets (PP Effects). Now, you can set needed Params in class via CfgWeapons & it will be extracted to functions.

Added example class & 2 classes for RHSUSAF compatibility patch too (possible required "ace_nightvision" to be added in "requiredAddons[]" list via /compat_rhs_usf3/config.cpp).
I'd tested everything in a bit different form & it was required, so... Unfortunately, currently i'm not at home & can't check it right now.

**Misc.**

I also found & fix issues caused by A3_GPNVG18 mod, so will add compatibility patch ASAP.

Made by: JDT, AleM.
With Great Thanks to: BaerMitUmlaut

**To Do**
- [x] Add compatibility patch for A3_GPNVG18 (CANCELLED)

P.S. That's way totally work, but i will proceed my 'research'. Want to hide params & make selection with colorPreset[] = "White" or "Green". Try'd a lot, but still not found the right solution.