### PR TITLE
Ballistics - Add shotgun shell projectile magazine variety

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -6,6 +6,89 @@ class CfgAmmo {
         timeToLive=6;
     };
 
+    class B_12Gauge_Pellets_Submunition : BulletBase { //#00 Buckshot
+        //vanilla values have been left as comments for reference purposes
+        //cost = 1;
+        //hit = 20;
+        //simulationStep = 0.0001;
+        //cartridge = "";
+        //submunitionAmmo = "B_12Gauge_Pellets_Submunition_Deploy";
+        submunitionConeType[] = {"poissondisc", 9};  //#00 Buckshot generally has 9 pellets per shell
+        //submunitionConeType[] = {"poissondisc", 18};
+        //submunitionConeAngle = 0.8;
+        //triggerSpeedCoef[] = {0.85, 1};
+        triggerTime = 0.015; // Shot takes ~5-15 feet to start spreading out and the vanilla triggerTime is too short to allow that
+        //triggerTime = 0.001;
+    };
+    class B_12Gauge_Pellets_Submunition_Deploy : BulletBase {
+        airFriction = -0.0030;
+        //airFriction = -0.0067;
+        hit = 2.55; //vanilla hit is way too high
+        //hit = 6;
+        //indirectHit = 0;
+        //indirectHitRange = 0;
+        //typicalSpeed = 360;
+        //deflecting = 35;
+    };
+
+    class ACE_12Gauge_Pellets_Submunition_No0 : B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No0_Deploy";
+        submunitionConeType[] = {"poissondisc", 9};
+        submunitionConeAngle = 0.81;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No0_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.0033;
+        hit = 2.27;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No1 : B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No1_Deploy";
+        submunitionConeType[] = {"poissondisc", 11};
+        submunitionConeAngle = 0.83;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No1_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.0038;
+        hit = 1.86;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No2 : B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No2_Deploy";
+        submunitionConeType[] = {"poissondisc", 14};
+        submunitionConeAngle = 0.85;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No2_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.0048;
+        hit = 1.46;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No3 : B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Deploy";
+        submunitionConeType[] = {"poissondisc", 18};
+        submunitionConeAngle = 0.87;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No3_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.0067;
+        hit = 1.13;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No4 : B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Deploy";
+        submunitionConeType[] = {"poissondisc", 21};
+        submunitionConeAngle = 0.89;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No4_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.0085;
+        hit = 0.97;
+    };
+    class ACE_12Gauge_Pellets_Submunition_No7 : B_12Gauge_Pellets_Submunition {
+        hit = 3;
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No7_Deploy";
+        submunitionConeType[] = {"poissondisc", 291};
+        submunitionConeAngle = 1.2;
+        triggerSpeedCoef[] = {0.7, 1};
+    };
+    class ACE_12Gauge_Pellets_Submunition_No7_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.1083;
+        hit = 0.09;
+    };
+
+
     class B_556x45_Ball : BulletBase {
         airFriction=-0.00130094;
         tracerScale = 1;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -31,61 +31,61 @@ class CfgAmmo {
         //deflecting = 35;
     };
 
-    class ACE_12Gauge_Pellets_Submunition_No0: B_12Gauge_Pellets_Submunition {
-        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No0_Deploy";
+    class ACE_12Gauge_Pellets_Submunition_No0_Buck: B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No0_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 9};
         submunitionConeAngle = 0.81;
     };
-    class ACE_12Gauge_Pellets_Submunition_No0_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No0_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0033;
         hit = 2.27;
     };
-    class ACE_12Gauge_Pellets_Submunition_No1: B_12Gauge_Pellets_Submunition {
-        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No1_Deploy";
+    class ACE_12Gauge_Pellets_Submunition_No1_Buck: B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No1_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 11};
         submunitionConeAngle = 0.83;
     };
-    class ACE_12Gauge_Pellets_Submunition_No1_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No1_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0038;
         hit = 1.86;
     };
-    class ACE_12Gauge_Pellets_Submunition_No2: B_12Gauge_Pellets_Submunition {
-        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No2_Deploy";
+    class ACE_12Gauge_Pellets_Submunition_No2_Buck: B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No2_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 14};
         submunitionConeAngle = 0.85;
     };
-    class ACE_12Gauge_Pellets_Submunition_No2_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No2_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0048;
         hit = 1.46;
     };
-    class ACE_12Gauge_Pellets_Submunition_No3: B_12Gauge_Pellets_Submunition {
-        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Deploy";
+    class ACE_12Gauge_Pellets_Submunition_No3_Buck: B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 18};
         submunitionConeAngle = 0.87;
     };
-    class ACE_12Gauge_Pellets_Submunition_No3_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0067;
         hit = 1.13;
     };
-    class ACE_12Gauge_Pellets_Submunition_No4: B_12Gauge_Pellets_Submunition {
-        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Deploy";
+    class ACE_12Gauge_Pellets_Submunition_No4_Buck: B_12Gauge_Pellets_Submunition {
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 21};
         submunitionConeAngle = 0.89;
     };
-    class ACE_12Gauge_Pellets_Submunition_No4_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No4_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0085;
         hit = 0.97;
     };
-    class ACE_12Gauge_Pellets_Submunition_No7: B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No4_Bird: B_12Gauge_Pellets_Submunition {
         hit = 3;
-        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No7_Deploy";
-        submunitionConeType[] = {"poissondisc", 291};
-        submunitionConeAngle = 1.2;
-        triggerSpeedCoef[] = {0.7, 1};
+        submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Bird_Deploy";
+        submunitionConeType[] = {"poissondisc", 135};
+        submunitionConeAngle = 1.1;
+        triggerSpeedCoef[] = {0.8, 1};
     };
-    class ACE_12Gauge_Pellets_Submunition_No7_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
-        airFriction = -0.1083;
-        hit = 0.09;
+    class ACE_12Gauge_Pellets_Submunition_No4_Bird_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+        airFriction = -0.0800;
+        hit = 0.15;
     };
 
     class B_556x45_Ball : BulletBase {

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -17,7 +17,7 @@ class CfgAmmo {
         //submunitionConeType[] = {"poissondisc", 18};
         //submunitionConeAngle = 0.8;
         //triggerSpeedCoef[] = {0.85, 1};
-        triggerTime = 0.015; // Shot takes ~5-15 feet to start spreading out and the vanilla triggerTime is too short to allow that
+        triggerTime = 0.008; // Shot takes ~5-15 feet to start spreading out and the vanilla triggerTime is too short to allow that
         //triggerTime = 0.001;
     };
     class B_12Gauge_Pellets_Submunition_Deploy: BulletBase {

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -88,7 +88,6 @@ class CfgAmmo {
         hit = 0.09;
     };
 
-
     class B_556x45_Ball : BulletBase {
         airFriction=-0.00130094;
         tracerScale = 1;

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -6,8 +6,12 @@ class CfgAmmo {
         timeToLive=6;
     };
 
+    class ShotgunBase;
+
     class B_12Gauge_Pellets_Submunition: BulletBase { //#00 Buckshot
         //vanilla values have been left as comments for reference purposes
+        caliber = 0.525; //penetration of ~3mm RHA, ~9.6mm metal
+        //caliber = 1; //too high, ~5.7mm of RHA (380*1*15/1000=5.7), ~18.25 metal
         //cost = 1;
         //hit = 20;
         //simulationStep = 0.0001;
@@ -23,6 +27,7 @@ class CfgAmmo {
     class B_12Gauge_Pellets_Submunition_Deploy: BulletBase {
         airFriction = -0.0030;
         //airFriction = -0.0067;
+        caliber = 0.525;
         hit = 2.55; //vanilla hit is way too high
         //hit = 6;
         //indirectHit = 0;
@@ -31,52 +36,67 @@ class CfgAmmo {
         //deflecting = 35;
     };
 
+    class B_12Gauge_Pellets: ShotgunBase { //This doesn't seem to be used for anything, but I want to standardize the caliber with the other pellet classes.
+        caliber = 0.525; //3mm RHA, probably still too high though as RHA is hardened.
+    };
+
     class ACE_12Gauge_Pellets_Submunition_No0_Buck: B_12Gauge_Pellets_Submunition {
+        caliber = 0.5;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No0_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 9};
         submunitionConeAngle = 0.81;
     };
     class ACE_12Gauge_Pellets_Submunition_No0_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0033;
+        caliber = 0.5;
         hit = 2.27;
     };
     class ACE_12Gauge_Pellets_Submunition_No1_Buck: B_12Gauge_Pellets_Submunition {
+        caliber = 0.475;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No1_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 11};
         submunitionConeAngle = 0.83;
     };
     class ACE_12Gauge_Pellets_Submunition_No1_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0038;
+        caliber = 0.475;
         hit = 1.86;
     };
     class ACE_12Gauge_Pellets_Submunition_No2_Buck: B_12Gauge_Pellets_Submunition {
+        caliber = 0.45;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No2_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 14};
         submunitionConeAngle = 0.85;
     };
     class ACE_12Gauge_Pellets_Submunition_No2_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0048;
+        caliber = 0.45;
         hit = 1.46;
     };
     class ACE_12Gauge_Pellets_Submunition_No3_Buck: B_12Gauge_Pellets_Submunition {
+        caliber = 0.425;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 18};
         submunitionConeAngle = 0.87;
     };
     class ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0067;
+        caliber = 0.425;
         hit = 1.13;
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Buck: B_12Gauge_Pellets_Submunition {
+        caliber = 0.4;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 21};
         submunitionConeAngle = 0.89;
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0085;
+        caliber = 0.4;
         hit = 0.97;
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Bird: B_12Gauge_Pellets_Submunition {
+        caliber = 0.2;
         hit = 3;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Bird_Deploy";
         submunitionConeType[] = {"poissondisc", 135};
@@ -84,8 +104,14 @@ class CfgAmmo {
         triggerSpeedCoef[] = {0.8, 1};
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Bird_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+        caliber = 0.2;
         airFriction = -0.0800;
         hit = 0.15;
+    };
+
+    class B_12Gauge_Slug: BulletBase {
+        //caliber = 3; //too high, ~20mm of RHA (450*3*15/1000=20), ~64mm metal
+        caliber = 1.037; //~7mm RHA, ~22.4mm metal, probably still too high though as RHA is hardened.
     };
 
     class B_556x45_Ball : BulletBase {

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -6,7 +6,7 @@ class CfgAmmo {
         timeToLive=6;
     };
 
-    class B_12Gauge_Pellets_Submunition : BulletBase { //#00 Buckshot
+    class B_12Gauge_Pellets_Submunition: BulletBase { //#00 Buckshot
         //vanilla values have been left as comments for reference purposes
         //cost = 1;
         //hit = 20;
@@ -20,7 +20,7 @@ class CfgAmmo {
         triggerTime = 0.015; // Shot takes ~5-15 feet to start spreading out and the vanilla triggerTime is too short to allow that
         //triggerTime = 0.001;
     };
-    class B_12Gauge_Pellets_Submunition_Deploy : BulletBase {
+    class B_12Gauge_Pellets_Submunition_Deploy: BulletBase {
         airFriction = -0.0030;
         //airFriction = -0.0067;
         hit = 2.55; //vanilla hit is way too high
@@ -31,59 +31,59 @@ class CfgAmmo {
         //deflecting = 35;
     };
 
-    class ACE_12Gauge_Pellets_Submunition_No0 : B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No0: B_12Gauge_Pellets_Submunition {
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No0_Deploy";
         submunitionConeType[] = {"poissondisc", 9};
         submunitionConeAngle = 0.81;
     };
-    class ACE_12Gauge_Pellets_Submunition_No0_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No0_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0033;
         hit = 2.27;
     };
-    class ACE_12Gauge_Pellets_Submunition_No1 : B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No1: B_12Gauge_Pellets_Submunition {
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No1_Deploy";
         submunitionConeType[] = {"poissondisc", 11};
         submunitionConeAngle = 0.83;
     };
-    class ACE_12Gauge_Pellets_Submunition_No1_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No1_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0038;
         hit = 1.86;
     };
-    class ACE_12Gauge_Pellets_Submunition_No2 : B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No2: B_12Gauge_Pellets_Submunition {
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No2_Deploy";
         submunitionConeType[] = {"poissondisc", 14};
         submunitionConeAngle = 0.85;
     };
-    class ACE_12Gauge_Pellets_Submunition_No2_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No2_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0048;
         hit = 1.46;
     };
-    class ACE_12Gauge_Pellets_Submunition_No3 : B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No3: B_12Gauge_Pellets_Submunition {
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Deploy";
         submunitionConeType[] = {"poissondisc", 18};
         submunitionConeAngle = 0.87;
     };
-    class ACE_12Gauge_Pellets_Submunition_No3_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No3_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0067;
         hit = 1.13;
     };
-    class ACE_12Gauge_Pellets_Submunition_No4 : B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No4: B_12Gauge_Pellets_Submunition {
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Deploy";
         submunitionConeType[] = {"poissondisc", 21};
         submunitionConeAngle = 0.89;
     };
-    class ACE_12Gauge_Pellets_Submunition_No4_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No4_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0085;
         hit = 0.97;
     };
-    class ACE_12Gauge_Pellets_Submunition_No7 : B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No7: B_12Gauge_Pellets_Submunition {
         hit = 3;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No7_Deploy";
         submunitionConeType[] = {"poissondisc", 291};
         submunitionConeAngle = 1.2;
         triggerSpeedCoef[] = {0.7, 1};
     };
-    class ACE_12Gauge_Pellets_Submunition_No7_Deploy : B_12Gauge_Pellets_Submunition_Deploy {
+    class ACE_12Gauge_Pellets_Submunition_No7_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.1083;
         hit = 0.09;
     };

--- a/addons/ballistics/CfgMagazineWells.hpp
+++ b/addons/ballistics/CfgMagazineWells.hpp
@@ -2,34 +2,34 @@ class CfgMagazineWells {
 
     class CBA_12g_2rnds {
         ADDON[] = {
-                "ACE_2Rnd_12Gauge_Pellets_No0_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No1_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No2_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No3_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No4_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No4_Bird"
+            "ACE_2Rnd_12Gauge_Pellets_No0_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No1_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No2_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No3_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No4_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No4_Bird"
         };
     };
 
     class HunterShotgun_01_12GA { //Vanilla magwell
         ADDON[] = {
-                "ACE_2Rnd_12Gauge_Pellets_No0_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No1_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No2_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No3_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No4_Buck",
-                "ACE_2Rnd_12Gauge_Pellets_No4_Bird"
+            "ACE_2Rnd_12Gauge_Pellets_No0_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No1_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No2_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No3_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No4_Buck",
+            "ACE_2Rnd_12Gauge_Pellets_No4_Bird"
         };
     };
 
     class UBS_12GA { //Vanilla magwell
         ADDON[] = {
-                "ACE_6Rnd_12Gauge_Pellets_No0_Buck",
-                "ACE_6Rnd_12Gauge_Pellets_No1_Buck",
-                "ACE_6Rnd_12Gauge_Pellets_No2_Buck",
-                "ACE_6Rnd_12Gauge_Pellets_No3_Buck",
-                "ACE_6Rnd_12Gauge_Pellets_No4_Buck",
-                "ACE_6Rnd_12Gauge_Pellets_No4_Bird"
+            "ACE_6Rnd_12Gauge_Pellets_No0_Buck",
+            "ACE_6Rnd_12Gauge_Pellets_No1_Buck",
+            "ACE_6Rnd_12Gauge_Pellets_No2_Buck",
+            "ACE_6Rnd_12Gauge_Pellets_No3_Buck",
+            "ACE_6Rnd_12Gauge_Pellets_No4_Buck",
+            "ACE_6Rnd_12Gauge_Pellets_No4_Bird"
         };
     };
 
@@ -60,10 +60,10 @@ class CfgMagazineWells {
     };
     class STANAG_556x45 { //Vanilla magwell
         ADDON[] = {
-                "ACE_30Rnd_556x45_Stanag_M995_AP_mag",
-                "ACE_30Rnd_556x45_Stanag_Mk262_mag",
-                "ACE_30Rnd_556x45_Stanag_Mk318_mag",
-                "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
+            "ACE_30Rnd_556x45_Stanag_M995_AP_mag",
+            "ACE_30Rnd_556x45_Stanag_Mk262_mag",
+            "ACE_30Rnd_556x45_Stanag_Mk318_mag",
+            "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
     };
 

--- a/addons/ballistics/CfgMagazineWells.hpp
+++ b/addons/ballistics/CfgMagazineWells.hpp
@@ -1,5 +1,38 @@
 class CfgMagazineWells {
 
+    class CBA_12g_2rnds {
+        ADDON[] = {
+                "ACE_2Rnd_12Gauge_Pellets_0",
+                "ACE_2Rnd_12Gauge_Pellets_1",
+                "ACE_2Rnd_12Gauge_Pellets_2",
+                "ACE_2Rnd_12Gauge_Pellets_3",
+                "ACE_2Rnd_12Gauge_Pellets_4",
+                "ACE_2Rnd_12Gauge_Pellets_7"
+        };
+    };
+
+    class HunterShotgun_01_12GA { //Vanilla magwell
+        ADDON[] = {
+                "ACE_2Rnd_12Gauge_Pellets_0",
+                "ACE_2Rnd_12Gauge_Pellets_1",
+                "ACE_2Rnd_12Gauge_Pellets_2",
+                "ACE_2Rnd_12Gauge_Pellets_3",
+                "ACE_2Rnd_12Gauge_Pellets_4",
+                "ACE_2Rnd_12Gauge_Pellets_7"
+        };
+    };
+
+    class UBS_12GA { //Vanilla magwell
+        ADDON[] = {
+                "ACE_6Rnd_12Gauge_Pellets_0",
+                "ACE_6Rnd_12Gauge_Pellets_1",
+                "ACE_6Rnd_12Gauge_Pellets_2",
+                "ACE_6Rnd_12Gauge_Pellets_3",
+                "ACE_6Rnd_12Gauge_Pellets_4",
+                "ACE_6Rnd_12Gauge_Pellets_7"
+        };
+    };
+
     class CBA_65x39_MX {
         ADDON[] = {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim",

--- a/addons/ballistics/CfgMagazineWells.hpp
+++ b/addons/ballistics/CfgMagazineWells.hpp
@@ -2,34 +2,34 @@ class CfgMagazineWells {
 
     class CBA_12g_2rnds {
         ADDON[] = {
-                "ACE_2Rnd_12Gauge_Pellets_0",
-                "ACE_2Rnd_12Gauge_Pellets_1",
-                "ACE_2Rnd_12Gauge_Pellets_2",
-                "ACE_2Rnd_12Gauge_Pellets_3",
-                "ACE_2Rnd_12Gauge_Pellets_4",
-                "ACE_2Rnd_12Gauge_Pellets_7"
+                "ACE_2Rnd_12Gauge_Pellets_No0_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No1_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No2_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No3_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No4_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No4_Bird"
         };
     };
 
     class HunterShotgun_01_12GA { //Vanilla magwell
         ADDON[] = {
-                "ACE_2Rnd_12Gauge_Pellets_0",
-                "ACE_2Rnd_12Gauge_Pellets_1",
-                "ACE_2Rnd_12Gauge_Pellets_2",
-                "ACE_2Rnd_12Gauge_Pellets_3",
-                "ACE_2Rnd_12Gauge_Pellets_4",
-                "ACE_2Rnd_12Gauge_Pellets_7"
+                "ACE_2Rnd_12Gauge_Pellets_No0_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No1_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No2_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No3_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No4_Buck",
+                "ACE_2Rnd_12Gauge_Pellets_No4_Bird"
         };
     };
 
     class UBS_12GA { //Vanilla magwell
         ADDON[] = {
-                "ACE_6Rnd_12Gauge_Pellets_0",
-                "ACE_6Rnd_12Gauge_Pellets_1",
-                "ACE_6Rnd_12Gauge_Pellets_2",
-                "ACE_6Rnd_12Gauge_Pellets_3",
-                "ACE_6Rnd_12Gauge_Pellets_4",
-                "ACE_6Rnd_12Gauge_Pellets_7"
+                "ACE_6Rnd_12Gauge_Pellets_No0_Buck",
+                "ACE_6Rnd_12Gauge_Pellets_No1_Buck",
+                "ACE_6Rnd_12Gauge_Pellets_No2_Buck",
+                "ACE_6Rnd_12Gauge_Pellets_No3_Buck",
+                "ACE_6Rnd_12Gauge_Pellets_No4_Buck",
+                "ACE_6Rnd_12Gauge_Pellets_No4_Bird"
         };
     };
 

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -5,95 +5,95 @@ class CfgMagazines {
     class VehicleMagazine;
 
     class 2Rnd_12Gauge_Pellets: CA_Magazine {
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_00_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No00_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No00_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No00_Buck_Description);
     };
-    class ACE_2Rnd_12Gauge_Pellets_0: 2Rnd_12Gauge_Pellets {
+    class ACE_2Rnd_12Gauge_Pellets_No0_Buck: 2Rnd_12Gauge_Pellets {
         author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_0_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_0_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_0_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No0";
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No0_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No0_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No0_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No0_Buck";
     };
-    class ACE_2Rnd_12Gauge_Pellets_1: ACE_2Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_1_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_1_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_1_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No1";
+    class ACE_2Rnd_12Gauge_Pellets_No1_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No1_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No1_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No1_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No1_Buck";
     };
-    class ACE_2Rnd_12Gauge_Pellets_2: ACE_2Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_2_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_2_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_2_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No2";
+    class ACE_2Rnd_12Gauge_Pellets_No2_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No2_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No2_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No2_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No2_Buck";
     };
-    class ACE_2Rnd_12Gauge_Pellets_3: ACE_2Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_3_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_3_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_3_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No3";
+    class ACE_2Rnd_12Gauge_Pellets_No3_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No3_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No3_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No3_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No3_Buck";
     };
-    class ACE_2Rnd_12Gauge_Pellets_4: ACE_2Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_4_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_4_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_4_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No4";
+    class ACE_2Rnd_12Gauge_Pellets_No4_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No4_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No4_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No4_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No4_Buck";
     };
-    class ACE_2Rnd_12Gauge_Pellets_7: ACE_2Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(2Rnd_12Gauge_Pellets_7_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_7_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_7_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No7";
+    class ACE_2Rnd_12Gauge_Pellets_No4_Bird: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_No4_Bird_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No4_Bird_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No4_Bird_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No4_Bird";
     };
 
     class 6Rnd_12Gauge_Pellets: 2Rnd_12Gauge_Pellets {
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_00_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No00_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No00_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No00_Buck_Description);
     };
-    class ACE_6Rnd_12Gauge_Pellets_0: 6Rnd_12Gauge_Pellets {
+    class ACE_6Rnd_12Gauge_Pellets_No0_Buck: 6Rnd_12Gauge_Pellets {
         author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_0_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_0_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_0_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No0";
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No0_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No0_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No0_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No0_Buck";
     };
-    class ACE_6Rnd_12Gauge_Pellets_1: ACE_6Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_1_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_1_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_1_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No1";
+    class ACE_6Rnd_12Gauge_Pellets_No1_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No1_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No1_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No1_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No1_Buck";
     };
-    class ACE_6Rnd_12Gauge_Pellets_2: ACE_6Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_2_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_2_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_2_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No2";
+    class ACE_6Rnd_12Gauge_Pellets_No2_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No2_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No2_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No2_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No2_Buck";
     };
-    class ACE_6Rnd_12Gauge_Pellets_3: ACE_6Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_3_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_3_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_3_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No3";
+    class ACE_6Rnd_12Gauge_Pellets_No3_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No3_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No3_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No3_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No3_Buck";
     };
-    class ACE_6Rnd_12Gauge_Pellets_4: ACE_6Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_4_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_4_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_4_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No4";
+    class ACE_6Rnd_12Gauge_Pellets_No4_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No4_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No4_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No4_Buck_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No4_Buck";
     };
-    class ACE_6Rnd_12Gauge_Pellets_7: ACE_6Rnd_12Gauge_Pellets_0 {
-        displayName = CSTRING(6Rnd_12Gauge_Pellets_7_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_7_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_7_Description);
-        ammo = "ACE_12Gauge_Pellets_Submunition_No7";
+    class ACE_6Rnd_12Gauge_Pellets_No4_Bird: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_No4_Bird_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No4_Bird_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No4_Bird_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No4_Bird";
     };
 
     class 15Rnd_12Gauge_Pellets: 6Rnd_12Gauge_Pellets {
-        displayName = CSTRING(15Rnd_12Gauge_Pellets_00_Name);
-        displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
-        descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
+        displayName = CSTRING(15Rnd_12Gauge_Pellets_No00_Buck_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_No00_Buck_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_No00_Buck_Description);
     };
 
     class 30Rnd_580x42_Mag_F: CA_Magazine {

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -3,7 +3,99 @@ class CfgMagazines {
 
     class CA_Magazine;
     class VehicleMagazine;
-    
+
+    class 2Rnd_12Gauge_Pellets : CA_Magazine {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_00_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
+    };
+    class ACE_2Rnd_12Gauge_Pellets_0 : 2Rnd_12Gauge_Pellets {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_0_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_0_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_0_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No0";
+    };
+    class ACE_2Rnd_12Gauge_Pellets_1 : ACE_2Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_1_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_1_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_1_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No1";
+    };
+    class ACE_2Rnd_12Gauge_Pellets_2 : ACE_2Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_2_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_2_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_2_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No2";
+    };
+    class ACE_2Rnd_12Gauge_Pellets_3 : ACE_2Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_3_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_3_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_3_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No3";
+    };
+    class ACE_2Rnd_12Gauge_Pellets_4 : ACE_2Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_4_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_4_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_4_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No4";
+    };
+    class ACE_2Rnd_12Gauge_Pellets_7 : ACE_2Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(2Rnd_12Gauge_Pellets_7_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_7_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_7_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No7";
+    };
+
+    class 6Rnd_12Gauge_Pellets : 2Rnd_12Gauge_Pellets {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_00_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
+    };
+    class ACE_6Rnd_12Gauge_Pellets_0 : 6Rnd_12Gauge_Pellets {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_0_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_0_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_0_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No0";
+    };
+    class ACE_6Rnd_12Gauge_Pellets_1 : ACE_6Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_1_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_1_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_1_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No1";
+    };
+    class ACE_6Rnd_12Gauge_Pellets_2 : ACE_6Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_2_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_2_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_2_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No2";
+    };
+    class ACE_6Rnd_12Gauge_Pellets_3 : ACE_6Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_3_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_3_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_3_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No3";
+    };
+    class ACE_6Rnd_12Gauge_Pellets_4 : ACE_6Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_4_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_4_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_4_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No4";
+    };
+    class ACE_6Rnd_12Gauge_Pellets_7 : ACE_6Rnd_12Gauge_Pellets_0 {
+        displayName = CSTRING(6Rnd_12Gauge_Pellets_7_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_7_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_7_Description);
+        ammo = "ACE_12Gauge_Pellets_Submunition_No7";
+    };
+
+    class 15Rnd_12Gauge_Pellets : 6Rnd_12Gauge_Pellets {
+        displayName = CSTRING(15Rnd_12Gauge_Pellets_00_Name);
+        displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
+        descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
+    };
+
     class 30Rnd_580x42_Mag_F: CA_Magazine {
         initSpeed = 950;
     };

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -4,93 +4,93 @@ class CfgMagazines {
     class CA_Magazine;
     class VehicleMagazine;
 
-    class 2Rnd_12Gauge_Pellets : CA_Magazine {
+    class 2Rnd_12Gauge_Pellets: CA_Magazine {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_00_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
     };
-    class ACE_2Rnd_12Gauge_Pellets_0 : 2Rnd_12Gauge_Pellets {
+    class ACE_2Rnd_12Gauge_Pellets_0: 2Rnd_12Gauge_Pellets {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(2Rnd_12Gauge_Pellets_0_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_0_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_0_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No0";
     };
-    class ACE_2Rnd_12Gauge_Pellets_1 : ACE_2Rnd_12Gauge_Pellets_0 {
+    class ACE_2Rnd_12Gauge_Pellets_1: ACE_2Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_1_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_1_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_1_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No1";
     };
-    class ACE_2Rnd_12Gauge_Pellets_2 : ACE_2Rnd_12Gauge_Pellets_0 {
+    class ACE_2Rnd_12Gauge_Pellets_2: ACE_2Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_2_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_2_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_2_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No2";
     };
-    class ACE_2Rnd_12Gauge_Pellets_3 : ACE_2Rnd_12Gauge_Pellets_0 {
+    class ACE_2Rnd_12Gauge_Pellets_3: ACE_2Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_3_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_3_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_3_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No3";
     };
-    class ACE_2Rnd_12Gauge_Pellets_4 : ACE_2Rnd_12Gauge_Pellets_0 {
+    class ACE_2Rnd_12Gauge_Pellets_4: ACE_2Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_4_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_4_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_4_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No4";
     };
-    class ACE_2Rnd_12Gauge_Pellets_7 : ACE_2Rnd_12Gauge_Pellets_0 {
+    class ACE_2Rnd_12Gauge_Pellets_7: ACE_2Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_7_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_7_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_7_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No7";
     };
 
-    class 6Rnd_12Gauge_Pellets : 2Rnd_12Gauge_Pellets {
+    class 6Rnd_12Gauge_Pellets: 2Rnd_12Gauge_Pellets {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_00_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_00_Description);
     };
-    class ACE_6Rnd_12Gauge_Pellets_0 : 6Rnd_12Gauge_Pellets {
+    class ACE_6Rnd_12Gauge_Pellets_0: 6Rnd_12Gauge_Pellets {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(6Rnd_12Gauge_Pellets_0_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_0_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_0_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No0";
     };
-    class ACE_6Rnd_12Gauge_Pellets_1 : ACE_6Rnd_12Gauge_Pellets_0 {
+    class ACE_6Rnd_12Gauge_Pellets_1: ACE_6Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_1_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_1_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_1_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No1";
     };
-    class ACE_6Rnd_12Gauge_Pellets_2 : ACE_6Rnd_12Gauge_Pellets_0 {
+    class ACE_6Rnd_12Gauge_Pellets_2: ACE_6Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_2_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_2_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_2_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No2";
     };
-    class ACE_6Rnd_12Gauge_Pellets_3 : ACE_6Rnd_12Gauge_Pellets_0 {
+    class ACE_6Rnd_12Gauge_Pellets_3: ACE_6Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_3_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_3_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_3_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No3";
     };
-    class ACE_6Rnd_12Gauge_Pellets_4 : ACE_6Rnd_12Gauge_Pellets_0 {
+    class ACE_6Rnd_12Gauge_Pellets_4: ACE_6Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_4_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_4_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_4_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No4";
     };
-    class ACE_6Rnd_12Gauge_Pellets_7 : ACE_6Rnd_12Gauge_Pellets_0 {
+    class ACE_6Rnd_12Gauge_Pellets_7: ACE_6Rnd_12Gauge_Pellets_0 {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_7_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_7_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_7_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No7";
     };
 
-    class 15Rnd_12Gauge_Pellets : 6Rnd_12Gauge_Pellets {
+    class 15Rnd_12Gauge_Pellets: 6Rnd_12Gauge_Pellets {
         displayName = CSTRING(15Rnd_12Gauge_Pellets_00_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_00_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_00_Description);

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -2,91 +2,91 @@
 <Project name="ACE">
     <Package name="Ballistics">
         <!-- Shotguns -->
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_00_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No00_Buck_NameShort">
             <English>#00 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_00_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No00_Buck_Description">
             <English>#00 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_0_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No0_Buck_NameShort">
             <English>#0 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_0_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No0_Buck_Description">
             <English>#0 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_1_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No1_Buck_NameShort">
             <English>#1 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_1_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No1_Buck_Description">
             <English>#1 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_2_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No2_Buck_NameShort">
             <English>#2 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_2_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No2_Buck_Description">
             <English>#2 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_3_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No3_Buck_NameShort">
             <English>#3 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_3_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No3_Buck_Description">
             <English>#3 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_4_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Buck_NameShort">
             <English>#4 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_4_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Buck_Description">
             <English>#4 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_7_NameShort">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Bird_NameShort">
             <English>#7 Birdshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_7_Description">
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Bird_Description">
             <English>#7 Birdshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_00_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 2Rnd #00 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_0_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No0_Buck_Name">
             <English>12 Gauge 2Rnd #0 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_1_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No1_Buck_Name">
             <English>12 Gauge 2Rnd #1 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_2_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No2_Buck_Name">
             <English>12 Gauge 2Rnd #2 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_3_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No3_Buck_Name">
             <English>12 Gauge 2Rnd #3 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_4_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No4_Buck_Name">
             <English>12 Gauge 2Rnd #4 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_7_Name">
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No4_Bird_Name">
             <English>12 Gauge 2Rnd #7 Birdshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_00_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 6Rnd #00 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_0_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No0_Buck_Name">
             <English>12 Gauge 6Rnd #0 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_1_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No1_Buck_Name">
             <English>12 Gauge 6Rnd #1 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_2_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No2_Buck_Name">
             <English>12 Gauge 6Rnd #2 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_3_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No3_Buck_Name">
             <English>12 Gauge 6Rnd #3 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_4_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No4_Buck_Name">
             <English>12 Gauge 6Rnd #4 Buckshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_7_Name">
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No4_Bird_Name">
             <English>12 Gauge 6Rnd #7 Birdshot</English>
         </Key>
-        <Key ID="STR_ACE_Ballistics_15Rnd_12Gauge_Pellets_00_Name">
+        <Key ID="STR_ACE_Ballistics_15Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 15Rnd #00 Buckshot</English>
         </Key>
         <!-- QBU -->

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -1,6 +1,94 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Ballistics">
+        <!-- Shotguns -->
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_00_NameShort">
+            <English>#00 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_00_Description">
+            <English>#00 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_0_NameShort">
+            <English>#0 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_0_Description">
+            <English>#0 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_1_NameShort">
+            <English>#1 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_1_Description">
+            <English>#1 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_2_NameShort">
+            <English>#2 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_2_Description">
+            <English>#2 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_3_NameShort">
+            <English>#3 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_3_Description">
+            <English>#3 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_4_NameShort">
+            <English>#4 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_4_Description">
+            <English>#4 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_7_NameShort">
+            <English>#7 Birdshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_7_Description">
+            <English>#7 Birdshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_00_Name">
+            <English>12 Gauge 2Rnd #00 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_0_Name">
+            <English>12 Gauge 2Rnd #0 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_1_Name">
+            <English>12 Gauge 2Rnd #1 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_2_Name">
+            <English>12 Gauge 2Rnd #2 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_3_Name">
+            <English>12 Gauge 2Rnd #3 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_4_Name">
+            <English>12 Gauge 2Rnd #4 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_7_Name">
+            <English>12 Gauge 2Rnd #7 Birdshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_00_Name">
+            <English>12 Gauge 6Rnd #00 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_0_Name">
+            <English>12 Gauge 6Rnd #0 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_1_Name">
+            <English>12 Gauge 6Rnd #1 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_2_Name">
+            <English>12 Gauge 6Rnd #2 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_3_Name">
+            <English>12 Gauge 6Rnd #3 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_4_Name">
+            <English>12 Gauge 6Rnd #4 Buckshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_7_Name">
+            <English>12 Gauge 6Rnd #7 Birdshot</English>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_15Rnd_12Gauge_Pellets_00_Name">
+            <English>12 Gauge 15Rnd #00 Buckshot</English>
+        </Key>
         <!-- QBU -->
         <Key ID="STR_ACE_Ballistics_20Rnd_65x47_Scenar_mag_Name">
             <English>6.5x47mm 20Rnd Mag (HPBT Scenar)</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Change the vanilla buckshot from what appears to be No. 3 based on pellet count to No. 00, as No. 00 is the most common for combat shotguns.
- Add multiple additional types of shotgun projectiles, including Nos. 0, 1, 2, 3, 4 buckshot and No. 7 birdshot.
- Add magazines for them for the over/under and underbarrel shotguns.

* Changed to No4 birdshot for better performance. ~~The No. 7 bird shot has many more pellets/submunitions than the others and needs to be tested for performance issues~~.
* I haven't done extra magazines for the demining drone weapon, should they be added?
* I should probably do something with the `caliber` value for the ammo as shot does not penetrate armour well.