### PR TITLE
WIP: Maps - Add topographic map item

### DIFF
--- a/addons/map/CfgWeapons.hpp
+++ b/addons/map/CfgWeapons.hpp
@@ -23,4 +23,8 @@ class CfgWeapons {
             };
         };
     };
+    class ItemMap;
+    class ace_TopographicMap: ItemMap {
+        displayName = "Topo test";
+    };
 };

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
         units[] = {};
-        weapons[] = {};
+        weapons[] = {"ace_TopographicMap"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
@@ -65,6 +65,69 @@ class RscMapControl {
     sizeExGrid = 0.032;
 };
 
+
+// Topographic Map:
+class ctrlMap;
+class GVAR(topographicCtrl): ctrlMap {
+    idc = 9051;
+
+    // scaleMin = 0.005;
+    // scaleMax = 10;  //Lets the mini display zoom out far enough
+    drawObjects = 0;
+    text = "#(argb,8,8,3)color(1,1,1,1)";
+    maxSatelliteAlpha = 0;
+
+    alphaFadeStartScale = 100;
+    alphaFadeEndScale = 100;
+    colorSea[] = {0.467,0.631,1,0.25};
+    colorCountlinesWater[] = {0.491,0.577,0.702,0.3};
+    colorMainCountlinesWater[] = {0.491,0.577,0.702,0.6};
+    colorGrid[] = {0,0,0,0.15};
+    colorGridMap[] = {0,0,0,0.2};
+
+    //Text sizes:
+    sizeExLabel = 0;
+    // sizeExGrid =
+    sizeExUnits = 0;
+    // sizeExNames = //Marker's Text
+    sizeExInfo = 0;
+    sizeExLevel = 0;
+    // sizeEx =
+
+    ptsPerSquareRoad = 0.75;
+    ptsPerSquareObj = 2000; //don't show buildings
+
+    showCountourInterval = 1;
+
+    colorTracks[] = {0.0,0.0,0.0,0.25};
+    colorTracksFill[] = {0.0,0.0,0.0,0.25};
+    colorRoads[] = {0.0,0.0,0.0,0.5};
+    colorRoadsFill[] = {1,1,0,0.5};
+    colorMainRoads[] = {0.0,0.0,0.0,1};
+    colorMainRoadsFill[] = {1,0.6,0.4,1};
+    colorRailWay[] = {0.8,0.2,0,1};
+
+    colorBackground[] = {0.929412, 0.929412, 0.929412, 1.0};
+    colorOutside[] = {0.929412, 0.929412, 0.929412, 1.0};
+    colorCountlines[] = {0.647059, 0.533333, 0.286275, 1};
+    colorMainCountlines[] = {0.858824, 0, 0,1};
+    colorForest[] = {0.6, 0.8, 0.2, 0.1};
+    colorForestBorder[] = {0,1,0,0.25};
+    colorLevels[] = {0.0, 0.0, 0.0, 0.5};
+    colorRocks[] = {0.50, 0.50, 0.50, 0};
+
+    class Legend {
+        x = SafeZoneX+SafeZoneW-.340;
+        y = SafeZoneY+SafeZoneH-.152;
+        font = "RobotoCondensed";
+        w = .340;
+        h = .152;
+        sizeEx = 0.039210;
+        colorBackground[] = {0.906000, 0.901000, 0.880000, 0.5};
+        color[] = {0, 0, 0, 0.75};
+    };
+};
+
 class RscMap;
 class RscDisplayArcadeMap_Layout_2: RscMap { //"Traditional" Editor:
     class controlsBackground {
@@ -89,6 +152,7 @@ class RscDisplayMainMap {
             onDraw = QUOTE([ctrlParent (_this select 0)] call DFUNC(onDrawMap));
             #include "MapTweaks.hpp"
         };
+        class ACE_topoMap: GVAR(topographicCtrl) {};
     };
     // get rid of the "center to player position" - button (as it works even on elite)
     class controls {

--- a/addons/map/functions/fnc_onDrawMap.sqf
+++ b/addons/map/functions/fnc_onDrawMap.sqf
@@ -15,7 +15,40 @@
  * Public: No
  */
 
-((_this select 0) displayCtrl 1016) ctrlShow GVAR(mapShowCursorCoordinates);
+params ["_display"];
+
+(_display displayCtrl 1016) ctrlShow GVAR(mapShowCursorCoordinates);
 
 // hide clock when no watch in inventory, or whatever never ever
-((_this select 0) displayCtrl 101) ctrlShow GVAR(hasWatch);
+(_display displayCtrl 101) ctrlShow GVAR(hasWatch);
+
+
+private _hasAceTopo = ((assignedItems ace_player) param [0, ""]) == "ace_TopographicMap";
+private _ctrlTopoMap = _display displayCtrl 9051;
+private _ctrlMap = _display displayCtrl 51;
+
+if (!((ctrlShown _ctrlTopoMap) isEqualTo _hasAceTopo)) then {
+    TRACE_1("updating ctrls",_hasAceTopo);
+    _ctrlMap ctrlShow false;
+    _ctrlMap ctrlCommit 0;
+    _ctrlTopoMap ctrlShow false;
+    _ctrlTopoMap ctrlCommit 0;
+
+    _ctrlTopoMap ctrlSetPosition ctrlPosition _ctrlMap;
+
+    _ctrlMap ctrlShow true;
+    _ctrlMap ctrlCommit 0;
+    _ctrlTopoMap ctrlShow _hasAceTopo;
+    _ctrlTopoMap ctrlCommit 0;
+};
+if (_hasAceTopo) then {
+    if (ctrlMapAnimDone _ctrlMap) then {
+        // update old map to the new maps position and scale
+        private _ctrlPos = ctrlPosition _ctrlMap;
+        private _centerScreen = [_ctrlPos#0 + _ctrlPos#2 / 2, _ctrlPos#1 + _ctrlPos#3 / 2];
+        private _centerPos = _ctrlTopoMap ctrlMapScreenToWorld _centerScreen;
+        private _scale = ctrlMapScale _ctrlTopoMap;
+        _ctrlMap ctrlMapAnimAdd [0.01, _scale, _centerPos];
+        ctrlMapAnimCommit _ctrlMap;
+    };
+};

--- a/addons/map_gestures/functions/fnc_receiverInit.sqf
+++ b/addons/map_gestures/functions/fnc_receiverInit.sqf
@@ -23,3 +23,4 @@ if (!isNil QGVAR(DrawMapHandlerID)) then {
     GVAR(DrawMapHandlerID) = nil;
 };
 GVAR(DrawMapHandlerID) = findDisplay 12 displayCtrl 51 ctrlAddEventHandler ["Draw", {call FUNC(drawMapGestures)}];
+ findDisplay 12 displayCtrl 9051 ctrlAddEventHandler ["Draw", {call FUNC(drawMapGestures)}]; // #TopoHack

--- a/addons/maptools/XEH_postInitClient.sqf
+++ b/addons/maptools/XEH_postInitClient.sqf
@@ -21,6 +21,7 @@ GVAR(mapTool_isRotating) = false;
     ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseButtonDown", {[1, _this] call FUNC(handleMouseButton);}];
     ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseButtonUp", {[0, _this] call FUNC(handleMouseButton)}];
     ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["Draw", {call FUNC(updateMapToolMarkers); call FUNC(openMapGpsUpdate);}];
+    ((findDisplay 12) displayCtrl 9051) ctrlAddEventHandler ["Draw", {call FUNC(updateMapToolMarkers);}]; // #TopoHack
 }, []] call CBA_fnc_waitUntilAndExecute;
 
 ["visibleMap", {

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -67,6 +67,7 @@
     if !((ctrlIDD _mapDisplay) in GVAR(mapDisplaysWithDrawEHs)) then {
         GVAR(mapDisplaysWithDrawEHs) pushBack (ctrlIDD _mapDisplay);
         _mapCtrl ctrlAddEventHandler ["Draw", {_this call FUNC(mapDrawEH)}]; // @todo check if persistent
+        (_mapDisplay displayCtrl 9051) ctrlAddEventHandler ["Draw", {_this call FUNC(mapDrawEH)}]; // #TopoHack
     };
 
     ////////////////////


### PR DESCRIPTION
Adds a simple topo map that doesn't magically show every single building, wall, rock and tree


New:
![20200405185251_1](https://user-images.githubusercontent.com/9376747/78513215-a4e88b00-776f-11ea-96ab-e12c50ba259b.jpg)

Old (sat tex off):
![20200405185242_1](https://user-images.githubusercontent.com/9376747/78513231-b5990100-776f-11ea-81ec-48372a94cb5f.jpg)

Creates a new map ctrl over the old one
this breaks **anything** that uses drawEH on the old map (`dspCtrl 51`)
but surprisingly button down stuff still seems to works fine, same with markers for the most part
ace already has decent support for non "itemMap"

ideas:
- [ ] probably re-add hill numbers
- [ ] maybe show urban areas with some kind of shading?
