### PR TITLE
Fix slow motion falling of SLAM mines

### DIFF
--- a/addons/explosives/CfgEventHandlers.hpp
+++ b/addons/explosives/CfgEventHandlers.hpp
@@ -38,3 +38,9 @@ class Extended_DisplayLoad_EventHandlers {
         ADDON = QUOTE(_this call COMPILE_FILE(XEH_missionDisplayLoad));
     };
 };
+
+class Extended_Init_EventHandlers {
+    class ACE_Explosives_Place_SLAM {
+        ADDON = QUOTE(params ['_mine']; if (local _mine) then {_mine setCenterOfMass [ARR_3(0,-0.035,0.05)]; _mine setMass 5});
+    };
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #2770

Center of mass was previously not centered but too far back. It's now a little lower than the actual model's center. Mass was increased to 5 imaginary units, default is 0. Looks more realistic when falling now.