### PR TITLE
Arsenal - Fix Rate Of Fire stat

### DIFF
--- a/addons/arsenal/ACE_Arsenal_Stats.hpp
+++ b/addons/arsenal/ACE_Arsenal_Stats.hpp
@@ -33,7 +33,7 @@ class GVAR(stats) {
         displayName= "$STR_a3_rscdisplayarsenal_stat_rof";
         showBar = 1;
         showText = 1;
-        barStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_2([ARR_2(-1.4, 0.31)], [ARR_2(1, 0.01)])])] call FUNC(statBarStatement_default));
+        barStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_2([ARR_2(-1.4, 0.31)], [ARR_2(1, 0.01)])])] call FUNC(statBarStatement_rateOfFIre));
         textStatement = QUOTE([ARR_3((_this select 0) select 0, _this select 1, [ARR_2([ARR_2(-1.4, 0.31)], false)])] call FUNC(statTextStatement_rateOfFire));
         tabs[] = {{0,1}, {}};
     };

--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -50,6 +50,7 @@ PREP(sortPanel);
 PREP(statBarStatement_accuracy);
 PREP(statBarStatement_default);
 PREP(statBarStatement_impact);
+PREP(statBarStatement_rateOfFIre);
 PREP(statTextStatement_accuracy);
 PREP(statTextStatement_mass);
 PREP(statTextStatement_rateOfFire);

--- a/addons/arsenal/functions/fnc_statBarStatement_rateOfFIre.sqf
+++ b/addons/arsenal/functions/fnc_statBarStatement_rateOfFIre.sqf
@@ -1,13 +1,13 @@
 /*
  * Author: Alganthe
- * Rate of fire text statement.
+ * Rate of fire bar statement.
  *
  * Arguments:
- * 0: stat (STRING)
+ * 0: stats array (ARRAY)
  * 1: item config path (CONFIG)
- * 2: Args for configExtreme
+ * 2: Args
  *  2.1: Stat limits (ARRAY of BOOL)
- *  2.2: Evaluate as a logarithmic number (BOOL)
+ *  2.2: Bar limits (ARRAY of SCALAR)
  *
  * Return Value:
  * Number
@@ -17,16 +17,15 @@
 #include "script_component.hpp"
 
 params ["_stat", "_config", "_args"];
-_args params ["_statMinMax", "_configExtremeBool"];
+_args params ["_statMinMax", "_barLimits"];
 
 private _fireModes = getArray (_config >> "modes");
 private _fireRate = [];
 
 {
-    _fireRate pushBackUnique (getNumber (_config >> _x >> "reloadTime"));
+    _fireRate pushBackUnique log (getNumber (_config >> _x >> "reloadTime"));
 } foreach _fireModes;
 
 _fireRate sort true;
-_fireRate = _fireRate select 0;
 
-format ["%1 rpm", round (60 / _fireRate]
+linearConversion [_statMinMax select 0, _statMinMax select 1, _fireRate select 0, _barLimits select 0, _barLimits select 1]

--- a/addons/arsenal/functions/fnc_statTextStatement_rateOfFire.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_rateOfFire.sqf
@@ -29,4 +29,4 @@ private _fireRate = [];
 _fireRate sort true;
 _fireRate = _fireRate select 0;
 
-format ["%1 rpm", round (60 / _fireRate]
+format ["%1 rpm", round (60 / _fireRate)]


### PR DESCRIPTION
**When merged this pull request will:**
- The stat was wrong when the default ROF was different than the firemode one (example: hlc pistols)