### PR TITLE
Move gunbag type from inheritance to config property

### DIFF
--- a/addons/gunbag/CfgVehicles.hpp
+++ b/addons/gunbag/CfgVehicles.hpp
@@ -73,6 +73,7 @@ class CfgVehicles {
         hiddenSelectionsTextures[] = {QPATHTOF(data\gunbag_co.paa)};
         maximumLoad = 80;
         mass = 11;
+        ADDON = 1;
     };
 
     class GVAR(Tan): ADDON {

--- a/addons/gunbag/functions/fnc_calculateMass.sqf
+++ b/addons/gunbag/functions/fnc_calculateMass.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: Ir0n1E
- * Calculate mass of weapon an items.
+ * Calculate mass of weapon and items.
  *
  * Arguments:
  * 0: Weapon <STRING>

--- a/addons/gunbag/functions/fnc_canInteract.sqf
+++ b/addons/gunbag/functions/fnc_canInteract.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: Ir0n1E
- * Check if client able to interact with gunbag.
+ * Check if client is able to interact with gunbag.
  *
  * Arguments:
  * 0: Unit <OBJECT>

--- a/addons/gunbag/functions/fnc_hasGunbag.sqf
+++ b/addons/gunbag/functions/fnc_hasGunbag.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: Ir0n1E
- * Switches gunbag full/empty for mass calculation.
+ * Check if unit has a gunbag.
  *
  * Arguments:
  * 0: Unit <OBJECT>
@@ -17,4 +17,4 @@
 
 params ["_unit"];
 
-(backpackContainer _unit) isKindOf QUOTE(ADDON)
+getNumber (configFile >> "CfgVehicles" >> (backpack _unit) >> QUOTE(ADDON)) == 1

--- a/docs/wiki/framework/gunbag-framework.md
+++ b/docs/wiki/framework/gunbag-framework.md
@@ -1,7 +1,7 @@
 ---
 layout: wiki
 title: Gunbag Framework
-description: Explains how to set-up gunbags
+description: Explains how to set up gunbags
 group: framework
 parent: wiki
 order: 7
@@ -14,12 +14,12 @@ version:
 
 ## 1. Overview
 
-ACE provides a gunbag thing that you can put any gun inside.
+ACE Gunbag provides a framework that allows users to enable putting a gun inside a backpack.
 
 
 ## 2. Config Values
 
-The config entry `ace_gunbag` needs to be set to 1 to enable a backback to be a gunbag
+The `ace_gunbag` config entry needs to be set to `1` to enable a backpack to be a gunbag.
 
 ```cpp
 class Bag_Base;

--- a/docs/wiki/framework/gunbag-framework.md
+++ b/docs/wiki/framework/gunbag-framework.md
@@ -24,7 +24,6 @@ The config entry `ace_gunbag` needs to be set to 1 to enable a backback to be a 
 ```cpp
 class Bag_Base;
 class ace_gunbag: Bag_Base {
-    _generalMacro = QUOTE(ADDON);
     author = "Ir0n1E";
     scope = 2;
     displayName = CSTRING(Displayname);

--- a/docs/wiki/framework/gunbag-framework.md
+++ b/docs/wiki/framework/gunbag-framework.md
@@ -1,0 +1,40 @@
+---
+layout: wiki
+title: Gunbag Framework
+description: Explains how to set-up gunbags
+group: framework
+parent: wiki
+order: 7
+mod: ace
+version:
+  major: 3
+  minor: 13
+  patch: 0
+---
+
+## 1. Overview
+
+ACE provides a gunbag thing that you can put any gun inside.
+
+
+## 2. Config Values
+
+The config entry `ace_gunbag` needs to be set to 1 to enable a backback to be a gunbag
+
+```cpp
+class Bag_Base;
+class ace_gunbag: Bag_Base {
+    _generalMacro = QUOTE(ADDON);
+    author = "Ir0n1E";
+    scope = 2;
+    displayName = CSTRING(Displayname);
+    model = QPATHTOF(data\ace_gunbag.p3d);
+    picture = QPATHTOF(ui\gunbag_ca.paa);
+    icon = QPATHTOF(ui\gunbag_icon_ca.paa);
+    hiddenSelections[] = {"Camo", "insignia"};
+    hiddenSelectionsTextures[] = {QPATHTOF(data\gunbag_co.paa)};
+    maximumLoad = 80;
+    mass = 11;
+    ace_gunbag = 1;
+};
+```


### PR DESCRIPTION
From Feature request
https://github.com/acemod/ACE3/issues/3594#issuecomment-495924308
@ImplicitDeny

Makes it easier for 3rd parties to create gunbags without adding a ACE dependency.
Slight performance hit (I assume) for config lookup instead of isKindOf, though isKindOf is also not much cheaper I think. Not big enough difference to be worth testing or caching.
Or... Maybe caching, leaving that up to you, don't think its worth.

Noticed we don't have a gunbag wiki page. Someone should add one someday ^^