### PR TITLE
Adapt to HEMTT (User)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ release/*
 releases/*
 hemtt
 hemtt.exe
+tools/hemtt*.tar.gz*
+tools/hemtt*.zip*
 tools/temp
 *.cache
 *.pbo

--- a/tools/setup.bat
+++ b/tools/setup.bat
@@ -1,0 +1,25 @@
+;@Findstr -bv ;@F "%~f0" | powershell -command - & goto:eof
+
+$VERSION = "0.6.1"
+$ARCH = if ([Environment]::Is64BitProcess) {"x86_64"} else {"i686"}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip {
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$client = New-Object Net.WebClient
+
+Write-Output "=> Downloading HEMTT..."
+$client.DownloadFile("https://github.com/synixebrett/HEMTT/releases/download/v$VERSION/hemtt-v$VERSION-$ARCH-pc-windows-msvc.zip", "hemtt-v$VERSION-$ARCH-pc-windows-msvc.zip")
+$client.dispose()
+
+Write-Output "=> Extracting HEMTT..."
+Unzip "hemtt-v$VERSION-$ARCH-pc-windows-msvc.zip" "..\."
+Remove-Item "hemtt-v$VERSION-$ARCH-pc-windows-msvc.zip"
+
+Write-Output "=> Updating HEMTT..."
+& ..\hemtt.exe update

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,0 +1,12 @@
+VERSION=0.6.1
+ARCH=$(uname -m)
+
+echo "=> Downloading HEMTT..."
+wget -q --show-progress https://github.com/synixebrett/HEMTT/releases/download/v$VERSION/hemtt-v$VERSION-$ARCH-unknown-linux-gnu.tar.gz
+
+echo "=> Extracting HEMTT..."
+tar -xzf hemtt-v$VERSION-$ARCH-unknown-linux-gnu.tar.gz -C ../.
+rm hemtt-v$VERSION-$ARCH-unknown-linux-gnu.tar.gz
+
+echo "=> Updating HEMTT..."
+../hemtt update


### PR DESCRIPTION
_Continuation of https://github.com/acemod/ACE3/pull/6900 for general use._

**When merged this pull request will:**
- Add scripts (`setup.bat` and `setup.sh`) to download project-specific HEMTT binary

**TODO ACE3:**
- [ ] Add release/publish procedure (ref. https://github.com/CBATeam/CBA_A3/pull/730#issuecomment-411018642) (HEMTT script)
- [ ] Documentation (reuse #6362)
- [ ] Use Windows Installer instead of project-specific binary and download script (https://github.com/synixebrett/HEMTT/pull/60) - requires update compatibility fix
- [ ] Switch to HEMTT release builds (final)

**TODO HEMTT:**
- [ ] Release proper 0.7.x (restructure)
- [ ] Update versions in files (like `make.py` or `Makefile`) (https://github.com/synixebrett/HEMTT/issues/16)