### PR TITLE
Zeus - Fix possible enum error with assignTeam

### DIFF
--- a/addons/zeus/functions/fnc_moduleGroupSide.sqf
+++ b/addons/zeus/functions/fnc_moduleGroupSide.sqf
@@ -48,7 +48,7 @@ if (GETVAR(_unit,ACE_isUnconscious,false) && {GETMVAR(EGVAR(medical,moveUnitsFro
     {
         private _team = assignedTeam _x;
         [_x] joinSilent _newGroup;
-        _x assignTeam _team;
+        if (_team != "") then { _x assignTeam _team; };
     } forEach units _unit;
     deleteGroup _oldGroup;
 };


### PR DESCRIPTION
```
Error Foreign error: Unknown enum value: ""
```
`assignedTeam` can now return ""
`assignTeam ""` can throw enum error on "", but only units in your group 
units in your group shouldn't return "",
so this might not even be necessary, but doesn't hurt to be safe