### PR TITLE
Reload - Fix display ammo count in vehicle

### DIFF
--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -63,13 +63,12 @@ if (hasInterface && {!(_typeOf in GVAR(initializedStaticTypes))}) then {
         [_typeOf, 0, ["ACE_MainActions"], _disassembleAction] call EFUNC(interact_menu,addActionToClass);
     };
 
-    if (GVAR(ammoHandling) == 0) exitWith {};
 
     private _ammoActionPath = [];
     private _magazineLocation = getText (configFile >> "CfgVehicles" >> _typeOf >> QUOTE(ADDON) >> "magazineLocation");
     private _condition = { //IGNORE_PRIVATE_WARNING ["_target", "_player"];
-        // If weapon assembly/disassembly is enabled we enable ammo handling
-        if !([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3])) exitWith { false };
+        // If magazine handling is enabled or weapon assembly/disassembly is enabled we enable ammo handling
+        if ((GVAR(ammoHandling) == 0) && {!([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3]))}) exitWith { false };
         [_player, _target, ["isNotSwimming", "isNotSitting"]] call EFUNC(common,canInteractWith)
     };
     private _childenCode = {

--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -63,12 +63,13 @@ if (hasInterface && {!(_typeOf in GVAR(initializedStaticTypes))}) then {
         [_typeOf, 0, ["ACE_MainActions"], _disassembleAction] call EFUNC(interact_menu,addActionToClass);
     };
 
+    if (GVAR(ammoHandling) == 0) exitWith {};
 
     private _ammoActionPath = [];
     private _magazineLocation = getText (configFile >> "CfgVehicles" >> _typeOf >> QUOTE(ADDON) >> "magazineLocation");
     private _condition = { //IGNORE_PRIVATE_WARNING ["_target", "_player"];
-        // If magazine handling is enabled or weapon assembly/disassembly is enabled we enable ammo handling
-        if ((GVAR(ammoHandling) == 0) && {!([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3]))}) exitWith { false };
+        // If weapon assembly/disassembly is enabled we enable ammo handling
+        if !([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3])) exitWith { false };
         [_player, _target, ["isNotSwimming", "isNotSitting"]] call EFUNC(common,canInteractWith)
     };
     private _childenCode = {

--- a/addons/reload/CfgEventHandlers.hpp
+++ b/addons/reload/CfgEventHandlers.hpp
@@ -20,7 +20,15 @@ class Extended_PostInit_EventHandlers {
 class Extended_Take_EventHandlers {
     class CAManBase {
         class ACE_AmmoIndicatorReload {
-            clientTake = QUOTE(params ['_unit']; if (_unit == ACE_player && {GVAR(DisplayText)} && {(_this select 1) in [ARR_3(uniformContainer _unit, vestContainer _unit, backpackContainer _unit)]} && {_this select 2 == currentMagazine _unit}) then {[ARR_2(_unit, vehicle _unit)] call FUNC(displayAmmo)};);
+            clientTake = QUOTE( \
+                params [ARR_3('_unit', '_container', '_item')]; \
+                if ( \
+                    _unit == ACE_player \
+                    && {GVAR(DisplayText)} \
+                    && {_container in [ARR_3(uniformContainer _unit, vestContainer _unit, backpackContainer _unit)]} \
+                    && {_item == currentMagazine _unit} \
+                ) then {_unit call DFUNC(displayAmmo)}; \
+            );
         };
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- title;
- ~~fix no `Check ammo` interaction on statics when CSW ammo handling is disabled;~~
- fix and improve `Take` EH;
- optimize fnc_displayAmmo.

When drag magazine to your weapon in gear in vehicle it will display empty ammo count. To fix it `weaponState` should be used instead of `currentWeapon`, `currentMuzzle` and `currentMagazine`.