### PR TITLE
Arsenal - Filter firemodes for precision display by showToPlayer

### DIFF
--- a/addons/arsenal/functions/fnc_statTextStatement_accuracy.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_accuracy.sqf
@@ -23,7 +23,9 @@ private _fireModes = getArray (_config >> "modes");
 private _dispersion = [];
 
 {
-    _dispersion pushBackUnique (getNumber (_config >> _x >> "dispersion"));
+    if (getNumber (_config >> _x >> "showToPlayer") != 0) then {
+        _dispersion pushBackUnique (getNumber (_config >> _x >> "dispersion"));
+    };
 } foreach _fireModes;
 
 _dispersion sort true;


### PR DESCRIPTION
**When merged this pull request will:**
- Change the precision display in the ACE Arsenal to ignore AI-only firemodes

There is a number of weapons, such as the NIArms M14DMR, RHS M249s and NIArms SiG 553s, that have an AI-only firemode with a lower `dispersion` value than any mode available to players. The current implementation shows those values on the Arsenal interface, painting a rather misleading picture.

I have considered checking for existence of the `showToPlayer` property first, but it is already defined on the base classes for weapons (`Default`) and firemodes (`Mode_SemiAuto`).
