### PR TITLE
Medical Engine - Report any fatal head damage

### DIFF
--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -82,6 +82,11 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
 
     _allDamages sort false;
     (_allDamages select 0) params ["_receivedDamage", "", "_woundedHitPoint"];
+    if (_damageHead >= HEAD_DAMAGE_THRESHOLD) then {
+        TRACE_3("reporting fatal head damage instead of max",_damageHead,_receivedDamage,_woundedHitPoint);
+        _receivedDamage = _damageHead;
+        _woundedHitPoint = "Head";
+    };
 
     // We know it's structural when no specific hitpoint is damaged
     if (_receivedDamage == 0) then {


### PR DESCRIPTION
Shoot man with autocannon
` incoming: _allDamages=[[2.21103,3,"Head"],[5.88152,4,"Body"],[5.04804,1.15436,"LeftArm"],[5.30232,1.27997,"RightArm"],[20.4579,1.1125,"LeftLeg"],[35.2891,1.05652,"RightLeg"]], _damageStructural=0.398899`

2.2 damage to head should be fatal, but it instead picks the largest leg damage, which takes a while to kill