### PR TITLE
Fixed Typo from change to chance

### DIFF
--- a/addons/medical/ACE_Medical_Treatments.hpp
+++ b/addons/medical/ACE_Medical_Treatments.hpp
@@ -687,9 +687,9 @@ class ACE_Medical_Advanced {
     class Treatment {
         class Bandaging {
             // Field dressing is normal average treatment
-            // packing bandage is average treatment, higher reopen change, longer reopening delay
-            // elastic bandage is higher treatment, higher reopen change, shorter reopen delay
-            // quickclot is lower treatment, lower reopen change, longer reopening delay
+            // packing bandage is average treatment, higher reopen chance, longer reopening delay
+            // elastic bandage is higher treatment, higher reopen chance, shorter reopen delay
+            // quickclot is lower treatment, lower reopen chance, longer reopening delay
             class Bandage { // basic bandage
                 effectiveness = 5;
                 reopeningChance = 0;


### PR DESCRIPTION
This change will correct the typo when describing bandage types.