### PR TITLE
Med menu zeus

### DIFF
--- a/addons/interaction/ACE_ZeusActions.hpp
+++ b/addons/interaction/ACE_ZeusActions.hpp
@@ -37,8 +37,7 @@ class ACE_ZeusActions {
         };
 
         class medicalMenu {
-          displayName = "Open Medical Menu"; // TODO - localize
-          //icon = QPATHTOEF(medical_menu\data\icons\triage_card_small.paa);
+          displayName = ECSTRING(Medical_Menu,OpenMenu);
           statement = "_unit = objNull; { if ((side _x in [east,west,resistance,civilian]) ) exitWith { _unit = _x; }; } forEach (curatorSelected select 0); bis_fnc_curatorObjectPlaced_mouseOver = ['OBJECT',_unit]; [{isNull (findDisplay 91919)},{params ['_unit']; _unit call ace_medical_menu_fnc_openMenu;}, [_unit],3] call CBA_fnc_waitUntilAndExecute;";
         };
     };

--- a/addons/interaction/ACE_ZeusActions.hpp
+++ b/addons/interaction/ACE_ZeusActions.hpp
@@ -35,6 +35,12 @@ class ACE_ZeusActions {
             icon = "\A3\Modules_F_Curator\Data\portraitRemoteControl_ca.paa";
             statement = "_unit = objNull; { if ((side _x in [east,west,resistance,civilian]) && !(isPlayer _x)) exitWith { _unit = _x; }; } forEach (curatorSelected select 0); bis_fnc_curatorObjectPlaced_mouseOver = ['OBJECT',_unit]; (group _target) createUnit ['ModuleRemoteControl_F',[0,0,0],[],0,'NONE'];";
         };
+
+        class medicalMenu {
+          displayName = "Open Medical Menu"; // TODO - localize
+          //icon = QPATHTOEF(medical_menu\data\icons\triage_card_small.paa);
+          statement = "_unit = objNull; { if ((side _x in [east,west,resistance,civilian]) ) exitWith { _unit = _x; }; } forEach (curatorSelected select 0); bis_fnc_curatorObjectPlaced_mouseOver = ['OBJECT',_unit]; [{isNull (findDisplay 91919)},{params ['_unit']; _unit call ace_medical_menu_fnc_openMenu;}, [_unit],3] call CBA_fnc_waitUntilAndExecute;";
+        };
     };
 
     class ZeusGroups {

--- a/addons/medical_menu/functions/fnc_canOpenMenu.sqf
+++ b/addons/medical_menu/functions/fnc_canOpenMenu.sqf
@@ -20,6 +20,6 @@ params ["_caller", "_target"];
 
 (alive _caller)
 && {!isNull _target}
-&& {((_caller distance _target) < GVAR(maxRange)) || {(vehicle _caller) == (vehicle _target)}} //for now, ignore range when in same vehicle
+&& {((_caller distance _target) < GVAR(maxRange)) || {(vehicle _caller) == (vehicle _target)} || {_caller in allCurators}} //for now, ignore range when in same vehicle or zeus
 && {(GVAR(allow) == 1) || {(GVAR(allow) == 2) && {(vehicle _caller != _caller) || {vehicle _target != _target}}}}
 && {(GVAR(useMenu) == 1) || {(GVAR(useMenu) == 2) && {(vehicle _caller != _caller) || {vehicle _target != _target}}}}

--- a/addons/medical_menu/functions/fnc_canOpenMenu.sqf
+++ b/addons/medical_menu/functions/fnc_canOpenMenu.sqf
@@ -20,6 +20,6 @@ params ["_caller", "_target"];
 
 (alive _caller)
 && {!isNull _target}
-&& {((_caller distance _target) < GVAR(maxRange)) || {(vehicle _caller) == (vehicle _target)} || {_caller in allCurators}} //for now, ignore range when in same vehicle or zeus
+&& {((_caller distance _target) < GVAR(maxRange)) || {(vehicle _caller) == (vehicle _target)} || {!isNull findDisplay 312}} //for now, ignore range when in same vehicle or zeus
 && {(GVAR(allow) == 1) || {(GVAR(allow) == 2) && {(vehicle _caller != _caller) || {vehicle _target != _target}}}}
 && {(GVAR(useMenu) == 1) || {(GVAR(useMenu) == 2) && {(vehicle _caller != _caller) || {vehicle _target != _target}}}}

--- a/addons/medical_menu/functions/fnc_onMenuOpen.sqf
+++ b/addons/medical_menu/functions/fnc_onMenuOpen.sqf
@@ -75,7 +75,7 @@ GVAR(MenuPFHID) = [{
     [GVAR(LatestDisplayOptionMenu)] call FUNC(handleUI_DisplayOptions);
 
     //Check that it's valid to stay open:
-    if !(([ACE_player, GVAR(INTERACTION_TARGET), ["isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call FUNC(canOpenMenu)}) then {
+    if !(([ACE_player, GVAR(INTERACTION_TARGET), ["isNotInside", "isNotSwimming", "isnotinzeus"]] call EFUNC(common,canInteractWith)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call FUNC(canOpenMenu)}) then {
         closeDialog 314412;
         //If we failed because of distance check, show UI message:
         if ((ACE_player distance GVAR(INTERACTION_TARGET)) > GVAR(maxRange)) then {

--- a/addons/medical_menu/functions/fnc_onMenuOpen.sqf
+++ b/addons/medical_menu/functions/fnc_onMenuOpen.sqf
@@ -75,7 +75,7 @@ GVAR(MenuPFHID) = [{
     [GVAR(LatestDisplayOptionMenu)] call FUNC(handleUI_DisplayOptions);
 
     //Check that it's valid to stay open:
-    if !(([ACE_player, GVAR(INTERACTION_TARGET), ["isNotInside", "isNotSwimming", "isnotinzeus"]] call EFUNC(common,canInteractWith)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call FUNC(canOpenMenu)}) then {
+    if !(([ACE_player, GVAR(INTERACTION_TARGET), ["isNotInside", "isNotSwimming", "isNotInZeus"]] call EFUNC(common,canInteractWith)) && {[ACE_player, GVAR(INTERACTION_TARGET)] call FUNC(canOpenMenu)}) then {
         closeDialog 314412;
         //If we failed because of distance check, show UI message:
         if ((ACE_player distance GVAR(INTERACTION_TARGET)) > GVAR(maxRange)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Allow Zeus to open the medical menu on any unit in the mission via `ace_medical_menu_fnc_openMenu`
  - Adds a condition check to `fnc_canOpenMenu` that returns true if the player has the curator interface open
  - Adds exception to `fnc_onMenuOpen` that allows `fnc_canInteractWith` to return true if player is zeus.

**Rationale**
- I'd like to allow game master to better assess damage using the medical menu on players in the mission. This could either be done via the function call listed above or in a zeus module to be developed later.