### PR TITLE
Fix right tab listNbox not showing last item on first load in ACE Arsenal

### DIFF
--- a/addons/arsenal/defines.hpp
+++ b/addons/arsenal/defines.hpp
@@ -237,8 +237,6 @@ _buttonCurrentMag2Ctrl ctrlCommit FADE_DELAY;\
     ];\
     _x ctrlCommit 0;\
 } foreach [\
-    IDC_rightTabContent,\
-    IDC_rightTabContentListnBox,\
     IDC_blockRightFrame,\
     IDC_blockRighttBackground\
 ];
@@ -284,8 +282,6 @@ _buttonCurrentMag2Ctrl ctrlCommit FADE_DELAY;\
     ];\
     _x ctrlCommit 0;\
 } foreach [\
-    IDC_rightTabContent,\
-    IDC_rightTabContentListnBox,\
     IDC_blockRightFrame,\
     IDC_blockRighttBackground\
 ];

--- a/addons/arsenal/ui/RscAttributes.hpp
+++ b/addons/arsenal/ui/RscAttributes.hpp
@@ -490,7 +490,7 @@ class GVAR(display) {
             onSetFocus = QUOTE(GVAR(rightTabFocus) = true);
             onKillFocus = QUOTE(GVAR(rightTabFocus) = false);
             x = QUOTE(safezoneX + safezoneW - 93 * GRID_W);
-            h = QUOTE(safezoneH - 34.5 * GRID_H);
+            h = QUOTE(safezoneH - 28 * GRID_H);
         };
         class rightTabContentListnBox : RscListNBox {
             idc = IDC_rightTabContentListnBox;
@@ -512,7 +512,7 @@ class GVAR(display) {
             x = QUOTE(safezoneX + safezoneW - 93 * GRID_W);
             y = QUOTE(safezoneY + 14 * GRID_H);
             w = QUOTE(80 * GRID_W);
-            h = QUOTE(safezoneH - 34.5 * GRID_H);
+            h = QUOTE(safezoneH - 34 * GRID_H);
             sizeEx = QUOTE(7 * GRID_H);
         };
         class sortLeftTab: RscCombo {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the right tab listNbox from eating the last item of the list. 

~Go figure why that happens tho :/ , at least it's fixed.~
Welp, if you resize listBox and listNbox controls while they're filled, the rows will get eaten by the arma dragon.

Bugged behavior can be seen below, (not my gif, thanks mharis001 for bringing up this issue):
https://gfycat.com/MassiveThreadbareDavidstiger
