### PR TITLE
Zeus - Group Side Module: preserve group id and assigned team

### DIFF
--- a/addons/zeus/functions/fnc_moduleGroupSide.sqf
+++ b/addons/zeus/functions/fnc_moduleGroupSide.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: SilentSpike
+ * Author: SilentSpike, Brett
  * Zeus module function to change side of a group on dialog confirmation
  *
  * Arguments:
@@ -25,20 +25,36 @@ if (_side == _newSide) exitWith {};
 private _oldGroup = group _unit;
 private _newGroup = createGroup _newSide;
 
+// Preserve groupid from the previous group if doesn't already exist
+call {
+    scopeName "groupidsearch";
+    {
+        if (side _x isEqualTo _newSide && {(groupId _oldGroup) isEqualTo (groupId _newGroup)}) then {
+            breakOut "groupidsearch";
+        }
+    } forEach allGroups;
+    _newGroup setGroupIdGlobal [groupId _oldGroup];
+};
+
 // Pretty hacky, will replace units return group with this new group if unconcious
 if (GETVAR(_unit,ACE_isUnconscious,false) && {GETMVAR(EGVAR(medical,moveUnitsFromGroupOnUnconscious),false)}) then {
-        private _previousGroupsList = _unit getVariable [QEGVAR(common,previousGroupSwitchTo), []];
+    private _previousGroupsList = _unit getVariable [QEGVAR(common,previousGroupSwitchTo), []];
 
-        {
-            if ("ACE_isUnconscious" == (_x select 2)) exitWith {
-                _x set [0,_newGroup];
-                _x set [1,_newSide];
-                _previousGroupsList set [_forEachIndex, _x];
-            };
-        } forEach _previousGroupsList;
+    {
+        if ("ACE_isUnconscious" == (_x select 2)) exitWith {
+            _x set [0,_newGroup];
+            _x set [1,_newSide];
+            _previousGroupsList set [_forEachIndex, _x];
+        };
+    } forEach _previousGroupsList;
 
-        _unit setVariable [QEGVAR(common,previousGroupSwitchTo), _previousGroupsList, true];
+    _unit setVariable [QEGVAR(common,previousGroupSwitchTo), _previousGroupsList, true];
 } else {
-    (units _unit) joinSilent _newGroup;
+    // Preserve assignedTeam for each unit
+    {
+        private _team = assignedTeam _x;
+        [_x] joinSilent _newGroup;
+        _x assignTeam _team;
+    } forEach units _unit;
     deleteGroup _oldGroup;
 };

--- a/addons/zeus/functions/fnc_moduleGroupSide.sqf
+++ b/addons/zeus/functions/fnc_moduleGroupSide.sqf
@@ -26,13 +26,7 @@ private _oldGroup = group _unit;
 private _newGroup = createGroup _newSide;
 
 // Preserve groupid from the previous group if doesn't already exist
-call {
-    scopeName "groupidsearch";
-    {
-        if (side _x isEqualTo _newSide && {(groupId _oldGroup) isEqualTo (groupId _newGroup)}) then {
-            breakOut "groupidsearch";
-        }
-    } forEach allGroups;
+if ((allGroups findIf {side _x isEqualTo _newSide && {(groupId _oldGroup) isEqualTo (groupId _newGroup)}}) == -1) then {
     _newGroup setGroupIdGlobal [groupId _oldGroup];
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Close #6568 
- Preserve the group id when switching the group's side if it is not taken
- Preserve the assigned team color of units in the group being switched

**Notes:**
If the `Move units from group on unconscious` setting is enabled and a unit is unconscious when the module is used they will join the new group when they are woken up as expected. They will not keep their assigned team however and will join the white team when woken up. That would require changing code related to the `moveUnitsFromGroupOnUnconscious` setting and I don't think it is worth it for this edge case.