### PR TITLE
Arsenal - Fix script stat script errors for odd weapons

### DIFF
--- a/addons/arsenal/functions/fnc_statBarStatement_accuracy.sqf
+++ b/addons/arsenal/functions/fnc_statBarStatement_accuracy.sqf
@@ -18,14 +18,18 @@
 
 params ["_stat", "_config", "_args"];
 _args params ["_statMinMax", "_barLimits"];
+TRACE_4("statBarStatement_accuracy",_stat,_config,_statMinMax,_barLimits);
 
 private _fireModes = getArray (_config >> "modes");
 private _dispersion = [];
 
 {
-    _dispersion pushBackUnique log (getNumber (_config >> _x >> "dispersion"));
+    private _n = log (getNumber (_config >> _x >> "dispersion"));
+    if (!finite _n) then {_n = 0;};
+    _dispersion pushBackUnique _n;
 } foreach _fireModes;
 
 _dispersion sort true;
+TRACE_1("",_dispersion);
 
 linearConversion [_statMinMax select 0, _statMinMax select 1, _dispersion param [0, 0], _barLimits select 0, _barLimits select 1]

--- a/addons/arsenal/functions/fnc_statBarStatement_rateOfFIre.sqf
+++ b/addons/arsenal/functions/fnc_statBarStatement_rateOfFIre.sqf
@@ -23,7 +23,9 @@ private _fireModes = getArray (_config >> "modes");
 private _fireRate = [];
 
 {
-    _fireRate pushBackUnique log (getNumber (_config >> _x >> "reloadTime"));
+    private _n = log (getNumber (_config >> _x >> "reloadTime"));
+    if (!finite _n) then {_n = 0;};
+    _fireRate pushBackUnique _n;
 } foreach _fireModes;
 
 _fireRate sort true;

--- a/addons/arsenal/functions/fnc_statTextStatement_rateOfFire.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_rateOfFire.sqf
@@ -11,7 +11,7 @@
  *  2.2: Evaluate as a logarithmic number (BOOL)
  *
  * Return Value:
- * Number
+ * String
  *
  * Public: No
 */
@@ -29,4 +29,5 @@ private _fireRate = [];
 _fireRate sort true;
 _fireRate = _fireRate param [0, 0];
 
+if (_fireRate == 0) exitWith {"PEWPEWPEW"};
 format ["%1 rpm", round (60 / _fireRate)]


### PR DESCRIPTION
Open arsenal on unconscious civ ("ace fake weapon")
it has odd stats, e.g. `log 0` = bad

```
Error in expression <each _fireModes;

_fireRate sort true;

linearConversion [_statMinMax select 0, >
  Error position: <linearConversion [_statMinMax select 0, >
  Error Type Not a Number, expected Number
File z\ace\addons\arsenal\functions\fnc_statBarStatement_rateOfFIre.sqf, line 31
Error in expression <am [0, 0];

format ["%1 rpm", round (60 / _fireRate)]
>
  Error position: </ _fireRate)]
>
  Error Zero divisor
File z\ace\addons\arsenal\functions\fnc_statTextStatement_rateOfFire.sqf, line 32
Error in expression <ch _fireModes;

_dispersion sort true;

linearConversion [_statMinMax select 0, >
  Error position: <linearConversion [_statMinMax select 0, >
  Error Type Not a Number, expected Number
File z\ace\addons\arsenal\functions\fnc_statBarStatement_accuracy.sqf, line 31
```

