### PR TITLE
Fix Rearming Pylon Magazines

### DIFF
--- a/addons/finger/functions/fnc_keyPress.sqf
+++ b/addons/finger/functions/fnc_keyPress.sqf
@@ -48,7 +48,7 @@ private _nearbyMen = (ACE_player nearObjects ["CAManBase", (GVAR(maxRange) + 2)]
             {alive _x} &&
             {(_x == (vehicle _x)) || {(vehicle _x) isKindOf "StaticWeapon"}} &&
             {GVAR(indicatorForSelf) || {_x != ACE_player}} &&
-            {!(lineIntersects [(eyePos _x), _playerEyePosASL, ACE_player, _x])} &&
+            {!(lineIntersects [(eyePos _x), _playerEyePosASL, ACE_player, vehicle _x])} &&
             {[_x] call EFUNC(common,isPlayer)}) then {
 
         _sendFingerToPlayers pushBack _x;

--- a/addons/finger/functions/fnc_keyPress.sqf
+++ b/addons/finger/functions/fnc_keyPress.sqf
@@ -48,7 +48,7 @@ private _nearbyMen = (ACE_player nearObjects ["CAManBase", (GVAR(maxRange) + 2)]
             {alive _x} &&
             {(_x == (vehicle _x)) || {(vehicle _x) isKindOf "StaticWeapon"}} &&
             {GVAR(indicatorForSelf) || {_x != ACE_player}} &&
-            {!(lineIntersects [(eyePos _x), _playerEyePosASL, ACE_player, vehicle _x])} &&
+            {!(lineIntersects [(eyePos _x), _playerEyePosASL, vehicle ACE_player, vehicle _x])} &&
             {[_x] call EFUNC(common,isPlayer)}) then {
 
         _sendFingerToPlayers pushBack _x;

--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -27,12 +27,26 @@ TRACE_7("rearmSuccessLocal",_vehicle,_unit,_turretPath,_numMagazines,_magazineCl
 private _rounds = getNumber (configFile >> "CfgMagazines" >> _magazineClass >> "count");
 
 if (_pylon > 0) exitWith {
-    if (_turretPath isEqualTo [-1]) then {_turretPath = [];}; // Convert back to pylon turret format
-    private _currentCount = _vehicle ammoOnPylon _pylon;
-    private _newCount = ((_currentCount max 0) + _numRounds) min _rounds;
-    TRACE_2("",_pylon,_magazineClass,_newCount);
-    _vehicle setPylonLoadOut [_pylon, _magazineClass, false, _turretPath];
-    _vehicle setAmmoOnPylon [_pylon, _newCount];
+    if (GVAR(level) == 1) then {
+        // Fill magazine completely
+        if (_turretPath isEqualTo [-1]) then {_turretPath = [];}; // Convert back to pylon turret format
+        TRACE_2("",_pylon,_magazineClass,_rounds);
+        _vehicle setPylonLoadOut [_pylon, _magazineClass, true, _turretPath];
+        [QEGVAR(common,displayTextStructured), [[LSTRING(Hint_RearmedTriple), _rounds,
+            getText(configFile >> "CfgMagazines" >> _magazineClass >> "displayName"),
+            getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "displayName")], 3, _unit], [_unit]] call CBA_fnc_targetEvent;
+    } else {
+        // Fill only at most _numRounds
+        if (_turretPath isEqualTo [-1]) then {_turretPath = [];}; // Convert back to pylon turret format
+        private _currentCount = _vehicle ammoOnPylon _pylon;
+        private _newCount = ((_currentCount max 0) + _numRounds) min _rounds;
+        TRACE_2("",_pylon,_magazineClass,_newCount);
+        _vehicle setPylonLoadOut [_pylon, _magazineClass, true, _turretPath];
+        _vehicle setAmmoOnPylon [_pylon, _newCount];
+        [QEGVAR(common,displayTextStructured), [[LSTRING(Hint_RearmedTriple), _newCount,
+            getText(configFile >> "CfgMagazines" >> _magazineClass >> "displayName"),
+            getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "displayName")], 3, _unit], [_unit]] call CBA_fnc_targetEvent;
+    };
 };
 
 private _currentRounds = 0;

--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -43,7 +43,7 @@ if (_pylon > 0) exitWith {
         TRACE_2("",_pylon,_magazineClass,_newCount);
         _vehicle setPylonLoadOut [_pylon, _magazineClass, true, _turretPath];
         _vehicle setAmmoOnPylon [_pylon, _newCount];
-        [QEGVAR(common,displayTextStructured), [[LSTRING(Hint_RearmedTriple), _newCount,
+        [QEGVAR(common,displayTextStructured), [[LSTRING(Hint_RearmedTriple), _numRounds,
             getText(configFile >> "CfgMagazines" >> _magazineClass >> "displayName"),
             getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "displayName")], 3, _unit], [_unit]] call CBA_fnc_targetEvent;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Rearm pylon magazines properly if the `Rearm Amount` setting is set to `Entire Magazine` (Previously if the magazine was a pylon magazine then it would only rearm based on caliber. Did not check `ace_rearm_level`)
- Adds the `displayTextStructured` text box to inform the player of the number of rounds rearmed if the magazine is a pylon magazine.
- Sets the `forced` flag on the `setPylonLoadOut` command to `true` so the rearm system is capable of rearming scripted pylon weapons.
- Fixes [#5395](https://github.com/acemod/ACE3/issues/5395)
