### PR TITLE
Zeus - FIX ace_zeus_fnc_moduleSetMedicalVehicle setting wrong variable

### DIFF
--- a/addons/zeus/functions/fnc_moduleSetMedicalVehicle.sqf
+++ b/addons/zeus/functions/fnc_moduleSetMedicalVehicle.sqf
@@ -40,9 +40,9 @@ if !(["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
                 if (GETVAR(_unit,EGVAR(captives,isHandcuffed),false)) then {
                     [LSTRING(OnlyNonCaptive)] call FUNC(showMessage);
                 } else {
-                    private _medicN = GETVAR(_unit,EGVAR(medical,isMedicalVehicle),0);
-                    if (_medicN < 1) then {
-                        _unit setVariable [QEGVAR(medical,isMedicalVehicle), 1, true];
+                    private _medicN = GETVAR(_unit,EGVAR(medical,isMedicalVehicle),false);
+                    if !(_medicN) then {
+                        _unit setVariable [QEGVAR(medical,isMedicalVehicle), true, true];
                     };
                 };
             };

--- a/addons/zeus/functions/fnc_moduleSetMedicalVehicle.sqf
+++ b/addons/zeus/functions/fnc_moduleSetMedicalVehicle.sqf
@@ -40,9 +40,9 @@ if !(["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
                 if (GETVAR(_unit,EGVAR(captives,isHandcuffed),false)) then {
                     [LSTRING(OnlyNonCaptive)] call FUNC(showMessage);
                 } else {
-                    private _medicN = GETVAR(_unit,EGVAR(medical,medicClass),0);
+                    private _medicN = GETVAR(_unit,EGVAR(medical,isMedicalVehicle),0);
                     if (_medicN < 1) then {
-                        _unit setVariable [QEGVAR(medical,medicClass), 1, true];
+                        _unit setVariable [QEGVAR(medical,isMedicalVehicle), 1, true];
                     };
                 };
             };


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Since medical rewrite a vehicle is medical  if `isMedicalVehicle` is setted to `true`. Now Zeus module set variable `ace_medical_isMedicalVehicle` instead of `ace_medical_medicClass`