### PR TITLE
ACE nightvision edits, ffv nvg overlay fix

### DIFF
--- a/addons/nightvision/initSettings.sqf
+++ b/addons/nightvision/initSettings.sqf
@@ -52,3 +52,48 @@
     false, // isGlobal
     {[QGVAR(shutterEffects), _this] call EFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;
+
+[
+    QGVAR(airFogMultiplier), "SLIDER",
+    [LSTRING(airFogMultiplier_DisplayName),LSTRING(airFogMultiplier_Description)],
+    localize LSTRING(Category),
+    [0,1,0.5,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(airFogMultiplier), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(binoFogMultiplier), "SLIDER",
+    [LSTRING(binoFogMultiplier_DisplayName),LSTRING(binoFogMultiplier_Description)],
+    localize LSTRING(Category),
+    [0,1,0.5,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(binoFogMultiplier), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(carFogMultiplier), "SLIDER",
+    [LSTRING(carFogMultiplier_DisplayName),LSTRING(carFogMultiplier_Description)],
+    localize LSTRING(Category),
+    [0,1,0.5,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(carFogMultiplier), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(staticFogMultiplier), "SLIDER",
+    [LSTRING(staticFogMultiplier_DisplayName),LSTRING(staticFogMultiplier_Description)],
+    localize LSTRING(Category),
+    [0,1,0.5,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(staticFogMultiplier), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(tankFogMultiplier), "SLIDER",
+    [LSTRING(tankFogMultiplier_DisplayName),LSTRING(tankFogMultiplier_Description)],
+    localize LSTRING(Category),
+    [0,1,0.5,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(tankFogMultiplier), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -283,7 +283,6 @@
             <German>Visierunschärfe</German>
             <Chinese>瞄準具模糊程度</Chinese>
             <Chinesesimp>瞄准具模糊程度</Chinesesimp>
-            <Italian>Blur durante la mira</Italian>
         </Key>
         <Key ID="STR_ACE_NightVision_noiseScaling_DisplayName">
             <English>NVG Noise Scale</English>
@@ -291,7 +290,6 @@
             <Chinese>夜視鏡雜訊程度</Chinese>
             <Chinesesimp>夜视镜杂讯程度</Chinesesimp>
             <Japanese>暗視装置のノイズ度</Japanese>
-            <Italian>Fattore di Disturbo del NVG</Italian>
         </Key>
         <Key ID="STR_ACE_NightVision_noiseScaling_Description">
             <English>Image noise intensity when wearing NVGs</English>
@@ -299,21 +297,48 @@
             <Chinese>調整配戴夜視鏡時畫面雜訊的多寡。</Chinese>
             <Chinesesimp>调整配戴夜视镜时画面杂讯的多寡。</Chinesesimp>
             <Japanese>暗視装置を使用時に起きる画像ノイズの強度です</Japanese>
-            <Italian>Intensità del disturbo dell'immagine quando i NVG sono equipaggiati</Italian>
         </Key>
         <Key ID="STR_ACE_NightVision_shutterEffects_DisplayName">
             <English>Shutter Effects</English>
             <Japanese>シャッター効果</Japanese>
             <Chinesesimp>快门效果</Chinesesimp>
             <Chinese>快門效果</Chinese>
-            <Italian>Effetti lampeggianti</Italian>
         </Key>
         <Key ID="STR_ACE_NightVision_shutterEffects_description">
             <English>Rolling shutter effect from muzzle flashes</English>
             <Japanese>発射炎が作るローリング シャッター効果です</Japanese>
             <Chinesesimp>枪械开火时产生瞬间快门效果</Chinesesimp>
             <Chinese>槍開火時瞬間產生快門效果</Chinese>
-            <Italian>Effetto lampeggiante dato dal lampo dello sparo</Italian>
+        </Key>
+		<Key ID="STR_ACE_NightVision_airFogMultiplier_DisplayName">
+            <English>Air Fog Multiplier</English>
+        </Key>
+		<Key ID="STR_ACE_NightVision_airFogMultiplier_Description">
+            <English>Fog multiplier when in plane/helicopter.</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_binoFogMultiplier_DisplayName">
+            <English>Binoculars Fog Multiplier</English>
+        </Key>
+		<Key ID="STR_ACE_NightVision_binoFogMultiplier_Description">
+            <English>Fog multiplier when looking through NV capable binoculars.</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_carFogMultiplier_DisplayName">
+            <English>Car Fog Multiplier</English>
+        </Key>
+		<Key ID="STR_ACE_NightVision_carFogMultiplier_Description">
+            <English>Fog multiplier when in NV capable car turret.</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_staticFogMultiplier_DisplayName">
+            <English>Static Weapon Fog Multiplier</English>
+        </Key>
+		<Key ID="STR_ACE_NightVision_staticFogMultiplier_Description">
+            <English>Fog multiplier when in NV capable static weapon.</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_tankFogMultiplier_DisplayName">
+            <English>Tank Fog Multiplier</English>
+        </Key>
+		<Key ID="STR_ACE_NightVision_tankFogMultiplier_Description">
+            <English>Fog multiplier when in NV capable tank turret.</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Changed hardcoded 0.5 NVG fog modifier for players in "air" type vehicle to CBA option (0.1 to 1.0 range).
- Added CBA options for fog modifier (0.1 to 1.0 ranges) for tank crew, car crew, static weapons and when using NV-capable binoculars.
- These fog modifiers are only applied when in gunner view of a NV-capable seat/turret, otherwise players still use their own NVGs.
- NV-capable binoculars work from FFV seats with binocular modifier.
- Fixed nvg overlay not applying when using FFV seats/ADS from FFV.
- Added ADS blur when using non-NV capable static weapons, technical turrets with NV goggles.

Known issues:
- When coming  out of binos, noticable flash at the corners of the screen before the NVG overlay is applied. Issue present in current ACE release. Wasn't able to resolve.
- UAV cameras are affected by ACE_player's nightvision status. If ACE_player has nightvision on, the NVG effects are overlaid on the UAV camera. Issue present in current ACE release.
- Unable to reliably detect when player controlled UAV is changing vision modes to account for UAVs. Potential bug with CBA Visionmode player EH. The EH doesn't trigger when changing from normal to night vision in when remote controlling drone. Raised issue on CBA github, https://github.com/CBATeam/CBA_A3/issues/1004

First time contributing, let me know if I missed anything.