### PR TITLE
fix armake issues with latest release against ACE3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: acemod/armake
+      - image: acemod/armake:master
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This issue has been resolved in Armake on the master branch. By switching to the `:master` tag we can use armake to build the ACE project again.

