### PR TITLE
Extensions - Fix buffer overflows and Artillery Tables for GCC

### DIFF
--- a/extensions/advanced_ballistics/AdvancedBallistics.cpp
+++ b/extensions/advanced_ballistics/AdvancedBallistics.cpp
@@ -295,7 +295,7 @@ extern "C"
 
 void __stdcall RVExtensionVersion(char *output, int outputSize)
 {
-    strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+    strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
 }
 
 void __stdcall RVExtension(char *output, int outputSize, const char *function)
@@ -303,7 +303,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
     ZERO_OUTPUT();
     std::stringstream outputStr;
     if (!strcmp(function, "version")) {
-        strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+        strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
         EXTENSION_RETURN();
     }
 
@@ -328,7 +328,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         // int n = sprintf(output,  "%f", retard);
 
         outputStr << retard;
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
 
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "atmosphericCorrection")) {
@@ -347,7 +347,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         ballisticCoefficient = calculateAtmosphericCorrection(ballisticCoefficient, temperature, pressure, humidity, atmosphereModel);
         //int n = sprintf(output,  "%f", ballisticCoefficient);
         outputStr << ballisticCoefficient;
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "new")) {
         unsigned int index = 0;
@@ -453,7 +453,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
             bulletDatabase[index].randGenerator.seed(bulletDatabase[index].randSeed);
         }
 
-        strncpy(output, "", outputSize);
+        strncpy(output, "", outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "simulate")) {
         // simulate:0:[-0.109985,542.529,-3.98301]:[3751.57,5332.23,214.252]:[0.598153,2.38829,0]:28.6:0:0.481542:0:215.16
@@ -622,7 +622,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         bulletDatabase[index].bulletVelocityPreviousFrame = bulletVelocityCurrentFrame + velocityOffset;
 
         outputStr << "[" << velocityOffset.x() << "," << velocityOffset.y() << "," << velocityOffset.z() << "]";
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "set")) {
         int height = 0;
@@ -637,7 +637,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         map->gridBuildingNums.push_back(numObjects);
         map->gridSurfaceIsWater.push_back(surfaceIsWater);
 
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "init")) {
         int mapSize = 0;
@@ -653,7 +653,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         map = &mapDatabase[worldName];
         if (map->gridHeights.size() == gridCells) {
             outputStr << "Terrain already initialized";
-            strncpy(output, outputStr.str().c_str(), outputSize);
+            strncpy(output, outputStr.str().c_str(), outputSize - 1);
             EXTENSION_RETURN();
         }
 
@@ -666,7 +666,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         map->gridBuildingNums.reserve(gridCells);
         map->gridSurfaceIsWater.reserve(gridCells);
 
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "replicateVanillaZero")) {
         float zeroRange = strtof(strtok_s(NULL, ":", &next_token), NULL);
@@ -676,7 +676,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         float zeroAngle = replicateVanillaZero(zeroRange, initSpeed, airFriction);
 
         outputStr << DEGREES(zeroAngle);
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "calcZero")) {
         double zeroRange = strtod(strtok_s(NULL, ":", &next_token), NULL);
@@ -687,7 +687,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         double zeroAngle = calculateVanillaZero(zeroRange, initSpeed, airFriction, boreHeight);
 
         outputStr << DEGREES(zeroAngle);
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     } else if (!strcmp(mode, "calcZeroAB")) {
         double zeroRange = strtod(strtok_s(NULL, ":", &next_token), NULL);
@@ -703,9 +703,9 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         double zeroAngle = calculateAdvancedZero(zeroRange, muzzleVelocity, boreHeight, temperature, pressure, humidity, ballisticCoefficient, dragModel, atmosphereModel);
 
         outputStr << DEGREES(zeroAngle);
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         EXTENSION_RETURN();
     }
-    strncpy(output, outputStr.str().c_str(), outputSize);
+    strncpy(output, outputStr.str().c_str(), outputSize - 1);
     EXTENSION_RETURN();
 }

--- a/extensions/artillerytables/artillerytables.cpp
+++ b/extensions/artillerytables/artillerytables.cpp
@@ -205,14 +205,14 @@ std::string simulateCalcRangeTableLine(const double _rangeToHit, const double _m
 }
 
 void __stdcall RVExtensionVersion(char* output, int outputSize) {
-    strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+    strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
 }
 void __stdcall RVExtension(char* output, int outputSize, const char* function) {
     if (!strcmp(function, "version")) {
         RVExtensionVersion(output, outputSize);
         return;
     }
-    strncpy(output, "error - use args version of callExtension", outputSize);
+    strncpy(output, "error - use args version of callExtension", outputSize - 1);
 }
 int __stdcall RVExtensionArgs(char* output, int outputSize, const char* function, const char** args, int argsCnt) {
     if (!strcmp(function, "version")) {
@@ -254,7 +254,7 @@ int __stdcall RVExtensionArgs(char* output, int outputSize, const char* function
 
         std::stringstream outputStr; // debug max distance and thead count
         outputStr << "[" << bestDistance << "," << fWorkers.size() << "]";
-        strncpy(output, outputStr.str().c_str(), outputSize);
+        strncpy(output, outputStr.str().c_str(), outputSize - 1);
         return 0;
     }
 
@@ -274,10 +274,10 @@ int __stdcall RVExtensionArgs(char* output, int outputSize, const char* function
             result = fWorkers[getLineIndex].get();
             getLineIndex++;
         }
-        strncpy(output, result.c_str(), outputSize);
+        strncpy(output, result.c_str(), outputSize - 1);
         return 1;
     }
 
-    strncpy(output, "error - invalid function", outputSize);
+    strncpy(output, "error - invalid function", outputSize - 1);
     return RETURN_INVALID_FUNCTION; // Error: function not valid
 }

--- a/extensions/artillerytables/artillerytables.hpp
+++ b/extensions/artillerytables/artillerytables.hpp
@@ -10,9 +10,9 @@
 #define RETURN_WRONG_ARG_COUNT      -1002
 
 extern "C" {
-    __declspec(dllexport) void __stdcall RVExtension(char* output, int outputSize, const char* function);
-    __declspec(dllexport) int __stdcall RVExtensionArgs(char* output, int outputSize, const char* function, const char** argv, int argc);
-    __declspec(dllexport) void __stdcall RVExtensionVersion(char* output, int outputSize);
+    EXPORT void __stdcall RVExtension(char* output, int outputSize, const char* function);
+    EXPORT int __stdcall RVExtensionArgs(char* output, int outputSize, const char* function, const char** argv, int argc);
+    EXPORT void __stdcall RVExtensionVersion(char* output, int outputSize);
 }
 
 std::tuple<double, double, double> simulateShot(const double _fireAngleRad, const double _muzzleVelocity, const double _heightOfTarget, const double _crossWind, const double _tailWind, const double _temperature, const double _airDensity, double _airFriction);

--- a/extensions/break_line/ace_break_line.cpp
+++ b/extensions/break_line/ace_break_line.cpp
@@ -64,9 +64,9 @@ std::string addLineBreaks(const std::vector<std::string> &words) {
 void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     ZERO_OUTPUT();
     if (!strcmp(function, "version")) {
-        strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+        strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
     } else {
-        strncpy(output, addLineBreaks(splitString(function)).c_str(), outputSize);
+        strncpy(output, addLineBreaks(splitString(function)).c_str(), outputSize - 1);
     }
     EXTENSION_RETURN();
 }

--- a/extensions/clipboard/ace_clipboard.cpp
+++ b/extensions/clipboard/ace_clipboard.cpp
@@ -33,7 +33,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     }
 
     if (!strcmp(function, "version")) {
-        std::strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+        std::strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
         EXTENSION_RETURN();
     }
 
@@ -72,7 +72,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     }
 
     if (result.length() > 1) {
-        strncpy(output, result.c_str(), outputSize);
+        strncpy(output, result.c_str(), outputSize - 1);
     }
 
     #endif

--- a/extensions/dynload/ace_dynload.cpp
+++ b/extensions/dynload/ace_dynload.cpp
@@ -61,6 +61,6 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     ace::dispatch::get().call(command, _args, result);
 
  
-    sprintf_s(output, outputSize, "%s", result.c_str());
+    sprintf_s(output, outputSize - 1, "%s", result.c_str());
     EXTENSION_RETURN();
 }

--- a/extensions/dynload/ace_dynload.cpp
+++ b/extensions/dynload/ace_dynload.cpp
@@ -60,7 +60,6 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     // Real functionality goes here
     ace::dispatch::get().call(command, _args, result);
 
- 
     sprintf_s(output, outputSize - 1, "%s", result.c_str());
     EXTENSION_RETURN();
 }

--- a/extensions/fcs/ace_fcs.cpp
+++ b/extensions/fcs/ace_fcs.cpp
@@ -96,7 +96,7 @@ double getSolution(double initSpeed, double airFriction, double angleTarget, dou
 void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     ZERO_OUTPUT();
     if (!strcmp(function, "version")) {
-        strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+        strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
     } else {
         std::vector<std::string> argStrings = splitString(function);
         double initSpeed = std::stod(argStrings[0]);
@@ -109,7 +109,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
         std::stringstream sstream;
         sstream << result;
 
-        strncpy(output, sstream.str().c_str(), outputSize);
+        strncpy(output, sstream.str().c_str(), outputSize - 1);
     }
     EXTENSION_RETURN();
 }

--- a/extensions/medical/medical.cpp
+++ b/extensions/medical/medical.cpp
@@ -33,7 +33,7 @@ std::vector<std::string> parseExtensionInput(const std::string& input)
 
 void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     if (!strcmp(function, "version")) {
-        strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+        strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
     }
     else
     {
@@ -85,6 +85,6 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
             }
         }
 
-        strncpy(output, returnValue.c_str(), outputSize);
+        strncpy(output, returnValue.c_str(), outputSize - 1);
     }
 }

--- a/extensions/parse_imagepath/ace_parse_imagepath.cpp
+++ b/extensions/parse_imagepath/ace_parse_imagepath.cpp
@@ -40,9 +40,9 @@ std::string getImagePathFromStructuredText(const std::string & input) {
 void __stdcall RVExtension(char *output, int outputSize, const char *function) {
     ZERO_OUTPUT();
     if (!strcmp(function, "version")) {
-        strncpy(output, ACE_FULL_VERSION_STR, outputSize);
+        strncpy(output, ACE_FULL_VERSION_STR, outputSize - 1);
     } else {
-        strncpy(output, getImagePathFromStructuredText(function).c_str(), outputSize);
+        strncpy(output, getImagePathFromStructuredText(function).c_str(), outputSize - 1);
     }
     EXTENSION_RETURN();
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Fix buffer overflows (only visible in Debug build) - following https://github.com/IDI-Systems/acre2/pull/924
- Artillery Tables for GCC - use `EXPORT` macro

Builds fine, but not tested in-game.