### PR TITLE
Fix and use hemorrhage stringtable descriptions

### DIFF
--- a/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
@@ -56,23 +56,19 @@ if (_show == 1) then {
             _genericMessages pushback [localize LSTRING(Status_Bleeding), [1, 0.1, 0.1, 1]];
         };
 
-        // Show more information if advancedDiagnose is enabled
-        if (EGVAR(medical,advancedDiagnose)) then {
-            switch (GET_HEMORRHAGE(_target)) do {
-                case 1;
-                case 2: {
-                    _genericMessages pushBack [LLSTRING(Lost_Blood2), [1, 0.1, 0.1, 1]];
-                };
-                case 3: {
-                    _genericMessages pushBack [LLSTRING(Lost_Blood3), [1, 0.1, 0.1, 1]];
-                };
-                case 4: {
-                    _genericMessages pushBack [LLSTRING(Lost_Blood4), [1, 0.1, 0.1, 1]];
-                };
-            };
-        } else {
-            if (GET_HEMORRHAGE(_target) > 0) then {
+        // Give a qualitative description of the blood volume lost
+        switch (GET_HEMORRHAGE(_target)) do {
+            case 1: {
                 _genericMessages pushBack [LLSTRING(Lost_Blood1), [1, 0.1, 0.1, 1]];
+            };
+            case 2: {
+                _genericMessages pushBack [LLSTRING(Lost_Blood2), [1, 0.1, 0.1, 1]];
+            };
+            case 3: {
+                _genericMessages pushBack [LLSTRING(Lost_Blood3), [1, 0.1, 0.1, 1]];
+            };
+            case 4: {
+                _genericMessages pushBack [LLSTRING(Lost_Blood4), [1, 0.1, 0.1, 1]];
             };
         };
 

--- a/addons/medical_gui/functions/fnc_updateUIInfo.sqf
+++ b/addons/medical_gui/functions/fnc_updateUIInfo.sqf
@@ -31,23 +31,19 @@ if IS_BLEEDING(_target) then {
     _genericMessages pushBack [localize ELSTRING(medical,Status_Bleeding), [1, 0.1, 0.1, 1]];
 };
 
-// Show more information if advancedDiagnose is enabled
-if (EGVAR(medical,advancedDiagnose)) then {
-    switch (GET_HEMORRHAGE(_target)) do {
-        case 1;
-        case 2: {
-            _genericMessages pushBack [LLSTRING(Lost_Blood2), [1, 0.1, 0.1, 1]];
-        };
-        case 3: {
-            _genericMessages pushBack [LLSTRING(Lost_Blood3), [1, 0.1, 0.1, 1]];
-        };
-        case 4: {
-            _genericMessages pushBack [LLSTRING(Lost_Blood4), [1, 0.1, 0.1, 1]];
-        };
-    };
-} else {
-    if (GET_HEMORRHAGE(_target) > 0) then {
+// Give a qualitative description of the blood volume lost
+switch (GET_HEMORRHAGE(_target)) do {
+    case 1: {
         _genericMessages pushBack [LLSTRING(Lost_Blood1), [1, 0.1, 0.1, 1]];
+    };
+    case 2: {
+        _genericMessages pushBack [LLSTRING(Lost_Blood2), [1, 0.1, 0.1, 1]];
+    };
+    case 3: {
+        _genericMessages pushBack [LLSTRING(Lost_Blood3), [1, 0.1, 0.1, 1]];
+    };
+    case 4: {
+        _genericMessages pushBack [LLSTRING(Lost_Blood4), [1, 0.1, 0.1, 1]];
     };
 };
 

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -845,10 +845,13 @@
             <Chinese>大量失血</Chinese>
         </Key>
         <!--
-            Strings above and below this seem to differ in some languages, determine which is best to use
+            Strings above match Blood2 but seem to differ in some languages, determine which is best to use
         -->
         <Key ID="STR_ACE_Medical_GUI_Lost_Blood1">
-            <English>Lost a lot of Blood</English>
+            <English>Lost some blood</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_Lost_Blood2">
+            <English>Lost a lot of blood</English>
             <German>Hat eine große Menge Blut verloren</German>
             <Russian>Большая кровопотеря</Russian>
             <Spanish>Mucha sangre perdida</Spanish>
@@ -863,14 +866,11 @@
             <Chinesesimp>大量失血中</Chinesesimp>
             <Chinese>大量失血中</Chinese>
         </Key>
-        <Key ID="STR_ACE_Medical_GUI_Lost_Blood2">
-            <English>Lost some blood</English>
-        </Key>
         <Key ID="STR_ACE_Medical_GUI_Lost_Blood3">
-            <English>Lost a lot of blood</English>
+            <English>Lost a large amount of blood</English>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_Lost_Blood4">
-            <English>Lost a large amount of blood</English>
+            <English>Lost a fatal amount of blood</English>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_STATUS_TOURNIQUET_APPLIED">
             <English>Tourniquet [CAT]</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Always use the more descriptive hemorrhage strings in GUI feedback (otherwise we're just arbitrarily limiting information the player can see).
- Update the hemorrhage descriptions to more closely reflect the blood volume simulation.
