### PR TITLE
Added missing Czech translation strings

### DIFF
--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -6,146 +6,175 @@
             <English>#00 Buckshot</English>
             <Chinese>#00 鹿彈</Chinese>
             <Japanese>#00 バックショット</Japanese>
+            <Czech>#00 Broky velké</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No00_Buck_Description">
             <English>#00 Buckshot</English>
             <Chinese>#00 鹿彈</Chinese>
             <Japanese>#00 バックショット</Japanese>
+            <Czech>#00 Broky velké - kalibr 8.38 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No0_Buck_NameShort">
             <English>#0 Buckshot</English>
             <Chinese>#0 鹿彈</Chinese>
             <Japanese>#0 バックショット</Japanese>
+            <Czech>#0 Broky velké</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No0_Buck_Description">
             <English>#0 Buckshot</English>
             <Chinese>#0 鹿彈</Chinese>
             <Japanese>#0 バックショット</Japanese>
+            <Czech>#0 Broky velké -  kalibr 8.1 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No1_Buck_NameShort">
             <English>#1 Buckshot</English>
             <Chinese>#1 鹿彈</Chinese>
             <Japanese>#1 バックショット</Japanese>
+            <Czech>#1 Broky velké</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No1_Buck_Description">
             <English>#1 Buckshot</English>
             <Chinese>#1 鹿彈</Chinese>
             <Japanese>#1 バックショット</Japanese>
+            <Czech>#1 Broky velké -  kalibr 7.6 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No2_Buck_NameShort">
             <English>#2 Buckshot</English>
             <Chinese>#2 鹿彈</Chinese>
             <Japanese>#2 バックショット</Japanese>
+            <Czech>#2 Broky velké</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No2_Buck_Description">
             <English>#2 Buckshot</English>
             <Chinese>#2 鹿彈</Chinese>
             <Japanese>#2 バックショット</Japanese>
+            <Czech>#2 Broky velké -  kalibr 6.9 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No3_Buck_NameShort">
             <English>#3 Buckshot</English>
             <Chinese>#3 鹿彈</Chinese>
             <Japanese>#3 バックショット</Japanese>
+            <Czech>#3 Broky velké</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No3_Buck_Description">
             <English>#3 Buckshot</English>
             <Chinese>#3 鹿彈</Chinese>
             <Japanese>#3 バックショット</Japanese>
+            <Czech>#3 Broky velké -  kalibr 6.4 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Buck_NameShort">
             <English>#4 Buckshot</English>
             <Chinese>#4 鹿彈</Chinese>
             <Japanese>#4 バックショット</Japanese>
+            <Czech>#4 Broky velké</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Buck_Description">
             <English>#4 Buckshot</English>
             <Chinese>#4 鹿彈</Chinese>
             <Japanese>#4 バックショット</Japanese>
+            <Czech>#4 Broky velké -  kalibr 6.1 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Bird_NameShort">
             <English>#7 Birdshot</English>
             <Chinese>#7 鹿彈</Chinese>
             <Japanese>#7 バックショット</Japanese>
+            <Czech>#7 Broky malé</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Bird_Description">
             <English>#7 Birdshot</English>
             <Chinese>#7 鹿彈</Chinese>
             <Japanese>#7 バックショット</Japanese>
+            <Czech>#7 Broky malé - kalibr 2.54 mm</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 2Rnd #00 Buckshot</English>
             <Chinese>12鉛徑 2發  #00 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #00 バックショット</Japanese>
+            <Czech>2x #00 Broky velké (kalibr 8.38 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No0_Buck_Name">
             <English>12 Gauge 2Rnd #0 Buckshot</English>
             <Chinese>12鉛徑 2發  #0 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #0 バックショット</Japanese>
+            <Czech>2x #0 Broky velké (kalibr 8.1 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No1_Buck_Name">
             <English>12 Gauge 2Rnd #1 Buckshot</English>
             <Chinese>12鉛徑 2發  #1 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #1 バックショット</Japanese>
+            <Czech>2x #1 Broky velké (kalibr 7.6 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No2_Buck_Name">
             <English>12 Gauge 2Rnd #2 Buckshot</English>
             <Chinese>12鉛徑 2發  #2 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #2 バックショット</Japanese>
+            <Czech>2x #2 Broky velké (kalibr 6.9 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No3_Buck_Name">
             <English>12 Gauge 2Rnd #3 Buckshot</English>
             <Chinese>12鉛徑 2發  #3 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #3 バックショット</Japanese>
+            <Czech>2x #3 Broky velké (kalibr 6.4 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No4_Buck_Name">
             <English>12 Gauge 2Rnd #4 Buckshot</English>
             <Chinese>12鉛徑 2發  #4 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #4 バックショット</Japanese>
+            <Czech>2x #4 Broky velké (kalibr 6.1 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No4_Bird_Name">
             <English>12 Gauge 2Rnd #7 Birdshot</English>
             <Chinese>12鉛徑 2發  #7 鹿彈</Chinese>
             <Japanese>12 ゲージ 2 発入り #7 バックショット</Japanese>
+            <Czech>2x #7 Broky malé (kalibr 2.54 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 6Rnd #00 Buckshot</English>
             <Chinese>12鉛徑 6發  #00 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #00 バックショット</Japanese>
+            <Czech>6x #00 Broky velké (kalibr 8.38 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No0_Buck_Name">
             <English>12 Gauge 6Rnd #0 Buckshot</English>
             <Chinese>12鉛徑 6發  #0 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #0 バックショット</Japanese>
+            <Czech>6x #0 Broky velké (kalibr 8.1 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No1_Buck_Name">
             <English>12 Gauge 6Rnd #1 Buckshot</English>
             <Chinese>12鉛徑 6發  #1 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #1 バックショット</Japanese>
+            <Czech>6x #1 Broky velké (kalibr 7.6 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No2_Buck_Name">
             <English>12 Gauge 6Rnd #2 Buckshot</English>
             <Chinese>12鉛徑 6發  #2 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #2 バックショット</Japanese>
+            <Czech>6x #2 Broky velké (kalibr 6.9 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No3_Buck_Name">
             <English>12 Gauge 6Rnd #3 Buckshot</English>
             <Chinese>12鉛徑 6發  #3 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #3 バックショット</Japanese>
+            <Czech>6x #3 Broky velké (kalibr 6.4 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No4_Buck_Name">
             <English>12 Gauge 6Rnd #4 Buckshot</English>
             <Chinese>12鉛徑 6發  #4 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #4 バックショット</Japanese>
+            <Czech>6x #4 Broky velké (kalibr 6.1 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No4_Bird_Name">
             <English>12 Gauge 6Rnd #7 Birdshot</English>
             <Chinese>12鉛徑 6發  #7 鹿彈</Chinese>
             <Japanese>12 ゲージ 6 発入り #7 バックショット</Japanese>
+            <Czech>6x #7 Broky malé (kalibr 2.54 mm)</Czech>
         </Key>
         <Key ID="STR_ACE_Ballistics_15Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 15Rnd #00 Buckshot</English>
             <Chinese>12鉛徑 15發  #00 鹿彈</Chinese>
             <Japanese>12 ゲージ 15 発入り #00 バックショット</Japanese>
+            <Czech>15x #00 Broky velké (kalibr 8.38 mm)</Czech>
         </Key>
         <!-- QBU -->
         <Key ID="STR_ACE_Ballistics_20Rnd_65x47_Scenar_mag_Name">

--- a/addons/chemlights/stringtable.xml
+++ b/addons/chemlights/stringtable.xml
@@ -13,6 +13,7 @@
             <Chinesesimp>萤光棒</Chinesesimp>
             <Russian>Химсвет</Russian>
             <Portuguese>Bastões de Luz</Portuguese>
+            <Czech>Chemická světla</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Action_Prepare">
             <English>Prepare %1</English>
@@ -26,6 +27,7 @@
             <Chinesesimp>使用%1</Chinesesimp>
             <Russian>Приготовить %1</Russian>
             <Portuguese>Preparar %1</Portuguese>
+            <Czech>Připravit %1</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Action_Prepare_Done">
             <English>%1&lt;br/&gt;Prepared</English>
@@ -39,6 +41,7 @@
             <Chinesesimp>%1&lt;br/&gt;已使用</Chinesesimp>
             <Russian>%1&lt;br/&gt;Приготовлен</Russian>
             <Portuguese>%1&lt;br/&gt;Preparado</Portuguese>
+            <Czech>%1&lt;br/&gt;Připraveno</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Inventory_Full">
             <English>No inventory space</English>
@@ -68,6 +71,7 @@
             <Chinesesimp>[ACE] 萤光棒</Chinesesimp>
             <Russian>[ACE] Химсвет</Russian>
             <Portuguese>[ACE] Bastões de Luz</Portuguese>
+            <Czech>[ACE] Chemická světla</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Orange_DisplayName">
             <English>Chemlight (Orange)</English>
@@ -81,6 +85,7 @@
             <Chinesesimp>萤光棒 (橘色)</Chinesesimp>
             <Russian>Химсвет (Оранжевый)</Russian>
             <Portuguese>Bastão de Luz (Laranja)</Portuguese>
+            <Czech>Chemické světlo (Oranžové)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Orange_DisplayNameShort">
             <English>Orange Light</English>
@@ -94,6 +99,7 @@
             <Chinesesimp>橘色光</Chinesesimp>
             <Russian>Оранжевый свет</Russian>
             <Portuguese>Luz Laranja</Portuguese>
+            <Czech>Oranžové světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Orange_DescriptionShort">
             <English>Type: Light - Orange&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -107,6 +113,7 @@
             <Chinesesimp>类型: 光 - 橘色&lt;br /&gt;发数: 1&lt;br /&gt;使用于: 手</Chinesesimp>
             <Russian>Тип: Свет - Оранжевый&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Laranja&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
+            <Czech>Typ: Světlo - Oranžové&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_White_DisplayName">
             <English>Chemlight (White)</English>
@@ -120,6 +127,7 @@
             <Chinesesimp>萤光棒 (白色)</Chinesesimp>
             <Russian>Химсвет (Белый)</Russian>
             <Portuguese>Bastão de Luz (Branco)</Portuguese>
+            <Czech>Chemické světlo (Bílé)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_White_DisplayNameShort">
             <English>White Light</English>
@@ -133,6 +141,7 @@
             <Chinesesimp>白色光</Chinesesimp>
             <Russian>Белый свет</Russian>
             <Portuguese>Luz Branca</Portuguese>
+            <Czech>Bílé světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_White_DescriptionShort">
             <English>Type: Light - White&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -146,6 +155,7 @@
             <Chinesesimp>类型: 光 - 白色&lt;br /&gt;发数: 1&lt;br /&gt;使用于: 手</Chinesesimp>
             <Russian>Тип: Свет - Белый&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Branco&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
+            <Czech>Typ: Světlo - Bílé&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiRed_DisplayName">
             <English>Chemlight (Hi Red)</English>
@@ -159,6 +169,7 @@
             <Chinesesimp>萤光棒 (超亮红色)</Chinesesimp>
             <Russian>Химсвет (Ярко-Красный)</Russian>
             <Portuguese>Bastão de Luz (Vermelho Forte)</Portuguese>
+            <Czech>Chemické světlo (Červené jasné)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiRed_DisplayNameShort">
             <English>Red Hi Light</English>
@@ -172,6 +183,7 @@
             <Chinesesimp>超亮红色光</Chinesesimp>
             <Russian>Яркий Красный свет</Russian>
             <Portuguese>Luz forte vermelha</Portuguese>
+            <Czech>Červené jasné světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiRed_DescriptionShort">
             <English>Type: Light - Red Hi (30 minute)&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -185,6 +197,7 @@
             <Chinesesimp>类型: 光 - 超亮红色 (30分钟)&lt;br /&gt;发数: 1&lt;br /&gt;使用于: 手</Chinesesimp>
             <Russian>Тип: Свет - Ярко-Красный (30 минут)&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Vermelho Forte (30 minutos)&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
+            <Czech>Typ: Světlo - Červené jasné&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiYellow_DisplayName">
             <English>Chemlight (Hi Yellow)</English>
@@ -198,6 +211,7 @@
             <Chinesesimp>萤光棒 (超亮黄色)</Chinesesimp>
             <Russian>Химсвет (Ярко-Желтый)</Russian>
             <Portuguese>Bastão de Luz (Amarelo Forte)</Portuguese>
+            <Czech>Chemické světlo (Žluté jasné)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiYellow_DisplayNameShort">
             <English>Yellow Hi Light</English>
@@ -211,6 +225,7 @@
             <Chinesesimp>超亮黄色光</Chinesesimp>
             <Russian>Яркий Желтый свет</Russian>
             <Portuguese>Luz forte amarela</Portuguese>
+            <Czech>Žluté jasné světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiYellow_DescriptionShort">
             <English>Type: Light - Yellow Hi (30 minute)&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -224,6 +239,7 @@
             <Chinesesimp>类型: 光 - 超亮黄色 (30分钟)&lt;br /&gt;发数: 1&lt;br /&gt;使用于: 手</Chinesesimp>
             <Russian>Тип: Свет - Ярко-Желтый (30 минут)&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Amarelo Forte (30 minutos)&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
+            <Czech>Typ: Světlo - Žluté jasné&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiWhite_DisplayName">
             <English>Chemlight (Hi White)</English>
@@ -237,6 +253,7 @@
             <Chinesesimp>萤光棒 (超亮白色)</Chinesesimp>
             <Russian>Химсвет (Ярко-Белый)</Russian>
             <Portuguese>Bastão de Luz (Branco Forte)</Portuguese>
+            <Czech>Chemické světlo (Bílé jasné)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiWhite_DisplayNameShort">
             <English>White Hi Light</English>
@@ -250,6 +267,7 @@
             <Chinesesimp>超亮白色光</Chinesesimp>
             <Russian>Яркий Белый свет</Russian>
             <Portuguese>Luz forte branca</Portuguese>
+            <Czech>Bílé jasné světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiWhite_DescriptionShort">
             <English>Type: Light - White Hi (30 minute)&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -263,6 +281,7 @@
             <Chinesesimp>类型: 光 - 超亮白色 (30分钟)&lt;br /&gt;发数: 1&lt;br /&gt;使用于: 手</Chinesesimp>
             <Russian>Тип: Свет - Ярко-Белый (30 минут)&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Branco Forte (30 minutos)&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
+            <Czech>Typ: Světlo - Bílé jasné&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiBlue_DisplayName">
             <English>Chemlight (Hi Blue)</English>
@@ -274,6 +293,7 @@
             <Russian>Химсвет (Ярко-Синий)</Russian>
             <Portuguese>Bastão de Luz (Azul Forte)</Portuguese>
             <Chinese>螢光棒（超亮藍色）</Chinese>
+            <Czech>Chemické světlo (Modré jasné)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiBlue_DisplayNameShort">
             <English>Blue Hi Light</English>
@@ -285,6 +305,7 @@
             <Russian>Яркий Синий свет</Russian>
             <Portuguese>Luz forte azul</Portuguese>
             <Chinese>超亮藍色光</Chinese>
+            <Czech>Modré jasné světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiBlue_DescriptionShort">
             <English>Type: Light - Blue Hi (30 minute)&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -296,6 +317,7 @@
             <Russian>Тип: Свет - Ярко-Синий (30 минут)&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Azul Forte (30 minutos)&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
             <Chinese>類型: 光 - 超亮藍色 (30分鐘)&lt;br /&gt;發數: 1&lt;br /&gt;使用於: 手</Chinese>
+            <Czech>Typ: Světlo - Modré jasné&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiGreen_DisplayName">
             <English>Chemlight (Hi Green)</English>
@@ -307,6 +329,7 @@
             <Russian>Химсвет (Ярко-Зеленый)</Russian>
             <Portuguese>Bastão de Luz (Verde Forte)</Portuguese>
             <Chinese>螢光棒（超亮綠色）</Chinese>
+            <Czech>Chemické světlo (Zelené jasné)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiGreen_DisplayNameShort">
             <English>Green Hi Light</English>
@@ -318,6 +341,7 @@
             <Russian>Яркий Зеленый свет</Russian>
             <Portuguese>Luz forte verde</Portuguese>
             <Chinese>超亮綠色光</Chinese>
+            <Czech>Zelené jasné světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_HiGreen_DescriptionShort">
             <English>Type: Light - Green Hi (30 minute)&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -329,6 +353,7 @@
             <Russian>Тип: Свет - Ярко-Зеленый (30 минут)&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Verde Forte (30 minutos)&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
             <Chinese>類型: 光 - 超亮綠色 (30分鐘)&lt;br /&gt;發數: 1&lt;br /&gt;使用於: 手</Chinese>
+            <Czech>Typ: Světlo - Zelené jasné&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_UltraHiOrange_DisplayName">
             <English>Chemlight (Ultra-Hi Orange)</English>
@@ -340,6 +365,7 @@
             <Russian>Химсвет (Ультраяркий Оранжевый)</Russian>
             <Portuguese>Bastão de Luz (Laranja Ultra Forte)</Portuguese>
             <Chinese>螢光棒（極亮橘色）</Chinese>
+            <Czech>Chemické světlo (Oranžové velmi jasné)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_UltraHiOrange_DisplayNameShort">
             <English>Orange Ultra-Hi Light</English>
@@ -351,6 +377,7 @@
             <Russian>Ультраяркий Оранжевый свет</Russian>
             <Portuguese>Luz ultra forte laranja</Portuguese>
             <Chinese>極亮橘色光</Chinese>
+            <Czech>Oranžové velmi jasné světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_UltraHiOrange_DescriptionShort">
             <English>Type: Light - Orange Ultra-Hi (5 minute)&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -362,6 +389,7 @@
             <Russian>Тип: Свет - Ультраяркий Оранжевый (5 минут)&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Laranja Ultra Forte (5 minutos)&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
             <Chinese>類型: 光 - 極亮橘色 (5分鐘)&lt;br /&gt;發數: 1&lt;br /&gt;使用於: 手</Chinese>
+            <Czech>Typ: Světlo - Oranžové velmi jasné&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_IR_DisplayName">
             <English>Chemlight (IR)</English>
@@ -375,6 +403,7 @@
             <Chinesesimp>萤光棒 (红外线)</Chinesesimp>
             <Russian>Химсвет (Инфракрасный)</Russian>
             <Portuguese>Bastão de Luz (IV)</Portuguese>
+            <Czech>Chemické světlo (Infračervené)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_IR_DisplayNameShort">
             <English>IR Light</English>
@@ -388,6 +417,7 @@
             <Chinesesimp>红外线光</Chinesesimp>
             <Russian>Инфракрасный свет</Russian>
             <Portuguese>Bastão de luz infravermelho</Portuguese>
+            <Czech>Infračervené světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_IR_DescriptionShort">
             <English>Type: Light - Infrared&lt;br /&gt;Rounds: 1&lt;br /&gt;Used in: Hand</English>
@@ -401,6 +431,7 @@
             <Chinesesimp>类型: 光 - 红外线&lt;br /&gt;发数: 1&lt;br /&gt;使用于: 手</Chinesesimp>
             <Russian>Тип: Свет - Инфракрасный&lt;br /&gt;1 штука&lt;br /&gt;В руках</Russian>
             <Portuguese>Tipo: Luz - Infravermelho&lt;br/&gt;Usos: 1&lt;br/&gt;Usado em: Mão</Portuguese>
+            <Czech>Typ: Světlo - Infračervené&lt;br/&gt;Počet použití: 1&lt;br/&gt;Použít v ruce</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Empty_DisplayName">
             <English>Chemlight Shield (Empty)</English>
@@ -414,6 +445,7 @@
             <Chinesesimp>萤光棒保护壳 (空)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Пуст)</Russian>
             <Portuguese>Estojo de Luz (Vazio)</Portuguese>
+            <Czech>Clona na chemické světlo</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Empty_DescriptionShort">
             <English>Shield for chemlights. Combine with chemlight to prepare reading light.</English>
@@ -427,6 +459,7 @@
             <Chinesesimp>萤光棒的保护壳. 与萤光棒结合后可充当阅读灯.</Chinesesimp>
             <Russian>Защитный контейнер для Химсвета. Объедините с Химсветом, чтобы подготовить Свет для чтения</Russian>
             <Portuguese>Estojo para os bastões de luz. Combine com o bastão de luz para preparar luz de leitura.</Portuguese>
+            <Czech>Clona na chemické světlo. Při vložení chemického světla vznikne praktické světlo na čtení.</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Green_DisplayName">
             <English>Chemlight Shield (Green)</English>
@@ -440,6 +473,7 @@
             <Chinesesimp>萤光棒保护壳 (绿色)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Зел)</Russian>
             <Portuguese>Estojo de Luz (Verde)</Portuguese>
+            <Czech>Clona s vloženým chemickým světlem (Zelené)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Green_DescriptionShort">
             <English>Green reading light.</English>
@@ -453,6 +487,7 @@
             <Chinesesimp>绿色阅读灯。</Chinesesimp>
             <Russian>Ночник из Химсвета (Зеленый)</Russian>
             <Portuguese>Luz de leitura verde.</Portuguese>
+            <Czech>Zelené světlo na čtení.</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Red_DisplayName">
             <English>Chemlight Shield (Red)</English>
@@ -466,6 +501,7 @@
             <Chinesesimp>萤光棒保护壳 (红色)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Красн)</Russian>
             <Portuguese>Estojo de Luz (Vermelho)</Portuguese>
+            <Czech>Clona s vloženým chemickým světlem (Červené)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Red_DescriptionShort">
             <English>Red reading light.</English>
@@ -479,6 +515,7 @@
             <Chinesesimp>红色阅读灯。</Chinesesimp>
             <Russian>Ночник из Химсвета (Красный)</Russian>
             <Portuguese>Luz de leitura vermelha.</Portuguese>
+            <Czech>Červené světlo na čtení.</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Blue_DisplayName">
             <English>Chemlight Shield (Blue)</English>
@@ -492,6 +529,7 @@
             <Chinesesimp>萤光棒保护壳 (蓝色)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Син)</Russian>
             <Portuguese>Estojo de Luz (Azul)</Portuguese>
+            <Czech>Clona s vloženým chemickým světlem (Modré)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Blue_DescriptionShort">
             <English>Blue reading light.</English>
@@ -505,6 +543,7 @@
             <Chinesesimp>蓝色阅读灯。</Chinesesimp>
             <Russian>Ночник из Химсвета (Синий)</Russian>
             <Portuguese>Luz de leitura azul.</Portuguese>
+            <Czech>Modré světlo na čtení.</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Yellow_DisplayName">
             <English>Chemlight Shield (Yellow)</English>
@@ -518,6 +557,7 @@
             <Chinesesimp>萤光棒保护壳 (黄色)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Желт)</Russian>
             <Portuguese>Estojo de Luz (Amarelo)</Portuguese>
+            <Czech>Clona s vloženým chemickým světlem (Žluté)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Yellow_DescriptionShort">
             <English>Yellow reading light.</English>
@@ -531,6 +571,7 @@
             <Chinesesimp>黄色阅读灯。</Chinesesimp>
             <Russian>Ночник из Химсвета (Желтый)</Russian>
             <Portuguese>Luz de leitura amarela.</Portuguese>
+            <Czech>Žluté světlo na čtení.</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Orange_DisplayName">
             <English>Chemlight Shield (Orange)</English>
@@ -544,6 +585,7 @@
             <Chinesesimp>萤光棒保护壳 (橘色)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Оранж)</Russian>
             <Portuguese>Estojo de Luz (Laranja)</Portuguese>
+            <Czech>Clona s vloženým chemickým světlem (Oranžové)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_Orange_DescriptionShort">
             <English>Orange reading light.</English>
@@ -557,6 +599,7 @@
             <Chinesesimp>橘色阅读灯。</Chinesesimp>
             <Russian>Ночник из Химсвета (Оранжевый)</Russian>
             <Portuguese>Luz de leitura laranja.</Portuguese>
+            <Czech>Oranžové světlo na čtení.</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_White_DisplayName">
             <English>Chemlight Shield (White)</English>
@@ -570,6 +613,7 @@
             <Chinesesimp>萤光棒保护壳 (白色)</Chinesesimp>
             <Russian>Контейнер для Химсвета (Белый)</Russian>
             <Portuguese>Estojo de Luz (Branco)</Portuguese>
+            <Czech>Clona s vloženým chemickým světlem (Bílé)</Czech>
         </Key>
         <Key ID="STR_ACE_Chemlights_Shield_White_DescriptionShort">
             <English>White reading light.</English>
@@ -583,6 +627,7 @@
             <Chinesesimp>白色阅读灯。</Chinesesimp>
             <Russian>Ночник из Химсвета (Белый)</Russian>
             <Portuguese>Luz de leitura branca.</Portuguese>
+            <Czech>Bílé světlo na čtení.</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -464,6 +464,7 @@
             <English>Defines the action to be taken if a player does not have the correct PBOs.</English>
             <French>Définit l'action à effectuer si un joueur n'a pas les bons PBOs.</French>
             <Chinese>設定當玩家有錯誤的PBO檔案時要如何處置。</Chinese>
+            <Czech>Nastavuje jakou akci provést pokud hráč nemá správné PBO.</Czech>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsCheckAll">
             <English>Check PBO All</English>
@@ -477,12 +478,13 @@
             <Russian>Проверять все PBO</Russian>
             <Portuguese>Checar Todos os PBOs</Portuguese>
             <French>Vérifier tous les PBOs</French>
-            <Czech>Zkontrolovat všechnz PBO</Czech>
+            <Czech>Zkontrolovat všechny PBO</Czech>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsCheckAllDesc">
             <English>Check all addons, not only those of ACE.</English>
             <French>Vérifie tous les addons, même ceux qui ne sont pas liés à ACE.</French>
             <Chinese>檢查全部的插件而非只有ACE。</Chinese>
+            <Czech>Zkontrolovat všechny addony a ne jenom ACE.</Czech>
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsWhitelist">
             <English>Check PBO Whitelist</English>
@@ -502,6 +504,7 @@
             <English>Define a list of regardless allowed addons.</English>
             <French>Permet de définir une liste d'addons autorisés systématiquement.</French>
             <Chinese>定義哪些插件是允許使用的。</Chinese>
+            <Czech>Nastavte seznam addonů, které jsou povolené.</Czech>
         </Key>
         <Key ID="STR_ACE_Common_SettingFeedbackIconsName">
             <English>Feedback icons</English>

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -134,6 +134,7 @@
             <Korean>지도 색상에 표시되는 이름의 색상을 결정합니다.</Korean>
             <Chinesesimp>定义名称文字颜色。使其与地图标识器颜色有所区别。</Chinesesimp>
             <Chinese>定義名稱文字顏色。使其與地圖指示器顏色有所區別</Chinese>
+            <Czech>Barva jména zobrazeného vedle značky ukazovátka na mapě.</Czech>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_defaultLeadColor_displayName">
             <English>Lead Default Color</English>

--- a/addons/switchunits/stringtable.xml
+++ b/addons/switchunits/stringtable.xml
@@ -66,6 +66,7 @@
             <English>Enable switch side</English>
             <French>Activer le changement de camp</French>
             <Chinese>啟用陣營切換</Chinese>
+            <Czech>Povolit změnu strany</Czech>
         </Key>
         <Key ID="STR_ACE_SwitchUnits_SwitchToWest_DisplayName">
             <English>Switch to West?</English>
@@ -216,7 +217,7 @@
             <Polish>Aktywuje bezpieczną strefę wokół jednostek przeciwnika. Gracze nie mogą zmieniać strony wewnątrz tej strefy.</Polish>
             <Spanish>Habilita una zona segura alrededor de las unidades enemigas. Los jugadores no pueden cambiar de unidad dentro de la zona segura.</Spanish>
             <German>Aktiviere eine Sicherheitszone um feindliche Einheiten? Spieler können nicht zu Einheiten in der Sicherheitszone wechseln.</German>
-            <Czech>Povolit bezpečnou zónu kolem nepřátelských jednotek? Hráči se nemohou změnit strany/jednotky uvnitř bezpečné zóny.</Czech>
+            <Czech>Povolit bezpečnou zónu kolem nepřátelských jednotek? Hráči nemohou změnit strany/jednotky uvnitř bezpečné zóny.</Czech>
             <Portuguese>Habilitar uma zona segur ao redor das unidades inimigas? Jogadores não conseguirão trocar para unidades dentro dessa zona segura.</Portuguese>
             <French>Active une zone de sécurité autour des unités ennemies. Les joueurs ne peuvent pas changer de camp à l'intérieur de cette zone.</French>
             <Hungarian>Engedélyezve legyen-e egy biztonságos zóna az ellenségek körül? A játékosok nem tudnak a biztonságos zónán belüli egységekre váltani.</Hungarian>


### PR DESCRIPTION
**When merged this pull request will:**
- Add missing Czech translation for chemlights, ballistics, map_gestures, common, switchunits
- *Note: I was somewhat liberal with translating shotgun ammo and added caliber of the various types to description or short name where there was no description to "localize" the names to people who don't know US system (as we don't use it here AFAIK).*
- Part of https://github.com/acemod/ACE3/issues/367

