### PR TITLE
Medical - Fix being stuck in unconscious animation after ragdoll

### DIFF
--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -63,7 +63,7 @@
     } forEach (crew _vehicle);
 }, true, ["ParachuteBase"]] call CBA_fnc_addClassEventHandler;
 
-// fixes units being stuck in unconscious animation when being knocked over by a physix object
+// Fixes units being stuck in unconscious animation when being knocked over by a PhysX object
 ["CAManBase", "AnimDone", {
     params ["_unit", "_anim"];
     if (local _unit && {_anim == "unconscious" && {lifeState _unit != "INCAPACITATED"}}) then {

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -62,3 +62,11 @@
         [QEGVAR(medical,woundReceived), [_x, "Head", _lethality, _killer, "#vehiclecrash", [HITPOINT_INDEX_HEAD,1]], _x] call CBA_fnc_targetEvent;
     } forEach (crew _vehicle);
 }, true, ["ParachuteBase"]] call CBA_fnc_addClassEventHandler;
+
+// fixes units being stuck in unconscious animation when being knocked over by a physix object
+["CAManBase", "AnimDone", {
+    params ["_unit", "_anim"];
+    if (local _unit && {_anim == "unconscious" && {lifeState _unit != "INCAPACITATED"}}) then {
+        [_unit, false] call FUNC(setUnconsciousAnim);
+    };
+}, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -69,4 +69,4 @@
     if (local _unit && {_anim == "unconscious" && {lifeState _unit != "INCAPACITATED"}}) then {
         [_unit, false] call FUNC(setUnconsciousAnim);
     };
-}, true, [], true] call CBA_fnc_addClassEventHandler;
+}] call CBA_fnc_addClassEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Get units out of unconscious animation after a physix object hit them

Addressing issue #7403

Note:
This code might not be fully optimal as it runs on every local unit. Thanks to commy2 for show me the way of propositional calculus.

https://streamable.com/com1h