### PR TITLE
Medical Engine without parentheses

### DIFF
--- a/addons/medical_engine/script_component.hpp
+++ b/addons/medical_engine/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT medical_engine
-#define COMPONENT_BEAUTIFIED Medical (Engine)
+#define COMPONENT_BEAUTIFIED Medical Engine
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL


### PR DESCRIPTION
**When merged this pull request will:**
- Make Medical beautified component names consistent