### PR TITLE
Translations - Add missing Czech translation strings

### DIFF
--- a/addons/aircraft/stringtable.xml
+++ b/addons/aircraft/stringtable.xml
@@ -59,6 +59,7 @@
             <Polish>30mm Odłamkowo-Burzące - Zapalające</Polish>
             <German>30mm Hochexplosiv/Brandladung</German>
             <Japanese>30mm 焼夷りゅう弾</Japanese>
+            <Czech>30mm Tříštivo-trhavá zápalná střela</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionShortHEI">
             <English>30mm HEI</English>
@@ -67,6 +68,7 @@
             <Polish>30mm OB-Z</Polish>
             <German>30mm HEB</German>
             <Japanese>30mm HEI</Japanese>
+            <Czech>30mm HEI</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionAP">
             <English>30mm DU Armor Piercing</English>
@@ -75,6 +77,7 @@
             <Polish>30mm Zubożony Uran - Przebijające</Polish>
             <German>30mm abgereichertes panzerbrechendes Uraniumgeschoss</German>
             <Japanese>30mm DU 徹甲弾</Japanese>
+            <Czech>30mm Protipancéřová střela z ochuzeného Uranu</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionShortAP">
             <English>30mm DU AP</English>
@@ -83,6 +86,7 @@
             <Polish>30mm ZU-P</Polish>
             <German>30mm DU-PB</German>
             <Japanese>30mm DU AP</Japanese>
+            <Czech>30 mm DU AP</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionCM41">
             <English>30mm Combat Mix 4:1 DU:HEI</English>
@@ -91,6 +95,7 @@
             <Polish>30mm Mieszanka bojowa 4:1 ZU:OB-Z</Polish>
             <German>30mm Kampfmischung 4:1 DU:HEB</German>
             <Japanese>30mm コンバット ミックス 4:1 DU:HEI</Japanese>
+            <Czech>30mm Bojový Mix 4:1 DU:HEI</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionShortCM41">
             <English>30mm CM 4:1</English>
@@ -99,6 +104,7 @@
             <Polish>30mm MB 4:1</Polish>
             <German>30mm KM 4:1</German>
             <Japanese>30mm CM 4:1</Japanese>
+            <Czech>30mm BM 4:1</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionCM51">
             <English>30mm Combat Mix 5:1 DU:HEI</English>
@@ -107,6 +113,7 @@
             <Polish>30mm Mieszanka bojowa 5:1 ZU:OB-Z</Polish>
             <German>30mm Kampfmischung 5:1 DU:HEB</German>
             <Japanese>30mm コンバット ミックス 5:1 DU:HEI</Japanese>
+            <Czech>30mm Bojový Mix 5:1 DU:HEI</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionShortCM51">
             <English>30mm CM 5:1</English>
@@ -115,6 +122,7 @@
             <Polish>30mm MB 5:1</Polish>
             <German>30mm KM 5:1</German>
             <Japanese>30mm CM 5:1</Japanese>
+            <Czech>30mm BM 5:1</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1398,6 +1398,7 @@
             <Japanese>セルフ インタラクションに動作を表示</Japanese>
             <Italian>Mostra le azioni nel menu di interazione con se stessi</Italian>
             <Spanish>Mostrar la acción en el menú de interacción propio</Spanish>
+            <Czech>Zobrazit akci v menu vlastních interakcí</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -370,6 +370,7 @@
         </Key>
         <Key ID="STR_ACE_CSW_StaticM2ShieldBag_displayName">
             <English>[CSW] Static M2 w/ Shield</English>
+            <Czech>[CSW] Statická zbraň M2 se štítem</Czech>
         </Key>
         <Key ID="STR_ACE_CSW_StaticAutoHMGBag_displayName">
             <English>[CSW] Static XM312 Gun (Autonomous)</English>

--- a/addons/dragging/stringtable.xml
+++ b/addons/dragging/stringtable.xml
@@ -91,6 +91,7 @@
             <German>Heben/Senken | (Strg + Scrollen) Drehen</German>
             <French>Lever/Baisser | (Ctrl + Scroll) Rotation</French>
             <Japanese>上げる/下げる | (Ctrl + スクロール) 回転</Japanese>
+            <Czech>Zvednout/Snížit | (Ctrl + Kolečko myši) Otáčet</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -327,6 +327,7 @@
             <Japanese>ファスト ロープ</Japanese>
             <Spanish>Cuerdas rápidas</Spanish>
             <Polish>Zjazd na linach</Polish>
+            <Czech>Slaňování</Czech>
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_requireRopeItems_displayName">
             <English>Require rope item to deploy</English>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -51,6 +51,7 @@
             <Chinese>腎上腺素甦醒率加成</Chinese>
             <German>Erhöhung der Aufwachüberprüfungsrate durch Epinephrin</German>
             <Japanese>アドレナリン覚醒率の上昇</Japanese>
+            <Czech>Zvýšení pravděpodobnosti probuzení s Epinefrinem</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_spontaneousWakeUpEpinephrineBoost_Description">
             <English>Increases how often spontaneous wake up checks happen when patient has Epinephrine in their system.</English>
@@ -170,11 +171,13 @@
             <English>Fracture Chance</English>
             <French>Chance de fracture</French>
             <Japanese>骨折確率</Japanese>
+            <Czech>Šance na zlomeninu</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_FractureChance_Description">
             <English>The probability of a fracture causing wound resulting in a fracture.</English>
             <French>La probabilité pour qu'une blessure pouvant causer une fracture en crée effectivement une.</French>
             <Japanese>骨折の原因となる負傷で骨折する確率を決定します。</Japanese>
+            <Czech>Výška šance kdy zranění způsobující zlomeniny skutečně způsobí zlomeninu.</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_MedicalSettings_enableFor_DisplayName">
             <English>Enabled for</English>

--- a/addons/medical_damage/stringtable.xml
+++ b/addons/medical_damage/stringtable.xml
@@ -636,12 +636,14 @@
             <German>Schwelle für Schaden</German>
             <French>Seuil de dégâts</French>
             <Japanese>ユニットのダメージしきい値</Japanese>
+            <Czech>Práh poškození</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Damage_Eden_threshold_Description">
             <English>Sets the amount of damage a unit can receive before going unconscious. (0 for mission default)</English>
             <German>Legt die Höhe des Schadens fest, den eine Einheit erhalten kann, bevor diese ohnmächtig wird. (0 für Misionsnormalwert)</German>
             <French>Définit la quantité de dégâts que l'unité peut subir avant de perdre connaissance (ou mourir, si l'option "Somme des traumatismes" est sélectionnée).\n(0 utilise la valeur définie dans la mission.)</French>
             <Japanese>ユニットが気絶するまで許容できるダメージ値を設定できます。標準: 0</Japanese>
+            <Czech>Určuje kolik poškození může jednotka utrpět než upadne do bezvědomí. (pro použití standardní hodnoty mise zadejte 0)</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_feedback/stringtable.xml
+++ b/addons/medical_feedback/stringtable.xml
@@ -25,7 +25,7 @@
             <French>Effet de douleur</French>
             <Hungarian>Fájdalom-effekt típusa</Hungarian>
             <Portuguese>Tipo do efeito de dor</Portuguese>
-            <Czech>Typ bolesti - efekt</Czech>
+            <Czech>Efekt pro bolest</Czech>
             <Japanese>痛み効果種類</Japanese>
             <Korean>고통 효과 종류</Korean>
             <Chinese>疼痛效果類型</Chinese>
@@ -108,30 +108,35 @@
             <Russian>Визуальный эффект низкого объема крови</Russian>
             <French>Effet de faible volume sanguin</French>
             <Japanese>低血液量時の効果種類</Japanese>
+            <Czech>Efekt pro nízké množství krve</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_Description">
             <English>Selects the used low blood volume effect type.</English>
             <Russian>Выбирает тип визуализации эффекта низкого объема крови.</Russian>
             <French>Permet de choisir quel effet provoque un faible volume sanguin.</French>
             <Japanese>低血液量時の効果を選択できます。</Japanese>
+            <Czech>Nastavuje který efekt pro nízké množství krve bude používán.</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_colorCorrection">
             <English>Color Fading</English>
             <Russian>Потеря цветности</Russian>
             <French>Atténuation des couleurs</French>
             <Japanese>退色</Japanese>
+            <Czech>Ztráta barev</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_icon">
             <English>Icon</English>
             <Russian>Иконка</Russian>
             <French>Icône</French>
             <Japanese>アイコン</Japanese>
+            <Czech>Ikona</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_both">
             <English>Icon + Color Fading</English>
             <Russian>Иконка + Потеря цветности</Russian>
             <French>Icône + Atténuation des couleurs</French>
             <Japanese>アイコンと退色</Japanese>
+            <Czech>Ikona + Ztráta barev</Czech>
         </Key>
         <Container name="Settings">
             <Key ID="STR_ACE_Medical_Feedback_enableScreams_DisplayName">

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -101,13 +101,14 @@
             <English>Enabled &amp; Can Reopen</English>
             <French>Activé &amp; peuvent se rouvrir</French>
             <Japanese>有効 &amp; 再開放</Japanese>
+            <Czech>Zapnuto &amp; Úrazy se mohou znovu otevřít</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
             <English>Clear Trauma After Bandage</English>
             <Japanese>治療後に外傷を削除</Japanese>
             <Chinese>包紮即痊癒</Chinese>
             <French>Guérir les blessures pansées</French>
-            <Czech>Vyčistit úraz po obvázání</Czech>
+            <Czech>Odebrat úraz po obvázání</Czech>
             <Polish>Usuń uraz po zabandażowaniu</Polish>
             <Italian>Rimozione ferite bendate</Italian>
             <German>Entferne Trauma nach Bandagierung.</German>
@@ -120,6 +121,7 @@
             <Italian>Controlla se le parti del corpo completamente bendate sono guarite.</Italian>
             <German>Kontrolliert, ob voll bandagierte Körperteile geheilt werden.</German>
             <Chinese>控制說當傷口處理好的時候是否直接痊癒。</Chinese>
+            <Czech>Nastavuje zda se plně obvázané části těla vyléčí.</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_LocationsBoostTraining_DisplayName">
             <English>Locations Boost Training</English>
@@ -338,6 +340,7 @@
             <French>Utilisation de la trousse sanitaire sur soi-même</French>
             <Polish>Używanie apteczki osobistej na sobie</Polish>
             <Japanese>応急処置キットの自己使用</Japanese>
+            <Czech>Samo-použití osobní lékárničky (PAK)</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AllowSelfPAK_Description">
             <English>Enables the use of PAKs to heal oneself.</English>
@@ -347,6 +350,7 @@
             <French>Définit si le joueur peut utiliser la trousse sanitaire pour se soigner lui-même.</French>
             <Polish>Pozwala na użycie apteczki osobistej na sobie</Polish>
             <Japanese>応急処置キットを使って、自分を治療できるようにします。</Japanese>
+            <Czech>Umožňuje použít osobní lékárničku (PAK) na sama sebe.</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TimeCoefficientPAK_DisplayName">
             <English>Time Coefficient PAK</English>
@@ -497,6 +501,7 @@
             <French>Pose de perfusion autorisée pour</French>
             <Chinese>允許操作點滴</Chinese>
             <Japanese>IV 輸血の制限</Japanese>
+            <Czech>Povolit IV transfuzi</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicIV_Description">
             <English>Training level required to transfuse IVs.</English>
@@ -505,6 +510,7 @@
             <French>Définit quelle qualification médicale est requise pour pouvoir poser des perfusions intraveineuses.</French>
             <Chinese>要有何種醫療水準才可注射點滴。</Chinese>
             <Japanese>IV 輸血を行うのに訓練済レベルを要求とします。</Japanese>
+            <Czech>Úroveň výcviku nutná pro IV transfuzi.</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">
             <English>Convert Vanilla Items</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -121,7 +121,7 @@
             <Italian>Controlla se le parti del corpo completamente bendate sono guarite.</Italian>
             <German>Kontrolliert, ob voll bandagierte Körperteile geheilt werden.</German>
             <Chinese>控制說當傷口處理好的時候是否直接痊癒。</Chinese>
-            <Czech>Nastavuje zda se plně obvázané části těla vyléčí.</Czech>
+            <Czech>Nastavuje zda jsou plně obvázané části těla vyléčena.</Czech>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_LocationsBoostTraining_DisplayName">
             <English>Locations Boost Training</English>

--- a/addons/quickmount/stringtable.xml
+++ b/addons/quickmount/stringtable.xml
@@ -66,6 +66,7 @@
             <Portuguese>Esta opção permite entrada rápida para o veículo que você está olhando</Portuguese>
             <Japanese>この機能により直接見ている車両へすぐさま搭乗できます。</Japanese>
             <Italian>Questa opzione permette l'entrata rapida nel veicolo che si sta guardando.</Italian>
+            <Czech>Tato možnost umožňuje rychle nastoupit do vozidla na které se díváte.</Czech>
         </Key>
         <Key ID="STR_ACE_QuickMount_Distance">
             <English>Distance</English>

--- a/addons/vehicles/stringtable.xml
+++ b/addons/vehicles/stringtable.xml
@@ -154,6 +154,7 @@
             <Polish>Przeskok limitera prędkości</Polish>
             <French>Pas du limiteur de vitesse</French>
             <Japanese>設定速度の増減量</Japanese>
+            <Czech>Krokování omezovače rychlosti</Czech>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds missing Czech translation strings
- Part of #367 

**Notes:**
- Some fairly generic military shorthands like "AP" and "DU" haven't been translated as they're generally known, but their description has been fully translated.
- One medical translation was changed from literal translation to more descriptive of what actually happens.
