### PR TITLE
Interaction Menu - fix a crash when loading savegames

### DIFF
--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -84,9 +84,9 @@ if (isNil QGVAR(inheritedActions)) then {
     private _type = typeOf _object;
 
     {
-        _x params ["_addedClasses", "_class", "_typeNum", "_parentPath", "_action"];
+        _x params ["_addedClasses", "_objectType", "_typeNum", "_parentPath", "_action"];
 
-        if (_object isKindOf _class && {_addedClasses pushBackUnique _type != -1}) then {
+        if (_object isKindOf _objectType && {_addedClasses pushBackUnique _type != -1}) then {
             [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
         };
     } forEach GVAR(inheritedActions);

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -83,7 +83,7 @@ GVAR(inheritedManClasses) = [];
     params ["_object"];
     private _type = typeOf _object;
 
-    if ((_object isKindOf "CaManBase") && {GVAR(inheritedManClasses) pushBackUnique _type != -1}) then {
+    if ((_object isKindOf "CAManBase") && {GVAR(inheritedManClasses) pushBackUnique _type != -1}) then {
         {
             _x params ["_typeNum", "_parentPath", "_action"];
             [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -75,14 +75,20 @@ GVAR(lastTimeSearchedActions) = -1000;
 [] call FUNC(compileMenuZeus);
 
 // Handle addActionToClass with Inheritance flag set
-if (isNil QGVAR(inheritedActions)) then {
-    GVAR(inheritedActions) = [];
-};
+GVAR(inheritedActions) = [];
+GVAR(inheritedManActions) = []; // Actions only for CAManBase
+GVAR(inheritedManClasses) = [];
 
 ["All", "InitPost", {
     params ["_object"];
     private _type = typeOf _object;
 
+    if ((_object isKindOf "CaManBase") && {GVAR(inheritedManClasses) pushBackUnique _type != -1}) then {
+        {
+            _x params ["_typeNum", "_parentPath", "_action"];
+            [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+        } forEach GVAR(inheritedManActions);
+    };
     {
         _x params ["_addedClasses", "_objectType", "_typeNum", "_parentPath", "_action"];
 

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -74,28 +74,38 @@ GVAR(lastTimeSearchedActions) = -1000;
 // Init zeus menu
 [] call FUNC(compileMenuZeus);
 
-// Handle addActionToClass with Inheritance flag set
-GVAR(inheritedActions) = [];
-GVAR(inheritedManActions) = []; // Actions only for CAManBase
-GVAR(inheritedManClasses) = [];
+// Handle addActionToClass with Inheritance flag set (CAManBase actions are seperated for speed)
+GVAR(inheritedActionsAll) = [];
+GVAR(inheritedClassesAll) = [];
+GVAR(inheritedActionsMan) = [];
+GVAR(inheritedClassesMan) = [];
 
 ["All", "InitPost", {
+    BEGIN_COUNTER(InitPost);
     params ["_object"];
     private _type = typeOf _object;
 
-    if ((_object isKindOf "CAManBase") && {GVAR(inheritedManClasses) pushBackUnique _type != -1}) then {
-        {
-            _x params ["_typeNum", "_parentPath", "_action"];
-            [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
-        } forEach GVAR(inheritedManActions);
-    };
-    {
-        _x params ["_addedClasses", "_objectType", "_typeNum", "_parentPath", "_action"];
+    if (GVAR(inheritedClassesAll) pushBackUnique _type == -1) exitWith { END_COUNTER(InitPost); };
 
-        if (_object isKindOf _objectType && {_addedClasses pushBackUnique _type != -1}) then {
+    {
+        _x params ["_objectType", "_typeNum", "_parentPath", "_action"];
+        if (_object isKindOf _objectType) then {
             [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
         };
-    } forEach GVAR(inheritedActions);
+    } forEach GVAR(inheritedActionsAll);
+    END_COUNTER(InitPost);
+}, true, ["CAManBase"]] call CBA_fnc_addClassEventHandler;
+["CAManBase", "InitPost", {
+    BEGIN_COUNTER(InitPost);
+    params ["_object"];
+    private _type = typeOf _object;
+
+    if (GVAR(inheritedClassesMan) pushBackUnique _type == -1) exitWith { END_COUNTER(InitPost); };
+    {
+        _x params ["_typeNum", "_parentPath", "_action"];
+        [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+    } forEach GVAR(inheritedActionsMan);
+    END_COUNTER(InitPost);
 }] call CBA_fnc_addClassEventHandler;
 
 ADDON = true;

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -94,7 +94,7 @@ GVAR(inheritedClassesMan) = [];
         };
     } forEach GVAR(inheritedActionsAll);
     END_COUNTER(InitPost);
-}, true, ["CAManBase"]] call CBA_fnc_addClassEventHandler;
+}] call CBA_fnc_addClassEventHandler;
 ["CAManBase", "InitPost", {
     BEGIN_COUNTER(InitPost);
     params ["_object"];

--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -74,4 +74,22 @@ GVAR(lastTimeSearchedActions) = -1000;
 // Init zeus menu
 [] call FUNC(compileMenuZeus);
 
+// Handle addActionToClass with Inheritance flag set
+if (isNil QGVAR(inheritedActions)) then {
+    GVAR(inheritedActions) = [];
+};
+
+["All", "InitPost", {
+    params ["_object"];
+    private _type = typeOf _object;
+
+    {
+        _x params ["_addedClasses", "_class", "_typeNum", "_parentPath", "_action"];
+
+        if (_object isKindOf _class && {_addedClasses pushBackUnique _type != -1}) then {
+            [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+        };
+    } forEach GVAR(inheritedActions);
+}] call CBA_fnc_addClassEventHandler;
+
 ADDON = true;

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -25,27 +25,24 @@ if (!params [["_objectType", "", [""]], ["_typeNum", 0, [0]], ["_parentPath", []
     ERROR("Bad Params");
     []
 };
-TRACE_4("params",_objectType,_typeNum,_parentPath,_action);
+TRACE_4("addActionToClass",_objectType,_typeNum,_parentPath,_action);
 
 if (param [4, false, [false]]) exitwith {
+    BEGIN_COUNTER(addAction);
     if (_objectType == "CAManBase") then {
-        GVAR(inheritedManActions) pushBack [_typeNum, _parentPath, _action];
+        GVAR(inheritedActionsMan) pushBack [_typeNum, _parentPath, _action];
         {
             [_x, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
-        } forEach GVAR(inheritedManClasses);
+        } forEach GVAR(inheritedClassesMan);
     } else {
-        private _addedClasses = [];
-        GVAR(inheritedActions) pushBack [_addedClasses, _objectType, _typeNum, _parentPath, _action];
-
+        GVAR(inheritedActionsAll) pushBack [_objectType, _typeNum, _parentPath, _action];
         {
-            private _object = _x;
-            private _type = typeOf _object;
-
-            if (_addedClasses pushBackUnique _type != -1) then {
-                [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+            if (_x isKindOf _objectType) then {
+                [_x, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
             };
-        } forEach entities [[_objectType], [], true, true];
+        } forEach GVAR(inheritedClassesAll);
     };
+    END_COUNTER(addAction);
 
     // Return the full path
     (_parentPath + [_action select 0])

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -39,7 +39,7 @@ if (param [4, false, [false]]) exitwith {
         private _object = _x;
         private _type = typeOf _object;
 
-        if (_object isKindOf _objectType && {_addedClasses pushBackUnique _type != -1}) then {
+        if (_addedClasses pushBackUnique _type != -1) then {
             [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
         };
     } forEach entities [[_objectType], [], true, true];

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -28,21 +28,24 @@ if (!params [["_objectType", "", [""]], ["_typeNum", 0, [0]], ["_parentPath", []
 TRACE_4("params",_objectType,_typeNum,_parentPath,_action);
 
 if (param [4, false, [false]]) exitwith {
-    if (isNil QGVAR(inheritedActions)) then {
-        GVAR(inheritedActions) = [];
+    if (_objectType == "CaManBase") then {
+        GVAR(inheritedManActions) pushBack [_typeNum, _parentPath, _action];
+        {
+            [_x, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+        } forEach GVAR(inheritedManClasses);
+    } else {
+        private _addedClasses = [];
+        GVAR(inheritedActions) pushBack [_addedClasses, _objectType, _typeNum, _parentPath, _action];
+
+        {
+            private _object = _x;
+            private _type = typeOf _object;
+
+            if (_addedClasses pushBackUnique _type != -1) then {
+                [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
+            };
+        } forEach entities [[_objectType], [], true, true];
     };
-
-    private _addedClasses = [];
-    GVAR(inheritedActions) pushBack [_addedClasses, _objectType, _typeNum, _parentPath, _action];
-
-    {
-        private _object = _x;
-        private _type = typeOf _object;
-
-        if (_addedClasses pushBackUnique _type != -1) then {
-            [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
-        };
-    } forEach entities [[_objectType], [], true, true];
 
     // Return the full path
     (_parentPath + [_action select 0])

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -39,7 +39,7 @@ if (param [4, false, [false]]) exitwith {
         private _object = _x;
         private _type = typeOf _object;
 
-        if (_object isKindOf _class && {_addedClasses pushBackUnique _type != -1}) then {
+        if (_object isKindOf _objectType && {_addedClasses pushBackUnique _type != -1}) then {
             [_type, _typeNum, _parentPath, _action] call FUNC(addActionToClass);
         };
     } forEach entities [[_objectType], [], true, true];

--- a/addons/interact_menu/functions/fnc_addActionToClass.sqf
+++ b/addons/interact_menu/functions/fnc_addActionToClass.sqf
@@ -28,7 +28,7 @@ if (!params [["_objectType", "", [""]], ["_typeNum", 0, [0]], ["_parentPath", []
 TRACE_4("params",_objectType,_typeNum,_parentPath,_action);
 
 if (param [4, false, [false]]) exitwith {
-    if (_objectType == "CaManBase") then {
+    if (_objectType == "CAManBase") then {
         GVAR(inheritedManActions) pushBack [_typeNum, _parentPath, _action];
         {
             [_x, _typeNum, _parentPath, _action] call FUNC(addActionToClass);

--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -122,7 +122,7 @@ private _actions = [_actionsCfg, 0] call _recurseFnc;
 
 // ace_interaction_fnc_addPassengerAction expects ACE_MainActions to be first
 // Other mods can change the order that configs are added, so we should verify this now and resort if needed
-if (_objectType isKindOf "CaManBase") then {
+if (_objectType isKindOf "CAManBase") then {
     if ((((_actions select 0) select 0) select 0) != "ACE_MainActions") then {
         INFO_1("ACE_MainActions not first for man [%1]",_objectType);
         private _mainActions = [];

--- a/addons/laser/functions/fnc_addLaserTarget.sqf
+++ b/addons/laser/functions/fnc_addLaserTarget.sqf
@@ -31,7 +31,7 @@ _vehicle setVariable [QGVAR(targetObject), _targetObject, true];
 private _laserMethod = QFUNC(findLaserSource);
 
 private _vehicleSourceSelection = "";
-if (_vehicle isKindOf "CaManBase") then {
+if (_vehicle isKindOf "CAManBase") then {
     _vehicleSourceSelection = "pilot";
 } else {
     { // Go through turrets on vehicle and find the laser

--- a/addons/medical/dev/test_hitpointConfigs.sqf
+++ b/addons/medical/dev/test_hitpointConfigs.sqf
@@ -5,7 +5,7 @@
 #include "\z\ace\addons\medical\script_component.hpp"
 
 // UAV-AI should get filtered by scope check
-private _mans = configProperties [configFile >> "CfgVehicles", "(isClass _x) && {(getNumber (_x >> 'scope')) == 2} && {configName _x isKindOf 'CaManBase'}", true];
+private _mans = configProperties [configFile >> "CfgVehicles", "(isClass _x) && {(getNumber (_x >> 'scope')) == 2} && {configName _x isKindOf 'CAManBase'}", true];
 INFO_1("Checking mans for medical hitpoints [%1 mans]",count _mans);
 
 private _testPass = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Currently any mission with sufficiently enough soldiers placed crashes when loading a savegame, because the game runs out of memory when deserializing arrays.
- The addInteractionToClass function from interact_menu with allowInheritance flag set adds an (retroactively applied) Init event handler to the object class for every added action, so the actions can be added to descendant classes of the base class the action was added to.
- ACE Medical adds a lot of actions to the CAManBase base class.
- This means ~250 more Init events on CAManBase when Medical is loaded.
- The array is referenced on every CAManBase object and thus creates a big save file, which cannot be loaded without running out of memory.

- This PR rewrites the allowInheritance part of the addInteractionToClass function to drastically reduce the memory usage.
- Realistically this is just a BI bug we will keep running into, but we can avoid it with this memory optimization.
