### PR TITLE
Move all events in handleUnitVitals to single switch statement

### DIFF
--- a/addons/medical/script_macros_medical.hpp
+++ b/addons/medical/script_macros_medical.hpp
@@ -26,6 +26,7 @@
 #define BLOOD_VOLUME_CLASS_2_HEMORRHAGE 5.100 // lost more than 15% blood, Class II Hemorrhage
 #define BLOOD_VOLUME_CLASS_3_HEMORRHAGE 4.200 // lost more than 30% blood, Class III Hemorrhage
 #define BLOOD_VOLUME_CLASS_4_HEMORRHAGE 3.600 // lost more than 40% blood, Class IV Hemorrhage
+#define BLOOD_VOLUME_FATAL 3.0 // Lost more than 50% blood, Fatal
 
 // IV Change per second calculation:
 // 250 ml should take 60 seconds to fill. 250 ml / 60 s ~ 4.1667 ml/s.

--- a/addons/medical_damage/functions/fnc_woundsHandler.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandler.sqf
@@ -75,6 +75,7 @@ private _bodyPartVisParams = [_unit, false, false, false, false]; // params arra
 #endif
 
     if (_bodyPartNToAdd == 0 && {_woundDamage > LETHAL_HEAD_DAMAGE_THRESHOLD}) then {
+        TRACE_2("FatalInjury",_unit,_woundDamage);
         [QEGVAR(medical,FatalInjury), _unit] call CBA_fnc_localEvent;
     };
 

--- a/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
@@ -125,6 +125,7 @@ private _woundsCreated = [];
 #endif
 
             if (_bodyPartNToAdd == 0 && {_woundDamage > LETHAL_HEAD_DAMAGE_THRESHOLD}) then {
+                TRACE_2("FatalInjury",_unit,_woundDamage);
                 [QEGVAR(medical,FatalInjury), _unit] call CBA_fnc_localEvent;
             };
 

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -51,9 +51,6 @@ if (_hemorrhage != GET_HEMORRHAGE(_unit)) then {
 private _bloodLoss = GET_BLOOD_LOSS(_unit);
 if (_bloodLoss > 0) then {
     _unit setVariable [QGVAR(bloodloss), _bloodLoss, _syncValues];
-
-    [QEGVAR(medical,Injury), _unit] call CBA_fnc_localEvent;
-
     if !IS_BLEEDING(_unit) then {
         _unit setVariable [VAR_IS_BLEEDING, true, true];
     };
@@ -85,9 +82,42 @@ private _heartRate = [_unit, _deltaT, _syncValues] call FUNC(updateHeartRate);
 private _bloodPressure = GET_BLOOD_PRESSURE(_unit);
 _unit setVariable [VAR_BLOOD_PRESS, _bloodPressure, _syncValues];
 
+_bloodPressure params ["_bloodPressureL", "_bloodPressureH"];
+
 private _cardiacOutput = [_unit] call EFUNC(medical_status,getCardiacOutput);
-if (_bloodLoss > BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput) then {
-    [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
+
+switch (true) do {
+    case (_bloodVolume < BLOOD_VOLUME_FATAL): {
+        TRACE_3("BloodVolume Fatal",_unit,BLOOD_VOLUME_FATAL,_bloodVolume);
+        [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_heartRate < 20): {
+        TRACE_2("heartRate Fatal",_unit,_heartRate);
+        [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_heartRate < 20): {
+        TRACE_2("heartRate Fatal",_unit,_heartRate);
+        [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_bloodPressureH < 50): {
+        TRACE_2("bloodPressureH Fatal",_unit,_bloodPressureH);
+        [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_bloodPressureL < 40): {
+        [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_heartRate < 30): {
+        [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_bloodLoss > BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput): {
+        [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
+    };
+    case (_bloodLoss > 0): {
+        [QEGVAR(medical,Injury), _unit] call CBA_fnc_localEvent;
+    };
+    case (_inPain): {
+        [QEGVAR(medical,Injury), _unit] call CBA_fnc_localEvent;
+    };
 };
 
 #ifdef DEBUG_MODE_FULL
@@ -95,13 +125,5 @@ if (!isPlayer _unit) then {
     hintSilent format["blood volume: %1, blood loss: [%2, %3]\nhr: %4, bp: %5, pain: %6", round(_bloodVolume * 100) / 100, round(_bloodLoss * 1000) / 1000, round((_bloodLoss / (0.001 max _cardiacOutput)) * 100) / 100, round(_heartRate), _bloodPressure, round(_painLevel * 100) / 100];
 };
 #endif
-
-_bloodPressure params ["_bloodPressureL", "_bloodPressureH"];
-if (_bloodPressureL < 40 || {_heartRate < 30}) then {
-    [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
-};
-if ((_heartRate < 20) || {_heartRate > 220} || {_bloodPressureH < 50}) then {
-    [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
-};
 
 END_COUNTER(Vitals);

--- a/addons/medical_vitals/script_component.hpp
+++ b/addons/medical_vitals/script_component.hpp
@@ -2,7 +2,7 @@
 #define COMPONENT_BEAUTIFIED Medical Vitals
 #include "\z\ace\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
+#define DEBUG_MODE_FULL
 #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 


### PR DESCRIPTION
Move all events in handleUnitVitals to single switch statement to make it easier to see when each event is fired.

Also adds a case for the lower blood volume, that will trigger if medication is at play. This means it's now more urgently to bandage up. 

