### PR TITLE
fix moved markers not synched

### DIFF
--- a/addons/markers/functions/fnc_movePFH.sqf
+++ b/addons/markers/functions/fnc_movePFH.sqf
@@ -22,8 +22,9 @@ if (isNull _ctrlMap || !GVAR(moving)) exitWith {
     (_this select 1) call CBA_fnc_removePerFrameHandler;
 
     private _finalPos = getMarkerPos _marker;
+    private _overrule = [QGVAR(markerMoveEnded), [ACE_player, _marker, _originalPos, _finalPos]] call CBA_fnc_localEvent;
 
-    if !([QGVAR(markerMoveEnded), [ACE_player, _marker, _originalPos, _finalPos]] call CBA_fnc_localEvent) then {
+    if (!isNil "_overrule" && {_overrule isEqualTo true}) then {
         _marker setMarkerPosLocal _originalPos;
     } else {
         [QGVAR(setMarkerPosLocal), [_marker, _finalPos]] call CBA_fnc_globalEvent;

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Markers
 #include "\z\ace\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_MARKERS

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Markers
 #include "\z\ace\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_MARKERS


### PR DESCRIPTION
**When merged this pull request will:**
- without attached event handler, localEvent reports `nil`, which should be treated as `false` (don't overwrite movement)
- fix #6702
