### PR TITLE
Introduce bleedout condition and fix IV hemorrhage

### DIFF
--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -28,7 +28,7 @@
 #define BLOOD_VOLUME_CLASS_2_HEMORRHAGE 5.100 // lost more than 15% blood, Class II Hemorrhage
 #define BLOOD_VOLUME_CLASS_3_HEMORRHAGE 4.200 // lost more than 30% blood, Class III Hemorrhage
 #define BLOOD_VOLUME_CLASS_4_HEMORRHAGE 3.600 // lost more than 40% blood, Class IV Hemorrhage
-#define BLOOD_VOLUME_FATAL 3.0 // Lost more than 50% blood, Fatal
+#define BLOOD_VOLUME_FATAL 3.0 // Lost more than 50% blood, Unrecoverable
 
 // IV Change per second calculation:
 // 250 ml should take 60 seconds to fill. 250 ml / 60 s ~ 4.1667 ml/s.

--- a/addons/medical_statemachine/Statemachine.hpp
+++ b/addons/medical_statemachine/Statemachine.hpp
@@ -105,6 +105,10 @@ class ACE_Medical_StateMachine {
             condition = QFUNC(conditionExecutionDeath);
             events[] = {QEGVAR(medical,FatalInjury)};
         };
+        class Bleedout {
+            targetState = "Dead";
+            events[] = {QEGVAR(medical,Bleedout)};
+        };
     };
     class Dead {
         // When the unit is killed it's no longer handled by the statemachine

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -40,9 +40,9 @@ _unit setVariable [VAR_BLOOD_VOL, _bloodVolume, _syncValues];
 
 // Set variables for synchronizing information across the net
 private _hemorrhage = switch (true) do {
-    case (_bloodVolume < BLOOD_VOLUME_CLASS_4_HEMORRHAGE): { 3 };
-    case (_bloodVolume < BLOOD_VOLUME_CLASS_3_HEMORRHAGE): { 2 };
-    case (_bloodVolume < BLOOD_VOLUME_CLASS_2_HEMORRHAGE): { 1 };
+    case (_bloodVolume < BLOOD_VOLUME_CLASS_4_HEMORRHAGE): { 4 };
+    case (_bloodVolume < BLOOD_VOLUME_CLASS_3_HEMORRHAGE): { 3 };
+    case (_bloodVolume < BLOOD_VOLUME_CLASS_2_HEMORRHAGE): { 2 };
     case (_bloodVolume < BLOOD_VOLUME_CLASS_1_HEMORRHAGE): { 1 };
     default {0};
 };
@@ -92,6 +92,10 @@ private _cardiacOutput = [_unit] call EFUNC(medical_status,getCardiacOutput);
 switch (true) do {
     case (_bloodVolume < BLOOD_VOLUME_FATAL): {
         TRACE_3("BloodVolume Fatal",_unit,BLOOD_VOLUME_FATAL,_bloodVolume);
+        [QEGVAR(medical,Bleedout), _unit] call CBA_fnc_localEvent;
+    };
+    case (_hemorrhage == 4): {
+        TRACE_3("Class IV Hemorrhage",_unit,_hemorrhage,_bloodVolume);
         [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
     };
     case (_heartRate < 20 || {_heartRate > 220}): {


### PR DESCRIPTION
**When merged this pull request will:**
- Add a death condition for units who've lost more than 50% of their original blood volume
- Change the blood volume cardiac arrest condition to occur after 40% is lost (class IV hemorrhage) to emulate hypovolemic shock

Source on those values:
https://www.medicaldaily.com/breaking-point-how-much-blood-can-human-body-lose-350792

This PR relates to #6277 in that the fatal injury system really is designed to emulate damage to vital organs and so allowing it to occur on any bodypart isn't using it as intended. Instead, if we introduce a bleedout death condition we fix #5510 via another means which makes more sense. #6277 can then be re-purposed to allow fatal injury on the torso to emulate damage to organs located there.

We probably need to investigate the current bleed rates in the rewrite and tweak the factors on those to be balanced to these realistic limits on blood volume.