### PR TITLE
Clean up ace_main requiredAddons

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -6,14 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {
-            "A3_Data_F_Enoch_Loadorder",
-            "A3_Data_F_Mod_Loadorder",
-            // CBA
-            "cba_ui",
-            "cba_xeh",
-            "cba_jr"
-        };
+        requiredAddons[] = {"cba_main"};
         author = ECSTRING(common,ACETeam);
         url = CSTRING(URL);
         VERSION_CONFIG;


### PR DESCRIPTION
**When merged this pull request will:**
- `cba_main` requires all other CBA components, and `cba_common` requires A3 load orders
