### PR TITLE
RHS Compats - Update bases classes for RHS 4.6

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_afrf3/CfgMagazines.hpp
@@ -1,8 +1,8 @@
 class cfgMagazines {
     class VehicleMagazine;
-    class rhs_30Rnd_545x39_AK;
+    class rhs_30Rnd_545x39_7N6_AK;
 
-    class rhs_100Rnd_762x54mmR: rhs_30Rnd_545x39_AK {
+    class rhs_100Rnd_762x54mmR: rhs_30Rnd_545x39_7N6_AK {
         ace_isbelt = 1;
     };
     class rhs_mag_127x108mm_50: VehicleMagazine {

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -67,7 +67,8 @@ class CfgWeapons {
         ACE_barrelTwist = 240.03;
         ACE_barrelLength = 645.16;
     };
-    class rhs_weap_rpk74m: rhs_weap_pkp {
+    class rhs_weap_rpk74;
+    class rhs_weap_rpk74m: rhs_weap_rpk74 {
         ACE_barrelTwist = 195.072;
         ACE_barrelLength = 589.28;
     };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -67,8 +67,7 @@ class CfgWeapons {
         ACE_barrelTwist = 240.03;
         ACE_barrelLength = 645.16;
     };
-    class rhs_weap_rpk74;
-    class rhs_weap_rpk74m: rhs_weap_rpk74 {
+    class rhs_weap_rpk74: rhs_weap_pkp {
         ACE_barrelTwist = 195.072;
         ACE_barrelLength = 589.28;
     };

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -7,9 +7,6 @@ class cfgMagazines {
     class rhsusf_100Rnd_556x45_soft_pouch: rhs_mag_30Rnd_556x45_M855A1_Stanag {
         ace_isbelt = 1;
     };
-    class rhsusf_100Rnd_556x45_M200_soft_pouch: rhs_mag_30Rnd_556x45_M200_Stanag {
-        ace_isbelt = 1;
-    };
     class rhsusf_50Rnd_762x51: CA_Magazine {
         ace_isbelt = 1;
     };

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -2,7 +2,6 @@ class cfgMagazines {
     class CA_Magazine;
     class VehicleMagazine;
     class rhs_mag_30Rnd_556x45_M855A1_Stanag;
-    class rhs_mag_30Rnd_556x45_M200_Stanag;
 
     class rhsusf_100Rnd_556x45_soft_pouch: rhs_mag_30Rnd_556x45_M855A1_Stanag {
         ace_isbelt = 1;


### PR DESCRIPTION
```
Updating base class rhs_30Rnd_545x39_7N6_AK->rhs_30Rnd_545x39_AK, by z\ace\addons\compat_rhs_afrf3\config.cpp/cfgMagazines/rhs_100Rnd_762x54mmR/ (original rhsafrf\addons\rhs_c_weapons\config.bin)
Updating base class rhs_weap_rpk74->rhs_weap_pkp, by z\ace\addons\compat_rhs_afrf3\config.cpp/CfgWeapons/rhs_weap_rpk74m/ (original rhsafrf\addons\rhs_c_weapons\config.bin)
Updating base class rhsusf_100Rnd_556x45_soft_pouch->rhs_mag_30Rnd_556x45_M200_Stanag, by z\ace\addons\compat_rhs_usf3\config.cpp/cfgMagazines/rhsusf_100Rnd_556x45_M200_soft_pouch/ (original rhsusf\addons\rhsusf_c_weapons\config.bin)
```
