### PR TITLE
Medical Feedback - fix heart rate effect

### DIFF
--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -24,10 +24,13 @@ GVAR(heartBeatEffectRunning) = false;
     if (_unit != ACE_player) exitWith {};
 
     // Toggle unconscious player's ability to talk in radio addons
-    _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
-    _unit setVariable ["tf_unable_to_use_radio", _unconscious]; // Only used locally
-    _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
-
+    if (["tfar_core"] call EFUNC(common,isModLoaded)) then {
+        _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
+        _unit setVariable ["tf_unable_to_use_radio", _unconscious]; // Only used locally
+    };
+    if (["acre_sys_core"] call EFUNC(common,isModLoaded)) then {
+        _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
+    };
     // Greatly reduce player's hearing ability while unconscious (affects radio addons)
     [QUOTE(ADDON), VOL_UNCONSCIOUS, _unconscious] call EFUNC(common,setHearingCapability);
 
@@ -40,22 +43,29 @@ GVAR(heartBeatEffectRunning) = false;
     params ["_unit"];
 
     if (_unit != ACE_player) exitWith {};
-
-    _unit setVariable ["tf_voiceVolume", 1, true];
-    _unit setVariable ["tf_unable_to_use_radio", false];
-    _unit setVariable ["acre_sys_core_isDisabled", false, true];
+    if (["tfar_core"] call EFUNC(common,isModLoaded)) then {
+        _unit setVariable ["tf_voiceVolume", 1, true];
+        _unit setVariable ["tf_unable_to_use_radio", false];
+    };
+    if (["acre_sys_core"] call EFUNC(common,isModLoaded)) then {
+        _unit setVariable ["acre_sys_core_isDisabled", false, true];
+    };
     [QUOTE(ADDON), 1, false] call EFUNC(common,setHearingCapability);
 }] call CBA_fnc_addEventHandler;
 
 // Update effects to match new unit's current status (this also handles respawn)
 ["unit", {
-    params ["_new", "_old"];
+    params ["_new"];
 
     private _status = _new getVariable ["ace_unconscious", false];
 
-    _new setVariable ["tf_voiceVolume", [1, 0] select _status, true];
-    _new setVariable ["tf_unable_to_use_radio", _status];
-    _new setVariable ["acre_sys_core_isDisabled", _status, true];
+    if (["tfar_core"] call EFUNC(common,isModLoaded)) then {
+        _new setVariable ["tf_voiceVolume", [1, 0] select _status, true];
+        _new setVariable ["tf_unable_to_use_radio", _status];
+    };
+    if (["acre_sys_core"] call EFUNC(common,isModLoaded)) then {
+        _new setVariable ["acre_sys_core_isDisabled", _status, true];
+    };
     [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);
     [_status, 0] call FUNC(effectUnconscious);
     ["unconscious", _status] call EFUNC(common,setDisableUserInputStatus);

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -47,7 +47,7 @@ GVAR(heartBeatEffectRunning) = false;
         _unit setVariable ["tf_voiceVolume", 1, true];
         _unit setVariable ["tf_unable_to_use_radio", false];
     };
-    if (["acre_sys_core"] call EFUNC(common,isModLoaded)) then {
+    if (["acre_main"] call EFUNC(common,isModLoaded)) then {
         _unit setVariable ["acre_sys_core_isDisabled", false, true];
     };
     [QUOTE(ADDON), 1, false] call EFUNC(common,setHearingCapability);

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -28,7 +28,7 @@ GVAR(heartBeatEffectRunning) = false;
         _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
         _unit setVariable ["tf_unable_to_use_radio", _unconscious]; // Only used locally
     };
-    if (["acre_sys_core"] call EFUNC(common,isModLoaded)) then {
+    if (["acre_main"] call EFUNC(common,isModLoaded)) then {
         _unit setVariable ["acre_sys_core_isDisabled", _unconscious, true];
     };
     // Greatly reduce player's hearing ability while unconscious (affects radio addons)
@@ -63,7 +63,7 @@ GVAR(heartBeatEffectRunning) = false;
         _new setVariable ["tf_voiceVolume", [1, 0] select _status, true];
         _new setVariable ["tf_unable_to_use_radio", _status];
     };
-    if (["acre_sys_core"] call EFUNC(common,isModLoaded)) then {
+    if (["acre_main"] call EFUNC(common,isModLoaded)) then {
         _new setVariable ["acre_sys_core_isDisabled", _status, true];
     };
     [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -24,7 +24,7 @@ GVAR(heartBeatEffectRunning) = false;
     if (_unit != ACE_player) exitWith {};
 
     // Toggle unconscious player's ability to talk in radio addons
-    if (["tfar_core"] call EFUNC(common,isModLoaded)) then {
+    if (["task_force_radio"] call EFUNC(common,isModLoaded)) then {
         _unit setVariable ["tf_voiceVolume", [1, 0] select _unconscious, true];
         _unit setVariable ["tf_unable_to_use_radio", _unconscious]; // Only used locally
     };
@@ -43,7 +43,7 @@ GVAR(heartBeatEffectRunning) = false;
     params ["_unit"];
 
     if (_unit != ACE_player) exitWith {};
-    if (["tfar_core"] call EFUNC(common,isModLoaded)) then {
+    if (["task_force_radio"] call EFUNC(common,isModLoaded)) then {
         _unit setVariable ["tf_voiceVolume", 1, true];
         _unit setVariable ["tf_unable_to_use_radio", false];
     };
@@ -59,7 +59,7 @@ GVAR(heartBeatEffectRunning) = false;
 
     private _status = _new getVariable ["ace_unconscious", false];
 
-    if (["tfar_core"] call EFUNC(common,isModLoaded)) then {
+    if (["task_force_radio"] call EFUNC(common,isModLoaded)) then {
         _new setVariable ["tf_voiceVolume", [1, 0] select _status, true];
         _new setVariable ["tf_unable_to_use_radio", _status];
     };

--- a/addons/medical_feedback/functions/fnc_effectHeartBeat.sqf
+++ b/addons/medical_feedback/functions/fnc_effectHeartBeat.sqf
@@ -4,18 +4,18 @@
  * Handles the hear beat sound.
  *
  * Arguments:
- * 0: Heart rate <NUMBER>
+ * None
  *
  * Return Value:
  * None
  *
  * Example:
- * [120] call ace_medical_feedback_fnc_effectHeartBeat
+ * [] call ace_medical_feedback_fnc_effectHeartBeat
  *
  * Public: No
  */
 
-params ["_heartRate"];
+private _heartRate = GET_HEART_RATE(ACE_player);
 
 if (_heartRate == 0) exitWith {
     TRACE_1("Ending heart beat effect - zero",_heartRate);


### PR DESCRIPTION
and limit setVar for acre/tfar (slightly less network traffic)

effectHeartbeat would recurse with no params
`[FUNC(effectHeartBeat), [], _waitTime] call CBA_fnc_waitAndExecute;`
so `_heartbeat` was undefined, this changes it to get the current HR each time the func is run