### PR TITLE
Medical GUI - Localize partial wound, fix injury list color flashing

### DIFF
--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -72,7 +72,7 @@ switch (GET_FRACTURES(_target) select _selectionN) do {
 };
 
 // Indicate the amount of pain the unit is in
-if ([_target] call EFUNC(common,isAwake)) then {
+if (_target call EFUNC(common,isAwake)) then {
     private _pain = GET_PAIN_PERCEIVED(_target);
     if (_pain > 0) then {
         private _painText = switch (true) do {
@@ -113,7 +113,7 @@ private _fnc_getWoundDescription = {
     if (_amountOf >= 1) then {
         format ["%1x %2", ceil _amountOf, _woundName];
     } else {
-        format ["Partial %1", _woundName];
+        format [localize LSTRING(PartialX), _woundName];
     };
 };
 
@@ -156,7 +156,8 @@ lbClear _ctrl;
 
 {
     _x params ["_text", "_color"];
-    private _index = _ctrl lbAdd _text;
-    _ctrl lbSetColor [_index, _color];
-    _ctrl lbSetSelectColor [_index, _color];
+
+    _ctrl lbSetColor [_ctrl lbAdd _text, _color];
 } forEach _entries;
+
+_ctrl lbSetCurSel -1;

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -916,5 +916,8 @@
             <Chinesesimp>检伤分类卡</Chinesesimp>
             <Chinese>檢傷分類卡</Chinese>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_PartialX">
+            <English>Partial %1</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add stringtable entry for "Partial %1" wound description
- Fix injury list color flashing when an entry was selected
