### PR TITLE
Repair - Add settings to control item requirements for different actions

### DIFF
--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -37,7 +37,7 @@ class ACE_Repair {
             requiredEngineer = QGVAR(engineerSetting_Repair);
             repairingTime = 15;
             callbackSuccess = QUOTE(call FUNC(doRepair));
-            items[] = {"ToolKit"};
+            items = QGVAR(miscRepairRequiredItems);
             itemConsumed = QGVAR(consumeItem_ToolKit);
             claimObjects[] = {};
         };
@@ -74,6 +74,7 @@ class ACE_Repair {
             repairingTime = 30;
             condition = "-1 != ((getAllHitPointsDamage _target param [2,[]]) findIf {_x > 0})";
             callbackSuccess = QUOTE(call FUNC(doFullRepair));
+            items = QGVAR(fullRepairRequiredItems);
             itemConsumed = QGVAR(consumeItem_ToolKit);
         };
     };

--- a/addons/repair/ACE_Settings.hpp
+++ b/addons/repair/ACE_Settings.hpp
@@ -1,4 +1,3 @@
-// Warning: do not remove without handling wheelRepairRequiredItems's _values config on line 32 [used in repair/canRepair]
 class ACE_Settings {
     class GVAR(displayTextOnRepair) {
         movedToSQF = 1;
@@ -29,7 +28,6 @@ class ACE_Settings {
     };
     class GVAR(wheelRepairRequiredItems) {
         movedToSQF = 1;
-        _values[] = {{}, {"ToolKit"}};
     };
     class GVAR(autoShutOffEngineWhenStartingRepair) {
         movedToSQF = 1;

--- a/addons/repair/functions/fnc_canRepair.sqf
+++ b/addons/repair/functions/fnc_canRepair.sqf
@@ -37,16 +37,11 @@ private _engineerRequired = if (isNumber (_config >> "requiredEngineer")) then {
 };
 if !([_caller, _engineerRequired] call FUNC(isEngineer)) exitWith {false};
 
-//Items can be an array of required items or a string to a ACE_Setting array
+// Items can be an array of required items or a string to a missionNamespace variable
 private _items = if (isArray (_config >> "items")) then {
     getArray (_config >> "items");
 } else {
-    private _settingName = getText (_config >> "items");
-    private _settingItemsArray = getArray (configFile >> "ACE_Settings" >> _settingName >> "_values");
-    if ((isNil _settingName) || {(missionNamespace getVariable _settingName) >= (count _settingItemsArray)}) exitWith {
-        ERROR("bad setting"); ["BAD"]
-    };
-    _settingItemsArray select (missionNamespace getVariable _settingName);
+    missionNamespace getVariable [getText (_config >> "items"), []]
 };
 if (count _items > 0 && {!([_caller, _items] call FUNC(hasItems))}) exitWith {false};
 

--- a/addons/repair/functions/fnc_repair.sqf
+++ b/addons/repair/functions/fnc_repair.sqf
@@ -43,16 +43,11 @@ if ((isEngineOn _target) && {!GVAR(autoShutOffEngineWhenStartingRepair)}) exitWi
     false
 };
 
-//Items can be an array of required items or a string to a ACE_Setting array
+// Items can be an array of required items or a string to a missionNamespace variable
 private _items = if (isArray (_config >> "items")) then {
     getArray (_config >> "items");
 } else {
-    private _settingName = getText (_config >> "items");
-    private _settingItemsArray = getArray (configFile >> "ACE_Settings" >> _settingName >> "_values");
-    if ((isNil _settingName) || {(missionNamespace getVariable _settingName) >= (count _settingItemsArray)}) exitWith {
-        ERROR("bad setting"); ["BAD"]
-    };
-    _settingItemsArray select (missionNamespace getVariable _settingName);
+    missionNamespace getVariable [getText (_config >> "items"), []]
 };
 if (count _items > 0 && {!([_caller, _items] call FUNC(hasItems))}) exitWith {false};
 

--- a/addons/repair/initSettings.sqf
+++ b/addons/repair/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_repair]:
-
 [
     QGVAR(displayTextOnRepair), "CHECKBOX",
     [LSTRING(SettingDisplayTextName), LSTRING(SettingDisplayTextDesc)],
@@ -11,7 +9,7 @@
 
 [
     QGVAR(engineerSetting_repair), "LIST",
-    [LSTRING(engineerSetting_Repair_name), LSTRING(engineerSetting_Repair_description)], 
+    [LSTRING(engineerSetting_Repair_name), LSTRING(engineerSetting_Repair_description)],
     [localize ELSTRING(OptionsMenu,CategoryLogistics), localize "str_state_repair"],
     [[0,1,2],[LSTRING(engineerSetting_anyone), LSTRING(engineerSetting_EngineerOnly), LSTRING(engineerSetting_AdvancedOnly)],1], // [values, titles, defaultIndex]
     true, // isGlobal
@@ -83,12 +81,30 @@
 ] call CBA_settings_fnc_init;
 
 [
-    QGVAR(wheelRepairRequiredItems), "LIST",
-    [LSTRING(wheelRepairRequiredItems_name), LSTRING(wheelRepairRequiredItems_description)],
+    QGVAR(wheelRepairRequiredItems),
+    "LIST",
+    [LSTRING(WheelRepairRequiredItems_DisplayName), LSTRING(WheelRepairRequiredItems_Description)],
     [localize ELSTRING(OptionsMenu,CategoryLogistics), localize "str_state_repair"],
-    [[0,1],["None", "ToolKit"],0], // [values, titles, defaultIndex]
-    true, // isGlobal
-    {[QGVAR(wheelRepairRequiredItems), _this] call EFUNC(common,cbaSettings_settingChanged)}
+    [[[], ["ToolKit"]], ["STR_A3_None", "STR_A3_CfgWeapons_Toolkit0"], 0],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(miscRepairRequiredItems),
+    "LIST",
+    [LSTRING(MiscRepairRequiredItems_DisplayName), LSTRING(MiscRepairRequiredItems_Description)],
+    [localize ELSTRING(OptionsMenu,CategoryLogistics), localize "str_state_repair"],
+    [[[], ["ToolKit"]], ["STR_A3_None", "STR_A3_CfgWeapons_Toolkit0"], 1],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(fullRepairRequiredItems),
+    "LIST",
+    [LSTRING(FullRepairRequiredItems_DisplayName), LSTRING(FullRepairRequiredItems_Description)],
+    [localize ELSTRING(OptionsMenu,CategoryLogistics), localize "str_state_repair"],
+    [[[], ["ToolKit"]], ["STR_A3_None", "STR_A3_CfgWeapons_Toolkit0"], 1],
+    true
 ] call CBA_settings_fnc_init;
 
 [

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1783,8 +1783,8 @@
             <Chinesesimp>选择的备件数量</Chinesesimp>
             <Chinese>選擇的備件數量</Chinese>
         </Key>
-        <Key ID="STR_ACE_Repair_wheelRepairRequiredItems_name">
-            <English>Wheel repair requirements</English>
+        <Key ID="STR_ACE_Repair_WheelRepairRequiredItems_DisplayName">
+            <English>Wheel Repair Requirements</English>
             <German>Erfordernisse zur Reifenreperatur</German>
             <Polish>Wym. naprawy kół</Polish>
             <Spanish>Requisitos de reparación de ruedas</Spanish>
@@ -1798,8 +1798,8 @@
             <Chinesesimp>维修轮胎限制</Chinesesimp>
             <Chinese>維修輪胎限制</Chinese>
         </Key>
-        <Key ID="STR_ACE_Repair_wheelRepairRequiredItems_description">
-            <English>Items required to remove/replace wheels</English>
+        <Key ID="STR_ACE_Repair_WheelRepairRequiredItems_Description">
+            <English>Items required to remove/replace wheels.</English>
             <German>Gegenstänge, die zum Entfernen/Austauschen eines Reifens benötigt werden</German>
             <Polish>Przedmioty potrzebne do wymiany kół</Polish>
             <Spanish>Elementos necesarios para quitar/cambiar ruedas</Spanish>
@@ -1812,6 +1812,18 @@
             <Korean>바퀴를 제거/교체하는데 필요한 물건</Korean>
             <Chinesesimp>需要特定物品来移除/更换车轮</Chinesesimp>
             <Chinese>需要特定物品來移除/更換車輪</Chinese>
+        </Key>
+        <Key ID="STR_ACE_Repair_MiscRepairRequiredItems_DisplayName">
+            <English>Misc Repair Requirements</English>
+        </Key>
+        <Key ID="STR_ACE_Repair_MiscRepairRequiredItems_Description">
+            <English>Items required to repair a specific vehicle component or remove/replace tracks.</English>
+        </Key>
+        <Key ID="STR_ACE_Repair_FullRepairRequiredItems_DisplayName">
+            <English>Full Repair Requirements</English>
+        </Key>
+        <Key ID="STR_ACE_Repair_FullRepairRequiredItems_Description">
+            <English>Items required to perform a full vehicle repair.</English>
         </Key>
         <Key ID="STR_ACE_Repair_shutOffEngineWarning">
             <English>Engine must be off to repair</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add `miscRepairRequiredItems` and `fullRepairRequiredItems` settings to control whether a toolkit is required for misc and full repairs
- Remove need to read `_values` array from `ACE_Settings` config
- Close #6549 