### PR TITLE
Only force enable input when player is killed

### DIFF
--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -39,7 +39,7 @@ TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
 if (_unit isEqualTo (_unit getVariable [QGVAR(killed), objNull])) exitWith {}; // ensure event is only called once
 _unit setVariable [QGVAR(killed), _unit];
 
-if (IS_UNCONSCIOUS(_unit)) then {
+if (_unit == player) then {
     // Enable user input before respawn, in case mission is using respawnTemplates
     ["unconscious", false] call EFUNC(common,setDisableUserInputStatus);
 };


### PR DESCRIPTION
A quick hotfix for the implementation of #7502
