### PR TITLE
WIP: uniqueItemsPlayer

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -179,6 +179,7 @@ PREP(toNumber);
 PREP(unhideUnit);
 PREP(uniqueElements);
 PREP(uniqueItems);
+PREP(uniqueItemsPlayer);
 PREP(unloadPerson);
 PREP(unloadPersonLocal);
 PREP(unmuteUnit);

--- a/addons/common/functions/fnc_uniqueItemsPlayer.sqf
+++ b/addons/common/functions/fnc_uniqueItemsPlayer.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: mharis001, PabstMirror
+ * Returns list of unique items in ACE_player's inventory.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Items <ARRAY>
+ *
+ * Example:
+ * call ace_common_fnc_uniqueItemsPlayer
+ *
+ * Public: No
+ */
+
+if (isNil QGVAR(uniqueItemsCache)) then {
+    GVAR(uniqueItemsCache) = (getItemCargo uniformContainer ACE_player) select 0;
+    GVAR(uniqueItemsCache) append ((getItemCargo vestContainer ACE_player) select 0);
+    GVAR(uniqueItemsCache) append ((getItemCargo backpackContainer ACE_player) select 0);
+    GVAR(uniqueItemsCache) arrayIntersect GVAR(uniqueItemsCache)
+};
++GVAR(uniqueItemsCache)


### PR DESCRIPTION
Stripped down fast version that's just for ace_player
20 items, 4 unique (ammo bearer unit placed in editor)
`"ACE_CableTie" in (items player)` 0.0034 ms
`"ACE_CableTie" in (player call ace_common_fnc_uniqueItems)` 0.0056 ms
`"ACE_CableTie" in (call ace_common_fnc_uniqueItemsPlayer)` 0.0024 ms
