### PR TITLE
Map - Allow enabling BFT setting after mission start

### DIFF
--- a/addons/map/XEH_postInitClient.sqf
+++ b/addons/map/XEH_postInitClient.sqf
@@ -24,12 +24,6 @@ call FUNC(determineZoom);
         }, 0, []] call CBA_fnc_addPerFrameHandler;
     };
 
-    // Start Blue Force Tracking if Enabled
-    if (GVAR(BFT_Enabled)) then {
-        GVAR(BFT_markers) = [];
-        [FUNC(blueForceTrackingUpdate), GVAR(BFT_Interval), []] call CBA_fnc_addPerFrameHandler;
-    };
-
     //illumination settings
     if (GVAR(mapIllumination)) then {
         ["loadout", {

--- a/addons/map/initSettings.sqf
+++ b/addons/map/initSettings.sqf
@@ -85,7 +85,7 @@
     [0, 30, 1, 1],
     true,
     {[QGVAR(BFT_Interval), _this] call EFUNC(common,cbaSettings_settingChanged)},
-    false
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/map/initSettings.sqf
+++ b/addons/map/initSettings.sqf
@@ -69,8 +69,7 @@
     {
         [QGVAR(BFT_Enabled), _this] call EFUNC(common,cbaSettings_settingChanged);
         
-        if (isNil QGVAR(BFT_markers)) then
-        {
+        if (isNil QGVAR(BFT_markers)) then {
             GVAR(BFT_markers) = [];
             [FUNC(blueForceTrackingUpdate), GVAR(BFT_Interval), []] call CBA_fnc_addPerFrameHandler;
         };

--- a/addons/map/initSettings.sqf
+++ b/addons/map/initSettings.sqf
@@ -7,7 +7,7 @@
     true,
     {[QGVAR(mapIllumination), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(mapGlow),
@@ -18,7 +18,7 @@
     true,
     {[QGVAR(mapGlow), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(mapShake),
@@ -27,7 +27,7 @@
     format["ACE %1", localize LSTRING(Module_DisplayName)],
     true,
     true
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(mapLimitZoom),
@@ -36,7 +36,7 @@
     format["ACE %1", localize LSTRING(Module_DisplayName)],
     false,
     true
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(mapShowCursorCoordinates),
@@ -45,7 +45,7 @@
     format["ACE %1", localize LSTRING(Module_DisplayName)],
     false,
     true
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(DefaultChannel),
@@ -56,7 +56,7 @@
     true,
     {[QGVAR(DefaultChannel), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 // Blue Force Tracking
 [
@@ -66,9 +66,17 @@
     [format ["ACE %1", localize LSTRING(Module_DisplayName)], localize LSTRING(BFT_Module_DisplayName)],
     false,
     true,
-    {[QGVAR(BFT_Enabled), _this] call EFUNC(common,cbaSettings_settingChanged)},
-    true // Needs mission restart
-] call CBA_settings_fnc_init;
+    {
+        [QGVAR(BFT_Enabled), _this] call EFUNC(common,cbaSettings_settingChanged);
+        
+        if (isNil QGVAR(BFT_markers)) then
+        {
+            GVAR(BFT_markers) = [];
+            [FUNC(blueForceTrackingUpdate), GVAR(BFT_Interval), []] call CBA_fnc_addPerFrameHandler;
+        };
+    },
+    false
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(BFT_Interval),
@@ -78,8 +86,8 @@
     [0, 30, 1, 1],
     true,
     {[QGVAR(BFT_Interval), _this] call EFUNC(common,cbaSettings_settingChanged)},
-    true // Needs mission restart
-] call CBA_settings_fnc_init;
+    false
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(BFT_ShowPlayerNames),
@@ -89,8 +97,8 @@
     false,
     true,
     {[QGVAR(BFT_ShowPlayerNames), _this] call EFUNC(common,cbaSettings_settingChanged)},
-    true // Needs mission restart
-] call CBA_settings_fnc_init;
+    false
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(BFT_HideAiGroups),
@@ -100,5 +108,5 @@
     false,
     true,
     {[QGVAR(BFT_HideAiGroups), _this] call EFUNC(common,cbaSettings_settingChanged)},
-    true // Needs mission restart
-] call CBA_settings_fnc_init;
+    false
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
**When merged this pull request will:**
- change to CBA_fnc_addSetting not the internal fnc CBA_settings_fnc_init
- some vars can edited in the mission
- if BFT was disabled at mission start an den enabled it now works...
