### PR TITLE
Zeus - Don't trigger suicide bomber if unconsicous

### DIFF
--- a/addons/zeus/functions/fnc_moduleSuicideBomber.sqf
+++ b/addons/zeus/functions/fnc_moduleSuicideBomber.sqf
@@ -46,11 +46,13 @@ if (_autoSeek) then {
     params ["_args", "_pfhID"];
     _args params [["_unit", objNull], ["_activationSide", west], ["_activationRadius", 10], ["_explosionSize", 0], ["_autoSeek", false]];
 
-    // Unit deleted, killed or unconscious
-    if (isNull _unit || {!alive _unit} || {!([_unit] call EFUNC(common,isAwake))}) exitWith {
+    // Unit deleted or killed
+    if (isNull _unit || {!alive _unit}) exitWith {
         [_pfhID] call CBA_fnc_removePerFrameHandler;
-        LOG("Unit deleted, killed or unconscious, PFH removed");
+        LOG("Unit deleted or killed, PFH removed");
     };
+
+    if (!([_unit] call EFUNC(common,isAwake))) exitWith {};
 
     // Detonation
     private _nearObjects = (_unit nearObjects _activationRadius) select {side _x == _activationSide && {_x != _unit} && {alive _x}};

--- a/addons/zeus/functions/fnc_moduleSuicideBomber.sqf
+++ b/addons/zeus/functions/fnc_moduleSuicideBomber.sqf
@@ -46,10 +46,10 @@ if (_autoSeek) then {
     params ["_args", "_pfhID"];
     _args params [["_unit", objNull], ["_activationSide", west], ["_activationRadius", 10], ["_explosionSize", 0], ["_autoSeek", false]];
 
-    // Unit deleted or killed
-    if (isNull _unit || {!alive _unit}) exitWith {
+    // Unit deleted, killed or unconscious
+    if (isNull _unit || {!alive _unit} || {!([_unit] call EFUNC(common,isAwake))}) exitWith {
         [_pfhID] call CBA_fnc_removePerFrameHandler;
-        LOG("Unit deleted or killed, PFH removed");
+        LOG("Unit deleted, killed or unconscious, PFH removed");
     };
 
     // Detonation


### PR DESCRIPTION
Not sure if it is intended but this will prevent the detonation if the suicide bomber is unconscious. From my point of view, the suicider is not supposed to activate his bomb when he is unconscious. Let me know ...

**When merged this pull request will:**
- check  if `[_unit] call EFUNC(common,isAwake)` before trigger the bomb.