### PR TITLE
Tagging - Added ability to specify custom model

### DIFF
--- a/addons/tagging/functions/fnc_addCustomTag.sqf
+++ b/addons/tagging/functions/fnc_addCustomTag.sqf
@@ -10,6 +10,7 @@
  * 3: Textures Paths <ARRAY>
  * 4: Icon Path <STRING> (default: "")
  * 5: Material Paths <ARRAY> (optional)
+ * 6: Tag Model <STRING> (optional)
  *
  * Return Value:
  * Sucessfully Added Tag <BOOL>
@@ -26,7 +27,8 @@ params [
     ["_requiredItem", "", [""]],
     ["_textures", [], [[]]],
     ["_icon", "", [""]],
-    ["_materials", [], [[]]]
+    ["_materials", [], [[]]],
+    ["_tagModel", "UserTexture1m_F", [""]]
 ];
 
 // Verify
@@ -52,4 +54,4 @@ if (_textures isEqualTo []) exitWith {
 _identifier = [_identifier] call CBA_fnc_removeWhitespace;
 
 // Add
-[QGVAR(applyCustomTag), [_identifier, _displayName, _requiredItem, _textures, _icon, _materials]] call CBA_fnc_globalEventJIP;
+[QGVAR(applyCustomTag), [_identifier, _displayName, _requiredItem, _textures, _icon, _materials, _tagModel]] call CBA_fnc_globalEventJIP;

--- a/addons/tagging/functions/fnc_applyCustomTag.sqf
+++ b/addons/tagging/functions/fnc_applyCustomTag.sqf
@@ -10,6 +10,7 @@
  * 3: Textures Paths <ARRAY>
  * 4: Icon Path <STRING> (default: "")
  * 5: Material Paths <ARRAY>
+ * 6: Tag Model <STRING> (optional)
  *
  * Return Value:
  * None

--- a/addons/tagging/functions/fnc_compileConfigTags.sqf
+++ b/addons/tagging/functions/fnc_compileConfigTags.sqf
@@ -48,8 +48,13 @@
 
     private _icon = getText (_x >> "icon");
 
+    private _tagModel = getText (_x >> "tagModel");
+    if (_tagModel == "") then {
+        _tagModel = "UserTexture1m_F";
+    };
+
     if (!_failure) then {
-        GVAR(cachedTags) pushBack [_class, _displayName, _requiredItem, _textures, _icon, _materials];
+        GVAR(cachedTags) pushBack [_class, _displayName, _requiredItem, _textures, _icon, _materials, _tagModel];
         GVAR(cachedRequiredItems) pushBackUnique _requiredItem;
     };
 } forEach ("true" configClasses (configFile >> "ACE_Tags"));

--- a/addons/tagging/functions/fnc_createTag.sqf
+++ b/addons/tagging/functions/fnc_createTag.sqf
@@ -20,7 +20,7 @@
  * Public: No
  */
 
-params ["_tagPosASL", "_vectorDirAndUp", "_texture", "_object", "_unit", ["_material","",[""]]];
+params ["_tagPosASL", "_vectorDirAndUp", "_texture", "_object", "_unit", ["_material","",[""]], ["_tagModel", "UserTexture1m_F", [""]]];
 TRACE_5("createTag:",_tagPosASL,_vectorDirAndUp,_texture,_object,_unit);
 
 if (_texture == "") exitWith {
@@ -28,7 +28,7 @@ if (_texture == "") exitWith {
     false
 };
 
-private _tag = createSimpleObject ["UserTexture1m_F", _tagPosASL];
+private _tag = createSimpleObject [_tagModel, _tagPosASL];
 _tag setObjectTextureGlobal [0, _texture];
 if (_material != "") then { _tag setObjectMaterialGlobal [0, _material] };
 _tag setVectorDirAndUp _vectorDirAndUp;

--- a/addons/tagging/functions/fnc_quickTag.sqf
+++ b/addons/tagging/functions/fnc_quickTag.sqf
@@ -49,7 +49,7 @@ if (GVAR(quickTag) == 3) then {
 // Tag
 if !(_possibleTags isEqualTo []) then {
     private _availableTags = _possibleTags select {(_x select 2) in (_unit call EFUNC(common,uniqueItems))};
-    (selectRandom _availableTags) params ["", "", "", "_textures", "", "_materials"];
+    (selectRandom _availableTags) params ["", "", "", "_textures", "", "_materials", "_tagModel"];
 
     (
         if (count _textures == count _materials) then {
@@ -60,5 +60,5 @@ if !(_possibleTags isEqualTo []) then {
         }
     ) params ["_randomTexture", "_randomMaterial"];
 
-    [_unit, _randomTexture, _randomMaterial] call FUNC(tag);
+    [_unit, _randomTexture, _randomMaterial, _tagModel] call FUNC(tag);
 };

--- a/addons/tagging/functions/fnc_tag.sqf
+++ b/addons/tagging/functions/fnc_tag.sqf
@@ -7,6 +7,7 @@
  * 0: Unit <OBJECT>
  * 1: The colour of the tag (valid colours are black, red, green and blue or full path to custom texture) <STRING>
  * 2: Material of the tag <STRING> (Optional)
+ * 3: Tag Model <STRING> (optional)
  *
  * Return Value:
  * Sucess <BOOL>
@@ -20,7 +21,8 @@
 params [
     ["_unit", objNull, [objNull]],
     ["_texture", "", [""]],
-    ["_material", "", [""]]
+    ["_material", "", [""]],
+    ["_tagModel", "UserTexture1m_F", [""]]
 ];
 
 if (isNull _unit || {_texture == ""}) exitWith {

--- a/docs/wiki/framework/tagging-framework.md
+++ b/docs/wiki/framework/tagging-framework.md
@@ -27,7 +27,9 @@ class ACE_Tags {
         displayName = "My Tag";  // Name of your tag being displayed in the interaction menu
         requiredItem = "ACE_SpraypaintBlack";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
         textures[] = {"path\to\texture1.paa", "path\to\texture2.paa"};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {"path\to\material.rvmat"}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
         icon = "path\to\icon.paa";  // Icon being displayed in the interaction menu
+        tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
     };
 };
 ```
@@ -46,6 +48,8 @@ class ACE_Tags {
 2  | Required Item | String | Required
 3  | Textures | Array | Required
 4  | Icon | String | Optional (default: `""` - Default white point)
+5  | Material Paths | Array | Optional (default: `[]] - No custom material)
+6  | Tag Model | String | Optional (default: `"UserTexture1m_F"` - 1x1m texture surface)
 **R** | Successfully Added Tag | Boolean | Return value
 
 #### 2.1.1 Example


### PR DESCRIPTION
**When merged this pull request will:**

Give modders the ability to specify the Object that will be created when you create a tag.
Main intention is that I want 10x10m textures, but could either add a boolean for 1x1m/10x10m or just let the modder configure literally every possible variant (There is also 1x2m and maybe others in some mods)

It accepts a p3d file path, or a CfgVehicles classname.