### PR TITLE
FIX French STR_ACE_Common_Anywhere

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1019,7 +1019,7 @@
             <German>Überall</German>
             <Czech>Kdekoliv</Czech>
             <Portuguese>Qualquer lugar</Portuguese>
-            <French>PArtout</French>
+            <French>Partout</French>
             <Hungarian>Akárhol</Hungarian>
             <Italian>Ovunque</Italian>
             <Japanese>どこでも</Japanese>


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Remove the camel case in the translation of anywhere in french
