### PR TITLE
FIX: Explosive does not spawn at the correct altitude in fnc_moduleSuicideBomber

### DIFF
--- a/addons/zeus/functions/fnc_moduleSuicideBomber.sqf
+++ b/addons/zeus/functions/fnc_moduleSuicideBomber.sqf
@@ -55,7 +55,7 @@ if (_autoSeek) then {
     // Detonation
     private _nearObjects = (_unit nearObjects _activationRadius) select {side _x == _activationSide && {_x != _unit} && {alive _x}};
     if !(_nearObjects isEqualTo []) then {
-        createVehicle [EXPLOSIVES select _explosionSize, getPos _unit, [], 0, "CAN_COLLIDE"];
+        createVehicle [EXPLOSIVES select _explosionSize, _unit, [], 0, "CAN_COLLIDE"];
         [_pfhID] call CBA_fnc_removePerFrameHandler;
         LOG("Explosion created, PFH removed");
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Use `_unit` (Object) as position parameter for `createVehicle` instead of `getPos _unit` (Position array). 
- The bomb spawn at the correct altitude so the player and the suicider are killed as intended.
- basic testing code in debug console : 
```
// On Altis,
player allowdamage false;
player setPosASL [16894.5,13467.2,2.19884];

private _group = createGroup civilian;
private _unit = _group createUnit ["C_Man_casual_5_F", [16900.5,13458.1,2.19796], [], 0, "CAN_COLLIDE"];

createVehicle ["R_TBG32V_F", getPos _unit, [], 0, "CAN_COLLIDE"]; //Nobody is killed
//createVehicle ["R_TBG32V_F", _unit, [], 0, "CAN_COLLIDE"]; //Everybody is killed

```