### PR TITLE
Rearm - Fix mk6 mortar being reloadable when ammoHandling is enabled

### DIFF
--- a/addons/rearm/functions/fnc_addRearmActions.sqf
+++ b/addons/rearm/functions/fnc_addRearmActions.sqf
@@ -20,6 +20,10 @@ params ["_truck"];
 private _vehicles = nearestObjects [_truck, ["AllVehicles"], 20];
 _vehicles = _vehicles select {(_x != _truck) && {!(_x isKindOf "CAManBase")} && {!(_x getVariable [QGVAR(disabled), false])}};
 
+if (missionNamespace getVariable [QEGVAR(mk6mortar,useAmmoHandling), false]) then {
+    _vehicles = _vehicles select {!(_x isKindOf "Mortar_01_base_F")};
+};
+
 private _vehicleActions = [];
 {
     private _vehicle = _x;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the mk6 mortar being allowed to be rearmed when ammo handling is enabled.

close #6540