### PR TITLE
Don't mark help wanted as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,7 @@ exemptLabels:
   - status/cherrypick
   - status/merge on release
   - sticky
+  - help wanted
 
 # Label to use when marking an issue as stale
 staleLabel: status/stale


### PR DESCRIPTION
Help-wanted tickets are easy to solve things, that the core team usually doesn't do because they are unimportant and to leave them to beginners.
Thus they often go "stale", but they shouldn't.