### PR TITLE
Medical - Change WoundReopening default setting

### DIFF
--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -25,7 +25,7 @@
     "CHECKBOX",
     [LSTRING(WoundReopening_DisplayName), LSTRING(WoundReopening_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    true,
+    false,
     true
 ] call CBA_settings_fnc_init;
 


### PR DESCRIPTION
Just changes the default of woundReopening; 
I believe this setting has a high chance of causing confusion for unexperienced player.

Matches old medical
```
class GVAR(enableAdvancedWounds) {
    value = 0;
```