### PR TITLE
HuntIR - Move magwell compat to huntIR config

### DIFF
--- a/addons/huntir/CfgMagazineWells.hpp
+++ b/addons/huntir/CfgMagazineWells.hpp
@@ -2,7 +2,7 @@ class CfgMagazineWells {
     class CBA_40mm_M203 {
         ADDON[] = {"ACE_HuntIR_M203"};
     };
-    class UGL_40x36 { //Vanilla
+    class UGL_40x36 { //Vanilla and RHS [rhsusf\addons\rhsusf_c_weapons\cfgMagazineWells.hpp]
         ADDON[] = {"ACE_HuntIR_M203"};
     };    
 };

--- a/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
@@ -1,5 +1,0 @@
-class CfgMagazineWells {
-    class UGL_40x36 { // rhsusf\addons\rhsusf_c_weapons\cfgMagazineWells.hpp
-        ADDON[] = {"ACE_HuntIR_M203"};
-    };
-};

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -17,7 +17,6 @@ class CfgPatches {
 #include "CfgAmmo.hpp"
 #include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
-#include "CfgMagazineWells.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgGlasses.hpp"


### PR DESCRIPTION
Removes magWell for huntIR from rhs compat because it was added to the base huntIR configs.
The removes the need to run huntIR when using ace and rhs as it would throw
`Warning Message: No entry 'bin\config.bin/CfgMagazines.ACE_HuntIR_M203'`