### PR TITLE
(repair) - isRepairVehicle handling values according to wiki

### DIFF
--- a/addons/repair/functions/fnc_isRepairVehicle.sqf
+++ b/addons/repair/functions/fnc_isRepairVehicle.sqf
@@ -20,4 +20,5 @@ TRACE_1("params",_vehicle);
 
 if (_vehicle isKindOf "CAManBase") exitWith {false};
 
-((_vehicle getVariable ["ACE_isRepairVehicle", getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(canRepair))]) > 0);
+// Value can be integer or boolean
+([false, true] select (_vehicle getVariable ["ACE_isRepairVehicle", getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(canRepair))])) // return

--- a/addons/repair/functions/fnc_isRepairVehicle.sqf
+++ b/addons/repair/functions/fnc_isRepairVehicle.sqf
@@ -21,4 +21,5 @@ TRACE_1("params",_vehicle);
 if (_vehicle isKindOf "CAManBase") exitWith {false};
 
 // Value can be integer or boolean
-([false, true] select (_vehicle getVariable ["ACE_isRepairVehicle", getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(canRepair))])) // return
+private _value = _vehicle getVariable ["ACE_isRepairVehicle", getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(canRepair))];
+_value in [1, true] // return


### PR DESCRIPTION
The wiki states that `ACE_isRepairVehicle` is a boolean but this function only checked for integer values, resulting in a script error for whoever used the wiki value. 

**When merged this pull request will:**
-  Make isRepairVehicle handle both types 
