### PR TITLE
Medical Status - Fix double execution of `killed` event

### DIFF
--- a/addons/medical_status/XEH_PREP.hpp
+++ b/addons/medical_status/XEH_PREP.hpp
@@ -6,6 +6,7 @@ PREP(getBloodVolumeChange);
 PREP(getCardiacOutput);
 PREP(getMedicationCount);
 PREP(handleKilled);
+PREP(handleKilledMission);
 PREP(hasStableVitals);
 PREP(initUnit);
 PREP(isBeingCarried);

--- a/addons/medical_status/XEH_preInit.sqf
+++ b/addons/medical_status/XEH_preInit.sqf
@@ -23,4 +23,6 @@ PREP_RECOMPILE_END;
     #endif
 }, nil, [IGNORE_BASE_UAVPILOTS], true] call CBA_fnc_addClassEventHandler;
 
+addMissionEventHandler ["EntityKilled", {_this call FUNC(handleKilledMission)}];
+
 ADDON = true;

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -21,6 +21,14 @@
 params ["_unit", "_killer", "_instigator", "_useEffects"];
 TRACE_4("handleKilled",_unit,_killer,_instigator,_useEffects);
 
+// ensure event is only called once
+if (_unit isEqualTo (_unit getVariable [QGVAR(killed), objNull])) exitWith {
+    _this set [0, objNull];
+    _this set [1, objNull];
+    _this set [2, objNull];
+};
+_unit setVariable [QGVAR(killed), _unit];
+
 private _causeOfDeath = _unit getVariable [QEGVAR(medical,causeOfDeath), "#scripted"];
 
 // if undefined then it's a death not caused by ace's setDead (mission setDamage, disconnect)
@@ -34,10 +42,7 @@ if (_causeOfDeath != "#scripted") then {
         _this set [2, _instigator];
     };
 };
-TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
-
-if (_unit isEqualTo (_unit getVariable [QGVAR(killed), objNull])) exitWith {}; // ensure event is only called once
-_unit setVariable [QGVAR(killed), _unit];
+TRACE_3("killer mission info",_killer,_instigator,_causeOfDeath);
 
 if (_unit == player) then {
     // Enable user input before respawn, in case mission is using respawnTemplates

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -42,7 +42,7 @@ if (_causeOfDeath != "#scripted") then {
         _this set [2, _instigator];
     };
 };
-TRACE_3("killer mission info",_killer,_instigator,_causeOfDeath);
+TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
 
 if (_unit == player) then {
     // Enable user input before respawn, in case mission is using respawnTemplates

--- a/addons/medical_status/functions/fnc_handleKilledMission.sqf
+++ b/addons/medical_status/functions/fnc_handleKilledMission.sqf
@@ -42,4 +42,4 @@ if (_causeOfDeath != "#scripted") then {
         _this set [2, _instigator];
     };
 };
-TRACE_3("killer info",_killer,_instigator,_causeOfDeath);
+TRACE_3("killer mission info",_killer,_instigator,_causeOfDeath);

--- a/addons/medical_status/functions/fnc_handleKilledMission.sqf
+++ b/addons/medical_status/functions/fnc_handleKilledMission.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Vanilla EntityKilled mission EH, attempts to set correct source/killer for other killed event handlers.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Killer <OBJECT>
+ * 2: Instigator <OBJECT>
+ * 3: Use Effects <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject, player, player, true] call ace_medical_status_fnc_handleKilledMission
+ *
+ * Public: No
+ */
+
+params ["_unit", "_killer", "_instigator", "_useEffects"];
+TRACE_4("handleKilledMission",_unit,_killer,_instigator,_useEffects);
+
+private _causeOfDeath = _unit getVariable [QEGVAR(medical,causeOfDeath), "#scripted"];
+
+// if undefined then it's a death not caused by ace's setDead (mission setDamage, disconnect)
+if (_causeOfDeath != "#scripted") then {
+    _killer = _unit getVariable [QEGVAR(medical,lastDamageSource), _killer]; // vehicle
+    _instigator = _unit getVariable [QEGVAR(medical,lastInstigator), _instigator]; // unit in the turret
+
+    // All Killed EHs uses the same array, so we can modify it now to pass the correct killer/instigator
+    if (missionNamespace getVariable [QEGVAR(medical,modifyKilledArray), true]) then { // getVar so this can be disabled
+        _this set [1, _killer];
+        _this set [2, _instigator];
+    };
+};

--- a/addons/medical_status/functions/fnc_handleKilledMission.sqf
+++ b/addons/medical_status/functions/fnc_handleKilledMission.sqf
@@ -21,6 +21,14 @@
 params ["_unit", "_killer", "_instigator", "_useEffects"];
 TRACE_4("handleKilledMission",_unit,_killer,_instigator,_useEffects);
 
+// ensure event is only called once
+if (_unit isEqualTo (_unit getVariable [QGVAR(killedMission), objNull])) exitWith {
+    _this set [0, objNull];
+    _this set [1, objNull];
+    _this set [2, objNull];
+};
+_unit setVariable [QGVAR(killedMission), _unit];
+
 private _causeOfDeath = _unit getVariable [QEGVAR(medical,causeOfDeath), "#scripted"];
 
 // if undefined then it's a death not caused by ace's setDead (mission setDamage, disconnect)
@@ -34,3 +42,4 @@ if (_causeOfDeath != "#scripted") then {
         _this set [2, _instigator];
     };
 };
+TRACE_3("killer info",_killer,_instigator,_causeOfDeath);

--- a/addons/medical_status/functions/fnc_setDead.sqf
+++ b/addons/medical_status/functions/fnc_setDead.sqf
@@ -26,4 +26,4 @@ _unit setVariable [QEGVAR(medical,causeOfDeath), _reason, true];
 [QEGVAR(medical,death), [_unit]] call CBA_fnc_localEvent;
 
 // Kill the unit without changing visual apperance
-[_unit, 1] call EFUNC(medical_engine,setStructuralDamage);
+[EFUNC(medical_engine,setStructuralDamage), [_unit, 1]] call CBA_fnc_execNextFrame;

--- a/addons/medical_status/functions/fnc_setDead.sqf
+++ b/addons/medical_status/functions/fnc_setDead.sqf
@@ -26,4 +26,4 @@ _unit setVariable [QEGVAR(medical,causeOfDeath), _reason, true];
 [QEGVAR(medical,death), [_unit]] call CBA_fnc_localEvent;
 
 // Kill the unit without changing visual apperance
-[EFUNC(medical_engine,setStructuralDamage), [_unit, 1]] call CBA_fnc_execNextFrame;
+[_unit, 1] call EFUNC(medical_engine,setStructuralDamage);


### PR DESCRIPTION
**When merged this pull request will:**
- replace close #7531
- close #7185
- close #3111
- Copies the fix for Object Killed event to the Mission Killed event (a.k.a. EntityKilled, which is a terrible name for a non entity=mission event...).

```sqf
bob1 addEventHandler ["Killed", { 
    systemChat str ["Object Killed", _this]; 
}];

addMissionEventHandler ["EntityKilled", { 
    systemChat str ["Mission Killed", _this]; 
}];
```

~~Note that execNextFrame is how we killed units pre rewrite. The biggest issue was incorrect returns, but Pabst solved that independently and removed my reason for moving setDamage into HandleDamage in the first place.~~

Secondary execution runs with null objects. Should dedmen fix https://feedback.bistudio.com/T149510, the issue will be gone.