### PR TITLE
Common - checkfiles use cba's list of CfgPatches

### DIFF
--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -40,9 +40,7 @@ if ([_cbaRequiredAr, _cbaVersionAr] call cba_versioning_fnc_version_compare) the
 };
 
 //private _addons = activatedAddons; // broken with High-Command module, see #2134
-private _addons = "true" configClasses (configFile >> "CfgPatches");//
-_addons = _addons apply {toLower configName _x};//
-_addons = _addons select {_x find "ace_" == 0};
+private _addons = (cba_common_addons select {(_x select [0,4]) == "ace_"}) apply {toLower _x};
 
 private _oldCompats = [];
 {


### PR DESCRIPTION
for full modset
`count cba_common_addons = 3275`

most of the cost is in `configClasses`

```
44.7826 ms
private _addons = "true" configClasses (configFile >> "CfgPatches");
_addons = _addons apply {toLower configName _x};
z = _addons select {_x find "ace_" == 0};

4.5045 ms
z = (cba_common_addons select {(_x select [0,4]) == "ace_"}) apply {toLower _x};
```