### PR TITLE
Map Gestures - Use object itself as center for nearEntities in getProximityPlayers

### DIFF
--- a/addons/map_gestures/functions/fnc_getProximityPlayers.sqf
+++ b/addons/map_gestures/functions/fnc_getProximityPlayers.sqf
@@ -18,7 +18,7 @@
 
 params ["_unit", "_range"];
 
-private _proximityPlayers = (getPos _unit) nearEntities [["CAMAnBase"], _range];
+private _proximityPlayers = _unit nearEntities [["CAMAnBase"], _range];
 _proximityPlayers deleteAt (_proximityPlayers find _unit);
 _proximityPlayers append (crew vehicle _unit);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Use the given unit as centre for `nearEntities` in `ace_map_gestures_fnc_getProximityPlayers`
- Previous `(getPos _unit)` would result in an empty return when stood in a building as height is reported as ~0, so the search performs at ground level
- `nearEntities` requires `PositionAGL`, `getPos` gives `PositionAGLS`
