### PR TITLE
Arsenal - Adjust macros for newest pboProject

### DIFF
--- a/addons/arsenal/defines.hpp
+++ b/addons/arsenal/defines.hpp
@@ -362,7 +362,8 @@ _buttonCurrentMag2Ctrl ctrlCommit FADE_DELAY;\
     {(_accsArray select 2) findIf {_x == _item} > -1} ||\
     {(_accsArray select 3) findIf {_x == _item} > -1}
 
-#define CHECK_ASSIGNED_ITEMS\
+// PboProject 2.45 has problems with these macros for some reason, adding a single space before the \ fixes
+#define CHECK_ASSIGNED_ITEMS \
     (GVAR(virtualItems) select 10) findIf {_x == _item} > -1 ||\
     {(GVAR(virtualItems) select 11) findIf {_x == _item} > -1} ||\
     {(GVAR(virtualItems) select 12) findIf {_x == _item} > -1} ||\
@@ -370,7 +371,7 @@ _buttonCurrentMag2Ctrl ctrlCommit FADE_DELAY;\
     {(GVAR(virtualItems) select 14) findIf {_x == _item} > -1} ||\
     {(GVAR(virtualItems) select 8) findIf {_x == _item} > -1}
 
-#define CHECK_CONTAINER\
+#define CHECK_CONTAINER \
     (GVAR(virtualItems) select 4) findIf {_x == _item} > -1 ||\
     {(GVAR(virtualItems) select 5) findIf {_x == _item} > -1} ||\
     {(GVAR(virtualItems) select 6) findIf {_x == _item} > -1}
@@ -381,7 +382,7 @@ _buttonCurrentMag2Ctrl ctrlCommit FADE_DELAY;\
     {isClass (_glassesCfg >> _item)} ||\
     {isClass (_magCfg >> _item)}
 
-#define CHECK_CONTAINER_ITEMS\
+#define CHECK_CONTAINER_ITEMS \
     (GVAR(virtualItems) select 3) findIf {_x == _item} > -1 ||\
     {(_accsArray select 0) findIf {_x == _item} > -1} ||\
     {(_accsArray select 1) findIf {_x == _item} > -1} ||\


### PR DESCRIPTION
Latest mikroTools (pbo Project 2.45 / Dll 7.15)
```
In File \z\ace\addons\arsenal\defines.hpp: circa Line 371 Expected (...) during define expansion
"arsenal.pbo not produced due to error(s)" 
```

Seems to not like empty macro lines, but I have no clue why only these 3 are causing problems.