### PR TITLE
Interaction - Pass Magazine fixes

### DIFF
--- a/addons/interaction/functions/fnc_canPassMagazine.sqf
+++ b/addons/interaction/functions/fnc_canPassMagazine.sqf
@@ -21,9 +21,9 @@ params ["_player", "_target", "_weapon"];
 if (!GVAR(enableMagazinePassing)) exitWith {false};
 if (((vehicle _target) != _target) && {(vehicle _target) != (vehicle _player)}) exitWith {false};
 
-private _compatibleMags = getArray (configfile >> "CfgWeapons" >> _weapon >> "magazines");
-{
+private _compatibleMags = [_weapon] call CBA_fnc_compatibleMagazines;
+
+(magazinesAmmoFull _player) findIf {
     _x params ["_className", "", "_loaded"];
-    if ((_className in _compatibleMags) && {!_loaded} && {_target canAdd _className}) exitWith {true};
-    false
-} foreach (magazinesAmmoFull _player);
+    (_className in _compatibleMags) && {!_loaded} && {_target canAdd _className}
+} > -1

--- a/addons/interaction/functions/fnc_passMagazine.sqf
+++ b/addons/interaction/functions/fnc_passMagazine.sqf
@@ -12,21 +12,24 @@
  * None
  *
  * Example:
- * [_player, _target, "arifle_MX_F"] call ace_interaction_fnc_magToPassazine
+ * [_player, _target, "arifle_MX_F"] call ace_interaction_fnc_passMagazine
  *
  * Public: No
  */
 params ["_player", "_target", "_weapon"];
 
-private _compatibleMags = getArray (configfile >> "CfgWeapons" >> _weapon >> "magazines");
-private _filteredMags = magazinesAmmoFull _player select {(_x select 0) in _compatibleMags && {!(_x select 2)}};
+private _compatibleMags = [_weapon] call CBA_fnc_compatibleMagazines;
+private _filteredMags = magazinesAmmoFull _player select {
+    _x params ["_className", "", "_loaded"];
+    (_className in _compatibleMags) && {!_loaded} && {_target canAdd _className}
+};
 
 //select magazine with most ammo
 private _magToPass = _filteredMags select 0;
 private _magToPassIndex = 0;
 {
     _x params ["_className", "_ammoCount"];
-    if ((_ammoCount > (_magToPass select 1)) && (_target canAdd _className)) then {
+    if (_ammoCount > (_magToPass select 1)) then {
         _magToPass = _x;
         _magToPassIndex = _forEachIndex;
     };


### PR DESCRIPTION
Use CBA_fnc_compatibleMagazines
Fix nil return in canPassMagazine if player has no mags (`forEach` never ran)
Ensure target canAdd (`private _magToPass = _filteredMags select 0;` could be a 200rnd belt that target can't add, but it's ammo count would be larger than smaller mags that the target could add)