### PR TITLE
Arsenal - Don't force Camera position in Arsenal Loadouts list

### DIFF
--- a/addons/arsenal/functions/fnc_onLoadoutsClose.sqf
+++ b/addons/arsenal/functions/fnc_onLoadoutsClose.sqf
@@ -18,8 +18,6 @@ GVAR(currentLoadoutsTab) = nil;
 private _arsenalDisplay = findDisplay IDD_ace_arsenal;
 private _mouseBlockCtrl = _arsenalDisplay displayCtrl IDC_mouseBlock;
 
-GVAR(cameraPosition) = GVAR(previousCameraPos);
-GVAR(previousCameraPos) = nil;
 GVAR(loadoutsSearchbarFocus) = nil;
 GVAR(loadoutsPanelFocus) =  nil;
 

--- a/addons/arsenal/functions/fnc_onLoadoutsOpen.sqf
+++ b/addons/arsenal/functions/fnc_onLoadoutsOpen.sqf
@@ -30,9 +30,6 @@ GVAR(currentLoadoutsTab) = -1;
 GVAR(loadoutsSearchbarFocus) = false;
 GVAR(loadoutsPanelFocus) =  false;
 
-GVAR(previousCameraPos) = GVAR(cameraPosition);
-GVAR(cameraPosition) = [5,0,20,[-0.85,0,0.85]];
-
 private _panelContentCtrl = _display displayCtrl IDC_contentPanel;
 _panelContentCtrl ctrlSetFontHeight (4.5 * GRID_H);
 _panelContentCtrl ctrlCommit 0;


### PR DESCRIPTION
It's plain annoying when you are close to a building or wall or any kind of obstacle, then carefully position your camera such that you can see yourself,
but once you open the loadouts selection your camera is suddenly inside a wall and you see pure nothingness, or another player is standing in the way such that you can't see yourself.

You have to constantly enter/leave the loadouts menu to be able to see if the loadout that you just loaded is the one you wanted, and opening the loadout menu with dozens of saved loadouts is quite slow.