### PR TITLE
make.py - cleanup old optional pbos before rename

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -432,9 +432,15 @@ def cleanup_optionals(mod):
 
 
                 if (os.path.isfile(src_file_path)):
+                    if (os.path.isfile(dst_file_path)):
+                        # print("Cleanuping up old file {}".format(dst_file_path))
+                        os.remove(dst_file_path);
                     #print("Preserving {}".format(file_name))
                     os.renames(src_file_path,dst_file_path)
                 if (os.path.isfile(src_sig_path)):
+                    if (os.path.isfile(dst_sig_path)):
+                        # print("Cleanuping up old file {}".format(dst_sig_path))
+                        os.remove(dst_sig_path);
                     #print("Preserving {}".format(sigFile_name))
                     os.renames(src_sig_path,dst_sig_path)
             except FileExistsError:


### PR DESCRIPTION
make tried to rename (cut/paste) and would fail because a pbo from an older build already existed in that spot
```
Copying dll => P:\z\ace\ace_parse_imagepath_x64.dll

Cleaning P:\z\ace\addons\compat_adr_97
Cleanuping up old file P:\z\ace\release\@ace\optionals\@ace_compat_adr_97\addons\ace_compat_adr_97.pbo
ERROR: ace_compat_adr_97.pbo already exists
Cleaning P:\z\ace\addons\compat_r3f
Cleanuping up old file P:\z\ace\release\@ace\optionals\@ace_compat_r3f\addons\ace_compat_r3f.pbo
ERROR: ace_compat_r3f.pbo already exists
```