### PR TITLE
mk6mortar - Tweak charge UI for 1.86

### DIFF
--- a/addons/mk6mortar/RscInGameUI.hpp
+++ b/addons/mk6mortar/RscInGameUI.hpp
@@ -9,7 +9,7 @@ class RscInGameUI {
             idc = 80085;
             colorText[] = {1, 1, 1, 1};
             colorBackground[] = {0, 0, 0, 0.1};
-            x = "(profilenamespace getVariable ['IGUI_GRID_WEAPON_X', ((safezoneX + safezoneW) - (12.4 * (((safezoneW / safezoneH) min 1.2) / 40)) - 0.5 * (((safezoneW / safezoneH) min 1.2) / 40))])";
+            x = "3.8 * (((safezoneW / safezoneH) min 1.2) / 40) + (profilenamespace getvariable [""IGUI_GRID_WEAPON_X"",((safezoneX + safezoneW) - (10 * (((safezoneW / safezoneH) min 1.2) / 40)) - 4.3 * (((safezoneW / safezoneH) min 1.2) / 40))])";
             y = "2.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) + (profilenamespace getVariable ['IGUI_GRID_WEAPON_Y', (safezoneY + 0.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25))])";
             w = "10 * (((safezoneW / safezoneH) min 1.2) / 40)";
             h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";


### PR DESCRIPTION
shifts the mortar charge text to the right to match the rest of the UI which changed slightly

bis: `Added: Current fire mode indicator to the IGUI of mortars`
they now both show up, but I think that's fine for now