### PR TITLE
Fastroping - Disable ACRE features for helper objects

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -79,6 +79,10 @@ class CfgVehicles {
         class ACE_SelfActions {};
         EGVAR(cargo,hasCargo) = 0;
         EGVAR(cargo,space) = 0;
+        // ACRE 2.6.0 Compatibility
+        acre_hasInfantryPhone = 0;
+        class AcreRacks {};
+        class AcreIntercoms {};
     };
     class ACE_friesAnchorBar: ACE_friesBase {
         author = "jokoho48";
@@ -160,6 +164,10 @@ class CfgVehicles {
         class TransportItems {};
         EGVAR(cargo,hasCargo) = 0;
         EGVAR(cargo,space) = 0;
+        // ACRE 2.6.0 Compatibility
+        acre_hasInfantryPhone = 0;
+        class AcreRacks {};
+        class AcreIntercoms {};
     };
 
     class Helicopter_Base_H;


### PR DESCRIPTION
Disables Racks, Intercom, Infentry Phone on fast roping helper objects
(Inherited because they are type `Helicopter`)

Configs shouldn't cause issue if not using acre.