### PR TITLE
add functions to copy and paste groups and waypoints in game

### DIFF
--- a/addons/ai/XEH_PREP.hpp
+++ b/addons/ai/XEH_PREP.hpp
@@ -2,3 +2,8 @@ PREP(drawCuratorGarrisonPathing);
 PREP(garrison);
 PREP(unGarrison);
 PREP(garrisonMove);
+
+PREP(copyGroup);
+PREP(createGroup);
+PREP(copyWaypoints);
+PREP(applyWaypoints);

--- a/addons/ai/functions/fnc_applyWaypoints.sqf
+++ b/addons/ai/functions/fnc_applyWaypoints.sqf
@@ -1,0 +1,62 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Set group's waypoints.
+ *
+ * Arguments:
+ *  0: A group <GROUP, OBJECT>
+ *  1: Waypoints from ace_ai_fnc_copyWaypoints <ARRAY>
+ *
+ * Return Value:
+ *  Nothing
+ *
+ * Example:
+ *  [group1, _waypoints1] call ace_ai_fnc_applyWaypoints;
+ *
+ * Public: Yes
+ */
+
+params [["_group", grpNull, [grpNull, objNull]], ["_waypointData", [], [[]]]];
+
+if (_group isEqualType objNull) then {
+    _group = group _group;
+};
+
+// group waypoints
+for "_i" from 1 to count waypoints _group do {
+    deleteWaypoint [_group, 0];
+};
+
+{
+    _x params [
+        "_type",
+        "_description",
+        "_name",
+        "_position",
+        "_completionRadius",
+        "_combatMode",
+        "_behaviour",
+        "_formation",
+        "_speed",
+        "_statements",
+        "_script",
+        "_triggers"
+    ];
+
+    private _waypoint = _group addWaypoint [[0,0,0], 0];
+    _waypoint setWaypointType _type;
+    _waypoint setWaypointDescription _description;
+    _waypoint setWaypointName _name;
+    _waypoint setWaypointPosition [_position, 0];
+    _waypoint setWaypointCompletionRadius _completionRadius;
+    _waypoint setWaypointCombatMode _combatMode;
+    _waypoint setWaypointBehaviour _behaviour;
+    _waypoint setWaypointFormation _formation;
+    _waypoint setWaypointSpeed _speed;
+    _waypoint setWaypointStatements _statements;
+    _waypoint setWaypointScript _script;
+
+    {
+        _x synchronizeTrigger [_waypoint];
+    } forEach _triggers;
+} forEach _waypointData;

--- a/addons/ai/functions/fnc_copyGroup.sqf
+++ b/addons/ai/functions/fnc_copyGroup.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Copy a group and its units.
+ *
+ * Arguments:
+ *  0: A group <GROUP>
+ *
+ * Return Value:
+ *  Group data <ARRAY>
+ *
+ * Example:
+ *  private _groupData = _group call ace_ai_fnc_copyGroup;
+ *
+ * Public: Yes
+ */
+
+params [["_group", grpNull, [grpNull, objNull]]];
+
+private _side = SIDES find side _group;
+
+if (_side == -1) then {
+    _side = 1;
+};
+
+private _groupData = [
+    _side,
+    behaviour leader _group,
+    combatMode _group
+];
+
+private _unitsData = units _group apply {[
+    typeOf _x,
+    getPosWorld _x,
+    getDir _x,
+    skill _x,
+    getUnitLoadout _x
+]};
+
+_groupData + [_unitsData]

--- a/addons/ai/functions/fnc_copyWaypoints.sqf
+++ b/addons/ai/functions/fnc_copyWaypoints.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Copy group's waypoints.
+ *
+ * Arguments:
+ *  0: A group <GROUP, OBJECT>
+ *
+ * Return Value:
+ *  Waypoint data <ARRAY>
+ *
+ * Example:
+ *  private _waypoints1 = group1 call ace_ai_fnc_copyWaypoints;
+ *
+ * Public: Yes
+ */
+
+params [["_group", grpNull, [grpNull, objNull]]];
+
+if (_group isEqualType objNull) then {
+    _group = group _group;
+};
+
+private _waypointData = waypoints _group apply {[
+    waypointType _x,
+    waypointDescription _x,
+    waypointName _x,
+    waypointPosition _x,
+    waypointCompletionRadius _x,
+    waypointCombatMode _x,
+    waypointBehaviour _x,
+    waypointFormation _x,
+    waypointSpeed _x,
+    waypointStatements _x,
+    waypointScript _x,
+    synchronizedTriggers _x
+]};
+
+_waypointData

--- a/addons/ai/functions/fnc_createGroup.sqf
+++ b/addons/ai/functions/fnc_createGroup.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Creates a group with units.
+ *
+ * Arguments:
+ *  0: Group data from ace_ai_fnc_copyGroup <ARRAY>
+ *
+ * Return Value:
+ *  The group <GROUP>
+ *
+ * Example:
+ *  private _group = _groupData call ace_ai_fnc_createGroup;
+ *
+ * Public: Yes
+ */
+
+params ["_side", "_behaviour", "_combatMode", "_unitsData"];
+
+// group
+private _group = createGroup (SIDES select _side);
+_group setBehaviour _behaviour;
+_group setCombatMode _combatMode;
+
+// group members
+{
+    _x params ["_type", "_pos", "_dir", "_skill", "_loadout"];
+
+    private _unit = _group createUnit [_type, [0,0,0], [], 0, "NONE"];
+    _unit setDir _dir;
+    _unit setPosWorld _pos;
+    _unit setSkill _skill;
+    _unit setUnitLoadout _loadout;
+} forEach _unitsData;
+
+_group

--- a/addons/ai/script_component.hpp
+++ b/addons/ai/script_component.hpp
@@ -15,3 +15,5 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+
+#define SIDES [east, west, resistance, civilian]


### PR DESCRIPTION
**When merged this pull request will:**
- adds functions to copy and paste groups
- adds functions to copy and paste waypoint sets from one group to another

Example, mission start
```sqf
groupData = group1 call ace_ai_fnc_copyGroup;
waypointData = group1 call ace_ai_fnc_copyWaypoints;
```

Whenever you want to spawn the exact same units as reinforcements
```sqf
group2 = groupData call ace_ai_fnc_createGroup;
[group2, waypointData] call ace_ai_fnc_applyWaypoints;
```

copyGroup/createGroup replicate:
- group side
- group behavior and combat mode
- units in the group:
-- class
-- loadout
-- position and facing
-- skill

copyWaypoints/applyWaypoints:
- replicates all waypoints including
-- name, description, type
-- position, radius
-- group behavior, combat mode, formation changes
-- associated scripts and conditions
-- synchronized triggers
- applyWaypoints overwrites all current waypoints
- does not copy triggers, but assigns the old triggers, therefore they must be set to repeatable

I appologize if we have this already somewhere. I couldn't find anything as unbelievable as this sounds, because this is something pretty basic.

@ todo
- [ ] add a module for mission makers?
