### PR TITLE
Medical - Skip unneeded setVars on initUnit

### DIFF
--- a/addons/medical_status/CfgEventHandlers.hpp
+++ b/addons/medical_status/CfgEventHandlers.hpp
@@ -19,8 +19,7 @@ class Extended_PostInit_EventHandlers {
 class Extended_Init_EventHandlers {
     class CAManBase {
         class ADDON {
-            onRespawn = 1;
-            init = QUOTE(call FUNC(initUnit));
+            init = QUOTE([ARR_2((_this select 0), false)] call FUNC(initUnit));
         };
     };
 };

--- a/addons/medical_status/functions/fnc_initUnit.sqf
+++ b/addons/medical_status/functions/fnc_initUnit.sqf
@@ -5,17 +5,22 @@
  *
  * Arguments:
  * 0: The Unit <OBJECT>
+ * 1: Is Respawned <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [bob] call ace_medical_status_fnc_init
+ * [bob, false] call ace_medical_status_fnc_initUnit
  *
  * Public: No
  */
 
-params ["_unit"];
+params ["_unit", ["_isRespawn", true]];
+
+if (!_isRespawn) then { // Always add respawn EH (same as CBA's onRespawn=1)
+    _unit addEventHandler ["Respawn", {[(_this select 0), true] call FUNC(initUnit)}];
+};
 
 if (!local _unit) exitWith {};
 
@@ -23,6 +28,8 @@ if (damage _unit > 0) then {
     _unit setDamage 0;
 };
 
+if (_isRespawn) then {
+TRACE_1("reseting all vars on respawn",_isRespawn); // note: state is handled by ace_medical_statemachine_fnc_resetStateDefault
 // - Blood and heart ----------------------------------------------------------
 _unit setVariable [VAR_BLOOD_VOL, DEFAULT_BLOOD_VOLUME, true];
 _unit setVariable [VAR_HEART_RATE, DEFAULT_HEART_RATE, true];
@@ -56,9 +63,6 @@ _unit setVariable [QEGVAR(medical,triageCard), [], true];
 
 // damage storage
 _unit setVariable [QEGVAR(medical,bodyPartDamage), [0,0,0,0,0,0], true];
-#ifdef DEBUG_TESTRESULTS
-_unit setVariable [QEGVAR(medical,bodyPartStatus), [0,0,0,0,0,0], true];
-#endif
 
 // medication
 _unit setVariable [VAR_MEDICATIONS, [], true];
@@ -69,6 +73,7 @@ private _logs = _unit getVariable [QEGVAR(medical,allLogs), []];
     _unit setVariable [_x, nil];
 } forEach _logs;
 _unit setVariable [QEGVAR(medical,allLogs), [], true];
+};
 
 [{
     params ["_unit"];

--- a/addons/medical_treatment/functions/fnc_treatmentFullHealLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentFullHealLocal.sqf
@@ -54,9 +54,6 @@ _target setVariable [QEGVAR(medical,ivBags), nil, true];
 
 // damage storage
 _target setVariable [QEGVAR(medical,bodyPartDamage), [0,0,0,0,0,0], true];
-#ifdef DEBUG_TESTRESULTS
-_target setVariable [QEGVAR(medical,bodyPartStatus), [0,0,0,0,0,0], true];
-#endif
 
 // generic medical admin
 _target setVariable [VAR_CRDC_ARRST, false, true];


### PR DESCRIPTION
For old issue https://github.com/acemod/ACE3/issues/3169

As long as we have good default values for all of our `getVariable` we should be able to skip broadcasting default values on unit init.

e.g. 200 AI * 20 setVars = useless network traffic