### PR TITLE
Explosives - Fix place explosives cache not being cleared on respawn (#7637)

### DIFF
--- a/addons/explosives/CfgEventHandlers.hpp
+++ b/addons/explosives/CfgEventHandlers.hpp
@@ -9,6 +9,7 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
+
 class Extended_PostInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_postInit));
@@ -21,11 +22,18 @@ class Extended_Killed_EventHandlers {
     };
 };
 
+class Extended_Respawn_EventHandlers {
+    class CAManBase {
+        GVAR(respawnHandler) = QUOTE(_this call FUNC(onRespawn));
+    };
+};
+
 class Extended_Take_EventHandlers {
     class CAManBase {
         GVAR(takeHandler) = QUOTE(call FUNC(onInventoryChanged));
     };
 };
+
 class Extended_Put_EventHandlers {
     class CAManBase {
         GVAR(takeHandler) = QUOTE([ARR_3(_this select 1, _this select 0, _this select 2)] call FUNC(onInventoryChanged));

--- a/addons/explosives/XEH_PREP.hpp
+++ b/addons/explosives/XEH_PREP.hpp
@@ -24,6 +24,7 @@ PREP(getPlacedExplosives);
 PREP(getSpeedDialExplosive);
 PREP(module);
 PREP(onIncapacitated);
+PREP(onRespawn);
 PREP(onInventoryChanged);
 PREP(openTimerUI);
 PREP(placeExplosive);

--- a/addons/explosives/functions/fnc_onRespawn.sqf
+++ b/addons/explosives/functions/fnc_onRespawn.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+/*
+ * Author: Whigital
+ * Clears cached variable containing placeable explosives.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Corspe <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ *
+ * Public: No
+ */
+
+params [
+    "_unit",
+    "_corpse"
+];
+
+TRACE_2("params",_unit,_corpse);
+
+if (_unit == player) then {
+    [
+        {ACE_player == player},
+        {[ACE_player, QGVAR(explosiveActions)] call EFUNC(common,eraseCache);}
+    ] call CBA_fnc_waitUntilAndExecute;
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `ace_explosives_explosiveActions` not being cleared at respawn.

Addresses issue #7637

It isn't pretty, but it works. Any improvement suggestions welcome ....
