### PR TITLE
Backblast - Fix damage disabled units receiving damage from backblast

### DIFF
--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -57,7 +57,7 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
             if (_x == ACE_player) then {[_damage * 100] call BIS_fnc_bloodEffect};
 
             TRACE_1("",isDamageAllowed _x);
-            if (isDamageAllowed _x) then {
+            if (isDamageAllowed _x && {_x getVariable [QEGVAR(medical,allowDamage), true]}) then {
                 if (isClass (configFile >> "CfgPatches" >> "ACE_Medical")) then {
                     [_x, _damage, "body", "backblast", _firer] call EFUNC(medical,addDamageToUnit);
                 } else {

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -56,12 +56,13 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
             // If the target is the ACE_player
             if (_x == ACE_player) then {[_damage * 100] call BIS_fnc_bloodEffect};
 
-            if (isClass (configFile >> "CfgPatches" >> "ACE_Medical")) then {
-                [_x, _damage, "body", "backblast", _firer] call EFUNC(medical,addDamageToUnit);
-            } else {
-                TRACE_1("",isDamageAllowed _x);
-                if (!isDamageAllowed _x) exitWith {}; // Skip damage if not allowed
-                _x setDamage (damage _x + _damage);
+            TRACE_1("",isDamageAllowed _x);
+            if (isDamageAllowed _x) then {
+                if (isClass (configFile >> "CfgPatches" >> "ACE_Medical")) then {
+                    [_x, _damage, "body", "backblast", _firer] call EFUNC(medical,addDamageToUnit);
+                } else {
+                    _x setDamage (damage _x + _damage);
+                };
             };
 
             #ifdef DEBUG_MODE_FULL


### PR DESCRIPTION
**When merged this pull request will:**
- Will not damage units from over pressure if damage is disabled

Fix for #7429