### PR TITLE
Additional weight override parameter for setCarryable/setDraggable

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -116,6 +116,7 @@ OnkelDisMaster <onkeldismaster@gmail.com>
 Orbis2358 <mgkid3310@naver.com>
 oscarmolinadev
 PaxJaromeMalues <seemax1991@gmail.com>
+PiZZADOX <509thParachuteInfantry@gmail.com>
 Phyma <sethramstrom@gmail.com>
 pokertour
 Professor <lukas.trneny@wo.cz>

--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
-        authors[] = {"Garth 'L-H' de Wet", "commy2"};
+        authors[] = {"Garth 'L-H' de Wet", "commy2", "PiZZADOX"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };

--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -25,6 +25,6 @@ if !([_unit, _target, []] call EFUNC(common,canInteractWith)) exitWith {false};
 if ((_unit getHitPointDamage "HitLegs") >= 0.5) exitWith {false};
 
 // a static weapon has to be empty for dragging (ignore UAV AI)
-if (((typeOf _target) isKindOf "StaticWeapon") && {!({!((getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) isEqualto "UAVPilot")} count crew _target isEqualto -1)}) exitWith {false};
+if (((typeOf _target) isKindOf "StaticWeapon") && {!({!((getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) isEqualto "UAVPilot")} count crew _target isEqualto 0)}) exitWith {false};
 
 alive _target && {vehicle _target isEqualto _target} && {_target getVariable [QGVAR(canCarry), false]} && {animationState _target in ["", "unconscious"] || (_target getVariable ["ACE_isUnconscious", false]) || (_target isKindOf "CAManBase" && {(_target getHitPointDamage "HitLegs") > 0.4})}

--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -25,6 +25,6 @@ if !([_unit, _target, []] call EFUNC(common,canInteractWith)) exitWith {false};
 if ((_unit getHitPointDamage "HitLegs") >= 0.5) exitWith {false};
 
 // a static weapon has to be empty for dragging (ignore UAV AI)
-if (((typeOf _target) isKindOf "StaticWeapon") && {{(getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) != "UAVPilot"} count crew _target > 0}) exitWith {false};
+if (((typeOf _target) isKindOf "StaticWeapon") && {!({!((getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) isEqualto "UAVPilot")} count crew _target isEqualto -1)}) exitWith {false};
 
-alive _target && {vehicle _target == _target} && {_target getVariable [QGVAR(canCarry), false]} && {animationState _target in ["", "unconscious"] || (_target getVariable ["ACE_isUnconscious", false]) || (_target isKindOf "CAManBase" && {(_target getHitPointDamage "HitLegs") > 0.4})}
+alive _target && {vehicle _target isEqualto _target} && {_target getVariable [QGVAR(canCarry), false]} && {animationState _target in ["", "unconscious"] || (_target getVariable ["ACE_isUnconscious", false]) || (_target isKindOf "CAManBase" && {(_target getHitPointDamage "HitLegs") > 0.4})}

--- a/addons/dragging/functions/fnc_canDrag.sqf
+++ b/addons/dragging/functions/fnc_canDrag.sqf
@@ -21,6 +21,6 @@ params ["_unit", "_target"];
 if !([_unit, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
 // a static weapon has to be empty for dragging (ignore UAV AI)
-if ((typeOf _target) isKindOf "StaticWeapon" && {{(getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) != "UAVPilot"} count crew _target > 0}) exitWith {false};
+if ((typeOf _target) isKindOf "StaticWeapon" && {!({!((getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) isEqualto "UAVPilot")} count crew _target isEqualto -1)}) exitWith {false};
 
-alive _target && {vehicle _target == _target} && {_target getVariable [QGVAR(canDrag), false]} && {animationState _target in ["", "unconscious"] || (_target getVariable ["ACE_isUnconscious", false]) || (_target isKindOf "CAManBase" && {(_target getHitPointDamage "HitLegs") > 0.4})};
+alive _target && {vehicle _target isEqualto _target} && {_target getVariable [QGVAR(canDrag), false]} && {animationState _target in ["", "unconscious"] || (_target getVariable ["ACE_isUnconscious", false]) || (_target isKindOf "CAManBase" && {(_target getHitPointDamage "HitLegs") > 0.4})}

--- a/addons/dragging/functions/fnc_canDrag.sqf
+++ b/addons/dragging/functions/fnc_canDrag.sqf
@@ -21,6 +21,6 @@ params ["_unit", "_target"];
 if !([_unit, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
 // a static weapon has to be empty for dragging (ignore UAV AI)
-if ((typeOf _target) isKindOf "StaticWeapon" && {!({!((getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) isEqualto "UAVPilot")} count crew _target isEqualto -1)}) exitWith {false};
+if ((typeOf _target) isKindOf "StaticWeapon" && {!({!((getText (configFile >> "CfgVehicles" >> (typeOf _x) >> "simulation")) isEqualto "UAVPilot")} count crew _target isEqualto 0)}) exitWith {false};
 
 alive _target && {vehicle _target isEqualto _target} && {_target getVariable [QGVAR(canDrag), false]} && {animationState _target in ["", "unconscious"] || (_target getVariable ["ACE_isUnconscious", false]) || (_target isKindOf "CAManBase" && {(_target getHitPointDamage "HitLegs") > 0.4})}

--- a/addons/dragging/functions/fnc_setCarryable.sqf
+++ b/addons/dragging/functions/fnc_setCarryable.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, PiZZADOX
  * Enable the object to be carried.
  *
  * Arguments:
@@ -8,17 +8,19 @@
  * 1: true to enable carrying, false to disable <BOOL>
  * 2: Position offset for attachTo command <ARRAY> (default: [0,1,1])
  * 3: Direction in degree to rotate the object after attachTo <NUMBER> (default: 0)
+ * 4: Override weight limit (optional; default: false) <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [object, true, [0,1,1], 0] call ace_dragging_fnc_setCarryable;
+ * [object, true, [0,1,1], 0, false] call ace_dragging_fnc_setCarryable;
  *
  * Public: Yes
  */
 
-params ["_object", "_enableCarry", "_position", "_direction"];
+//IGNORE_PRIVATE_WARNING ["_player", "_target"];
+params ["_object", "_enableCarry", "_position", "_direction", ["_ignoreWeightCarry",false,[false]]];
 
 if (isNil "_position") then {
     _position = _object getVariable [QGVAR(carryPosition), [0,1,1]];
@@ -32,6 +34,7 @@ if (isNil "_direction") then {
 _object setVariable [QGVAR(canCarry), _enableCarry];
 _object setVariable [QGVAR(carryPosition), _position];
 _object setVariable [QGVAR(carryDirection), _direction];
+_object setVariable [QGVAR(ignoreWeightCarry), _ignoreWeightCarry];
 
 // add action to class if it is not already present
 private _type = typeOf _object;

--- a/addons/dragging/functions/fnc_setDraggable.sqf
+++ b/addons/dragging/functions/fnc_setDraggable.sqf
@@ -1,25 +1,26 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, PiZZADOX
  * Enable the object to be dragged.
  *
  * Arguments:
  * 0: Any object <OBJECT>
  * 1: true to enable dragging, false to disable <BOOL>
- * 2: Position offset for attachTo command (optinal; default: [0,0,0])<ARRAY>
+ * 2: Position offset for attachTo command (optional; default: [0,0,0])<ARRAY>
  * 3: Direction in degree to rotate the object after attachTo (optional; default: 0) <NUMBER>
+ * 4: Override weight limit (optional; default: false) <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [object, true, [0,0,0], 0] call ace_dragging_fnc_setDraggable;
+ * [object, true, [0,0,0], 0, false] call ace_dragging_fnc_setDraggable;
  *
  * Public: Yes
  */
 
 //IGNORE_PRIVATE_WARNING ["_player", "_target"];
-params ["_object", "_enableDrag", "_position", "_direction"];
+params ["_object", "_enableDrag", "_position", "_direction", ["_ignoreWeightDrag",false,[false]]];
 
 if (isNil "_position") then {
     _position = _object getVariable [QGVAR(dragPosition), [0,0,0]];
@@ -33,6 +34,7 @@ if (isNil "_direction") then {
 _object setVariable [QGVAR(canDrag), _enableDrag];
 _object setVariable [QGVAR(dragPosition), _position];
 _object setVariable [QGVAR(dragDirection), _direction];
+_object setVariable [QGVAR(ignoreWeightDrag), _ignoreWeightDrag];
 
 // add action to class if it is not already present
 private _type = typeOf _object;

--- a/addons/dragging/functions/fnc_startCarry.sqf
+++ b/addons/dragging/functions/fnc_startCarry.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, PiZZADOX
  * Start the carrying process.
  *
  * Arguments:
@@ -19,11 +19,17 @@
 params ["_unit", "_target"];
 TRACE_2("params",_unit,_target);
 
-// check weight
-private _weight = [_target] call FUNC(getWeight);
+scopeName "main";
 
-if (_weight > missionNamespace getVariable ["ACE_maxWeightCarry", 1E11]) exitWith {
-    [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
+// exempt from weight check if object has override variable set
+if !(GETVAR(_target,GVAR(ignoreWeightCarry),false)) then {
+	// check weight
+	private _weight = [_target] call FUNC(getWeight);
+
+	if (_weight > (GETMVAR(ACE_maxWeightCarry,1E11))) exitWith {
+	    [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
+		breakOut "main";
+	};
 };
 
 private _timer = CBA_missionTime + 5;
@@ -32,7 +38,7 @@ private _timer = CBA_missionTime + 5;
 if (_target isKindOf "CAManBase") then {
 
     // add a primary weapon if the unit has none.
-    if (primaryWeapon _unit == "") then {
+    if (primaryWeapon _unit isEqualto "") then {
         _unit addWeapon "ACE_FakePrimaryWeapon";
     };
 

--- a/addons/dragging/functions/fnc_startCarryPFH.sqf
+++ b/addons/dragging/functions/fnc_startCarryPFH.sqf
@@ -58,7 +58,7 @@ if (_target isKindOf "CAManBase") then {
     };
 
     // wait for the unit to stand up
-    if (stance _unit == "STAND") exitWith {
+    if (stance _unit isEqualto "STAND") exitWith {
         TRACE_4("Start carry object",_unit,_target,_timeOut,CBA_missionTime);
         [_unit, _target] call FUNC(carryObject);
 

--- a/addons/dragging/functions/fnc_startDrag.sqf
+++ b/addons/dragging/functions/fnc_startDrag.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, PiZZADOX
  * Start the dragging process.
  *
  * Arguments:
@@ -19,16 +19,22 @@
 params ["_unit", "_target"];
 TRACE_2("params",_unit,_target);
 
-// check weight
-private _weight = [_target] call FUNC(getWeight);
+scopeName "main";
 
-if (_weight > missionNamespace getVariable ["ACE_maxWeightDrag", 1E11]) exitWith {
-    [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
+// exempt from weight check if object has override variable set
+if !(GETVAR(_target,GVAR(ignoreWeightDrag),false)) then {
+	// check weight
+	private _weight = [_target] call FUNC(getWeight);
+
+	if (_weight > (GETMVAR(ACE_maxWeightDrag,1E11))) exitWith {
+	    [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
+		breakOut "main";
+	};
 };
 
 // add a primary weapon if the unit has none.
 // @todo prevent opening inventory when equipped with a fake weapon
-if (primaryWeapon _unit == "") then {
+if (primaryWeapon _unit isEqualto "") then {
     _unit addWeapon "ACE_FakePrimaryWeapon";
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add an additional optional parameter to the `ace_dragging_fnc_setCarryable` and `ace_dragging_fnc_setDraggable` functions that sets a object variable that can skip the weight check in `ace_dragging_fnc_startCarry`  and `ace_dragging_fnc_startCarry` respectively. 

- Existing function parameter format is `[object, true, [0,1,1], 0] call ace_dragging_fnc_setCarryable;` which is compatible with this PR.

eg. `[object, true, [0,1,1], 0, true] call ace_dragging_fnc_setCarryable;`
would override the carry weight check on the object.

- This would be useful if mission makers want the ability to carry/drag a specific heavy object without disabling/nullifying the weight checks globally, similar to how mission makers could use `setMass` in the past.

-  Addresses https://github.com/acemod/ACE3/issues/4141
