### PR TITLE
Add stale configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - impact/large
+  - kind/critical bug
+  - kind/bug
+  - status/accepting-pr
+  - status/cherrypick
+  - status/merge on release
+  - sticky
+
+# Label to use when marking an issue as stale
+staleLabel: status/stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to inactivity. Please re-open
+  if this still requires investigation.
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
Add stale bot configuration. Mark anything inactive for >6 months as stale. Close after 14 days of no activity on stale issues.


