### PR TITLE
Add ace hearing support to the tank DLC helmet

### DIFF
--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -68,4 +68,8 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR
     };
 
+    class H_Tank_base_F;
+    class H_Tank_black_F: H_Tank_base_F {
+        HEARING_PROTECTION_VICCREW
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- `H_Tank_black_F` doesn't have hearing support yet, so here it is.