### PR TITLE
Medical - Updated basic blood IV treatment time to be coherent to advanced medical

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -64,7 +64,7 @@ class ACE_Medical_Actions {
             allowSelfTreatment = 0;
             category = "advanced";
             requiredMedic = 1;
-            treatmentTime = 20;
+            treatmentTime = 7;
             items[] = {"ACE_bloodIV"};
             // callbackSuccess = QUOTE(DFUNC(treatmentBasic_bloodbag));
             callbackSuccess = QUOTE(DFUNC(treatmentIV));


### PR DESCRIPTION
Ever since the way basic medical applied blood IVs was changed to the advanced medical counterpart, I thought something was amiss. After today looking around some configs for another project I noticed that the treatment time for basic medical is still set to 20, while advanced medical has 7 seconds across the board.
So why not change it to 7 to be the same as advanced? 20 seconds was good as basic applied blood instantly without blood flow, but now you must wait 20 seconds and wait for the blood to be transfused.
This is mostly to have transfusing blood to be the same in both medical systems until the medical rewrite arrives.

When merged this pull request will:
- Change Blood IV treatment time from 20 to 7 seconds

