### PR TITLE
Tools - Run Release Drafter only on original ACE3 repository

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Drafter
+        if: github.repository == 'acemod/ACE3'
         uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent running it on forks and failing builds.