### PR TITLE
Fix inconsistent mm usage

### DIFF
--- a/addons/aircraft/stringtable.xml
+++ b/addons/aircraft/stringtable.xml
@@ -56,7 +56,7 @@
             <English>30mm High-Explosive Incendiary</English>
             <Spanish>30mm Alto Explosivo Incendiaria</Spanish>
             <Chinese>30毫米高爆燃燒彈</Chinese>
-            <French>30 mm High-Explosive Incendiary</French>
+            <French>30mm High-Explosive Incendiary</French>
             <Polish>30mm Odłamkowo-Burzące - Zapalające</Polish>
             <Turkish>30mm Yüksek Patlayıcı </Turkish>
             <German>30mm Hochexplosiv/Brandladung</German>
@@ -67,7 +67,7 @@
             <English>30mm HEI</English>
             <Spanish>30mm AEI</Spanish>
             <Chinese>30毫米高爆燃燒</Chinese>
-            <French>30 mm HEI</French>
+            <French>30mm HEI</French>
             <Polish>30mm OB-Z</Polish>
             <Turkish>30mm HEI</Turkish>
             <German>30mm HEB</German>
@@ -78,7 +78,7 @@
             <English>30mm DU Armor Piercing</English>
             <Spanish>30mm UE Perforante de Blindaje</Spanish>
             <Chinese>30毫米貧化鈾穿甲彈 </Chinese>
-            <French>30 mm UA Armor Piercing</French>
+            <French>30mm UA Armor Piercing</French>
             <Polish>30mm Zubożony Uran - Przebijające</Polish>
             <Turkish>30mm DU Zırh Delici</Turkish>
             <German>30mm abgereichertes panzerbrechendes Uraniumgeschoss</German>
@@ -89,18 +89,18 @@
             <English>30mm DU AP</English>
             <Spanish>30mm UE AP</Spanish>
             <Chinese>30毫米貧鈾穿甲</Chinese>
-            <French>30 mm UA AP</French>
+            <French>30mm UA AP</French>
             <Polish>30mm ZU-P</Polish>
             <Turkish>30mm DU AP</Turkish>
             <German>30mm DU-PB</German>
             <Japanese>30mm DU AP</Japanese>
-            <Czech>30 mm DU AP</Czech>
+            <Czech>30mm DU AP</Czech>
         </Key>
         <Key ID="STR_ACE_Aircraft_GatlingDescriptionCM41">
             <English>30mm Combat Mix 4:1 DU:HEI</English>
             <Spanish>30mm Mezcla de Combate 4:1 UE:AEI</Spanish>
             <Chinese>30毫米戰鬥混合彈4:1 穿甲:高爆</Chinese>
-            <French>30 mm Mix de Combat 4:1 UA:HEI</French>
+            <French>30mm Mix de Combat 4:1 UA:HEI</French>
             <Polish>30mm Mieszanka bojowa 4:1 ZU:OB-Z</Polish>
             <Turkish>30mm Combat Mix 4:1 DU:HEI</Turkish>
             <German>30mm Kampfmischung 4:1 DU:HEB</German>
@@ -111,7 +111,7 @@
             <English>30mm CM 4:1</English>
             <Spanish>30mm MC 4:1</Spanish>
             <Chinese>30毫米 穿高混合 4:1</Chinese>
-            <French>30 mm MdC 4:1</French>
+            <French>30mm MdC 4:1</French>
             <Polish>30mm MB 4:1</Polish>
             <Turkish>30mm CM 4:1</Turkish>
             <German>30mm KM 4:1</German>
@@ -122,7 +122,7 @@
             <English>30mm Combat Mix 5:1 DU:HEI</English>
             <Spanish>30mm Mezcla de Combate 5:1 UE:AEI</Spanish>
             <Chinese>30毫米戰鬥混合彈5:1 穿甲:高爆</Chinese>
-            <French>30 mm Mix de Combat 5:1 UA:HEI</French>
+            <French>30mm Mix de Combat 5:1 UA:HEI</French>
             <Polish>30mm Mieszanka bojowa 5:1 ZU:OB-Z</Polish>
             <Turkish>30mm Combat Mix 5:1 DU:HEI</Turkish>
             <German>30mm Kampfmischung 5:1 DU:HEB</German>
@@ -133,7 +133,7 @@
             <English>30mm CM 5:1</English>
             <Spanish>30mm MC 5:1</Spanish>
             <Chinese>30毫米 穿高混合 5:1</Chinese>
-            <French>30 mm MdC 5:1</French>
+            <French>30mm MdC 5:1</French>
             <Polish>30mm MB 5:1</Polish>
             <Turkish>30mm CM 5:1</Turkish>
             <German>30mm KM 5:1</German>

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -21,7 +21,7 @@
             <Italian>#00 Buckshot</Italian>
             <Japanese>#00 バックショット</Japanese>
             <French>Chevrotine #00</French>
-            <Czech>#00 Broky velké - kalibr 8.38 mm</Czech>
+            <Czech>#00 Broky velké - kalibr 8.38mm</Czech>
             <Polish>#00 Śrut</Polish>
             <Portuguese>#00 Chumbo</Portuguese>
             <Turkish>#00 Irisaçma</Turkish>
@@ -45,7 +45,7 @@
             <Italian>#0 Buckshot</Italian>
             <Japanese>#0 バックショット</Japanese>
             <French>Chevrotine #0</French>
-            <Czech>#0 Broky velké -  kalibr 8.1 mm</Czech>
+            <Czech>#0 Broky velké -  kalibr 8.1mm</Czech>
             <Polish>#0 Śrut</Polish>
             <Portuguese>#0 Chumbo</Portuguese>
             <Turkish>#0 Irisaçma</Turkish>
@@ -69,7 +69,7 @@
             <Italian>#1 Buckshot</Italian>
             <Japanese>#1 バックショット</Japanese>
             <French>Chevrotine #1</French>
-            <Czech>#1 Broky velké -  kalibr 7.6 mm</Czech>
+            <Czech>#1 Broky velké -  kalibr 7.6mm</Czech>
             <Polish>#1 Śrut</Polish>
             <Portuguese>#1 Chumbo</Portuguese>
             <Turkish>#1 Irisaçma</Turkish>
@@ -93,7 +93,7 @@
             <Italian>#2 Buckshot</Italian>
             <Japanese>#2 バックショット</Japanese>
             <French>Chevrotine #2</French>
-            <Czech>#2 Broky velké -  kalibr 6.9 mm</Czech>
+            <Czech>#2 Broky velké -  kalibr 6.9mm</Czech>
             <Polish>#2 Śrut</Polish>
             <Portuguese>#2 Chumbo</Portuguese>
             <Turkish>#2 Irisaçma</Turkish>
@@ -117,7 +117,7 @@
             <Italian>#3 Buckshot</Italian>
             <Japanese>#3 バックショット</Japanese>
             <French>Chevrotine #3</French>
-            <Czech>#3 Broky velké -  kalibr 6.4 mm</Czech>
+            <Czech>#3 Broky velké -  kalibr 6.4mm</Czech>
             <Polish>#3 Śrut</Polish>
             <Portuguese>#3 Chumbo</Portuguese>
             <Turkish>#3 Irisaçma</Turkish>
@@ -141,7 +141,7 @@
             <Italian>#4 Buckshot</Italian>
             <Japanese>#4 バックショット</Japanese>
             <French>Chevrotine #4</French>
-            <Czech>#4 Broky velké -  kalibr 6.1 mm</Czech>
+            <Czech>#4 Broky velké -  kalibr 6.1mm</Czech>
             <Polish>#4 Śrut</Polish>
             <Portuguese>#4 Chumbo</Portuguese>
             <Turkish>#4 Irisaçma</Turkish>
@@ -164,7 +164,7 @@
             <Italian>#7 Birdshot</Italian>
             <Japanese>#7 バックショット</Japanese>
             <French>Grenaille No.4</French>
-            <Czech>#7 Broky malé - kalibr 2.54 mm</Czech>
+            <Czech>#7 Broky malé - kalibr 2.54mm</Czech>
             <Polish>#7 Śrut Drobny (Birdshot)</Polish>
             <Turkish>#7 Küçük saçma</Turkish>
         </Key>
@@ -175,7 +175,7 @@
             <Italian>12 Gauge 2Rnd #00 Buckshot</Italian>
             <Japanese>12 ゲージ 2 発入り #00 バックショット</Japanese>
             <French>2 balles cal. 12 Chevrotine #00</French>
-            <Czech>2x #00 Broky velké (kalibr 8.38 mm)</Czech>
+            <Czech>2x #00 Broky velké (kalibr 8.38mm)</Czech>
             <Polish>12 Gauge 2 naboje #00 Śrut</Polish>
             <Portuguese>Chumbo #00 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -186,7 +186,7 @@
             <Italian>12 Gauge 2Rnd #0 Buckshot</Italian>
             <Japanese>12 ゲージ 2 発入り #0 バックショット</Japanese>
             <French>2 balles cal. 12 Chevrotine #0</French>
-            <Czech>2x #0 Broky velké (kalibr 8.1 mm)</Czech>
+            <Czech>2x #0 Broky velké (kalibr 8.1mm)</Czech>
             <Polish>12 Gauge 2 naboje #0 Śrut</Polish>
             <Portuguese>Chumbo #0 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -197,7 +197,7 @@
             <Italian>12 Gauge 2Rnd #1 Buckshot</Italian>
             <Japanese>12 ゲージ 2 発入り #1 バックショット</Japanese>
             <French>2 balles cal. 12 Chevrotine #1</French>
-            <Czech>2x #1 Broky velké (kalibr 7.6 mm)</Czech>
+            <Czech>2x #1 Broky velké (kalibr 7.6mm)</Czech>
             <Polish>12 Gauge 2 naboje #1 Śrut</Polish>
             <Portuguese>Chumbo #1 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -208,7 +208,7 @@
             <Italian>12 Gauge 2Rnd #2 Buckshot</Italian>
             <Japanese>12 ゲージ 2 発入り #2 バックショット</Japanese>
             <French>2 balles cal. 12 Chevrotine #2</French>
-            <Czech>2x #2 Broky velké (kalibr 6.9 mm)</Czech>
+            <Czech>2x #2 Broky velké (kalibr 6.9mm)</Czech>
             <Polish>12 Gauge 2 naboje #2 Śrut</Polish>
             <Portuguese>Chumbo #2 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -219,7 +219,7 @@
             <Italian>12 Gauge 2Rnd #3 Buckshot</Italian>
             <Japanese>12 ゲージ 2 発入り #3 バックショット</Japanese>
             <French>2 balles cal. 12 Chevrotine #3</French>
-            <Czech>2x #3 Broky velké (kalibr 6.4 mm)</Czech>
+            <Czech>2x #3 Broky velké (kalibr 6.4mm)</Czech>
             <Polish>12 Gauge 2 naboje #3 Śrut</Polish>
             <Portuguese>Chumbo #3 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -230,7 +230,7 @@
             <Italian>12 Gauge 2Rnd #4 Buckshot</Italian>
             <Japanese>12 ゲージ 2 発入り #4 バックショット</Japanese>
             <French>2 balles cal. 12 Chevrotine #4</French>
-            <Czech>2x #4 Broky velké (kalibr 6.1 mm)</Czech>
+            <Czech>2x #4 Broky velké (kalibr 6.1mm)</Czech>
             <Polish>12 Gauge 2 naboje #4 Śrut</Polish>
             <Portuguese>Chumbo #4 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -241,7 +241,7 @@
             <Italian>12 Gauge 2Rnd #7 Birdshot</Italian>
             <Japanese>12 ゲージ 2 発入り #7 バックショット</Japanese>
             <French>2 balles cal. 12 Grenaille No.4</French>
-            <Czech>2x #7 Broky malé (kalibr 2.54 mm)</Czech>
+            <Czech>2x #7 Broky malé (kalibr 2.54mm)</Czech>
             <Polish>12 Gauge 2 naboje #7 Śrut</Polish>
             <Portuguese>Chumbo #7 Calibre Doze 2 Tiros</Portuguese>
         </Key>
@@ -252,7 +252,7 @@
             <Italian>12 Gauge 6Rnd #00 Buckshot</Italian>
             <Japanese>12 ゲージ 6 発入り #00 バックショット</Japanese>
             <French>6 balles cal. 12 Chevrotine #00</French>
-            <Czech>6x #00 Broky velké (kalibr 8.38 mm)</Czech>
+            <Czech>6x #00 Broky velké (kalibr 8.38mm)</Czech>
             <Polish>12 Gauge 6 naboi #00 Śrut</Polish>
             <Portuguese>Chumbo #00 Calibre Doze 6 Tiros</Portuguese>
         </Key>
@@ -263,7 +263,7 @@
             <Italian>12 Gauge 6Rnd #0 Buckshot</Italian>
             <Japanese>12 ゲージ 6 発入り #0 バックショット</Japanese>
             <French>6 balles cal. 12 Chevrotine #0</French>
-            <Czech>6x #0 Broky velké (kalibr 8.1 mm)</Czech>
+            <Czech>6x #0 Broky velké (kalibr 8.1mm)</Czech>
             <Polish>12 Gauge 6 naboi #0 Śrut</Polish>
             <Portuguese>Chumbo #0 Calibre Doze 6 Tiros</Portuguese>
         </Key>
@@ -274,7 +274,7 @@
             <Italian>12 Gauge 6Rnd #1 Buckshot</Italian>
             <Japanese>12 ゲージ 6 発入り #1 バックショット</Japanese>
             <French>6 balles cal. 12 Chevrotine #1</French>
-            <Czech>6x #1 Broky velké (kalibr 7.6 mm)</Czech>
+            <Czech>6x #1 Broky velké (kalibr 7.6mm)</Czech>
             <Polish>12 Gauge 6 naboi #1 Śrut</Polish>
             <Portuguese>Chumbo #1 Calibre Doze 6 Tiros</Portuguese>
         </Key>
@@ -285,7 +285,7 @@
             <Italian>12 Gauge 6Rnd #2 Buckshot</Italian>
             <Japanese>12 ゲージ 6 発入り #2 バックショット</Japanese>
             <French>6 balles cal. 12 Chevrotine #2</French>
-            <Czech>6x #2 Broky velké (kalibr 6.9 mm)</Czech>
+            <Czech>6x #2 Broky velké (kalibr 6.9mm)</Czech>
             <Polish>12 Gauge 6 naboi #2 Śrut</Polish>
             <Portuguese>Chumbo #2 Calibre Doze 6 Tiros</Portuguese>
         </Key>
@@ -296,7 +296,7 @@
             <Italian>12 Gauge 6Rnd #3 Buckshot</Italian>
             <Japanese>12 ゲージ 6 発入り #3 バックショット</Japanese>
             <French>6 balles cal. 12 Chevrotine #3</French>
-            <Czech>6x #3 Broky velké (kalibr 6.4 mm)</Czech>
+            <Czech>6x #3 Broky velké (kalibr 6.4mm)</Czech>
             <Polish>12 Gauge 6 naboi #3 Śrut</Polish>
             <Portuguese>Chumbo #3 Calibre Doze 6 Tiros</Portuguese>
         </Key>
@@ -307,7 +307,7 @@
             <Italian>12 Gauge 6Rnd #4 Buckshot</Italian>
             <Japanese>12 ゲージ 6 発入り #4 バックショット</Japanese>
             <French>6 balles cal. 12 Chevrotine #4</French>
-            <Czech>6x #4 Broky velké (kalibr 6.1 mm)</Czech>
+            <Czech>6x #4 Broky velké (kalibr 6.1mm)</Czech>
             <Polish>12 Gauge 6 naboi #4 Śrut</Polish>
             <Portuguese>Chumbo #4 Calibre Doze 6 Tiros</Portuguese>
         </Key>
@@ -318,7 +318,7 @@
             <Italian>12 Gauge 6Rnd #7 Birdshot</Italian>
             <Japanese>12 ゲージ 6 発入り #7 バックショット</Japanese>
             <French>6 balles cal. 12 Grenaille No.4</French>
-            <Czech>6x #7 Broky malé (kalibr 2.54 mm)</Czech>
+            <Czech>6x #7 Broky malé (kalibr 2.54mm)</Czech>
             <Polish>12 Gauge 6 naboi #7 Śrut</Polish>
         </Key>
         <Key ID="STR_ACE_Ballistics_15Rnd_12Gauge_Pellets_No00_Buck_Name">
@@ -328,7 +328,7 @@
             <Italian>12 Gauge 15Rnd #00 Buckshot</Italian>
             <Japanese>12 ゲージ 15 発入り #00 バックショット</Japanese>
             <French>15 balles cal. 12 Chevrotine #00</French>
-            <Czech>15x #00 Broky velké (kalibr 8.38 mm)</Czech>
+            <Czech>15x #00 Broky velké (kalibr 8.38mm)</Czech>
             <Polish>12 Gauge 15 naboi #00 Śrut</Polish>
             <Portuguese>Chumbo #00 Calibre Doze 15 Tiros</Portuguese>
         </Key>
@@ -1593,7 +1593,7 @@
             <Spanish>Calibre: 5.56x45mm NATO (Mk262)&lt;br /&gt;Balas: 30</Spanish>
             <Russian>Калибр: 5,56x45 мм NATO (Mk262)&lt;br /&gt;Патронов: 30</Russian>
             <German>Kaliber: 5,56x45mm NATO (Mk262)&lt;br /&gt;Patronen: 30</German>
-            <Italian>Calibro: 5.56x45 mm NATO (Mk262)&lt;br /&gt;Munizioni: 30</Italian>
+            <Italian>Calibro: 5.56x45mm NATO (Mk262)&lt;br /&gt;Munizioni: 30</Italian>
             <Czech>Ráže: 5.56x45mm NATO (Mk262)&lt;br /&gt;Nábojů: 30</Czech>
             <Portuguese>Calibre: 5.56x45mm NATO (Mk262)&lt;br/&gt;Cartuchos: 30</Portuguese>
             <Hungarian>Kaliber: 5,56x45mm NATO (Mk262)&lt;br /&gt;Lövedékek: 30</Hungarian>
@@ -1642,7 +1642,7 @@
             <Spanish>Calibre: 5.56x45mm NATO (Mk318)&lt;br /&gt;Balas: 30</Spanish>
             <Russian>Калибр: 5,56x45 мм NATO (Mk318)&lt;br /&gt;Патронов: 30</Russian>
             <German>Kaliber: 5,56x45mm NATO (Mk318)&lt;br /&gt;Patronen: 30</German>
-            <Italian>Calibro: 5.56x45 mm NATO (Mk318)&lt;br /&gt;Munizioni: 30</Italian>
+            <Italian>Calibro: 5.56x45mm NATO (Mk318)&lt;br /&gt;Munizioni: 30</Italian>
             <Czech>Ráže: 5.56x45mm NATO (Mk318)&lt;br /&gt;Nábojů: 30</Czech>
             <Portuguese>Calibre: 5.56x45mm NATO (Mk318)&lt;br/&gt;Cartuchos: 30</Portuguese>
             <Hungarian>Kaliber: 5,56x45mm NATO (Mk318)&lt;br /&gt;Lövedékek: 30</Hungarian>
@@ -1691,7 +1691,7 @@
             <Spanish>Calibre: 5.56x45mm NATO (M995 AP)&lt;br /&gt;Balas: 30</Spanish>
             <Russian>Калибр: 5,56x45 мм NATO (M995 бронебойные)&lt;br /&gt;Патронов: 30</Russian>
             <German>Kaliber: 5,56x45mm NATO (M995 AP)&lt;br /&gt;Patronen: 30</German>
-            <Italian>Calibro: 5.56x45 mm NATO (M995 AP)&lt;br /&gt;Munizioni: 30</Italian>
+            <Italian>Calibro: 5.56x45mm NATO (M995 AP)&lt;br /&gt;Munizioni: 30</Italian>
             <Czech>Ráže: 5.56x45mm NATO (M995 AP)&lt;br /&gt;Nábojů: 30</Czech>
             <Portuguese>Calibre: 5.56x45mm NATO (M995 AP)&lt;br/&gt;Cartuchos: 30</Portuguese>
             <Hungarian>Kaliber: 5,56x45mm NATO (M995 páncéltörő)&lt;br /&gt;Lövedékek: 30</Hungarian>
@@ -1740,7 +1740,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (M118LR)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M118LR)&lt;br /&gt;Патронов: 10</Russian>
             <German>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Patronen: 10</German>
-            <Italian>Calibro: 7.62x51 mm NATO (M118LR)&lt;br /&gt;Munizioni: 10</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (M118LR)&lt;br /&gt;Munizioni: 10</Italian>
             <Czech>Ráže: 7.62x51mm NATO (M118LR)&lt;br /&gt;Nábojů: 10</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (M118LR)&lt;br/&gt;Cartuchos: 10</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Lövedékek: 10</Hungarian>
@@ -1789,7 +1789,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (M118LR)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M118LR)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x51 mm NATO (M118LR)&lt;br /&gt;Munizioni: 20</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (M118LR)&lt;br /&gt;Munizioni: 20</Italian>
             <Czech>Ráže: 7.62x51mm NATO (M118LR)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (M118LR)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (M118LR)&lt;br /&gt;Lövedékek: 20</Hungarian>
@@ -1838,7 +1838,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk316 Mod 0)&lt;br /&gt;Патронов: 10</Russian>
             <German>Kaliber: 7,62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Patronen: 10</German>
-            <Italian>Calibro: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Munizioni: 10</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Munizioni: 10</Italian>
             <Czech>Ráže: 7.62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Nábojů: 10</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (Mk316 Mod 0)&lt;br/&gt;Cartuchos: 10</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Lövedékek: 10</Hungarian>
@@ -1887,7 +1887,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk316 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x51 mm NATO (Mk316 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
             <Czech>Ráže: 7.62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (Mk316 Mod 0)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (Mk316 Mod 0)&lt;br /&gt;Lövedékek: 20</Hungarian>
@@ -1936,7 +1936,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk319 Mod 0)&lt;br /&gt;Патронов: 10</Russian>
             <German>Kaliber: 7,62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Patronen: 10</German>
-            <Italian>Calibro: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Munizioni: 10</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Munizioni: 10</Italian>
             <Czech>Ráže: 7.62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Nábojů: 10</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (Mk319 Mod 0)&lt;br/&gt;Cartuchos: 10</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Lövedékek: 10</Hungarian>
@@ -1985,7 +1985,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (Mk319 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x51 mm NATO (Mk319 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
             <Czech>Ráže: 7.62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (Mk319 Mod 0)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (Mk319 Mod 0)&lt;br /&gt;Lövedékek: 20</Hungarian>
@@ -2034,7 +2034,7 @@
             <Spanish>Calibre: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Balas: 10</Spanish>
             <Russian>Калибр: 7,62x51 мм NATO (M993 бронебойные)&lt;br /&gt;Патронов: 10</Russian>
             <German>Kaliber: 7,62x51mm NATO (M993 AP)&lt;br /&gt;Patronen: 10</German>
-            <Italian>Calibro: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Munizioni: 10</Italian>
+            <Italian>Calibro: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Munizioni: 10</Italian>
             <Czech>Ráže: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Nábojů: 10</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (M993 AP)&lt;br/&gt;Cartuchos: 10</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (M993 páncéltörő)&lt;br /&gt;Lövedékek: 10</Hungarian>
@@ -2082,8 +2082,8 @@
             <French>Calibre: 7,62x51mm NATO (M993 AP)&lt;br /&gt;Cartouches: 20</French>
             <Russian>Калибр: 7,62x51 мм NATO (M993 бронебойные)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x51mm NATO (M993 AP)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Munizioni: 20</Italian>
-            <Spanish>Calibre: 7.62x51 mm NATO (M993 AP)&lt;br /&gt;Balas: 20</Spanish>
+            <Italian>Calibro: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Munizioni: 20</Italian>
+            <Spanish>Calibre: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Balas: 20</Spanish>
             <Czech>Ráže: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x51mm NATO (M993 AP)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (M993 páncéltörő)&lt;br /&gt;Lövedékek: 20</Hungarian>
@@ -2132,7 +2132,7 @@
             <Spanish>Calibre: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x67 мм NATO (Mk248 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x51mm NATO (Mk248 Mod 0)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x67 mm NATO (Mk248 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
+            <Italian>Calibro: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
             <Czech>Ráže: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x67mm NATO (Mk248 Mod 0)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (Mk248 Mod 0)&lt;br /&gt;Lövedékek: 20</Hungarian>
@@ -2181,7 +2181,7 @@
             <Spanish>Calibre: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x67 мм NATO (Mk248 Mod 1)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x51mm NATO (Mk248 Mod 1)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x67 mm NATO (Mk248 Mod 1)&lt;br /&gt;Munizioni: 20</Italian>
+            <Italian>Calibro: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Munizioni: 20</Italian>
             <Czech>Ráže: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x67mm NATO (Mk248 Mod 1)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x51mm NATO (Mk248 Mod 1)&lt;br /&gt;Lövedékek: 20</Hungarian>
@@ -2230,7 +2230,7 @@
             <Spanish>Calibre: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Balas: 20</Spanish>
             <Russian>Калибр: 7,62x67 мм NATO (Berger Hybrid OTM)&lt;br /&gt;Патронов: 20</Russian>
             <German>Kaliber: 7,62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x67 mm NATO (Berger Hybrid OTM)&lt;br /&gt;Munizioni: 20</Italian>
+            <Italian>Calibro: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Munizioni: 20</Italian>
             <Czech>Ráže: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Nábojů: 20</Czech>
             <Portuguese>Calibre: 7.26x67mm NATO (Berger Hybrid OTM)&lt;br/&gt;Cartuchos: 20</Portuguese>
             <Hungarian>Kaliber: 7,62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Lövedékek: 20</Hungarian>

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -417,8 +417,8 @@
             <English>[CSW] 12.7x108mm HMG Belt</English>
             <German>[CSW] 12.7x108mm HMG-Gurt</German>
             <Portuguese>[CSW] Cinto de Munição - 12.7x108mm HMG</Portuguese>
-            <French>[CSW] Bande 12,7x108 mm HMG</French>
-            <Japanese>[CSW] 12.7x108 mm HMG ベルト</Japanese>
+            <French>[CSW] Bande 12,7x108mm HMG</French>
+            <Japanese>[CSW] 12.7x108mm HMG ベルト</Japanese>
             <Chinese>[CSW]12.7x108毫米 重機槍彈鏈</Chinese>
             <Italian>[CSW] 12.7x108mm HMG Belt</Italian>
             <Czech>[CSW] Pás 12.7×108mm pro těžký kulomet</Czech>
@@ -429,8 +429,8 @@
             <English>[CSW] 12.7x99mm HMG Belt</English>
             <German>[CSW] 12.7x99mm HMG-Gurt</German>
             <Portuguese>[CSW] Cinto de Munição - 12.7x99mm HMG</Portuguese>
-            <French>[CSW] Bande 12,7x99 mm HMG</French>
-            <Japanese>[CSW] 12.7x99 mm HMG ベルト</Japanese>
+            <French>[CSW] Bande 12,7x99mm HMG</French>
+            <Japanese>[CSW] 12.7x99mm HMG ベルト</Japanese>
             <Chinese>[CSW]12.7x99毫米 重機槍彈鏈</Chinese>
             <Italian>[CSW] 12.7x99mm HMG Belt</Italian>
             <Czech>[CSW] Pás 12.7×99mm pro těžký kulomet</Czech>
@@ -441,8 +441,8 @@
             <English>[CSW] 12.7x99mm Tracer HMG Belt (Red)</English>
             <German>[CSW] 12.7x99mm Leuchtspur HMG-Gurt (Rot)</German>
             <Portuguese>[CSW] Cinto de Munição - 12.7x99mm HMG (Traçante Vermelho)</Portuguese>
-            <French>[CSW] Bande 12,7x99 mm HMG traçantes (Rouges)</French>
-            <Japanese>[CSW] 12.7x99 mm HMG 曳光弾ベルト (赤)</Japanese>
+            <French>[CSW] Bande 12,7x99mm HMG traçantes (Rouges)</French>
+            <Japanese>[CSW] 12.7x99mm HMG 曳光弾ベルト (赤)</Japanese>
             <Chinese>[CSW] 12.7x99毫米 重機槍曳光彈鏈（紅色）</Chinese>
             <Italian>[CSW] 12.7x99mm Tracer HMG Belt (Red)</Italian>
             <Czech>[CSW] Pás 12.7×99mm pro těžký kulomet (červená stopovka)</Czech>
@@ -453,8 +453,8 @@
             <English>[CSW] 12.7x99mm Tracer HMG Belt (Green)</English>
             <German>[CSW] 12.7x99mm Leuchtspur HMG-Gurt (Grün)</German>
             <Portuguese>[CSW] Cinto de Munição - 12.7x99mm HMG (Traçante Verde)</Portuguese>
-            <French>[CSW] Bande 12,7x99 mm HMG traçantes (Vertes)</French>
-            <Japanese>[CSW] 12.7x99 mm HMG 曳光弾ベルト (緑)</Japanese>
+            <French>[CSW] Bande 12,7x99mm HMG traçantes (Vertes)</French>
+            <Japanese>[CSW] 12.7x99mm HMG 曳光弾ベルト (緑)</Japanese>
             <Chinese>[CSW] 12.7x99毫米 重機槍曳光彈鏈（綠色）</Chinese>
             <Italian>[CSW] 12.7x99mm Tracer HMG Belt (Green)</Italian>
             <Czech>[CSW] Pás 12.7×99mm pro těžký kulomet (zelená stopovka)</Czech>
@@ -465,8 +465,8 @@
             <English>[CSW] 12.7x99mm Tracer HMG Belt (Yellow)</English>
             <German>[CSW] 12.7x99mm Leuchtspur HMG-Gurt (Gelb)</German>
             <Portuguese>[CSW] Cinto de Munição - 12.7x99mm HMG (Traçante Amarelo)</Portuguese>
-            <French>[CSW] Bande 12,7x99 mm HMG traçantes (Jaunes)</French>
-            <Japanese>[CSW] 12.7x99 mm HMG 曳光弾ベルト (黄)</Japanese>
+            <French>[CSW] Bande 12,7x99mm HMG traçantes (Jaunes)</French>
+            <Japanese>[CSW] 12.7x99mm HMG 曳光弾ベルト (黄)</Japanese>
             <Chinese>[CSW] 12.7x99毫米 重機槍曳光彈鏈（黃色）</Chinese>
             <Italian>[CSW] 12.7x99mm Tracer HMG Belt (Yellow)</Italian>
             <Czech>[CSW] Pás 12.7×99mm pro těžký kulomet (žlutá stopovka)</Czech>
@@ -477,8 +477,8 @@
             <English>[CSW] 20mm Grenade GMG Belt</English>
             <German>[CSW] 20mm Granate GMG-Gurt</German>
             <Portuguese>[CSW] Cinto de Munição - Granada 20mm GMG</Portuguese>
-            <French>[CSW] Bande grenades 20 mm GMG</French>
-            <Japanese>[CSW] 20 mm てき弾 GMG ベルト</Japanese>
+            <French>[CSW] Bande grenades 20mm GMG</French>
+            <Japanese>[CSW] 20mm てき弾 GMG ベルト</Japanese>
             <Chinese>[CSW]20毫米 榴彈 榴彈機槍彈鏈</Chinese>
             <Italian>[CSW] 20mm Grenade GMG Belt</Italian>
             <Czech>[CSW] Pás 20mm granátů pro granátomet</Czech>

--- a/addons/flashsuppressors/stringtable.xml
+++ b/addons/flashsuppressors/stringtable.xml
@@ -2,55 +2,55 @@
 <Project name="ACE">
     <Package name="FlashSuppressors">
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_H">
-            <English>Flash Suppressor (6.5 mm)</English>
-            <Hungarian>Lángrejtő (6,5 mm)</Hungarian>
-            <German>Mündungsfeuerdämpfer (6,5 mm)</German>
+            <English>Flash Suppressor (6.5mm)</English>
+            <Hungarian>Lángrejtő (6,5mm)</Hungarian>
+            <German>Mündungsfeuerdämpfer (6,5mm)</German>
             <Italian>Soppressore di fiamma (6.5mm)</Italian>
             <Portuguese>Supressor de Clarão (6,5mm)</Portuguese>
-            <Polish>Tłumik płomienia (6,5 mm)</Polish>
-            <Czech>Tlumič plamene (6,5 mm)</Czech>
-            <French>Cache-flamme (6,5 mm)</French>
+            <Polish>Tłumik płomienia (6,5mm)</Polish>
+            <Czech>Tlumič plamene (6,5mm)</Czech>
+            <French>Cache-flamme (6,5mm)</French>
             <Russian>Пламегаситель (6,5 мм)</Russian>
-            <Spanish>Bocacha (6,5 mm)</Spanish>
-            <Japanese>消炎器 (6.5 mm)</Japanese>
-            <Korean>소염기 (6.5 mm)</Korean>
-            <Chinesesimp>消光器 (6.5 mm)</Chinesesimp>
+            <Spanish>Bocacha (6,5mm)</Spanish>
+            <Japanese>消炎器 (6.5mm)</Japanese>
+            <Korean>소염기 (6.5mm)</Korean>
+            <Chinesesimp>消光器 (6.5mm)</Chinesesimp>
             <Chinese>消光器 (6.5 毫米)</Chinese>
-            <Turkish>Flash Suppressor (6.5 mm)</Turkish>
+            <Turkish>Flash Suppressor (6.5mm)</Turkish>
         </Key>
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_B">
-            <English>Flash Suppressor (7.62 mm)</English>
-            <Hungarian>Lángrejtő (7,62 mm)</Hungarian>
-            <German>Mündungsfeuerdämpfer (7,62 mm)</German>
+            <English>Flash Suppressor (7.62mm)</English>
+            <Hungarian>Lángrejtő (7,62mm)</Hungarian>
+            <German>Mündungsfeuerdämpfer (7,62mm)</German>
             <Italian>Soppressore di fiamma (7.62mm)</Italian>
             <Portuguese>Supressor de Clarão (7,62mm)</Portuguese>
-            <Polish>Tłumik płomienia (7,62 mm)</Polish>
-            <Czech>Tlumič plamene (7,62 mm)</Czech>
-            <French>Cache-flamme (7,62 mm)</French>
+            <Polish>Tłumik płomienia (7,62mm)</Polish>
+            <Czech>Tlumič plamene (7,62mm)</Czech>
+            <French>Cache-flamme (7,62mm)</French>
             <Russian>Пламегаситель (7,62 мм)</Russian>
-            <Spanish>Bocacha (7,62 mm)</Spanish>
-            <Japanese>消炎器 (7.62 mm)</Japanese>
-            <Korean>소염기 (7.62 mm)</Korean>
-            <Chinesesimp>消光器 (7.62 mm)</Chinesesimp>
+            <Spanish>Bocacha (7,62mm)</Spanish>
+            <Japanese>消炎器 (7.62mm)</Japanese>
+            <Korean>소염기 (7.62mm)</Korean>
+            <Chinesesimp>消光器 (7.62mm)</Chinesesimp>
             <Chinese>消光器 (7.62 毫米)</Chinese>
-            <Turkish>Flash Suppressor (7.62 mm)</Turkish>
+            <Turkish>Flash Suppressor (7.62mm)</Turkish>
         </Key>
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_L">
-            <English>Flash Suppressor (5.56 mm)</English>
-            <Hungarian>Lángrejtő (5,56 mm)</Hungarian>
-            <German>Mündungsfeuerdämpfer (5,56 mm)</German>
+            <English>Flash Suppressor (5.56mm)</English>
+            <Hungarian>Lángrejtő (5,56mm)</Hungarian>
+            <German>Mündungsfeuerdämpfer (5,56mm)</German>
             <Italian>Soppressore di fiamma (5.56mm)</Italian>
             <Portuguese>Supressor de Clarão (5,56mm)</Portuguese>
-            <Polish>Tłumik płomienia (5,56 mm)</Polish>
-            <Czech>Tlumič plamene (5,56 mm)</Czech>
-            <French>Cache-flamme (5,56 mm)</French>
+            <Polish>Tłumik płomienia (5,56mm)</Polish>
+            <Czech>Tlumič plamene (5,56mm)</Czech>
+            <French>Cache-flamme (5,56mm)</French>
             <Russian>Пламегаситель (5,56 мм)</Russian>
-            <Spanish>Bocacha (5,56 mm)</Spanish>
-            <Japanese>消炎器 (5.56 mm)</Japanese>
-            <Korean>소염기 (5.56 mm)</Korean>
-            <Chinesesimp>消光器 (5.56 mm)</Chinesesimp>
+            <Spanish>Bocacha (5,56mm)</Spanish>
+            <Japanese>消炎器 (5.56mm)</Japanese>
+            <Korean>소염기 (5.56mm)</Korean>
+            <Chinesesimp>消光器 (5.56mm)</Chinesesimp>
             <Chinese>消光器 (5.56 毫米)</Chinese>
-            <Turkish>Flash Suppressor (5.56 mm)</Turkish>
+            <Turkish>Flash Suppressor (5.56mm)</Turkish>
         </Key>
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_smg_01">
             <English>Flash Suppressor (.45 ACP)</English>
@@ -70,21 +70,21 @@
             <Turkish>Flash Suppressor (.45 ACP)</Turkish>
         </Key>
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_smg_02">
-            <English>Flash Suppressor (9 mm)</English>
-            <Hungarian>Lángrejtő (9 mm)</Hungarian>
-            <German>Mündungsfeuerdämpfer (9 mm)</German>
-            <Italian>Soppressore di fiamma (9 mm)</Italian>
+            <English>Flash Suppressor (9mm)</English>
+            <Hungarian>Lángrejtő (9mm)</Hungarian>
+            <German>Mündungsfeuerdämpfer (9mm)</German>
+            <Italian>Soppressore di fiamma (9mm)</Italian>
             <Portuguese>Supressor de Clarão (9mm)</Portuguese>
-            <Polish>Tłumik płomienia (9 mm)</Polish>
-            <Czech>Tlumič plamene (9 mm)</Czech>
-            <French>Cache-flamme (9 mm)</French>
+            <Polish>Tłumik płomienia (9mm)</Polish>
+            <Czech>Tlumič plamene (9mm)</Czech>
+            <French>Cache-flamme (9mm)</French>
             <Russian>Пламегаситель (9 мм)</Russian>
-            <Spanish>Bocacha (9 mm)</Spanish>
-            <Japanese>消炎器 (9 mm)</Japanese>
-            <Korean>소염기 (9 mm)</Korean>
-            <Chinesesimp>消光器 (9 mm)</Chinesesimp>
+            <Spanish>Bocacha (9mm)</Spanish>
+            <Japanese>消炎器 (9mm)</Japanese>
+            <Korean>소염기 (9mm)</Korean>
+            <Chinesesimp>消光器 (9mm)</Chinesesimp>
             <Chinese>消光器 (9 毫米)</Chinese>
-            <Turkish>Flash Suppressor (9 mm)</Turkish>
+            <Turkish>Flash Suppressor (9mm)</Turkish>
         </Key>
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_338">
             <English>Flash Suppressor (.338)</English>
@@ -104,21 +104,21 @@
             <Turkish>Flash Suppressor (.338)</Turkish>
         </Key>
         <Key ID="STR_ACE_FlashSuppressors_muzzle_mzls_93mmg">
-            <English>Flash Suppressor (9.3 mm)</English>
-            <Hungarian>Lángrejtő (9,3 mm)</Hungarian>
-            <German>Mündungsfeuerdämpfer (9,3 mm)</German>
+            <English>Flash Suppressor (9.3mm)</English>
+            <Hungarian>Lángrejtő (9,3mm)</Hungarian>
+            <German>Mündungsfeuerdämpfer (9,3mm)</German>
             <Italian>Soppressore di fiamma (9.3mm)</Italian>
             <Portuguese>Supressor de Clarão (9,3mm)</Portuguese>
-            <Polish>Tłumik płomienia (9,3 mm)</Polish>
-            <Czech>Tlumič plamene (9,3 mm)</Czech>
-            <French>Cache-flamme (9,3 mm)</French>
+            <Polish>Tłumik płomienia (9,3mm)</Polish>
+            <Czech>Tlumič plamene (9,3mm)</Czech>
+            <French>Cache-flamme (9,3mm)</French>
             <Russian>Пламегаситель (9,3 мм)</Russian>
-            <Spanish>Bocacha (9,3 mm)</Spanish>
-            <Japanese>消炎器 (9.3 mm)</Japanese>
-            <Korean>소염기 (9.3 mm)</Korean>
-            <Chinesesimp>消光器 (9.3 mm)</Chinesesimp>
+            <Spanish>Bocacha (9,3mm)</Spanish>
+            <Japanese>消炎器 (9.3mm)</Japanese>
+            <Korean>소염기 (9.3mm)</Korean>
+            <Chinesesimp>消光器 (9.3mm)</Chinesesimp>
             <Chinese>消光器 (9.3 毫米)</Chinese>
-            <Turkish>Flash Suppressor (9.3 mm)</Turkish>
+            <Turkish>Flash Suppressor (9.3mm)</Turkish>
         </Key>
     </Package>
 </Project>

--- a/addons/mk6mortar/stringtable.xml
+++ b/addons/mk6mortar/stringtable.xml
@@ -5,7 +5,7 @@
             <English>82mm Rangetable</English>
             <German>82mm Distanztabelle</German>
             <Polish>Tabela strzelnicza 82mm</Polish>
-            <French>Table de tir 82 mm</French>
+            <French>Table de tir 82mm</French>
             <Russian>82 мм Таблица дальностей и прицелов</Russian>
             <Spanish>Tabla de distancias de 82mm</Spanish>
             <Hungarian>82mm hatótáv-tábla</Hungarian>
@@ -22,7 +22,7 @@
             <English>Range Table for the Mk6 82mm Mortar</English>
             <German>Distanztabelle für den Mk6 82mm Mortar</German>
             <Polish>Tabela strzelnicza dla moździerza 82mm Mk6</Polish>
-            <French>Table de tir pour le mortier Mk6 82 mm.</French>
+            <French>Table de tir pour le mortier Mk6 82mm.</French>
             <Russian>Таблица дальностей и прицелов для Mk6 82 мм мортиры</Russian>
             <Spanish>Tabla de distancias para el mortero Mk6 de 82mm</Spanish>
             <Hungarian>Hatótáv-tábla a Mk6 82mm-es mozsárhoz</Hungarian>
@@ -39,7 +39,7 @@
             <English>Open 82mm Rangetable</English>
             <German>Öffne 82mm Distanztabelle</German>
             <Polish>Otwórz tabelę strzelniczą 82mm</Polish>
-            <French>Ouvrir la table de tir 82 mm</French>
+            <French>Ouvrir la table de tir 82mm</French>
             <Russian>Открыть 82 мм Таблицу дальностей и прицелов</Russian>
             <Spanish>Abrir tabla de distancias de 82mm</Spanish>
             <Hungarian>82mm hatótáv-tábla megnyitása</Hungarian>
@@ -394,7 +394,7 @@
             <German>82mm Sprengpatrone</German>
             <Spanish>Ronda 82mm HE</Spanish>
             <Polish>Pocisk wybuchowy kal. 82mm</Polish>
-            <French>Obus de 82 mm HE</French>
+            <French>Obus de 82mm HE</French>
             <Italian>Proiettile da 82mm HE</Italian>
             <Czech>82mm HE náboj</Czech>
             <Portuguese>Munição 82mm HE</Portuguese>
@@ -410,7 +410,7 @@
             <German>82mm Nebelpatrone</German>
             <Spanish>Ronda 82mm Humo</Spanish>
             <Polish>Pocisk dymny kal. 82mm</Polish>
-            <French>Obus de 82 mm fumigène</French>
+            <French>Obus de 82mm fumigène</French>
             <Italian>Proiettile Fumogeno da 82mm</Italian>
             <Czech>82mm Kouřový náboj</Czech>
             <Portuguese>Munição 82mm Fumaça</Portuguese>
@@ -426,7 +426,7 @@
             <German>82mm Leuchtpatrone</German>
             <Spanish>Ronda 82mm Iluminación</Spanish>
             <Polish>Pocisk oświetlający kal. 82mm</Polish>
-            <French>Obus de 82 mm éclairant</French>
+            <French>Obus de 82mm éclairant</French>
             <Italian>Proiettile illuminante da 82mm</Italian>
             <Czech>82mm Osvětlovací náboj</Czech>
             <Portuguese>Munição 82mm Iluminação</Portuguese>
@@ -442,7 +442,7 @@
             <German>82mm gelenkte Sprengpatrone</German>
             <Spanish>Ronda 82mm Guiada</Spanish>
             <Polish>Kierowany pocisk wybuchowy kal. 82mm</Polish>
-            <French>Obus de 82 mm HE guidé</French>
+            <French>Obus de 82mm HE guidé</French>
             <Italian>Proiettile HE guidato</Italian>
             <Czech>82mm HE náboj (naváděný)</Czech>
             <Portuguese>Munição 82mm HE Guiada</Portuguese>
@@ -458,7 +458,7 @@
             <German>82mm lasergelenkte Sprengpatrone</German>
             <Spanish>Ronda 82mm Guiada por Laser</Spanish>
             <Polish>Laserowo napr. pocisk wybuchowy kal. 82mm</Polish>
-            <French>Obus de 82 mm HE guidé au laser</French>
+            <French>Obus de 82mm HE guidé au laser</French>
             <Italian>Proiettile HE a guida laser</Italian>
             <Czech>82mm HE náboj (naváděný laserem)</Czech>
             <Portuguese>Munição 82mm HE Guiada por Laser </Portuguese>
@@ -489,7 +489,7 @@
             <German>[ACE] 82mm Sprengpatronenkiste</German>
             <Spanish>[ACE] Caja de municiones 82mm HE</Spanish>
             <Polish>[ACE] Skrzynka amunicji wybuchowej 82mm</Polish>
-            <French>[ACE] Obus de 82 mm HE</French>
+            <French>[ACE] Obus de 82mm HE</French>
             <Italian>[ACE] Scatola proiettili espolisvi ad alto potenziale (HE) da 82mm</Italian>
             <Czech>[ACE] Bedna s municí (82mm HE)</Czech>
             <Portuguese>[ACE] Caixa de Munição 82mm HE</Portuguese>
@@ -505,7 +505,7 @@
             <German>[ACE] 82mm Nebelpatronenkiste</German>
             <Spanish>[ACE] Caja de municiones 82mm Humo</Spanish>
             <Polish>[ACE] Skrzynka amunicji dymnej 82mm</Polish>
-            <French>[ACE] Obus de 82 mm fumigène</French>
+            <French>[ACE] Obus de 82mm fumigène</French>
             <Italian>[ACE] Scatola fumogeni da 82mm</Italian>
             <Czech>[ACE] Bedna s municí (82mm Dýmovnice)</Czech>
             <Portuguese>[ACE] Caixa de Munição 82mm Fumaça</Portuguese>
@@ -521,7 +521,7 @@
             <German>[ACE] 82mm Leuchtpatronenkiste</German>
             <Spanish>[ACE] Caja de municiones 82mm Iluminacion</Spanish>
             <Polish>[ACE] Skrzynka amunicji oświetlającej 82mm</Polish>
-            <French>[ACE] Obus de 82 mm éclairants</French>
+            <French>[ACE] Obus de 82mm éclairants</French>
             <Italian>[ACE] Scatola illuminanti da 82mm</Italian>
             <Czech>[ACE] Bedna s municí (82mm Světlice)</Czech>
             <Portuguese>[ACE] Caixa de Munição 82mm Iluminação</Portuguese>
@@ -537,7 +537,7 @@
             <German>[ACE] 82mm Standardkiste</German>
             <Spanish>[ACE] Caja de municiones 82mm por defecto</Spanish>
             <Polish>[ACE] Skrzynka amunicji standardowej 82mm</Polish>
-            <French>[ACE] Obus de 82 mm par défaut</French>
+            <French>[ACE] Obus de 82mm par défaut</French>
             <Italian>[ACE] Scatola proiettili 82mm standard</Italian>
             <Czech>[ACE] Bedna se standardní 82mm municí</Czech>
             <Portuguese>[ACE] Caixa de Munição 82mm Padrão</Portuguese>

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -93,7 +93,7 @@ class CfgWeapons {
     class arifle_Mk20_GL_plain_F: arifle_Mk20_GL_F {
         displayName = CSTRING(arifle_Mk20_GL_plain_Name);
     };
-    
+
     // P90 (1.86)
     class SMG_03_TR_BASE;
     class SMG_03_TR_black: SMG_03_TR_BASE {
@@ -145,8 +145,8 @@ class CfgWeapons {
     class SMG_03C_hex: SMG_03C_black {
         displayName = CSTRING(P90_Hex_Name);
     };
-    
-    
+
+
 
     // Vector
     class SMG_01_Base;
@@ -271,79 +271,79 @@ class CfgWeapons {
         displayName = CSTRING(srifle_DMR_02_sniper); //MAR-10 .338 (Sand);
     };
     class DMR_03_base_F: Rifle_Long_Base_F {
-        displayName = CSTRING(DMR_03); //Mk-I EMR 7.62 mm;
+        displayName = CSTRING(DMR_03); //Mk-I EMR 7.62mm;
     };
 
     class srifle_DMR_03_F: DMR_03_base_F {
-        displayName = CSTRING(srifle_DMR_03); //Mk-I EMR 7.62 mm (Black);
+        displayName = CSTRING(srifle_DMR_03); //Mk-I EMR 7.62mm (Black);
     };
 
     class srifle_DMR_03_khaki_F: srifle_DMR_03_F {
-        displayName = CSTRING(srifle_DMR_03_khaki); //Mk-I EMR 7.62 mm (Khaki);
+        displayName = CSTRING(srifle_DMR_03_khaki); //Mk-I EMR 7.62mm (Khaki);
     };
 
     class srifle_DMR_03_tan_F: srifle_DMR_03_F {
-        displayName = CSTRING(srifle_DMR_03_tan); //Mk-I EMR 7.62 mm (Sand);
+        displayName = CSTRING(srifle_DMR_03_tan); //Mk-I EMR 7.62mm (Sand);
     };
 
     class srifle_DMR_03_multicam_F: srifle_DMR_03_F {
-        displayName = CSTRING(srifle_DMR_03_multicam); //Mk-I EMR 7.62 mm (Camo);
+        displayName = CSTRING(srifle_DMR_03_multicam); //Mk-I EMR 7.62mm (Camo);
     };
 
     class srifle_DMR_03_woodland_F: srifle_DMR_03_F {
-        displayName = CSTRING(srifle_DMR_03_woodland); //Mk-I EMR 7.62 mm (Woodland);
+        displayName = CSTRING(srifle_DMR_03_woodland); //Mk-I EMR 7.62mm (Woodland);
     };
 
     class DMR_04_base_F: Rifle_Long_Base_F {
-        displayName = CSTRING(DMR_04); //ASP-1 Kir 12.7 mm;
+        displayName = CSTRING(DMR_04); //ASP-1 Kir 12.7mm;
     };
 
     class srifle_DMR_04_F: DMR_04_base_F {
-        displayName = CSTRING(srifle_DMR_04); //ASP-1 Kir 12.7 mm (Black);
+        displayName = CSTRING(srifle_DMR_04); //ASP-1 Kir 12.7mm (Black);
     };
 
     class srifle_DMR_04_Tan_F: srifle_DMR_04_F {
-        displayName = CSTRING(srifle_DMR_04_Tan); //ASP-1 Kir 12.7 mm (Tan);
+        displayName = CSTRING(srifle_DMR_04_Tan); //ASP-1 Kir 12.7mm (Tan);
     };
 
     class DMR_05_base_F: Rifle_Long_Base_F {
-        displayName = CSTRING(DMR_05); //Cyrus 9.3 mm;
+        displayName = CSTRING(DMR_05); //Cyrus 9.3mm;
     };
 
     class srifle_DMR_05_blk_F: DMR_05_base_F {
-        displayName = CSTRING(srifle_DMR_05_blk); //Cyrus 9.3 mm (Black)
+        displayName = CSTRING(srifle_DMR_05_blk); //Cyrus 9.3mm (Black)
     };
 
     class srifle_DMR_05_hex_F: srifle_DMR_05_blk_F {
-        displayName = CSTRING(srifle_DMR_05_hex); //Cyrus 9.3 mm (Hex);
+        displayName = CSTRING(srifle_DMR_05_hex); //Cyrus 9.3mm (Hex);
     };
 
     class srifle_DMR_05_tan_f: srifle_DMR_05_blk_F {
-        displayName = CSTRING(srifle_DMR_05_tan); //Cyrus 9.3 mm (Tan);
+        displayName = CSTRING(srifle_DMR_05_tan); //Cyrus 9.3mm (Tan);
     };
     class DMR_06_base_F: Rifle_Long_Base_F {
-        displayName = CSTRING(DMR_06); //Mk14 7.62 mm;
+        displayName = CSTRING(DMR_06); //Mk14 7.62mm;
     };
 
     class srifle_DMR_06_camo_F: DMR_06_base_F {
-        displayName = CSTRING(srifle_DMR_06_camo); //Mk14 7.62 mm (Camo)
+        displayName = CSTRING(srifle_DMR_06_camo); //Mk14 7.62mm (Camo)
     };
 
     class srifle_DMR_06_olive_F: srifle_DMR_06_camo_F {
-        displayName = CSTRING(srifle_DMR_06_olive); //Mk14 7.62 mm (Olive);
+        displayName = CSTRING(srifle_DMR_06_olive); //Mk14 7.62mm (Olive);
     };
 
     // marksmen mgs
     class MMG_01_base_F: Rifle_Long_Base_F {
-        displayName = CSTRING(MMG_01); //Navid 9.3 mm;
+        displayName = CSTRING(MMG_01); //Navid 9.3mm;
     };
 
     class MMG_01_hex_F: MMG_01_base_F {
-        displayName = CSTRING(MMG_01_hex); //Navid 9.3 mm (Hex);
+        displayName = CSTRING(MMG_01_hex); //Navid 9.3mm (Hex);
     };
 
     class MMG_01_tan_F: MMG_01_hex_F {
-        displayName = CSTRING(MMG_01_tan); //Navid 9.3 mm (Tan);
+        displayName = CSTRING(MMG_01_tan); //Navid 9.3mm (Tan);
     };
     class MMG_02_base_F: Rifle_Long_Base_F {
         displayName = CSTRING(MMG_02); //SPMG .338;
@@ -596,7 +596,7 @@ class CfgWeapons {
     class cannon_125mm: CannonCore {
         displayName = "2A46";
     };
-    
+
     class cannon_125mm_advanced : cannon_125mm {
         displayName = "2A82-1M";
     };
@@ -666,7 +666,7 @@ class CfgWeapons {
             displayName = "L21A1 RARDEN";
         };
     };
-    
+
     class autocannon_30mm_RCWS : autocannon_Base_F {
         displayName = "2A42";
     };
@@ -725,7 +725,7 @@ class CfgWeapons {
     class optic_ERCO_snd_f : optic_ERCO_blk_f {
         displayName = CSTRING(optic_erco_snd);
     };
-    
+
     class optic_LRPS : ItemCore {
         displayName = CSTRING(optic_lrps);
     };
@@ -738,7 +738,7 @@ class CfgWeapons {
     class ACE_optic_LRPS_2D : optic_LRPS {
         displayName = CSTRING(optic_lrps_2d);
     };
-    
+
     class optic_AMS_base;
     class optic_AMS: optic_AMS_base {
         displayName = CSTRING(optic_ams);
@@ -749,7 +749,7 @@ class CfgWeapons {
     class optic_AMS_snd: optic_AMS {
         displayName = CSTRING(optic_ams_snd);
     };
-    
+
     class optic_KHS_base;
     class optic_KHS_blk: optic_KHS_base {
         displayName = CSTRING(optic_khs_blk);
@@ -763,7 +763,7 @@ class CfgWeapons {
     class optic_KHS_tan: optic_KHS_blk {
         displayName = CSTRING(optic_khs_tan);
     };
-    
+
     class optic_DMS : ItemCore {
         displayName = CSTRING(optic_dms);
     };

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -4441,7 +4441,7 @@
             <Hungarian>5,7mm 50-as Tár</Hungarian>
             <German>5,7mm 50-Patronen-Magazin</German>
             <Spanish>Cargador de 50 balas SD de 5,7mm</Spanish>
-            <French>Ch. 5,7 mm 50 Cps</French>
+            <French>Ch. 5,7mm 50 Cps</French>
             <Polish>Magazynek 5,7mm 50rd</Polish>
             <Czech>5.7mm 50náb. Zásobník</Czech>
             <Portuguese>Carregador de 50 projéteis de 5.7mm</Portuguese>
@@ -4457,7 +4457,7 @@
             <English>Caliber: 5.7mm&lt;br /&gt;Rounds: 50&lt;br /&gt;Used in: P90</English>
             <German>Kaliber: 5,7mm&lt;br /&gt;Patronen: 50&lt;br /&gt;Eingesetzt von: P90</German>
             <Polish>Kaliber: 5,7mm&lt;br /&gt;Pociski: 50&lt;br /&gt;Używany w: P90</Polish>
-            <French>Calibre : 5,7 mm&lt;br /&gt;Cartouches : 50&lt;br /&gt;Utilisé avec : P90</French>
+            <French>Calibre : 5,7mm&lt;br /&gt;Cartouches : 50&lt;br /&gt;Utilisé avec : P90</French>
             <Spanish>Calibre: 5.7mm&lt;br /&gt;Balas: 50&lt;br /&gt;Se usa en: P90</Spanish>
             <Russian>Калибр: 5,7 мм&lt;br /&gt;Патронов: 50&lt;br /&gt;Используются с: P90</Russian>
             <Italian>Calibro: 5.7mm&lt;br /&gt;Munizioni: 50&lt;br /&gt;In uso su: P90</Italian>

--- a/addons/rearm/stringtable.xml
+++ b/addons/rearm/stringtable.xml
@@ -453,7 +453,7 @@
             <Czech>30mm HEI</Czech>
             <Italian>30mm HEI</Italian>
             <Spanish>30mm HEI</Spanish>
-            <French>30 mm HEI</French>
+            <French>30mm HEI</French>
             <Japanese>30mm HEI</Japanese>
             <Korean>30mm 고폭소이탄</Korean>
             <Chinesesimp>30mm 高爆燃烧弹</Chinesesimp>
@@ -469,7 +469,7 @@
             <Czech>30mm HEI-T</Czech>
             <Italian>30mm HEI-T</Italian>
             <Spanish>30mm HEI-T</Spanish>
-            <French>30 mm HEI-T</French>
+            <French>30mm HEI-T</French>
             <Japanese>30mm HEI-T</Japanese>
             <Korean>30mm 고폭소이예광탄</Korean>
             <Chinesesimp>30mm 高爆燃烧曳光弹</Chinesesimp>

--- a/docs/wiki/feature/advanced-fatigue.md
+++ b/docs/wiki/feature/advanced-fatigue.md
@@ -73,12 +73,12 @@ Each pathway has different properties: They store different amounts of ATP and c
 
 #### 2.2.1 Anaerobic Pathway
 
-This pathway is essentially responsible for your short term stamina. It has a very small capacity of ATP available (2300mmol), which is can provide a lot of ATP very fast (113.3mmol/s), but also replenished very quickly (56.7mmol/s). This pathway is pretty much what limits how long you can jog or sprint in one go, which is why we use it as an indicator for the stamina bar.
+This pathway is essentially responsible for your short term stamina. It has a very small capacity of ATP available (2300 mmol), which is can provide a lot of ATP very fast (113.3 mmol/s), but also replenished very quickly (56.7 mmol/s). This pathway is pretty much what limits how long you can jog or sprint in one go, which is why we use it as an indicator for the stamina bar.
 
 
 #### 2.2.2 Aerobic Pathways
 
-The two aerobic pathways store way bigger amounts of ATP than the anaerobic one, the first one stores over 1700 times as much ATP (4000 mol) and the second one still over 36 times as much ATP (84 mol) as the anaerobic pathway. However, they can also provide (13.3 and 16.7mmol) and replenish (6.6 and 5.83mmol) a lot less ATP then the anaerobic pathway.
+The two aerobic pathways store way bigger amounts of ATP than the anaerobic one, the first one stores over 1700 times as much ATP (4000 mol) and the second one still over 36 times as much ATP (84 mol) as the anaerobic pathway. However, they can also provide (13.3 and 16.7 mmol) and replenish (6.6 and 5.83 mmol) a lot less ATP then the anaerobic pathway.
 
 This means that while these will last a lot longer, they do not have such a large impact on your short term performance. Instead, they will drain slowly during the day, which means that at the end you will have less power available than at the beginning, depending on how much you exhausted yourself. However, at that point they will start influencing your short term performance.
 

--- a/docs/wiki/feature/advanced-fatigue.md
+++ b/docs/wiki/feature/advanced-fatigue.md
@@ -73,12 +73,12 @@ Each pathway has different properties: They store different amounts of ATP and c
 
 #### 2.2.1 Anaerobic Pathway
 
-This pathway is essentially responsible for your short term stamina. It has a very small capacity of ATP available (2300 mmol), which is can provide a lot of ATP very fast (113.3 mmol/s), but also replenished very quickly (56.7 mmol/s). This pathway is pretty much what limits how long you can jog or sprint in one go, which is why we use it as an indicator for the stamina bar.
+This pathway is essentially responsible for your short term stamina. It has a very small capacity of ATP available (2300mmol), which is can provide a lot of ATP very fast (113.3mmol/s), but also replenished very quickly (56.7mmol/s). This pathway is pretty much what limits how long you can jog or sprint in one go, which is why we use it as an indicator for the stamina bar.
 
 
 #### 2.2.2 Aerobic Pathways
 
-The two aerobic pathways store way bigger amounts of ATP than the anaerobic one, the first one stores over 1700 times as much ATP (4000 mol) and the second one still over 36 times as much ATP (84 mol) as the anaerobic pathway. However, they can also provide (13.3 and 16.7 mmol) and replenish (6.6 and 5.83 mmol) a lot less ATP then the anaerobic pathway.
+The two aerobic pathways store way bigger amounts of ATP than the anaerobic one, the first one stores over 1700 times as much ATP (4000 mol) and the second one still over 36 times as much ATP (84 mol) as the anaerobic pathway. However, they can also provide (13.3 and 16.7mmol) and replenish (6.6 and 5.83mmol) a lot less ATP then the anaerobic pathway.
 
 This means that while these will last a lot longer, they do not have such a large impact on your short term performance. Instead, they will drain slowly during the day, which means that at the end you will have less power available than at the beginning, depending on how much you exhausted yourself. However, at that point they will start influencing your short term performance.
 

--- a/docs/wiki/framework/advanced-ballistics-framework.md
+++ b/docs/wiki/framework/advanced-ballistics-framework.md
@@ -28,11 +28,11 @@ Example: M4
 class CfgWeapons {
     class yourWeaponClass {
         // >1:7 inch rifle twist
-        // 7 inches * 25.4(mm/in) = 177.8 mm
+        // 7 inches * 25.4(mm/in) = 177.8mm
         // Same as the Capital T in [Miller twist rule](https://en.wikipedia.org/wiki/Miller_twist_rule){:target="_blank"} (convert to metric)
         ACE_barrelTwist = 177.8;
 
-        // >14.5 in (370 mm)
+        // >14.5 in (370mm)
         ACE_barrelLength = 368.3;
 
         // Right handed is 1, Left is -1, none is 0

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -2,18 +2,18 @@ class cfgMagazines {
     class CA_Magazine;
     class VehicleMagazine;
     class rhsusf_mag_40Rnd_46x30_AP: CA_Magazine {
-        descriptionShort = "Caliber: 4.6x30 mm<br/>Rounds: 40<br/>Used in: MP7A2";
+        descriptionShort = "Caliber: 4.6x30mm<br/>Rounds: 40<br/>Used in: MP7A2";
         initSpeed = 680; // according with the ACE_muzzleVelocities at 15°C, default RHS value 680.1
     };
     class rhsusf_mag_40Rnd_46x30_FMJ: CA_Magazine {
-        descriptionShort = "Caliber: 4.6x30 mm<br/>Rounds: 40<br/>Used in: MP7A2";
+        descriptionShort = "Caliber: 4.6x30mm<br/>Rounds: 40<br/>Used in: MP7A2";
         initSpeed = 620; // default RHS value according with the ACE_muzzleVelocities at 15°C
         lastRoundsTracer = 0;
         picture = "\rhsusf\addons\rhsusf_weapons2\glock17g4\data\rhs_mag1_glock17g4_ca.paa";
         tracersEvery = 0;
     };
     class rhsusf_mag_40Rnd_46x30_JHP: CA_Magazine {
-        descriptionShort = "Caliber: 4.6x30 mm<br/>Rounds: 40<br/>Used in: MP7A2";
+        descriptionShort = "Caliber: 4.6x30mm<br/>Rounds: 40<br/>Used in: MP7A2";
         initSpeed = 690; // according with the ACE_muzzleVelocities at 15°C, default RHS value 620
     };
     class rhs_mag_30Rnd_556x45_M855A1_Stanag;

--- a/optionals/tracers/stringtable.xml
+++ b/optionals/tracers/stringtable.xml
@@ -3,568 +3,568 @@
     <Package name="Tracers">
         <Container name="magazines">
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_green">
-                <English>5.56 mm 150Rnd Reload Tracer (Green) Mag</English>
-                <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Magazin</German>
+                <English>5.56mm 150Rnd Reload Tracer (Green) Mag</English>
+                <German>150 Schuss 5,56mm Nachlade-Leuchtspur (Grün) Magazin</German>
                 <Russian>Магазин 150 патр. 5.56 мм с послед. трас. (Зеленый)</Russian>
-                <Italian>5.56 mm 150 colpi ricarica traccianti (verdi) caricatore</Italian>
-                <Czech>5.56 mm 150 ranný zásobník, stopovka pro přebití (Zelená)</Czech>
+                <Italian>5.56mm 150 colpi ricarica traccianti (verdi) caricatore</Italian>
+                <Czech>5.56mm 150 ranný zásobník, stopovka pro přebití (Zelená)</Czech>
                 <Portuguese>Recarregar magazine de 150 balas tracejantes (verde)</Portuguese>
-                <Japanese>5.56 mm 150発入り 残通知 曳光弾 (緑) マガジン</Japanese>
+                <Japanese>5.56mm 150発入り 残通知 曳光弾 (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_yellow">
-                <English>5.56 mm 150Rnd Reload Tracer (Yellow) Mag</English>
-                <German>150 Schuss 5,56 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+                <English>5.56mm 150Rnd Reload Tracer (Yellow) Mag</English>
+                <German>150 Schuss 5,56mm Nachlade-Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 150 патр. 5.56 мм с послед. трас. (Желтый)</Russian>
-                <Italian>5.56 mm 150 colpi Ricarica traccianti (gialli) caricatore</Italian>
-                <Czech>5.56 mm 150 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
+                <Italian>5.56mm 150 colpi Ricarica traccianti (gialli) caricatore</Italian>
+                <Czech>5.56mm 150 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
                 <Portuguese>Recarregar magazine 150 balas tracejantes (Amarelo)</Portuguese>
-                <Japanese>5.56 mm 150発入り 残通知 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>5.56mm 150発入り 残通知 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_green">
-                <English>5.56 mm 150Rnd Tracer (Green) Mag</English>
-                <German>150 Schuss 5,56 mm Leuchtspur (Grün) Magazin</German>
+                <English>5.56mm 150Rnd Tracer (Green) Mag</English>
+                <German>150 Schuss 5,56mm Leuchtspur (Grün) Magazin</German>
                 <Russian>Магазин 150 патр. 5.56 мм трассирующих (Зеленый)</Russian>
-                <Italian>5.56 mm 150 colpi traccianti (verdi) caricatore</Italian>
-                <Czech>5.56 mm 150 ranný zásobník, stopovka (Zelená)</Czech>
+                <Italian>5.56mm 150 colpi traccianti (verdi) caricatore</Italian>
+                <Czech>5.56mm 150 ranný zásobník, stopovka (Zelená)</Czech>
                 <Portuguese>Magazine 5.56mm Tracejante (verde)</Portuguese>
-                <Japanese>5.56 mm 150発入り 曳光弾 (緑) マガジン</Japanese>
+                <Japanese>5.56mm 150発入り 曳光弾 (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_green_description">
-                <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
-                <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
+                <English>Caliber: 5.56x45mm Tracer - Green&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
+                <German>Kaliber: 5,56x45mm Leuchtspur - grün&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
                 <Russian>Калибр: 5.56x45 мм, трассер Зеленый&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: SPAR-16S</Russian>
-                <Italian>calibro: 5.56x46 mm traccianti - verdi&lt;br/&gt; Colpi: 150&lt;br/&gt; Usati in: SPAR-16S </Italian>
-                <Czech>Kalibr: 5.56×45 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: SPAR-16S</Czech>
+                <Italian>calibro: 5.56x46mm traccianti - verdi&lt;br/&gt; Colpi: 150&lt;br/&gt; Usati in: SPAR-16S </Italian>
+                <Czech>Kalibr: 5.56×45mm Stopovka - Zelená&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: SPAR-16S</Czech>
                 <Portuguese>Calibre 5.56x45mm Tracejante - Verde&lt;br/&gt;Balas:150&lt;br/&gt;Usado em: Spar-16S</Portuguese>
-                <Japanese>口径: 5.56x45 mm 曳光弾 - 緑&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: SPAR-16S</Japanese>
+                <Japanese>口径: 5.56x45mm 曳光弾 - 緑&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: SPAR-16S</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_yellow">
-                <English>5.56 mm 150Rnd Tracer (Yellow) Mag</English>
-                <German>150 Schuss 5,56 mm Leuchtspur (Gelb) Magazin</German>
+                <English>5.56mm 150Rnd Tracer (Yellow) Mag</English>
+                <German>150 Schuss 5,56mm Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 150 патр. 5.56 мм трассирующих (Желтый)</Russian>
-                <Italian>5.56 mm 150Colpi Traccianti (gialli) caricatore</Italian>
-                <Czech>5.56 mm 150 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Italian>5.56mm 150Colpi Traccianti (gialli) caricatore</Italian>
+                <Czech>5.56mm 150 ranný zásobník, stopovka (Žlutá)</Czech>
                 <Portuguese>Magazine 5.56mm 150 balas tracejante (amarelo)</Portuguese>
-                <Japanese>5.56 mm 150発入り 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>5.56mm 150発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_556x45_Drum_tracer_yellow_description">
-                <English>Caliber: 5.56x45 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
-                <German>Kaliber: 5,56x45 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
+                <English>Caliber: 5.56x45mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: SPAR-16S</English>
+                <German>Kaliber: 5,56x45mm Leuchtspur - gelb&lt;br /&gt;Schuss: 150&lt;br /&gt;Verwendet in: SPAR-16S</German>
                 <Russian>Калибр: 5.56x45 мм, трассер Желтый&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: SPAR-16S</Russian>
                 <Italian>calibro:5.56x45 traccianti - gialli &lt;br/&gt;Colpi:150&lt;br/&gt;Usati in: SPAR-16S</Italian>
-                <Czech>Kalibr: 5.56×45 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: SPAR-16S</Czech>
+                <Czech>Kalibr: 5.56×45mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: SPAR-16S</Czech>
                 <Portuguese>Calibre: 5.56x45mm Tracejante - Amarelo &lt;br/&gt;Balas:150&lt;br/&gt;Usado em:Spar-16S</Portuguese>
-                <Japanese>口径: 5.56x45 mm 曳光弾 - 黄&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: SPAR-16S</Japanese>
+                <Japanese>口径: 5.56x45mm 曳光弾 - 黄&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: SPAR-16S</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_green">
-                <English>5.56 mm 200Rnd Reload Tracer (Green) Box</English>
-                <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
+                <English>5.56mm 200Rnd Reload Tracer (Green) Box</English>
+                <German>200 Schuss 5,56mm Nachlade-Leuchtspur (Grün) Kasten</German>
                 <Russian>Короб 200 патр. 5.56 мм с послед. трас. (Зеленый)</Russian>
-                <Italian>5.56 mm 200colpi Ricarica traccianti (verdi) scatola</Italian>
-                <Czech>5.56 mm 200 ranný box, stopovka pro přebití (Zelená)</Czech>
+                <Italian>5.56mm 200colpi Ricarica traccianti (verdi) scatola</Italian>
+                <Czech>5.56mm 200 ranný box, stopovka pro přebití (Zelená)</Czech>
                 <Portuguese>Recarregar Caixa 5.56mm 200 Balas tracejantes (verdes)</Portuguese>
-                <Japanese>5.56 mm 200発入り 残通知 曳光弾 (緑) ボックス</Japanese>
+                <Japanese>5.56mm 200発入り 残通知 曳光弾 (緑) ボックス</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_tracer_green">
-                <English>5.56 mm 200Rnd Tracer (Green) Box</English>
-                <German>200 Schuss 5,56 mm Nachlade-Leuchtspur (Grün) Kasten</German>
+                <English>5.56mm 200Rnd Tracer (Green) Box</English>
+                <German>200 Schuss 5,56mm Nachlade-Leuchtspur (Grün) Kasten</German>
                 <Russian>Короб 200 патр. 5.56 мм трассирующих (Зеленый)</Russian>
-                <Italian>5.56 mm 200colpi Traccianti (verdi) Scatola</Italian>
-                <Czech>5.56 mm 200 ranný box, stopovka (Zelená)</Czech>
+                <Italian>5.56mm 200colpi Traccianti (verdi) Scatola</Italian>
+                <Czech>5.56mm 200 ranný box, stopovka (Zelená)</Czech>
                 <Portuguese>Caixa 5.56mm 200 balas tracejantes (verdes) </Portuguese>
-                <Japanese>5.56 mm 200発入り 曳光弾 (緑) ボックス</Japanese>
+                <Japanese>5.56mm 200発入り 曳光弾 (緑) ボックス</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_556x45_Box_tracer_green_description">
-                <English>Caliber: 5.56x45 mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
-                <German>Kaliber: 5,56x45 mm Leuchtspur - grün&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
+                <English>Caliber: 5.56x45mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: LIM-85</English>
+                <German>Kaliber: 5,56x45mm Leuchtspur - grün&lt;br /&gt;Schuss: 200&lt;br /&gt;Verwendet in: LIM-85</German>
                 <Russian>Калибр: 5.56x45 мм, трассер Зеленый&lt;br /&gt;Патронов: 200&lt;br /&gt;Используется в: LIM-85</Russian>
-                <Italian>Calibro: 5.56x45 mm Traccianti - Verdi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: LIM-85</Italian>
-                <Czech>Kalibr: 5.56×45 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: LIM-85</Czech>
-                <Portuguese>Calibre:5.56x45 mm Tracejante - Verde &lt;br/&gt;Balas: 200&lt;br/&gt;Usado em:LIM-85</Portuguese>
-                <Japanese>口径: 5.56x45 mm 曳光弾 - 緑&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: LIM-85</Japanese>
+                <Italian>Calibro: 5.56x45mm Traccianti - Verdi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: LIM-85</Italian>
+                <Czech>Kalibr: 5.56×45mm Stopovka - Zelená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: LIM-85</Czech>
+                <Portuguese>Calibre:5.56x45mm Tracejante - Verde &lt;br/&gt;Balas: 200&lt;br/&gt;Usado em:LIM-85</Portuguese>
+                <Japanese>口径: 5.56x45mm 曳光弾 - 緑&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: LIM-85</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_red">
-                <English>5.8 mm 30Rnd Reload Tracer (Red) Mag</English>
-                <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
+                <English>5.8mm 30Rnd Reload Tracer (Red) Mag</English>
+                <German>30 Schuss 5,8mm Nachlade-Leuchtspur (Rot) Magazin</German>
                 <Russian>Магазин 30 патр. 5.8 мм с послед. трас. (Красный)</Russian>
-                <Italian>5.8 mm 30Colpi Ricarica Tracciante (Rosso) Caricatore</Italian>
-                <Czech>5.8 mm 30 ranný zásobník, stopovka pro přebití (Červená)</Czech>
+                <Italian>5.8mm 30Colpi Ricarica Tracciante (Rosso) Caricatore</Italian>
+                <Czech>5.8mm 30 ranný zásobník, stopovka pro přebití (Červená)</Czech>
                 <Portuguese>Recarregar magazine 5.8mm 30 Balas tracejantes (vermelho)</Portuguese>
-                <Japanese>5.8 mm 30発入り 残通知 曳光弾 (赤) マガジン</Japanese>
+                <Japanese>5.8mm 30発入り 残通知 曳光弾 (赤) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_yellow">
-                <English>5.8 mm 30Rnd Reload Tracer (Yellow) Mag</English>
-                <German>30 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+                <English>5.8mm 30Rnd Reload Tracer (Yellow) Mag</English>
+                <German>30 Schuss 5,8mm Nachlade-Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 30 патр. 5.8 мм с послед. трас. (Желтый)</Russian>
-                <Italian>5.8 mm 30Colpi ricarica Traccianti (Giallo) Caricatore</Italian>
-                <Czech>5.8 mm 30 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
+                <Italian>5.8mm 30Colpi ricarica Traccianti (Giallo) Caricatore</Italian>
+                <Czech>5.8mm 30 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
                 <Portuguese>Recarregar magazine 5.8mm 30 Balas tracejantes (amarelo)</Portuguese>
-                <Japanese>5.8 mm 30発入り 残通知 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>5.8mm 30発入り 残通知 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_red">
-                <English>5.8 mm 30Rnd Tracer (Red) Mag</English>
-                <German>30 Schuss 5,8 mm Leuchtspur (Rot) Magazin</German>
+                <English>5.8mm 30Rnd Tracer (Red) Mag</English>
+                <German>30 Schuss 5,8mm Leuchtspur (Rot) Magazin</German>
                 <Russian>Магазин 30 патр. 5.8 мм трассирующих (Красный)</Russian>
-                <Italian>5.8 mm 30Colpi Traccianti (rossi) Caricatore</Italian>
-                <Czech>5.8 mm 30 ranný zásobník, stopovka (Červená)</Czech>
-                <Portuguese>Magazine 5.8 mm 30 balas tracejantes (vermelho)</Portuguese>
-                <Japanese>5.8 mm 30発入り 曳光弾 (赤) マガジン</Japanese>
+                <Italian>5.8mm 30Colpi Traccianti (rossi) Caricatore</Italian>
+                <Czech>5.8mm 30 ranný zásobník, stopovka (Červená)</Czech>
+                <Portuguese>Magazine 5.8mm 30 balas tracejantes (vermelho)</Portuguese>
+                <Japanese>5.8mm 30発入り 曳光弾 (赤) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_red_description">
-                <English>Caliber: 5.8x42 mm Tracer - Red&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
-                <German>Kaliber: 5,8x42 mm Leuchtspur - rot&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
+                <English>Caliber: 5.8x42mm Tracer - Red&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
+                <German>Kaliber: 5,8x42mm Leuchtspur - rot&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
                 <Russian>Калибр: 5.8x42 мм, трассер Красный&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: CAR-95, CAR-95 GL</Russian>
-                <Italian>Calibro: 5.8x42 mm Traccianti - Rossi&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: CAR-95, CAR-95 GL</Italian>
-                <Czech>Kalibr: 5.8×42 mm Stopovka - Červená&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: CAR-95, CAR-95 GL</Czech>
-                <Portuguese>Calibre: 5.8x42 mm Tracejante - Vermelho&lt;br/&gt;Balas:30&lt;br/&gt;Usado em CAR-95, CAR-95 GL</Portuguese>
-                <Japanese>口径: 5.8x42 mm 曳光弾 - 赤&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: CAR-95, CAR-95 GL</Japanese>
+                <Italian>Calibro: 5.8x42mm Traccianti - Rossi&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: CAR-95, CAR-95 GL</Italian>
+                <Czech>Kalibr: 5.8×42mm Stopovka - Červená&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: CAR-95, CAR-95 GL</Czech>
+                <Portuguese>Calibre: 5.8x42mm Tracejante - Vermelho&lt;br/&gt;Balas:30&lt;br/&gt;Usado em CAR-95, CAR-95 GL</Portuguese>
+                <Japanese>口径: 5.8x42mm 曳光弾 - 赤&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: CAR-95, CAR-95 GL</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_yellow">
-                <English>5.8 mm 30Rnd Tracer (Yellow) Mag</English>
-                <German>30 Schuss 5,8 mm Leuchtspur (Gelb) Magazin</German>
+                <English>5.8mm 30Rnd Tracer (Yellow) Mag</English>
+                <German>30 Schuss 5,8mm Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 30 патр. 5.8 мм трассирующих (Желтый)</Russian>
-                <Italian>5.8 mm 30Colpi Traccianti (Giallo) Caricatore</Italian>
-                <Czech>5.8 mm 30 ranný zásobník, stopovka (Žlutá)</Czech>
-                <Portuguese>Magazine 5.8 mm 30 balas tracejante (amarelo)</Portuguese>
-                <Japanese>5.8 mm 30発入り 曳光弾 (黄) マガジン</Japanese>
+                <Italian>5.8mm 30Colpi Traccianti (Giallo) Caricatore</Italian>
+                <Czech>5.8mm 30 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Portuguese>Magazine 5.8mm 30 balas tracejante (amarelo)</Portuguese>
+                <Japanese>5.8mm 30発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_580x42_Mag_tracer_yellow_description">
-                <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
-                <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
+                <English>Caliber: 5.8x42mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</English>
+                <German>Kaliber: 5,8x42mm Leuchtspur - gelb&lt;br /&gt;Schuss: 30&lt;br /&gt;Verwendet in: CAR-95, CAR-95 GL</German>
                 <Russian>Калибр: 5.8x42 мм, трассер Желтый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в: CAR-95, CAR-95 GL</Russian>
-                <Italian>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</Italian>
-                <Czech>Kalibr: 5.8×42 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: CAR-95, CAR-95 GL</Czech>
-                <Portuguese>Calibre: 5.8x42 mm Tracejante - Amarelo &lt;br/&gt;Balas: 30&lt;br/&gt;Usado em: CAR-95, CAR-95 GL</Portuguese>
-                <Japanese>口径: 5.8x42 mm 曳光弾 - 黄&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: CAR-95, CAR-95 GL</Japanese>
+                <Italian>Caliber: 5.8x42mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: CAR-95, CAR-95 GL</Italian>
+                <Czech>Kalibr: 5.8×42mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: CAR-95, CAR-95 GL</Czech>
+                <Portuguese>Calibre: 5.8x42mm Tracejante - Amarelo &lt;br/&gt;Balas: 30&lt;br/&gt;Usado em: CAR-95, CAR-95 GL</Portuguese>
+                <Japanese>口径: 5.8x42mm 曳光弾 - 黄&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: CAR-95, CAR-95 GL</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_red">
-                <English>5.8 mm 100Rnd Reload Tracer (Red) Mag</English>
-                <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Rot) Magazin</German>
+                <English>5.8mm 100Rnd Reload Tracer (Red) Mag</English>
+                <German>100 Schuss 5,8mm Nachlade-Leuchtspur (Rot) Magazin</German>
                 <Russian>Магазин 100 патр. 5.8 мм с послед. трас. (Красный)</Russian>
-                <Italian>5,8 mm 100Colpi Ricarica Tracciante (rosso) Caricatore</Italian>
-                <Czech>5.8 mm 100 ranný zásobník, stopovka pro přebití (Červená)</Czech>
-                <Portuguese>Recarregar magazine 5.8 mm 100 balas tracejante (vermelho)</Portuguese>
-                <Japanese>5.8 mm 100発入り 残通知 曳光弾 (赤) マガジン</Japanese>
+                <Italian>5,8mm 100Colpi Ricarica Tracciante (rosso) Caricatore</Italian>
+                <Czech>5.8mm 100 ranný zásobník, stopovka pro přebití (Červená)</Czech>
+                <Portuguese>Recarregar magazine 5.8mm 100 balas tracejante (vermelho)</Portuguese>
+                <Japanese>5.8mm 100発入り 残通知 曳光弾 (赤) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_yellow">
-                <English>5.8 mm 100Rnd Reload Tracer (Yellow) Mag</English>
-                <German>100 Schuss 5,8 mm Nachlade-Leuchtspur (Gelb) Magazin</German>
+                <English>5.8mm 100Rnd Reload Tracer (Yellow) Mag</English>
+                <German>100 Schuss 5,8mm Nachlade-Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 100 патр. 5.8 мм с послед. трас. (Желтый)</Russian>
-                <Italian>5.8 mm 100Colpi Ricarica Traccianti (gialli) Caricatore</Italian>
-                <Czech>5.8 mm 100 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
-                <Portuguese>Recarregar magazine 5.8 mm 100 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>5.8 mm 100発入り 残通知 曳光弾 (黄) マガジン</Japanese>
+                <Italian>5.8mm 100Colpi Ricarica Traccianti (gialli) Caricatore</Italian>
+                <Czech>5.8mm 100 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
+                <Portuguese>Recarregar magazine 5.8mm 100 balas tracejantes (amarelo)</Portuguese>
+                <Japanese>5.8mm 100発入り 残通知 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_red">
-                <English>5.8 mm 100Rnd Tracer (Red) Mag</English>
-                <German>100 Schuss 5,8 mm Leuchtspur (Rot) Magazin</German>
+                <English>5.8mm 100Rnd Tracer (Red) Mag</English>
+                <German>100 Schuss 5,8mm Leuchtspur (Rot) Magazin</German>
                 <Russian>Магазин 100 патр. 5.8 мм трассирующих (Красный)</Russian>
-                <Italian>5.8 mm 100Colpi Ricarica Traccianti (rossi) Caricatore</Italian>
-                <Czech>5.8 mm 100 ranný zásobník, stopovka (Červená)</Czech>
-                <Portuguese>Magazine 5.8 mm 100 balas tracejantes (vermelho)</Portuguese>
-                <Japanese>5.8 mm 100発入り 曳光弾 (赤) マガジン</Japanese>
+                <Italian>5.8mm 100Colpi Ricarica Traccianti (rossi) Caricatore</Italian>
+                <Czech>5.8mm 100 ranný zásobník, stopovka (Červená)</Czech>
+                <Portuguese>Magazine 5.8mm 100 balas tracejantes (vermelho)</Portuguese>
+                <Japanese>5.8mm 100発入り 曳光弾 (赤) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_red_description">
-                <English>Caliber: 5.8x42 mm Tracer - Red&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
-                <German>Kaliber: 5,8x42 mm Leuchtspur - rot&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
+                <English>Caliber: 5.8x42mm Tracer - Red&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
+                <German>Kaliber: 5,8x42mm Leuchtspur - rot&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
                 <Russian>Калибр: 5.8x42 мм, трассер Красный&lt;br /&gt;Патронов: 100&lt;br /&gt;Используется в: CAR-95, CAR-95 GL</Russian>
-                <Italian>Calibro: 5.8x42 mm Tracciante - Rosso&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: CAR-95-1</Italian>
-                <Czech>Kalibr: 5.8×42 mm Stopovka - Červená&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: CAR-95-1</Czech>
-                <Portuguese>Calibre: 5.8x42 mm Tracejante - Vermelho&lt;br/&gt;Balas:100&lt;br/&gt;Usado em CAR-95-1</Portuguese>
-                <Japanese>口径: 5.8x42 mm 曳光弾 - 赤&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: CAR-95-1</Japanese>
+                <Italian>Calibro: 5.8x42mm Tracciante - Rosso&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: CAR-95-1</Italian>
+                <Czech>Kalibr: 5.8×42mm Stopovka - Červená&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: CAR-95-1</Czech>
+                <Portuguese>Calibre: 5.8x42mm Tracejante - Vermelho&lt;br/&gt;Balas:100&lt;br/&gt;Usado em CAR-95-1</Portuguese>
+                <Japanese>口径: 5.8x42mm 曳光弾 - 赤&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: CAR-95-1</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_yellow">
-                <English>5.8 mm 100Rnd Tracer (Yellow) Mag</English>
-                <German>100 Schuss 5,8 mm Leuchtspur (Gelb) Magazin</German>
+                <English>5.8mm 100Rnd Tracer (Yellow) Mag</English>
+                <German>100 Schuss 5,8mm Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 100 патр. 5.8 мм трассирующих (Желтый)</Russian>
                 <Italian>5.8mm 100Colpi Traccianti (gialli) Caricatore</Italian>
-                <Czech>5.8 mm 100 ranný zásobník, stopovka (Žlutá)</Czech>
-                <Portuguese>Magazine 5.8 mm 100 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>5.8 mm 100発入り 曳光弾 (黄) マガジン</Japanese>
+                <Czech>5.8mm 100 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Portuguese>Magazine 5.8mm 100 balas tracejantes (amarelo)</Portuguese>
+                <Japanese>5.8mm 100発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_580x42_Drum_tracer_yellow_description">
-                <English>Caliber: 5.8x42 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
-                <German>Kaliber: 5,8x42 mm Leuchtspur - gelb&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
+                <English>Caliber: 5.8x42mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: CAR-95-1</English>
+                <German>Kaliber: 5,8x42mm Leuchtspur - gelb&lt;br /&gt;Schuss: 100&lt;br /&gt;Verwendet in: CAR-95-1</German>
                 <Russian>Калибр: 5.8x42 мм, трассер Желтый&lt;br /&gt;Патронов: 100&lt;br /&gt;Используется в: CAR-95, CAR-95 GL</Russian>
-                <Italian>Calibro: 5.8x42 mm Traccianti - Gialli&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: CAR-95-1</Italian>
-                <Czech>Kalibr: 5.8×42 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: CAR-95-1</Czech>
-                <Portuguese>Calibre: 5.8x42 mm Tracejante - Amarelo&lt;br/&gt;Balas:100&lt;br/&gt;Usado em CAR-95-1</Portuguese>
-                <Japanese>口径: 5.8x42 mm 曳光弾 - 黄&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: CAR-95-1</Japanese>
+                <Italian>Calibro: 5.8x42mm Traccianti - Gialli&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: CAR-95-1</Italian>
+                <Czech>Kalibr: 5.8×42mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: CAR-95-1</Czech>
+                <Portuguese>Calibre: 5.8x42mm Tracejante - Amarelo&lt;br/&gt;Balas:100&lt;br/&gt;Usado em CAR-95-1</Portuguese>
+                <Japanese>口径: 5.8x42mm 曳光弾 - 黄&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: CAR-95-1</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_green">
                 <English>6.5mm 30Rnd Reload Tracer (Green) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Grün) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм с послед. трас. (Зеленый)</Russian>
                 <Italian>6.5mm 30Colpi Ricarica Traccianti(verdi) Caricatore</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka pro přebití (Zelená)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka pro přebití (Zelená)</Czech>
                 <Portuguese>Recarregar magazine 6.5mm 30 balas tracejantes (verde)</Portuguese>
-                <Japanese>6.5 mm 30発入り 残通知 曳光弾 (緑) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 残通知 曳光弾 (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_green_description">
-                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
-                <German>Kaliber: 6.5x39 mm Nachlade-Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+                <English>Caliber: 6.5x39mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39mm Nachlade-Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Зеленый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в: MX/C/M/SW/3GL</Russian>
-                <Italian>Calibro: 6.5x39 mm Traccianti - Verdi&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante - Verde&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 緑&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
+                <Italian>Calibro: 6.5x39mm Traccianti - Verdi&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Zelená&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante - Verde&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 緑&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_yellow">
                 <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм с послед. трас. (Желтый)</Russian>
                 <Italian>6.5mm 30Colpi Ricarica Traccianti (Gialli) Caricatore</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
                 <Portuguese>Recarregar magazine 6.5mm 30 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>6.5 mm 30発入り 残通知 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 残通知 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_yellow_description">
-                <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
-                <German>Kaliber: 6.5x39 mm Nachlade-Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+                <English>Caliber: 6.5x39mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39mm Nachlade-Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Желтый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в: MX/C/M/SW/3GL</Russian>
-                <Italian>Calibro: 6.5x39 mm Tracciante - Giallo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante - Amarelo&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 黄&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
+                <Italian>Calibro: 6.5x39mm Tracciante - Giallo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante - Amarelo&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 黄&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_green">
                 <English>6.5mm 30Rnd Tracer (Green) Mag</English>
                 <German>30 Schuss 6.5mm Leuchtspur (Grün) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм трассирующих (Зеленый)</Russian>
                 <Italian>6.5mm 30Colpi Traccianti (Verdi) Caricatore</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka (Zelená)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka (Zelená)</Czech>
                 <Portuguese>Magazine 6.5mm 30 balas tracejantes (verde)</Portuguese>
-                <Japanese>6.5 mm 30発入り 曳光弾 (緑) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 曳光弾 (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_green_description">
-                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
-                <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+                <English>Caliber: 6.5x39mm Tracer - Green&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39mm Leuchtspur - Grün&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Зеленый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в: MX/C/M/SW/3GL</Russian>
-                <Italian>Calibro: 6.5x39 mm traccianti - Verdi&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante - Verde&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 緑&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
+                <Italian>Calibro: 6.5x39mm traccianti - Verdi&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Zelená&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante - Verde&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 緑&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_yellow">
                 <English>6.5mm 30Rnd Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм трассирующих (Желтый)</Russian>
                 <Italian>6.5mm 30 Colpi Traccianti (Gialli) Caricatore</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka (Žlutá)</Czech>
                 <Portuguese>Magazine 6.5mm 30 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>6.5 mm 30発入り 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_mx_tracer_yellow_description">
-                <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
-                <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
+                <English>Caliber: 6.5x39mm Tracer - Yellow&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: MX/C/M/SW/3GL</English>
+                <German>Kaliber: 6.5x39mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 30&lt;br /&gt;Verwendet in: MX/C/M/SW/3GL</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Желтый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в: MX/C/M/SW/3GL</Russian>
-                <Italian>Caliber: 6.5x39 mm Tracciante - Giallo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante - Amarelo&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 黄&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
+                <Italian>Caliber: 6.5x39mm Tracciante - Giallo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: MX/C/M/SW/3GL</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: MX/C/M/SW/3GL</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante - Amarelo&lt;br/&gt;Balas:30&lt;br/&gt;Usado em: MX/C/M/SW/3GL</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 黄&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: MX/C/M/SW/3GL</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_green">
                 <English>6.5mm 100Rnd Mixed Mag (Green)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (grün)</German>
                 <Russian>Магазин 100 патр. 6.5 мм TE4 (Зеленый)</Russian>
                 <Italian>6.5mm 100Colpi Misti Caricatore (verdi)</Italian>
-                <Czech>6.5 mm 100 ranný zásobník, částečná stopovka (Zelená)</Czech>
+                <Czech>6.5mm 100 ranný zásobník, částečná stopovka (Zelená)</Czech>
                 <Portuguese>Magazine 6.5mm 100 balas misturadas (verde)</Portuguese>
-                <Japanese>6.5 mm 100発入り 混合 (緑) マガジン</Japanese>
+                <Japanese>6.5mm 100発入り 混合 (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_yellow">
                 <English>6.5mm 100Rnd Mixed Mag (Yellow)</English>
                 <German>100 Schuss 6.5mm Magazin gemischt (gelb)</German>
                 <Russian>Магазин 100 патр. 6.5 мм TE4 (Желтый)</Russian>
                 <Italian>6.5mm 100Colpi Misti Caricatore (gialli)</Italian>
-                <Czech>6.5 mm 100 ranný zásobník, částečná stopovka (Žlutá)</Czech>
+                <Czech>6.5mm 100 ranný zásobník, částečná stopovka (Žlutá)</Czech>
                 <Portuguese>Magazine 6.5mm 100 balas misturadas (amarelo)</Portuguese>
-                <Japanese>6.5 mm 100発入り 混合 (黄) マガジン</Japanese>
+                <Japanese>6.5mm 100発入り 混合 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_green">
                 <English>6.5mm 100Rnd Mag Tracer (Green)</English>
                 <German>100 Schuss 6.5mm Magazin Leuchtspur (Grün)</German>
                 <Russian>Магазин 100 патр. 6.5 мм трассирующих (Зеленый)</Russian>
                 <Italian>6.5mm 100Colpi Caricatore Tracciante (verde)</Italian>
-                <Czech>6.5 mm 100 ranný zásobník, stopovka (Zelená)</Czech>
+                <Czech>6.5mm 100 ranný zásobník, stopovka (Zelená)</Czech>
                 <Portuguese>Magazine 6.5mm 100 balas tracejantes</Portuguese>
-                <Japanese>6.5 mm 100発入り (緑) マガジン</Japanese>
+                <Japanese>6.5mm 100発入り (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_green_description">
-                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
-                <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
+                <English>Caliber: 6.5x39mm Tracer - Green&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
+                <German>Kaliber: 6.5x39mm Leuchtspur - Grün&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Зеленый&lt;br /&gt;Патронов: 100&lt;br /&gt;Используется в: MX SW</Russian>
-                <Italian>Calibro: 6.5x39 mm Traccianti - Verdi&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: MX SW</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: MX SW</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante - Verde&lt;br/&gt;Balas: 100&lt;br/&gt;Usado em: MX SW</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 緑&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: MX SW</Japanese>
+                <Italian>Calibro: 6.5x39mm Traccianti - Verdi&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: MX SW</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Zelená&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: MX SW</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante - Verde&lt;br/&gt;Balas: 100&lt;br/&gt;Usado em: MX SW</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 緑&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: MX SW</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_yellow">
                 <English>6.5mm 100Rnd Mag Tracer (Yellow)</English>
                 <German>100 Schuss 6.5mm Magazin Leuchtspur (Gelb)</German>
                 <Russian>Магазин 100 патр. 6.5 мм трассирующих (Желтый)</Russian>
                 <Italian>6.5mm 100Colpi Caricatore Traccianti (giallo)</Italian>
-                <Czech>6.5 mm 100 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Czech>6.5mm 100 ranný zásobník, stopovka (Žlutá)</Czech>
                 <Portuguese>Magazine 6.5mm 100 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>6.5 mm 100発入り 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>6.5mm 100発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_100Rnd_65x39_mx_tracer_yellow_description">
-                <English>Caliber: 6.5x39 mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
-                <German>Kaliber: 6.5x39 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
+                <English>Caliber: 6.5x39mm Tracer - Yellow&lt;br /&gt;Rounds: 100&lt;br /&gt;Used in: MX SW</English>
+                <German>Kaliber: 6.5x39mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 100&lt;br /&gt;Verwendet in: MX SW</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Желтый&lt;br /&gt;Патронов: 100&lt;br /&gt;Используется в: MX SW</Russian>
-                <Italian>Calibro: 6.5x39 mm Traccianti -  Gialli&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: MX SW</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: MX SW</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante - Amarelo&lt;br/&gt;Balas: 100&lt;br/&gt;Usado em: MX SW</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 黄&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: MX SW</Japanese>
+                <Italian>Calibro: 6.5x39mm Traccianti -  Gialli&lt;br /&gt;Colpi: 100&lt;br /&gt;Usati in: MX SW</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 100&lt;br /&gt;Použito v: MX SW</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante - Amarelo&lt;br/&gt;Balas: 100&lt;br/&gt;Usado em: MX SW</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 黄&lt;br /&gt;弾数: 100&lt;br /&gt;使用武器: MX SW</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_red">
                 <English>6.5mm 30Rnd Reload Tracer (Red) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Rot) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм с послед. трас. (Красный)</Russian>
                 <Italian>6.5mm 30Colpi Ricarica Traccianti (Rossi) Caricatore </Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka pro přebití (Červená)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka pro přebití (Červená)</Czech>
                 <Portuguese>Recarregar magazine 6.5mm 30 balas tracejantes (vermelho)</Portuguese>
-                <Japanese>6.5 mm 30発入り 残通知 曳光弾 (赤) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 残通知 曳光弾 (赤) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_yellow">
                 <English>6.5mm 30Rnd Reload Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Nachlade-Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм с послед. трас. (Желтый)</Russian>
                 <Italian>6.5mm 30Colpi Ricarica Traccianti (gialli) Caricatore</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka pro přebití (Žlutá)</Czech>
                 <Portuguese>Recarregar magazine 6.5mm 30 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>6.5 mm 30発入り 残通知 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 残通知 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_red">
                 <English>6.5mm 30Rnd Tracer (Red) Mag</English>
                 <German>30 Schuss 6.5mm Leuchtspur (Rot) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм трассирующих (Красный)</Russian>
                 <Italian>6.5mm 30Colpi Traccianti (rossi) Caricatori</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka (Červená)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka (Červená)</Czech>
                 <Portuguese>Magazine 6.5mm 30 balas tracejantes (vermelho)</Portuguese>
-                <Japanese>6.5 mm 30発入り 曳光弾 (赤) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 曳光弾 (赤) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_red_description">
-                <English>Caliber: 6.5x39 mm Tracer (Red) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
+                <English>Caliber: 6.5x39mm Tracer (Red) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
                 <German>Kaliber: 6,5x39mm Leuchtspur (Rot) ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Красный безгильзовый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в:  Katiba, Type 115</Russian>
-                <Italian>Calibro: 6.5x39 mm Traccianti (Rossi) - Senza Bossolo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: Katiba, Type 115</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Červená - Beznábojnicová&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: Katiba, Type 115</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Tracejante (Vermelho) - Sem Cartucho&lt;br/&gt;Balas: 30&lt;br/&gt;Usado em: Katiba, Type 115</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 赤 (ケースレス)&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: Katiba, Type 115</Japanese>
+                <Italian>Calibro: 6.5x39mm Traccianti (Rossi) - Senza Bossolo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: Katiba, Type 115</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Červená - Beznábojnicová&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: Katiba, Type 115</Czech>
+                <Portuguese>Calibre: 6.5x39mm Tracejante (Vermelho) - Sem Cartucho&lt;br/&gt;Balas: 30&lt;br/&gt;Usado em: Katiba, Type 115</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 赤 (ケースレス)&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: Katiba, Type 115</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_yellow">
                 <English>6.5mm 30Rnd Tracer (Yellow) Mag</English>
                 <German>30 Schuss 6.5mm Leuchtspur (Gelb) Magazin</German>
                 <Russian>Магазин 30 патр. 6.5 мм трассирующих (Желтый)</Russian>
                 <Italian>6.5mm 30 Colpi Traccianti (gialli) Caricatore</Italian>
-                <Czech>6.5 mm 30 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Czech>6.5mm 30 ranný zásobník, stopovka (Žlutá)</Czech>
                 <Portuguese>Magazine 6.5mm 30 balas tracejantes (amarelo)</Portuguese>
-                <Japanese>6.5 mm 30発入り 曳光弾 (黄) マガジン</Japanese>
+                <Japanese>6.5mm 30発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_30Rnd_65x39_katiba_tracer_yellow_description">
-                <English>Caliber: 6.5x39 mm Tracer (Yellow) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
+                <English>Caliber: 6.5x39mm Tracer (Yellow) - Caseless&lt;br /&gt;Rounds: 30&lt;br /&gt;Used in: Katiba, Type 115</English>
                 <German>Kaliber: 6,5x39mm Leuchtspur (Rot) ‒ hülsenlos&lt;br /&gt;Patronen: 30&lt;br /&gt;Eingesetzt von: Katiba, Typ 115</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Желтый безгильзовый&lt;br /&gt;Патронов: 30&lt;br /&gt;Используется в:  Katiba, Type 115</Russian>
-                <Italian>Calibro: 6.5x39 mm Traccianti (Gialli) - Senza Bossolo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: Katiba, Type 115</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Žlutá - Beznábojnicová&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: Katiba, Type 115</Czech>
-                <Portuguese>Caliber: 6.5x39 mm Tracejante (Vermelho) - Sem Cartucho&lt;br/&gt;Balas: 30&lt;br/&gt;Usado em: Katiba, Type 115</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 黄 (ケースレス)&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: Katiba, Type 115</Japanese>
+                <Italian>Calibro: 6.5x39mm Traccianti (Gialli) - Senza Bossolo&lt;br /&gt;Colpi: 30&lt;br /&gt;Usati in: Katiba, Type 115</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Žlutá - Beznábojnicová&lt;br /&gt;Nábojů: 30&lt;br /&gt;Použito v: Katiba, Type 115</Czech>
+                <Portuguese>Caliber: 6.5x39mm Tracejante (Vermelho) - Sem Cartucho&lt;br/&gt;Balas: 30&lt;br/&gt;Usado em: Katiba, Type 115</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 黄 (ケースレス)&lt;br /&gt;弾数: 30&lt;br /&gt;使用武器: Katiba, Type 115</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_green">
-                <English>6.5 mm 200Rnd Belt Case Mixed (Green)</English>
-                <German>6,5 mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
+                <English>6.5mm 200Rnd Belt Case Mixed (Green)</English>
+                <German>6,5mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
                 <Russian>Короб 200 патр. 6.5 мм TE4 (Зеленый)</Russian>
                 <Italian>6.5mm 200Colpi Caricatore esteso Misti (Verdi)</Italian>
-                <Czech>6.5 mm 200 ranný pás, částečná stopovka (Zelená)</Czech>
-                <Portuguese>Caixa de Cinto 6.5 mm 200 Balas Misturados (Verde) </Portuguese>
-                <Japanese>6.5 mm 200発入り 混合 (緑) ベルト ケース </Japanese>
+                <Czech>6.5mm 200 ranný pás, částečná stopovka (Zelená)</Czech>
+                <Portuguese>Caixa de Cinto 6.5mm 200 Balas Misturados (Verde) </Portuguese>
+                <Japanese>6.5mm 200発入り 混合 (緑) ベルト ケース </Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_green_description">
-                <English>Caliber: 6.5x39 mm Mixed - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
-                <German>Kaliber: 6.5x39 mm Gemischt - Grün&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+                <English>Caliber: 6.5x39mm Mixed - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39mm Gemischt - Grün&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
                 <Russian>Калибр: 6.5x39 мм, трассер каждый 4 Зеленый&lt;br /&gt;Патронов: 200&lt;br /&gt;Используется в: Mk200</Russian>
-                <Italian>Calibro: 6.5x39 mm Misti - Verdi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: Mk200</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
-                <Portuguese>Calibre: 6.5x39 mm Misturado - Verde&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
-                <Japanese>口径: 6.5x39 mm 混合 - 緑&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
+                <Italian>Calibro: 6.5x39mm Misti - Verdi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: Mk200</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Zelená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
+                <Portuguese>Calibre: 6.5x39mm Misturado - Verde&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
+                <Japanese>口径: 6.5x39mm 混合 - 緑&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_red">
-                <English>6.5 mm 200Rnd Belt Case Mixed (Red)</English>
-                <German>6,5 mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
+                <English>6.5mm 200Rnd Belt Case Mixed (Red)</English>
+                <German>6,5mm 200-Schuss-Gurtkiste Gemischt (grün)</German>
                 <Russian>Короб 200 патр. 6.5 мм TE4 (Красный)</Russian>
-                <Italian>6.5 mm 200Colpi Caritore maggiorato Misti (rossi)</Italian>
-                <Czech>6.5 mm 200 ranný pás, částečná stopovka (Červená)</Czech>
-                <Portuguese>Caixa de Cinto 6.5 mm 200 balas misturadas (Vermelho)</Portuguese>
-                <Japanese>6.5 mm 200発入り 混合 (赤) ベルト ケース </Japanese>
+                <Italian>6.5mm 200Colpi Caritore maggiorato Misti (rossi)</Italian>
+                <Czech>6.5mm 200 ranný pás, částečná stopovka (Červená)</Czech>
+                <Portuguese>Caixa de Cinto 6.5mm 200 balas misturadas (Vermelho)</Portuguese>
+                <Japanese>6.5mm 200発入り 混合 (赤) ベルト ケース </Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_red_description">
-                <English>Caliber: 6.5x39 mm Mixed - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
-                <German>Kaliber: 6.5x39 mm Mixed - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+                <English>Caliber: 6.5x39mm Mixed - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39mm Mixed - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
                 <Russian>Калибр: 6.5x39 мм, трассер каждый 4 Красный&lt;br /&gt;Патронов: 200&lt;br /&gt;Используется в: Mk200</Russian>
-                <Italian>Calibro: 6.5x39 mm Misti - Rossi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: Mk200</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Červená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
-                <Portuguese>Caliber: 6.5x39 mm Misturado - Vermelho&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
-                <Japanese>口径: 6.5x39 mm 混合 - 赤&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
+                <Italian>Calibro: 6.5x39mm Misti - Rossi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: Mk200</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Červená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
+                <Portuguese>Caliber: 6.5x39mm Misturado - Vermelho&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
+                <Japanese>口径: 6.5x39mm 混合 - 赤&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_green">
-                <English>6.5 mm 200Rnd Belt Case Tracer (Green)</English>
-                <German>6,5 mm 200-Schuss-Gurtkiste Leuchtspur (grün)</German>
+                <English>6.5mm 200Rnd Belt Case Tracer (Green)</English>
+                <German>6,5mm 200-Schuss-Gurtkiste Leuchtspur (grün)</German>
                 <Russian>Короб 200 патр. 6.5 мм трассирующих (Зеленый)</Russian>
-                <Italian>6.5 mm 200Colpi Caricatore maggiorato Traccianti (verdi)</Italian>
-                <Czech>6.5 mm 200 ranný pás, částečná stopovka (Zelená)</Czech>
-                <Portuguese>Caixa de Cinto 6;5 mm 200 balas tracejantes (Verde)</Portuguese>
-                <Japanese>6.5 mm 200発入り 混合 (緑) ベルト ケース </Japanese>
+                <Italian>6.5mm 200Colpi Caricatore maggiorato Traccianti (verdi)</Italian>
+                <Czech>6.5mm 200 ranný pás, částečná stopovka (Zelená)</Czech>
+                <Portuguese>Caixa de Cinto 6;5mm 200 balas tracejantes (Verde)</Portuguese>
+                <Japanese>6.5mm 200発入り 混合 (緑) ベルト ケース </Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_green_description">
-                <English>Caliber: 6.5x39 mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
-                <German>Kaliber: 6.5x39 mm Leuchtspur - Grün&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+                <English>Caliber: 6.5x39mm Tracer - Green&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39mm Leuchtspur - Grün&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Зеленый&lt;br /&gt;Патронов: 200&lt;br /&gt;Используется в: Mk200</Russian>
-                <Italian>Calibri: 6.5x39 mm Traccianti - Verdi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati In: Mk200</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Zelená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
-                <Polish>Kaliber: 6.5x39 mm Smugowa - Zielona&lt;br /&gt;Sztuk: 200&lt;br /&gt;Używana w: Mk200</Polish>
-                <Portuguese>Caliber: 6.5x39 mm Tracejante - Verde&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 緑&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
+                <Italian>Calibri: 6.5x39mm Traccianti - Verdi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati In: Mk200</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Zelená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
+                <Polish>Kaliber: 6.5x39mm Smugowa - Zielona&lt;br /&gt;Sztuk: 200&lt;br /&gt;Używana w: Mk200</Polish>
+                <Portuguese>Caliber: 6.5x39mm Tracejante - Verde&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 緑&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_red">
-                <English>6.5 mm 200Rnd Belt Case Tracer (Red)</English>
-                <German>6,5 mm 200-Schuss-Gurtkiste Leuchtspur (rot)</German>
+                <English>6.5mm 200Rnd Belt Case Tracer (Red)</English>
+                <German>6,5mm 200-Schuss-Gurtkiste Leuchtspur (rot)</German>
                 <Russian>Короб 200 патр. 6.5 мм трассирующих (Красный)</Russian>
-                <Italian>6.5 mm 200Colpi Caricatore Maggiorato Tracciante (rossi)</Italian>
-                <Czech>6.5 mm 200 ranný pás, stopovka (Červená)</Czech>
-                <Polish>6.5 mm Magazynek pudełkowy 200szt. Smugowa (Czerwona)</Polish>
-                <Portuguese>Caixa de Cinto 6.5 mm 200 Balas Tracejantes (Vermelho)</Portuguese>
-                <Japanese>6.5 mm 200発入り 曳光弾 (赤) ベルト ケース </Japanese>
+                <Italian>6.5mm 200Colpi Caricatore Maggiorato Tracciante (rossi)</Italian>
+                <Czech>6.5mm 200 ranný pás, stopovka (Červená)</Czech>
+                <Polish>6.5mm Magazynek pudełkowy 200szt. Smugowa (Czerwona)</Polish>
+                <Portuguese>Caixa de Cinto 6.5mm 200 Balas Tracejantes (Vermelho)</Portuguese>
+                <Japanese>6.5mm 200発入り 曳光弾 (赤) ベルト ケース </Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_200Rnd_65x39_cased_Box_tracer_red_description">
-                <English>Caliber: 6.5x39 mm Tracer - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
-                <German>Kaliber: 6.5x39 mm Leuchtspur - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
+                <English>Caliber: 6.5x39mm Tracer - Red&lt;br /&gt;Rounds: 200&lt;br /&gt;Used in: Mk200</English>
+                <German>Kaliber: 6.5x39mm Leuchtspur - Rot&lt;br /&gt;Patronen: 200&lt;br /&gt;Verwendet in: Mk200</German>
                 <Russian>Калибр: 6.5x39 мм, трассер Красный&lt;br /&gt;Патронов: 200&lt;br /&gt;Используется в: Mk200</Russian>
-                <Italian>Calibro: 6.5x39 mm Traccianti - Rossi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: Mk200</Italian>
-                <Czech>Kalibr: 6.5×39 mm Stopovka - Červená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
-                <Polish>Kaliber: 6.5x39 mm Smugowa - Czerwona&lt;br /&gt;Sztuk: 200&lt;br /&gt;Używana w: Mk200</Polish>
-                <Portuguese>Caliber: 6.5x39 mm Tracejante - Vermelho&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
-                <Japanese>口径: 6.5x39 mm 曳光弾 - 赤&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
+                <Italian>Calibro: 6.5x39mm Traccianti - Rossi&lt;br /&gt;Colpi: 200&lt;br /&gt;Usati in: Mk200</Italian>
+                <Czech>Kalibr: 6.5×39mm Stopovka - Červená&lt;br /&gt;Nábojů: 200&lt;br /&gt;Použito v: Mk200</Czech>
+                <Polish>Kaliber: 6.5x39mm Smugowa - Czerwona&lt;br /&gt;Sztuk: 200&lt;br /&gt;Używana w: Mk200</Polish>
+                <Portuguese>Caliber: 6.5x39mm Tracejante - Vermelho&lt;br/&gt;Balas: 200&lt;br/&gt;Usado em: Mk200</Portuguese>
+                <Japanese>口径: 6.5x39mm 曳光弾 - 赤&lt;br /&gt;弾数: 200&lt;br /&gt;使用武器: Mk200</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_green">
-                <English>7.62 mm 20Rnd Tracer (Green) Mag</English>
-                <German>7,62 mm 20-Schuss-Magazin Leuchtspur (Grün)</German>
+                <English>7.62mm 20Rnd Tracer (Green) Mag</English>
+                <German>7,62mm 20-Schuss-Magazin Leuchtspur (Grün)</German>
                 <Russian>Магазин 20 патр. 7.62 мм трассирующих (Зеленый)</Russian>
-                <Italian>7.62 mm 20Colpi Traccianti (verdi) Caricatore</Italian>
-                <Czech>7.62 mm 20 ranný zásobník, stopovka (Zelená)</Czech>
-                <Polish>7.62 mm Magazynek 20szt. Smugowa (Zielona)</Polish>
-                <Portuguese>Magazine 7.62 mm 20 Balas Tracejantes (verdes)</Portuguese>
-                <Japanese>7.62 mm 20発入り 曳光弾 (緑) マガジン</Japanese>
+                <Italian>7.62mm 20Colpi Traccianti (verdi) Caricatore</Italian>
+                <Czech>7.62mm 20 ranný zásobník, stopovka (Zelená)</Czech>
+                <Polish>7.62mm Magazynek 20szt. Smugowa (Zielona)</Polish>
+                <Portuguese>Magazine 7.62mm 20 Balas Tracejantes (verdes)</Portuguese>
+                <Japanese>7.62mm 20発入り 曳光弾 (緑) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_green_description">
-                <English>Caliber: 7.62x51 mm NATO Tracer - Green&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
-                <German>Kaliber: 7,62x51 mm NATO Leuchtspur - grün&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
-                <Russian>Калибр: 7.62x51 mm NATO, трассер Зеленый&lt;br /&gt;Патронов: 20&lt;br /&gt;Используется в:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Russian>
-                <Italian>Calibro: 7.62x51 mm NATO Traccianti - Verdi&lt;br /&gt;Colpi: 20&lt;br /&gt;Usati in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Italian>
-                <Czech>Kalibr: 7.62×51 mm NATO Stopovka - Zelená&lt;br /&gt;Nábojů: 20&lt;br /&gt;Použito v: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Czech>
-                <Polish>Kaliber: 7.62x51 mm NATO Smugowa - Zielona&lt;br /&gt;Sztuk: 20&lt;br /&gt;Używana w:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Polish>
-                <Portuguese>Calibre: 7.62x51 mm NATO Tracejante - Verde&lt;br/&gt;Balas: 20&lt;br/&gt;Usado em: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Portuguese>
-                <Japanese>口径: 7.62x51 mm NATO 曳光弾 - 緑&lt;br /&gt;弾数: 20&lt;br /&gt;使用武器: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Japanese>
+                <English>Caliber: 7.62x51mm NATO Tracer - Green&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
+                <German>Kaliber: 7,62x51mm NATO Leuchtspur - grün&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
+                <Russian>Калибр: 7.62x51mm NATO, трассер Зеленый&lt;br /&gt;Патронов: 20&lt;br /&gt;Используется в:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Russian>
+                <Italian>Calibro: 7.62x51mm NATO Traccianti - Verdi&lt;br /&gt;Colpi: 20&lt;br /&gt;Usati in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Italian>
+                <Czech>Kalibr: 7.62×51mm NATO Stopovka - Zelená&lt;br /&gt;Nábojů: 20&lt;br /&gt;Použito v: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Czech>
+                <Polish>Kaliber: 7.62x51mm NATO Smugowa - Zielona&lt;br /&gt;Sztuk: 20&lt;br /&gt;Używana w:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Polish>
+                <Portuguese>Calibre: 7.62x51mm NATO Tracejante - Verde&lt;br/&gt;Balas: 20&lt;br/&gt;Usado em: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Portuguese>
+                <Japanese>口径: 7.62x51mm NATO 曳光弾 - 緑&lt;br /&gt;弾数: 20&lt;br /&gt;使用武器: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_yellow">
-                <English>7.62 mm 20Rnd Tracer (Yellow) Mag</English>
-                <German>7,62 mm 20-Schuss-Magazin Leuchtspur (Gelb)</German>
+                <English>7.62mm 20Rnd Tracer (Yellow) Mag</English>
+                <German>7,62mm 20-Schuss-Magazin Leuchtspur (Gelb)</German>
                 <Russian>Магазин 20 патр. 7.62 мм трассирующих (Желтый)</Russian>
-                <Italian>7.62 mm 20Colpi Traccianti (Gialli) Caricatori</Italian>
-                <Czech>7.62 mm 20 ranný zásobník, stopovka (Žlutá)</Czech>
-                <Polish>7.62 mm Magazynek 20szt. Smugowa (Żółta)</Polish>
-                <Portuguese>Magazine 7.62 mm 20 Balas Tracejantes (Amarelo)</Portuguese>
-                <Japanese>7.62 mm 20発入り 曳光弾 (黄) マガジン</Japanese>
+                <Italian>7.62mm 20Colpi Traccianti (Gialli) Caricatori</Italian>
+                <Czech>7.62mm 20 ranný zásobník, stopovka (Žlutá)</Czech>
+                <Polish>7.62mm Magazynek 20szt. Smugowa (Żółta)</Polish>
+                <Portuguese>Magazine 7.62mm 20 Balas Tracejantes (Amarelo)</Portuguese>
+                <Japanese>7.62mm 20発入り 曳光弾 (黄) マガジン</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_20Rnd_762x51_Mag_Tracer_yellow_description">
-                <English>Caliber: 7.62x51 mm NATO Tracer - Yellow&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
-                <German>Kaliber: 7,62x51 mm NATO Leuchtspur - gelb&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
-                <Russian>Калибр: 7.62x51 mm NATO, трассер Желтый&lt;br /&gt;Патронов: 20&lt;br /&gt;Используется в:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Russian>
-                <Italian>Calibro: 7.62x51 mm NATO Traccianti - Gialli&lt;br /&gt;Colpi: 20&lt;br /&gt;Usati in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Italian>
-                <Czech>Kalibr: 7.62×51 mm NATO Stopovka - Žlutá&lt;br /&gt;Nábojů: 20&lt;br /&gt;Použito v: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Czech>
-                <Polish>Kaliber: 7.62x51 mm NATO Smugowa - Żółta&lt;br /&gt;Sztuk: 20&lt;br /&gt;Używana w:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Polish>
-                <Portuguese>Calibre: 7.62x51 mm NATO Tracejante - Amarelo&lt;br/&gt;Balas: 20&lt;br/&gt;Usado em: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Portuguese>
-                <Japanese>口径: 7.62x51 mm NATO 曳光弾 - 黄&lt;br /&gt;弾数: 20&lt;br /&gt;使用武器: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Japanese>
+                <English>Caliber: 7.62x51mm NATO Tracer - Yellow&lt;br /&gt;Rounds: 20&lt;br /&gt;Used in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</English>
+                <German>Kaliber: 7,62x51mm NATO Leuchtspur - gelb&lt;br /&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</German>
+                <Russian>Калибр: 7.62x51mm NATO, трассер Желтый&lt;br /&gt;Патронов: 20&lt;br /&gt;Используется в:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Russian>
+                <Italian>Calibro: 7.62x51mm NATO Traccianti - Gialli&lt;br /&gt;Colpi: 20&lt;br /&gt;Usati in: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Italian>
+                <Czech>Kalibr: 7.62×51mm NATO Stopovka - Žlutá&lt;br /&gt;Nábojů: 20&lt;br /&gt;Použito v: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Czech>
+                <Polish>Kaliber: 7.62x51mm NATO Smugowa - Żółta&lt;br /&gt;Sztuk: 20&lt;br /&gt;Używana w:  Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Polish>
+                <Portuguese>Calibre: 7.62x51mm NATO Tracejante - Amarelo&lt;br/&gt;Balas: 20&lt;br/&gt;Usado em: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Portuguese>
+                <Japanese>口径: 7.62x51mm NATO 曳光弾 - 黄&lt;br /&gt;弾数: 20&lt;br /&gt;使用武器: Mk18 ABR, Mk-I EMR, Mk14, SPAR-17</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_red">
                 <English>7.62mm 150Rnd Box Mixed (Red)</English>
                 <German>7.62mm 150 Schuss Kiste Gemischt (rot)</German>
                 <Russian>Короб 150 патр. 7.62 мм TE4 (Красный)</Russian>
                 <Italian>7.62mm 150Colpi Caricatore Maggiorato Misti (rossi)</Italian>
-                <Czech>7.62 mm 150 ranný pás, částečná stopovka (Červená)</Czech>
-                <Polish>7.62 mm Magazynek pudełkowy 150szt. Mieszana (Czerwona)</Polish>
+                <Czech>7.62mm 150 ranný pás, částečná stopovka (Červená)</Czech>
+                <Polish>7.62mm Magazynek pudełkowy 150szt. Mieszana (Czerwona)</Polish>
                 <Portuguese>Caixa 7.62mm 150 Balas Misturadas (Vermelho)</Portuguese>
-                <Japanese>7.62 mm 150発入り 混合 (緑) ボックス</Japanese>
+                <Japanese>7.62mm 150発入り 混合 (緑) ボックス</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_yellow">
                 <English>7.62mm 150Rnd Box Mixed (Yellow)</English>
                 <German>7.62mm 150 Schuss Kiste Gemischt (gelb)</German>
                 <Russian>Короб 150 патр. 7.62 мм TE4 (Желтый)</Russian>
                 <Italian>7.62mm 150Colpi Caricatore Maggiorato Misti (Gialli)</Italian>
-                <Czech>7.62 mm 150 ranný pás, částečná stopovka (Žlutá)</Czech>
-                <Polish>7.62 mm Magazynek pudełkowy 150szt. Mieszana (Żółta)</Polish>
+                <Czech>7.62mm 150 ranný pás, částečná stopovka (Žlutá)</Czech>
+                <Polish>7.62mm Magazynek pudełkowy 150szt. Mieszana (Żółta)</Polish>
                 <Portuguese>Caixa 7.62mm 150 Balas Misturadas (Amarelo)</Portuguese>
-                <Japanese>7.62 mm 150発入り 混合 (黄) ボックス</Japanese>
+                <Japanese>7.62mm 150発入り 混合 (黄) ボックス</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_red">
                 <English>7.62mm 150Rnd Box Tracer (Red)</English>
                 <German>7.62mm 150 Schuss Kiste Leuchtspur (rot)</German>
                 <Russian>Короб 150 патр. 7.62 мм трассирующих (Красный)</Russian>
                 <Italian>7.62mm 150Colpi Caricatore Maggiorato (Rossi)</Italian>
-                <Czech>7.62 mm 150 ranný pás, stopovka (Červená)</Czech>
+                <Czech>7.62mm 150 ranný pás, stopovka (Červená)</Czech>
                 <Polish>7.62mm Magazynek pudełkowy 150szt. Smugowa (Czerwona)</Polish>
                 <Portuguese>Caixa 7.62mm 150 Balas Misturadas (Vermelho)</Portuguese>
-                <Japanese>7.62 mm 150発入り 曳光弾 (赤) ボックス</Japanese>
+                <Japanese>7.62mm 150発入り 曳光弾 (赤) ボックス</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_red_description">
-                <English>Caliber: 7.62x54 mm Tracer - Red&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
-                <German>Kaliber: 7.62x54 mm Leuchtspur - Rot&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
-                <Russian>Калибр: 7.62x51 mm NATO, трассер Красный&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: Zafir</Russian>
-                <Italian>Calibro: 7.62x54 mm Traccianti - Rossi&lt;br /&gt;Colpi: 150&lt;br /&gt;Usati in: Zafir</Italian>
-                <Czech>Kalibr: 7.62×54 mm Stopovka - Červená&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: Zafir</Czech>
-                <Polish>Kaliber: 7.62x54 mm Smugowa - Czerwona&lt;br /&gt;Sztuk: 150&lt;br /&gt;Używana w: Zafir</Polish>
-                <Portuguese>Calibre: 7.62x54 mm Tracejante - Vermelho&lt;br/&gt;Balas: 150&lt;br/&gt;Usado em:Zafir</Portuguese>
-                <Japanese>口径: 7.62x54 mm 曳光弾 - 赤&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: ザフィル</Japanese>
+                <English>Caliber: 7.62x54mm Tracer - Red&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
+                <German>Kaliber: 7.62x54mm Leuchtspur - Rot&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
+                <Russian>Калибр: 7.62x51mm NATO, трассер Красный&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: Zafir</Russian>
+                <Italian>Calibro: 7.62x54mm Traccianti - Rossi&lt;br /&gt;Colpi: 150&lt;br /&gt;Usati in: Zafir</Italian>
+                <Czech>Kalibr: 7.62×54mm Stopovka - Červená&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: Zafir</Czech>
+                <Polish>Kaliber: 7.62x54mm Smugowa - Czerwona&lt;br /&gt;Sztuk: 150&lt;br /&gt;Używana w: Zafir</Polish>
+                <Portuguese>Calibre: 7.62x54mm Tracejante - Vermelho&lt;br/&gt;Balas: 150&lt;br/&gt;Usado em:Zafir</Portuguese>
+                <Japanese>口径: 7.62x54mm 曳光弾 - 赤&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: ザフィル</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_yellow">
                 <English>7.62mm 150Rnd Box Tracer (Yellow)</English>
                 <German>7.62mm 150 Schuss Kiste Leuchtspur (Rot)</German>
                 <Russian>Короб 150 патр. 7.62 мм трассирующих (Желтый)</Russian>
                 <Italian>7.62mm 150Colpi Caricatore Maggiorato Traccianti (gialli)</Italian>
-                <Czech>7.62 mm 150 ranný pás, stopovka (Žlutá)</Czech>
-                <Polish>7.62 mm Magazynek pudełkowy 150szt. Smugowa (Żółta)</Polish>
+                <Czech>7.62mm 150 ranný pás, stopovka (Žlutá)</Czech>
+                <Polish>7.62mm Magazynek pudełkowy 150szt. Smugowa (Żółta)</Polish>
                 <Portuguese>Caixa 7.62mm 150 Balas Tracejantes (Amarelo)</Portuguese>
-                <Japanese>7.62 mm 150発入り 曳光弾 (緑) ボックス</Japanese>
+                <Japanese>7.62mm 150発入り 曳光弾 (緑) ボックス</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_762x54_Box_Tracer_yellow_description">
-                <English>Caliber: 7.62x54 mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
-                <German>Kaliber: 7.62x54 mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
-                <Russian>Калибр: 7.62x51 mm NATO, трассер Желтый&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: Zafir</Russian>
-                <Italian>Calibro: 7.62x54 mm Traccianti - Gialli&lt;br /&gt;Colpi: 150&lt;br /&gt;Usati in: Zafir</Italian>
-                <Czech>Kalibr: 7.62×54 mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: Zafir</Czech>
-                <Polish>Kaliber: 7.62x54 mm Smugowa - Żółta&lt;br /&gt;Sztuk: 150&lt;br /&gt;Używana w: Zafir</Polish>
-                <Portuguese>Calibre: 7.62x54 mm Tracejante - Amarelo&lt;br/&gt;Balas: 150&lt;br/&gt;Usado em:Zafir</Portuguese>
-                <Japanese>口径: 7.62x54 mm 曳光弾 - 黄&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: ザフィル</Japanese>
+                <English>Caliber: 7.62x54mm Tracer - Yellow&lt;br /&gt;Rounds: 150&lt;br /&gt;Used in: Zafir</English>
+                <German>Kaliber: 7.62x54mm Leuchtspur - Gelb&lt;br /&gt;Patronen: 150&lt;br /&gt;Verwendet in: Zafir</German>
+                <Russian>Калибр: 7.62x51mm NATO, трассер Желтый&lt;br /&gt;Патронов: 150&lt;br /&gt;Используется в: Zafir</Russian>
+                <Italian>Calibro: 7.62x54mm Traccianti - Gialli&lt;br /&gt;Colpi: 150&lt;br /&gt;Usati in: Zafir</Italian>
+                <Czech>Kalibr: 7.62×54mm Stopovka - Žlutá&lt;br /&gt;Nábojů: 150&lt;br /&gt;Použito v: Zafir</Czech>
+                <Polish>Kaliber: 7.62x54mm Smugowa - Żółta&lt;br /&gt;Sztuk: 150&lt;br /&gt;Używana w: Zafir</Polish>
+                <Portuguese>Calibre: 7.62x54mm Tracejante - Amarelo&lt;br/&gt;Balas: 150&lt;br/&gt;Usado em:Zafir</Portuguese>
+                <Japanese>口径: 7.62x54mm 曳光弾 - 黄&lt;br /&gt;弾数: 150&lt;br /&gt;使用武器: ザフィル</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_yellow">
                 <English>9.3mm 150Rnd Belt Mixed (Yellow)</English>
                 <German>9.3mm 150 Schuss Gurt gemischt (Gelb)</German>
                 <Russian>Лента 150 патр. 9.3 мм TE4 (Желтый)</Russian>
                 <Italian>9.3mm 150Colpi Caricatore Maggiorato (Giallo)</Italian>
-                <Czech>9.3 mm 150 ranný pás, částečná stopovka (Žlutá)</Czech>
-                <Polish>9.3 mm Taśma 150szt. Mieszana (Żółta)</Polish>
+                <Czech>9.3mm 150 ranný pás, částečná stopovka (Žlutá)</Czech>
+                <Polish>9.3mm Taśma 150szt. Mieszana (Żółta)</Polish>
                 <Portuguese>Cinto 9.3mm 150 Balas Misturadas (Amarelo)</Portuguese>
-                <Japanese>9.3 mm 150発入り 混合 (黄) ベルト</Japanese>
+                <Japanese>9.3mm 150発入り 混合 (黄) ベルト</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_150Rnd_93x64_Mag_red">
                 <English>9.3mm 150Rnd Belt Mixed (Red)</English>
                 <German>9.3mm 150 Schuss Gurt gemischt (Rot)</German>
                 <Russian>Лента 150 патр. 9.3 мм TE4 (Красный)</Russian>
                 <Italian>9.3mm 150Colpi Caricatore Maggiorato (Rosso)</Italian>
-                <Czech>9.3 mm 150 ranný pás, částečná stopovka (Červená)</Czech>
-                <Polish>9.3 mm Taśma 150szt. Mieszana (Czerwona)</Polish>
+                <Czech>9.3mm 150 ranný pás, částečná stopovka (Červená)</Czech>
+                <Polish>9.3mm Taśma 150szt. Mieszana (Czerwona)</Polish>
                 <Portuguese>Cinto 9.3mm 150 Balas Misturadas (Vermelho)</Portuguese>
-                <Japanese>9.3 mm 150発入り 混合 (赤) ベルト</Japanese>
+                <Japanese>9.3mm 150発入り 混合 (赤) ベルト</Japanese>
             </Key>
             <Key ID="STR_ACE_Tracers_130Rnd_338_Mag_yellow">
                 <English>.338 NM 130Rnd Belt Mixed (Yellow)</English>


### PR DESCRIPTION
**When merged this pull request will:**
- No more "82 mm" or similar, all replaced with "82mm"
- I ran a `([.\d]+)\smm` -> `$1mm`  find and replace

Notes:
This seems to be the more widely used option, ACE is already mostly using the "no space" version, CUP is entirely without spaces