### PR TITLE
Dragging - Add compatibilty for 1.84 static weapons and radars

### DIFF
--- a/addons/dragging/CfgVehicles.hpp
+++ b/addons/dragging/CfgVehicles.hpp
@@ -30,7 +30,7 @@ class CfgVehicles {
         GVAR(dragDirection) = 0;
     };
 
-    // Big 1.70 Autonomous AA Turrets
+    // Big 1.70 and 1.84 Autonomous AA Turrets
     class StaticMGWeapon;
     class AAA_System_01_base_F: StaticMGWeapon { // Praetorian 1C (aka Phalanx CIWS)
         GVAR(canCarry) = 0;
@@ -41,6 +41,30 @@ class CfgVehicles {
         GVAR(canDrag) = 0;
     };
     class SAM_System_02_base_F: StaticMGWeapon { // Mk21 Centurion
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+    class SAM_System_03_base_F: StaticMGWeapon { // MIM-145 Defender
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+    class SAM_System_04_base_F: StaticMGWeapon { // S-750 Rhea
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+    class B_Ship_Gun_01_base_F: StaticMGWeapon { // Mk45 Hammer
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+    class B_Ship_MRLS_01_base_F: StaticMGWeapon { // Mk41 VLS
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+    class Radar_System_01_base_F: StaticMGWeapon { // AN/MPQ-105 Radar
+        GVAR(canCarry) = 0;
+        GVAR(canDrag) = 0;
+    };
+    class Radar_System_02_base_F: StaticMGWeapon { // R-750 Cronus Radar
         GVAR(canCarry) = 0;
         GVAR(canDrag) = 0;
     };

--- a/addons/reload/XEH_postInit.sqf
+++ b/addons/reload/XEH_postInit.sqf
@@ -9,6 +9,8 @@ if (!hasInterface) exitWith {};
     if !([ACE_player, vehicle ACE_player, ["isNotInside", "isNotSwimming", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {false};
     // Conditions: specific
     if !(ACE_player call CBA_fnc_canUseWeapon || {(vehicle ACE_player) isKindOf "StaticWeapon"}) exitWith {false};
+    // Ignore if controlling UAV (blocks radar keybind)
+    if (!isNull (ACE_controlledUAV param [0, objNull])) exitWith {false};
 
     // Statement
     [ACE_player] call FUNC(checkAmmo);


### PR DESCRIPTION
Disable dragging for 1.84 things (Fix #6491)
Also disable check ammo keybind when controlling uav
Ctrl+R turns radar on/off on some of these new "UAVs"