### PR TITLE
Medical - fix the Enoch pilot uniform not taking damage, fix hitpoints test

### DIFF
--- a/addons/medical/XEH_preStart.sqf
+++ b/addons/medical/XEH_preStart.sqf
@@ -1,3 +1,5 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.hpp"
+
+[false] call compile preprocessFileLineNumbers QPATHTOF(dev\test_hitpointConfigs.sqf);

--- a/addons/medical/dev/test_hitpointConfigs.sqf
+++ b/addons/medical/dev/test_hitpointConfigs.sqf
@@ -1,12 +1,18 @@
-// PabstMirror
+// PabstMirror, commy2
 // ["medicalHitpoints"] call ace_common_fnc_runTests;
-// execVM "\z\ace\addons\medical\dev\test_hitpointConfigs.sqf"
+// call compile preprocessFileLineNumbers "\z\ace\addons\medical\dev\test_hitpointConfigs.sqf"
 
 #include "\z\ace\addons\medical\script_component.hpp"
 
 // UAV-AI should get filtered by scope check
-private _mans = configProperties [configFile >> "CfgVehicles", "(isClass _x) && {(getNumber (_x >> 'scope')) == 2} && {configName _x isKindOf 'CAManBase'}", true];
-INFO_1("Checking mans for medical hitpoints [%1 mans]",count _mans);
+
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgVehicles = configFile >> "CfgVehicles";
+
+private _uniforms = "getNumber (_x >> 'scope') == 2 && {configName _x isKindOf ['Uniform_Base', _cfgWeapons]}" configClasses _cfgWeapons;
+private _units = _uniforms apply {_cfgVehicles >> getText (_x >> "ItemInfo" >> "uniformClass")};
+
+INFO_1("Checking mans for medical hitpoints [%1 units]",count _units);
 
 private _testPass = true;
 {
@@ -22,12 +28,12 @@ private _testPass = true;
         _testPass = false;
     };
 
-    if (((_hitpoints findIf {_x == "HitLeftArm"}) == -1) || {(_hitpoints findIf {_x == "HitLeftArm"}) == -1}
+    if (((_hitpoints findIf {_x == "HitLeftArm"}) == -1) || {(_hitpoints findIf {_x == "HitRightArm"}) == -1}
             || {(_hitpoints findIf {_x == "HitLeftLeg"}) == -1} || {(_hitpoints findIf {_x == "HitRightLeg"}) == -1}
             || {(_hitpoints findIf {_x == "HitHead"}) == -1} || {(_hitpoints findIf {_x == "HitBody"}) == -1}) then {
         WARNING_2("%1 missing ace hitpoints: %2",_typeOf,_hitpoints);
         _testPass = false;
     };
-} forEach _mans;
+} forEach _units;
 
 _testPass

--- a/addons/medical/dev/test_hitpointConfigs.sqf
+++ b/addons/medical/dev/test_hitpointConfigs.sqf
@@ -11,6 +11,9 @@ private _cfgVehicles = configFile >> "CfgVehicles";
 
 private _uniforms = "getNumber (_x >> 'scope') == 2 && {configName _x isKindOf ['Uniform_Base', _cfgWeapons]}" configClasses _cfgWeapons;
 private _units = _uniforms apply {_cfgVehicles >> getText (_x >> "ItemInfo" >> "uniformClass")};
+if (param [0, false]) then { // Check all units (if naked)
+   _units append ((configProperties [configFile >> "CfgVehicles", "(isClass _x) && {(getNumber (_x >> 'scope')) == 2} && {configName _x isKindOf 'CAManBase'}", true]));
+};
 
 INFO_1("Checking mans for medical hitpoints [%1 units]",count _units);
 

--- a/addons/medical/dev/test_hitpointConfigs.sqf
+++ b/addons/medical/dev/test_hitpointConfigs.sqf
@@ -12,10 +12,11 @@ private _cfgVehicles = configFile >> "CfgVehicles";
 private _uniforms = "getNumber (_x >> 'scope') == 2 && {configName _x isKindOf ['Uniform_Base', _cfgWeapons]}" configClasses _cfgWeapons;
 private _units = _uniforms apply {_cfgVehicles >> getText (_x >> "ItemInfo" >> "uniformClass")};
 if (param [0, false]) then { // Check all units (if naked)
+    INFO("checking ALL units");
    _units append ((configProperties [configFile >> "CfgVehicles", "(isClass _x) && {(getNumber (_x >> 'scope')) == 2} && {configName _x isKindOf 'CAManBase'}", true]));
 };
 
-INFO_1("Checking mans for medical hitpoints [%1 units]",count _units);
+INFO_1("Checking uniforms for correct medical hitpoints [%1 units]",count _units);
 
 private _testPass = true;
 {

--- a/addons/medical_engine/CfgVehicles.hpp
+++ b/addons/medical_engine/CfgVehicles.hpp
@@ -113,4 +113,12 @@ class CfgVehicles {
             ADD_ACE_HITPOINTS(3,3);
         };
     };
+
+    // Enoch
+    class I_E_Man_Base_F;
+    class I_E_Uniform_01_coveralls_F: I_E_Man_Base_F {
+        class HitPoints {
+            ADD_ACE_HITPOINTS(2,2);
+        };
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Check all units linked by public items instead of public untis
- HitRightArm was missing (HitLeftArm used twice)

This picks up:
```
14:58:49 [ACE] (medical) INFO: Checking mans for medical hitpoints [160 units]
14:58:49 [ACE] (medical) WARNING: I_E_Uniform_01_coveralls_F has bad last hitpoint: ["HitFace","HitNeck","HitHead","HitPelvis","HitAbdomen","HitDiaphragm","HitChest","HitBody","HitArms","HitHands","HitLegs","Incapacitated"]
14:58:49 [ACE] (medical) WARNING: I_E_Uniform_01_coveralls_F missing ace hitpoints: ["HitFace","HitNeck","HitHead","HitPelvis","HitAbdomen","HitDiaphragm","HitChest","HitBody","HitArms","HitHands","HitLegs","Incapacitated"]
```

- [x] fix I_E_Uniform_01_coveralls_F (worn by I_E_Helipilot_F)
- close #7526