### PR TITLE
fix repair strings

### DIFF
--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -1815,19 +1815,19 @@
         </Key>
         <Key ID="STR_ACE_Repair_MiscRepairRequiredItems_DisplayName">
             <English>Misc Repair Requirements</English>
-            <English>部分修理条件</English>
+            <Japanese>部分修理条件</Japanese>
         </Key>
         <Key ID="STR_ACE_Repair_MiscRepairRequiredItems_Description">
             <English>Items required to repair a specific vehicle component or remove/replace tracks.</English>
-            <English>車両の特定コンポーネントか履帯の除去/交換にアイテムを必要とします。</English>
+            <Japanese>車両の特定コンポーネントか履帯の除去/交換にアイテムを必要とします。</Japanese>
         </Key>
         <Key ID="STR_ACE_Repair_FullRepairRequiredItems_DisplayName">
             <English>Full Repair Requirements</English>
-            <English>完全修理条件</English>
+            <Japanese>完全修理条件</Japanese>
         </Key>
         <Key ID="STR_ACE_Repair_FullRepairRequiredItems_Description">
             <English>Items required to perform a full vehicle repair.</English>
-            <English>車両の完全修理にアイテムを必要とします。</English>
+            <Japanese>車両の完全修理にアイテムを必要とします。</Japanese>
         </Key>
         <Key ID="STR_ACE_Repair_shutOffEngineWarning">
             <English>Engine must be off to repair</English>


### PR DESCRIPTION
ref #7274 👍 - only found after merge because pr was old

Run python3 tools/stringtable_validator.py
Checking addons/repair/stringtable.xml:
  ERROR: Key 'STR_ACE_Repair_MiscRepairRequiredItems_DisplayName' has 2 English translations.
  ERROR: Key 'STR_ACE_Repair_MiscRepairRequiredItems_Description' has 2 English translations.
  ERROR: Key 'STR_ACE_Repair_FullRepairRequiredItems_DisplayName' has 2 English translations.
  ERROR: Key 'STR_ACE_Repair_FullRepairRequiredItems_Description' has 2 English translations.
Found 4 error(s).