### PR TITLE
Hellfire - Update to use 1.82 submunition

### DIFF
--- a/addons/frag/CfgAmmo.hpp
+++ b/addons/frag/CfgAmmo.hpp
@@ -134,16 +134,6 @@ class CfgAmmo {
         GVAR(gurney_c) = 2700;
         GVAR(gurney_k) = 1/2;
     };
-    class ACE_Hellfire_AGM114K: M_PG_AT {
-        // Source: http://www.designation-systems.net/dusrm/m-114.html
-        GVAR(enabled) = 1;
-
-        GVAR(classes)[] = {QGVAR(medium), QGVAR(medium_HD)};
-        GVAR(metal) = 8000;
-        GVAR(charge) = 2400;
-        GVAR(gurney_c) = 2700;
-        GVAR(gurney_k) = 1/2;
-    };
     class RocketBase;
     class R_80mm_HE: RocketBase {
         GVAR(skip) = 1;
@@ -171,6 +161,16 @@ class CfgAmmo {
         GVAR(classes)[] = {QGVAR(medium), QGVAR(medium_HD)};
         GVAR(metal) = 10000;
         GVAR(charge) = 3000;
+        GVAR(gurney_c) = 2700;
+        GVAR(gurney_k) = 1/2;
+    };
+    class ACE_Hellfire_AGM114K: M_Scalpel_AT {
+        // Source: http://www.designation-systems.net/dusrm/m-114.html
+        GVAR(enabled) = 1;
+
+        GVAR(classes)[] = {QGVAR(medium), QGVAR(medium_HD)};
+        GVAR(metal) = 8000;
+        GVAR(charge) = 2400;
         GVAR(gurney_c) = 2700;
         GVAR(gurney_k) = 1/2;
     };

--- a/addons/hellfire/CfgAmmo.hpp
+++ b/addons/hellfire/CfgAmmo.hpp
@@ -1,7 +1,7 @@
 class CfgAmmo {
-    class M_PG_AT;
+    class M_Scalpel_AT;
 
-    class ACE_Hellfire_AGM114K: M_PG_AT {
+    class ACE_Hellfire_AGM114K: M_Scalpel_AT {
         displayName = "AGM-114K";
         displayNameShort = "AGM-114K";
         description = "AGM-114K";
@@ -10,9 +10,6 @@ class CfgAmmo {
         model = "\A3\Weapons_F\Ammo\Missile_AT_03_fly_F";
         proxyShape = "\A3\Weapons_F\Ammo\Missile_AT_03_F";
 
-        hit = 1400;
-        indirectHit = 71;
-        indirectHitRange = 4.5;
         effectsMissile = "missile2";
 
         irLock = 0;
@@ -47,7 +44,7 @@ class CfgAmmo {
             seekerAccuracy = 1;         // seeker accuracy multiplier
 
             seekerMinRange = 1;
-            seekerMaxRange = 5000;      // Range from the missile which the seeker can visually search
+            seekerMaxRange = 8000;      // Range from the missile which the seeker can visually search
 
             // Attack profile type selection
             defaultAttackProfile = "hellfire";
@@ -62,6 +59,7 @@ class CfgAmmo {
         hit = 200;
         indirectHit = 200;
         indirectHitRange = 12;
+        submunitionAmmo = "";
         explosionEffects = "BombExplosion";
         class ace_missileguidance: ace_missileguidance {
             enabled = 1; // Missile Guidance must be explicitly enabled


### PR DESCRIPTION
**When merged this pull request will:**
- Change hellfire to use Vikhr (`M_Scalpel_AT`) as base missile along with its submunition configuration
- Remove damage changes to Kilo as damage is dealt by submunition
- Remove submunition from November
- Increase hellfire seeker max range to 8km
- Update frag base class

