### PR TITLE
Medical - Adding option to convert vanilla medical gear

### DIFF
--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -310,4 +310,11 @@ class ACE_Settings {
         value = 3;
         sliderSettings[] = {0, 30, 3, 0};
     };
+    class GVAR(convertVanillaMedicalItems) {
+        category = CSTRING(Category_Medical);
+        displayName = CSTRING(MedicalSettings_convertVanillaMedicalItems_DisplayName);
+        description = CSTRING(MedicalSettings_convertVanillaMedicalItems_Description);
+        typeName = "BOOL";
+        value = 1;
+    };
 };

--- a/addons/medical/functions/fnc_itemCheck.sqf
+++ b/addons/medical/functions/fnc_itemCheck.sqf
@@ -18,35 +18,43 @@
 params ["_unit"];
 
 while {({_x == "FirstAidKit"} count items _unit) > 0} do {
-    _unit removeItem "FirstAidKit";
-    if (GVAR(level) >= 2) then {
-        _unit addItem "ACE_fieldDressing";
-        _unit addItem "ACE_packingBandage";
-        _unit addItem "ACE_morphine";
-        _unit addItem "ACE_tourniquet";
+    if (GVAR(convertVanillaMedicalItems)) then {
+        _unit removeItem "FirstAidKit";
+        if (GVAR(level) >= 2) then {
+            _unit addItem "ACE_fieldDressing";
+            _unit addItem "ACE_packingBandage";
+            _unit addItem "ACE_morphine";
+            _unit addItem "ACE_tourniquet";
+        } else {
+            _unit addItem "ACE_fieldDressing";
+            _unit addItem "ACE_fieldDressing";
+            _unit addItem "ACE_morphine";
+        };
     } else {
-        _unit addItem "ACE_fieldDressing";
-        _unit addItem "ACE_fieldDressing";
-        _unit addItem "ACE_morphine";
+        _unit removeItem "FirstAidKit";
     };
 };
 
 while {({_x == "Medikit"} count items _unit) > 0} do {
-    _unit removeItem "Medikit";
-    if (GVAR(level) >= 2) then {
-        _unit addItemToBackpack "ACE_fieldDressing";
-        _unit addItemToBackpack "ACE_packingBandage";
-        _unit addItemToBackpack "ACE_packingBandage";
-        _unit addItemToBackpack "ACE_epinephrine";
-        _unit addItemToBackpack "ACE_morphine";
-        _unit addItemToBackpack "ACE_salineIV_250";
-        _unit addItemToBackpack "ACE_tourniquet";
+    if (GVAR(convertVanillaMedicalItems)) then {
+        _unit removeItem "Medikit";
+        if (GVAR(level) >= 2) then {
+            _unit addItemToBackpack "ACE_fieldDressing";
+            _unit addItemToBackpack "ACE_packingBandage";
+            _unit addItemToBackpack "ACE_packingBandage";
+            _unit addItemToBackpack "ACE_epinephrine";
+            _unit addItemToBackpack "ACE_morphine";
+            _unit addItemToBackpack "ACE_salineIV_250";
+            _unit addItemToBackpack "ACE_tourniquet";
+        } else {
+            _unit addItemToBackpack "ACE_epinephrine";
+            _unit addItemToBackpack "ACE_epinephrine";
+            _unit addItemToBackpack "ACE_epinephrine";
+            _unit addItemToBackpack "ACE_epinephrine";
+            _unit addItemToBackpack "ACE_bloodIV";
+            _unit addItemToBackpack "ACE_bloodIV";
+        };
     } else {
-        _unit addItemToBackpack "ACE_epinephrine";
-        _unit addItemToBackpack "ACE_epinephrine";
-        _unit addItemToBackpack "ACE_epinephrine";
-        _unit addItemToBackpack "ACE_epinephrine";
-        _unit addItemToBackpack "ACE_bloodIV";
-        _unit addItemToBackpack "ACE_bloodIV";
+        _unit removeItem "Medikit";
     };
 };

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -5665,5 +5665,11 @@
             <Chinese>當隊員對嗎啡/腎上腺素/阿托品過量時，會使他的傷害更重</Chinese>
             <Italian>Rende il paziente suscettibile di overdose da morfina, epinefrina o atropina.</Italian>
         </Key>
+        <Key ID="STR_ACE_Medical_MedicalSettings_convertVanillaMedicalItems_DisplayName">
+            <English>Convert vanilla medical items to ACE medical items</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_MedicalSettings_convertVanillaMedicalItems_Description">
+            <English>Enables or disables if vanilla medical items are converted to ACE medical items or removed</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**Give an option to convert vanilla medical items to ACE ones**
Adds a setting to disable the conversion from vanilla medical to ACE medical but still removes the original item. Defaults to true to keep current behaviour the same.

Figured it might be useful for people running missions with vanilla gear in and they don't want them being auto-converted to ACE meds, rather just having them removed.
