### PR TITLE
Improve unconscious volume handling

### DIFF
--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -21,6 +21,7 @@ GVAR(heartBeatEffectRunning) = false;
 ["ace_unconscious", {
     params ["_unit", "_unconscious"];
 
+    // Toggle unit's ability to talk in radio addons
     if (local _unit) then {
         _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
         _unit setVariable ["tf_unable_to_use_radio", _unconscious, true];
@@ -31,11 +32,18 @@ GVAR(heartBeatEffectRunning) = false;
 
     [_unconscious, 1] call FUNC(effectUnconscious);
     ["unconscious", _unconscious] call EFUNC(common,setDisableUserInputStatus);
+
+    // Greatly reduce players hearing ability while unconscious (affects radio addons)
+    [QUOTE(ADDON), VOL_UNCONSCIOUS, _unconscious] call EFUNC(common,setHearingCapability);
 }] call CBA_fnc_addEventHandler;
 
+// Update effects to match new unit's current status
 ["unit", {
     params ["_new", "_old"];
+
     private _status = _new getVariable ["ace_unconscious", false];
+
     [_status, 0] call FUNC(effectUnconscious);
     ["unconscious", _status] call EFUNC(common,setDisableUserInputStatus);
+    [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);
 }] call CBA_fnc_addPlayerEventHandler;

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -10,17 +10,6 @@
     [_unit, "moan", PAIN_TO_MOAN(_painLevel)] call FUNC(playInjuredSound);
 }] call CBA_fnc_addEventHandler;
 
-// Toggle unconscious units' ability to talk in radio addons
-["ace_unconscious",{
-    params ["_unit", "_unconscious"];
-
-    if (local _unit) then {
-        _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
-        _unit setVariable ["tf_unable_to_use_radio", _unconscious, true];
-        _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
-    };
-}];
-
 if (!hasInterface) exitWith {};
 
 GVAR(nextFadeIn) = 0;
@@ -34,20 +23,28 @@ GVAR(heartBeatEffectRunning) = false;
 
     if (_unit != ACE_player) exitWith {};
 
+    // Toggle unconscious player's ability to talk in radio addons
+    _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
+    _unit setVariable ["tf_unable_to_use_radio", _unconscious, true];
+    _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
+
+    // Greatly reduce player's hearing ability while unconscious (affects radio addons)
+    [QUOTE(ADDON), VOL_UNCONSCIOUS, _unconscious] call EFUNC(common,setHearingCapability);
+
     [_unconscious, 1] call FUNC(effectUnconscious);
     ["unconscious", _unconscious] call EFUNC(common,setDisableUserInputStatus);
-
-    // Greatly reduce players hearing ability while unconscious (affects radio addons)
-    [QUOTE(ADDON), VOL_UNCONSCIOUS, _unconscious] call EFUNC(common,setHearingCapability);
 }] call CBA_fnc_addEventHandler;
 
-// Update effects to match new unit's current status
+// Update effects to match new unit's current status (this also handles respawn)
 ["unit", {
     params ["_new", "_old"];
 
     private _status = _new getVariable ["ace_unconscious", false];
 
+    _new setVariable ["tf_voiceVolume", [1, 0] select _status, true];
+    _new setVariable ["tf_unable_to_use_radio", _status, true];
+    _new setVariable ["acre_sys_core_isDisabled", _status, true];
+    [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);
     [_status, 0] call FUNC(effectUnconscious);
     ["unconscious", _status] call EFUNC(common,setDisableUserInputStatus);
-    [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);
 }] call CBA_fnc_addPlayerEventHandler;

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -25,7 +25,7 @@ GVAR(heartBeatEffectRunning) = false;
 
     // Toggle unconscious player's ability to talk in radio addons
     _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
-    _unit setVariable ["tf_unable_to_use_radio", _unconscious, true];
+    _unit setVariable ["tf_unable_to_use_radio", _unconscious]; // Only used locally
     _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
 
     // Greatly reduce player's hearing ability while unconscious (affects radio addons)
@@ -42,7 +42,7 @@ GVAR(heartBeatEffectRunning) = false;
     if (_unit != ACE_player) exitWith {};
 
     _unit setVariable ["tf_voiceVolume", 1, true];
-    _unit setVariable ["tf_unable_to_use_radio", false, true];
+    _unit setVariable ["tf_unable_to_use_radio", false];
     _unit setVariable ["acre_sys_core_isDisabled", false, true];
     [QUOTE(ADDON), 1, false] call EFUNC(common,setHearingCapability);
 }] call CBA_fnc_addEventHandler;
@@ -54,7 +54,7 @@ GVAR(heartBeatEffectRunning) = false;
     private _status = _new getVariable ["ace_unconscious", false];
 
     _new setVariable ["tf_voiceVolume", [1, 0] select _status, true];
-    _new setVariable ["tf_unable_to_use_radio", _status, true];
+    _new setVariable ["tf_unable_to_use_radio", _status];
     _new setVariable ["acre_sys_core_isDisabled", _status, true];
     [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);
     [_status, 0] call FUNC(effectUnconscious);

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -10,6 +10,17 @@
     [_unit, "moan", PAIN_TO_MOAN(_painLevel)] call FUNC(playInjuredSound);
 }] call CBA_fnc_addEventHandler;
 
+// Toggle unconscious units' ability to talk in radio addons
+["ace_unconscious",{
+    params ["_unit", "_unconscious"];
+
+    if (local _unit) then {
+        _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
+        _unit setVariable ["tf_unable_to_use_radio", _unconscious, true];
+        _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
+    };
+}];
+
 if (!hasInterface) exitWith {};
 
 GVAR(nextFadeIn) = 0;
@@ -20,13 +31,6 @@ GVAR(heartBeatEffectRunning) = false;
 
 ["ace_unconscious", {
     params ["_unit", "_unconscious"];
-
-    // Toggle unit's ability to talk in radio addons
-    if (local _unit) then {
-        _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
-        _unit setVariable ["tf_unable_to_use_radio", _unconscious, true];
-        _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
-    };
 
     if (_unit != ACE_player) exitWith {};
 

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -35,6 +35,18 @@ GVAR(heartBeatEffectRunning) = false;
     ["unconscious", _unconscious] call EFUNC(common,setDisableUserInputStatus);
 }] call CBA_fnc_addEventHandler;
 
+// Reset volume upon death for spectators
+[QEGVAR(medical,death), {
+    params ["_unit"];
+
+    if (_unit != ACE_player) exitWith {};
+
+    _unit setVariable ["tf_voiceVolume", 1, true];
+    _unit setVariable ["tf_unable_to_use_radio", false, true];
+    _unit setVariable ["acre_sys_core_isDisabled", false, true];
+    [QUOTE(ADDON), 1, false] call EFUNC(common,setHearingCapability);
+}] call CBA_fnc_addEventHandler;
+
 // Update effects to match new unit's current status (this also handles respawn)
 ["unit", {
     params ["_new", "_old"];

--- a/addons/medical_feedback/script_component.hpp
+++ b/addons/medical_feedback/script_component.hpp
@@ -34,3 +34,5 @@
 #define SND_HEARBEAT_FAST   (selectRandom ["ACE_heartbeat_fast_1", "ACE_heartbeat_fast_2", "ACE_heartbeat_fast_3"])
 #define SND_HEARBEAT_NORMAL (selectRandom ["ACE_heartbeat_norm_1", "ACE_heartbeat_norm_2"])
 #define SND_HEARBEAT_SLOW   (selectRandom ["ACE_heartbeat_slow_1", "ACE_heartbeat_slow_2"])
+
+#define VOL_UNCONSCIOUS 0.25

--- a/addons/medical_statemachine/Statemachine.hpp
+++ b/addons/medical_statemachine/Statemachine.hpp
@@ -107,8 +107,7 @@ class ACE_Medical_StateMachine {
         };
     };
     class Dead {
-        // TODO: this needs to be handled by a function instead of inline scripts
-        // Probably also needs additional logic to deal with edge cases
-        onStateEntered = "_this setDamage 1"; // killing a unit also exits the state machine for this unit
+        // When the unit is killed it's no longer handled by the statemachine
+        onStateEntered = QFUNC(enteredStateDeath);
     };
 };

--- a/addons/medical_statemachine/XEH_PREP.hpp
+++ b/addons/medical_statemachine/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 PREP(conditionCardiacArrestTimer);
 PREP(conditionExecutionDeath);
 PREP(enteredStateCardiacArrest);
+PREP(enteredStateDeath);
 PREP(enteredStateFatalInjury);
 PREP(handleStateDefault);
 PREP(handleStateInjured);

--- a/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf
+++ b/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+/*
+ * Author: SilentSpike
+ * Handles a unit reaching the point of death.
+ *
+ * Arguments:
+ * 0: The Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+
+// TODO: Probably also needs additional logic to deal with edge cases
+
+// Send a local event before death
+[QEGVAR(medical,death), [_unit]] call CBA_fnc_localEvent;
+
+_unit setDamage 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Lower the player's hearing when they go unconscious (both game sounds and addon local/radio voices).
  - Perhaps this should only affect voices?
- Re-evaluate player's ability to talk and hear upon changing unit
  - Fix potential for players to be able to talk if they transition into an already unconscious AI unit that was previously local to dedicated/headless.
  - Fix potential for players to respawn and not be able to hear or talk.
    - [x] We should probably be resetting these on death anyway because players could be in an external spectator system during that time.
  - This also removes the large number of variables being set on AI and never used.