### PR TITLE
Zeus Actions - Fix config code breaking during build

### DIFF
--- a/addons/interaction/ACE_ZeusActions.hpp
+++ b/addons/interaction/ACE_ZeusActions.hpp
@@ -54,7 +54,7 @@ class ACE_ZeusActions {
             displayName = "$STR_repair";
             icon = "\A3\ui_f\data\igui\cfg\actions\repair_ca.paa";
             condition = QUOTE(ZEUS_ACTION_CONDITION && {-1 < (curatorSelected select 0) findIf {_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}}});
-            statement = QUOTE({if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {_x setDamage 0}} forEach (curatorSelected select 0));
+            statement = QUOTE(call FUNC(repair_Statement));
         };
     };
 

--- a/addons/interaction/XEH_preInit.sqf
+++ b/addons/interaction/XEH_preInit.sqf
@@ -6,9 +6,11 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-DFUNC(repair_Statement) = {
-    TRACE_1("repairStatement",_this)
-    {if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {_x setDamage 0}} forEach (curatorSelected select 0)
+DFUNC(repair_Statement) = { // moved from config because of build problems
+    TRACE_1("repair_Statement",_this);
+    {
+        if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then { _x setDamage 0; };
+    } forEach (curatorSelected select 0)
 };
 
 ADDON = true;

--- a/addons/interaction/XEH_preInit.sqf
+++ b/addons/interaction/XEH_preInit.sqf
@@ -6,4 +6,9 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+DFUNC(repair_Statement) = {
+    TRACE_1("repairStatement",_this)
+    {if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {_x setDamage 0}} forEach (curatorSelected select 0)
+};
+
 ADDON = true;

--- a/addons/rearm/ACE_ZeusActions.hpp
+++ b/addons/rearm/ACE_ZeusActions.hpp
@@ -4,13 +4,7 @@ class ACE_ZeusActions {
             displayName = CSTRING(Rearm);
             icon = QPATHTOF(ui\icon_rearm_interact.paa);
             condition = QUOTE(ZEUS_ACTION_CONDITION && {-1 < (curatorSelected select 0) findIf {_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}}});
-            statement = QUOTE( \
-                { \
-                    if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then { \
-                        [ARR_2(objNull,_x)] call ace_rearm_fnc_rearmEntireVehicleSuccess; \
-                    }; \
-                } forEach (curatorSelected select 0); \
-            );
+            statement = QUOTE(call FUNC(rearm_statement));
         };
     };
 };

--- a/addons/rearm/XEH_preInit.sqf
+++ b/addons/rearm/XEH_preInit.sqf
@@ -8,4 +8,12 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+DFUNC(rearm_statement) = {
+    {
+        if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {
+            [objNull, _x] call ace_rearm_fnc_rearmEntireVehicleSuccess;
+        };
+    } forEach (curatorSelected select 0);
+};
+
 ADDON = true;

--- a/addons/rearm/XEH_preInit.sqf
+++ b/addons/rearm/XEH_preInit.sqf
@@ -11,7 +11,7 @@ PREP_RECOMPILE_END;
 DFUNC(rearm_statement) = {
     {
         if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {
-            [objNull, _x] call ace_rearm_fnc_rearmEntireVehicleSuccess;
+            [objNull, _x] call FUNC(rearmEntireVehicleSuccess);
         };
     } forEach (curatorSelected select 0);
 };

--- a/addons/rearm/XEH_preInit.sqf
+++ b/addons/rearm/XEH_preInit.sqf
@@ -8,7 +8,8 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
-DFUNC(rearm_statement) = {
+DFUNC(rearm_statement) = { // moved from config because of build problems
+    TRACE_1("rearm_statement",_this);
     {
         if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then {
             [objNull, _x] call FUNC(rearmEntireVehicleSuccess);


### PR DESCRIPTION
Actually fix #6847
Thanks to @dystopian for testing RC

`getText (configfile >> "ACE_ZeusActions" >> "ZeusUnits" >> "ace_interaction_repair" >> "statement")`
>`"{if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}"`

`) then {...` gets cut off
I'm not sure why it breaks, macro usage looks ok to me.