### PR TITLE
Compile minedetector scripts at preStart

### DIFF
--- a/addons/minedetector/CfgEventHandlers.hpp
+++ b/addons/minedetector/CfgEventHandlers.hpp
@@ -1,3 +1,8 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));

--- a/addons/minedetector/XEH_preStart.sqf
+++ b/addons/minedetector/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"


### PR DESCRIPTION
Move 100ms of preInit code to preStart

![tracy_2019-02-08_14-55-57](https://user-images.githubusercontent.com/3768165/52482499-b48f3280-2bb1-11e9-99f3-d6cfe5887238.png)
