### PR TITLE
[explosives] Correct class inheritance for ACE_IEDLandSmall_Range_Ammo

### DIFF
--- a/addons/explosives/CfgAmmo.hpp
+++ b/addons/explosives/CfgAmmo.hpp
@@ -164,7 +164,7 @@ class CfgAmmo {
     class ACE_IEDLandSmall_Command_Ammo: IEDLandSmall_Remote_Ammo {
         mineTrigger = "RemoteTrigger";
     };
-    class ACE_IEDLandSmall_Range_Ammo: IEDLandBig_Remote_Ammo {
+    class ACE_IEDLandSmall_Range_Ammo: IEDLandSmall_Remote_Ammo {
         mineTrigger = "RangeTriggerShort";
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
Update the class inheritance for `ACE_IEDLandSmall_Range_Ammo` from `IEDLandBig_Remote_Ammo` to `IEDLandSmall_Remote_Ammo` so the correct model is used. Addresses issue #7015.

close #7015