### PR TITLE
Medical Feedback - Fix overriding hearing setting when unconscious

### DIFF
--- a/addons/medical_feedback/XEH_postInit.sqf
+++ b/addons/medical_feedback/XEH_postInit.sqf
@@ -46,7 +46,8 @@ GVAR(bloodTickCounter) = 0;
     [!_unconscious, _unit] call EFUNC(common,setVolume);
 
     // Greatly reduce player's hearing ability while unconscious (affects radio addons)
-    [QUOTE(ADDON), VOL_UNCONSCIOUS, _unconscious] call EFUNC(common,setHearingCapability);
+    private _volume = missionNamespace getVariable [QEGVAR(hearing,unconsciousnessVolume), VOL_UNCONSCIOUS];
+    [QUOTE(ADDON), _volume, _unconscious] call EFUNC(common,setHearingCapability);
 
     [true] call FUNC(handleEffects);
     ["unconscious", _unconscious] call EFUNC(common,setDisableUserInputStatus);
@@ -70,7 +71,8 @@ GVAR(bloodTickCounter) = 0;
 
     [!_status, _new] call EFUNC(common,setVolume);
 
-    [QUOTE(ADDON), VOL_UNCONSCIOUS, _status] call EFUNC(common,setHearingCapability);
+    private _volume = missionNamespace getVariable [QEGVAR(hearing,unconsciousnessVolume), VOL_UNCONSCIOUS];
+    [QUOTE(ADDON), _volume, _status] call EFUNC(common,setHearingCapability);
     [true] call FUNC(handleEffects);
     ["unconscious", _status] call EFUNC(common,setDisableUserInputStatus);
 }] call CBA_fnc_addPlayerEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Currently if `ace_hearing_unconsciousnessVolume` > 0.25 it will be ignored in favor of
https://github.com/acemod/ACE3/blob/b30f023c042d4182091218f39db92b98f34e24ba/addons/medical_feedback/script_component.hpp#L40