### PR TITLE
Ballistics - Fix AI Accuracy on weapons

### DIFF
--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -14,91 +14,75 @@ class CfgWeapons {
 
     // GM6 Lynx
     class GM6_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
+        AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.45);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.4,1.7);
         };
     };
 
     // M200 Intervention
     class LRR_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
+        AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.50);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.4,1.7);
         };
     };
 
     // MX
     class arifle_MX_Base_F: Rifle_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,4);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,4,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2,3);
         };
     };
 
     // KH2002 Sama
     class arifle_katiba_Base_F: Rifle_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2,3);
         };
     };
 
     // CTAR-21
     class Tavor_base_F: Rifle_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2,3);
         };
     };
 
     // F2000
     class mk20_base_F: Rifle_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2,3);
         };
     };
 
@@ -117,91 +101,75 @@ class CfgWeapons {
 
     // Noreen "Bad News" ULR
     class DMR_02_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,2);
+        AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,2,3);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.61);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.4,1.7);
         };
     };
 
     // VS-121
     class DMR_01_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+        AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4,1.7);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2,3);
         };
     };
 
     // Mk14 Mod 1 EBR
     class EBR_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
+        AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2,3);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2,3);
         };
     };
 
     // SIG 556
     class DMR_03_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+        AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2,3);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2,3);
         };
     };
 
     // ASP-1 Kir
     class DMR_04_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,2);
+        AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,2,3);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.0);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.4,1.7);
         };
     };
 
     // Cyrus
     class DMR_05_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
+        AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2,3);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.67);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.67);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
+            AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2,3);
         };
     };
 
@@ -210,28 +178,23 @@ class CfgWeapons {
         ACE_barrelLength = 558.8;
         ACE_barrelTwist = 304.8;
         initSpeed = -0.999395;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
+        AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2,3);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2,3);
         };
     };
 
     class DMR_06_hunter_base_F: DMR_06_base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,2);
+        AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,2,3);
         class Single: Single {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.4,1.7);
         };
     };
 
@@ -245,21 +208,18 @@ class CfgWeapons {
             "ACE_100Rnd_65x39_caseless_mag_Tracer_Dim",
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,24);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,21);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,21,24);
         initSpeed = -0.981912;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 406.4;
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2,3);
         };
     };
 
@@ -272,21 +232,18 @@ class CfgWeapons {
             "ACE_30Rnd_65x47_Scenar_mag",
             "ACE_30Rnd_65_Creedmor_mag"
         };
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,4);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,4,6);
         initSpeed = -1.0;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 457.2;
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,2,3);
         };
     };
 
@@ -307,18 +264,15 @@ class CfgWeapons {
         initSpeed = -0.869636;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 264.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,2,3);
         };
     };
 
@@ -327,18 +281,15 @@ class CfgWeapons {
         initSpeed = -0.999864;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,2,3);
         };
     };
 
@@ -357,18 +308,15 @@ class CfgWeapons {
         initSpeed = -0.991536;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
+        AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.81);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+            AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2,3);
         };
     };
 
@@ -395,24 +343,20 @@ class CfgWeapons {
 
     // RFB SDAR
     class SDAR_base_F: Rifle_Base_F {
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,14);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,10);
+        AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,10,14);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(3.0);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.4);
+            AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.4,1.7);
         };
 
         class Burst: Mode_Burst {
             dispersion = MOA_TO_RAD(3.0);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2.4);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.9);
+            AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.9,2.4);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(3.0);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2);
+            AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2,3);
         };
     };
 
@@ -520,18 +464,15 @@ class CfgWeapons {
         initSpeed = -0.978947;
         ACE_barrelTwist = 244.0;
         ACE_barrelLength = 463.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2,3);
         };
     };
 
@@ -540,8 +481,7 @@ class CfgWeapons {
         initSpeed = -0.99998;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 640.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,3);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,2);
+        AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,2,3);
         magazines[] = {
             "20Rnd_650x39_Cased_Mag_F",
             "ACE_20Rnd_65x47_Scenar_mag",
@@ -549,8 +489,7 @@ class CfgWeapons {
         };
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.01);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.4,1.7);
         };
     };
 
@@ -559,18 +498,15 @@ class CfgWeapons {
         initSpeed = -1.0;
         ACE_barrelTwist = 244.0;
         ACE_barrelLength = 600.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,2,3);
         };
     };
 
@@ -579,18 +515,15 @@ class CfgWeapons {
         initSpeed = -0.984262;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 463.0;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4,6);
         class Single: Mode_SemiAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4,1.7);
         };
 
         class FullAuto: Mode_FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2,3);
         };
     };
 
@@ -616,18 +549,15 @@ class CfgWeapons {
         initSpeed = -0.961294;
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 393.7;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,4);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,4,6);
         class Single: Single {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.4,1.7);
         };
 
         class FullAuto: FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,2,3);
         };
     };
 
@@ -677,18 +607,15 @@ class CfgWeapons {
         initSpeed = -0.946382;
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 266.7;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
+        AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4,6);
         class Single: Single {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4,1.7);
         };
 
         class FullAuto: FullAuto {
             dispersion = MOA_TO_RAD(0.90);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
+            AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2,3);
         };
     };
 
@@ -766,14 +693,12 @@ class CfgWeapons {
         ACE_barrelLength = 459.74;
         class Single: Single {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.4,1.7);
         };
 
         class FullAuto: FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,2,3);
         };
     };
 
@@ -832,18 +757,15 @@ class CfgWeapons {
         initSpeed = -0.974297;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 406.4;
-        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,6);
-        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,4);
+        AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,4,6);
         class Single: Single {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.7);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.4);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.4,1.7);
         };
 
         class FullAuto: FullAuto {
             dispersion = MOA_TO_RAD(1.12);
-            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,3);
-            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,2);
+            AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,2,3);
         };
     };
 

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -14,59 +14,91 @@ class CfgWeapons {
 
     // GM6 Lynx
     class GM6_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.45);
+            dispersion = EVAL_MOA_TO_RAD(0.45);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.4);
         };
     };
 
     // M200 Intervention
     class LRR_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.50);
+            dispersion = EVAL_MOA_TO_RAD(0.50);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.4);
         };
     };
 
     // MX
     class arifle_MX_Base_F: Rifle_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,4);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
         };
     };
 
     // KH2002 Sama
     class arifle_katiba_Base_F: Rifle_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
         };
     };
 
     // CTAR-21
     class Tavor_base_F: Rifle_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
         };
     };
 
     // F2000
     class mk20_base_F: Rifle_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
         };
     };
 
@@ -85,59 +117,91 @@ class CfgWeapons {
 
     // Noreen "Bad News" ULR
     class DMR_02_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,2);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.61);
+            dispersion = EVAL_MOA_TO_RAD(0.61);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.4);
         };
     };
 
     // VS-121
     class DMR_01_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         };
     };
 
     // Mk14 Mod 1 EBR
     class EBR_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
         };
     };
 
     // SIG 556
     class DMR_03_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         };
     };
 
     // ASP-1 Kir
     class DMR_04_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,2);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.0);
+            dispersion = EVAL_MOA_TO_RAD(1.0);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.4);
         };
     };
 
     // Cyrus
     class DMR_05_base_F: Rifle_Long_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.67);
+            dispersion = EVAL_MOA_TO_RAD(0.67);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.67);
+            dispersion = EVAL_MOA_TO_RAD(0.67);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
         };
     };
 
@@ -146,18 +210,28 @@ class CfgWeapons {
         ACE_barrelLength = 558.8;
         ACE_barrelTwist = 304.8;
         initSpeed = -0.999395;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
         };
     };
 
     class DMR_06_hunter_base_F: DMR_06_base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,2);
         class Single: Single {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.4);
         };
     };
 
@@ -171,15 +245,21 @@ class CfgWeapons {
             "ACE_100Rnd_65x39_caseless_mag_Tracer_Dim",
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,24);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,21);
         initSpeed = -0.981912;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 406.4;
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
         };
     };
 
@@ -192,15 +272,21 @@ class CfgWeapons {
             "ACE_30Rnd_65x47_Scenar_mag",
             "ACE_30Rnd_65_Creedmor_mag"
         };
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,4);
         initSpeed = -1.0;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 457.2;
-        class Single: Single {
-            dispersion = MOA_TO_RAD(0.90);
+        class Single: Mode_SemiAuto {
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
         };
 
-        class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+        class FullAuto: Mode_FullAuto {
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,2);
         };
     };
 
@@ -221,12 +307,18 @@ class CfgWeapons {
         initSpeed = -0.869636;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 264.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,2);
         };
     };
 
@@ -235,12 +327,18 @@ class CfgWeapons {
         initSpeed = -0.999864;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,2);
         };
     };
 
@@ -259,12 +357,18 @@ class CfgWeapons {
         initSpeed = -0.991536;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.81);
+            dispersion = EVAL_MOA_TO_RAD(0.81);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         };
     };
 
@@ -291,16 +395,24 @@ class CfgWeapons {
 
     // RFB SDAR
     class SDAR_base_F: Rifle_Base_F {
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,14);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,10);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(3.0);
+            dispersion = EVAL_MOA_TO_RAD(3.0);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.4);
         };
 
         class Burst: Mode_Burst {
-            dispersion = MOA_TO_RAD(3.0);
+            dispersion = EVAL_MOA_TO_RAD(3.0);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2.4);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.9);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(3.0);
+            dispersion = EVAL_MOA_TO_RAD(3.0);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2);
         };
     };
 
@@ -408,12 +520,18 @@ class CfgWeapons {
         initSpeed = -0.978947;
         ACE_barrelTwist = 244.0;
         ACE_barrelLength = 463.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
         };
     };
 
@@ -422,13 +540,17 @@ class CfgWeapons {
         initSpeed = -0.99998;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 640.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,3);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,2);
         magazines[] = {
             "20Rnd_650x39_Cased_Mag_F",
             "ACE_20Rnd_65x47_Scenar_mag",
             "ACE_20Rnd_65_Creedmor_mag"
         };
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.01);
+            dispersion = EVAL_MOA_TO_RAD(1.01);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.4);
         };
     };
 
@@ -437,12 +559,18 @@ class CfgWeapons {
         initSpeed = -1.0;
         ACE_barrelTwist = 244.0;
         ACE_barrelLength = 600.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,2);
         };
     };
 
@@ -451,12 +579,18 @@ class CfgWeapons {
         initSpeed = -0.984262;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 463.0;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
         };
     };
 
@@ -482,12 +616,18 @@ class CfgWeapons {
         initSpeed = -0.961294;
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 393.7;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,4);
         class Single: Single {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,2);
         };
     };
 
@@ -537,12 +677,18 @@ class CfgWeapons {
         initSpeed = -0.946382;
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 266.7;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
         class Single: Single {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(0.90);
+            dispersion = EVAL_MOA_TO_RAD(0.90);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
         };
     };
 
@@ -619,11 +765,15 @@ class CfgWeapons {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 459.74;
         class Single: Single {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,2);
         };
     };
 
@@ -682,12 +832,18 @@ class CfgWeapons {
         initSpeed = -0.974297;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 406.4;
+        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,6);
+        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,4);
         class Single: Single {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.7);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(1.12);
+            dispersion = EVAL_MOA_TO_RAD(1.12);
+            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,3);
+            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,2);
         };
     };
 

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -236,12 +236,12 @@ class CfgWeapons {
         initSpeed = -1.0;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 457.2;
-        class Single: Mode_SemiAuto {
+        class Single: Single {
             dispersion = MOA_TO_RAD(0.90);
             AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4,1.7);
         };
 
-        class FullAuto: Mode_FullAuto {
+        class FullAuto: FullAuto {
             dispersion = MOA_TO_RAD(0.90);
             AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,2,3);
         };

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -14,91 +14,91 @@ class CfgWeapons {
 
     // GM6 Lynx
     class GM6_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.45);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.4);
+            dispersion = MOA_TO_RAD(0.45);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.45),0.00035,1.4);
         };
     };
 
     // M200 Intervention
     class LRR_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.50);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.4);
+            dispersion = MOA_TO_RAD(0.50);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.50),0.00018,1.4);
         };
     };
 
     // MX
     class arifle_MX_Base_F: Rifle_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,4);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
         };
     };
 
     // KH2002 Sama
     class arifle_katiba_Base_F: Rifle_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
         };
     };
 
     // CTAR-21
     class Tavor_base_F: Rifle_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
         };
     };
 
     // F2000
     class mk20_base_F: Rifle_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
         };
     };
 
@@ -117,91 +117,91 @@ class CfgWeapons {
 
     // Noreen "Bad News" ULR
     class DMR_02_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,2);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.61);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.4);
+            dispersion = MOA_TO_RAD(0.61);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.61),0.00044,1.4);
         };
     };
 
     // VS-121
     class DMR_01_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         };
     };
 
     // Mk14 Mod 1 EBR
     class EBR_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.4);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00073,2);
         };
     };
 
     // SIG 556
     class DMR_03_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         };
     };
 
     // ASP-1 Kir
     class DMR_04_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,2);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.0);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.4);
+            dispersion = MOA_TO_RAD(1.0);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.0),0.0029,1.4);
         };
     };
 
     // Cyrus
     class DMR_05_base_F: Rifle_Long_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.67);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.4);
+            dispersion = MOA_TO_RAD(0.67);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.67);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
+            dispersion = MOA_TO_RAD(0.67);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.67),0.00073,2);
         };
     };
 
@@ -210,28 +210,28 @@ class CfgWeapons {
         ACE_barrelLength = 558.8;
         ACE_barrelTwist = 304.8;
         initSpeed = -0.999395;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.4);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00087,2);
         };
     };
 
     class DMR_06_hunter_base_F: DMR_06_base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,2);
         class Single: Single {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.4);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.000435,1.4);
         };
     };
 
@@ -245,21 +245,21 @@ class CfgWeapons {
             "ACE_100Rnd_65x39_caseless_mag_Tracer_Dim",
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim"
         };
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,24);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,21);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,24);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,21);
         initSpeed = -0.981912;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 406.4;
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00087,2);
         };
     };
 
@@ -272,21 +272,21 @@ class CfgWeapons {
             "ACE_30Rnd_65x47_Scenar_mag",
             "ACE_30Rnd_65_Creedmor_mag"
         };
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,4);
         initSpeed = -1.0;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 457.2;
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00073,2);
         };
     };
 
@@ -307,18 +307,18 @@ class CfgWeapons {
         initSpeed = -0.869636;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 264.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00073,2);
         };
     };
 
@@ -327,18 +327,18 @@ class CfgWeapons {
         initSpeed = -0.999864;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00058,2);
         };
     };
 
@@ -357,18 +357,18 @@ class CfgWeapons {
         initSpeed = -0.991536;
         ACE_barrelTwist = 279.4;
         ACE_barrelLength = 508.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.81);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
+            dispersion = MOA_TO_RAD(0.81);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.81),0.00058,2);
         };
     };
 
@@ -395,24 +395,24 @@ class CfgWeapons {
 
     // RFB SDAR
     class SDAR_base_F: Rifle_Base_F {
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,14);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,10);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,14);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,10);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(3.0);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.4);
+            dispersion = MOA_TO_RAD(3.0);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.4);
         };
 
         class Burst: Mode_Burst {
-            dispersion = EVAL_MOA_TO_RAD(3.0);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2.4);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.9);
+            dispersion = MOA_TO_RAD(3.0);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2.4);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,1.9);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(3.0);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2);
+            dispersion = MOA_TO_RAD(3.0);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(3.0),0.00131,2);
         };
     };
 
@@ -520,18 +520,18 @@ class CfgWeapons {
         initSpeed = -0.978947;
         ACE_barrelTwist = 244.0;
         ACE_barrelLength = 463.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00116,2);
         };
     };
 
@@ -540,17 +540,17 @@ class CfgWeapons {
         initSpeed = -0.99998;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 640.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,3);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,2);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,3);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,2);
         magazines[] = {
             "20Rnd_650x39_Cased_Mag_F",
             "ACE_20Rnd_65x47_Scenar_mag",
             "ACE_20Rnd_65_Creedmor_mag"
         };
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.01);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.4);
+            dispersion = MOA_TO_RAD(1.01);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.01),0.00044,1.4);
         };
     };
 
@@ -559,18 +559,18 @@ class CfgWeapons {
         initSpeed = -1.0;
         ACE_barrelTwist = 244.0;
         ACE_barrelLength = 600.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,6);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00102,2);
         };
     };
 
@@ -579,18 +579,18 @@ class CfgWeapons {
         initSpeed = -0.984262;
         ACE_barrelTwist = 228.6;
         ACE_barrelLength = 463.0;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
         class Single: Mode_SemiAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
         };
 
         class FullAuto: Mode_FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
         };
     };
 
@@ -616,18 +616,18 @@ class CfgWeapons {
         initSpeed = -0.961294;
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 393.7;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,4);
         class Single: Single {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00145,2);
         };
     };
 
@@ -677,18 +677,18 @@ class CfgWeapons {
         initSpeed = -0.946382;
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 266.7;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,4);
         class Single: Single {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(0.90);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
+            dispersion = MOA_TO_RAD(0.90);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(0.90),0.00116,2);
         };
     };
 
@@ -765,15 +765,15 @@ class CfgWeapons {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 459.74;
         class Single: Single {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00087,2);
         };
     };
 
@@ -832,18 +832,18 @@ class CfgWeapons {
         initSpeed = -0.974297;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 406.4;
-        aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,6);
-        aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,4);
+        aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,6);
+        aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,4);
         class Single: Single {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.7);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.4);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.7);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,1.4);
         };
 
         class FullAuto: FullAuto {
-            dispersion = EVAL_MOA_TO_RAD(1.12);
-            aiDispersionCoefY = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,3);
-            aiDispersionCoefX = EVAL_AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,2);
+            dispersion = MOA_TO_RAD(1.12);
+            aiDispersionCoefY = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,3);
+            aiDispersionCoefX = AI_DISPERSION(MOA_TO_RAD(1.12),0.00145,2);
         };
     };
 

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -134,7 +134,9 @@
 #define MRAD_TO_DEG(d) ((d) / 17.45329252) // Conversion factor: 9 / (50 * PI)
 #define MOA_TO_RAD(d) ((d) * 0.00029088) // Conversion factor: PI / 10800
 
-#define AI_DISPERSION(newDispersion,oldDispersion,oldCoef) ((oldDispersion * oldCoef) / (newDispersion))
+#define AI_DISPERSION(newDispersion,oldDispersion,oldCoefY,oldCoefX)\
+aiDispersionCoefX = (((oldDispersion) * (oldCoefX)) / (newDispersion));\
+aiDispersionCoefY = (((oldDispersion) * (oldCoefY)) / (newDispersion))\
 
 #define ZEUS_ACTION_CONDITION ([_target, {QUOTE(QUOTE(ADDON)) in curatorAddons _this}, missionNamespace, QUOTE(QGVAR(zeusCheck)), 1E11, 'ace_interactMenuClosed'] call EFUNC(common,cachedCall))
 

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -133,10 +133,8 @@
 #define DEG_TO_MRAD(d) ((d) * 17.45329252) // Conversion factor: (50 * PI) / 9
 #define MRAD_TO_DEG(d) ((d) / 17.45329252) // Conversion factor: 9 / (50 * PI)
 #define MOA_TO_RAD(d) ((d) * 0.00029088) // Conversion factor: PI / 10800
-#define EVAL_MOA_TO_RAD(d) __EVAL(MOA_TO_RAD(d))
 
 #define AI_DISPERSION(newDispersion,oldDispersion,oldCoef) ((oldDispersion * oldCoef) / (newDispersion))
-#define EVAL_AI_DISPERSION(newDispersion,oldDispersion,oldCoef) __EVAL(AI_DISPERSION(newDispersion,oldDispersion,oldCoef))
 
 #define ZEUS_ACTION_CONDITION ([_target, {QUOTE(QUOTE(ADDON)) in curatorAddons _this}, missionNamespace, QUOTE(QGVAR(zeusCheck)), 1E11, 'ace_interactMenuClosed'] call EFUNC(common,cachedCall))
 

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -135,8 +135,8 @@
 #define MOA_TO_RAD(d) ((d) * 0.00029088) // Conversion factor: PI / 10800
 
 #define AI_DISPERSION(newDispersion,oldDispersion,oldCoefY,oldCoefX)\
-aiDispersionCoefX = (((oldDispersion) * (oldCoefX)) / (newDispersion));\
-aiDispersionCoefY = (((oldDispersion) * (oldCoefY)) / (newDispersion))\
+aiDispersionCoefX = (oldDispersion) * (oldCoefX) / (newDispersion);\
+aiDispersionCoefY = (oldDispersion) * (oldCoefY) / (newDispersion)
 
 #define ZEUS_ACTION_CONDITION ([_target, {QUOTE(QUOTE(ADDON)) in curatorAddons _this}, missionNamespace, QUOTE(QGVAR(zeusCheck)), 1E11, 'ace_interactMenuClosed'] call EFUNC(common,cachedCall))
 

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -133,6 +133,10 @@
 #define DEG_TO_MRAD(d) ((d) * 17.45329252) // Conversion factor: (50 * PI) / 9
 #define MRAD_TO_DEG(d) ((d) / 17.45329252) // Conversion factor: 9 / (50 * PI)
 #define MOA_TO_RAD(d) ((d) * 0.00029088) // Conversion factor: PI / 10800
+#define EVAL_MOA_TO_RAD(d) __EVAL(MOA_TO_RAD(d))
+
+#define AI_DISPERSION(newDispersion,oldDispersion,oldCoef) ((oldDispersion * oldCoef) / (newDispersion))
+#define EVAL_AI_DISPERSION(newDispersion,oldDispersion,oldCoef) __EVAL(AI_DISPERSION(newDispersion,oldDispersion,oldCoef))
 
 #define ZEUS_ACTION_CONDITION ([_target, {QUOTE(QUOTE(ADDON)) in curatorAddons _this}, missionNamespace, QUOTE(QGVAR(zeusCheck)), 1E11, 'ace_interactMenuClosed'] call EFUNC(common,cachedCall))
 


### PR DESCRIPTION
**When merged this pull request will:**
- Change `aiDispersionCoefX/Y` values to suit the lowered dispersion values set by Ballistics
- Change dispersion and aiDispersionCoefX/Y to `__EVAL()`

Related ticket: https://github.com/acemod/ACE3/issues/6948  
Possibly related pull: https://github.com/acemod/ACE3/pull/4484

<details>
<summary>Notes:</summary>

Comparing Vanilla and ACE hit ratios, using a Katiba without optic on Regular difficulty, 0.9 skill on all sub-skills, AI hit ~24% of shots.  
With ACE Ballistics, same scenario, AI hit ~86% of shots.
[Testing scenario](https://dropbox.com/s/j46m247dd9b1n5w/aiAccuracyTest1.VR.rar?dl=0)

I found this to be caused by that the `aiDispersionCoefX/Y` values to be left at default, on both firemode and weapon class.

To calculate new values I went with this assumption:  
`dispersion * aiDispersionCoef = effective dispersion`

Using that assumption I calculate `aiDispersionCoefX/Y` using:  
`(oldDispersion * oldAIDispersionCoef)/newDispersion = newAIDispersionCoef`

**Example GM6 Lynx:**  
Without ace: 0.00035 * 1.7 = 0.000595 effective dispersion
With ace: 0.00013 * 1.7 = 0.000221 effective dispersion, lower than the default dispersion

**With changes:**

((0.00035 * 1.7)/0.00013) = 4.577 new aiDispersionCoef  
(0.00035 * 1.7) = 0.000595 effective dispersion // Default  
(0.00013 * 4.577) = 0.000595 effective dispersion  // ACE w.Changes

The same formula was used on both firemode and weapon class, I'm not entirely sure how exactly they link to weapon accuracy, but both do appear to affect it. If I were to guess, it goes something along the lines of `weaponDispersionCoef * firemodeDispersionCoef * dispersion = effective dispersion`. [Relevant](https://forums.bohemia.net/forums/topic/150499-ai-discussion-dev-branch/?do=findComment&comment=3289475)

Changing values to be within `__EVAL()`s instead of macros appeared to lower accuracy by ~5%, though that might have been due to testing error.

**Result:**  
Using a Katiba without optic on Regular difficulty, 0.9 skill on all sub-skills, AI hit ~32% of shots, higher than vanilla but much less than 86%.

</details>