### PR TITLE
Remove arsenal when already present

### DIFF
--- a/addons/zeus/functions/fnc_moduleAddAceArsenal.sqf
+++ b/addons/zeus/functions/fnc_moduleAddAceArsenal.sqf
@@ -29,6 +29,7 @@ switch (true) do {
         [LSTRING(OnlyAlive)] call FUNC(showMessage);
     };
     default {
+        [_object, true] call EFUNC(arsenal,removeBox);
         [_object, true, true] call EFUNC(arsenal,initBox);
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the issue that the `Add full Arsenal` Zeus module fails when the box already has an Arsenal.
