### PR TITLE
Treatment - cap max animation speed

### DIFF
--- a/addons/advanced_fatigue/XEH_preInit.sqf
+++ b/addons/advanced_fatigue/XEH_preInit.sqf
@@ -10,5 +10,6 @@ PREP_RECOMPILE_END;
 
 GVAR(staminaBarWidth) = 10 * (((safezoneW / safezoneH) min 1.2) / 40);
 GVAR(dutyList) = [[], []];
+GVAR(setAnimExclusions) = [];
 
 ADDON = true;

--- a/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
@@ -58,8 +58,9 @@ if (GVAR(ppeBlackoutLast) == 1) then {
 
 // - Physical effects ---------------------------------------------------------
 if (GVAR(isSwimming)) exitWith {
-    _unit setAnimSpeedCoef linearConversion [0.7, 0.9, _fatigue, 1, 0.5, true];
-
+    if (GVAR(setAnimExclusions) isEqualTo []) then {
+        _unit setAnimSpeedCoef linearConversion [0.7, 0.9, _fatigue, 1, 0.5, true];
+    };
     if ((isSprintAllowed _unit) && {_fatigue > 0.7}) then {
         [_unit, "blockSprint", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
     } else {
@@ -69,7 +70,10 @@ if (GVAR(isSwimming)) exitWith {
     };
 };
 if ((getAnimSpeedCoef _unit) != 1) then {
-    _unit setAnimSpeedCoef 1;
+    if (GVAR(setAnimExclusions) isEqualTo []) then {
+        TRACE_1("reset",getAnimSpeedCoef _unit);
+        _unit setAnimSpeedCoef 1;
+    };
 };
 
 if (_overexhausted) then {

--- a/addons/medical_treatment/functions/fnc_getBandageTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getBandageTime.sqf
@@ -12,13 +12,16 @@
  * Return Value:
  * Time in seconds <NUMBER>
  *
+ * Example:
+ * [player, cursorTarget, "Head", "FieldDressing"] call ace_medical_treatment_fnc_getBandageTime
+ *
  * Public: No
  */
 
 params ["_medic", "_patient", "_bodypart", "_bandage"];
 
 private _partIndex = ALL_BODY_PARTS find toLower _bodyPart;
-if (_partIndex < 0) exitWith { 0 };
+if (_partIndex < 0) exitWith { ERROR_1("invalid bodyPart %1",_bodyPart); };
 
 private _targetWound = [_patient, _bandage, _partIndex] call FUNC(findMostEffectiveWound);
 _targetWound params ["_wound", "_woundIndex", "_effectiveness"];
@@ -48,4 +51,4 @@ if (_medic == _patient) then {
 };
 
 // Nobody can bandage instantly
-_bandageTime max 1
+_bandageTime max 2

--- a/addons/medical_treatment/functions/fnc_getBandageTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getBandageTime.sqf
@@ -21,7 +21,7 @@
 params ["_medic", "_patient", "_bodypart", "_bandage"];
 
 private _partIndex = ALL_BODY_PARTS find toLower _bodyPart;
-if (_partIndex < 0) exitWith { ERROR_1("invalid bodyPart %1",_bodyPart); };
+if (_partIndex < 0) exitWith { 0 };
 
 private _targetWound = [_patient, _bandage, _partIndex] call FUNC(findMostEffectiveWound);
 _targetWound params ["_wound", "_woundIndex", "_effectiveness"];

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -111,7 +111,7 @@ if (vehicle _medic == _medic && {_medicAnim != ""}) then {
     // Speed up animation based on treatment time (but cap max to prevent odd animiations/cam shake)
     private _animRatio = (_animDuration / _treatmentTime) min 3;
     TRACE_3("setAnimSpeedCoef",_animRatio,_animDuration,_treatmentTime);
-    _medic setAnimSpeedCoef _animRatio;
+    [QEGVAR(common,setAnimSpeedCoef), [_medic, _animRatio]] call CBA_fnc_globalEvent;
     if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
         EGVAR(advanced_fatigue,setAnimExclusions) pushBack QUOTE(ADDON);
     };

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -111,7 +111,7 @@ if (vehicle _medic == _medic && {_medicAnim != ""}) then {
     // Speed up animation based on treatment time (but cap max to prevent odd animiations/cam shake)
     private _animRatio = (_animDuration / _treatmentTime) min 3;
     TRACE_3("setAnimSpeedCoef",_animRatio,_animDuration,_treatmentTime);
-    [QEGVAR(common,setAnimSpeedCoef), [_medic, _animRatio]] call CBA_fnc_globalEvent;
+    _medic setAnimSpeedCoef _animRatio;
     if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
         EGVAR(advanced_fatigue,setAnimExclusions) pushBack QUOTE(ADDON);
     };

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -108,8 +108,13 @@ if (vehicle _medic == _medic && {_medicAnim != ""}) then {
     [_medic, _endInAnim] call EFUNC(common,doAnimation);
     _medic setVariable [QGVAR(endInAnim), _endInAnim];
 
-    // Speed up animation based on treatment time
-    [QEGVAR(common,setAnimSpeedCoef), [_medic, _animDuration / _treatmentTime]] call CBA_fnc_globalEvent;
+    // Speed up animation based on treatment time (but cap max to prevent odd animiations/cam shake)
+    private _animRatio = (_animDuration / _treatmentTime) min 3;
+    TRACE_3("setAnimSpeedCoef",_animRatio,_animDuration,_treatmentTime);
+    [QEGVAR(common,setAnimSpeedCoef), [_medic, _animRatio]] call CBA_fnc_globalEvent;
+    if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
+        EGVAR(advanced_fatigue,setAnimExclusions) pushBack QUOTE(ADDON);
+    };
 };
 
 // Play a random treatment sound globally if defined

--- a/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
@@ -38,7 +38,7 @@ if (!isNil "_endInAnim") then {
 };
 
 // Reset medic animation speed coefficient
-_medic setAnimSpeedCoef 1;
+[QEGVAR(common,setAnimSpeedCoef), [_medic, 1]] call CBA_fnc_globalEvent;
 if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
     EGVAR(advanced_fatigue,setAnimExclusions) deleteAt (EGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ADDON));
 };

--- a/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
@@ -39,6 +39,9 @@ if (!isNil "_endInAnim") then {
 
 // Reset medic animation speed coefficient
 [QEGVAR(common,setAnimSpeedCoef), [_medic, 1]] call CBA_fnc_globalEvent;
+if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
+    EGVAR(advanced_fatigue,setAnimExclusions) deleteAt (EGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ADDON));
+};
 
 // Call treatment specific failure callback
 GET_FUNCTION(_callbackFailure,configFile >> QGVAR(actions) >> _classname >> "callbackFailure");

--- a/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
@@ -38,7 +38,7 @@ if (!isNil "_endInAnim") then {
 };
 
 // Reset medic animation speed coefficient
-[QEGVAR(common,setAnimSpeedCoef), [_medic, 1]] call CBA_fnc_globalEvent;
+_medic setAnimSpeedCoef 1;
 if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
     EGVAR(advanced_fatigue,setAnimExclusions) deleteAt (EGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ADDON));
 };

--- a/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
@@ -33,7 +33,7 @@ if (!isNil "_endInAnim") then {
 };
 
 // Reset medic animation speed coefficient
-[QEGVAR(common,setAnimSpeedCoef), [_medic, 1]] call CBA_fnc_globalEvent;
+_medic setAnimSpeedCoef 1;
 if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
     EGVAR(advanced_fatigue,setAnimExclusions) deleteAt (EGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ADDON));
 };

--- a/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
@@ -33,7 +33,7 @@ if (!isNil "_endInAnim") then {
 };
 
 // Reset medic animation speed coefficient
-_medic setAnimSpeedCoef 1;
+[QEGVAR(common,setAnimSpeedCoef), [_medic, 1]] call CBA_fnc_globalEvent;
 if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
     EGVAR(advanced_fatigue,setAnimExclusions) deleteAt (EGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ADDON));
 };

--- a/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
@@ -34,6 +34,9 @@ if (!isNil "_endInAnim") then {
 
 // Reset medic animation speed coefficient
 [QEGVAR(common,setAnimSpeedCoef), [_medic, 1]] call CBA_fnc_globalEvent;
+if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
+    EGVAR(advanced_fatigue,setAnimExclusions) deleteAt (EGVAR(advanced_fatigue,setAnimExclusions) find QUOTE(ADDON));
+};
 
 // Call treatment specific success callback
 GET_FUNCTION(_callbackSuccess,configFile >> QGVAR(actions) >> _classname >> "callbackSuccess");


### PR DESCRIPTION
part of #6913

caps max anim speed to 3x, which still seems fast but not terrible
and add lock to prevent advanced fatigue from reseting setAnimSpeedCoef

needs mp testing, but I don't think we need global events for the setters (AF doesn't use it)
