### PR TITLE
Copy inherited compiled self actions instead of recompiling

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -22,9 +22,21 @@ if (_target isEqualType objNull) then {
     _objectType = typeOf _target;
 };
 private _namespace = GVAR(ActSelfNamespace);
-
+diag_log _objectType;
 // Exit if the action menu is already compiled for this class
 if !(isNil {_namespace getVariable _objectType}) exitWith {};
+
+if (("configName _x == 'ACE_SelfActions'" configClasses (configFile >> "CfgVehicles" >> _objectType)) isEqualTo []) exitWith {
+    //This class doesn't have self actions, it just inherits them. So we don't have to recompile and can just copy from parent
+
+    private _parentType = configName inheritsFrom (configFile >> "CfgVehicles" >> _objectType);
+
+    //Make sure the parent is compiled
+    [_parentType] call FUNC(compileMenuSelfAction);
+
+    //Copy classes from parent
+    _namespace setVariable [_objectType, _namespace getVariable _parentType];
+};
 
 
 private _recurseFnc = {

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -22,7 +22,7 @@ if (_target isEqualType objNull) then {
     _objectType = typeOf _target;
 };
 private _namespace = GVAR(ActSelfNamespace);
-diag_log _objectType;
+
 // Exit if the action menu is already compiled for this class
 if !(isNil {_namespace getVariable _objectType}) exitWith {};
 

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -35,7 +35,7 @@ if (("configName _x == 'ACE_SelfActions'" configClasses (configFile >> "CfgVehic
     [_parentType] call FUNC(compileMenuSelfAction);
 
     //Copy classes from parent
-    _namespace setVariable [_objectType, _namespace getVariable _parentType];
+    _namespace setVariable [_objectType, +(_namespace getVariable _parentType)];
 };
 
 


### PR DESCRIPTION
Previously it would compile the selfActions 11 times (for 11 different CAManBase types)
even though they all have the exact same config actions, all inherited from CAManBase.

This PR makes it skip compiling actions if the class itself has no unique self actinons and will instead just copy the parent (if the parent doesn't have actions either, it will already be a copy of it's parent)


The problem I see is that if someone add's scripted actions to CAManBase with inherit disabled.
If the sub class is compiled later it will copy these scripted actions that were added to CAManBase, and they will be inherited even though inherit parameter (addActionToClass) was false.


Before: ![](https://s.sqf.ovh/Tracy_2019-01-24_16-06-43.png)
The 624 number is 624 calls to `compile`. They are compiling the exact same stuff 11 times.
After: ![](https://s.sqf.ovh/Tracy_2019-01-24_16-28-46.png)


Traces if you wanna look at the data yourself.

BeforeFix trace is coming in an hour.

[AfterFix_ASP_Tracy.zip](https://github.com/acemod/ACE3/files/2792379/AfterFix_ASP_Tracy.zip)
