### PR TITLE
NightVision - Don't apply AimDownSightsBlur on optics with integrated night vision

### DIFF
--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -21,6 +21,7 @@ GVAR(ppeffectRadialBlur) = -1;
 GVAR(ppeffectColorCorrect) = -1;
 GVAR(ppeffectBlur) = -1;
 
+GVAR(isUsingMagnification) = false;
 
 ["ace_settingsInitialized", {
     TRACE_4("settingsInitialized",GVAR(disableNVGsWithSights),GVAR(fogScaling),GVAR(noiseScaling),GVAR(effectScaling));

--- a/addons/nightvision/functions/fnc_onCameraViewChanged.sqf
+++ b/addons/nightvision/functions/fnc_onCameraViewChanged.sqf
@@ -20,7 +20,7 @@ params ["_unit", "_cameraView"];
 TRACE_2("onCameraViewChanged",_unit,_cameraView);
 
 // Refresh goggle effect (e.g. switching to vehicle's NVG)
-FUNC(refreshGoggleType) call CBA_fnc_execNextFrame;
+call FUNC(refreshGoggleType);
 
 if (GVAR(disableNVGsWithSights) && {(hmd _unit) != ""}) then {
     if ((vehicle _unit == _unit)

--- a/addons/nightvision/functions/fnc_onCameraViewChanged.sqf
+++ b/addons/nightvision/functions/fnc_onCameraViewChanged.sqf
@@ -20,7 +20,7 @@ params ["_unit", "_cameraView"];
 TRACE_2("onCameraViewChanged",_unit,_cameraView);
 
 // Refresh goggle effect (e.g. switching to vehicle's NVG)
-[] call FUNC(refreshGoggleType);
+FUNC(refreshGoggleType) call CBA_fnc_execNextFrame;
 
 if (GVAR(disableNVGsWithSights) && {(hmd _unit) != ""}) then {
     if ((vehicle _unit == _unit)

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -16,7 +16,9 @@
  * Public: No
  */
 
-if ((currentVisionMode ACE_player) != 1) exitWith {
+private _unit = ACE_player;
+
+if (currentVisionMode _unit != 1) exitWith {
     GVAR(running) = false;
     [false] call FUNC(setupDisplayEffects);
     [GVAR(PFID)] call CBA_fnc_removePerFrameHandler;
@@ -28,7 +30,7 @@ if ((currentVisionMode ACE_player) != 1) exitWith {
 };
 if (EGVAR(common,OldIsCamera)) exitWith {
     if (GVAR(running)) then {
-        TRACE_2("pausing NVG for scripted camera",alive ACE_player,EGVAR(common,OldIsCamera));
+        TRACE_2("pausing NVG for scripted camera",alive _unit,EGVAR(common,OldIsCamera));
         GVAR(running) = false;
         [false] call FUNC(setupDisplayEffects);
     };
@@ -45,7 +47,7 @@ BEGIN_COUNTER(borderScaling);
 private _scale = (call EFUNC(common,getZoom)) * 1.12513;
 if (!(GVAR(defaultPositionBorder) isEqualTo [])) then {
     // Prevents issues when "zooming out" on ultra wide monitors - The square mask would be narrower than the screen
-    if (((GVAR(defaultPositionBorder) select 2) * _scale) < safeZoneW) then {
+    if ((GVAR(defaultPositionBorder) select 2) * _scale < safeZoneW) then {
         _scale = safeZoneW / (GVAR(defaultPositionBorder) select 2);
     };
     [(uiNamespace getVariable QGVAR(titleDisplay)) displayCtrl 1000, GVAR(defaultPositionHex), _scale] call FUNC(scaleCtrl);
@@ -87,10 +89,11 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     private _fogApply = linearConversion [0, 1, _effectiveLight, ST_NVG_MAXFOG, ST_NVG_MINFOG, true];
 
     // Modify blur if looking down scope
-    if ((cameraView == "GUNNER") && {[ACE_player] call CBA_fnc_canUseWeapon}) then {
-        if (currentWeapon ACE_player == "") exitWith {};
-        if (currentWeapon ACE_player == primaryWeapon ACE_player) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_RIFLE]}; // Rifles are bad
-        if (currentWeapon ACE_player == handgunWeapon ACE_player) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_PISTOL]}; // Pistols aren't so bad
+    if (cameraView == "GUNNER" && {[_unit] call CBA_fnc_canUseWeapon && {systemChat str (0.75 call CBA_fnc_getFOV select 1); 0.75 call CBA_fnc_getFOV select 1 < 3.01}}) then {
+        private _weapon = currentWeapon _unit;
+        if (_weapon == "") exitWith {};
+        if (_weapon == primaryWeapon _unit) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_RIFLE]}; // Rifles are bad
+        if (_weapon == handgunWeapon _unit) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_PISTOL]}; // Pistols aren't so bad
     };
 
     // Scale general effects based on ace_nightvision_effectScaling setting
@@ -99,7 +102,7 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     _contrastFinal = linearConversion [0, 1, GVAR(effectScaling), 1, _contrastFinal];
 
     // Add adjusted NVG brightness
-    private _playerBrightSetting = ACE_player getVariable [QGVAR(NVGBrightness), 0];
+    private _playerBrightSetting = _unit getVariable [QGVAR(NVGBrightness), 0];
     _brightFinal = _brightFinal + (_playerBrightSetting / 20);
 
     // Scale grain effects based on ace_nightvision_noiseScaling setting
@@ -148,9 +151,12 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
 
     // Modify local fog:
     if (GVAR(fogScaling) > 0) then {
-        if (((vehicle ACE_player) != ACE_player) && {(vehicle ACE_player) isKindOf "Air"}) then {  // For flying in particular, can refine nicer later.
+        private _vehicle = vehicle _unit;
+
+        if (_vehicle != _unit && {_vehicle isKindOf "Air"}) then {  // For flying in particular, can refine nicer later.
             _fogApply = _fogApply * ST_NVG_AIR_FOG_MULTIPLIER;
         };
+
         _fogApply = linearConversion [0, 1, GVAR(priorFog) select 0, (GVAR(fogScaling) * _fogApply), 1]; // mix in old fog if present
         GVAR(nvgFog) = [_fogApply, 0, 0];
         0 setFog GVAR(nvgFog)

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -57,6 +57,11 @@ if (!(GVAR(defaultPositionBorder) isEqualTo [])) then {
 };
 END_COUNTER(borderScaling);
 
+if !(IS_MAGNIFIED isEqualTo GVAR(isUsingMagnification)) then {
+    GVAR(isUsingMagnification) = IS_MAGNIFIED;
+    GVAR(nextEffectsUpdate) = -1;
+};
+
 if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     // Update radial blur as it depends on zoom level, so should be changed each frame like the border/hex
     if (GVAR(ppeffectRadialBlur) != -1) then {
@@ -89,7 +94,7 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     private _fogApply = linearConversion [0, 1, _effectiveLight, ST_NVG_MAXFOG, ST_NVG_MINFOG, true];
 
     // Modify blur if looking down scope
-    if (cameraView == "GUNNER" && {[_unit] call CBA_fnc_canUseWeapon && {0.75 call CBA_fnc_getFOV select 1 < 3.01}}) then {
+    if (cameraView == "GUNNER" && {[_unit] call CBA_fnc_canUseWeapon && {!GVAR(isUsingMagnification)}}) then {
         private _weapon = currentWeapon _unit;
         if (_weapon == "") exitWith {};
         if (_weapon == primaryWeapon _unit) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_RIFLE]}; // Rifles are bad

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -89,7 +89,7 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     private _fogApply = linearConversion [0, 1, _effectiveLight, ST_NVG_MAXFOG, ST_NVG_MINFOG, true];
 
     // Modify blur if looking down scope
-    if (cameraView == "GUNNER" && {[_unit] call CBA_fnc_canUseWeapon && {systemChat str (0.75 call CBA_fnc_getFOV select 1); 0.75 call CBA_fnc_getFOV select 1 < 3.01}}) then {
+    if (cameraView == "GUNNER" && {[_unit] call CBA_fnc_canUseWeapon && {0.75 call CBA_fnc_getFOV select 1 < 3.01}}) then {
         private _weapon = currentWeapon _unit;
         if (_weapon == "") exitWith {};
         if (_weapon == primaryWeapon _unit) exitWith {_blurFinal = _blurFinal * linearConversion [0, 1, GVAR(aimDownSightsBlur), 1, ST_NVG_CAMERA_BLUR_SIGHTS_RIFLE]}; // Rifles are bad

--- a/addons/nightvision/script_component.hpp
+++ b/addons/nightvision/script_component.hpp
@@ -46,3 +46,5 @@
 
 #define ST_NVG_NOISESHARPNESS_MIN 1.2
 #define ST_NVG_NOISESHARPNESS_MAX 1
+
+#define IS_MAGNIFIED (0.75 call CBA_fnc_getFOV select 1 > 3.01)


### PR DESCRIPTION
**When merged this pull request will:**
- fix #6666 super satan
- replace close #6942

To explain: If the Magnification is > 3, we can safely assume that we're not looking down iron/holo/cqb sights, but are instead dealing with an optic with actual (!= from RMB zoom) magnification and thus integrated night vision (potentially with its own blur effects).

We need to refresh the effect every time magnification is changed from <3 to >3 and vice versa, as there is no OpticsMode event.