### PR TITLE
Make small UAVs battery life more realistic

### DIFF
--- a/addons/logistics_uavbattery/CfgVehicles.hpp
+++ b/addons/logistics_uavbattery/CfgVehicles.hpp
@@ -11,6 +11,7 @@ class CfgVehicles {
         };
     };
     class UAV_01_base_F: Helicopter_Base_F {
+        fuelCapacity = 19; // Around 30 minutes hovering
         class ACE_Actions: ACE_Actions{
             class ACE_MainActions: ACE_MainActions {
                 class GVAR(RefuelUAV) {
@@ -23,6 +24,7 @@ class CfgVehicles {
         };
     };
     class UAV_06_base_F: Helicopter_Base_F {
+        fuelCapacity = 16; // Around 25 minutes hovering
         class ACE_Actions: ACE_Actions{
             class ACE_MainActions: ACE_MainActions {
                 class GVAR(RefuelUAV) {


### PR DESCRIPTION
**When merged this pull request will:**
- Balance the darter battery life to be around 30 minutes.
- Balance the AL-6 Pelican battery life to be around 25 minutes.

Quadcopters and hexacopters can currently fly for hours, not only this is wildly unrealistic, it removes the need for UAV batteries altogether and makes them able to fly absolutely insane distances, this PR fixes this.

Fuel capacity was calculated by giving each drone 1 fuel capacity and making them hover for a minute then multiply the result by the desired battery life.