### PR TITLE
Fixes to unconsciousness and damageTypes systems

### DIFF
--- a/addons/medical_damage/ACE_Medical_Injuries.hpp
+++ b/addons/medical_damage/ACE_Medical_Injuries.hpp
@@ -7,7 +7,7 @@ class ACE_Medical_Injuries {
         // Source: Scarle
         //  Also called scrapes, they occur when the skin is rubbed away by friction against another rough surface (e.g. rope burns and skinned knees).
         class Abrasion {
-            causes[] = {"falling", "ropeburn", "vehiclecrash", "unknown"};
+            causes[] = {"falling", "ropeburn", "vehiclecrash", "collision", "unknown"};
             bleeding = 0.001;
             pain = 0.4;
             minDamage = 0.01;
@@ -15,7 +15,7 @@ class ACE_Medical_Injuries {
         };
         // Occur when an entire structure or part of it is forcibly pulled away, such as the loss of a permanent tooth or an ear lobe. Explosions, gunshots, and animal bites may cause avulsions.
         class Avulsion {
-            causes[] = {"explosive", "vehiclecrash", "grenade", "shell", "bullet", "backblast", "bite"};
+            causes[] = {"explosive", "vehiclecrash", "collision", "grenade", "shell", "bullet", "backblast", "bite"};
             bleeding = 0.25;
             pain = 1.0;
             minDamage = 0.01;
@@ -23,7 +23,7 @@ class ACE_Medical_Injuries {
         };
         // Also called bruises, these are the result of a forceful trauma that injures an internal structure without breaking the skin. Blows to the chest, abdomen, or head with a blunt instrument (e.g. a football or a fist) can cause contusions.
         class Contusion {
-            causes[] = {"bullet", "backblast", "punch", "vehiclecrash", "falling"};
+            causes[] = {"bullet", "backblast", "punch", "vehiclecrash", "collision", "falling"};
             bleeding = 0.0;
             pain = 0.3;
             minDamage = 0.02;
@@ -31,7 +31,7 @@ class ACE_Medical_Injuries {
         };
         // Occur when a heavy object falls onto a person, splitting the skin and shattering or tearing underlying structures.
         class Crush {
-            causes[] = {"falling", "vehiclecrash", "punch", "unknown"};
+            causes[] = {"falling", "vehiclecrash", "collision", "punch", "unknown"};
             bleeding = 0.05;
             pain = 0.8;
             minDamage = 0.1;
@@ -39,7 +39,7 @@ class ACE_Medical_Injuries {
         };
         // Slicing wounds made with a sharp instrument, leaving even edges. They may be as minimal as a paper cut or as significant as a surgical incision.
         class Cut {
-            causes[] = {"vehiclecrash", "grenade", "explosive", "shell", "backblast", "stab", "unknown"};
+            causes[] = {"vehiclecrash", "collision", "grenade", "explosive", "shell", "backblast", "stab", "unknown"};
             bleeding = 0.04;
             pain = 0.1;
             minDamage = 0.1;
@@ -47,7 +47,7 @@ class ACE_Medical_Injuries {
         // Also called tears, these are separating wounds that produce ragged edges. They are produced by a tremendous force against the body, either from an internal source as in childbirth, or from an external source like a punch.
         class Laceration {
             selections[] = {"All"};
-            causes[] = {"vehiclecrash", "punch"};
+            causes[] = {"vehiclecrash", "collision", "punch"};
             bleeding = 0.05;
             pain = 0.2;
             minDamage = 0.01;
@@ -95,6 +95,10 @@ class ACE_Medical_Injuries {
             thresholds[] = {{0.5, 5}, {0.3, 2}, {0.05, 1}};
             selectionSpecific = 0;
         };
+        class collision {
+            thresholds[] = {{0.5, 5}, {0.3, 2}, {0.05, 1}};
+            selectionSpecific = 0;
+        };
         class backblast {
             thresholds[] = {{1, 6}, {0.55, 5}, {0, 2}};
             selectionSpecific = 0;
@@ -114,6 +118,10 @@ class ACE_Medical_Injuries {
         class ropeburn {
             thresholds[] = {{0.1, 1}};
             selectionSpecific = 1;
+        };
+        //No related wounds as drowning should not cause wounds/bleeding. Can be extended for internal injuries if they are added.
+        class drowning {
+            thresholds[] = {{0, 0}};
         };
         class unknown {
             thresholds[] = {{0.1, 1}};

--- a/addons/medical_damage/functions/fnc_woundsHandler.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandler.sqf
@@ -22,6 +22,10 @@ if (_typeOfDamage isEqualTo "") then {
     _typeOfDamage = "unknown";
 };
 
+if (isNil {GVAR(allDamageTypesData) getVariable _typeOfDamage} ) then {
+    _typeOfDamage = "unknown";
+};
+
 // Administration for open wounds and ids
 private _openWounds = _unit getVariable [QEGVAR(medical,openWounds), []];
 private _woundID = _unit getVariable [QEGVAR(medical,lastUniqueWoundID), 1];  // Unique wound ids are not used anywhere: ToDo Remove from openWounds array

--- a/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
@@ -26,17 +26,14 @@ if (_typeOfDamage isEqualTo "") then {
     _typeOfDamage = "unknown";
 };
 
+if (isNil {GVAR(allDamageTypesData) getVariable _typeOfDamage} ) then {
+    _typeOfDamage = "unknown";
+};
+
 // Get the damage type information. Format: [typeDamage thresholds, selectionSpecific, woundTypes]
 // WoundTypes are the available wounds for this damage type. Format [[classID, selections, bleedingRate, pain], ..]
 private _damageTypeInfo = [GVAR(allDamageTypesData) getVariable _typeOfDamage] param [0, [[], false, []]];
 _damageTypeInfo params ["_thresholds", "_isSelectionSpecific", "_woundTypes"];
-
-// It appears we are dealing with an unknown type of damage.
-if (_woundTypes isEqualTo []) then {
-    // grabbing the configuration for unknown damage type
-    _damageTypeInfo = [GVAR(allDamageTypesData) getVariable "unknown"] param [0, [[], false, []]];
-    _woundTypes = _damageTypeInfo select 2;
-};
 
 // find the available injuries for this damage type and damage amount
 private _highestPossibleSpot = -1;

--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -116,7 +116,7 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
             // Momentum transfers to body/head for worse wounding
             // Higher momentum results in higher chance for head to be hit for more lethality
             if (_receivedDamage > 0.35) then {
-                private _headHitWeight = (_receivedDamage / 2) max 1;
+                private _headHitWeight = (_receivedDamage / 2) min 1;
                 _woundedHitPoint = selectRandomWeighted ["Body", (1 - _headHitWeight), "Head", _headHitWeight];
             };
         } else {

--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -114,8 +114,10 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
 
             // Significant damage suggests high relative velocity
             // Momentum transfers to body/head for worse wounding
+            // Higher momentum results in higher chance for head to be hit for more lethality
             if (_receivedDamage > 0.35) then {
-                 _woundedHitPoint = selectRandom ["Body", "Head"];
+                private _headHitWeight = (_receivedDamage / 2) max 1;
+                _woundedHitPoint = selectRandomWeighted ["Body", (1 - _headHitWeight), "Head", _headHitWeight];
             };
         } else {
             // Anything else is almost guaranteed to be fire damage

--- a/addons/medical_status/functions/fnc_setUnconscious.sqf
+++ b/addons/medical_status/functions/fnc_setUnconscious.sqf
@@ -27,7 +27,7 @@ _unit setVariable [VAR_UNCON, _active, true];
 if (_active) then {
     // Don't bother setting this if not used
     if (EGVAR(medical,spontaneousWakeUpChance) > 0) then {
-        _unit setVariable [QGVAR(lastWakeUpCheck), CBA_missiontime];
+        _unit setVariable [QEGVAR(medical,lastWakeUpCheck), CBA_missionTime];
     };
 
     if (_unit == ACE_player) then {
@@ -39,7 +39,7 @@ if (_active) then {
     };
 } else {
     // Unit has woken up, no longer need to track this
-    _unit setVariable [QGVAR(lastWakeUpCheck), nil];
+    _unit setVariable [QEGVAR(medical,lastWakeUpCheck), nil];
 };
 
 // This event doesn't correspond to unconscious in statemachine

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -126,7 +126,7 @@ switch (true) do {
             [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
         };
     };
-    case (_bloodLoss > BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput): {
+    case (_bloodLoss / EGVAR(medical,bleedingCoefficient) > BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput ): {
         [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
     };
     case (_bloodLoss > 0): {

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -126,7 +126,7 @@ switch (true) do {
             [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
         };
     };
-    case (_bloodLoss / EGVAR(medical,bleedingCoefficient) > BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput ): {
+    case (_bloodLoss / EGVAR(medical,bleedingCoefficient) > BLOOD_LOSS_KNOCK_OUT_THRESHOLD * _cardiacOutput): {
         [QEGVAR(medical,CriticalVitals), _unit] call CBA_fnc_localEvent;
     };
     case (_bloodLoss > 0): {


### PR DESCRIPTION
**When merged this pull request will:**
- Ensure units go unconscious CriticalVitals when bleeding 0.5 of max regardless of bleedingCoefficient (without this fix a bleeding bleedingCoefficient of 0.5 or less prevents units from going KO due to blood loss in any circumstances)
- Fix unit not having lastWakeUpCheck set due to incorrect variable macro
- Fix the detection for unknown damageTypes (should now fire with damageType "Unknown")
- Add collision damageType used by the damageHandler to the config (same settings as vehicleCrash)
- Changes collision wound location selection to be weighted to increase lethality on collisions with high momentum 

