### PR TITLE
Fastroping - Fix deployAI not unwinding ropes

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -50,28 +50,28 @@ class CfgVehicles {
             };
             class ACE_deployRopes12 {
                 displayName = CSTRING(Interaction_deployRopes12);
-                condition = QUOTE([ARR_3(_target, _player, 'ACE_rope12')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QUOTE(QGVAR(deployRopes)), [ARR_3(_target, _player, 'ACE_rope12'))]] call CBA_fnc_serverEvent);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope12')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope12'))]] call CBA_fnc_serverEvent);
             };
             class ACE_deployRopes15 {
                 displayName = CSTRING(Interaction_deployRopes15);
-                condition = QUOTE([ARR_3(_target, _player, 'ACE_rope15')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QUOTE(QGVAR(deployRopes)), [ARR_3(_target, _player, 'ACE_rope15'))]] call CBA_fnc_serverEvent);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope15')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope15'))]] call CBA_fnc_serverEvent);
             };
             class ACE_deployRopes18 {
                 displayName = CSTRING(Interaction_deployRopes18);
-                condition = QUOTE([ARR_3(_target, _player, 'ACE_rope18')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QUOTE(QGVAR(deployRopes)), [ARR_3(_target, _player, 'ACE_rope18'))]] call CBA_fnc_serverEvent);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope18')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope18'))]] call CBA_fnc_serverEvent);
             };
             class ACE_deployRopes27 {
                 displayName = CSTRING(Interaction_deployRopes27);
-                condition = QUOTE([ARR_3(_target, _player, 'ACE_rope27')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QUOTE(QGVAR(deployRopes)), [ARR_3(_target, _player, 'ACE_rope27'))]] call CBA_fnc_serverEvent);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope27')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope27'))]] call CBA_fnc_serverEvent);
             };
             class ACE_deployRopes36 {
                 displayName = CSTRING(Interaction_deployRopes36);
-                condition = QUOTE([ARR_4(_target, _player, 'ACE_rope36', true)] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QUOTE(QGVAR(deployRopes)), [ARR_3(_target, _player, 'ACE_rope36'))]] call CBA_fnc_serverEvent);
+                condition = QUOTE([ARR_4(_target,_player,'ACE_rope36',true)] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope36'))]] call CBA_fnc_serverEvent);
             };
             class ACE_cutRopes {
                 displayName = CSTRING(Interaction_cutRopes);

--- a/addons/fastroping/functions/fnc_deployAI.sqf
+++ b/addons/fastroping/functions/fnc_deployAI.sqf
@@ -59,10 +59,13 @@ if (_createDeploymentGroup) then {
 };
 
 private  _deployTime = 0;
+
 if (getText (_config >> QGVAR(onPrepare)) != "") then {
     _deployTime = [_vehicle] call (missionNamespace getVariable (getText (_config >> QGVAR(onPrepare))));
 };
-[{[_this] call FUNC(deployRopes)}, _vehicle, _deployTime] call CBA_fnc_waitAndExecute;
+
+[FUNC(deployRopes), _vehicle, _deployTime] call CBA_fnc_waitAndExecute;
+
 driver _vehicle disableAI "MOVE";
 
 DFUNC(deployAIRecursive) = {

--- a/addons/fastroping/functions/fnc_deployRopes.sqf
+++ b/addons/fastroping/functions/fnc_deployRopes.sqf
@@ -34,7 +34,7 @@ if (_ropeLength <= 0) then {
 
 TRACE_3("",_ropeClass,_ropeLength,GVAR(requireRopeItems));
 
-if (GVAR(requireRopeItems)) then {
+if (GVAR(requireRopeItems) && {_ropeClass != ""}) then {
     if (_ropeClass in (_player call EFUNC(common,uniqueItems))) then {
         _player removeItem _ropeClass;
     } else {

--- a/addons/fastroping/functions/fnc_deployRopes.sqf
+++ b/addons/fastroping/functions/fnc_deployRopes.sqf
@@ -16,7 +16,8 @@
  *
  * Public: No
  */
-params ["_vehicle", "_player", "_ropeClass"];
+
+params ["_vehicle", ["_player", objNull], ["_ropeClass", ""]];
 TRACE_3("deployRopes",_vehicle,_player,_ropeClass);
 
 private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
@@ -26,9 +27,15 @@ private _deployedRopes = _vehicle getVariable [QGVAR(deployedRopes), []];
 private _hookAttachment = _vehicle getVariable [QGVAR(FRIES), _vehicle];
 
 private _ropeLength = getNumber (configfile >> "CfgWeapons" >> _ropeClass >> QGVAR(ropeLength));
+
+if (_ropeLength <= 0) then {
+    _ropeLength = DEFAULT_ROPE_LENGTH;
+};
+
 TRACE_3("",_ropeClass,_ropeLength,GVAR(requireRopeItems));
+
 if (GVAR(requireRopeItems)) then {
-    if (_ropeClass in (items _player)) then {
+    if (_ropeClass in (_player call EFUNC(common,uniqueItems))) then {
         _player removeItem _ropeClass;
     } else {
         _vehicle removeItem _ropeClass;

--- a/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeServerPFH.sqf
@@ -28,7 +28,7 @@ if (isNull _hook) exitWith {
     [_pfhHandle] call CBA_fnc_removePerFrameHandler;
 };
 
-private _ropeLength = _vehicle getVariable [QGVAR(ropeLength), 34.5];
+private _ropeLength = _vehicle getVariable [QGVAR(ropeLength), DEFAULT_ROPE_LENGTH];
 
 //Start fast roping
 if (getMass _dummy != 80) exitWith {

--- a/addons/fastroping/script_component.hpp
+++ b/addons/fastroping/script_component.hpp
@@ -17,6 +17,7 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
+#define DEFAULT_ROPE_LENGTH 34.5
 
 #define ANIMS_HOOK ["extendHookRight", "extendHookLeft"]
 #define ANIMS_ANIMATEDOOR ["door_R", "door_L", "CargoRamp_Open", "Door_rear_source", "Door_6_source", "CargoDoorR", "CargoDoorL"]


### PR DESCRIPTION
**When merged this pull request will:**
- After introduction of different rope lengths, `deployRopes` does not unwind ropes when called from `deployAI` because a rope class is not provided
- This PR fixes that by using the old rope length of 34.5 when the config entry `GVAR(ropeLength)` is not a positive number
