### PR TITLE
 Cookoff - Reword settings and move to cba

### DIFF
--- a/addons/cookoff/ACE_Settings.hpp
+++ b/addons/cookoff/ACE_Settings.hpp
@@ -1,40 +1,18 @@
 
 class ACE_Settings {
     class GVAR(enable) {
-        category = CSTRING(displayName);
-        displayName = CSTRING(enable_name);
-        description = CSTRING(enable_tooltip);
-        value = 0;
-        typeName = "BOOL";
+        movedToSqf = 1;
     };
     class GVAR(enableAmmobox) {
-        category = CSTRING(displayName);
-        displayName = CSTRING(enableBoxCookoff_name);
-        description = CSTRING(enableBoxCookoff_tooltip);
-        value = 1;
-        typeName = "BOOL";
+        movedToSQF = 1;
     };
     class GVAR(enableAmmoCookoff) { // For CBA Setting Switch: we can eliminate and just use (ammoCookoffDuration == 0)
-        category = CSTRING(displayName);
-        displayName = CSTRING(enableAmmoCookoff_name);
-        description = CSTRING(enableAmmoCookoff_tooltip);
-        value = 1;
-        typeName = "BOOL";
+        movedToSQF = 1;
     };
     class GVAR(ammoCookoffDuration) {
-        category = CSTRING(displayName);
-        displayName = CSTRING(ammoCookoffDuration_name);
-        description = CSTRING(ammoCookoffDuration_tooltip);
-        value = 1;
-        typeName = "SCALAR";
-        sliderSettings[] = {0, 5, 1, 1};
+        movedToSQF = 1;
     };
     class GVAR(probabilityCoef) {
-        category = CSTRING(displayName);
-        displayName = CSTRING(probabilityCoef_name);
-        description = CSTRING(probabilityCoef_tooltip);
-        value = 1;
-        typeName = "SCALAR";
-        sliderSettings[] = {0, 5, 1, 1};
+        movedToSQF = 1;
     };
 };

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -7,8 +7,8 @@ class Cfg3DEN {
                     class GVAR(enable) {
                         property = QGVAR(enable);
                         control = "Checkbox";
-                        displayName = CSTRING(enable_name);
-                        tooltip = CSTRING(enable_tooltip);
+                        displayName = CSTRING(enable_hd_name);
+                        tooltip = CSTRING(enable_hd_tooltip);
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
                         condition = "objectVehicle";

--- a/addons/cookoff/XEH_preInit.sqf
+++ b/addons/cookoff/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -1,0 +1,51 @@
+// CBA Settings [ADDON: ace_cookoff]:
+
+[
+    QGVAR(enable), "CHECKBOX",
+    [LSTRING(enable_hd_name), LSTRING(enable_hd_tooltip)],
+    LSTRING(category_displayName),
+    false, // default value
+    true, // isGlobal
+    {[QGVAR(enable), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(enableAmmobox), "CHECKBOX",
+    [LSTRING(enableBoxCookoff_name), LSTRING(enableBoxCookoff_tooltip)],
+    LSTRING(category_displayName),
+    true, // default value
+    true, // isGlobal
+    {[QGVAR(enableAmmobox), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(enableAmmoCookoff), "CHECKBOX",
+    [LSTRING(enableAmmoCookoff_name), LSTRING(enableAmmoCookoff_tooltip)],
+    LSTRING(category_displayName),
+    true, // default value
+    true, // isGlobal
+    {[QGVAR(enableAmmoCookoff), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(ammoCookoffDuration), "SLIDER",
+    [LSTRING(ammoCookoffDuration_name), LSTRING(ammoCookoffDuration_tooltip)],
+    LSTRING(category_displayName),
+    [0,5,1,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(ammoCookoffDuration), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(probabilityCoef), "SLIDER",
+    [LSTRING(probabilityCoef_name), LSTRING(probabilityCoef_tooltip)],
+    LSTRING(category_displayName),
+    [0,5,1,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
+    true, // isGlobal
+    {[QGVAR(probabilityCoef), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
+] call CBA_settings_fnc_init;

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -16,7 +16,7 @@
             <English>Damage handling and turret effects</English>
         </Key>
         <Key ID="STR_ACE_CookOff_enable_hd_tooltip">
-            <English>Changes damage handling on vehicles and adds turret explosion effects</English>
+            <English>Changes damage handling for cook off and turret explosion effects</English>
         </Key>
         <Key ID="STR_ACE_CookOff_generic_turret_wreck">
             <English>Wreck (Turret)</English>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -1,42 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="CookOff">
-        <Key ID="STR_ACE_CookOff_displayName">
-            <English>Cook off</English>
-            <Italian>Esplosione</Italian>
-            <Chinese>殉爆效果</Chinese>
-            <Chinesesimp>殉爆效果</Chinesesimp>
-            <Japanese>誘爆</Japanese>
-            <Korean>쿡오프</Korean>
-            <German>Durchzündung</German>
-            <French>Cook off</French>
-            <Polish>Samozapłon</Polish>
+        <Key ID="STR_ACE_CookOff_category_displayName">
+            <English>ACE Cook off</English>
+            <Italian>ACE Esplosione</Italian>
+            <Chinese>ACE 殉爆效果</Chinese>
+            <Chinesesimp>ACE 殉爆效果</Chinesesimp>
+            <Japanese>ACE 誘爆</Japanese>
+            <Korean>ACE 쿡오프</Korean>
+            <German>ACE Durchzündung</German>
+            <French>ACE Cook off</French>
+            <Polish>ACE Samozapłon</Polish>
         </Key>
-        <Key ID="STR_ACE_CookOff_enable_name">
-            <English>Enable cook off</English>
-            <German>Durchzündung ermöglichen</German>
-            <Czech>Povolit explozi munice</Czech>
-            <Russian>Включить воспламенение</Russian>
-            <Japanese>誘爆を有効化</Japanese>
-            <Korean>쿡오프 현상 활성화</Korean>
-            <Polish>Aktywuj efekty samozapłonu amunicji</Polish>
-            <French>Activer le cook off</French>
-            <Italian>Abilita Esplosione</Italian>
-            <Chinese>開啟殉爆效果</Chinese>
-            <Chinesesimp>开启殉爆效果</Chinesesimp>
+        <Key ID="STR_ACE_CookOff_enable_hd_name">
+            <English>Damage handling and turret effects</English>
         </Key>
-        <Key ID="STR_ACE_CookOff_enable_tooltip">
-            <English>Enables cook off and related vehicle destruction effects.</English>
-            <German>Ermöglicht Durchzündung und zugehörige Fahrzeug-Zerstörungseffekte.</German>
-            <Czech>Povolí explozi munice a její následné ničivé efekty.</Czech>
-            <Russian>Включает воспламенение и сопутствующие эффекты повреждения техники.</Russian>
-            <Japanese>誘爆を有効化し、車両が誘爆によって破壊されていきます。</Japanese>
-            <Korean>쿡오프 현상을 활성화 하고 관련된 차량에 폭발 이펙트를 적용합니다.</Korean>
-            <Polish>Aktywuje efekt samozapłonu amunicji na zniszczonych pojazdach.</Polish>
-            <French>Active le cook-off (autocombustion des munitions) et les effets de destruction liés.</French>
-            <Italian>Abilita l'esplosione e i relativi effetti di distruzione del veicolo.</Italian>
-            <Chinese>開啟此功能後，將使有關載具在損毀時有殉爆的效果</Chinese>
-            <Chinesesimp>开启此功能后，将使有关载具在损毁时有殉爆的效果。</Chinesesimp>
+        <Key ID="STR_ACE_CookOff_enable_hd_tooltip">
+            <English>Changes damage handling on vehicles and adds turret explosion effects</English>
         </Key>
         <Key ID="STR_ACE_CookOff_generic_turret_wreck">
             <English>Wreck (Turret)</English>


### PR DESCRIPTION
```
class GVAR(enableAmmoCookoff) { 
// For CBA Setting Switch: we can eliminate and just use (ammoCookoffDuration == 0)
```
are we ok actually doing this, I think it might have been written back when we though we would lose all saved setting when converting?