### PR TITLE
Fix typo in med and issue related to unconsciousness

### DIFF
--- a/addons/medical/ACE_Medical_Actions.hpp
+++ b/addons/medical/ACE_Medical_Actions.hpp
@@ -561,7 +561,7 @@ class ACE_LegLeft {
         icon = QPATHTOF(UI\icons\autoInjector.paa);
     };
     class Adenosine: Morphine {
-        displayName = CSTRING(Inject_Atropine);
+        displayName = CSTRING(Inject_Adenosine);
         condition = QUOTE([ARR_4(_player, _target, 'leg_l', 'Adenosine')] call DFUNC(canTreatCached));
         statement = QUOTE([ARR_4(_player, _target, 'leg_l', 'Adenosine')] call DFUNC(treatment));
         EXCEPTIONS
@@ -707,7 +707,7 @@ class ACE_LegRight {
         icon = QPATHTOF(UI\icons\autoInjector.paa);
     };
     class Adenosine: Morphine {
-        displayName = CSTRING(Inject_Atropine);
+        displayName = CSTRING(Inject_Adenosine);
         condition = QUOTE([ARR_4(_player, _target, 'leg_r', 'Adenosine')] call DFUNC(canTreatCached));
         statement = QUOTE([ARR_4(_player, _target, 'leg_r', 'Adenosine')] call DFUNC(treatment));
         EXCEPTIONS

--- a/addons/medical/ACE_Medical_SelfActions.hpp
+++ b/addons/medical/ACE_Medical_SelfActions.hpp
@@ -197,7 +197,7 @@ class Medical {
             icon = QPATHTOF(UI\icons\autoInjector.paa);
         };
         class Adenosine: Morphine {
-            displayName = CSTRING(Inject_Atropine);
+            displayName = CSTRING(Inject_Adenosine);
             condition = QUOTE([ARR_4(_player, _target, 'hand_l', 'Adenosine')] call DFUNC(canTreatCached));
             exceptions[] = {"isNotInside", "isNotSwimming"};
             statement = QUOTE([ARR_4(_player, _target, 'hand_l', 'Adenosine')] call DFUNC(treatment));
@@ -402,7 +402,7 @@ class Medical {
             icon = QPATHTOF(UI\icons\autoInjector.paa);
         };
         class Adenosine: Morphine {
-            displayName = CSTRING(Inject_Atropine);
+            displayName = CSTRING(Inject_Adenosine);
             condition = QUOTE([ARR_4(_player, _target, 'leg_l', 'Adenosine')] call DFUNC(canTreatCached));
             exceptions[] = {"isNotInside", "isNotSwimming"};
             statement = QUOTE([ARR_4(_player, _target, 'leg_l', 'Adenosine')] call DFUNC(treatment));
@@ -492,7 +492,7 @@ class Medical {
             icon = QPATHTOF(UI\icons\autoInjector.paa);
         };
         class Adenosine: Morphine {
-            displayName = CSTRING(Inject_Atropine);
+            displayName = CSTRING(Inject_Adenosine);
             condition = QUOTE([ARR_4(_player, _target, 'leg_r', 'Adenosine')] call DFUNC(canTreatCached));
             exceptions[] = {"isNotInside", "isNotSwimming"};
             statement = QUOTE([ARR_4(_player, _target, 'leg_r', 'Adenosine')] call DFUNC(treatment));

--- a/addons/medical/functions/fnc_unconsciousPFH.sqf
+++ b/addons/medical/functions/fnc_unconsciousPFH.sqf
@@ -51,6 +51,12 @@ if (!alive _unit) exitWith {
 // In case the unit is no longer in an unconscious state, we are going to check if we can already reset the animation
 if !(_unit getVariable ["ACE_isUnconscious",false]) exitWith {
     TRACE_7("ACE_DEBUG_Unconscious_PFH",_unit, _args, [_unit] call FUNC(isBeingCarried), [_unit] call FUNC(isBeingDragged), _idPFH, _unit getVariable QGVAR(unconsciousArguments),animationState _unit);
+
+    //Unmute the unit before the carry check
+    _unit setVariable ["tf_voiceVolume", 1, true];
+    _unit setVariable ["tf_unable_to_use_radio", false, true];
+    _unit setVariable ["acre_sys_core_isDisabled", false, true];
+
     // TODO, handle this with carry instead, so we can remove the PFH here.
     // Wait until the unit isn't being carried anymore, so we won't end up with wierd animations
     if !(([_unit] call FUNC(isBeingCarried)) || ([_unit] call FUNC(isBeingDragged))) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix adenosine displayname being wrong in some medical interactions 
- Fix unconscious units waking up while being carried staying muted 

For the unconscious units, turns out the global EH isn't called if the unit is being carried, and the muting / unmutting relies on it.