### PR TITLE
Compat_rhs_usf3 - Improve RHS:USAF explosives compatibility

### DIFF
--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -1,4 +1,3 @@
-
 class CfgAmmo {
     class BulletBase;
     class B_127x99_Ball;
@@ -315,5 +314,10 @@ class CfgAmmo {
 
     class rhsusf_mine_m14_ammo: MineBase {
         ace_explosives_defuseObjectPosition[] = {-0.02, -0.015, 0.02};
+    };
+
+    class APERSMine_Range_Ammo;
+    class rhsusf_mine_m49a1_3m_ammo: APERSMine_Range_Ammo {
+        ace_explosives_defuseObjectPosition[] = {0, 0.016, 0.296};
     };
 };

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -298,22 +298,22 @@ class CfgAmmo {
         ACE_caliber = 9;
     };
 
+    // ACE Explosives
     class PipeBombBase;
     class rhsusf_m112_ammo: PipeBombBase {
-        ace_explosives_magazine = "rhsusf_m112_mag";
-        ace_explosives_Explosive = "rhsusf_m112_ammo_scripted";
-        ace_explosives_size = 0;
-        ace_explosives_defuseObjectPosition[] = {-0.155,0,0.01};
-        soundActivation[] = {"", 0, 0, 0};
-        soundDeactivation[] = {"", 0, 0, 0};
+        ace_explosives_defuseObjectPosition[] = {0.055, 0, 0.038};
     };
 
     class rhsusf_m112x4_ammo: PipeBombBase {
-        ace_explosives_magazine = "rhsusf_m112x4_mag";
-        ace_explosives_Explosive = "rhsusf_m112x4_ammo_scripted";
-        ace_explosives_size = 0;
-        ace_explosives_defuseObjectPosition[] = {-0.155,0.025,0.01};
-        soundActivation[] = {"", 0, 0, 0};
-        soundDeactivation[] = {"", 0, 0, 0};
+        ace_explosives_defuseObjectPosition[] = {0.055, -0.025, 0.102};
+    };
+
+    class MineBase;
+    class rhsusf_mine_m19_ammo: MineBase {
+        ace_explosives_defuseObjectPosition[] = {0, 0.02, 0.046};
+    };
+
+    class rhsusf_mine_m14_ammo: MineBase {
+        ace_explosives_defuseObjectPosition[] = {-0.02, -0.015, 0.02};
     };
 };

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -56,10 +56,11 @@ class cfgMagazines {
         ammo = "ACE_Hellfire_AGM114L";
     };
 
+    // ACE Explosives
     class rhsusf_m112_mag: CA_Magazine {
         ace_explosives_DelayTime = 1;
         ace_explosives_Placeable = 1;
-        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_m112_DemoCharge";
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_explosive_m112";
         useAction = 0;
         class ACE_Triggers {
             SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch"};
@@ -75,26 +76,12 @@ class cfgMagazines {
     };
 
     class rhsusf_m112x4_mag: rhsusf_m112_mag {
-        ace_explosives_DelayTime = 1;
-        ace_explosives_Placeable = 1;
-        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_m112x4_DemoCharge";
-        useAction = 0;
-        class ACE_Triggers {
-            SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch"};
-            class Timer {
-                FuseTime = 0.5;
-            };
-            class Command {
-                FuseTime = 0.5;
-            };
-            class MK16_Transmitter: Command {};
-            class DeadmanSwitch: Command {};
-        };
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_explosive_m112x4";
     };
 
     class ATMine_Range_Mag;
     class rhs_mine_M19_mag: ATMine_Range_Mag {
-        ace_explosives_SetupObject = "ACE_Explosives_Place_rhs_mine_M19_Mine";
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_mine_M19";
         class ACE_Triggers {
             SupportedTriggers[] = {"PressurePlate"};
             class PressurePlate {
@@ -104,7 +91,7 @@ class cfgMagazines {
     };
 
     class rhsusf_mine_m14_mag: ATMine_Range_Mag {
-        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_mine_m14_mag_Mine";
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_mine_m14";
         class ACE_Triggers {
             SupportedTriggers[] = {"PressurePlate"};
             class PressurePlate {

--- a/optionals/compat_rhs_usf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_usf3/CfgMagazines.hpp
@@ -100,6 +100,24 @@ class cfgMagazines {
         };
     };
 
+    class rhsusf_mine_m49a1_3m_mag: ATMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_mine_m49a1_3m";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+            class Tripwire {
+                digDistance = 0.125;
+            };
+        };
+    };
+
+    class rhsusf_mine_m49a1_6m_mag: rhsusf_mine_m49a1_3m_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_mine_m49a1_6m";
+    };
+
+    class rhsusf_mine_m49a1_10m_mag: rhsusf_mine_m49a1_3m_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhsusf_mine_m49a1_10m";
+    };
+
    // RHS magazines for crew handled ammo
     class rhs_mag_TOW;
     class GVAR(mag_TOW): rhs_mag_TOW {

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -428,4 +428,24 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhsusf_mine_m49a1_3m: ACE_Explosives_Place {
+        displayName = "M49A1 (3m)";
+        model = "\rhsusf\addons\rhsusf_weapons\mines\rhsusf_m49a1_a_e";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, -0.016, 0.296]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhsusf_mine_m49a1_6m: ACE_Explosives_Place_rhsusf_mine_m49a1_3m {
+        displayName = "M49A1 (6m)";
+        model = "\rhsusf\addons\rhsusf_weapons\mines\rhsusf_m49a1_b_e";
+    };
+
+    class ACE_Explosives_Place_rhsusf_mine_m49a1_10m: ACE_Explosives_Place_rhsusf_mine_m49a1_3m {
+        displayName = "M49A1 (10m)";
+        model = "\rhsusf\addons\rhsusf_weapons\mines\rhsusf_m49a1_c_e";
+    };
 };

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -388,42 +388,43 @@ class CfgVehicles {
         };
     };
 
-    class ACE_Explosives_Place_rhsusf_m112_DemoCharge: ACE_Explosives_Place {
+    // ACE Explosives
+    class ACE_Explosives_Place_rhsusf_explosive_m112: ACE_Explosives_Place {
         displayName = "$STR_RHSUSF_M112_EXPLOSIVE_DISPLAY_NAME";
         model = "\rhsusf\addons\rhsusf_weapons\explosives\rhsusf_m112x1_e";
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
-                position = "[-0.155,0,0.01]";
+                position = "[-0.055, 0, 0.038]";
             };
         };
     };
 
-    class ACE_Explosives_Place_rhsusf_m112x4_DemoCharge: ACE_Explosives_Place {
+    class ACE_Explosives_Place_rhsusf_explosive_m112x4: ACE_Explosives_Place {
         displayName = "$STR_RHSUSF_M112X4_EXPLOSIVE_DISPLAY_NAME";
         model = "\rhsusf\addons\rhsusf_weapons\explosives\rhsusf_m112x4_e";
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
-                position = "[-0.155,0.025,0.01]";
+                position = "[-0.055, 0.025, 0.102]";
             };
         };
     };
 
-    class ACE_Explosives_Place_rhs_mine_M19_Mine: ACE_Explosives_Place {
+    class ACE_Explosives_Place_rhsusf_mine_M19: ACE_Explosives_Place {
         displayName = "$STR_RHSUSF_M19_ATMINE_DISPLAY_NAME";
         model = "\rhsusf\addons\rhsusf_weapons\mines\rhsusf_m19_e";
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
-                position = "[0.011,0.011,0.045]";
+                position = "[-0.014, -0.002, 0.046]";
             };
         };
     };
 
-    class ACE_Explosives_Place_rhsusf_mine_m14_mag_Mine: ACE_Explosives_Place {
+    class ACE_Explosives_Place_rhsusf_mine_m14: ACE_Explosives_Place {
         displayName = "$STR_RHSUSF_M14_APMINE_DISPLAY_NAME";
-        model = "\rhsusf\addons\rhsusf_weapons\mines\rhsusf_m14_e";
+        model = "\rhsusf\addons\rhsusf_weapons\mines\rhsusf_m14_d";
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
-                position = "[0.02,0.015,0.02]";
+                position = "[-0.002, 0.022, 0.02]";
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Improve **RHS:USAF** compatibility with `ACE Explosives`

Linked to issue #7714

*Note:* Tripwire mines did note have stringtable entries, so hardcoded `displayName` properties from **RHS:USAF** config 😞 