### PR TITLE
Medical Treatment - Scale bandage time based on amount of wound treated

### DIFF
--- a/addons/medical_treatment/functions/fnc_getBandageTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getBandageTime.sqf
@@ -37,7 +37,9 @@ private _category = (_classID % 10);
 private _bandageTime = [BANDAGE_TIME_S, BANDAGE_TIME_M, BANDAGE_TIME_L] select _category;
 
 // Scale bandage time based on amount left and effectiveness (less time if only a little wound left)
-_bandageTime = _bandageTime * (linearConversion [0, _effectiveness, _amountOf, 0.666, 1, true]);
+if (GVAR(advancedBandages)) then { // basicBandage will have a very high effectiveness and can be ignored
+    _bandageTime = _bandageTime * (linearConversion [0, _effectiveness, _amountOf, 0.666, 1, true]);
+};
 
 // Medics are more practised at applying bandages
 if ([_medic] call FUNC(isMedic)) then {

--- a/addons/medical_treatment/functions/fnc_getBandageTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getBandageTime.sqf
@@ -34,11 +34,10 @@ _wound params ["_classID", "", "_amountOf", "_bloodloss", "_damage"];
 private _category = (_classID % 10);
 
 // Base bandage time is based on wound size and remaining percentage
-private _bandageTime = ([
-    BANDAGE_TIME_S,
-    BANDAGE_TIME_M,
-    BANDAGE_TIME_L
-] select _category) * _amountOf;
+private _bandageTime = [BANDAGE_TIME_S, BANDAGE_TIME_M, BANDAGE_TIME_L] select _category;
+
+// Scale bandage time based on amount left and effectiveness (less time if only a little wound left)
+_bandageTime = _bandageTime * (linearConversion [0, _effectiveness, _amountOf, 0.666, 1, true]);
 
 // Medics are more practised at applying bandages
 if ([_medic] call FUNC(isMedic)) then {
@@ -51,4 +50,4 @@ if (_medic == _patient) then {
 };
 
 // Nobody can bandage instantly
-_bandageTime max 2
+_bandageTime max 2.25

--- a/addons/medical_treatment/functions/fnc_getBandageTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getBandageTime.sqf
@@ -21,7 +21,7 @@
 params ["_medic", "_patient", "_bodypart", "_bandage"];
 
 private _partIndex = ALL_BODY_PARTS find toLower _bodyPart;
-if (_partIndex < 0) exitWith { 0 };
+if (_partIndex < 0) exitWith { ERROR_1("invalid partIndex - %1",_this); 0 };
 
 private _targetWound = [_patient, _bandage, _partIndex] call FUNC(findMostEffectiveWound);
 _targetWound params ["_wound", "_woundIndex", "_effectiveness"];
@@ -51,5 +51,6 @@ if (_medic == _patient) then {
     _bandageTime = _bandageTime + BANDAGE_TIME_MOD_SELF;
 };
 
+TRACE_1("",_bandageTime);
 // Nobody can bandage instantly
 _bandageTime max 2.25


### PR DESCRIPTION
Was scaling treatment time by `_amountOf`
e.g. if you have 10x wounds, a bandage would still only treat the `effectiveness` defined in the configs
so it would take longer, but you wouldn't actually be doing any more work

- `_amountOf > _effectiveness` - scale by 1
 - `_effectiveness > _amountOf` - scale down to a max of 2/3

also further increases min bandage time to 2.25 to help with animation problems