### PR TITLE
Ballistics - BI P90 and RHS MP7 updated

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -604,15 +604,17 @@ class CfgAmmo {
         ACE_barrelLengths[]={304.8, 406.4, 609.6};
     };
     class B_570x28_Ball: BulletBase {
-        ACE_caliber = 5.7;
+        ACE_caliber = 5.7; // https://bobp.cip-bobp.org/uploads/tdcc/tab-i/tabical-en-page7.pdf
         ACE_bulletLength = 21.6; // http://blog.thejustnation.org/2011/04/5-7x28mm-ammo-review/
         ACE_bulletMass = 2; // based on the SS190
-        ACE_ballisticCoefficients[] = {0.177}; //http://m.delphiforums.com/autogun/messages/5267/7
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {0.084}; // https://www.thefirearmblog.com/blog/2016/10/24/modern-personal-defense-weapon-calibers-4-6x30mm-hk/
         ACE_velocityBoundaries[] = {};
-        ACE_standardAtmosphere = "ASM"; // 50/50 chance to get it right
+        ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 7;
-        ACE_muzzleVelocities[] = {716,776};
-        ACE_barrelLengths[] = {264,407};
+        ACE_muzzleVelocities[] = {716, 776}; // at 21°C, 715-775 m/s at 15°C according with the 50Rnd_570x28_SMG_03 initSpeed
+        ACE_barrelLengths[] = {264, 407};
+        airFriction = -0.002619; // default BI value -0.001412
     };
     class B_19mm_HE: BulletBase {
         tracerScale = 1;

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -75,6 +75,7 @@ class CfgWeapons {
         ACE_barrelTwist = 228.6; // 1:9 inch twist
         ACE_barrelLength = 407;
         ACE_twistDirection = 1;
+        initSpeed = -1.083916; // 775 m/s according with the ACE_muzzleVelocities at 15°C, default BI value -1.1 (786 m/s)
         modes[] = {"Single"};
     };
     class SMG_03C_BASE: SMG_03_TR_BASE {

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -141,13 +141,13 @@ class CfgAmmo {
         ACE_bulletLength = 21;
         ACE_bulletMass = 2.6;
         ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
-        ACE_ballisticCoefficients[] = {0.171};
+        ACE_ballisticCoefficients[] = {0.089};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
-        ACE_dragModel = 1;
+        ACE_dragModel = 7;
         ACE_muzzleVelocities[] = {621}; // at 21°C, 620 m/s at 15°C according with the 4.6x30 FMJ magazine initSpeed
         ACE_barrelLengths[] = {180};
-        airFriction = -0.002556; // default RHS value -0.0027667
+        airFriction = -0.002635; // default RHS value -0.0027667
     };
     class rhs_ammo_46x30_JHP: rhs_ammo_46x30_FMJ { // RUAG Ammotec
         ACE_caliber = 4.65;

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -136,8 +136,8 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {875, 910, 930, 945};
         ACE_barrelLengths[] = {330.2, 406.4, 508.0, 609.6};
     };
-    class rhs_ammo_46x30_FMJ: rhs_ammo_556x45_M855A1_Ball { // RUAG Ammotec
-        ACE_caliber = 4.65;
+    class rhs_ammo_46x30_FMJ: rhs_ammo_556x45_M855A1_Ball { // RUAG Ammotec: https://www.heckler-koch.com/en/products/military/submachine-guns/mp7a1/mp7a2/ammunition.html
+        ACE_caliber = 4.65; // https://bobp.cip-bobp.org/uploads/tdcc/tab-i/4-6-x-30-en.pdf
         ACE_bulletLength = 21;
         ACE_bulletMass = 2.6;
         ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
@@ -145,8 +145,9 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {620};
+        ACE_muzzleVelocities[] = {621}; // at 21°C, 620 m/s at 15°C according with the 4.6x30 FMJ magazine initSpeed
         ACE_barrelLengths[] = {180};
+        airFriction = -0.002556; // default RHS value -0.0027667
     };
     class rhs_ammo_46x30_JHP: rhs_ammo_46x30_FMJ { // RUAG Ammotec
         ACE_caliber = 4.65;
@@ -157,8 +158,9 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {690};
+        ACE_muzzleVelocities[] = {691}; // at 21°C, 690 m/s at 15°C according with the 4.6x30 JHP magazine initSpeed
         ACE_barrelLengths[] = {180};
+        airFriction = -0.003723; // default RHS value -0.00348301
     };
     class rhs_ammo_46x30_AP: rhs_ammo_46x30_FMJ { // RUAG Ammotec
         ACE_caliber = 4.65;
@@ -169,8 +171,9 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {680};
+        ACE_muzzleVelocities[] = {681}; // at 21°C, 680 m/s at 15°C according with the 4.6x30 AP magazine initSpeed
         ACE_barrelLengths[] = {180};
+        airFriction = -0.003045; // default RHS value -0.00266241
     };
     class rhs_ammo_45ACP_MHP: BulletBase { // B_45ACP_Ball (ballistics/CfgAmmo.hpp)
         ACE_caliber = 11.481;

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -1,6 +1,21 @@
 class cfgMagazines {
     class CA_Magazine;
     class VehicleMagazine;
+    class rhsusf_mag_40Rnd_46x30_AP: CA_Magazine {
+        descriptionShort = "Caliber: 4.6x30 mm<br/>Rounds: 40<br/>Used in: MP7A2";
+        initSpeed = 680; // according with the ACE_muzzleVelocities at 15°C, default RHS value 680.1
+    };
+    class rhsusf_mag_40Rnd_46x30_FMJ: CA_Magazine {
+        descriptionShort = "Caliber: 4.6x30 mm<br/>Rounds: 40<br/>Used in: MP7A2";
+        initSpeed = 620; // default RHS value according with the ACE_muzzleVelocities at 15°C
+        lastRoundsTracer = 0;
+        picture = "\rhsusf\addons\rhsusf_weapons2\glock17g4\data\rhs_mag1_glock17g4_ca.paa";
+        tracersEvery = 0;
+    };
+    class rhsusf_mag_40Rnd_46x30_JHP: CA_Magazine {
+        descriptionShort = "Caliber: 4.6x30 mm<br/>Rounds: 40<br/>Used in: MP7A2";
+        initSpeed = 690; // according with the ACE_muzzleVelocities at 15°C, default RHS value 620
+    };
     class rhs_mag_30Rnd_556x45_M855A1_Stanag;
 
     class rhsusf_100Rnd_556x45_soft_pouch: rhs_mag_30Rnd_556x45_M855A1_Stanag {

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -119,9 +119,11 @@ class CfgWeapons {
     };
     class SMG_02_base_F;
     class rhsusf_weap_MP7A1_base_f: SMG_02_base_F {
+        ACE_barrelLength = 180;
+        ACE_barrelTwist = 160;
+        ACE_IronSightBaseAngle = -0.286479; // 5 mRad POA = POI at the default discreteDistance 100 m, SMG_02_base_F default value 0.434847
+        ACE_RailBaseAngle = 0; // SMG_02_base_F default value 0.0217724
         ACE_RailHeightAboveBore = 5;
-        ACE_barrelTwist = 160.0;
-        ACE_barrelLength = 180.0;
     };
     // RHS pistols
     class hgun_ACPC2_F;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the RHS MP7 magazines and zeroing.
- Update the BI P90 and RHS MP7 ballistics with these [HK MVs](https://www.heckler-koch.com/en/products/military/submachine-guns/mp7a1/mp7a2/ammunition.html) and [BCs](https://www.thefirearmblog.com/blog/2016/10/24/modern-personal-defense-weapon-calibers-4-6x30mm-hk/) references.
AirFrictions according with all MVs at the normal conditions (15°C, 1013 hPa, 0%).

> ##########################################
Ammo Class: rhs_ammo_46x30_FMJ
_Drag model: 7_
_Ballistic coefficient: 0.089_
MaxRanges (m): [300, 300]
MuzzleVelocities (m/s): [615, 625]
Max. Velocity diff (m/s): 19.83
Max. Drop diff (cm): 0.99
Max. Tof diff (ms): 4.0
Optimal airFriction: 0.002635
##########################################
Ammo Class: rhs_ammo_46x30_JHP
_Drag model: 1_
_Ballistic coefficient: 0.112_
MaxRanges (m): [300, 300]
MuzzleVelocities (m/s): [685, 695]
Max. Velocity diff (m/s): 45.25
Max. Drop diff (cm): 2.48
Max. Tof diff (ms): 26.0
Optimal airFriction: 0.00372331
##########################################
Ammo Class: rhs_ammo_46x30_AP
_Drag model: 1_
_Ballistic coefficient: 0.141_
MaxRanges (m): [300, 300]
MuzzleVelocities (m/s): [675, 685]
Max. Velocity diff (m/s): 26.24
Max. Drop diff (cm): 0.67
Max. Tof diff (ms): 9.0
Optimal airFriction: 0.00304544
##########################################
Ammo Class: B_570x28_Ball
_Drag model: 7_
_Ballistic coefficient: 0.084_
MaxRanges (m): [300, 400]
MuzzleVelocities (m/s): [715, 755]
Max. Velocity diff (m/s): 23.6
Max. Drop diff (cm): 1.95
Max. Tof diff (ms): 10.0
Optimal airFriction: 0.00261886
##########################################