### PR TITLE
Common - Optimize arithmeticGetResult function

### DIFF
--- a/addons/common/functions/fnc_arithmeticGetResult.sqf
+++ b/addons/common/functions/fnc_arithmeticGetResult.sqf
@@ -1,12 +1,12 @@
 #include "script_component.hpp"
 /*
  * Author: PabstMirror
- * Gets arithmetic result from a set.
+ * Returns the arithmetic result of performing the given operation on a set.
  *
  * Arguments:
- * 0: Namespace <OBJECT><LOCATION><MISSIONNAMESPACE>
+ * 0: Namespace <OBJECT|LOCATION|NAMESPACE>
  * 1: Number Set ID <STRING>
- * 2: Operation (sum, product, min, max, avg) (Case Sensitive) <STRING>
+ * 2: Operation (max, min, sum, product, avg) (Case Sensitive) <STRING>
  *
  * Return Value:
  * Value <NUMBER>
@@ -18,51 +18,44 @@
  * Public: Yes
  */
 
-params ["_namespace", "_setID", "_op"];
-TRACE_3("arithmeticGetResult",_namespace,_setID,_op);
+params ["_namespace", "_setID", "_operation"];
+TRACE_3("arithmeticGetResult",_namespace,_setID,_operation);
 
 private _data = (_namespace getVariable _setID) param [2, []];
 
-switch (_op) do {
-    case ("max"): {
-        private _result = -1e99;
-        {
-            _result = _result max (call _x);
-            nil
-        } count _data;
-        _result // return
+switch (_operation) do {
+    case "max": {
+        selectMax (_data apply {call _x})
     };
-    case ("sum"): {
+    case "min": {
+        selectMin (_data apply {call _x})
+    };
+    case "sum": {
         private _result = 0;
+
         {
-            _result = _result + (call _x);
-            nil
-        } count _data;
-        _result // return
+            _result = _result + call _x;
+        } forEach _data;
+
+        _result
     };
-    case ("product"): {
+    case "product": {
         private _result = 1;
+
         {
-            _result = _result * (call _x);
-            nil
-        } count _data;
-        _result // return
+            _result = _result * call _x;
+        } forEach _data;
+
+        _result
     };
-    case ("min"): {
-        private _result = 1e99;
-        {
-            _result = _result min (call _x);
-            nil
-        } count _data;
-        _result // return
-    };
-    case ("avg"): {
+    case "avg": {
         private _result = 0;
+
         {
-            _result = _result + (call _x);
-            nil
-        } count _data;
-        _result / (count _data); // return
+            _result = _result + call _x;
+        } forEach _data;
+
+        _result / count _data
     };
     default {3735928559};
 };

--- a/addons/common/functions/fnc_arithmeticGetResult.sqf
+++ b/addons/common/functions/fnc_arithmeticGetResult.sqf
@@ -21,7 +21,7 @@
 params ["_namespace", "_setID", "_operation"];
 TRACE_3("arithmeticGetResult",_namespace,_setID,_operation);
 
-private _data = (_namespace getVariable _setID) param [2, []];
+private _data = (_namespace getVariable _setID) param [2, [{0}]];
 
 switch (_operation) do {
     case "max": {

--- a/addons/common/functions/fnc_arithmeticSetSource.sqf
+++ b/addons/common/functions/fnc_arithmeticSetSource.sqf
@@ -4,7 +4,7 @@
  * Adds or removes a source to an arithmetic set.
  *
  * Arguments:
- * 0: Namespace <OBJECT><LOCATION><MISSIONNAMESPACE>
+ * 0: Namespace <OBJECT|LOCATION|NAMESPACE>
  * 1: Number Set ID <STRING>
  * 2: Source <STRING>
  * 3: Code that returns a number (can access var _namespace) [use {} to remove] <CODE>
@@ -20,13 +20,15 @@
  */
 
 params ["_namespace", "_setID", "_source", "_variable"];
-TRACE_4("params",_namespace,_setID,_source,_variable);
+TRACE_4("arithmeticSetSource",_namespace,_setID,_source,_variable);
 
 private _hash = _namespace getVariable _setID;
+
 if (isNil "_hash") then {
     _hash = [] call CBA_fnc_hashCreate;
     _namespace setVariable [_setID, _hash];
 };
+
 if (_variable isEqualTo {}) then {
     TRACE_1("removing",_source);
     [_hash, _source] call CBA_fnc_hashRem;


### PR DESCRIPTION
**When merged this pull request will:**
- Optimize `arithmeticGetResult` common function by using `selectMax` and `selectMin` commands rather than `count` loop
    - Will provide a small performance improvement
    - For the current `ACE_setCustomAimCoef` (2 sources) with the "max" operation: ~0.0234 ms to ~0.0207 ms
- Change `count` to `forEach` (faster than `count` + `true/false/nil`)
- Cleanup some unnecessary parentheses
