### PR TITLE
Dragging - Fix player getting locked with isCarrying

### DIFF
--- a/addons/dragging/functions/fnc_startCarryPFH.sqf
+++ b/addons/dragging/functions/fnc_startCarryPFH.sqf
@@ -35,7 +35,7 @@ if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {
 // same as dragObjectPFH, checks if object is deleted or dead OR (target moved away from carrier (weapon disasembled))
 if (!alive _target || {_unit distance _target > 10}) then {
     TRACE_4("dead/distance",_unit,_target,_timeOut,CBA_missionTime);
-    [_unit, _target] call FUNC(dropObject);
+    [_unit, _target] call FUNC(dropObject_carry);
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
@@ -54,7 +54,7 @@ if (_target isKindOf "CAManBase") then {
 
         // drop if in timeout
         private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
-        [_unit, _draggedObject] call FUNC(dropObject);
+        [_unit, _draggedObject] call FUNC(dropObject_carry);
     };
 
     // wait for the unit to stand up


### PR DESCRIPTION
Player could get bugged with `player getVariable "ace_dragging_isCarrying"` set to true
(then cannot use ace interaction menu)

Reproduce:
Try to carry unconscious X
During pickup anim, X gets shot and dies

FUNC(dropObject) sets QGVAR(isDragging)
FUNC(dropObject_carry) sets QGVAR(isCarrying)
