### PR TITLE
Compat R3F: #6171 updated

### DIFF
--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -28,7 +28,7 @@ class CfgMagazines {
         initSpeed = 850; // R3F config
     };
     class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {}; // AtragMx GunList: 5.56x45mm M855
-    class R3F_10Rnd_762x51_FRF2: CA_magazine { // AtragMx GunList: 5.56x45mm M855
+    class R3F_10Rnd_762x51_FRF2: CA_magazine { // AtragMx GunList: R3F FRF2 M993
         initSpeed = 850; // R3F config
     };
     class R3F_200Rnd_556x45_MINIMI: CA_magazine { // AtragMx GunList: 5.56x45mm M855
@@ -37,23 +37,23 @@ class CfgMagazines {
     class R3F_100Rnd_762x51_MINIMI: CA_magazine { // AtragMx GunList: 7.62x51mm M80
         initSpeed = 820; // R3F config
     };
-    class R3F_20Rnd_762x51_HK417: CA_magazine { // AtragMx GunList: 7.62x51mm M80
+    class R3F_20Rnd_762x51_HK417: CA_magazine { // AtragMx GunList: 7.62x51mm M80 / HK417L 20": R3F HK417L M80
         initSpeed = 820; // R3F config
     };
-    class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80
-    class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: 12.7x99mm
+    class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80 / HK417L 20": R3F HK417L M80
+    class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: R3F PGM M33
         initSpeed = 780; // R3F config
     };
-    class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: 12.7x99mm
+    class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: R3F PGM M33
         initSpeed = 780; // R3F config
     };
-    class R3F_10Rnd_127x99_M107: CA_magazine { // AtragMx GunList: 12.7x99mm
+    class R3F_10Rnd_127x99_M107: CA_magazine { // AtragMx GunList: R3F M107 M33
         initSpeed = 850; // R3F config
     };
-    class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 { // AtragMx GunList: 12.7x99mm
+    class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 { // AtragMx GunList: R3F M107 M33
         initSpeed = 850; // R3F config
     };
-    class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: 12.7x99mm
+    class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: R3F TAC50 M33
         initSpeed = 820; // R3F config
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -247,7 +247,7 @@ class CfgWeapons {
     };
     class R3F_J4: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Riflescope_LTE_J4_Datasheet_GB.pdf
         ACE_ScopeHeightAboveRail = 3.20641;
-        ACE_ScopeAdjust_Vertical[] = {0, 16};
+        ACE_ScopeAdjust_Vertical[] = {-8, 8};
         ACE_ScopeAdjust_Horizontal[] = {-8, 8};
         ACE_ScopeAdjust_VerticalIncrement = 0.2;
         ACE_ScopeAdjust_HorizontalIncrement = 0.2;
@@ -267,8 +267,8 @@ class CfgWeapons {
         ACE_ScopeHeightAboveRail = 4.28091;
     };
     class R3F_J8: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
-        ACE_ScopeHeightAboveRail = 4.474;
-        ACE_ScopeAdjust_Vertical[] = {0, 20};
+        ACE_ScopeHeightAboveRail = 4.474; // Inaccurate BDC reticle, designed to work with the vanilla ballistic and R3F values.
+        ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
@@ -296,9 +296,9 @@ class CfgWeapons {
         };
     };
     class R3F_J10: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
-        ACE_ScopeZeroRange = 1400; // Inaccurate reticle, designed to work with the vanilla ballistic.
+        ACE_ScopeZeroRange = 1400; // Inaccurate BDC reticle, designed to work with the vanilla ballistic and R3F values.
         ACE_ScopeHeightAboveRail = 4.474;
-        ACE_ScopeAdjust_Vertical[] = {0, 20};
+        ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
@@ -476,22 +476,22 @@ class CfgWeapons {
 class ACE_ATragMX_Presets {
     class R3F_PGM_Hecate_II {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F PGM M33", 780, 100, 0.0879633, -0.00062115, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F PGM M33", 780, 100, 0.0845596, -0.00062115, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_M107 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F M107 M33", 850, 100, 0.0879633, -0.000601, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F M107 M33", 850, 100, 0.0841653, -0.000601, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_TAC50 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F TAC50 M33", 820, 100, 0.0879633, -0.00060964, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F TAC50 M33", 820, 100, 0.0872461, -0.00060964, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_FRF2 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F FRF2 M993", 850, 100, 0.0803840, -0.00110718, 6.35, 0, 2, 10, 120, 0, 0, 8.230, 7.82, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
+        preset[] = {"R3F FRF2 M993", 850, 100, 0.0783702, -0.00110718, 6.35, 0, 2, 10, 120, 0, 0, 8.230, 7.82, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
     };
     class R3F_HK417L {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F HK417L M80", 820, 100, 0.0909184, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 27.94, 0.398, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
+        preset[] = {"R3F HK417L M80", 820, 100, 0.0884448, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 27.94, 0.398, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- update the AtragMx presets' `Scope Base Angle` for all rifles :

**From the ACE3 Slack by @ulteq**
>I have an idea how you could calculate it yourself with the current ace3 release.

>1. Load your custom profile (with an arbitrary scope base angle) into the ATragMX
>2. Open the Gun/Ammo Page and close it with the 'Done' button.
>3. Execute `copyToClipboard Str(ace_atragmx_workingMemory select 3);` into the debug console

>This should dump the correct scope base angle for the current profile into the windows clipboard.

As usual, many thanks for your help. :)

- fix my splendid mistakes to the J4,J8 and J10 `ACE_ScopeAdjust_Vertical`.
- update the CfgMagazines according to the new Gunlist.