### PR TITLE
Realisticnames - Update AMS and KHS's name

### DIFF
--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -675,6 +675,30 @@ class CfgWeapons {
     class optic_LRPS_tna_F : optic_LRPS {
         displayName = CSTRING(optic_lrps_tna);
     };
+    
+    class optic_AMS_base;
+    class optic_AMS: optic_AMS_base {
+        displayName = CSTRING(optic_ams);
+    };
+    class optic_AMS_khk: optic_AMS {
+        displayName = CSTRING(optic_ams_khk);
+    };
+    class optic_AMS_snd: optic_AMS {
+        displayName = CSTRING(optic_ams_snd);
+    };
+     class optic_KHS_base;
+    class optic_KHS_blk: optic_KHS_base {
+        displayName = CSTRING(optic_khs_blk);
+    };
+    class optic_KHS_hex: optic_KHS_blk {
+        displayName = CSTRING(optic_khs_hex);
+    };
+    class optic_KHS_old: ItemCore {
+        displayName = CSTRING(optic_khs_old);
+    };
+    class optic_KHS_tan: optic_KHS_blk {
+        displayName = CSTRING(optic_khs_tan);
+    };
 
     class optic_DMS : ItemCore {
         displayName = CSTRING(optic_dms);

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -686,7 +686,8 @@ class CfgWeapons {
     class optic_AMS_snd: optic_AMS {
         displayName = CSTRING(optic_ams_snd);
     };
-     class optic_KHS_base;
+    
+    class optic_KHS_base;
     class optic_KHS_blk: optic_KHS_base {
         displayName = CSTRING(optic_khs_blk);
     };
@@ -699,7 +700,7 @@ class CfgWeapons {
     class optic_KHS_tan: optic_KHS_blk {
         displayName = CSTRING(optic_khs_tan);
     };
-
+    
     class optic_DMS : ItemCore {
         displayName = CSTRING(optic_dms);
     };

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3384,28 +3384,28 @@
             <Japanese>US Optics MR-10 (Sand)</Japanese>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_blk">
-            <English>KALHES Helia (Black)</English>
-            <Chinese>KALHES Helia (Black)</Chinese>
-            <Chinesesimp>KALHES Helia (Black)</Chinesesimp>
-            <Japanese>KALHES Helia (Black)</Japanese>
+            <English>KAHLES Helia (Black)</English>
+            <Chinese>KAHLES Helia (Black)</Chinese>
+            <Chinesesimp>KAHLES Helia (Black)</Chinesesimp>
+            <Japanese>KAHLES Helia (Black)</Japanese>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_hex">
-            <English>KALHES Helia (Hex)</English>
-            <Chinese>KALHES Helia (Hex)</Chinese>
-            <Chinesesimp>KALHES Helia (Hex)</Chinesesimp>
-            <Japanese>KALHES Helia (Hex)</Japanese>
+            <English>KAHLES Helia (Hex)</English>
+            <Chinese>KAHLES Helia (Hex)</Chinese>
+            <Chinesesimp>KAHLES Helia (Hex)</Chinesesimp>
+            <Japanese>KAHLES Helia (Hex)</Japanese>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_old">
-            <English>KALHES Helia (Old)</English>
-            <Chinese>KALHES Helia (Old)</Chinese>
-            <Chinesesimp>KALHES Helia (Old)</Chinesesimp>
-            <Japanese>KALHES Helia (Old)</Japanese>
+            <English>KAHLES Helia (Old)</English>
+            <Chinese>KAHLES Helia (Old)</Chinese>
+            <Chinesesimp>KAHLES Helia (Old)</Chinesesimp>
+            <Japanese>KAHLES Helia (Old)</Japanese>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_tan">
-            <English>KALHES Helia (Tan)</English>
-            <Chinese>KALHES Helia (Tan)</Chinese>
-            <Chinesesimp>KALHES Helia (Tan)</Chinesesimp>
-            <Japanese>KALHES Helia (Tan)</Japanese>
+            <English>KAHLES Helia (Tan)</English>
+            <Chinese>KAHLES Helia (Tan)</Chinese>
+            <Chinesesimp>KAHLES Helia (Tan)</Chinesesimp>
+            <Japanese>KAHLES Helia (Tan)</Japanese>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_dms">
             <English>Burris XTR II</English>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3365,6 +3365,48 @@
             <Chinesesimp>Nightforce NXS (丛林色)</Chinesesimp>
             <Japanese>Nightforce NXS (熱帯)</Japanese>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ams">
+            <English>US Optics MR-10 (Black)</English>
+            <Chinese>US Optics MR-10 (Black)</Chinese>
+            <Chinesesimp>US Optics MR-10 (Black)</Chinesesimp>
+            <Japanese>US Optics MR-10 (Black)</Japanese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ams_khk">
+            <English>US Optics MR-10 (Khaki)</English>
+            <Chinese>US Optics MR-10 (Khaki)</Chinese>
+            <Chinesesimp>US Optics MR-10 (Khaki)</Chinesesimp>
+            <Japanese>US Optics MR-10 (Khaki)</Japanese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_ams_snd">
+            <English>US Optics MR-10 (Sand)</English>
+            <Chinese>US Optics MR-10 (Sand)</Chinese>
+            <Chinesesimp>US Optics MR-10 (Sand)</Chinesesimp>
+            <Japanese>US Optics MR-10 (Sand)</Japanese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_khs_blk">
+            <English>KALHES Helia (Black)</English>
+            <Chinese>KALHES Helia (Black)</Chinese>
+            <Chinesesimp>KALHES Helia (Black)</Chinesesimp>
+            <Japanese>KALHES Helia (Black)</Japanese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_khs_hex">
+            <English>KALHES Helia (Hex)</English>
+            <Chinese>KALHES Helia (Hex)</Chinese>
+            <Chinesesimp>KALHES Helia (Hex)</Chinesesimp>
+            <Japanese>KALHES Helia (Hex)</Japanese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_khs_old">
+            <English>KALHES Helia (Old)</English>
+            <Chinese>KALHES Helia (Old)</Chinese>
+            <Chinesesimp>KALHES Helia (Old)</Chinesesimp>
+            <Japanese>KALHES Helia (Old)</Japanese>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_khs_tan">
+            <English>KALHES Helia (Tan)</English>
+            <Chinese>KALHES Helia (Tan)</Chinese>
+            <Chinesesimp>KALHES Helia (Tan)</Chinesesimp>
+            <Japanese>KALHES Helia (Tan)</Japanese>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_optic_dms">
             <English>Burris XTR II</English>
             <Chinese>Burris XTR II</Chinese>


### PR DESCRIPTION
**When merged this pull request will:**

Add the real name to these two scopes : 

- Magnification graduation AMS texture : https://imgur.com/a/9ppBAyR
[The only US Optics scope](https://www.usoptics.com/discontinued-optics/#MR) with this magnification.

- Magnification graduation KHS texture : https://imgur.com/a/0F0UkuK
This Kahles scope was certainly the discontinued Kahles Helia 5 scope 3D model
but the actual [Kahles Helia](http://www.kahles.at/jagd/produkte/zielfernrohre/?tx_kahlesproducts_category%5Bproduct%5D=3&tx_kahlesproducts_category%5Baction%5D=show&tx_kahlesproducts_category%5Bcontroller%5D=Product&cHash=39ce16ce5f7c7a36f20179a249d6200d) could be a decent choice.

As usual, the 3D models don't match exactly with the real scopes, only with the 2035 ones.