### PR TITLE
Cargo - Add condition checking during load/unload

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -94,13 +94,12 @@ GVAR(objectAction) = [
         {locked _target < 2} &&
         {alive _target} &&
         {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)} &&
-        {0 < {
-                private _type = typeOf _x;
-                private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];
-                private _hasCargoConfig = getNumber (configFile >> "CfgVehicles" >> _type >> QGVAR(hasCargo)) == 1;
-                (_hasCargoPublic || _hasCargoConfig) && {_x != _target} &&
-                {([_target, _x] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
-            } count (nearestObjects [_player, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)])}
+        {((nearestObjects [_target, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)]) findIf {
+            private _hasCargoConfig = 1 == getNumber (configFile >> "CfgVehicles" >> typeOf _x >> QGVAR(hasCargo));
+            private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];
+            (_hasCargoConfig || {_hasCargoPublic}) && {_x != _target} && {alive _x} && {locked _x < 2} &&
+            {([_target, _x] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
+        }) > -1}
     },
     LINKFUNC(addCargoVehiclesActions)
 ] call EFUNC(interact_menu,createAction);

--- a/addons/cargo/functions/fnc_addCargoVehiclesActions.sqf
+++ b/addons/cargo/functions/fnc_addCargoVehiclesActions.sqf
@@ -25,7 +25,7 @@ private _statement = {
 private _vehicles = (nearestObjects [_target, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)]) select {
     private _hasCargoConfig = 1 == getNumber (configFile >> "CfgVehicles" >> typeOf _x >> QGVAR(hasCargo));
     private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];
-    (_hasCargoConfig || {_hasCargoPublic}) && {_x != _target} &&
+    (_hasCargoConfig || {_hasCargoPublic}) && {_x != _target} && {alive _x} && {locked _x < 2} &&
     {([_target, _x] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
 };
 

--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -42,12 +42,20 @@ if ([_object, _vehicle] call FUNC(canLoadItemIn)) then {
         GVAR(loadTimeCoefficient) * _size,
         [_object, _vehicle],
         {
+            TRACE_1("load finish",_this); 
             [objNull, _this select 0 select 0, true] call EFUNC(common,claim);
             ["ace_loadCargo", _this select 0] call CBA_fnc_localEvent;
         },
-        {[objNull, _this select 0 select 0, true] call EFUNC(common,claim)},
+        {
+            TRACE_1("load fail",_this);
+            [objNull, _this select 0 select 0, true] call EFUNC(common,claim)
+        },
         localize LSTRING(LoadingItem),
-        {true},
+        {
+            (_this select 0) params ["_item", "_target"];
+            (alive _target) && {locked _target < 2} && {alive _item}
+                && {([_item, _target] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
+        },
         ["isNotSwimming"]
     ] call EFUNC(common,progressBar);
     _return = true;

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -72,10 +72,17 @@ if ([_item, GVAR(interactionVehicle), ACE_player] call FUNC(canUnloadItem)) then
     [
         GVAR(loadTimeCoefficient) * _size,
         [_item, GVAR(interactionVehicle), ACE_player],
-        {["ace_unloadCargo", _this select 0] call CBA_fnc_localEvent},
-        {},
+        {TRACE_1("unload finish",_this); ["ace_unloadCargo", _this select 0] call CBA_fnc_localEvent},
+        {TRACE_1("unload fail",_this);},
         localize LSTRING(UnloadingItem),
-        {true},
+        {
+            (_this select 0) params ["_item", "_target", "_player"];
+            
+            (alive _target)
+            && {locked _target < 2}
+            && {([_player, _target] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
+            && {_item in (_target getVariable [QGVAR(loaded), []])}
+        },
         ["isNotSwimming"]
     ] call EFUNC(common,progressBar);
 } else {


### PR DESCRIPTION
Fix:
Car could drive off during loading and progress bar would continue
Showed load actions for blownup/dead vehicles 

postInit - use `findIf`
addCargoVehiclesActions - check alive and not locked
startLoadIn/startUnload - add checks during progressBar