### PR TITLE
Medical - Add Global Wound Reopen Chance Modifer

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -63,6 +63,7 @@ Codingboy
 Coren <coren4@gmail.com>
 Crusty
 C0kkie
+dgibso29 <dgibpipeline@gmail.com>
 Dharma Bellamkonda <dharma.bellamkonda@gmail.com>
 Dimaslg <dimaslg@telecable.es>
 diwako

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -63,7 +63,7 @@ Codingboy
 Coren <coren4@gmail.com>
 Crusty
 C0kkie
-dgibso29 <dgibpipeline@gmail.com>
+dgibso29 <gibson@earringpranks.com>
 Dharma Bellamkonda <dharma.bellamkonda@gmail.com>
 Dimaslg <dimaslg@telecable.es>
 diwako

--- a/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
@@ -27,6 +27,7 @@ private _reopeningChance = DEFAULT_BANDAGE_REOPENING_CHANCE;
 private _reopeningMinDelay = DEFAULT_BANDAGE_REOPENING_MIN_DELAY;
 private _reopeningMaxDelay = DEFAULT_BANDAGE_REOPENING_MAX_DELAY;
 private _reopeningModifer = GVAR(woundReopenChance);
+
 // Get the default values for the used bandage
 private _config = configFile >> QUOTE(ADDON) >> "Bandaging";
 
@@ -43,7 +44,7 @@ if (isClass (_config >> _className)) then {
     private _woundTreatmentConfig = _config >> _className;
 
     if (isNumber (_woundTreatmentConfig >> "reopeningChance")) then {
-        _reopeningChance = getNumber (_woundTreatmentConfig >> "reopeningChance");
+        _reopeningChance = getNumber (_woundTreatmentConfig >> "reopeningChance");        
     };
 
     if (isNumber (_woundTreatmentConfig >> "reopeningMinDelay")) then {

--- a/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
@@ -26,7 +26,6 @@ private _className = EGVAR(medical_damage,woundClassNamesComplex) select _classI
 private _reopeningChance = DEFAULT_BANDAGE_REOPENING_CHANCE;
 private _reopeningMinDelay = DEFAULT_BANDAGE_REOPENING_MIN_DELAY;
 private _reopeningMaxDelay = DEFAULT_BANDAGE_REOPENING_MAX_DELAY;
-private _reopeningModifer = GVAR(woundReopenChance);
 
 // Get the default values for the used bandage
 private _config = configFile >> QUOTE(ADDON) >> "Bandaging";
@@ -44,7 +43,7 @@ if (isClass (_config >> _className)) then {
     private _woundTreatmentConfig = _config >> _className;
 
     if (isNumber (_woundTreatmentConfig >> "reopeningChance")) then {
-        _reopeningChance = getNumber (_woundTreatmentConfig >> "reopeningChance");        
+        _reopeningChance = getNumber (_woundTreatmentConfig >> "reopeningChance");
     };
 
     if (isNumber (_woundTreatmentConfig >> "reopeningMinDelay")) then {
@@ -85,7 +84,7 @@ _target setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
 
 TRACE_1("",_reopeningChance);
 // Check if we are ever going to reopen this
-if (random 1 <= _reopeningChance * _reopeningModifer) then {
+if (random 1 <= _reopeningChance * GVAR(woundReopenChance)) then {
     private _delay = _reopeningMinDelay + random (_reopeningMaxDelay - _reopeningMinDelay);
     TRACE_1("Will open",_delay);
     [{

--- a/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
@@ -26,7 +26,7 @@ private _className = EGVAR(medical_damage,woundClassNamesComplex) select _classI
 private _reopeningChance = DEFAULT_BANDAGE_REOPENING_CHANCE;
 private _reopeningMinDelay = DEFAULT_BANDAGE_REOPENING_MIN_DELAY;
 private _reopeningMaxDelay = DEFAULT_BANDAGE_REOPENING_MAX_DELAY;
-
+private _reopeningModifer = 0.5;
 // Get the default values for the used bandage
 private _config = configFile >> QUOTE(ADDON) >> "Bandaging";
 
@@ -84,7 +84,7 @@ _target setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
 
 TRACE_1("",_reopeningChance);
 // Check if we are ever going to reopen this
-if (random 1 <= _reopeningChance) then {
+if (random 1 <= _reopeningChance * _reopeningModifer) then {
     private _delay = _reopeningMinDelay + random (_reopeningMaxDelay - _reopeningMinDelay);
     TRACE_1("Will open",_delay);
     [{

--- a/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
+++ b/addons/medical_treatment/functions/fnc_handleBandageOpening.sqf
@@ -26,7 +26,7 @@ private _className = EGVAR(medical_damage,woundClassNamesComplex) select _classI
 private _reopeningChance = DEFAULT_BANDAGE_REOPENING_CHANCE;
 private _reopeningMinDelay = DEFAULT_BANDAGE_REOPENING_MIN_DELAY;
 private _reopeningMaxDelay = DEFAULT_BANDAGE_REOPENING_MAX_DELAY;
-private _reopeningModifer = 0.5;
+private _reopeningModifer = GVAR(woundReopenChance);
 // Get the default values for the used bandage
 private _config = configFile >> QUOTE(ADDON) >> "Bandaging";
 

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -26,6 +26,16 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(woundReopenChance),
+    "SLIDER",
+    [LSTRING(WoundReopenChance_DisplayName), LSTRING(WoundReopenChance_Description)],
+    [ELSTRING[medical,Category, LSTRING(SubCategory_Treatment)],
+    [0, 2, 1, 2, true],
+    true
+    call CBA_settings_fnc_init;
+]
+
+[
     QGVAR(clearTraumaAfterBandage),
     "CHECKBOX",
     [LSTRING(ClearTraumaAfterBandage_DisplayName), LSTRING(ClearTraumaAfterBandage_Description)],

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -29,11 +29,10 @@
     QGVAR(woundReopenChance),
     "SLIDER",
     [LSTRING(WoundReopenChance_DisplayName), LSTRING(WoundReopenChance_Description)],
-    [ELSTRING[medical,Category, LSTRING(SubCategory_Treatment)],
-    [0, 2, 1, 2, true],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0, 2, 1, 2],
     true
-    call CBA_settings_fnc_init;
-]
+] call CBA_settings_fnc_init;
 
 [
     QGVAR(clearTraumaAfterBandage),

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -30,7 +30,7 @@
     "SLIDER",
     [LSTRING(WoundReopenChance_DisplayName), LSTRING(WoundReopenChance_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0, 2, 1, 2],
+    [0, 5, 1, 2],
     true
 ] call CBA_settings_fnc_init;
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -113,8 +113,8 @@
             <Czech>Zranění ran znovu</Czech>
             <Russian>Рана вновь открывается шанс</Russian>
         </Key>
-            <Key ID="Controls the chance of wounds reopening if Advanced Bandages, Can Reopen is enabled. A value of 2 is 200%, while a value of 0 is 0%.">
-            <English>Enabled &amp; Can Reopen</English>
+            <Key ID="WoundReopenChance_Description">
+            <English>Controls the chance of wounds reopening if Advanced Bandages, Can Reopen is enabled. A value of 2 is 200%, while a value of 0 is 0%.</English>
             <French>Contrôle les chances de réouverture des blessures si les bandages avancés, la réouverture peut être activée. Une valeur de 2 est de 200%, tandis qu'une valeur de 0 est de 0%.</French>
             <Czech>Řídí šanci na opětovné otevření ran, pokud je povoleno Advanced Bandage, Can Reopen. Hodnota 2 je 200%, zatímco hodnota 0 je 0%.</Czech>
             <Russian>Управляет шансом повторного открытия ран, если включены дополнительные повязки, Can Reopen. Значение 2 составляет 200%, а значение 0 - 0%.</Russian>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -107,6 +107,18 @@
             <Czech>Zapnuto &amp; Úrazy se mohou znovu otevřít</Czech>
             <Russian>Включено и может открыться заново</Russian>
         </Key>
+            <Key ID="WoundReopenChance_DisplayName">
+            <English>Wound Reopen Chance</English>
+            <French>Chance de réouverture de blessure</French>
+            <Czech>Zranění ran znovu</Czech>
+            <Russian>Рана вновь открывается шанс</Russian>
+        </Key>
+            <Key ID="Controls the chance of wounds reopening if Advanced Bandages, Can Reopen is enabled. A value of 2 is 200%, while a value of 0 is 0%.">
+            <English>Enabled &amp; Can Reopen</English>
+            <French>Contrôle les chances de réouverture des blessures si les bandages avancés, la réouverture peut être activée. Une valeur de 2 est de 200%, tandis qu'une valeur de 0 est de 0%.</French>
+            <Czech>Řídí šanci na opětovné otevření ran, pokud je povoleno Advanced Bandage, Can Reopen. Hodnota 2 je 200%, zatímco hodnota 0 je 0%.</Czech>
+            <Russian>Управляет шансом повторного открытия ран, если включены дополнительные повязки, Can Reopen. Значение 2 составляет 200%, а значение 0 - 0%.</Russian>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
             <English>Clear Trauma After Bandage</English>
             <Japanese>治療後に外傷を削除</Japanese>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -107,13 +107,13 @@
             <Czech>Zapnuto &amp; Úrazy se mohou znovu otevřít</Czech>
             <Russian>Включено и может открыться заново</Russian>
         </Key>
-            <Key ID="WoundReopenChance_DisplayName">
+        <Key ID="STR_ACE_Medical_Treatment_WoundReopenChance_DisplayName">
             <English>Wound Reopen Chance</English>
             <French>Chance de réouverture de blessure</French>
             <Czech>Zranění ran znovu</Czech>
             <Russian>Рана вновь открывается шанс</Russian>
         </Key>
-            <Key ID="WoundReopenChance_Description">
+        <Key ID="STR_ACE_Medical_Treatment_WoundReopenChance_Description">
             <English>Controls the chance of wounds reopening if Advanced Bandages, Can Reopen is enabled. A value of 2 is 200%, while a value of 0 is 0%.</English>
             <French>Contrôle les chances de réouverture des blessures si les bandages avancés, la réouverture peut être activée. Une valeur de 2 est de 200%, tandis qu'une valeur de 0 est de 0%.</French>
             <Czech>Řídí šanci na opětovné otevření ran, pokud je povoleno Advanced Bandage, Can Reopen. Hodnota 2 je 200%, zatímco hodnota 0 je 0%.</Czech>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -108,16 +108,18 @@
             <Russian>Включено и может открыться заново</Russian>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_WoundReopenChance_DisplayName">
-            <English>Wound Reopen Chance</English>
-            <French>Chance de réouverture de blessure</French>
-            <Czech>Zranění ran znovu</Czech>
-            <Russian>Рана вновь открывается шанс</Russian>
+            <English>Wound Reopening Coefficient</English>
+            <French>Coefficient de réouverture des plaies</French>
+            <German>Wundwiederöffnungskoeffizient</German>
+            <Czech>Koeficient opětovného otevření rány</Czech>
+            <Russian>Коэффициент повторного открытия раны</Russian>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_WoundReopenChance_Description">
-            <English>Controls the chance of wounds reopening if Advanced Bandages, Can Reopen is enabled. A value of 2 is 200%, while a value of 0 is 0%.</English>
-            <French>Contrôle les chances de réouverture des blessures si les bandages avancés, la réouverture peut être activée. Une valeur de 2 est de 200%, tandis qu'une valeur de 0 est de 0%.</French>
-            <Czech>Řídí šanci na opětovné otevření ran, pokud je povoleno Advanced Bandage, Can Reopen. Hodnota 2 je 200%, zatímco hodnota 0 je 0%.</Czech>
-            <Russian>Управляет шансом повторного открытия ран, если включены дополнительные повязки, Can Reopen. Значение 2 составляет 200%, а значение 0 - 0%.</Russian>
+            <English>Coefficient for controlling the wound reopening chance. The final reopening chance is determined by multiplying this value with the specific reopening chance for the wound type and bandage used.</English>
+            <French>Coefficient de contrôle des chances de réouverture de la plaie. La chance de réouverture finale est déterminée en multipliant cette valeur par la chance de réouverture spécifique pour le type de plaie et le bandage utilisés.</French>
+            <German>Koeffizient zur Kontrolle der Wundöffnungswahrscheinlichkeit. Die endgültige Wiedereröffnungschance wird bestimmt, indem dieser Wert mit der spezifischen Wiedereröffnungschance für den verwendeten Wundtyp und Verband multipliziert wird.</German>
+            <Czech>Koeficient pro řízení šance na opětovné otevření rány. Konečná šance na opětovné otevření se stanoví vynásobením této hodnoty specifickou šancí na opětovné otevření pro použitý typ rány a obvaz.</Czech>
+            <Russian>Коэффициент контроля вероятности повторного открытия раны. Окончательный шанс повторного открытия определяется путем умножения этого значения на определенный шанс повторного открытия для используемого типа раны и повязки.</Russian>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
             <English>Clear Trauma After Bandage</English>


### PR DESCRIPTION
As it says on the tin, this PR adds a Global Wound Reopen Chance Modifier to the Medical Treatment Addon Settings. This modifier is utilized in `fnc_handleBandageOpening.sqf`, where it modifies the re-open chance. This is applied per bandage/wound, allowing the various bandage's distinctive values to be modified equally.

This has been tested and is working.

I'll pop in to Slack, but please let me know what else needs to be done, etc. Thank you!

![image](https://user-images.githubusercontent.com/22088666/83589239-3d597c80-a521-11ea-8547-87f6a4796cae.png)