### PR TITLE
Pylons - Remove ace_zeus from requiredAddons

### DIFF
--- a/addons/pylons/config.cpp
+++ b/addons/pylons/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interact_menu", "ace_zeus"};
+        requiredAddons[] = {"ace_interact_menu"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"654wak654"};
         url = ECSTRING(main,URL);

--- a/addons/pylons/functions/fnc_showDialog.sqf
+++ b/addons/pylons/functions/fnc_showDialog.sqf
@@ -18,6 +18,8 @@
 
 params ["_aircraft", ["_isCurator", false]];
 
+if (_isCurator && {!(["ace_zeus"] call EFUNC(common,isModLoaded))}) exitWith { WARNING("ace_zeus not loaded"); };
+
 if !(typeOf _aircraft in GVAR(aircraftWithPylons)) exitWith {
     if (_isCurator) then {
         [LSTRING(AircraftDoesntHavePylons)] call EFUNC(zeus,showMessage);


### PR DESCRIPTION
pylons only needed ace_zeus for `EFUNC(zeus,showMessage)`
but the only way the function would be called with `_isCurator ` is from ace_zeus
so no need for requiredAddons entry