### PR TITLE
Fix minor typo in fnc_cachedCall

### DIFF
--- a/addons/common/functions/fnc_cachedCall.sqf
+++ b/addons/common/functions/fnc_cachedCall.sqf
@@ -25,7 +25,7 @@ params ["_params", "_function", "_namespace", "_uid", "_duration", "_event"];
 if ((_namespace getVariable [_uid, [-99999]]) select 0 < diag_tickTime) then {
     _namespace setVariable [_uid, [diag_tickTime + _duration, _params call _function]];
 
-    // Does the cache needs to be cleared on an event?
+    // Does the cache need to be cleared on an event?
     if (!isNil "_event") then {
         private _varName = format [QGVAR(clearCache_%1), _event];
         private _cacheList = missionNamespace getVariable _varName;


### PR DESCRIPTION
Sorry. But I just couldn't stop thinking about it.
Also as I see _event is a string.. Shouldn't that default to empty string and test for empty string? as users might pass in empty string to show "no event"