### PR TITLE
Compat_rhs_gref3 - Add RHS:GREF explosives compatibility

### DIFF
--- a/optionals/compat_rhs_gref3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_gref3/CfgAmmo.hpp
@@ -106,4 +106,9 @@ class CfgAmmo {
     class rhs_mine_stockmine43_4m_ammo: rhs_mine_stockmine43_2m_ammo {
         ace_explosives_defuseObjectPosition[] = {-2, 0, 0.25};
     };
+
+    class DemoCharge_Remote_Ammo;
+    class rhs_charge_M2tet_x2_ammo: DemoCharge_Remote_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0.095, 0, 0.055};
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_gref3/CfgAmmo.hpp
@@ -38,4 +38,29 @@ class CfgAmmo {
     class rhs_mine_a200_dz35_ammo: rhs_mine_a200_bz_ammo {
         ace_explosives_defuseObjectPosition[] = {0, 0, 0.02};
     };
+
+    class rhs_mine_glasmine43_hz_ammo: APERSMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.015};
+    };
+
+    class rhs_mine_glasmine43_bz_ammo: rhs_mine_glasmine43_hz_ammo {
+        ace_minedetector_detectable = 0;
+    };
+
+    class rhs_mine_bounding_trigger_base;
+    class rhs_mine_m2a3b_press_ammo: rhs_mine_bounding_trigger_base {
+        ace_explosives_defuseObjectPosition[] = {0, 0.046, 0.02};
+    };
+
+    class rhs_mine_m2a3b_wire_ammo: rhs_mine_m2a3b_press_ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0.046, 0.125};
+    };
+
+    class rhs_mine_M3_pressure_ammo: APERSMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.015};
+    };
+    
+    class rhs_mine_M3_tripwire_ammo: rhs_mine_M3_pressure_ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.055};
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_gref3/CfgAmmo.hpp
@@ -80,4 +80,30 @@ class CfgAmmo {
     class rhs_mine_Mk2_tripwire_ammo: rhs_mine_Mk2_pressure_ammo {
         ace_explosives_defuseObjectPosition[] = {0, 0, 0.055};
     };
+
+    class APERSBoundingMine_Range_Ammo;
+    class rhs_mine_smine35_press_ammo: APERSBoundingMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.03};
+    };
+
+    class rhs_mine_smine35_trip_ammo: rhs_mine_bounding_trigger_base {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.04};
+    };
+
+    class rhs_mine_smine44_trip_ammo: rhs_mine_smine35_trip_ammo {
+        ace_explosives_defuseObjectPosition[] = {-0.03, 0, 0.015};
+    };
+
+    class rhs_mine_smine44_press_ammo: APERSBoundingMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {-0.02, 0, 0.02};
+    };
+
+    class APERSTripMine_Wire_Ammo;
+    class rhs_mine_stockmine43_2m_ammo: APERSTripMine_Wire_Ammo {
+        ace_explosives_defuseObjectPosition[] = {-1, 0, 0.25};
+    };
+
+    class rhs_mine_stockmine43_4m_ammo: rhs_mine_stockmine43_2m_ammo {
+        ace_explosives_defuseObjectPosition[] = {-2, 0, 0.25};
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_gref3/CfgAmmo.hpp
@@ -52,8 +52,8 @@ class CfgAmmo {
         ace_explosives_defuseObjectPosition[] = {0, 0.046, 0.02};
     };
 
-    class rhs_mine_m2a3b_wire_ammo: rhs_mine_m2a3b_press_ammo {
-        ace_explosives_defuseObjectPosition[] = {0, 0.046, 0.125};
+    class rhs_mine_m2a3b_trip_ammo: rhs_mine_m2a3b_press_ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0.046, 0.055};
     };
 
     class rhs_mine_M3_pressure_ammo: APERSMine_Range_Ammo {
@@ -61,6 +61,23 @@ class CfgAmmo {
     };
     
     class rhs_mine_M3_tripwire_ammo: rhs_mine_M3_pressure_ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.055};
+    };
+
+    class ATMine_Range_Ammo;
+    class rhs_mine_TM43_ammo: ATMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.072};
+    };
+
+    class rhs_mine_M7A2_ammo: APERSMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.067};
+    };
+
+    class rhs_mine_Mk2_pressure_ammo: APERSMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.02};
+    };
+
+    class rhs_mine_Mk2_tripwire_ammo: rhs_mine_Mk2_pressure_ammo {
         ace_explosives_defuseObjectPosition[] = {0, 0, 0.055};
     };
 };

--- a/optionals/compat_rhs_gref3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_gref3/CfgAmmo.hpp
@@ -28,4 +28,14 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={785, 800, 815};
         ACE_barrelLengths[]={508.0, 599.948, 660.4};
     };
+
+    // ACE Explosives
+    class APERSMine_Range_Ammo;
+    class rhs_mine_a200_bz_ammo: APERSMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.035};
+    };
+
+    class rhs_mine_a200_dz35_ammo: rhs_mine_a200_bz_ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.02};
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_gref3/CfgMagazines.hpp
@@ -185,4 +185,20 @@ class CfgMagazines {
             };
         };
     };
+
+    class DemoCharge_Remote_Mag;
+    class rhs_charge_M2tet_x2_mag: DemoCharge_Remote_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_charge_M2tet_x2";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch"};
+            class Timer {
+                FuseTime = 0.5;
+            };
+            class Command {
+                FuseTime = 0.5;
+            };
+            class MK16_Transmitter: Command {};
+            class DeadmanSwitch: Command {};
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_gref3/CfgMagazines.hpp
@@ -125,4 +125,64 @@ class CfgMagazines {
             };
         };
     };
+
+    class rhs_mine_smine35_press_mag: APERSBoundingMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_smine35_press";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.18;
+            };
+        };
+    };
+
+    class rhs_mine_smine35_trip_mag: rhs_mine_smine35_press_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_smine35_trip";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0;
+            };
+        };
+    };
+
+    class rhs_mine_smine44_trip_mag: APERSBoundingMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_smine44_trip";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0;
+            };
+        };
+    };
+
+    class rhs_mine_smine44_press_mag: rhs_mine_smine44_trip_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_smine44_press";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.175;
+            };
+        };
+    };
+
+    class rhs_mine_stockmine43_2m_mag: APERSTripMine_Wire_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_stockmine43_2m";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0.25;
+            };
+        };
+    };
+
+    class rhs_mine_stockmine43_4m_mag: rhs_mine_stockmine43_2m_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_stockmine43_4m";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0.25;
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_gref3/CfgMagazines.hpp
@@ -6,4 +6,26 @@ class CfgMagazines {
     class rhsgref_296Rnd_792x57_SmE_belt: CA_Magazine {
         ACE_isBelt = 1;
     };
+
+    // ACE Explosives
+    class APERSMine_Range_Mag;
+    class rhs_mine_a200_bz_mag: APERSMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_a200_bz";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.05;
+            };
+        };
+    };
+
+    class rhs_mine_a200_dz35_mag: rhs_mine_a200_bz_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_a200_dz35";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.04;
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_gref3/CfgMagazines.hpp
@@ -84,4 +84,45 @@ class CfgMagazines {
             };
         };
     };
+
+    class ATMine_Range_Mag;
+    class rhs_mine_TM43_mag: ATMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_TM43";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.057;
+            };
+        };
+    };
+
+    class rhs_mine_M7A2_mag: APERSMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_M7A2";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.062;
+            };
+        };
+    };
+
+    class rhs_mine_mk2_pressure_mag: APERSMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_mk2_pressure";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0;
+            };
+        };
+    };
+
+    class rhs_mine_Mk2_tripwire_mag: APERSTripMine_Wire_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_Mk2_tripwire";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0;
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_gref3/CfgMagazines.hpp
@@ -28,4 +28,60 @@ class CfgMagazines {
             };
         };
     };
+
+    class rhs_mine_glasmine43_hz_mag: APERSMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_glasmine43_hz";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.01;
+            };
+        };
+    };
+
+    class rhs_mine_glasmine43_bz_mag: rhs_mine_glasmine43_hz_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_glasmine43_bz";
+    };
+
+    class APERSBoundingMine_Range_Mag;
+    class rhs_mine_m2a3b_press_mag: APERSBoundingMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_m2a3b_press";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.185;
+            };
+        };
+    };
+
+    class rhs_mine_m2a3b_trip_mag: rhs_mine_m2a3b_press_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_m2a3b_trip";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0.13;
+            };
+        };
+    };
+
+    class rhs_mine_m3_pressure_mag: APERSMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_m3_pressure";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = -0.015;
+            };
+        };
+    };
+
+    class APERSTripMine_Wire_Mag;
+    class rhs_mine_M3_tripwire_mag: APERSTripMine_Wire_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_M3_tripwire";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0;
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/CfgVehicles.hpp
@@ -208,4 +208,14 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhs_charge_M2tet_x2: ACE_Explosives_Place {
+        displayName = "Tetrytol Charge (2.5lb Placed)";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M2_TETRYTOL_x2\M2TET_x2_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[-0.125, 0, 0.055]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/CfgVehicles.hpp
@@ -148,4 +148,64 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhs_mine_smine35_press: ACE_Explosives_Place {
+        displayName = "S.Mi.35 (S.Mi.Z.35) APB Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Smine35\SMI35_ITEM_PRESS";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.217]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_smine35_trip: ACE_Explosives_Place {
+        displayName = "S.Mi.35 (W) APB Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Smine35\SMI35_HELPER_TRIP";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.02]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_smine44_trip: ACE_Explosives_Place {
+        displayName = "S.Mi.44 (W) APB Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Smine44\SMI44_HELPER_TRIP";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0.03, 0, 0.015]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_smine44_press: ACE_Explosives_Place {
+        displayName = "S.Mi.44 (S.Mi.Z.44) APB Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Smine44\SMI44_ITEM_PRESS";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0.02, 0, 0.21]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_stockmine43_2m: ACE_Explosives_Place {
+        displayName = "St.Mi.43/I (2m) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Stockmine43\STMI43_HELPER_2M";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[1, 0, 0.25]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_stockmine43_4m: ACE_Explosives_Place {
+        displayName = "St.Mi.43/II (4m) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Stockmine43\STMI43_HELPER_4M";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[2, 0, 0.25]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/CfgVehicles.hpp
@@ -53,4 +53,59 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhs_mine_glasmine43_hz: ACE_Explosives_Place {
+        displayName = "Gl.Mi.43 (H.Z.44) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Glasmine43\GLMI43_HZ_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.105]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_glasmine43_bz: ACE_Explosives_Place_rhs_mine_glasmine43_hz {
+        displayName = "Gl.Mi.43 (B.Z.) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\Glasmine43\GLMI43_BZ_ITEM";
+    };
+
+    class ACE_Explosives_Place_rhs_mine_m2a3b_press: ACE_Explosives_Place {
+        displayName = "M2A3B APB Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M2A3B\M2A3_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[-0.052, 0, 0.225]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_m2a3b_trip: ACE_Explosives_Place_rhs_mine_m2a3b_press {
+        displayName = "M2A3B (Tripwire) APB Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M2A3B\M2A3_HELPER_TRIPWIRE";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, -0.046, 0.06]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_m3_pressure: ACE_Explosives_Place {
+        displayName = "M3 AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M3\M3_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.23]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_M3_tripwire: ACE_Explosives_Place_rhs_mine_m3_pressure {
+        displayName = "M3 (Tripwire) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M3\M6M7FUZE_HELPER_TRIPWIRE";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.055]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/CfgVehicles.hpp
@@ -108,4 +108,44 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhs_mine_TM43: ACE_Explosives_Place {
+        displayName = "Tellermine 43";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\TM43\TM43";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.072]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_M7A2: ACE_Explosives_Place {
+        displayName = "M7A2 AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M7A2\M7A2_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.066]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_mk2_pressure: ACE_Explosives_Place {
+        displayName = "Mk 2 AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\MKII_BOOBYTRAP\MKII_TRAP_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[-0.09, 0, 0.011]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_Mk2_tripwire: ACE_Explosives_Place {
+        displayName = "Mk 2 (Tripwire) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\M3\M6M7FUZE_HELPER_TRIPWIRE";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.055]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/CfgVehicles.hpp
@@ -25,4 +25,32 @@ class CfgVehicles {
             disassembleTurret = QEGVAR(csw,kordTripodLow);
         };
     };
+
+    // ACE Explosives
+    class Items_base_F;
+    class ACE_Explosives_Place: Items_base_F {
+        class ACE_Actions {
+            class ACE_MainActions;
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_a200_bz: ACE_Explosives_Place {
+        displayName = "Beh.Schu.Mi.A200 (B.Z.) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\A200\A200_BZ_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.095]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhs_mine_a200_dz35: ACE_Explosives_Place_rhs_mine_a200_bz {
+        displayName = "Beh.Schu.Mi.A200 (D.Z.35) AP Mine";
+        model = "\rhsgref\addons\rhsgref_weapons2\mines\A200\A200_DZ35_ITEM";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.125]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_gref3/config.cpp
+++ b/optionals/compat_rhs_gref3/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_csw", "rhsgref_main", "rhsgref_c_weapons"};
+        requiredAddons[] = {"ace_explosives", "ace_csw", "rhsgref_main", "rhsgref_c_weapons"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror", "Ruthberg", "Anton"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
**When merged this pull request will:**
- Add **RHS:GREF** compatibility with `ACE Explosives`

Linked to issue #7714

_Note:_ None of the classes had stringtable entries, so `displayName` attributes are the hardcoded values from **RHS:GREF** config 😒 