### PR TITLE
Realistic Names - Rename RGN to V40 Mini-Grenade, fix some trailing spaces

### DIFF
--- a/addons/realisticnames/CfgMagazines.hpp
+++ b/addons/realisticnames/CfgMagazines.hpp
@@ -396,6 +396,10 @@ class CfgMagazines {
         displayName = CSTRING(HandGrenade_Name);
         displayNameShort = "M67";
     };
+    class MiniGrenade: CA_Magazine {
+        displayName = CSTRING(MiniGrenade_Name);
+        displayNameShort = "V40";
+    };
     class SmokeShell: HandGrenade {
         displayName = CSTRING(SmokeShell_Name);
     };

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -395,7 +395,7 @@
             <Russian>HEMTT Контейнер</Russian>
             <Portuguese>HEMTT Contêiner</Portuguese>
             <Hungarian>HEMTT (konténer)</Hungarian>
-            <Italian>HEMTT portacontainer </Italian>
+            <Italian>HEMTT portacontainer</Italian>
             <Japanese>HEMTT コンテナ型</Japanese>
             <Korean>HEMTT 컨테이너</Korean>
             <Chinese>重型增程機動戰術卡車 (貨櫃)</Chinese>
@@ -1242,7 +1242,7 @@
             <German>M112 Sprengladung</German>
             <Spanish>Bloque de demolición M112</Spanish>
             <Polish>Ładunek burzący M112</Polish>
-            <Czech>Výbušná nálož M112 </Czech>
+            <Czech>Výbušná nálož M112</Czech>
             <French>M112 Block de Démolition</French>
             <Russian>M112 подрывной заряд</Russian>
             <Portuguese>M112 Carga de Demolição</Portuguese>
@@ -1390,7 +1390,7 @@
             <German>M15 Panzerabwehrmine</German>
             <Spanish>Mina antitanque M15</Spanish>
             <Polish>Mina przeciwpancerna M15</Polish>
-            <Czech>M15 Protitanková mina </Czech>
+            <Czech>M15 Protitanková mina</Czech>
             <French>M15 Mine antichar</French>
             <Russian>M15 противотанковая мина</Russian>
             <Portuguese>M15 Mina anticarro</Portuguese>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1258,7 +1258,7 @@
             <German>M67 Splittergranate</German>
             <Spanish>Granada de fragmentación M67</Spanish>
             <Polish>Granat obronny M67</Polish>
-            <Czech>Granát M67 </Czech>
+            <Czech>Granát M67</Czech>
             <French>M67 Grenade à fragmentation</French>
             <Russian>M67 ручная осколочная граната</Russian>
             <Portuguese>M67 Granada de fragmentação</Portuguese>
@@ -1268,6 +1268,22 @@
             <Korean>M67 세열 수류탄</Korean>
             <Chinese>M67破片手榴彈</Chinese>
             <Chinesesimp>M67破片手榴弹</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_MiniGrenade_Name">
+            <English>V40 Mini-Grenade</English>
+            <German>V40 Minigranate</German>
+            <Spanish>V40 Mini-Grenade</Spanish>
+            <Polish>V40 Mini-Grenade</Polish>
+            <Czech>V40 Mini-Grenade</Czech>
+            <French>V40 Mini-Grenade</French>
+            <Russian>V40 Mini-Grenade</Russian>
+            <Portuguese>V40 Mini-Grenade</Portuguese>
+            <Hungarian>V40 Mini-Grenade</Hungarian>
+            <Italian>V40 Mini-Grenade</Italian>
+            <Japanese>V40 Mini-Grenade</Japanese>
+            <Korean>V40 Mini-Grenade</Korean>
+            <Chinese>V40 Mini-Grenade</Chinese>
+            <Chinesesimp>V40 Mini-Grenade</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_SmokeShell_Name">
             <English>M83 Smoke Grenade (White)</English>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1272,18 +1272,6 @@
         <Key ID="STR_ACE_RealisticNames_MiniGrenade_Name">
             <English>V40 Mini-Grenade</English>
             <German>V40 Minigranate</German>
-            <Spanish>V40 Mini-Grenade</Spanish>
-            <Polish>V40 Mini-Grenade</Polish>
-            <Czech>V40 Mini-Grenade</Czech>
-            <French>V40 Mini-Grenade</French>
-            <Russian>V40 Mini-Grenade</Russian>
-            <Portuguese>V40 Mini-Grenade</Portuguese>
-            <Hungarian>V40 Mini-Grenade</Hungarian>
-            <Italian>V40 Mini-Grenade</Italian>
-            <Japanese>V40 Mini-Grenade</Japanese>
-            <Korean>V40 Mini-Grenade</Korean>
-            <Chinese>V40 Mini-Grenade</Chinese>
-            <Chinesesimp>V40 Mini-Grenade</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_SmokeShell_Name">
             <English>M83 Smoke Grenade (White)</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Rename vanilla "RGN" grenade to "V40 Mini-Grenade"
- Add German translation for V40
- Remove trailing spaces in Czech strings for M67 grenade, M15 AT mine and M112 demo block; and in Italian string for HEMTT (Container).

**This pull request will not:**
- Add any other translation for V40
- Attempt to do any fixes on strings in non-Latin charsets.


And while we're at it: Shouldn't it be "Nebel" instead of "Rauch" for the German smokes?