### PR TITLE
Cook Off - Change Cook Off events to global and add to events docs

### DIFF
--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -21,7 +21,7 @@ if (_vehicle getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _vehicle setVariable [QGVAR(isCookingOff), true];
 
 if (local _vehicle) then {
-    [QGVAR(cookOff), _vehicle] call CBA_fnc_remoteEvent;
+    [QGVAR(cookOff), _vehicle] call CBA_fnc_globalEvent;
 };
 
 [{

--- a/addons/cookoff/functions/fnc_cookOffBox.sqf
+++ b/addons/cookoff/functions/fnc_cookOffBox.sqf
@@ -21,7 +21,7 @@ if (_box getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _box setVariable [QGVAR(isCookingOff), true];
 
 if (local _box) then {
-    [QGVAR(cookOffBox), _box] call CBA_fnc_remoteEvent;
+    [QGVAR(cookOffBox), _box] call CBA_fnc_globalEvent;
 };
 
 [{

--- a/addons/cookoff/functions/fnc_engineFire.sqf
+++ b/addons/cookoff/functions/fnc_engineFire.sqf
@@ -21,7 +21,7 @@ if (_vehicle getVariable [QGVAR(isEngineSmoking), false]) exitWith {};
 _vehicle setVariable [QGVAR(isEngineSmoking), true];
 
 if (local _vehicle) then {
-    [QGVAR(engineFire), _vehicle] call CBA_fnc_remoteEvent;
+    [QGVAR(engineFire), _vehicle] call CBA_fnc_globalEvent;
 };
 
 private _offset = getArray (_vehicle call CBA_fnc_getObjectConfig >> QGVAR(engineSmokeOffset));

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -97,6 +97,13 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 |`ace_refuel_tick` | [_source, _target, _amount] | Local | Listen | Amount of fuel transferred in a tick
 |`ace_refuel_stopped` | [_source, _target] | Local | Listen | Refueling has stopped
 
+### 2.10 Cook Off (`ace_cookoff`)
+
+| Event Key | Parameters | Locality | Type | Description |
+|----------|---------|---------|---------|---------|---------|
+|`ace_cookoff_cookOff` | [_vehicle] | Global | Listen | Vehicle cook off has started
+|`ace_cookoff_cookOffBox` | [_box] | Global | Listen | Ammo box cook off has started
+|`ace_cookoff_engineFire` | [_vehicle] | Global | Listen | Engine fire has started
 
 ## 3. Usage
 Also Reference [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} documentation.

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -101,9 +101,9 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 
 | Event Key | Parameters | Locality | Type | Description |
 |----------|---------|---------|---------|---------|---------|
-|`ace_cookoff_cookOff` | [_vehicle] | Global | Listen | Vehicle cook off has started
-|`ace_cookoff_cookOffBox` | [_box] | Global | Listen | Ammo box cook off has started
-|`ace_cookoff_engineFire` | [_vehicle] | Global | Listen | Engine fire has started
+|`ace_cookoff_cookOff` | _vehicle | Global | Listen | Vehicle cook off has started
+|`ace_cookoff_cookOffBox` | _box | Global | Listen | Ammo box cook off has started
+|`ace_cookoff_engineFire` | _vehicle | Global | Listen | Engine fire has started
 
 ## 3. Usage
 Also Reference [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} documentation.


### PR DESCRIPTION
**When merged this pull request will:**
- Broadcast `ace_cookoff_cookOff`, `ace_cookoff_cookOffBox` and `ace_cookoff_engineFire` globally, event wasn't sent locally before
- Add both events to events documentation
