### PR TITLE
Run vitals loop during cardiac arrest

### DIFF
--- a/addons/medical_statemachine/functions/fnc_leftStateCardiacArrest.sqf
+++ b/addons/medical_statemachine/functions/fnc_leftStateCardiacArrest.sqf
@@ -21,7 +21,7 @@ params ["_unit"];
 _unit setVariable [QGVAR(cardiacArrestTime), nil];
 _unit setVariable [QEGVAR(medical,cardiacArrestStart), nil];
 
-// Temporary fix for vitals loop on cardiac arrest exit
-_unit setVariable [QGVAR(lastTimeUpdated), CBA_missionTime];
+// Vitals loop is halted during cardiac arrest, so this resets the time tracking for it
+_unit setVariable [QEGVAR(medical_vitals,lastTimeUpdated), CBA_missionTime];
 
 [_unit, false] call EFUNC(medical_status,setCardiacArrest);


### PR DESCRIPTION
The bleedout condition will never occur currently since bleeding stops during cardiac arrest unless CPR is administered and the vitals loop doesn't even run so the condition is never checked.

This fixes that by running the loop during cardiac arrest and also allows bleeding to continue if heart rate is 0, just at a fixed reduced rate.

Additionally this fixes #6530