### PR TITLE
Cargo - Support of object without `ace_cargo_size` defined in config or `-1` config value

### DIFF
--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -20,10 +20,8 @@
 params ["_item", "_vehicle", ["_unloader", objNull]];
 TRACE_3("params",_item,_vehicle,_unloader);
 
-private _itemClass = if (_item isEqualType "") then {_item} else {typeOf _item};
-
 //This covers testing vehicle stability and finding a safe position
-private _emptyPosAGL = [_vehicle, _itemClass, _unloader] call EFUNC(common,findUnloadPosition);
+private _emptyPosAGL = [_vehicle, _item, _unloader] call EFUNC(common,findUnloadPosition);
 TRACE_1("findUnloadPosition",_emptyPosAGL);
 
 if ((count _emptyPosAGL) != 3) exitWith {

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -48,10 +48,10 @@ if (_cargo isKindOf "CAManBase") then {
     private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
         getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
     } else {
-        if (isNil QEFUNC(cargo,getSizeItem)) then {
-            _radiusOfItem;
-        } else {
+        if (["ace_cargo"] call EFUNC(common,isModLoaded)) then {
             [_cargo] call EFUNC(cargo,getSizeItem);
+        } else {
+            _radiusOfItem;
         };
     };
     if !(_itemSize isEqualTo -1) then {

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Source Vehicle <OBJECT>
- * 1: Cargo Classname <STRING>
+ * 1: Cargo <OBJECT> or <STRING>
  * 2: Unloader (player) <OBJECT> (default: objNull)
  * 3: Max Distance (meters) <NUMBER> (default: 10)
  * 4: Check Vehicle is Stable <BOOL> (default: true)
@@ -27,8 +27,8 @@
 //Manual collision tests (count and radius):
 #define COL_TEST_COUNT 12
 
-params ["_vehicle", "_typeOfCargo", ["_theUnloader", objNull], ["_maxDistance", 10], ["_checkVehicleIsStable", true]];
-TRACE_5("params",_vehicle,_typeOfCargo,_theUnloader,_maxDistance,_checkVehicleIsStable);
+params ["_vehicle", "_cargo", ["_theUnloader", objNull], ["_maxDistance", 10], ["_checkVehicleIsStable", true]];
+TRACE_5("params",_vehicle,_cargo,_theUnloader,_maxDistance,_checkVehicleIsStable);
 
 scopeName "main";
 
@@ -40,12 +40,18 @@ if (_checkVehicleIsStable) then {
 };
 
 private _radiusOfItem = 1;
-if (_typeOfCargo isKindOf "CAManBase") then {
+if (_cargo isKindOf "CAManBase") then {
     _radiusOfItem = 1.1;
 } else {
     //`sizeOf` is unreliable, and does not work with object types that don't exist on map, so estimate size based on cargo size
-    if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
-        _radiusOfItem = (((getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) ^ 0.35) max 0.75);
+    private _typeOfCargo = if (_cargo isEqualType "") then {_cargo} else {typeOf _cargo};
+    private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> [_typeOfCargo] select (_cargo isEqualType "") >> QEGVAR(cargo,size))) then {
+        getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
+    } else {
+        [_cargo] call EFUNC(cargo,getSizeItem);
+    };
+    if !(_itemSize isEqualTo -1) then {
+        _radiusOfItem = (_itemSize ^ 0.35) max 0.75;
     };
 };
 

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -48,7 +48,7 @@ if (_cargo isKindOf "CAManBase") then {
     private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
         getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
     } else {
-        [_cargo] call EFUNC(cargo,getSizeItem);
+        [[_cargo] call EFUNC(cargo,getSizeItem)] param [0, _radiusOfItem];
     };
     if !(_itemSize isEqualTo -1) then {
         _radiusOfItem = (_itemSize ^ 0.35) max 0.75;

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -48,7 +48,11 @@ if (_cargo isKindOf "CAManBase") then {
     private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
         getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
     } else {
-        [[_cargo] call EFUNC(cargo,getSizeItem)] param [0, _radiusOfItem];
+        if (isNil QEFUNC(cargo,getSizeItem)) then {
+            _radiusOfItem;
+        } else {
+            [_cargo] call EFUNC(cargo,getSizeItem);
+        };
     };
     if !(_itemSize isEqualTo -1) then {
         _radiusOfItem = (_itemSize ^ 0.35) max 0.75;

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -45,7 +45,7 @@ if (_cargo isKindOf "CAManBase") then {
 } else {
     //`sizeOf` is unreliable, and does not work with object types that don't exist on map, so estimate size based on cargo size
     private _typeOfCargo = if (_cargo isEqualType "") then {_cargo} else {typeOf _cargo};
-    private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> [_typeOfCargo] select (_cargo isEqualType "") >> QEGVAR(cargo,size))) then {
+    private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
         getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
     } else {
         [_cargo] call EFUNC(cargo,getSizeItem);

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -45,7 +45,7 @@ if (_cargo isKindOf "CAManBase") then {
 } else {
     //`sizeOf` is unreliable, and does not work with object types that don't exist on map, so estimate size based on cargo size
     private _typeOfCargo = if (_cargo isEqualType "") then {_cargo} else {typeOf _cargo};
-    private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
+    private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size)) && {getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size)) != -1}) then {
         getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
     } else {
         if (["ace_cargo"] call FUNC(isModLoaded)) then {

--- a/addons/common/functions/fnc_findUnloadPosition.sqf
+++ b/addons/common/functions/fnc_findUnloadPosition.sqf
@@ -48,13 +48,13 @@ if (_cargo isKindOf "CAManBase") then {
     private _itemSize = if (isNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size))) then {
         getNumber (configFile >> "CfgVehicles" >> _typeOfCargo >> QEGVAR(cargo,size));
     } else {
-        if (["ace_cargo"] call EFUNC(common,isModLoaded)) then {
+        if (["ace_cargo"] call FUNC(isModLoaded)) then {
             [_cargo] call EFUNC(cargo,getSizeItem);
         } else {
             _radiusOfItem;
         };
     };
-    if !(_itemSize isEqualTo -1) then {
+    if (_itemSize != -1) then {
         _radiusOfItem = (_itemSize ^ 0.35) max 0.75;
     };
 };


### PR DESCRIPTION
close #6357 

Actually, if `_typeofcargo` does not have `ace_cargo_size` define in config, the `_radiusOfItem` of the object is `1`. This inconsistency can be avoid by using the `ace_cargo_fnc_getSizeItem` which take an object as parameter and get the size of the object defined manually by user ( `ace_cargo_fnc_setsize`). 

By having a `_radiusOfItem` more accurate, the `ace_common_fnc_findUnloadPosition` will find better position for unloading and avoid vehicle explosion when big objects, without `ace_cargo_size` defined in config, are unloaded.

I don't know if it is the best way to handle this case but at least it is a work around. Cheers.

**When merged this pull request will:**
- `ace_common_fnc_findUnloadPosition` can take object as parameter
- Prefer the config way instead to determine the size of `_cargo` directly with  `ace_cargo_fnc_getSizeItem` (this avoid inconsistency when player `ace_cargo_fnc_setsize` of an object lower from the `ace_cargo_size` defined in config)
- Also check if the config value is not `-1` to avoid the issue: https://github.com/acemod/ACE3/issues/6357#issuecomment-393525374
- If `ace_cargo_size` is not define in config, use the `ace_cargo_fnc_getSizeItem` to get object size set by player with `ace_cargo_fnc_setsize`
- Update the `ace_cargo_fnc_unloadItem` accordingly (use the cargo object instead of the class name).