### PR TITLE
Repair - Disable repair on ERA/Slat armor hitpoints

### DIFF
--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -72,7 +72,7 @@ class ACE_Repair {
             requiredEngineer = QGVAR(engineerSetting_fullRepair);
             repairLocations[] = {QGVAR(fullRepairLocation)};
             repairingTime = 30;
-            condition = "0 < ({_x>0} count (getAllHitPointsDamage _target param [2,[]]))";
+            condition = "-1 != ((getAllHitPointsDamage _target param [2,[]]) findIf {_x > 0})";
             callbackSuccess = QUOTE(call FUNC(doFullRepair));
             itemConsumed = QGVAR(consumeItem_ToolKit);
         };

--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -424,7 +424,7 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_04_base_F: Helicopter_Base_H {
-        GVAR(hitpointGroups)[] = { {"HitEngine", {"HitEngine1", "HitEngine2"}}, {"Glass_1_hitpoint", {"Glass_2_hitpoint", "Glass_3_hitpoint", "Glass_4_hitpoint", "Glass_5_hitpoint", "Glass_6_hitpoint", "Glass_7_hitpoint", "Glass_8_hitpoint", "Glass_9_hitpoint", "Glass_10_hitpoint", "Glass_11_hitpoint", "Glass_12_hitpoint", "Glass_13_hitpoint", "Glass_14_hitpoint", "Glass_15_hitpoint", "Glass_16_hitpoint", "Glass_17_hitpoint", "Glass_18_hitpoint", "Glass_19_hitpoint", "Glass_20_hitpoint"}} };
+        GVAR(hitpointGroups)[] = { {"HitEngine", {"HitEngine1", "HitEngine2"}} };
     };
     class O_Heli_Transport_04_repair_F: Heli_Transport_04_base_F {
         GVAR(canRepair) = 1;
@@ -458,16 +458,10 @@ class CfgVehicles {
     };
 
     class Car_F;
-    class Offroad_01_base_F: Car_F {
-        GVAR(hitpointGroups)[] = { {"HitGlass1", {"HitGlass2"}} };
-    };
+    class Offroad_01_base_F: Car_F {};
     class Offroad_01_repair_base_F: Offroad_01_base_F {
         GVAR(canRepair) = 1;
         transportRepair = 0;
-    };
-
-    class MRAP_01_base_F: Car_F {
-        GVAR(hitpointGroups)[] = { {"HitGlass1", {"HitGlass2", "HitGlass3", "HitGlass4", "HitGlass5", "HitGlass6"}} };
     };
 
     class B_Truck_01_mover_F;

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -18,13 +18,11 @@
 if (!hasInterface) exitWith {};
 
 params ["_vehicle"];
-TRACE_2("params", _vehicle,typeOf _vehicle);
-
 private _type = typeOf _vehicle;
-
-private _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
+TRACE_2("addRepairActions", _vehicle,_type);
 
 // do nothing if the class is already initialized
+private _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 if (_type in _initializedClasses) exitWith {};
 
 // get all hitpoints and selections
@@ -39,10 +37,15 @@ private _hitPointsAddedAmount = [];
 private _processedHitpoints = [];
 private _icon = QPATHTOF(ui\repair_0_ca.paa);
 
+
+// Custom position can be defined via config for associated hitpoint
+private _hitpointPositions = getArray (configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointPositions));
+// Associated hitpoints can be grouped via config to produce a single repair action
+private _hitpointGroups = getArray(configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointGroups));
+
 {
     private _selection = _x;
     private _hitpoint = toLower (_hitPoints select _forEachIndex);
-
     if (_selection in _wheelHitSelections) then {
         // Wheels should always be unique
         if (_hitpoint in _processedHitpoints) exitWith {TRACE_3("Duplicate Wheel",_hitpoint,_forEachIndex,_selection);};
@@ -67,56 +70,52 @@ private _icon = QPATHTOF(ui\repair_0_ca.paa);
         _action = [_name, _text, _icon, _statement, _condition, {}, [_hitpoint], _position, 2] call EFUNC(interact_menu,createAction);
         [_type, 0, [], _action] call EFUNC(interact_menu,addActionToClass);
     } else {
-        //Skip glass hitpoints
-        if ((_hitPoint find "glass") != -1) exitWith {
-            TRACE_3("Skipping Glass",_hitpoint,_forEachIndex,_selection);
-        };
         // Empty selections don't exist
+        if (_selection isEqualTo "") exitWith { TRACE_3("Skipping Empty Sel",_hitpoint,_forEachIndex,_selection); };
         // Empty hitpoints don't contain enough information
-        if (_selection isEqualTo "") exitWith { TRACE_3("Selection Empty",_hitpoint,_forEachIndex,_selection); };
-        if (_hitpoint isEqualTo "") exitWith { TRACE_3("Hitpoint Empty",_hitpoint,_forEachIndex,_selection); };
+        if (_hitpoint isEqualTo "") exitWith { TRACE_3("Skipping Empty Hit",_hitpoint,_forEachIndex,_selection); };
+        // Ignore glass hitpoints
+        if ((_hitPoint find "glass") != -1) exitWith { TRACE_3("Skipping Glass",_hitpoint,_forEachIndex,_selection); };
+        // Ignore hitpoints starting with # (seems to be lights)
+        if ((_hitpoint select [0,1]) == "#") exitWith { TRACE_3("Skipping # hit",_hitpoint,_forEachIndex,_selection); };
+        // Ignore ERA/Slat armor (vanilla uses hitera_/hitslat_, pre-1.82 RHS uses era_)
+        // ToDo: see how community utilizes new armor system, could also check getText (_hitpointConfig >> "simulation")
+        if (((_hitpoint select [0,7]) == "hitera_") || {(_hitpoint select [0,8]) == "hitslat_"} || {(_hitpoint select [0,4]) == "era_"}) exitWith { TRACE_3("Skipping ERA/SLAT",_hitpoint,_forEachIndex,_selection); };
+
+
         //Depends hitpoints shouldn't be modified directly (will be normalized)
         // Biki: Clearing 'depends' in case of inheritance cannot be an empty string (rpt warnings), but rather a "0" value.
         if (!((getText (configFile >> "CfgVehicles" >> _type >> "HitPoints" >> _hitpoint >> "depends")) in ["", "0"])) exitWith {
             TRACE_3("Skip Depends",_hitpoint,_forEachIndex,_selection);
         };
 
-        // Associated hitpoints can be grouped via config to produce a single repair action
-        private _groupsConfig = configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointGroups);
         private _childHitPoint = false;
-        if (isArray _groupsConfig) then {
+        {
             {
-                {
-                    if (_hitpoint == _x) exitWith {
-                        _childHitPoint = true;
-                    };
-                } forEach (_x select 1);
-            } forEach (getArray _groupsConfig);
-        };
+                if (_hitpoint == _x) exitWith {
+                    _childHitPoint = true;
+                };
+            } forEach (_x select 1);
+        } forEach _hitpointGroups;
         // If the current selection is associated with a child hitpoint, then skip
         if (_childHitPoint) exitWith { TRACE_3("childHitpoint",_hitpoint,_forEachIndex,_selection); };
 
         // Find the action position
         private _position = compile format ["_target selectionPosition ['%1', 'HitPoints'];", _selection];
-
-        // Custom position can be defined via config for associated hitpoint
-        private _positionsConfig = configFile >> "CfgVehicles" >> _type >> QGVAR(hitpointPositions);
-        if (isArray _positionsConfig) then {
-            {
-                _x params ["_hit", "_pos"];
-                if (_hitpoint == _hit) exitWith {
-                    if (_pos isEqualType []) exitWith {
-                        _position = _pos; // Position in model space
-                    };
-                    if (_pos isEqualType "") exitWith {
-                        _position = compile format ["_target selectionPosition ['%1', 'HitPoints'];", _pos];
-                    };
-                    ERROR_3("Invalid custom position %1 of hitpoint %2 in vehicle %3.",_position,_hitpoint,_type);
+        {
+            _x params ["_hit", "_pos"];
+            if (_hitpoint == _hit) exitWith {
+                if (_pos isEqualType []) exitWith {
+                    _position = _pos; // Position in model space
                 };
-            } forEach (getArray _positionsConfig);
-        };
+                if (_pos isEqualType "") exitWith {
+                    _position = compile format ["_target selectionPosition ['%1', 'HitPoints'];", _pos];
+                };
+                ERROR_3("Invalid custom position %1 of hitpoint %2 in vehicle %3.",_position,_hitpoint,_type);
+            };
+        } forEach _hitpointPositions;
 
-        // Prepair the repair action
+        // Prepare the repair action
         private _name = format ["Repair_%1_%2", _forEachIndex, _selection];
 
         // Find localized string and track those added for numerization
@@ -151,7 +150,7 @@ private _icon = QPATHTOF(ui\repair_0_ca.paa);
             };
         };
 
-        _processedHitPoints pushBack _hitPoint;
+        _processedHitPoints pushBack _hitpoint;
     };
 } forEach _hitSelections;
 

--- a/addons/repair/functions/fnc_isEngineer.sqf
+++ b/addons/repair/functions/fnc_isEngineer.sqf
@@ -17,7 +17,6 @@
 #include "script_component.hpp"
 
 params ["_unit", ["_engineerN", 1]];
-TRACE_2("params",_unit,_engineerN);
 
 private _class = _unit getVariable ["ACE_IsEngineer", _unit getUnitTrait "engineer"];
 
@@ -25,4 +24,5 @@ private _class = _unit getVariable ["ACE_IsEngineer", _unit getUnitTrait "engine
 // We cannot move this function to common because we require the GVAR(engineerSetting_Repair), which only makes sense to include in the repair module.
 if (_class isEqualType false) then {_class = [0, 1] select _class};
 
+TRACE_3("isEngineer",_unit,_engineerN,_class);
 _class >= _engineerN;

--- a/addons/repair/functions/fnc_modifyInteraction.sqf
+++ b/addons/repair/functions/fnc_modifyInteraction.sqf
@@ -18,11 +18,11 @@
  */
 #include "script_component.hpp"
 
-params ["_target", "_player", "_args", "_actionData"];
-TRACE_4("params",_target,_player,_args,_actionData);
+params ["_target", "", "", "_actionData"];
 
 // Interaction dots numbered 0..8, white to red.
 // Convert damage to number (rounding up), so that even slight damage can bee seen
 
 private _fileName = format [QPATHTOF(ui\damage_%1_ca.paa), ceil (linearConversion [0, 1, damage _target, 0, 8, true])];
+TRACE_2("modifyInteraction",_target,_fileName);
 _actionData set [2, _fileName];

--- a/addons/repair/functions/fnc_modifySelectionInteraction.sqf
+++ b/addons/repair/functions/fnc_modifySelectionInteraction.sqf
@@ -18,8 +18,7 @@
  */
 #include "script_component.hpp"
 
-params ["_target", "_player", "_args", "_actionData"];
-TRACE_4("params",_target,_player,_args,_actionData);
+params ["_target", "", "_args", "_actionData"];
 
 // Interaction wrenches numbered 0..8, white to red.
 // Convert damage to number (rounding up), so that even slight damage can bee seen
@@ -28,5 +27,5 @@ private _fileName = format [
     QPATHTOF(ui\repair_%1_ca.paa),
     ceil (linearConversion [0, 1, _target getHitPointDamage (_args select 0), 0, 8, true])
 ];
-
+TRACE_2("modifyInteraction",_target,_fileName);
 _actionData set [2, _fileName];

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -745,7 +745,7 @@
             <Portuguese>Comandante Torre</Portuguese>
             <Italian>Comandante Torretta</Italian>
             <Hungarian>Parancsnok Lövegtorony</Hungarian>
-            <Russian>Командир Башню</Russian>
+            <Russian>Башня командира</Russian>
             <Japanese>指揮官 砲塔</Japanese>
             <Korean>지휘관 포탑</Korean>
             <Chinesesimp>指挥官 炮塔</Chinesesimp>
@@ -761,7 +761,7 @@
             <Portuguese>Comandante Canhão</Portuguese>
             <Italian>Comandante Cannone</Italian>
             <Hungarian>Parancsnok Ágyú</Hungarian>
-            <Russian>Командир Пушку</Russian>
+            <Russian>Пушка командира</Russian>
             <Japanese>指揮官 砲</Japanese>
             <Korean>지휘관 포</Korean>
             <Chinesesimp>指挥官 枪</Chinesesimp>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -735,6 +735,38 @@
             <Chinesesimp>枪</Chinesesimp>
             <Chinese>槍</Chinese>
         </Key>
+        <Key ID="STR_ACE_Repair_HitComTurret">
+            <English>Commander Turret</English>
+            <German>Kommandant Turm</German>
+            <Spanish>Comandante Torreta</Spanish>
+            <French>Commander Tourelle</French>
+            <Polish>Dowódca Wieżyczka</Polish>
+            <Czech>Velitel Věž</Czech>
+            <Portuguese>Comandante Torre</Portuguese>
+            <Italian>Comandante Torretta</Italian>
+            <Hungarian>Parancsnok Lövegtorony</Hungarian>
+            <Russian>Командир Башню</Russian>
+            <Japanese>指揮官 砲塔</Japanese>
+            <Korean>지휘관 포탑</Korean>
+            <Chinesesimp>指挥官 炮塔</Chinesesimp>
+            <Chinese>指揮官 砲塔</Chinese>
+        </Key>
+        <Key ID="STR_ACE_Repair_HitComGun">
+            <English>Commander Gun</English>
+            <German>Kommandant Kanone</German>
+            <Spanish>Comandante Cañón</Spanish>
+            <French>Commander Canon</French>
+            <Polish>Dowódca Działo</Polish>
+            <Czech>Velitel Kanón</Czech>
+            <Portuguese>Comandante Canhão</Portuguese>
+            <Italian>Comandante Cannone</Italian>
+            <Hungarian>Parancsnok Ágyú</Hungarian>
+            <Russian>Командир Пушку</Russian>
+            <Japanese>指揮官 砲</Japanese>
+            <Korean>지휘관 포</Korean>
+            <Chinesesimp>指挥官 枪</Chinesesimp>
+            <Chinese>指揮官 槍</Chinese>
+        </Key>
         <Key ID="STR_ACE_Repair_HitMissiles">
             <English>Missiles</English>
             <German>Rakete</German>

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -59,28 +59,8 @@ class CfgVehicles {
     class rhs_a3spruttank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 400;
     };
-
-#define ERA(num) QUOTE(era_##num##_hitpoint)
-#define ERA_2_28 ERA(2), ERA(3), ERA(4), ERA(5), ERA(6), ERA(7), ERA(8), ERA(9), ERA(10), ERA(11), ERA(12), ERA(13), ERA(14), ERA(15), ERA(16), ERA(17), ERA(18), ERA(19), ERA(20), ERA(21), ERA(22), ERA(23), ERA(24), ERA(25), ERA(26), ERA(27), ERA(28)
-#define ERA_2_31 ERA_2_28, ERA(29), ERA(30), ERA(31)
-#define ERA_2_32 ERA_2_31, ERA(32)
-#define ERA_2_35 ERA_2_32, ERA(33), ERA(34), ERA(35)
-#define ERA_2_36 ERA_2_35, ERA(36)
-
     class rhs_a3t72tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 1200;
-    };
-    class rhs_t72bb_tv: rhs_a3t72tank_base {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_31}}};
-    };
-    class rhs_t72bc_tv: rhs_a3t72tank_base {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_32}}};
-    };
-    class rhs_t72bd_tv: rhs_a3t72tank_base {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_32}}};
     };
     class rhs_tank_base: Tank_F {
         EGVAR(refuel,fuelCapacity) = 1200;
@@ -166,28 +146,6 @@ class CfgVehicles {
     class rhs_t80b: rhs_tank_base {
         EGVAR(refuel,fuelCapacity) = 1100;
     };
-    class rhs_t80bv: rhs_t80b {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_28}}};
-    };
-    class rhs_t80a: rhs_t80bv {};
-    class rhs_t80u: rhs_t80a {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_35}}};
-    };
-    class rhs_t80uk: rhs_t80u {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_36}}};
-    };
-    class rhs_t80ue1: rhs_t80a {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_36}}};
-    };
-    class rhs_t80um: rhs_t80u {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_36}}};
-    };
-
     class Truck_F: Car_F {};
     class RHS_Ural_BaseTurret: Truck_F {
         EGVAR(refuel,fuelCapacity) = 360;

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -44,30 +44,10 @@ class CfgVehicles {
         };
     };
 
-#define ERA(num) QUOTE(era_##num##_hitpoint)
-#define ERA_2_34 ERA(2), ERA(3), ERA(4), ERA(5), ERA(6), ERA(7), ERA(8), ERA(9), ERA(10), ERA(11), ERA(12), ERA(13), ERA(14), ERA(15), ERA(16), ERA(17), ERA(18), ERA(19), ERA(20), ERA(21), ERA(22), ERA(23), ERA(24), ERA(25), ERA(26), ERA(27), ERA(28), ERA(29), ERA(30), ERA(31), ERA(32), ERA(33), ERA(34)
-#define ERA_2_45 ERA_2_34, ERA(35), ERA(36), ERA(37), ERA(38), ERA(39), ERA(40), ERA(41), ERA(42), ERA(43), ERA(44), ERA(45)
-#define ERA_2_46 ERA_2_45, ERA(46)
-#define ERA_2_59 ERA_2_46, ERA(47), ERA(48), ERA(49), ERA(50), ERA(51), ERA(52), ERA(53), ERA(54), ERA(55), ERA(56), ERA(57), ERA(58), ERA(59)
-
     class MBT_01_base_F: Tank_F {};
     class rhsusf_m1a1tank_base: MBT_01_base_F {
         EGVAR(refuel,fuelCapacity) = 1909;
     };
-    class rhsusf_m1a1aim_tuski_wd: rhsusf_m1a1tank_base {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_34}}};
-    };
-    class rhsusf_m1a2tank_base;
-    class rhsusf_m1a2sep1tuskid_usarmy: rhsusf_m1a2tank_base {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_34}}};
-    };
-    class rhsusf_m1a2sep1tuskiiwd_usarmy: rhsusf_m1a2sep1tuskid_usarmy {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_46}}};
-    };
-
     class Helicopter_Base_F: Helicopter {
         class Eventhandlers;
     };
@@ -291,20 +271,6 @@ class CfgVehicles {
     class APC_Tracked_03_base_F;
     class RHS_M2A2_Base: APC_Tracked_03_base_F {
         EGVAR(refuel,fuelCapacity) = 746;
-    };
-    class RHS_M2A2: RHS_M2A2_Base {};
-    class RHS_M2A2_BUSKI: RHS_M2A2 {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_45}}};
-    };
-    class RHS_M2A3: RHS_M2A2 {};
-    class RHS_M2A3_BUSKI: RHS_M2A3 {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_45}}};
-    };
-    class RHS_M2A3_BUSKIII: RHS_M2A3_BUSKI {
-        ace_repair_hitpointPositions[] = {{ERA(1), {0,0,0}}};
-        ace_repair_hitpointGroups[] = {{ERA(1), {ERA_2_59}}};
     };
 
     class Plane_CAS_01_base_F;


### PR DESCRIPTION
- Disable "miscRepair" action for all era and slat armor hitpoints.
- Can still be repaired via "Full Repair"

ERA is consumable and it doesn't really make sense to be repairable with just a toolkit.
There are multiple hit-points and leaving them in makes interaction cluttered.

ToDo?
FullRepair has steep requirements by default (adv engineer, repair facility)
We could add a "Repair ERA" action, availiable when near a repair vehicle or facility.