### PR TITLE
Fastroping - Fix 3den default value

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -7,7 +7,7 @@
         expression = QUOTE(if (_value) then {[_this] call FUNC(equipFRIES)}); \
         typeName = "BOOL"; \
         condition = "objectVehicle"; \
-        defaultValue = false; \
+        defaultValue = "(false)"; \
     }; \
 }
 


### PR DESCRIPTION
Close #5550

When compiled it was being turned into `defaultValue = 0`