### PR TITLE
Round stringtable completion to 2 decimals

### DIFF
--- a/tools/stringtablediag.py
+++ b/tools/stringtablediag.py
@@ -117,7 +117,7 @@ def main():
                 language,
                 keysum - localizedsum[i],
                 ", ".join(missing[i]),
-                round(100 * localizedsum[i] / keysum)))
+                round(100 * localizedsum[i] / keysum, 2)))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**When merged this pull request will:**
- Title

We have over 2800 strings, Japanese is currently missing 5, which shows up as 100% because `2795/(2800+) >= 99.82%` which we round. Rounding to 2 decimals will show more accurate values.