### PR TITLE
RHS Compat - Change IHADSS hearing to crew, add pilot visors

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -128,6 +128,17 @@ class CfgWeapons {
     class rhs_zsh7a: H_HelmetB {
         HEARING_PROTECTION_VICCREW
     };
+    class rhs_zsh7a_alt : rhs_zsh7a {
+        ACE_Protection = 1;
+    };
+    class rhs_zsh7a_mike;
+    class rhs_zsh7a_mike_alt : rhs_zsh7a_mike {
+        ACE_Protection = 1;
+    };
+    class rhs_zsh7a_mike_green;
+    class rhs_zsh7a_mike_green_alt : rhs_zsh7a_mike_green {
+        ACE_Protection = 1;
+    };
 
     class rhs_gssh18: H_HelmetB {
         HEARING_PROTECTION_EARMUFF

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -128,15 +128,15 @@ class CfgWeapons {
     class rhs_zsh7a: H_HelmetB {
         HEARING_PROTECTION_VICCREW
     };
-    class rhs_zsh7a_alt : rhs_zsh7a {
+    class rhs_zsh7a_alt: rhs_zsh7a {
         ACE_Protection = 1;
     };
     class rhs_zsh7a_mike;
-    class rhs_zsh7a_mike_alt : rhs_zsh7a_mike {
+    class rhs_zsh7a_mike_alt: rhs_zsh7a_mike {
         ACE_Protection = 1;
     };
     class rhs_zsh7a_mike_green;
-    class rhs_zsh7a_mike_green_alt : rhs_zsh7a_mike_green {
+    class rhs_zsh7a_mike_green_alt: rhs_zsh7a_mike_green {
         ACE_Protection = 1;
     };
 

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -251,9 +251,6 @@ class CfgWeapons {
     #define HEARING_PROTECTION_PELTOR EGVAR(hearing,protection) = 0.75; EGVAR(hearing,lowerVolume) = 0;
     // Fast Helmets
     class rhsusf_opscore_01;
-    class rhsusf_ihadss: rhsusf_opscore_01 {
-        HEARING_PROTECTION_PELTOR
-    };
     class rhsusf_opscore_ut_pelt_nsw: rhsusf_opscore_01 {
         HEARING_PROTECTION_PELTOR
     };
@@ -413,13 +410,66 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR
     };
 
-
     class rhsusf_hgu56p: rhsusf_opscore_01 {
+        HEARING_PROTECTION_VICCREW
+    };
+    class rhsusf_hgu56p_visor : rhsusf_hgu56p {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_black;
+    class rhsusf_hgu56p_visor_black : rhsusf_hgu56p_black {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_green;
+    class rhsusf_hgu56p_visor_green : rhsusf_hgu56p_green {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_visor_mask : rhsusf_hgu56p {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_visor_mask_black : rhsusf_hgu56p_black {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_visor_mask_Empire_black : rhsusf_hgu56p_black {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_visor_mask_green : rhsusf_hgu56p_green {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_mask_smiley;
+    class rhsusf_hgu56p_visor_mask_smiley : rhsusf_hgu56p_mask_smiley {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_pink;
+    class rhsusf_hgu56p_visor_mask_pink : rhsusf_hgu56p_pink {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_visor_pink : rhsusf_hgu56p_pink {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_saf;
+    class rhsusf_hgu56p_visor_saf : rhsusf_hgu56p_saf {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_usa;
+    class rhsusf_hgu56p_visor_usa : rhsusf_hgu56p_usa {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_white;
+    class rhsusf_hgu56p_visor_white : rhsusf_hgu56p_white {
+        ACE_Protection = 1;
+    };
+    class rhsusf_hgu56p_visor_mask_black_skull;
+    class rhsusf_hgu56p_mask_black_skull : rhsusf_hgu56p_visor_mask_black_skull {
+        ACE_Protection = 0;
+    };
+    class rhsusf_ihadss: rhsusf_opscore_01 {
         HEARING_PROTECTION_VICCREW
     };
 
     class H_HelmetB;
     class RHS_jetpilot_usaf: H_HelmetB {
+        ACE_Protection = 1;
         HEARING_PROTECTION_VICCREW
     };
 

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -413,54 +413,54 @@ class CfgWeapons {
     class rhsusf_hgu56p: rhsusf_opscore_01 {
         HEARING_PROTECTION_VICCREW
     };
-    class rhsusf_hgu56p_visor : rhsusf_hgu56p {
+    class rhsusf_hgu56p_visor: rhsusf_hgu56p {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_black;
-    class rhsusf_hgu56p_visor_black : rhsusf_hgu56p_black {
+    class rhsusf_hgu56p_visor_black: rhsusf_hgu56p_black {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_green;
-    class rhsusf_hgu56p_visor_green : rhsusf_hgu56p_green {
+    class rhsusf_hgu56p_visor_green: rhsusf_hgu56p_green {
         ACE_Protection = 1;
     };
-    class rhsusf_hgu56p_visor_mask : rhsusf_hgu56p {
+    class rhsusf_hgu56p_visor_mask: rhsusf_hgu56p {
         ACE_Protection = 1;
     };
-    class rhsusf_hgu56p_visor_mask_black : rhsusf_hgu56p_black {
+    class rhsusf_hgu56p_visor_mask_black: rhsusf_hgu56p_black {
         ACE_Protection = 1;
     };
-    class rhsusf_hgu56p_visor_mask_Empire_black : rhsusf_hgu56p_black {
+    class rhsusf_hgu56p_visor_mask_Empire_black: rhsusf_hgu56p_black {
         ACE_Protection = 1;
     };
-    class rhsusf_hgu56p_visor_mask_green : rhsusf_hgu56p_green {
+    class rhsusf_hgu56p_visor_mask_green: rhsusf_hgu56p_green {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_mask_smiley;
-    class rhsusf_hgu56p_visor_mask_smiley : rhsusf_hgu56p_mask_smiley {
+    class rhsusf_hgu56p_visor_mask_smiley: rhsusf_hgu56p_mask_smiley {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_pink;
-    class rhsusf_hgu56p_visor_mask_pink : rhsusf_hgu56p_pink {
+    class rhsusf_hgu56p_visor_mask_pink: rhsusf_hgu56p_pink {
         ACE_Protection = 1;
     };
-    class rhsusf_hgu56p_visor_pink : rhsusf_hgu56p_pink {
+    class rhsusf_hgu56p_visor_pink: rhsusf_hgu56p_pink {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_saf;
-    class rhsusf_hgu56p_visor_saf : rhsusf_hgu56p_saf {
+    class rhsusf_hgu56p_visor_saf: rhsusf_hgu56p_saf {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_usa;
-    class rhsusf_hgu56p_visor_usa : rhsusf_hgu56p_usa {
+    class rhsusf_hgu56p_visor_usa: rhsusf_hgu56p_usa {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_white;
-    class rhsusf_hgu56p_visor_white : rhsusf_hgu56p_white {
+    class rhsusf_hgu56p_visor_white: rhsusf_hgu56p_white {
         ACE_Protection = 1;
     };
     class rhsusf_hgu56p_visor_mask_black_skull;
-    class rhsusf_hgu56p_mask_black_skull : rhsusf_hgu56p_visor_mask_black_skull {
+    class rhsusf_hgu56p_mask_black_skull: rhsusf_hgu56p_visor_mask_black_skull {
         ACE_Protection = 0;
     };
     class rhsusf_ihadss: rhsusf_opscore_01 {


### PR DESCRIPTION
**When merged this pull request will:**
- Change ace_hearing config on the IHADSS helmet to crew helmet level (0.6 muffling, 0.85 protection) instead of Peltor level (no muffling, 0.75 protection). While it inherits from a random FAST helmet, it is actually a heli pilot helmet; RHS's inheritance structure is just that nonsensical.
- Add ace_goggles `ACE_Protection` (protects from post processing caused by rotor downwash) to pilot helmets with visors for RHS blue and red (there don't seem to be any new items in green or other green). Inheritance branches out pretty heavily, so this is about as short as that code is gonna get.
