### PR TITLE
Rearm - Add distance setting

### DIFF
--- a/addons/rearm/functions/fnc_addRearmActions.sqf
+++ b/addons/rearm/functions/fnc_addRearmActions.sqf
@@ -18,7 +18,7 @@
 
 params ["_truck", "_player"];
 
-private _vehicles = nearestObjects [_truck, ["AllVehicles"], 20];
+private _vehicles = nearestObjects [_truck, ["AllVehicles"], GVAR(distance)];
 _vehicles = _vehicles select {(_x != _truck) && {!(_x isKindOf "CAManBase")} && {!(_x getVariable [QGVAR(disabled), false])}};
 
 private _cswCarryMagazines = [];

--- a/addons/rearm/functions/fnc_rearm.sqf
+++ b/addons/rearm/functions/fnc_rearm.sqf
@@ -46,7 +46,7 @@ private _magazineDisplayName = _magazineClass call FUNC(getMagazineName);
     format [localize LSTRING(RearmAction), getText(configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName"), _magazineDisplayName],
     {
         param [0] params ["_target", "_unit"];
-        (_unit distanceSqr _target) <= REARM_ACTION_DISTANCE_SQR
+        _player distance _vehicle <= GVAR(distance);
     },
     ["isnotinside"]
 ] call EFUNC(common,progressBar);

--- a/addons/rearm/functions/fnc_rearm.sqf
+++ b/addons/rearm/functions/fnc_rearm.sqf
@@ -46,7 +46,7 @@ private _magazineDisplayName = _magazineClass call FUNC(getMagazineName);
     format [localize LSTRING(RearmAction), getText(configFile >> "CfgVehicles" >> (typeOf _target) >> "displayName"), _magazineDisplayName],
     {
         param [0] params ["_target", "_unit"];
-        _player distance _vehicle <= GVAR(distance);
+        _player distance _target <= GVAR(distance);
     },
     ["isnotinside"]
 ] call EFUNC(common,progressBar);

--- a/addons/rearm/functions/fnc_rearmEntireVehicle.sqf
+++ b/addons/rearm/functions/fnc_rearmEntireVehicle.sqf
@@ -28,7 +28,7 @@ TRACE_3("rearmEntireVehicle",_truck,_player,_vehicle);
     format [localize LSTRING(BasicRearmAction), getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "displayName")],
     {
         param [0] params ["", "_vehicle", "_player"];
-        (_player distanceSqr _vehicle) <= REARM_ACTION_DISTANCE_SQR
+        _player distance _vehicle <= GVAR(distance);
     },
     ["isnotinside"]
 ] call EFUNC(common,progressBar);

--- a/addons/rearm/initSettings.sqf
+++ b/addons/rearm/initSettings.sqf
@@ -20,7 +20,7 @@
 
 [
     QGVAR(distance), "SLIDER",
-    [localize LSTRING(distance_DisplayName), localize LSTRING(distance_Description)],
+    [localize LSTRING(RearmSettings_distance_DisplayName), localize LSTRING(RearmSettings_distance_Description)],
     [localize ELSTRING(OptionsMenu,CategoryLogistics), localize LSTRING(DisplayName)],
     [10, 50, 20, 0],
     true, // isGlobal

--- a/addons/rearm/initSettings.sqf
+++ b/addons/rearm/initSettings.sqf
@@ -22,7 +22,7 @@
     QGVAR(distance), "SLIDER",
     [localize LSTRING(distance_DisplayName), localize LSTRING(distance_Description)],
     [localize ELSTRING(OptionsMenu,CategoryLogistics), localize LSTRING(DisplayName)],
-    [10, 100, 20, 0],
+    [10, 50, 20, 0],
     true, // isGlobal
     {[QGVAR(supply), _this] call EFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;

--- a/addons/rearm/initSettings.sqf
+++ b/addons/rearm/initSettings.sqf
@@ -17,3 +17,12 @@
     true, // isGlobal
     {[QGVAR(supply), _this] call EFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;
+
+[
+    QGVAR(distance), "SLIDER",
+    [localize LSTRING(distance_DisplayName), localize LSTRING(distance_Description)],
+    [localize ELSTRING(OptionsMenu,CategoryLogistics), localize LSTRING(DisplayName)],
+    [10, 100, 20, 0],
+    true, // isGlobal
+    {[QGVAR(supply), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;

--- a/addons/rearm/stringtable.xml
+++ b/addons/rearm/stringtable.xml
@@ -612,5 +612,13 @@
             <Italian>Il rifornimento delle munizioni (-1 per disabilitarlo)</Italian>
             <Russian>Объем боеприпасов для перевооружения (-1 для отмены)</Russian>
         </Key>
+        <Key ID="STR_ACE_Rearm_RearmSettings_distance_DisplayName">
+            <English>Rearm distance</English>
+            <French>Distance de réarmement</French>
+        </Key>
+        <Key ID="STR_ACE_Rearm_RearmSettings_distance_Description">
+            <English>The maximum distance a vehicle can be rearmed at</English>
+            <French>Distance maximale à laquelle un véhicle peut être réarmé</French>
+        </Key>
     </Package>
 </Project>

--- a/addons/rearm/stringtable.xml
+++ b/addons/rearm/stringtable.xml
@@ -615,6 +615,7 @@
         <Key ID="STR_ACE_Rearm_RearmSettings_distance_DisplayName">
             <English>Rearm distance</English>
             <French>Distance de réarmement</French>
+            <German>Aufrüstbereich</German>
         </Key>
         <Key ID="STR_ACE_Rearm_RearmSettings_distance_Description">
             <English>The maximum distance a vehicle can be rearmed at</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a setting to change the distance a vehicle can be rearmed at.

Someone asked for it on slack and I figured that this could indeed be a setting, the default value is set to the current value (20m) minimum at 10 and maximum at 50.