### PR TITLE
Arsenal - Fix weight stat for NVGs

### DIFF
--- a/addons/arsenal/functions/fnc_statTextStatement_mass.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_mass.sqf
@@ -17,12 +17,12 @@ params ["", "_config"];
 
 private _mass = getNumber (_config >> "mass");
 
-if (_mass == 0 && {isClass (_config >> "WeaponSlotsInfo")}) then {
-    _mass = getNumber (_config >> "WeaponSlotsInfo" >> "mass");
-};
-
 if (_mass == 0 && {isClass (_config >> "itemInfo")}) then {
     _mass = getNumber (_config >> "itemInfo" >> "mass");
+};
+
+if (_mass == 0 && {isClass (_config >> "WeaponSlotsInfo")}) then {
+    _mass = getNumber (_config >> "WeaponSlotsInfo" >> "mass");
 };
 
 format ["%1kg (%2lb)",((_mass * 0.1 * (1/2.2046) * 100) / 100) ToFixed 2, ((_mass * 0.1 * 100) / 100) ToFixed 2]


### PR DESCRIPTION
Fix #6320

Prioritize using `itemInfo` before `WeaponSlotsInfo`
Only effects NVGs, and this behaviour matches engine (`loadAbs player`)