### PR TITLE
Nightvision - Increase max amount of IR rays to 64

### DIFF
--- a/addons/nightvision/CfgIRLaserSettings.hpp
+++ b/addons/nightvision/CfgIRLaserSettings.hpp
@@ -1,3 +1,3 @@
 class CfgIRLaserSettings {
-    maxNumberOfRays = 64;
+    maxNumberOfRays = 64; // Default is 24.
 };

--- a/addons/nightvision/CfgIRLaserSettings.hpp
+++ b/addons/nightvision/CfgIRLaserSettings.hpp
@@ -1,0 +1,3 @@
+class CfgIRLaserSettings {
+    maxNumberOfRays = 64;
+};

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
+#include "CfgIRLaserSettings.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
 #include "ACE_Settings.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Increase the maximum amount of rendered IR rays to 64, as mentioned [here](https://youtu.be/sOrUP0Rq6Jg?t=498).
