### PR TITLE
Captives - Use the doApplyHandcuffs function for keybind

### DIFF
--- a/addons/captives/XEH_postInit.sqf
+++ b/addons/captives/XEH_postInit.sqf
@@ -44,7 +44,7 @@ if (!hasInterface) exitWith {};
     if ((_target distance ACE_player) > getNumber (configFile >> "CfgVehicles" >> "CAManBase" >> "ACE_Actions" >> "ACE_ApplyHandcuffs" >> "distance")) exitWith {false};
 
     if ([ACE_player, _target] call FUNC(canApplyHandcuffs)) exitWith {
-        [QGVAR(setHandcuffed), [_target, true], _target] call CBA_fnc_targetEvent;
+        [player, _target] call ACE_captives_fnc_doApplyHandcuffs;
         true
     };
     false

--- a/addons/captives/XEH_postInit.sqf
+++ b/addons/captives/XEH_postInit.sqf
@@ -44,7 +44,7 @@ if (!hasInterface) exitWith {};
     if ((_target distance ACE_player) > getNumber (configFile >> "CfgVehicles" >> "CAManBase" >> "ACE_Actions" >> "ACE_ApplyHandcuffs" >> "distance")) exitWith {false};
 
     if ([ACE_player, _target] call FUNC(canApplyHandcuffs)) exitWith {
-        [player, _target] call ACE_captives_fnc_doApplyHandcuffs;
+        [ACE_player, _target] call FUNC(doApplyHandcuffs);
         true
     };
     false


### PR DESCRIPTION
**When merged this pull request will:**
- The problem is that the shortcut checks if the unit has cabletie but if you use the shortcut it will not remove the cabletie from the unit. Better use the thing i changed to do this.