### PR TITLE
Ballistics - Fix DMR_03 (SIG556) initSpeed

### DIFF
--- a/addons/ballistics/CfgMagazineWells.hpp
+++ b/addons/ballistics/CfgMagazineWells.hpp
@@ -46,7 +46,7 @@ class CfgMagazineWells {
         };
     };
 
-    class CBA_65x39_Katiba {
+    class Katiba_65x39 {
         ADDON[] = {
             "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };

--- a/addons/ballistics/CfgMagazineWells.hpp
+++ b/addons/ballistics/CfgMagazineWells.hpp
@@ -35,14 +35,20 @@ class CfgMagazineWells {
     class MX_65x39 { //Vanilla magwell
         ADDON[] = {
             "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim",
-            "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim",
             "ACE_30Rnd_65x47_Scenar_mag",
             "ACE_30Rnd_65_Creedmor_mag"
         };
     };
+
     class MX_65x39_Large { //Vanilla magwell
         ADDON[] = {
             "ACE_100Rnd_65x39_caseless_mag_Tracer_Dim"
+        };
+    };
+
+    class CBA_65x39_Katiba {
+        ADDON[] = {
+            "ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim"
         };
     };
 
@@ -60,6 +66,7 @@ class CfgMagazineWells {
             "ACE_30Rnd_556x45_Stanag_Tracer_Dim"
         };
     };
+
     class STANAG_556x45 { //Vanilla magwell
         ADDON[] = {
             "ACE_30Rnd_556x45_Stanag_M995_AP_mag",
@@ -84,6 +91,7 @@ class CfgMagazineWells {
             "ACE_20Rnd_762x51_M993_AP_Mag"
         };
     };
+
     class CBA_762x51_HK417 {
         ADDON[] = {
             "ACE_20Rnd_762x51_Mag_Tracer",
@@ -99,6 +107,7 @@ class CfgMagazineWells {
             "ACE_20Rnd_762x51_M993_AP_Mag"
         };
     };
+
     class CBA_762x51_SR25 {
         ADDON[] = {
             "ACE_20Rnd_762x51_Mag_Tracer",
@@ -114,6 +123,7 @@ class CfgMagazineWells {
             "ACE_20Rnd_762x51_M993_AP_Mag"
         };
     };
+
     class CBA_762x51_G3 {
         ADDON[] = {
             "ACE_20Rnd_762x51_Mag_Tracer",
@@ -175,16 +185,19 @@ class CfgMagazineWells {
             "ACE_16Rnd_9x19_mag"
         };
     };
+
     class CBA_9x19_P228 { // SIG P228
         ADDON[] = {
             "ACE_16Rnd_9x19_mag"
         };
     };
+
     class CBA_9x19_P239 { // SIG P239
         ADDON[] = {
             "ACE_16Rnd_9x19_mag"
         };
     };
+
     class CBA_9x19_HiPower {
         ADDON[] = {
             "ACE_16Rnd_9x19_mag"
@@ -196,6 +209,7 @@ class CfgMagazineWells {
             "ACE_10Rnd_762x54_Tracer_mag"
         };
     };
+
     class CBA_762x54R_SVD {
         ADDON[] = {
             "ACE_10Rnd_762x54_Tracer_mag"

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -9,6 +9,7 @@ class CfgMagazines {
         displayNameShort = CSTRING(12Gauge_Pellets_No00_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No00_Buck_Description);
     };
+
     class ACE_2Rnd_12Gauge_Pellets_No0_Buck: 2Rnd_12Gauge_Pellets {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(2Rnd_12Gauge_Pellets_No0_Buck_Name);
@@ -16,30 +17,35 @@ class CfgMagazines {
         descriptionShort = CSTRING(12Gauge_Pellets_No0_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No0_Buck";
     };
+
     class ACE_2Rnd_12Gauge_Pellets_No1_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_No1_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No1_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No1_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No1_Buck";
     };
+
     class ACE_2Rnd_12Gauge_Pellets_No2_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_No2_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No2_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No2_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No2_Buck";
     };
+
     class ACE_2Rnd_12Gauge_Pellets_No3_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_No3_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No3_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No3_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No3_Buck";
     };
+
     class ACE_2Rnd_12Gauge_Pellets_No4_Buck: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_No4_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No4_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No4_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No4_Buck";
     };
+
     class ACE_2Rnd_12Gauge_Pellets_No4_Bird: ACE_2Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(2Rnd_12Gauge_Pellets_No4_Bird_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No4_Bird_NameShort);
@@ -52,6 +58,7 @@ class CfgMagazines {
         displayNameShort = CSTRING(12Gauge_Pellets_No00_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No00_Buck_Description);
     };
+
     class ACE_6Rnd_12Gauge_Pellets_No0_Buck: 6Rnd_12Gauge_Pellets {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No0_Buck_Name);
@@ -59,30 +66,35 @@ class CfgMagazines {
         descriptionShort = CSTRING(12Gauge_Pellets_No0_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No0_Buck";
     };
+
     class ACE_6Rnd_12Gauge_Pellets_No1_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No1_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No1_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No1_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No1_Buck";
     };
+
     class ACE_6Rnd_12Gauge_Pellets_No2_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No2_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No2_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No2_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No2_Buck";
     };
+
     class ACE_6Rnd_12Gauge_Pellets_No3_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No3_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No3_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No3_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No3_Buck";
     };
+
     class ACE_6Rnd_12Gauge_Pellets_No4_Buck: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No4_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No4_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No4_Buck_Description);
         ammo = "ACE_12Gauge_Pellets_Submunition_No4_Buck";
     };
+
     class ACE_6Rnd_12Gauge_Pellets_No4_Bird: ACE_6Rnd_12Gauge_Pellets_No0_Buck {
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No4_Bird_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No4_Bird_NameShort);
@@ -99,18 +111,23 @@ class CfgMagazines {
     class 30Rnd_580x42_Mag_F: CA_Magazine {
         initSpeed = 950;
     };
+
     class 20Rnd_650x39_Cased_Mag_F: CA_Magazine {
         initSpeed = 806;
     };
+
     class 30Rnd_65x39_caseless_mag: CA_Magazine {
         initSpeed = 774;
     };
+
     class 30Rnd_65x39_caseless_green: 30Rnd_65x39_caseless_mag {
         initSpeed = 788;
     };
+
     class 100Rnd_65x39_caseless_mag: CA_Magazine {
         initSpeed = 774;
     };
+
     class 100Rnd_65x39_caseless_mag_Tracer;
     class ACE_100Rnd_65x39_caseless_mag_Tracer_Dim: 100Rnd_65x39_caseless_mag_Tracer {
         author = ECSTRING(common,ACETeam);
@@ -120,9 +137,11 @@ class CfgMagazines {
         descriptionShort = CSTRING(100Rnd_65x39_caseless_mag_Tracer_DimDescription);
         picture = "\A3\weapons_f\data\ui\m_100rnd_65x39_yellow_ca.paa";
     };
+
     class 200Rnd_65x39_cased_Box: 100Rnd_65x39_caseless_mag {
         initSpeed = 743;
     };
+
     class ACE_200Rnd_65x39_cased_Box_Tracer_Dim: 200Rnd_65x39_cased_Box {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_65x39_Caseless_Tracer_Dim";
@@ -132,6 +151,7 @@ class CfgMagazines {
         picture = "\A3\weapons_f\data\ui\m_200rnd_65x39_yellow_ca.paa";
         initSpeed = 774;
     };
+
     class 30Rnd_65x39_caseless_mag_Tracer;
     class ACE_30Rnd_65x39_caseless_mag_Tracer_Dim: 30Rnd_65x39_caseless_mag_Tracer {
         author = ECSTRING(common,ACETeam);
@@ -140,6 +160,7 @@ class CfgMagazines {
         displayNameShort = CSTRING(30Rnd_65x39_caseless_mag_Tracer_DimNameShort);
         descriptionShort = CSTRING(30Rnd_65x39_caseless_mag_Tracer_DimDescription);
     };
+
     class 30Rnd_65x39_caseless_green_mag_Tracer;
     class ACE_30Rnd_65x39_caseless_green_mag_Tracer_Dim: 30Rnd_65x39_caseless_green_mag_Tracer {
         author = ECSTRING(common,ACETeam);
@@ -152,25 +173,31 @@ class CfgMagazines {
     class 30Rnd_545x39_Mag_F: CA_Magazine {
         initSpeed = 735; // default BI value according with the ACE_muzzleVelocities at 15°C
     };
-    
+
     class 30Rnd_556x45_Stanag: CA_Magazine {
         initSpeed = 909;
     };
+
     class 30Rnd_556x45_Stanag_green: 30Rnd_556x45_Stanag {
         initSpeed = 869;
     };
+
     class 30Rnd_556x45_Stanag_red: 30Rnd_556x45_Stanag {
         initSpeed = 869;
     };
+
     class 30Rnd_556x45_Stanag_Tracer_Red: 30Rnd_556x45_Stanag {
         initSpeed = 869;
     };
+
     class 30Rnd_556x45_Stanag_Tracer_Green: 30Rnd_556x45_Stanag {
         initSpeed = 869;
     };
+
     class 30Rnd_556x45_Stanag_Tracer_Yellow: 30Rnd_556x45_Stanag {
         initSpeed = 889;
     };
+
     class ACE_30Rnd_556x45_Stanag_M995_AP_mag: 30Rnd_556x45_Stanag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_556x45_Ball_M995_AP";
@@ -179,6 +206,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(30Rnd_556x45_Stanag_M995_AP_mag_Description);
         initSpeed = 875;
     };
+
     class ACE_30Rnd_556x45_Stanag_Mk262_mag: 30Rnd_556x45_Stanag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_556x45_Ball_Mk262";
@@ -187,6 +215,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(30Rnd_556x45_Stanag_Mk262_mag_Description);
         initSpeed = 832;
     };
+
     class ACE_30Rnd_556x45_Stanag_Mk318_mag: 30Rnd_556x45_Stanag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_556x45_Ball_Mk318";
@@ -195,38 +224,43 @@ class CfgMagazines {
         descriptionShort = CSTRING(30Rnd_556x45_Stanag_Mk318_mag_Description);
         initSpeed = 923;
     };
+
     class ACE_30Rnd_556x45_Stanag_Tracer_Dim: 30Rnd_556x45_Stanag_Tracer_Red {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_B_556x45_Ball_Tracer_Dim";
         displayName = CSTRING(30Rnd_556x45_mag_Tracer_DimName);
         displayNameShort = CSTRING(30Rnd_556x45_mag_Tracer_DimNameShort);
         descriptionShort = CSTRING(30Rnd_556x45_mag_Tracer_DimDescription);
-        picture = "\A3\weapons_f\data\ui\m_20stanag_red_ca.paa";
     };
 
     class 200Rnd_556x45_Box_F: CA_Magazine {
         initSpeed = 889;
     };
+
     class 200Rnd_556x45_Box_Red_F: 200Rnd_556x45_Box_F {
         initSpeed = 869;
     };
-    
+
     class 30Rnd_762x39_Mag_F: CA_Magazine {
         initSpeed = 715; // default BI value according with the ACE_muzzleVelocities at 15°C
     };
-    
+
     class 20Rnd_762x51_Mag: CA_Magazine {
         initSpeed = 827;
     };
+
     class 10Rnd_762x51_Mag: 20Rnd_762x51_Mag {
         initSpeed = 833;
     };
+
     class 150Rnd_762x51_Box: CA_Magazine {
         initSpeed = 833;
     };
+
     class 150Rnd_762x51_Box_Tracer: 150Rnd_762x51_Box {
         initSpeed = 833;
     };
+
     class ACE_20Rnd_762x51_Mag_Tracer: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "B_762x51_Tracer_Red";
@@ -262,6 +296,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(10Rnd_762x51_M118LR_Mag_Description);
         initSpeed = 780;
     };
+
     class ACE_10Rnd_762x51_Mk316_Mod_0_Mag: 10Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_Mk316_Mod_0";
@@ -271,6 +306,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(10Rnd_762x51_Mk316_Mod_0_Mag_Description);
         initSpeed = 790;
     };
+
     class ACE_10Rnd_762x51_Mk319_Mod_0_Mag: 10Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_Mk319_Mod_0";
@@ -280,6 +316,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(10Rnd_762x51_Mk319_Mod_0_Mag_Description);
         initSpeed = 900;
     };
+
     class ACE_10Rnd_762x51_M993_AP_Mag: 10Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_M993_AP";
@@ -289,6 +326,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(10Rnd_762x51_M993_AP_Mag_Description);
         initSpeed = 920;
     };
+
     class ACE_20Rnd_762x51_M118LR_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_M118LR";
@@ -297,6 +335,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x51_M118LR_Mag_Description);
         initSpeed = 785;
     };
+
     class ACE_20Rnd_762x51_Mk316_Mod_0_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_Mk316_Mod_0";
@@ -306,6 +345,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x51_Mk316_Mod_0_Mag_Description);
         initSpeed = 798;
     };
+
     class ACE_20Rnd_762x51_Mk319_Mod_0_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_Mk319_Mod_0";
@@ -314,6 +354,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x51_Mk319_Mod_0_Mag_Description);
         initSpeed = 910;
     };
+
     class ACE_20Rnd_762x51_M993_AP_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_M993_AP";
@@ -323,6 +364,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x51_M993_AP_Mag_Description);
         initSpeed = 930;
     };
+
     class ACE_20Rnd_762x67_Mk248_Mod_0_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x67_Ball_Mk248_Mod_0";
@@ -331,6 +373,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_Description);
         initSpeed = 865;
     };
+
     class ACE_20Rnd_762x67_Mk248_Mod_1_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x67_Ball_Mk248_Mod_1";
@@ -339,6 +382,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_Description);
         initSpeed = 847;
     };
+
     class ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag: 20Rnd_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x67_Ball_Berger_Hybrid_OTM";
@@ -347,6 +391,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_Description);
         initSpeed = 800;
     };
+
     class ACE_30Rnd_65x47_Scenar_mag: 30Rnd_65x39_caseless_mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_65x47_Ball_Scenar";
@@ -355,6 +400,7 @@ class CfgMagazines {
         displayNameShort = CSTRING(30Rnd_65x47_Scenar_mag_NameShort);
         descriptionShort = CSTRING(30Rnd_65x47_Scenar_mag_Description);
     };
+
     class ACE_20Rnd_65x47_Scenar_mag: 20Rnd_650x39_Cased_Mag_F {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_65x47_Ball_Scenar";
@@ -363,6 +409,7 @@ class CfgMagazines {
         displayNameShort = CSTRING(20Rnd_65x47_Scenar_mag_NameShort);
         descriptionShort = CSTRING(20Rnd_65x47_Scenar_mag_Description);
     };
+
     class ACE_30Rnd_65_Creedmor_mag: 30Rnd_65x39_caseless_mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_65_Creedmor_Ball";
@@ -371,6 +418,7 @@ class CfgMagazines {
         displayNameShort = CSTRING(30Rnd_65_Creedmor_mag_NameShort);
         descriptionShort = CSTRING(30Rnd_65_Creedmor_mag_Description);
     };
+
     class ACE_20Rnd_65_Creedmor_mag: 20Rnd_650x39_Cased_Mag_F {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_65_Creedmor_Ball";
@@ -379,9 +427,11 @@ class CfgMagazines {
         displayNameShort = CSTRING(20Rnd_65_Creedmor_mag_NameShort);
         descriptionShort = CSTRING(20Rnd_65_Creedmor_mag_Description);
     };
+
     class 10Rnd_338_Mag: CA_Magazine {
         initSpeed = 880;
     };
+
     class ACE_10Rnd_338_300gr_HPBT_Mag: 10Rnd_338_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_338_Ball";
@@ -390,6 +440,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(10Rnd_338_300gr_HPBT_Mag_Description);
         initSpeed = 800;
     };
+
     class ACE_10Rnd_338_API526_Mag: 10Rnd_338_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_338_Ball_API526";
@@ -398,10 +449,11 @@ class CfgMagazines {
         descriptionShort = CSTRING(10Rnd_338_API526_Mag_Description);
         initSpeed = 880;
     };
-    
+
     class 7Rnd_408_Mag: CA_Magazine {
         initSpeed = 867;
     };
+
     class ACE_7Rnd_408_305gr_Mag: 7Rnd_408_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_408_Ball";
@@ -415,6 +467,7 @@ class CfgMagazines {
     class 5Rnd_127x108_APDS_Mag: 5Rnd_127x108_Mag {
         initSpeed = 820;
     };
+
     class ACE_5Rnd_127x99_Mag: 5Rnd_127x108_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "B_127x99_Ball";
@@ -423,6 +476,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(5Rnd_127x99_Mag_Description);
         initSpeed = 900;
     };
+
     class ACE_5Rnd_127x99_API_Mag: 5Rnd_127x108_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_127x99_API";
@@ -431,6 +485,7 @@ class CfgMagazines {
         descriptionShort = CSTRING(5Rnd_127x99_API_Mag_Description);
         initSpeed = 900;
     };
+
     class ACE_5Rnd_127x99_AMAX_Mag: 5Rnd_127x108_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_127x99_Ball_AMAX";
@@ -443,12 +498,15 @@ class CfgMagazines {
     class 30Rnd_9x21_Mag: CA_Magazine {
         initSpeed = 430;
     };
+
     class 30Rnd_9x21_Green_Mag: 30Rnd_9x21_Mag {
         initSpeed = 402;
     };
+
     class 30Rnd_9x21_Mag_SMG_02: 30Rnd_9x21_Mag {
         initSpeed = 430;
     };
+
     class 30Rnd_9x21_Mag_SMG_02_Tracer_Green: 30Rnd_9x21_Mag_SMG_02 {
         initSpeed = 402;
     };
@@ -480,9 +538,11 @@ class CfgMagazines {
     class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {
         initSpeed = 430;
     };
+
     class 10Rnd_9x21_Mag: 16Rnd_9x21_Mag {
         initSpeed = 430;
     };
+
     class ACE_16Rnd_9x19_mag: 16Rnd_9x21_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_9x19_Ball";
@@ -495,6 +555,7 @@ class CfgMagazines {
     class 10Rnd_762x54_Mag: 10Rnd_762x51_Mag {
         initSpeed = 836;
     };
+
     class ACE_10Rnd_762x54_Tracer_mag: 10Rnd_762x54_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x54_Ball_7T2";

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -57,7 +57,7 @@ class CfgWeapons {
     };
 
     class srifle_DMR_03_F: DMR_03_base_F {
-        initSpeed = -0.991536;
+        initSpeed = -0.991536; // Default vanilla value 940
     };
 
     // ASP-1 Kir

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -7,7 +7,8 @@ class CfgWeapons {
 
     // Rifle_Long_Base_F Sniper Marksman
     // GM6 Lynx
-    class GM6_base_F: Rifle_Long_Base_F {
+    class GM6_base_F: Rifle_Long_Base_F {};
+    class srifle_GM6_F: GM6_base_F {
         ACE_barrelLength = 730;
         ACE_barrelTwist = 381.0;
         initSpeed = -1.0;
@@ -17,7 +18,8 @@ class CfgWeapons {
     };
 
     // M200 Intervention
-    class LRR_base_F: Rifle_Long_Base_F {
+    class LRR_base_F: Rifle_Long_Base_F {};
+    class srifle_LRR_F: LRR_base_F {
         ACE_barrelLength = 736.6;
         ACE_barrelTwist = 330.2;
         initSpeed = -1.0;
@@ -27,55 +29,59 @@ class CfgWeapons {
     };
 
     // Mk14 Mod 1 EBR
-    class EBR_base_F: Rifle_Long_Base_F {
+    class EBR_base_F: Rifle_Long_Base_F {};
+    class srifle_EBR_F: EBR_base_F {
         ACE_barrelLength = 457.2;
         ACE_barrelTwist = 304.8;
         initSpeed = -0.979444;
     };
 
     // VS-121
-    class DMR_01_base_F: Rifle_Long_Base_F {
+    class DMR_01_base_F: Rifle_Long_Base_F {};
+    class srifle_DMR_01_F: DMR_01_base_F {
         ACE_barrelLength = 609.6;
         ACE_barrelTwist = 241.3;
         initSpeed = -1.00019;
     };
 
     // Noreen "Bad News" ULR
-    class DMR_02_base_F: Rifle_Long_Base_F {
+    class DMR_02_base_F: Rifle_Long_Base_F {};
+    class srifle_DMR_02_F: DMR_02_base_F {
         ACE_barrelLength = 508.0;
         ACE_barrelTwist = 254.0;
         initSpeed = -1.0;
     };
 
     // SIG 556
-    class DMR_03_base_F: Rifle_Long_Base_F {
+    class DMR_03_base_F: Rifle_Long_Base_F {};
+    class srifle_DMR_03_F: DMR_03_base_F {
         ACE_barrelLength = 508.0;
         ACE_barrelTwist = 254.0;
+        initSpeed = -0.991536;
         magazineWell[] += {
             "CBA_762x51_M14"
         }; // vanilla magazineWell[] = {"M14_762x51"};
     };
 
-    class srifle_DMR_03_F: DMR_03_base_F {
-        initSpeed = -0.991536; // Default vanilla value 940
-    };
-
     // ASP-1 Kir
-    class DMR_04_base_F: Rifle_Long_Base_F {
+    class DMR_04_base_F: Rifle_Long_Base_F {};
+    class srifle_DMR_04_F: DMR_04_base_F {
         ACE_barrelLength = 450.088;
         ACE_barrelTwist = 203.2;
         initSpeed = -1.0;
     };
 
     // Cyrus
-    class DMR_05_base_F: Rifle_Long_Base_F {
+    class DMR_05_base_F: Rifle_Long_Base_F {};
+    class srifle_DMR_05_blk_F: DMR_05_base_F {
         ACE_barrelLength = 620.0;
         ACE_barrelTwist = 360.0;
         initSpeed = -1.0; // 780 m/s according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C)
     };
 
     // M14
-    class DMR_06_base_F: Rifle_Long_Base_F {
+    class DMR_06_base_F: Rifle_Long_Base_F {};
+    class srifle_DMR_06_camo_F: DMR_06_base_F {
         ACE_barrelLength = 558.8;
         ACE_barrelTwist = 304.8;
         initSpeed = -0.999395;
@@ -115,14 +121,16 @@ class CfgWeapons {
     };
 
     // HK121
-    class MMG_01_base_F: Rifle_Long_Base_F { // https://www.heckler-koch.com/en/products/military/machine-guns/mg5/mg5/technical-data.html93x
+    class MMG_01_base_F: Rifle_Long_Base_F {}; // https://www.heckler-koch.com/en/products/military/machine-guns/mg5/mg5/technical-data.html
+    class MMG_01_hex_F: MMG_01_base_F {
         ACE_barrelLength = 550.0;
         ACE_barrelTwist = 360.0;
         initSpeed = -1.0; // 768 m/s according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C)
     };
 
     // LWMMG
-    class MMG_02_base_F: Rifle_Long_Base_F {
+    class MMG_02_base_F: Rifle_Long_Base_F {};
+    class MMG_02_camo_F: MMG_02_base_F {
         ACE_barrelLength = 609.6;
         ACE_barrelTwist = 234.95;
         initSpeed = -1.0;
@@ -130,31 +138,33 @@ class CfgWeapons {
 
     // Rifle_Base_F
     // MX variants
-    class arifle_MX_Base_F: Rifle_Base_F {
-        ACE_barrelTwist = 228.6;
-    };
+    class arifle_MX_Base_F: Rifle_Base_F {};
 
     // MX LSW
     class arifle_MX_SW_F: arifle_MX_Base_F {
         ACE_barrelLength = 406.4;
+        ACE_barrelTwist = 228.6;
         initSpeed = -0.981912;
     };
 
     // MXM
     class arifle_MXM_F: arifle_MX_Base_F {
         ACE_barrelLength = 457.2;
+        ACE_barrelTwist = 228.6;
         initSpeed = -1.0;
     };
 
     // MX
     class arifle_MX_F: arifle_MX_Base_F {
         ACE_barrelLength = 368.3;
+        ACE_barrelTwist = 228.6;
         initSpeed = -0.972222;
     };
 
     // MX 3GL
     class arifle_MX_GL_F: arifle_MX_Base_F {
         ACE_barrelLength = 368.3;
+        ACE_barrelTwist = 228.6;
         initSpeed = -0.972222;
     };
 
@@ -166,42 +176,43 @@ class CfgWeapons {
     };
 
     // KH2002 Sama variants
-    class arifle_katiba_Base_F: Rifle_Base_F {
-        ACE_barrelTwist = 203.2;
-    };
+    class arifle_katiba_Base_F: Rifle_Base_F {};
 
     // KH2002 Sama
     class arifle_Katiba_F: arifle_katiba_Base_F {
         ACE_barrelLength = 508.0;
+        ACE_barrelTwist = 203.2;
         initSpeed = -1.0;
     };
 
     // KH2002C Sama
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
         ACE_barrelLength = 393.7;
+        ACE_barrelTwist = 203.2;
         initSpeed = -0.961294;
     };
 
     // KH2002 Sama KGL
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
         ACE_barrelLength = 508.0;
+        ACE_barrelTwist = 203.2;
         initSpeed = -1.0;
     };
 
     // CTAR-21 variants
-    class Tavor_base_F: Rifle_Base_F {
-        ACE_barrelTwist = 177.8;
-    };
+    class Tavor_base_F: Rifle_Base_F {};
 
      // CTAR-21
     class arifle_TRG20_F: Tavor_base_F {
         ACE_barrelLength = 381.0;
+        ACE_barrelTwist = 177.8;
         initSpeed = -0.961496;
     };
 
     // TAR-21
     class arifle_TRG21_F: Tavor_base_F {
         ACE_barrelLength = 459.74;
+        ACE_barrelTwist = 177.8;
         initSpeed = -1.0;
     };
 
@@ -211,25 +222,26 @@ class CfgWeapons {
     };
 
     // F2000 variants
-    class mk20_base_F: Rifle_Base_F {
-        ACE_barrelTwist = 177.8;
-    };
+    class mk20_base_F: Rifle_Base_F {};
 
     // F2000
     class arifle_Mk20_F: mk20_base_F {
         ACE_barrelLength = 441.96;
+        ACE_barrelTwist = 177.8;
         initSpeed = -0.992849;
     };
 
     // F2000 Tactical
     class arifle_Mk20C_F: mk20_base_F {
         ACE_barrelLength = 406.4;
+        ACE_barrelTwist = 177.8;
         initSpeed = -0.974297;
     };
 
     // F2000 EGLM
     class arifle_Mk20_GL_F: mk20_base_F {
         ACE_barrelLength = 406.4;
+        ACE_barrelTwist = 177.8;
         initSpeed = -0.974297;
     };
 
@@ -269,7 +281,8 @@ class CfgWeapons {
     };
 
     // RFB SDAR
-    class SDAR_base_F: Rifle_Base_F {
+    class SDAR_base_F: Rifle_Base_F {};
+    class arifle_SDAR_F: SDAR_base_F {
         ACE_barrelLength = 457.2;
         ACE_barrelTwist = 285.75;
         initSpeed = -0.998321;
@@ -341,32 +354,26 @@ class CfgWeapons {
 
     // Rifle_Short_Base_F
     // CPW
-    class pdw2000_base_F: Rifle_Short_Base_F {
+    class pdw2000_base_F: Rifle_Short_Base_F {};
+    class hgun_PDW2000_F: pdw2000_base_F {
         ACE_barrelLength = 177.8;
         ACE_barrelTwist = 228.6;
-    };
-
-    class hgun_PDW2000_F: pdw2000_base_F {
         initSpeed = -0.994186;
     };
 
     // Vector SMG
-    class SMG_01_Base: Rifle_Short_Base_F {
+    class SMG_01_Base: Rifle_Short_Base_F {};
+    class SMG_01_F: SMG_01_Base {
         ACE_barrelLength = 139.7;
         ACE_barrelTwist = 406.4;
-    };
-
-    class SMG_01_F: SMG_01_Base {
         initSpeed = -1.00148;
     };
 
     // Scorpion Evo 3 A1
-    class SMG_02_base_F: Rifle_Short_Base_F  {
+    class SMG_02_base_F: Rifle_Short_Base_F  {};
+    class SMG_02_F: SMG_02_base_F  {
         ACE_barrelLength = 195.58;
         ACE_barrelTwist = 254.0;
-    };
-
-    class SMG_02_F: SMG_02_base_F  {
         initSpeed = -1.00029;
     };
 

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -51,10 +51,13 @@ class CfgWeapons {
     class DMR_03_base_F: Rifle_Long_Base_F {
         ACE_barrelLength = 508.0;
         ACE_barrelTwist = 254.0;
-        initSpeed = -0.991536;
         magazineWell[] += {
             "CBA_762x51_M14"
         }; // vanilla magazineWell[] = {"M14_762x51"};
+    };
+
+    class srifle_DMR_03_F: DMR_03_base_F {
+        initSpeed = -0.991536;
     };
 
     // ASP-1 Kir


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the `DMR_03_base_F` `initSpeed`.
- Fix the missing `arifle_katiba_Base_F` 30 rnd IR-Dim magazine (KH2002 Sama variants).
- Fix the `ACE_30Rnd_556x45_Stanag_Tracer_Dim` picture (30 rnd magazine icon instead 20 rnd).