### PR TITLE
Improve Reload TakeEH

### DIFF
--- a/addons/explosives/CfgEventHandlers.hpp
+++ b/addons/explosives/CfgEventHandlers.hpp
@@ -24,7 +24,7 @@ class Extended_Killed_EventHandlers {
 
 class Extended_Take_EventHandlers {
     class CAManBase {
-        GVAR(takeHandler) = QUOTE([ARR_3(_this select 0, _this select 1, _this select 2)] call FUNC(onInventoryChanged));
+        GVAR(takeHandler) = QUOTE(call FUNC(onInventoryChanged));
     };
 };
 class Extended_Put_EventHandlers {

--- a/addons/reload/CfgEventHandlers.hpp
+++ b/addons/reload/CfgEventHandlers.hpp
@@ -20,7 +20,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_Take_EventHandlers {
     class CAManBase {
         class ACE_AmmoIndicatorReload {
-            clientTake = QUOTE(if (_this select 0 == ACE_player && {GVAR(DisplayText)} && {(_this select 1) in [ARR_3(uniformContainer (_this select 0), vestContainer (_this select 0), backpackContainer (_this select 0))]} && {_this select 2 == currentMagazine (_this select 0)}) then {[ARR_2(_this select 0, vehicle (_this select 0))] call FUNC(displayAmmo)};);
+            clientTake = QUOTE(params ['_unit']; if (_unit == ACE_player && {GVAR(DisplayText)} && {(_this select 1) in [ARR_3(uniformContainer _unit, vestContainer _unit, backpackContainer _unit)]} && {_this select 2 == currentMagazine _unit}) then {[ARR_2(_unit, vehicle _unit)] call FUNC(displayAmmo)};);
         };
     };
 };


### PR DESCRIPTION
No reason to call `_this select 0` 7 times in total.

Improvement should be around 0.03ms per call. Yeah. Not much.

Gonna take a look at taking items from containers in general. Maybe I can find more improvements.

Biggest cause of lag when taking items from containers in my setup seems to be ASR AI. config lookup for uniform/vest/backpack each time you take whatever item even if your clothing didn't change.