### PR TITLE
[medical-rewrite] Fix wrong macro

### DIFF
--- a/addons/medical_treatment/ACE_Settings.hpp
+++ b/addons/medical_treatment/ACE_Settings.hpp
@@ -52,7 +52,7 @@ class ACE_Settings {
         values[] = {"Off", "Low", "Medium", "High", "Ultra"};
         _values[] = { 0, 50, 100, 1000, 5000 };
     };
-    class GVAR(medical,increaseTrainingInLocations) {
+    class EGVAR(medical,increaseTrainingInLocations) {
         category = CSTRING(Category_Medical);
         displayName = CSTRING(increaseTrainingInLocations_DisplayName);
         description = CSTRING(increaseTrainingInLocations_Description);


### PR DESCRIPTION
**When merged this pull request will:**
- Nightly build failed because the macro was broken (either `EGVAR` with two arguments or `GVAR` with one)
- For backwards compatibility it should be `EGVAR`.

However i would plead to not maintain backwards comp with the rewrite and so change it to `GVAR`, but thats up to you.
