### PR TITLE
Scopes - Update AMS, KHS and LRPS "ACE_ScopeAdjust"

### DIFF
--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -156,8 +156,8 @@ class CfgWeapons {
 
     class optic_AMS_base : ItemCore {
         ACE_ScopeHeightAboveRail = 3.8933;
-        ACE_ScopeAdjust_Vertical[] = {-4, 30};
-        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_Vertical[] = {0, 16};
+        ACE_ScopeAdjust_Horizontal[] = {-11, 11};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
@@ -176,8 +176,8 @@ class CfgWeapons {
 
     class optic_KHS_base : ItemCore {
         ACE_ScopeHeightAboveRail = 4.30723;
-        ACE_ScopeAdjust_Vertical[] = {-4, 30};
-        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_Vertical[] = {0, 19};
+        ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {
@@ -196,8 +196,8 @@ class CfgWeapons {
 
     class optic_KHS_old : ItemCore {
         ACE_ScopeHeightAboveRail = 4.30723;
-        ACE_ScopeAdjust_Vertical[] = {-4, 30};
-        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_Vertical[] = {0, 19};
+        ACE_ScopeAdjust_Horizontal[] = {-9, 9};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -104,8 +104,8 @@ class CfgWeapons {
     
     class optic_LRPS : ItemCore {
         ACE_ScopeHeightAboveRail = 4.2098;
-        ACE_ScopeAdjust_Vertical[] = {-4, 30};
-        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_Vertical[] = {0, 27};
+        ACE_ScopeAdjust_Horizontal[] = {-8, 8};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo : InventoryOpticsItem_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**

Update the `ACE_ScopeAdjust_Vertical` and the `ACE_ScopeAdjust_Horizontal` according with the real US Optics (AMS), KAHLES (KHS) and NF NXS 5.5-22x56 (LRPS) technical datas : 

- [US Optics MR-10 specifications](https://www.usoptics.com/discontinued-optics/#MR)

- [KAHLES Helia technical data](http://www.kahles.at/en/hunt/products/riflescopes/?tx_kahlesproducts_category%5Bproduct%5D=3&tx_kahlesproducts_category%5Baction%5D=show&tx_kahlesproducts_category%5Bcontroller%5D=Product&cHash=39ce16ce5f7c7a36f20179a249d6200d)

- The LRPS texture part with the NF magnification : https://imgur.com/3TBBplS

  [Nightforce NXS 5.5-22x56 specifications](http://nightforceoptics.com/nxs/5-5-22x56)