### PR TITLE
Cleanup ace_vehicles for 1.82

### DIFF
--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -522,8 +522,8 @@ class CfgWeapons {
     class LMG_coax: LMG_RCWS {
         displayName = "PKT";
     };
-    // class ACE_LMG_coax_PKT_mem2: LMG_coax {};
-    class ACE_LMG_coax_MAG58_mem2: LMG_coax {
+    class LMG_coax_ext: LMG_coax {};
+    class ACE_LMG_coax_ext_MAG58: LMG_coax_ext {
         displayName = "MAG 58M";
     };
     class ACE_LMG_coax_MAG58_mem3: LMG_coax {

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -68,44 +68,17 @@ class CfgVehicles {
 
     class APC_Tracked_01_base_F: Tank_F {
         fuelCapacity = 500 * FUEL_FACTOR;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets;
-            };
-        };
     };
 
     class APC_Tracked_02_base_F: Tank_F {
         fuelCapacity = 600 * FUEL_FACTOR; // NO FUCKING DATA
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
-        };
-    };
-
-    class O_APC_Tracked_02_base_F: APC_Tracked_02_base_F {};
-
-    class O_APC_Tracked_02_cannon_F: O_APC_Tracked_02_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_PKT_mem2","missiles_titan"};
-                magazines[] = {"140Rnd_30mm_MP_shells_Tracer_Green","60Rnd_30mm_APFSDS_shells_Tracer_Green","2000Rnd_762x51_Belt_Green","2Rnd_GAT_missiles"};
-            };
-        };
     };
 
     class APC_Tracked_03_base_F: Tank_F {
         fuelCapacity = 660 * FUEL_FACTOR;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_30mm","ACE_LMG_coax_L94A1_mem3"};
-                magazines[] = {"140Rnd_30mm_MP_shells_Tracer_Yellow","60Rnd_30mm_APFSDS_shells_Tracer_Yellow","1000Rnd_762x51_Belt_Yellow","1000Rnd_762x51_Belt_Yellow"};
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
+                weapons[] = {"autocannon_30mm","ACE_LMG_coax_L94A1_mem3"}; // Base 1.82: "autocannon_30mm","LMG_coax"
             };
         };
     };
@@ -114,11 +87,7 @@ class CfgVehicles {
         fuelCapacity = 550 * FUEL_FACTOR;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"cannon_120mm_long","ACE_LMG_coax_MAG58_mem3"};
-                magazines[] = {"28Rnd_120mm_APFSDS_shells_Tracer_Yellow","14Rnd_120mm_HE_shells_Tracer_Yellow","2000Rnd_762x51_Belt_Yellow","2000Rnd_762x51_Belt_Yellow"};
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
+                weapons[] = {"cannon_120mm_long","ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "cannon_120mm_long","LMG_coax"
             };
         };
     };
@@ -127,64 +96,54 @@ class CfgVehicles {
         fuelCapacity = 500 * FUEL_FACTOR;
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"cannon_120mm","ACE_LMG_coax_MAG58_mem2"};
-                magazines[] = {"32Rnd_120mm_APFSDS_shells_Tracer_Red","16Rnd_120mm_HE_shells_Tracer_Red","2000Rnd_762x51_Belt_Red","2000Rnd_762x51_Belt_Red"};
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
+                weapons[] = {"cannon_120mm", "ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "cannon_120mm","LMG_coax"
             };
         };
     };
 
     class B_MBT_01_base_F: MBT_01_base_F {};
-
     class B_MBT_01_cannon_F: B_MBT_01_base_F {};
-
-    class MBT_02_base_F: Tank_F {
-        fuelCapacity = 600 * FUEL_FACTOR; // again, couldn't find proper data
+    class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
+                weapons[] = {"cannon_120mm", "ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "cannon_120mm","LMG_coax"
             };
         };
     };
+    
+    
+    
+    class MBT_02_base_F: Tank_F {
+        fuelCapacity = 600 * FUEL_FACTOR; // again, couldn't find proper data
+    };
+
+    
+    // Change boat minigun ammo to 7.62
 
     class Ship_F: Ship {};
-
     class Boat_F: Ship_F {};
-
     class Boat_Armed_01_base_F: Boat_F {
         class Turrets: Turrets {
             class FrontTurret;
             class RearTurret: FrontTurret {};
         };
     };
-
-    class Boat_Armed_01_minigun_base_F: Boat_Armed_01_base_F {};
-
-    class B_Boat_Armed_01_minigun_F: Boat_Armed_01_minigun_base_F {
+    class Boat_Armed_01_minigun_base_F: Boat_Armed_01_base_F {
         class Turrets: Turrets {
-            class FrontTurret: FrontTurret {};
             class RearTurret: RearTurret {
-                magazines[] = {"2000Rnd_762x51_Belt_T_Red"};
+                magazines[] = {"2000Rnd_762x51_Belt_T_Red"}; // Base 1.82: "2000Rnd_65x39_belt_Tracer_Red"
             };
         };
     };
-
     class I_Boat_Armed_01_minigun_F: Boat_Armed_01_minigun_base_F {
         class Turrets: Turrets {
-            class FrontTurret: FrontTurret {};
             class RearTurret: RearTurret {
-                magazines[] = {"2000Rnd_762x51_Belt_T_Yellow"};
+                magazines[] = {"2000Rnd_762x51_Belt_T_Yellow"}; // Base 1.82: "2000Rnd_65x39_Belt_Tracer_Yellow"
             };
         };
     };
 
-    class Truck_F: Car_F {
-        class Turrets: Turrets {};
-    };
+    class Truck_F: Car_F {};
 
     class MRAP_01_base_F: Car_F {
         fuelCapacity = 510 * FUEL_FACTOR;
@@ -193,15 +152,7 @@ class CfgVehicles {
     class MRAP_02_base_F: Car_F {
         fuelCapacity = 500 * FUEL_FACTOR; // couldn't find any data for the punisher
     };
-
-    class O_MRAP_02_F: MRAP_02_base_F {
-        class Turrets;
-    };
-
-    class Offroad_01_base_F: Car_F {
-        //fuelCapacity = 45;
-    };
-
+    
     class MRAP_03_base_F: Car_F {
         fuelCapacity = 860 * FUEL_FACTOR;
         smokeLauncherGrenadeCount = 3;
@@ -217,7 +168,6 @@ class CfgVehicles {
         smokeLauncherGrenadeCount = 3;
         smokeLauncherAngle = 80;
         class Turrets: Turrets {
-            class MainTurret: MainTurret {};
             class CommanderTurret: CommanderTurret {
                 stabilizedInAxes = 3;
             };
@@ -228,7 +178,6 @@ class CfgVehicles {
         smokeLauncherGrenadeCount = 3;
         smokeLauncherAngle = 80;
         class Turrets: Turrets {
-            class MainTurret: MainTurret {};
             class CommanderTurret: CommanderTurret {
                 stabilizedInAxes = 3;
             };
@@ -237,190 +186,46 @@ class CfgVehicles {
 
     class Truck_01_base_F: Truck_F {
         fuelCapacity = 644 * FUEL_FACTOR;
-        class Turrets;
     };
 
     class Truck_02_base_F: Truck_F {
         fuelCapacity = 1100 * FUEL_FACTOR;
-        class Turrets;
     };
 
     class Truck_03_base_F: Truck_F {
         fuelCapacity = 900 * FUEL_FACTOR; // NO. FUCKING. DATA.
-        class Turrets;
-    };
-
-    class Hatchback_01_base_F: Car_F {
-        //fuelCapacity = 45;
-        class Turrets;
-    };
-
-    class SUV_01_base_F: Car_F {
-        //fuelCapacity = 45;
-        class Turrets;
-    };
-
-    class Van_01_base_F: Truck_F {
-        //fuelCapacity = 45;
-        class Turrets;
     };
 
     class APC_Wheeled_01_base_F: Wheeled_APC_F {
         fuelCapacity = 800 * FUEL_FACTOR;
         class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
+            class MainTurret: MainTurret {};
         };
     };
-
     class B_APC_Wheeled_01_base_F: APC_Wheeled_01_base_F {};
-
     class B_APC_Wheeled_01_cannon_F: B_APC_Wheeled_01_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_40mm_CTWS","ACE_LMG_coax_MAG58_mem2"};
-                magazines[] = {"60Rnd_40mm_GPR_Tracer_Red_shells","40Rnd_40mm_APFSDS_Tracer_Red_shells","2000Rnd_762x51_Belt_Red"};
+                weapons[] = {"autocannon_40mm_CTWS","ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "autocannon_40mm_CTWS","LMG_coax"
             };
         };
     };
 
     class APC_Wheeled_02_base_F: Wheeled_APC_F {
         fuelCapacity = 700 * FUEL_FACTOR;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets;
-            };
-
-            class CommanderOptics: CommanderOptics {};
-        };
-    };
-
-    class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                weapons[] = {"cannon_105mm","ACE_LMG_coax_MAG58_mem2"};
-                magazines[] = {"40Rnd_105mm_APFSDS_T_Red","20Rnd_105mm_HEAT_MP_T_Red","2000Rnd_762x51_Belt_Red","2000Rnd_762x51_Belt_Red"};
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
-        };
     };
 
     class APC_Wheeled_03_base_F: Wheeled_APC_F {
         fuelCapacity = 700 * FUEL_FACTOR;
         class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class Turrets: Turrets {
-                    class CommanderOptics: CommanderOptics {};
-                };
-            };
+            class MainTurret: MainTurret {};
         };
     };
-
     class I_APC_Wheeled_03_base_F: APC_Wheeled_03_base_F {};
-
     class I_APC_Wheeled_03_cannon_F: I_APC_Wheeled_03_base_F {
         class Turrets: Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_MAG58_mem2","missiles_titan"};
-                magazines[] = {"140Rnd_30mm_MP_shells_Tracer_Yellow","60Rnd_30mm_APFSDS_shells_Tracer_Yellow","2000Rnd_762x51_Belt_Yellow","2Rnd_GAT_missiles"};
-            };
-        };
-    };
-
-    // static mgs shouldn't use 500 rnd mags.
-    class StaticWeapon: LandVehicle {
-        class Turrets {
-            class MainTurret; //: NewTurret {};
-        };
-    };
-
-    class StaticMGWeapon: StaticWeapon {};
-
-    class HMG_01_base_F: StaticMGWeapon {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag","100Rnd_127x99_mag","100Rnd_127x99_mag","100Rnd_127x99_mag","100Rnd_127x99_mag"};
-            };
-        };
-    };
-
-    class B_HMG_01_F: HMG_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red"};
-            };
-        };
-    };
-
-    class O_HMG_01_F: HMG_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green"};
-            };
-        };
-    };
-
-    class I_HMG_01_F: HMG_01_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow"};
-            };
-        };
-    };
-
-    class HMG_01_high_base_F: HMG_01_base_F {};
-
-    class B_HMG_01_high_F: HMG_01_high_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red"};
-            };
-        };
-    };
-
-    class O_HMG_01_high_F: HMG_01_high_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green"};
-            };
-        };
-    };
-
-    class I_HMG_01_high_F: HMG_01_high_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow"};
-            };
-        };
-    };
-
-    class HMG_01_A_base_F: HMG_01_base_F {};
-
-    class B_HMG_01_A_F: HMG_01_A_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Red"};
-            };
-        };
-    };
-
-    class O_HMG_01_A_F: HMG_01_A_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Green"};
-            };
-        };
-    };
-
-    class I_HMG_01_A_F: HMG_01_A_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                magazines[] = {"100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag_Tracer_Yellow"};
+                weapons[] = {"autocannon_30mm_CTWS","ACE_LMG_coax_ext_MAG58", "missiles_titan"}; // Base 1.82: "autocannon_30mm_CTWS","LMG_coax_ext","missiles_titan"
             };
         };
     };

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -3,30 +3,15 @@ class CfgWeapons {
     class MGunCore;
     class MGun: MGunCore {};
     class LMG_RCWS: MGun {};
+    class LMG_coax: LMG_RCWS {};
+    class LMG_coax_ext: LMG_coax {};
 
-    class LMG_coax;
     class ACE_LMG_coax_L94A1_mem3: LMG_coax {};
-    class ACE_LMG_coax_PKT_mem2: LMG_coax {
-        class GunParticles {
-            class effect1 {
-                positionName = "usti hlavne2";
-                directionName = "konec hlavne2";
-                effectName = "MachineGunCloud";
-            };
-        };
-    };
     class ACE_LMG_coax_MAG58_mem3: LMG_coax {};
-    class ACE_LMG_coax_MAG58_mem2: LMG_coax {
-        class GunParticles {
-            class effect1 {
-                positionName = "usti hlavne2";
-                directionName = "konec hlavne2";
-                effectName = "MachineGunCloud";
-            };
-        };
-    };
+    class ACE_LMG_coax_ext_MAG58: LMG_coax_ext {};
 
     class LMG_Minigun: LMG_RCWS {
+        // Add the following: "2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt"
         magazines[] = {"PylonWeapon_2000Rnd_65x39_belt", "1000Rnd_65x39_Belt","1000Rnd_65x39_Belt_Green","1000Rnd_65x39_Belt_Tracer_Green","1000Rnd_65x39_Belt_Tracer_Red","1000Rnd_65x39_Belt_Tracer_Yellow","1000Rnd_65x39_Belt_Yellow","2000Rnd_65x39_Belt","2000Rnd_65x39_Belt_Green","2000Rnd_65x39_Belt_Tracer_Green","2000Rnd_65x39_Belt_Tracer_Green_Splash","2000Rnd_65x39_Belt_Tracer_Red","2000Rnd_65x39_Belt_Tracer_Yellow","2000Rnd_65x39_Belt_Tracer_Yellow_Splash","2000Rnd_65x39_Belt_Yellow","2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","200Rnd_65x39_Belt","200Rnd_65x39_Belt_Tracer_Green","200Rnd_65x39_Belt_Tracer_Red","200Rnd_65x39_Belt_Tracer_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt","500Rnd_65x39_Belt","500Rnd_65x39_Belt_Tracer_Red_Splash","500Rnd_65x39_Belt_Tracer_Green_Splash","500Rnd_65x39_Belt_Tracer_Yellow_Splash"};
     };
 
@@ -36,18 +21,8 @@ class CfgWeapons {
 
     class HMG_01: HMG_127 {
         reloadTime = 0.23;
-
         class manual: manual {
             reloadTime = 0.23;
         };
-        class close: manual {};
-        class short: close {};
-        class medium: close {};
-        class far: close {};
-    };
-
-    // make static weapons compatible with 100rnd mag variants
-    class HMG_static: HMG_01 {
-        magazines[] = {"500Rnd_127x99_mag","500Rnd_127x99_mag_Tracer_Red","500Rnd_127x99_mag_Tracer_Green","500Rnd_127x99_mag_Tracer_Yellow","200Rnd_127x99_mag","200Rnd_127x99_mag_Tracer_Red","200Rnd_127x99_mag_Tracer_Green","200Rnd_127x99_mag_Tracer_Yellow","100Rnd_127x99_mag","100Rnd_127x99_mag_Tracer_Red","100Rnd_127x99_mag_Tracer_Green","100Rnd_127x99_mag_Tracer_Yellow"};
     };
 };


### PR DESCRIPTION
Close #6220

Vanilla 1.82 changes: Some tanks now have HEAT rounds, APCs seem to have much more 30mm ammo, they split up the 2000rnd tank mg into individual belts, same with HMGs


- Now use vanilla magazine loadouts for most vehicles
- mem2 weapons no long exist
- cleanup configs
