### PR TITLE
Rearm - Fix some magazine types duplicating during rearm

### DIFF
--- a/addons/rearm/functions/fnc_setTurretMagazineAmmo.sqf
+++ b/addons/rearm/functions/fnc_setTurretMagazineAmmo.sqf
@@ -57,7 +57,7 @@ if (!_magLoadedInWeapon) then {
      * To prevent that, we must remove all magazines that would fit into the weapon and then add
      * them back with the magazine-to-be-loaded being the first. */
 
-    private _allowedMagClassesInWeapon = [_loadedWeapon] call CBA_fnc_compatibleMagazines;
+    private _allowedMagClassesInWeapon = [_loadedWeapon, true] call CBA_fnc_compatibleMagazines;
 
     /* Current ammo counts of all allowed magazine classes in weapon.
      * Example: [["8Rnd_82mm_Mo_shells", [8, 8, 2]], ["8Rnd_82mm_Mo_Flare_white", [7]]] */


### PR DESCRIPTION
**When merged this pull request will:**
- Ensure all compatible magazine types for a turret are detected regardless of config implementation details
- Prevent magazines being infinitely duplicated loading to server performance issues for specific magazine/turret configs

Some vehicles (issue discovered with the RHS's Bradley Busk III) report no compatible magazines when running CBA_fnc_compatibleMagazines without the allMuzzles parameter. This leads to the magazine type which will be added by the rearm action not getting removed before hand. Due to the code's assumption that all magazines have been removed, this leads to the filled magazines being added on top of the old (still loaded) magazines. Due to the old magazines still not being full the rearm option remains leading players to continuously duplicate the magazine count which for us has lead to server performance issues.

As the stated goal of the code is to find all allowed magazine classes in the weapon, it is expected that getting the magazines for all weapons should not lead to any issues other than a potential increased performance load for the specific setTurretMagazineAmmo function. All additional found magazine types due to this change should simply be removed and re-added as the comments state is intended by this function.
