### PR TITLE
Arsenal - Fix main menu mission

### DIFF
--- a/addons/arsenal/missions/Arsenal.VR/CfgEventHandlers.hpp
+++ b/addons/arsenal/missions/Arsenal.VR/CfgEventHandlers.hpp
@@ -1,11 +1,11 @@
 class Extended_PreInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+        init = QUOTE(call compile preprocessFileLineNumbers 'XEH_preInit.sqf');
     };
 };
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+        init = QUOTE(call compile preprocessFileLineNumbers 'XEH_postInit.sqf');
     };
 };

--- a/addons/arsenal/missions/Arsenal.VR/CfgEventHandlers.hpp
+++ b/addons/arsenal/missions/Arsenal.VR/CfgEventHandlers.hpp
@@ -1,3 +1,4 @@
+// These files are from the VR mission, not the base addon folder
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call compile preprocessFileLineNumbers 'XEH_preInit.sqf');

--- a/addons/arsenal/missions/Arsenal.VR/XEH_preInit.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/XEH_preInit.sqf
@@ -1,4 +1,6 @@
 #include "script_component.hpp"
 
+INFO("Loading VR Mission");
+
 PREP(onPause);
 PREP(createTarget);

--- a/addons/arsenal/missions/Arsenal.VR/fnc_createTarget.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/fnc_createTarget.sqf
@@ -52,6 +52,10 @@ _target setVariable ["origin", _position];
 
 _target addEventHandler ["killed", {
     params ["_target"];
+
+    // Killed may fire twice, 2nd will be null - https://github.com/acemod/ACE3/pull/7561
+    if (isNull _target)  exitWith { TRACE_1("Ignoring null death",_target); };
+
     private _position = _target getVariable ["origin", position _target];
     private _varName = vehicleVarName _target;
 

--- a/addons/arsenal/missions/Arsenal.VR/fnc_createTarget.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/fnc_createTarget.sqf
@@ -54,7 +54,7 @@ _target addEventHandler ["killed", {
     params ["_target"];
 
     // Killed may fire twice, 2nd will be null - https://github.com/acemod/ACE3/pull/7561
-    if (isNull _target)  exitWith { TRACE_1("Ignoring null death",_target); };
+    if (isNull _target) exitWith { TRACE_1("Ignoring null death",_target); };
 
     private _position = _target getVariable ["origin", position _target];
     private _varName = vehicleVarName _target;


### PR DESCRIPTION
Fix #7584

- Macros broke loading the mission's XEH_preInit
- With double killed XEH, 2nd time it's now objNull and threw script error because of a
`missionNamespace setvariable [_varName`

edit: I still think setting `objNull` is the best solution to the double killed xeh, just need to watch out for odd uses like this one