### PR TITLE
Spectator - Restore HUD when coming out of spectator

### DIFF
--- a/addons/spectator/functions/fnc_ui.sqf
+++ b/addons/spectator/functions/fnc_ui.sqf
@@ -187,4 +187,7 @@ if (_init) then {
 
     // Ensure chat is shown again
     showChat true;
+
+    // Restore HUD
+    [] call EFUNC(common,showHud);
 };


### PR DESCRIPTION
Fixes #7186

**When merged this pull request will:**
- Restore HUD for player when coming out of spectator just in case it was hidden by `ace_spectator_fnc_cam_setCameraMode`
