### PR TITLE
Use @ace3mod for documentation updates

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Deploy
       if: github.repository == 'acemod/ACE3' && ! contains(github.event.head_commit.message, '[ci skip]')
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.DOCS_TOKEN }}
       run: python3 tools/deploy.py

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-    - ci-docs  # master
+    - master
 
 jobs:
   update:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-    - master
+    - ci-docs  # master
 
 jobs:
   update:

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -27,7 +27,7 @@ REPOUSER = "acemod"
 REPONAME = "ACE3"
 REPOPATH = "{}/{}".format(REPOUSER,REPONAME)
 
-BRANCH = "ci-docs"  # "master"
+BRANCH = "master"
 
 
 def update_translations(repo):

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -27,7 +27,7 @@ REPOUSER = "acemod"
 REPONAME = "ACE3"
 REPOPATH = "{}/{}".format(REPOUSER,REPONAME)
 
-BRANCH = "master"
+BRANCH = "ci-docs"  # "master"
 
 
 def update_translations(repo):


### PR DESCRIPTION
Default GitHub provided `${{ secrets.GITHUB_TOKEN }}` has no settable permission to push past protected branches where we specifically allow it. This PR falls back to @ace3mod's Private Access Token (set in repository secrets) which has those permission, like we did with Travis CI.