### PR TITLE
Realistic names for new assets from Tanks DLC

### DIFF
--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -257,6 +257,10 @@ class CfgVehicles {
     class I_Truck_02_box_F: Truck_02_box_base_F {
         displayName = CSTRING(Truck_02_box_Name);
     };
+    class Truck_02_MRL_base_F;
+    class I_Truck_02_MRL_F: Truck_02_MRL_base_F {
+        displayName = CSTRING(Truck_02_MRL_Name);
+    };
     class I_Truck_02_medical_F: Truck_02_medical_base_F {
         displayName = CSTRING(Truck_02_medical_Name);
     };

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -779,4 +779,37 @@ class CfgVehicles {
         displayName = CSTRING(lsv_02_at);
     };
 
+    // Rooikat 120 (Rhino MGS)
+    class Wheeled_APC_F;
+    class AFV_Wheeled_01_base_F : Wheeled_APC_F {
+        displayName = CSTRING(afv_wheeled_01);
+    };
+    class AFV_Wheeled_01_up_base_F : AFV_Wheeled_01_base_F {
+        displayName = CSTRING(afv_wheeled_01_up);
+    };
+
+    // T-14 Armata (T-140 Angara)
+    class MBT_04_base_F;
+    class MBT_04_cannon_base_F : MBT_04_base_F {
+        displayName = CSTRING(MBT_04_cannon);
+    };
+    class MBT_04_command_base_F : MBT_04_base_F {
+        displayName = CSTRING(MBT_04_command);
+    };
+
+    // Wiesel 2 (AWC 302 Nyx)
+    class LT_01_base_F;
+    class LT_01_AA_base_F : LT_01_base_F {
+        displayName = CSTRING(LT_01_AA);
+    };
+    class LT_01_AT_base_F : LT_01_base_F {
+        displayName = CSTRING(LT_01_AT);
+    };
+    class LT_01_cannon_base_F : LT_01_base_F {
+        displayName = CSTRING(LT_01_cannon);
+    };
+    class LT_01_scout_base_F : LT_01_base_F {
+        displayName = CSTRING(LT_01_scout);
+    };
+
 };

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -730,12 +730,25 @@ class CfgVehicles {
     // APEX/Tanoa
 
     // Jeep Wrangler
-    class Offroad_02_unarmed_base_F;
+    class Offroad_02_base_F;
+    class Offroad_02_unarmed_base_F : Offroad_02_base_F {};
     class C_Offroad_02_unarmed_F: Offroad_02_unarmed_base_F {
         displayName = CSTRING(C_Offroad_02_unarmed);
     };
     class I_C_Offroad_02_unarmed_F: Offroad_02_unarmed_base_F {
         displayName = CSTRING(C_Offroad_02_unarmed);
+    };
+    class Offroad_02_at_base_F: Offroad_02_base_F {
+        displayName = CSTRING(C_Offroad_02_at);
+    };
+    class I_C_Offroad_02_at_F: Offroad_02_at_base_F {
+        displayName = CSTRING(C_Offroad_02_at);
+    };
+    class Offroad_02_lmg_base_F: Offroad_02_base_F {
+        displayName = CSTRING(C_Offroad_02_lmg);
+    };
+    class I_C_Offroad_02_lmg_F: Offroad_02_lmg_base_F {
+        displayName = CSTRING(C_Offroad_02_lmg);
     };
 
     // Cessna

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -780,35 +780,52 @@ class CfgVehicles {
     };
 
     // Rooikat 120 (Rhino MGS)
-    class Wheeled_APC_F;
-    class AFV_Wheeled_01_base_F : Wheeled_APC_F {
+    class AFV_Wheeled_01_base_F;
+    class B_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
         displayName = CSTRING(afv_wheeled_01);
     };
-    class AFV_Wheeled_01_up_base_F : AFV_Wheeled_01_base_F {
+    class B_T_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
+        displayName = CSTRING(afv_wheeled_01);
+    };
+    class AFV_Wheeled_01_up_base_F;
+    class B_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
+        displayName = CSTRING(afv_wheeled_01_up);
+    };
+    class B_T_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
         displayName = CSTRING(afv_wheeled_01_up);
     };
 
     // T-14 Armata (T-140 Angara)
-    class MBT_04_base_F;
-    class MBT_04_cannon_base_F : MBT_04_base_F {
+    class MBT_04_cannon_base_F;
+    class O_MBT_04_cannon_F : MBT_04_cannon_base_F {
         displayName = CSTRING(MBT_04_cannon);
     };
-    class MBT_04_command_base_F : MBT_04_base_F {
+    class O_T_MBT_04_cannon_F : MBT_04_cannon_base_F {
+        displayName = CSTRING(MBT_04_cannon);
+    };
+    class MBT_04_command_base_F;
+    class O_MBT_04_command_F : MBT_04_command_base_F {
+        displayName = CSTRING(MBT_04_command);
+    };
+    class O_T_MBT_04_command_F : MBT_04_command_base_F {
         displayName = CSTRING(MBT_04_command);
     };
 
     // Wiesel 2 (AWC 302 Nyx)
-    class LT_01_base_F;
-    class LT_01_AA_base_F : LT_01_base_F {
+    class LT_01_AA_base_F;
+    class I_LT_01_AA_F : LT_01_AA_base_F {
         displayName = CSTRING(LT_01_AA);
     };
-    class LT_01_AT_base_F : LT_01_base_F {
+    class LT_01_AT_base_F;
+    class I_LT_01_AT_F : LT_01_AT_base_F {
         displayName = CSTRING(LT_01_AT);
     };
-    class LT_01_cannon_base_F : LT_01_base_F {
+    class LT_01_cannon_base_F;
+    class I_LT_01_cannon_F : LT_01_cannon_base_F {
         displayName = CSTRING(LT_01_cannon);
     };
-    class LT_01_scout_base_F : LT_01_base_F {
+    class LT_01_scout_base_F;
+    class I_LT_01_scout_F : LT_01_scout_base_F {
         displayName = CSTRING(LT_01_scout);
     };
 

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -186,6 +186,13 @@ class CfgVehicles {
     class O_APC_Wheeled_02_base_F : APC_Wheeled_02_base_F {
         displayName = CSTRING(APC_Wheeled_02_rcws_Name);
     };
+    class APC_Wheeled_02_base_v2_F : APC_Wheeled_02_base_F{};
+    class O_APC_Wheeled_02_rcws_v2_F : APC_Wheeled_02_base_v2_F {
+        displayName = CSTRING(APC_Wheeled_02_rcws_Name);
+    };
+    class O_T_APC_Wheeled_02_rcws_v2_ghex_F : APC_Wheeled_02_base_v2_F {
+        displayName = CSTRING(APC_Wheeled_02_rcws_Name);
+    };
 
     class I_APC_Wheeled_03_base_F;
     class I_APC_Wheeled_03_cannon_F: I_APC_Wheeled_03_base_F {

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -807,7 +807,7 @@ class CfgVehicles {
     class O_T_MBT_04_cannon_F : MBT_04_cannon_base_F {
         displayName = CSTRING(MBT_04_cannon);
     };
-    class MBT_04_command_base_F;
+    class MBT_04_command_base_F; // Keep "K" designation for command variant.
     class O_MBT_04_command_F : MBT_04_command_base_F {
         displayName = CSTRING(MBT_04_command);
     };

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -763,6 +763,9 @@ class CfgVehicles {
     class LSV_01_light_base_F : LSV_01_base_F {
         displayName = CSTRING(lsv_01_light);
     };
+    class LSV_01_AT_base_F : LSV_01_base_F {
+        displayName = CSTRING(lsv_01_at);
+    };
 
     // Light Strike Vehicle Mk. II (Qilin)
     class LSV_02_base_F;
@@ -771,6 +774,9 @@ class CfgVehicles {
     };
     class LSV_02_unarmed_base_F : LSV_02_base_F {
         displayName = CSTRING(lsv_02_unarmed);
+    };
+    class LSV_02_AT_base_F : LSV_02_base_F {
+        displayName = CSTRING(lsv_02_at);
     };
 
 };

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -186,7 +186,7 @@ class CfgVehicles {
     class O_APC_Wheeled_02_base_F : APC_Wheeled_02_base_F {
         displayName = CSTRING(APC_Wheeled_02_rcws_Name);
     };
-    class APC_Wheeled_02_base_v2_F : APC_Wheeled_02_base_F{};
+    class APC_Wheeled_02_base_v2_F;
     class O_APC_Wheeled_02_rcws_v2_F : APC_Wheeled_02_base_v2_F {
         displayName = CSTRING(APC_Wheeled_02_rcws_Name);
     };

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -452,6 +452,11 @@ class CfgWeapons {
         };
     };
 
+    class HMG_127_APC : HMG_127 {};
+    class ACE_HMG_127_KORD : HMG_127_APC {
+        displayName = "6P49 Kord";
+    };
+
     class HMG_01: HMG_127 {
         displayName = "XM312";
     };
@@ -534,6 +539,10 @@ class CfgWeapons {
     class cannon_125mm: CannonCore {
         displayName = "2A46";
     };
+    
+    class cannon_125mm_advanced : cannon_125mm {
+        displayName = "2A82-1M";
+    };
 
     // coax machine guns
     class LMG_coax: LMG_RCWS {
@@ -596,6 +605,10 @@ class CfgWeapons {
         class HE: HE {
             displayName = "L21A1 RARDEN";
         };
+    };
+    
+    class autocannon_30mm_RCWS : autocannon_Base_F {
+        displayName = "2A42";
     };
 
     class cannon_20mm : autocannon_Base_F {

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -559,7 +559,10 @@ class CfgWeapons {
         displayName = "L94A1";
     };
     class ACE_LMG_coax_ext_MG3: LMG_coax_ext {
-        displayName = "MG3";
+        displayName = "H&K MG3";
+    };
+    class ACE_LMG_coax_DenelMG4 : LMG_coax {
+        displayName = "Denel MG4";
     };
 
     // more autocannons

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -361,6 +361,9 @@ class CfgWeapons {
     class Missile_AGM_01_Plane_CAS_02_F: Missile_AGM_02_Plane_CAS_01_F {
         displayName = "Kh-25MTP";
     };
+    class missiles_Vorona : MissileLauncher {
+        displayName = CSTRING(missiles_vorona);
+    };
 
     // rockets
     class Rocket_04_HE_Plane_CAS_01_F: RocketPods {

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -520,6 +520,10 @@ class CfgWeapons {
         class player: player {};
     };
 
+    class ACE_cannon_120mm_GT12: cannon_120mm {
+        displayName = "GT12";
+    };
+
     class cannon_105mm: CannonCore {
         displayName = "M68";
         class player: Mode_SemiAuto {

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -495,6 +495,10 @@ class CfgWeapons {
         displayName = "Mini-Spike";
     };
 
+    class missiles_SAAMI : MissileLauncher {
+        displayName = "FIM-92F";
+    };
+
     // mortar
     class mortar_155mm_AMOS: CannonCore {
         displayName = "L/52";
@@ -541,6 +545,9 @@ class CfgWeapons {
     class ACE_LMG_coax_L94A1_mem3: LMG_coax {
         displayName = "L94A1";
     };
+    class ACE_LMG_coax_ext_MG3: LMG_coax {
+        displayName = "MG3";
+    };
 
     // more autocannons
     class autocannon_Base_F;
@@ -584,6 +591,20 @@ class CfgWeapons {
 
         class HE: HE {
             displayName = "L21A1 RARDEN";
+        };
+    };
+
+    class cannon_20mm : autocannon_Base_F {
+        class AP : autocannon_Base_F {};
+        class HE : autocannon_Base_F {};
+    };
+    class ACE_cannon_20mm_Rh202 : cannon_20mm {
+        displayName = "MK20 Rh 202";
+        class AP: AP {
+            displayName = "MK20 Rh 202";
+        };
+        class HE: HE {
+            displayName = "MK20 Rh 202";
         };
     };
 

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -633,6 +633,90 @@ class CfgWeapons {
         displayName = "UTG Defender 126";
     };
 
+    class optic_hamr : ItemCore {
+        displayName = CSTRING(optic_hamr);
+    };
+    class optic_Hamr_khk_F : optic_hamr {
+        displayName = CSTRING(optic_hamr_khk);
+    };
+
+    class optic_Arco : ItemCore {
+        displayName = CSTRING(optic_arco);
+    };
+    class optic_Arco_blk_F : optic_Arco {
+        displayName = CSTRING(optic_arco_blk);
+    };
+    class optic_Arco_ghex_F : optic_Arco {
+        displayName = CSTRING(optic_arco_ghex);
+    };
+
+    class optic_ERCO_blk_f : optic_Arco {
+        displayName = CSTRING(optic_erco_blk);
+    };
+    class optic_ERCO_khk_f : optic_ERCO_blk_f {
+        displayName = CSTRING(optic_erco_khk);
+    };
+    class optic_ERCO_snd_f : optic_ERCO_blk_f {
+        displayName = CSTRING(optic_erco_snd);
+    };
+    
+    class optic_LRPS : ItemCore {
+        displayName = CSTRING(optic_lrps);
+    };
+    class optic_LRPS_ghex_F : optic_LRPS {
+        displayName = CSTRING(optic_lrps_ghex);
+    };
+    class optic_LRPS_tna_F : optic_LRPS {
+        displayName = CSTRING(optic_lrps_tna);
+    };
+
+    class optic_DMS : ItemCore {
+        displayName = CSTRING(optic_dms);
+    };
+    class optic_DMS_ghex_F : optic_DMS {
+        displayName = CSTRING(optic_dms_ghex);
+    };
+
+    class optic_holosight : ItemCore {
+        displayName = CSTRING(optic_holosight);
+    };
+    class optic_Holosight_blk_F : optic_holosight {
+        displayName = CSTRING(optic_holosight_blk);
+    };
+    class optic_Holosight_khk_F : optic_holosight {
+        displayName = CSTRING(optic_holosight_khk);
+    };
+    class optic_Holosight_smg : ItemCore {
+        displayName = CSTRING(optic_holosight_smg);
+    };
+    class optic_Holosight_smg_blk_F : optic_Holosight_smg {
+        displayName = CSTRING(optic_holosight_smg_blk);
+    };
+    class optic_Holosight_smg_khk_F : optic_Holosight_smg {
+        displayName = CSTRING(optic_holosight_smg_khk);
+    };
+
+    class optic_MRCO : ItemCore {
+        displayName = CSTRING(optic_MRCO);
+    };
+
+    class optic_Yorris : ItemCore {
+        displayName = CSTRING(optic_Yorris);
+    };
+
+    class optic_ACO : ItemCore {
+        displayName = CSTRING(optic_ACO);
+    };
+    class optic_ACO_grn : ItemCore {
+        displayName = CSTRING(optic_ACO_grn);
+    };
+    class optic_ACO_smg : ItemCore {
+        displayName = CSTRING(optic_ACO_smg);
+    };
+    class optic_ACO_grn_smg : ItemCore {
+        displayName = CSTRING(optic_ACO_grn_smg);
+    };
+
     // APEX/Tanoa
 
     // QBZ-95 and variants

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -545,7 +545,7 @@ class CfgWeapons {
     class ACE_LMG_coax_L94A1_mem3: LMG_coax {
         displayName = "L94A1";
     };
-    class ACE_LMG_coax_ext_MG3: LMG_coax {
+    class ACE_LMG_coax_ext_MG3: LMG_coax_ext {
         displayName = "MG3";
     };
 

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -192,6 +192,14 @@ class CfgWeapons {
         displayName = CSTRING(launch_NLAW_Name);
     };
 
+    class launch_Vorona_base_F;
+    class launch_O_Vorona_brown_F : launch_Vorona_base_F {
+        displayName = CSTRING(launch_Vorona_brown);
+    };
+    class launch_O_Vorona_green_F : launch_Vorona_base_F {
+        displayName = CSTRING(launch_Vorona_green);
+    };
+
     // marksmen marksman
     class DMR_02_base_F: Rifle_Long_Base_F {
         displayName = CSTRING(DMR_02); //MAR-10 .338;

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3142,6 +3142,10 @@
             <Chinese>"北極星"先進佈署越野車 (XM312重機槍)</Chinese>
             <Chinesesimp>"北极星"先进布署越野车 (XM312重机枪)</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_01_at">
+            <English>Polaris DAGOR (AT)</English>
+            <German>Polaris DAGOR (AT)</German>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_01_unarmed">
             <English>Polaris DAGOR</English>
             <German>Polaris DAGOR</German>
@@ -3162,6 +3166,10 @@
             <Japanese>LSV Mk. II (M134)</Japanese>
             <Chinese>輕型突擊車2式 (M134迷你機炮)</Chinese>
             <Chinesesimp>轻型突击车2式 (M134迷你机炮)</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_lsv_02_at">
+            <English>LSV Mk. II (AT)</English>
+            <German>LSV Mk. II (AT)</German>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_02_unarmed">
             <English>LSV Mk. II</English>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1603,6 +1603,18 @@
             <Chinese>"迷你長釘"導彈發射器 (反坦克)</Chinese>
             <Chinesesimp>"迷你长钉"导弹发射器 (反坦克)</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_launch_Vorona_brown">
+            <English>Metis-M (Brown)</English>
+            <German>Metis-M (Braun)</German>
+            <French>Metis-M (Brun)</French>
+            <Russian>Метис-М (Кори́чневый)</Russian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_launch_Vorona_green">
+            <English>Metis-M (Green)</English>
+            <German>Metis-M (Grün)</German>
+            <French>Metis-M (Verde)</French>
+            <Russian>Метис-М (Зелёный)</Russian>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_arifle_MX_Name">
             <English>MX</English>
             <German>MX</German>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2613,6 +2613,14 @@
             <Chinese>"牧馬人"吉普車</Chinese>
             <Chinesesimp>"牧马人"吉普车</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_at">
+            <English>Jeep Wrangler (SPG-9)</English>
+            <German>Jeep Wrangler (SPG-9)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_C_Offroad_02_lmg">
+            <English>Jeep Wrangler (LMG)</English>
+            <German>Jeep Wrangler (LMG)</German>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_C_Plane_Civil_01">
             <English>Cessna TTx</English>
             <Czech>Cessna TTx</Czech>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3242,6 +3242,98 @@
             <English>Wiesel 2 RFCV (Radar)</English>
             <German>Wiesel 2 AFF (Radar)</German>
         </Key>
-
+        <Key ID="STR_ACE_RealisticNames_optic_hamr">
+            <English>Leupold Mark 4 HAMR</English>
+            <German>Leupold Mark 4 HAMR</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_hamr_khk">
+            <English>Leupold Mark 4 HAMR (Khaki)</English>
+            <German>Leupold Mark 4 HAMR (Khaki)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_arco">
+            <English>ELCAN SpecterOS (Tan)</English>
+            <German>ELCAN SpecterOS (Beige)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_arco_blk">
+            <English>ELCAN SpecterOS (Black)</English>
+            <German>ELCAN SpecterOS (Schwarz)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_arco_ghex">
+            <English>ELCAN SpecterOS (Green Hex)</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_erco_blk">
+            <English>SIG BRAVO4 / ROMEO3 (Black)</English>
+            <German>SIG BRAVO4 / ROMEO3 (Schwarz)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_erco_khk">
+            <English>SIG BRAVO4 / ROMEO3 (Khaki)</English>
+            <German>SIG BRAVO4 / ROMEO3 (Khaki)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_erco_snd">
+            <English>SIG BRAVO4 / ROMEO3 (Sand)</English>
+            <German>SIG BRAVO4 / ROMEO3 (Beige)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_lrps">
+            <English>Nightforce NXS</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_lrps_ghex">
+            <English>Nightforce NXS (Grenn Hex)</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_lrps_tna">
+            <English>Nightforce NXS (Jungle)</English>
+            <German>Nightforce NXS (Dschungel)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_dms">
+            <English>Burris XTR II</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_dms_ghex">
+            <English>Burris XTR II (Green Hex)</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_holosight">
+            <English>EOTech XPS3 (Tan)</English>
+            <German>EOTech XPS3 (Beige)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_holosight_blk">
+            <English>EOTech XPS3 (Black)</English>
+            <German>EOTech XPS3 (Schwarz)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_holosight_khk">
+            <English>EOTech XPS3 (Khaki)</English>
+            <German>EOTech XPS3 (Khaki)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_holosight_smg">
+            <English>EOTech XPS3 SMG (Tan)</English>
+            <German>EOTech XPS3 SMG (Beige)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_holosight_smg_blk">
+            <English>EOTech XPS3 SMG (Black)</English>
+            <German>EOTech XPS3 SMG (Schwarz)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_holosight_smg_khk">
+            <English>EOTech XPS3 SMG (Khaki)</English>
+            <German>EOTech XPS3 SMG (Khaki)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_mrco">
+            <English>IOR-Valada Pitbull 2</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_Yorris">
+            <English>Burris FastFire 2</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ACO">
+            <English>C-More Railway (Red)</English>
+            <German>C-More Railway (Rot)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ACO_grn">
+            <English>C-More Railway (Green)</English>
+            <German>C-More Railway (Grün)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ACO_smg">
+            <English>C-More Railway SMG (Red)</English>
+            <German>C-More Railway SMG (Rot)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ACO_grn_smg">
+            <English>C-More Railway SMG (Green)</English>
+            <German>C-More Railway SMG (Grün)</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1603,6 +1603,12 @@
             <Chinese>"迷你長釘"導彈發射器 (反坦克)</Chinese>
             <Chinesesimp>"迷你长钉"导弹发射器 (反坦克)</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_missiles_vorona">
+            <English>Metis-M</English>
+            <German>Metis-M</German>
+            <French>Metis-M</French>
+            <Russian>Метис-М</Russian>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_launch_Vorona_brown">
             <English>Metis-M (Brown)</English>
             <German>Metis-M (Braun)</German>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -657,6 +657,10 @@
             <Chinese>"卡瑪斯"卡車 (醫療)</Chinese>
             <Chinesesimp>"卡玛斯"卡车 (医疗)</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_Truck_02_MRL_Name">
+            <English>KamAZ MRL</English>
+            <German>KamAS MRL</German>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_MRAP_02_Name">
             <English>Karatel</English>
             <German>Karatel</German>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3143,8 +3143,8 @@
             <Chinesesimp>"北极星"先进布署越野车 (XM312重机枪)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_01_at">
-            <English>Polaris DAGOR (AT)</English>
-            <German>Polaris DAGOR (AT)</German>
+            <English>Polaris DAGOR (Mini-Spike AT)</English>
+            <German>Polaris DAGOR (Mini-Spike PzAbw)</German>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_01_unarmed">
             <English>Polaris DAGOR</English>
@@ -3168,8 +3168,8 @@
             <Chinesesimp>轻型突击车2式 (M134迷你机炮)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_02_at">
-            <English>LSV Mk. II (AT)</English>
-            <German>LSV Mk. II (AT)</German>
+            <English>LSV Mk. II (Metis-M)</English>
+            <German>LSV Mk. II (Metis-M)</German>
         </Key>
         <Key ID="STR_ACE_RealisticNames_lsv_02_unarmed">
             <English>LSV Mk. II</English>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3178,5 +3178,40 @@
             <Chinese>輕型突擊車2式</Chinese>
             <Chinesesimp>轻型突击车2式</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_afv_wheeled_01">
+            <English>Rooikat 120</English>
+            <German>Rooikat 120</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_afv_wheeled_01_up">
+            <English>Rooikat 120 UP</English>
+            <German>Rooikat 120 UP</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_MBT_04_cannon">
+            <English>T-14 Armata</English>
+            <German>T-14 Armata</German>
+            <Russian>Т-14 Армата</Russian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_MBT_04_command">
+            <English>T-14K Armata</English>
+            <German>T-14K Armata</German>
+            <Russian>Т-14К Армата</Russian>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_LT_01_AA">
+            <English>Wiesel 2 Ozelot (AA)</English>
+            <German>Wiesel 2 Ozelot (FlaRaWaTrg)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_LT_01_AT">
+            <English>Wiesel 2 (ATGM)</English>
+            <German>Wiesel 2 (PzAbw)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_LT_01_cannon">
+            <English>Wiesel 2 (MK20)</English>
+            <German>Wiesel 2 (MK20)</German>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_LT_01_scout">
+            <English>Wiesel 2 RFCV (Radar)</English>
+            <German>Wiesel 2 AFF (Radar)</German>
+        </Key>
+
     </Package>
 </Project>

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -292,4 +292,26 @@ class CfgVehicles {
             };
         };
     };
+
+    // Tanks DLC Armata
+    class MBT_04_base_F : Tank_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {
+                class Turrets : Turrets {
+                    class CommanderOptics: CommanderOptics {};
+                };
+            };
+        };
+    };
+    class MBT_04_cannon_base_F : MBT_04_base_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {
+                class Turrets : Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        weapons[] = {"ACE_HMG_127_KORD","SmokeLauncher"};
+                    };
+                };
+            };
+        };
+    };
 };

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -229,4 +229,27 @@ class CfgVehicles {
             };
         };
     };
+
+    // Wiesel 2
+    class LT_01_base_F : Tank_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {};
+        };
+    };
+    class LT_01_cannon_base_F : LT_01_base_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {};
+        };
+    };
+    class I_LT_01_cannon_F : LT_01_cannon_base_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {
+                weapons[] = {
+                    "SmokeLauncher",
+                    "ACE_LMG_coax_ext_MG3",
+                    "ACE_cannon_20mm_Rh202"
+                };
+            };
+        };
+    };
 };

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -238,11 +238,6 @@ class CfgVehicles {
     };
     class LT_01_cannon_base_F : LT_01_base_F {
         class Turrets : Turrets {
-            class MainTurret : MainTurret {};
-        };
-    };
-    class I_LT_01_cannon_F : LT_01_cannon_base_F {
-        class Turrets : Turrets {
             class MainTurret : MainTurret {
                 weapons[] = {
                     "SmokeLauncher",
@@ -255,40 +250,6 @@ class CfgVehicles {
 
     // Tanks DLC Rooikat 120
     class AFV_Wheeled_01_base_F : wheeled_APC_F {
-        class Turrets : Turrets {
-            class MainTurret : MainTurret {};
-        };
-    };
-    class AFV_Wheeled_01_up_base_F : AFV_Wheeled_01_base_F {
-        class Turrets : Turrets {
-            class MainTurret : MainTurret {};
-        };
-    };
-    class B_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
-        class Turrets : Turrets {
-            class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
-                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
-            };
-        };
-    };
-    class B_T_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
-        class Turrets : Turrets {
-            class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
-                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
-            };
-        };
-    };
-    class B_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
-        class Turrets : Turrets {
-            class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
-                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
-            };
-        };
-    };
-    class B_T_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
         class Turrets : Turrets {
             class MainTurret: MainTurret {
                 weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -230,7 +230,7 @@ class CfgVehicles {
         };
     };
 
-    // Wiesel 2
+    // Tanks DLC Wiesel 2
     class LT_01_base_F : Tank_F {
         class Turrets : Turrets {
             class MainTurret : MainTurret {};
@@ -249,6 +249,46 @@ class CfgVehicles {
                     "ACE_LMG_coax_ext_MG3",
                     "ACE_cannon_20mm_Rh202"
                 };
+            };
+        };
+    };
+
+    // Tanks DLC Rooikat 120
+    class AFV_Wheeled_01_base_F : wheeled_APC_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {};
+        };
+    };
+    class AFV_Wheeled_01_up_base_F : AFV_Wheeled_01_base_F {
+        class Turrets : Turrets {
+            class MainTurret : MainTurret {};
+        };
+    };
+    class B_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
+        class Turrets : Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+            };
+        };
+    };
+    class B_T_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
+        class Turrets : Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+            };
+        };
+    };
+    class B_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
+        class Turrets : Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+            };
+        };
+    };
+    class B_T_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
+        class Turrets : Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
             };
         };
     };

--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -267,28 +267,32 @@ class CfgVehicles {
     class B_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
         class Turrets : Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
+                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
             };
         };
     };
     class B_T_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F {
         class Turrets : Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
+                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
             };
         };
     };
     class B_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
         class Turrets : Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
+                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
             };
         };
     };
     class B_T_AFV_Wheeled_01_up_cannon_F : AFV_Wheeled_01_up_base_F {
         class Turrets : Turrets {
             class MainTurret: MainTurret {
-                weapons[] = {"ACE_cannon_120mm_GT12","MMG_02_coax"};
+                weapons[] = {"ACE_cannon_120mm_GT12","ACE_LMG_coax_DenelMG4"};
+                magazines[] = {"12Rnd_120mm_APFSDS_shells_Tracer_Red","8Rnd_120mm_HE_shells_Tracer_Red","8Rnd_120mm_HEAT_MP_T_Red","4Rnd_120mm_LG_cannon_missiles","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red","200Rnd_762x51_Belt_T_Red"};
             };
         };
     };

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -9,6 +9,7 @@ class CfgWeapons {
     class ACE_LMG_coax_L94A1_mem3: LMG_coax {};
     class ACE_LMG_coax_MAG58_mem3: LMG_coax {};
     class ACE_LMG_coax_ext_MAG58: LMG_coax_ext {};
+    class ACE_LMG_coax_ext_MG3: LMG_coax_ext {};
 
     class LMG_Minigun: LMG_RCWS {
         // Add the following: "2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt"
@@ -25,4 +26,9 @@ class CfgWeapons {
             reloadTime = 0.23;
         };
     };
+
+    class CannonCore;
+    class autocannon_Base_F : CannonCore {};
+    class cannon_20mm : autocannon_Base_F {};
+    class ACE_cannon_20mm_Rh202 : cannon_20mm {};
 };

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -27,8 +27,12 @@ class CfgWeapons {
         };
     };
 
+    // Tanks DLC: weapons for Wiesel and Rooikat
     class CannonCore;
     class autocannon_Base_F : CannonCore {};
     class cannon_20mm : autocannon_Base_F {};
     class ACE_cannon_20mm_Rh202 : cannon_20mm {};
+
+    class cannon_120mm : CannonCore {};
+    class ACE_cannon_120mm_GT12 : cannon_120mm {};
 };

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -10,6 +10,7 @@ class CfgWeapons {
     class ACE_LMG_coax_MAG58_mem3: LMG_coax {};
     class ACE_LMG_coax_ext_MAG58: LMG_coax_ext {};
     class ACE_LMG_coax_ext_MG3: LMG_coax_ext {};
+    class ACE_LMG_coax_DenelMG4 : LMG_coax {};
 
     class LMG_Minigun: LMG_RCWS {
         // Add the following: "2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt"

--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -27,6 +27,9 @@ class CfgWeapons {
         };
     };
 
+    class HMG_127_APC : HMG_127 {};
+    class ACE_HMG_127_KORD : HMG_127_APC {};
+
     // Tanks DLC: weapons for Wiesel and Rooikat
     class CannonCore;
     class autocannon_Base_F : CannonCore {};
@@ -35,4 +38,5 @@ class CfgWeapons {
 
     class cannon_120mm : CannonCore {};
     class ACE_cannon_120mm_GT12 : cannon_120mm {};
+
 };


### PR DESCRIPTION
**When merged this pull request will:**
Add realistic names for new assets from Tanks DLC.

Vehicles:
- [X]  LSV AT-Variants.
- [X] Rhino MGS -> Rooikat
- [X] T140 Angara -> T14 Armata
- [X] AWC 302 Nyx -> Wiesel 2;
    - Wiesel 2 Ozelot (AA)
    - Wiesel 2 ATGM
    - Wiesel 2 AFF
    - Wiesel 2 MK20
- [x]  Zamak MLR -> Kamaz MLR
- [x] MB4WD armed -> Jeep Wrangler
- [x] New Marid -> Otokar ARMA

Vehicle Weapons:
- [X] Vorona -> Metis-M
- [X] Rooikat 120mm Gun -> GT12
- [x] Rooikat Coax SPMG .338 ->Denel MG4 (Added manufacturer's name to distinguish from H&K MG4)
- [x] Armata Commander M2 -> KORD
- [x] Armata K Commander Autocannon -> 2A42
- [x] Armata K Main Cannon -> 2A82-1M (source: [German Wikipedia](https://de.wikipedia.org/wiki/T-14#Bewaffnung))
- [x] Ozelot SAAMI -> FIM92F Stinger
- [x] Wiesel MK20 PKT -> MG3
- [x] Wiesel MK20 Autocannon -> MK20 Rh 202
- [x] Wiesel AT Firefist -> Keep for now

Weapons:
- [X] Vorona -> Metis-M
- [X] MAAWS Mk4 Mod 0 / Mod 1 -> no change

I was in the flow, so I added Optics Attachments as well.

More to be added. Please add assets i may have missed in this PR.