### PR TITLE
Arsenal -  Fix script error for weapons with 3+ muzzles

### DIFF
--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -78,7 +78,7 @@ private _compatibleMagazines = [[[], []], [[], []], [[], []]];
         private _index = _forEachIndex;
 
         {
-            private _subIndex = _forEachIndex;
+            private _subIndex = _forEachIndex min 1;
             {
                 ((_compatibleMagazines select _index) select _subIndex) pushBackUnique (configName (configFile >> "CfgMagazines" >> _x))
             } foreach ([getArray (_weaponConfig >> _x >> "magazines"), getArray (_weaponConfig >> "magazines")] select (_x == "this"));


### PR DESCRIPTION
Contact device has 10 muzzles
```
13:00:00 Error in expression <{
((_compatibleMagazines select _index) select _subIndex) pushBackUnique (config>
13:00:00   Error position: <select _subIndex) pushBackUnique (config>
13:00:00   Error Zero divisor
13:00:00 File z\ace\addons\arsenal\functions\fnc_fillRightPanel.sqf..., line 83
```