### PR TITLE
Cookoff- Damage handling disabled by default

### DIFF
--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -4,7 +4,7 @@ class ACE_Settings {
         category = CSTRING(displayName);
         displayName = CSTRING(enable_name);
         description = CSTRING(enable_tooltip);
-        value = 1;
+        value = 0;
         typeName = "BOOL";
     };
     class GVAR(enableAmmobox) {


### PR DESCRIPTION
Ref
#5102
#6261
#6255

With the recent damage system changes in 1.82 ace_cookoff may have issues.
This PR will simply change the default setting to disabled.