### PR TITLE
Zeus - UI improvements and additional objects setting for Editable Objects module

### DIFF
--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -24,7 +24,7 @@ if (isServer) then {
     [QGVAR(addObjects), {
         params ["_objects", ["_curator", objNull]];
 
-        if !(isNull _curator) exitWith { _curator addCuratorEditableObjects [_objects, true]; };
+        if (!isNull _curator) exitWith {_curator addCuratorEditableObjects [_objects, true]};
 
         {
             _x addCuratorEditableObjects [_objects, true];
@@ -33,7 +33,7 @@ if (isServer) then {
     [QGVAR(removeObjects), {
         params ["_objects", ["_curator", objNull]];
 
-        if !(isNull _curator) exitWith { _curator removeCuratorEditableObjects [_objects, true]; };
+        if (!isNull _curator) exitWith {_curator removeCuratorEditableObjects [_objects, true]};
 
         {
             _x removeCuratorEditableObjects [_objects, true];

--- a/addons/zeus/functions/fnc_ui_editableObjects.sqf
+++ b/addons/zeus/functions/fnc_ui_editableObjects.sqf
@@ -47,7 +47,7 @@ private _fnc_onConfirm = {
 
     private _radius = GETVAR(_display,GVAR(radius),100);
     private _editingMode = lbCurSel (_display displayCtrl 19181) > 0;
-    private _allCurators = [getAssignedCuratorLogic player, objNull] select (lbCurSel (_display displayCtrl 19182));
+    private _allCurators = [getAssignedCuratorLogic player, objNull] select lbCurSel (_display displayCtrl 19182);
     private _additionalObjects = lbCurSel (_display displayCtrl 19183);
 
     private _objects = nearestObjects [_logic, ["All"], _radius];
@@ -58,7 +58,6 @@ private _fnc_onConfirm = {
             _objects append (allUnits + allDeadMen select {!(_x isKindOf "HeadlessClient_F")});
         };
     };
-    _objects arrayIntersect _objects; // Incase additional objects were also in radius
 
     if (_editingMode) then {
         [QGVAR(addObjects), [_objects, _allCurators]] call CBA_fnc_serverEvent;

--- a/addons/zeus/functions/fnc_ui_editableObjects.sqf
+++ b/addons/zeus/functions/fnc_ui_editableObjects.sqf
@@ -48,7 +48,17 @@ private _fnc_onConfirm = {
     private _radius = GETVAR(_display,GVAR(radius),100);
     private _editingMode = lbCurSel (_display displayCtrl 19181) > 0;
     private _allCurators = [getAssignedCuratorLogic player, objNull] select (lbCurSel (_display displayCtrl 19182));
-    private _objects = nearestObjects [getPos _logic, ["All"], _radius];
+    private _additionalObjects = lbCurSel (_display displayCtrl 19183);
+
+    private _objects = nearestObjects [_logic, ["All"], _radius];
+    if (_additionalObjects == 1) then {
+        _objects append call CBA_fnc_players;
+    } else {
+        if (_additionalObjects == 2) then {
+            _objects append (allUnits + allDeadMen select {!(_x isKindOf "HeadlessClient_F")});
+        };
+    };
+    _objects arrayIntersect _objects; // Incase additional objects were also in radius
 
     if (_editingMode) then {
         [QGVAR(addObjects), [_objects, _allCurators]] call CBA_fnc_serverEvent;

--- a/addons/zeus/functions/fnc_ui_garrison.sqf
+++ b/addons/zeus/functions/fnc_ui_garrison.sqf
@@ -1,6 +1,6 @@
 /*
- * Author: alganthe
- * Initalises the "Garrison" zeus module display.
+ * Author: alganthe, mharis001
+ * Initializes the "Garrison" Zeus module display.
  *
  * Arguments:
  * 0: Garrison controls group <CONTROL>
@@ -9,26 +9,24 @@
  * None
  *
  * Example:
- * onSetFocus = "_this call ace_zeus_fnc_ui_garrison"
+ * [CONTROL] call ace_zeus_fnc_ui_garrison
  *
  * Public: No
 */
 #include "script_component.hpp"
 
-disableSerialization;
-
 params ["_control"];
 
-//Generic Init:
-private _display = ctrlparent _control;
-private _ctrlButtonOK = _display displayctrl 1; //IDC_OK
-private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objnull);
-TRACE_1("logicObject",_logic);
+// Generic init
+private _display = ctrlParent _control;
+private _ctrlButtonOK = _display displayCtrl 1; // IDC_OK
+private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objNull);
+TRACE_1("Logic Object",_logic);
 
-_control ctrlRemoveAllEventHandlers "setFocus";
+_control ctrlRemoveAllEventHandlers "SetFocus";
 
-// Handles errors
-private _unit = effectiveCommander (attachedTo _logic);
+// Validate module target
+private _unit = effectiveCommander attachedTo _logic;
 
 scopeName "Main";
 private _fnc_errorAndClose = {
@@ -54,26 +52,9 @@ switch (false) do {
     };
 };
 
-//Specific on-load stuff:
-private _listbox = _display displayCtrl 73063;
-{
-    _listbox lbSetValue  [_listbox lbAdd (_x select 0), _x select 1];
-} forEach [
-    [localize LSTRING(ModuleGarrison_FillingModeEven), 0],
-    [localize LSTRING(ModuleGarrison_FillingModeBuilding), 1],
-    [localize LSTRING(ModuleGarrison_FillingModeRandom), 2]
-];
-
-_listbox lbSetCurSel 0;
-
-//Specific on-load stuff:
-(_display displayCtrl 73061) cbSetChecked (_logic getVariable ["TopDownFilling",false]);
-(_display displayCtrl 73062) cbSetChecked (_logic getVariable ["Teleport",false]);
-
+// Specific onLoad stuff
 private _fnc_onUnload = {
-    params ["_display"];
-
-    private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objnull);
+    private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objNull);
     if (isNull _logic) exitWith {};
 
     deleteVehicle _logic;
@@ -82,22 +63,19 @@ private _fnc_onUnload = {
 private _fnc_onConfirm = {
     params [["_ctrlButtonOK", controlNull, [controlNull]]];
 
-    private _display = ctrlparent _ctrlButtonOK;
+    private _display = ctrlParent _ctrlButtonOK;
     if (isNull _display) exitWith {};
 
-    private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objnull);
+    private _logic = GETMVAR(BIS_fnc_initCuratorAttributes_target,objNull);
     if (isNull _logic) exitWith {};
 
-    private _lb = _display displayCtrl 73063;
-
     private _radius = GETVAR(_display,GVAR(radius),50);
-    private _position = GETVAR(_display,GVAR(position),getPos _logic);
-    private _mode = _lb lbValue (lbCurSel _lb);
-    private _TopDownFilling = cbChecked (_display displayCtrl 73061);
-    private _teleport = cbChecked (_display displayCtrl 73062);
+    private _teleport = lbCurSel (_display displayCtrl 73061) > 0;
+    private _topDown = lbCurSel (_display displayCtrl 73062) > 0;
+    private _fillingMode = lbCurSel (_display displayCtrl 73063);
 
-    [_logic, _position ,_radius, _mode, _TopDownFilling, _teleport] call FUNC(moduleGarrison);
+    [_logic, getPos _logic, _radius, _fillingMode, _topDown, _teleport] call FUNC(moduleGarrison);
 };
 
-_display displayAddEventHandler ["unload", _fnc_onUnload];
-_ctrlButtonOK ctrlAddEventHandler ["buttonclick", _fnc_onConfirm];
+_display displayAddEventHandler ["Unload", _fnc_onUnload];
+_ctrlButtonOK ctrlAddEventHandler ["ButtonClick", _fnc_onConfirm];

--- a/addons/zeus/functions/fnc_ui_toggleFlashlight.sqf
+++ b/addons/zeus/functions/fnc_ui_toggleFlashlight.sqf
@@ -15,8 +15,6 @@
  */
 #include "script_component.hpp"
 
-#define COMBO_ITEMS [[LSTRING(SelectedGroup), "\a3\ui_f_curator\data\displays\rscdisplaycurator\modegroups_ca.paa"], ["STR_WEST", "\a3\ui_f\data\map\diary\icons\playerwest_ca.paa"], ["STR_EAST", "\a3\ui_f\data\map\diary\icons\playereast_ca.paa"], ["STR_guerrila", "\a3\ui_f\data\map\diary\icons\playerguer_ca.paa"], ["STR_Civilian", "\a3\ui_f\data\map\diary\icons\playerciv_ca.paa"]]
-
 params ["_control"];
 
 // Generic init
@@ -28,7 +26,7 @@ TRACE_1("Logic Object",_logic);
 _control ctrlRemoveAllEventHandlers "SetFocus";
 
 // Validate module target
-private _unit = effectiveCommander (attachedTo _logic);
+private _unit = effectiveCommander attachedTo _logic;
 
 scopeName "Main";
 private _fnc_errorAndClose = {
@@ -51,19 +49,11 @@ if !(isNull _unit) then {
 };
 
 // Specific onLoad stuff
-private _combo = _display displayCtrl 56220;
-
-// Add target combo options (only add selected group option if placed on unit)
-{
-    _x params ["_text", "_icon"];
-    _combo lbSetPicture [_combo lbAdd (localize _text), _icon];
-} forEach (COMBO_ITEMS select [[0, 1] select (isNull _unit), 5]);
-
-_combo lbSetCurSel 0;
-
-// Set default flashlight status
-if !(isNull _unit) then {
-    (_display displayCtrl 56218) lbSetCurSel ([0, 1] select (_unit isFlashlightOn (currentWeapon _unit)));
+// Remove selected group option in not placed on unit and set default flashlight status
+if (isNull _unit) then {
+    (_display displayCtrl 56220) lbDelete 0;
+} else {
+    (_display displayCtrl 56218) lbSetCurSel ([0, 1] select (_unit isFlashlightOn currentWeapon _unit));
 };
 
 private _fnc_onUnload = {

--- a/addons/zeus/functions/fnc_ui_toggleNvg.sqf
+++ b/addons/zeus/functions/fnc_ui_toggleNvg.sqf
@@ -15,8 +15,6 @@
  */
 #include "script_component.hpp"
 
-#define COMBO_ITEMS [[LSTRING(SelectedGroup), "\a3\ui_f_curator\data\displays\rscdisplaycurator\modegroups_ca.paa"], ["STR_WEST", "\a3\ui_f\data\map\diary\icons\playerwest_ca.paa"], ["STR_EAST", "\a3\ui_f\data\map\diary\icons\playereast_ca.paa"], ["STR_guerrila", "\a3\ui_f\data\map\diary\icons\playerguer_ca.paa"], ["STR_Civilian", "\a3\ui_f\data\map\diary\icons\playerciv_ca.paa"]]
-
 params ["_control"];
 
 // Generic init
@@ -28,7 +26,7 @@ TRACE_1("Logic Object",_logic);
 _control ctrlRemoveAllEventHandlers "SetFocus";
 
 // Validate module target
-private _unit = effectiveCommander (attachedTo _logic);
+private _unit = effectiveCommander attachedTo _logic;
 
 scopeName "Main";
 private _fnc_errorAndClose = {
@@ -51,18 +49,10 @@ if !(isNull _unit) then {
 };
 
 // Specific onLoad stuff
-private _combo = _display displayCtrl 92856;
-
-// Add target combo options (only add selected group option if placed on unit)
-{
-    _x params ["_text", "_icon"];
-    _combo lbSetPicture [_combo lbAdd (localize _text), _icon];
-} forEach (COMBO_ITEMS select [[0, 1] select (isNull _unit), 5]);
-
-_combo lbSetCurSel 0;
-
-// Set default NVG status
-if !(isNull _unit) then {
+// Remove selected group option in not placed on unit and set default NVG status
+if (isNull _unit) then {
+    (_display displayCtrl 92856) lbDelete 0;
+} else {
     (_display displayCtrl 92855) lbSetCurSel ([0, 1] select !(hmd _unit isEqualTo ""));
 };
 

--- a/addons/zeus/script_component.hpp
+++ b/addons/zeus/script_component.hpp
@@ -17,9 +17,9 @@
 #include "\z\ace\addons\main\script_macros.hpp"
 
 // UI grid
-#define SIZEX ((safezoneW / safezoneH) min 1.2)
+#define SIZEX ((safeZoneW / safeZoneH) min 1.2)
 #define SIZEY (SIZEX / 1.2)
 #define W_PART(num) (num * (SIZEX / 40))
 #define H_PART(num) (num * (SIZEY / 25))
-#define X_PART(num) (W_PART(num) + (safezoneX + (safezoneW - SIZEX)/2))
-#define Y_PART(num) (H_PART(num) + (safezoneY + (safezoneH - SIZEY)/2))
+#define X_PART(num) (W_PART(num) + (safeZoneX + (safeZoneW - SIZEX) / 2))
+#define Y_PART(num) (H_PART(num) + (safeZoneY + (safeZoneH - SIZEY) / 2))

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -1409,54 +1409,6 @@
             <Russian>Устройство будет активно пытаться найти и перейти к соседним единицам активации. Диапазон автоматического поиска основан на умении снимать расстояние на расстоянии не менее 100 метров.</Russian>
             <Spanish>La unidad intentará buscar activamente y moverse hacia las unidades cercanas del lado de activación. El rango de Auto Seek se basa en la habilidad de distancia al punto de la unidad con un mínimo de 100 metros.</Spanish>
         </Key>
-        <Key ID="STR_ACE_Zeus_ModuleSuicideBomber_Small">
-            <English>Small</English>
-            <Chinese>小</Chinese>
-            <Chinesesimp>小</Chinesesimp>
-            <Czech>Malý</Czech>
-            <French>Petit</French>
-            <German>Klein</German>
-            <Hungarian>Kicsi</Hungarian>
-            <Italian>Piccolo</Italian>
-            <Japanese>小</Japanese>
-            <Korean>작은</Korean>
-            <Polish>Mały</Polish>
-            <Portuguese>Pequeno</Portuguese>
-            <Russian>Маленький</Russian>
-            <Spanish>Pequeña</Spanish>
-        </Key>
-        <Key ID="STR_ACE_Zeus_ModuleSuicideBomber_Medium">
-            <English>Medium</English>
-            <Chinese>中</Chinese>
-            <Chinesesimp>中</Chinesesimp>
-            <Czech>Střední</Czech>
-            <French>Moyen</French>
-            <German>Mittel</German>
-            <Hungarian>Közepes</Hungarian>
-            <Italian>medio</Italian>
-            <Japanese>中</Japanese>
-            <Korean>매질</Korean>
-            <Polish>Średni</Polish>
-            <Portuguese>Médio</Portuguese>
-            <Russian>средний</Russian>
-            <Spanish>Medio</Spanish>
-        </Key>
-        <Key ID="STR_ACE_Zeus_ModuleSuicideBomber_Large">
-            <English>Large</English>
-            <Chinese>大</Chinese>
-            <Chinesesimp>大</Chinesesimp>
-            <Czech>Velký</Czech>
-            <French>Grand</French>
-            <German>Groß</German>
-            <Hungarian>Nagy</Hungarian>
-            <Italian>Grande</Italian>
-            <Japanese>大</Japanese>
-            <Korean>큰</Korean>
-            <Polish>Duży</Polish>
-            <Portuguese>ampla</Portuguese>
-            <Russian>большой</Russian>
-            <Spanish>Grande</Spanish>
-        </Key>
         <Key ID="STR_ACE_Zeus_ModuleSuicideBomber_AlreadyBomber">
             <English>Unit is already a suicide bomber</English>
             <Chinese>這個單位已經是自殺炸彈手了</Chinese>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -315,6 +315,12 @@
             <Chinesesimp>确认变更给所有编辑者</Chinesesimp>
             <Chinese>確認變更給所有編輯者</Chinese>
         </Key>
+        <Key ID="STR_ACE_Zeus_ModuleEditableObjects_AdditionalObjects">
+            <English>Additional Objects</English>
+        </Key>
+        <Key ID="STR_ACE_Zeus_ModuleEditableObjects_AdditionalObjects_Tooltip">
+            <English>Additional objects to include in the action regardless of Task Radius</English>
+        </Key>
         <Key ID="STR_ACE_Zeus_ModuleGlobalSetSkill_DisplayName">
             <English>Global AI Skill</English>
             <French>Compétence global de l'IA</French>
@@ -917,6 +923,15 @@
             <Chinesesimp>需要一个不存在的插件</Chinesesimp>
             <Chinese>需要一個不存在的插件</Chinese>
             <Korean>현재 없는 애드온을 필요로 합니다</Korean>
+        </Key>
+        <Key ID="STR_ACE_Zeus_None">
+            <English>None</English>
+        </Key>
+        <Key ID="STR_ACE_Zeus_Players">
+            <English>Players</English>
+        </Key>
+        <Key ID="STR_ACE_Zeus_PlayersAndAI">
+            <English>Players and AI</English>
         </Key>
         <Key ID="STR_ACE_Zeus_AddObjectsToCurator">
             <English>Add Objects to Curator</English>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -1137,7 +1137,7 @@
             <Korean>장비 추가</Korean>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleGarrison_DisplayName">
-            <English>Garrison group</English>
+            <English>Garrison Group</English>
             <French>Garnir zone</French>
             <Japanese>歩哨グループ</Japanese>
             <Italian>Proteggi gruppo</Italian>
@@ -1209,7 +1209,7 @@
             <Korean>순간이동</Korean>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleUnGarrison_DisplayName">
-            <English>Un-garrison group</English>
+            <English>Un-garrison Group</English>
             <French>Dégarnir zone</French>
             <Japanese>非歩哨グループ</Japanese>
             <Italian>Non proteggere gruppo</Italian>

--- a/addons/zeus/ui/RscAttributes.hpp
+++ b/addons/zeus/ui/RscAttributes.hpp
@@ -361,7 +361,7 @@ class GVAR(RscTeleportPlayers): RscDisplayAttributes {
                     x = 0;
                     y = 0;
                     w = W_PART(26);
-                    h = H_PART(8.5);
+                    h = H_PART(8.1);
                     class controls {
                         class Title: RscText {
                             idc = -1;
@@ -844,7 +844,7 @@ class GVAR(RscSuicideBomber): RscDisplayAttributes {
                             h = H_PART(1);
                             rows = 1;
                             columns = 3;
-                            strings[] = {CSTRING(ModuleSuicideBomber_Small), CSTRING(ModuleSuicideBomber_Medium), CSTRING(ModuleSuicideBomber_Large)};
+                            strings[] = {"$STR_small", "$STR_medium", "$STR_large"};
                         };
                         class AutoSeekLabel: DistanceLabel {
                             idc = -1;

--- a/addons/zeus/ui/RscAttributes.hpp
+++ b/addons/zeus/ui/RscAttributes.hpp
@@ -86,7 +86,7 @@ class GVAR(RscEditableObjects): RscDisplayAttributes {
                     x = 0;
                     y = 0;
                     w = W_PART(26);
-                    h = H_PART(2.1);
+                    h = H_PART(3.2);
                     class controls {
                         class EditingModeLabel: RscText {
                             idc = -1;
@@ -117,6 +117,17 @@ class GVAR(RscEditableObjects): RscDisplayAttributes {
                             idc = 19182;
                             y = H_PART(1.1);
                             strings[] = {ECSTRING(common,No), ECSTRING(common,Yes)};
+                        };
+                        class AdditionalObjectsLabel: EditingModeLabel {
+                            text = CSTRING(ModuleEditableObjects_AdditionalObjects);
+                            tooltip = CSTRING(ModuleEditableObjects_AdditionalObjects_Tooltip);
+                            y = H_PART(2.2);
+                        };
+                        class AdditionalObjects: EditingMode {
+                            idc = 19183;
+                            y = H_PART(2.2);
+                            columns = 3;
+                            strings[] = {CSTRING(None), CSTRING(Players), CSTRING(PlayersAndAI)};
                         };
                     };
                 };

--- a/addons/zeus/ui/RscAttributes.hpp
+++ b/addons/zeus/ui/RscAttributes.hpp
@@ -371,7 +371,7 @@ class GVAR(RscTeleportPlayers): RscDisplayAttributes {
                             y = 0;
                             w = W_PART(26);
                             h = H_PART(1);
-                            colorBackground[] = {0,0,0,0.5};
+                            colorBackground[] = {0, 0, 0, 0.5};
                         };
                         class Unit: RscListbox {
                             idc = 16189;
@@ -500,63 +500,66 @@ class GVAR(RscGarrison): RscDisplayAttributes {
         class Title: Title {};
         class Content: Content {
             class Controls {
+                class radius: GVAR(AttributeRadius) {};
                 class Garrison: RscControlsGroupNoScrollbars {
                     onSetFocus = QUOTE(_this call FUNC(ui_garrison));
                     idc = 73060;
                     x = 0;
                     y = 0;
                     w = W_PART(26);
-                    h = H_PART(8.5);
+                    h = H_PART(6.2);
                     class controls {
-                        class radius: GVAR(AttributeRadius) {};
-                        class TopDownFillingTitle: Title {
-                            idc = -1;
-                            text = CSTRING(ModuleGarrison_TopDownFillingText);
-                            toolTip = CSTRING(ModuleGarrison_TopDownFillingTooltip);
-                            x = 0;
-                            y = H_PART(1.2);
-                            w = W_PART(10);
-                            h = H_PART(1);
-                            colorBackground[] = {0,0,0,0.5};
-                        };
-                        class TopDownFilling: RscCheckBox {
-                            idc = 73061;
-                            x = W_PART(10.1);
-                            y = H_PART(1.2);
-                            w = W_PART(1);
-                            h = H_PART(1);
-                        };
-                        class TeleportTitle: Title {
+                        class TeleportLabel: RscText {
                             idc = -1;
                             text = CSTRING(ModuleGarrison_TeleportText);
                             x = 0;
-                            y = H_PART(2.3);
+                            y = 0;
                             w = W_PART(10);
                             h = H_PART(1);
-                            colorBackground[] = {0,0,0,0.5};
+                            colorBackground[] = {0, 0, 0, 0.5};
                         };
-                        class Teleport: RscCheckBox {
-                            idc = 73062;
+                        class Teleport: ctrlToolbox {
+                            idc = 73061;
                             x = W_PART(10.1);
-                            y = H_PART(2.3);
-                            w = W_PART(1);
+                            y = 0;
+                            w = W_PART(15.9);
                             h = H_PART(1);
+                            rows = 1;
+                            columns = 2;
+                            strings[] = {ECSTRING(common,No), ECSTRING(common,Yes)};
                         };
-                        class FillingModeTitle: RscText {
-                            idc = -1;
+                        class TopDownLabel: TeleportLabel {
+                            text = CSTRING(ModuleGarrison_TopDownFillingText);
+                            tooltip = CSTRING(ModuleGarrison_TopDownFillingTooltip);
+                            y = H_PART(1.1);
+                        };
+                        class TopDown: Teleport {
+                            idc = 73062;
+                            y = H_PART(1.1);
+                        };
+                        class FillingModeLabel: TeleportLabel {
                             text = CSTRING(ModuleGarrison_FillingModeText);
-                            x = 0;
-                            y = H_PART(3.5);
+                            y = H_PART(2.2);
                             w = W_PART(26);
-                            h = H_PART(1);
-                            colorBackground[] = {0,0,0,0.5};
                         };
                         class FillingMode: RscListbox {
                             idc = 73063;
                             x = 0;
-                            y = H_PART(4.5);
+                            y = H_PART(3.2);
                             w = W_PART(26);
-                            h = H_PART(4);
+                            h = H_PART(3);
+                            class Items {
+                                class Even {
+                                    text = CSTRING(ModuleGarrison_FillingModeEven);
+                                    default = 1;
+                                };
+                                class Building {
+                                    text = CSTRING(ModuleGarrison_FillingModeBuilding);
+                                };
+                                class Random {
+                                    text = CSTRING(ModuleGarrison_FillingModeRandom);
+                                };
+                            };
                         };
                     };
                 };

--- a/addons/zeus/ui/RscAttributes.hpp
+++ b/addons/zeus/ui/RscAttributes.hpp
@@ -618,6 +618,29 @@ class GVAR(RscToggleNvg): RscDisplayAttributes {
                             w = W_PART(15.9);
                             h = H_PART(1);
                             colorBackground[] = {0, 0, 0, 0.7};
+                            class Items {
+                                class Group {
+                                    text = CSTRING(SelectedGroup);
+                                    picture = "\a3\ui_f_curator\data\displays\rscdisplaycurator\modegroups_ca.paa";
+                                    default = 1;
+                                };
+                                class BLUFOR {
+                                    text = "$STR_WEST";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playerwest_ca.paa";
+                                };
+                                class OPFOR {
+                                    text = "$STR_EAST";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playereast_ca.paa";
+                                };
+                                class Independent {
+                                    text = "$STR_guerrila";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playerguer_ca.paa";
+                                };
+                                class Civilian {
+                                    text = "$STR_Civilian";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playerciv_ca.paa";
+                                };
+                            };
                         };
                     };
                 };
@@ -684,6 +707,29 @@ class GVAR(RscToggleFlashlight): RscDisplayAttributes {
                             w = W_PART(15.9);
                             h = H_PART(1);
                             colorBackground[] = {0, 0, 0, 0.7};
+                            class Items {
+                                class Group {
+                                    text = CSTRING(SelectedGroup);
+                                    picture = "\a3\ui_f_curator\data\displays\rscdisplaycurator\modegroups_ca.paa";
+                                    default = 1;
+                                };
+                                class BLUFOR {
+                                    text = "$STR_WEST";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playerwest_ca.paa";
+                                };
+                                class OPFOR {
+                                    text = "$STR_EAST";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playereast_ca.paa";
+                                };
+                                class Independent {
+                                    text = "$STR_guerrila";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playerguer_ca.paa";
+                                };
+                                class Civilian {
+                                    text = "$STR_Civilian";
+                                    picture = "\a3\ui_f\data\map\diary\icons\playerciv_ca.paa";
+                                };
+                            };
                         };
                     };
                 };


### PR DESCRIPTION
**When merged this pull request will:**
- Add "Additional Objects" setting to Update Editable Objects module
    - Allows for quickly adding units to Zeus without trying to place the module in range or using a large radius
- Fix Teleport Players UI height and use A3 strings
- Improve Garrison module UI and capitalize module names
    - Before: 
![garrison_ui_old](https://user-images.githubusercontent.com/34453221/41206789-f8a73ccc-6cd7-11e8-9bef-9b8e4e7ff488.png)
   - After: 
![garrison_ui_new](https://user-images.githubusercontent.com/34453221/41206792-fec36068-6cd7-11e8-9387-84dd0c74aa06.png)
- Improve/cleanup Toggle NVGs and Toggle Flashlights UI by adding combo items through config

