### PR TITLE
Translations - Update / Fix Russian

### DIFF
--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -1255,7 +1255,7 @@
         </Key>
         <Key ID="STR_ACE_Arsenal_AttributeExport_Tooltip">
             <English>Export current items list as an array for use in scripts</English>
-            <Spanish>Exportar la lista actual de objetos como una tabla para su uso en scripts&gt;</Spanish>
+            <Spanish>Exportar la lista actual de objetos como una tabla para su uso en scripts</Spanish>
             <German>Exportiert aktuelle Gegenstände als Array, um es in Scripten zu verwenden</German>
             <Japanese>スクリプト用に現在のアイテム リストをアレイでエクスポートします</Japanese>
             <Italian>Esporta l'attuale lista di elementi come un array, per essere usati negli script</Italian>

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -1255,7 +1255,7 @@
         </Key>
         <Key ID="STR_ACE_Arsenal_AttributeExport_Tooltip">
             <English>Export current items list as an array for use in scripts</English>
-            <Spanish>Exportar la lista actual de objetos como una tabla para su uso en scripts></Spanish>
+            <Spanish>Exportar la lista actual de objetos como una tabla para su uso en scripts&gt;</Spanish>
             <German>Exportiert aktuelle Gegenstände als Array, um es in Scripten zu verwenden</German>
             <Japanese>スクリプト用に現在のアイテム リストをアレイでエクスポートします</Japanese>
             <Italian>Esporta l'attuale lista di elementi come un array, per essere usati negli script</Italian>
@@ -1322,11 +1322,13 @@
         <Key ID="STR_ACE_Arsenal_StatExplosionTime">
             <English>Fuse Time</English>
             <French>Retard avant détonation</French>
+            <Russian>Задержка детонации</Russian>
         </Key>
         <Key ID="STR_ACE_Arsenal_DetonatesOnImpact">
             <English>Detonates on impact</English>
             <German>Aufschlagzünder</German>
             <French>Détonation à l'impact</French>
+            <Russian>Детонация от удара</Russian>
         </Key>
     </Package>
 </Project>

--- a/addons/dragging/stringtable.xml
+++ b/addons/dragging/stringtable.xml
@@ -37,7 +37,7 @@
         </Key>
         <Key ID="STR_ACE_Dragging_DragKeybind">
             <English>Drag/Release Object</English>
-            <Russian>Тащить/Отпустить Объекты</Russian>
+            <Russian>Тащить/Отпустить Объект</Russian>
             <Spanish>Arrastrar/Soltar Objeto</Spanish>
             <Polish>Ciągnij/Puść Obiekt</Polish>
             <Czech>Táhnout/Položit Objekt</Czech>
@@ -55,6 +55,7 @@
         <Key ID="STR_ACE_Dragging_CarryKeybind">
             <English>Carry/Release Object</English>
             <French>Porter/Lâcher un objet</French>
+            <Russian>Нести/Отпустить Объект</Russian>
         </Key>
         <Key ID="STR_ACE_Dragging_UnableToDrag">
             <English>Item too heavy</English>

--- a/addons/gforces/stringtable.xml
+++ b/addons/gforces/stringtable.xml
@@ -5,6 +5,7 @@
             <English>ACE G-Forces</English>
             <Polish>ACE Przeciążenia</Polish>
             <French>ACE Force gravitationnelle</French>
+            <Russian>ACE Перегрузки</Russian>
         </Key>
         <Key ID="STR_ACE_GForces_enabledFor_displayName">
             <English>Gforces Effects</English>
@@ -56,11 +57,13 @@
             <English>G-Force Coefficient</English>
             <Polish>Współczynnk przeciążenia</Polish>
             <French>Coefficient de force gravitationnelle</French>
+            <Russian>Коэффициент перегрузки</Russian>
         </Key>
         <Key ID="STR_ACE_GForces_Coefficient_Description">
             <English>Controls strength of G-Force affecting players.</English>
             <Polish>Wpływa na siłe przeciążeń oddziałujących na graczy</Polish>
             <French>Coefficient permettant d'ajuster le niveau de force gravitationnelle affectant les joueurs.</French>
+            <Russian>Определяет силу перегрузок, влияющих на игроков.</Russian>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -1079,6 +1079,7 @@
             <English>Patient Info</English>
             <Polish>Informacje o pacjencie</Polish>
             <French>Informations patient</French>
+            <Russian>Информация о пациенте</Russian>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Added missing Russian translations and remove traling `>` symbol from Spanish translation