### PR TITLE
[medical_status] Enable user input between death and respawn

### DIFF
--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -38,4 +38,10 @@ TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
 
 if (_unit isEqualTo (_unit getVariable [QGVAR(killed), objNull])) exitWith {}; // ensure event is only called once
 _unit setVariable [QGVAR(killed), _unit];
+
+if (_unit getVariable ["ACE_isUnconscious", false]) then {
+    // Enable user input before respawn, in case mission is using respawnTemplates
+    ["unconscious", false] call EGVAR(common,setDisableUserInputStatus);
+};
+
 ["ace_killed", [_unit, _causeOfDeath, _killer, _instigator]] call CBA_fnc_globalEvent;

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -41,7 +41,7 @@ _unit setVariable [QGVAR(killed), _unit];
 
 if (_unit getVariable ["ACE_isUnconscious", false]) then {
     // Enable user input before respawn, in case mission is using respawnTemplates
-    ["unconscious", false] call EGVAR(common,setDisableUserInputStatus);
+    ["unconscious", false] call EFUNC(common,setDisableUserInputStatus);
 };
 
 ["ace_killed", [_unit, _causeOfDeath, _killer, _instigator]] call CBA_fnc_globalEvent;

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -39,7 +39,7 @@ TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
 if (_unit isEqualTo (_unit getVariable [QGVAR(killed), objNull])) exitWith {}; // ensure event is only called once
 _unit setVariable [QGVAR(killed), _unit];
 
-if (_unit getVariable [VAR_UNCON, false]) then {
+if (IS_UNCONSCIOUS(_unit)) then {
     // Enable user input before respawn, in case mission is using respawnTemplates
     ["unconscious", false] call EFUNC(common,setDisableUserInputStatus);
 };

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -39,7 +39,7 @@ TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
 if (_unit isEqualTo (_unit getVariable [QGVAR(killed), objNull])) exitWith {}; // ensure event is only called once
 _unit setVariable [QGVAR(killed), _unit];
 
-if (_unit getVariable ["ACE_isUnconscious", false]) then {
+if (_unit getVariable [VAR_UNCON, false]) then {
     // Enable user input before respawn, in case mission is using respawnTemplates
     ["unconscious", false] call EFUNC(common,setDisableUserInputStatus);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Enables user input before respawn so that the respawn interface can be interacted with.

Addresses https://github.com/acemod/ACE3/issues/7356