### PR TITLE
MissileGuidance - Allow using vanilla fire mode key

### DIFF
--- a/addons/javelin/CfgWeapons.hpp
+++ b/addons/javelin/CfgWeapons.hpp
@@ -1,8 +1,16 @@
+class Mode_SemiAuto;
 class CfgWeapons {
-    
-    class missiles_titan_static;
+    class MissileLauncher;
+    class missiles_titan: MissileLauncher {
+        class Player: MissileLauncher {
+            EGVAR(missileGuidance,attackProfile) = "JAV_DIR";
+        };
+        class TopDown: Player {
+            EGVAR(missileGuidance,attackProfile) = "JAV_TOP";
+        };
+    };
+    class missiles_titan_static: missiles_titan {};
     class GVAR(Titan_Static): missiles_titan_static {
-        modes[] = {"Player"};
         GVAR(enabled) = 1;
         weaponInfoType = "ACE_RscOptics_javelin";
         modelOptics = QPATHTOF(data\reticle_titan.p3d);
@@ -13,7 +21,16 @@ class CfgWeapons {
         lockedTargetSound[] = {"",0,1};
     };
 
-    class launch_Titan_short_base;
+    class Launcher_Base_F;
+    class launch_Titan_base: Launcher_Base_F {
+        class Single: Mode_SemiAuto {
+            EGVAR(missileGuidance,attackProfile) = "JAV_DIR";
+        };
+        class TopDown: Single {
+            EGVAR(missileGuidance,attackProfile) = "JAV_TOP";
+        };
+    };
+    class launch_Titan_short_base: launch_Titan_base {};
     class launch_B_Titan_short_F: launch_Titan_short_base {
         GVAR(enabled) = 1;
         weaponInfoType = "ACE_RscOptics_javelin";

--- a/addons/javelin/functions/fnc_showFireMode.sqf
+++ b/addons/javelin/functions/fnc_showFireMode.sqf
@@ -15,10 +15,16 @@
  * Public: No
  */
 
-private _currentShooter = if (ACE_player call CBA_fnc_canUseWeapon) then {ACE_player} else {vehicle ACE_player};
-private _currentFireMode = _currentShooter getVariable ["ace_missileguidance_attackProfile", "JAV_TOP"];
+(if (((vehicle ACE_player) == ACE_player) || {ACE_player call CBA_fnc_canUseWeapon}) then {
+    weaponState ACE_player
+} else {
+    _turretPath = if (ACE_player == (driver _currentShooter)) then {[-1]} else {ACE_player call CBA_fnc_turretPath};
+    weaponState [vehicle ACE_player, _turretPath]
+}) params ["_weapon", "", "_mode"];
 
-TRACE_1("showFireMode", _currentFireMode);
+private _currentFireMode = getText (configFile >> "CfgWeapons" >> _weapon >> _mode >> QEGVAR(missileGuidance,attackProfile));
+
+TRACE_3("showFireMode",_weapon,_mode,_currentFireMode);
 
 if (_currentFireMode == "JAV_TOP") then {
     __JavelinIGUITop ctrlSetTextColor __ColorGreen;

--- a/addons/javelin/functions/fnc_showFireMode.sqf
+++ b/addons/javelin/functions/fnc_showFireMode.sqf
@@ -26,6 +26,12 @@ private _currentFireMode = getText (configFile >> "CfgWeapons" >> _weapon >> _mo
 
 TRACE_3("showFireMode",_weapon,_mode,_currentFireMode);
 
+if (_currentFireMode == "") then {
+    private _currentShooter = if (ACE_player call CBA_fnc_canUseWeapon) then {ACE_player} else {vehicle ACE_player};
+    _currentFireMode = _currentShooter getVariable ["ace_missileguidance_attackProfile", "JAV_TOP"];
+    TRACE_1("using getVar",_currentFireMode);
+};
+
 if (_currentFireMode == "JAV_TOP") then {
     __JavelinIGUITop ctrlSetTextColor __ColorGreen;
     __JavelinIGUIDir ctrlSetTextColor __ColorGray;

--- a/addons/javelin/functions/fnc_showFireMode.sqf
+++ b/addons/javelin/functions/fnc_showFireMode.sqf
@@ -26,7 +26,7 @@ private _currentFireMode = getText (configFile >> "CfgWeapons" >> _weapon >> _mo
 
 TRACE_3("showFireMode",_weapon,_mode,_currentFireMode);
 
-if (_currentFireMode == "") then {
+if (_currentFireMode == "") then { // backwards compatiblity for addons using ace_javelin (CUP)
     private _currentShooter = if (ACE_player call CBA_fnc_canUseWeapon) then {ACE_player} else {vehicle ACE_player};
     _currentFireMode = _currentShooter getVariable ["ace_missileguidance_attackProfile", "JAV_TOP"];
     TRACE_1("using getVar",_currentFireMode);

--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -93,6 +93,7 @@ class CfgAmmo {
             // Attack profile type selection
             defaultAttackProfile = "JAV_TOP";
             attackProfiles[] = { "JAV_TOP", "JAV_DIR" };
+            useModeForAttackProfile = 1;
         };
     };
     class ACE_Javelin_FGM148_static: ACE_Javelin_FGM148 {

--- a/addons/missileguidance/functions/fnc_cycleAttackProfileKeyDown.sqf
+++ b/addons/missileguidance/functions/fnc_cycleAttackProfileKeyDown.sqf
@@ -84,7 +84,7 @@ private _currentFireMode = if (_useModeForAttackProfile) then {
         if ((_xWeapon == _weapon) && {(getText (configFile >> "CfgWeapons" >> _weapon >> _xMode >> QGVAR(attackProfile))) == _nextFireMode}) exitWith {
             TRACE_2("Restoring",_weaponIndex,weaponState _currentShooter);
         };
-        if ((weaponState _weaponStateToken) isEqualTo ["","","","",0]) exitWith {ERROR("weaponState not found");};
+        if ((weaponState _weaponStateToken) isEqualTo ["","","","",0]) exitWith {ERROR_2("weaponState not found",_weapon,_nextFireMode);};
     };
 } else {
     TRACE_2("setVariable attackProfile",_currentShooter,_nextFireMode);

--- a/addons/missileguidance/functions/fnc_cycleAttackProfileKeyDown.sqf
+++ b/addons/missileguidance/functions/fnc_cycleAttackProfileKeyDown.sqf
@@ -23,18 +23,19 @@ if (!([ACE_player, objNull, ["isNotInside"]] call EFUNC(common,canInteractWith))
 
 private _currentShooter = objNull;
 private _currentMagazine = "";
+private _turretPath = [];
 if (isNull (ACE_controlledUAV param [0, objNull])) then {
     if (((vehicle ACE_player) == ACE_player) || {ACE_player call CBA_fnc_canUseWeapon}) then {
         _currentShooter = ACE_player;
         _currentMagazine = currentMagazine ACE_player;
     } else {
         _currentShooter = vehicle ACE_player;
-        private _turretPath = if (ACE_player == (driver _currentShooter)) then {[-1]} else {ACE_player call CBA_fnc_turretPath};
+        _turretPath = if (ACE_player == (driver _currentShooter)) then {[-1]} else {ACE_player call CBA_fnc_turretPath};
         _currentMagazine = _currentShooter currentMagazineTurret _turretPath;
     };
 } else {
     _currentShooter = ACE_controlledUAV select 0;
-    private _turretPath = ACE_controlledUAV select 2;
+    _turretPath = ACE_controlledUAV select 2;
     _currentMagazine = _currentShooter currentMagazineTurret _turretPath;
 };
 
@@ -47,6 +48,11 @@ TRACE_3("",_currentShooter,_currentMagazine,_ammo);
 // Bail if guidance is disabled for this ammo
 if ((getNumber (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON) >> "enabled")) != 1) exitWith {TRACE_1("not enabled",_ammo)};
 
+private _useModeForAttackProfile = (getNumber (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON) >> "useModeForAttackProfile")) == 1;
+private _weaponStateToken = if (_currentShooter isEqualTo ACE_player) then { _currentShooter } else { [_currentShooter, _turretPath] };
+(weaponState _weaponStateToken) params ["_weapon", "", "_mode"];
+TRACE_4("",_useModeForAttackProfile,_weaponStateToken,_weapon,_mode);
+
 // Verify ammo has explicity added guidance config (ignore inheritances)
 private _configs = configProperties [(configFile >> "CfgAmmo" >> _ammo), QUOTE(configName _x == QUOTE(QUOTE(ADDON))), false];
 if ((count _configs) < 1) exitWith {TRACE_2("not explicity enabled",_ammo,_configs)};
@@ -54,7 +60,11 @@ if ((count _configs) < 1) exitWith {TRACE_2("not explicity enabled",_ammo,_confi
 private _attackProfiles = getArray (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON) >> "attackProfiles");
 if ((count _attackProfiles) <= 1) exitWith {TRACE_1("no choices for attack profile",_attackProfiles)};
 
-private _currentFireMode = _currentShooter getVariable [QGVAR(attackProfile), "#undefined"];
+private _currentFireMode = if (_useModeForAttackProfile) then {
+    getText (configFile >> "CfgWeapons" >> _weapon >> _mode >> QGVAR(attackProfile))
+} else {
+    _currentShooter getVariable [QGVAR(attackProfile), "#undefined"]
+};
 
 // Just like onFired, this is case sensitive!
 private _index = _attackProfiles find _currentFireMode;
@@ -65,7 +75,21 @@ _index = (_index + 1) % (count _attackProfiles);
 private _nextFireMode = _attackProfiles select _index;
 TRACE_4("",_currentFireMode,_nextFireMode,_index,_attackProfiles);
 
-_currentShooter setVariable [QGVAR(attackProfile), _nextFireMode, false];
+
+private _currentFireMode = if (_useModeForAttackProfile) then {
+    TRACE_2("setting fire mode",_weaponStateToken,_nextFireMode);
+    for "_weaponIndex" from 0 to 299 do {
+        ACE_player action ["SwitchWeapon", _currentShooter, ACE_player, _weaponIndex];
+        (weaponState _weaponStateToken) params ["_xWeapon", "", "_xMode"];
+        if ((_xWeapon == _weapon) && {(getText (configFile >> "CfgWeapons" >> _weapon >> _xMode >> QGVAR(attackProfile))) == _nextFireMode}) exitWith {
+            TRACE_2("Restoring",_weaponIndex,weaponState _currentShooter);
+        };
+        if ((weaponState _weaponStateToken) isEqualTo ["","","","",0]) exitWith {ERROR("weaponState not found");};
+    };
+} else {
+    TRACE_2("setVariable attackProfile",_currentShooter,_nextFireMode);
+    _currentShooter setVariable [QGVAR(attackProfile), _nextFireMode, false];
+};
 
 playSound "ACE_Sound_Click";
 

--- a/addons/missileguidance/functions/fnc_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_onFired.sqf
@@ -17,7 +17,7 @@
  * Public: No
  */
 
-params ["_shooter","","","","_ammo","","_projectile"];
+params ["_shooter","_weapon","","_mode","_ammo","","_projectile"];
 
 // Bail on not missile
 if (!(_ammo isKindOf "MissileBase")) exitWith {};
@@ -44,6 +44,9 @@ private _target = _shooter getVariable [QGVAR(target), nil];
 private _targetPos = _shooter getVariable [QGVAR(targetPosition), nil];
 private _seekerType = _shooter getVariable [QGVAR(seekerType), nil];
 private _attackProfile = _shooter getVariable [QGVAR(attackProfile), nil];
+if ((getNumber (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON) >> "useModeForAttackProfile")) == 1) then {
+    _attackProfile = getText (configFile >> "CfgWeapons" >> _weapon >> _mode >> QGVAR(attackProfile))
+};
 private _lockMode = _shooter getVariable [QGVAR(lockMode), nil];
 
 private _laserCode = _shooter getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];

--- a/addons/nlaw/CfgAmmo.hpp
+++ b/addons/nlaw/CfgAmmo.hpp
@@ -29,6 +29,7 @@ class CfgAmmo {
             // Attack profile type selection
             defaultAttackProfile = QGVAR(directAttack);
             attackProfiles[] = {QGVAR(directAttack), QGVAR(overflyTopAttack)};
+            useModeForAttackProfile = 1;
             showHintOnCycle = 1;
 
             // Run once at fired event

--- a/addons/nlaw/CfgWeapons.hpp
+++ b/addons/nlaw/CfgWeapons.hpp
@@ -1,3 +1,5 @@
+class Mode_SemiAuto;
+
 class CfgWeapons {
     class Launcher_Base_F;
     class launch_NLAW_F: Launcher_Base_F {
@@ -8,6 +10,12 @@ class CfgWeapons {
                 distanceZoomMin = 0;
                 distanceZoomMax = 0;
             };
+        };
+        class Single: Mode_SemiAuto {
+            EGVAR(missileGuidance,attackProfile) = QGVAR(directAttack);
+        };
+        class Overfly: Single {
+            EGVAR(missileGuidance,attackProfile) = QGVAR(overflyTopAttack);
         };
     };
 };

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -243,6 +243,7 @@ class CfgAmmo {
             // Attack profile type selection
             defaultAttackProfile = "JAV_TOP";
             attackProfiles[] = { "JAV_TOP", "JAV_DIR" };
+            useModeForAttackProfile = 1;
         };
     };
 

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -220,6 +220,13 @@ class CfgWeapons {
         canLock = 0;
         lockingTargetSound[] = {"",0,1};
         lockedTargetSound[] = {"",0,1};
+        class Single;
+        class Cruise: Single {
+            EGVAR(missileGuidance,attackProfile) = "JAV_DIR";
+        };
+        class TopDown: Single {
+            EGVAR(missileGuidance,attackProfile) = "JAV_TOP";
+        };
     };
 
     class Launcher_Base_F;


### PR DESCRIPTION
Fix #6595

Uses vanilla fire `mode[]` to select attack profile for some weapons.
(You can press F to cycle direct/topDown)
Fully compatible with the ace's cycle guidance key