### PR TITLE
Interaction - Add condition to zeus actions

### DIFF
--- a/addons/interaction/ACE_ZeusActions.hpp
+++ b/addons/interaction/ACE_ZeusActions.hpp
@@ -7,7 +7,7 @@ class ACE_ZeusActions {
 
         class stance {
             displayName = "$STR_A3_RscAttributeUnitPos_Title";
-            condition = QUOTE(-1 < (curatorSelected select 0) findIf {_x isKindOf 'CAManBase'});
+            condition = QUOTE(ZEUS_ACTION_CONDITION && {-1 < (curatorSelected select 0) findIf {_x isKindOf 'CAManBase'}});
 
             class prone {
                 displayName = "$STR_Pos_Down";
@@ -34,7 +34,7 @@ class ACE_ZeusActions {
         class remoteControl {
             displayName = "$STR_A3_CfgVehicles_ModuleRemoteControl_F";
             icon = "\A3\Modules_F_Curator\Data\portraitRemoteControl_ca.paa";
-            condition = QUOTE(-1 < (curatorSelected select 0) findIf {_x isKindOf 'CAManBase'});
+            condition = QUOTE(ZEUS_ACTION_CONDITION && {-1 < (curatorSelected select 0) findIf {_x isKindOf 'CAManBase'}});
             statement = QUOTE( \
                 private _units = curatorSelected select 0; \
                 private _unit = _units param [ARR_2( \
@@ -52,7 +52,7 @@ class ACE_ZeusActions {
         class GVAR(repair) {
             displayName = "$STR_repair";
             icon = "\A3\ui_f\data\igui\cfg\actions\repair_ca.paa";
-            condition = QUOTE(-1 < (curatorSelected select 0) findIf {_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}});
+            condition = QUOTE(ZEUS_ACTION_CONDITION && {-1 < (curatorSelected select 0) findIf {_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}}});
             statement = QUOTE({if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {_x setDamage 0}} forEach (curatorSelected select 0));
         };
     };
@@ -64,6 +64,7 @@ class ACE_ZeusActions {
 
         class behaviour {
             displayName = "$STR_Combat_Mode";
+            condition = QUOTE(ZEUS_ACTION_CONDITION);
 
             class careless {
                 displayName = "$STR_Combat_Careless";
@@ -93,6 +94,7 @@ class ACE_ZeusActions {
 
         class speed {
             displayName = "$STR_HC_Menu_Speed";
+            condition = QUOTE(ZEUS_ACTION_CONDITION);
 
             class limited {
                 displayName = "$STR_Speed_Limited";
@@ -113,6 +115,7 @@ class ACE_ZeusActions {
 
         class formation {
             displayName = "$STR_Formation";
+            condition = QUOTE(ZEUS_ACTION_CONDITION);
 
             class wedge {
                 displayName = "$STR_Wedge";
@@ -169,6 +172,7 @@ class ACE_ZeusActions {
 
         class behaviour {
             displayName = "$STR_Combat_Mode";
+            condition = QUOTE(ZEUS_ACTION_CONDITION);
 
             class careless {
                 displayName = "$STR_Combat_Careless";
@@ -198,6 +202,7 @@ class ACE_ZeusActions {
 
         class speed {
             displayName = "$STR_HC_Menu_Speed";
+            condition = QUOTE(ZEUS_ACTION_CONDITION);
 
             class limited {
                 displayName = "$STR_Speed_Limited";
@@ -218,6 +223,7 @@ class ACE_ZeusActions {
 
         class formation {
             displayName = "$STR_Formation";
+            condition = QUOTE(ZEUS_ACTION_CONDITION);
 
             class wedge {
                 displayName = "$STR_Wedge";

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -134,4 +134,6 @@
 #define MRAD_TO_DEG(d) ((d) / 17.45329252) // Conversion factor: 9 / (50 * PI)
 #define MOA_TO_RAD(d) ((d) * 0.00029088) // Conversion factor: PI / 10800
 
+#define ZEUS_ACTION_CONDITION (QUOTE(QUOTE(ADDON)) in curatorAddons _target)
+
 #include "script_debug.hpp"

--- a/addons/rearm/ACE_ZeusActions.hpp
+++ b/addons/rearm/ACE_ZeusActions.hpp
@@ -2,8 +2,8 @@ class ACE_ZeusActions {
     class ZeusUnits {
         class GVAR(rearm) {
             displayName = CSTRING(Rearm);
-            icon = "\z\ace\addons\rearm\ui\icon_rearm_interact.paa";
-            condition = QUOTE(-1 < (curatorSelected select 0) findIf {_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}});
+            icon = QPATHTOF(ui\icon_rearm_interact.paa);
+            condition = QUOTE(ZEUS_ACTION_CONDITION && {-1 < (curatorSelected select 0) findIf {_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}}});
             statement = QUOTE( \
                 { \
                     if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then { \


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Zeus modules can be disabled/enabled with `removeCuratorAddons`/`addCuratorAddons` commands. This PR adds condition which checks if addon is enabled for curator and thus zeus interaction menu are controlled the same way.
