### PR TITLE
WeaponSelect - Fix putWeaponAway animation

### DIFF
--- a/addons/weaponselect/functions/fnc_putWeaponAway.sqf
+++ b/addons/weaponselect/functions/fnc_putWeaponAway.sqf
@@ -17,6 +17,4 @@
 
 params ["_unit"];
 
-_unit call EFUNC(common,fixLoweredRifleAnimation);
-
 _unit action ["SwitchWeapon", _unit, _unit, 299];


### PR DESCRIPTION
Fix #6610
Could reproduce issue if rifle was in lowered state.
Tested in local MP, seems to work fine without the call.
