### PR TITLE
Hide "Activate Mine" action

### DIFF
--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -31,6 +31,9 @@ class CfgPatches {
 
 class CfgActions {
     class None;
+    class ActivateMine: None {
+        show = 0;
+    };
     class Deactivate:None {
         show = 0;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes #6342

The only other way to hide the action would be adding another magazine to the GroundWeaponHolder. That's not really an option though since we'd have to continously check all of them on the map.