### PR TITLE
Add option to remove action from all child classes

### DIFF
--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -9,12 +9,13 @@
  * 2: Parent path of the new action <ARRAY>
  * 3: Action <ARRAY>
  * 4: Use Inheritance <BOOL> (default: false)
+ * 5: Classes excluded from inheritance. <ARRAY> (default: [])
  *
  * Return Value:
  * The entry full path, which can be used to remove the entry, or add children entries <ARRAY>.
  *
  * Example:
- * [typeOf cursorTarget, 0, ["ACE_TapShoulderRight"],VulcanPinchAction] call ace_interact_menu_fnc_addActionToClass;
+ * [typeOf cursorTarget, 0, ["ACE_TapShoulderRight"], VulcanPinchAction] call ace_interact_menu_fnc_addActionToClass;
  *
  * Public: Yes
  */
@@ -27,18 +28,19 @@ if (!params [["_objectType", "", [""]], ["_typeNum", 0, [0]], ["_parentPath", []
 TRACE_4("params",_objectType,_typeNum,_parentPath,_action);
 
 if (param [4, false, [false]]) exitwith {
+    private _excluded = param [5, [], [[]]];
     if (isNil QGVAR(inheritedActions)) then {GVAR(inheritedActions) = [];};
     private _index = GVAR(inheritedActions) pushBack [[], _typeNum, _parentPath, _action];
     private _initEH = compile format ['
         params ["_object"];
-        private _typeOf = typeOf _object;
         (GVAR(inheritedActions) select %1) params ["_addedClasses", "_typeNum", "_parentPath", "_action"];
+        private _typeOf = typeOf _object;
         if (_typeOf in _addedClasses) exitWith {};
         _addedClasses pushBack _typeOf;
         [_typeOf, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
     ', _index];
     TRACE_2("Added inheritable action",_objectType,_index);
-    [_objectType, "init", _initEH, true, [], true] call CBA_fnc_addClassEventHandler;
+    [_objectType, "init", _initEH, true, _excluded, true] call CBA_fnc_addClassEventHandler;
 
     // Return the full path
     (_parentPath + [_action select 0])

--- a/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
+++ b/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
@@ -17,7 +17,17 @@
  */
 #include "script_component.hpp"
 
-params ["_objectType", "_typeNum", "_fullPath"];
+params ["_objectType", "_typeNum", "_fullPath", ["_inherit", false, [false]]];
+
+// Call this function for all child classes if inheritance is enabled.
+if (_inherit) then {
+    private _children = (
+        (format ["_class = configName _x; (_class isKindOf '%1') && (_class != '%1')", _objectType]) configClasses (configFile >> "CfgVehicles")
+    ) apply {configName _x};
+    {
+        [_x, _typeNum, _fullPath] call FUNC(removeActionFromClass)
+    } forEach _children;
+};
 
 private _res = _fullPath call FUNC(splitPath);
 _res params ["_parentPath", "_actionName"];

--- a/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
+++ b/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
@@ -21,13 +21,9 @@
 params ["_objectType", "_typeNum", "_fullPath", ["_inherit", false, [false]]];
 
 // Call this function for all child classes if inheritance is enabled.
-if (_inherit) then {
-    private _children = (
-        (format ["_class = configName _x; (_class isKindOf '%1') && (_class != '%1')", _objectType]) configClasses (configFile >> "CfgVehicles")
-    ) apply {configName _x};
-    {
-        [_x, _typeNum, _fullPath] call FUNC(removeActionFromClass)
-    } forEach _children;
+if (_inherit) exitWith {
+    private _children = (format ["(configName _x) isKindOf '%1'", _objectType]) configClasses (configFile >> "CfgVehicles");
+    _children apply { [configName _x, _typeNum, _fullPath] call FUNC(removeActionFromClass) };
 };
 
 private _res = _fullPath call FUNC(splitPath);

--- a/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
+++ b/addons/interact_menu/functions/fnc_removeActionFromClass.sqf
@@ -6,12 +6,13 @@
  * 0: TypeOf of the class <STRING>
  * 1: Type of action, 0 for actions, 1 for self-actions <NUMBER>
  * 2: Full path of the new action <ARRAY>
+ * 3: Allow inheritance <BOOL> (default: false)
  *
  * Return Value:
  * None
  *
  * Example:
- * [typeOf cursorTarget, 0,["ACE_TapShoulderRight","VulcanPinch"]] call ace_interact_menu_fnc_removeActionFromClass;
+ * [typeOf cursorTarget, 0,["ACE_TapShoulderRight","VulcanPinch"], true] call ace_interact_menu_fnc_removeActionFromClass;
  *
  * Public: No
  */


### PR DESCRIPTION
- Currently, `ace_interact_menu_fnc_removeActionFromClass` doesn't support inheritance. This PR fixes that issue.
- Allows excluding classes from fnc_addActionToClass.

fixes #5009

To do:
- [ ]  Prevent initEH adding the action after calling fnc_removeActionFromClass