### PR TITLE
RHS Compat - Add 2 round hellfire to pylon options

### DIFF
--- a/addons/hellfire/CfgMagazineWells.hpp
+++ b/addons/hellfire/CfgMagazineWells.hpp
@@ -1,0 +1,4 @@
+class CfgMagazineWells {
+    class GVAR(magwell_K) {};
+    class GVAR(magwell_N) {};
+};

--- a/addons/hellfire/CfgMagazineWells.hpp
+++ b/addons/hellfire/CfgMagazineWells.hpp
@@ -1,4 +1,4 @@
 class CfgMagazineWells {
-    class GVAR(magwell_K) {};
-    class GVAR(magwell_N) {};
+    class GVAR(K) {};
+    class GVAR(N) {};
 };

--- a/addons/hellfire/CfgWeapons.hpp
+++ b/addons/hellfire/CfgWeapons.hpp
@@ -6,7 +6,7 @@ class CfgWeapons {
         EGVAR(laser,canSelect) = 1; // can ace_laser lock (allows switching laser code)
         EGVAR(laser,showHud) = 1; // show attack profile / lock on hud
         magazines[] = {"6Rnd_ACE_Hellfire_AGM114K", "PylonMissile_1Rnd_ACE_Hellfire_AGM114K", "PylonRack_1Rnd_ACE_Hellfire_AGM114K", "PylonRack_3Rnd_ACE_Hellfire_AGM114K", "PylonRack_4Rnd_ACE_Hellfire_AGM114K"};
-        magazineWell[] = {QGVAR(magwell_K)};
+        magazineWell[] = {QGVAR(K)};
         autoFire = 0;
         canLock = 0;
         weaponLockSystem = 0;
@@ -27,6 +27,6 @@ class CfgWeapons {
     class GVAR(launcher_N): GVAR(launcher) {
         displayName = "AGM-114N Hellfire II";
         magazines[] = {"6Rnd_ACE_Hellfire_AGM114N", "PylonMissile_1Rnd_ACE_Hellfire_AGM114N", "PylonRack_1Rnd_ACE_Hellfire_AGM114N", "PylonRack_3Rnd_ACE_Hellfire_AGM114N", "PylonRack_4Rnd_ACE_Hellfire_AGM114N"};
-        magazineWell[] = {QGVAR(magwell_N)};
+        magazineWell[] = {QGVAR(N)};
     };
 };

--- a/addons/hellfire/CfgWeapons.hpp
+++ b/addons/hellfire/CfgWeapons.hpp
@@ -6,7 +6,7 @@ class CfgWeapons {
         EGVAR(laser,canSelect) = 1; // can ace_laser lock (allows switching laser code)
         EGVAR(laser,showHud) = 1; // show attack profile / lock on hud
         magazines[] = {"6Rnd_ACE_Hellfire_AGM114K", "PylonMissile_1Rnd_ACE_Hellfire_AGM114K", "PylonRack_1Rnd_ACE_Hellfire_AGM114K", "PylonRack_3Rnd_ACE_Hellfire_AGM114K", "PylonRack_4Rnd_ACE_Hellfire_AGM114K"};
-        
+        magazineWell[] = {QGVAR(magwell_K)};
         autoFire = 0;
         canLock = 0;
         weaponLockSystem = 0;
@@ -14,7 +14,7 @@ class CfgWeapons {
         lockedTargetSound[] = {"",0,1};
         soundFly[] = {"A3\Sounds_F\weapons\Rockets\rocket_fly_1",1,1.1,700};
         nameSound = "MissileLauncher";
-        sounds[] = {"StandardSound"};        
+        sounds[] = {"StandardSound"};
         class StandardSound {
             begin1[] = {"A3\Sounds_F\weapons\Rockets\missile_1",1.12202,1.3,1000};
             soundBegin[] = {"begin1",1};
@@ -27,5 +27,6 @@ class CfgWeapons {
     class GVAR(launcher_N): GVAR(launcher) {
         displayName = "AGM-114N Hellfire II";
         magazines[] = {"6Rnd_ACE_Hellfire_AGM114N", "PylonMissile_1Rnd_ACE_Hellfire_AGM114N", "PylonRack_1Rnd_ACE_Hellfire_AGM114N", "PylonRack_3Rnd_ACE_Hellfire_AGM114N", "PylonRack_4Rnd_ACE_Hellfire_AGM114N"};
+        magazineWell[] = {QGVAR(magwell_N)};
     };
 };

--- a/addons/hellfire/config.cpp
+++ b/addons/hellfire/config.cpp
@@ -18,5 +18,6 @@ class CfgPatches {
 #include "CfgAmmo.hpp"
 #include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgMagazineWells.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"

--- a/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
@@ -1,8 +1,8 @@
 class CfgMagazineWells {
     class ace_hellfire_K {
-        GVAR[] = {QGVAR(pylon_mag_2rnd_hellfire_k)};
+        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_k)};
     };
     class ace_hellfire_N {
-        GVAR[] = {GVAR(pylon_mag_2rnd_hellfire_n)};
+        ADDON[] = {GVAR(pylon_mag_2rnd_hellfire_n)};
     };
 };

--- a/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
@@ -1,0 +1,8 @@
+class CfgMagazineWells {
+    class ace_hellfire_magwell_K {
+        GVAR[] = {QGVAR(pylon_mag_2rnd_hellfire_k)};
+    };
+    class ace_hellfire_magwell_N {
+        GVAR[] = {GVAR(pylon_mag_2rnd_hellfire_n)};
+    };
+};

--- a/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazineWells.hpp
@@ -1,8 +1,8 @@
 class CfgMagazineWells {
-    class ace_hellfire_magwell_K {
+    class ace_hellfire_K {
         GVAR[] = {QGVAR(pylon_mag_2rnd_hellfire_k)};
     };
-    class ace_hellfire_magwell_N {
+    class ace_hellfire_N {
         GVAR[] = {GVAR(pylon_mag_2rnd_hellfire_n)};
     };
 };

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -23,4 +23,17 @@ class cfgMagazines {
         EGVAR(overpressure,range) = 0;
         EGVAR(overpressure,damage) = 0;
     };
+
+    class rhs_mag_AGM114K_2;
+    class GVAR(pylon_mag_2rnd_hellfire_k): rhs_mag_AGM114K_2 {
+        displayName = "2x AGM-114K [ACE]";
+        pylonWeapon = "ace_hellfire_launcher";
+        ammo = "ACE_Hellfire_AGM114K";
+    };
+    class GVAR(pylon_mag_2rnd_hellfire_n): rhs_mag_AGM114K_2 {
+        displayName = "2x AGM-114N [ACE]";
+        pylonWeapon = "ace_hellfire_launcher_N";
+        ammo = "ACE_Hellfire_AGM114N";
+    };
+
 };

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -17,6 +17,7 @@ class CfgPatches {
 #include "CfgAmmo.hpp"
 #include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgMagazineWells.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgGlasses.hpp"


### PR DESCRIPTION
Close #5957

Using RHS model, adds new mag that uses ace's guidance for pylon options RHS choppers.
