### PR TITLE
Common - Fix script error with uniqueItems in scheduled

### DIFF
--- a/addons/common/functions/fnc_uniqueItems.sqf
+++ b/addons/common/functions/fnc_uniqueItems.sqf
@@ -11,7 +11,7 @@
  * Items <ARRAY>
  *
  * Example:
- * [_player] call ace_common_fnc_uniqueItems
+ * [player] call ace_common_fnc_uniqueItems
  *
  * Public: No
  */
@@ -28,12 +28,10 @@ private _fnc_getItems = {
 
 // Use cached items list if unit is ACE_player
 if (_unit isEqualTo ACE_player) then {
-    private _items = GVAR(uniqueItemsCache);
-    if (isNil "_items") then {
-        _items = call _fnc_getItems;
-        GVAR(uniqueItemsCache) = _items;
+    if (isNil QGVAR(uniqueItemsCache)) then {
+        GVAR(uniqueItemsCache) = call _fnc_getItems;
     };
-    +_items
+    +GVAR(uniqueItemsCache)
 } else {
     call _fnc_getItems;
 };


### PR DESCRIPTION
Fixes popup script error when using function in scheduled (still worked fine)
`[] spawn {x3 = [player] call ace_common_fnc_uniqueItems};`
```
 Error Undefined variable in expression: ace_common_uniqueitemscache
```
tiny bit faster as well