### PR TITLE
Fastroping - Fix FRIES removal

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,6 +18,7 @@ Janus
 jokoho482 <jokoho482@gmail.com>
 Jonpas <jonpas33@gmail.com>
 Kieran
+mharis001 <mhariszakar@gmail.com>
 NouberNou
 PabstMirror <pabstmirror@gmail.com>
 Ruthberg <ulteq@web.de>
@@ -114,7 +115,6 @@ Luigi "Luigium" Myrini <luigium@outlook.fr>
 Macusercom <macusercom@gmail.com>
 MarcBook
 meat <p.humberdroz@gmail.com>
-mharis001 <mhariszakar@gmail.com>
 Michail Nikolaev
 MikeMatrix <m.braun92@gmail.com>
 nic547 <nic547@outlook.com>

--- a/addons/fastroping/XEH_preInit.sqf
+++ b/addons/fastroping/XEH_preInit.sqf
@@ -8,4 +8,10 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+if (isServer) then {
+    ["Helicopter", "Deleted", LINKFUNC(unequipFRIES)] call CBA_fnc_addClassEventHandler;
+};
+
+["Helicopter", "Killed", LINKFUNC(unequipFRIES)] call CBA_fnc_addClassEventHandler;
+
 ADDON = true;

--- a/addons/fastroping/functions/fnc_equipFRIES.sqf
+++ b/addons/fastroping/functions/fnc_equipFRIES.sqf
@@ -14,18 +14,16 @@
  *
  * Public: Yes
  */
+
 params ["_vehicle"];
 
 private _config = configFile >> "CfgVehicles" >> typeOf _vehicle;
 if !(isNumber (_config >> QGVAR(enabled))) then {
-    ["%1 has not been configured for ACE_Fastroping.", getText (_config >> "DisplayName")] call BIS_fnc_error;
+    ["%1 has not been configured for ACE_Fastroping.", getText (_config >> "displayName")] call BIS_fnc_error;
 } else {
     if (getNumber (_config >> QGVAR(enabled)) == 2) then {
         private _fries = (getText (_config >> QGVAR(friesType))) createVehicle [0, 0, 0];
-        _fries attachTo [_vehicle, (getArray (_config >> QGVAR(friesAttachmentPoint)))];
+        _fries attachTo [_vehicle, getArray (_config >> QGVAR(friesAttachmentPoint))];
         _vehicle setVariable [QGVAR(FRIES), _fries, true];
-
-        _vehicle addEventHandler ["Killed", FUNC(unequipFRIES)];
-        _vehicle addEventHandler ["Deleted", FUNC(unequipFRIES)];
     };
 };

--- a/addons/fastroping/functions/fnc_unequipFRIES.sqf
+++ b/addons/fastroping/functions/fnc_unequipFRIES.sqf
@@ -14,11 +14,12 @@
  *
  * Public: Yes
  */
+
 params ["_vehicle"];
 
 deleteVehicle (_vehicle getVariable [QGVAR(FRIES), objNull]);
 _vehicle setVariable [QGVAR(FRIES), nil, true];
 
-if !((_vehicle getVariable [QGVAR(deployedRopes), []] isEqualTo [])) then {
+if !(_vehicle getVariable [QGVAR(deployedRopes), []] isEqualTo []) then {
     [_vehicle] call FUNC(cutRopes);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix FRIES removal when helicopter is killed or deleted
- `equipFRIES` function could be called on any machine and as a result
    - the killed event would not work as expected if the locality of the helicopter changed
    - the deleted event would not work as expected if added on a client that later disconnects

