### PR TITLE
Arsenal - Don't warn when calling removeUnitTrackProjectiles

### DIFF
--- a/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
@@ -29,7 +29,9 @@ cba_diagnostic_projectileMaxLines = 10;
         _x hideObject true;
     } forEach (allMissionObjects "" - [_player]);
 
-    _player call CBA_fnc_removeUnitTrackProjectiles;
+    if ((_player getVariable ["cba_projectile_firedEhId", -1]) != -1) then {
+        _player call CBA_fnc_removeUnitTrackProjectiles;
+    };
     _player setFatigue 0;
 
     // Esc to close mission


### PR DESCRIPTION
Prevents
```
[CBA] (diagnostic) WARNING: Unit has no or a wrong eventId (-1). x\cba\addons\diagnostic\fnc_removeUnitTrackProjectiles.sqf:32
```

