### PR TITLE
Add IR beam to visible laser mode

### DIFF
--- a/addons/laserpointer/CfgWeapons.hpp
+++ b/addons/laserpointer/CfgWeapons.hpp
@@ -36,7 +36,11 @@ class CfgWeapons {
         class ItemInfo: InventoryFlashLightItem_Base_F {
             mass = 6;
 
-            class Pointer {};
+            class Pointer {
+                irLaserPos = "laser pos";
+                irLaserEnd = "laser dir";
+                irDistance = 5;
+            };
 
             class FlashLight {
                 color[] = {0,0,0};


### PR DESCRIPTION
**When merged this pull request will:**
- Add an IR beam to a visible laser mode for vanilla laser pointers

Visible laser is low enough power that the beam leading to the dot  is not visible to the naked eye but should still be visible for light magnification devices like NVGs. 
This PR enables the vanilla IR pointer module in addition the previously displayed laser dot which uses the vanilla flashlight module and drawIcon3D.