### PR TITLE
Custom Materials for tagging

### DIFF
--- a/addons/tagging/functions/fnc_addCustomTag.sqf
+++ b/addons/tagging/functions/fnc_addCustomTag.sqf
@@ -9,6 +9,7 @@
  * 2: Required Item <STRING>
  * 3: Textures Paths <ARRAY>
  * 4: Icon Path <STRING> (default: "")
+ * 5: Material Paths <ARRAY> (optional)
  *
  * Return Value:
  * Sucessfully Added Tag <BOOL>
@@ -24,7 +25,8 @@ params [
     ["_displayName", "", [""]],
     ["_requiredItem", "", [""]],
     ["_textures", [], [[]]],
-    ["_icon", "", [""]]
+    ["_icon", "", [""]],
+    ["_materials", [], [[]]]
 ];
 
 // Verify
@@ -50,4 +52,4 @@ if (_textures isEqualTo []) exitWith {
 _identifier = [_identifier] call CBA_fnc_removeWhitespace;
 
 // Add
-[QGVAR(applyCustomTag), [_identifier, _displayName, _requiredItem, _textures, _icon]] call CBA_fnc_globalEventJIP;
+[QGVAR(applyCustomTag), [_identifier, _displayName, _requiredItem, _textures, _icon, _materials]] call CBA_fnc_globalEventJIP;

--- a/addons/tagging/functions/fnc_addTagActions.sqf
+++ b/addons/tagging/functions/fnc_addTagActions.sqf
@@ -28,12 +28,15 @@ private _actions = [];
             _icon,
             {
                 (_this select 2) params ["_unit", "_class", "_textures", "", "_materials"];
-                private _randomTexture = selectRandom _textures;
-                private _randomMaterial =  if (count _textures == count _materials) then {
-                    _materials select (_textures find _randomTexture)
-                } else {
-                    selectRandom _materials
-                };
+
+                (
+                    if (count _textures == count _materials) then {
+                        private _textureIndex = floor random count _textures;
+                        [_textures select _textureIndex, _materials select _textureIndex]
+                    } else {
+                        [selectRandom _textures, selectRandom _materials]
+                    }
+                ) params ["_randomTexture", "_randomMaterial"];
 
                 [_unit, _randomTexture, _randomMaterial] call FUNC(tag);
                 _unit setVariable [QGVAR(lastUsedTag), _class];

--- a/addons/tagging/functions/fnc_addTagActions.sqf
+++ b/addons/tagging/functions/fnc_addTagActions.sqf
@@ -19,7 +19,7 @@ params ["_unit"];
 
 private _actions = [];
 {
-    _x params ["_class", "_displayName", "_requiredItem", "_textures", "_icon"];
+    _x params ["_class", "_displayName", "_requiredItem", "_textures", "_icon", "_materials"];
 
     _actions pushBack [
         [
@@ -27,8 +27,15 @@ private _actions = [];
             _displayName,
             _icon,
             {
-                (_this select 2) params ["_unit", "_class", "_textures"];
-                [_unit, selectRandom _textures] call FUNC(tag);
+                (_this select 2) params ["_unit", "_class", "_textures", "", "_materials"];
+                private _randomTexture = selectRandom _textures;
+                private _randomMaterial =  if (count _textures == count _materials) then {
+                    _materials select (_textures find _randomTexture)
+                } else {
+                    selectRandom _materials
+                };
+
+                [_unit, _randomTexture, _randomMaterial] call FUNC(tag);
                 _unit setVariable [QGVAR(lastUsedTag), _class];
             },
             {
@@ -36,7 +43,7 @@ private _actions = [];
                 _requiredItem in (_unit call EFUNC(common,uniqueItems))
             },
             {},
-            [_unit, _class, _textures, _requiredItem]
+            [_unit, _class, _textures, _requiredItem, _materials]
         ] call EFUNC(interact_menu,createAction),
         [],
         _unit

--- a/addons/tagging/functions/fnc_applyCustomTag.sqf
+++ b/addons/tagging/functions/fnc_applyCustomTag.sqf
@@ -9,6 +9,7 @@
  * 2: Required Item <STRING>
  * 3: Textures Paths <ARRAY>
  * 4: Icon Path <STRING> (default: "")
+ * 5: Material Paths <ARRAY>
  *
  * Return Value:
  * None

--- a/addons/tagging/functions/fnc_compileConfigTags.sqf
+++ b/addons/tagging/functions/fnc_compileConfigTags.sqf
@@ -44,10 +44,12 @@
         _failure = true;
     };
 
+    private _materials = getArray (_x >> "materials");
+
     private _icon = getText (_x >> "icon");
 
     if (!_failure) then {
-        GVAR(cachedTags) pushBack [_class, _displayName, _requiredItem, _textures, _icon];
+        GVAR(cachedTags) pushBack [_class, _displayName, _requiredItem, _textures, _icon, _materials];
         GVAR(cachedRequiredItems) pushBackUnique _requiredItem;
     };
 } forEach ("true" configClasses (configFile >> "ACE_Tags"));

--- a/addons/tagging/functions/fnc_createTag.sqf
+++ b/addons/tagging/functions/fnc_createTag.sqf
@@ -9,6 +9,7 @@
  * 2: Colour of the tag (valid colours are black, red, green and blue or full path to custom texture) <STRING>
  * 3: Object it should be tied to <OBJECT>
  * 4: Unit that created the tag <OBJECT>
+ * 5: Material of the tag <STRING> (Optional)
  *
  * Return Value:
  * Tag created <BOOL>
@@ -19,7 +20,7 @@
  * Public: No
  */
 
-params ["_tagPosASL", "_vectorDirAndUp", "_texture", "_object", "_unit"];
+params ["_tagPosASL", "_vectorDirAndUp", "_texture", "_object", "_unit", ["_material","",[""]]];
 TRACE_5("createTag:",_tagPosASL,_vectorDirAndUp,_texture,_object,_unit);
 
 if (_texture == "") exitWith {
@@ -29,9 +30,10 @@ if (_texture == "") exitWith {
 
 private _tag = createSimpleObject ["UserTexture1m_F", _tagPosASL];
 _tag setObjectTextureGlobal [0, _texture];
+if (_material != "") then { _tag setObjectMaterialGlobal [0, _material] };
 _tag setVectorDirAndUp _vectorDirAndUp;
 
-// Throw a global event for mision makers
+// Throw a global event for mission makers
 ["ace_tagCreated", [_tag, _texture, _object, _unit]] call CBA_fnc_globalEvent;
 
 if (isNull _object) exitWith {true};

--- a/addons/tagging/functions/fnc_quickTag.sqf
+++ b/addons/tagging/functions/fnc_quickTag.sqf
@@ -49,5 +49,13 @@ if (GVAR(quickTag) == 3) then {
 // Tag
 if !(_possibleTags isEqualTo []) then {
     private _availableTags = _possibleTags select {(_x select 2) in (_unit call EFUNC(common,uniqueItems))};
-    [_unit, selectRandom ((selectRandom _availableTags) select 3)] call FUNC(tag);
+    (selectRandom _availableTags) params ["", "", "", "_textures", "", "_materials"];
+    private _randomTexture = selectRandom _textures;
+    private _randomMaterial =  if (count _textures == count _materials) then {
+        _materials select (_textures find _randomTexture)
+    } else {
+        selectRandom _materials
+    };
+
+    [_unit, _randomTexture, _randomMaterial] call FUNC(tag);
 };

--- a/addons/tagging/functions/fnc_quickTag.sqf
+++ b/addons/tagging/functions/fnc_quickTag.sqf
@@ -50,12 +50,15 @@ if (GVAR(quickTag) == 3) then {
 if !(_possibleTags isEqualTo []) then {
     private _availableTags = _possibleTags select {(_x select 2) in (_unit call EFUNC(common,uniqueItems))};
     (selectRandom _availableTags) params ["", "", "", "_textures", "", "_materials"];
-    private _randomTexture = selectRandom _textures;
-    private _randomMaterial =  if (count _textures == count _materials) then {
-        _materials select (_textures find _randomTexture)
-    } else {
-        selectRandom _materials
-    };
+
+    (
+        if (count _textures == count _materials) then {
+            private _textureIndex = floor random count _textures;
+            [_textures select _textureIndex, _materials select _textureIndex]
+        } else {
+            [selectRandom _textures, selectRandom _materials]
+        }
+    ) params ["_randomTexture", "_randomMaterial"];
 
     [_unit, _randomTexture, _randomMaterial] call FUNC(tag);
 };

--- a/addons/tagging/functions/fnc_tag.sqf
+++ b/addons/tagging/functions/fnc_tag.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: The colour of the tag (valid colours are black, red, green and blue or full path to custom texture) <STRING>
+ * 2: Material of the tag <STRING> (Optional)
  *
  * Return Value:
  * Sucess <BOOL>
@@ -18,7 +19,8 @@
 
 params [
     ["_unit", objNull, [objNull]],
-    ["_texture", "", [""]]
+    ["_texture", "", [""]],
+    ["_material", "", [""]]
 ];
 
 if (isNull _unit || {_texture == ""}) exitWith {
@@ -110,6 +112,6 @@ private _vectorDirAndUp = [_surfaceNormal vectorMultiply -1, _v3];
 
     // Tell the server to create the tag and handle its destruction
     [QGVAR(createTag), _this] call CBA_fnc_serverEvent;
-}, [_touchingPoint vectorAdd (_surfaceNormal vectorMultiply 0.06), _vectorDirAndUp, _texture, _object, _unit], 0.6] call CBA_fnc_waitAndExecute;
+}, [_touchingPoint vectorAdd (_surfaceNormal vectorMultiply 0.06), _vectorDirAndUp, _texture, _object, _unit, _material], 0.6] call CBA_fnc_waitAndExecute;
 
 true


### PR DESCRIPTION
Allows to use custom materials (rvmat) for tag's.
Adds additional "materials" array to the config.
When there are the same number of materials as textures, it will select a random texture and the corresponding material. If the numbers are different it will select random texture and random material.

Allows for things like this:

![arma3_x64_2018-11-25_16-34-57](https://user-images.githubusercontent.com/3768165/48980971-0c002500-f0d0-11e8-8f7e-6d2b84ac208e.png)

Glow-in-the-dark tags.

Next question would be if we also want to directly implement a glow-in-the-dark spraycan directly in ACE.