### PR TITLE
Add Check ammo self interaction setting

### DIFF
--- a/addons/reload/CfgVehicles.hpp
+++ b/addons/reload/CfgVehicles.hpp
@@ -1,6 +1,17 @@
 class CfgVehicles {
     class Man;
     class CAManBase: Man {
+        class ACE_SelfActions {
+            class ACE_Equipment {
+                class GVAR(checkAmmo) {
+                    displayName = CSTRING(checkAmmo);
+                    condition = QUOTE(GVAR(showCheckAmmoSelf) && {_player call FUNC(canCheckAmmoSelf)});
+                    statement = QUOTE(call FUNC(checkAmmo));
+                    exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};
+                };
+            };
+        };
+
         class ACE_Actions {
             class ACE_Weapon {
                 class GVAR(LinkBelt) {

--- a/addons/reload/XEH_PREP.hpp
+++ b/addons/reload/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 
 PREP(canCheckAmmo);
+PREP(canCheckAmmoSelf);
 PREP(getAmmoToLinkBelt);
 PREP(checkAmmo);
 PREP(displayAmmo);

--- a/addons/reload/XEH_postInit.sqf
+++ b/addons/reload/XEH_postInit.sqf
@@ -8,7 +8,7 @@ if (!hasInterface) exitWith {};
     // Conditions: canInteract
     if !([ACE_player, vehicle ACE_player, ["isNotInside", "isNotSwimming", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {false};
     // Conditions: specific
-    if !(ACE_player call CBA_fnc_canUseWeapon || {(vehicle ACE_player) isKindOf "StaticWeapon"}) exitWith {false};
+    if !(ACE_player call FUNC(canCheckAmmoSelf)) exitWith {false};
     // Ignore if controlling UAV (blocks radar keybind)
     if (!isNull (ACE_controlledUAV param [0, objNull])) exitWith {false};
 

--- a/addons/reload/XEH_preInit.sqf
+++ b/addons/reload/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/reload/functions/fnc_canCheckAmmoSelf.sqf
+++ b/addons/reload/functions/fnc_canCheckAmmoSelf.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+/*
+ * Author: veteran29
+ * Check if the player can check his own ammo.
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ *
+ * Return Value:
+ * Can check ammo <BOOL>
+ *
+ * Example:
+ * [cursorObject] call ace_reload_fnc_canCheckAmmoSelf
+ *
+ * Public: No
+ */
+
+params ["_player"];
+
+_player call CBA_fnc_canUseWeapon && {!((vehicle _player) isKindOf "StaticWeapon")}

--- a/addons/reload/initSettings.sqf
+++ b/addons/reload/initSettings.sqf
@@ -1,0 +1,9 @@
+
+[
+    QGVAR(showCheckAmmoSelf),
+    "CHECKBOX",
+    [LSTRING(SettingShowCheckAmmoSelf), LSTRING(SettingShowCheckAmmoSelfDesc)],
+    localize ELSTRING(common,ACEKeybindCategoryWeapons),
+    false, // default value
+    2 // isGlobal
+] call CBA_fnc_addSetting;

--- a/addons/reload/initSettings.sqf
+++ b/addons/reload/initSettings.sqf
@@ -5,5 +5,5 @@
     [LSTRING(SettingShowCheckAmmoSelf), LSTRING(SettingShowCheckAmmoSelfDesc)],
     localize ELSTRING(common,ACEKeybindCategoryWeapons),
     false, // default value
-    2 // isGlobal
+    0 // isGlobal
 ] call CBA_fnc_addSetting;

--- a/addons/reload/stringtable.xml
+++ b/addons/reload/stringtable.xml
@@ -33,6 +33,14 @@
             <Chinesesimp>在重新装填时检查新弹匣上的弹药.</Chinesesimp>
             <Chinese>在重新裝填時檢查新彈匣上的彈藥.</Chinese>
         </Key>
+        <Key ID="STR_ACE_Reload_SettingShowCheckAmmoSelf">
+            <English>Always show check ammo self interaction</English>
+            <Polish>Zawsze pokazuj interakcję od sprawdzania amunicji</Polish>
+        </Key>
+        <Key ID="STR_ACE_Reload_SettingShowCheckAmmoSelfDesc">
+            <English>Shows check ammo self interaction even when not in static weapons.</English>
+            <Polish>Pokazuje interakcję od sprawdzania amunicji poza bronią statyczną.</Polish>
+        </Key>
         <Key ID="STR_ACE_Reload_checkAmmo">
             <English>Check Ammo</English>
             <German>Munition prüfen</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds an option to always have "Check ammo" self interaction, not only in static weapons
