### PR TITLE
Cookoff - Allow enabling only on player crewed vehicles

### DIFF
--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -12,7 +12,7 @@ class Cfg3DEN {
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
                         condition = "objectVehicle";
-                        defaultValue = QUOTE((GETMVAR(QGVAR(enable),0)) in [1,2]);
+                        defaultValue = QUOTE((GETMVAR(QGVAR(enable),0)) in [ARR_2(1,2)]);
                     };
                     class GVAR(enableAmmoCookoff) {
                         property = QGVAR(enableAmmoCookoff);

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -14,16 +14,6 @@ class Cfg3DEN {
                         condition = "objectVehicle";
                         defaultValue = QUOTE(GETMVAR(QGVAR(enable),true));
                     };
-                    class GVAR(disableForAI) {
-                        property = QGVAR(disableForAI);
-                        control = "Checkbox";
-                        displayName = CSTRING(disableForAI_name);
-                        tooltip = CSTRING(disableForAI_tooltip);
-                        expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
-                        typeName = "BOOL";
-                        condition = "objectVehicle";
-                        defaultValue = QUOTE(GETMVAR(QGVAR(disableForAI),false));
-                    };
                     class GVAR(enableAmmoCookoff) {
                         property = QGVAR(enableAmmoCookoff);
                         control = "Checkbox";

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -12,7 +12,7 @@ class Cfg3DEN {
                         expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
                         typeName = "BOOL";
                         condition = "objectVehicle";
-                        defaultValue = QUOTE(GETMVAR(QGVAR(enable),true));
+                        defaultValue = QUOTE((GETMVAR(QGVAR(enable),0)) in [1,2]);
                     };
                     class GVAR(enableAmmoCookoff) {
                         property = QGVAR(enableAmmoCookoff);

--- a/addons/cookoff/CfgEden.hpp
+++ b/addons/cookoff/CfgEden.hpp
@@ -14,6 +14,16 @@ class Cfg3DEN {
                         condition = "objectVehicle";
                         defaultValue = QUOTE(GETMVAR(QGVAR(enable),true));
                     };
+                    class GVAR(disableForAI) {
+                        property = QGVAR(disableForAI);
+                        control = "Checkbox";
+                        displayName = CSTRING(disableForAI_name);
+                        tooltip = CSTRING(disableForAI_tooltip);
+                        expression = QUOTE(if !(_value) then {_this setVariable [ARR_3('%s',_value,true)];};);
+                        typeName = "BOOL";
+                        condition = "objectVehicle";
+                        defaultValue = QUOTE(GETMVAR(QGVAR(disableForAI),false));
+                    };
                     class GVAR(enableAmmoCookoff) {
                         property = QGVAR(enableAmmoCookoff);
                         control = "Checkbox";

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -26,6 +26,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
         GVAR(cacheTankDuplicates) setVariable [_typeOf, _duplicateHitpoints];
     };
 
+    _vehicle setVariable [QGVAR(disableForAI), GVAR(disableForAI), true];
     _vehicle addEventHandler ["HandleDamage", {
         if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
             ["tank", _this] call FUNC(handleDamage);
@@ -52,6 +53,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
         GVAR(cacheTankDuplicates) setVariable [_typeOf, _duplicateHitpoints];
     };
 
+    _vehicle setVariable [QGVAR(disableForAI), GVAR(disableForAI), true];
     _vehicle addEventHandler ["HandleDamage", {
         if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
             ["tank", _this] call FUNC(handleDamage);
@@ -62,6 +64,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 ["Car", "init", {
     params ["_vehicle"];
 
+    _vehicle setVariable [QGVAR(disableForAI), GVAR(disableForAI), true];
     _vehicle addEventHandler ["HandleDamage", {
         if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
             ["car", _this] call FUNC(handleDamage);

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -83,7 +83,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0) then {
+    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
         if (random 1 < 0.15) then {
             (_this select 0) call FUNC(blowOffTurret);
         };

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -27,7 +27,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     };
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
@@ -53,7 +53,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     };
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
@@ -63,7 +63,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     params ["_vehicle"];
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
             ["car", _this] call FUNC(handleDamage);
         };
     }];
@@ -89,7 +89,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
+    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
         if (random 1 < 0.15) then {
             (_this select 0) call FUNC(blowOffTurret);
         };

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -26,9 +26,8 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
         GVAR(cacheTankDuplicates) setVariable [_typeOf, _duplicateHitpoints];
     };
 
-    _vehicle setVariable [QGVAR(disableForAI), GVAR(disableForAI), true];
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
@@ -53,9 +52,8 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
         GVAR(cacheTankDuplicates) setVariable [_typeOf, _duplicateHitpoints];
     };
 
-    _vehicle setVariable [QGVAR(disableForAI), GVAR(disableForAI), true];
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
             ["tank", _this] call FUNC(handleDamage);
         };
     }];
@@ -64,9 +62,8 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 ["Car", "init", {
     params ["_vehicle"];
 
-    _vehicle setVariable [QGVAR(disableForAI), GVAR(disableForAI), true];
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)]) then {
+        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
             ["car", _this] call FUNC(handleDamage);
         };
     }];
@@ -92,7 +89,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable),GVAR(enable)]) then {
+    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0 ) then {
         if (random 1 < 0.15) then {
             (_this select 0) call FUNC(blowOffTurret);
         };

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -27,9 +27,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     };
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
-            ["tank", _this] call FUNC(handleDamage);
-        };
+        ["tank", _this] call FUNC(handleDamage);
     }];
 }, nil, nil, true] call CBA_fnc_addClassEventHandler;
 
@@ -53,9 +51,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     };
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
-            ["tank", _this] call FUNC(handleDamage);
-        };
+        ["tank", _this] call FUNC(handleDamage);
     }];
 }, nil, nil, true] call CBA_fnc_addClassEventHandler;
 
@@ -63,9 +59,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
     params ["_vehicle"];
 
     _vehicle addEventHandler ["HandleDamage", {
-        if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
-            ["car", _this] call FUNC(handleDamage);
-        };
+        ["car", _this] call FUNC(handleDamage);
     }];
 }, nil, ["Wheeled_APC_F"], true] call CBA_fnc_addClassEventHandler;
 
@@ -89,7 +83,7 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
+    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] !=0) then {
         if (random 1 < 0.15) then {
             (_this select 0) call FUNC(blowOffTurret);
         };

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -21,6 +21,10 @@ _thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIn
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
 
+// Check for players and exit if none found and the disable for AI setting is true
+private _playerCrew = (fullCrew [_vehicle, "", false]) findIf {isPlayer (_x #0)};
+if (_vehicle getVariable [QGVAR(disableForAI), GVAR(disableForAI)] && _playerCrew isEqualTo -1) exitWith {};
+
 // get hitpoint name
 private _hitpoint = "#structural";
 

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -21,6 +21,9 @@ _thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIn
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
 
+// If cookoff is disabled exit
+if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] in [0, false]) exitWith {};
+
 // Check for players and exit if none found and the enable for players only setting is true
 if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] isEqualTo 2 && {fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} == -1}) exitWith {};
 

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -21,9 +21,8 @@ _thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIn
 // it's already dead, who cares?
 if (damage _vehicle >= 1) exitWith {};
 
-// Check for players and exit if none found and the disable for AI setting is true
-private _hasPlayerInCrew = fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} != -1;
-if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] isEqualTo 2 && !_hasPlayerInCrew) exitWith {};
+// Check for players and exit if none found and the enable for players only setting is true
+if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] isEqualTo 2 && {fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} == -1}) exitWith {};
 
 // get hitpoint name
 private _hitpoint = "#structural";

--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -22,8 +22,8 @@ _thisHandleDamage params ["_vehicle", "", "_damage", "_source", "_ammo", "_hitIn
 if (damage _vehicle >= 1) exitWith {};
 
 // Check for players and exit if none found and the disable for AI setting is true
-private _playerCrew = (fullCrew [_vehicle, "", false]) findIf {isPlayer (_x #0)};
-if (_vehicle getVariable [QGVAR(disableForAI), GVAR(disableForAI)] && _playerCrew isEqualTo -1) exitWith {};
+private _hasPlayerInCrew = fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} != -1;
+if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] isEqualTo 2 && !_hasPlayerInCrew) exitWith {};
 
 // get hitpoint name
 private _hitpoint = "#structural";

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -4,7 +4,7 @@
     QGVAR(enable), "LIST",
     [LSTRING(enable_hd_name), LSTRING(enable_hd_tooltip)],
     LSTRING(category_displayName),
-    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", "STR_A3_OPTIONS_ENABLED", "STR_ACE_CookOff_enableForPlayers"], 0],
+    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", "STR_A3_OPTIONS_ENABLED", LSTRING(enableForPlayers)], 0],
     true, // isGlobal
     {[QGVAR(enable), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -4,7 +4,7 @@
     QGVAR(enable), "LIST",
     [LSTRING(enable_hd_name), LSTRING(enable_hd_tooltip)],
     LSTRING(category_displayName),
-    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", "STR_A3_OPTIONS_ENABLED", LSTRING(enableForPlayers_name)], 0]
+    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", "STR_A3_OPTIONS_ENABLED", "STR_ACE_CookOff_enableForPlayers"], 0],
     true, // isGlobal
     {[QGVAR(enable), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -1,22 +1,12 @@
 // CBA Settings [ADDON: ace_cookoff]:
 
 [
-    QGVAR(enable), "CHECKBOX",
+    QGVAR(enable), "LIST",
     [LSTRING(enable_hd_name), LSTRING(enable_hd_tooltip)],
     LSTRING(category_displayName),
-    false, // default value
+    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", "STR_A3_OPTIONS_ENABLED", LSTRING(enableForPlayers_name)], 0]
     true, // isGlobal
     {[QGVAR(enable), _this] call EFUNC(common,cbaSettings_settingChanged)},
-    true // Needs mission restart
-] call CBA_settings_fnc_init;
-
-[
-    QGVAR(disableForAI), "CHECKBOX",
-    [LSTRING(disableForAI_name), LSTRING(disableForAI_tooltip)],
-    LSTRING(category_displayName),
-    false, // default value
-    true, // isGlobal
-    {[QGVAR(disableForAI), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart
 ] call CBA_settings_fnc_init;
 

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -11,6 +11,16 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(disableForAI), "CHECKBOX",
+    [LSTRING(disableForAI_name), LSTRING(disableForAI_tooltip)],
+    LSTRING(category_displayName),
+    false, // default value
+    true, // isGlobal
+    {[QGVAR(disableForAI), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
+] call CBA_settings_fnc_init;
+
+[
     QGVAR(enableAmmobox), "CHECKBOX",
     [LSTRING(enableBoxCookoff_name), LSTRING(enableBoxCookoff_tooltip)],
     LSTRING(category_displayName),

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -4,7 +4,7 @@
     QGVAR(enable), "LIST",
     [LSTRING(enable_hd_name), LSTRING(enable_hd_tooltip)],
     LSTRING(category_displayName),
-    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", "STR_A3_OPTIONS_ENABLED", LSTRING(enableForPlayers)], 0],
+    [[0, 1, 2], ["STR_A3_OPTIONS_DISABLED", ELSTRING(common,playerOnly), ELSTRING(common,playersAndAI)], 0],
     true, // isGlobal
     {[QGVAR(enable), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -25,11 +25,8 @@
             <Japanese>誘爆の損傷処理と砲塔の爆発効果を変更します。</Japanese>
             <Russian>Изменяет обработку урона для возгорания и эффекта срыва башни</Russian>
         </Key>
-        <Key ID="STR_ACE_CookOff_disableForAI_name">
-            <English>Disable cook off for AI vehicles</English>
-        </Key>
-        <Key ID="STR_ACE_CookOff_disableForAI_tooltip">
-            <English>Cook off will only run on player crewed vehicles</English>
+        <Key ID="STR_ACE_CookOff_enableForPlayers_name">
+            <English>Enable for player crewed vehicles</English>
         </Key>
         <Key ID="STR_ACE_CookOff_generic_turret_wreck">
             <English>Wreck (Turret)</English>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -25,9 +25,6 @@
             <Japanese>誘爆の損傷処理と砲塔の爆発効果を変更します。</Japanese>
             <Russian>Изменяет обработку урона для возгорания и эффекта срыва башни</Russian>
         </Key>
-        <Key ID="STR_ACE_CookOff_enableForPlayers">
-            <English>Enable for player crewed vehicles</English>
-        </Key>
         <Key ID="STR_ACE_CookOff_generic_turret_wreck">
             <English>Wreck (Turret)</English>
             <French>Épave (tourelle)</French>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -25,7 +25,7 @@
             <Japanese>誘爆の損傷処理と砲塔の爆発効果を変更します。</Japanese>
             <Russian>Изменяет обработку урона для возгорания и эффекта срыва башни</Russian>
         </Key>
-        <Key ID="STR_ACE_CookOff_enableForPlayers_name">
+        <Key ID="STR_ACE_CookOff_enableForPlayers">
             <English>Enable for player crewed vehicles</English>
         </Key>
         <Key ID="STR_ACE_CookOff_generic_turret_wreck">

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -25,6 +25,12 @@
             <Japanese>誘爆の損傷処理と砲塔の爆発効果を変更します。</Japanese>
             <Russian>Изменяет обработку урона для возгорания и эффекта срыва башни</Russian>
         </Key>
+        <Key ID="STR_ACE_CookOff_disableForAI_name">
+            <English>Disable cook off for AI vehicles</English>
+        </Key>
+        <Key ID="STR_ACE_CookOff_disableForAI_tooltip">
+            <English>Cook off will only run on player crewed vehicles</English>
+        </Key>
         <Key ID="STR_ACE_CookOff_generic_turret_wreck">
             <English>Wreck (Turret)</English>
             <French>Épave (tourelle)</French>


### PR DESCRIPTION
**When merged this pull request will:**
- Add an extra cookoff setting to allow cookoff to only occur on player crewed vehicles

I know cookoff is now disabled by default due to it's weird issues where vehicles could take excessive amounts of damage. For people that mainly do co-ops it would be nice to still have it work for player controlled vehicles.

Tested locally and seems to work as expected, open to input especially on names (I'm terrible at them)!
