### PR TITLE
Medical - Fix epinephrine wake-up chance boost string

### DIFF
--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -42,14 +42,7 @@
             <Spanish>La probabilidad de que una unidad estabilizada recupere la conciencia y se levante (se comprueba cada 15 segundos)</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_spontaneousWakeUpEpinephrineBoost_DisplayName">
-            <English>Epinephrine Increases Wake Up Chance</English>
-            <Japanese>アドレナリンで覚醒確率上昇</Japanese>
-            <Chinese>腎上腺素甦醒機率增加</Chinese>
-            <French>L'épinéphrine augmente les chances de réveil</French>
-            <Italian>L'epinefrina aumenta la possibilità di rialzarsi</Italian>
-            <Czech>Epinefrin zvyšuje šanci na probuzení</Czech>
-            <Portuguese>Epinefrina Aumenta a chance de acordar</Portuguese>
-            <Spanish>Epinefrina, aumenta la posibilidad de despertar</Spanish>
+            <English>Epinephrine Wake Up Chance Boost</English>
         </Key>
         <Key ID="STR_ACE_Medical_spontaneousWakeUpEpinephrineBoost_Description">
             <English>Increases how often spontaneous wake up checks happen when patient has Epinephrine in their system.</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Title - ref. https://github.com/acemod/ACE3/issues/7378#issuecomment-570726654

Not sure if it's a direct multiplier due to connection with epinephrine effectiveness, so I used "boost" as is in the setting name.

Could also be improved with showing it as a percentage in the UI.