### PR TITLE
Medical - Unlock air controls when going uncon

### DIFF
--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -47,7 +47,7 @@ if (_active) then {
         };
     };
     // Unlock controls for copilot if unit is pilot of aircraft
-    if (((vehicle _unit) isKindOf "Air") && {_unit == driver vehicle _unit}) then {
+    if (vehicle _unit isKindOf "Air" && {_unit == driver vehicle _unit}) then {
         TRACE_1("pilot of air vehicle - unlocking controls",vehicle _unit);
         // Do "Unlock controls" user action, co-pilot will then have to do the "Take Controls" actions
         _unit action ["UnlockVehicleControl", vehicle _unit];

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -49,7 +49,7 @@ if (_active) then {
     // Unlock controls for copilot if unit is pilot of aircraft
     if (((vehicle _unit) isKindOf "Air") && {_unit == driver vehicle _unit}) then {
         TRACE_1("pilot of air vehicle - unlocking controls",vehicle _unit);
-        // Do "Unlock controls" user action (co-pilot will then have to do the "Take Controls" actions)
+        // Do "Unlock controls" user action, co-pilot will then have to do the "Take Controls" actions
         _unit action ["UnlockVehicleControl", vehicle _unit];
     };
 } else {

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -46,6 +46,12 @@ if (_active) then {
             closeDialog 0;
         };
     };
+    // Unlock controls for copilot if unit is pilot of aircraft
+    if (((vehicle _unit) isKindOf "Air") && {_unit == driver vehicle _unit}) then {
+        TRACE_1("pilot of air vehicle - unlocking controls",vehicle _unit);
+        // Do "Unlock controls" user action (co-pilot will then have to do the "Take Controls" actions)
+        _unit action ["UnlockVehicleControl", vehicle _unit];
+    };
 } else {
     // Unit has woken up, no longer need to track this
     _unit setVariable [QEGVAR(medical,lastWakeUpCheck), nil];


### PR DESCRIPTION
When pilot of aircraft goes uncon then do "Unlock controls" user action 
(co-pilot will then have to do the "Take Controls" actions)

Recently saw a need for this 😄 
Could add a setting (or hidden getVar setting), don't really think it needs one.