### PR TITLE
[medical-rewrite] Removed icon from legacy modules

### DIFF
--- a/addons/medical/CfgVehicles.hpp
+++ b/addons/medical/CfgVehicles.hpp
@@ -8,7 +8,7 @@ class CfgVehicles {
     class ACE_moduleMedicalSettings: ACE_Module {
         scope = 1;
         displayName = CSTRING(MedicalSettings_Module_DisplayName);
-        icon = QPATHTOF(UI\Icon_Module_Medical_ca.paa);
+        icon = "";
         category = "ACE";
         function = QFUNC(moduleMedicalSettings);
         functionPriority = 1;

--- a/addons/medical_gui/CfgVehicles.hpp
+++ b/addons/medical_gui/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
     class ACE_moduleMedicalMenuSettings: ACE_Module {
         scope = 1;
         displayName = CSTRING(module_DisplayName);
-        icon = QPATHTOEF(medical,UI\Icon_Module_Medical_ca.paa);
+        icon = "";
         category = "ACE_medical";
         function = QUOTE(DFUNC(module));
         functionPriority = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove the Icon property from the old setting module.
- The icon was moved from `medical` component to `medical_gui` causing errors during build.