### PR TITLE
Unblacklist vanilla medical items from arsenal

### DIFF
--- a/addons/medical_treatment/CfgWeapons.hpp
+++ b/addons/medical_treatment/CfgWeapons.hpp
@@ -8,14 +8,12 @@ class CfgWeapons {
 
     class FirstAidKit: ItemCore {
         type = 0;
-        EGVAR(arsenal,hide) = 1;
         class ItemInfo: InventoryFirstAidKitItem_Base_F {
             mass = 4;
         };
     };
     class Medikit: ItemCore {
         type = 0;
-        EGVAR(arsenal,hide) = 1;
         class ItemInfo: MedikitItem {
             mass = 60;
         };


### PR DESCRIPTION
- The replacement setting may be disabled so we shouldn't prevent their addition
- If it isn't, they will be replaced with suitable items which is fine (and someone may want to design a mission that works either way)