### PR TITLE
Medical Feedback - Fix DISABLE_VANILLA_DAMAGE_EFFECTS

### DIFF
--- a/addons/medical/functions/fnc_addDamageToUnit.sqf
+++ b/addons/medical/functions/fnc_addDamageToUnit.sqf
@@ -34,8 +34,8 @@ if (_bodyPartIndex < 0) exitWith {ERROR_1("addDamageToUnit - bad selection %1", 
 _bodyPart = ["Head", "Body", "LeftArm", "RightArm", "LeftLeg", "RightLeg"] select _bodyPartIndex;
 
 if (!isNull _instigator) then {
-    _unit setVariable [QEGVAR(medical_engine,lastShooter), _instigator];
-    _unit setVariable [QEGVAR(medical_engine,lastInstigator), _instigator];
+    _unit setVariable [QEGVAR(medical,lastDamageSource), _instigator];
+    _unit setVariable [QEGVAR(medical,lastInstigator), _instigator];
 };
 
 #ifdef DEBUG_TESTRESULTS

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -20,7 +20,7 @@
             _unit addEventHandler ["HandleDamage", {_this call FUNC(handleDamage)}]
         ];
     };
-}, nil, nil, true] call CBA_fnc_addClassEventHandler;
+}, nil, [IGNORE_BASE_UAVPILOTS], true] call CBA_fnc_addClassEventHandler;
 
 #ifdef DEBUG_MODE_FULL
 [QEGVAR(medical,woundReceived), {
@@ -30,24 +30,6 @@
 }] call CBA_fnc_addEventHandler;
 #endif
 
-// Kill vanilla bleeding feedback effects.
-#ifdef DISABLE_VANILLA_DAMAGE_EFFECTS
-[{
-    {isNil _x} count [
-        "BIS_fnc_feedback_damageCC",
-        "BIS_fnc_feedback_damageRadialBlur",
-        "BIS_fnc_feedback_damageBlur"
-    ] == 0
-}, {
-    {
-        ppEffectDestroy _x;
-    } forEach [
-        BIS_fnc_feedback_damageCC,
-        BIS_fnc_feedback_damageRadialBlur,
-        BIS_fnc_feedback_damageBlur
-    ];
-}] call CBA_fnc_waitUntilAndExecute;
-#endif
 
 // this handles moving units into vehicles via load functions or zeus
 // needed, because the vanilla INCAPACITATED state does not handle vehicles

--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -45,8 +45,8 @@ if (_hitPoint in ["hithead", "hitbody", "hithands", "hitlegs"]) exitWith {_oldDa
 // This hitpoint is set to trigger last, evaluate all the stored damage values
 // to determine where wounds are applied
 if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
-    _unit setVariable [QGVAR(lastShooter), _shooter];
-    _unit setVariable [QGVAR(lastInstigator), _instigator];
+    _unit setVariable [QEGVAR(medical,lastDamageSource), _shooter];
+    _unit setVariable [QEGVAR(medical,lastInstigator), _instigator];
 
     private _damageStructural = _unit getVariable [HIT_STRUCTURAL, 0];
 

--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -151,3 +151,6 @@
 // Cache expiry values, in seconds
 #define IN_MEDICAL_FACILITY_CACHE_EXPIRY 1
 #define CAN_TREAT_CONDITION_CACHE_EXPIRY 2
+
+// Ignore UAV/Drone AI Base Classes
+#define IGNORE_BASE_UAVPILOTS "B_UAV_AI", "O_UAV_AI", "UAV_AI_base_F"

--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -70,3 +70,24 @@ GVAR(heartBeatEffectRunning) = false;
     [_status, 0] call FUNC(effectUnconscious);
     ["unconscious", _status] call EFUNC(common,setDisableUserInputStatus);
 }] call CBA_fnc_addPlayerEventHandler;
+
+
+// Kill vanilla bleeding feedback effects.
+#ifdef DISABLE_VANILLA_DAMAGE_EFFECTS
+TRACE_1("disabling vanilla bleeding feedback effects",_this);
+[{
+    {isNil _x} count [
+        "BIS_fnc_feedback_damageCC",
+        "BIS_fnc_feedback_damageRadialBlur",
+        "BIS_fnc_feedback_damageBlur"
+    ] == 0
+}, {
+    {
+        ppEffectDestroy _x;
+    } forEach [
+        BIS_fnc_feedback_damageCC,
+        BIS_fnc_feedback_damageRadialBlur,
+        BIS_fnc_feedback_damageBlur
+    ];
+}] call CBA_fnc_waitUntilAndExecute;
+#endif

--- a/addons/medical_status/functions/fnc_setDead.sqf
+++ b/addons/medical_status/functions/fnc_setDead.sqf
@@ -22,7 +22,7 @@ _unit setVariable [VAR_BLOOD_PRESS, [0, 0], true];
 // Kill the unit without changing visual apperance
 [_unit, 1] call EFUNC(medical_engine,setStructuralDamage);
 
-private _lastShooter = _unit getVariable [QEGVAR(medical_engine,lastShooter), objNull];
-private _lastInstigator = _unit getVariable [QEGVAR(medical_engine,lastInstigator), objNull];
+private _lastShooter = _unit getVariable [QEGVAR(medical,lastDamageSource), objNull];
+private _lastInstigator = _unit getVariable [QEGVAR(medical,lastInstigator), objNull];
 
 ["ace_killed", [_unit, _reason, _lastShooter, _lastInstigator]] call CBA_fnc_globalEvent;


### PR DESCRIPTION
`DISABLE_VANILLA_DAMAGE_EFFECTS` was only defined in medical_feedback
so it wasn't running, and I'm pretty sure this is where it belongs
it's also now under a `hasInterface` check