### PR TITLE
Medical - Fix typo in vital adjustment conditional

### DIFF
--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -87,7 +87,7 @@ if !(_adjustments isEqualTo []) then {
             private _effectRatio = (((_timeInSystem / _timeTillMaxEffect) ^ 2) min 1) * (_maxTimeInSystem - _timeInSystem) / _maxTimeInSystem;
             if (_hrAdjust != 0) then { _hrTargetAdjustment = _hrTargetAdjustment + _hrAdjust * _effectRatio; };
             if (_painAdjust != 0) then { _painSupressAdjustment = _painSupressAdjustment + _painAdjust * _effectRatio; };
-            if (_hrAdjust != 0) then { _peripheralResistanceAdjustment = _peripheralResistanceAdjustment + _flowAdjust * _effectRatio; };
+            if (_flowAdjust != 0) then { _peripheralResistanceAdjustment = _peripheralResistanceAdjustment + _flowAdjust * _effectRatio; };
         };
     } forEach _adjustments;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Ensure flow adjustments are applied in vital loop if they are not equal to 0 (instead of checking if heart rate adjustments are not equal to 0)
