### PR TITLE
Update RHS AFRF static weapon carry icons

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -169,7 +169,7 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\podnos_2b14_ca.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_2b14_82mm_msv_ca.paa";
     };
 
     class GVAR(nsv_carry): Launcher_Base_F {
@@ -189,7 +189,7 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\mg\bis_kord\kord_CA.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\RHS_NSV_TriPod_MSV_ca.paa";
     };
 
     class GVAR(kord_carry): Launcher_Base_F {
@@ -210,7 +210,7 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\kord6u16sp_ca.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_KORD_MSV_ca.paa";
     };
 
     class GVAR(ags30_carry): Launcher_Base_F {
@@ -230,7 +230,7 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\ags_static_CA.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\RHS_AGS30_TriPod_MSV_ca.paa";
     };
 
     class GVAR(spg9_carry): Launcher_Base_F {
@@ -250,7 +250,7 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\spg9_CA.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_SPG9_INS_ca.paa";
     };
     class GVAR(spg9m_carry): GVAR(spg9_carry) {
         class ACE_CSW {
@@ -276,7 +276,7 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\metis_at13_CA.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_Metis_9k115_2_msv_ca.paa";
     };
 
     class GVAR(kornet_carry): Launcher_Base_F {
@@ -294,6 +294,6 @@ class CfgWeapons {
         scope = 2;
         model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
         modes[] = {};
-        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\metis_at13_CA.paa";
+        picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_Kornet_9M133_2_msv_ca.paa";
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix missing RHS AFRF static weapon icons
- Change 3d-ish Kord image used by NSV to same style as the other icons and correct NSV image
- Change Metis image used by Kornet to correct Kornet image

**Current pboproject output:**
```
Warning: rapWarning: **********missing file(s)***************
Warning: \z\ace\addons\compat_rhs_afrf3\CfgWeapons.hpp circa Line 172: \rhsafrf\addons\rhs_heavyweapons\data\ico\podnos_2b14_ca.paa
Warning: \z\ace\addons\compat_rhs_afrf3\CfgWeapons.hpp circa Line 213: \rhsafrf\addons\rhs_heavyweapons\data\ico\kord6u16sp_ca.paa
Warning: \z\ace\addons\compat_rhs_afrf3\CfgWeapons.hpp circa Line 233: \rhsafrf\addons\rhs_heavyweapons\data\ico\ags_static_CA.paa
Warning: \z\ace\addons\compat_rhs_afrf3\CfgWeapons.hpp circa Line 253: \rhsafrf\addons\rhs_heavyweapons\data\ico\spg9_CA.paa
Warning: \z\ace\addons\compat_rhs_afrf3\CfgWeapons.hpp circa Line 279: \rhsafrf\addons\rhs_heavyweapons\data\ico\metis_at13_CA.paa
Warning: \z\ace\addons\compat_rhs_afrf3\CfgWeapons.hpp circa Line 297: \rhsafrf\addons\rhs_heavyweapons\data\ico\metis_at13_CA.paa
\z\ace\addons\compat_rhs_afrf3\config.cpp has errors
rapWarning: **********missing file(s)***************

Missing File Summary
CfgWeapons.hpp : \rhsafrf\addons\rhs_heavyweapons\data\ico\podnos_2b14_ca.paa
CfgWeapons.hpp : \rhsafrf\addons\rhs_heavyweapons\data\ico\kord6u16sp_ca.paa
CfgWeapons.hpp : \rhsafrf\addons\rhs_heavyweapons\data\ico\ags_static_CA.paa
CfgWeapons.hpp : \rhsafrf\addons\rhs_heavyweapons\data\ico\spg9_CA.paa
CfgWeapons.hpp : \rhsafrf\addons\rhs_heavyweapons\data\ico\metis_at13_CA.paa
"compat_rhs_afrf3.pbo not produced due to error(s)"
```