### PR TITLE
Medical - Arm fracture effect not persisting with setting

### DIFF
--- a/addons/medical_engine/functions/fnc_updateDamageEffects.sqf
+++ b/addons/medical_engine/functions/fnc_updateDamageEffects.sqf
@@ -39,8 +39,8 @@ if (EGVAR(medical,fractures) > 0) then {
             TRACE_1("updating status effect",_isSprintBlocked);
             [_unit, "blockSprint", QEGVAR(medical,fracture), _isSprintBlocked] call EFUNC(common,statusEffect_set);
         };
-        if ((_fractures select 2) == 1) then { _aimFracture = _aimFracture + 2; };
-        if ((_fractures select 3) == 1) then { _aimFracture = _aimFracture + 2; };
+        if ((_fractures select 2) == -1) then { _aimFracture = _aimFracture + 2; };
+        if ((_fractures select 3) == -1) then { _aimFracture = _aimFracture + 2; };
     };
     _unit setVariable [QGVAR(aimFracture), _aimFracture, false]; // local only var, used in ace_medical's postInit to set ACE_setCustomAimCoef
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Ensure a splinted arm causes light aim fracture effects with appropriate settings

Currently the setting causes additional aim fracture effects when the arm has a fracture (array element = 1) while a splinted arm (array element = -1) does not cause any effects. Based on the name of the setting I assume it is intended to give light effects (2 per arm) while splinted with the "full fracture" effects being the same regardless of which setting is used.
