### PR TITLE
Update wiki description of interaction framework

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -132,6 +132,7 @@ Riccardo Petricca <petriccarcc@gmail.com>
 Robert Boklahánics <bokirobi@gmail.com>
 ruPaladin <happyworm24@rambler.ru>
 Rutger "RedBery" Meijering <c.redbery@gmail.com>
+Schwaggot <tom.ryan@posteo.de>
 simon84 <badguy360th@gmail.com>
 Skengman2
 Sniperwolf572 <tenga6@gmail.com>

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -21,7 +21,7 @@ Something the user would do to themselves or to their vehicle (eg. Put in ear pl
 - **Zeus** (`ACE_ZeusActions`)
 Available to Zeus
 
-`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions. Be ware that the functions modify the UI, and therefore need to be executed on client-side to take effect.
+`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions. Be aware that the functions modify the UI, and therefore need to be executed on client-side to take effect.
 
 The simplest action is just a condition and statement. The code to these are passed `[_target, _player, _actionParams]`. `_player` is `ace_player`; `_target` is the object being interacted with; and the 3rd argument is the optional action parameters (default `[]`).
 

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -21,7 +21,8 @@ Something the user would do to themselves or to their vehicle (eg. Put in ear pl
 - **Zeus** (`ACE_ZeusActions`)
 Available to Zeus
 
-`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions, it is generally preferred to add actions via config. Zeus actions can only be added via config.
+`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions. Zeus actions can only be 
+added via config. Functions will not be executed on server, only on clients with interface.
 
 The simplest action is just a condition and statement. The code to these are passed `[_target, _player, _actionParams]`. `_player` is `ace_player`; `_target` is the object being interacted with; and the 3rd argument is the optional action parameters (default `[]`).
 

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -21,8 +21,7 @@ Something the user would do to themselves or to their vehicle (eg. Put in ear pl
 - **Zeus** (`ACE_ZeusActions`)
 Available to Zeus
 
-`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions (which will be executed only on server and clients where 
-```hasInterface``` is ```true```).
+`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions. Be ware that the functions modify the UI, and therefore need to be executed on client-side to take effect.
 
 The simplest action is just a condition and statement. The code to these are passed `[_target, _player, _actionParams]`. `_player` is `ace_player`; `_target` is the object being interacted with; and the 3rd argument is the optional action parameters (default `[]`).
 

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -21,8 +21,8 @@ Something the user would do to themselves or to their vehicle (eg. Put in ear pl
 - **Zeus** (`ACE_ZeusActions`)
 Available to Zeus
 
-`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions. Zeus actions can only be 
-added via config. Functions will not be executed on server, only on clients with interface.
+`ACE_Actions` and `ACE_SelfActions` can be added via config or by calling functions (which will be executed only on server and clients where 
+```hasInterface``` is ```true```).
 
 The simplest action is just a condition and statement. The code to these are passed `[_target, _player, _actionParams]`. `_player` is `ace_player`; `_target` is the object being interacted with; and the 3rd argument is the optional action parameters (default `[]`).
 


### PR DESCRIPTION
**When merged this pull request will:**
- update the wiki description of the interaction menu framework
- adds a hint that functions will be not executed on server
- removes 'it is generally preferred to add actions via config' as suggested by jonpas on Slack