### PR TITLE
Safemode - Fixed keybind conflict

### DIFF
--- a/addons/safemode/functions/fnc_lockSafety.sqf
+++ b/addons/safemode/functions/fnc_lockSafety.sqf
@@ -17,9 +17,6 @@
  * Public: No
  */
 
-// don't immediately switch back
-if (inputAction "nextWeapon" > 0) exitWith {};
-
 params ["_unit", "_weapon", "_muzzle"];
 
 private _safedWeapons = _unit getVariable [QGVAR(safedWeapons), []];


### PR DESCRIPTION
**When merged this pull request will:**
-  Remove a (legacy?) check from fnc_lockSafety which prevented it from working if the keybind was a superset of the vanilla 'switch fire mode' keybind. The check seems to be trying to prevent a conflict, but that's already handled by cba keybinds.

Example:
 - switch fire mode - F
 - toggle safety - Ctrl+F
 - when pressing Ctrl+F nothing happens