### PR TITLE
version check handle minor versions below 10

### DIFF
--- a/addons/common/scripts/checkVersionNumber.sqf
+++ b/addons/common/scripts/checkVersionNumber.sqf
@@ -10,7 +10,7 @@ private _files = CBA_common_addons select {
 
 private _versions = [];
 {
-    getText (configFile >> "CfgPatches" >> _x >> "version") splitString "." params ["_major", "_minor"];
+    getText (configFile >> "CfgPatches" >> _x >> "version") splitString "." params [["_major", "0"], ["_minor", "0"]];
     private _version = parseNumber _major + parseNumber _minor/100;
     _versions set [_forEachIndex, _version];
 } forEach _files;

--- a/addons/common/scripts/checkVersionNumber.sqf
+++ b/addons/common/scripts/checkVersionNumber.sqf
@@ -4,13 +4,14 @@
 private _aceWhitelist = missionNamespace getVariable ["ACE_Version_Whitelist", []];
 private _files = CBA_common_addons select {
     (_x select [0,3] != "a3_") &&
-    {_x select [0,4] != "ace_"} && 
+    {_x select [0,4] != "ace_"} &&
     {!((toLower _x) in _aceWhitelist)}
 };
 
 private _versions = [];
 {
-    private _version = parseNumber getText (configFile >> "CfgPatches" >> _x >> "version");
+    getText (configFile >> "CfgPatches" >> _x >> "version") splitString "." params ["_major", "_minor"];
+    private _version = parseNumber _major + parseNumber _minor/100;
     _versions set [_forEachIndex, _version];
 } forEach _files;
 


### PR DESCRIPTION
**When merged this pull request will:**
- fix #6871

Note that a big rewrite of this function, that would for example handle `1.99 < 1.100` etc. correctly is not desirable. The function has to be cross compatible between all versions due to its nature and therefore this transferred variable should stay a number and not become an array or string.
