### PR TITLE
Medical - Combine advancedBandages and woundReopening settings

### DIFF
--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -104,45 +104,34 @@ if (_totalIvVolume >= 1) then {
 // Add entries for open, bandaged, and stitched wounds
 private _woundEntries = [];
 
-private _fnc_getWoundDescription = {
-    private _classIndex = _woundClassID / 10;
-    private _category = _woundClassID % 10;
-    private _className = EGVAR(medical_damage,woundsData) select _classIndex select 6;
-    private _suffix = ["Minor", "Medium", "Large"] select _category;
-    private _woundName = localize format [ELSTRING(medical_damage,%1_%2), _className, _suffix];
-    if (_amountOf >= 1) then {
-        format ["%1x %2", ceil _amountOf, _woundName];
-    } else {
-        format [localize LSTRING(PartialX), _woundName];
-    };
+private _fnc_processWounds = {
+    params ["_wounds", "_format", "_color"];
+
+    {
+        _x params ["_woundClassID", "_bodyPartN", "_amountOf"];
+
+        if (_selectionN == _bodyPartN && {_amountOf > 0}) then {
+            private _classIndex = _woundClassID / 10;
+            private _category   = _woundClassID % 10;
+
+            private _className = EGVAR(medical_damage,woundsData) select _classIndex select 6;
+            private _suffix = ["Minor", "Medium", "Large"] select _category;
+            private _woundName = localize format [ELSTRING(medical_damage,%1_%2), _className, _suffix];
+
+            private _woundDescription = if (_amountOf >= 1) then {
+                format ["%1x %2", ceil _amountOf, _woundName]
+            } else {
+                format [localize LSTRING(PartialX), _woundName]
+            };
+
+            _woundEntries pushBack [format [_format, _woundDescription], _color];
+        };
+    } forEach _wounds;
 };
 
-{
-    _x params ["_woundClassID", "_bodyPartN", "_amountOf"];
-    if (_selectionN == _bodyPartN) then {
-        if (_amountOf > 0) then {
-            _woundEntries pushBack [call _fnc_getWoundDescription, [1, 1, 1, 1]];
-        } else {
-            if !(EGVAR(medical_treatment,advancedBandages) && {EGVAR(medical_treatment,woundReopening)}) then {
-                _woundEntries pushBack [format ["[B] %1", call _fnc_getWoundDescription], [0.7, 0.7, 0.7, 1]];
-            };
-        };
-    };
-} forEach GET_OPEN_WOUNDS(_target);
-
-{
-    _x params ["_woundClassID", "_bodyPartN", "_amountOf"];
-    if (_selectionN == _bodyPartN && {_amountOf > 0}) then {
-        _woundEntries pushBack [format ["[B] %1", call _fnc_getWoundDescription], [0.88, 0.7, 0.65, 1]];
-    };
-} forEach GET_BANDAGED_WOUNDS(_target);
-
-{
-    _x params ["_woundClassID", "_bodyPartN", "_amountOf"];
-    if (_selectionN == _bodyPartN && {_amountOf > 0}) then {
-        _woundEntries pushBack [format ["[S] %1", call _fnc_getWoundDescription], [0.7, 0.7, 0.7, 1]];
-    };
-} forEach GET_STITCHED_WOUNDS(_target);
+[GET_OPEN_WOUNDS(_target), "%1", [1, 1, 1, 1]] call _fnc_processWounds;
+[GET_BANDAGED_WOUNDS(_target), "[B] %1", [0.88, 0.7, 0.65, 1]] call _fnc_processWounds;
+[GET_STITCHED_WOUNDS(_target), "[S] %1", [0.7, 0.7, 0.7, 1]] call _fnc_processWounds;
 
 // Handle no wound entries
 if (_woundEntries isEqualTo []) then {

--- a/addons/medical_treatment/functions/fnc_bandageLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_bandageLocal.sqf
@@ -46,12 +46,12 @@ _patient setVariable [VAR_OPEN_WOUNDS, _openWounds, true];
 [_patient] call EFUNC(medical_status,updateWoundBloodLoss);
 
 // Handle the reopening of bandaged wounds
-if (_impact > 0 && {GVAR(advancedBandages) && {GVAR(woundReopening)}}) then {
+if (_impact > 0 && {GVAR(advancedBandages) == 2}) then {
     [_patient, _impact, _partIndex, _woundIndex, _wound, _bandage] call FUNC(handleBandageOpening);
 };
 
 // Check if we fixed limping from this treatment
-if ((EGVAR(medical,limping) == 1) && {_partIndex > 3} && {_amountOf <= 0} && {_patient getVariable [QEGVAR(medical,isLimping), false]}) then {
+if (EGVAR(medical,limping) == 1 && {_partIndex > 3} && {_amountOf <= 0} && {_patient getVariable [QEGVAR(medical,isLimping), false]}) then {
     [_patient] call EFUNC(medical_engine,updateDamageEffects);
 };
 

--- a/addons/medical_treatment/functions/fnc_canBandage.sqf
+++ b/addons/medical_treatment/functions/fnc_canBandage.sqf
@@ -22,7 +22,7 @@
 params ["_medic", "_patient", "_bodyPart", "_bandage"];
 
 // Bandage type and bandage setting XNOR to show only active actions
-if ((_bandage == "BasicBandage") isEqualTo GVAR(advancedBandages)) exitWith {false};
+if ((_bandage == "BasicBandage") isEqualTo (GVAR(advancedBandages) != 0)) exitWith {false};
 
 private _index = ALL_BODY_PARTS find toLower _bodyPart;
 private _canBandage = false;

--- a/addons/medical_treatment/functions/fnc_getBandageTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getBandageTime.sqf
@@ -28,7 +28,7 @@ _targetWound params ["_wound", "_woundIndex", "_effectiveness"];
 TRACE_3("findMostEffectiveWound",_wound,_woundIndex,_effectiveness);
 
 // Everything is patched up on this body part already
-if (_wound isEqualTo EMPTY_WOUND) exitWith { 0 };
+if (_wound isEqualTo EMPTY_WOUND) exitWith {0};
 
 _wound params ["_classID", "", "_amountOf", "_bloodloss", "_damage"];
 private _category = (_classID % 10);
@@ -37,8 +37,9 @@ private _category = (_classID % 10);
 private _bandageTime = [BANDAGE_TIME_S, BANDAGE_TIME_M, BANDAGE_TIME_L] select _category;
 
 // Scale bandage time based on amount left and effectiveness (less time if only a little wound left)
-if (GVAR(advancedBandages)) then { // basicBandage will have a very high effectiveness and can be ignored
-    _bandageTime = _bandageTime * (linearConversion [0, _effectiveness, _amountOf, 0.666, 1, true]);
+// Basic bandage treatment will have a very high effectiveness and can be ignored
+if (GVAR(advancedBandages) != 0) then {
+    _bandageTime = _bandageTime * linearConversion [0, _effectiveness, _amountOf, 0.666, 1, true];
 };
 
 // Medics are more practised at applying bandages

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -8,15 +8,6 @@
 ] call CBA_settings_fnc_init;
 
 [
-    QGVAR(advancedBandages),
-    "CHECKBOX",
-    [LSTRING(AdvancedBandages_DisplayName), LSTRING(AdvancedBandages_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    true,
-    true
-] call CBA_settings_fnc_init;
-
-[
     QGVAR(advancedMedication),
     "CHECKBOX",
     [LSTRING(AdvancedMedication_DisplayName), LSTRING(AdvancedMedication_Description)],
@@ -25,14 +16,12 @@
     true
 ] call CBA_settings_fnc_init;
 
-// todo: verify that this setting does not require a restart
-// todo: this setting requires advanced bandages to be enabled, they should be independent
 [
-    QGVAR(woundReopening),
-    "CHECKBOX",
-    [LSTRING(WoundReopening_DisplayName), LSTRING(WoundReopening_Description)],
+    QGVAR(advancedBandages),
+    "LIST",
+    [LSTRING(AdvancedBandages_DisplayName), LSTRING(AdvancedBandages_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    false,
+    [[0, 1, 2], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(AdvancedBandages_EnabledCanReopen)], 1],
     true
 ] call CBA_settings_fnc_init;
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -45,7 +45,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedMedication_DisplayName">
             <English>Advanced Medication</English>
-            <German>Erweiterte Medikamente</German>
+            <German>Erweiterte Medikation</German>
             <Japanese>アドバンスド医薬品</Japanese>
             <Russian>Расширенные Лекарства</Russian>
             <French>Médication avancée</French>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -43,27 +43,6 @@
             <Italian>Abilita le azioni di controllo del polso, controllo della pressione sanguigna e controllo della risposta al trattamento invece dell'azione generica Diagnose.\ Se disabilitata, l'azione di RCP sarà mostrata solo quando l'esecuzione della RCP è appropriata.\Le azioni abilitate da questa impostazione sono necessarie per determinare se una persona è in stato di incoscienza o in arresto cardiaco.</Italian>
             <Czech>Povoluje kontrolu srdečního tepu, krevního tlaku a reakce pacienta namísto univerzální diagnózy.\nKdyž je tato možnost vypnuta, CPR akce bude dostupná pouze pokud je vhodné ji provést.\nAkce které tato možnost zapíná jsou nutné k určení zda je pacient v bezvědomí nebo má srdeční zástavu.</Czech>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_DisplayName">
-            <English>Advanced Bandages</English>
-            <German>Erweiterte Bandagen</German>
-            <Japanese>アドバンスド包帯</Japanese>
-            <Russian>Расширенная Перевязка</Russian>
-            <French>Pansements avancés</French>
-            <Portuguese>Ataduras Avançadas</Portuguese>
-            <Chinese>進階包紮</Chinese>
-            <Italian>Bendaggi avanzati</Italian>
-            <Czech>Pokročilé obvazy</Czech>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_Description">
-            <English>Enables treatment actions for different bandage types instead of the generic Bandage action.</English>
-            <Japanese>有効化すると通常の包帯動作に代わり、様々な種類がある包帯で治療ができます。</Japanese>
-            <French>Active différents types de bandages, à choisir judicieusement en fonction des plaies.</French>
-            <Russian>Включает действия для разных типов повязок, вместо общего действия «Перевязка».</Russian>
-            <Portuguese>Ativa o uso de tipos diferentes de ataduras ao invés de apenas a atadura básica.</Portuguese>
-            <Chinese>啟用不同繃帶的可用行為而非一般包紮動作。</Chinese>
-            <Italian>Permette azioni di trattamento per diversi tipi di bendaggio al posto del bendaggio generico.</Italian>
-            <Czech>Povoluje specifické obvazy s různými vlastnostmi namísto jednoho univerzálního obvazu.</Czech>
-        </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedMedication_DisplayName">
             <English>Advanced Medication</English>
             <German>Erweiterte Medikamente</German>
@@ -83,25 +62,29 @@
             <Chinese>是否擴展藥物管控使其更深度化。並且，啟用腺苷以及阿托品的使用次數</Chinese>
             <Czech>Povoluje hlubší a rozšířené zacházení s léčivy. Také aktivuje Adenosin a Atropin.</Czech>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_WoundReopening_DisplayName">
-            <English>Wound Reopening</English>
-            <Japanese>創傷再開放</Japanese>
-            <French>Réouverture des plaies</French>
-            <Russian>Повторное открытие ран</Russian>
-            <Portuguese>Reabrir Feridas</Portuguese>
-            <Chinese>傷口再度裂開</Chinese>
-            <Italian>Riapertura della ferita</Italian>
-            <Czech>Znovuotevření ran</Czech>
+        <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_DisplayName">
+            <English>Advanced Bandages</English>
+            <German>Erweiterte Bandagen</German>
+            <Japanese>アドバンスド包帯</Japanese>
+            <Russian>Расширенная Перевязка</Russian>
+            <French>Pansements avancés</French>
+            <Portuguese>Ataduras Avançadas</Portuguese>
+            <Chinese>進階包紮</Chinese>
+            <Italian>Bendaggi avanzati</Italian>
+            <Czech>Pokročilé obvazy</Czech>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_WoundReopening_Description">
-            <English>Enables the reopening of bandaged wounds. Requires Advanced Bandages to be enabled.</English>
-            <Japanese>有効化すると治療をした創傷を再開放します。アドバンスド包帯を有効化している必要があります。</Japanese>
-            <French>Permet la réouverture des plaies pansées.\nNécessite que l'option "pansements avancés" soit activée.</French>
-            <Russian>Разрешает повторное открытие перевязанных ран. Требуются опция «Расширенная Перевязка».</Russian>
-            <Portuguese>Permite que ferimentos atados possam reabrir. Requer Ataduras Avançadas para funcionar.</Portuguese>
-            <Chinese>啟用包紮過的傷口是否會再度裂開。需要啟用「進階包紮」之功能。</Chinese>
-            <Czech>Povoluje znovuotevírání obvázaných zranění. Vyžaduje zapnuté Pokročilé obvazy.</Czech>
-            <Italian>Permette la riapertura delle ferite fasciate. Richiede l'abilitazione di Bende Avanzate.</Italian>
+        <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_Description">
+            <English>Enables treatment actions for different bandage types instead of the generic Bandage action.\nAdditionally, the reopening of bandaged wounds can also be enabled.</English>
+            <Japanese>有効化すると通常の包帯動作に代わり、様々な種類がある包帯で治療ができます。</Japanese>
+            <French>Active différents types de bandages, à choisir judicieusement en fonction des plaies.</French>
+            <Russian>Включает действия для разных типов повязок, вместо общего действия «Перевязка».</Russian>
+            <Portuguese>Ativa o uso de tipos diferentes de ataduras ao invés de apenas a atadura básica.</Portuguese>
+            <Chinese>啟用不同繃帶的可用行為而非一般包紮動作。</Chinese>
+            <Italian>Permette azioni di trattamento per diversi tipi di bendaggio al posto del bendaggio generico.</Italian>
+            <Czech>Povoluje specifické obvazy s různými vlastnostmi namísto jednoho univerzálního obvazu.</Czech>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_EnabledCanReopen">
+            <English>Enabled &amp; Can Reopen</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
             <English>Clear Trauma After Bandage</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -58,15 +58,18 @@
             <Portuguese>Medicação Avançada</Portuguese>
             <Chinese>進階醫療用品</Chinese>
             <Czech>Pokročilé léky</Czech>
+            <Italian>Medicazione avanzata</Italian>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedMedication_Description">
             <English>Enables extended, more in-depth medication handling. Also, enables the use of Adenosine.</English>
             <Russian>Устанавливает расширенное использование лекарств</Russian>
             <Japanese>有効化するともっと多くの多様な機能を持つ医薬品を使えます。また、アデノシンとアトロピンが利用可能になります。</Japanese>
-            <French>Permet une manipulation étendue et plus appronfondie des médicaments.\nEn outre, permet l'utilisation d'adénosine et d'atropine.</French>
+            <French>Permet une manipulation étendue et plus approfondie des médicaments.\nEn outre, permet l'utilisation d'adénosine.</French>
             <Portuguese>Ativa a manipulação avançada de medicações. Também permite o uso de Adenosina e Atropina.</Portuguese>
             <Chinese>是否擴展藥物管控使其更深度化。並且，啟用腺苷以及阿托品的使用次數</Chinese>
             <Czech>Povoluje hlubší a rozšířené zacházení s léčivy. Také aktivuje Adenosin a Atropin.</Czech>
+            <Italian>Abilita una gestione della medicazione più estesa e approfondita. Permette inoltre l'utilizzo dell'Adenosina.</Italian>
+            <German>Ermöglicht erweiterte, mehr tiefgründigere Anwendung von Medikationen. Ebenso ermöglicht es die Benutzung von Adenosin.</German>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_DisplayName">
             <English>Advanced Bandages</English>
@@ -82,6 +85,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_Description">
             <English>Enables treatment actions for different bandage types instead of the generic Bandage action.\nAdditionally, the reopening of bandaged wounds can also be enabled.</English>
+            <German>Ermöglicht Behandlungsaktionen für verschiedene Bandagentypen anstelle der gewöhnlichen Bandageaktionen.</German>
             <Japanese>有効化すると通常の包帯動作に代わり、様々な種類がある包帯で治療ができます。</Japanese>
             <French>Active différents types de bandages, à choisir judicieusement en fonction des plaies.</French>
             <Russian>Включает действия для разных типов повязок, вместо общего действия «Перевязка».</Russian>
@@ -90,7 +94,6 @@
             <Italian>Permette azioni di trattamento per diversi tipi di bendaggio al posto del bendaggio generico.</Italian>
             <Czech>Povoluje specifické obvazy s různými vlastnostmi namísto jednoho univerzálního obvazu.</Czech>
             <Polish>Umożliwia wybranie konkretnego rodzaju bandaża zamiast ogólnej akcji bandażowania.</Polish>
-            <German>Ermöglicht Behandlungsaktionen für verschiedene Bandagentypen anstelle der gewöhnlichen Bandageaktionen.</German>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_EnabledCanReopen">
             <English>Enabled &amp; Can Reopen</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Combine `advancedBandages` and `woundReopening` settings into a single 3 option setting
    - `woundReopening` was only used when `advancedBandages` was enabled - since `BasicBandage` can't reopen
- Remove "grey bandaged wounds" from displaying in injury lists
    - Caused confusion as these weren't actual bandaged wounds instead, open wounds with amount of zero
- Improve injury lists wound entry adding code