### PR TITLE
Medical Add Variable PAK Times

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -126,6 +126,7 @@ ramius86 <pasini86@hotmail.com>
 Raspu86
 Riccardo Petricca <petriccarcc@gmail.com>
 Robert Boklahánics <bokirobi@gmail.com>
+RulingCommander <rulingcommander@gmail.com>
 ruPaladin <happyworm24@rambler.ru>
 simon84 <badguy360th@gmail.com>
 Skengman2

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -256,7 +256,7 @@ class ACE_Settings {
         description = CSTRING(AdvancedMedicalSettings_UseTimeMin_PAK_Description);
         typeName = "SCALAR";
         value = 10;
-        sliderSettings[] = {0, 3600, 10, 0};
+        sliderSettings[] = {0, GVAR(useTimeMax_PAK), 10, 0};
     };
     class GVAR(useTimeMax_PAK) {
         category = CSTRING(Category_Medical);
@@ -264,7 +264,7 @@ class ACE_Settings {
         description = CSTRING(AdvancedMedicalSettings_UseTimeMax_PAK_Description);
         typeName = "SCALAR";
         value = 120;
-        sliderSettings[] = {0, 3600, 120, 0};
+        sliderSettings[] = {GVAR(useTimeMin_PAK), 3600, 120, 0};
     };
     class GVAR(keepLocalSettingsSynced) {
         category = CSTRING(Category_Medical);

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -252,19 +252,19 @@ class ACE_Settings {
     };
     class GVAR(useTimeMin_PAK) {
         category = CSTRING(Category_Medical);
-        displayname = CSTRING(AdvancedMedicalSettings_UseTimeMin_PAK_DisplayName);
-        description = CSTRING(AdvancedMedicalSettings_UseTimeMin_PAK_Description);
+        displayname = CSTRING(AdvancedMedicalSettings_useTimeMin_PAK_DisplayName);
+        description = CSTRING(AdvancedMedicalSettings_useTimeMin_PAK_Description);
         typeName = "SCALAR";
         value = 10;
-        sliderSettings[] = {0, GVAR(useTimeMax_PAK), 10, 0};
+        sliderSettings[] = {0, 3600, 10, 0};
     };
-    class GVAR(useTimeMax_PAK) {
+    class GVAR(useTimeCoeff_PAK) {
         category = CSTRING(Category_Medical);
-        displayname = CSTRING(AdvancedMedicalSettings_UseTimeMax_PAK_DisplayName);
-        description = CSTRING(AdvancedMedicalSettings_UseTimeMax_PAK_Description);
+        displayname = CSTRING(AdvancedMedicalSettings_useTimeCoeff_PAK_DisplayName);
+        description = CSTRING(AdvancedMedicalSettings_useTimeCoeff_PAK_Description);
         typeName = "SCALAR";
-        value = 120;
-        sliderSettings[] = {GVAR(useTimeMin_PAK), 3600, 120, 0};
+        value = 12;
+        sliderSettings[] = {1, 20, 12, 1};
     };
     class GVAR(keepLocalSettingsSynced) {
         category = CSTRING(Category_Medical);

--- a/addons/medical/ACE_Settings.hpp
+++ b/addons/medical/ACE_Settings.hpp
@@ -250,6 +250,22 @@ class ACE_Settings {
         value = 0;
         values[] = {"Anytime", "Stable"};
     };
+    class GVAR(useTimeMin_PAK) {
+        category = CSTRING(Category_Medical);
+        displayname = CSTRING(AdvancedMedicalSettings_UseTimeMin_PAK_DisplayName);
+        description = CSTRING(AdvancedMedicalSettings_UseTimeMin_PAK_Description);
+        typeName = "SCALAR";
+        value = 10;
+        sliderSettings[] = {0, 3600, 10, 0};
+    };
+    class GVAR(useTimeMax_PAK) {
+        category = CSTRING(Category_Medical);
+        displayname = CSTRING(AdvancedMedicalSettings_UseTimeMax_PAK_DisplayName);
+        description = CSTRING(AdvancedMedicalSettings_UseTimeMax_PAK_Description);
+        typeName = "SCALAR";
+        value = 120;
+        sliderSettings[] = {0, 3600, 120, 0};
+    };
     class GVAR(keepLocalSettingsSynced) {
         category = CSTRING(Category_Medical);
         displayName = CSTRING(MedicalSettings_keepLocalSettingsSynced_DisplayName);

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
@@ -21,4 +21,4 @@ private _totalDamage = 0;
     _totalDamage = _totalDamage + _x;
 } forEach (_this getVariable [QGVAR(bodyPartStatus), []]);
 
-(GVAR(useTimeMin_PAK) max (_totalDamage * 10) min GVAR(useTimeMax_PAK))
+(GVAR(useTimeMin_PAK) max (_totalDamage * 10) min (GVAR(useTimeCoeff_PAK)*GVAR(useTimeMin_PAK)))

--- a/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
+++ b/addons/medical/functions/fnc_treatmentAdvanced_fullHealTreatmentTime.sqf
@@ -21,4 +21,4 @@ private _totalDamage = 0;
     _totalDamage = _totalDamage + _x;
 } forEach (_this getVariable [QGVAR(bodyPartStatus), []]);
 
-(10 max (_totalDamage * 10) min 120)
+(GVAR(useTimeMin_PAK) max (_totalDamage * 10) min GVAR(useTimeMax_PAK))

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -4712,17 +4712,17 @@
             <Chinesesimp>何时可以使用个人急救包?</Chinesesimp>
             <Chinese>何時可以使用個人急救包?</Chinese>
         </Key>
-        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_UseTimeMin_PAK_DisplayName">
-            <English>Min. Time PAK</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_UseTimeMin_PAK_Description">
-            <English>Minimum time to use a PAK. Recommended less than Max. Time PAK.</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeMax_PAK_DisplayName">
-            <English>Max. Time PAK</English>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeMin_PAK_DisplayName">
+            <English>Pak Time Minimum</English>
         </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeMin_PAK_Description">
-            <English>Maximum time to use a PAK. Recommended greater than Min. Time PAK.</English>
+            <English>Minimum time to use a PAK.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeCoeff_PAK_DisplayName">
+            <English>PAK Time Coefficient</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeCoeff_PAK_Description">
+            <English>Coefficient for maximum PAK time. Max=Coefficient*Min.</English>
         </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_anywhere">
             <English>Anywhere</English>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -4712,6 +4712,18 @@
             <Chinesesimp>何时可以使用个人急救包?</Chinesesimp>
             <Chinese>何時可以使用個人急救包?</Chinese>
         </Key>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_UseTimeMin_PAK_DisplayName">
+            <English>Min. Time PAK</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_UseTimeMin_PAK_Description">
+            <English>Minimum time to use a PAK. Recommended less than Max. Time PAK.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeMax_PAK_DisplayName">
+            <English>Max. Time PAK</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_useTimeMin_PAK_Description">
+            <English>Maximum time to use a PAK. Recommended greater than Min. Time PAK.</English>
+        </Key>
         <Key ID="STR_ACE_Medical_AdvancedMedicalSettings_anywhere">
             <English>Anywhere</English>
             <Russian>Где угодно</Russian>


### PR DESCRIPTION
**When merged this pull request will:**
- Introduce new settings in the ACE Medical settings: PAK Time Minimum and PAK Time Coefficient.
- Use variable Min and Max PAK time settings in place of hard-coded values for PAK time. Max PAK time will be derived from Min * Coefficient.
- Add stringtable.xml entries for newly defined Min and Coefficient PAK time settings.
