### PR TITLE
FCS - Switch to using vanilla FCS for attack helicopters

### DIFF
--- a/addons/fcs/CfgVehicles.hpp
+++ b/addons/fcs/CfgVehicles.hpp
@@ -97,35 +97,4 @@ class CfgVehicles {
             };
         };
     };
-
-    // AIR VEHICLES
-    class Air: AllVehicles {};
-
-    class Helicopter: Air {
-        class Turrets {
-            class MainTurret;
-        };
-    };
-
-    class Helicopter_Base_F: Helicopter {};
-
-    class Heli_Attack_01_base_F: Helicopter_Base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
-
-    class Heli_Attack_02_base_F: Helicopter_Base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                GVAR(Enabled) = 1;
-                discreteDistance[] = {};
-                discreteDistanceInitIndex = 0;
-            };
-        };
-    };
 };

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -152,33 +152,15 @@ class CfgVehicles {
     };
 
     class Heli_Attack_02_base_F: Helicopter_Base_F {};
-    class rhs_mi28_base: Heli_Attack_02_base_F {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0; // Note: This is still required because of inheritance from Heli_Attack_02_base_F
-            };
-        };
-    };
-
     class RHS_Ka52_base: Heli_Attack_02_base_F {
         EGVAR(refuel,fuelCapacity) = 1870;
         EGVAR(fastroping,enabled) = 0;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0; // Note: This is still required because of inheritance from Heli_Attack_02_base_F
-            };
-        };
     };
 
     class RHS_Mi24_base: Heli_Attack_02_base_F {
         EGVAR(map,vehicleLightColor)[] = {1,0,0,0.1};
         EGVAR(refuel,fuelCapacity) = 1851;
         EGVAR(fastroping,enabled) = 0;
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                EGVAR(fcs,enabled) = 0; // Note: This is still required because of inheritance from Heli_Attack_02_base_F
-            };
-        };
     };
 
     class rhs_t80b: rhs_tank_base {

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -196,23 +196,9 @@ class CfgVehicles {
         EGVAR(hellfire,addLaserDesignator) = 1;
     };
 
-    class RHS_AH1Z: RHS_AH1Z_base {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                ace_fcs_Enabled = 0; // Note: This is still required because of inheritance from Heli_Attack_01_base_F
-            };
-        };
-    };
     class RHS_AH64_base: Heli_Attack_01_base_F {
         EGVAR(refuel,fuelCapacity) = 1420;
         EGVAR(hellfire,addLaserDesignator) = 1;
-    };
-    class RHS_AH64D: RHS_AH64_base {
-        class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                ace_fcs_Enabled = 0; // Note: This is still required because of inheritance from Heli_Attack_01_base_F
-            };
-        };
     };
 
     class MBT_01_arty_base_F;


### PR DESCRIPTION
1.82 changelog:
>Tweaked: Blackfish and gunship helicopters gunners now use FCS instead of CCIP (press 'T' before firing)

No difference between their system and ours now.