### PR TITLE
Fix duplicate japanese strings

### DIFF
--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -3213,7 +3213,6 @@
         <Key ID="STR_ACE_RealisticNames_lsv_02_armed">
             <English>LSV Mk. II (M134)</English>
             <German>LSV Mk. II (M134)</German>
-            <Japanese>LSV Mk. II (M134)</Japanese>
             <Chinese>輕型突擊車2式 (M134迷你機炮)</Chinese>
             <Chinesesimp>轻型突击车2式 (M134迷你机炮)</Chinesesimp>
             <Japanese>LSV Mk. II (M134)</Japanese>
@@ -3228,7 +3227,6 @@
         <Key ID="STR_ACE_RealisticNames_lsv_02_unarmed">
             <English>LSV Mk. II</English>
             <German>LSV Mk. II</German>
-            <Japanese>LSV Mk. II</Japanese>
             <Chinese>輕型突擊車2式</Chinese>
             <Chinesesimp>轻型突击车2式</Chinesesimp>
             <Japanese>LSV Mk. II</Japanese>


### PR DESCRIPTION
**When merged this pull request will:**
- 43c52585852205afdd4a61bf61d0c1ba9a2d2b63 created 2 duplicate strings in realisticNames, this PR remove the 2 extras.