### PR TITLE
Add magazines with different tracer colors for some vanilla weapons

### DIFF
--- a/optionals/tracers/CfgAmmo.hpp
+++ b/optionals/tracers/CfgAmmo.hpp
@@ -33,6 +33,8 @@ class CfgAmmo {
     // class B_556x45_Ball_Tracer_White: B_556x45_Ball {model = PATHTOF(ace_TracerWhite2.p3d);}; //New class for testing
 
     class B_580x42_Ball_F: BulletBase {model = PATHTOF(ace_TracerGreen2.p3d);};
+    class ACE_580x42_Ball_Tracer_Red: B_580x42_Ball_F {model = PATHTOF(ace_TracerRed2.p3d);};
+    class ACE_580x42_Ball_Tracer_Yellow: B_580x42_Ball_F {model = PATHTOF(ace_TracerYellow2.p3d);};
 
     class B_65x39_Caseless: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
     class B_65x39_Caseless_green: B_65x39_Caseless {model = PATHTOF(ace_TracerGreen2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_green
@@ -86,14 +88,14 @@ class CfgAmmo {
     class B_338_Ball: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
 
     class B_338_NM_Ball: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
-    class ACE_B_338_NM_Ball_red : B_338_NM_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
-    class ACE_B_338_NM_Ball_yellow : B_338_NM_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
+    class ACE_338_NM_Ball_red : B_338_NM_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
+    class ACE_338_NM_Ball_yellow : B_338_NM_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
 
     class B_127x54_Ball: BulletBase {model = PATHTOF(ace_TracerGreen2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_green
 
     class B_93x64_Ball: BulletBase {model = PATHTOF(ace_TracerGreen2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_green
-    class ace_B_93x64_Ball_tracer_red : B_93x64_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
-    class ace_B_93x64_Ball_tracer_yellow : B_93x64_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
+    class ACE_93x64_Ball_tracer_red : B_93x64_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
+    class ACE_93x64_Ball_tracer_yellow : B_93x64_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
 
     //Autocannon
     class B_19mm_HE: BulletBase {model = PATHTOF(ace_TracerWhite2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_white

--- a/optionals/tracers/CfgAmmo.hpp
+++ b/optionals/tracers/CfgAmmo.hpp
@@ -86,10 +86,14 @@ class CfgAmmo {
     class B_338_Ball: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
 
     class B_338_NM_Ball: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
+    class ACE_B_338_NM_Ball_red : B_338_NM_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
+    class ACE_B_338_NM_Ball_yellow : B_338_NM_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
 
     class B_127x54_Ball: BulletBase {model = PATHTOF(ace_TracerGreen2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_green
 
     class B_93x64_Ball: BulletBase {model = PATHTOF(ace_TracerGreen2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_green
+    class ace_B_93x64_Ball_tracer_red : B_93x64_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
+    class ace_B_93x64_Ball_tracer_yellow : B_93x64_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
 
     //Autocannon
     class B_19mm_HE: BulletBase {model = PATHTOF(ace_TracerWhite2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_white

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -1,4 +1,12 @@
 class CfgMagazineWells {
+    class CBA_556x45_STANAG_2D_XL {
+        ADDON[] = {
+            "ACE_150Rnd_556x45_Drum_Mag_F_Green",
+            "ACE_150Rnd_556x45_Drum_Mag_F_Yellow",
+            "ACE_150Rnd_556x45_Drum_Mag_Tracer_F_Green",
+            "ACE_150Rnd_556x45_Drum_Mag_Tracer_F_Yellow"
+        };
+    };
     class CBA_556x45_MINIMI {
         ADDON[] = {
             "ACE_200Rnd_556x45_Box_F_Green",

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -45,12 +45,38 @@ class CfgMagazineWells {
             "ACE_100Rnd_65x39_caseless_mag_tracer_yellow"
         };
     };
+    class CBA_65x39_Katiba {
+        ADDON[] = {
+            "ACE_30Rnd_65x39_katiba_red",
+            "ACE_30Rnd_65x39_katiba_yellow",
+            "ACE_30Rnd_65x39_katiba_tracer_red",
+            "ACE_30Rnd_65x39_katiba_tracer_yellow"
+        };
+    };
     class CBA_65x39_Mk200 {
         ADDON[] = {
             "ACE_200Rnd_65x39_cased_Box_green",
             "ACE_200Rnd_65x39_cased_Box_yellow",
             "ACE_200Rnd_65x39_cased_Box_Tracer_green",
             "ACE_200Rnd_65x39_cased_Box_Tracer_yellow"
+        };
+    };
+    class CBA_762x51_HK417 {
+        ADDON[] = {
+            "ACE_20Rnd_762x51_Mag_Tracer_green",
+            "ACE_20Rnd_762x51_Mag_Tracer_yellow"
+        };
+    };
+    class CBA_762x51_M14 {
+        ADDON[] = {
+            "ACE_20Rnd_762x51_Mag_Tracer_green",
+            "ACE_20Rnd_762x51_Mag_Tracer_yellow"
+        };
+    };
+    class CBA_762x51_G3 {
+        ADDON[] = {
+            "ACE_20Rnd_762x51_Mag_Tracer_green",
+            "ACE_20Rnd_762x51_Mag_Tracer_yellow"
         };
     };
     class CBA_762x54R_LINKS {

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -1,4 +1,20 @@
 class CfgMagazineWells {
+    class CBA_580x42_TYPE95 {
+        ADDON[] = {
+            "ACE_30Rnd_580x42_Mag_F_red",
+            "ACE_30Rnd_580x42_Mag_F_yellow",
+            "ACE_30Rnd_580x42_Mag_Tracer_F_red",
+            "ACE_30Rnd_580x42_Mag_Tracer_F_yellow"
+        };
+    };
+    class CBA_580x42_TYPE95_XL {
+        ADDON[] = {
+            "ACE_100Rnd_580x42_Mag_F_red",
+            "ACE_100Rnd_580x42_Mag_F_yellow",
+            "ACE_100Rnd_580x42_Mag_Tracer_F_red",
+            "ACE_100Rnd_580x42_Mag_Tracer_F_yellow"
+        };
+    };
     class CBA_65x39_MX {
         ADDON[] = {
             "ACE_30Rnd_65x39_caseless_mag_green",

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -1,4 +1,12 @@
 class CfgMagazineWells {
+    class STANAG_556x45_Large {
+        ADDON[] = {
+            "ACE_150Rnd_556x45_Drum_green",
+            "ACE_150Rnd_556x45_Drum_yellow",
+            "ACE_150Rnd_556x45_Drum_tracer_green",
+            "ACE_150Rnd_556x45_Drum_tracer_yellow"
+        };
+    };
     class CBA_556x45_STANAG_2D_XL {
         ADDON[] = {
             "ACE_150Rnd_556x45_Drum_green",
@@ -7,10 +15,24 @@ class CfgMagazineWells {
             "ACE_150Rnd_556x45_Drum_tracer_yellow"
         };
     };
+    class M249_556x45 {
+        ADDON[] = {
+            "ACE_200Rnd_556x45_Box_green",
+            "ACE_200Rnd_556x45_Box_tracer_green"
+        };
+    };
     class CBA_556x45_MINIMI {
         ADDON[] = {
             "ACE_200Rnd_556x45_Box_green",
             "ACE_200Rnd_556x45_Box_tracer_green"
+        };
+    };
+    class CTAR_580x42 {
+        ADDON[] = {
+            "ACE_30Rnd_580x42_Mag_red",
+            "ACE_30Rnd_580x42_Mag_yellow",
+            "ACE_30Rnd_580x42_Mag_tracer_red",
+            "ACE_30Rnd_580x42_Mag_tracer_yellow"
         };
     };
     class CBA_580x42_TYPE95 {
@@ -21,12 +43,28 @@ class CfgMagazineWells {
             "ACE_30Rnd_580x42_Mag_tracer_yellow"
         };
     };
+    class CTAR_580x42_Large {
+        ADDON[] = {
+            "ACE_100Rnd_580x42_Drum_red",
+            "ACE_100Rnd_580x42_Drum_yellow",
+            "ACE_100Rnd_580x42_Drum_tracer_red",
+            "ACE_100Rnd_580x42_Drum_tracer_yellow"
+        };
+    };
     class CBA_580x42_TYPE95_XL {
         ADDON[] = {
             "ACE_100Rnd_580x42_Drum_red",
             "ACE_100Rnd_580x42_Drum_yellow",
             "ACE_100Rnd_580x42_Drum_tracer_red",
             "ACE_100Rnd_580x42_Drum_tracer_yellow"
+        };
+    };
+    class MX_65x39 {
+        ADDON[] = {
+            "ACE_30Rnd_65x39_mx_green",
+            "ACE_30Rnd_65x39_mx_yellow",
+            "ACE_30Rnd_65x39_mx_tracer_green",
+            "ACE_30Rnd_65x39_mx_tracer_yellow"
         };
     };
     class CBA_65x39_MX {
@@ -45,12 +83,28 @@ class CfgMagazineWells {
             "ACE_100Rnd_65x39_mx_tracer_yellow"
         };
     };
+    class Katiba_65x39 {
+        ADDON[] = {
+            "ACE_30Rnd_65x39_katiba_red",
+            "ACE_30Rnd_65x39_katiba_yellow",
+            "ACE_30Rnd_65x39_katiba_tracer_red",
+            "ACE_30Rnd_65x39_katiba_tracer_yellow"
+        };
+    };
     class CBA_65x39_Katiba {
         ADDON[] = {
             "ACE_30Rnd_65x39_katiba_red",
             "ACE_30Rnd_65x39_katiba_yellow",
             "ACE_30Rnd_65x39_katiba_tracer_red",
             "ACE_30Rnd_65x39_katiba_tracer_yellow"
+        };
+    };
+    class Mk200_65x39 {
+        ADDON[] = {
+            "ACE_200Rnd_65x39_cased_Box_green",
+            "ACE_200Rnd_65x39_cased_Box_red",
+            "ACE_200Rnd_65x39_cased_Box_tracer_green",
+            "ACE_200Rnd_65x39_cased_Box_tracer_red"
         };
     };
     class CBA_65x39_Mk200 {

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -1,0 +1,46 @@
+class CfgMagazineWells {
+    class CBA_65x39_MX {
+        ADDON[] = {
+            "ACE_30Rnd_65x39_caseless_mag_green",
+            "ACE_30Rnd_65x39_caseless_mag_yellow",
+            "ACE_30Rnd_65x39_caseless_mag_tracer_green",
+            "ACE_30Rnd_65x39_caseless_mag_tracer_yellow"
+        };
+    };
+    class CBA_65x39_MX_XL {
+        ADDON[] = {
+            "ACE_100Rnd_65x39_caseless_mag_green",
+            "ACE_100Rnd_65x39_caseless_mag_yellow",
+            "ACE_100Rnd_65x39_caseless_mag_tracer_green",
+            "ACE_100Rnd_65x39_caseless_mag_tracer_yellow"
+        };
+    };
+    class CBA_65x39_Mk200 {
+        ADDON[] = {
+            "ACE_200Rnd_65x39_cased_Box_green",
+            "ACE_200Rnd_65x39_cased_Box_yellow",
+            "ACE_200Rnd_65x39_cased_Box_Tracer_green",
+            "ACE_200Rnd_65x39_cased_Box_Tracer_yellow"
+        };
+    };
+    class CBA_762x54R_LINKS {
+        ADDON[] = {
+            "ACE_150Rnd_762x54_Box_yellow",
+            "ACE_150Rnd_762x54_Box_red",
+            "ACE_150Rnd_762x54_Box_tracer_yellow",
+            "ACE_150Rnd_762x54_Box_tracer_red"
+        };
+    };
+    class CBA_93x64_LINKS {
+        ADDON[] = {
+            "ACE_150Rnd_93x64_Mag_yellow",
+            "ACE_150Rnd_93x64_Mag_red"
+        };
+    };
+    class CBA_338NM_LINKS {
+        ADDON[] = {
+            "ACE_130Rnd_338_Mag_yellow",
+            "ACE_130Rnd_338_Mag_green"
+        };
+    };
+};

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -1,48 +1,48 @@
 class CfgMagazineWells {
     class CBA_556x45_STANAG_2D_XL {
         ADDON[] = {
-            "ACE_150Rnd_556x45_Drum_Mag_F_Green",
-            "ACE_150Rnd_556x45_Drum_Mag_F_Yellow",
-            "ACE_150Rnd_556x45_Drum_Mag_Tracer_F_Green",
-            "ACE_150Rnd_556x45_Drum_Mag_Tracer_F_Yellow"
+            "ACE_150Rnd_556x45_Drum_green",
+            "ACE_150Rnd_556x45_Drum_yellow",
+            "ACE_150Rnd_556x45_Drum_tracer_green",
+            "ACE_150Rnd_556x45_Drum_tracer_yellow"
         };
     };
     class CBA_556x45_MINIMI {
         ADDON[] = {
-            "ACE_200Rnd_556x45_Box_F_Green",
-            "ACE_200Rnd_556x45_Box_Tracer_F_Green"
+            "ACE_200Rnd_556x45_Box_green",
+            "ACE_200Rnd_556x45_Box_tracer_green"
         };
     };
     class CBA_580x42_TYPE95 {
         ADDON[] = {
-            "ACE_30Rnd_580x42_Mag_F_red",
-            "ACE_30Rnd_580x42_Mag_F_yellow",
-            "ACE_30Rnd_580x42_Mag_Tracer_F_red",
-            "ACE_30Rnd_580x42_Mag_Tracer_F_yellow"
+            "ACE_30Rnd_580x42_Mag_red",
+            "ACE_30Rnd_580x42_Mag_yellow",
+            "ACE_30Rnd_580x42_Mag_tracer_red",
+            "ACE_30Rnd_580x42_Mag_tracer_yellow"
         };
     };
     class CBA_580x42_TYPE95_XL {
         ADDON[] = {
-            "ACE_100Rnd_580x42_Mag_F_red",
-            "ACE_100Rnd_580x42_Mag_F_yellow",
-            "ACE_100Rnd_580x42_Mag_Tracer_F_red",
-            "ACE_100Rnd_580x42_Mag_Tracer_F_yellow"
+            "ACE_100Rnd_580x42_Drum_red",
+            "ACE_100Rnd_580x42_Drum_yellow",
+            "ACE_100Rnd_580x42_Drum_tracer_red",
+            "ACE_100Rnd_580x42_Drum_tracer_yellow"
         };
     };
     class CBA_65x39_MX {
         ADDON[] = {
-            "ACE_30Rnd_65x39_caseless_mag_green",
-            "ACE_30Rnd_65x39_caseless_mag_yellow",
-            "ACE_30Rnd_65x39_caseless_mag_tracer_green",
-            "ACE_30Rnd_65x39_caseless_mag_tracer_yellow"
+            "ACE_30Rnd_65x39_mx_green",
+            "ACE_30Rnd_65x39_mx_yellow",
+            "ACE_30Rnd_65x39_mx_tracer_green",
+            "ACE_30Rnd_65x39_mx_tracer_yellow"
         };
     };
     class CBA_65x39_MX_XL {
         ADDON[] = {
-            "ACE_100Rnd_65x39_caseless_mag_green",
-            "ACE_100Rnd_65x39_caseless_mag_yellow",
-            "ACE_100Rnd_65x39_caseless_mag_tracer_green",
-            "ACE_100Rnd_65x39_caseless_mag_tracer_yellow"
+            "ACE_100Rnd_65x39_mx_green",
+            "ACE_100Rnd_65x39_mx_yellow",
+            "ACE_100Rnd_65x39_mx_tracer_green",
+            "ACE_100Rnd_65x39_mx_tracer_yellow"
         };
     };
     class CBA_65x39_Katiba {
@@ -56,15 +56,15 @@ class CfgMagazineWells {
     class CBA_65x39_Mk200 {
         ADDON[] = {
             "ACE_200Rnd_65x39_cased_Box_green",
-            "ACE_200Rnd_65x39_cased_Box_yellow",
-            "ACE_200Rnd_65x39_cased_Box_Tracer_green",
-            "ACE_200Rnd_65x39_cased_Box_Tracer_yellow"
+            "ACE_200Rnd_65x39_cased_Box_red",
+            "ACE_200Rnd_65x39_cased_Box_tracer_green",
+            "ACE_200Rnd_65x39_cased_Box_tracer_red"
         };
     };
     class CBA_762x51_HK417 {
         ADDON[] = {
-            "ACE_20Rnd_762x51_Mag_Tracer_green",
-            "ACE_20Rnd_762x51_Mag_Tracer_yellow"
+            "ACE_20Rnd_762x51_Mag_tracer_green",
+            "ACE_20Rnd_762x51_Mag_tracer_yellow"
         };
     };
     class CBA_762x51_M14 {
@@ -81,22 +81,22 @@ class CfgMagazineWells {
     };
     class CBA_762x54R_LINKS {
         ADDON[] = {
-            "ACE_150Rnd_762x54_Box_yellow",
             "ACE_150Rnd_762x54_Box_red",
-            "ACE_150Rnd_762x54_Box_tracer_yellow",
-            "ACE_150Rnd_762x54_Box_tracer_red"
+            "ACE_150Rnd_762x54_Box_yellow",
+            "ACE_150Rnd_762x54_Box_tracer_red",
+            "ACE_150Rnd_762x54_Box_tracer_yellow"
         };
     };
     class CBA_93x64_LINKS {
         ADDON[] = {
-            "ACE_150Rnd_93x64_Mag_yellow",
-            "ACE_150Rnd_93x64_Mag_red"
+            "ACE_150Rnd_93x64_Mag_red",
+            "ACE_150Rnd_93x64_Mag_yellow"
         };
     };
     class CBA_338NM_LINKS {
         ADDON[] = {
-            "ACE_130Rnd_338_Mag_yellow",
-            "ACE_130Rnd_338_Mag_green"
+            "ACE_130Rnd_338_Mag_green",
+            "ACE_130Rnd_338_Mag_yellow"
         };
     };
 };

--- a/optionals/tracers/CfgMagazineWells.hpp
+++ b/optionals/tracers/CfgMagazineWells.hpp
@@ -1,4 +1,10 @@
 class CfgMagazineWells {
+    class CBA_556x45_MINIMI {
+        ADDON[] = {
+            "ACE_200Rnd_556x45_Box_F_Green",
+            "ACE_200Rnd_556x45_Box_Tracer_F_Green"
+        };
+    };
     class CBA_580x42_TYPE95 {
         ADDON[] = {
             "ACE_30Rnd_580x42_Mag_F_red",

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -89,10 +89,12 @@ class CfgMagazines {
     class 30Rnd_65x39_caseless_mag_tracer;
     class ACE_30Rnd_65x39_mx_tracer_green : 30Rnd_65x39_caseless_mag_tracer {
         ammo = "B_65x39_Caseless_green";
+        picture = "a3\weapons_f\Data\UI\m_30stanag_caseless_green_CA.paa";
         STRINGS(30Rnd_65x39_mx_tracer_green);
     };
     class ACE_30Rnd_65x39_mx_tracer_yellow : 30Rnd_65x39_caseless_mag_tracer {
         ammo = "B_65x39_Caseless_yellow";
+        picture = "a3\weapons_f\Data\UI\m_30stanag_caseless_yellow_CA.paa";
         STRINGS(30Rnd_65x39_mx_tracer_yellow);
     };
 
@@ -109,10 +111,12 @@ class CfgMagazines {
     class 100Rnd_65x39_caseless_mag_tracer;
     class ACE_100Rnd_65x39_mx_tracer_green : 100Rnd_65x39_caseless_mag_tracer {
         ammo = "B_65x39_Caseless_green";
+        picture = "a3\weapons_f\Data\UI\M_100Rnd_65x39_green_CA.paa";
         STRINGS(100Rnd_65x39_mx_tracer_green);
     };
     class ACE_100Rnd_65x39_mx_tracer_yellow : 100Rnd_65x39_caseless_mag_tracer {
         ammo = "B_65x39_Caseless_yellow";
+        picture = "a3\weapons_f\Data\UI\M_100Rnd_65x39_yellow_CA.paa";
         STRINGS(100Rnd_65x39_mx_tracer_yellow);
     };
 
@@ -130,10 +134,12 @@ class CfgMagazines {
     class 30Rnd_65x39_caseless_green_tracer;
     class ACE_30Rnd_65x39_katiba_tracer_red : 30Rnd_65x39_caseless_green_tracer {
         ammo = "B_65x39_Caseless";
+        picture = "a3\weapons_f\Data\UI\m_20stanag_red_CA.paa";
         STRINGS(30Rnd_65x39_katiba_tracer_red);
     };
     class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_tracer {
         ammo = "B_65x39_Caseless_yellow";
+        picture = "a3\weapons_f\Data\UI\m_20stanag_yellow_CA.paa";
         STRINGS(30Rnd_65x39_katiba_tracer_yellow);
     };
 
@@ -151,10 +157,12 @@ class CfgMagazines {
     class 200Rnd_65x39_cased_Box_tracer;
     class ACE_200Rnd_65x39_cased_Box_tracer_green : 200Rnd_65x39_cased_Box_tracer {
         ammo = "B_65x39_Case_green";
+        picture = "a3\weapons_f\Data\UI\M_200Rnd_65x39_green_CA.paa";
         STRINGS(200Rnd_65x39_cased_Box_tracer_green);
     };
     class ACE_200Rnd_65x39_cased_Box_tracer_red : 200Rnd_65x39_cased_Box_tracer {
         ammo = "B_65x39_Case";
+        picture = "a3\weapons_f\Data\UI\M_200Rnd_65x39_red_CA.paa";
         STRINGS(200Rnd_65x39_cased_Box_tracer_red);
     };
 

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -39,7 +39,7 @@ class CfgMagazines {
     MAG(100Rnd_580x42_Mag_Tracer_F,red,ACE_580x42_Ball_Tracer_red);
     MAG(100Rnd_580x42_Mag_Tracer_F,yellow,ACE_580x42_Ball_Tracer_yellow);
 
-	// 6.5mm Caseless
+	// 6.5mm Caseless MX
 	class 30Rnd_65x39_caseless_mag;
     MAG(30Rnd_65x39_caseless_mag,green,B_65x39_Caseless_green);
     MAG(30Rnd_65x39_caseless_mag,yellow,B_65x39_Caseless_yellow);
@@ -56,6 +56,33 @@ class CfgMagazines {
     MAG(100Rnd_65x39_caseless_mag_tracer,green,B_65x39_Caseless_green);
     MAG(100Rnd_65x39_caseless_mag_tracer,yellow,B_65x39_Caseless_yellow);
 
+    // 6.5mm Caseless Katiba
+    class 30Rnd_65x39_caseless_green;
+    class ACE_30Rnd_65x39_katiba_red : 30Rnd_65x39_caseless_green {
+        author = ECSTRING(common,ACETeam);
+        ammo = QUOTE(B_65x39_Caseless);
+        displayName = CSTRING(30Rnd_65x39_katiba_red);
+    };
+    class ACE_30Rnd_65x39_katiba_yellow : 30Rnd_65x39_caseless_green {
+        author = ECSTRING(common,ACETeam);
+        ammo = QUOTE(B_65x39_Caseless_yellow);
+        displayName = CSTRING(30Rnd_65x39_katiba_yellow);
+    };
+
+    class 30Rnd_65x39_caseless_green_Tracer;
+    class ACE_30Rnd_65x39_katiba_tracer_red : 30Rnd_65x39_caseless_green_Tracer {
+        author = ECSTRING(common,ACETeam);
+        ammo = QUOTE(B_65x39_Caseless);
+        displayName = CSTRING(30Rnd_65x39_katiba_tracer_red);
+        descriptionShort = CSTRING(30Rnd_65x39_katiba_tracer_red_description);
+    };
+    class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_Tracer {
+        author = ECSTRING(common,ACETeam);
+        ammo = QUOTE(B_65x39_Caseless_yellow);
+        displayName = CSTRING(30Rnd_65x39_katiba_tracer_yellow);
+        descriptionShort = CSTRING(30Rnd_65x39_katiba_yellow_tracer_description);
+    };
+
     // 6.5mm Cased
 	class 200Rnd_65x39_cased_Box;
     MAG(200Rnd_65x39_cased_Box,green,B_65x39_Case_Green);
@@ -65,7 +92,22 @@ class CfgMagazines {
     MAG(200Rnd_65x39_cased_Box_Tracer,green,B_65x39_Case_Green);
     MAG(200Rnd_65x39_cased_Box_Tracer,red,B_65x39_Case);
 
-    // 7.62x54
+    // 7.62x51 (NATO)
+    class ACE_20Rnd_762x51_Mag_Tracer;
+    class ACE_20Rnd_762x51_Mag_Tracer_green : ACE_20Rnd_762x51_Mag_Tracer {
+        author = ECSTRING(common,ACETeam);
+        ammo = QUOTE(B_762x51_Tracer_Green);
+        displayName = CSTRING(20Rnd_762x51_Mag_Tracer_green);
+        descriptionShort = CSTRING(20Rnd_762x51_Mag_Tracer_green_description);
+    };
+    class ACE_20Rnd_762x51_Mag_Tracer_yellow : ACE_20Rnd_762x51_Mag_Tracer {
+        author = ECSTRING(common,ACETeam);
+        ammo = QUOTE(B_762x51_Tracer_Yellow);
+        displayName = CSTRING(20Rnd_762x51_Mag_Tracer_yellow);
+        descriptionShort = CSTRING(20Rnd_762x51_Mag_Tracer_yellow_description);
+    };
+
+    // 7.62x54 (Russian)
 	class 150Rnd_762x54_Box;
     MAG(150Rnd_762x54_Box,yellow,B_762x54_Tracer_Yellow);
     MAG(150Rnd_762x54_Box,red,B_762x54_Tracer_Red);

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -1,4 +1,4 @@
-#define STRINGS(magazine) author = ECSTRING(common,ACETeam); displayName = CSTRING(magazine); descriptionShort = CSTRING(DOUBLES(magazine,description))
+#define STRINGS(magazine) author = ECSTRING(common,ACETeam); displayName = CSTRING(magazine)
 
 class CfgMagazines {
 
@@ -17,10 +17,12 @@ class CfgMagazines {
     class ACE_150Rnd_556x45_Drum_tracer_green : 150Rnd_556x45_Drum_Mag_tracer_F {
         ammo = "B_556x45_Ball_tracer_green";
         STRINGS(150Rnd_556x45_Drum_tracer_green);
+        descriptionShort = CSTRING(150Rnd_556x45_Drum_tracer_green_description);
     };
     class ACE_150Rnd_556x45_Drum_tracer_yellow : 150Rnd_556x45_Drum_Mag_tracer_F {
         ammo = "B_556x45_Ball_tracer_yellow";
         STRINGS(150Rnd_556x45_Drum_tracer_yellow);
+        descriptionShort = CSTRING(150Rnd_556x45_Drum_tracer_green_description);
     };
 
     class 200Rnd_556x45_Box_F;
@@ -32,6 +34,7 @@ class CfgMagazines {
     class ACE_200Rnd_556x45_Box_tracer_green : 200Rnd_556x45_Box_tracer_F {
         ammo = "B_556x45_Ball_tracer_green";
         STRINGS(200Rnd_556x45_Box_tracer_green);
+        descriptionShort = CSTRING(200Rnd_556x45_Box_tracer_green_description);
     };
 
     // 5.8mm
@@ -49,10 +52,12 @@ class CfgMagazines {
     class ACE_30Rnd_580x42_Mag_tracer_red : 30Rnd_580x42_Mag_tracer_F {
         ammo = "ACE_580x42_Ball_tracer_red";
         STRINGS(30Rnd_580x42_Mag_tracer_red);
+        descriptionShort = CSTRING(30Rnd_580x42_Mag_tracer_red_description);
     };
     class ACE_30Rnd_580x42_Mag_tracer_yellow : 30Rnd_580x42_Mag_tracer_F {
         ammo = "ACE_580x42_Ball_tracer_yellow";
         STRINGS(30Rnd_580x42_Mag_tracer_yellow);
+        descriptionShort = CSTRING(30Rnd_580x42_Mag_tracer_yellow_description);
     };
 
     class 100Rnd_580x42_Mag_F;
@@ -69,10 +74,12 @@ class CfgMagazines {
     class ACE_100Rnd_580x42_Drum_tracer_red : 100Rnd_580x42_Mag_tracer_F {
         ammo = "ACE_580x42_Ball_tracer_red";
         STRINGS(100Rnd_580x42_Drum_tracer_red);
+        descriptionShort = CSTRING(100Rnd_580x42_Drum_tracer_red_description);
     };
     class ACE_100Rnd_580x42_Drum_tracer_yellow : 100Rnd_580x42_Mag_tracer_F {
         ammo = "ACE_580x42_Ball_tracer_yellow";
         STRINGS(100Rnd_580x42_Drum_tracer_yellow);
+        descriptionShort = CSTRING(100Rnd_580x42_Drum_tracer_yellow_description);
     };
 
 	// 6.5mm Caseless MX
@@ -80,10 +87,12 @@ class CfgMagazines {
     class ACE_30Rnd_65x39_mx_green : 30Rnd_65x39_caseless_mag {
         ammo = "B_65x39_Caseless_green";
         STRINGS(30Rnd_65x39_mx_green);
+        descriptionShort = CSTRING(30Rnd_65x39_mx_green_description);
     };
     class ACE_30Rnd_65x39_mx_yellow : 30Rnd_65x39_caseless_mag {
         ammo = "B_65x39_Caseless_yellow";
         STRINGS(30Rnd_65x39_mx_yellow);
+        descriptionShort = CSTRING(30Rnd_65x39_mx_yellow_description);
     };
 
     class 30Rnd_65x39_caseless_mag_tracer;
@@ -91,11 +100,13 @@ class CfgMagazines {
         ammo = "B_65x39_Caseless_green";
         picture = "a3\weapons_f\Data\UI\m_30stanag_caseless_green_CA.paa";
         STRINGS(30Rnd_65x39_mx_tracer_green);
+        descriptionShort = CSTRING(30Rnd_65x39_mx_tracer_green_description);
     };
     class ACE_30Rnd_65x39_mx_tracer_yellow : 30Rnd_65x39_caseless_mag_tracer {
         ammo = "B_65x39_Caseless_yellow";
         picture = "a3\weapons_f\Data\UI\m_30stanag_caseless_yellow_CA.paa";
         STRINGS(30Rnd_65x39_mx_tracer_yellow);
+        descriptionShort = CSTRING(30Rnd_65x39_mx_tracer_yellow_description);
     };
 
     class 100Rnd_65x39_caseless_mag;
@@ -113,11 +124,13 @@ class CfgMagazines {
         ammo = "B_65x39_Caseless_green";
         picture = "a3\weapons_f\Data\UI\M_100Rnd_65x39_green_CA.paa";
         STRINGS(100Rnd_65x39_mx_tracer_green);
+        descriptionShort = CSTRING(100Rnd_65x39_mx_tracer_green_description);
     };
     class ACE_100Rnd_65x39_mx_tracer_yellow : 100Rnd_65x39_caseless_mag_tracer {
         ammo = "B_65x39_Caseless_yellow";
         picture = "a3\weapons_f\Data\UI\M_100Rnd_65x39_yellow_CA.paa";
         STRINGS(100Rnd_65x39_mx_tracer_yellow);
+        descriptionShort = CSTRING(100Rnd_65x39_mx_tracer_yellow_description);
     };
 
     // 6.5mm Caseless Katiba
@@ -136,11 +149,13 @@ class CfgMagazines {
         ammo = "B_65x39_Caseless";
         picture = "a3\weapons_f\Data\UI\m_20stanag_red_CA.paa";
         STRINGS(30Rnd_65x39_katiba_tracer_red);
+        descriptionShort = CSTRING(30Rnd_65x39_katiba_tracer_red_description);
     };
     class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_mag_Tracer {
         ammo = "B_65x39_Caseless_yellow";
         picture = "a3\weapons_f\Data\UI\m_20stanag_yellow_CA.paa";
         STRINGS(30Rnd_65x39_katiba_tracer_yellow);
+        descriptionShort = CSTRING(30Rnd_65x39_katiba_tracer_yellow_description);
     };
 
     // 6.5mm Cased
@@ -148,10 +163,12 @@ class CfgMagazines {
     class ACE_200Rnd_65x39_cased_Box_green : 200Rnd_65x39_cased_Box {
         ammo = "B_65x39_Case_green";
         STRINGS(200Rnd_65x39_cased_Box_green);
+        descriptionShort = CSTRING(200Rnd_65x39_cased_Box_green_description);
     };
     class ACE_200Rnd_65x39_cased_Box_red : 200Rnd_65x39_cased_Box {
         ammo = "B_65x39_Case";
         STRINGS(200Rnd_65x39_cased_Box_red);
+        descriptionShort = CSTRING(200Rnd_65x39_cased_Box_red_description);
     };
 
     class 200Rnd_65x39_cased_Box_tracer;
@@ -159,11 +176,13 @@ class CfgMagazines {
         ammo = "B_65x39_Case_green";
         picture = "a3\weapons_f\Data\UI\M_200Rnd_65x39_green_CA.paa";
         STRINGS(200Rnd_65x39_cased_Box_tracer_green);
+        descriptionShort = CSTRING(200Rnd_65x39_cased_Box_tracer_green_description);
     };
     class ACE_200Rnd_65x39_cased_Box_tracer_red : 200Rnd_65x39_cased_Box_tracer {
         ammo = "B_65x39_Case";
         picture = "a3\weapons_f\Data\UI\M_200Rnd_65x39_red_CA.paa";
         STRINGS(200Rnd_65x39_cased_Box_tracer_red);
+        descriptionShort = CSTRING(200Rnd_65x39_cased_Box_tracer_red_description);
     };
 
     // 7.62x51 (NATO)
@@ -171,10 +190,12 @@ class CfgMagazines {
     class ACE_20Rnd_762x51_Mag_tracer_green : ACE_20Rnd_762x51_Mag_tracer {
         ammo = "B_762x51_tracer_green";
         STRINGS(20Rnd_762x51_Mag_tracer_green);
+        descriptionShort = CSTRING(20Rnd_762x51_Mag_tracer_green_description);
     };
     class ACE_20Rnd_762x51_Mag_tracer_yellow : ACE_20Rnd_762x51_Mag_tracer {
         ammo = "B_762x51_tracer_yellow";
         STRINGS(20Rnd_762x51_Mag_tracer_yellow);
+        descriptionShort = CSTRING(20Rnd_762x51_Mag_tracer_green_description);
     };
 
     // 7.62x54 (Russian)
@@ -192,10 +213,12 @@ class CfgMagazines {
     class ACE_150Rnd_762x54_Box_tracer_red : 150Rnd_762x54_Box_tracer {
         ammo = "B_762x54_tracer_red";
         STRINGS(150Rnd_762x54_Box_tracer_red);
+        descriptionShort = CSTRING(150Rnd_762x54_Box_tracer_red_description);
     };
     class ACE_150Rnd_762x54_Box_tracer_yellow : 150Rnd_762x54_Box_tracer {
         ammo = "B_762x54_tracer_yellow";
         STRINGS(150Rnd_762x54_Box_tracer_yellow);
+        descriptionShort = CSTRING(150Rnd_762x54_Box_tracer_yellow_description);
     };
 
     // 9.3x64

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -131,13 +131,13 @@ class CfgMagazines {
         STRINGS(30Rnd_65x39_katiba_yellow);
     };
 
-    class 30Rnd_65x39_caseless_green_tracer;
-    class ACE_30Rnd_65x39_katiba_tracer_red : 30Rnd_65x39_caseless_green_tracer {
+    class 30Rnd_65x39_caseless_green_mag_Tracer;
+    class ACE_30Rnd_65x39_katiba_tracer_red : 30Rnd_65x39_caseless_green_mag_Tracer {
         ammo = "B_65x39_Caseless";
         picture = "a3\weapons_f\Data\UI\m_20stanag_red_CA.paa";
         STRINGS(30Rnd_65x39_katiba_tracer_red);
     };
-    class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_tracer {
+    class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_mag_Tracer {
         ammo = "B_65x39_Caseless_yellow";
         picture = "a3\weapons_f\Data\UI\m_20stanag_yellow_CA.paa";
         STRINGS(30Rnd_65x39_katiba_tracer_yellow);

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -1,0 +1,55 @@
+#define MAG(base,color,ammotype) class TRIPLES(ACE,base,color) : base { \
+    author = ECSTRING(common,ACETeam); \
+    ammo = QUOTE(ammotype); \
+    displayName = CSTRING(DOUBLES(base,color)); \
+    descriptionShort = CSTRING(TRIPLES(base,color,description)); \
+}
+
+class CfgMagazines {
+
+	// 6.5mm Caseless
+	class 30Rnd_65x39_caseless_mag;
+    MAG(30Rnd_65x39_caseless_mag,green,B_65x39_Caseless_green);
+    MAG(30Rnd_65x39_caseless_mag,yellow,B_65x39_Caseless_yellow);
+
+	class 30Rnd_65x39_caseless_mag_tracer;
+    MAG(30Rnd_65x39_caseless_mag_tracer,green,B_65x39_Caseless_green);
+    MAG(30Rnd_65x39_caseless_mag_tracer,yellow,B_65x39_Caseless_yellow);
+
+	class 100Rnd_65x39_caseless_mag;
+    MAG(100Rnd_65x39_caseless_mag,green,B_65x39_Caseless_green);
+    MAG(100Rnd_65x39_caseless_mag,yellow,B_65x39_Caseless_yellow);
+
+	class 100Rnd_65x39_caseless_mag_tracer;
+    MAG(100Rnd_65x39_caseless_mag_tracer,green,B_65x39_Caseless_green);
+    MAG(100Rnd_65x39_caseless_mag_tracer,yellow,B_65x39_Caseless_yellow);
+
+    // 6.5mm Cased
+	class 200Rnd_65x39_cased_Box;
+    MAG(200Rnd_65x39_cased_Box,green,B_65x39_Case_Green);
+    MAG(200Rnd_65x39_cased_Box,red,B_65x39_Case);
+
+	class 200Rnd_65x39_cased_Box_Tracer;
+    MAG(200Rnd_65x39_cased_Box_Tracer,green,B_65x39_Case_Green);
+    MAG(200Rnd_65x39_cased_Box_Tracer,red,B_65x39_Case);
+
+    // 7.62x54
+	class 150Rnd_762x54_Box;
+    MAG(150Rnd_762x54_Box,yellow,B_762x54_Tracer_Yellow);
+    MAG(150Rnd_762x54_Box,red,B_762x54_Tracer_Red);
+
+	class 150Rnd_762x54_Box_Tracer;
+    MAG(150Rnd_762x54_Box_Tracer,yellow,B_762x54_Tracer_Yellow);
+    MAG(150Rnd_762x54_Box_Tracer,red,B_762x54_Tracer_Red);
+
+    // 9.3x64
+	class 150Rnd_93x64_Mag;
+    MAG(150Rnd_93x64_Mag,yellow,ACE_93x64_Tracer_Yellow);
+    MAG(150Rnd_93x64_Mag,red,ACE_93x64_Tracer_Red);
+
+    // .338 NM
+	class 130Rnd_338_Mag;
+    MAG(130Rnd_338_Mag,yellow,ACE_338_NM_Tracer_Yellow);
+    MAG(130Rnd_338_Mag,green,ACE_338_NM_Tracer_Green);
+
+};

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -1,129 +1,214 @@
-#define MAG(base,color,ammotype) class TRIPLES(ACE,base,color) : base { \
-    author = ECSTRING(common,ACETeam); \
-    ammo = QUOTE(ammotype); \
-    displayName = CSTRING(DOUBLES(base,color)); \
-    descriptionShort = CSTRING(TRIPLES(base,color,description)); \
-}
+#define STRINGS(magazine) author = ECSTRING(common,ACETeam); displayName = CSTRING(magazine); descriptionShort = CSTRING(DOUBLES(magazine,description))
 
 class CfgMagazines {
 
     // 5.56mm
     class 150Rnd_556x45_Drum_Mag_F;
-    MAG(150Rnd_556x45_Drum_Mag_F,green,B_556x45_Ball_Tracer_Green);
-    MAG(150Rnd_556x45_Drum_Mag_F,yellow,B_556x45_Ball_Tracer_Yellow);
+    class ACE_150Rnd_556x45_Drum_green : 150Rnd_556x45_Drum_Mag_F {
+        ammo = "B_556x45_Ball_tracer_green";
+        STRINGS(150Rnd_556x45_Drum_green);
+    };
+    class ACE_150Rnd_556x45_Drum_yellow : 150Rnd_556x45_Drum_Mag_F {
+        ammo = "B_556x45_Ball_tracer_yellow";
+        STRINGS(150Rnd_556x45_Drum_yellow);
+    };
 
-    class 150Rnd_556x45_Drum_Mag_Tracer_F;
-    MAG(150Rnd_556x45_Drum_Mag_Tracer_F,green,B_556x45_Ball_Tracer_Green);
-    MAG(150Rnd_556x45_Drum_Mag_Tracer_F,yellow,B_556x45_Ball_Tracer_Yellow);
+    class 150Rnd_556x45_Drum_Mag_tracer_F;
+    class ACE_150Rnd_556x45_Drum_tracer_green : 150Rnd_556x45_Drum_Mag_tracer_F {
+        ammo = "B_556x45_Ball_tracer_green";
+        STRINGS(150Rnd_556x45_Drum_tracer_green);
+    };
+    class ACE_150Rnd_556x45_Drum_tracer_yellow : 150Rnd_556x45_Drum_Mag_tracer_F {
+        ammo = "B_556x45_Ball_tracer_yellow";
+        STRINGS(150Rnd_556x45_Drum_tracer_yellow);
+    };
 
     class 200Rnd_556x45_Box_F;
-    MAG(200Rnd_556x45_Box_F,green,B_556x45_Ball_Tracer_Green);
-
-    class 200Rnd_556x45_Box_Tracer_F;
-    MAG(200Rnd_556x45_Box_Tracer_F,green,B_556x45_Ball_Tracer_Green);
+    class ACE_200Rnd_556x45_Box_green : 200Rnd_556x45_Box_F {
+        ammo = "B_556x45_Ball_tracer_green";
+        STRINGS(200Rnd_556x45_Box_green);
+    };
+    class 200Rnd_556x45_Box_tracer_F;
+    class ACE_200Rnd_556x45_Box_tracer_green : 200Rnd_556x45_Box_tracer_F {
+        ammo = "B_556x45_Ball_tracer_green";
+        STRINGS(200Rnd_556x45_Box_tracer_green);
+    };
 
     // 5.8mm
     class 30Rnd_580x42_Mag_F;
-    MAG(30Rnd_580x42_Mag_F,red,ACE_580x42_Ball_Tracer_red);
-    MAG(30Rnd_580x42_Mag_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+    class ACE_30Rnd_580x42_Mag_red : 30Rnd_580x42_Mag_F {
+        ammo = "ACE_580x42_Ball_tracer_red";
+        STRINGS(30Rnd_580x42_Mag_red);
+    };
+    class ACE_30Rnd_580x42_Mag_yellow : 30Rnd_580x42_Mag_F {
+        ammo = "ACE_580x42_Ball_tracer_yellow";
+        STRINGS(30Rnd_580x42_Mag_yellow);
+    };
 
-    class 30Rnd_580x42_Mag_Tracer_F;
-    MAG(30Rnd_580x42_Mag_Tracer_F,red,ACE_580x42_Ball_Tracer_red);
-    MAG(30Rnd_580x42_Mag_Tracer_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+    class 30Rnd_580x42_Mag_tracer_F;
+    class ACE_30Rnd_580x42_Mag_tracer_red : 30Rnd_580x42_Mag_tracer_F {
+        ammo = "ACE_580x42_Ball_tracer_red";
+        STRINGS(30Rnd_580x42_Mag_tracer_red);
+    };
+    class ACE_30Rnd_580x42_Mag_tracer_yellow : 30Rnd_580x42_Mag_tracer_F {
+        ammo = "ACE_580x42_Ball_tracer_yellow";
+        STRINGS(30Rnd_580x42_Mag_tracer_yellow);
+    };
 
     class 100Rnd_580x42_Mag_F;
-    MAG(100Rnd_580x42_Mag_F,red,ACE_580x42_Ball_Tracer_red);
-    MAG(100Rnd_580x42_Mag_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+    class ACE_100Rnd_580x42_Drum_red : 100Rnd_580x42_Mag_F {
+        ammo = "ACE_580x42_Ball_tracer_red";
+        STRINGS(100Rnd_580x42_Drum_red);
+    };
+    class ACE_100Rnd_580x42_Drum_yellow : 100Rnd_580x42_Mag_F {
+        ammo = "ACE_580x42_Ball_tracer_yellow";
+        STRINGS(100Rnd_580x42_Drum_yellow);
+    };
 
-    class 100Rnd_580x42_Mag_Tracer_F;
-    MAG(100Rnd_580x42_Mag_Tracer_F,red,ACE_580x42_Ball_Tracer_red);
-    MAG(100Rnd_580x42_Mag_Tracer_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+    class 100Rnd_580x42_Mag_tracer_F;
+    class ACE_100Rnd_580x42_Drum_tracer_red : 100Rnd_580x42_Mag_tracer_F {
+        ammo = "ACE_580x42_Ball_tracer_red";
+        STRINGS(100Rnd_580x42_Drum_tracer_red);
+    };
+    class ACE_100Rnd_580x42_Drum_tracer_yellow : 100Rnd_580x42_Mag_tracer_F {
+        ammo = "ACE_580x42_Ball_tracer_yellow";
+        STRINGS(100Rnd_580x42_Drum_tracer_yellow);
+    };
 
 	// 6.5mm Caseless MX
-	class 30Rnd_65x39_caseless_mag;
-    MAG(30Rnd_65x39_caseless_mag,green,B_65x39_Caseless_green);
-    MAG(30Rnd_65x39_caseless_mag,yellow,B_65x39_Caseless_yellow);
+    class 30Rnd_65x39_caseless_mag;
+    class ACE_30Rnd_65x39_mx_green : 30Rnd_65x39_caseless_mag {
+        ammo = "B_65x39_Caseless_green";
+        STRINGS(30Rnd_65x39_mx_green);
+    };
+    class ACE_30Rnd_65x39_mx_yellow : 30Rnd_65x39_caseless_mag {
+        ammo = "B_65x39_Caseless_yellow";
+        STRINGS(30Rnd_65x39_mx_yellow);
+    };
 
-	class 30Rnd_65x39_caseless_mag_tracer;
-    MAG(30Rnd_65x39_caseless_mag_tracer,green,B_65x39_Caseless_green);
-    MAG(30Rnd_65x39_caseless_mag_tracer,yellow,B_65x39_Caseless_yellow);
+    class 30Rnd_65x39_caseless_mag_tracer;
+    class ACE_30Rnd_65x39_mx_tracer_green : 30Rnd_65x39_caseless_mag_tracer {
+        ammo = "B_65x39_Caseless_green";
+        STRINGS(30Rnd_65x39_mx_tracer_green);
+    };
+    class ACE_30Rnd_65x39_mx_tracer_yellow : 30Rnd_65x39_caseless_mag_tracer {
+        ammo = "B_65x39_Caseless_yellow";
+        STRINGS(30Rnd_65x39_mx_tracer_yellow);
+    };
 
-	class 100Rnd_65x39_caseless_mag;
-    MAG(100Rnd_65x39_caseless_mag,green,B_65x39_Caseless_green);
-    MAG(100Rnd_65x39_caseless_mag,yellow,B_65x39_Caseless_yellow);
+    class 100Rnd_65x39_caseless_mag;
+    class ACE_100Rnd_65x39_mx_green : 100Rnd_65x39_caseless_mag {
+        ammo = "B_65x39_Caseless_green";
+        STRINGS(100Rnd_65x39_mx_green);
+    };
+    class ACE_100Rnd_65x39_mx_yellow : 100Rnd_65x39_caseless_mag {
+        ammo = "B_65x39_Caseless_yellow";
+        STRINGS(100Rnd_65x39_mx_yellow);
+    };
 
-	class 100Rnd_65x39_caseless_mag_tracer;
-    MAG(100Rnd_65x39_caseless_mag_tracer,green,B_65x39_Caseless_green);
-    MAG(100Rnd_65x39_caseless_mag_tracer,yellow,B_65x39_Caseless_yellow);
+    class 100Rnd_65x39_caseless_mag_tracer;
+    class ACE_100Rnd_65x39_mx_tracer_green : 100Rnd_65x39_caseless_mag_tracer {
+        ammo = "B_65x39_Caseless_green";
+        STRINGS(100Rnd_65x39_mx_tracer_green);
+    };
+    class ACE_100Rnd_65x39_mx_tracer_yellow : 100Rnd_65x39_caseless_mag_tracer {
+        ammo = "B_65x39_Caseless_yellow";
+        STRINGS(100Rnd_65x39_mx_tracer_yellow);
+    };
 
     // 6.5mm Caseless Katiba
     class 30Rnd_65x39_caseless_green;
     class ACE_30Rnd_65x39_katiba_red : 30Rnd_65x39_caseless_green {
-        author = ECSTRING(common,ACETeam);
-        ammo = QUOTE(B_65x39_Caseless);
-        displayName = CSTRING(30Rnd_65x39_katiba_red);
+        ammo = "B_65x39_Caseless";
+        STRINGS(30Rnd_65x39_katiba_red);
     };
     class ACE_30Rnd_65x39_katiba_yellow : 30Rnd_65x39_caseless_green {
-        author = ECSTRING(common,ACETeam);
-        ammo = QUOTE(B_65x39_Caseless_yellow);
-        displayName = CSTRING(30Rnd_65x39_katiba_yellow);
+        ammo = "B_65x39_Caseless_yellow";
+        STRINGS(30Rnd_65x39_katiba_yellow);
     };
 
-    class 30Rnd_65x39_caseless_green_Tracer;
-    class ACE_30Rnd_65x39_katiba_tracer_red : 30Rnd_65x39_caseless_green_Tracer {
-        author = ECSTRING(common,ACETeam);
-        ammo = QUOTE(B_65x39_Caseless);
-        displayName = CSTRING(30Rnd_65x39_katiba_tracer_red);
-        descriptionShort = CSTRING(30Rnd_65x39_katiba_tracer_red_description);
+    class 30Rnd_65x39_caseless_green_tracer;
+    class ACE_30Rnd_65x39_katiba_tracer_red : 30Rnd_65x39_caseless_green_tracer {
+        ammo = "B_65x39_Caseless";
+        STRINGS(30Rnd_65x39_katiba_tracer_red);
     };
-    class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_Tracer {
-        author = ECSTRING(common,ACETeam);
-        ammo = QUOTE(B_65x39_Caseless_yellow);
-        displayName = CSTRING(30Rnd_65x39_katiba_tracer_yellow);
-        descriptionShort = CSTRING(30Rnd_65x39_katiba_yellow_tracer_description);
+    class ACE_30Rnd_65x39_katiba_tracer_yellow : 30Rnd_65x39_caseless_green_tracer {
+        ammo = "B_65x39_Caseless_yellow";
+        STRINGS(30Rnd_65x39_katiba_tracer_yellow);
     };
 
     // 6.5mm Cased
-	class 200Rnd_65x39_cased_Box;
-    MAG(200Rnd_65x39_cased_Box,green,B_65x39_Case_Green);
-    MAG(200Rnd_65x39_cased_Box,red,B_65x39_Case);
+    class 200Rnd_65x39_cased_Box;
+    class ACE_200Rnd_65x39_cased_Box_green : 200Rnd_65x39_cased_Box {
+        ammo = "B_65x39_Case_green";
+        STRINGS(200Rnd_65x39_cased_Box_green);
+    };
+    class ACE_200Rnd_65x39_cased_Box_red : 200Rnd_65x39_cased_Box {
+        ammo = "B_65x39_Case";
+        STRINGS(200Rnd_65x39_cased_Box_red);
+    };
 
-	class 200Rnd_65x39_cased_Box_Tracer;
-    MAG(200Rnd_65x39_cased_Box_Tracer,green,B_65x39_Case_Green);
-    MAG(200Rnd_65x39_cased_Box_Tracer,red,B_65x39_Case);
+    class 200Rnd_65x39_cased_Box_tracer;
+    class ACE_200Rnd_65x39_cased_Box_tracer_green : 200Rnd_65x39_cased_Box_tracer {
+        ammo = "B_65x39_Case_green";
+        STRINGS(200Rnd_65x39_cased_Box_tracer_green);
+    };
+    class ACE_200Rnd_65x39_cased_Box_tracer_red : 200Rnd_65x39_cased_Box_tracer {
+        ammo = "B_65x39_Case";
+        STRINGS(200Rnd_65x39_cased_Box_tracer_red);
+    };
 
     // 7.62x51 (NATO)
-    class ACE_20Rnd_762x51_Mag_Tracer;
-    class ACE_20Rnd_762x51_Mag_Tracer_green : ACE_20Rnd_762x51_Mag_Tracer {
-        author = ECSTRING(common,ACETeam);
-        ammo = QUOTE(B_762x51_Tracer_Green);
-        displayName = CSTRING(20Rnd_762x51_Mag_Tracer_green);
-        descriptionShort = CSTRING(20Rnd_762x51_Mag_Tracer_green_description);
+    class ACE_20Rnd_762x51_Mag_tracer;
+    class ACE_20Rnd_762x51_Mag_tracer_green : ACE_20Rnd_762x51_Mag_tracer {
+        ammo = "B_762x51_tracer_green";
+        STRINGS(20Rnd_762x51_Mag_tracer_green);
     };
-    class ACE_20Rnd_762x51_Mag_Tracer_yellow : ACE_20Rnd_762x51_Mag_Tracer {
-        author = ECSTRING(common,ACETeam);
-        ammo = QUOTE(B_762x51_Tracer_Yellow);
-        displayName = CSTRING(20Rnd_762x51_Mag_Tracer_yellow);
-        descriptionShort = CSTRING(20Rnd_762x51_Mag_Tracer_yellow_description);
+    class ACE_20Rnd_762x51_Mag_tracer_yellow : ACE_20Rnd_762x51_Mag_tracer {
+        ammo = "B_762x51_tracer_yellow";
+        STRINGS(20Rnd_762x51_Mag_tracer_yellow);
     };
 
     // 7.62x54 (Russian)
-	class 150Rnd_762x54_Box;
-    MAG(150Rnd_762x54_Box,yellow,B_762x54_Tracer_Yellow);
-    MAG(150Rnd_762x54_Box,red,B_762x54_Tracer_Red);
+    class 150Rnd_762x54_Box;
+    class ACE_150Rnd_762x54_Box_red : 150Rnd_762x54_Box {
+        ammo = "B_762x54_tracer_red";
+        STRINGS(150Rnd_762x54_Box_red);
+    };
+    class ACE_150Rnd_762x54_Box_yellow : 150Rnd_762x54_Box {
+        ammo = "B_762x54_tracer_yellow";
+        STRINGS(150Rnd_762x54_Box_yellow);
+    };
 
-	class 150Rnd_762x54_Box_Tracer;
-    MAG(150Rnd_762x54_Box_Tracer,yellow,B_762x54_Tracer_Yellow);
-    MAG(150Rnd_762x54_Box_Tracer,red,B_762x54_Tracer_Red);
+    class 150Rnd_762x54_Box_tracer;
+    class ACE_150Rnd_762x54_Box_tracer_red : 150Rnd_762x54_Box_tracer {
+        ammo = "B_762x54_tracer_red";
+        STRINGS(150Rnd_762x54_Box_tracer_red);
+    };
+    class ACE_150Rnd_762x54_Box_tracer_yellow : 150Rnd_762x54_Box_tracer {
+        ammo = "B_762x54_tracer_yellow";
+        STRINGS(150Rnd_762x54_Box_tracer_yellow);
+    };
 
     // 9.3x64
-	class 150Rnd_93x64_Mag;
-    MAG(150Rnd_93x64_Mag,yellow,ACE_93x64_Tracer_Yellow);
-    MAG(150Rnd_93x64_Mag,red,ACE_93x64_Tracer_Red);
+    class 150Rnd_93x64_Mag;
+    class ACE_150Rnd_93x64_Mag_red : 150Rnd_93x64_Mag {
+        ammo = "ACE_93x64_tracer_red";
+        STRINGS(150Rnd_93x64_Mag_red);
+    };
+    class ACE_150Rnd_93x64_Mag_yellow : 150Rnd_93x64_Mag {
+        ammo = "ACE_93x64_tracer_yellow";
+        STRINGS(150Rnd_93x64_Mag_yellow);
+    };
 
     // .338 NM
-	class 130Rnd_338_Mag;
-    MAG(130Rnd_338_Mag,yellow,ACE_338_NM_Tracer_Yellow);
-    MAG(130Rnd_338_Mag,green,ACE_338_NM_Tracer_Green);
-
+    class 130Rnd_338_Mag;
+    class ACE_130Rnd_338_Mag_green : 130Rnd_338_Mag {
+        ammo = "ACE_338_NM_tracer_green";
+        STRINGS(130Rnd_338_Mag_green);
+    };
+    class ACE_130Rnd_338_Mag_yellow : 130Rnd_338_Mag {
+        ammo = "ACE_338_NM_tracer_yellow";
+        STRINGS(130Rnd_338_Mag_yellow);
+    };
 };

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -7,6 +7,13 @@
 
 class CfgMagazines {
 
+    // 5.56mm
+    class 200Rnd_556x45_Box_F;
+    MAG(200Rnd_556x45_Box_F,green,B_556x45_Ball_Tracer_Green);
+
+    class 200Rnd_556x45_Box_Tracer_F;
+    MAG(200Rnd_556x45_Box_Tracer_F,green,B_556x45_Ball_Tracer_Green);
+
     // 5.8mm
     class 30Rnd_580x42_Mag_F;
     MAG(30Rnd_580x42_Mag_F,red,ACE_580x42_Ball_Tracer_red);

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -8,6 +8,14 @@
 class CfgMagazines {
 
     // 5.56mm
+    class 150Rnd_556x45_Drum_Mag_F;
+    MAG(150Rnd_556x45_Drum_Mag_F,green,B_556x45_Ball_Tracer_Green);
+    MAG(150Rnd_556x45_Drum_Mag_F,yellow,B_556x45_Ball_Tracer_Yellow);
+
+    class 150Rnd_556x45_Drum_Mag_Tracer_F;
+    MAG(150Rnd_556x45_Drum_Mag_Tracer_F,green,B_556x45_Ball_Tracer_Green);
+    MAG(150Rnd_556x45_Drum_Mag_Tracer_F,yellow,B_556x45_Ball_Tracer_Yellow);
+
     class 200Rnd_556x45_Box_F;
     MAG(200Rnd_556x45_Box_F,green,B_556x45_Ball_Tracer_Green);
 

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -7,6 +7,23 @@
 
 class CfgMagazines {
 
+    // 5.8mm
+    class 30Rnd_580x42_Mag_F;
+    MAG(30Rnd_580x42_Mag_F,red,ACE_580x42_Ball_Tracer_red);
+    MAG(30Rnd_580x42_Mag_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+
+    class 30Rnd_580x42_Mag_Tracer_F;
+    MAG(30Rnd_580x42_Mag_Tracer_F,red,ACE_580x42_Ball_Tracer_red);
+    MAG(30Rnd_580x42_Mag_Tracer_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+
+    class 100Rnd_580x42_Mag_F;
+    MAG(100Rnd_580x42_Mag_F,red,ACE_580x42_Ball_Tracer_red);
+    MAG(100Rnd_580x42_Mag_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+
+    class 100Rnd_580x42_Mag_Tracer_F;
+    MAG(100Rnd_580x42_Mag_Tracer_F,red,ACE_580x42_Ball_Tracer_red);
+    MAG(100Rnd_580x42_Mag_Tracer_F,yellow,ACE_580x42_Ball_Tracer_yellow);
+
 	// 6.5mm Caseless
 	class 30Rnd_65x39_caseless_mag;
     MAG(30Rnd_65x39_caseless_mag,green,B_65x39_Caseless_green);

--- a/optionals/tracers/config.cpp
+++ b/optionals/tracers/config.cpp
@@ -16,27 +16,3 @@ class CfgPatches {
 
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
-
-// CfgMagazines and CfgWeapons are included for testing only and may be removed for release version.
-// There is also an ammo class B_556x45_Ball_Tracer_White commented out in CfgAmmo
-// this should also be uncommented when testing white tracers.
-/*
-class CfgMagazines {
-    class 200Rnd_556x45_Box_Tracer_F;
-    class 200Rnd_556x45_Box_Green_F : 200Rnd_556x45_Box_Tracer_F {
-        ammo = "B_556x45_Ball_Tracer_Green";
-        displayName = "5.56 mm 200Rnd Tracer (Green) Box";
-    };
-    class 200Rnd_556x45_Box_White_F : 200Rnd_556x45_Box_Tracer_F {
-        ammo = "B_556x45_Ball_Tracer_White";
-        displayName = "5.56 mm 200Rnd Tracer (White) Box";
-    };
-};
-
-class CfgWeapons {
-    class LMG_03_base_F;
-    class LMG_03_F : LMG_03_base_F {
-        magazines[] = {"200Rnd_556x45_Box_F","200Rnd_556x45_Box_Red_F","200Rnd_556x45_Box_Tracer_F","200Rnd_556x45_Box_Tracer_Red_F","200Rnd_556x45_Box_Green_F","200Rnd_556x45_Box_White_F"};
-    };
-};
-*/

--- a/optionals/tracers/config.cpp
+++ b/optionals/tracers/config.cpp
@@ -16,3 +16,4 @@ class CfgPatches {
 
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgMagazineWells.hpp"

--- a/optionals/tracers/config.cpp
+++ b/optionals/tracers/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches {
 };
 
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
 
 // CfgMagazines and CfgWeapons are included for testing only and may be removed for release version.
 // There is also an ammo class B_556x45_Ball_Tracer_White commented out in CfgAmmo

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -184,6 +184,31 @@
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
 
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_red">
+                <English>6.5mm 30Rnd Reload Tracer (Red) Mag</English>
+                <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Rot) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_yellow">
+                <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
+                <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_red">
+                <English>6.5mm 30Rnd Tracer (Red) Mag</English>
+                <German>30 Schuss 6.5mm Leuchtspur (Rot) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_red_description">
+                <English>Caliber: 6.5x39 mm Tracer (Red) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
+                <German>Kaliber: 6,5x39mm Leuchtspur (Rot) ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_yellow">
+                <English>6.5mm 30Rnd Tracer (Yellow) Mag</English>
+                <German>30 Schuss 6.5mm Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_yellow_description">
+                <English>Caliber: 6.5x39 mm Tracer (Yellow) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
+                <German>Kaliber: 6,5x39mm Leuchtspur (Rot) ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
+            </Key>
+
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_green">
                 <English>6.5 mm 200Rnd Belt Case Mixed (Green)</English>
                 <German>6,5 mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
@@ -215,6 +240,23 @@
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_red_description">
                 <English>Caliber: 6.5x39 mm Tracer - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_green">
+                <English>7.62 mm 20Rnd Tracer (Green) Mag</English>
+                <German>7,62 mm 20-Schuss-Magazin Leuchtspur (Grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_green_description">
+                <English>Caliber: 7.62x51 mm NATO Tracer - Green&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
+                <German>Kaliber: 7,62x51 mm NATO Leuchtspur - grün&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_yellow">
+                <English>7.62 mm 20Rnd Tracer (Yellow) Mag</English>
+                <German>7,62 mm 20-Schuss-Magazin Leuchtspur (Gelb)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_yellow_description">
+                <English>Caliber: 7.62x51 mm NATO Tracer - Yellow&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
+                <German>Kaliber: 7,62x51 mm NATO Leuchtspur - gelb&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
             </Key>
 
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_red">

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -1,0 +1,172 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACE_tracer">
+    <Package name="main">
+        <Container name="magazines">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_green">
+                <English>6.5mm 30Rnd Reload Tracer (Green) Mag</English>
+                <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Grün) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_green_description">
+                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39 mm Nachlade-Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_yellow">
+                <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
+                <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_yellow_description">
+                <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39 mm Nachlade-Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_green">
+                <English>6.5mm 30Rnd Tracer (Green) Mag</English>
+                <German>30 Schuss 6.5mm Leuchtspur (Grün) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_green_description">
+                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_yellow">
+                <English>6.5mm 30Rnd Tracer (Yellow) Mag</English>
+                <German>30 Schuss 6.5mm Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_yellow_description">
+                <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_green">
+                <English>6.5mm 100Rnd Mag (Mixed Green)</English>
+                <German>100 Schuss 6.5mm Magazin (Gemischt Grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_green_description">
+                <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
+                <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_yellow">
+                <English>6.5mm 100Rnd Mag (Mixed Yellow)</English>
+                <German>100 Schuss 6.5mm Magazin (Gemischt Gelb)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_yellow_description">
+                <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
+                <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_green">
+                <English>6.5mm 100Rnd Mag (Tracer Green)</English>
+                <German>100 Schuss 6.5mm Magazin (Leuchtspur Grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_green_description">
+                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
+                <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_yellow">
+                <English>6.5mm 100Rnd Mag (Tracer Yellow)</English>
+                <German>100 Schuss 6.5mm Magazin (Leuchtspur Gelb)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_yellow_description">
+                <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
+                <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_green">
+                <English>6.5 mm 200Rnd Belt Case Mixed (Green)</English>
+                <German>6,5 mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_green_description">
+                <English>Caliber: 6.5x39 mm Mixed - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39 mm Gemischt - Grün&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_red">
+                <English>6.5 mm 200Rnd Belt Case Mixed (Red)</English>
+                <German>6,5 mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_red_description">
+                <English>Caliber: 6.5x39 mm Mixed - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39 mm Mixed - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_green">
+                <English>6.5 mm 200Rnd Belt Case Tracer (Green)</English>
+                <German>6,5 mm 200-Schuss-Gurtkiste Leuchtspur (grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_green_description">
+                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_red">
+                <English>6.5 mm 200Rnd Belt Case Tracer (Red)</English>
+                <German>6,5 mm 200-Schuss-Gurtkiste Leuchtspur (rot)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_red_description">
+                <English>Caliber: 6.5x39 mm Tracer - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39 mm Leuchtspur - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_red">
+                <English>7.62mm 150Rnd Box Mixed (Red)</English>
+                <German>7.62mm 150 Schuss Kiste Gemischt (rot)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_red_description">
+                <English>Caliber: 7.62x54 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
+                <German>Kaliber: 7.62x54 mm&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_yellow">
+                <English>7.62mm 150Rnd Box Mixed (Yellow)</English>
+                <German>7.62mm 150 Schuss Kiste Gemischt (gelb)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_yellow_description">
+                <English>Caliber: 7.62x54 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
+                <German>Kaliber: 7.62x54 mm&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_red">
+                <English>7.62mm 150Rnd Box Tracer (Red)</English>
+                <German>7.62mm 150 Schuss Kiste Leuchtspur (rot)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_red_description">
+                <English>Caliber: 7.62x54 mm Tracer - Red&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
+                <German>Kaliber: 7.62x54 mm Leuchtspur - Rot&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_yellow">
+                <English>7.62mm 150Rnd Box Tracer (Yellow)</English>
+                <German>7.62mm 150 Schuss Kiste Leuchtspur (Rot)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_yellow_description">
+                <English>Caliber: 7.62x54 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
+                <German>Kaliber: 7.62x54 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_yellow">
+                <English>9.3mm 150Rnd Belt Mixed (Yellow)</English>
+                <German>9.3mm 150 Schuss Gurt gemischt (Gelb)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_yellow_description">
+                <English>Caliber: 9.3x64mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
+                <German>Kaliber: 9,3 x 64 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_red">
+                <English>9.3mm 150Rnd Belt Mixed (Red)</English>
+                <German>9.3mm 150 Schuss Gurt gemischt (Rot)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_red_description">
+                <English>Caliber: 9.3x64mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
+                <German>Kaliber: 9,3 x 64 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_yellow">
+                <English>.338 NM 130Rnd Belt Mixed (Yellow)</English>
+                <German>.338 NM 130 Schuss Gurt gemischt (gelb)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_yellow_description">
+                <English>Caliber: .338 Norma Magnum&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
+                <German>Kaliber: .338 Norma Magnum&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_green">
+                <English>.338 NM 130Rnd Belt Mixed (Green)</English>
+                <German>.338 NM 130 Schuss Gurt gemischt (grün)</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_green_description">
+                <English>Caliber: .338 Norma Magnum&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
+                <German>Kaliber: .338 Norma Magnum&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
+            </Key>
+        </Container>
+    </Package>
+</Project>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -2,6 +2,72 @@
 <Project name="ACE_tracer">
     <Package name="main">
         <Container name="magazines">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_red">
+                <English>5.8 mm 30Rnd Reload Tracer (Red) Mag</English>
+                <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_red_description">
+                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
+                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_yellow">
+                <English>5.8 mm 30Rnd Reload Tracer (Yellow) Mag</English>
+                <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_yellow_description">
+                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
+                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_red">
+                <English>5.8 mm 30Rnd Tracer (Red) Mag</English>
+                <German>30 Schuss 5,8 mm Leuchtspur (Rot) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_red_description">
+                <English>Caliber: 5.8x42 mm Tracer - Red&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
+                <German>Kaliber: 5,8x42 mm Leuchtspur - rot&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_yellow">
+                <English>5.8 mm 30Rnd Tracer (Yellow) Mag</English>
+                <German>30 Schuss 5,8 mm Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_yellow_description">
+                <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
+                <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
+            </Key>
+
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_red">
+                <English>5.8 mm 100Rnd Reload Tracer (Red) Mag</English>
+                <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_red_description">
+                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
+                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_yellow">
+                <English>5.8 mm 100Rnd Reload Tracer (Yellow) Mag</English>
+                <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_yellow_description">
+                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
+                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_red">
+                <English>5.8 mm 100Rnd Tracer (Red) Mag</English>
+                <German>100 Schuss 5,8 mm Leuchtspur (Rot) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_red_description">
+                <English>Caliber: 5.8x42 mm Tracer - Red&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
+                <German>Kaliber: 5,8x42 mm Leuchtspur - rot&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_yellow">
+                <English>5.8 mm 100Rnd Tracer (Yellow) Mag</English>
+                <German>100 Schuss 5,8 mm Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_yellow_description">
+                <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
+                <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
+            </Key>
+
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_green">
                 <English>6.5mm 30Rnd Reload Tracer (Green) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Grün) Magazin</German>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -2,184 +2,184 @@
 <Project name="ACE_tracer">
     <Package name="main">
         <Container name="magazines">
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_green">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_green">
                 <English>5.56 mm 150Rnd Reload Tracer (Green) Mag</English>
                 <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_green_description">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_green_description">
                 <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
                 <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_yellow">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_yellow">
                 <English>5.56 mm 150Rnd Reload Tracer (Yellow) Mag</English>
                 <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_yellow_description">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_yellow_description">
                 <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
                 <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_green">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_green">
                 <English>5.56 mm 150Rnd Tracer (Green) Mag</English>
                 <German>150 Schuss 5,56 mm Leuchtspur (Grün) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_green_description">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_green_description">
                 <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
                 <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_yellow">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_yellow">
                 <English>5.56 mm 150Rnd Tracer (Yellow) Mag</English>
                 <German>150 Schuss 5,56 mm Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_yellow_description">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_yellow_description">
                 <English>Caliber: 5.56x45 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
                 <German>Kaliber: 5,56x45 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
             </Key>
 
-            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_F_green">
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_green">
                 <English>5.56 mm 200Rnd Reload Tracer (Green) Box</English>
                 <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_F_green_description">
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_green_description">
                 <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
                 <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_Tracer_F_green">
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_tracer_green">
                 <English>5.56 mm 200Rnd Tracer (Green) Box</English>
                 <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_Tracer_F_green_description">
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_tracer_green_description">
                 <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
                 <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
             </Key>
 
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_red">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_red">
                 <English>5.8 mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_red_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_red_description">
                 <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
                 <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_yellow">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_yellow">
                 <English>5.8 mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_yellow_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_yellow_description">
                 <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
                 <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_red">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_red">
                 <English>5.8 mm 30Rnd Tracer (Red) Mag</English>
                 <German>30 Schuss 5,8 mm Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_red_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_red_description">
                 <English>Caliber: 5.8x42 mm Tracer - Red&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
                 <German>Kaliber: 5,8x42 mm Leuchtspur - rot&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_yellow">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_yellow">
                 <English>5.8 mm 30Rnd Tracer (Yellow) Mag</English>
                 <German>30 Schuss 5,8 mm Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_Tracer_F_yellow_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_yellow_description">
                 <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
                 <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
             </Key>
 
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_red">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_red">
                 <English>5.8 mm 100Rnd Reload Tracer (Red) Mag</English>
                 <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_red_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_red_description">
                 <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
                 <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_yellow">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_yellow">
                 <English>5.8 mm 100Rnd Reload Tracer (Yellow) Mag</English>
                 <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_F_yellow_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_yellow_description">
                 <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
                 <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_red">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_red">
                 <English>5.8 mm 100Rnd Tracer (Red) Mag</English>
                 <German>100 Schuss 5,8 mm Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_red_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_red_description">
                 <English>Caliber: 5.8x42 mm Tracer - Red&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
                 <German>Kaliber: 5,8x42 mm Leuchtspur - rot&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_yellow">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_yellow">
                 <English>5.8 mm 100Rnd Tracer (Yellow) Mag</English>
                 <German>100 Schuss 5,8 mm Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Mag_Tracer_F_yellow_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_yellow_description">
                 <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
                 <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
             </Key>
 
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_green">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_green">
                 <English>6.5mm 30Rnd Reload Tracer (Green) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Grün) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_green_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_green_description">
                 <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
                 <German>Kaliber: 6.5x39 mm Nachlade-Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_yellow">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_yellow">
                 <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_yellow_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_yellow_description">
                 <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
                 <German>Kaliber: 6.5x39 mm Nachlade-Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_green">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_green">
                 <English>6.5mm 30Rnd Tracer (Green) Mag</English>
                 <German>30 Schuss 6.5mm Leuchtspur (Grün) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_green_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_green_description">
                 <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_yellow">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_yellow">
                 <English>6.5mm 30Rnd Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Leuchtspur (Gelb) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_caseless_mag_tracer_yellow_description">
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_yellow_description">
                 <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
             </Key>
 
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_green">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_green">
                 <English>6.5mm 100Rnd Mixed Mag (Green)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (grün)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_green_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_green_description">
                 <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_yellow">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_yellow">
                 <English>6.5mm 100Rnd Mixed Mag (Yellow)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (gelb)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_yellow_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_yellow_description">
                 <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_green">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_green">
                 <English>6.5mm 100Rnd Mag Tracer (Green)</English>
                 <German>100 Schuss 6.5mm Magazin Leuchtspur (Grün)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_green_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_green_description">
                 <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_yellow">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_yellow">
                 <English>6.5mm 100Rnd Mag Tracer (Yellow)</English>
                 <German>100 Schuss 6.5mm Magazin Leuchtspur (Gelb)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_yellow_description">
+            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_yellow_description">
                 <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
@@ -188,9 +188,17 @@
                 <English>6.5mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Rot) Magazin</German>
             </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_red_description">
+                <English>Caliber: 6.5x39 mm - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
+                <German>Kaliber: 6,5x39mm ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
+            </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_yellow">
                 <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_yellow_description">
+                <English>Caliber: 6.5x39 mm - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
+                <German>Kaliber: 6,5x39mm ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_red">
                 <English>6.5mm 30Rnd Tracer (Red) Mag</English>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -6,17 +6,9 @@
                 <English>5.56 mm 150Rnd Reload Tracer (Green) Mag</English>
                 <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_green_description">
-                <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
-                <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_yellow">
                 <English>5.56 mm 150Rnd Reload Tracer (Yellow) Mag</English>
                 <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_yellow_description">
-                <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
-                <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_green">
                 <English>5.56 mm 150Rnd Tracer (Green) Mag</English>
@@ -39,10 +31,6 @@
                 <English>5.56 mm 200Rnd Reload Tracer (Green) Box</English>
                 <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_green_description">
-                <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
-                <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_tracer_green">
                 <English>5.56 mm 200Rnd Tracer (Green) Box</English>
                 <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
@@ -56,17 +44,9 @@
                 <English>5.8 mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_red_description">
-                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
-                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_yellow">
                 <English>5.8 mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_yellow_description">
-                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
-                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_red">
                 <English>5.8 mm 30Rnd Tracer (Red) Mag</English>
@@ -89,17 +69,9 @@
                 <English>5.8 mm 100Rnd Reload Tracer (Red) Mag</English>
                 <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_red_description">
-                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
-                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_yellow">
                 <English>5.8 mm 100Rnd Reload Tracer (Yellow) Mag</English>
                 <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_yellow_description">
-                <English>Caliber: 5.8x42 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
-                <German>Kaliber: 5,8x42 mm&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_red">
                 <English>5.8 mm 100Rnd Tracer (Red) Mag</English>
@@ -155,17 +127,9 @@
                 <English>6.5mm 100Rnd Mixed Mag (Green)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (grün)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_green_description">
-                <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
-                <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_yellow">
                 <English>6.5mm 100Rnd Mixed Mag (Yellow)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (gelb)</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_yellow_description">
-                <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
-                <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_green">
                 <English>6.5mm 100Rnd Mag Tracer (Green)</English>
@@ -188,17 +152,9 @@
                 <English>6.5mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Rot) Magazin</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_red_description">
-                <English>Caliber: 6.5x39 mm - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
-                <German>Kaliber: 6,5x39mm ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_yellow">
                 <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_yellow_description">
-                <English>Caliber: 6.5x39 mm - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
-                <German>Kaliber: 6,5x39mm ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_red">
                 <English>6.5mm 30Rnd Tracer (Red) Mag</English>
@@ -271,17 +227,9 @@
                 <English>7.62mm 150Rnd Box Mixed (Red)</English>
                 <German>7.62mm 150 Schuss Kiste Gemischt (rot)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_red_description">
-                <English>Caliber: 7.62x54 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
-                <German>Kaliber: 7.62x54 mm&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_yellow">
                 <English>7.62mm 150Rnd Box Mixed (Yellow)</English>
                 <German>7.62mm 150 Schuss Kiste Gemischt (gelb)</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_yellow_description">
-                <English>Caliber: 7.62x54 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
-                <German>Kaliber: 7.62x54 mm&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_red">
                 <English>7.62mm 150Rnd Box Tracer (Red)</English>
@@ -304,34 +252,18 @@
                 <English>9.3mm 150Rnd Belt Mixed (Yellow)</English>
                 <German>9.3mm 150 Schuss Gurt gemischt (Gelb)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_yellow_description">
-                <English>Caliber: 9.3x64mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
-                <German>Kaliber: 9,3 x 64 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_red">
                 <English>9.3mm 150Rnd Belt Mixed (Red)</English>
                 <German>9.3mm 150 Schuss Gurt gemischt (Rot)</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_red_description">
-                <English>Caliber: 9.3x64mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Navid</English>
-                <German>Kaliber: 9,3 x 64 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet für: Navid</German>
             </Key>
 
             <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_yellow">
                 <English>.338 NM 130Rnd Belt Mixed (Yellow)</English>
                 <German>.338 NM 130 Schuss Gurt gemischt (gelb)</German>
             </Key>
-            <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_yellow_description">
-                <English>Caliber: .338 Norma Magnum&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
-                <German>Kaliber: .338 Norma Magnum&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
-            </Key>
             <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_green">
                 <English>.338 NM 130Rnd Belt Mixed (Green)</English>
                 <German>.338 NM 130 Schuss Gurt gemischt (grün)</German>
-            </Key>
-            <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_green_description">
-                <English>Caliber: .338 Norma Magnum&lt;br /&gt;Rounds: 130&lt;br /&gt;Used in: SPMG</English>
-                <German>Kaliber: .338 Norma Magnum&lt;br /&gt;Schuss: 130&lt;br /&gt;Verwendet für: SPMG</German>
             </Key>
         </Container>
     </Package>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -36,32 +36,32 @@
             </Key>
 
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_green">
-                <English>6.5mm 100Rnd Mag (Mixed Green)</English>
-                <German>100 Schuss 6.5mm Magazin (Gemischt Grün)</German>
+                <English>6.5mm 100Rnd Mixed Mag (Green)</English>
+                <German>100 Schuss 6.5mm Magazin gemischt (grün)</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_green_description">
                 <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_yellow">
-                <English>6.5mm 100Rnd Mag (Mixed Yellow)</English>
-                <German>100 Schuss 6.5mm Magazin (Gemischt Gelb)</German>
+                <English>6.5mm 100Rnd Mixed Mag (Yellow)</English>
+                <German>100 Schuss 6.5mm Magazin gemischt (gelb)</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_yellow_description">
                 <English>Caliber: 6.5x39 mm&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_green">
-                <English>6.5mm 100Rnd Mag (Tracer Green)</English>
-                <German>100 Schuss 6.5mm Magazin (Leuchtspur Grün)</German>
+                <English>6.5mm 100Rnd Mag Tracer (Green)</English>
+                <German>100 Schuss 6.5mm Magazin Leuchtspur (Grün)</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_green_description">
                 <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_yellow">
-                <English>6.5mm 100Rnd Mag (Tracer Yellow)</English>
-                <German>100 Schuss 6.5mm Magazin (Leuchtspur Gelb)</German>
+                <English>6.5mm 100Rnd Mag Tracer (Yellow)</English>
+                <German>100 Schuss 6.5mm Magazin Leuchtspur (Gelb)</German>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_caseless_mag_tracer_yellow_description">
                 <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -26,7 +26,6 @@
                 <English>Caliber: 5.56x45 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
                 <German>Kaliber: 5,56x45 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_green">
                 <English>5.56 mm 200Rnd Reload Tracer (Green) Box</English>
                 <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
@@ -39,7 +38,6 @@
                 <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
                 <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_red">
                 <English>5.8 mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
@@ -64,7 +62,6 @@
                 <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
                 <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_red">
                 <English>5.8 mm 100Rnd Reload Tracer (Red) Mag</English>
                 <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
@@ -89,7 +86,6 @@
                 <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
                 <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_green">
                 <English>6.5mm 30Rnd Reload Tracer (Green) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Grün) Magazin</German>
@@ -122,7 +118,6 @@
                 <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_green">
                 <English>6.5mm 100Rnd Mixed Mag (Green)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (grün)</German>
@@ -147,7 +142,6 @@
                 <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_red">
                 <English>6.5mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Rot) Magazin</German>
@@ -172,7 +166,6 @@
                 <English>Caliber: 6.5x39 mm Tracer (Yellow) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
                 <German>Kaliber: 6,5x39mm Leuchtspur (Rot) ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_green">
                 <English>6.5 mm 200Rnd Belt Case Mixed (Green)</English>
                 <German>6,5 mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
@@ -205,7 +198,6 @@
                 <English>Caliber: 6.5x39 mm Tracer - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
                 <German>Kaliber: 6.5x39 mm Leuchtspur - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_green">
                 <English>7.62 mm 20Rnd Tracer (Green) Mag</English>
                 <German>7,62 mm 20-Schuss-Magazin Leuchtspur (Grün)</German>
@@ -222,7 +214,6 @@
                 <English>Caliber: 7.62x51 mm NATO Tracer - Yellow&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
                 <German>Kaliber: 7,62x51 mm NATO Leuchtspur - gelb&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_red">
                 <English>7.62mm 150Rnd Box Mixed (Red)</English>
                 <German>7.62mm 150 Schuss Kiste Gemischt (rot)</German>
@@ -247,7 +238,6 @@
                 <English>Caliber: 7.62x54 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
                 <German>Kaliber: 7.62x54 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_yellow">
                 <English>9.3mm 150Rnd Belt Mixed (Yellow)</English>
                 <German>9.3mm 150 Schuss Gurt gemischt (Gelb)</German>
@@ -256,7 +246,6 @@
                 <English>9.3mm 150Rnd Belt Mixed (Red)</English>
                 <German>9.3mm 150 Schuss Gurt gemischt (Rot)</German>
             </Key>
-
             <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_yellow">
                 <English>.338 NM 130Rnd Belt Mixed (Yellow)</English>
                 <German>.338 NM 130 Schuss Gurt gemischt (gelb)</German>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -2,6 +2,39 @@
 <Project name="ACE_tracer">
     <Package name="main">
         <Container name="magazines">
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_green">
+                <English>5.56 mm 150Rnd Reload Tracer (Green) Mag</English>
+                <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_green_description">
+                <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
+                <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_yellow">
+                <English>5.56 mm 150Rnd Reload Tracer (Yellow) Mag</English>
+                <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_F_yellow_description">
+                <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
+                <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_green">
+                <English>5.56 mm 150Rnd Tracer (Green) Mag</English>
+                <German>150 Schuss 5,56 mm Leuchtspur (Grün) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_green_description">
+                <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
+                <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_yellow">
+                <English>5.56 mm 150Rnd Tracer (Yellow) Mag</English>
+                <German>150 Schuss 5,56 mm Leuchtspur (Gelb) Magazin</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_Mag_Tracer_F_yellow_description">
+                <English>Caliber: 5.56x45 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
+                <German>Kaliber: 5,56x45 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
+            </Key>
+
             <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_F_green">
                 <English>5.56 mm 200Rnd Reload Tracer (Green) Box</English>
                 <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -2,6 +2,23 @@
 <Project name="ACE_tracer">
     <Package name="main">
         <Container name="magazines">
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_F_green">
+                <English>5.56 mm 200Rnd Reload Tracer (Green) Box</English>
+                <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_F_green_description">
+                <English>Caliber: 5.56x45 mm&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
+                <German>Kaliber: 5,56x45 mm&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_Tracer_F_green">
+                <English>5.56 mm 200Rnd Tracer (Green) Box</English>
+                <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
+            </Key>
+            <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_Tracer_F_green_description">
+                <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
+                <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
+            </Key>
+
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_F_red">
                 <English>5.8 mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>


### PR DESCRIPTION
**When merged this pull request will:**
Adds the following magazines:

| calibre | rounds / shape | tracer (reload, mixed, every) | color (green, red, yellow) | /w image |
|:-------:|:--------:|:----:|:------:|:--------:|
| 5.56x45 | 150 Drum | r, e | g, y   | no       |
| 5.56x45 | 200 Belt | m, e | g      | no       |
| 5.8x42  | 30       | r, e | r, y   | no       |
| 5.8x42  | 100 Drum | r, e | r, y   | no       |
| 6.5 mx  | 30       | r, e | g, y   | yes      |
| 6.5 mx  | 100 Stick| r, e | g, y   | yes      |
| 6.5 kat.| 30       | r, e | r, y   | yes      |
| 6.5 case| 200 Belt | m, e | g, y   | yes      |
| 7.62x51 | 20       | e    | g, y   | no       |
| 7.62x54 | 150 Belt | m, e | r, y   | no       |
| 9.3x64  | 150 Belt | m    | r, y   | no       |
| .338 NM | 130 Belt | m    | g, y   | no       |

All Magazines are added to the same CBA & Vanilla Magazine Wells as their vanilla base classes.
