### PR TITLE
RHS Compat - Add Mk17 barrel length config entries

### DIFF
--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -58,6 +58,21 @@ class CfgWeapons {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 419.1;
     };
+    class rhs_weap_SCAR_H_CQC_Base;
+    class rhs_weap_mk17_CQC: rhs_weap_SCAR_H_CQC_Base {
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 330.2;
+    };
+    class rhs_weap_SCAR_H_STD_Base;
+    class rhs_weap_mk17_STD: rhs_weap_SCAR_H_STD_Base {
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 406.4;
+    };
+    class rhs_weap_SCAR_H_LB_Base;
+    class rhs_weap_mk17_LB: rhs_weap_SCAR_H_LB_Base {
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 508;
+    };
     class rhs_weap_m4a1_blockII;
     class rhs_weap_mk18: rhs_weap_m4a1_blockII {
         ACE_RailHeightAboveBore = 2.6068;


### PR DESCRIPTION
Was missing barrel lengths so the LB version was performing the same as the CQC version. Used FNs website for the barrel lengths. 

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/)
- Follow title standard `Component - Add|Fix|Improve|Change|Make|Remove bananas`
