### PR TITLE
Fix undefined variable in View Distance

### DIFF
--- a/addons/viewdistance/functions/fnc_changeViewDistance.sqf
+++ b/addons/viewdistance/functions/fnc_changeViewDistance.sqf
@@ -29,9 +29,11 @@ if (_objectViewDistanceCoeff isEqualType 0) then {
     if (_objectViewDistanceCoeff > 0) then {
         setObjectViewDistance (_objectViewDistanceCoeff * viewDistance);
     } else {
-        // Restore correct view distance when changing from FoV Based to Off
-        // Restoring directly inside PFH's self-exit resulted in the need of selecting another option to take effect
-        setObjectViewDistance GVAR(fovBasedPFHminimalViewDistance);
+        if (!isNil QGVAR(fovBasedPFHminimalViewDistance)) then {
+            // Restore correct view distance when changing from FoV Based to Off
+            // Restoring directly inside PFH's self-exit resulted in the need of selecting another option to take effect
+            setObjectViewDistance GVAR(fovBasedPFHminimalViewDistance);
+        };
     };
 } else {
     if (isNil QGVAR(fovBasedPFHminimalViewDistance)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #7141 

Needs to be tested and made sure switching functions accordingly. I assumed here that when switching to "Off" nothing changes (unless it was in FoV mode) and is simply a way to allow setting object view distance via vanilla settings (simple disable of ACE system).