### PR TITLE
WIP: Get rid of call compile's

### DIFF
--- a/addons/common/functions/fnc_addActionEventHandler.sqf
+++ b/addons/common/functions/fnc_addActionEventHandler.sqf
@@ -45,22 +45,24 @@ _actions pushBack [_condition, _statement];
 
 // first action to add, unit needs addAction command
 if (_actionID == -1) then {
-    private _addAction = call compile format [
-        "[
-            '',
-            {[{if (inputAction '%1' == 0) exitWith {}; {if (_this call (_x select 0)) then {_this call (_x select 1)}} forEach (((_this select 0) getVariable '%2') select 1 select 2)}, _this] call CBA_fnc_directCall},
-            nil,
-            -1,
-            false,
-            true,
-            '%1',
-            ""if (_this != ACE_player || {vehicle _this != _target}) exitWith {false}; _actions = (_this getVariable '%2') select 1 select 2; _count = count _actions; _index = 0; _return = false; while {_index < _count && {!_return}} do {_return = [_target, _this] call ((_actions select _index) select 0); _index = _index + 1}; _return""
-        ]",
+    _actionID = _unit addAction [
+        '',
+        {
+            [{
+                (_this select 3) params ["_action", "_name"];
+                if (inputAction _action == 0) exitWith {}; 
+                {
+                    if (_this call (_x select 0)) then {_this call (_x select 1)}
+                } forEach (((_this select 0) getVariable _name) select 1 select 2);
+            }, _this] call CBA_fnc_directCall;
+        },
+        [_action, _name],
+        -1,
+        false,
+        true,
         _action,
-        _name
+        format ["if (_this != ACE_player || {vehicle _this != _target}) exitWith {false}; _actions = (_this getVariable '%1') select 1 select 2; _count = count _actions; _index = 0; _return = false; while {_index < _count && {!_return}} do {_return = [_target, _this] call ((_actions select _index) select 0); _index = _index + 1}; _return", _name]
     ];
-
-    _actionID = _unit addAction _addAction;
 };
 
 _unit setVariable [_name, [_actionID, [_id, _actionIDs, _actions], _unit], false];

--- a/addons/common/functions/fnc_addActionMenuEventHandler.sqf
+++ b/addons/common/functions/fnc_addActionMenuEventHandler.sqf
@@ -54,14 +54,7 @@ _actionIDs pushBack _id;
 
 private _addAction = call compile format [
     "[
-        '%2',
-        {[{if (inputAction '%1' == 0) then {if (_this call (%3 select 2)) then {_this call (%3 select 3)}} else {_this call (%3 select 1)}}, _this] call CBA_fnc_directCall},
-        nil,
-        %4,
-        false,
-        true,
-        '%1',
-        ""if (_this != ACE_player || {vehicle _this != _target}) exitWith {false}; [_target, _this] call (%3 select 0)""
+
     ]",
     _action,
     _displayName,
@@ -69,7 +62,26 @@ private _addAction = call compile format [
     _priority
 ];
 
-private _actionID = _unit addAction _addAction;
+private _actionID = _unit addAction [
+        _displayName,
+        {
+            [{
+                (_this select 3) params ["_action", "_statement", "_condition2", "_statement2"];
+                if (inputAction _action == 0) then {
+                    if (_this call _condition2) then {_this call _statement2}
+                } else {
+                    _this call _statement
+                }
+            }, _this] call CBA_fnc_directCall
+        },
+        [_action, _statement, _condition2, _statement2],
+        _priority,
+        false,
+        true,
+        _action,
+        format ["if (_this != ACE_player || {vehicle _this != _target}) exitWith {false}; [_target, _this] call (%1 select 0)", _nameVar]
+
+];
 
 _actions pushBack [_actionID, _nameVar];
 

--- a/addons/common/functions/fnc_debugModule.sqf
+++ b/addons/common/functions/fnc_debugModule.sqf
@@ -17,5 +17,5 @@
 
 params ["_entity"];
 
-GVAR(LOGDISPLAY_LEVEL) = call compile (_entity getVariable ["logDisplayLevel","4"]);
-GVAR(LOGLEVEL) = call compile (_entity getVariable ["logLevel","4"]);
+GVAR(LOGDISPLAY_LEVEL) = (parseSimpleArray format ["[%1]", _entity getVariable ["logDisplayLevel","4"]]) select 0;
+GVAR(LOGLEVEL) = (parseSimpleArray format ["[%1]", _entity getVariable ["logLevel","4"]]) select 0;

--- a/addons/common/functions/fnc_receiveRequest.sqf
+++ b/addons/common/functions/fnc_receiveRequest.sqf
@@ -47,8 +47,8 @@ if (!isNil QGVAR(RECIEVE_REQUEST_ADD_ACTION_DECLINE)) then {
     GVAR(RECIEVE_REQUEST_ADD_ACTION_DECLINE) = nil;
 };
 
-GVAR(RECIEVE_REQUEST_ADD_ACTION_ACCEPT) = _target addAction ["Accept", compile format["[player,'%1', true] call FUNC(onAnswerRequest);", _requestID]];
-GVAR(RECIEVE_REQUEST_ADD_ACTION_DECLINE) = _target addAction ["Decline", compile format["[player,'%1', false] call FUNC(onAnswerRequest);", _requestID]];
+GVAR(RECIEVE_REQUEST_ADD_ACTION_ACCEPT) = _target addAction ["Accept", {[player, _this select 3, true] call FUNC(onAnswerRequest)}, _requestID];
+GVAR(RECIEVE_REQUEST_ADD_ACTION_DECLINE) = _target addAction ["Decline", {[player, _this select 3, false] call FUNC(onAnswerRequest)}, _requestID];
 
 GVAR(RECIEVE_REQUEST_ID_KEY_BINDING) = _requestID;
 

--- a/addons/common/functions/fnc_sendRequest.sqf
+++ b/addons/common/functions/fnc_sendRequest.sqf
@@ -26,5 +26,5 @@ if (isPlayer _target) then {
     [QGVAR(receiveRequest), [_caller, _target, _requestID, _requestMessage, _callBack], _target] call CBA_fnc_targetEvent;
 } else {
     // accept it, since it's an AI.
-    [_caller, _target, true] call compile _callBack;
+    [_caller, _target, true] call _callBack;
 };

--- a/addons/map_gestures/functions/fnc_moduleGroupSettings.sqf
+++ b/addons/map_gestures/functions/fnc_moduleGroupSettings.sqf
@@ -23,9 +23,9 @@ TRACE_3("params",_logic,_units,_activated);
 if (!_activated) exitWith {};
 
 // Transcode string setting into usable array. Example: "1,1,1,1" -> [1, 1, 1, 1]
-private _leadColor = call compile ("[" + (_logic getVariable ["leadColor", ""]) + "]");
+private _leadColor = parseSimpleArray ("[" + (_logic getVariable ["leadColor", ""]) + "]");
 if (!([_leadColor] call FUNC(isValidColorArray))) exitWith {ERROR("leadColor is not a valid color array.")};
-private _color = call compile ("[" + (_logic getVariable ["color", ""]) + "]");
+private _color = parseSimpleArray ("[" + (_logic getVariable ["color", ""]) + "]");
 if (!([_color] call FUNC(isValidColorArray))) exitWith {ERROR("color is not a valid color array.")};
 
 // Add all synchronized groups and reference custom configuration for them

--- a/addons/markers/functions/fnc_mapDrawEH.sqf
+++ b/addons/markers/functions/fnc_mapDrawEH.sqf
@@ -38,7 +38,7 @@ private _drawColor = getArray (_colorConfig >> "color");
 //Convert possible code into numbers
 {
     if (_x isEqualType "") then {
-        _drawColor set [_forEachIndex, call compile _x];
+        _drawColor set [_forEachIndex, parseSimpleArray (format ["[%1]",_x])];
     };
 } forEach _drawColor;
 

--- a/addons/mk6mortar/functions/fnc_turretDisplayLoaded.sqf
+++ b/addons/mk6mortar/functions/fnc_turretDisplayLoaded.sqf
@@ -45,13 +45,7 @@ private _fnc_hideControl = {
     if (_hideCtrl) then {
         _pos = [-9,-9,0,0];
     } else {
-        {
-            if (isNumber (_path >> _x)) then {
-                _pos pushBack (getNumber (_path >> _x));
-            } else {
-                _pos pushBack (call compile (getText (_path >> _x)));
-            };
-        } forEach ["x", "y", "w", "h"];
+        _pos = ["x", "y", "w", "h"] apply {getNumber (_path >> _x)};
     };
     (_display displayCtrl _idc) ctrlSetPosition _pos;
     (_display displayCtrl _idc) ctrlCommit 0;

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -52,8 +52,8 @@ if (isNil "_recoil") then {
     TRACE_3("Caching Recoil config",_weapon,_muzzle,_recoil);
 
     // parse numbers
-    _recoil set [0, call compile format ["%1", _recoil select 0]];
-    _recoil set [1, call compile format ["%1", _recoil select 1]];
+    if ((_recoil select 0) isEqualType "") then {_recoil set [0, call compile (_recoil select 0)]};
+    if ((_recoil select 1) isEqualType "") then {_recoil set [1, call compile (_recoil select 1)]};
 
     missionNamespace setVariable [format [QGVAR(%1-%2), _weapon, _muzzle], _recoil];
 };

--- a/addons/zeus/functions/fnc_bi_moduleCurator.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleCurator.sqf
@@ -240,7 +240,7 @@ if (_activated) then {
         _addons = [];
         {
             if (typeof _x == "ModuleCuratorAddAddons_F") then {
-                _paramAddons = call compile ("[" + (_x getvariable ["addons",""]) + "]");
+                _paramAddons = parseSimpleArray ("[" + (_x getvariable ["addons",""]) + "]");
                 {
                     if !(_x in _addons) then {_addons set [count _addons,_x];};
                     {


### PR DESCRIPTION
The fnc_bi_moduleCurator change might be problematic as parseSimpleArray doesn't allow spaces after comma's. But users might try to use spaces in the textbox in the module.
Same for ace_map_gestures_fnc_moduleGroupSettings