### PR TITLE
Fix cardiac arrest timeout

### DIFF
--- a/addons/medical_statemachine/functions/fnc_conditionCardiacArrestTimer.sqf
+++ b/addons/medical_statemachine/functions/fnc_conditionCardiacArrestTimer.sqf
@@ -14,6 +14,6 @@
 params ["_unit"];
 
 private _startTime = _unit getVariable [QGVAR(cardiacArrestStart), CBA_missionTime];
-private _lifeTime = _unit getVariable [QGVAR(cardiacArrestTime), GVAR(cardiacArrestTime)];
+private _lifeTime = _unit getVariable [QGVAR(cardiacArrestTime), EGVAR(medical,cardiacArrestTime)];
 
 (CBA_missionTime - _startTime) > _lifeTime

--- a/addons/medical_statemachine/functions/fnc_enteredStateCardiacArrest.sqf
+++ b/addons/medical_statemachine/functions/fnc_enteredStateCardiacArrest.sqf
@@ -18,7 +18,7 @@ params ["_unit"];
 private _time = EGVAR(medical,cardiacArrestTime);
 _time = _time + random [_time*-0.1, 0, _time*0.1];
 
-_unit setVariable [QEGVAR(medical,cardiacArrestTime), _time];
-_unit setVariable [QEGVAR(medical,cardiacArrestStart), CBA_missionTime];
+_unit setVariable [QGVAR(cardiacArrestTime), _time];
+_unit setVariable [QGVAR(cardiacArrestStart), CBA_missionTime];
 
 [_unit] call EFUNC(medical_status,setCardiacArrest);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix units not dying when their cardiac arrest timer runs out (some misaligned GVARs after restructure).
