### PR TITLE
Fixes damage redirection issues

### DIFF
--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -141,6 +141,17 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
         [QGVAR(woundReceived), [_unit, _woundedHitPoint, _receivedDamage, _shooter, _ammo]] call CBA_fnc_localEvent;
     };
 
+    // resetting these single-damage-event tracker vars, if we don't do this then
+    // subsequent wounds will be piled onto the selection which has accumulated
+    // the most wounding
+    {
+        _unit setVariable [_x, 0];
+    } forEach [
+        QGVAR($HitFace),QGVAR($HitNeck),QGVAR($HitHead),
+        QGVAR($HitPelvis),QGVAR($HitAbdomen),QGVAR($HitDiaphragm),QGVAR($HitChest),QGVAR($HitBody),
+        QGVAR($HitLeftArm),QGVAR($HitRightArm),QGVAR($HitLeftLeg),QGVAR($HitRightLeg)
+    ];
+
     0
 };
 


### PR DESCRIPTION
Units accumulate damage in the local variables
"ACE_Medical_Engine_$HitXXXX", but these are never reset. The way these
vars are used is as a single-damage-event tracker, and the end result of
not resetting their value when they're done being used is that a
specific $HitXXXX can accumulate enough damage to cause the "select
wound with highest damage" code to always select _it_ for the next wound
event, even if it wasn't the primary target of the last wound event.

I.E. I get shot in the right leg badly. If I then get winged in the left
arm, that wound will end up on my right leg, because when the code runs,
it finds QGVAR($HitRightLeg) > QGVAR($HitLeftArm), and so it applies the
wound to the right leg.

**When merged this pull request will:**
- Fix the above-described issue
