### PR TITLE
Repair - Fix facility is like vehicle

### DIFF
--- a/addons/repair/functions/fnc_isInRepairFacility.sqf
+++ b/addons/repair/functions/fnc_isInRepairFacility.sqf
@@ -21,19 +21,22 @@ TRACE_1("params",_object);
 private _position = getPosASL _object;
 private _isInBuilding = false;
 
-private _objects = (lineIntersectsWith [_object modelToWorldVisual [0, 0, (_position select 2)], _object modelToWorldVisual [0, 0, (_position select 2) +10], _object]);
-{
-    if (_x getVariable ["ACE_isRepairFacility", getNumber (configFile >> "CfgVehicles" >> typeOf _x >> QGVAR(canRepair))] > 0) exitWith {
+private _checkObject = {
+    if (
+        _x getVariable ["ACE_isRepairFacility", getNumber (configFile >> "CfgVehicles" >> typeOf _x >> QGVAR(canRepair))] > 0
+        && {!(_x isKindOf "AllVehicles")} // check if it's not repair vehicle
+        && {alive _x}
+    ) exitWith {
         _isInBuilding = true;
     };
-} forEach _objects;
-
-if (!_isInBuilding) then {
-    _objects = position _object nearObjects 7.5;
-    {
-        if (_x getVariable ["ACE_isRepairFacility", getNumber (configFile >> "CfgVehicles" >> typeOf _x >> QGVAR(canRepair))] > 0) exitWith {
-            _isInBuilding = true;
-        };
-    } forEach _objects;
 };
-_isInBuilding;
+
+private _objects = (lineIntersectsWith [_object modelToWorldVisual [0, 0, (_position select 2)], _object modelToWorldVisual [0, 0, (_position select 2) +10], _object]);
+_checkObject forEach _objects;
+
+if (_isInBuilding) exitWith {true};
+
+_objects = position _object nearObjects 7.5;
+_checkObject forEach _objects;
+
+_isInBuilding


### PR DESCRIPTION
**When merged this pull request will:**
- (1) fix config-based facility acts as repair vehicles;
- fix repair at dead facility (if it's possible);
- optimize `fnc_isInRepairFacility` a little.

(1) Config-based facilities have the same config value name as repair vehicles (`GVAR(canRepair)`). When there is a dead config-based repair vehicle near it becomes repair facility and can affect repair routines. This PR excludes `AllVehicles` child classes from facilities. Maybe simulation check would be more efficient but I think it's OK.