### PR TITLE
Arsenal - Various additions and fixes

### DIFF
--- a/addons/arsenal/ACE_Arsenal_Stats.hpp
+++ b/addons/arsenal/ACE_Arsenal_Stats.hpp
@@ -33,7 +33,7 @@ class GVAR(stats) {
         displayName= "$STR_a3_rscdisplayarsenal_stat_rof";
         showBar = 1;
         showText = 1;
-        barStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_3([ARR_2(-1.4, 0.31)], [ARR_2(1, 0.01)], true)])] call FUNC(statBarStatement_default));
+        barStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_2([ARR_2(-1.4, 0.31)], [ARR_2(1, 0.01)])])] call FUNC(statBarStatement_default));
         textStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_2([ARR_2(-1.4, 0.31)], false)])] call FUNC(statTextStatement_rateOfFire));
         tabs[] = {{0,1}, {}};
     };
@@ -44,7 +44,7 @@ class GVAR(stats) {
         displayName = "$STR_a3_rscdisplayarsenal_stat_dispersion";
         showBar = 1;
         showText = 1;
-        barStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_3([ARR_2(-4, -1.7)], [ARR_2(1, 0.01)], true)])] call FUNC(statBarStatement_default));
+        barStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_3([ARR_2(-4, -1.7)], [ARR_2(1, 0.01)], true)])] call FUNC(statBarStatement_accuracy));
         textStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_2([ARR_2(-4, -1.7)], false)])] call FUNC(statTextStatement_accuracy));
         tabs[] = {{0,1}, {}};
     };

--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -47,6 +47,7 @@ PREP(removeVirtualItems);
 PREP(scanConfig);
 PREP(showItem);
 PREP(sortPanel);
+PREP(statBarStatement_accuracy);
 PREP(statBarStatement_default);
 PREP(statBarStatement_impact);
 PREP(statTextStatement_accuracy);

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -29,6 +29,12 @@ private _ctrlPanel = _display displayCtrl IDC_leftTabContent;
 _ctrlBackground ctrlSetFade 0;
 _ctrlBackground ctrlCommit FADE_DELAY;
 
+// Force a "refresh" animation of the panel
+_ctrlPanel ctrlSetFade 1;
+_ctrlPanel ctrlCommit 0;
+_ctrlPanel ctrlSetFade 0;
+_ctrlPanel ctrlCommit FADE_DELAY;
+
 _ctrlPanel lbSetCurSel -1;
 
 // Handle icons and filling

--- a/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
+++ b/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
@@ -115,4 +115,6 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
     } foreach (_sharedLoadoutsVars apply {GVAR(sharedLoadoutsNamespace) getVariable _x});
 };
 
+[QGVAR(loadoutsListFilled), [_display]] call CBA_fnc_localEvent;
+
 _contentPanelCtrl lnbSort [1, false];

--- a/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
+++ b/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
@@ -115,6 +115,6 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
     } foreach (_sharedLoadoutsVars apply {GVAR(sharedLoadoutsNamespace) getVariable _x});
 };
 
-[QGVAR(loadoutsListFilled), [_display]] call CBA_fnc_localEvent;
+[QGVAR(loadoutsListFilled), [_display, _control]] call CBA_fnc_localEvent;
 
 _contentPanelCtrl lnbSort [1, false];

--- a/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
+++ b/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
@@ -22,6 +22,12 @@ _textEditBoxCtrl ctrlSetText "";
 private _sharingEnabled = (GVAR(allowSharedLoadouts) && {isMultiplayer});
 private _sharedLoadoutsVars = GVAR(sharedLoadoutsNamespace) getVariable QGVAR(sharedLoadoutsVars);
 
+// Force a "refresh" animation of the panel
+_contentPanelCtrl ctrlSetFade 1;
+_contentPanelCtrl ctrlCommit 0;
+_contentPanelCtrl ctrlSetFade 0;
+_contentPanelCtrl ctrlCommit FADE_DELAY;
+
 _contentPanelCtrl lnbSetCurSelRow -1;
 lnbClear _contentPanelCtrl;
 

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -134,6 +134,12 @@ switch (GVAR(currentLeftPanel)) do {
     };
 };
 
+// Force a "refresh" animation of the panel
+_ctrlPanel ctrlSetFade 1;
+_ctrlPanel ctrlCommit 0;
+_ctrlPanel ctrlSetFade 0;
+_ctrlPanel ctrlCommit FADE_DELAY;
+
 _itemsToCheck = _itemsToCheck apply {toLower _x};
 _compatibleItems =  _compatibleItems apply {toLower _x};
 

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -286,9 +286,7 @@ switch (_ctrlIDC) do {
     };
 };
 
-if (GVAR(currentRightPanel) != _ctrlIDC) then {
-    (_display displayCtrl IDC_rightSearchbar) ctrlSetText "";
-};
+(_display displayCtrl IDC_rightSearchbar) ctrlSetText "";
 
 GVAR(currentRightPanel) = _ctrlIDC;
 

--- a/addons/arsenal/functions/fnc_loadoutsChangeTab.sqf
+++ b/addons/arsenal/functions/fnc_loadoutsChangeTab.sqf
@@ -74,6 +74,6 @@ switch (ctrlIDC _control) do {
 
 GVAR(currentLoadoutsTab) = ctrlIDC _control;
 
-[QGVAR(loadoutsTabChanged), [_display]] call CBA_fnc_localEvent;
+[QGVAR(loadoutsTabChanged), [_display, _control]] call CBA_fnc_localEvent;
 
 [_display, _control] call FUNC(fillLoadoutsList);

--- a/addons/arsenal/functions/fnc_loadoutsChangeTab.sqf
+++ b/addons/arsenal/functions/fnc_loadoutsChangeTab.sqf
@@ -74,4 +74,6 @@ switch (ctrlIDC _control) do {
 
 GVAR(currentLoadoutsTab) = ctrlIDC _control;
 
+[QGVAR(loadoutsTabChanged), [_display]] call CBA_fnc_localEvent;
+
 [_display, _control] call FUNC(fillLoadoutsList);

--- a/addons/arsenal/functions/fnc_onLoadoutsClose.sqf
+++ b/addons/arsenal/functions/fnc_onLoadoutsClose.sqf
@@ -28,4 +28,6 @@ _mouseBlockCtrl ctrlCommit 0;
 
 [_arsenalDisplay] call FUNC(buttonHide);
 
+[QGVAR(loadoutsDisplayClosed), [_display]] call CBA_fnc_localEvent;
+
 [_arsenalDisplay , _arsenalDisplay displayCtrl GVAR(currentLeftPanel)] call FUNC(fillLeftPanel);

--- a/addons/arsenal/functions/fnc_onLoadoutsClose.sqf
+++ b/addons/arsenal/functions/fnc_onLoadoutsClose.sqf
@@ -28,6 +28,6 @@ _mouseBlockCtrl ctrlCommit 0;
 
 [_arsenalDisplay] call FUNC(buttonHide);
 
-[QGVAR(loadoutsDisplayClosed), [_display]] call CBA_fnc_localEvent;
+[QGVAR(loadoutsDisplayClosed), []] call CBA_fnc_localEvent;
 
 [_arsenalDisplay , _arsenalDisplay displayCtrl GVAR(currentLeftPanel)] call FUNC(fillLeftPanel);

--- a/addons/arsenal/functions/fnc_onLoadoutsOpen.sqf
+++ b/addons/arsenal/functions/fnc_onLoadoutsOpen.sqf
@@ -57,4 +57,6 @@ if !(GVAR(allowSharedLoadouts) && {isMultiplayer}) then {
     _buttonShareLoadoutsBackgroundCtrl ctrlCommit 0;
 };
 
+[QGVAR(loadoutsDisplayOpened), [_display]] call CBA_fnc_localEvent;
+
 [_display, _display displayCtrl IDC_buttonMyLoadouts] call FUNC(loadoutsChangeTab);

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -28,28 +28,33 @@ private _selectCorrectPanelWeapon = [_weaponDefaultRightPanel, _display displayC
 private _containerDefaultRightPanel = _display displayCtrl IDC_buttonMisc;
 private _selectCorrectPanelContainer = [_containerDefaultRightPanel, _display displayCtrl GVAR(currentRightPanel)] select (!(isNil QGVAR(currentRightPanel)) && {GVAR(currentRightPanel) in [RIGHT_PANEL_ITEMS_IDCS]});
 
+private _fnc_clearPreviousWepMags = {
+    private _compatibleMags = getArray (configfile >> "cfgweapons" >> _baseWeapon >> "magazines");
+    {
+        GVAR(center) removeMagazines _x;
+    } foreach _compatibleMags;
+
+    GVAR(currentItems) set [15, uniformItems GVAR(center)];
+    GVAR(currentItems) set [16, vestItems GVAR(center)];
+    GVAR(currentItems) set [17, backpackItems GVAR(center)];
+};
+
 switch (GVAR(currentLeftPanel)) do {
 
     case IDC_buttonPrimaryWeapon : {
         private _baseWeapon = ((GVAR(currentItems) select 0) call bis_fnc_baseWeapon);
 
-        if ((GVAR(currentItems) select 0) != _item && {_baseWeapon != _item}) then {
+        if (_item == "") then {
+            call _fnc_clearPreviousWepMags;
 
-            private _compatibleMags = getArray (configfile >> "cfgweapons" >> _baseWeapon >> "magazines");
-            {
-                GVAR(center) removeMagazines _x;
-            } foreach _compatibleMags;
+            GVAR(center) removeWeapon (primaryWeapon GVAR(center));
+            GVAR(currentItems) set [18, ["", "", "", "", "", ""]];
+            GVAR(currentItems) set [0, _item];
 
-            GVAR(currentItems) set [15, uniformItems GVAR(center)];
-            GVAR(currentItems) set [16, vestItems GVAR(center)];
-            GVAR(currentItems) set [17, backpackItems GVAR(center)];
-
-            if (_item == "") then {
-
-                GVAR(center) removeWeapon (primaryWeapon GVAR(center));
-                GVAR(currentItems) set [18, ["", "", "", "", "", ""]];
-                GVAR(currentItems) set [0, _item];
-            } else {
+            TOGGLE_RIGHT_PANEL_HIDE
+        } else {
+            if ((GVAR(currentItems) select 0) != _item && {_baseWeapon != _item}) then {
+                call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
                 GVAR(center) addWeapon _item;
@@ -65,11 +70,7 @@ switch (GVAR(currentLeftPanel)) do {
                 GVAR(currentItems) set [18, (primaryWeaponItems GVAR(center)) + ([_primaryMags + [""], _primaryMags] select (count _primaryMags > 1))];
                 GVAR(currentItems) set [0, _item];
             };
-        };
 
-        if (_item == "") then {
-            TOGGLE_RIGHT_PANEL_HIDE
-        } else {
             TOGGLE_RIGHT_PANEL_WEAPON
             [_display, _selectCorrectPanelWeapon] call FUNC(fillRightPanel);
         };
@@ -81,23 +82,17 @@ switch (GVAR(currentLeftPanel)) do {
     case IDC_buttonHandgun : {
         private _baseWeapon = ((GVAR(currentItems) select 2) call bis_fnc_baseWeapon);
 
-        if ((GVAR(currentItems) select 2) != _item && {_baseWeapon != _item}) then {
+        if (_item == "") then {
+            call _fnc_clearPreviousWepMags;
 
-            private _compatibleMags = getArray (configfile >> "cfgweapons" >> _baseWeapon >> "magazines");
-            {
-                GVAR(center) removeMagazines _x;
-            } foreach _compatibleMags;
+            GVAR(center) removeWeapon (handgunWeapon GVAR(center));
+            GVAR(currentItems) set [18, ["", "", "", "", "", ""]];
+            GVAR(currentItems) set [2, _item];
 
-            GVAR(currentItems) set [15, uniformItems GVAR(center)];
-            GVAR(currentItems) set [16, vestItems GVAR(center)];
-            GVAR(currentItems) set [17, backpackItems GVAR(center)];
-
-            if (_item == "") then {
-
-                GVAR(center) removeWeapon (handgunWeapon GVAR(center));
-                GVAR(currentItems) set [18, ["", "", "", "", "", ""]];
-                GVAR(currentItems) set [2, _item];
-            } else {
+            TOGGLE_RIGHT_PANEL_HIDE
+        } else {
+            if ((GVAR(currentItems) select 2) != _item && {_baseWeapon != _item}) then {
+                call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
                 GVAR(center) addWeapon _item;
@@ -113,11 +108,7 @@ switch (GVAR(currentLeftPanel)) do {
                 GVAR(currentItems) set [20, (handgunItems GVAR(center)) + ([_handgunMags + [""], _handgunMags] select (count _handgunMags > 1))];
                 GVAR(currentItems) set [2, _item];
             };
-        };
 
-        if (_item == "") then {
-            TOGGLE_RIGHT_PANEL_HIDE
-        } else {
             TOGGLE_RIGHT_PANEL_WEAPON
             [_display, [_selectCorrectPanelWeapon, _weaponDefaultRightPanel] select (GVAR(currentRightPanel) == IDC_buttonCurrentMag2)] call FUNC(fillRightPanel);
         };
@@ -129,23 +120,16 @@ switch (GVAR(currentLeftPanel)) do {
     case IDC_buttonSecondaryWeapon : {
         private _baseWeapon = ((GVAR(currentItems) select 1) call bis_fnc_baseWeapon);
 
-        if ((GVAR(currentItems) select 1) != _item && {_baseWeapon != _item}) then {
+        if (_item == "") then {
+            call _fnc_clearPreviousWepMags;
 
-            private _compatibleMags = getArray (configfile >> "cfgweapons" >> _baseWeapon >> "magazines");
-            {
-                GVAR(center) removeMagazines _x;
-            } foreach _compatibleMags;
-
-            GVAR(currentItems) set [15, uniformItems GVAR(center)];
-            GVAR(currentItems) set [16, vestItems GVAR(center)];
-            GVAR(currentItems) set [17, backpackItems GVAR(center)];
-
-            if (_item == "") then {
-
-                GVAR(center) removeWeapon (secondaryWeapon GVAR(center));
-                GVAR(currentItems) set [18, ["", "", "", "", "", ""]];
-                GVAR(currentItems) set [1, _item];
-            } else {
+            GVAR(center) removeWeapon (secondaryWeapon GVAR(center));
+            GVAR(currentItems) set [18, ["", "", "", "", "", ""]];
+            GVAR(currentItems) set [1, _item];
+            TOGGLE_RIGHT_PANEL_HIDE
+        } else {
+            if ((GVAR(currentItems) select 1) != _item && {_baseWeapon != _item}) then {
+                call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
                 GVAR(center) addWeapon _item;
@@ -161,11 +145,7 @@ switch (GVAR(currentLeftPanel)) do {
                 GVAR(currentItems) set [19, (secondaryWeaponItems GVAR(center)) + ([_secondaryMags + [""], _secondaryMags] select (count _secondaryMags > 1))];
                 GVAR(currentItems) set [1, _item];
             };
-        };
 
-        if (_item == "") then {
-            TOGGLE_RIGHT_PANEL_HIDE
-        } else {
             TOGGLE_RIGHT_PANEL_WEAPON
             [_display, [_selectCorrectPanelWeapon, _weaponDefaultRightPanel] select (GVAR(currentRightPanel) == IDC_buttonCurrentMag2)] call FUNC(fillRightPanel);
         };
@@ -175,14 +155,18 @@ switch (GVAR(currentLeftPanel)) do {
     };
 
     case IDC_buttonHeadgear : {
+
         if (_item == "") then {
             removeHeadgear GVAR(center);
             GVAR(currentItems) set [3, _item];
         } else {
-            GVAR(center) addHeadgear _item;
-            GVAR(currentItems) set [3, _item];
+            if ((GVAR(currentItems) select 3) != _item) then {
+                GVAR(center) addHeadgear _item;
+                GVAR(currentItems) set [3, _item];
+            };
         };
         call FUNC(showItem);
+
         TOGGLE_RIGHT_PANEL_HIDE
         [_display, _control, _curSel, (configFile >> "CfgWeapons" >> _item)] call FUNC(itemInfo);
     };
@@ -196,17 +180,19 @@ switch (GVAR(currentLeftPanel)) do {
             TOGGLE_RIGHT_PANEL_HIDE
         } else {
 
-            GVAR(center) forceAddUniform _item;
+            if ((GVAR(currentItems) select 4) != _item) then {
+                GVAR(center) forceAddUniform _item;
 
-            while {count uniformItems GVAR(center) > 0} do {
-                GVAR(center) removeItemFromUniform (uniformItems GVAR(center) select 0);
-            }; //--- Remove default config contents
+                while {count uniformItems GVAR(center) > 0} do {
+                    GVAR(center) removeItemFromUniform (uniformItems GVAR(center) select 0);
+                }; //--- Remove default config contents
 
-            {GVAR(center) addItemtoUniform _x} foreach (GVAR(currentItems) select 15);
-            GVAR(currentItems) set [4, _item];
+                {GVAR(center) addItemtoUniform _x} foreach (GVAR(currentItems) select 15);
+                GVAR(currentItems) set [4, _item];
 
-            [GVAR(center), ""] call bis_fnc_setUnitInsignia;
-            [GVAR(center), GVAR(currentInsignia)] call bis_fnc_setUnitInsignia;
+                [GVAR(center), ""] call bis_fnc_setUnitInsignia;
+                [GVAR(center), GVAR(currentInsignia)] call bis_fnc_setUnitInsignia;
+            };
 
             TOGGLE_RIGHT_PANEL_CONTAINER
             [_display, _selectCorrectPanelContainer] call FUNC(fillRightPanel);
@@ -225,13 +211,15 @@ switch (GVAR(currentLeftPanel)) do {
             TOGGLE_RIGHT_PANEL_HIDE
         } else {
 
-            GVAR(center) addVest _item;
-            while {count vestItems GVAR(center) > 0} do {
-                GVAR(center) removeItemFromVest (VestItems GVAR(center) select 0);
-            }; //--- Remove default config contents
-            {GVAR(center) addItemToVest _x} foreach (GVAR(currentItems) select 16);
+            if ((GVAR(currentItems) select 5) != _item) then {
+                GVAR(center) addVest _item;
+                while {count vestItems GVAR(center) > 0} do {
+                    GVAR(center) removeItemFromVest (VestItems GVAR(center) select 0);
+                }; //--- Remove default config contents
+                {GVAR(center) addItemToVest _x} foreach (GVAR(currentItems) select 16);
 
-            GVAR(currentItems) set [5, _item];
+                GVAR(currentItems) set [5, _item];
+            };
 
             TOGGLE_RIGHT_PANEL_CONTAINER
             [_display, _selectCorrectPanelContainer] call FUNC(fillRightPanel);
@@ -250,14 +238,16 @@ switch (GVAR(currentLeftPanel)) do {
             TOGGLE_RIGHT_PANEL_HIDE
         } else {
 
-            removeBackpack GVAR(center);
-            GVAR(center) addBackpack _item;
-            while {count backpackItems GVAR(center) > 0} do {
-                GVAR(center) removeItemFromBackpack (backpackItems GVAR(center) select 0);
-            }; //--- Remove default config contents
-            {GVAR(center) addItemToBackpack _x} foreach (GVAR(currentItems) select 17);
+            if ((GVAR(currentItems) select 6) != _item) then {
+                removeBackpack GVAR(center);
+                GVAR(center) addBackpack _item;
+                while {count backpackItems GVAR(center) > 0} do {
+                    GVAR(center) removeItemFromBackpack (backpackItems GVAR(center) select 0);
+                }; //--- Remove default config contents
+                {GVAR(center) addItemToBackpack _x} foreach (GVAR(currentItems) select 17);
 
-            GVAR(currentItems) set [6, _item];
+                GVAR(currentItems) set [6, _item];
+            };
 
             TOGGLE_RIGHT_PANEL_CONTAINER
             [_display, _selectCorrectPanelContainer] call FUNC(fillRightPanel);
@@ -272,8 +262,10 @@ switch (GVAR(currentLeftPanel)) do {
             removeGoggles GVAR(center);
             GVAR(currentItems) set [7, _item];
         } else {
-            GVAR(center) addGoggles _item;
-            GVAR(currentItems) set [7, _item];
+            if ((GVAR(currentItems) select 7) != _item) then {
+                GVAR(center) addGoggles _item;
+                GVAR(currentItems) set [7, _item];
+            };
         };
 
         call FUNC(showItem);
@@ -286,8 +278,10 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) unlinkItem (GVAR(currentItems) select 8);
             GVAR(currentItems) set [8, _item];
         } else {
-            GVAR(center) linkItem _item;
-            GVAR(currentItems) set [8, _item];
+            if ((GVAR(currentItems) select 8) != _item) then {
+                GVAR(center) linkItem _item;
+                GVAR(currentItems) set [8, _item];
+            };
         };
 
         call FUNC(showItem);
@@ -300,10 +294,12 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) removeWeapon (binocular GVAR(center));
             GVAR(currentItems) set [9, _item];
         } else {
-            GVAR(center) addWeapon _item;
-            GVAR(currentItems) set [9, _item];
-            call FUNC(showItem);
-            ADDBINOCULARSMAG
+            if ((GVAR(currentItems) select 9) != _item) then {
+                GVAR(center) addWeapon _item;
+                GVAR(currentItems) set [9, _item];
+                call FUNC(showItem);
+                ADDBINOCULARSMAG
+            };
         };
         call FUNC(showItem);
         TOGGLE_RIGHT_PANEL_HIDE
@@ -315,8 +311,10 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) unlinkItem (GVAR(currentItems) select 10) select 0;
             GVAR(currentItems) set [10, _item];
         } else {
-            GVAR(center) linkItem _item;
-            GVAR(currentItems) set [10, _item];
+            if ((GVAR(currentItems) select 10) != _item) then {
+                GVAR(center) linkItem _item;
+                GVAR(currentItems) set [10, _item];
+            };
         };
 
         call FUNC(showItem);
@@ -329,8 +327,10 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) unlinkItem (GVAR(currentItems) select 11) select 0;
             GVAR(currentItems) set [11, _item];
         } else {
-            GVAR(center) linkItem _item;
-            GVAR(currentItems) set [11, _item];
+            if ((GVAR(currentItems) select 11) != _item) then {
+                GVAR(center) linkItem _item;
+                GVAR(currentItems) set [11, _item];
+            };
         };
 
         call FUNC(showItem);
@@ -343,8 +343,10 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) unlinkItem (GVAR(currentItems) select 12) select 0;
             GVAR(currentItems) set [12, _item];
         } else {
-            GVAR(center) linkItem _item;
-            GVAR(currentItems) set [12, _item];
+            if ((GVAR(currentItems) select 12) != _item) then {
+                GVAR(center) linkItem _item;
+                GVAR(currentItems) set [12, _item];
+            };
         };
 
         call FUNC(showItem);
@@ -357,8 +359,10 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) unlinkItem (GVAR(currentItems) select 13);
             GVAR(currentItems) set [13, _item];
         } else {
-            GVAR(center) linkItem _item;
-            GVAR(currentItems) set [13, _item];
+            if ((GVAR(currentItems) select 13) != _item) then {
+                GVAR(center) linkItem _item;
+                GVAR(currentItems) set [13, _item];
+            };
         };
 
         call FUNC(showItem);
@@ -371,8 +375,10 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(center) unlinkItem (GVAR(currentItems) select 14) select 0;
             GVAR(currentItems) set [14, _item];
         } else {
-            GVAR(center) linkItem _item;
-            GVAR(currentItems) set [14, _item];
+            if ((GVAR(currentItems) select 14) != _item) then {
+                GVAR(center) linkItem _item;
+                GVAR(currentItems) set [14, _item];
+            };
         };
 
         call FUNC(showItem);

--- a/addons/arsenal/functions/fnc_removeStat.sqf
+++ b/addons/arsenal/functions/fnc_removeStat.sqf
@@ -33,11 +33,7 @@ call FUNC(compileStats);
     };
 
     {
-        private _currentIDIndex = _x findIf (_x select 0 == _currentID);
-
-        if (_currentIDIndex > -1) then {
-            _x deleteAt _currentIDIndex;
-        };
+        _x deleteAt (_x findIf {_x select 0 == _currentID});
     } foreach _tabToChange;
 } foreach _IDList;
 

--- a/addons/arsenal/functions/fnc_removeStat.sqf
+++ b/addons/arsenal/functions/fnc_removeStat.sqf
@@ -33,13 +33,11 @@ call FUNC(compileStats);
     };
 
     {
-        private _currentPage = _x;
+        private _currentIDIndex = _x findIf (_x select 0 == _currentID);
 
-        {
-            if (_x select 0 == _currentID) then {
-                _currentPage deleteAt _forEachIndex;
-            };
-        } foreach _currentPage;
+        if (_currentIDIndex > -1) then {
+            _x deleteAt _currentIDIndex;
+        };
     } foreach _tabToChange;
 } foreach _IDList;
 

--- a/addons/arsenal/functions/fnc_statBarStatement_accuracy.sqf
+++ b/addons/arsenal/functions/fnc_statBarStatement_accuracy.sqf
@@ -1,0 +1,31 @@
+/*
+ * Author: Alganthe
+ * Accuracy bar statement.
+ *
+ * Arguments:
+ * 0: stats array (ARRAY)
+ * 1: item config path (CONFIG)
+ * 2: Args
+ *  2.1: Stat limits (ARRAY of BOOL)
+ *  2.2: Bar limits (ARRAY of SCALAR)
+ *
+ * Return Value:
+ * Number
+ *
+ * Public: No
+*/
+#include "script_component.hpp"
+
+params ["_stat", "_config", "_args"];
+_args params ["_statMinMax", "_barLimits"];
+
+private _fireModes = getArray (_config >> "modes");
+private _dispersion = [];
+
+{
+    _dispersion pushBackUnique log (getNumber (_config >> _x >> "dispersion"));
+} foreach _fireModes;
+
+_dispersion sort true;
+
+linearConversion [_statMinMax select 0, _statMinMax select 1, _dispersion select 0, _barLimits select 0, _barLimits select 1]

--- a/addons/arsenal/functions/fnc_statTextStatement_accuracy.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_accuracy.sqf
@@ -19,13 +19,14 @@
 params ["_stat", "_config", "_args"];
 _args params ["_statMinMax", "_configExtremeBool"];
 
-private _statValues = [
-    [_config],
-    [_stat],
-    [_configExtremeBool],
-    [_statMinMax select 0]
-] call BIS_fnc_configExtremes;
+private _fireModes = getArray (_config >> "modes");
+private _dispersion = [];
 
-private _dispersion = (_statValues select 1) select 0;
+{
+    _dispersion pushBackUnique (getNumber (_config >> _x >> "dispersion"));
+} foreach _fireModes;
+
+_dispersion sort true;
+_dispersion = _dispersion select 0;
 
 format ["%1 MIL (%2 MOA)", (_dispersion * 1000) toFixed 2, (_dispersion / pi * 10800) ToFixed 1];


### PR DESCRIPTION
**When merged this pull request will:**
- Add 4 new EHs for the loadouts display:

| Name  | Arguments |
| ------------- | ------------- |
| ace_arsenal_loadoutsDisplayOpened | loadouts screen display (DISPLAY) |
| ace_arsenal_loadoutsDisplayClosed | none |
| ace_arsenal_loadoutsTabChanged | loadouts screen display (DISPLAY), tab control (CONTROL) |
| ace_arsenal_loadoutsListFilled | loadouts screen display (DISPLAY), tab control (CONTROL) |

- Fix the accuracy stat not being accurate, the stat used the default value, now the bar and numbers shown are what they should be.
- Improve onSelChangedLeft to limit the accessory stripping issue #6307 , using setUnitLoadout with a modified array would potentially break multiple other features or cause other issues, this is the best fix until we get the ability to add accessories to weapons in containers.
- Added some fade in for the left, right, and loadout content panels to make the UI feel snappier.
- Clear the right searchbar whenever you click on another item in the left panel (or the same one you have).