### PR TITLE
Fixed Slideshow action numbering

### DIFF
--- a/addons/slideshow/functions/fnc_createSlideshow.sqf
+++ b/addons/slideshow/functions/fnc_createSlideshow.sqf
@@ -49,10 +49,10 @@ if (isServer) then {
     {
         _x setObjectTextureGlobal [0, _images select 0];
     } count _objects;
-
-    // Number of slideshows (multiple modules support)
-    GVAR(slideshows) = GVAR(slideshows) + 1;
 };
+
+// Number of slideshows (multiple modules support)
+GVAR(slideshows) = GVAR(slideshows) + 1;
 
 private _currentSlideshow = GVAR(slideshows); // Local variable in case GVAR gets changed during execution of below code
 


### PR DESCRIPTION
Slideshow Action vaiable names would not be named on clients because counting was only done on the server, this would result in all actions on one object showing up in the same slideshow set

Changed:
Moved counting outside of Server Scope, therfore counting is also done on the client and everything works correctly

PR as discussed with @jonpas on slack, tested both locally and on dedicated server