### PR TITLE
Common - Fix ACE displayTextStructured overlap CBA_fnc_notify

### DIFF
--- a/addons/ai/functions/fnc_garrison.sqf
+++ b/addons/ai/functions/fnc_garrison.sqf
@@ -30,12 +30,12 @@ private _currentUnitMoveList = missionNameSpace getVariable [QGVAR(garrison_unit
 
 if (_startingPos isEqualTo [0,0,0]) exitWith {
     TRACE_1("fnc_garrison: StartingPos error",_startingPos);
-    [LSTRING(GarrisonInvalidPosition)] call EFUNC(common,displayTextStructured);
+    [LSTRING(GarrisonInvalidPosition)] call CBA_fnc_notify;
 };
 
 if (count _unitsArray == 0 || {isNull (_unitsArray select 0)}) exitWith {
     TRACE_1("fnc_garrison: Units error",_unitsArray);
-    [LSTRING(GarrisonNoUnits)] call EFUNC(common,displayTextStructured);
+    [LSTRING(GarrisonNoUnits)] call CBA_fnc_notify;
 };
 
 private _buildings = nearestObjects [_startingPos, _buildingTypes, ([_fillingRadius, 50] select (_fillingRadius < 50))];
@@ -45,7 +45,7 @@ if (_fillingRadius >= 50) then {
 
 if (count _buildings == 0) exitWith {
     TRACE_1("fnc_garrison: Building error",_buildings);
-    [LSTRING(GarrisonNoBuilding)] call EFUNC(common,displayTextStructured);
+    [LSTRING(GarrisonNoBuilding)] call CBA_fnc_notify;
 };
 
 private _buildingsIndex = [];
@@ -91,7 +91,7 @@ private _count = 0;
 {_count = _count + count _x} foreach _buildingsIndex;
 if ( (count _unitsArray) - _count > 0) then {
     TRACE_4("fnc_garrison: Not enough spots to place all units",_unitsArray,count _unitsArray,_count,((count _unitsArray) - _count > 0));
-    [LSTRING(GarrisonNotEnoughPos)] call EFUNC(common,displayTextStructured);
+    [LSTRING(GarrisonNotEnoughPos)] call CBA_fnc_notify;
 };
 
 private _placedUnits = [];

--- a/addons/artillerytables/functions/fnc_turretPFEH.sqf
+++ b/addons/artillerytables/functions/fnc_turretPFEH.sqf
@@ -20,7 +20,7 @@
 if (shownArtilleryComputer && {GVAR(disableArtilleryComputer)}) then {
     // Still Don't like this solution, but it works
     closeDialog 0;
-    [localize LSTRING(disableArtilleryComputer_displayName)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(disableArtilleryComputer_displayName)] call CBA_fnc_notify;
 };
 
 // Restart display if null (not just at start, this will happen periodicly)

--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -41,7 +41,7 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
     _attachedItem attachTo [_unit, [0.05, -0.09, 0.1], "leftshoulder"];
     if (!_silentScripted) then {
         _unit removeItem _itemClassname;  // Remove item
-        [_onAttachText, 2] call EFUNC(common,displayTextStructured);
+        [_onAttachText] call CBA_fnc_notify;
     };
     _unit setVariable [QGVAR(attached), [[_attachedItem, _itemClassname]], true];
 } else {

--- a/addons/attach/functions/fnc_detach.sqf
+++ b/addons/attach/functions/fnc_detach.sqf
@@ -47,7 +47,7 @@ private _isChemlight = _attachedObject isKindOf "Chemlight_base";
 
 // Exit if can't add the item
 if (!(_unit canAdd _itemName) && {!_isChemlight}) exitWith {
-    [localize LSTRING(Inventory_Full)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(Inventory_Full)] call CBA_fnc_notify;
 };
 
 // Add item to inventory (unless it's a chemlight)
@@ -83,4 +83,4 @@ if (_itemDisplayName == "") then {
     _itemDisplayName = getText (configFile >> "CfgMagazines" >> _itemName >> "displayName");
 };
 
-[format [localize LSTRING(Item_Detached), _itemDisplayName], 2] call EFUNC(common,displayTextStructured);
+[format [localize LSTRING(Item_Detached), _itemDisplayName]] call CBA_fnc_notify;

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -81,7 +81,7 @@ private _closeInDistance = (_closeInMax + _closeInMin) / 2;
 //Checks (too close to center or can't attach)
 if (((_startDistanceFromCenter - _closeInDistance) < 0.1) || {!([_attachToVehicle, _unit, _itemClassname] call FUNC(canAttach))}) exitWith {
     TRACE_2("no valid spot found",_closeInDistance,_startDistanceFromCenter);
-    [localize LSTRING(Failed)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(Failed)] call CBA_fnc_notify;
 };
 
 //Move it out slightly, for visability sake (better to look a little funny than be embedded//sunk in the hull and be useless)
@@ -101,4 +101,4 @@ private _attachList = _attachToVehicle getVariable [QGVAR(attached), []];
 _attachList pushBack [_attachedObject, _itemClassname];
 _attachToVehicle setVariable [QGVAR(attached), _attachList, true];
 
-[_onAttachText, 2] call EFUNC(common,displayTextStructured);
+[_onAttachText] call CBA_fnc_notify;

--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -14,7 +14,7 @@
     private _itemName = getText (configFile >> "CfgVehicles" >> typeOf _item >> "displayName");
     private _vehicleName = getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName");
 
-    [[_hint, _itemName, _vehicleName], 3.0] call EFUNC(common,displayTextStructured);
+    format [_hint, _itemName, _vehicleName] call CBA_fnc_notify;
 
     if (_loaded) then {
         // Invoke listenable event
@@ -35,7 +35,7 @@
     private _itemName = getText (configFile >> "CfgVehicles" >> _itemClass >> "displayName");
     private _vehicleName = getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName");
 
-    [[_hint, _itemName, _vehicleName], 3.0] call EFUNC(common,displayTextStructured);
+    format [_hint, _itemName, _vehicleName] call CBA_fnc_notify;
 
     if (_unloaded) then {
         // Invoke listenable event

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -96,14 +96,10 @@ _itemObject setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vecto
 }, 1, [_itemObject]] call CBA_fnc_addPerFrameHandler;
 
 if (_showHint) then {
-    [
-        [
-            LSTRING(UnloadedItem),
-            getText (configFile >> "CfgVehicles" >> typeOf _itemObject >> "displayName"),
-            getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName")
-        ],
-        3
-    ] call EFUNC(common,displayTextStructured);
+    format [LSTRING(UnloadedItem),
+        getText (configFile >> "CfgVehicles" >> typeOf _itemObject >> "displayName"),
+        getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName")
+    ] call CBA_fnc_notify;
 };
 
 // Invoke listenable event

--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -42,7 +42,7 @@ if ([_object, _vehicle] call FUNC(canLoadItemIn)) then {
         GVAR(loadTimeCoefficient) * _size,
         [_object, _vehicle],
         {
-            TRACE_1("load finish",_this); 
+            TRACE_1("load finish",_this);
             [objNull, _this select 0 select 0, true] call EFUNC(common,claim);
             ["ace_loadCargo", _this select 0] call CBA_fnc_localEvent;
         },
@@ -62,7 +62,7 @@ if ([_object, _vehicle] call FUNC(canLoadItemIn)) then {
 } else {
     private _displayName = getText (configFile >> "CfgVehicles" >> typeOf _object >> "displayName");
 
-    [[LSTRING(LoadingFailed), _displayName], 3] call EFUNC(common,displayTextStructured);
+    format [LSTRING(LoadingFailed), _displayName] call CBA_fnc_notify;
 };
 
 _return

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -49,7 +49,7 @@ if (GVAR(interactionParadrop)) exitWith {
             params ["_args", "", "", "_errorCode"]; // show warning if we failed because of flight conditions
             if (_errorCode == 3) then {
                 _args params ["_item", "_target", "_player"];
-                [localize LSTRING(unlevelFlightWarning)] call EFUNC(common,displayTextStructured);
+                [localize LSTRING(unlevelFlightWarning)] call CBA_fnc_notify;
             };
         },
         localize LSTRING(UnloadingItem),
@@ -77,7 +77,7 @@ if ([_item, GVAR(interactionVehicle), ACE_player] call FUNC(canUnloadItem)) then
         localize LSTRING(UnloadingItem),
         {
             (_this select 0) params ["_item", "_target", "_player"];
-            
+
             (alive _target)
             && {locked _target < 2}
             && {([_player, _target] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}
@@ -89,5 +89,5 @@ if ([_item, GVAR(interactionVehicle), ACE_player] call FUNC(canUnloadItem)) then
     private _itemClass = if (_item isEqualType "") then {_item} else {typeOf _item};
     private _displayName = getText (configFile >> "CfgVehicles" >> _itemClass >> "displayName");
 
-    [[LSTRING(UnloadingFailed), _displayName], 3] call EFUNC(common,displayTextStructured);
+    format [LSTRING(UnloadingFailed), _displayName] call CBA_fnc_notify;
 };

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -28,7 +28,7 @@ if ((count _emptyPosAGL) != 3) exitWith {
     TRACE_4("Could not find unload pos",_vehicle,getPosASL _vehicle,isTouchingGround _vehicle,speed _vehicle);
     if ((!isNull _unloader) && {_unloader == ACE_player}) then {
         //display text saying there are no safe places to exit the vehicle
-        [localize ELSTRING(common,NoRoomToUnload)] call EFUNC(common,displayTextStructured);
+        [localize ELSTRING(common,NoRoomToUnload)] call CBA_fnc_notify;
     };
     false
 };

--- a/addons/common/functions/fnc_displayTextStructured.sqf
+++ b/addons/common/functions/fnc_displayTextStructured.sqf
@@ -23,7 +23,7 @@ params [["_text", ""], ["_size", 1.5, [0]], ["_target", ACE_player, [objNull]], 
 
 if (_target != ACE_player) exitWith {};
 
-if (typeName _text != "TEXT") then {
+if (typeName _text != "TEXT") exitwith {
     if (_text isEqualType []) then {
         if (count _text > 0) then {
             {
@@ -37,7 +37,7 @@ if (typeName _text != "TEXT") then {
     if (_text isEqualType "" && {isLocalized _text}) then {
         _text = localize _text;
     };
-    _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
+    (parseText format ["<t align='center'>%1</t>", _text]) call CBA_fnc_notify;
 };
 
 _text call CBA_fnc_notify;

--- a/addons/common/functions/fnc_displayTextStructured.sqf
+++ b/addons/common/functions/fnc_displayTextStructured.sqf
@@ -40,36 +40,4 @@ if (typeName _text != "TEXT") then {
     _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
 };
 
-private _isShown = ctrlShown (uiNamespace getVariable ["ACE_ctrlHint", controlNull]);
-
-("ACE_RscHint" call BIS_fnc_rscLayer) cutRsc ["ACE_RscHint", "PLAIN", 0, true];
-
-disableSerialization;
-private _ctrlHint = uiNamespace getVariable "ACE_ctrlHint";
-
-_ctrlHint ctrlSetBackgroundColor GVAR(displayTextColor);
-_ctrlHint ctrlSetTextColor GVAR(displayTextFontColor);
-
-// Use profile settings from CfgUIGrids.hpp
-private _xPos = profilenamespace getVariable ["IGUI_GRID_ACE_displayText_X", ((safezoneX + safezoneW) - (10 *(((safezoneW / safezoneH) min 1.2) / 40)) - 2.9 *(((safezoneW / safezoneH) min 1.2) / 40))];
-private _yPos = profilenamespace getVariable ["IGUI_GRID_ACE_displayText_Y", safeZoneY + 0.175 * safezoneH];
-private _wPos =  (_width *(((safezoneW / safezoneH) min 1.2) / 40));
-private _hPos = _size * (2 *((((safezoneW / safezoneH) min 1.2) / 1.2) / 25));
-
-// Ensure still in bounds for large width/height
-_xPos = safezoneX max (_xPos min (safezoneX + safezoneW - _wPos));
-_yPos = safeZoneY max (_yPos min (safeZoneY + safezoneH - _hPos));
-
-// Zeus Interface Open and Display would be under the "CREATE" list
-if (!isNull curatorCamera) then {
-    _xPos = _xPos min ((safezoneX + safezoneW - 12.5 * (((safezoneW / safezoneH) min 1.2) / 40)) - _wPos);
-};
-
-private _position = [_xPos, _yPos, _wPos, _hPos];
-
-_ctrlHint ctrlSetPosition _position;
-_ctrlHint ctrlCommit 0;
-
-_ctrlHint ctrlSetStructuredText _text;
-_ctrlHint ctrlSetPosition _position;
-_ctrlHint ctrlCommit ([0.5, 0] select _isShown);
+_text call CBA_fnc_notify;

--- a/addons/common/functions/fnc_displayTextStructured.sqf
+++ b/addons/common/functions/fnc_displayTextStructured.sqf
@@ -23,7 +23,7 @@ params [["_text", ""], ["_size", 1.5, [0]], ["_target", ACE_player, [objNull]], 
 
 if (_target != ACE_player) exitWith {};
 
-if (typeName _text != "TEXT") exitwith {
+if (typeName _text != "TEXT") then {
     if (_text isEqualType []) then {
         if (count _text > 0) then {
             {
@@ -37,7 +37,39 @@ if (typeName _text != "TEXT") exitwith {
     if (_text isEqualType "" && {isLocalized _text}) then {
         _text = localize _text;
     };
-    (format ["<t align='center'>%1</t>", _text]) call CBA_fnc_notify;
+    _text = composeText [lineBreak, parseText format ["<t align='center'>%1</t>", _text]];
 };
 
-str(_text) call CBA_fnc_notify;
+private _isShown = ctrlShown (uiNamespace getVariable ["ACE_ctrlHint", controlNull]);
+
+("ACE_RscHint" call BIS_fnc_rscLayer) cutRsc ["ACE_RscHint", "PLAIN", 0, true];
+
+disableSerialization;
+private _ctrlHint = uiNamespace getVariable "ACE_ctrlHint";
+
+_ctrlHint ctrlSetBackgroundColor GVAR(displayTextColor);
+_ctrlHint ctrlSetTextColor GVAR(displayTextFontColor);
+
+// Use profile settings from CfgUIGrids.hpp
+private _xPos = profilenamespace getVariable ["IGUI_GRID_ACE_displayText_X", ((safezoneX + safezoneW) - (10 *(((safezoneW / safezoneH) min 1.2) / 40)) - 2.9 *(((safezoneW / safezoneH) min 1.2) / 40))];
+private _yPos = profilenamespace getVariable ["IGUI_GRID_ACE_displayText_Y", safeZoneY + 0.175 * safezoneH];
+private _wPos =  (_width *(((safezoneW / safezoneH) min 1.2) / 40));
+private _hPos = _size * (2 *((((safezoneW / safezoneH) min 1.2) / 1.2) / 25));
+
+// Ensure still in bounds for large width/height
+_xPos = safezoneX max (_xPos min (safezoneX + safezoneW - _wPos));
+_yPos = safeZoneY max (_yPos min (safeZoneY + safezoneH - _hPos));
+
+// Zeus Interface Open and Display would be under the "CREATE" list
+if (!isNull curatorCamera) then {
+    _xPos = _xPos min ((safezoneX + safezoneW - 12.5 * (((safezoneW / safezoneH) min 1.2) / 40)) - _wPos);
+};
+
+private _position = [_xPos, _yPos, _wPos, _hPos];
+
+_ctrlHint ctrlSetPosition _position;
+_ctrlHint ctrlCommit 0;
+
+_ctrlHint ctrlSetStructuredText _text;
+_ctrlHint ctrlSetPosition _position;
+_ctrlHint ctrlCommit ([0.5, 0] select _isShown);

--- a/addons/common/functions/fnc_displayTextStructured.sqf
+++ b/addons/common/functions/fnc_displayTextStructured.sqf
@@ -37,7 +37,7 @@ if (typeName _text != "TEXT") exitwith {
     if (_text isEqualType "" && {isLocalized _text}) then {
         _text = localize _text;
     };
-    (parseText format ["<t align='center'>%1</t>", _text]) call CBA_fnc_notify;
+    (format ["<t align='center'>%1</t>", _text]) call CBA_fnc_notify;
 };
 
-_text call CBA_fnc_notify;
+str(_text) call CBA_fnc_notify;

--- a/addons/dogtags/functions/fnc_addDogtagItem.sqf
+++ b/addons/dogtags/functions/fnc_addDogtagItem.sqf
@@ -27,5 +27,5 @@ private _displayText = format [localize LSTRING(takeDogtagSuccess), _nickName];
 
 // display message
 [{
-    [_this, 2.5] call EFUNC(common,displayTextStructured);
+    [_this] call CBA_fnc_notify;
 }, _displayText, DOGTAG_SHOW_DELAY] call CBA_fnc_waitAndExecute;

--- a/addons/dogtags/functions/fnc_takeDogtag.sqf
+++ b/addons/dogtags/functions/fnc_takeDogtag.sqf
@@ -38,7 +38,7 @@ playSound3D [
 // display message
 if ((_target getVariable [QGVAR(dogtagTaken), objNull]) == _target) then {
     [{
-        [_this, 2.5] call EFUNC(common,displayTextStructured);
+        [_this] call CBA_fnc_notify;
     }, localize LSTRING(dogtagAlreadyTaken), DOGTAG_SHOW_DELAY] call CBA_fnc_waitAndExecute;
 } else {
     _target setVariable [QGVAR(dogtagTaken), _target, true];

--- a/addons/dragging/functions/fnc_startCarry.sqf
+++ b/addons/dragging/functions/fnc_startCarry.sqf
@@ -25,7 +25,7 @@ if (!GETVAR(_target,GVAR(ignoreWeightCarry),false) && {
     _weight > GETMVAR(ACE_maxWeightCarry,1E11)
 }) exitWith {
     // exit if object weight is over global var value
-    [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(UnableToDrag)] call CBA_fnc_notify;
 };
 
 private _timer = CBA_missionTime + 5;

--- a/addons/dragging/functions/fnc_startDrag.sqf
+++ b/addons/dragging/functions/fnc_startDrag.sqf
@@ -25,7 +25,7 @@ if (!GETVAR(_target,GVAR(ignoreWeightDrag),false) && {
     _weight > GETMVAR(ACE_maxWeightDrag,1E11)
 }) exitWith {
     // exit if object weight is over global var value
-    [localize LSTRING(UnableToDrag)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(UnableToDrag)] call CBA_fnc_notify;
 };
 
 // add a primary weapon if the unit has none.

--- a/addons/explosives/functions/fnc_addCellphoneIED.sqf
+++ b/addons/explosives/functions/fnc_addCellphoneIED.sqf
@@ -49,7 +49,7 @@ _count = _count + 1;
 publicVariable QGVAR(CellphoneIEDs);
 
 //display IED number message:
-[format ["IED %1 code: %2", _count, _code]] call EFUNC(common,displayTextStructured);
+[format ["IED %1 code: %2", _count, _code]] call CBA_fnc_notify;
 
 if !(_hasRequired) exitWith {};
 [format ["IED %1", _count], _code] call FUNC(addToSpeedDial);

--- a/addons/explosives/functions/fnc_addClacker.sqf
+++ b/addons/explosives/functions/fnc_addClacker.sqf
@@ -45,4 +45,4 @@ _clacker pushBack [_explosive, getNumber(_config >> "FuseTime"), format [localiz
 _unit setVariable [QGVAR(Clackers), _clacker, true];
 
 //display clacker code message:
-[format [localize LSTRING(DetonateCode), GVAR(PlacedCount)]] call EFUNC(common,displayTextStructured);
+[format [localize LSTRING(DetonateCode), GVAR(PlacedCount)]] call CBA_fnc_notify;

--- a/addons/fcs/functions/fnc_keyUp.sqf
+++ b/addons/fcs/functions/fnc_keyUp.sqf
@@ -123,5 +123,5 @@ if (_playSound) then {
 };
 
 if (_showHint) then {
-    [format ["%1: %2", localize LSTRING(ZeroedTo), _distance]] call EFUNC(common,displayTextStructured);
+    [format ["%1: %2", localize LSTRING(ZeroedTo), _distance]] call CBA_fnc_notify;
 };

--- a/addons/fcs/functions/fnc_reset.sqf
+++ b/addons/fcs/functions/fnc_reset.sqf
@@ -23,4 +23,4 @@ params ["_vehicle", "_turret"];
 [_vehicle, format ["%1_%2", QGVAR(Elevation), _turret],  0] call EFUNC(common,setVariablePublic);
 [_vehicle, format ["%1_%2", QGVAR(Azimuth),   _turret],  0] call EFUNC(common,setVariablePublic);
 
-[localize LSTRING(HasBeenReset)] call EFUNC(common,displayTextStructured);
+[localize LSTRING(HasBeenReset)] call CBA_fnc_notify;

--- a/addons/grenades/functions/fnc_nextMode.sqf
+++ b/addons/grenades/functions/fnc_nextMode.sqf
@@ -33,10 +33,10 @@ private _hint = localize ([
     LSTRING(HighThrow),
     LSTRING(PreciseThrow),
     LSTRING(RollGrenade),
-    LSTRING(DropGrenade)  
+    LSTRING(DropGrenade)
 ] select _mode);
 
-[_hint] call EFUNC(common,displayTextStructured);
+[_hint] call CBA_fnc_notify;
 
 GVAR(currentThrowMode) = _mode;
 

--- a/addons/gunbag/functions/fnc_offGunbagCallback.sqf
+++ b/addons/gunbag/functions/fnc_offGunbagCallback.sqf
@@ -23,7 +23,7 @@ private _gunbag = backpackContainer _target;
 private _state = _gunbag getVariable [QGVAR(gunbagWeapon), []];
 
 if (_state isEqualTo []) exitWith {
-    [localize LSTRING(empty)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(empty)] call CBA_fnc_notify;
 };
 
 _state params ["_weapon", "_items", "_magazines"];

--- a/addons/gunbag/functions/fnc_status.sqf
+++ b/addons/gunbag/functions/fnc_status.sqf
@@ -20,7 +20,7 @@ params ["_unit"];
 private _state = (backpackContainer _unit) getVariable [QGVAR(gunbagWeapon), []];
 
 if (_state isEqualTo []) then {
-    [localize LSTRING(empty)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(empty)] call CBA_fnc_notify;
 } else {
     _state params ["_weapon"];
 

--- a/addons/hearing/functions/fnc_putInEarplugs.sqf
+++ b/addons/hearing/functions/fnc_putInEarplugs.sqf
@@ -26,13 +26,13 @@ _player removeItem "ACE_EarPlugs";
 _player setVariable ["ACE_hasEarPlugsIn", true, true];
 
 if (_displayHint) then {
-    [localize LSTRING(EarPlugs_Are_On)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(EarPlugs_Are_On)] call CBA_fnc_notify;
 };
 
 //Force an immediate fast volume update:
 [[true]] call FUNC(updateVolume);
 
 // No Earplugs in inventory, telling user
-//[localize LSTRING(NoPlugs)] call EFUNC(common,displayTextStructured);
+//[localize LSTRING(NoPlugs)] call CBA_fnc_notify;
 
 [] call FUNC(updateHearingProtection);

--- a/addons/hearing/functions/fnc_removeEarplugs.sqf
+++ b/addons/hearing/functions/fnc_removeEarplugs.sqf
@@ -21,7 +21,7 @@ params ["_player", ["_displayHint", false, [false]]];
 if (!GVAR(EnableCombatDeafness)) exitWith {};
 
 if !(_player canAdd "ACE_EarPlugs") exitWith { // inventory full
-    [localize LSTRING(Inventory_Full)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(Inventory_Full)] call CBA_fnc_notify;
 };
 
 // Plugs already in and removing them.
@@ -30,7 +30,7 @@ _player addItem "ACE_EarPlugs";
 _player setVariable ["ACE_hasEarPlugsIn", false, true];
 
 if (_displayHint) then {
-    [localize LSTRING(EarPlugs_Are_Off)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(EarPlugs_Are_Off)] call CBA_fnc_notify;
 };
 
 //Force an immediate fast volume update:

--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -87,7 +87,7 @@ GVAR(isOpeningDoor) = false;
     if (_unit == ACE_player) then {
         addCamShake [4, 0.5, 5];
         private _message = parseText format ([["%1 &gt;", localize LSTRING(YouWereTappedRight)], ["&lt; %1", localize LSTRING(YouWereTappedLeft)]] select (_shoulderNum == 1));
-        [_message] call EFUNC(common,displayTextStructured);
+        [_message] call CBA_fnc_notify;
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/interaction/functions/fnc_joinTeam.sqf
+++ b/addons/interaction/functions/fnc_joinTeam.sqf
@@ -32,6 +32,6 @@ if (_unit == ACE_player) then {
         _message = format [localize LSTRING(JoinedTeam), _team];
     };
     if (_displayHint) then {
-        [_message] call EFUNC(common,displayTextStructured);
+        [_message] call CBA_fnc_notify;
     };
 };

--- a/addons/laser/functions/fnc_keyLaserCodeChange.sqf
+++ b/addons/laser/functions/fnc_keyLaserCodeChange.sqf
@@ -61,6 +61,6 @@ TRACE_2("",_oldLaserCode,_newLaserCode);
 if (_oldLaserCode != _newLaserCode) then {
     _currentShooter setVariable [QGVAR(code), _newLaserCode, true];
 };
-[format ["%1: %2", localize LSTRING(laserCode), _newLaserCode]] call EFUNC(common,displayTextStructured);
+[format ["%1: %2", localize LSTRING(laserCode), _newLaserCode]] call CBA_fnc_notify;
 
 true

--- a/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
+++ b/addons/medical_gui/functions/fnc_displayPatientInformation.sqf
@@ -40,7 +40,7 @@ if (isNull _display) then {
         if (ACE_player distance _target > MAX_DISTANCE && {vehicle _target != vehicle ACE_player}) exitWith {
             [_pfhID] call CBA_fnc_removePerFrameHandler;
             QGVAR(RscPatientInfo) cutFadeOut 0.3;
-            [[ELSTRING(medical,DistanceToFar), _target call EFUNC(common,getName)], 2] call EFUNC(common,displayTextStructured);
+            format [ELSTRING(medical,DistanceToFar), _target call EFUNC(common,getName)] call CBA_fnc_notify;
         };
 
         // Update body image

--- a/addons/medical_gui/functions/fnc_menuPFH.sqf
+++ b/addons/medical_gui/functions/fnc_menuPFH.sqf
@@ -20,7 +20,7 @@ if !([ACE_player, GVAR(target), ["isNotInside", "isNotSwimming"]] call EFUNC(com
     closeDialog 0;
     // Show hint if distance condition failed
     if ((ACE_player distance GVAR(target) > GVAR(maxDistance)) && {vehicle ACE_player != vehicle GVAR(target)}) then {
-        [[ELSTRING(medical,DistanceToFar), GVAR(target) call EFUNC(common,getName)], 2] call EFUNC(common,displayTextStructured);
+        format [ELSTRING(medical,DistanceToFar), GVAR(target) call EFUNC(common,getName)] call CBA_fnc_notify;
     };
 };
 

--- a/addons/medical_treatment/functions/fnc_checkResponse.sqf
+++ b/addons/medical_treatment/functions/fnc_checkResponse.sqf
@@ -19,6 +19,6 @@
 params ["_medic", "_patient"];
 
 private _output = [LSTRING(Check_Response_Unresponsive), LSTRING(Check_Response_Responsive)] select (_patient call EFUNC(common,isAwake));
-[[_output, _patient call EFUNC(common,getName)], 2] call EFUNC(common,displayTextStructured);
+format [_output, _patient call EFUNC(common,getName)] call CBA_fnc_notify;
 
 [_patient, "quick_view", _output, [[_patient, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);

--- a/addons/medical_treatment/functions/fnc_diagnose.sqf
+++ b/addons/medical_treatment/functions/fnc_diagnose.sqf
@@ -46,4 +46,4 @@ if (alive _patient) then {
     };
 };
 
-[_messages, 3] call EFUNC(common,displayTextStructured);
+[_messages] call CBA_fnc_notify;

--- a/addons/medical_treatment/functions/fnc_loadUnit.sqf
+++ b/addons/medical_treatment/functions/fnc_loadUnit.sqf
@@ -21,7 +21,7 @@ params ["_medic", "_patient", ["_vehicle", objNull]];
 TRACE_3("loadUnit",_medic,_patient,_vehicle);
 
 if (_patient call EFUNC(common,isAwake)) exitWith {
-    [[LSTRING(CanNotLoad), _patient call EFUNC(common,getName)]] call EFUNC(common,displayTextStructured);
+    format [LSTRING(CanNotLoad), _patient call EFUNC(common,getName)] call CBA_fnc_notify;
 };
 
 if (_patient call EFUNC(medical_status,isBeingCarried)) then {
@@ -44,7 +44,7 @@ if (isNull _vehicle) exitWith { TRACE_1("no vehicle found",_vehicle); };
     TRACE_2("success",_unit,_vehicle);
     private _patientName = [_unit, false, true] call EFUNC(common,getName);
     private _vehicleName = getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName");
-    [[LSTRING(LoadedInto), _patientName, _vehicleName], 3] call EFUNC(common,displayTextStructured);
+    format [LSTRING(LoadedInto), _patientName, _vehicleName] call CBA_fnc_notify;
 }, [_patient, _vehicle], 3, {
     params ["_unit", "_emptyPos"];
     WARNING_3("loadPerson failed to load %1[local %2] -> %3 ",_unit,local _unit,_vehicle);

--- a/addons/medical_treatment/functions/fnc_tourniquet.sqf
+++ b/addons/medical_treatment/functions/fnc_tourniquet.sqf
@@ -24,7 +24,7 @@ params ["_medic", "_patient", "_bodyPart", "", "", "_usedItem"];
 
 // Exit if there is a tourniquet already applied to body part
 if ([_patient, _bodyPart] call FUNC(hasTourniquetAppliedTo)) exitWith {
-    ["There is already a tourniquet on this body part!", 1.5] call EFUNC(common,displayTextStructured); // todo: localize
+    "There is already a tourniquet on this body part!" call CBA_fnc_notify; // todo: localize
 };
 
 [_patient, _usedItem] call FUNC(addToTriageCard);

--- a/addons/medical_treatment/functions/fnc_tourniquetRemove.sqf
+++ b/addons/medical_treatment/functions/fnc_tourniquetRemove.sqf
@@ -26,7 +26,7 @@ private _partIndex = ALL_BODY_PARTS find toLower _bodyPart;
 private _tourniquets = GET_TOURNIQUETS(_patient);
 
 if (_tourniquets select _partIndex == 0) exitWith {
-    [LSTRING(noTourniquetOnBodyPart), 1.5] call EFUNC(common,displayTextStructured);
+    [LSTRING(noTourniquetOnBodyPart)] call CBA_fnc_notify;
 };
 
 _tourniquets set [_partIndex, 0];

--- a/addons/medical_treatment/functions/fnc_unloadUnit.sqf
+++ b/addons/medical_treatment/functions/fnc_unloadUnit.sqf
@@ -37,7 +37,7 @@ if (_patient call EFUNC(common,isAwake)) exitWith {
     TRACE_2("success",_unit,_vehicle);
     private _patientName = [_unit, false, true] call EFUNC(common,getName);
     private _vehicleName = getText (configFile >> "CfgVehicles" >> typeOf _vehicle >> "displayName");
-    [[LSTRING(UnloadedFrom), _patientName, _vehicleName], 3] call EFUNC(common,displayTextStructured);
+    format [LSTRING(UnloadedFrom), _patientName, _vehicleName] call CBA_fnc_notify;
 }, [_patient, vehicle _patient], 3, {
     params ["_unit", "_vehicle"];
     WARNING_3("unloadPerson failed to unload %1[local %2] -> %3 ",_unit,local _unit,_vehicle);

--- a/addons/minedetector/functions/fnc_connectHeadphones.sqf
+++ b/addons/minedetector/functions/fnc_connectHeadphones.sqf
@@ -20,7 +20,7 @@ params ["_unit", "_state"];
 _unit setVariable [QGVAR(isUsingHeadphones), _state];
 
 if (_state) then {
-    [localize LSTRING(HeadphonesConnected)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(HeadphonesConnected)] call CBA_fnc_notify;
 } else {
-    [localize LSTRING(HeadphonesDisconnected)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(HeadphonesDisconnected)] call CBA_fnc_notify;
 };

--- a/addons/missileguidance/functions/fnc_cycleAttackProfileKeyDown.sqf
+++ b/addons/missileguidance/functions/fnc_cycleAttackProfileKeyDown.sqf
@@ -95,5 +95,5 @@ playSound "ACE_Sound_Click";
 
 if ((getNumber (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON) >> "showHintOnCycle")) == 1) then {
     private _localizedName = getText (configFile >> QGVAR(AttackProfiles) >> _nextFireMode >> "name");
-    [_localizedName] call EFUNC(common,displayTextStructured);
+    [_localizedName] call CBA_fnc_notify;
 };

--- a/addons/mk6mortar/functions/fnc_handlePlayerVehicleChanged.sqf
+++ b/addons/mk6mortar/functions/fnc_handlePlayerVehicleChanged.sqf
@@ -50,7 +50,7 @@ if (_lastFireMode != -1) then {
         if (shownArtilleryComputer && {!GVAR(allowComputerRangefinder)}) then {
             //Don't like this solution, but it works
             closeDialog 0;
-            [parseText "Computer Disabled"] call EFUNC(common,displayTextStructured);
+            ["Computer Disabled"] call CBA_fnc_notify;
         };
 
         private _display = uiNamespace getVariable ["ACE_Mk6_RscWeaponRangeArtillery", displayNull];

--- a/addons/movement/functions/fnc_climb.sqf
+++ b/addons/movement/functions/fnc_climb.sqf
@@ -18,7 +18,7 @@
 params ["_unit"];
 
 if !([_unit] call FUNC(canClimb)) exitWith {
-    [localize LSTRING(CanNotClimb)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(CanNotClimb)] call CBA_fnc_notify;
 };
 
 if !(_unit getVariable [QGVAR(isClimbInit), false]) then {

--- a/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
+++ b/addons/nightvision/functions/fnc_changeNVGBrightness.sqf
@@ -27,7 +27,7 @@ _brightness = ((_brightness + _changeInBrightness) min 0) max -6;
 _player setVariable [QGVAR(NVGBrightness), _brightness, false];
 
 // Display default setting as 0
-[format [LLSTRING(NVGBrightness), _brightness - _defaultBrightness]] call EFUNC(common,displayTextStructured);
+format [LLSTRING(NVGBrightness), _brightness - _defaultBrightness] call CBA_fnc_notify;
 playSound "ACE_Sound_Click";
 
 // Handle brightness only if effects are disabled

--- a/addons/overheating/functions/fnc_clearJam.sqf
+++ b/addons/overheating/functions/fnc_clearJam.sqf
@@ -54,14 +54,14 @@ if (_weapon in _jammedWeapons) then {
         };
         if (GVAR(DisplayTextOnJam)) then {
             [{
-                [localize LSTRING(WeaponUnjammed)] call EFUNC(common,displayTextStructured);
+                [localize LSTRING(WeaponUnjammed)] call CBA_fnc_notify;
             }, [], _delay] call CBA_fnc_waitAndExecute;
         };
     } else {
         // Failure
         if (GVAR(DisplayTextOnJam)) then {
             [{
-                [localize LSTRING(WeaponUnjamFailed)] call EFUNC(common,displayTextStructured);
+                [localize LSTRING(WeaponUnjamFailed)] call CBA_fnc_notify;
             }, [], _delay] call CBA_fnc_waitAndExecute;
         };
     };

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -66,7 +66,7 @@ if (_unit getVariable [QGVAR(JammingActionID), -1] == -1) then {
         playSound3D ["a3\sounds_f\weapons\Other\dry9.wss", _this select 0, false, eyePos (_this select 0), 1, 1, 15];
 
         if (!(missionNamespace getVariable [QGVAR(knowAboutJam), false]) && {(_this select 1) ammo currentWeapon (_this select 1) > 0} && {GVAR(DisplayTextOnJam)}) then {
-            [localize LSTRING(WeaponJammed)] call EFUNC(common,displayTextStructured);
+            [localize LSTRING(WeaponJammed)] call CBA_fnc_notify;
             GVAR(knowAboutJam) = true;
         };
     };

--- a/addons/quickmount/functions/fnc_addFreeSeatsActions.sqf
+++ b/addons/quickmount/functions/fnc_addFreeSeatsActions.sqf
@@ -43,7 +43,7 @@
             params [ARR_4("_player","_damageBlocked","_moveBackCode","_moveBackParams")]; \
             [ARR_2(_player,_moveBackParams)] call _moveBackCode; \
             if (_damageBlocked) then {_player allowDamage true}; \
-            localize "str_mis_state_failed" call EFUNC(common,displayTextStructured); \
+            localize "str_mis_state_failed" call CBA_fnc_notify; \
         } \
     )] call CBA_fnc_waitUntilAndExecute;
 

--- a/addons/quickmount/functions/fnc_getInNearest.sqf
+++ b/addons/quickmount/functions/fnc_getInNearest.sqf
@@ -38,7 +38,7 @@ if ((isNull _target) && {alive _interactionTarget}) then {
 };
 
 if (locked _target in [2,3]) exitWith {
-    [localize LSTRING(VehicleLocked)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(VehicleLocked)] call CBA_fnc_notify;
     true
 };
 
@@ -124,7 +124,7 @@ if (!isNull _target &&
 
     if (!_hasAction) then {
         TRACE_1("no empty seats",_hasAction);
-        [localize LSTRING(VehicleFull)] call EFUNC(common,displayTextStructured);
+        [localize LSTRING(VehicleFull)] call CBA_fnc_notify;
     };
 };
 

--- a/addons/rearm/functions/fnc_readSupplyCounter.sqf
+++ b/addons/rearm/functions/fnc_readSupplyCounter.sqf
@@ -29,9 +29,9 @@ if (GVAR(supply) == 1) then {
             params ["_args"];
             _args params [["_unit", objNull, [objNull]], ["_truck", objNull, [objNull]], ["_supplyCount", 0, [0]]];
             if (_supplyCount > 0 ) then {
-                [[LSTRING(Hint_RemainingSupplyPoints), _supplyCount], 2, _unit] call EFUNC(common,displayTextStructured);
+                format [LSTRING(Hint_RemainingSupplyPoints), _supplyCount] call CBA_fnc_notify;
             } else {
-                [LSTRING(Hint_Empty), 2, _unit] call EFUNC(common,displayTextStructured);
+                [LSTRING(Hint_Empty)] call CBA_fnc_notify;
             };
             true
         },
@@ -62,9 +62,9 @@ if (GVAR(supply) == 1) then {
                 } count _magazines;
             };
             if (_supply > 1.5) then {
-                [[LSTRING(Hint_RemainingAmmo), _text], _supply, _unit, (_numChars/2.9)] call EFUNC(common,displayTextStructured);
+                format [LSTRING(Hint_RemainingAmmo), _text] call CBA_fnc_notify;
             } else {
-                [LSTRING(Hint_Empty), 2, _unit] call EFUNC(common,displayTextStructured);
+                [LSTRING(Hint_Empty)] call CBA_fnc_notify;
             };
             true
         },

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -56,7 +56,7 @@ private _modelVectorLow = _startingPosASL vectorFromTo (AGLtoASL (_sink modelToW
 
 //Checks (too close to center or can't attach)
 if (_bestPosASL isEqualTo []) exitWith {
-    [localize LSTRING(Failed)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(Failed)] call CBA_fnc_notify;
 };
 
 //Move it out slightly, for visibility sake (better to look a little funny than be embedded//sunk in the hull and be useless)

--- a/addons/refuel/functions/fnc_readFuelCounter.sqf
+++ b/addons/refuel/functions/fnc_readFuelCounter.sqf
@@ -26,4 +26,4 @@ private _fuelCounter = if (_currentFuel == REFUEL_INFINITE_FUEL) then {
 };
 
 private _fuelCounter = 0.01 * round (100 * _fuelCounter);
-[[LSTRING(Hint_FuelCounter), _fuelCounter], 1.5, _unit] call EFUNC(common,displayTextStructured);
+format [LSTRING(Hint_FuelCounter), _fuelCounter] call CBA_fnc_notify;

--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -50,7 +50,7 @@ if (_maxFuel == 0) then {
     private _hoseLength = _source getVariable [QGVAR(hoseLength), GVAR(hoseLength)];
     private _tooFar = ((_sink modelToWorld _connectToPoint) distance (_source modelToWorld _connectFromPoint)) > (_hoseLength - 2);
     if (_tooFar && {!(_nozzle getVariable [QGVAR(jerryCan), false])}) exitWith {
-        [LSTRING(Hint_TooFar), 2, _unit] call EFUNC(common,displayTextStructured);
+        [LSTRING(Hint_TooFar)] call CBA_fnc_notify;
 
         [objNull, _nozzle] call FUNC(dropNozzle);
         _nozzle setVariable [QGVAR(isConnected), false, true];
@@ -65,7 +65,7 @@ if (_maxFuel == 0) then {
     if (_fueling) then {
         private _fuelInSource = [_source] call FUNC(getFuel);
         if (_fuelInSource == 0) exitWith {
-            [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);
+            [LSTRING(Hint_SourceEmpty)] call CBA_fnc_notify;
             _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
             _nozzle setVariable [QGVAR(isRefueling), false, true];
         };
@@ -82,14 +82,14 @@ if (_maxFuel == 0) then {
         if (_fuelInSource < 0 && {_fuelInSource > REFUEL_INFINITE_FUEL}) then {
             _fuelInSource = 0;
             _finished = true;
-            [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);
+            [LSTRING(Hint_SourceEmpty)] call CBA_fnc_notify;
         };
 
         private _fuelInSink = (_unit getVariable [QGVAR(tempFuel), _startFuel])  + ( _rateTime / _maxFuel);
         if (_fuelInSink > 1) then {
             _fuelInSink = 1;
             _finished = true;
-            [LSTRING(Hint_Completed), 2, _unit] call EFUNC(common,displayTextStructured);
+            [LSTRING(Hint_Completed)] call CBA_fnc_notify;
         };
         _unit setVariable [QGVAR(tempFuel), _fuelInSink];
 

--- a/addons/refuel/functions/fnc_startNozzleInHandsPFH.sqf
+++ b/addons/refuel/functions/fnc_startNozzleInHandsPFH.sqf
@@ -87,7 +87,7 @@ TRACE_2("start",_unit,_nozzle);
         DROP_NOZZLE
         UNHOLSTER_WEAPON
         END_PFH
-        [LSTRING(Hint_TooFar), 2, _unit] call EFUNC(common,displayTextStructured);
+        [LSTRING(Hint_TooFar)] call CBA_fnc_notify;
     };
 
     private _hintLMB = "";

--- a/addons/refuel/functions/fnc_turnOff.sqf
+++ b/addons/refuel/functions/fnc_turnOff.sqf
@@ -20,5 +20,5 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 
 _nozzle setVariable [QGVAR(lastTickMissionTime), nil];
 _nozzle setVariable [QGVAR(isRefueling), false, true];
-[LSTRING(Hint_Stopped), 1.5, _unit] call EFUNC(common,displayTextStructured);
+[LSTRING(Hint_Stopped)] call CBA_fnc_notify;
 [QGVAR(stopped), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;

--- a/addons/refuel/functions/fnc_turnOn.sqf
+++ b/addons/refuel/functions/fnc_turnOn.sqf
@@ -20,5 +20,5 @@ params [["_unit", objNull, [objNull]], ["_nozzle", objNull, [objNull]]];
 
 _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime];
 _nozzle setVariable [QGVAR(isRefueling), true, true];
-[LSTRING(Hint_Started), 1.5, _unit] call EFUNC(common,displayTextStructured);
+[LSTRING(Hint_Started)] call CBA_fnc_notify;
 [QGVAR(started), [_nozzle getVariable QGVAR(source), _nozzle getVariable QGVAR(sink)]] call CBA_fnc_localEvent;

--- a/addons/reloadlaunchers/functions/fnc_load.sqf
+++ b/addons/reloadlaunchers/functions/fnc_load.sqf
@@ -36,11 +36,11 @@ private _onSuccess =  {
     (_this select 0 select 0) removeMagazine (_this select 0 select 3);
     [QGVAR(reloadLauncher), _this select 0, _this select 0 select 1] call CBA_fnc_targetEvent;
 
-    [localize LSTRING(LauncherLoaded)] call DEFUNC(common,displayTextStructured);
+    [localize LSTRING(LauncherLoaded)] call CBA_fnc_notify;
 };
 
 private _onFailure = {
-    [localize ELSTRING(common,ActionAborted)] call DEFUNC(common,displayTextStructured);
+    [localize ELSTRING(common,ActionAborted)] call CBA_fnc_notify;
 };
 
 private _condition = {

--- a/addons/repair/functions/fnc_doRemoveTrack.sqf
+++ b/addons/repair/functions/fnc_doRemoveTrack.sqf
@@ -38,5 +38,5 @@ TRACE_2("new track created",_newTrack,damage _newTrack);
 
 // display text message if enabled
 if (GVAR(DisplayTextOnRepair)) then {
-    [localize LSTRING(RemovedTrack)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(RemovedTrack)] call CBA_fnc_notify;
 };

--- a/addons/repair/functions/fnc_doRemoveWheel.sqf
+++ b/addons/repair/functions/fnc_doRemoveWheel.sqf
@@ -38,5 +38,5 @@ TRACE_2("new wheel created",_newWheel,damage _newWheel);
 
 // display text message if enabled
 if (GVAR(DisplayTextOnRepair)) then {
-    [localize LSTRING(RemovedWheel)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(RemovedWheel)] call CBA_fnc_notify;
 };

--- a/addons/repair/functions/fnc_doRepair.sqf
+++ b/addons/repair/functions/fnc_doRepair.sqf
@@ -72,5 +72,5 @@ if (GVAR(DisplayTextOnRepair)) then {
     ([_hitPointClassname, _textLocalized, _textDefault] call FUNC(getHitPointString)) params ["_text"];
 
     // Display text
-    [_text] call EFUNC(common,displayTextStructured);
+    [_text] call CBA_fnc_notify;
 };

--- a/addons/repair/functions/fnc_doRepairTrack.sqf
+++ b/addons/repair/functions/fnc_doRepairTrack.sqf
@@ -45,5 +45,5 @@ deleteVehicle _track;
 
 // display text message if enabled
 if (GVAR(DisplayTextOnRepair)) then {
-    [LSTRING(ReplacedTrack)] call EFUNC(common,displayTextStructured);
+    [LSTRING(ReplacedTrack)] call CBA_fnc_notify;
 };

--- a/addons/repair/functions/fnc_doReplaceTrack.sqf
+++ b/addons/repair/functions/fnc_doReplaceTrack.sqf
@@ -48,5 +48,5 @@ deleteVehicle _track;
 
 // display text message if enabled
 if (GVAR(DisplayTextOnRepair)) then {
-    [LSTRING(ReplacedTrack)] call EFUNC(common,displayTextStructured);
+    [LSTRING(ReplacedTrack)] call CBA_fnc_notify;
 };

--- a/addons/repair/functions/fnc_doReplaceWheel.sqf
+++ b/addons/repair/functions/fnc_doReplaceWheel.sqf
@@ -48,5 +48,5 @@ deleteVehicle _wheel;
 
 // display text message if enabled
 if (GVAR(DisplayTextOnRepair)) then {
-    [LSTRING(ReplacedWheel)] call EFUNC(common,displayTextStructured);
+    [LSTRING(ReplacedWheel)] call CBA_fnc_notify;
 };

--- a/addons/repair/functions/fnc_repair.sqf
+++ b/addons/repair/functions/fnc_repair.sqf
@@ -39,7 +39,7 @@ if ((isEngineOn _target) && {GVAR(autoShutOffEngineWhenStartingRepair)}) then {
     [QEGVAR(common,engineOn), [_target, false], _target] call CBA_fnc_targetEvent;
 };
 if ((isEngineOn _target) && {!GVAR(autoShutOffEngineWhenStartingRepair)}) exitWith {
-    [LSTRING(shutOffEngineWarning), 1.5, _caller] call EFUNC(common,displayTextStructured);
+    [LSTRING(shutOffEngineWarning)] call CBA_fnc_notify;
     false
 };
 

--- a/addons/respawn/functions/fnc_moveRallypoint.sqf
+++ b/addons/respawn/functions/fnc_moveRallypoint.sqf
@@ -36,7 +36,7 @@ if (_position isEqualTo []) then {_position = getPosATL _unit};
 
 _position set [2, 0];
 
-[localize LSTRING(Deploy)] call EFUNC(common,displayTextStructured);
+[localize LSTRING(Deploy)] call CBA_fnc_notify;
 
 [{
     params ["_rallypoint", "_unit", "_position"];
@@ -48,5 +48,5 @@ _position set [2, 0];
 
     ["ace_rallypointMoved", [_rallypoint, _side, _position]] call CBA_fnc_globalEvent;
 
-    [localize LSTRING(Deployed)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(Deployed)] call CBA_fnc_notify;
 }, [_rallypoint, _unit, _position], 5] call CBA_fnc_waitAndExecute;

--- a/addons/respawn/functions/fnc_teleportToRallypoint.sqf
+++ b/addons/respawn/functions/fnc_teleportToRallypoint.sqf
@@ -27,4 +27,4 @@ if (isNull _rallypoint) exitWith {};
 
 _unit setPosASL getPosASL _rallypoint;
 
-[[localize LSTRING(TeleportedToRallypoint), localize LSTRING(TeleportedToBase)] select _toBase] call EFUNC(common,displayTextStructured);
+[[localize LSTRING(TeleportedToRallypoint), localize LSTRING(TeleportedToBase)] select _toBase] call CBA_fnc_notify;

--- a/addons/switchunits/functions/fnc_switchUnit.sqf
+++ b/addons/switchunits/functions/fnc_switchUnit.sqf
@@ -34,7 +34,7 @@ if (GVAR(EnableSafeZone)) then {
 
 // exitWith doesn't exit past the "if(EnableSafeZone)" block
 if (_leave) exitWith {
-    [localize LSTRING(TooCloseToEnemy)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(TooCloseToEnemy)] call CBA_fnc_notify;
 };
 
 // should switch locality
@@ -46,7 +46,7 @@ if (_leave) exitWith {
     params ["_args", "_pfhId"];
     _args params ["_unit", "_oldUnit"];
 
-    [localize LSTRING(TryingToSwitch)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(TryingToSwitch)] call CBA_fnc_notify;
 
     if (local _unit) exitWith {
         _oldUnit setVariable [QGVAR(IsPlayerControlled), false, true];
@@ -75,7 +75,7 @@ if (_leave) exitWith {
             ["ace_setOwner", [_oldUnit, _oldOwner]] call CBA_fnc_serverEvent;
         };
 
-        [localize LSTRING(SwitchedUnit)] call EFUNC(common,displayTextStructured);
+        [localize LSTRING(SwitchedUnit)] call CBA_fnc_notify;
 
         [_pfhId] call CBA_fnc_removePerFrameHandler;
     };

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -25,7 +25,7 @@ if (isNil "_cachedElement") exitWith {TRACE_1("nil element",_this)};
 
 if (!_force && {!GVAR(allowSelectiveUI)}) exitWith {
     TRACE_1("not allowed",_this);
-    [LSTRING(Disallowed), 2] call EFUNC(common,displayTextStructured);
+    [LSTRING(Disallowed)] call CBA_fnc_notify;
     false
 };
 
@@ -46,7 +46,7 @@ if (
     if (!call (_x select 0)) exitWith {
         // Display and print info which component forced the element except for default vehicle check
         if (_showHint) then {
-            [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
+            [LSTRING(Disabled)] call CBA_fnc_notify;
             INFO_2("Attempted modification of a forced User Interface element '%1' by '%2'.",_element,_x select 1);
         };
         _show = false;
@@ -59,7 +59,7 @@ if (!_force) then {
     if (!isNil "_setElement") then {
         _setElement params ["_sourceSet", "_showSet"];
         if (_showHint) then {
-            [LSTRING(Disabled), 2] call EFUNC(common,displayTextStructured);
+            [LSTRING(Disabled)] call CBA_fnc_notify;
             INFO_2("Attempted modification of a forced User Interface element '%1' by '%2'.",_element,_sourceSet);
         };
         _show = _showSet;

--- a/addons/ui/functions/fnc_setElements.sqf
+++ b/addons/ui/functions/fnc_setElements.sqf
@@ -19,7 +19,7 @@ params [["_showHint", false]];
 
 if (isArray (missionConfigFile >> "showHUD")) exitWith {
     if (_showHint) then {
-        [LSTRING(Disabled)] call EFUNC(common,displayTextStructured);
+        [LSTRING(Disabled)] call CBA_fnc_notify;
     };
 };
 

--- a/addons/vehicles/XEH_postInit.sqf
+++ b/addons/vehicles/XEH_postInit.sqf
@@ -34,7 +34,7 @@ GVAR(isSpeedLimiter) = false;
 ["ACE3 Vehicles", QGVAR(scrollUp), localize LSTRING(IncreaseSpeedLimit), {
     if (GVAR(isSpeedLimiter)) then {
         GVAR(speedLimit) = round (GVAR(speedLimit) + GVAR(speedLimiterStep)) max (5 max GVAR(speedLimiterStep));
-        [["%1: %2", LSTRING(SpeedLimit), GVAR(speedLimit)]] call EFUNC(common,displayTextStructured);
+        [["%1: %2", LSTRING(SpeedLimit), GVAR(speedLimit)]] call CBA_fnc_notify;
         true
     };
 }, {false}, [MOUSE_SCROLL_UP, [false, true, false]], false] call CBA_fnc_addKeybind; // Ctrl + Mouse Wheel Scroll Up
@@ -42,7 +42,7 @@ GVAR(isSpeedLimiter) = false;
 ["ACE3 Vehicles", QGVAR(scrollDown), localize LSTRING(DecreaseSpeedLimit), {
     if (GVAR(isSpeedLimiter)) then {
         GVAR(speedLimit) = round (GVAR(speedLimit) - GVAR(speedLimiterStep)) max (5 max GVAR(speedLimiterStep));
-        [["%1: %2", LSTRING(SpeedLimit), GVAR(speedLimit)]] call EFUNC(common,displayTextStructured);
+        [["%1: %2", LSTRING(SpeedLimit), GVAR(speedLimit)]] call CBA_fnc_notify;
         true
     };
 }, {false}, [MOUSE_SCROLL_DOWN, [false, true, false]], false] call CBA_fnc_addKeybind; // Ctrl + Mouse Wheel Scroll Down

--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -19,12 +19,12 @@
 params ["_driver", "_vehicle"];
 
 if (GVAR(isSpeedLimiter)) exitWith {
-    [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
+    [localize LSTRING(Off)] call CBA_fnc_notify;
     playSound "ACE_Sound_Click";
     GVAR(isSpeedLimiter) = false;
 };
 
-[localize LSTRING(On)] call EFUNC(common,displayTextStructured);
+[localize LSTRING(On)] call CBA_fnc_notify;
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;
 

--- a/addons/viewdistance/functions/fnc_changeViewDistance.sqf
+++ b/addons/viewdistance/functions/fnc_changeViewDistance.sqf
@@ -55,6 +55,6 @@ if (_showPrompt) then {
             ] select (_newViewDistance <= _viewDistanceLimit);
             _text = _text + format ["<br/><t align='center'>%1 %2%3</t>", localize LSTRING(objectinfotext), _objectViewDistanceCoeff * 100, "%"];
         };
-        [parseText _text, 2] call EFUNC(common,displayTextStructured);
+        _text call CBA_fnc_notify;
     };
 };

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -79,6 +79,6 @@ if (hasInterface) then {
     [QGVAR(zeusCreated), {
         params ["_zeus"];
         GVAR(zeus) = _zeus;
-        [localize "str_a3_cfgvehicles_moduletasksetstate_f_arguments_state_values_created_0"] call EFUNC(common,displayTextStructured);
+        [localize "str_a3_cfgvehicles_moduletasksetstate_f_arguments_state_values_created_0"] call CBA_fnc_notify;
     }] call CBA_fnc_addEventHandler;
 };


### PR DESCRIPTION
ACE displayTextStructured overlap `CBA_fnc_notify`. This pull request add `CBA_fnc_notify`. So all mod/mission using `CBA_fnc_notify` will not overlap with ACE notification.

**When merged this pull request will:**
- Use `CBA_fnc_notify` and not `EFUNC(common,displayTextStructured)` when possible