### PR TITLE
Fix performance factor breaking stamina recovery

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
+++ b/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
@@ -53,7 +53,9 @@ GVAR(ae1Reserve) = GVAR(ae1Reserve) - _ae1Power / WATTSPERATP;
 GVAR(ae2Reserve) = GVAR(ae2Reserve) - _ae2Power / WATTSPERATP;
 GVAR(anReserve)  = GVAR(anReserve)  -  _anPower / WATTSPERATP;
 // Increase anearobic fatigue
-GVAR(anFatigue)  = GVAR(anFatigue) + _anPower * (0.057 / GVAR(peakPower)) * 1.1;
+// 1264.64 = 0.057 / peakPower with default VO2 max
+// See #6163
+GVAR(anFatigue)  = GVAR(anFatigue) + _anPower * 1264.64 * 1.1;
 
 // Aerobic ATP reserve recovery
 GVAR(ae1Reserve) = ((GVAR(ae1Reserve) + OXYGEN * 6.60 * (GVAR(ae1PathwayPower) - _ae1Power) / GVAR(ae1PathwayPower) * GVAR(recoveryFactor)) min AE1_MAXRESERVE) max 0;

--- a/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
+++ b/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
@@ -55,7 +55,7 @@ GVAR(anReserve)  = GVAR(anReserve)  -  _anPower / WATTSPERATP;
 // Increase anearobic fatigue
 // 1264.64 = 0.057 / peakPower with default VO2 max
 // See #6163
-GVAR(anFatigue)  = GVAR(anFatigue) + _anPower * 1264.64 * 1.1;
+GVAR(anFatigue)  = GVAR(anFatigue) + _anPower * (0.057 / 1264.64) * 1.1;
 
 // Aerobic ATP reserve recovery
 GVAR(ae1Reserve) = ((GVAR(ae1Reserve) + OXYGEN * 6.60 * (GVAR(ae1PathwayPower) - _ae1Power) / GVAR(ae1PathwayPower) * GVAR(recoveryFactor)) min AE1_MAXRESERVE) max 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix performance factor breaking stamina recovery

From the original VBS documentation:

---

**Acidosis accumulation**
`anaerobicFatigue += anaerobicDwork * maxPowerFatigueRatio * 1.1;`
[...]
`maxPowerFatigueRatio` is a constant designed to scale the accumulation and recovery of anaerobicFatigue: `maxPowerFatigueRatio = 0.057 / peakPower;`

---

They might mean that it's a constant regardless of the actual peakPower, which is calculated from the VO₂max (which in turn is adjusted by the performance factor). This seems to fix issue #6163.