### PR TITLE
Remove PhysX from ugl smoke grenades

### DIFF
--- a/addons/grenades/CfgAmmo.hpp
+++ b/addons/grenades/CfgAmmo.hpp
@@ -1,4 +1,3 @@
-
 class CfgAmmo {
     class Default;
     class Grenade: Default {
@@ -160,5 +159,76 @@ class CfgAmmo {
         effectsSmoke = "ACE_Incendiary";
         whistleDist = 0;    // no BIS explosion effects
         whistleOnFire = 0;  // no BIS firing effects
+    };
+
+    // fix smoke bounce
+    class G_40mm_Smoke;
+    class ACE_G_40mm_Smoke: G_40mm_Smoke {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_Smoke_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_Smoke_invisible): G_40mm_Smoke {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+
+    class G_40mm_SmokeRed;
+    class ACE_G_40mm_SmokeRed: G_40mm_SmokeRed {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_SmokeRed_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_SmokeRed_invisible): G_40mm_SmokeRed {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+
+    class G_40mm_SmokeGreen;
+    class ACE_G_40mm_SmokeGreen: G_40mm_SmokeGreen {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_SmokeGreen_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_SmokeGreen_invisible): G_40mm_SmokeGreen {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+
+    class G_40mm_SmokeYellow;
+    class ACE_G_40mm_SmokeYellow: G_40mm_SmokeYellow {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_SmokeYellow_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_SmokeYellow_invisible): G_40mm_SmokeYellow {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+
+    class G_40mm_SmokePurple;
+    class ACE_G_40mm_SmokePurple: G_40mm_SmokePurple {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_SmokePurple_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_SmokePurple_invisible): G_40mm_SmokePurple {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+
+    class G_40mm_SmokeBlue;
+    class ACE_G_40mm_SmokeBlue: G_40mm_SmokeBlue {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_SmokeBlue_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_SmokeBlue_invisible): G_40mm_SmokeBlue {
+        model = "\A3\weapons_f\empty.p3d";
+    };
+
+    class G_40mm_SmokeOrange;
+    class ACE_G_40mm_SmokeOrange: G_40mm_SmokeOrange {
+        GVAR(attachedAmmo) = QGVAR(G_40mm_SmokeOrange_invisible);
+        simulation = "shotDeploy";
+        deflectionSlowDown = 0.3;
+    };
+    class GVAR(G_40mm_SmokeOrange_invisible): G_40mm_SmokeOrange {
+        model = "\A3\weapons_f\empty.p3d";
     };
 };

--- a/addons/grenades/CfgMagazines.hpp
+++ b/addons/grenades/CfgMagazines.hpp
@@ -1,4 +1,3 @@
-
 class CfgMagazines {
     class HandGrenade;
     class ACE_HandFlare_Base: HandGrenade {
@@ -119,5 +118,29 @@ class CfgMagazines {
         ammo = "ACE_40mm_Flare_ir";
         displayName = CSTRING(40mm_flare_ir);
         descriptionShort = CSTRING(parachute_flare_ir_description);
+    };
+
+    // fix smoke bounce
+    class 1Rnd_HE_Grenade_shell;
+    class 1Rnd_Smoke_Grenade_shell: 1Rnd_HE_Grenade_shell {
+        ammo = "ACE_G_40mm_Smoke";
+    };
+    class 1Rnd_SmokeRed_Grenade_shell: 1Rnd_Smoke_Grenade_shell {
+        ammo = "ACE_G_40mm_SmokeRed";
+    };
+    class 1Rnd_SmokeGreen_Grenade_shell: 1Rnd_Smoke_Grenade_shell {
+        ammo = "ACE_G_40mm_SmokeGreen";
+    };
+    class 1Rnd_SmokeYellow_Grenade_shell: 1Rnd_Smoke_Grenade_shell {
+        ammo = "ACE_G_40mm_SmokeYellow";
+    };
+    class 1Rnd_SmokePurple_Grenade_shell: 1Rnd_Smoke_Grenade_shell {
+        ammo = "ACE_G_40mm_SmokePurple";
+    };
+    class 1Rnd_SmokeBlue_Grenade_shell: 1Rnd_Smoke_Grenade_shell {
+        ammo = "ACE_G_40mm_SmokeBlue";
+    };
+    class 1Rnd_SmokeOrange_Grenade_shell: 1Rnd_Smoke_Grenade_shell {
+        ammo = "ACE_G_40mm_SmokeOrange";
     };
 };

--- a/addons/grenades/CfgVehicles.hpp
+++ b/addons/grenades/CfgVehicles.hpp
@@ -1,4 +1,3 @@
-
 class CfgVehicles {
     class NATO_Box_Base;
     class Box_NATO_Grenades_F: NATO_Box_Base {

--- a/addons/grenades/CfgWeapons.hpp
+++ b/addons/grenades/CfgWeapons.hpp
@@ -1,4 +1,3 @@
-
 class CfgWeapons {
     class GrenadeLauncher;
     class Throw: GrenadeLauncher {

--- a/addons/grenades/functions/fnc_throwGrenade.sqf
+++ b/addons/grenades/functions/fnc_throwGrenade.sqf
@@ -26,9 +26,9 @@ if (isNull _projectile) then {
 private _config = configFile >> "CfgAmmo" >> _ammo;
 
 // fix smoke bounce
-if (isText (_config >> QGVAR(attachedAmmo)) && {local _unit}) then {
+if (isText (_config >> QGVAR(attachedAmmo))) then {
     private _attachedAmmo = getText (_config >> QGVAR(attachedAmmo));
-    private _attachedProjectile = _attachedAmmo createVehicle [0,0,0];
+    private _attachedProjectile = _attachedAmmo createVehicleLocal [0,0,0];
     _attachedProjectile attachTo [_projectile, [0,0,0]];
 };
 

--- a/addons/grenades/functions/fnc_throwGrenade.sqf
+++ b/addons/grenades/functions/fnc_throwGrenade.sqf
@@ -18,14 +18,21 @@
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle", "_gunner", "_turret"];
 TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile, _vehicle, _gunner, _turret);
 
-if (_weapon != "Throw") exitWith {};
-
 // http://feedback.arma3.com/view.php?id=12340
 if (isNull _projectile) then {
     _projectile = nearestObject [_unit, _ammo];
 };
 
 private _config = configFile >> "CfgAmmo" >> _ammo;
+
+// fix smoke bounce
+if (isText (_config >> QGVAR(attachedAmmo)) && {local _unit}) then {
+    private _attachedAmmo = getText (_config >> QGVAR(attachedAmmo));
+    private _attachedProjectile = _attachedAmmo createVehicle [0,0,0];
+    _attachedProjectile attachTo [_projectile, [0,0,0]];
+};
+
+if (_weapon != "Throw") exitWith {};
 
 // handle special grenades and sounds
 if (local _unit) then {


### PR DESCRIPTION
**When merged this pull request will:**
With default values, the only (apparent) differences between shotSmokeX and shotDeploy are:
- no smoke creation
- no smoke sound
- old physics with configurable bounce (`deflectionSlowDown` etc.)

shotSmoke has smoke creation, but no smoke sounds, which is why #4648 was rejected.

Best way to achieve old physcis, but with smoke sound was to attach a shotSmokeX to a shotShell/shotSmoke/shotDeploy. Of these shotDeploy is the only one that has no side effects (explosion of shotShell, [duplicate] smoke creation of shotSmoke) with default values.
There don't seem to be duplicated bounce sound effects, likely because (most) physics are disabled for attached objects.

Both, the "physics projectile" (shotDeploy) and the "smoke projectile" (shotSmokeX) are deleted after timeToLive.