### PR TITLE
Medical Blood - Small optimizations

### DIFF
--- a/addons/medical_blood/XEH_postInit.sqf
+++ b/addons/medical_blood/XEH_postInit.sqf
@@ -30,13 +30,13 @@ if (isServer) then {
     if ((GVAR(enabledFor) == 1) && {!hasInterface}) exitWith {}; // 1: enabledFor_OnlyPlayers
 
     private _listcode = if (GVAR(enabledFor) == 1) then {
-        {[ACE_player]} // ace_player is only possible local player
+        {if (alive ACE_player) then {[ACE_player]} else {[]}} // ace_player is only possible local player
     } else {
         EFUNC(common,getLocalUnits) // filter all local units
     };
 
     private _stateMachine = [_listcode, true] call CBA_statemachine_fnc_create;
-    [_stateMachine, {call FUNC(onBleeding)}, {}, {}, "Bleeding"] call CBA_statemachine_fnc_addState;
+    [_stateMachine, LINKFUNC(onBleeding), {}, {}, "Bleeding"] call CBA_statemachine_fnc_addState;
 
     [QEGVAR(medical,woundReceived), FUNC(handleWoundReceived)] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/medical_blood/functions/fnc_onBleeding.sqf
+++ b/addons/medical_blood/functions/fnc_onBleeding.sqf
@@ -20,12 +20,10 @@ params ["_unit"];
 if (!([_unit] call FUNC(isBleeding))) exitWith {};
 if (((vehicle _unit) != _unit) && {!((vehicle _unit) isKindOf "StaticWeapon")}) exitWith {}; // Don't bleed on ground if mounted
 
-private _lastTime = _unit getVariable [QGVAR(lastTime), -10];
-private _bloodLoss = (if (GVAR(useAceMedical)) then {GET_BLOOD_LOSS(_unit) * 2.5} else {getDammage _unit * 2}) min 6;
-TRACE_1("",_bloodLoss);
-
-if ((CBA_missionTime - _lastTime) + _bloodLoss >= 8 + random 2) then {
-    _unit setVariable [QGVAR(lastTime), CBA_missionTime];
+if (CBA_missionTime > (_unit getVariable [QGVAR(nextTime), -10])) then {
+    private _bloodLoss = (if (GVAR(useAceMedical)) then {GET_BLOOD_LOSS(_unit) * 2.5} else {getDammage _unit * 2}) min 6;
+    TRACE_2("",_unit,_bloodLoss);
+    _unit setVariable [QGVAR(nextTime), CBA_missionTime + 8 + random 2 - _bloodLoss];
 
     private _position = getPosASL _unit;
     _position = _position vectorAdd [
@@ -36,5 +34,5 @@ if ((CBA_missionTime - _lastTime) + _bloodLoss >= 8 + random 2) then {
     _position set [2, 0];
 
     private _bloodDrop = ["blooddrop_1", "blooddrop_2", "blooddrop_3", "blooddrop_4"] select floor (_bloodLoss min 3);
-    [_bloodDrop, _position, getDir _unit] call FUNC(createBlood);
+    [_bloodDrop, _position] call FUNC(createBlood);
 };

--- a/addons/medical_blood/functions/fnc_spurt.sqf
+++ b/addons/medical_blood/functions/fnc_spurt.sqf
@@ -22,7 +22,6 @@
 #define OFFSET 0.25
 
 params ["_unit", "_dir", "_damage"];
-_damage = _damage min 1;
 
 private _distanceBetweenDrops = DISTANCE_BETWEEN_DROPS * _damage;
 private _offset = OFFSET + _distanceBetweenDrops;


### PR DESCRIPTION
- don't bleed for dead players
- switch to "nextTime" time calc reduces calls to `GET_BLOOD_LOSS`
- min damage in already done in handleWoundReceived