### PR TITLE
Fix incorrect reopening chance for QuikClot on large abrasions

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment.hpp
@@ -440,7 +440,7 @@ class ADDON {
             };
             class AbrasionLarge: Abrasion {
                 effectiveness = 0.7;
-                reopeningChance = 5;
+                reopeningChance = 0.5;
             };
 
             class Avulsion: Abrasion {


### PR DESCRIPTION
**When merged this pull request will:**
- title, use [value from old medical](https://github.com/acemod/ACE3/blob/v3.12.6/addons/medical/ACE_Medical_Treatments.hpp#L1128), Close #7364 
