### PR TITLE
Maptools - Don't convert vanilla straight lines

### DIFF
--- a/addons/maptools/functions/fnc_handleMouseButton.sqf
+++ b/addons/maptools/functions/fnc_handleMouseButton.sqf
@@ -24,8 +24,10 @@ TRACE_2("params",_dir,_params);
 if ((_button == 0) && {GVAR(freedrawing) || _ctrlKey}) exitWith {
     if (GVAR(freedrawing) && {_dir == 0}) then {
         GVAR(freedrawing) = false;
-        GVAR(drawPosEnd) = _control ctrlMapScreenToWorld [_screenPosX, _screenPosY];
-        TRACE_2("Ending Line",GVAR(freedrawing),GVAR(drawPosEnd));
+        if (_shiftKey) exitWith {
+            TRACE_1("using vanilla straight line",_shiftKey);
+        };
+        TRACE_2("Ending Line",GVAR(freedrawing),GVAR(freeDrawingData));
         [{
             if (allMapMarkers isEqualTo []) exitWith {};
             private _markerName = allMapMarkers select (count allMapMarkers - 1);


### PR DESCRIPTION
If shift is still held down on mouse button release then we can assume they were already drawing a straight line so don't convert it to the thick ace style