### PR TITLE
Changed version to versionStr as fix for #7478

### DIFF
--- a/addons/common/functions/fnc_getVersion.sqf
+++ b/addons/common/functions/fnc_getVersion.sqf
@@ -15,4 +15,4 @@
  * Public: Yes
  */
 
-getText (configFile >> "CfgPatches" >> "ACE_main" >> "version") // return
+getText (configFile >> "CfgPatches" >> "ACE_main" >> "versionStr") // return


### PR DESCRIPTION
`ace_common_fnc_getVersion` currently returns "" due to using `getText()` on a number config entry. I'm unsure if using `versionStr` provides intended behavior since `version` is a shorter version of `versionStr`, this however provides a result which seems to be in line with the docstring above.

**When merged this pull request will:**
- Fix #7478 
- Changed `version` to `versionStr` based on the return type specified in docs, its likely that `version` used to contain `versionStr`'s information. If need be the alternative: `str getNumber ()` would also work.
