### PR TITLE
Only switch side if necessary on loading

### DIFF
--- a/addons/common/functions/fnc_loadPerson.sqf
+++ b/addons/common/functions/fnc_loadPerson.sqf
@@ -29,7 +29,15 @@ if (isNull _vehicle) then {
 };
 
 if (!isNull _vehicle) then {
-    [_unit, true, GROUP_SWITCH_ID, side group _caller] call FUNC(switchToGroupSide);
+    switch (true) do {
+        case ((crew _vehicle isEqualTo []) && {side _caller != side _unit}): {
+            [_unit, true, GROUP_SWITCH_ID, side _caller] call FUNC(switchToGroupSide);
+        };
+        case (side _vehicle != side _unit): {
+            [_unit, true, GROUP_SWITCH_ID, side _vehicle] call FUNC(switchToGroupSide);
+        };
+    };
+
     ["ace_loadPersonEvent", [_unit, _vehicle, _caller], _unit] call CBA_fnc_targetEvent;
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- When loading units into vehicles, only switch side if
  - vehicle is empty and *loader* has a different side than the target or
  - vehicle is crewed and *vehicle* has a different side than the target
- Fix #6333 

Previously the unit would always switch to the side of the person loading the unit into the vehicle. That most likely did also not work when the loader has a different side than the crew of the vehicle. This *should* cover all cases.

Needs multiplayer testing.