### PR TITLE
Fix environmental damage sources

### DIFF
--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -102,13 +102,13 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
                 _woundedHitPoint = selectRandom ["LeftLeg", "RightLeg", "Body", "Head"];
             };
             _ammo = "#falling";
-            TRACE_4("Fall Damage",_shooter,_instigator,_damage,_receivedDamage);
+            TRACE_5("Fall Damage",_unit,_shooter,_instigator,_damage,_receivedDamage);
         } else {
             // Getting hit by a vehicle lists the driver as the shooter
             if !(isNull _shooter) then {
                 _woundedHitPoint = "Body";
                 _ammo = "#vehiclecrash";
-                TRACE_4("Collision Damage",_shooter,_instigator,_damage,_receivedDamage);
+                TRACE_5("Collision Damage",_unit,_shooter,_instigator,_damage,_receivedDamage);
             } else {
                 // Anything else is probably fire damage
                 _woundedHitPoint = selectRandom ["LeftLeg", "RightLeg", "Body"];
@@ -118,7 +118,7 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
                     // if the new sum is large enough, reset variable and continue with it added in
                     _unit setVariable [QGVAR(trivialDamage), 0];
                     _receivedDamage = _combinedDamage;
-                    TRACE_4("Burning",_shooter,_instigator,_damage,_receivedDamage);
+                    TRACE_5("Burning",_unit,_shooter,_instigator,_damage,_receivedDamage);
                 } else {
                     // otherwise just save the new sum into the variable and exit
                     _unit setVariable [QGVAR(trivialDamage), _combinedDamage];
@@ -154,7 +154,7 @@ if (
     {_damage isEqualTo (_oldDamage + 0.005)}
 ) exitWith {
     [QEGVAR(medical,woundReceived), [_unit, "Body", _newDamage, _unit, "#drowning"]] call CBA_fnc_localEvent;
-    TRACE_4("Drowning",_shooter,_instigator,_damage,_newDamage);
+    TRACE_5("Drowning",_unit,_shooter,_instigator,_damage,_newDamage);
 
     0
 };
@@ -167,9 +167,10 @@ if (
     _ammo isEqualTo "" &&
     {_vehicle != _unit} &&
     {vectorMagnitude (velocity _vehicle) > 5}
+    // todo: no way to detect if stationary and another vehicle hits you
 ) exitWith {
     [QEGVAR(medical,woundReceived), [_unit, "Body", _newDamage, _unit, "#vehiclecrash"]] call CBA_fnc_localEvent;
-    TRACE_4("Vehicle Crash",_shooter,_instigator,_damage,_newDamage);
+    TRACE_5("Vehicle Crash",_unit,_shooter,_instigator,_damage,_newDamage);
 
     0
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Tidy, optimise and comment handle damage code.
- Fix some environmental damage conditions:
  - ~~There was no sanity check on fall damage to see if the unit was in a vehicle to avoid weird edge cases.~~ Outdated, we now first check for a `_shooter` to handle this.
  - Vehicle crashes would never trigger because they don't fire the EH for all hitpoints like most damage sources do.
  - ~~Being hit by a vehicle would work (unintentionally), but was not explicitly checked for - which is now done by checking if a shooter exists.~~ Outdated, we now only check if a shooter exists to know collision damage has occurred, it's irrelevant if a vehicle caused it.

I tested all of this in the editor and can confirm the added traces for each damage source now fire when expected.

Point of interest: as you can see in the comments, vehicle collisions do fire the EH multiple times and that seems to scale to crash intensity so I think we can just let it happen and avoid complicated code to work around that.
