### PR TITLE
Reload - Fix static weapon ammo check

### DIFF
--- a/addons/reload/functions/fnc_displayAmmo.sqf
+++ b/addons/reload/functions/fnc_displayAmmo.sqf
@@ -42,6 +42,11 @@ if (_target isKindOf "StaticWeapon") then {
             };
         } forEach _magazines;
     };
+    
+    // For static weapons the muzzle seemingly never returns anything for static weapons with/without people inside
+    if (_muzzle == "") then {
+        _muzzle = _weapon;
+    };
 };
 
 if (_magazine == "") exitWith {};


### PR DESCRIPTION
For some reason ARMA never returns any muzzle for crewed/non crewed static weapons. Work around this by always returning whatever weapon the static weapon has no matter what

fixes #7540 
