### PR TITLE
Arsenal - Correct openBox center check

### DIFF
--- a/addons/arsenal/functions/fnc_openBox.sqf
+++ b/addons/arsenal/functions/fnc_openBox.sqf
@@ -22,7 +22,7 @@ params [["_object", objNull, [objNull]], ["_center", objNull, [objNull]], ["_mod
 if (
     isNull _object ||
     {isNull _center} ||
-    {!(_center isKindOf "Man")} ||
+    {!(_center isKindOf "CAManBase")} ||
     {!(isNull objectParent _center) && {!is3DEN}}
 ) exitWith {};
 


### PR DESCRIPTION
**When merged this pull request will:**
- Change `openBox` to check for `CAManBase` rather than `Man`
- Prevents opening arsenal on animals, like goats...
![arsenal_goat](https://user-images.githubusercontent.com/34453221/39670105-7c1d3d78-50cb-11e8-98ca-8fa2d4ca2013.png)

