### PR TITLE
Medical - Add ability for unit specific damage threshold

### DIFF
--- a/addons/medical_damage/CfgEden.hpp
+++ b/addons/medical_damage/CfgEden.hpp
@@ -1,0 +1,28 @@
+class Cfg3DEN {
+    class Attributes {
+        class Slider;
+        class GVAR(slider): Slider {
+            attributeLoad = "params [""_ctrlGroup""]; private _slider = _ctrlGroup controlsGroupCtrl 100; private _edit = _ctrlGroup controlsGroupCtrl 101; _slider sliderSetPosition _value; _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber); ";
+            attributeSave = "params [""_ctrlGroup""]; sliderPosition (_ctrlGroup controlsGroupCtrl 100); ";
+            onLoad = "params [""_ctrlGroup""]; private _slider = _ctrlGroup controlsGroupCtrl 100; private _edit = _ctrlGroup controlsGroupCtrl 101; _slider sliderSetRange [0, 10]; _slider ctrlAddEventHandler [""SliderPosChanged"", { params [""_slider""]; private _edit = (ctrlParentControlsGroup _slider) controlsGroupCtrl 101; private _value = sliderPosition _slider;  _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber); }]; _edit ctrlAddEventHandler [""KillFocus"", { params [""_edit""]; private _slider = (ctrlParentControlsGroup _edit) controlsGroupCtrl 100; private _value = ((parseNumber ctrlText _edit) min 10) max 0; _slider sliderSetPosition _value; _edit ctrlSetText str _value; }];";
+        };
+    };
+    class Object {
+        class AttributeCategories {
+            class ace_attributes {
+                class Attributes {
+                    class GVAR(threshold) {
+                        property = QUOTE(threshold);
+                        control = QGVAR(slider);
+                        displayName = CSTRING(Eden_threshold_DisplayName);
+                        tooltip = CSTRING(Eden_threshold_Description);
+                        expression = QUOTE(if (_value >= 0.1) then {_this setVariable [ARR_3(QQEGVAR(medical,damageThreshold),_value,true)]});
+                        typeName = "NUMBER";
+                        condition = "objectBrain";
+                        defaultValue = 0;
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/medical_damage/CfgEden.hpp
+++ b/addons/medical_damage/CfgEden.hpp
@@ -2,9 +2,30 @@ class Cfg3DEN {
     class Attributes {
         class Slider;
         class GVAR(slider): Slider {
-            attributeLoad = "params [""_ctrlGroup""]; private _slider = _ctrlGroup controlsGroupCtrl 100; private _edit = _ctrlGroup controlsGroupCtrl 101; _slider sliderSetPosition _value; _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber); ";
-            attributeSave = "params [""_ctrlGroup""]; sliderPosition (_ctrlGroup controlsGroupCtrl 100); ";
-            onLoad = "params [""_ctrlGroup""]; private _slider = _ctrlGroup controlsGroupCtrl 100; private _edit = _ctrlGroup controlsGroupCtrl 101; _slider sliderSetRange [0, 10]; _slider ctrlAddEventHandler [""SliderPosChanged"", { params [""_slider""]; private _edit = (ctrlParentControlsGroup _slider) controlsGroupCtrl 101; private _value = sliderPosition _slider;  _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber); }]; _edit ctrlAddEventHandler [""KillFocus"", { params [""_edit""]; private _slider = (ctrlParentControlsGroup _edit) controlsGroupCtrl 100; private _value = ((parseNumber ctrlText _edit) min 10) max 0; _slider sliderSetPosition _value; _edit ctrlSetText str _value; }];";
+            attributeLoad = "params [""_ctrlGroup""];\
+            private _slider = _ctrlGroup controlsGroupCtrl 100;\
+            private _edit = _ctrlGroup controlsGroupCtrl 101;\
+            _slider sliderSetPosition _value;\
+            _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber);";
+            attributeSave = "params [""_ctrlGroup""];\
+            sliderPosition (_ctrlGroup controlsGroupCtrl 100); ";
+            onLoad = "params [""_ctrlGroup""];\
+            private _slider = _ctrlGroup controlsGroupCtrl 100;\
+            private _edit = _ctrlGroup controlsGroupCtrl 101;\
+            _slider sliderSetRange [0, 10];\
+            _slider ctrlAddEventHandler [""SliderPosChanged"", {\
+                params [""_slider""];\
+                private _edit = (ctrlParentControlsGroup _slider) controlsGroupCtrl 101;\
+                private _value = sliderPosition _slider;\
+                _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber);\
+            }];\
+            _edit ctrlAddEventHandler [""KillFocus"", {\
+                params [""_edit""];\
+                private _slider = (ctrlParentControlsGroup _edit) controlsGroupCtrl 100;\
+                private _value = ((parseNumber ctrlText _edit) min 10) max 0;\
+                _slider sliderSetPosition _value;\
+                _edit ctrlSetText str _value;\
+            }];";
         };
     };
     class Object {

--- a/addons/medical_damage/CfgEden.hpp
+++ b/addons/medical_damage/CfgEden.hpp
@@ -6,7 +6,7 @@ class Cfg3DEN {
             private _slider = _ctrlGroup controlsGroupCtrl 100;\
             private _edit = _ctrlGroup controlsGroupCtrl 101;\
             _slider sliderSetPosition _value;\
-            _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber);";
+            _edit ctrlSetText (if (_value < 0.1) then {localize ""str_disp_default""} else {[_value, 1, 1] call CBA_fnc_formatNumber});";
             attributeSave = "params [""_ctrlGroup""];\
             sliderPosition (_ctrlGroup controlsGroupCtrl 100); ";
             onLoad = "params [""_ctrlGroup""];\
@@ -17,14 +17,14 @@ class Cfg3DEN {
                 params [""_slider""];\
                 private _edit = (ctrlParentControlsGroup _slider) controlsGroupCtrl 101;\
                 private _value = sliderPosition _slider;\
-                _edit ctrlSetText ([_value, 1, 1] call CBA_fnc_formatNumber);\
+                _edit ctrlSetText (if (_value < 0.1) then {localize ""str_disp_default""} else {[_value, 1, 1] call CBA_fnc_formatNumber});\
             }];\
             _edit ctrlAddEventHandler [""KillFocus"", {\
                 params [""_edit""];\
                 private _slider = (ctrlParentControlsGroup _edit) controlsGroupCtrl 100;\
                 private _value = ((parseNumber ctrlText _edit) min 10) max 0;\
                 _slider sliderSetPosition _value;\
-                _edit ctrlSetText str _value;\
+                _edit ctrlSetText (if (_value < 0.1) then { localize ""str_disp_default"" } else {[_value, 1, 1] call CBA_fnc_formatNumber});\
             }];";
         };
     };
@@ -39,7 +39,7 @@ class Cfg3DEN {
                         tooltip = CSTRING(Eden_threshold_Description);
                         expression = QUOTE(if (_value >= 0.1) then {_this setVariable [ARR_3(QQEGVAR(medical,damageThreshold),_value,true)]});
                         typeName = "NUMBER";
-                        condition = "objectBrain";
+                        condition = "objectControllable";
                         defaultValue = 0;
                     };
                 };

--- a/addons/medical_damage/config.cpp
+++ b/addons/medical_damage/config.cpp
@@ -18,6 +18,7 @@ class CfgPatches {
 #include "ACE_Medical_Injuries.hpp"
 #include "CfgEventHandlers.hpp"
 #include "CfgAmmo.hpp"
+#include "CfgEden.hpp"
 
 /*
 class ACE_Extensions {

--- a/addons/medical_damage/functions/fnc_determineIfFatal.sqf
+++ b/addons/medical_damage/functions/fnc_determineIfFatal.sqf
@@ -39,7 +39,7 @@ if (EGVAR(medical,fatalDamageSource) in [0, 2]) then {
 };
 if (EGVAR(medical,fatalDamageSource) in [1, 2]) then {
     // Sum of trauma to critical areas can be fatal (e.g. many small hits)
-    private _damageThreshold = if (isPlayer _unit) then { EGVAR(medical,playerDamageThreshold) } else { EGVAR(medical,AIDamageThreshold) };
+    private _damageThreshold = GET_DAMAGE_THRESHOLD(_unit);
     private _headThreshhold = 1.25 * _damageThreshold;
     private _bodyThreshhold = 1.5 * _damageThreshold;
 

--- a/addons/medical_damage/functions/fnc_handleIncapacitation.sqf
+++ b/addons/medical_damage/functions/fnc_handleIncapacitation.sqf
@@ -30,10 +30,7 @@ _bodyPartDamage params ["_headDamage", "_bodyDamage", "_leftArmDamage", "_rightA
     };
 } forEach GET_OPEN_WOUNDS(_unit);
 
-private _damageThreshold = [
-    EGVAR(medical,AIDamageThreshold),
-    EGVAR(medical,playerDamageThreshold)
-] select (isPlayer _unit);
+private _damageThreshold = GET_DAMAGE_THRESHOLD(_unit);
 
 if ((_headDamage > _damageThreshold / 2) || {_bodyDamage > _damageThreshold} || {(_painLevel >= PAIN_UNCONSCIOUS) && {random 1 < 0.1}}) then {
     [QEGVAR(medical,CriticalInjury), _unit] call CBA_fnc_localEvent;

--- a/addons/medical_damage/stringtable.xml
+++ b/addons/medical_damage/stringtable.xml
@@ -631,5 +631,13 @@
             <Turkish>Ikisinden biri</Turkish>
             <German>Beide</German>
         </Key>
+        <Key ID="STR_ACE_Medical_Damage_Eden_threshold_DisplayName">
+            <English>Unit Damage Threshold</English>
+            <German>Schwelle für Schaden</German>
+        </Key>
+        <Key ID="STR_ACE_Medical_Damage_Eden_threshold_Description">
+            <English>Sets the amount of damage a unit can receive before going unconscious. (0 for mission default)</English>
+            <German>Legt die Höhe des Schadens fest, den eine Einheit erhalten kann, bevor diese ohnmächtig wird. (0 für Misionsnormalwert)</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -179,6 +179,7 @@
 #define GET_OPEN_WOUNDS(unit)       (unit getVariable [VAR_OPEN_WOUNDS, []])
 #define GET_BANDAGED_WOUNDS(unit)   (unit getVariable [VAR_BANDAGED_WOUNDS, []])
 #define GET_STITCHED_WOUNDS(unit)   (unit getVariable [VAR_STITCHED_WOUNDS, []])
+#define GET_DAMAGE_THRESHOLD(unit)  (unit getVariable [QEGVAR(medical,unitDamageThreshold), [EGVAR(medical,AIDamageThreshold),EGVAR(medical,playerDamageThreshold)] select (isPlayer unit)])
 
 // The following function calls are defined here just for consistency
 #define GET_BLOOD_LOSS(unit)        ([unit] call EFUNC(medical_status,getBloodLoss))

--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -179,7 +179,7 @@
 #define GET_OPEN_WOUNDS(unit)       (unit getVariable [VAR_OPEN_WOUNDS, []])
 #define GET_BANDAGED_WOUNDS(unit)   (unit getVariable [VAR_BANDAGED_WOUNDS, []])
 #define GET_STITCHED_WOUNDS(unit)   (unit getVariable [VAR_STITCHED_WOUNDS, []])
-#define GET_DAMAGE_THRESHOLD(unit)  (unit getVariable [QEGVAR(medical,unitDamageThreshold), [EGVAR(medical,AIDamageThreshold),EGVAR(medical,playerDamageThreshold)] select (isPlayer unit)])
+#define GET_DAMAGE_THRESHOLD(unit)  (unit getVariable [QEGVAR(medical,damageThreshold), [EGVAR(medical,AIDamageThreshold),EGVAR(medical,playerDamageThreshold)] select (isPlayer unit)])
 
 // The following function calls are defined here just for consistency
 #define GET_BLOOD_LOSS(unit)        ([unit] call EFUNC(medical_status,getBloodLoss))


### PR DESCRIPTION
**When merged this pull request will:**
- Allows mission makers to set damage threshold per unit
- added macro to get damage threshold
- if no variable is set on the unit the global CBA setting value will be used

The new macro differentiates between AI and player.

The variable name for this is currently `ace_medical_unitDamageThreshold`. This is the same name the old medical system used. However the value was an array of 3 values in the old system. Now it is just a number.
So, it is debatable which name for the variable should be used.
