### PR TITLE
Tactical Ladder - Fix args to cancleTLdeploy

### DIFF
--- a/addons/tacticalladder/functions/fnc_cancelTLdeploy.sqf
+++ b/addons/tacticalladder/functions/fnc_cancelTLdeploy.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * [_ladder] call ace_tacticalladder_fnc_cancelTLdeploy
+ * [player, 1] call ace_tacticalladder_fnc_cancelTLdeploy
  *
  * Public: No
  */

--- a/addons/tacticalladder/functions/fnc_handleInteractMenuOpened.sqf
+++ b/addons/tacticalladder/functions/fnc_handleInteractMenuOpened.sqf
@@ -18,5 +18,5 @@
 params ["_unit"];
 
 if (!isNull GETMVAR(GVAR(ladder),objNull) && {GVAR(ladder) in attachedObjects _unit}) then {
-    [_unit, GVAR(ladder)] call FUNC(cancelTLdeploy);
+    [_unit, 1] call FUNC(cancelTLdeploy);
 };

--- a/addons/tacticalladder/functions/fnc_handleKilled.sqf
+++ b/addons/tacticalladder/functions/fnc_handleKilled.sqf
@@ -18,5 +18,5 @@
 params ["_unit"];
 
 if (!isNull GETMVAR(ladder,objNull) && {GVAR(ladder) in attachedObjects _unit}) then {
-    [_unit, GVAR(ladder)] call FUNC(cancelTLdeploy);
+    [_unit, 1] call FUNC(cancelTLdeploy);
 };

--- a/addons/tacticalladder/functions/fnc_handlePlayerChanged.sqf
+++ b/addons/tacticalladder/functions/fnc_handlePlayerChanged.sqf
@@ -21,9 +21,9 @@ if (isNull GETGVAR(ladder,objNull)) exitWith {};
 params ["_newPlayer", "_oldPlayer"];
 
 if (GVAR(ladder) in attachedObjects _newPlayer) then {
-    [_newPlayer, GVAR(ladder)] call FUNC(cancelTLdeploy);
+    [_newPlayer, 1] call FUNC(cancelTLdeploy);
 };
 
 if (GVAR(ladder) in attachedObjects _oldPlayer) then {
-    [_oldPlayer, GVAR(ladder)] call FUNC(cancelTLdeploy);
+    [_oldPlayer, 1] call FUNC(cancelTLdeploy);
 };

--- a/addons/tacticalladder/functions/fnc_handleUnconscious.sqf
+++ b/addons/tacticalladder/functions/fnc_handleUnconscious.sqf
@@ -20,5 +20,5 @@ params ["_unit"];
 if (!local _unit) exitWith {};
 
 if (!isNull GETMVAR(ladder,objNull) && {GVAR(ladder) in attachedObjects _unit}) then {
-    [_unit, GVAR(ladder)] call FUNC(cancelTLdeploy);
+    [_unit, 1] call FUNC(cancelTLdeploy);
 };


### PR DESCRIPTION
Fix #6232

cancelTLdeploy expects `[unit, mouse button key]`
