### PR TITLE
Changed: Scripted calls to putInEarPlugs/joinTeam won't show hint

### DIFF
--- a/addons/hearing/CfgVehicles.hpp
+++ b/addons/hearing/CfgVehicles.hpp
@@ -7,7 +7,7 @@ class CfgVehicles {
                     displayName = CSTRING(EarPlugs_On);
                     condition = QUOTE(GVAR(EnableCombatDeafness) && {!([_player] call FUNC(hasEarPlugsIn)) && {'ACE_EarPlugs' in items _player}});
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting"};
-                    statement = QUOTE( [_player] call FUNC(putInEarPlugs) );
+                    statement = QUOTE( [_player, true] call FUNC(putInEarPlugs) );
                     showDisabled = 0;
                     icon = QPATHTOF(UI\ACE_earplugs_x_ca.paa);
                 };
@@ -15,7 +15,7 @@ class CfgVehicles {
                     displayName = CSTRING(EarPlugs_Off);
                     condition = QUOTE( GVAR(EnableCombatDeafness) && {[_player] call FUNC(hasEarPlugsIn)});
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting"};
-                    statement = QUOTE( [_player] call FUNC(removeEarPlugs) );
+                    statement = QUOTE( [_player, true] call FUNC(removeEarPlugs) );
                     showDisabled = 0;
                     icon = QPATHTOF(UI\ACE_earplugs_x_ca.paa);
                 };

--- a/addons/hearing/functions/fnc_putInEarplugs.sqf
+++ b/addons/hearing/functions/fnc_putInEarplugs.sqf
@@ -5,18 +5,18 @@
  *
  * Arguments:
  * 0: Unit (player) <OBJECT>
- * 1: Display hint <BOOL> (default: true)
+ * 1: Display hint <BOOL> (default: false)
  *
  * Return Value:
  * None
  *
  * Example:
- * [ace_player] call ace_hearing_fnc_putInEarplugs
+ * [ace_player, false] call ace_hearing_fnc_putInEarplugs
  *
  * Public: No
  */
 
-params ["_player", ["_displayHint", true, [true]]];
+params ["_player", ["_displayHint", false, [false]]];
 
 if (!GVAR(EnableCombatDeafness)) exitWith {};
 

--- a/addons/hearing/functions/fnc_putInEarplugs.sqf
+++ b/addons/hearing/functions/fnc_putInEarplugs.sqf
@@ -5,6 +5,7 @@
  *
  * Arguments:
  * 0: Unit (player) <OBJECT>
+ * 1: Display hint <BOOL> (default: true)
  *
  * Return Value:
  * None
@@ -15,7 +16,7 @@
  * Public: No
  */
 
-params ["_player"];
+params ["_player", ["_displayHint", true, [true]]];
 
 if (!GVAR(EnableCombatDeafness)) exitWith {};
 
@@ -24,7 +25,9 @@ _player removeItem "ACE_EarPlugs";
 
 _player setVariable ["ACE_hasEarPlugsIn", true, true];
 
-[localize LSTRING(EarPlugs_Are_On)] call EFUNC(common,displayTextStructured);
+if (_displayHint) then {
+    [localize LSTRING(EarPlugs_Are_On)] call EFUNC(common,displayTextStructured);
+};
 
 //Force an immediate fast volume update:
 [[true]] call FUNC(updateVolume);

--- a/addons/hearing/functions/fnc_removeEarplugs.sqf
+++ b/addons/hearing/functions/fnc_removeEarplugs.sqf
@@ -5,17 +5,18 @@
  *
  * Arguments:
  * 0: Unit (player) <OBJECT>
+ * 1: Display hint <BOOL> (default false)
  *
  * Return Value:
  * None
  *
  * Example:
- * [ace_player] call ace_hearing_fnc_removeEarplugs
+ * [ace_player, false] call ace_hearing_fnc_removeEarplugs
  *
  * Public: No
  */
 
-params ["_player"];
+params ["_player", ["_displayHint", false, [false]]];
 
 if (!GVAR(EnableCombatDeafness)) exitWith {};
 
@@ -28,7 +29,9 @@ _player addItem "ACE_EarPlugs";
 
 _player setVariable ["ACE_hasEarPlugsIn", false, true];
 
-[localize LSTRING(EarPlugs_Are_Off)] call EFUNC(common,displayTextStructured);
+if (_displayHint) then {
+    [localize LSTRING(EarPlugs_Are_Off)] call EFUNC(common,displayTextStructured);
+};
 
 //Force an immediate fast volume update:
 [[true]] call FUNC(updateVolume);

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -79,7 +79,7 @@ class CfgVehicles {
                     class ACE_AssignTeamRed {
                         displayName = CSTRING(AssignTeamRed);
                         condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinTeam));
-                        statement = QUOTE([ARR_2(_target,'RED')] call DFUNC(joinTeam));
+                        statement = QUOTE([ARR_3(_target,'RED',true)] call DFUNC(joinTeam));
                         exceptions[] = {"isNotSwimming"};
                         showDisabled = 1;
                         icon = QPATHTOF(UI\team\team_red_ca.paa);
@@ -87,7 +87,7 @@ class CfgVehicles {
                     class ACE_AssignTeamGreen {
                         displayName = CSTRING(AssignTeamGreen);
                         condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinTeam));
-                        statement = QUOTE([ARR_2(_target,'GREEN')] call DFUNC(joinTeam));
+                        statement = QUOTE([ARR_3(_target,'GREEN',true)] call DFUNC(joinTeam));
                         exceptions[] = {"isNotSwimming"};
                         showDisabled = 1;
                         icon = QPATHTOF(UI\team\team_green_ca.paa);
@@ -95,7 +95,7 @@ class CfgVehicles {
                     class ACE_AssignTeamBlue {
                         displayName = CSTRING(AssignTeamBlue);
                         condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinTeam));
-                        statement = QUOTE([ARR_2(_target,'BLUE')] call DFUNC(joinTeam));
+                        statement = QUOTE([ARR_3(_target,'BLUE',true)] call DFUNC(joinTeam));
                         exceptions[] = {"isNotSwimming"};
                         showDisabled = 1;
                         icon = QPATHTOF(UI\team\team_blue_ca.paa);
@@ -103,7 +103,7 @@ class CfgVehicles {
                     class ACE_AssignTeamYellow {
                         displayName = CSTRING(AssignTeamYellow);
                         condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinTeam));
-                        statement = QUOTE([ARR_2(_target,'YELLOW')] call DFUNC(joinTeam));
+                        statement = QUOTE([ARR_3(_target,'YELLOW',true)] call DFUNC(joinTeam));
                         exceptions[] = {"isNotSwimming"};
                         showDisabled = 1;
                         icon = QPATHTOF(UI\team\team_yellow_ca.paa);
@@ -111,7 +111,7 @@ class CfgVehicles {
                     class ACE_UnassignTeam {
                         displayName = CSTRING(LeaveTeam);
                         condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinTeam) && {assignedTeam _target != 'MAIN'});
-                        statement = QUOTE([ARR_2(_target,'MAIN')] call DFUNC(joinTeam));
+                        statement = QUOTE([ARR_3(_target,'MAIN',true)] call DFUNC(joinTeam));
                         exceptions[] = {"isNotSwimming"};
                         showDisabled = 1;
                         icon = QPATHTOF(UI\team\team_white_ca.paa);
@@ -251,7 +251,7 @@ class CfgVehicles {
                     displayName = CSTRING(JoinTeamRed);
                     condition = QUOTE(true);
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting", "isNotOnLadder", "isNotRefueling"};
-                    statement = QUOTE([ARR_2(_player,'RED')] call DFUNC(joinTeam));
+                    statement = QUOTE([ARR_3(_player,'RED',true)] call DFUNC(joinTeam));
                     showDisabled = 1;
                     icon = QPATHTOF(UI\team\team_red_ca.paa);
                 };
@@ -259,7 +259,7 @@ class CfgVehicles {
                     displayName = CSTRING(JoinTeamGreen);
                     condition = QUOTE(true);
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting", "isNotOnLadder", "isNotRefueling"};
-                    statement = QUOTE([ARR_2(_player,'GREEN')] call DFUNC(joinTeam));
+                    statement = QUOTE([ARR_3(_player,'GREEN',true)] call DFUNC(joinTeam));
                     showDisabled = 1;
                     icon = QPATHTOF(UI\team\team_green_ca.paa);
                 };
@@ -267,7 +267,7 @@ class CfgVehicles {
                     displayName = CSTRING(JoinTeamBlue);
                     condition = QUOTE(true);
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting", "isNotOnLadder", "isNotRefueling"};
-                    statement = QUOTE([ARR_2(_player,'BLUE')] call DFUNC(joinTeam));
+                    statement = QUOTE([ARR_3(_player,'BLUE',true)] call DFUNC(joinTeam));
                     showDisabled = 1;
                     icon = QPATHTOF(UI\team\team_blue_ca.paa);
                 };
@@ -275,7 +275,7 @@ class CfgVehicles {
                     displayName = CSTRING(JoinTeamYellow);
                     condition = QUOTE(true);
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting", "isNotOnLadder", "isNotRefueling"};
-                    statement = QUOTE([ARR_2(_player,'YELLOW')] call DFUNC(joinTeam));
+                    statement = QUOTE([ARR_3(_player,'YELLOW',true)] call DFUNC(joinTeam));
                     showDisabled = 1;
                     icon = QPATHTOF(UI\team\team_yellow_ca.paa);
                 };
@@ -283,7 +283,7 @@ class CfgVehicles {
                     displayName = CSTRING(LeaveTeam);
                     condition = QUOTE(assignedTeam _player != 'MAIN');
                     exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting", "isNotOnLadder", "isNotRefueling"};
-                    statement = QUOTE([ARR_2(_player,'MAIN')] call DFUNC(joinTeam));
+                    statement = QUOTE([ARR_3(_player,'MAIN',true)] call DFUNC(joinTeam));
                     showDisabled = 1;
                     icon = QPATHTOF(UI\team\team_white_ca.paa);
                 };

--- a/addons/interaction/functions/fnc_joinTeam.sqf
+++ b/addons/interaction/functions/fnc_joinTeam.sqf
@@ -6,18 +6,18 @@
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: Team <STRING>
- * 2: Display hint <BOOL> (default: true)
+ * 2: Display hint <BOOL> (default: false)
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, "YELLOW"] call ace_interaction_fnc_joinTeam
+ * [player, "YELLOW", false] call ace_interaction_fnc_joinTeam
  *
  * Public: No
  */
 
-params ["_unit", "_team", ["_displayHint", true, [true]]];
+params ["_unit", "_team", ["_displayHint", false, [false]]];
 
 ["CBA_teamColorChanged", [_unit, _team]] call CBA_fnc_globalEvent;
 

--- a/addons/interaction/functions/fnc_joinTeam.sqf
+++ b/addons/interaction/functions/fnc_joinTeam.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: Team <STRING>
+ * 2: Display hint <BOOL> (default: true)
  *
  * Return Value:
  * None
@@ -16,7 +17,7 @@
  * Public: No
  */
 
-params ["_unit", "_team"];
+params ["_unit", "_team", ["_displayHint", true, [true]]];
 
 ["CBA_teamColorChanged", [_unit, _team]] call CBA_fnc_globalEvent;
 
@@ -30,6 +31,7 @@ if (_unit == ACE_player) then {
         _team = localize format [LSTRING(Team%1), _team];
         _message = format [localize LSTRING(JoinedTeam), _team];
     };
-
-    [_message] call EFUNC(common,displayTextStructured);
+    if (_displayHint) then {
+        [_message] call EFUNC(common,displayTextStructured);
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Added ability to suppress hint message for team switch
- Added ability to suppress hint message for earplugs

This ability can be useful when it comes to scripted auto solutions to avoid a heap of messages on spawn, respawn or recently logged in clients.