### PR TITLE
Ignore missing hitpoints on playable logic

### DIFF
--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -8,7 +8,9 @@
     reverse _allHitPoints;
 
     if (_allHitPoints param [0, ""] != "ACE_HDBracket") then {
-        if ((getText (([_unit] call CBA_fnc_getObjectConfig) >> "simulation")) == "UAVPilot") exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
+        private _config = [_unit] call CBA_fnc_getObjectConfig;
+        if (getText (_config >> "simulation") == "UAVPilot") exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
+        if (getNumber (_config >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
         ERROR_1("Bad hitpoints for unit type ""%1""",typeOf _unit);
     } else {
         // Calling this function inside curly brackets allows the usage of


### PR DESCRIPTION
`VirtualMan_F` inherits from `CAManBase` so the code to add the handle damage EH throws out an rpt error on playable logic units who don't have the required `ace_hdbracket` hitpoint:
```rpt
15:49:28 [ACE] (medical_engine) ERROR: Bad hitpoints for unit type "ace_spectator_virtual" z\ace\addons\medical_engine\XEH_postInit.sqf:12
```

For similar reasons, there's also a lot of spam along the lines of:
```rpt
15:49:29 [ACE] (interact_menu) ERROR: Failed to add action - action (ace_medical_gui_CheckPulse) to parent ["ACE_ArmLeft"] on object ace_spectator_virtual [0] z\ace\addons\interact_menu\functions\fnc_addActionToClass.sqf:67
```

Not as simple to fix, but also not very urgent so we can deal with it down the line.