### PR TITLE
Add Extensions CI Workflow (Windows)

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -3,7 +3,11 @@ name: Extensions CI
 on:
   pull_request:
     paths:
-    - extensions/**
+    - 'extensions/**'
+      #- 'extensions/*/*'
+      #- 'extensions/*/*/*'
+      #- 'extensions/*/*/*/*'
+      #- 'extensions/*/*/*/*/*'
 
 jobs:
   build:

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix. os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
 
     steps:
     - name: Checkout the source code
@@ -26,5 +26,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@master
       with:
-        name: ace3_extensions-${{ matrix.os }}
+        name: ace3_extensions-${{ matrix.os }}-debug
         path: extensions/build

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,4 +1,4 @@
-name: Extensions CI
+name: Extensions
 
 on:
   pull_request:

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,0 +1,26 @@
+name: Extensions CI
+
+on:
+  pull_request:
+    paths:
+    - extensions/**
+
+jobs:
+  build:
+    runs-on: ${{ matrix. os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@master
+    - name: Build
+      run: |
+        cd extensions/build
+        cmake .. && cmake --build .
+    - name: Upload Artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: ace3_extensions-${{ matrix.os }}
+        path: extensions/build

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -3,11 +3,11 @@ name: Extensions CI
 on:
   pull_request:
     paths:
-    - 'extensions/**'
-      #- 'extensions/*/*'
-      #- 'extensions/*/*/*'
-      #- 'extensions/*/*/*/*'
-      #- 'extensions/*/*/*/*/*'
+    - 'extensions/*'
+    - 'extensions/*/*'
+    - 'extensions/*/*/*'
+    - 'extensions/*/*/*/*'
+    - 'extensions/*/*/*/*/*'
 
 jobs:
   build:

--- a/extensions/medical/DamageType.cpp
+++ b/extensions/medical/DamageType.cpp
@@ -5,6 +5,7 @@ ace::medical::injuries::DamageType::DamageType(std::string aTypeName, double min
 {
 }
 
+
 ace::medical::injuries::DamageType::~DamageType()
 {
 }

--- a/extensions/medical/DamageType.cpp
+++ b/extensions/medical/DamageType.cpp
@@ -5,7 +5,6 @@ ace::medical::injuries::DamageType::DamageType(std::string aTypeName, double min
 {
 }
 
-
 ace::medical::injuries::DamageType::~DamageType()
 {
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Build extensions on every PR that makes changes in `extensions/` folder or its sub-folders (max 5 levels deep due to no `**` pattern support) and provide them in build artifacts for easier testing (they will not be built in `RelWithDebInfo` for Windows, but just `Debug`.

Only Windows at the moment. Not sure how to install multilib package on Ubuntu for `bits/c++config.h`.