### PR TITLE
Update stringtable.xml

### DIFF
--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -514,18 +514,18 @@
             <Chinesesimp>"非洲小狐"防地雷反伏击车 (榴弹机枪)</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_RealisticNames_MBT_03_cannon_Name">
-            <English>Leopard 2SG</English>
-            <German>Leopard 2SG</German>
-            <Spanish>Leopard 2SG</Spanish>
-            <Polish>Leopard 2SG</Polish>
-            <Czech>Leopard 2SG</Czech>
-            <French>Leopard 2SG</French>
-            <Russian>Леопард 2SG</Russian>
-            <Portuguese>Leopard 2SG</Portuguese>
-            <Hungarian>Leopard 2SG</Hungarian>
-            <Italian>Leopard 2SG</Italian>
-            <Japanese>レオパルド 2SG</Japanese>
-            <Korean>Leopard 2SG</Korean>
+            <English>Leopard 2 Revolution</English>
+            <German>Leopard 2 Revolution</German>
+            <Spanish>Leopard 2 Revolution</Spanish>
+            <Polish>Leopard 2 Revolution</Polish>
+            <Czech>Leopard 2 Revolution</Czech>
+            <French>Leopard 2 Revolution</French>
+            <Russian>Леопард 2 Revolution</Russian>
+            <Portuguese>Leopard 2 Revolution</Portuguese>
+            <Hungarian>Leopard 2 Revolution</Hungarian>
+            <Italian>Leopard 2 Revolution</Italian>
+            <Japanese>レオパルド 2 Revolution</Japanese>
+            <Korean>Leopard 2 Revolution</Korean>
             <Chinese>"豹2型新加坡版"主戰坦克</Chinese>
             <Chinesesimp>"豹2型新加坡版"主战坦克</Chinesesimp>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Name change for Leopard 2SG into Leopard 2 Revolution
- Leopard 2SG looks more like the Leopard 2 Revolution.
Although they look very similar, due to the new Rheinmetall-Armor both tanks are equipped with, they are not equal (espacially how the headlights are integrated and the type of secondary armament on top of the turret).

Leopard 2SG:
![19410779696_1ae9117657_b](https://user-images.githubusercontent.com/15272840/48338486-10efbe00-e666-11e8-8228-8c2bf536ee6d.jpg)

MBT - Revolution (or maybe it would be called "Leopard 2 Revolution", for it's a prototype and not in service for a nation like in "Arma's-Future World"):
![48327950-e855cd00-e641-11e8-9238-513983bffddb](https://user-images.githubusercontent.com/15272840/48338736-b73bc380-e666-11e8-9513-294a00715543.jpg)

MBT - 52 Kuma (Arma3-Vanilla):
![48328381-f1479e00-e643-11e8-8f36-e5e7b518992d](https://user-images.githubusercontent.com/15272840/48338843-0255d680-e667-11e8-8e59-10d81ceaadb3.jpg)