### PR TITLE
Nametags - Adjustable colors settings

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -65,6 +65,7 @@ Drill <drill87@gmail.com>
 Dudakov aka [OMCB]Kaban <dudakov.s@gmail.com>
 Drofseh <drofseh@gmail.com>
 Dslyecxi <dslyecxi@gmail.com>
+Eclipser <jms@modeemi.fi>
 ElTyranos
 eRazeri
 evromalarkey <evromalarkey@gmail.com>

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -6,6 +6,41 @@ class ACE_Settings {
         displayName = CSTRING(DefaultNametagColor);
         category = CSTRING(Module_DisplayName);
     };
+    class GVAR(nametagColorMain) {
+        value[] = {1.00, 1.00, 1.00, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = CSTRING(MainNametagColor);
+        category = CSTRING(Module_DisplayName);
+    };
+    class GVAR(nametagColorRed) {
+        value[] = {1.00, 0.67, 0.67, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = CSTRING(RedNametagColor);
+        category = CSTRING(Module_DisplayName);
+    };
+    class GVAR(nametagColorGreen) {
+        value[] = {0.67, 1.00, 0.67, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = CSTRING(GreenNametagColor);
+        category = CSTRING(Module_DisplayName);
+    };
+    class GVAR(nametagColorBlue) {
+        value[] = {0.67, 0.67, 1.00, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = CSTRING(BlueNametagColor);
+        category = CSTRING(Module_DisplayName);
+    };
+    class GVAR(nametagColorYellow) {
+        value[] = {1.00, 1.00, 0.67, 1};
+        typeName = "COLOR";
+        isClientSettable = 1;
+        displayName = CSTRING(YellowNametagColor);
+        category = CSTRING(Module_DisplayName);
+    };
     class GVAR(showPlayerNames) {
         value = 1;
         typeName = "SCALAR";

--- a/addons/nametags/ACE_Settings.hpp
+++ b/addons/nametags/ACE_Settings.hpp
@@ -1,45 +1,6 @@
 class ACE_Settings {
     class GVAR(defaultNametagColor) {
-        value[] = {0.77, 0.51, 0.08, 1};
-        typeName = "COLOR";
-        isClientSettable = 1;
-        displayName = CSTRING(DefaultNametagColor);
-        category = CSTRING(Module_DisplayName);
-    };
-    class GVAR(nametagColorMain) {
-        value[] = {1.00, 1.00, 1.00, 1};
-        typeName = "COLOR";
-        isClientSettable = 1;
-        displayName = CSTRING(MainNametagColor);
-        category = CSTRING(Module_DisplayName);
-    };
-    class GVAR(nametagColorRed) {
-        value[] = {1.00, 0.67, 0.67, 1};
-        typeName = "COLOR";
-        isClientSettable = 1;
-        displayName = CSTRING(RedNametagColor);
-        category = CSTRING(Module_DisplayName);
-    };
-    class GVAR(nametagColorGreen) {
-        value[] = {0.67, 1.00, 0.67, 1};
-        typeName = "COLOR";
-        isClientSettable = 1;
-        displayName = CSTRING(GreenNametagColor);
-        category = CSTRING(Module_DisplayName);
-    };
-    class GVAR(nametagColorBlue) {
-        value[] = {0.67, 0.67, 1.00, 1};
-        typeName = "COLOR";
-        isClientSettable = 1;
-        displayName = CSTRING(BlueNametagColor);
-        category = CSTRING(Module_DisplayName);
-    };
-    class GVAR(nametagColorYellow) {
-        value[] = {1.00, 1.00, 0.67, 1};
-        typeName = "COLOR";
-        isClientSettable = 1;
-        displayName = CSTRING(YellowNametagColor);
-        category = CSTRING(Module_DisplayName);
+        movedToSQF = 1;
     };
     class GVAR(showPlayerNames) {
         value = 1;

--- a/addons/nametags/XEH_preInit.sqf
+++ b/addons/nametags/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -58,7 +58,7 @@ _fnc_parameters = {
     if ((group _target) != (group _player)) then {
         _color = +GVAR(defaultNametagColor); //Make a copy, then multiply both alpha values (allows client to decrease alpha in settings)
     } else {
-        _color = [+GVAR(nametagColorMain), +GVAR(nametagColorRed), +GVAR(nametagColorGreen), +GVAR(nametagColorBlue), +GVAR(nametagColorYellow)] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0);
+        _color = +([GVAR(nametagColorMain), GVAR(nametagColorRed), GVAR(nametagColorGreen), GVAR(nametagColorBlue), GVAR(nametagColorYellow)] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0));
     };
     _color set [3, (_color select 3) * _alpha];
 

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -58,7 +58,15 @@ _fnc_parameters = {
     if ((group _target) != (group _player)) then {
         _color = +GVAR(defaultNametagColor); //Make a copy, then multiply both alpha values (allows client to decrease alpha in settings)
     } else {
-        _color = +([GVAR(nametagColorMain), GVAR(nametagColorRed), GVAR(nametagColorGreen), GVAR(nametagColorBlue), GVAR(nametagColorYellow)] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0));
+        _color = +([
+            GVAR(nametagColorMain),
+            GVAR(nametagColorRed),
+            GVAR(nametagColorGreen),
+            GVAR(nametagColorBlue),
+            GVAR(nametagColorYellow)
+        ] select (
+            (["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0
+        ));
     };
     _color set [3, (_color select 3) * _alpha];
 

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -57,10 +57,10 @@ _fnc_parameters = {
     private _color = [1, 1, 1, _alpha];
     if ((group _target) != (group _player)) then {
         _color = +GVAR(defaultNametagColor); //Make a copy, then multiply both alpha values (allows client to decrease alpha in settings)
-        _color set [3, (_color select 3) * _alpha];
     } else {
-        _color = [[1, 1, 1, _alpha], [1, 0, 0, _alpha], [0, 1, 0, _alpha], [0, 0, 1, _alpha], [1, 1, 0, _alpha]] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0);
+        _color = [+GVAR(nametagColorMain), +GVAR(nametagColorRed), +GVAR(nametagColorGreen), +GVAR(nametagColorBlue), +GVAR(nametagColorYellow)] select ((["MAIN", "RED", "GREEN", "BLUE", "YELLOW"] find ([assignedTeam _target] param [0, "MAIN"])) max 0);
     };
+    _color set [3, (_color select 3) * _alpha];
 
     private _scale = [0.333, 0.5, 0.666, 0.83333, 1] select GVAR(tagSize);
 

--- a/addons/nametags/initSettings.sqf
+++ b/addons/nametags/initSettings.sqf
@@ -1,0 +1,56 @@
+// CBA Settings [ADDON: ace_nametags]:
+
+[
+    QGVAR(defaultNametagColor), "COLOR",
+    [LSTRING(DefaultNametagColor)],
+    [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize "str_a3_rscdisplaygameoptions_buttongui"],
+    [0.77, 0.51, 0.08, 1],
+    false, // isGlobal
+    {[QGVAR(defaultNametagColor), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(nametagColorMain), "COLOR",
+    ["str_team_main"],
+    [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize "str_a3_rscdisplaygameoptions_buttongui"],
+    [1.00, 1.00, 1.00, 1],
+    false, // isGlobal
+    {[QGVAR(nametagColorMain), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(nametagColorRed), "COLOR",
+    ["str_team_red"],
+    [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize "str_a3_rscdisplaygameoptions_buttongui"],
+    [1.00, 0.67, 0.67, 1],
+    false, // isGlobal
+    {[QGVAR(nametagColorRed), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(nametagColorGreen), "COLOR",
+    ["str_team_green"],
+    [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize "str_a3_rscdisplaygameoptions_buttongui"],
+    [0.67, 1.00, 0.67, 1],
+    false, // isGlobal
+    {[QGVAR(nametagColorGreen), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(nametagColorBlue), "COLOR",
+    ["str_team_blue"],
+    [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize "str_a3_rscdisplaygameoptions_buttongui"],
+    [0.67, 0.67, 1.00, 1],
+    false, // isGlobal
+    {[QGVAR(nametagColorBlue), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(nametagColorYellow),
+    "COLOR",
+    ["str_team_yellow"],
+    [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize "str_a3_rscdisplaygameoptions_buttongui"],
+    [1.00, 1.00, 0.67, 1],
+    false, // isGlobal
+    {[QGVAR(nametagColorYellow), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -146,19 +146,19 @@
             <Chinese>預設名稱顏色 (非同小隊隊友) </Chinese>
         </Key>
         <Key ID="STR_ACE_NameTags_MainNametagColor">
-            <English>Default Team Nametag Color</English>
+            <English>Default Team Name Tag Color</English>
         </Key>
         <Key ID="STR_ACE_NameTags_RedNametagColor">
-            <English>Red Team Nametag Color</English>
+            <English>Red Team Name Tag Color</English>
         </Key>
         <Key ID="STR_ACE_NameTags_GreenNametagColor">
-            <English>Green Team Nametag Color</English>
+            <English>Green Team Name Tag Color</English>
         </Key>
         <Key ID="STR_ACE_NameTags_BlueNametagColor">
-            <English>Blue Team Nametag Color</English>
+            <English>Blue Team Name Tag Color</English>
         </Key>
         <Key ID="STR_ACE_NameTags_YellowNametagColor">
-            <English>Yellow Team Nametag Color</English>
+            <English>Yellow Team Name Tag Color</English>
         </Key>
         <Key ID="STR_ACE_NameTags_Module_DisplayName">
             <English>Name Tags</English>

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -145,6 +145,21 @@
             <Chinesesimp>预设名字颜色 (非同小队队友) </Chinesesimp>
             <Chinese>預設名稱顏色 (非同小隊隊友) </Chinese>
         </Key>
+        <Key ID="STR_ACE_NameTags_MainNametagColor">
+            <English>Default Team Nametag Color</English>
+        </Key>
+        <Key ID="STR_ACE_NameTags_RedNametagColor">
+            <English>Red Team Nametag Color</English>
+        </Key>
+        <Key ID="STR_ACE_NameTags_GreenNametagColor">
+            <English>Green Team Nametag Color</English>
+        </Key>
+        <Key ID="STR_ACE_NameTags_BlueNametagColor">
+            <English>Blue Team Nametag Color</English>
+        </Key>
+        <Key ID="STR_ACE_NameTags_YellowNametagColor">
+            <English>Yellow Team Nametag Color</English>
+        </Key>
         <Key ID="STR_ACE_NameTags_Module_DisplayName">
             <English>Name Tags</English>
             <Polish>Ustawienia imion</Polish>

--- a/addons/nametags/stringtable.xml
+++ b/addons/nametags/stringtable.xml
@@ -145,21 +145,6 @@
             <Chinesesimp>预设名字颜色 (非同小队队友) </Chinesesimp>
             <Chinese>預設名稱顏色 (非同小隊隊友) </Chinese>
         </Key>
-        <Key ID="STR_ACE_NameTags_MainNametagColor">
-            <English>Default Team Name Tag Color</English>
-        </Key>
-        <Key ID="STR_ACE_NameTags_RedNametagColor">
-            <English>Red Team Name Tag Color</English>
-        </Key>
-        <Key ID="STR_ACE_NameTags_GreenNametagColor">
-            <English>Green Team Name Tag Color</English>
-        </Key>
-        <Key ID="STR_ACE_NameTags_BlueNametagColor">
-            <English>Blue Team Name Tag Color</English>
-        </Key>
-        <Key ID="STR_ACE_NameTags_YellowNametagColor">
-            <English>Yellow Team Name Tag Color</English>
-        </Key>
         <Key ID="STR_ACE_NameTags_Module_DisplayName">
             <English>Name Tags</English>
             <Polish>Ustawienia imion</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- Add settings for nametag team colors
- Make default colors lighter to make them easier to read
