### PR TITLE
ace_infoDisplayChanged will now trigger also for mods

### DIFF
--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -23,6 +23,9 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayMission {
         ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
     };
+    class RscUnitInfo {
+        ADDON = QUOTE([ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Any')])] call CBA_fnc_localEvent;);
+    };
 };
 
 class Extended_InitPost_EventHandlers {

--- a/addons/common/RscInfoType.hpp
+++ b/addons/common/RscInfoType.hpp
@@ -1,27 +1,23 @@
 
 class RscInGameUI {
-    class RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Any')])] call CBA_fnc_localEvent;);
-    };
-
     class RscUnitInfoNoHUD {
         onLoad = QUOTE([ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Any')])] call CBA_fnc_localEvent;);
     };
 
     class RscUnitInfoSoldier: RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgSoldier',     _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Soldier')])]     call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgSoldier',     _this select 0)];);
     };
 
     class RscUnitInfoTank: RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgVehicle',     _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Vehicle')])]     call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgVehicle',     _this select 0)];);
     };
 
     class RscUnitInfoAirNoWeapon: RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgAircraft',    _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Aircraft')])]    call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgAircraft',    _this select 0)];);
     };
 
     class RscUnitInfoAir: RscUnitInfoAirNoWeapon {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgAircraft',    _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Aircraft')])]    call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgAircraft',    _this select 0)];);
     };
 
     class RscUnitInfo_AH64D_gunner {
@@ -33,11 +29,11 @@ class RscInGameUI {
     };
 
     class RscUnitInfoSubmarine: RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgSubmarine',   _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Submarine')])]   call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgSubmarine',   _this select 0)];);
     };
 
     class RscUnitInfoShip: RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgShip',        _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Ship')])]        call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgShip',        _this select 0)];);
     };
 
     class RscWeaponEmpty {
@@ -97,7 +93,7 @@ class RscInGameUI {
     };
 
     class RscUnitInfoParachute: RscUnitInfo {
-        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgParachute',   _this select 0)]; [ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Parachute')])]   call CBA_fnc_localEvent;);
+        onLoad = QUOTE([ARR_4(""onLoad"",_this,""RscUnitInfo"",'IGUI')] call (uinamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable [ARR_2('ACE_dlgParachute',   _this select 0)];);
     };
 
     class RscUnitVehicle {


### PR DESCRIPTION
**When merged this pull request will:**
- add 'RscUnitInfo' to Extended_DisplayLoad_EventHandlers
- because 90% of the RscInGameUIs are use BIS_fnc_initDisplay with RscUnitInfo
- instead of adding onLoad to all mod RscInGameUIs (example: RHS) it will go over the cba xeh

This works now perfect for my desire, the rhs jets now also get a limited UI by the Ace_UI addon. But i dont know what side effects this triggers.
