### PR TITLE
Docs/Wiki - Fix formatting for BIS evh warning

### DIFF
--- a/docs/wiki/development/coding-guidelines.md
+++ b/docs/wiki/development/coding-guidelines.md
@@ -606,14 +606,12 @@ Event handlers in ACE3 are implemented through the CBA event system (ACE3's own 
 
 More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events){:target="_blank"} pages.
 
-<div class="panel info">
-    <h5>Warning about BIS event handlers:</h5>
-    <p>BIS's event handlers (`addEventHandler`, `addMissionEventHandler`) are slow when passing a large code variable. Use a short code block that calls the function you want.</p>
-    ```js
-    player addEventHandler ["Fired", FUNC(handleFired)]; // bad
-    player addEventHandler ["Fired", {call FUNC(handleFired)}]; // good
-    ```
-</div>
+**Warning about BIS event handlers:**
+BIS's event handlers (`addEventHandler`, `addMissionEventHandler`) are slow when passing a large code variable. Use a short code block that calls the function you want.
+```js
+player addEventHandler ["Fired", FUNC(handleFired)]; // bad
+player addEventHandler ["Fired", {call FUNC(handleFired)}]; // good
+```
 
 ### 7.4 Hashes
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix formatting for `BIS event handlers warning` under section `7.3`.

Some HTML snuck in there, breaking the markdown.