### PR TITLE
Add treatment notifications

### DIFF
--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -77,7 +77,7 @@ Initalises logic for treatment notifications shown to the player
 [QGVAR(treatment_initiated), {
     params ["_medic", "_patient"];
 
-    // Notifications don't make sense for self-healing or when dead
+    // Notifications are unwanted for self-healing or when dead
     if (_medic == _patient || {!alive _patient}) exitWith {};
 
     // Can't tell who is providing aid when you're unconscious
@@ -94,7 +94,7 @@ Initalises logic for treatment notifications shown to the player
 [QGVAR(treatment_ended), {
     params ["_medic", "_patient", "_responders"];
 
-    // Notifications don't make sense for self-healing or when dead
+    // Notifications are unwanted for self-healing or when dead
     if (_medic == _patient || {!alive _patient}) exitWith {};
 
     // If someone else is still treating it's useful to know
@@ -108,7 +108,7 @@ Initalises logic for treatment notifications shown to the player
         };
 
         QGVAR(notification) cutText [
-            format [LLSTRING(TreatingYou2), _name],
+            format [LLSTRING(StillTreatingYou), _name],
             "PLAIN DOWN"
         ];
     };

--- a/addons/medical_feedback/stringtable.xml
+++ b/addons/medical_feedback/stringtable.xml
@@ -39,7 +39,7 @@
             <Key ID="STR_ACE_Medical_feedback_TreatingYou">
                 <English>%1 is treating you</English>
             </Key>
-            <Key ID="STR_ACE_Medical_feedback_TreatingYou2">
+            <Key ID="STR_ACE_Medical_feedback_StillTreatingYou">
                 <English>%1 is still treating you</English>
             </Key>
             <Key ID="STR_ACE_Medical_treatment_UnknownPerson">

--- a/addons/medical_feedback/stringtable.xml
+++ b/addons/medical_feedback/stringtable.xml
@@ -35,6 +35,17 @@
                 <Chinese>啟用傷者的尖叫聲</Chinese>
             </Key>
         </Container>
+        <Container name="TreatmentNotification">
+            <Key ID="STR_ACE_Medical_feedback_TreatingYou">
+                <English>% is treating you</English>
+            </Key>
+            <Key ID="STR_ACE_Medical_feedback_TreatingYou2">
+                <English>% is still treating you</English>
+            </Key>
+            <Key ID="STR_ACE_Medical_treatment_UnknownPerson">
+                <English>Somebody</English>
+            </Key>
+        </Container>
         <Key ID="STR_ACE_Medical_feedback_painEffectType">
             <English>Pain Effect Type</English>
             <German>Schmerzeffekt-Typ</German>

--- a/addons/medical_feedback/stringtable.xml
+++ b/addons/medical_feedback/stringtable.xml
@@ -37,10 +37,10 @@
         </Container>
         <Container name="TreatmentNotification">
             <Key ID="STR_ACE_Medical_feedback_TreatingYou">
-                <English>% is treating you</English>
+                <English>%1 is treating you</English>
             </Key>
             <Key ID="STR_ACE_Medical_feedback_TreatingYou2">
-                <English>% is still treating you</English>
+                <English>%1 is still treating you</English>
             </Key>
             <Key ID="STR_ACE_Medical_treatment_UnknownPerson">
                 <English>Somebody</English>

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -26,6 +26,9 @@ if (isServer) then {
 [QGVAR(initiated), {
     params ["_caller", "_target"];
 
+    // Don't track self-treatment
+    if (_caller isEqualTo _target) exitWith {};
+
     // Add the new responder
     private _responders = _target getVariable [QGVAR(responders), []];
     _responders pushBackUnique _caller;
@@ -40,6 +43,9 @@ if (isServer) then {
 // Remove tracked players when they stop treating
 private _treatmentEnded = {
     params ["_caller", "_target"];
+
+    // Don't track self-treatment
+    if (_caller isEqualTo _target) exitWith {};
 
     // Remove the old responder
     private _responders = _target getVariable [QGVAR(responders), []];
@@ -64,12 +70,6 @@ private _treatmentEnded = {
 };
 [QGVAR(success), _treatmentEnded] call CBA_fnc_addEventHandler;
 [QGVAR(failure), _treatmentEnded] call CBA_fnc_addEventHandler;
-
-// We stop tracking who is treating a dead patient
-[QEGVAR(medical,death), {
-    params ["_unit"];
-    _unit setVariable [QGVAR(responders), nil];
-}] call CBA_fnc_addEventHandler;
 
 // Update the responders array upon switching unit
 ["unit", {

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -73,21 +73,26 @@ private _treatmentEnded = {
 
 // Update the responders array upon switching unit
 ["unit", {
-    params ["_unit"];
+    params ["_newUnit", "_oldUnit"];
+
+    // In case of respawn nobody is treating you
+    if !(alive _oldUnit) exitWith {
+        _newUnit setVariable [QGVAR(responders), nil];
+    };
 
     // See comments in _treatmentEnded for details
-    private _responders = _unit getVariable [QGVAR(responders), []];
+    private _responders = _newUnit getVariable [QGVAR(responders), []];
     _responders = _responders select {
         !isNull _x &&
         {[_x] call EFUNC(common,isPlayer)}
     };
-    _unit setVariable [QGVAR(responders), _responders];
+    _newUnit setVariable [QGVAR(responders), _responders];
 
     // Raise a notification event if the unit switched to is already being treated
     if !(_responders isEqualTo []) then {
         [
             QEGVAR(medical_feedback,treatment_initiated),
-            [_responders select 0, _unit]
+            [_responders select 0, _newUnit]
         ] call CBA_fnc_localEvent;
     };
 }] call CBA_fnc_addPlayerEventHandler;

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -21,3 +21,60 @@ if (isServer) then {
 [QGVAR(actionCheckPulseLocal), FUNC(actionCheckPulseLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(actionCheckBloodPressureLocal), FUNC(actionCheckBloodPressureLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(actionPlaceInBodyBag), FUNC(actionPlaceInBodyBag)] call CBA_fnc_addEventHandler;
+
+// Notification lets the player known if they're being treated
+[QGVAR(initiated), {
+    params ["_caller", "_target"];
+
+    // Notifications don't make sense for self-healing or when dead
+    if (_target != ACE_player || {_target == _caller} || {!alive _target}) exitWith {};
+
+    // Can't tell who is providing aid when you're unconscious
+    private _name = if IS_UNCONSCIOUS(_target) then {
+        LLSTRING(UnknownPerson);
+    } else {
+        name _caller
+    };
+
+    QGVAR(notification) cutText [format [LLSTRING(Notification), _name], "PLAIN DOWN"];
+
+    // We track who is currently treating the unit
+    private _responders = _target getVariable [QGVAR(responders), []];
+    _responders pushBack _caller;
+    _target setVariable [QGVAR(responders), _responders];
+}] call CBA_fnc_addEventHandler;
+
+// Notification may no longer apply when treatment ends
+private _treatmentEnded = {
+    params ["_caller", "_target"];
+
+    // Notifications don't make sense for self-healing or when dead
+    if (_target != ACE_player || {_target == _caller} || {!alive _target}) exitWith {};
+
+    // Remove from tracking (in place)
+    private _responders = _target getVariable [QGVAR(responders), []];
+    _responders deleteAt (_responders find _caller);
+
+    // If someone else is still treating it's useful to know
+    if (_responders isEqualTo []) then {
+        QGVAR(notification) cutFadeOut 1;
+    } else {
+        private _name = if IS_UNCONSCIOUS(_target) then {
+            LLSTRING(UnknownPerson);
+        } else {
+            name (_responders select 0)
+        };
+        QGVAR(notification) cutText [format [LLSTRING(Notification2), _name], "PLAIN DOWN"];
+    };
+};
+[QGVAR(success), _treatmentEnded] call CBA_fnc_addEventHandler;
+[QGVAR(failure), _treatmentEnded] call CBA_fnc_addEventHandler;
+
+// A dead patient no longer needs a notification
+[QEGVAR(medical,death), {
+    params ["_unit"];
+    _unit setVariable [QGVAR(responders), nil];
+    if (_unit == ACE_player) then {
+        QGVAR(notification) cutFadeOut 1;
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -202,6 +202,9 @@ if !(_startCallback isEqualType {}) then {
     ["isnotinside"]
 ] call EFUNC(common,progressBar);
 
+// Treatment event is used for aid notifications
+[QGVAR(initiated), [_caller, _target], _target] call CBA_fnc_targetEvent;
+
 // display icon
 private _iconDisplayed = getText (_config >> "actionIconPath");
 

--- a/addons/medical_treatment/functions/fnc_treatment_failure.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment_failure.sqf
@@ -54,3 +54,6 @@ if !(_callback isEqualType {}) then {
 };
 
 _args call _callback;
+
+// Treatment event is used for aid notifications
+[QGVAR(failure), [_caller, _target], _target] call CBA_fnc_targetEvent;

--- a/addons/medical_treatment/functions/fnc_treatment_success.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment_success.sqf
@@ -69,3 +69,6 @@ _args pushBack _bloodLossOnBodyPart;
 _args call FUNC(litterCreate);
 
 ["ace_treatmentSucceded", [_caller, _target, _bodyPart, _className]] call CBA_fnc_localEvent;
+
+// Treatment event is used for aid notifications
+[QGVAR(success), [_caller, _target], _target] call CBA_fnc_targetEvent;

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -371,17 +371,6 @@
                 <Japanese>医療廃棄物オブジェクトが表示されつづける時間を設定しますか？-1 は永遠です。</Japanese>
             </Key>
         </Container>
-        <Container name="AidNotification">
-            <Key ID="STR_ACE_Medical_treatment_Notification">
-                <English>% is treating you</English>
-            </Key>
-            <Key ID="STR_ACE_Medical_treatment_Notification2">
-                <English>% is still treating you</English>
-            </Key>
-            <Key ID="STR_ACE_Medical_treatment_UnknownPerson">
-                <English>Somebody</English>
-            </Key>
-        </Container>
         <Key ID="STR_ACE_Medical_treatment_medicalSupplyCrate">
             <English>[ACE] Medical Supply Crate (Basic)</English>
             <Russian>[ACE] Ящик с медикаментами (базовая медицина)</Russian>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -371,6 +371,17 @@
                 <Japanese>医療廃棄物オブジェクトが表示されつづける時間を設定しますか？-1 は永遠です。</Japanese>
             </Key>
         </Container>
+        <Container name="AidNotification">
+            <Key ID="STR_ACE_Medical_treatment_Notification">
+                <English>% is treating you</English>
+            </Key>
+            <Key ID="STR_ACE_Medical_treatment_Notification2">
+                <English>% is still treating you</English>
+            </Key>
+            <Key ID="STR_ACE_Medical_treatment_UnknownPerson">
+                <English>Somebody</English>
+            </Key>
+        </Container>
         <Key ID="STR_ACE_Medical_treatment_medicalSupplyCrate">
             <English>[ACE] Medical Supply Crate (Basic)</English>
             <Russian>[ACE] Ящик с медикаментами (базовая медицина)</Russian>


### PR DESCRIPTION
One of ShackTac's added features, these provide the player with feedback to show that they are being treated.

I imagine we will want to provide a setting for these, but I think for development's sake we should worry about adding new settings at the end when we know everything is working without them.
