### PR TITLE
Medical - Make vehicle explosions kill players even with prevent instant death enabled

### DIFF
--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: KoffeinFlummi, Glowbal, commy2
  * Main HandleDamage EH function.
@@ -19,7 +20,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 _this = _this select [0, 7];
 params ["_unit", "_selection", "_damage", "_shooter", "_projectile", "_hitPointIndex"];

--- a/addons/medical/functions/fnc_handleDamage.sqf
+++ b/addons/medical/functions/fnc_handleDamage.sqf
@@ -1,4 +1,3 @@
-#include "script_component.hpp"
 /*
  * Author: KoffeinFlummi, Glowbal, commy2
  * Main HandleDamage EH function.
@@ -20,6 +19,7 @@
  *
  * Public: No
  */
+#include "script_component.hpp"
 
 _this = _this select [0, 7];
 params ["_unit", "_selection", "_damage", "_shooter", "_projectile", "_hitPointIndex"];
@@ -111,8 +111,7 @@ if ((_minLethalDamage <= _newDamage) && {[_unit, [_effectiveSelectionName] call 
 if (_unit getVariable [QGVAR(preventInstaDeath), GVAR(preventInstaDeath)]) exitWith {
     private _delayedUnconsicous = false;
     if (_vehicle != _unit and {damage _vehicle >= 1}) then {
-        [_unit] call EFUNC(common,unloadPerson);
-        _delayedUnconsicous = true;
+        [_unit] call FUNC(setDead);
     };
 
     if (_damageReturn >= 0.9 && {_selection in ["", "head", "body"]}) exitWith {


### PR DESCRIPTION
**When prevent instant death is enabled, vehicles exploding will now kill occupants**

I'm not quite sure if this is correct for prevent instant death but it seems a bit silly for your vehicle to explode and you just flop out unconscious. Also if you're playing with cookoff, you generally die to cookoff after falling out anyway.

This is slightly counter to the actual name of the option however so open to input on this, I did ask in Slack a while ago but didn't get any responses.
