### PR TITLE
Fix ladder dismount animation bug

### DIFF
--- a/addons/medical_engine/CfgMoves.hpp
+++ b/addons/medical_engine/CfgMoves.hpp
@@ -13,7 +13,7 @@ class CfgMovesMaleSdr: CfgMovesBasic {
 
         // wake me up inside
         class Unconscious: Default {
-            InterpolateTo[] = {"DeadState",0.1,"ACE_UnconsciousOutProne",0.2};
+            InterpolateTo[] = {"DeadState",0.1};
         };
 
         class AmovPpneMstpSnonWnonDnon;


### PR DESCRIPTION
Not sure of the original reason we interpolate to this ACE unconscious animation, but removing it seemingly has no effect and fixes all the other animations that were broken by it. Thanks to Bismarck for the fix 👍

Fixes #6227 
