### PR TITLE
Stop AI firing at unconscious units

### DIFF
--- a/addons/medical_status/functions/fnc_setUnconscious.sqf
+++ b/addons/medical_status/functions/fnc_setUnconscious.sqf
@@ -24,6 +24,9 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
+// Stop AI firing at unconscious units in most situations (global effect)
+[_unit, "setHidden", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
+
 if (_active) then {
     // Don't bother setting this if not used
     if (EGVAR(medical,spontaneousWakeUpChance) > 0) then {


### PR DESCRIPTION
This just reimplemented the behaviour from #5864

I believe we thought using `setUnconscious` command would make this unnecessary, but testing seems to show that's not the case.
