### PR TITLE
Fixed incorrect classnames in tracer magazines

### DIFF
--- a/optionals/tracers/CfgAmmo.hpp
+++ b/optionals/tracers/CfgAmmo.hpp
@@ -88,7 +88,7 @@ class CfgAmmo {
     class B_338_Ball: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
 
     class B_338_NM_Ball: BulletBase {model = PATHTOF(ace_TracerRed2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_red
-    class ACE_338_NM_Ball_red : B_338_NM_Ball {model = PATHTOF(ace_TracerRed2.p3d);};
+    class ACE_338_NM_Ball_green : B_338_NM_Ball {model = PATHTOF(ace_TracerGreen2.p3d);};
     class ACE_338_NM_Ball_yellow : B_338_NM_Ball {model = PATHTOF(ace_TracerYellow2.p3d);};
 
     class B_127x54_Ball: BulletBase {model = PATHTOF(ace_TracerGreen2.p3d);}; //Replaces \A3\Weapons_f\Data\bullettracer\tracer_green

--- a/optionals/tracers/CfgMagazines.hpp
+++ b/optionals/tracers/CfgMagazines.hpp
@@ -224,22 +224,22 @@ class CfgMagazines {
     // 9.3x64
     class 150Rnd_93x64_Mag;
     class ACE_150Rnd_93x64_Mag_red : 150Rnd_93x64_Mag {
-        ammo = "ACE_93x64_tracer_red";
+        ammo = "ACE_93x64_Ball_tracer_red";
         STRINGS(150Rnd_93x64_Mag_red);
     };
     class ACE_150Rnd_93x64_Mag_yellow : 150Rnd_93x64_Mag {
-        ammo = "ACE_93x64_tracer_yellow";
+        ammo = "ACE_93x64_Ball_tracer_yellow";
         STRINGS(150Rnd_93x64_Mag_yellow);
     };
 
     // .338 NM
     class 130Rnd_338_Mag;
     class ACE_130Rnd_338_Mag_green : 130Rnd_338_Mag {
-        ammo = "ACE_338_NM_tracer_green";
+        ammo = "ACE_338_NM_Ball_green";
         STRINGS(130Rnd_338_Mag_green);
     };
     class ACE_130Rnd_338_Mag_yellow : 130Rnd_338_Mag {
-        ammo = "ACE_338_NM_tracer_yellow";
+        ammo = "ACE_338_NM_Ball_yellow";
         STRINGS(130Rnd_338_Mag_yellow);
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix wrong reference to CfgAmmo classes in CfgMagazines of four magazines
- Fix wrong tracer colour of one ammo class (red tracers are already included in the game)


