### PR TITLE
Common - Handle changes to UAVControl command (multi seat)

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -312,7 +312,7 @@ addMissionEventHandler ["PlayerViewChanged", {
         if (isNull player) exitWith {true};
         private _UAV = getConnectedUAV player;
         if (!alive player) then {_UAV = objNull;};
-        private _position = (UAVControl _UAV) param [1, ""];
+        private _position = [player] call FUNC(getUavControlPosition);
         private _seatAI = objNull;
         private _turret = [];
         switch (toLower _position) do {


### PR DESCRIPTION
https://community.bistudio.com/wiki/UAVControl
>Since Arma 3 v1.95.146028 this command returns both driver and gunner units if the UAV is controlled by 2 players. Here is the list of all expected outputs:
>[player1, "DRIVER", player2, "GUNNER"] - player1 is controlling the UAV and is the pilot, player2 is controlling UAV and is the gunner

Using UAV Terminal, I still can't control a UAV in-use by someone else, but maybe that will come later?