### PR TITLE
CSW - Add local event when weapon is deployed sucessfully

### DIFF
--- a/addons/csw/functions/fnc_assemble_deployWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_deployWeapon.sqf
@@ -54,6 +54,7 @@
             if ((_tripodPos select 2) < 0.5) then {
                 _csw setVectorUp (surfaceNormal _tripodPos);
             };
+            [QGVAR(deployWeaponSucceeded), [_csw]] call CBA_fnc_localEvent;
             TRACE_2("csw placed",_csw,_assembledClassname);
         }, [_assembledClassname, _tripodDir, _tripodPos]] call CBA_fnc_execNextFrame;
     };


### PR DESCRIPTION
This will help mission maker to track weapon deployment through CSW like the BI version does: https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#WeaponAssembled 

**When merged this pull request will:**
- This add a local event triggered when a CSW weapon is deployed successfully
- Add a `CBA_fnc_localEvent` under the name `ace_csw_deployWeaponSucceeded`