### PR TITLE
Medical rewrite bug fixes

### DIFF
--- a/addons/medical_gui/functions/fnc_handleUI_DisplayOptions.sqf
+++ b/addons/medical_gui/functions/fnc_handleUI_DisplayOptions.sqf
@@ -97,7 +97,7 @@ private _entries = [ACE_player, GVAR(INTERACTION_TARGET), _name] call FUNC(getTr
     private _ctrl = (_display displayCtrl (START_IDC + _forEachIndex));
     if (!(_forEachIndex > AMOUNT_OF_ENTRIES)) then {
         _ctrl ctrlSetText (_x select 0);
-        private _code = format ["ace_medical_menu_pendingReopen = true; call %1;", (_x select 3)];
+        private _code = format ["ace_medical_gui_pendingReopen = true; call %1;", (_x select 3)];
         _ctrl ctrlSetEventHandler ["ButtonClick", _code];
         _ctrl ctrlSetTooltip (_x select 0); // TODO implement
         _ctrl ctrlShow true;

--- a/addons/medical_statemachine/functions/fnc_conditionExecutionDeath.sqf
+++ b/addons/medical_statemachine/functions/fnc_conditionExecutionDeath.sqf
@@ -14,4 +14,4 @@
 
 params ["_unit"];
 
-(GVAR(fatalInjuryCondition) < 2) && {!(_unit getVariable [QGVAR(deathBlocked), false])}
+(GVAR(fatalInjuryCondition) < 2) && {!(_unit getVariable [QEGVAR(medical,deathBlocked), false])}

--- a/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf
+++ b/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf
@@ -19,4 +19,7 @@ params ["_unit"];
 // Send a local event before death
 [QEGVAR(medical,death), [_unit]] call CBA_fnc_localEvent;
 
+_unit setVariable [VAR_HEART_RATE, 0, true];
+_unit setVariable [VAR_BLOOD_PRESS, [0, 0], true];
+
 _unit setDamage 1;

--- a/addons/medical_status/CfgEventHandlers.hpp
+++ b/addons/medical_status/CfgEventHandlers.hpp
@@ -19,7 +19,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_Init_EventHandlers {
     class CAManBase {
         class ADDON {
-            onRespawn = true;
+            onRespawn = 1;
             init = QUOTE(call FUNC(initUnit));
         };
     };

--- a/addons/medical_status/CfgEventHandlers.hpp
+++ b/addons/medical_status/CfgEventHandlers.hpp
@@ -19,6 +19,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_Init_EventHandlers {
     class CAManBase {
         class ADDON {
+            onRespawn = true;
             init = QUOTE(call FUNC(initUnit));
         };
     };

--- a/addons/medical_status/functions/fnc_initUnit.sqf
+++ b/addons/medical_status/functions/fnc_initUnit.sqf
@@ -17,6 +17,8 @@
 
 params ["_unit"];
 
+if (!local _unit) exitWith {};
+
 if (damage _unit > 0) then {
     _unit setDamage 0;
 };

--- a/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
+++ b/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
@@ -67,7 +67,7 @@ if !IN_CRDC_ARRST(_unit) then {
         };
         _targetHR = (_targetHR + _hrTargetAdjustment) max 0;
 
-        _hrChange = round(_targetHR - _heartRate) / 2; 
+        _hrChange = round(_targetHR - _heartRate) / 2;
     } else {
         _hrChange = -round(_heartRate / 10);
     };

--- a/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
+++ b/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
@@ -46,6 +46,7 @@ private _heartRate = GET_HEART_RATE(_unit);
 
 if !IN_CRDC_ARRST(_unit) then {
     private _hrChange = 0;
+    private _targetHR = 0;
     private _bloodVolume = GET_BLOOD_VOLUME(_unit);
     if (_bloodVolume > BLOOD_VOLUME_CLASS_4_HEMORRHAGE) then {
         GET_BLOOD_PRESSURE(_unit) params ["_bloodPressureL", "_bloodPressureH"];
@@ -57,7 +58,7 @@ if !IN_CRDC_ARRST(_unit) then {
             _targetBP = _targetBP * (_bloodVolume / DEFAULT_BLOOD_VOLUME);
         };
 
-        private _targetHR = DEFAULT_HEART_RATE;
+        _targetHR = DEFAULT_HEART_RATE;
         if (_bloodVolume < BLOOD_VOLUME_CLASS_2_HEMORRHAGE) then {
             _targetHR = _heartRate * (_targetBP / (45 max _meanBP));
         };
@@ -68,7 +69,6 @@ if !IN_CRDC_ARRST(_unit) then {
 
         _hrChange = round(_targetHR - _heartRate) / 2; 
     } else {
-        _targetHR = 0;
         _hrChange = -round(_heartRate / 10);
     };
     if (_hrChange < 0) then {
@@ -81,4 +81,3 @@ if !IN_CRDC_ARRST(_unit) then {
 _unit setVariable [VAR_HEART_RATE, _heartRate, _syncValue];
 
 _heartRate
-

--- a/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
+++ b/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
@@ -64,13 +64,18 @@ if !IN_CRDC_ARRST(_unit) then {
         if (_painLevel > 0.2) then {
             _targetHR = _targetHR max (80 + 50 * _painLevel);
         };
-        _targetHR = _targetHR + _hrTargetAdjustment;
+        _targetHR = (_targetHR + _hrTargetAdjustment) max 0;
 
-        _hrChange = round(_targetHR - _heartRate) / 2;
+        _hrChange = round(_targetHR - _heartRate) / 2; 
     } else {
+        _targetHR = 0;
         _hrChange = -round(_heartRate / 10);
     };
-    _heartRate = (_heartRate + _deltaT * _hrChange) max 0;
+    if (_hrChange < 0) then {
+        _heartRate = (_heartRate + _deltaT * _hrChange) max _targetHR;
+    } else {
+        _heartRate = (_heartRate + _deltaT * _hrChange) min _targetHR;
+    };
 };
 
 _unit setVariable [VAR_HEART_RATE, _heartRate, _syncValue];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix medical menu reopen setting
- Fix second delay on execution condition which had a broken macro causing players to fall through cardiac arrest to death immediately 
- Fix people reporting 40 HR (set from leaving cardiac arrest state) when dead
- Fix players having old stats on respawn (including references to arrays causing wounds to the old corpse to apply to the new player too)
- Fix locality issue on unit init causing JiP to reset all variables (wounds etc) on all units
- Fix updateHeartRate being allowed to go passed the target heart rate. This is an especially large issue as it made it completely impossible to perform CPR. During CPR the vitals would not be checked leading to the maximum deltaT of 10. On the first tick of handle vitals once CPR was successfully completed the function would be entered with a HR of 40 and the target HR would be 80. This would make the function 
40 +  ((80 - 40) / 2 )*10 = 240, which would be a HR high enough to push the unit back into cardiac arrest.

Note: I realize the respawn issue has been noted as fixed in #6518, but I can't find the respawn XEH noted in that PR. If I missed or misunderstood this I will of course happily take out my proposed fix. Also my apologies for the seemingly random mix of fixes. These were all the problems we ran into when running a test operation with the rewrite branch today.