### PR TITLE
Remove duplicate class declaration from laserpointer

### DIFF
--- a/addons/laserpointer/CfgJointRails.hpp
+++ b/addons/laserpointer/CfgJointRails.hpp
@@ -7,7 +7,6 @@ class asdg_FrontSideRail: asdg_SlotInfo {
     };
 };
 
-class PointerSlot;
 class PointerSlot_Rail: PointerSlot {
     class compatibleItems {
         ACE_acc_pointer_red = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix laserpointer not building

https://github.com/acemod/ACE3/blob/e8b104fe6129f33c1fb2b981afdf4dcf38a2ee13/addons/laserpointer/CfgWeapons.hpp#L3