### PR TITLE
Arsenal - Fix arsenal not working reliably on remote AI units.

### DIFF
--- a/addons/arsenal/functions/fnc_onArsenalClose.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalClose.sqf
@@ -66,6 +66,11 @@ if (is3DEN) then {
 deleteVehicle GVAR(cameraHelper);
 camDestroy GVAR(camera);
 
+if !(isnil QGVAR(moduleUsed)) then {
+    GVAR(moduleUsed) = nil;
+    objNull remoteControl GVAR(center);
+};
+
 if (isMultiplayer) then {
 
     [QGVAR(broadcastFace), [GVAR(center), GVAR(currentFace)], QGVAR(center) + "_face"] call CBA_fnc_globalEventJIP;

--- a/addons/arsenal/functions/fnc_onArsenalClose.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalClose.sqf
@@ -66,7 +66,7 @@ if (is3DEN) then {
 deleteVehicle GVAR(cameraHelper);
 camDestroy GVAR(camera);
 
-if !(isnil QGVAR(moduleUsed)) then {
+if (!isNil QGVAR(moduleUsed)) then {
     GVAR(moduleUsed) = nil;
     objNull remoteControl GVAR(center);
 };

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -57,7 +57,7 @@ switch (GVAR(currentLeftPanel)) do {
                 call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
-                GVAR(center) addWeaponGlobal _item;
+                GVAR(center) addWeapon _item;
                 GVAR(center) addWeaponItem [_item, [(getArray (configfile >> "cfgweapons" >> _item >> "magazines")) select 0]];
 
                 {
@@ -95,7 +95,7 @@ switch (GVAR(currentLeftPanel)) do {
                 call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
-                GVAR(center) addWeaponGlobal _item;
+                GVAR(center) addWeapon _item;
                 GVAR(center) addWeaponItem [_item, [(getArray (configfile >> "cfgweapons" >> _item >> "magazines")) select 0]];
 
                 {
@@ -132,7 +132,7 @@ switch (GVAR(currentLeftPanel)) do {
                 call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
-                GVAR(center) addWeaponGlobal _item;
+                GVAR(center) addWeapon _item;
                 GVAR(center) addWeaponItem [_item, [(getArray (configfile >> "cfgweapons" >> _item >> "magazines")) select 0]];
 
                 {
@@ -295,7 +295,7 @@ switch (GVAR(currentLeftPanel)) do {
             GVAR(currentItems) set [9, _item];
         } else {
             if ((GVAR(currentItems) select 9) != _item) then {
-                GVAR(center) addWeaponGlobal _item;
+                GVAR(center) addWeapon _item;
                 GVAR(currentItems) set [9, _item];
                 call FUNC(showItem);
                 ADDBINOCULARSMAG

--- a/addons/zeus/functions/fnc_bi_moduleArsenal.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleArsenal.sqf
@@ -39,6 +39,9 @@ if (_activated && local _logic) then {
                 [{
                     params ["_unit"];
 
+                    player remoteControl _unit;
+                    EGVAR(arsenal,moduleUsed) = true;
+
                     [_unit, _unit, true] call EFUNC(arsenal,openBox);
                 }, [_unit]] call CBA_fnc_directCall;
             } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix weapons not being switched when the AI is remote.
- Fix backpacks being dropped to the ground when the AI is remote.

AddWeaponGlobal is broken, so instead I force the player into remote controlling the unit instead.

This should not break anything unless the mission uses remoteControl scripting, but even then going into zeus should return you to the original unit anyways.

close #6701 