### PR TITLE
Fix unit info base class

### DIFF
--- a/addons/common/RscInfoType.hpp
+++ b/addons/common/RscInfoType.hpp
@@ -1,5 +1,6 @@
 
 class RscInGameUI {
+    class RscUnitInfo;
     class RscUnitInfoNoHUD {
         onLoad = QUOTE([ARR_2('ace_infoDisplayChanged', [ARR_2(_this select 0, 'Any')])] call CBA_fnc_localEvent;);
     };


### PR DESCRIPTION
Fix for #6422
```
Application terminated intentionally
ErrorMessage: File z\ace\addons\common\RscInfoType.hpp, line 5: /RscInGameUI.RscUnitInfoSoldier: Undefined base class 'RscUnitInfo'
```
