### PR TITLE
Prevent bandaging when not bleeding

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -12,7 +12,7 @@ class GVAR(Actions) {
         treatmentTime = QFUNC(getBandageTime);
         treatmentTimeSelfCoef = 1;
         items[] = {{"ACE_fieldDressing", "ACE_packingBandage", "ACE_elasticBandage", "ACE_quikclot"}};
-        condition = QUOTE(!GVAR(advancedBandages));
+        condition = QFUNC(canBandage);
         itemConsumed = 1;
         callbackSuccess = QFUNC(treatmentBandage);
         callbackFailure = "";
@@ -30,7 +30,6 @@ class GVAR(Actions) {
     class FieldDressing: BasicBandage {
         displayName = CSTRING(Actions_FieldDressing);
         items[] = {"ACE_fieldDressing"};
-        condition = QGVAR(advancedBandages);
         litter[] = {
             {"All", "_bloodLossOnBodyPart > 0", {{"ACE_MedicalLitter_bandage2", "ACE_MedicalLitter_bandage3"}}},
             {"All", "_bloodLossOnBodyPart <= 0", {"ACE_MedicalLitter_clean"}}
@@ -39,7 +38,6 @@ class GVAR(Actions) {
     class PackingBandage: BasicBandage {
         displayName = CSTRING(Actions_PackingBandage);
         items[] = {"ACE_packingBandage"};
-        condition = QGVAR(advancedBandages);
         litter[] = {
             {"All", "", {"ACE_MedicalLitter_packingBandage"}},
             {"All", "_bloodLossOnBodyPart > 0", {{"ACE_MedicalLitter_bandage2", "ACE_MedicalLitter_bandage3"}}},
@@ -49,7 +47,6 @@ class GVAR(Actions) {
     class ElasticBandage: BasicBandage {
         displayName = CSTRING(Actions_ElasticBandage);
         items[] = {"ACE_elasticBandage"};
-        condition = QGVAR(advancedBandages);
         litter[] = {
             {"All", "_bloodLossOnBodyPart > 0", {{"ACE_MedicalLitter_bandage2", "ACE_MedicalLitter_bandage3"}}},
             {"All", "_bloodLossOnBodyPart <= 0", {"ACE_MedicalLitter_clean"}}
@@ -58,7 +55,6 @@ class GVAR(Actions) {
     class QuikClot: BasicBandage {
         displayName = CSTRING(Actions_QuikClot);
         items[] = {"ACE_quikclot"};
-        condition = QGVAR(advancedBandages);
         litter[] = {
             {"All", "", {"ACE_MedicalLitter_QuickClot"}},
             {"All", "_bloodLossOnBodyPart > 0", {{"ACE_MedicalLitter_bandage2", "ACE_MedicalLitter_bandage3"}}},

--- a/addons/medical_treatment/XEH_PREP.hpp
+++ b/addons/medical_treatment/XEH_PREP.hpp
@@ -42,6 +42,7 @@ PREP(addToTriageCard);
 PREP(bodyCleanupLoop);
 PREP(calculateBlood);
 PREP(canAccessMedicalEquipment);
+PREP(canBandage);
 PREP(dropDownTriageCard);
 PREP(findMostEffectiveWound);
 PREP(getBandageTime);

--- a/addons/medical_treatment/functions/fnc_canBandage.sqf
+++ b/addons/medical_treatment/functions/fnc_canBandage.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: SilentSpike
+ * Prevents bandage actions from showing if selected body part isn't bleeding.
+ * Toggles between showing all or only basic bandage action for advanced setting.
+ *
+ * Arguments:
+ * 0: The medic <OBJECT>
+ * 1: The patient <OBJECT>
+ * 2: Body part <STRING>
+ * 3: Treatment class name <STRING>
+ *
+ * ReturnValue:
+ * Can Bandage <BOOL>
+ *
+ * Public: No
+ */
+
+params ["_medic", "_patient", "_bodypart", "_bandage"];
+
+// Bandage type and bandage setting XNOR to show only active actions
+if ((_bandage == "BasicBandage") isEqualTo GVAR(advancedBandages)) exitWith { false };
+
+private _index = ALL_BODY_PARTS find toLower _bodypart;
+private _canBandage = false;
+
+{
+    _x params ["", "", "_bodyPartN", "_amountOf", "_bleeding"];
+
+    // If any single wound on the bodypart is bleeding bandaging can go ahead
+    if (_bodyPartN == _index && {_amountOf * _bleeding > 0}) exitWith {
+        _canBandage = true;
+    };
+} forEach (_patient getVariable [QEGVAR(medical,openWounds), []]);
+
+_canBandage


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent the bandage actions from showing when the inspected body part isn't bleeding.

This a quality of life improvement because there's never a situation where you'd want to bandage a body part that isn't bleeding.