### PR TITLE
Quickmount - optimize generating subActions

### DIFF
--- a/addons/quickmount/CfgVehicles.hpp
+++ b/addons/quickmount/CfgVehicles.hpp
@@ -43,7 +43,7 @@ class CfgVehicles {
                     condition = QUOTE(call DFUNC(canShowFreeSeats)); \
                     statement = QUOTE(call DFUNC(getInNearest)); \
                     exceptions[] = {"isNotSwimming"}; \
-                    insertChildren = QUOTE(call DFUNC(addFreeSeatsActions)); \
+                    insertChildren = QUOTE((_this select 2) param [ARR_2(0, [])]); \
                 }; \
             }; \
         }; \
@@ -52,7 +52,7 @@ class CfgVehicles {
                 displayName = CSTRING(ChangeSeat); \
                 condition = QUOTE(call DFUNC(canShowFreeSeats)); \
                 statement = ""; \
-                insertChildren = QUOTE(call DFUNC(addFreeSeatsActions)); \
+                insertChildren = QUOTE((_this select 2) param [ARR_2(0, [])]); \
             }; \
         }
 

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Vehicle <OBJECT>
  * 1: Unit <OBJECT>
+ * 2: Args <ARRAY>
  *
  * Return Value:
  * Can show menu <BOOL>
@@ -16,8 +17,9 @@
  * Public: No
  */
 
-params ["_vehicle", "_unit"];
+params ["_vehicle", "_unit", "_args"];
 
+_args set [0, []];
 private _isInVehicle = _unit in _vehicle;
 
 GVAR(enabled)
@@ -36,4 +38,8 @@ GVAR(enabled)
     0.3 < vectorUp _vehicle select 2 // moveIn* and GetIn* don't work for flipped vehicles
     || {_vehicle isKindOf "Air"} // except Air
 }
-&& {!([] isEqualTo (_this call FUNC(addFreeSeatsActions)))} // this should be replaced with faster function
+&& {
+    private _subActions = _this call FUNC(addFreeSeatsActions);
+    _args set [0, _subActions];
+    !([] isEqualTo _subActions)
+}


### PR DESCRIPTION
Caches call to `FUNC(addFreeSeatsActions)` on the actions args
Before it would double call the function each time (~0.8ms on a Chinook)