### PR TITLE
Wiki - Fix arsenal framework section headings

### DIFF
--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -80,7 +80,7 @@ copyToClipboard str _items;
 
 IV. Paste the created array from your clipboard into the space where the items are listed CTRL+V. The array is created with brackets.
  ```
- 
+
 Examples:
 
 For a new Box: - `[_box, ["item1", "item2", "itemN"]] call ace_arsenal_fnc_initBox`
@@ -175,7 +175,7 @@ If a loadout with the same name exists, it will be overwritten.
 
 ACE Arsenal stats are customizable, this will show you how.
 
-### 5.1. Adding stats via config
+### 5.1 Adding stats via config
 
 ```cpp
 class ace_arsenal_stats {
@@ -185,7 +185,7 @@ class ace_arsenal_stats {
         scope = 2; // Only scope 2 show up in arsenal, scope 1 is used for base classes.
         displayName= "Test entry title"; // Title of the stat.
         priority = 0; // A higher value means the stat will be displayed higher on the page.
-        stats[] = {"mySuperStat"}; // Array of strings to pass to the statements, typically 
+        stats[] = {"mySuperStat"}; // Array of strings to pass to the statements, typically
         showBar = 1; // 0 disabled; 1 enabled;
         showText = 1; // 0 disabled; 1 enabled;
         barStatement = "1"; // Statement evaluated to set the bar progress, needs to return a NUMBER.
@@ -305,7 +305,7 @@ Right tabs:
 | 6 | Put |
 | 7 | Misc |
 
-#### 6.0 Eventhandlers
+## 6. Eventhandlers
 
 All are local.
 


### PR DESCRIPTION
**When merged this pull request will:**
- title, event handlers section appeared under stats section