### PR TITLE
don't make Explosives close one display at death

### DIFF
--- a/addons/explosives/functions/fnc_onIncapacitated.sqf
+++ b/addons/explosives/functions/fnc_onIncapacitated.sqf
@@ -24,7 +24,7 @@ if (_unit == ace_player) then {
     findDisplay 8855 closeDisplay 0;
 };
 
-// Exit if no item:
+// Exit if no item
 if (({_x == "ACE_DeadManSwitch"} count (items _unit)) == 0) exitWith {};
 
 private _range = getNumber (configFile >> "CfgWeapons" >> "ACE_DeadManSwitch" >> QGVAR(range));

--- a/addons/explosives/functions/fnc_onIncapacitated.sqf
+++ b/addons/explosives/functions/fnc_onIncapacitated.sqf
@@ -21,7 +21,7 @@ TRACE_1("params",_unit);
 
 if (_unit == ace_player) then {
     // close cellphone if open
-    closeDialog 0;
+    findDisplay 8855 closeDisplay 0;
 };
 
 // Exit if no item:


### PR DESCRIPTION
Explosives closes one display at killed.
This breaks e.g. the Life Respawn menu.
This PR makes the component no longer kill a display indiscriminately, but only the Cellphone one.

Debug script:
```sqf
player addEventHandler ["Killed", {
    createDialog "RscDisplayEmpty";
}];
```
Before this PR: no display created, after this PR: display created successfully.

Note: don't run the code twice. Only one display is closed, so executing it twice seemingly fixes the issue, but doesn't really.