### PR TITLE
Interaction - Allow RHIB push

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -565,6 +565,11 @@ class CfgVehicles {
         };
     };
 
+    class Boat_F;
+    class Boat_Transport_02_base_F: Boat_F {
+        GVAR(canPush) = 1;
+    };
+
     class StaticWeapon: LandVehicle {
         class ACE_Actions {
             class ACE_MainActions {


### PR DESCRIPTION
**When merged this pull request will:**
- title.

RHIB has in-game mass of 5000. It's more than CUP RHIB (2700) but less than Armed Speedboat (9000). That's why I'm not sure what is better: increase `FUNC(canPush)` mass limit (2600) or add config value.