### PR TITLE
Repair - Handle changes to getAllHitPointsDamage

### DIFF
--- a/addons/repair/dev/draw_showRepairInfo.sqf
+++ b/addons/repair/dev/draw_showRepairInfo.sqf
@@ -64,6 +64,6 @@ addMissionEventHandler ["Draw3D", {
             _output pushBack format ["%1: %2[%3] = %4", _forEachIndex, _hitPoint, _selection, cursorObject getHitIndex _forEachIndex];
             _output pushBack format ["- %1 -",_info];
         };
-    } forEach _hitPoints;
+    } forEach _hitSelections;
     hintSilent (_output joinString "\n");
 }];

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -28,7 +28,7 @@ private _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 if (_type in _initializedClasses) exitWith {};
 
 // get all hitpoints and selections
-(getAllHitPointsDamage _vehicle) params [["_hitPoints", []], ["_hitSelections", []]];
+(getAllHitPointsDamage _vehicle) params [["_hitPoints", []], ["_hitSelections", []]];  // Since 1.82 these are all lower case
 
 // get hitpoints of wheels with their selections
 ([_vehicle] call FUNC(getWheelHitPointsWithSelections)) params ["_wheelHitPoints", "_wheelHitSelections"];
@@ -41,7 +41,7 @@ private _icon = QPATHTOF(ui\repair_0_ca.paa);
 
 {
     private _selection = _x;
-    private _hitpoint = _hitPoints select _forEachIndex;
+    private _hitpoint = toLower (_hitPoints select _forEachIndex);
 
     if (_selection in _wheelHitSelections) then {
         // Wheels should always be unique
@@ -68,7 +68,7 @@ private _icon = QPATHTOF(ui\repair_0_ca.paa);
         [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
     } else {
         //Skip glass hitpoints
-        if (((toLower _hitPoint) find "glass") != -1) exitWith {
+        if ((_hitPoint find "glass") != -1) exitWith {
             TRACE_3("Skipping Glass",_hitpoint,_forEachIndex,_selection);
         };
         // Empty selections don't exist

--- a/addons/repair/functions/fnc_canMiscRepair.sqf
+++ b/addons/repair/functions/fnc_canMiscRepair.sqf
@@ -36,9 +36,10 @@ if (isArray _hitpointGroupConfig) then {
         // Exit using found hitpoint group if this hitpoint is leader of any
         if (_masterHitpoint == _hitPointClassname) exitWith {
             {
-                private _subHitIndex = _allHitPoints find _x;
+                private _subHitpoint = _x;
+                private _subHitIndex = _allHitPoints findIf {_x == _subHitpoint};
                 if (_subHitIndex == -1) then {
-                    ERROR("Hitpoint Not Found");
+                    ERROR_2("Invalid hitpoint %1 in hitpointGroups of %2",_subHitpoint,_target);
                 } else {
                     _hitpointGroup pushBack _subHitIndex;
                 };

--- a/addons/repair/functions/fnc_doRepair.sqf
+++ b/addons/repair/functions/fnc_doRepair.sqf
@@ -47,9 +47,10 @@ if (isArray _hitpointGroupConfig) then {
         // Exit using found hitpoint group if this hitpoint is leader of any
         if (_masterHitpoint == _hitPointClassname) exitWith {
             {
-                private _subHitIndex = _allHitPoints find _x; //convert hitpoint classname to index
+                private _subHitpoint = _x;
+                private _subHitIndex = _allHitPoints findIf {_x == _subHitpoint}; //convert hitpoint classname to index
                 if (_subHitIndex == -1) then {
-                    ERROR_2("Invalid hitpoint %1 in hitpointGroups of %2",_x,_vehicle);
+                    ERROR_2("Invalid hitpoint %1 in hitpointGroups of %2",_subHitpoint,_vehicle);
                 } else {
                     private _subPointCurDamage = _vehicle getHitIndex _hitPointIndex;
                     private _subPointNewDamage = (_subPointCurDamage - 0.5) max _postRepairDamageMin;

--- a/addons/repair/script_component.hpp
+++ b/addons/repair/script_component.hpp
@@ -16,4 +16,4 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
-#define TRACK_HITPOINTS ["HitLTrack", "HitRTrack"]
+#define TRACK_HITPOINTS ["hitltrack", "hitrtrack"]


### PR DESCRIPTION
Since 1.82 `getAllHitPointsDamage` returns lower case
Fix track repair and hit point groups being case sensitive
Part of #6248
