### PR TITLE
Medical Feedback - Fix short blackout on any pain

### DIFF
--- a/addons/medical_feedback/functions/fnc_initEffects.sqf
+++ b/addons/medical_feedback/functions/fnc_initEffects.sqf
@@ -39,7 +39,7 @@ if (GVAR(painEffectType) == 0) then {
     GVAR(ppPain) = [
         "ColorCorrections",
         13502,
-        [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+        [1, 1, 0, [1, 1, 1, 0], [1, 1, 1, 1], [0.33, 0.33, 0.33, 0], [0.59, 0.64, 0, 0, 0, 0, 4]]
     ] call _fnc_createEffect;
 } else {
     GVAR(ppPain) = [


### PR DESCRIPTION
Fix screen blanking out for 0.3 sec on first time taking any pain

`[player, 0.01] call ace_medical_fnc_adjustPainLevel`

ppEffect uses initial value from initEfects (which was black screen)
and then alternates between _initialAdjust and _delayedAdjust in FUNC(effectPain)
only effected painEffectType = 0