### PR TITLE
NLAW - Fix "no shape for" rpt warning

### DIFF
--- a/addons/nlaw/CfgAmmo.hpp
+++ b/addons/nlaw/CfgAmmo.hpp
@@ -39,11 +39,11 @@ class CfgAmmo {
     // Sub ammos used in OTA mode (see fnc_seeker.sqf)
     class ACE_NLAW_Explosion: ACE_NLAW { // Based on FCS-Airburst, will explode right away
         timeToLive = 0;
-        model = "";
+        model = "\A3\weapons_f\empty";
     };
     class ACE_NLAW_ShapedCharge: ACE_NLAW { // Shaped charge from rocket explosion, no effects
         timeToLive = 1;
-        model = "";
+        model = "\A3\weapons_f\empty";
         hit = 750;
         indirectHit = 0;
         indirectHitRange = 0;


### PR DESCRIPTION
```
No shape for ammo type ACE_NLAW_Explosion
No shape for ammo type ACE_NLAW_ShapedCharge
```
