### PR TITLE
switchUnits - Fix switching units not working (#6188)

### DIFF
--- a/addons/switchunits/functions/fnc_addMapFunction.sqf
+++ b/addons/switchunits/functions/fnc_addMapFunction.sqf
@@ -16,12 +16,9 @@
  * Public: No
  */
 
-params ["_unit", "_sides"];
-
-["theMapClick", "onMapSingleClick", {
-    // IGNORE_PRIVATE_WARNING(_pos,_shift,_alt)
+addMissionEventHandler ["MapSingleClick", {
+    params ["", "_pos"];
     if (alive ACE_player && {GVAR(OriginalUnit) getVariable ["ACE_CanSwitchUnits", false]}) then {
-        [_this, _pos, _shift, _alt] call FUNC(handleMapClick);
+        [GVAR(switchableSides), _pos] call FUNC(handleMapClick);
     };
-
-}, [_unit, _sides]] call BIS_fnc_addStackedEventHandler;
+}];

--- a/addons/switchunits/functions/fnc_handleMapClick.sqf
+++ b/addons/switchunits/functions/fnc_handleMapClick.sqf
@@ -18,8 +18,7 @@
  * Public: No
  */
 
-params ["_faction", "_pos"];
-_faction params ["", "_sides"];
+params ["_sides", "_pos"];
 
 private _nearestObjects = nearestObjects [_pos, ["Man"], 15];
 

--- a/addons/switchunits/functions/fnc_initPlayer.sqf
+++ b/addons/switchunits/functions/fnc_initPlayer.sqf
@@ -16,10 +16,10 @@
  * Public: No
  */
 
-params ["_playerUnit", "_sides"];
+params ["_playerUnit"];
 
 if (vehicle _playerUnit == _playerUnit) then {
-    [_sides] call FUNC(markAiOnMap);
+    [GVAR(switchableSides)] call FUNC(markAiOnMap);
 
     _playerUnit setVariable [QGVAR(IsPlayerUnit), true, true];
     _playerUnit allowDamage false;
@@ -38,5 +38,5 @@ if (vehicle _playerUnit == _playerUnit) then {
 
     [_playerUnit, "forceWalk", "ACE_SwitchUnits", true] call EFUNC(common,statusEffect_set);
 
-    [_playerUnit, _sides] call FUNC(addMapFunction);
+    [] call FUNC(addMapFunction);
 };

--- a/addons/switchunits/functions/fnc_startSwitchUnits.sqf
+++ b/addons/switchunits/functions/fnc_startSwitchUnits.sqf
@@ -18,14 +18,14 @@
 params ["_player"];
 
 if (GVAR(EnableSwitchUnits)) then {
-    private _sides = [];
+    GVAR(switchableSides) = [];
 
-    if (GVAR(SwitchToWest)) then {_sides pushBack west;};
-    if (GVAR(SwitchToEast)) then {_sides pushBack east;};
-    if (GVAR(SwitchToIndependent)) then {_sides pushBack independent;};
-    if (GVAR(SwitchToCivilian)) then {_sides pushBack civilian;};
+    if (GVAR(SwitchToWest)) then {GVAR(switchableSides) pushBack west;};
+    if (GVAR(SwitchToEast)) then {GVAR(switchableSides) pushBack east;};
+    if (GVAR(SwitchToIndependent)) then {GVAR(switchableSides) pushBack independent;};
+    if (GVAR(SwitchToCivilian)) then {GVAR(switchableSides) pushBack civilian;};
 
     if (_player getVariable ["ACE_CanSwitchUnits", false]) then {
-        [_player, _sides] call FUNC(initPlayer);
+        [_player] call FUNC(initPlayer);
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix switchUnits functionality

***

Clicking on a switchable unit currently does nothing (see #6188). 

It looks like `BIS_fnc_addStackedEventHandler` was changed at some point so that the arguments array is appended to `onMapSingleClick`'s passed params, resulting in switchUnits failing here:

https://github.com/acemod/ACE3/blob/master/addons/switchunits/functions/fnc_addMapFunction.sqf#L24

Quick fix would have been:
```
params ["_pos", "", "", "", "_unit", "_sides"];
if (alive ACE_player && {GVAR(OriginalUnit) getVariable ["ACE_CanSwitchUnits", false]}) then {
    [[_unit,_sides], _pos] call FUNC(handleMapClick);
};
```

This replaces `BIS_fnc_addStackedEventHandler` with [MapSingleClick](https://community.bistudio.com/wiki/Arma_3:_Event_Handlers/addMissionEventHandler#MapSingleClick) mission eventhandler instead and introduces `GVAR(switchableSides)`, because you can't pass arguments through `addMissionEventHandler`.
