### PR TITLE
[medical-rewrite] Fix cpr condition

### DIFF
--- a/addons/medical_treatment/functions/fnc_treatmentCPR_progress.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentCPR_progress.sqf
@@ -24,5 +24,3 @@ if (_target call EFUNC(common,isAwake)) exitWith {false};
 if !IN_CRDC_ARRST(_target) exitWith {false};
 
 [_target] call FUNC(calculateBlood); // Calculate blood volume. If their is no pulse, nothing happens!
-
-(alive _target) // CPR may only proceed if the patient is not dead


### PR DESCRIPTION
**When merged this pull request will:**
- Add a `alive` check to the cpr treatment condition.
- `fnc_treatmentCPR_progress.sqf` checks if the target is alive. If its dead cpr is stopped.
- This leads to the situation where you have cpr as an option but it stops right after the start.

Question here is what is intended behaviour: Should cpr be always available (and the alive checks therefor removed) or should it be only available when the target is alive (current state).
The first option has the downside that it allow players to fast check if somebody is alive (cpr option there => alive, cpr missing => dead).
