### PR TITLE
Cargo - CanLoadItem ignores vehicle height on scripted load

### DIFF
--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -6,7 +6,7 @@
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Holder Object (Vehicle) <OBJECT>
- * 2: Ignore interaction distance <BOOL>
+ * 2: Ignore interaction distance and stability checks <BOOL>
  *
  * Return Value:
  * Can load in <BOOL>
@@ -19,7 +19,7 @@
 
 params [["_item", "", [objNull,""]], "_vehicle", ["_ignoreInteraction", false]];
 
-if (speed _vehicle > 1 || {((getPos _vehicle) select 2) > 3}) exitWith {TRACE_1("vehicle not stable",_vehicle); false};
+if ((!_ignoreInteraction) && {speed _vehicle > 1 || {((getPos _vehicle) select 2) > 3}}) exitWith {TRACE_1("vehicle not stable",_vehicle); false};
 
 if (_item isEqualType objNull && {{alive _x && {getText (configFile >> "CfgVehicles" >> typeOf _x >> "simulation") != "UAVPilot"}} count crew _item > 0}) exitWith {
     TRACE_1("item is occupied",_item);

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -7,7 +7,7 @@
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Vehicle <OBJECT>
- * 2: Ignore interaction distance <BOOL>
+ * 2: Ignore interaction distance and stability checks <BOOL>
  *
  * Return Value:
  * Object loaded <BOOL>

--- a/addons/zeus/functions/fnc_moduleLoadIntoCargo.sqf
+++ b/addons/zeus/functions/fnc_moduleLoadIntoCargo.sqf
@@ -43,7 +43,7 @@ if (!alive _cargo) exitWith {
         params ["_successful", "_cargo", "_mousePosASL"];
         if (!_successful) exitWith {};
 
-        private _holder = (nearestObjects [ASLToAGL _mousePosASL, EGVAR(cargo,cargoHolderTypes), 5]) param [0, objNull];
+        private _holder = (nearestObjects [ASLToAGL _mousePosASL, EGVAR(cargo,cargoHolderTypes), 5, true]) param [0, objNull]; // 2d distance search
         if (isNull _holder) exitWith {
             [LSTRING(NothingSelected)] call FUNC(showMessage);
         };


### PR DESCRIPTION
Close #6616

- `_ignoreInteraction` now also skips the check for vehicle height and speed
- Zeus load cargo module uses 2d distance searching, making it possible to load into a flying helicopter 
(still tricky as you need to click on the ground below the chopper)