### PR TITLE
fix double execution of killed event

### DIFF
--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -24,7 +24,10 @@
         // "exitWith", which would be broken with "HandleDamage" otherwise.
         _unit setVariable [
             QEGVAR(medical,HandleDamageEHID),
-            _unit addEventHandler ["HandleDamage", {_this call FUNC(handleDamage)}]
+            _unit addEventHandler ["HandleDamage", {
+                private _return = _this call FUNC(handleDamage);
+                if (alive _unit) then {_return};
+            }]
         ];
     };
 }, nil, [IGNORE_BASE_UAVPILOTS], true] call CBA_fnc_addClassEventHandler;

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -27,7 +27,7 @@
             _unit addEventHandler ["HandleDamage", {
                 // Not returning anything for dead units prevents double execution of Killed events.
                 private _return = _this call FUNC(handleDamage);
-                if (alive _unit) then {_return};
+                if (alive param [0]) then {_return};
             }]
         ];
     };

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -25,7 +25,7 @@
         _unit setVariable [
             QEGVAR(medical,HandleDamageEHID),
             _unit addEventHandler ["HandleDamage", {
-                // Not returning anything for dead units prevents double execution for Killed events.
+                // Not returning anything for dead units prevents double execution of Killed events.
                 private _return = _this call FUNC(handleDamage);
                 if (alive _unit) then {_return};
             }]

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -25,6 +25,7 @@
         _unit setVariable [
             QEGVAR(medical,HandleDamageEHID),
             _unit addEventHandler ["HandleDamage", {
+                // Not returning anything for dead units prevents double execution for Killed events.
                 private _return = _this call FUNC(handleDamage);
                 if (alive _unit) then {_return};
             }]

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -28,6 +28,7 @@
                 // Not returning anything for dead units prevents double execution of Killed events.
                 private _return = _this call FUNC(handleDamage);
                 if (alive param [0]) then {_return};
+                nil
             }]
         ];
     };


### PR DESCRIPTION
**When merged this pull request will:**
- I can't reproduce the error if I don't return values when the unit is dead.

Don't ask why this works.