### PR TITLE
Add CPR Upper and Lower limits 

### DIFF
--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -128,6 +128,22 @@ class ACE_Settings {
         value = 120;
         sliderSettings[] = {0, 3600, 120, 0};
     };
+    class GVAR(CPRLowerLimit) {
+        category = CSTRING(Category_Medical);
+        displayName = CSTRING(ReviveSettings_CPRLowerLimit_DisplayName);
+        description = CSTRING(ReviveSettings_CPRLowerLimit_Description);
+        typeName = "SCALAR";
+        value = 0;
+        sliderSettings[] = {0, 120, 0, 0};
+    };
+    class GVAR(CPRUpperLimit) {
+        category = CSTRING(Category_Medical);
+        displayName = CSTRING(ReviveSettings_CPRUpperLimit_DisplayName);
+        description = CSTRING(ReviveSettings_CPRUpperLimit_Description);
+        typeName = "SCALAR";
+        value = 20;
+        sliderSettings[] = {0, 120, 20, 0};
+    };
     class GVAR(amountOfReviveLives) {
         category = CSTRING(Category_Medical);
         displayName = CSTRING(ReviveSettings_amountOfReviveLives_DisplayName);

--- a/addons/medical/XEH_postInit.sqf
+++ b/addons/medical/XEH_postInit.sqf
@@ -290,6 +290,13 @@ GVAR(lastHeartBeatSound) = CBA_missionTime;
         {((_this select 0) getVariable ["ACE_isDead", false])}
     ] call FUNC(addUnconsciousCondition);
 
+    ["ace_settingChanged", {
+        params ["_name"];
+
+        if (_name in [QGVAR(CPRLowerLimit), QGVAR(CPRUpperLimit)] && {GVAR(CPRLowerLimit) > GVAR(CPRUpperLimit)}) then {
+            // TODO: Don't allow for this somehow. Maybe go back to defaults?
+        };
+    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;
 
 // Prevent all types of interaction while unconscious

--- a/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_CPRLocal.sqf
@@ -22,7 +22,8 @@ params ["_caller","_target"];
 if (_target getVariable [QGVAR(inReviveState), false]) then {
     private _reviveStartTime = _target getVariable [QGVAR(reviveStartTime),0];
     if (_reviveStartTime > 0) then {
-        _target setVariable [QGVAR(reviveStartTime), (_reviveStartTime + random(20)) min CBA_missionTime];
+        private _timeAdded = GVAR(CPRLowerLimit) + random (GVAR(CPRUpperLimit) - GVAR(CPRLowerLimit));
+        _target setVariable [QGVAR(reviveStartTime), (_reviveStartTime + _timeAdded) min CBA_missionTime];
     };
 };
 

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -5054,6 +5054,18 @@
             <Chinesesimp>人员在等待复苏状态下能够等待的最大时间(秒)</Chinesesimp>
             <Chinese>人員在等待復甦狀態下能夠等待的最大時間(秒)</Chinese>
         </Key>
+        <Key ID="STR_ACE_Medical_ReviveSettings_CPRLowerLimit_DisplayName">
+            <English>CPR Lower Time Limit</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_ReviveSettings_CPRLowerLimit_Description">
+            <English>Minimum amount of time CPR will add to a unit's revive timer.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_ReviveSettings_CPRUpperLimit_DisplayName">
+            <English>CPR Upper Time Limit</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_ReviveSettings_CPRUpperLimit_Description">
+            <English>Maximum amount of time CPR will add to a unit's revive timer.</English>
+        </Key>
         <Key ID="STR_ACE_Medical_ReviveSettings_amountOfReviveLives_DisplayName">
             <English>Max Revive lives</English>
             <Russian>Макс. кол-во жизней</Russian>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds CPR lower and upper limits. This allows people to configure how long CPR adds to a unit's revive timer, while still keeping the randomness element.
- **WIP!** I'm not sure what's the best way to enforce `upperLimit >= lowerLimit`. Advice on this? (Check the TODO in XEH_postInit.sqf)