### PR TITLE
Interaction Menu - Fix MenuClosed event may not fire on menu type replacement

### DIFF
--- a/addons/interact_menu/XEH_clientInit.sqf
+++ b/addons/interact_menu/XEH_clientInit.sqf
@@ -105,6 +105,7 @@ format ["%1 (%2)", (localize LSTRING(SelfInteractKey)), localize ELSTRING(common
     if (_menuBackgroundSetting == 1) exitWith {[QGVAR(menuBackground), true] call EFUNC(common,blurScreen);};
     if (_menuBackgroundSetting == 2) exitWith {0 cutRsc [QGVAR(menuBackground), "PLAIN", 1, false];};
 }] call CBA_fnc_addEventHandler;
+
 ["ace_interactMenuClosed", {
     params ["_menuType"];
     private _menuBackgroundSetting = [GVAR(menuBackground), GVAR(menuBackgroundSelf)] select _menuType;

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -36,6 +36,12 @@ if (_menuType == 0) then {
     GVAR(keyDownSelfAction) = true;
 };
 GVAR(keyDownTime) = diag_tickTime;
+
+// Raise MenuClosed event whenever one type is replaced with another, because KeyUp code is not guaranteed.
+if (GVAR(openedMenuType) != -1) then {
+    ["ace_interactMenuClosed", [GVAR(openedMenuType)]] call CBA_fnc_localEvent;
+};
+
 GVAR(openedMenuType) = _menuType;
 GVAR(lastTimeSearchedActions) = -1000;
 GVAR(ParsedTextCached) = [];

--- a/addons/interact_menu/functions/fnc_keyUp.sqf
+++ b/addons/interact_menu/functions/fnc_keyUp.sqf
@@ -24,7 +24,7 @@ if (uiNamespace getVariable [QGVAR(cursorMenuOpened),false]) then {
     (findDisplay 91919) closeDisplay 2;
 };
 
-if(GVAR(actionSelected)) then {
+if (GVAR(actionSelected)) then {
     this = GVAR(selectedTarget);
 
     private _player = ACE_Player;


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Global variables already prevent double execution of the event in case anyone is worred.
- close #7381