### PR TITLE
Cargo - Fix tankx vehicles receiving water damage when loaded

### DIFF
--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -39,8 +39,8 @@ if (_item isEqualType objNull) then {
     [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
     
     // Cars below water will take engine damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
-    private _simulationType = getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation");
-    if (_simulationType == "carx" || {_simulationType == "tankx"}) then {
+    private _simulationType = toLower getText (configFile >> "CfgVehicles" >> typeOf _item >> "simulation");
+    if (_simulationType in ["carx", "tankx"]) then {
         TRACE_1("disabling vehicle damage",_item);
         [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
     };

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -39,7 +39,8 @@ if (_item isEqualType objNull) then {
     [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
     
     // Cars below water will take engine damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
-    if ((getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "carx" || (getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "tankx") then {
+    private _simulationType = getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation");
+    if (_simulationType == "carx" || _simulationType == "tankx") then {
         TRACE_1("disabling vehicle damage",_item);
         [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
     };

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -40,7 +40,7 @@ if (_item isEqualType objNull) then {
     
     // Cars below water will take engine damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
     private _simulationType = getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation");
-    if (_simulationType == "carx" || _simulationType == "tankx") then {
+    if (_simulationType == "carx" || {_simulationType == "tankx"}) then {
         TRACE_1("disabling vehicle damage",_item);
         [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
     };

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -39,8 +39,8 @@ if (_item isEqualType objNull) then {
     [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
     
     // Cars below water will take engine damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
-    if ((getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "carx") then {
-        TRACE_1("disabling car damage",_item);
+    if ((getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "carx" || (getText (configFile >> "CfgVehicles" >> (typeOf _item) >> "simulation")) == "tankx") then {
+        TRACE_1("disabling vehicle damage",_item);
         [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Include vehicles with the tankx simulation type in the water damage fix

Some vehicles (in our case the M119A2) receive damage when loaded on terrains with low elevation. This seems to be the same issue as was already solved for any vehicle using carx simulation, but as these vehicles use tankx instead they do not get made invulnerable. 

Simply adding an OR statement for tankx is probably not the cleanest solution, but it appears there are only 3 PhysX simulation types in Arma (last being shipx) so it should be ok. Feel free to suggest a different solution otherwise.