### PR TITLE
Tagging - Group spray paint items in Arsenal

### DIFF
--- a/addons/tagging/stringtable.xml
+++ b/addons/tagging/stringtable.xml
@@ -178,7 +178,7 @@
             <English>Spray Paint (Black)</English>
             <German>Sprühfarbe (Schwarz)</German>
             <Spanish>Pintura negra</Spanish>
-            <Polish>Czarna farba w sprayu</Polish>
+            <Polish>Farba w Sprayu (Czarna)</Polish>
             <French>Peinture pulvérisée noire</French>
             <Italian>Bomboletta spray nera</Italian>
             <Czech>Černý sprej</Czech>
@@ -193,7 +193,7 @@
             <English>Spray Paint (Red)</English>
             <German>Sprühfarbe (Rot)</German>
             <Spanish>Pintura roja</Spanish>
-            <Polish>Czerwona farba w sprayu</Polish>
+            <Polish>Farba w Sprayu (Czerwona)</Polish>
             <French>Peinture pulvérisée rouge</French>
             <Italian>Bomboletta spray rossa</Italian>
             <Czech>Červený sprej</Czech>
@@ -208,7 +208,7 @@
             <English>Spray Paint (Green)</English>
             <German>Sprühfarbe (Grün)</German>
             <Spanish>Pintura verde</Spanish>
-            <Polish>Zielona farba w sprayu</Polish>
+            <Polish>Farba w Sprayu (Zielona)</Polish>
             <French>Peinture pulvérisée verte</French>
             <Italian>Bomboletta spray verde</Italian>
             <Czech>Zelený sprej</Czech>
@@ -223,7 +223,7 @@
             <English>Spray Paint (Blue)</English>
             <German>Sprühfarbe (Blau)</German>
             <Spanish>Pintura azul</Spanish>
-            <Polish>Niebieska farba w sprayu</Polish>
+            <Polish>Farba w Sprayu (Niebieska)</Polish>
             <French>Peinture pulvérisée bleue</French>
             <Italian>Bomboletta spray blu</Italian>
             <Czech>Modrý sprej</Czech>

--- a/addons/tagging/stringtable.xml
+++ b/addons/tagging/stringtable.xml
@@ -175,7 +175,7 @@
             <Chinese>藍色X標記</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintBlack">
-            <English>Spray paint (Black)</English>
+            <English>Spray Paint (Black)</English>
             <German>Sprühfarbe (Schwarz)</German>
             <Spanish>Pintura negra</Spanish>
             <Polish>Czarna farba w sprayu</Polish>
@@ -190,7 +190,7 @@
             <Chinese>黑色噴漆</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintRed">
-            <English>Spray paint (Red)</English>
+            <English>Spray Paint (Red)</English>
             <German>Sprühfarbe (Rot)</German>
             <Spanish>Pintura roja</Spanish>
             <Polish>Czerwona farba w sprayu</Polish>
@@ -205,7 +205,7 @@
             <Chinese>紅色噴漆</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintGreen">
-            <English>Spray paint (Green)</English>
+            <English>Spray Paint (Green)</English>
             <German>Sprühfarbe (Grün)</German>
             <Spanish>Pintura verde</Spanish>
             <Polish>Zielona farba w sprayu</Polish>
@@ -220,7 +220,7 @@
             <Chinese>綠色噴漆</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintBlue">
-            <English>Spray paint (Blue)</English>
+            <English>Spray Paint (Blue)</English>
             <German>Sprühfarbe (Blau)</German>
             <Spanish>Pintura azul</Spanish>
             <Polish>Niebieska farba w sprayu</Polish>

--- a/addons/tagging/stringtable.xml
+++ b/addons/tagging/stringtable.xml
@@ -175,8 +175,8 @@
             <Chinese>藍色X標記</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintBlack">
-            <English>Black spray paint</English>
-            <German>Schwarze Sprühfarbe</German>
+            <English>Spray paint (Black)</English>
+            <German>Sprühfarbe (Schwarz)</German>
             <Spanish>Pintura negra</Spanish>
             <Polish>Czarna farba w sprayu</Polish>
             <French>Peinture pulvérisée noire</French>
@@ -190,8 +190,8 @@
             <Chinese>黑色噴漆</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintRed">
-            <English>Red spray paint</English>
-            <German>Rote Sprühfarbe</German>
+            <English>Spray paint (Red)</English>
+            <German>Sprühfarbe (Rot)</German>
             <Spanish>Pintura roja</Spanish>
             <Polish>Czerwona farba w sprayu</Polish>
             <French>Peinture pulvérisée rouge</French>
@@ -205,8 +205,8 @@
             <Chinese>紅色噴漆</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintGreen">
-            <English>Green spray paint</English>
-            <German>Grüne Sprühfarbe</German>
+            <English>Spray paint (Green)</English>
+            <German>Sprühfarbe (Grün)</German>
             <Spanish>Pintura verde</Spanish>
             <Polish>Zielona farba w sprayu</Polish>
             <French>Peinture pulvérisée verte</French>
@@ -220,8 +220,8 @@
             <Chinese>綠色噴漆</Chinese>
         </Key>
         <Key ID="STR_ACE_Tagging_SpraypaintBlue">
-            <English>Blue spray paint</English>
-            <German>Blaue Sprühfarbe</German>
+            <English>Spray paint (Blue)</English>
+            <German>Sprühfarbe (Blau)</German>
             <Spanish>Pintura azul</Spanish>
             <Polish>Niebieska farba w sprayu</Polish>
             <French>Peinture pulvérisée bleue</French>


### PR DESCRIPTION
**When merged this pull request will:**
- "Black spray paint" -> "Spray Paint (Black)"

I was in the arsenal and this annoyed me, slight QOL improvement
