### PR TITLE
Hearing - Added config for CSAT, Stealth and Racing Helmets

### DIFF
--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -68,8 +68,24 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR
     };
 
+    class H_HelmetB_TI_tna_F: H_HelmetB {
+        HEARING_PROTECTION_PELTOR
+    };
+
     class H_Tank_base_F;
     class H_Tank_black_F: H_Tank_base_F {
         HEARING_PROTECTION_VICCREW
+    };
+
+    class H_RacingHelmet_1_F: H_HelmetB_camo {
+        HEARING_PROTECTION_VICCREW
+    };
+
+    class H_HelmetO_ocamo: H_HelmetB {
+        HEARING_PROTECTION_PELTOR
+    }; // Defender and Assasin Helmet inherit.
+
+    class H_HelmetO_ViperSP_hex_f: H_HelmetB {
+        HEARING_PROTECTION_PELTOR
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Active hearing protection for all CSAT helmets. All of them cover the ears, most feature some kind of bulge, indicating hearing protection underneath.
- Active hearing protection for CTRG Stealth Helmet. It features visible hearing protection.
- Muffling for Racing Helmets (same as crew helmets etc.)