### PR TITLE
Quick Mount - Fix turrets without weapon treated as gunner

### DIFF
--- a/addons/quickmount/functions/fnc_getInNearest.sqf
+++ b/addons/quickmount/functions/fnc_getInNearest.sqf
@@ -70,13 +70,17 @@ if (!isNull _target &&
                 if ((!(_turretPath isEqualTo [])) && {_target lockedTurret _turretPath}) exitWith {TRACE_1("lockedTurret",_x);};
 
                 if (_effectiveRole == "turret") then {
-                    if ((getNumber (([_target, _turretPath] call CBA_fnc_getTurret) >> "isCopilot")) == 1) exitWith {
+                    private _turretConfig = [_target, _turretPath] call CBA_fnc_getTurret;
+                    if (getNumber (_turretConfig >> "isCopilot") == 1) exitWith {
                         _effectiveRole = "driver";
                     };
-                    if (_cargoIndex < 0) exitWith {
-                        _effectiveRole = "gunner"; // door gunners / 2nd turret
+                    if (
+                        _cargoIndex >= 0 // FFV
+                        || {"" isEqualTo getText (_turretConfig >> "gun")} // turret without weapon
+                    ) exitWith {
+                        _effectiveRole = "cargo";
                     };
-                    _effectiveRole = "cargo"; // probably a FFV
+                    _effectiveRole = "gunner"; // door gunners / 2nd turret
                 };
                 TRACE_2("",_effectiveRole,_x);
                 if (_effectiveRole != _desiredRole) exitWith {};
@@ -93,7 +97,7 @@ if (!isNull _target &&
                         {
                             if ((_x select 2) == _cargoIndex) exitWith {_cargoActionIndex = _forEachIndex};
                         } forEach (fullCrew [_target, "cargo", true]);
-                        
+
                         ACE_player action ["GetInCargo", _target, _cargoActionIndex];
                         TRACE_4("Geting In Cargo",_x,_role,_cargoActionIndex,_cargoIndex);
                     } else {


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Some vehicles have turrets without weapons. They should be treated as cargo not gunners because they can influence (Quick)mount order.
Vanilla vehicles: `B_T_VTOL_01_infantry_F`, `B_T_VTOL_01_vehicle_F` (passengers in cabin).
There are some vehicles in RHS and quite many in CUP. Especially CUP SUVs (like `CUP_I_SUV_Armored_ION`) where you first get in external cargo seats on SUV sides.