### PR TITLE
Spall - Don't throw script errors in doSpall if input is bad

### DIFF
--- a/addons/frag/functions/fnc_doSpall.sqf
+++ b/addons/frag/functions/fnc_doSpall.sqf
@@ -22,7 +22,10 @@ private _initialData = GVAR(spallHPData) select (_hitData select 0);
 _initialData params ["_hpId", "_object", "_roundType", "_round", "_curPos", "_velocity"];
 
 private _hpData = (_hitData select 1) select _hitPartDataIndex;
-(_hpData select 0) removeEventHandler ["hitPart", _hpId];
+private _objectHit = _hpData param [0, objNull];
+TRACE_1("",_objectHit);
+if ((isNil "_objectHit") || {isNull _objectHit}) exitWith {WARNING_1("Problem with hitPart data - bad object [%1]",_objectHit);};
+_objectHit removeEventHandler ["hitPart", _hpId];
 
 private _caliber = getNumber (configFile >> "CfgAmmo" >> _roundType >> "caliber");
 private _explosive = getNumber (configFile >> "CfgAmmo" >> _roundType >> "explosive");
@@ -54,6 +57,7 @@ if (_exit) exitWith {};
 private _unitDir = vectorNormalized _velocity;
 private _pos = _hpData select 3;
 private _spallPos = [];
+if ((isNil "_pos") || {!(_pos isEqualTypeArray [0,0,0])}) exitWith {WARNING_1("Problem with hitPart data - bad pos [%1]",_pos);};
 for "_i" from 0 to 100 do {
     private _pos1 = _pos vectorAdd (_unitDir vectorMultiply (0.01 * _i));
     private _pos2 = _pos vectorAdd (_unitDir vectorMultiply (0.01 * (_i + 1)));
@@ -80,9 +84,9 @@ if (_explosive > 0) then {
     private _gC = getNumber (configFile >> "CfgAmmo" >> _roundType >> QGVAR(GURNEY_C));
     if (_gC == 0) then {_gC = 2440; _warn = true;};
 
-    if (_warn) then {
-        WARNING_1("Ammo class %1 lacks proper explosive properties definitions for frag!",_roundType); //TODO: turn this off when we get closer to release
-    };
+    // if (_warn) then {
+        // WARNING_1("Ammo class %1 lacks proper explosive properties definitions for frag!",_roundType); //TODO: turn this off when we get closer to release
+    // };
 
     private _fragPower = (((_m / _c) + _k) ^ - (1 / 2)) * _gC;
     _spallPolar set [0, _fragPower * 0.66];
@@ -91,6 +95,7 @@ if (_explosive > 0) then {
 // diag_log text format ["SPALL POWER: %1", _spallPolar select 0];
 private _spread = 15 + (random 25);
 private _spallCount = 5 + (random 10);
+TRACE_1("",_spallCount);
 for "_i" from 1 to _spallCount do {
     private _elev = ((_spallPolar select 2) - _spread) + (random (_spread * 2));
     private _dir = ((_spallPolar select 1) - _spread) + (random (_spread * 2));

--- a/addons/frag/functions/fnc_spallHP.sqf
+++ b/addons/frag/functions/fnc_spallHP.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: ACE-Team
- *
+ * Handles the HitPart event
  *
  * Arguments:
  * None

--- a/addons/frag/functions/fnc_spallTrack.sqf
+++ b/addons/frag/functions/fnc_spallTrack.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: ACE-Team
- *
+ * Add HitPart EventHandler to objects in the projectile's path
  *
  * Arguments:
  * None


### PR DESCRIPTION
- Fix #5614
- Don't run tracking simulation on small caliber ammo that won't ever spall
