### PR TITLE
Use Slack badge from shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
         <img src="https://img.shields.io/badge/License-GPLv2-red.svg?style=flat-square" alt="ACE3 License">
     </a>
     <a href="https://slackin.ace3mod.com/">
-        <img src="https://slackin.ace3mod.com/badge.svg?style=flat-square&label=Slack" alt="ACE3 Slack">
+        <img src="https://img.shields.io/badge/Slack-Join-darkviolet.svg?style=flat-square" alt="ACE3 Slack">
     </a>
     <a href="https://circleci.com/gh/acemod/ACE3">
         <img src="https://circleci.com/gh/acemod/ACE3.svg?style=svg" alt="ACE3 Build Status">


### PR DESCRIPTION
**When merged this pull request will:**
- Use Slack badge from shields.io
  - No longer using Slackin, Community Inviter does not provide a Markdown badge.
