### PR TITLE
Make common_fnc_stringToColoredText accept hex string as color.

### DIFF
--- a/addons/common/functions/fnc_stringToColoredText.sqf
+++ b/addons/common/functions/fnc_stringToColoredText.sqf
@@ -4,7 +4,7 @@
  *
  * Arguments:
  * 0: Text <ANY>
- * 1: Color <ARRAY>
+ * 1: Color <ARRAY, STRING>
  *
  * Return Value:
  * Text <STRING>
@@ -20,12 +20,14 @@ params ["_string", "_color"];
 
 _string = format ["%1", _string];
 
-_color = (
-    [255 * (_color select 0), 2] call FUNC(toHex)
-) + (
-    [255 * (_color select 1), 2] call FUNC(toHex)
-) + (
-    [255 * (_color select 2), 2] call FUNC(toHex)
-);
+if (_color isEqualType 0) then {
+    _color = "#" + (
+        [255 * (_color select 0), 2] call FUNC(toHex)
+    ) + (
+        [255 * (_color select 1), 2] call FUNC(toHex)
+    ) + (
+        [255 * (_color select 2), 2] call FUNC(toHex)
+    );
+};
 
-parseText format ["<t align='center' color='#%2' >%1</t>", _string, _color]
+parseText format ["<t align='center' color='%1' >%2</t>", _color, _string]

--- a/addons/overheating/functions/fnc_displayTemperature.sqf
+++ b/addons/overheating/functions/fnc_displayTemperature.sqf
@@ -45,7 +45,7 @@ for "_a" from (_count + 1) to 12 do {
 
 TRACE_3("",_temperature,_color,_string);
 
-_text = composeText [_text, [_string, [0.5, 0.5, 0.5]] call EFUNC(common,stringToColoredText)];
+_text = composeText [_text, [_string, "#808080"] call EFUNC(common,stringToColoredText)];
 
 private _picture = getText (configFile >> "CfgWeapons" >> _weapon >> "picture");
 

--- a/addons/reload/functions/fnc_displayAmmo.sqf
+++ b/addons/reload/functions/fnc_displayAmmo.sqf
@@ -95,7 +95,7 @@ private _ammoBarsStructuredText = if (_showNumber) then {
         _string = _string + "|";
     };
 
-    composeText [_text, [_string, [0.5, 0.5, 0.5]] call EFUNC(common,stringToColoredText)];
+    composeText [_text, [_string, "#808080"] call EFUNC(common,stringToColoredText)];
 };
 
 


### PR DESCRIPTION
It seems kinda unintelligent to always convert constants like in
https://github.com/acemod/ACE3/blob/master/addons/reload/functions/fnc_displayAmmo.sqf#L98
into string dynamically. We already know it's constant so wouldn't it be nice if it didn't have to re-calculate the same result each time it's called?

Also
![brofiler_2018-04-09_13-24-10](https://user-images.githubusercontent.com/3768165/38495270-4e1ffcee-3bf9-11e8-9cfb-4064297125f8.png)
Looks like some uses could be quite a bit faster without always converting it.
Yeah that's only 0.1ms but.. why not get rid of it.