### PR TITLE
Explosives - Optimize creating explosive place actions

### DIFF
--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -1,4 +1,3 @@
-
 class CBA_Extended_EventHandlers;
 
 class CfgVehicles {
@@ -15,12 +14,11 @@ class CfgVehicles {
                 insertChildren = QUOTE([_player] call FUNC(addTransmitterActions););
                 class ACE_Place {
                     displayName = CSTRING(Place);
-                    condition = QUOTE((vehicle _player == _player) and {[_player] call FUNC(hasExplosives)});
                     statement = "";
-                    insertChildren = QUOTE([_player] call FUNC(addExplosiveActions););
+                    condition = "true";
                     exceptions[] = {"isNotSwimming"};
-                    showDisabled = 1;
                     icon = QPATHTOF(UI\Place_Explosive_ca.paa);
+                    insertChildren = QUOTE(_player call FUNC(addExplosiveActions));
                 };
                 class ACE_Cellphone {
                     displayName = CSTRING(cellphone_displayName);

--- a/addons/explosives/functions/fnc_addExplosiveActions.sqf
+++ b/addons/explosives/functions/fnc_addExplosiveActions.sqf
@@ -1,61 +1,42 @@
 /*
- * Author: Garth 'L-H' de Wet and CAA-Picard
- * Adds sub actions for all explosive magazines (from insertChildren)
+ * Author: Garth 'L-H' de Wet, CAA-Picard, mharis001
+ * Returns children actions for explosive magazines in the player's inventory.
  *
  * Arguments:
- * 0: Unit <OBJECT>
+ * 0: Player <OBJECT>
  *
  * Return Value:
  * Actions <ARRAY>
  *
  * Example:
- * [bob] call ace_explosives_fnc_addExplosiveActions
+ * [_player] call ace_explosives_fnc_addExplosiveActions
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_unit"];
-TRACE_1("params",_unit);
+[_this, {
+    params ["_player"];
+    TRACE_1("Creating explosive actions",_player);
 
-private _mags = magazines _unit;
-private _list = [];
-private _itemCount = [];
-{
-    private _item = ConfigFile >> "CfgMagazines" >> _x;
-    if (getNumber(_item >> QGVAR(Placeable)) == 1) then {
-        private _index = _list find _item;
-        if (_index != -1) then {
-            _itemCount set [_index, (_itemCount select _index) + 1];
-        } else {
-            _list pushBack _item;
-            _itemCount pushBack 1;
+    private _cfgMagazines = configFile >> "CfgMagazines";
+    private _magazines = magazines _player;
+    private _totalCount = count _magazines;
+
+    private _actions = [];
+    {
+        private _config = _cfgMagazines >> _x;
+        if (getNumber (_config >> QGVAR(Placeable)) == 1) then {
+            private _name = getText (_config >> "displayNameShort");
+            private _picture = getText (_config >> "picture");
+            if (_name isEqualTo "") then {
+                _name = getText (_config >> "displayName");
+            };
+
+            private _action = [_x, format ["%1 (%2)", _name, _totalCount - count (_magazines - [_x])], _picture, {[{_this call FUNC(setupExplosive)}, _this] call CBA_fnc_execNextFrame}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+            _actions pushBack [_action, [], _player];
         };
-    };
-} forEach _mags;
+    } forEach (_magazines arrayIntersect _magazines);
 
-private _children = [];
-
-{
-    private _name = getText (_x >> "displayNameShort");
-    if (_name isEqualTo "") then {
-        _name = getText (_x >> "displayName");
-    };
-
-    _children pushBack
-        [
-            [
-                format ["Explosive_%1", _forEachIndex],
-                format [_name + " (%1)", _itemCount select _forEachIndex],
-                getText(_x >> "picture"),
-                {[{_this call FUNC(setupExplosive)}, _this] call CBA_fnc_execNextFrame},
-                {true},
-                {},
-                (configName _x)
-            ] call EFUNC(interact_menu,createAction),
-            [],
-            _unit
-        ];
-} forEach _list;
-
-_children
+    _actions
+}, ACE_player, QGVAR(explosiveActions), 3600, "cba_events_loadoutEvent"] call EFUNC(common,cachedCall);

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -21,4 +21,4 @@ TRACE_1("params",_unit);
 private _cfgMagazines = configFile >> "CfgMagazines";
 private _magazines = magazines _unit;
 
-(_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1} > -1
+((_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1}) > -1

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -9,7 +9,7 @@
  * Has explosives <BOOL>
  *
  * Example:
- * [player] call ace_explosives_fnc_hasExplosives
+ * player call ace_explosives_fnc_hasExplosives
  *
  * Public: Yes
  */

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -21,4 +21,4 @@ TRACE_1("params",_unit);
 private _cfgMagazines = configFile >> "CfgMagazines";
 private _magazines = magazines _unit;
 
-(_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1}/*;0*/ > -1
+((_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1}) > -1

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -9,7 +9,7 @@
  * Has explosives <BOOL>
  *
  * Example:
- * player call ace_explosives_fnc_hasExplosives
+ * [player] call ace_explosives_fnc_hasExplosives
  *
  * Public: Yes
  */
@@ -21,4 +21,4 @@ TRACE_1("params",_unit);
 private _cfgMagazines = configFile >> "CfgMagazines";
 private _magazines = magazines _unit;
 
-(_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1} > -1
+(_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1}/*;0*/ > -1

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -21,4 +21,4 @@ TRACE_1("params",_unit);
 private _cfgMagazines = configFile >> "CfgMagazines";
 private _magazines = magazines _unit;
 
-_magazines arrayIntersect _magazines findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1} > -1
+(_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1} > -1

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -21,4 +21,4 @@ TRACE_1("params",_unit);
 private _cfgMagazines = configFile >> "CfgMagazines";
 private _magazines = magazines _unit;
 
-((_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1}) > -1
+(_magazines arrayIntersect _magazines) findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1} > -1

--- a/addons/explosives/functions/fnc_hasExplosives.sqf
+++ b/addons/explosives/functions/fnc_hasExplosives.sqf
@@ -1,15 +1,15 @@
 /*
- * Author: Garth 'L-H' de Wet
- * Whether the passed unit has any explosives on them.
+ * Author: Garth 'L-H' de Wet, mharis001
+ * Checks if given unit has any placeable explosives on them.
  *
  * Arguments:
  * 0: Unit <OBJECT>
  *
  * Return Value:
- * The unit has explosives <BOOL>
+ * Has explosives <BOOL>
  *
  * Example:
- * hasExplosives = [player] call ACE_Explosives_fnc_hasExplosives;
+ * [player] call ace_explosives_fnc_hasExplosives
  *
  * Public: Yes
  */
@@ -18,12 +18,7 @@
 params ["_unit"];
 TRACE_1("params",_unit);
 
-private _result = false;
+private _cfgMagazines = configFile >> "CfgMagazines";
 private _magazines = magazines _unit;
-{
-    if (getNumber (ConfigFile >> "CfgMagazines" >> _x >> QGVAR(Placeable)) == 1) exitWith {
-        _result = true;
-    };
-} count _magazines;
 
-_result
+_magazines arrayIntersect _magazines findIf {getNumber (_cfgMagazines >> _x >> QGVAR(Placeable)) == 1} > -1


### PR DESCRIPTION
**When merged this pull request will:**
- Optimize explosive place action (remove useless condition) and creating its children (optimized function and return is cached)

All of these were tested with `count magazines = 28` and `placeable explosives => 6, 2, 1, 1` (where each number represents the amount of a unique type of explosive).
- The old function took ~0.31 ms
- Useless condition on `ACE_Place` action took ~0.1 ms (time it takes `hasExplosives`)
- New function takes ~0.20 ms (without any caching)
- New function first time (with caching) takes ~0.23 ms (cachedCall adds ~0.03 ms)
- New function (when return is cached) takes ~0.009 ms

**Overall**: Instead of ~0.41 ms every second, the new method is ~0.23 ms after a change in the player's loadout and then ~0.009 ms (accessing the cached value) every second after that.

For an inventory with no placeable explosives and `count magazines = 17`: it is ~0.11 ms vs ~0.10 ms (first time after loadout change) and ~0.009 ms every time after that.