### PR TITLE
fix(medical): make sure vitals handling works properly again

### DIFF
--- a/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
@@ -53,7 +53,7 @@ if (_show == 1) then {
         _genericMessages pushback [localize _partText, [1, 1, 1, 1]];
 
         if IS_BLEEDING(_target) then {
-            _genericMessages pushback [localize LSTRING(Status_Bleeding), [1, 0.1, 0.1, 1]];
+            _genericMessages pushback [LLSTRING(Status_Bleeding), [1, 0.1, 0.1, 1]];
         };
 
         // Give a qualitative description of the blood volume lost
@@ -73,17 +73,17 @@ if (_show == 1) then {
         };
 
         if (((_target getVariable [QEGVAR(medical,tourniquets), [0,0,0,0,0,0]]) select _selectionN) > 0) then {
-            _genericMessages pushback [localize ELSTRING(medical,Status_Tourniquet_Applied), [0.77, 0.51, 0.08, 1]];
+            _genericMessages pushback [localize ELSTRING(medical_treatment,Status_Tourniquet_Applied), [0.77, 0.51, 0.08, 1]];
         };
         if (EGVAR(medical,showPainInMenu) && {[ACE_player, EGVAR(medical,medicSetting_PainVisualization)] call EFUNC(medical_treatment,isMedic)}) then {
             private _painLevel = GET_PAIN_PERCEIVED(_target);
             if (_painLevel > 0) then {
-                private _painText = localize ELSTRING(medical,Status_Pain);
+                private _painText = localize ELSTRING(medical_treatment,Status_Pain);
                 if (_painLevel < 0.1) then {
-                    _painText = localize ELSTRING(medical,Status_MildPain);
+                    _painText = localize ELSTRING(medical_treatment,Status_MildPain);
                 } else {
                     if (_painLevel > 0.5) then {
-                        _painText = localize ELSTRING(medical,Status_SeverePain);
+                        _painText = localize ELSTRING(medical_treatment,Status_SeverePain);
                     };
                 };
                 _genericMessages pushback [_painText, [1, 1, 1, 1]];
@@ -97,7 +97,7 @@ if (_show == 1) then {
         } foreach (_target getVariable [QEGVAR(medical,ivBags), []]);
 
         if (_totalIvVolume >= 1) then {
-            _genericMessages pushback [format[localize ELSTRING(medical,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
+            _genericMessages pushback [format[localize ELSTRING(medical_treatment,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
         };
 
         private _selectionTourniquet = _target getVariable [QEGVAR(medical,tourniquets), [0,0,0,0,0,0]];

--- a/addons/medical_gui/functions/fnc_updateUIInfo.sqf
+++ b/addons/medical_gui/functions/fnc_updateUIInfo.sqf
@@ -28,7 +28,7 @@ private _partText = [ELSTRING(medical_treatment,Head), ELSTRING(medical_treatmen
 _genericMessages pushBack [localize _partText, [1, 1, 1, 1]];
 
 if IS_BLEEDING(_target) then {
-    _genericMessages pushBack [localize ELSTRING(medical,Status_Bleeding), [1, 0.1, 0.1, 1]];
+    _genericMessages pushBack [LLSTRING(Status_Bleeding), [1, 0.1, 0.1, 1]];
 };
 
 // Give a qualitative description of the blood volume lost
@@ -48,18 +48,18 @@ switch (GET_HEMORRHAGE(_target)) do {
 };
 
 if (((_target getVariable [QEGVAR(medical,tourniquets), [0, 0, 0, 0, 0, 0]]) select _selectionN) > 0) then {
-    _genericMessages pushBack [localize ELSTRING(medical,Status_Tourniquet_Applied), [0.77, 0.51, 0.08, 1]];
+    _genericMessages pushBack [localize ELSTRING(medical_treatment,Status_Tourniquet_Applied), [0.77, 0.51, 0.08, 1]];
 };
 
 if (EGVAR(medical,showPainInMenu) && {[ACE_player, EGVAR(medical,medicSetting_PainVisualization)] call EFUNC(medical_treatment,isMedic)}) then {
     private _painLevel = GET_PAIN_PERCEIVED(_target);
     if (_painLevel > 0) then {
-        private _painText = localize ELSTRING(medical,Status_Pain);
+        private _painText = localize ELSTRING(medical_treatment,Status_Pain);
         if (_painLevel < 0.1) then {
-            _painText = localize ELSTRING(medical,Status_MildPain);
+            _painText = localize ELSTRING(medical_treatment,Status_MildPain);
         } else {
             if (_painLevel > 0.5) then {
-                _painText = localize ELSTRING(medical,Status_SeverePain);
+                _painText = localize ELSTRING(medical_treatment,Status_SeverePain);
             };
         };
         _genericMessages pushback [_painText, [1, 1, 1, 1]];
@@ -74,7 +74,7 @@ private _bloodBags = _target getVariable [QEGVAR(medical,ivBags), []];
 } foreach _bloodBags;
 
 if (_totalIvVolume >= 1) then {
-    _genericMessages pushBack [format [localize ELSTRING(medical,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
+    _genericMessages pushBack [format [localize ELSTRING(medical_treatment,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
 };
 
 private _selectionTourniquet = _target getVariable [QEGVAR(medical,tourniquets), [0,0,0,0,0,0]];

--- a/addons/medical_statemachine/Statemachine.hpp
+++ b/addons/medical_statemachine/Statemachine.hpp
@@ -8,7 +8,7 @@ class ACE_Medical_StateMachine {
         onState = QFUNC(handleStateDefault);
         class Injury {
             targetState = "Injured";
-            events[] = {QEGVAR(medical,Injury)};
+            events[] = {QEGVAR(medical,injured)};
         };
         class CriticalInjuryOrVitals {
             targetState = "Unconscious";

--- a/addons/medical_statemachine/functions/fnc_handleStateDefault.sqf
+++ b/addons/medical_statemachine/functions/fnc_handleStateDefault.sqf
@@ -3,8 +3,6 @@
 
 params ["_unit", "_stateName"];
 
-TRACE_2("defaultState:", _unit, _stateName);
-
 // If the unit died the loop is finished
 if (!alive _unit) exitWith {};
 

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -107,7 +107,7 @@ switch (true) do {
         TRACE_4("bloodPressure (H & L) + heartRate Fatal",_unit,_bloodPressureH,_bloodPressureL,_heartRate);
         [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
     };
-    case (_bloodPressureL => 190) {
+    case (_bloodPressureL >= 190): {
         TRACE_2("bloodPressure L above limits",_unit,_bloodPressureL);
         [QEGVAR(medical,FatalVitals), _unit] call CBA_fnc_localEvent;
     };


### PR DESCRIPTION
Make sure vitals handling works properly again.

- fix some syntax mistakes in vitals handling.
- fix incorrect event name in statemachine.
- fix stringtable references.



