### PR TITLE
Remove Redundancy in flashbangExplosionEh

### DIFF
--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -93,7 +93,7 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
 
     // Add ace_hearing ear ringing sound effect
     if (isClass (configFile >> "CfgPatches" >> "ACE_Hearing") && {_strength > 0 && {EGVAR(hearing,damageCoefficent) > 0.25}}) then {
-        private _earringingStrength = 40 * _strength * EGVAR(hearing,damageCoefficent);
+        private _earringingStrength = 40 * _strength;
         [_earringingStrength] call EFUNC(hearing,earRinging);
         TRACE_1("Earringing Strength",_earringingStrength);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Stop applying damageCoefficent which is applied later
  https://github.com/acemod/ACE3/blob/master/addons/hearing/functions/fnc_earRinging.sqf
