### PR TITLE
Italian Translation Update

### DIFF
--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -613,6 +613,7 @@
             <Korean>바닐라 로드아웃을 ace 아스날로 가져오기</Korean>
             <Chinese>匯入BI原廠虛擬軍火庫的裝備到ACE虛擬軍火庫中</Chinese>
             <Chinesesimp>汇入BI原厂虚拟军火库的装备到ACE虚拟军火库中</Chinesesimp>
+            <Italian>Importa l'arsenale virtuale BI nell'arsenale ACE</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_portLoadoutsPlayerError">
             <English>No player unit available! Place a unit and mark it as "Player".</English>
@@ -622,6 +623,7 @@
             <Korean>플레이어 유닛을 사용할 수 없습니다! 유닛을 놓고 "플레이어"라고 표시하십시오.</Korean>
             <Chinese>沒有可用的玩家單位!請擺放一個單位並設定成"玩家"</Chinese>
             <Chinesesimp>没有可用的玩家单位!请摆放一个单位并设定成"玩家"。</Chinesesimp>
+            <Italian>Non ci sono giocatori! Poisziona una unità e impostala come "Giocatore".</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_portLoadoutsLoadoutError">
             <English>No loadouts to import.</English>
@@ -631,6 +633,7 @@
             <Korean>가져올 로드 아웃이 없습니다.</Korean>
             <Chinese>沒有裝備被匯入</Chinese>
             <Chinesesimp>没有装备被汇入。</Chinesesimp>
+            <Italian>Non ci sono equipaggiamenti da importare.</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_Mission">
             <English>ACE Arsenal</English>
@@ -639,7 +642,7 @@
             <Korean>ACE 아스날</Korean>
             <Chinese>ACE虛擬軍火庫</Chinese>
             <Chinesesimp>ACE虚拟军火库</Chinesesimp>
-            <Italian>ACE Arsenale</Italian>
+            <Italian>Arsenale ACE</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_ReturnToArsenal">
             <English>Return to ACE Arsenal.</English>
@@ -648,6 +651,7 @@
             <Korean>ACE 아스날로 돌아가기</Korean>
             <Chinese>返回到ACE虛擬軍火庫</Chinese>
             <Chinesesimp>返回到ACE虚拟军火库。</Chinesesimp>
+            <Italian>Torna all'arsenale ACE</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_Mission_tooltip">
             <English>Use ACE Arsenal to try out different weapons and equipment.</English>
@@ -656,6 +660,7 @@
             <Korean>ACE Arsenal을 사용하여 다른 무기와 장비를 시험해보십시오.</Korean>
             <Chinese>使用ACE虛擬軍火庫來嘗試不同的武器與裝備</Chinese>
             <Chinesesimp>使用ACE虚拟军火库来尝试不同的武器与装备。</Chinesesimp>
+            <Italian>Usa l'arsenale ACE per provare armi ed equipaggiamenti vari.</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_Mission_overview">
             <English>Try weapons and equipment and create your own loadouts.</English>
@@ -664,6 +669,7 @@
             <Korean>무기와 장비를 사용해보고 자신의 로드아웃을 만듭니다.</Korean>
             <Chinese>嘗試不同的武器與裝備來組合你個人的裝備配置</Chinese>
             <Chinesesimp>尝试不同的武器与装备来组合你个人的装备配置。</Chinesesimp>
+            <Italian>Prova armi ed equipaggiamenti e creai i tuoi equipaggiamenti personalizzati.</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_buttonLoadoutsTooltip">
             <English>Open the loadouts screen</English>
@@ -671,6 +677,7 @@
             <Chinese>開啟裝備選單</Chinese>
             <Chinesesimp>开启装备选单</Chinesesimp>
             <Japanese>装備画面を開く</Japanese>
+            <Italian>Apri la pagina degli equipaggiamenti</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_buttonExportTooltip">
             <English>Export current / default loadouts</English>
@@ -678,6 +685,7 @@
             <Chinese>匯出當前/預設的裝備</Chinese>
             <Chinesesimp>汇出当前/预设的装备</Chinesesimp>
             <Japanese>現在 / 標準装備を出力</Japanese>
+            <Italian>Esporta l'equipaggiamento attuale oppure la lista degli equipaggiamenti di base</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_buttonImportTooltip">
             <English>Import current / default loadouts</English>
@@ -685,6 +693,7 @@
             <Chinese>匯入當前/預設的裝備</Chinese>
             <Chinesesimp>汇入当前/预设的装备</Chinesesimp>
             <Japanese>現在 / 標準装備を取込</Japanese>
+            <Italian>Importa l'equipaggiamento attuale oppure la lista degli equipaggiamenti di base</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_statPotassium">
             <English>Potassium levels</English>
@@ -692,6 +701,7 @@
             <Japanese>カリウム レベル</Japanese>
             <Chinesesimp>钾水平</Chinesesimp>
             <Chinese>鉀水平</Chinese>
+            <Italian>Ilvello di potassio</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_statMagnification">
             <English>Magnification</English>
@@ -715,6 +725,7 @@
             <Japanese>ページ</Japanese>
             <Chinesesimp>页面</Chinesesimp>
             <Chinese>頁面</Chinese>
+            <Italian>Pagina</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_enableIdentityTabsSettings">
             <English>Enable the faces / voices / insignias tabs</English>
@@ -722,6 +733,7 @@
             <Japanese>顔 / 声 / 記章タブを有効化</Japanese>
             <Chinesesimp>启用脸谱/声音/徽章/选项 </Chinesesimp>
             <Chinese>啟用臉譜/聲音/徽章選項</Chinese>
+            <Italian>Abilita volti, voci e insegne</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_buttonClearContainerTooltip">
             <English>Empty the selected container</English>
@@ -729,6 +741,7 @@
             <Japanese>選択されたコンテナは空です</Japanese>
             <Chinesesimp>选择的箱子是空的</Chinesesimp>
             <Chinese>清空選擇的箱子</Chinese>
+            <Italian>Svuota il contenitore selezionato</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_exportedClassnameText">
             <English>Exported class name to clipboard</English>
@@ -736,6 +749,7 @@
             <Japanese>クリップボードへクラスネームを出力</Japanese>
             <Chinesesimp>将种类复制到剪贴板</Chinesesimp>
             <Chinese>輸出 class name 到剪貼簿上</Chinese>
+            <Italian>Copiato il nome della classe negli appunti</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -370,7 +370,7 @@
             <German>Folgende Ausrüstung ist nicht mehr öffentlich:</German>
             <Polish>Następujący zestaw nie jest już publiczny:</Polish>
             <Japanese>次の装備は非公開になりました:</Japanese>
-            <Italian>Il seguente eequipaggiamento non è più pubblico:</Italian>
+            <Italian>Il seguente equipaggiamento non è più pubblico:</Italian>
             <Korean>다음 로드아웃이 더이상 공용이 아님:</Korean>
             <Chinese>以下的裝備已不再被分享:</Chinese>
             <Chinesesimp>以下的装备已不再被分享:</Chinesesimp>
@@ -639,6 +639,7 @@
             <Korean>ACE 아스날</Korean>
             <Chinese>ACE虛擬軍火庫</Chinese>
             <Chinesesimp>ACE虚拟军火库</Chinesesimp>
+            <Italian>ACE Arsenale</Italian>
         </Key>
         <Key ID="STR_ACE_Arsenal_ReturnToArsenal">
             <English>Return to ACE Arsenal.</English>

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -546,7 +546,7 @@
             <German>ACE-Arsenal</German>
             <Polish>ACE Arsenał</Polish>
             <Japanese>ACE 武器庫</Japanese>
-            <Italian>Arsenale ACE</Italian>
+            <Italian>ACE Arsenale</Italian>
             <Korean>ACE 아스날</Korean>
             <Chinese>ACE虛擬軍火庫</Chinese>
             <Chinesesimp>ACE虚拟军火库</Chinesesimp>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1170,6 +1170,7 @@
             <Chinese>允許調低音樂音量</Chinese>
             <Chinesesimp>允许调低音乐音量</Chinesesimp>
             <Japanese>音楽の音量低下を許可</Japanese>
+            <Italian>Permesso di abbassare la musica</Italian>
         </Key>
         <Key ID="STR_ACE_Common_AllowFadeMusicTooltip">
             <English>Allow ACE scripts to turn down the music.</English>
@@ -1178,16 +1179,19 @@
             <Chinese>允許ACE腳本去控制音樂的音量</Chinese>
             <Chinesesimp>允许ACE脚本去控制音乐的音量。</Chinesesimp>
             <Japanese>ACE スプリントへ音量低下を許可します。</Japanese>
+            <Italian>Permetti agli script di ACEdi abbassare la musica.</Italian>
         </Key>
         <Key ID="STR_ACE_Common_FlagBlack">
             <English>Flag (ACE - Black)</English>
             <Chinesesimp>旗帜(ACE-黑色):</Chinesesimp>
             <Chinese>旗幟(ACE-黑色)</Chinese>
+            <Italian>Bandiera (ACE - Nera)</Italian>
         </Key>
         <Key ID="STR_ACE_Common_FlagWhite">
             <English>Flag (ACE - White)</English>
             <Chinesesimp>旗帜(ACE-白色):</Chinesesimp>
             <Chinese>旗幟(ACE-白色)</Chinese>
+            <Italian>Bandiera (ACE - Bianca)</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -1025,6 +1025,7 @@
             <Japanese>爆発範囲</Japanese>
             <Chinesesimp>爆炸范围</Chinesesimp>
             <Chinese>爆炸範圍</Chinese>
+            <Italian>Raggio di detonazione</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/flashlights/stringtable.xml
+++ b/addons/flashlights/stringtable.xml
@@ -97,6 +97,7 @@
             <Japanese>光の色</Japanese>
             <Chinesesimp>地图上手电的颜色</Chinesesimp>
             <Chinese>地圖上使用手電筒的顏色</Chinese>
+            <Italian>Colore della luce sulla mappa</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/gforces/stringtable.xml
+++ b/addons/gforces/stringtable.xml
@@ -37,6 +37,7 @@
             <Japanese>耐 G 性</Japanese>
             <Chinesesimp>减少G力</Chinesesimp>
             <Chinese>減少G力</Chinese>
+            <Italian>Riduzione forza G</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/hearing/stringtable.xml
+++ b/addons/hearing/stringtable.xml
@@ -288,6 +288,7 @@
             <Japanese>聴覚保護</Japanese>
             <Chinesesimp>听力保护</Chinesesimp>
             <Chinese>聽力保護</Chinese>
+            <Italian>Protezione auditiva</Italian>
         </Key>
         <Key ID="STR_ACE_Hearing_statHearingLowerVolume">
             <English>Volume muffling</English>
@@ -295,30 +296,35 @@
             <Japanese>音量低下</Japanese>
             <Chinesesimp>降低音量</Chinesesimp>
             <Chinese>進低音量</Chinese>
+            <Italian>Volume attenuazione</Italian>
         </Key>
         <Key ID="STR_ACE_Hearing_earplugsVolume_DisplayName">
             <English>Earplugs Volume</English>
             <Japanese>耳栓時の音量</Japanese>
             <Chinesesimp>耳塞时音量</Chinesesimp>
             <Chinese>耳塞時音量</Chinese>
+            <Italian>Volume tappi per le orecchie</Italian>
         </Key>
         <Key ID="STR_ACE_Hearing_earplugsVolume_Description">
             <English>Volume when using earplugs.</English>
             <Japanese>耳栓使用時の音量を決定します。</Japanese>
             <Chinesesimp>决定带上耳塞时的音量</Chinesesimp>
             <Chinese>使用耳塞時音量</Chinese>
+            <Italian>Volume audio quandi si indossano i tappi per le orecchie.</Italian>
         </Key>
         <Key ID="STR_ACE_Hearing_unconsciousnessVolume_DisplayName">
             <English>Unconscious Volume</English>
             <Japanese>気絶時の音量</Japanese>
             <Chinesesimp>无意识时音量</Chinesesimp>
             <Chinese>昏迷時音量</Chinese>
+            <Italian>Volume quando incoscente</Italian>
         </Key>
         <Key ID="STR_ACE_Hearing_unconsciousnessVolume_Description">
             <English>Volume when unconscious.</English>
             <Japanese>気絶時の音量を決定します。</Japanese>
             <Chinesesimp>决定处于无意识时的音量</Chinesesimp>
             <Chinese>昏迷時使用耳塞的音量</Chinese>
+            <Italian>Volume quando incoscente.</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -451,6 +451,7 @@
             <Japanese>セレクターの色</Japanese>
             <Chinesesimp>选择器颜色</Chinesesimp>
             <Chinese>選單的顏色</Chinese>
+            <Italian>Controllo Settore</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -845,6 +845,7 @@
             <Russian>Перевернуть</Russian>
             <Japanese>ひっくり返す</Japanese>
             <Chinese>拋</Chinese>
+            <Italian>Gira</Italian>
         </Key>
         <Key ID="STR_ACE_Interaction_Interact">
             <English>Interact</English>

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -33,6 +33,7 @@
             <Korean>마커 이동 허가</Korean>
             <Chinese>誰可以移動標誌</Chinese>
             <Chinesesimp>谁可以移动标志</Chinesesimp>
+            <Italian>Permetti di spostare i marcatori a:</Italian>
         </Key>
         <Key ID="STR_ACE_Markers_MoveRestriction_Description">
             <English>Restricts which players are able to move markers while holding the Alt key.</English>
@@ -41,6 +42,7 @@
             <Korean>Alt 키를 누른 상태에서 마커를 움직일 수있는 플레이어를 제한합니다.</Korean>
             <Chinese>設定誰可以透過按住Alt鍵來移動標誌</Chinese>
             <Chinesesimp>设定谁可以透过按住Alt键来移动标志。</Chinesesimp>
+            <Italian>Limita quali giocatori possono spostare i marcatori mentre premono il tasto Alt.</Italian>
         </Key>
         <Key ID="STR_ACE_Markers_MoveRestriction_Nobody">
             <English>Nobody</English>
@@ -49,6 +51,7 @@
             <Korean>비활성</Korean>
             <Chinese>沒有人</Chinese>
             <Chinesesimp>没有人</Chinesesimp>
+            <Italian>Nessuno</Italian>
         </Key>
         <Key ID="STR_ACE_Markers_MoveRestriction_All">
             <English>All players</English>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -408,7 +408,7 @@
             <French>Transfusion (plasma)...</French>
             <Russian>Переливание плазмы...</Russian>
             <Hungarian>Infúzió vérplazmával...</Hungarian>
-            <Italian>Effettu la trasfusione di plasma...</Italian>
+            <Italian>Effettuo la trasfusione di plasma...</Italian>
             <Portuguese>Transfundindo plasma...</Portuguese>
             <Japanese>血しょうを投与しています・・・</Japanese>
             <Korean>혈장 수혈중...</Korean>
@@ -5628,36 +5628,42 @@
             <Japanese>処置中に気絶アニメーション</Japanese>
             <Chinesesimp>治疗时死亡动画</Chinesesimp>
             <Chinese>醫療時加入的昏迷動作</Chinese>
+            <Italian>Animazione da svenuto durante la cura</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_allowUnconsciousAnimationOnTreatment_Description">
             <English>Allow animation of unconscious patients during treatment.</English>
             <Japanese>患者の処置中に気絶アニメーションを許可します。</Japanese>
             <Chinesesimp>在无意识患者治疗时死亡,会播放死亡动画?</Chinesesimp>
             <Chinese>允許醫療時加入昏迷的動作</Chinese>
+            <Italian>Permette l'animazione da svenuto dei pazioenti durante loro la cura.</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_moveUnitsFromGroupOnUnconscious_DisplayName">
             <English>Move unconscious units from group</English>
             <Japanese>グループから気絶ユニットを移動</Japanese>
             <Chinesesimp>从小队中移除无意识伤者</Chinesesimp>
             <Chinese>從小隊中移動昏迷的單位</Chinese>
+            <Italian>Toglie le unità svenute dal grouppo</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_moveUnitsFromGroupOnUnconscious_Description">
             <English>When a group member goes unconscious, removes them from their group.</English>
             <Japanese>グループのメンバーが気絶すると、グループから退出させます。</Japanese>
             <Chinesesimp>当一个队员失去意识时,他将被移除出小队</Chinesesimp>
             <Chinese>當隊員昏迷時，將被他的小組中刪除</Chinese>
+            <Italian>Quando un membro del gruppo sviene, viene tolto dal gruppo.</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_enableOverdosing_DisplayName">
             <English>Overdosing</English>
             <Japanese>過剰投与</Japanese>
             <Chinesesimp>过量</Chinesesimp>
             <Chinese>過量</Chinese>
+            <Italian>Overdose</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_enableOverdosing_Description">
             <English>Makes patient vulnerable to Morphine/Epinephrine/Atropine overdosing.</English>
             <Japanese>モルヒネ/アドレナリン/アトロピンの過剰投与により患者を脆弱にします。</Japanese>
             <Chinesesimp>当队员处于吗啡/肾上腺素/阿托品过量时再次受伤,他的伤害会更重</Chinesesimp>
             <Chinese>當隊員對嗎啡/腎上腺素/阿托品過量時，會使他的傷害更重</Chinese>
+            <Italian>Rende il paziente suscettibile di overdose da morfina, epinefrina o atropina.</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_ai/stringtable.xml
+++ b/addons/medical_ai/stringtable.xml
@@ -6,12 +6,14 @@
             <Japanese>次に AI 治療を有効</Japanese>
             <Chinesesimp>AI医疗启用</Chinesesimp>
             <Chinese>AI醫療啟用</Chinese>
+            <Italian>AI medica per:</Italian>
         </Key>
         <Key ID="STR_ACE_medical_ai_enabledFor_Description">
             <English>Enable AI units to heal themselves and each other.</English>
             <Japanese>AI ユニットの自己や相互治療を有効化します。</Japanese>
             <Chinesesimp>使AI单位能够彼此治疗自己</Chinesesimp>
             <Chinese>啟用AI能夠彼此醫療自己</Chinese>
+            <Italian>Permette alle unità AI di curare se stesse e fra di loro.</Italian>
         </Key>
         <Key ID="STR_ACE_medical_ai_enabledFor_OnlyServerAndHC">
             <English>Only Server and HC</English>

--- a/addons/medical_menu/stringtable.xml
+++ b/addons/medical_menu/stringtable.xml
@@ -831,12 +831,14 @@
             <Japanese>治療メニューの最大範囲</Japanese>
             <Chinesesimp>医疗菜单最大范围</Chinesesimp>
             <Chinese>醫療選單最大範圍</Chinese>
+            <Italian>Dirstanza menù medico</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_Menu_maxRange_Descr">
             <English>Maximum distance from where the Medical Menu can be opened.</English>
             <Japanese>你可以打开医疗菜单的最大范围</Japanese>
             <Chinese>醫療選單可以開啟的最大距離</Chinese>
             <Chinesesimp>医疗选单可以开启的最大距离</Chinesesimp>
+            <Italian>Massima distanza dalla quale si può aprire il menù medico.</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -544,6 +544,7 @@
             <Japanese>プレイヤー名札の透明度</Japanese>
             <Chinesesimp>玩家名字标签透明度</Chinesesimp>
             <Chinese>玩家名稱透明度</Chinese>
+            <Italian>Trasparenza Etichette Nome</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -4,7 +4,7 @@
         <Key ID="STR_ACE_NightVision_Category">
             <English>ACE Nightvision</English>
             <Japanese>ACE 暗視装置</Japanese>
-            <Italian>Visione notturna ACE</Italian>
+            <Italian>ACE Visione notturna</Italian>
             <German>ACE-Nachtsicht</German>
             <Chinese>ACE夜視鏡</Chinese>
             <Chinesesimp>ACE夜视镜</Chinesesimp>

--- a/addons/pylons/stringtable.xml
+++ b/addons/pylons/stringtable.xml
@@ -4,7 +4,7 @@
         <Key ID="STR_ACE_Pylons_AircraftLoadoutTitle">
             <English>AIRCRAFT LOADOUT</English>
             <Japanese>航空機の兵装</Japanese>
-            <Italian>LOADOUT AEREO</Italian>
+            <Italian>ARMAMENTO DELL'AEREO</Italian>
             <Chinese>飛機武裝配置</Chinese>
             <Chinesesimp>飞机武器配置</Chinesesimp>
             <Korean>항공기 무장</Korean>
@@ -13,7 +13,7 @@
         <Key ID="STR_ACE_Pylons_LoadoutsFor">
             <English>Loadouts for %1</English>
             <Japanese>%1の兵装</Japanese>
-            <Italian>Loadouts per %1</Italian>
+            <Italian>Armamenti per %1</Italian>
             <Chinese>%1用的武裝配置</Chinese>
             <Chinesesimp>%1用的武器配置</Chinesesimp>
             <Korean>%1 무장</Korean>
@@ -49,7 +49,7 @@
         <Key ID="STR_ACE_Pylons_BannerText">
             <English>Pylons that are colored red will have to be manually rearmed.</English>
             <Japanese>赤色に設定されたパイロンは手動で再武装する必要があります。</Japanese>
-            <Italian>I Piloni di colore rosso devono essere riarmati manualmente.</Italian>
+            <Italian>I piloni di colore rosso devono essere riarmati manualmente.</Italian>
             <Chinese>以紅色標記出的派龍架必須以手動方式進行彈藥整補</Chinese>
             <Chinesesimp>以红色标记出的导弹挂架必须以手动方式进行弹药整补。</Chinesesimp>
             <Korean>붉은색의 파일런은 수동으로 재무장해야 합니다.</Korean>
@@ -95,31 +95,37 @@
             <English>Enable Pylons Menu for Zeus</English>
             <Chinesesimp>启用宙斯导弹挂架菜单</Chinesesimp>
             <Chinese>啟用派龍架選單給宙斯</Chinese>
+            <Italian>Abilita Menù Piloni da Zeus</Italian>
         </Key>
         <Key ID="STR_ACE_Pylons_EnabledForZeus_description">
             <English>Enables use of the zeus module.</English>
             <Chinesesimp>允许启用宙斯模组</Chinesesimp>
             <Chinese>允啟使用宙斯模塊</Chinese>
+            <Italian>Abilita l'uso dal modulo di Zeus</Italian>
         </Key>
         <Key ID="STR_ACE_Pylons_EnabledFromAmmoTrucks">
             <English>Enable Pylons Menu from Ammo Trucks</English>
             <Chinesesimp>启用弹药车导弹挂架菜单</Chinesesimp>
             <Chinese>啟用從彈藥卡車使用派龍架選單</Chinese>
+            <Italian>Abilita Menù Piloni da mezzi rifornimento munizioni</Italian>
         </Key>
         <Key ID="STR_ACE_Pylons_EnabledFromAmmoTrucks_description">
             <English>Enables use of pylons menu from ammo trucks.</English>
             <Chinesesimp>允许在弹药车上启用导弹挂架菜单</Chinesesimp>
             <Chinese>允許從彈藥卡車使用派龍架選單</Chinese>
+            <Italian>Abilita l'uso del Menù Piloni da mezzi rifornimento munizioni</Italian>
         </Key>
         <Key ID="STR_ACE_Pylons_AircraftDoesntHavePylons">
             <English>This aircraft doesn't have pylons</English>
             <Chinesesimp>这架飞机没有导弹挂架</Chinesesimp>
             <Chinese>這架飛機沒有派龍架</Chinese>
+            <Italian>Questo aereo non ha piloni</Italian>
         </Key>
         <Key ID="STR_ACE_Pylons_ConfigurePylonsDisabledForZeus">
             <English>Configure pylons module is disabled for zeus</English>
             <Chinesesimp>宙斯模组的导弹挂架已禁用</Chinesesimp>
             <Chinese>宙斯模塊的派龍架設定已被禁用</Chinese>
+            <Italian>Il modulo per configurare i piloni da Zeus è disabilitato</Italian>
         </Key>
         <Key ID="STR_ACE_Pylons_RearmNewPylons">
             <English>Rearm New Pylons</English>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1861,12 +1861,14 @@
             <Japanese>修理時にエンジン自動停止</Japanese>
             <Chinesesimp>维修时自动关闭发动机。</Chinesesimp>
             <Chinese>維修時自動關閉引擎</Chinese>
+            <Italian>Motore spento automaticamente durante la riparazione</Italian>
         </Key>
         <Key ID="STR_ACE_Repair_autoShutOffEngineWhenStartingRepair_description">
             <English>Automatically shut off the engine when doing repairs.</English>
             <Japanese>修理時にエンジンを自動で停止します。</Japanese>
             <Chinesesimp>修理时自动关闭发动机。</Chinesesimp>
             <Chinese>維修時自動關閉引擎</Chinese>
+            <Italian>Spegne automaticamente il motore quando si fanno riparazioni.</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/vehicles/stringtable.xml
+++ b/addons/vehicles/stringtable.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Vehicles">
         <Key ID="STR_ACE_Vehicles_On">
@@ -35,6 +35,7 @@
         </Key>
         <Key ID="STR_ACE_Vehicles_SpeedLimit">
             <English>Speed Limit</English>
+            <Italian>Limite di velocità</Italian>
         </Key>
         <Key ID="STR_ACE_Vehicles_SpeedLimiter">
             <English>Speed Limiter</English>
@@ -54,9 +55,11 @@
         </Key>
         <Key ID="STR_ACE_Vehicles_IncreaseSpeedLimit">
             <English>Increase Speed Limit</English>
+            <Italian>Aumenta limite di velocità</Italian>
         </Key>
         <Key ID="STR_ACE_Vehicles_DecreaseSpeedLimit">
             <English>Decrease Speed Limit</English>
+            <Italian>Diminuisce limite di velocità</Italian>
         </Key>
     </Package>
 </Project>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -276,14 +276,17 @@
         <Key ID="STR_ACE_Zeus_ModuleEditableObjects_EditingMode">
             <English>Editing Mode</English>
             <Chinese>編輯模式</Chinese>
+            <Italian>Modalità per editare</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleEditableObjects_EditingMode_Tooltip">
             <English>Add or remove editable objects from Zeus</English>
             <Chinese>新增或移除可編輯物件給宙斯</Chinese>
+            <Italian>Agguingi o rimuovi oggetti che Zeus può modificare</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleEditableObjects_AddObjects">
             <English>Add Objects</English>
             <Chinese>新增物件</Chinese>
+            <Italian>Aggiungi Oggetti</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleEditableObjects_RemoveObjects">
             <English>Remove Objects</English>
@@ -967,6 +970,7 @@
         <Key ID="STR_ACE_Zeus_SelectCargo">
             <English>Select cargo to unload</English>
             <Chinese>選擇要卸載的貨物</Chinese>
+            <Italian>Scegli il carico da scaricare</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_AttributeRadius">
             <English>Task Radius</English>
@@ -1082,12 +1086,14 @@
             <Japanese>目標を切り替え</Japanese>
             <Chinesesimp>切换目标</Chinesesimp>
             <Chinese>切換目標</Chinese>
+            <Italian>Scambia obiettivo</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_ToggleTarget_Tooltip">
             <English>Units affected by the toggle</English>
             <Japanese>ユニットは切り替えに影響を受けます</Japanese>
             <Chinesesimp>被选单位受切换影响</Chinesesimp>
             <Chinese>受切換所影響的單位</Chinese>
+            <Italian>Unità influenzate dallo scambio</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_SelectedGroup">
             <English>Selected Group</English>
@@ -1471,12 +1477,14 @@
             <Japanese>ACE 武器庫を追加</Japanese>
             <Chinesesimp>添加ACE模式军火库</Chinesesimp>
             <Chinese>增加完整的ACE軍火庫</Chinese>
+            <Italian>Aggiungi l'arsenale ACE completo</Italian>
         </Key>
         <Key ID="STR_ACE_Zeus_ModuleRemoveACEArsenal_DisplayName">
             <English>Remove ACE Arsenal</English>
             <Japanese>ACE 武器庫を削除</Japanese>
             <Chinesesimp>删除ACE模式军火库</Chinesesimp>
             <Chinese>移除ACE軍火庫</Chinese>
+            <Italian>Rimuovi l'arsenale ACE</Italian>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add and fix Italian translation for the modules: arsenal, nightvision, common, explosives, maverick, gforces, pylons, hearing, marksers, repair, flashlights, nametags, interaction, vehicles, medical_menu, medical_ai, interact_menu, medical

Just for info, the PBOs for testing have been built by using the `armake` branch with `tools\make.ps1` .