### PR TITLE
WIP: Interaction Menu - Only compile self actions when needed

### DIFF
--- a/addons/interact_menu/CfgEventHandlers.hpp
+++ b/addons/interact_menu/CfgEventHandlers.hpp
@@ -20,7 +20,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_InitPost_EventHandlers {
     class All {
         class GVAR(compileMenu) {
-            init = QUOTE(_this call FUNC(compileMenu);_this call FUNC(compileMenuSelfAction));
+            init = QUOTE(_this call FUNC(compileMenu););
         };
     };
 };

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -8,14 +8,14 @@ DFUNC(newControlableObject) = {
     private _type = typeOf _object;
     TRACE_2("newControlableObject",_object,_type);
     if (_type == "") exitWith {};
-    
-     [_type] call FUNC(compileMenuSelfAction);
+
     if (!(GVAR(controlableSelfActionsAdded) getVariable [_type, false])) then {
+        [_type] call FUNC(compileMenuSelfAction);
         GVAR(controlableSelfActionsAdded) setVariable [_type, true];
         [{
             TRACE_1("sending newControlableObject event",_this);
             [QGVAR(newControlableObject), _this] call CBA_fnc_localEvent;
-        }, [_type]] call CBA_fnc_execNextFrame;
+        }, [_type]] call CBA_fnc_execNextFrame; // delay event a frame to ensure postInit has run for all addons
     };
 };
 ["unit", {[_this select 0] call FUNC(newControlableObject)}, true] call CBA_fnc_addPlayerEventHandler;

--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -2,6 +2,28 @@
 
 if (!hasInterface) exitWith {};
 
+GVAR(controlableSelfActionsAdded) = [] call CBA_fnc_createNamespace;
+DFUNC(newControlableObject) = {
+    params ["_object"];
+    private _type = typeOf _object;
+    TRACE_2("newControlableObject",_object,_type);
+    if (_type == "") exitWith {};
+    
+     [_type] call FUNC(compileMenuSelfAction);
+    if (!(GVAR(controlableSelfActionsAdded) getVariable [_type, false])) then {
+        GVAR(controlableSelfActionsAdded) setVariable [_type, true];
+        [{
+            TRACE_1("sending newControlableObject event",_this);
+            [QGVAR(newControlableObject), _this] call CBA_fnc_localEvent;
+        }, [_type]] call CBA_fnc_execNextFrame;
+    };
+};
+["unit", {[_this select 0] call FUNC(newControlableObject)}, true] call CBA_fnc_addPlayerEventHandler;
+["vehicle", {[_this select 1] call FUNC(newControlableObject)}, true] call CBA_fnc_addPlayerEventHandler;
+["ACE_controlledUAV", {[_this select 0] call FUNC(newControlableObject)}] call CBA_fnc_addEventHandler;
+
+
+
 GVAR(blockDefaultActions) = [];
 
 GVAR(cachedBuildingTypes) = [];

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -82,7 +82,12 @@ if (hasInterface) then {
         [localize "str_a3_cfgvehicles_moduletasksetstate_f_arguments_state_values_created_0"] call EFUNC(common,displayTextStructured);
     }] call CBA_fnc_addEventHandler;
 
-    private _action = [
+    [QEGVAR(interact_menu,newControlableObject), {
+        params ["_type"];
+        if (!(_type isKindOf "CaManBase")) exitWith {};
+        TRACE_1("Adding zeus actions",_type);
+        
+        private _action = [
         QGVAR(create),
         LLSTRING(CreateZeus),
         "\A3\Ui_F_Curator\Data\Logos\arma3_curator_eye_32_ca.paa",
@@ -100,8 +105,8 @@ if (hasInterface) then {
             && {isNil QGVAR(zeus)}
         }
     ] call EFUNC(interact_menu,createAction);
-    ["CAManBase", 1, ["ACE_SelfActions"], _action, true] call EFUNC(interact_menu,addActionToClass);
-
+    [_type, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToClass);
+    
     _action = [
         QGVAR(delete),
         LLSTRING(DeleteZeus),
@@ -112,5 +117,6 @@ if (hasInterface) then {
         },
         {!(isNil QGVAR(zeus) || {isNull GVAR(zeus)})}
     ] call EFUNC(interact_menu,createAction);
-    ["CAManBase", 1, ["ACE_SelfActions"], _action, true] call EFUNC(interact_menu,addActionToClass);
+    [_type, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToClass);
+    }] call CBA_fnc_addEventHandler;
 };


### PR DESCRIPTION
Replace #6790 #6791

best of both worlds
adds new event `QEGVAR(interact_menu,newControlableObject)` that will run once for each unique thing a player controls, so we can add actions via code with no need to compile everything