### PR TITLE
Fix cardiac arrest time scale consistency by using seconds everywhere

### DIFF
--- a/addons/medical/XEH_preInit.sqf
+++ b/addons/medical/XEH_preInit.sqf
@@ -46,9 +46,9 @@ GVAR(STATE_MACHINE) = (configFile >> "ACE_Medical_StateMachine") call CBA_statem
 [
     QGVAR(cardiacArrestTime),
     "SLIDER",
-    ["Cardiac Arrest Time", "Sets how long cardiac arrest will last for on average (in minutes)."], //@todo
+    ["Cardiac Arrest Time", "Sets how long cardiac arrest will last for on average (in seconds)."], //@todo
     "ACE Medical", // @todo
-    [0, 30, 2, 0],
+    [0, 300, 30, 0],
     true
 ] call CBA_Settings_fnc_init;
 */

--- a/addons/medical/functions/fnc_conditionCardiacArrestTimer.sqf
+++ b/addons/medical/functions/fnc_conditionCardiacArrestTimer.sqf
@@ -16,4 +16,4 @@ params ["_unit"];
 private _startTime = _unit getVariable [QGVAR(cardiacArrestStart), CBA_missionTime];
 private _lifeTime = _unit getVariable [QGVAR(cardiacArrestTime), GVAR(cardiacArrestTime)];
 
-(CBA_missionTime - _startTime) > (_lifeTime * 60)
+(CBA_missionTime - _startTime) > _lifeTime

--- a/addons/medical/functions/fnc_enteredStateCardiacArrest.sqf
+++ b/addons/medical/functions/fnc_enteredStateCardiacArrest.sqf
@@ -14,6 +14,7 @@
 
 params ["_unit"];
 
+// 10% possible variance in cardiac arrest time
 private _time = GVAR(cardiacArrestTime);
 _time = _time + random [_time*-0.1, 0, _time*0.1];
 

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Medical">
         <Key ID="STR_ACE_Medical_Injuries">
@@ -3514,7 +3514,7 @@
             <English>In Cardiac Arrest</English>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_cardiacArrestTime_DisplayName">
-            <English>Cardiac Arrest time(s)</English>
+            <English>Cardiac Arrest time (seconds)</English>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_cardiacArrestTime_Description">
             <English>Defines how long it takes to die from cardiac arrest?</English>


### PR DESCRIPTION
This was changed from minutes to seconds at some point, but not everywhere. Just making it consistent.

Relates to #5510 as the unit would enter cardiac arrest at some point and die quickly (though doesn't fix the issue - we need another fatal condition for many wounds at once or similar).