### PR TITLE
Fix typo in realistic name for MRCO

### DIFF
--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3314,7 +3314,7 @@
             <German>EOTech XPS3 SMG (Khaki)</German>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_mrco">
-            <English>IOR-Valada Pitbull 2</English>
+            <English>IOR-Valdada Pitbull 2</English>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_Yorris">
             <English>Burris FastFire 2</English>


### PR DESCRIPTION
**When merged this pull request will:**
- "Valada" -> "Valdada"