### PR TITLE
Grenades - use correct type for cookoff_enabled, check for AI and variable on vehicle

### DIFF
--- a/addons/grenades/functions/fnc_incendiary.sqf
+++ b/addons/grenades/functions/fnc_incendiary.sqf
@@ -229,7 +229,14 @@ private _enginePosition = _vehicle modelToWorld (_vehicle selectionPosition _eng
 if (_position distance _enginePosition < EFFECT_SIZE * 2) then {
     _vehicle setHit [_engineSelection, 1];
 
-    if ("ace_cookoff" call EFUNC(common,isModLoaded) && {EGVAR(cookoff,enable)}) then {
-        _vehicle call EFUNC(cookoff,engineFire);
+    if ("ace_cookoff" call EFUNC(common,isModLoaded)) then {
+        private _isEnabled = _vehicle getVariable [QEGVAR(cookoff,enable), EGVAR(cookoff,enable)];
+        if (
+            !(_isEnabled in [0, false])
+            &&
+            !(_isEnabled isEqualTo 1 && {fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} == -1})
+        ) then {
+            _vehicle call EFUNC(cookoff,engineFire);
+        }
     };
 };

--- a/addons/grenades/functions/fnc_incendiary.sqf
+++ b/addons/grenades/functions/fnc_incendiary.sqf
@@ -230,13 +230,9 @@ if (_position distance _enginePosition < EFFECT_SIZE * 2) then {
     _vehicle setHit [_engineSelection, 1];
 
     if ("ace_cookoff" call EFUNC(common,isModLoaded)) then {
-        private _isEnabled = _vehicle getVariable [QEGVAR(cookoff,enable), EGVAR(cookoff,enable)];
-        if (
-            !(_isEnabled in [0, false])
-            &&
-            !(_isEnabled isEqualTo 1 && {fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} == -1})
-        ) then {
+        private _enabled = _vehicle getVariable [QEGVAR(cookoff,enable), EGVAR(cookoff,enable)];
+        if (_enabled in [2, true] || {_enabled isEqualTo 1 && {fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} != -1}}) then {
             _vehicle call EFUNC(cookoff,engineFire);
-        }
+        };
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- See title.
- Doesn't error with wrong type (setting was changed from boolean on/off to number off/players only/players and ai)
- Checks variable on vehicle (with setting as fallback)
- Doesn't trigger on empty or ai-only vehicles when setting is on "players only".