### PR TITLE
Medical - Increase Cardiact Arrest Time to 5 min

### DIFF
--- a/addons/medical_statemachine/initSettings.sqf
+++ b/addons/medical_statemachine/initSettings.sqf
@@ -38,6 +38,6 @@
     "TIME",
     [LSTRING(CardiacArrestTime_DisplayName), LSTRING(CardiacArrestTime_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory)],
-    [1, 3600, 30],
+    [1, 3600, 300],
     true
 ] call CBA_settings_fnc_init;


### PR DESCRIPTION
**When merged this pull request will:**
- Increase default Cardiac Arrest Time to 5 minutes.

As per research (by @alganthe I believe), this should be closer to reality. It can take more than that for brain cells to start dying.

Additionally, for gameplay reasons, this is a better default combined with all other settings on default.