### PR TITLE
Refuel - Add events for start, stop and progress

### DIFF
--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -102,6 +102,7 @@ if (_maxFuel == 0) then {
     };
 
     if (_finished) exitWith {
+        [QGVAR(refuelStopped), [_source, _sink]] call CBA_fnc_localEvent;
         _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
         _nozzle setVariable [QGVAR(isRefueling), false, true];
     };

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -93,6 +93,8 @@ if (_maxFuel == 0) then {
         };
         _unit setVariable [QGVAR(tempFuel), _fuelInSink];
 
+        [QGVAR(refuelTick), [_source, _sink, _rateTime]] call CBA_fnc_localEvent;
+
         [QEGVAR(common,setFuel), [_sink, _fuelInSink], _sink] call CBA_fnc_targetEvent;
         [_source, _fuelInSource] call FUNC(setFuel);
     } else {

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -93,7 +93,7 @@ if (_maxFuel == 0) then {
         };
         _unit setVariable [QGVAR(tempFuel), _fuelInSink];
 
-        [QGVAR(refuelTick), [_source, _sink, _rateTime]] call CBA_fnc_localEvent;
+        [QGVAR(tick), [_source, _sink, _rateTime]] call CBA_fnc_localEvent;
 
         [QEGVAR(common,setFuel), [_sink, _fuelInSink], _sink] call CBA_fnc_targetEvent;
         [_source, _fuelInSource] call FUNC(setFuel);

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -102,7 +102,7 @@ if (_maxFuel == 0) then {
     };
 
     if (_finished) exitWith {
-        [QGVAR(refuelStopped), [_source, _sink]] call CBA_fnc_localEvent;
+        [QGVAR(stopped), [_source, _sink]] call CBA_fnc_localEvent;
         _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
         _nozzle setVariable [QGVAR(isRefueling), false, true];
     };

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -21,3 +21,4 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
 _nozzle setVariable [QGVAR(isRefueling), false, true];
 [LSTRING(Hint_Stopped), 1.5, _unit] call EFUNC(common,displayTextStructured);
+[QGVAR(refuelStopped), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -21,4 +21,4 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
 _nozzle setVariable [QGVAR(isRefueling), false, true];
 [LSTRING(Hint_Stopped), 1.5, _unit] call EFUNC(common,displayTextStructured);
-[QGVAR(refuelStopped), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;
+[QGVAR(stopped), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -21,4 +21,4 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime];
 _nozzle setVariable [QGVAR(isRefueling), true, true];
 [LSTRING(Hint_Started), 1.5, _unit] call EFUNC(common,displayTextStructured);
-[QGVAR(refuelStarted), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;
+[QGVAR(started), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -21,3 +21,4 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime];
 _nozzle setVariable [QGVAR(isRefueling), true, true];
 [LSTRING(Hint_Started), 1.5, _unit] call EFUNC(common,displayTextStructured);
+[QGVAR(refuelStarted), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -89,6 +89,14 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 |----------|---------|---------|---------|---------|---------|
 |`ace_wireCuttingStarted` | [_unit, _fence] | Global | Listen | Fence cutting started
 
+### 2.9 Refuel (`ace_refuel`)
+
+| Event Key | Parameters | Locality | Type | Description |
+|----------|---------|---------|---------|---------|---------|
+|`ace_refuel_refuelStarted` | [_source, _target] | Local | Listen | Refueling has started
+|`ace_refuel_refuelTick` | [_source, _target, _amount] | Local | Listen | Amount of fuel transferred in a tick
+|`ace_refuel_refuelStopped` | [_source, _target] | Local | Listen | Refueling has stopped
+
 
 ## 3. Usage
 Also Reference [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} documentation.

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -93,9 +93,9 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 
 | Event Key | Parameters | Locality | Type | Description |
 |----------|---------|---------|---------|---------|---------|
-|`ace_refuel_refuelStarted` | [_source, _target] | Local | Listen | Refueling has started
-|`ace_refuel_refuelTick` | [_source, _target, _amount] | Local | Listen | Amount of fuel transferred in a tick
-|`ace_refuel_refuelStopped` | [_source, _target] | Local | Listen | Refueling has stopped
+|`ace_refuel_started` | [_source, _target] | Local | Listen | Refueling has started
+|`ace_refuel_tick` | [_source, _target, _amount] | Local | Listen | Amount of fuel transferred in a tick
+|`ace_refuel_stopped` | [_source, _target] | Local | Listen | Refueling has stopped
 
 
 ## 3. Usage


### PR DESCRIPTION
@synixebrett requested this.

`ace_refuel_refuelTick` might be renamed to just `ace_refuel_tick` ?
We also want a `refuelDone` event, but for that we need to store the amount of fuel that was transferred in the previous interaction.

I think local event is enough for this?



Todo:
- [x] Write documentation for eventhandlers