### PR TITLE
Missileguidance - Use checkVisibility to test LOS for missile seekers

### DIFF
--- a/addons/missileguidance/functions/fnc_checkLos.sqf
+++ b/addons/missileguidance/functions/fnc_checkLos.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: jaynus
- * Returns whether the seeker object can see the target position with lineIntersect
+ * Returns whether the seeker object can see the target position with checkVisibility
  *
  * Arguments:
  * 0: Seeker <OBJECT>
@@ -18,22 +18,5 @@
 
 params ["_seeker", "_target"];
 
-if ((isNil "_seeker") || {isNil "_target"}) exitWith {
-    ERROR_2("nil",_seeker,_target);
-    false
-};
-
-private _targetPos = getPosASL _target;
-private _targetAimPos = aimPos _target;
-private _seekerPos = getPosASL _seeker;
-private _return = true;
-
-if (!((terrainIntersectASL [_seekerPos, _targetPos]) && {terrainIntersectASL [_seekerPos, _targetAimPos]})) then {
-    if (lineIntersects [_seekerPos, _targetPos, _seeker, _target]) then {
-        _return = false;
-    };
-} else {
-    _return = false;
-};
-
-_return;
+private _visibility = [_seeker, "VIEW", _target] checkVisibility [getPosASL _seeker, aimPos _target];
+_visibility > 0.001


### PR DESCRIPTION
**When merged this pull request will:**
- Make missiles using optical guidance (for example the Javelin) now lose lock once the target gets behind smoke

0.001 as a visibility limit seemed reasonable with my testing with a smoke grenade, I'd rather go higher (missiles would then easier lose lock) than lower. If a tank pops a smoke wall, it should be _well_ within that limit anyways.

Not tested with actually firing a missile yet, since the tank would have to pop smoke at just the right time and also be moving, because the missile will still fly straight if it loses lock.

Closes #7012, also ref. #6744 which still needs additonal code when actually locking on to fix completely.