### PR TITLE
Medical - Fix severity of wound bleeding and adjust cardiac output calculations

### DIFF
--- a/addons/medical_damage/ACE_Medical_Injuries.hpp
+++ b/addons/medical_damage/ACE_Medical_Injuries.hpp
@@ -1,4 +1,4 @@
-// bleeding - maximum possible bleeding rate for a given wound type (0 .. 1)
+// bleeding - maximum possible percentage of cardiac output bled for a given wound type (0 .. 1)
 // pain - maximum possible pain level for a given wound type (0 .. 1)
 
 class ACE_Medical_Injuries {
@@ -16,7 +16,7 @@ class ACE_Medical_Injuries {
         // Occur when an entire structure or part of it is forcibly pulled away, such as the loss of a permanent tooth or an ear lobe. Explosions, gunshots, and animal bites may cause avulsions.
         class Avulsion {
             causes[] = {"explosive", "vehiclecrash", "collision", "grenade", "shell", "bullet", "backblast", "bite"};
-            bleeding = 0.25;
+            bleeding = 0.1;
             pain = 1.0;
             minDamage = 0.01;
             causeLimping = 1;
@@ -24,7 +24,7 @@ class ACE_Medical_Injuries {
         // Also called bruises, these are the result of a forceful trauma that injures an internal structure without breaking the skin. Blows to the chest, abdomen, or head with a blunt instrument (e.g. a football or a fist) can cause contusions.
         class Contusion {
             causes[] = {"bullet", "backblast", "punch", "vehiclecrash", "collision", "falling"};
-            bleeding = 0.0;
+            bleeding = 0;
             pain = 0.3;
             minDamage = 0.02;
             maxDamage = 0.35;
@@ -41,7 +41,7 @@ class ACE_Medical_Injuries {
         // Slicing wounds made with a sharp instrument, leaving even edges. They may be as minimal as a paper cut or as significant as a surgical incision.
         class Cut {
             causes[] = {"vehiclecrash", "collision", "grenade", "explosive", "shell", "backblast", "stab", "unknown"};
-            bleeding = 0.04;
+            bleeding = 0.01;
             pain = 0.1;
             minDamage = 0.1;
         };
@@ -56,7 +56,7 @@ class ACE_Medical_Injuries {
         // Also called velocity wounds, they are caused by an object entering the body at a high speed, typically a bullet or small peices of shrapnel.
         class VelocityWound {
             causes[] = {"bullet", "grenade","explosive", "shell", "unknown"};
-            bleeding = 0.5;
+            bleeding = 0.2;
             pain = 0.9;
             minDamage = 0.35;
             causeLimping = 1;

--- a/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
@@ -78,7 +78,7 @@ private _bodyPartVisParams = [_unit, false, false, false, false]; // params arra
     if (_damage > _thresholdMinDam) exitWith {
         private _woundDamage = _damage / (_thresholdWoundCount max 1); // If the damage creates multiple wounds
         for "_i" from 1 to _thresholdWoundCount do {
-            // Find the injury we are going to add. Format [ classID, allowdSelections, bleedingRate, injuryPain]
+            // Find the injury we are going to add. Format [ classID, allowedSelections, bleedingRate, injuryPain]
             private _oldInjury = if (random 1 < 0.15) then {
                 _woundTypes select _highestPossibleSpot
             } else {

--- a/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
@@ -93,14 +93,16 @@ private _bodyPartVisParams = [_unit, false, false, false, false]; // params arra
             _bodyPartVisParams set [[1,2,3,3,4,4] select _bodyPartNToAdd, true]; // Mark the body part index needs updating
 
 
-            // Config specifies bleeding and pain for worst possible wound
-            // Worse wound correlates to higher damage, damage is not capped at 1
             // Damage to limbs is scaled higher than body/torso by engine
             // Anything above this is guaranteed worst wound possible
-            private _worstDamage = [2, 4] select (_bodyPartNToAdd > 1);
+            private _worstDamage = [1.8, 4] select (_bodyPartNToAdd > 1);
 
             // More wounds means more likely to get nasty wound
-            private _bleedModifier = linearConversion [0.1, _worstDamage, _woundDamage * _i, 0.25, 1, true];
+            private _countModifier = 1 + random(_i - 1);
+
+            // Config specifies bleeding and pain for worst possible wound
+            // Worse wound correlates to higher damage, damage is not capped at 1
+            private _bleedModifier = linearConversion [0.1, _worstDamage, _woundDamage * _countModifier, 0.25, 1, true];
             private _painModifier = (_bleedModifier * random [0.7, 1, 1.3]) min 1; // Pain isn't directly scaled to bleeding
 
             private _bleeding = _injuryBleedingRate * _bleedModifier;

--- a/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
@@ -93,9 +93,9 @@ private _bodyPartVisParams = [_unit, false, false, false, false]; // params arra
             _bodyPartVisParams set [[1,2,3,3,4,4] select _bodyPartNToAdd, true]; // Mark the body part index needs updating
 
 
-            // Damage to limbs is scaled higher than body/torso by engine
-            // Anything above this is guaranteed worst wound possible
-            private _worstDamage = [1.8, 4] select (_bodyPartNToAdd > 1);
+            // Damage to limbs/head is scaled higher than torso by engine
+            // Anything above this value is guaranteed worst wound possible
+            private _worstDamage = [2, 1, 4, 4, 4, 4] select _bodyPartNToAdd;
 
             // More wounds means more likely to get nasty wound
             private _countModifier = 1 + random(_i - 1);

--- a/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerSQF.sqf
@@ -101,14 +101,14 @@ private _bodyPartVisParams = [_unit, false, false, false, false]; // params arra
 
             // More wounds means more likely to get nasty wound
             private _bleedModifier = linearConversion [0.1, _worstDamage, _woundDamage * _i, 0.25, 1, true];
-            private _painModifier = random [0.25, _bleedModifier, 1]; // Pain isn't directly scaled to bleeding
+            private _painModifier = (_bleedModifier * random [0.7, 1, 1.3]) min 1; // Pain isn't directly scaled to bleeding
 
             private _bleeding = _injuryBleedingRate * _bleedModifier;
             private _pain = _injuryPain * _painModifier;
             _painLevel = _painLevel + _pain;
 
-            // wound category (minor [0.25-0.5], medium [0.5-0.75], large [0.75-1])
-            private _category = floor linearConversion [0.25, 1, _bleedModifier, 0, 2.999, true];
+            // wound category (minor [0.25-0.5], medium [0.5-0.75], large [0.75+])
+            private _category = floor linearConversion [0.25, 0.75, _bleedModifier, 0, 2, true];
 
             private _classComplex = 10 * _woundClassIDToAdd + _category;
 

--- a/addons/medical_status/functions/fnc_getBloodLoss.sqf
+++ b/addons/medical_status/functions/fnc_getBloodLoss.sqf
@@ -7,7 +7,7 @@
  * 0: The Unit <OBJECT>
  *
  * Return Value:
- * Total blood loss of unit <NUMBER>
+ * Total blood loss of unit (litres/second) <NUMBER>
  *
  * Example:
  * [player] call ace_medical_status_fnc_getBloodLoss

--- a/addons/medical_status/functions/fnc_getBloodPressure.sqf
+++ b/addons/medical_status/functions/fnc_getBloodPressure.sqf
@@ -17,10 +17,10 @@
  */
 
 // Value is taken because with cardic output and resistance at default values, it will put blood pressure High at 120.
-#define MODIFIER_BP_HIGH    13.7142792
+#define MODIFIER_BP_HIGH    9.4736842
 
 // Value is taken because with cardic output and resistance at default values, it will put blood pressure Low at 80.
-#define MODIFIER_BP_LOW     9.1428528
+#define MODIFIER_BP_LOW     6.3157894
 
 params ["_unit"];
 

--- a/addons/medical_status/functions/fnc_getCardiacOutput.sqf
+++ b/addons/medical_status/functions/fnc_getCardiacOutput.sqf
@@ -1,13 +1,13 @@
 #include "script_component.hpp"
 /*
- * Author: Glowbal
+ * Author: Glowbal, SilentSpike
  * Get the cardiac output from the Heart, based on current Heart Rate and Blood Volume.
  *
  * Arguments:
  * 0: The Unit <OBJECT>
  *
  * Return Value:
- * Current cardiac output (liter per second) <NUMBER>
+ * Current cardiac output (litre per second) <NUMBER>
  *
  * Example:
  * [player] call ace_medical_status_fnc_getCardiacOutput
@@ -20,13 +20,18 @@
     Source: http://en.wikipedia.org/wiki/Cardiac_output
 */
 
-// to limit the amount of complex calculations necessary, we take a set modifier to calculate Stroke Volume.
-#define MODIFIER_CARDIAC_OUTPUT     0.1904761
+// Value taken from https://doi.org/10.1093%2Feurheartj%2Fehl336
+// as 94/95 ml ± 15 ml
+#define VENTRICLE_STROKE_VOL 95e-3
 
 params ["_unit"];
 
-private _bloodVolumeRatio = (GET_BLOOD_VOLUME(_unit) / DEFAULT_BLOOD_VOLUME);
+private _bloodVolumeRatio = GET_BLOOD_VOLUME(_unit) / DEFAULT_BLOOD_VOLUME;
 private _heartRate = GET_HEART_RATE(_unit);
-private _cardiacOutput = ((_bloodVolumeRatio / MODIFIER_CARDIAC_OUTPUT) + ((_heartRate / DEFAULT_HEART_RATE) - 1)) / 60;
 
-(0 max _cardiacOutput)
+// Blood volume ratio dictates how much is entering the ventricle (this is an approximation)
+private _entering = linearConversion [0.5, 1, _bloodVolumeRatio, 0, 1, true];
+
+private _cardiacOutput = (_entering * VENTRICLE_STROKE_VOL) * _heartRate / 60;
+
+0 max _cardiacOutput

--- a/addons/medical_status/functions/fnc_updateWoundBloodLoss.sqf
+++ b/addons/medical_status/functions/fnc_updateWoundBloodLoss.sqf
@@ -2,6 +2,7 @@
 /*
  * Author: Glowbal
  * Update total wound bleeding based on open wounds and tourniquets
+ * Wound bleeding = percentage of cardiac output lost
  *
  * Arguments:
  * 0: The Unit <OBJECT>

--- a/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
+++ b/addons/medical_vitals/functions/fnc_updateHeartRate.sqf
@@ -32,12 +32,12 @@ if !IN_CRDC_ARRST(_unit) then {
         private _painLevel = GET_PAIN_PERCEIVED(_unit);
 
         private _targetBP = 107;
-        if (_bloodVolume < BLOOD_VOLUME_CLASS_3_HEMORRHAGE) then {
+        if (_bloodVolume < BLOOD_VOLUME_CLASS_2_HEMORRHAGE) then {
             _targetBP = _targetBP * (_bloodVolume / DEFAULT_BLOOD_VOLUME);
         };
 
         _targetHR = DEFAULT_HEART_RATE;
-        if (_bloodVolume < BLOOD_VOLUME_CLASS_2_HEMORRHAGE) then {
+        if (_bloodVolume < BLOOD_VOLUME_CLASS_3_HEMORRHAGE) then {
             _targetHR = _heartRate * (_targetBP / (45 max _meanBP));
         };
         if (_painLevel > 0.2) then {


### PR DESCRIPTION
My attempt at fixing the bleeding in current medical rewrite. If we go this route it will deprecate #6941. My researching steps before implementing these changes can be found on #6906.

I'm simplifying the nastiness calculations so that the wound config specifies the worst wound and we scale it between 25% to 100% based on the wound damage and number of wounds received. Worth noting that the damage value is larger when limbs are damaged, so I'm scaling wounds to those half as much.

Similarly I've updated the wound configs to more reasonable maximum bleeding values based on the fact that they're percentages of cardiac output being bled.

~~In my testing, these values tend to give a bleeding of roughly 0.075 for a typical single gunshot wound which translates to approximately 5 minutes before entering cardiac arrest.~~


Unrelated to this PR, something I noticed during testing:
- If you shoot a unit in the face with a tank, it actually produces a nicer wound than a gunshot. I think this is due to the way we're processing incoming damage not recognising the severity of tank shells.