### PR TITLE
Replace BIS_fnc_MP calls with remoteExecCall commands

### DIFF
--- a/addons/zeus/functions/fnc_bi_moduleCurator.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleCurator.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: Bohemia Interactive
+ * Author: Bohemia Interactive, optimized by Anton
  * Module function for initalizing zeus
  * Edited to remove eagle and global ascension message
  * Added "zeusUnitAssigned" event call
@@ -25,7 +25,7 @@ if (_activated) then {
 
     //--- Terminate when not created on the server
     if (!isserver && local _logic && isnull (getassignedcuratorunit _logic)) exitwith {
-        [format ["%1 is trying to create curator logic ModuleCurator_F",profilename],"bis_fnc_error",false] call bis_fnc_mp;
+        format ["%1 is trying to create curator logic ModuleCurator_F", profilename] remoteExecCall ["bis_fnc_error", 2];
         deletevehicle _logic;
     };
 
@@ -162,7 +162,7 @@ if (_activated) then {
                     if ((_logic getVariable ["showNotification",true]) && GVAR(zeusAscension)) then {
                         {
                             if (isplayer _x) then {
-                                [["CuratorAssign",[_name,name _player]],"bis_fnc_showNotification",_x] call bis_fnc_mp;
+                                ["CuratorAssign", [_name, name _player]] remoteExecCall ["bis_fnc_showNotification", _x];
                             };
                         } forEach (curatoreditableobjects _logic);
                     };

--- a/addons/zeus/functions/fnc_bi_moduleMine.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleMine.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: Bohemia Interactive
+ * Author: Bohemia Interactive, optimized by Anton
  * Module function for spawning mines
  * Edited to remove forced map markers and mines being revealed to players
  *
@@ -41,7 +41,7 @@ if (_activated) then {
         };
 
         //--- Show hint to curator who placed the object
-        [[["Curator","PlaceMines"],nil,nil,nil,nil,nil,nil,true],"bis_fnc_advHint",_logic] call bis_fnc_mp;
+        [["Curator", "PlaceMines"], nil, nil, nil, nil, nil, nil, true] remoteExecCall ["bis_fnc_advHint", _logic];
 
         waituntil {sleep 0.1; isnull _explosive || isnull _logic || !alive _logic};
         if (isnull _logic) then {deletevehicle _explosive;} else {_explosive setdamage 1;};

--- a/addons/zeus/functions/fnc_bi_moduleProjectile.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleProjectile.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: Bohemia Interactive
+ * Author: Bohemia Interactive, optimized by Anton
  * Module function for spawning projectiles
  * Used by Curator artillery modules etc
  * Edited to remove radio warning and add ballistics support
@@ -98,7 +98,7 @@ if (_activated) then {
                         if (_side in [east,west,resistance,civilian]) then {
                             //--- Play radio (only if it wasn't played recently)
                             if (CBA_missionTime > _x getVariable ["BIS_fnc_moduleProjectile_radio",-_delay]) then {
-                                [[_side,_radio,"side"],"bis_fnc_sayMessage",_x] call bis_fnc_mp;
+                                [_side, _radio, "side"] remoteExecCall ["bis_fnc_sayMessage", _x];
                                 _x setVariable ["BIS_fnc_moduleProjectile_radio",CBA_missionTime + _delay];
                             };
                         };
@@ -107,7 +107,7 @@ if (_activated) then {
             };
         };
         if (count _hint > 0 && {count objectcurators _logic > 0}) then {
-            [[_hint,nil,nil,nil,nil,nil,nil,true],"bis_fnc_advHint",objectcurators _logic] call bis_fnc_mp;
+            [_hint, nil, nil, nil, nil, nil, nil, true] remoteExecCall ["bis_fnc_advHint", objectcurators _logic];
         };
         if (count _velocity == 3) then {
             _altitude = (_logic getvariable ["altitude",_altitude]) call bis_fnc_parsenumber;
@@ -126,7 +126,7 @@ if (_activated) then {
             };
 
             //--- Play sound
-            if (_sound != "") then {[[_logic,_sound,"say3D"],"bis_fnc_sayMessage"] call bis_fnc_mp;};
+            if (_sound != "") then {[_logic, _sound, "say3D"] remoteExecCall ["bis_fnc_sayMessage"];};
 
             //--- Create sound source
             _soundSource = if (_soundSourceClass != "") then {createSoundSource [_soundSourceClass,_pos,[],0]} else {objnull};
@@ -170,7 +170,7 @@ if (_activated) then {
                 //--- Delete curator spawned logic
                 if (_shakeStrength > 0) then {
                     if (_simulation == "shotsubmunitions") then {sleep 0.5;};
-                    [[_shakeStrength,0.7,[position _logic,_shakeRadius]],"bis_fnc_shakeCuratorCamera"] call bis_fnc_mp;
+                    [_shakeStrength, 0.7, [position _logic, _shakeRadius]] remoteExec ["bis_fnc_shakeCuratorCamera"];
                 };
                 deletevehicle _logic;
             } else {

--- a/addons/zeus/functions/fnc_bi_moduleRemoteControl.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleRemoteControl.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: Bohemia Interactive
+ * Author: Bohemia Interactive, optimized by Anton
  * Module function for remote controlling units as zeus
  * Edited to remove global wind sound
  *
@@ -58,7 +58,7 @@ if (_activated && local _logic && !isnull curatorcamera) then {
             // Added by ace_zeus to toggle remote control wind sound
             if (GVAR(remoteWind)) then {
                 //--- Play wind cue to all players
-                [format ["wind%1",ceil random 5],"bis_fnc_playsound"] call bis_fnc_mp;
+                format ["wind%1", ceil random 5] remoteExecCall ["bis_fnc_playsound"];
             };
 
             _blur = ppeffectcreate ["RadialBlur",144];


### PR DESCRIPTION
**When merged this pull request will:**
- Replace all [`BIS_fnc_MP`](https://community.bistudio.com/wiki/BIS_fnc_MP) calls with [`remoteExecCall`](https://community.bistudio.com/wiki/remoteExecCall) engine commands in ACE3.

**Motivation:**
- The [code optimization page](https://community.bistudio.com/wiki/Code_Optimisation) says to use them.

**Notes:**
- *Note 1*: [remoteExec](https://community.bistudio.com/wiki/remoteExec) is [unfortunately](https://ace3mod.com/wiki/development/arma-3-scheduler-and-our-practices.html) necessary ([remoteExecCall](https://community.bistudio.com/wiki/remoteExecCall) cannot be used) when calling [BIS_fnc_shakeCuratorCamera](https://community.bistudio.com/wiki/BIS_fnc_shakeCuratorCamera), as the function contains `sleep 0.05` at the end.
- *Note 2*: Advanced hints ([bis_fnc_advHint](https://community.bistudio.com/wiki/BIS_fnc_advHint)) only show up once in a session. It might save someone debugging time having this in mind when trying to display them.