### PR TITLE
Explosives - Allow setting custom timer limits

### DIFF
--- a/addons/explosives/functions/fnc_openTimerUI.sqf
+++ b/addons/explosives/functions/fnc_openTimerUI.sqf
@@ -15,6 +15,9 @@
  * Public: No
  */
 
+#define TIMER_VALUE_MIN_CUSTOM (missionNamespace getVariable [QGVAR(customTimerMin), TIMER_VALUE_MIN])
+#define TIMER_VALUE_MAX_CUSTOM (missionNamespace getVariable [QGVAR(customTimerMax), TIMER_VALUE_MAX])
+
 params ["_explosive"];
 TRACE_1("Opening timer UI",_explosive);
 
@@ -23,6 +26,9 @@ private _display = uiNamespace getVariable [QGVAR(timerDisplay), displayNull];
 
 // Update slider speed to 1s
 (_display displayCtrl IDC_TIMER_SLIDER) sliderSetSpeed [1, 1];
+(_display displayCtrl IDC_TIMER_SLIDER) sliderSetRange [TIMER_VALUE_MIN_CUSTOM, TIMER_VALUE_MAX_CUSTOM];
+(_display displayCtrl IDC_TIMER_SLIDER) sliderSetPosition (TIMER_VALUE_DEFAULT max TIMER_VALUE_MIN_CUSTOM min TIMER_VALUE_MAX_CUSTOM);
+
 
 // Add confirm button action
 GVAR(explosive) = _explosive;
@@ -52,7 +58,7 @@ _display displayAddEventHandler ["MouseZChanged", {
     if (cba_events_control) then {_change = _change * 10};
 
     private _slider = _display displayCtrl IDC_TIMER_SLIDER;
-    private _value = (sliderPosition _slider + _change) max TIMER_VALUE_MIN min TIMER_VALUE_MAX;
+    private _value = (sliderPosition _slider + _change) max TIMER_VALUE_MIN_CUSTOM min TIMER_VALUE_MAX_CUSTOM;
     _slider sliderSetPosition _value;
 }];
 

--- a/docs/wiki/framework/explosives-framework.md
+++ b/docs/wiki/framework/explosives-framework.md
@@ -204,3 +204,9 @@ Jammer that blocks RF triggers:
     true
 }] call ace_explosives_fnc_addDetonateHandler;
 ```
+
+#### 5.4 Custom timer limits
+`Added in 3.12.7`
+
+Can set custom min and max time for the timer trigger, can set one or both, time in seconds
+`ace_explosives_customTimerMin` / `ace_explosives_customTimerMax`


### PR DESCRIPTION
Can set custom min and max time for the timer trigger

e.g.
`ace_explosives_customTimerMin = 60` - can't set a time less than 60 seconds