### PR TITLE
 Map - Fix ambient light effect flicking

### DIFF
--- a/addons/map/functions/fnc_determineMapLight.sqf
+++ b/addons/map/functions/fnc_determineMapLight.sqf
@@ -10,7 +10,7 @@
  * 1: Color of the overlay <ARRAY>
  *
  * Example:
- * call ACE_map_fnc_determineMapLight
+ * [player] call ACE_map_fnc_determineMapLight
  *
  * Public: No
  */

--- a/addons/map/functions/fnc_simulateMapLight.sqf
+++ b/addons/map/functions/fnc_simulateMapLight.sqf
@@ -47,7 +47,7 @@ _colourList sort false;
 private _maxColour = _colourList select 0;
 
 //ambient colour fill
-_mapCtrl drawIcon ["#(rgb,8,8,3)color(1,1,1,1)", [_r / _maxColour, _g / _maxColour, _b / _maxColour,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
+_mapCtrl drawIcon ["#(rgb,8,8,3)color(1,1,1,1)", [_r / _maxColour, _g / _maxColour, _b / _maxColour, _colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
 
 if (_flashlight == "") then {
     //ambient shade fill

--- a/addons/map/functions/fnc_simulateMapLight.sqf
+++ b/addons/map/functions/fnc_simulateMapLight.sqf
@@ -47,7 +47,7 @@ _colourList sort false;
 private _maxColour = _colourList select 0;
 
 //ambient colour fill
-_mapCtrl drawIcon [format["#(rgb,8,8,3)color(1,1,1,1)"], [_r / _maxColour, _g / _maxColour, _b / _maxColour,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
+_mapCtrl drawIcon ["#(rgb,8,8,3)color(1,1,1,1)", [_r / _maxColour, _g / _maxColour, _b / _maxColour,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
 
 if (_flashlight == "") then {
     //ambient shade fill

--- a/addons/map/functions/fnc_simulateMapLight.sqf
+++ b/addons/map/functions/fnc_simulateMapLight.sqf
@@ -47,7 +47,7 @@ _colourList sort false;
 private _maxColour = _colourList select 0;
 
 //ambient colour fill
-_mapCtrl drawIcon [format["#(rgb,8,8,3)color(%1,%2,%3,1)", _r / _maxColour, _g / _maxColour, _b / _maxColour], [1,1,1,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
+_mapCtrl drawIcon [format["#(rgb,8,8,3)color(1,1,1,1)"], [_r / _maxColour, _g / _maxColour, _b / _maxColour,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
 
 if (_flashlight == "") then {
     //ambient shade fill


### PR DESCRIPTION
Fix  #6298

Old and new both look the same to me, but old has terrible flicking.
The change in numbers over time is incredible small (like 0.0002 change every 0.1 seconds).
It almost seems each time you reference a new procedural texture (like `#(rgb,8,8,3)color(0.95846,0.001,0.0056,1)`) it isn't available that frame, so you get a frame with no texture (the flicker); but that's a pretty rough theory.
I believe this may have broken in 1.82.

Feel free to test effects with
```
if ((diag_tickTime % 4) < 2) then {
    systemChat "old";
    _mapCtrl drawIcon [format["#(rgb,8,8,3)color(%1,%2,%3,1)", _r / _maxColour, _g / _maxColour, _b / _maxColour], [1,1,1,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
} else {
    systemChat "new";
    _mapCtrl drawIcon [format["#(rgb,8,8,3)color(1,1,1,1)"], [_r / _maxColour, _g / _maxColour, _b / _maxColour,_colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
};
```