### PR TITLE
Arsenal - Add support for mission defined unit insignias

### DIFF
--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -162,6 +162,16 @@ switch true do {
                 {
                     ["CfgUnitInsignia", configName _x, _ctrlPanel, "texture"] call FUNC(addListBoxItem);
                 } foreach ("true" configClasses (configFile >> "CfgUnitInsignia"));
+                
+                {
+                    private _displayName = getText (_x >> "displayName");
+                    private _className = configName _x;
+                    private _lbAdd =  _ctrlPanel lbAdd _displayName;
+
+                    _ctrlPanel lbSetData [_lbAdd, _className];
+                    _ctrlPanel lbSetPicture [_lbAdd, getText (_x >> "texture")];
+                    _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _className]];
+                } foreach ("true" configClasses (missionConfigFile >> "CfgUnitInsignia"));
             };
         };
     };

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -412,7 +412,14 @@ switch (GVAR(currentLeftPanel)) do {
 
         call FUNC(showItem);
         TOGGLE_RIGHT_PANEL_HIDE
-        [_display, _control, _curSel, (configFile >> "CfgUnitInsignia" >> _item)] call FUNC(itemInfo);
+
+        private _unitInsigniaConfig = (configFile >> "CfgUnitInsignia" >> _item);
+
+        if (configName _unitInsigniaConfig isEqualTo "") then {
+            [_display, _control, _curSel, (missionConfigFile >> "CfgUnitInsignia" >> _item)] call FUNC(itemInfo);
+        } else {
+            [_display, _control, _curSel, _unitInsigniaConfig] call FUNC(itemInfo);
+        };
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add support for mission defined unitInsignias in ACE Arsenal, with a working author infobox.

