### PR TITLE
Arsenal - Remove unused VRTraining class from Arsenal config

### DIFF
--- a/addons/arsenal/RscDisplayMain.hpp
+++ b/addons/arsenal/RscDisplayMain.hpp
@@ -9,7 +9,6 @@ class RscDisplayMain: RscStandardDisplay {
 
             class Controls: Controls {
                 class Bootcamp;
-                class VRTraining;
                 class Arsenal;
                 class GVAR(mission): Arsenal {
                     idc = -1;


### PR DESCRIPTION
Ref: https://forums.bohemia.net/forums/topic/193161-ace3-a-collaborative-merger-between-agm-cse-and-ace/?do=findComment&comment=3387061

apparently doesn't exist with contact loaded, and we don't use it anyway.