### PR TITLE
isUsingOptic function to fix night vision optics

### DIFF
--- a/addons/nightvision/RscTitles.hpp
+++ b/addons/nightvision/RscTitles.hpp
@@ -22,7 +22,7 @@ class RscTitles {
             class Mask: RscPicture {
                 idc = 1001;
             };
-            
+
             // Add blinders for side monitors for tripple monitors (mask won't cover them)
             class trippleHeadLeft: RscPicture {
                 idc = 1002;
@@ -36,6 +36,22 @@ class RscTitles {
                 idc = 1003;
                 x = "safeZoneXAbs + safeZoneWAbs - (safezoneX - safeZoneXABS) * ((getResolution select 4)/(16/3))";
             };
+        };
+    };
+};
+
+class RscOpticsValue;
+
+class RscInGameUI {
+    class RscUnitInfo;
+    class RscOptics_nightstalker: RscUnitInfo {
+        controls[] += {QGVAR(OpticsMode)};
+
+        class GVAR(OpticsMode): RscOpticsValue {
+            onLoad = QUOTE(_this call FUNC(initOpticsModeControl));
+            idc = 154;
+            w = 0;
+            h = 0;
         };
     };
 };

--- a/addons/nightvision/XEH_PREP.hpp
+++ b/addons/nightvision/XEH_PREP.hpp
@@ -1,4 +1,3 @@
-
 PREP(changeNVGBrightness);
 PREP(initModule);
 PREP(nonDedicatedFix);
@@ -10,3 +9,5 @@ PREP(pfeh);
 PREP(refreshGoggleType);
 PREP(scaleCtrl);
 PREP(setupDisplayEffects);
+PREP(initOpticsModeControl);
+PREP(isUsingOptic);

--- a/addons/nightvision/functions/fnc_initOpticsModeControl.sqf
+++ b/addons/nightvision/functions/fnc_initOpticsModeControl.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Stores latest optics mode control in array for FUNC(isUsingOptic) and flushes null controls.
+ *
+ * Arguments:
+ * 0: Optics mode helper control <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [true] call ace_nightvision_fnc_initOpticsModeControl
+ *
+ * Public: No
+ */
+
+params ["_control"];
+
+if (isNil QGVAR(OpticsModeControls)) then {
+    GVAR(OpticsModeControls) = [];
+};
+
+GVAR(OpticsModeControls) = GVAR(OpticsModeControls) select {!isNull _x};
+GVAR(OpticsModeControls) pushBack _control

--- a/addons/nightvision/functions/fnc_isUsingOptic.sqf
+++ b/addons/nightvision/functions/fnc_isUsingOptic.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Check if avatar is using the optics mode.
+ *
+ * Arguments:
+ * 0: Optics mode helper control <CONTROL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [true] call ace_nightvision_fnc_isUsingOptic
+ *
+ * Public: No
+ */
+
+(missionNamespace getVariable [QGVAR(OpticsModeControls), []]) findIf {ctrlShown _x} != -1


### PR DESCRIPTION
**When merged this pull request will:**
- Proof of concept function to report if optics mode is used
- `cameraView == "GUNNER"` reports true for CQB optics on top of the optic or weapon, but this really checks for the optics mode and only then reports `true`.
- for #6666 and #6942

```sqf
player addPrimaryWeaponitem "optic_nightstalker";
```

```sqf
call ace_nightvision_fnc_isUsingOptic
```

Obviously only works with comptaible optics, but support for it can be relatively easily added to anything in particular.