### PR TITLE
Fix rope redeploying without FRIES

### DIFF
--- a/addons/fastroping/functions/fnc_cutRopes.sqf
+++ b/addons/fastroping/functions/fnc_cutRopes.sqf
@@ -38,4 +38,7 @@ private _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
 } count _deployedRopes;
 
 _vehicle setVariable [QGVAR(deployedRopes), [], true];
-_vehicle setVariable [QGVAR(deploymentStage), 2, true];
+
+// Set new state (0 if no FRIES, 2 if FRIES for manual stowing)
+private _newState = [0, 2] select (isText (configFile >> "CfgVehicles" >> typeOf _vehicle >> QGVAR(onCut)));
+_vehicle setVariable [QGVAR(deploymentStage), _newState, true];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #5686 

Broken since #5533, this specific handling was removed, somehow missing this case. This just restores it without the delay (as FRIES stowing is still manual).