### PR TITLE
Medical Damage - Determine ammo damage type through config property

### DIFF
--- a/addons/medical_damage/CfgAmmo.hpp
+++ b/addons/medical_damage/CfgAmmo.hpp
@@ -64,7 +64,8 @@ class CfgAmmo {
     class Bo_Mk82: BombCore {
         ACE_damageType = "explosive";
     };
-    class ammo_Bomb_LaserGuidedBase: BombCore {
+    class LaserBombCore;
+    class ammo_Bomb_LaserGuidedBase: LaserBombCore {
         ACE_damageType = "explosive";
     };
     class BombDemine_01_Ammo_F: BombCore {

--- a/addons/medical_damage/CfgAmmo.hpp
+++ b/addons/medical_damage/CfgAmmo.hpp
@@ -1,0 +1,46 @@
+class CfgAmmo {
+	class BulletCore;
+	class BulletBase: BulletCore {
+		ACE_damageType = "bullet";
+	};
+	class ShotgunCore;
+	class ShotgunBase: ShotgunCore {
+		ACE_damageType = "bullet";
+	};
+	class Default;
+	class Grenade: Default {
+		ACE_damageType = "grenade";
+	};
+	class GrenadeCore: Default {
+		ACE_damageType = "grenade";
+	};
+	class TimeBombCore: Default {
+		ACE_damageType = "explosive";
+	};
+	class FuelExplosion: Default {
+		ACE_damageType = "explosive";
+	};
+	class RocketCore;
+	class RocketBase: RocketCore {
+		ACE_damageType = "explosive";
+	};
+	class MissileCore;
+	class MissileBase: MissileCore {
+		ACE_damageType = "explosive";
+	};
+	class BombCore: Default {
+		ACE_damageType = "explosive";
+	};
+	class ShellCore;
+	class ShellBase: ShellCore {
+		ACE_damageType = "shell";
+	};
+
+	// Autocannon rounds
+	class B_19mm_HE: BulletBase {
+		ACE_damageType = "explosive";
+	};
+	class B_35mm_AA: BulletBase {
+		ACE_damageType = "explosive";
+	};
+};

--- a/addons/medical_damage/CfgAmmo.hpp
+++ b/addons/medical_damage/CfgAmmo.hpp
@@ -1,46 +1,46 @@
 class CfgAmmo {
-	class BulletCore;
-	class BulletBase: BulletCore {
-		ACE_damageType = "bullet";
-	};
-	class ShotgunCore;
-	class ShotgunBase: ShotgunCore {
-		ACE_damageType = "bullet";
-	};
-	class Default;
-	class Grenade: Default {
-		ACE_damageType = "grenade";
-	};
-	class GrenadeCore: Default {
-		ACE_damageType = "grenade";
-	};
-	class TimeBombCore: Default {
-		ACE_damageType = "explosive";
-	};
-	class FuelExplosion: Default {
-		ACE_damageType = "explosive";
-	};
-	class RocketCore;
-	class RocketBase: RocketCore {
-		ACE_damageType = "explosive";
-	};
-	class MissileCore;
-	class MissileBase: MissileCore {
-		ACE_damageType = "explosive";
-	};
-	class BombCore: Default {
-		ACE_damageType = "explosive";
-	};
-	class ShellCore;
-	class ShellBase: ShellCore {
-		ACE_damageType = "shell";
-	};
-
-	// Autocannon rounds
-	class B_19mm_HE: BulletBase {
-		ACE_damageType = "explosive";
-	};
-	class B_35mm_AA: BulletBase {
-		ACE_damageType = "explosive";
-	};
+    class BulletCore;
+    class BulletBase: BulletCore {
+        ACE_damageType = "bullet";
+    };
+    class ShotgunCore;
+    class ShotgunBase: ShotgunCore {
+        ACE_damageType = "bullet";
+    };
+    class Default;
+    class Grenade: Default {
+        ACE_damageType = "grenade";
+    };
+    class GrenadeCore: Default {
+        ACE_damageType = "grenade";
+    };
+    class TimeBombCore: Default {
+        ACE_damageType = "explosive";
+    };
+    class FuelExplosion: Default {
+        ACE_damageType = "explosive";
+    };
+    class RocketCore;
+    class RocketBase: RocketCore {
+        ACE_damageType = "explosive";
+    };
+    class MissileCore;
+    class MissileBase: MissileCore {
+        ACE_damageType = "explosive";
+    };
+    class BombCore: Default {
+        ACE_damageType = "explosive";
+    };
+    class ShellCore;
+    class ShellBase: ShellCore {
+        ACE_damageType = "shell";
+    };
+    
+    // Autocannon rounds
+    class B_19mm_HE: BulletBase {
+        ACE_damageType = "explosive";
+    };
+    class B_35mm_AA: BulletBase {
+        ACE_damageType = "explosive";
+    };
 };

--- a/addons/medical_damage/CfgAmmo.hpp
+++ b/addons/medical_damage/CfgAmmo.hpp
@@ -7,19 +7,36 @@ class CfgAmmo {
     class ShotgunBase: ShotgunCore {
         ACE_damageType = "bullet";
     };
+
     class Default;
-    class Grenade: Default {
-        ACE_damageType = "grenade";
-    };
-    class GrenadeCore: Default {
-        ACE_damageType = "grenade";
-    };
-    class TimeBombCore: Default {
-        ACE_damageType = "explosive";
-    };
     class FuelExplosion: Default {
         ACE_damageType = "explosive";
     };
+    class Grenade: Default {
+        ACE_damageType = "grenade";
+    };
+    class GrenadeCore;
+    class GrenadeBase: GrenadeCore {
+        ACE_damageType = "grenade";
+    };
+
+    class MineCore;
+    class MineBase: MineCore {
+        ACE_damageType = "explosive";
+    };
+    class PipeBombCore;
+    class PipeBombBase: PipeBombCore {
+        ACE_damageType = "explosive";
+    };
+    class DirectionalBombCore;
+    class DirectionalBombBase: DirectionalBombCore {
+        ACE_damageType = "explosive";
+    };
+    class BoundingMineCore;
+    class BoundingMineBase: BoundingMineCore {
+        ACE_damageType = "explosive";
+    };
+
     class RocketCore;
     class RocketBase: RocketCore {
         ACE_damageType = "explosive";
@@ -28,19 +45,48 @@ class CfgAmmo {
     class MissileBase: MissileCore {
         ACE_damageType = "explosive";
     };
-    class BombCore: Default {
+
+    class SubmunitionCore;
+    class SubmunitionBase: SubmunitionCore {
         ACE_damageType = "explosive";
     };
+    class SubmunitionBullet: SubmunitionBase {
+        ACE_damageType = "bullet";
+    };
+
     class ShellCore;
     class ShellBase: ShellCore {
         ACE_damageType = "shell";
     };
+
+    // There is no BombBase so we modify these separately
+    class BombCore;
+    class Bo_Mk82: BombCore {
+        ACE_damageType = "explosive";
+    };
+    class ammo_Bomb_LaserGuidedBase: BombCore {
+        ACE_damageType = "explosive";
+    };
+    class BombDemine_01_Ammo_F: BombCore {
+        ACE_damageType = "explosive";
+    };
     
-    // Autocannon rounds
+    // Autocannon rounds are special (#7401)
     class B_19mm_HE: BulletBase {
         ACE_damageType = "explosive";
     };
+    class B_20mm: BulletBase {
+        ACE_damageType = "explosive";
+    };
+    class B_25mm: BulletBase {
+        ACE_damageType = "explosive";
+    };
     class B_35mm_AA: BulletBase {
+        ACE_damageType = "explosive";
+    };
+
+    // These are also special
+    class Gatling_30mm_HE_Plane_CAS_01_F: BulletBase {
         ACE_damageType = "explosive";
     };
 };

--- a/addons/medical_damage/XEH_preInit.sqf
+++ b/addons/medical_damage/XEH_preInit.sqf
@@ -16,9 +16,6 @@ addMissionEventHandler ["Loaded",{
     call FUNC(parseConfigForInjuries);
 }];
 
-// Cache for damage types of each ammo class
-GVAR(damageTypeCache) = false call CBA_fnc_createNamespace;
-
 // decide which woundsHandler to use by whether the extension is present or not
 // if ("ace_medical" callExtension "version" != "") then {
 

--- a/addons/medical_damage/XEH_preInit.sqf
+++ b/addons/medical_damage/XEH_preInit.sqf
@@ -16,6 +16,9 @@ addMissionEventHandler ["Loaded",{
     call FUNC(parseConfigForInjuries);
 }];
 
+// Cache for damage types of each ammo class
+GVAR(damageTypeCache) = false call CBA_fnc_createNamespace;
+
 // decide which woundsHandler to use by whether the extension is present or not
 // if ("ace_medical" callExtension "version" != "") then {
 

--- a/addons/medical_damage/config.cpp
+++ b/addons/medical_damage/config.cpp
@@ -17,6 +17,7 @@ class CfgPatches {
 #include "ACE_Settings.hpp"
 #include "ACE_Medical_Injuries.hpp"
 #include "CfgEventHandlers.hpp"
+#include "CfgAmmo.hpp"
 
 /*
 class ACE_Extensions {

--- a/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
+++ b/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
@@ -30,8 +30,8 @@ if (isNil "_damageType") then {
             getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")
         };
         default {
-            WARNING_1("Damage Type [%1] has no ACE_damageType",_typeOfProjectile);
-            toLower _typeOfProjectile
+            WARNING_1("Ammo Type [%1] has no ACE_damageType",_typeOfProjectile);
+            "unknown"
         };
     };
 

--- a/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
+++ b/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
@@ -30,11 +30,11 @@ if (isNil "_damageType") then {
             getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")
         };
         default {
-            WARNING_1("Ammo Type [%1] has no ACE_damageType",_typeOfProjectile);
-            "unknown"
+            toLower _typeOfProjectile
         };
     };
 
+    TRACE_2("getTypeOfDamage caching",_typeOfProjectile,_damageType);
     GVAR(damageTypeCache) setVariable [_typeOfProjectile, _damageType];
 };
 

--- a/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
+++ b/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
@@ -25,7 +25,10 @@ if (isNil "_damageType") then {
         case ((_typeOfProjectile select [0,1]) isEqualTo "#"): { _typeOfProjectile select [1] };
         // -- projectiles
         case (isText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")): { getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType") };
-        default {toLower _typeOfProjectile};
+        default {
+            WARNING_1("Damage Type [%1] has no ACE_damageType",_typeOfProjectile);
+            toLower _typeOfProjectile
+        };
     };
 
     GVAR(damageTypeCache) setVariable [_typeOfProjectile, _damageType];

--- a/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
+++ b/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
@@ -17,24 +17,18 @@
 
 params ["_typeOfProjectile"];
 
-// --- projectiles
-if (_typeOfProjectile isKindOf "BulletBase") exitWith {"bullet"};
-if (_typeOfProjectile isKindOf "ShotgunBase") exitWith {"bullet"};
-if (_typeOfProjectile isKindOf "GrenadeCore") exitWith {"grenade"};
-if (_typeOfProjectile isKindOf "TimeBombCore") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "MineCore") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "FuelExplosion") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "ShellBase") exitWith {"shell"};
-if (_typeOfProjectile isKindOf "RocketBase") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "MissileBase") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "LaserBombCore") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "BombCore") exitWith {"explosive"};
-if (_typeOfProjectile isKindOf "Grenade") exitWith {"grenade"};
+private _damageType = GVAR(damageTypeCache) getVariable _typeOfProjectile;
 
-// --- non-projectiles reported by custom handleDamge wrapper
-if ((_typeOfProjectile select [0,1]) isEqualTo "#") then {
-    _typeOfProjectile = _typeOfProjectile select [1];
+if (isNil "_damageType") then {
+    _damageType = switch (true) do {
+        // -- non-projectiles reported by custom handleDamage wrapper
+        case ((_typeOfProjectile select [0,1]) isEqualTo "#"): { _typeOfProjectile select [1] };
+        // -- projectiles
+        case (isText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")): { getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType") };
+        default {toLower _typeOfProjectile};
+    };
+
+    GVAR(damageTypeCache) setVariable [_typeOfProjectile, _damageType];
 };
 
-// --- otherwise
-toLower _typeOfProjectile
+_damageType // return

--- a/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
+++ b/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
@@ -21,10 +21,14 @@ private _damageType = GVAR(damageTypeCache) getVariable _typeOfProjectile;
 
 if (isNil "_damageType") then {
     _damageType = switch (true) do {
-        // -- non-projectiles reported by custom handleDamage wrapper
-        case ((_typeOfProjectile select [0,1]) isEqualTo "#"): { _typeOfProjectile select [1] };
-        // -- projectiles
-        case (isText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")): { getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType") };
+        // non-projectiles reported by custom handleDamage wrapper
+        case ((_typeOfProjectile select [0,1]) isEqualTo "#"): {
+            _typeOfProjectile select [1]
+        };
+        // projectiles
+        case (isText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")): {
+            getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")
+        };
         default {
             WARNING_1("Damage Type [%1] has no ACE_damageType",_typeOfProjectile);
             toLower _typeOfProjectile

--- a/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
+++ b/addons/medical_damage/functions/fnc_getTypeOfDamage.sqf
@@ -4,7 +4,7 @@
  * Get the type of damage based upon the projectile.
  *
  * Arguments:
- * 0: The projectile classname or object <STRING>
+ * 0: The projectile classname OR the name of a damage type <STRING>
  *
  * Return Value:
  * Type of damage <STRING>
@@ -20,18 +20,17 @@ params ["_typeOfProjectile"];
 private _damageType = GVAR(damageTypeCache) getVariable _typeOfProjectile;
 
 if (isNil "_damageType") then {
-    _damageType = switch (true) do {
-        // non-projectiles reported by custom handleDamage wrapper
-        case ((_typeOfProjectile select [0,1]) isEqualTo "#"): {
-            _typeOfProjectile select [1]
-        };
-        // projectiles
-        case (isText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")): {
-            getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")
-        };
-        default {
-            toLower _typeOfProjectile
-        };
+    if (isText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType")) then {
+        _damageType = getText (configFile >> "CfgAmmo" >> _typeOfProjectile >> "ACE_damageType");
+    } else {
+        WARNING_1("Ammo type [%1] has no ACE_damageType",_typeOfProjectile);
+        _damageType = "unknown";
+    };
+
+    // config may define an invalid damage type
+    if (isNil {GVAR(allDamageTypesData) getVariable _damageType}) then {
+        WARNING_2("Damage type [%1] for ammo [%2] not found",_typeOfDamage,_typeOfProjectile);
+        _damageType = "unknown";
     };
 
     TRACE_2("getTypeOfDamage caching",_typeOfProjectile,_damageType);

--- a/addons/medical_damage/functions/fnc_parseConfigForInjuries.sqf
+++ b/addons/medical_damage/functions/fnc_parseConfigForInjuries.sqf
@@ -78,6 +78,7 @@ private _selectionSpecificDefault = getNumber (_damageTypesConfig >> "selectionS
 
     GVAR(allDamageTypesData) setVariable [_className, [_thresholds, _selectionSpecific > 0, _woundTypes]];
     GVAR(damageTypeCache) setVariable [_className, _className];
+    GVAR(damageTypeCache) setVariable ["#"+_className, _className];
 
     /*
     // extension loading

--- a/addons/medical_damage/functions/fnc_parseConfigForInjuries.sqf
+++ b/addons/medical_damage/functions/fnc_parseConfigForInjuries.sqf
@@ -50,6 +50,8 @@ private _classID = 0;
 
 // --- parse damage types
 GVAR(allDamageTypesData) = [] call CBA_fnc_createNamespace;
+// cache for ammunition -> damageType
+GVAR(damageTypeCache) = [] call CBA_fnc_createNamespace;
 
 // minimum lethal damage collection, mapped to damageTypes
 private _damageTypesConfig = _injuriesConfigRoot >> "damageTypes";
@@ -75,6 +77,7 @@ private _selectionSpecificDefault = getNumber (_damageTypesConfig >> "selectionS
     private _selectionSpecific = GET_NUMBER(_damageTypeSubClassConfig >> "selectionSpecific",_selectionSpecificDefault);
 
     GVAR(allDamageTypesData) setVariable [_className, [_thresholds, _selectionSpecific > 0, _woundTypes]];
+    GVAR(damageTypeCache) setVariable [_className, _className];
 
     /*
     // extension loading

--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -120,7 +120,7 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
         // Any collision with terrain/vehicle/object has a shooter
         // Check this first because burning can happen at any velocity
         if !(isNull _shooter) then {
-            _ammo = "#collision"; // non-selectionSpecific so only _damageSelectionArray matters
+            _ammo = "collision"; // non-selectionSpecific so only _damageSelectionArray matters
 
             /*
               If shooter != unit then they hit unit, otherwise it could be:
@@ -130,7 +130,7 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
                Assume fall damage for downward velocity because it's most common
             */
             if (_shooter == _unit && {(velocity _unit select 2) < -2}) then {
-                _ammo = "#falling"; // non-selectionSpecific so only _damageSelectionArray matters
+                _ammo = "falling"; // non-selectionSpecific so only _damageSelectionArray matters
                 _damageSelectionArray = [HITPOINT_INDEX_RLEG, 1, HITPOINT_INDEX_LLEG, 1];
                 TRACE_5("Fall",_unit,_shooter,_instigator,_damage,_receivedDamage);
             } else {
@@ -152,7 +152,7 @@ if (_hitPoint isEqualTo "ace_hdbracket") exitWith {
         } else {
             // Anything else is almost guaranteed to be fire damage
             _damageSelectionArray = [HITPOINT_INDEX_BODY, 1, HITPOINT_INDEX_LLEG, 1, HITPOINT_INDEX_RLEG, 1];;
-            _ammo = "#unknown"; // non-selectionSpecific so only _damageSelectionArray matters
+            _ammo = "unknown"; // non-selectionSpecific so only _damageSelectionArray matters
 
             // Fire damage can occur as lots of minor damage events
             // Combine these until significant enough to wound
@@ -194,7 +194,7 @@ if (
     {getOxygenRemaining _unit <= 0.5} &&
     {_damage isEqualTo (_oldDamage + 0.005)}
 ) exitWith {
-    [QEGVAR(medical,woundReceived), [_unit, "Body", _newDamage, _unit, "#drowning", [HITPOINT_INDEX_BODY, 1]]] call CBA_fnc_localEvent;
+    [QEGVAR(medical,woundReceived), [_unit, "Body", _newDamage, _unit, "drowning", [HITPOINT_INDEX_BODY, 1]]] call CBA_fnc_localEvent;
     TRACE_5("Drowning",_unit,_shooter,_instigator,_damage,_newDamage);
 
     0
@@ -214,7 +214,7 @@ if (
         HITPOINT_INDEX_HEAD, 1, HITPOINT_INDEX_BODY, 1, HITPOINT_INDEX_LARM, 1, 
         HITPOINT_INDEX_RARM, 1, HITPOINT_INDEX_LLEG, 1, HITPOINT_INDEX_RLEG, 1
     ];
-    [QEGVAR(medical,woundReceived), [_unit, "Body", _newDamage, _unit, "#vehiclecrash", _damageSelectionArray]] call CBA_fnc_localEvent;
+    [QEGVAR(medical,woundReceived), [_unit, "Body", _newDamage, _unit, "vehiclecrash", _damageSelectionArray]] call CBA_fnc_localEvent;
     TRACE_5("Crash",_unit,_shooter,_instigator,_damage,_newDamage);
 
     0


### PR DESCRIPTION
**When merged this pull request will:**
- Add a new config property, `ACE_damageType`, to a variety of CfgAmmo base classes.
- Alter `fnc_getTypeOfDamage` to read this config property instead of having the values hard-coded. Results are cached.
- Override this property on `B_19mm_HE` and `B_35mm_AA` (fixes #7401)

Vanilla Badger, 1x indirect hit (very close), before:
![damageType-before](https://user-images.githubusercontent.com/2702114/76994422-3ff6fd80-6946-11ea-8915-d3983c7f24e0.jpg)

after:
![damageType-after](https://user-images.githubusercontent.com/2702114/76994437-44231b00-6946-11ea-8c99-550c44b70fa0.jpg)
