### PR TITLE
Fix ACE Arsenal accuracy stat bar being innacurate

### DIFF
--- a/addons/arsenal/functions/fnc_statBarStatement_accuracy.sqf
+++ b/addons/arsenal/functions/fnc_statBarStatement_accuracy.sqf
@@ -18,18 +18,19 @@
 
 params ["_stat", "_config", "_args"];
 _args params ["_statMinMax", "_barLimits"];
-TRACE_4("statBarStatement_accuracy",_stat,_config,_statMinMax,_barLimits);
 
 private _fireModes = getArray (_config >> "modes");
 private _dispersion = [];
 
 {
-    private _n = log (getNumber (_config >> _x >> "dispersion"));
-    if (!finite _n) then {_n = 0;};
-    _dispersion pushBackUnique _n;
+    if (getNumber (_config >> _x >> "showToPlayer") != 0) then {
+        private _n = log (getNumber (_config >> _x >> "dispersion"));
+
+        if (!finite _n) then {_n = 0;};
+        _dispersion pushBackUnique _n;
+    };
 } foreach _fireModes;
 
 _dispersion sort true;
-TRACE_1("",_dispersion);
 
 linearConversion [_statMinMax select 0, _statMinMax select 1, _dispersion param [0, 0], _barLimits select 0, _barLimits select 1]


### PR DESCRIPTION
- Fix statBarStatement still using AI values for firemodes 

Fixes #7162 