### PR TITLE
Cargo load ignore interaction distance parameter

### DIFF
--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -5,6 +5,7 @@
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Holder Object (Vehicle) <OBJECT>
+ * 2: Ignore interaction distance <BOOL>
  *
  * Return Value:
  * Can load in <BOOL>
@@ -16,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params [["_item", "", [objNull,""]], "_vehicle"];
+params [["_item", "", [objNull,""]], "_vehicle", ["_ignoreInteraction", false]];
 
 if (speed _vehicle > 1 || {((getPos _vehicle) select 2) > 3}) exitWith {TRACE_1("vehicle not stable",_vehicle); false};
 
@@ -34,7 +35,7 @@ if (_item  isEqualType "") then {
 } else {
     _validItem =
         (alive _item) &&
-        {([_item, _vehicle] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE};
+        {_ignoreInteraction || {([_item, _vehicle] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}};
 };
 
 _validItem &&

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Vehicle <OBJECT>
+ * 2: Force <BOOL>
  *
  * Return Value:
  * Object loaded <BOOL>
@@ -17,12 +18,13 @@
  */
 #include "script_component.hpp"
 
-params [["_item","",[objNull,""]], ["_vehicle",objNull,[objNull]]];
+params [["_item","",[objNull,""]], ["_vehicle",objNull,[objNull]], ["_force", false]];
 TRACE_2("params",_item,_vehicle);
 
-if !([_item, _vehicle] call FUNC(canLoadItemIn)) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
+if (!_force && {!([_item, _vehicle] call FUNC(canLoadItemIn))}) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
 
 private _loaded = _vehicle getVariable [QGVAR(loaded), []];
+TRACE_1("before loaded array",_loaded);
 _loaded pushBack _item;
 _vehicle setVariable [QGVAR(loaded), _loaded, true];
 

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -6,7 +6,7 @@
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Vehicle <OBJECT>
- * 2: Force <BOOL>
+ * 2: Ignore interaction distance <BOOL>
  *
  * Return Value:
  * Object loaded <BOOL>
@@ -18,10 +18,10 @@
  */
 #include "script_component.hpp"
 
-params [["_item","",[objNull,""]], ["_vehicle",objNull,[objNull]], ["_force", false]];
+params [["_item","",[objNull,""]], ["_vehicle",objNull,[objNull]], ["_ignoreInteraction", false]];
 TRACE_2("params",_item,_vehicle);
 
-if (!_force && {!([_item, _vehicle] call FUNC(canLoadItemIn))}) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
+if ({!([_item, _vehicle, _ignoreInteraction] call FUNC(canLoadItemIn))}) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
 
 private _loaded = _vehicle getVariable [QGVAR(loaded), []];
 TRACE_1("before loaded array",_loaded);

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -24,7 +24,6 @@ TRACE_2("params",_item,_vehicle);
 if !([_item, _vehicle, _ignoreInteraction] call FUNC(canLoadItemIn)) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
 
 private _loaded = _vehicle getVariable [QGVAR(loaded), []];
-TRACE_1("before loaded array",_loaded);
 _loaded pushBack _item;
 _vehicle setVariable [QGVAR(loaded), _loaded, true];
 

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -21,7 +21,7 @@
 params [["_item","",[objNull,""]], ["_vehicle",objNull,[objNull]], ["_ignoreInteraction", false]];
 TRACE_2("params",_item,_vehicle);
 
-if ({!([_item, _vehicle, _ignoreInteraction] call FUNC(canLoadItemIn))}) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
+if !([_item, _vehicle, _ignoreInteraction] call FUNC(canLoadItemIn)) exitWith {TRACE_2("cannot load",_item,_vehicle); false};
 
 private _loaded = _vehicle getVariable [QGVAR(loaded), []];
 TRACE_1("before loaded array",_loaded);


### PR DESCRIPTION
**When merged this pull request will:**
- Add an optional parameter to `ace_cargo_loadItem` & `ace_cargo_canLoadItemIn`
- Parameter allows interaction distance check in `ace_cargo_canLoadItemIn` to be ignored
- I needed this for a persistence implementation where supply boxes with inventories as ace cargo are made persistent, and couldn't previously be loaded in due to distance
- Maybe someone else will find this useful
