### PR TITLE
Czech medical typos and grammar

### DIFF
--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -165,7 +165,7 @@
             <Portuguese>Menu Médico</Portuguese>
             <Russian>Медицинское меню</Russian>
             <Spanish>Menú médico</Spanish>
-            <Czech>Zdravotnikcá nabídka</Czech>
+            <Czech>Zdravotnická nabídka</Czech>
             <Italian>Menù Medico</Italian>
             <French>Menu médical</French>
             <Japanese>治療メニュー</Japanese>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -802,7 +802,7 @@
             <Spanish>Vendaje (Básico)</Spanish>
             <French>Pansement individuel</French>
             <Polish>Bandaż (jałowy)</Polish>
-            <Czech>Obvaz (Standartní)</Czech>
+            <Czech>Obvaz (Standardní)</Czech>
             <Hungarian>Kötszer (Általános)</Hungarian>
             <Italian>Bendaggio (base)</Italian>
             <Portuguese>Bandagem(Básico)</Portuguese>
@@ -3537,7 +3537,7 @@
             <Hungarian>Test hullazsákba helyezése</Hungarian>
             <Italian>Metti il corpo nella sacca per cadaveri</Italian>
             <Portuguese>Colocar corpo dentro do saco para cadáver</Portuguese>
-            <Czech>Umístni tělo do pytle na mrtvoly</Czech>
+            <Czech>Umístit tělo do pytle na mrtvoly</Czech>
             <Japanese>死体袋に入れる</Japanese>
             <Korean>시체 가방에 담기</Korean>
             <Chinesesimp>将尸体放入尸袋</Chinesesimp>
@@ -3553,7 +3553,7 @@
             <Hungarian>Test hullazsákba helyezése...</Hungarian>
             <Italian>Stai mettendo il corpo nella sacca...</Italian>
             <Portuguese>Colocando corpo dentro do saco para cadáver...</Portuguese>
-            <Czech>Umístňuji tělo do pytle na mrtvoly...</Czech>
+            <Czech>Umisťuji tělo do pytle na mrtvoly...</Czech>
             <Japanese>死体袋へ入れています・・・</Japanese>
             <Korean>시체 가방에 담는중...</Korean>
             <Chinesesimp>将尸体放入尸袋中...</Chinesesimp>


### PR DESCRIPTION
**When merged this pull request will:**
Fix some typos in the Czech texts for medical items and GUI.

`Zdravotnikcá nabídka` → `Zdravotnická nabídka`
`Obvaz (Standartní)` → `Obvaz (Standardní)`
`Umístni tělo do pytle na mrtvoly` → `Umístit tělo do pytle na mrtvoly`
`Umístňuji tělo do pytle na mrtvoly...` → `Umisťuji tělo do pytle na mrtvoly...`
