### PR TITLE
Medical - Improve injured sound by exiting the function earlier if no player is around

### DIFF
--- a/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
@@ -34,7 +34,7 @@ private _distance = if (_type == "hit") then {
 } else {
     [10, 15, 20] select _severity;
 };
-private _targets = allPlayers inAreaArray [getPosWorld _unit, _distance, _distance];
+private _targets = allPlayers inAreaArray [getPosWorld _unit, _distance, _distance, 0, false, _distance];
 if (_targets isEqualTo []) exitWith {};
 
 // Handle timeout

--- a/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
@@ -28,6 +28,15 @@ if (!local _unit) exitWith {
 };
 if !(_unit call EFUNC(common,isAwake)) exitWith {};
 
+// Limit network traffic by only sending the event to players who can potentially hear it
+private _distance = if (_type == "hit") then {
+    [50, 60, 70] select _severity;
+} else {
+    [10, 15, 20] select _severity;
+};
+private _targets = _unit nearEntities ["CAManBase", _distance];
+if (_targets isEqualTo []) exitWith {};
+
 // Handle timeout
 if (_unit getVariable [QGVAR(soundTimeout) + _type, -1] > CBA_missionTime) exitWith {};
 private _timeOut = if (_type == "moan") then { TIME_OUT_MOAN # _severity } else { TIME_OUT_HIT };
@@ -46,11 +55,6 @@ if (isNull (configFile >> "CfgSounds" >> format ["ACE_moan_%1_low_1", _speaker])
 
 // Select actual sound
 private _variation = ["low", "mid", "high"] select _severity;
-private _distance = if (_type == "hit") then {
-    [50, 60, 70] select _severity;
-} else {
-    [10, 15, 20] select _severity;
-};
 
 private _cfgSounds = configFile >> "CfgSounds";
 private _targetClass = format ["ACE_%1_%2_%3_", _type, _speaker, _variation];
@@ -63,6 +67,4 @@ while {isClass (_cfgSounds >> (_targetClass + str _index))} do {
 private _sound = configName selectRandom _sounds;
 if (isNil "_sound") exitWith { WARNING_1("no sounds for target [%1]",_targetClass); };
 
-// Limit network traffic by only sending the event to players who can potentially hear it
-private _targets = _unit nearEntities ["CAManBase", _distance];
 [QGVAR(forceSay3D), [_unit, _sound, _distance], _targets] call CBA_fnc_targetEvent;

--- a/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
@@ -35,7 +35,7 @@ private _distance = if (_type == "hit") then {
     [10, 15, 20] select _severity;
 };
 private _targets = _unit nearEntities ["CAManBase", _distance];
-if ((_targets findIf {isPlayer _x}) == -1) exitWith {};
+if (_targets findIf {isPlayer _x} == -1) exitWith {};
 
 // Handle timeout
 if (_unit getVariable [QGVAR(soundTimeout) + _type, -1] > CBA_missionTime) exitWith {};

--- a/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
@@ -35,7 +35,7 @@ private _distance = if (_type == "hit") then {
     [10, 15, 20] select _severity;
 };
 private _targets = _unit nearEntities ["CAManBase", _distance];
-if (_targets isEqualTo []) exitWith {};
+if ((_targets findIf {isPlayer _x}) == -1) exitWith {};
 
 // Handle timeout
 if (_unit getVariable [QGVAR(soundTimeout) + _type, -1] > CBA_missionTime) exitWith {};

--- a/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
@@ -34,8 +34,8 @@ private _distance = if (_type == "hit") then {
 } else {
     [10, 15, 20] select _severity;
 };
-private _targets = _unit nearEntities ["CAManBase", _distance];
-if (_targets findIf {isPlayer _x} == -1) exitWith {};
+private _targets = allPlayers inAreaArray [getPosWorld _unit, _distance, _distance];
+if (_targets isEqualTo []) exitWith {};
 
 // Handle timeout
 if (_unit getVariable [QGVAR(soundTimeout) + _type, -1] > CBA_missionTime) exitWith {};


### PR DESCRIPTION
I notice `ace_medical_feedback_fnc_playInjuredSound` take an average time of execution around 300µs (~1000 call) even when no player is around the injured AI.

![Sans titre](https://user-images.githubusercontent.com/14364400/74279914-11b94900-4d1c-11ea-99f7-e7d13af3fadd.png)

The idea of this PR is to reduce this value by exiting the function earlier.

**When merged this pull request will:**
- Describe what this pull request will do
  - Exit the  `ace_medical_feedback_fnc_playInjuredSound` earlier if no player is around
- Each change in a separate line
  - Get the hearing distance 
  - Check if players are around
  - Exit if no players