### PR TITLE
Explosives - Remove "Activate mine" action menu item

### DIFF
--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -47,7 +47,7 @@ class CfgActions {
     class DeactivateMine:None {
         show = 0;
     };
-    class UseContainerMagazine:None {
+    class UseContainerMagazine: None {
         show = 0;
     };
 };

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -47,6 +47,9 @@ class CfgActions {
     class DeactivateMine:None {
         show = 0;
     };
+    class UseContainerMagazine:None {
+        show = 0;
+    };
 };
 
 class CfgMineTriggers {


### PR DESCRIPTION
The "Activate mine" action menu item was still showing, but only after an explosive was set, then diffused.

**When merged this pull request will:**
- Remove the "Activate mine" action menu item on a diffused explosive/mine