### PR TITLE
Medical - Add setting for medic level to transfuse IVs

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -147,7 +147,7 @@ class GVAR(actions) {
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         allowSelfTreatment = QGVAR(allowSelfIV);
         category = "advanced";
-        medicRequired = 1;
+        medicRequired = QGVAR(medicIV);
         treatmentTime = 12;
         items[] = {"ACE_bloodIV"};
         condition = "";

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -182,6 +182,15 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(medicIV),
+    "LIST",
+    [LSTRING(MedicIV_DisplayName), LSTRING(MedicIV_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 1],
+    true
+] call CBA_settings_fnc_init;
+
+[
     QGVAR(cprSuccessChance),
     "SLIDER",
     [LSTRING(CPRSuccessChance_DisplayName), LSTRING(CPRSuccessChance_Description)],

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -173,20 +173,20 @@
 ] call CBA_settings_fnc_init;
 
 [
-    QGVAR(allowSelfIV),
-    "LIST",
-    [LSTRING(AllowSelfIV_DisplayName), LSTRING(AllowSelfIV_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 1],
-    true
-] call CBA_settings_fnc_init;
-
-[
     QGVAR(medicIV),
     "LIST",
     [LSTRING(MedicIV_DisplayName), LSTRING(MedicIV_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
     [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 1],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(allowSelfIV),
+    "LIST",
+    [LSTRING(AllowSelfIV_DisplayName), LSTRING(AllowSelfIV_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 1],
     true
 ] call CBA_settings_fnc_init;
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -507,6 +507,14 @@
             <Polish>Pozwala przetoczyć płyny IV samemu sobie</Polish>
             <Italian>Abilita la trasfusione in endovena su se stessi.</Italian>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_MedicIV_DisplayName">
+            <English>Allow IV Transfusion</English>
+            <German>Erlaube Bluttransfusionen</German>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_MedicIV_Description">
+            <English>Training level required to transfuse IVs.</English>
+            <German>'Fähigkeiten-Level', das benötigt wird, um Blut zu transfunieren.</German>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">
             <English>Convert Vanilla Items</English>
             <German>Standard Arma-Equipment in ACE-Items umwandeln</German>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -511,11 +511,13 @@
             <English>Allow IV Transfusion</English>
             <German>Erlaube Bluttransfusionen</German>
             <Polish>Zezwalaj na przetaczanie płynów IV</Polish>
+            <French>Pose de perfusion autorisée pour</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicIV_Description">
             <English>Training level required to transfuse IVs.</English>
             <German>'Fähigkeiten-Level', das benötigt wird, um Blut zu transfundieren.</German>
             <Polish>Poziom wyszkolenia potrzebny aby móc przetaczać płyny IV.</Polish>
+            <French>Définit quelle qualification médicale est requise pour pouvoir poser des perfusions intraveineuses.</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">
             <English>Convert Vanilla Items</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -514,7 +514,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicIV_Description">
             <English>Training level required to transfuse IVs.</English>
-            <German>'Fähigkeiten-Level', das benötigt wird, um Blut zu transfunieren.</German>
+            <German>'Fähigkeiten-Level', das benötigt wird, um Blut zu transfundieren.</German>
             <Polish>Poziom wyszkolenia potrzebny aby móc przetaczać płyny IV.</Polish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">


### PR DESCRIPTION
**When merged this pull request will:**
- Add setting to allow transfusing blood for certain medic level
- Default value is "Medics only", same as the initial config value

Old medical had such a setting, thought it was nice to have it in the new one as well.

The German translation sounds weird to me, but oh well..