### PR TITLE
Explosives - Optimize interactEH function

### DIFF
--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -1,10 +1,10 @@
 /*
- * Author: PabstMirror
- * When interact_menu starts rendering (from "interact_keyDown" event)
- * Add defuse helpers to all nearby mines
+ * Author: PabstMirror, mharis001
+ * Dynamically adds "Defuse" actions to nearby mines when interact_menu is opened.
+ * Called by the "ace_interactMenuOpened" event.
  *
  * Arguments:
- * Interact Menu Type (0 - world, 1 - self) <NUMBER>
+ * Interact Menu Type (0 - World, 1 - Self) <NUMBER>
  *
  * Return Value:
  * None
@@ -12,61 +12,62 @@
  * Example:
  * [0] call ace_explosives_fnc_interactEH
  *
- * Public: Yes
+ * Public: No
  */
 #include "script_component.hpp"
 
 params ["_interactionType"];
-TRACE_1("params",_interactionType);
+TRACE_1("Explosives interactEH",_interactionType);
 
-//Ignore self-interaction menu
-if (_interactionType != 0) exitWith {};
-//Ignore while mounted:
-if ((vehicle ACE_player) != ACE_player) exitWith {};
-//Ignore if we don't have defuse kit
-if (!("ACE_DefusalKit" in (items ACE_player))) exitWith {};
+// Ignore self-interaction menu or mounted vehicle interaction
+// For performance reasons only add PFH if player has a defusal kit
+// If player somehow gets a defusal kit during keyDown, they will just have to reopen menu
+if (
+    _interactionType != 0
+    || {vehicle ACE_player != ACE_player}
+    || {!("ACE_DefusalKit" in ([ACE_player, false, true, true, true, false] call CBA_fnc_uniqueUnitItems))}
+) exitWith {};
 
 [{
-    params ["_args", "_pfID"];
-    _args params ["_setPosition", "_addedDefuseHelpers", "_minesHelped"];
+    BEGIN_COUNTER(interactEH);
+    params ["_args", "_pfhID"];
+    _args params ["_setPosition", "_addedHelpers", "_minesHelped"];
 
     if (!EGVAR(interact_menu,keyDown)) then {
-        TRACE_1("Cleaning Defuse Helpers",(count _addedDefuseHelpers));
-        {deleteVehicle _x;} forEach _addedDefuseHelpers;
-        [_pfID] call CBA_fnc_removePerFrameHandler;
+        TRACE_1("Cleaning defuse helpers",count _addedHelpers);
+        {deleteVehicle _x} forEach _addedHelpers;
+        [_pfhID] call CBA_fnc_removePerFrameHandler;
     } else {
         // Prevent Rare Error when ending mission with interact key down:
-        if (isNull ace_player) exitWith {};
+        if (isNull ACE_player) exitWith {};
+        private _player = ACE_player;
+        private _playerPos = getPosASL _player;
 
-        //If player moved >5 meters from last pos, then rescan
-        if (((getPosASL ace_player) distance _setPosition) > 5) then {
+        // Rescan if player has moved more than 5 meters from last position
+        if (_playerPos distance _setPosition > 5) then {
+            private _cfgAmmo = configFile >> "CfgAmmo";
             {
-                if (((_x distance ACE_player) < 15) && {!(_x in _minesHelped)} && {(getModelInfo _x) select 0 != "empty.p3d"}) then {
-
-                    private _config = configFile >> "CfgAmmo" >> typeOf _x;
+                if (_x distance _player < 15 && {!(_x in _minesHelped)} && {!(getModelInfo _x select 0 isEqualTo "empty.p3d")}) then {
+                    private _config = _cfgAmmo >> typeOf _x;
                     private _size = getNumber (_config >> QGVAR(size));
-                    TRACE_3("Making Defuse Helper",(_x),(typeOf _x),(_size == 1));
-                    private _defuseHelper = objNull;
-                    if (_size == 1) then {
-                        _defuseHelper = "ACE_DefuseObject_Large" createVehicleLocal (getPos _x);
-                    } else {
-                        _defuseHelper = "ACE_DefuseObject" createVehicleLocal (getPos _x);
+                    private _defuseClass = ["ACE_DefuseObject", "ACE_DefuseObject_Large"] select (_size == 1);
+                    private _defusePos = getArray (_config >> QGVAR(defuseObjectPosition));
+                    if (_defusePos isEqualTo []) then {
+                        _defusePos = [0, 0, 0];
                     };
 
-                    private _defuseObjectPosition = getArray (_config >> QGVAR(defuseObjectPosition));
-                    if (_defuseObjectPosition isEqualTo []) then {
-                        _defuseObjectPosition = [0,0,0];
-                    };
+                    TRACE_4("Creating defuse helper",_x,typeOf _x,_defuseClass,_defusePos);
+                    private _helper = _defuseClass createVehicleLocal [0, 0, 0];
 
-                    TRACE_1("DefuseObjectPosition",(_defuseObjectPosition));
-
-                    _defuseHelper attachTo [_x, _defuseObjectPosition];
-                    _defuseHelper setVariable [QGVAR(Explosive),_x];
-                    _addedDefuseHelpers pushBack _defuseHelper;
+                    _helper attachTo [_x, _defusePos];
+                    _helper setVariable [QGVAR(Explosive), _x];
+                    _addedHelpers pushBack _helper;
                     _minesHelped pushBack _x;
                 };
             } forEach allMines;
-            _args set [0, (getPosASL ace_player)];
+
+            _args set [0, _playerPos];
         };
     };
-}, 0.5, [((getPosASL ace_player) vectorAdd [-100,0,0]), [], []]] call CBA_fnc_addPerFrameHandler;
+    END_COUNTER(interactEH);
+}, 0.5, [getPosASL ACE_player vectorAdd [-100, 0, 0], [], []]] call CBA_fnc_addPerFrameHandler;

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -39,15 +39,15 @@ if (
         [_pfhID] call CBA_fnc_removePerFrameHandler;
     } else {
         // Prevent Rare Error when ending mission with interact key down:
-        if (isNull ACE_player) exitWith {};
         private _player = ACE_player;
+        if (isNull _player) exitWith {};
         private _playerPos = getPosASL _player;
 
         // Rescan if player has moved more than 5 meters from last position
-        if (_playerPos distance _setPosition > 5) then {
+        if (_playerPos distanceSqr _setPosition > 25) then {
             private _cfgAmmo = configFile >> "CfgAmmo";
             {
-                if (_x distance _player < 15 && {!(_x in _minesHelped)} && {!(getModelInfo _x select 0 isEqualTo "empty.p3d")}) then {
+                if (_x distanceSqr _player < 225 && {!(_x in _minesHelped)} && {!(getModelInfo _x select 0 isEqualTo "empty.p3d")}) then {
                     private _config = _cfgAmmo >> typeOf _x;
                     private _size = getNumber (_config >> QGVAR(size));
                     private _defuseClass = ["ACE_DefuseObject", "ACE_DefuseObject_Large"] select (_size == 1);


### PR DESCRIPTION
**When merged this pull request will:**
- Optimize explosives `interactEH` function (various minor improvements but mainly `createVehicleLocal [0, 0, 0]`)

Performance results for `ace_explosives_interactEH_counter`:

Test | Old | New
--- | --- | ---
count allMines = 30 (somewhat close) | 0.09198s / 43 = 2.13907ms | 0.0169678s / 35 = 0.484794ms
count allMines = 42 (nearby) | 0.0439453s / 24 = 1.83105ms | 0.0249634s / 28 = 0.891549ms
count allMines = 47 (far away) | 0.00402832s / 31 = 0.129946ms | 0.00604248s / 59 = 0.102415ms
count allMines = 159 (nearby) | 0.685913s / 106 = 6.47088ms | 0.248962s / 123 = 2.02408ms
