### PR TITLE
Medical- Use patient items first setting

### DIFF
--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -250,6 +250,13 @@ class ACE_Settings {
         value = 0;
         values[] = {"Anytime", "Stable"};
     };
+    class GVAR(usePatientItemsFirst) {
+        category = CSTRING(Category_Medical);
+        displayName = CSTRING(MedicalSettings_usePatientItemsFirst_DisplayName);
+        description = CSTRING(MedicalSettings_usePatientItemsFirst_Description);
+        typeName = "BOOL";
+        value = 1;
+    };
     class GVAR(keepLocalSettingsSynced) {
         category = CSTRING(Category_Medical);
         displayName = CSTRING(MedicalSettings_keepLocalSettingsSynced_DisplayName);

--- a/addons/medical/functions/fnc_useItem.sqf
+++ b/addons/medical/functions/fnc_useItem.sqf
@@ -24,13 +24,20 @@ if (isNil QGVAR(setting_allowSharedEquipment)) then {
     GVAR(setting_allowSharedEquipment) = true;
 };
 
-if (GVAR(setting_allowSharedEquipment) && {[_patient, _item] call EFUNC(common,hasItem)}) exitWith {
-    if (local _patient) then {
-        ["ace_useItem", [_patient, _item]] call CBA_fnc_localEvent;
-    } else {
-        ["ace_useItem", [_patient, _item], _patient] call CBA_fnc_targetEvent;
+private _use_patiten_item = {
+    params ["_patient", "_item"];
+    if ([_patient, _item] call EFUNC(common,hasItem)) exitWith {
+        if (local _patient) then {
+            ["ace_useItem", [_patient, _item]] call CBA_fnc_localEvent;
+        } else {
+            ["ace_useItem", [_patient, _item], _patient] call CBA_fnc_targetEvent;
+        };
+        [true, _patient];
     };
-    [true, _patient];
+};
+
+if (GVAR(usePatientItemsFirst) && {GVAR(setting_allowSharedEquipment)} && {[_patient, _item] call EFUNC(common,hasItem)}) exitWith {
+    [_patient, _item] call _use_patiten_item;
 };
 
 if ([_medic, _item] call EFUNC(common,hasItem)) exitWith {
@@ -40,6 +47,10 @@ if ([_medic, _item] call EFUNC(common,hasItem)) exitWith {
         ["ace_useItem", [_medic, _item], _medic] call CBA_fnc_targetEvent;
     };
     [true, _medic];
+};
+
+if (GVAR(setting_allowSharedEquipment) && {[_patient, _item] call EFUNC(common,hasItem)}) exitWith {
+    [_patient, _item] call _use_patiten_item;
 };
 
 private _return = [false, objNull];

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -4247,6 +4247,12 @@
             <Chinesesimp>修改疼痛强度的系数</Chinesesimp>
             <Chinese>修改疼痛強度的係數</Chinese>
         </Key>
+        <Key ID="STR_ACE_Medical_MedicalSettings_usePatientItemsFirst_DisplayName">
+            <English>Use patient's items first</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_MedicalSettings_usePatientItemsFirst_Description">
+            <English>Use the patient's medical items before using the medic's items.</English>
+        </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_keepLocalSettingsSynced_DisplayName">
             <English>Sync status</English>
             <Russian>Синхронизация статуса</Russian>


### PR DESCRIPTION
**When merged this pull request will:**
- Create a setting for using the patient's medical items first. Default is true to preserve current behavior
