### PR TITLE
Wiki - Fix incorrect fortify chat command example

### DIFF
--- a/docs/wiki/frameworkx/fortify-framework.md
+++ b/docs/wiki/frameworkx/fortify-framework.md
@@ -63,7 +63,7 @@ class ACEX_Fortify_Presets {
     };
  ```
 
- Then you will have to set the mission preset to `myMissionObjects` with `#fortify blufor myMissionObjects` to enable it.
+ Then you will have to set the mission preset to `myMissionObjects` with `#ace-fortify blufor myMissionObjects` to enable it.
  
 ## 1.3 Adding custom deploy handlers
 


### PR DESCRIPTION
**When merged this pull request will:**
- Chat command is `#ace-fortify` not `#fortify`, acemod/ACEX#192
