### PR TITLE
Reload - Fix check ammo display for empty GL launchers

### DIFF
--- a/addons/reload/functions/fnc_displayAmmo.sqf
+++ b/addons/reload/functions/fnc_displayAmmo.sqf
@@ -42,7 +42,7 @@ if (_target isKindOf "StaticWeapon") then {
             };
         } forEach _magazines;
     };
-    
+
     // For static weapons the muzzle seemingly never returns anything for static weapons with/without people inside
     if (_muzzle == "") then {
         _muzzle = _weapon;
@@ -76,10 +76,14 @@ if (_muzzle == _weapon) then {
 } else {
     _showNumber = true;
 
+    _ammo = _target ammo _muzzle;
+    if (_ammo == 0) then { _magazine = ""; };
+
     _count = if (_magazine != "") then {
         {_x == _magazine} count (magazines _target + [_magazine])
     } else {
-        {_x in getArray (configFile >> "CfgWeapons" >> _weapon >> _muzzle >> "Magazines")} count magazines _target
+        private _compatibleMagazines =  [configFile >> "CfgWeapons" >> _weapon >> _muzzle] call CBA_fnc_compatibleMagazines;
+        {_x in _compatibleMagazines} count magazines _target
     };
 };
 

--- a/addons/reload/functions/fnc_displayAmmo.sqf
+++ b/addons/reload/functions/fnc_displayAmmo.sqf
@@ -53,16 +53,32 @@ if (_magazine == "") exitWith {};
 if (_weapon == "") exitWith {};
 if (!( _muzzle isEqualType "")) then {_muzzle = _weapon};
 
-private _showNumber = false;
 private _ammo = 0;
-private _maxRounds = 1;
-private _count = 0;
+private _maxRounds = getNumber (configFile >> "CfgMagazines" >> _magazine >> "count") max 1;
+private _count = -1; // Show a count instead of ammo bars (ignore if -1)
 
 // not grenade launcher
 if (_muzzle == _weapon) then {
-    _maxRounds = getNumber (configFile >> "CfgMagazines" >> _magazine >> "count") max 1;
-
     _ammo = _target ammo _weapon;
+} else {
+    // grenade launcher (or some kind of seconday muzzle)
+    _ammo = _target ammo _muzzle;
+    if (_ammo > 0) then {
+        if (_maxRounds == 1) then { // singleShot so show count of identical mags available instead of ammo bars
+            _count = {_x == _magazine} count (magazines _target + [_magazine]) // add the loaded mag
+        };
+    } else {
+        if (_maxRounds <= 3) then { // empty GL/3GL - don't have a real magazine so just show count of any compatible mag
+            _magazine = "";
+            private _compatibleMagazines =  [configFile >> "CfgWeapons" >> _weapon >> _muzzle] call CBA_fnc_compatibleMagazines;
+            _count = {_x in _compatibleMagazines} count (magazines _target); // safe because everything is config case
+         };
+    };
+};
+
+private _ammoBarsStructuredText = if (_count >= 0) then {
+    parseText format ["<t align='center' >%1x</t>", _count]
+} else {
     if (_maxRounds >= COUNT_BARS) then {
         _count = round (COUNT_BARS * _ammo / _maxRounds);
 
@@ -72,24 +88,6 @@ if (_muzzle == _weapon) then {
         _count = _ammo;
     };
 
-    // grenade launcher
-} else {
-    _showNumber = true;
-
-    _ammo = _target ammo _muzzle;
-    if (_ammo == 0) then { _magazine = ""; };
-
-    _count = if (_magazine != "") then {
-        {_x == _magazine} count (magazines _target + [_magazine])
-    } else {
-        private _compatibleMagazines =  [configFile >> "CfgWeapons" >> _weapon >> _muzzle] call CBA_fnc_compatibleMagazines;
-        {_x in _compatibleMagazines} count magazines _target
-    };
-};
-
-private _ammoBarsStructuredText = if (_showNumber) then {
-    parseText format ["<t align='center' >%1x</t>", _count]
-} else {
     private _color = [((2 * (1 - _ammo / _maxRounds)) min 1), ((2 * _ammo / _maxRounds) min 1), 0];
 
     private _string = "";
@@ -114,6 +112,10 @@ if (_target isKindOf "StaticWeapon") then {
     private _text = composeText [_loadedName, linebreak, _ammoBarsStructuredText];
     [_text] call EFUNC(common,displayTextStructured);
 } else {
-    private _picture = getText (configFile >> "CfgMagazines" >> _magazine >> "picture");
-    [_ammoBarsStructuredText, _picture] call EFUNC(common,displayTextPicture);
+    if (_magazine != "") then {
+        private _picture = getText (configFile >> "CfgMagazines" >> _magazine >> "picture");
+        [_ammoBarsStructuredText, _picture] call EFUNC(common,displayTextPicture);
+    } else {
+        [_ammoBarsStructuredText, 1] call EFUNC(common,displayTextStructured);
+    };
 };


### PR DESCRIPTION
After shooting a rifle's GL, hitting check ammo would show there was a loaded shell and an incorrect mag count.

Now on empty it displays the count of total compatible mags
That code wasn't reachable before because there is a `if (_magazine == "") exitWith {};` at the top but seems to be the intent.