### PR TITLE
Add the ability to edit user placed markers

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -130,6 +130,7 @@ System98
 SzwedzikPL <szwedzikpl@gmail.com>
 Tachi <zaveruha007@gmail.com>
 Tessa Elieff <Fastroping Sound - CreativeCommons Attributions 3.0>
+Timi007 <timi007@gmx.net>
 Toaster <jonathan.pereira@gmail.com>
 Tonic
 Tourorist <tourorist@gmail.com>

--- a/addons/markers/XEH_preInit.sqf
+++ b/addons/markers/XEH_preInit.sqf
@@ -18,10 +18,11 @@ if (isNil QGVAR(MarkersCache)) then {
         private _marker = _config select _a;
 
         if (getNumber (_marker >> "scope") == 2) then {
+            private _class = configName _marker;
             private _name = getText (_marker >> "name");
             private _icon = getText (_marker >> "icon");
 
-            GVAR(MarkersCache) pushBack [_name, _a, _icon];
+            GVAR(MarkersCache) pushBack [_name, _a, _icon, _class];
         };
     };
 };
@@ -36,6 +37,7 @@ if (isNil QGVAR(MarkerColorsCache)) then {
         private _marker = _config select _a;
 
         if (getNumber (_marker >> "scope") == 2) then {
+            private _class = configName _marker;
             private _name = getText (_marker >> "name");
             private _rgba = getArray (_marker >> "color");
 
@@ -48,7 +50,7 @@ if (isNil QGVAR(MarkerColorsCache)) then {
             _rgba params ["_red", "_green", "_blue", "_alpha"];
             private _icon = format ["#(argb,8,8,3)color(%1,%2,%3,%4)", _red, _green, _blue, _alpha];
 
-            GVAR(MarkerColorsCache) pushBack [_name, _a, _icon];
+            GVAR(MarkerColorsCache) pushBack [_name, _a, _icon, _class];
         };
     };
 };

--- a/addons/markers/XEH_preInit.sqf
+++ b/addons/markers/XEH_preInit.sqf
@@ -17,7 +17,7 @@ if (isNil QGVAR(MarkersCache)) then {
     for "_a" from 0 to (count _config - 1) do {
         private _marker = _config select _a;
 
-        if (getNumber (_marker >> "scope") == 2) then {
+        if (getNumber (_marker >> "scope") isEqualTo 2) then {
             private _class = configName _marker;
             private _name = getText (_marker >> "name");
             private _icon = getText (_marker >> "icon");
@@ -36,7 +36,7 @@ if (isNil QGVAR(MarkerColorsCache)) then {
     for "_a" from 0 to (count _config - 1) do {
         private _marker = _config select _a;
 
-        if (getNumber (_marker >> "scope") == 2) then {
+        if (getNumber (_marker >> "scope") isEqualTo 2) then {
             private _class = configName _marker;
             private _name = getText (_marker >> "name");
             private _rgba = getArray (_marker >> "color");

--- a/addons/markers/functions/fnc_getEnabledChannels.sqf
+++ b/addons/markers/functions/fnc_getEnabledChannels.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: commy2
+ * Author: commy2, Timi007
  * Return enabled channels.
  *
  * Arguments:

--- a/addons/markers/functions/fnc_getEnabledChannels.sqf
+++ b/addons/markers/functions/fnc_getEnabledChannels.sqf
@@ -40,12 +40,8 @@ if (_localize) then {
     if (setCurrentChannel 4) then {
         _enabledChannels pushBack localize "str_channel_vehicle";
     };
-
-    if (setCurrentChannel 5) then {
-        _enabledChannels pushBack localize "str_channel_direct";
-    };
 } else {
-    for "_i" from 0 to 5 do {
+    for "_i" from 0 to 4 do {
         if (setCurrentChannel _i) then {
             _enabledChannels pushBack _i;
         };

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -55,7 +55,7 @@
 
     //check if entity under mouse is a user marker
     if (_mouseOverType isEqualTo "marker") then {
-        if (_marker find "_USER_DEFINED" != -1) then {
+        if !((_marker find "_USER_DEFINED") isEqualTo -1) then {
             GVAR(editingMarker) = _marker;
             //hide marker which is being edited because if the user cancels editing, it will still exits unchanged
             GVAR(editingMarker) setMarkerAlphaLocal 0;
@@ -71,7 +71,7 @@
 
     ////////////////////
     // Calculate center position of the marker placement ctrl
-    if (GVAR(editingMarker) != "") then {
+    if !(GVAR(editingMarker) isEqualTo "") then {
         //prevent changing the original marker position
         GVAR(currentMarkerPosition) = markerPos GVAR(editingMarker);
     } else {
@@ -86,7 +86,7 @@
     // prevent vanilla key input
     _display displayAddEventHandler ["KeyDown", {(_this select 1) in [200, 208]}];
 
-    if ((markerText GVAR(editingMarker)) != "") then {
+    if !((markerText GVAR(editingMarker)) isEqualTo "") then {
         //fill text input with text from marker which is being edited
         _text ctrlSetText (markerText GVAR(editingMarker));
     };
@@ -172,7 +172,7 @@
             };
         };
 
-        private _selectChannel = if (GVAR(editingMarker) != "") then {
+        private _selectChannel = if !(GVAR(editingMarker) isEqualTo "") then {
             //get the channel where the marker was placed in
             parseNumber ((GVAR(editingMarker) splitString "/") param [2, "3"])
         } else {
@@ -261,7 +261,7 @@
     // init marker angle slider
     _aceAngleSlider sliderSetRange [-180, 180];
 
-    if (GVAR(editingMarker) != "") then {
+    if !(GVAR(editingMarker) isEqualTo "") then {
         //get the original direction
         GVAR(currentMarkerAngle) = markerDir GVAR(editingMarker);
     };

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -48,7 +48,7 @@
 
     private _mapDisplay = displayParent _display;
     if (isNull _mapDisplay) exitWith {ERROR("No Map");};
-    private _mapCtrl = _mapDisplay displayctrl 51;
+    private _mapCtrl = _mapDisplay displayCtrl 51;
 
     GVAR(editingMarker) = "";
     (ctrlMapMouseOver _mapCtrl) params ["_mouseOverType", "_marker"];
@@ -57,7 +57,7 @@
     if (_mouseOverType isEqualTo "marker") then {
         if !((_marker find "_USER_DEFINED") isEqualTo -1) then {
             GVAR(editingMarker) = _marker;
-            //hide marker which is being edited because if the user cancels editing, it will still exits unchanged
+            //hide marker which is being edited because if the user cancels editing, it will still exist unchanged
             GVAR(editingMarker) setMarkerAlphaLocal 0;
         };
     };
@@ -223,7 +223,7 @@
         _aceShapeLB lbSetPicture [_forEachIndex, _pic];
 
         if ((markerType GVAR(editingMarker)) isEqualTo _classname) then {
-            //if the marker is beeing edited then get the original shape
+            //if the marker is being edited then get the original shape
             GVAR(curSelMarkerShape) = _forEachIndex;
         };
     } forEach GVAR(MarkersCache);
@@ -245,7 +245,7 @@
         _aceColorLB lbSetPicture [_forEachIndex, _pic];
 
         if ((markerColor GVAR(editingMarker)) isEqualTo _classname) then {
-            //if the marker is beeing edited then get the original color
+            //if the marker is being edited then get the original color
             GVAR(curSelMarkerColor) = _forEachIndex;
         };
     } forEach GVAR(MarkerColorsCache);

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: BIS, commy2
+ * Author: BIS, commy2, Timi007
  * Sets up the marker placement
  * Run instead of \a3\ui_f\scripts\GUI\RscDisplayInsertMarker.sqf
  *

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -46,23 +46,12 @@
     private _aceAngleSlider = _display displayctrl 1220;
     private _aceAngleSliderText = _display displayctrl 1221;
 
-    ////////////////////
-    // Install MapDrawEH on current map
-    private _mapIDD = -1;
-
-    {
-        if (!isNull (findDisplay _x)) exitWith {
-            _mapIDD = _x;
-        };
-        false
-    } count [12, 37, 52, 53, 160];
-
-    if (_mapIDD == -1) exitWith {
-        ERROR("No Map?");
-    };
+    private _mapDisplay = displayParent _display;
+    if (isNull _mapDisplay) exitWith {ERROR("No Map");};
+    private _mapCtrl = _mapDisplay displayctrl 51;
 
     GVAR(editingMarker) = "";
-    (ctrlMapMouseOver ((finddisplay _mapIDD) displayctrl 51)) params ["_mouseOverType", "_marker"];
+    (ctrlMapMouseOver _mapCtrl) params ["_mouseOverType", "_marker"];
 
     //check if entity under mouse is a user marker
     if (_mouseOverType isEqualTo "marker") then {
@@ -73,9 +62,11 @@
         };
     };
 
-    if !(_mapIDD in GVAR(mapDisplaysWithDrawEHs)) then {
-        GVAR(mapDisplaysWithDrawEHs) pushBack _mapIDD;
-        ((finddisplay _mapIDD) displayctrl 51) ctrlAddEventHandler ["Draw", {_this call FUNC(mapDrawEH)}]; // @todo check if persistent
+    ////////////////////
+    // Install MapDrawEH on current map
+    if !((ctrlIDD _mapDisplay) in GVAR(mapDisplaysWithDrawEHs)) then {
+        GVAR(mapDisplaysWithDrawEHs) pushBack (ctrlIDD _mapDisplay);
+        _mapCtrl ctrlAddEventHandler ["Draw", {_this call FUNC(mapDrawEH)}]; // @todo check if persistent
     };
 
     ////////////////////
@@ -86,7 +77,7 @@
     } else {
         private _pos = ctrlPosition _picture;
         _pos = [(_pos select 0) + (_pos select 2) / 2, (_pos select 1) + (_pos select 3) / 2];
-        GVAR(currentMarkerPosition) = ((finddisplay _mapIDD) displayctrl 51) ctrlMapScreenToWorld _pos;
+        GVAR(currentMarkerPosition) = _mapCtrl ctrlMapScreenToWorld _pos;
     };
 
     //Hide the bis picture:

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -61,6 +61,18 @@
         ERROR("No Map?");
     };
 
+    GVAR(editingMarker) = "";
+    (ctrlMapMouseOver ((finddisplay _mapIDD) displayctrl 51)) params ["_mouseOverType", "_marker"];
+
+    //check if entity under mouse is a user marker
+    if (_mouseOverType isEqualTo "marker") then {
+        if (_marker find "_USER_DEFINED" != -1) then {
+            GVAR(editingMarker) = _marker;
+            //hide marker which is being edited because if the user cancels editing, it will still exits unchanged
+            GVAR(editingMarker) setMarkerAlphaLocal 0;
+        };
+    };
+
     if !(_mapIDD in GVAR(mapDisplaysWithDrawEHs)) then {
         GVAR(mapDisplaysWithDrawEHs) pushBack _mapIDD;
         ((finddisplay _mapIDD) displayctrl 51) ctrlAddEventHandler ["Draw", {_this call FUNC(mapDrawEH)}]; // @todo check if persistent
@@ -68,10 +80,14 @@
 
     ////////////////////
     // Calculate center position of the marker placement ctrl
-    private _pos = ctrlPosition _picture;
-    _pos = [(_pos select 0) + (_pos select 2) / 2, (_pos select 1) + (_pos select 3) / 2];
-
-    GVAR(currentMarkerPosition) = ((findDisplay _mapIDD) displayCtrl 51) ctrlMapScreenToWorld _pos;
+    if (GVAR(editingMarker) != "") then {
+        //prevent changing the original marker position
+        GVAR(currentMarkerPosition) = markerPos GVAR(editingMarker);
+    } else {
+        private _pos = ctrlPosition _picture;
+        _pos = [(_pos select 0) + (_pos select 2) / 2, (_pos select 1) + (_pos select 3) / 2];
+        GVAR(currentMarkerPosition) = ((finddisplay _mapIDD) displayctrl 51) ctrlMapScreenToWorld _pos;
+    };
 
     //Hide the bis picture:
     _picture ctrlShow false;
@@ -79,12 +95,16 @@
     // prevent vanilla key input
     _display displayAddEventHandler ["KeyDown", {(_this select 1) in [200, 208]}];
 
+    if ((markerText GVAR(editingMarker)) != "") then {
+        //fill text input with text from marker which is being edited
+        _text ctrlSetText (markerText GVAR(editingMarker));
+    };
 
     //Focus on the text input
     ctrlSetFocus _text;
 
     //--- Background
-    _pos = ctrlposition _text;
+    private _pos = ctrlposition _text;
     _pos params ["_posX", "_posY", "_posW", "_posH"];
     _posX = _posX + 0.01;
     _posY = _posY min ((safeZoneH + safeZoneY) - (8 * _posH + 8 * BORDER));  //prevent buttons being placed below bottom edge of screen
@@ -161,12 +181,20 @@
             };
         };
 
-        private _currentChannelName = CHANNEL_NAMES param [currentChannel, localize "str_channel_group"];
+        private _selectChannel = if (GVAR(editingMarker) != "") then {
+            //get the channel where the marker was placed in
+            parseNumber ((GVAR(editingMarker) splitString "/") param [2, "3"])
+        } else {
+            currentChannel
+        };
+
+        private _currentChannelName = CHANNEL_NAMES param [_selectChannel, localize "str_channel_group"];
 
         // select current channel in list box, must be done after lbDelete
         for "_j" from 0 to (lbSize _channel - 1) do {
             if (_channel lbText _j == _currentChannelName) then {
                 _channel lbSetCurSel _j;
+                setCurrentChannel (CHANNEL_NAMES find _currentChannelName);
             };
         };
 
@@ -198,10 +226,15 @@
     // init marker shape lb
     lbClear _aceShapeLB;
     {
-        _x params ["_add", "_set", "_pic"];
+        _x params ["_add", "_set", "_pic", "_classname"];
         _aceShapeLB lbAdd _add;
         _aceShapeLB lbSetValue [_forEachIndex, _set];
         _aceShapeLB lbSetPicture [_forEachIndex, _pic];
+
+        if ((markerType GVAR(editingMarker)) isEqualTo _classname) then {
+            //if the marker is beeing edited then get the original shape
+            GVAR(curSelMarkerShape) = _forEachIndex;
+        };
     } forEach GVAR(MarkersCache);
 
     private _curSelShape = GETGVAR(curSelMarkerShape,0);
@@ -215,10 +248,15 @@
     // init marker color lb
     lbClear _aceColorLB;
     {
-        _x params ["_add", "_set", "_pic"];
+        _x params ["_add", "_set", "_pic", "_classname"];
         _aceColorLB lbAdd _add;
         _aceColorLB lbSetValue [_forEachIndex, _set];
         _aceColorLB lbSetPicture [_forEachIndex, _pic];
+
+        if ((markerColor GVAR(editingMarker)) isEqualTo _classname) then {
+            //if the marker is beeing edited then get the original color
+            GVAR(curSelMarkerColor) = _forEachIndex;
+        };
     } forEach GVAR(MarkerColorsCache);
 
     private _curSelColor = GETGVAR(curSelMarkerColor,0);
@@ -231,6 +269,11 @@
     ////////////////////
     // init marker angle slider
     _aceAngleSlider sliderSetRange [-180, 180];
+
+    if (GVAR(editingMarker) != "") then {
+        //get the original direction
+        GVAR(currentMarkerAngle) = markerDir GVAR(editingMarker);
+    };
 
     private _curSelAngle = GETGVAR(currentMarkerAngle,0);
     _aceAngleSlider sliderSetPosition _curSelAngle;

--- a/addons/markers/functions/fnc_placeMarker.sqf
+++ b/addons/markers/functions/fnc_placeMarker.sqf
@@ -20,8 +20,8 @@ disableserialization;
 params ["_display", "_closeNum"];
 TRACE_2("params",_display,_closeNum);
 
-if (_closeNum == 1) then {
-    if (GVAR(editingMarker) != "") then {
+if (_closeNum isEqualTo 1) then {
+    if !(GVAR(editingMarker) isEqualTo "") then {
         //delete "old" marker
         deleteMarker GVAR(editingMarker);
     };
@@ -38,7 +38,7 @@ if (_closeNum == 1) then {
 
     }, []] call CBA_fnc_execNextFrame;
 } else {
-    if (GVAR(editingMarker) != "") then {
+    if !(GVAR(editingMarker) isEqualTo "") then {
         //editing was canceled show the original marker again
         GVAR(editingMarker) setMarkerAlphaLocal 1;
     };

--- a/addons/markers/functions/fnc_placeMarker.sqf
+++ b/addons/markers/functions/fnc_placeMarker.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: commy2
+ * Author: commy2, Timi007
  * MarkerPlacement closed
  *
  * Arguments:

--- a/addons/markers/functions/fnc_placeMarker.sqf
+++ b/addons/markers/functions/fnc_placeMarker.sqf
@@ -21,6 +21,10 @@ params ["_display", "_closeNum"];
 TRACE_2("params",_display,_closeNum);
 
 if (_closeNum == 1) then {
+    if (GVAR(editingMarker) != "") then {
+        //delete "old" marker
+        deleteMarker GVAR(editingMarker);
+    };
     // set and send marker data the next frame. the actual marker isn't created yet
     [{
         [QGVAR(setMarkerNetwork), [
@@ -33,4 +37,11 @@ if (_closeNum == 1) then {
         ]] call CBA_fnc_globalEvent;
 
     }, []] call CBA_fnc_execNextFrame;
+} else {
+    if (GVAR(editingMarker) != "") then {
+        //editing was canceled show the original marker again
+        GVAR(editingMarker) setMarkerAlphaLocal 1;
+    };
 };
+
+GVAR(editingMarker) = "";

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -21,8 +21,7 @@
     localize "str_channel_side", \
     localize "str_channel_command", \
     localize "str_channel_group", \
-    localize "str_channel_vehicle", \
-    localize "str_channel_direct" \
+    localize "str_channel_vehicle" \
 ]
 
 #define MOVE_RESTRICTION_NOBODY -1


### PR DESCRIPTION
**When merged this pull request will:**
- Add the ability to edit user placed markers by double clicking at a marker
- Remove the direct channel as a valid channel because selecting it ingame will not select the default (group) channel but instead the global
- Optimize the method to get the current map display
- To some extend also allow to copy markers by e.g. starting to edit a marker, canceling it and then creating a new marker with the same properties as the edited marker