### PR TITLE
Rearm - Fix vehicles failing rearm due to case differences

### DIFF
--- a/addons/rearm/functions/fnc_getTurretMagazineAmmo.sqf
+++ b/addons/rearm/functions/fnc_getTurretMagazineAmmo.sqf
@@ -23,5 +23,5 @@
 
 params ["_vehicle", "_turretPath", "_magazineClass"];
 
-private _ammo = magazinesAllTurrets _vehicle select {(_x select 0) isEqualTo _magazineClass && {(_x select 1) isEqualTo _turretPath}} apply {_x select 2};
+private _ammo = magazinesAllTurrets _vehicle select {(_x select 0) == _magazineClass && {(_x select 1) isEqualTo _turretPath}} apply {_x select 2};
 _ammo

--- a/addons/rearm/functions/fnc_getTurretMagazineAmmo.sqf
+++ b/addons/rearm/functions/fnc_getTurretMagazineAmmo.sqf
@@ -23,5 +23,4 @@
 
 params ["_vehicle", "_turretPath", "_magazineClass"];
 
-private _ammo = magazinesAllTurrets _vehicle select {(_x select 0) == _magazineClass && {(_x select 1) isEqualTo _turretPath}} apply {_x select 2};
-_ammo
+magazinesAllTurrets _vehicle select {(_x select 0) == _magazineClass && {(_x select 1) isEqualTo _turretPath}} apply {_x select 2}


### PR DESCRIPTION
**When merged this pull request will:**
- Remove case sensitivity from class check in getTurretMagazineAmmo

Currently the check in getTurretMagazineAmmo compares the class used in cfgVehicles' magazines array (within the turret) to the config name in cfgMagazines (returned by magazinesAllTurrets). In some cases developers have not used the same capitalization in both of these places. Within most systems this is not a problem as config classes are not case sensitive, but in the case of getTurretMagazineAmmo it means the function fails leading to a failure of the rearm action.
