### PR TITLE
Map - Fix map shake moving to upper left corner

### DIFF
--- a/addons/map/functions/fnc_initMainMap.sqf
+++ b/addons/map/functions/fnc_initMainMap.sqf
@@ -7,6 +7,12 @@ if (ctrlIDD _display != IDD_MAIN_MAP) exitWith {};
 private _control = _display displayCtrl IDC_MAP;
 
 GVAR(lastStillPosition) = _control ctrlMapScreenToWorld [0.5, 0.5];
+[{
+    if (!GVAR(isShaking)) then { // player map position won't be correct until a frame later
+        GVAR(lastStillPosition) = _this ctrlMapScreenToWorld [0.5, 0.5];
+    };
+}, _control] call CBA_fnc_execNextFrame;
+
 GVAR(lastStillTime) = CBA_missionTime;
 GVAR(isShaking) = false;
 


### PR DESCRIPTION
Start walking then open map for the first time and it always radically moves map to uppper left corner of map.

`ctrlMapScreenToWorld [0.5, 0.5];` doesn't seem to be set until a frame after it's init