### PR TITLE
Respawn - Add save gear event

### DIFF
--- a/addons/respawn/functions/fnc_handleKilled.sqf
+++ b/addons/respawn/functions/fnc_handleKilled.sqf
@@ -22,6 +22,7 @@ params ["_unit"];
 if (ACE_player == _unit && {GVAR(SavePreDeathGear)}) then {
     _unit setVariable [QGVAR(unitGear), getUnitLoadout _unit];
     _unit setVariable [QGVAR(activeWeaponAndMuzzle), [currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit]];
+    [QGVAR(saveGear), _unit] call CBA_fnc_localEvent;
 };
 
 if (missionNamespace getVariable [QGVAR(showFriendlyFireMessage), false]) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Required for ACRE2 to add compatibility for proper radio assignment in combination with ACE Respawn's Save pre-death gear.

Not sure what else to put into the event, since all the data is on the unit anyways.

I am also pretty sure adding the event on killed event is fine, as long as whatever uses the event runs in unscheduled to make sure it happens before respawn kicks in.