### PR TITLE
Force lf line endings for docker entrypoint file

### DIFF
--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -2,3 +2,4 @@
 *.png binary
 *.jpg binary
 *.paa binary
+*.sh eol=lf


### PR DESCRIPTION
Docker Container won't start, because the linux image can't execute the entrypoint file with crlf line endings