### PR TITLE
Map Gestures - Add Briefingscreen support, Different Camera Range, Improve Responsiveness, and Toggles for Curators and Spectators Maps

### DIFF
--- a/addons/map_gestures/CfgEventHandlers.hpp
+++ b/addons/map_gestures/CfgEventHandlers.hpp
@@ -25,6 +25,10 @@ class Extended_DisplayLoad_EventHandlers {
     };
 
     class RscDiary { // for loading saves use uiNamespace because missionNamespace is not restored before map is loaded
+#ifdef DISABLE_COMPILE_CACHE
         ADDON = QUOTE(((_this select 0) displayCtrl ID_DIARY_MAP) call (missionNamespace getVariable [ARR_2('DFUNC(initDisplayDiary)', uiNamespace getVariable 'DFUNC(initDisplayDiary)')]););
+#else
+        ADDON = QUOTE(((_this select 0) displayCtrl ID_DIARY_MAP) call (uiNamespace getVariable 'DFUNC(initDisplayDiary)'););
+#endif
     };
 };

--- a/addons/map_gestures/CfgEventHandlers.hpp
+++ b/addons/map_gestures/CfgEventHandlers.hpp
@@ -23,7 +23,8 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayEGSpectator {
         ADDON = QUOTE((((_this select 0) displayCtrl ID_EG_MAP_CONTROL) controlsGroupCtrl ID_EG_MAP_CONTROLGROUP) call FUNC(initDisplaySpectator));
     };
+
     class RscDiary { // for loading saves use uiNamespace because missionNamespace is not restored before map is loaded
-        ADDON = QUOTE(((_this select 0) displayCtrl ID_DIARY_MAP) call (uiNamespace getVariable 'DFUNC(initDisplayDiary)'));
+        ADDON = QUOTE(((_this select 0) displayCtrl ID_DIARY_MAP) call (missionNamespace getVariable [ARR_2('DFUNC(initDisplayDiary)', uiNamespace getVariable 'DFUNC(initDisplayDiary)')]););
     };
 };

--- a/addons/map_gestures/functions/fnc_drawMapGestures.sqf
+++ b/addons/map_gestures/functions/fnc_drawMapGestures.sqf
@@ -5,13 +5,13 @@
  *
  * Arguments:
  * 0: Map Handle <CONTROL>
- * 1: Positions (objects or posAGLs) <ARRAY>
+ * 1: Positions (objects or posAGLs) with render distance <ARRAY<ARRAY<OBJECT,NUMBER>>>
  *
  * Return Value:
  * None
  *
  * Example:
- * [findDisplay 12 displayCtrl 51, [player]] call ace_map_gestures_fnc_drawMapGestures
+ * [findDisplay 12 displayCtrl 51, [[player, 0]]] call ace_map_gestures_fnc_drawMapGestures
  *
  * Public: No
  */
@@ -29,10 +29,8 @@ BEGIN_COUNTER(draw);
 #define TEXT_SHADOW 0
 
 if (!GVAR(enabled)) exitWith {};
-
 params ["_mapHandle", "_positions"];
-
-private _players = [[_positions, GVAR(maxRange)], FUNC(getProximityPlayers), missionNamespace, QGVAR(proximityPlayersCache), 1] call EFUNC(common,cachedCall);
+private _players = [_positions, FUNC(getProximityPlayers), missionNamespace, QGVAR(proximityPlayersCache), 1] call EFUNC(common,cachedCall);
 // Iterate over all nearby players and render their pointer if player is transmitting.
 {
     private _pos = _x getVariable QGVAR(pointPosition);

--- a/addons/map_gestures/functions/fnc_getProximityPlayers.sqf
+++ b/addons/map_gestures/functions/fnc_getProximityPlayers.sqf
@@ -8,31 +8,49 @@
  * 1: Range <NUMBER>
  *
  * Return Value:
- * All units in proximity <ARRAY<OBJECT>>
+ * All units in proximity with Distances to render from <ARRAY<ARRAY<OBJECT,NUMBER>>>
  *
  * Example:
- * [[player], 7] call ace_map_gestures_fnc_getProximityPlayers
+ * [[[player, 6]]] call ace_map_gestures_fnc_getProximityPlayers
  *
  * Public: No
  */
 
-params ["_positions", "_range"];
-
 private _proximityPlayers = [];
 
-{
-    _proximityPlayers append (_x nearEntities [["CAMAnBase"], _range]);
-    if (_x isEqualType objNull) then {
-        _proximityPlayers append (crew vehicle _x);
-    };
-} forEach _positions;
-
-_proximityPlayers = _proximityPlayers arrayIntersect _proximityPlayers;
-
-_proximityPlayers = _proximityPlayers select { [_x, false] call EFUNC(common,isPlayer); };
-
-if (GVAR(onlyShowFriendlys)) then {
-    _proximityPlayers = _proximityPlayers select { [side group ace_player, side _x] call BIS_fnc_areFriendly; };
+private _fnc_getProximitsPlayers = {
+    {
+        _x params ["_position", ["_range", GVAR(maxRange)]];
+        private _temp = (_position nearEntities [["CAMAnBase"], _range]);
+        if (_position isEqualType objNull) then {
+            _temp append (crew vehicle _position);
+            if (GVAR(onlyShowFriendlys)) then {
+                _temp = _temp select { [side group _position, side _x] call BIS_fnc_areFriendly; };
+            };
+        };
+        _proximityPlayers append _temp;
+    } forEach _this;
 };
 
+switch (_this) do {
+    case (0): { // All
+        _proximityPlayers append allUnits;
+    };
+    case (1): { // Players in Group
+        _proximityPlayers append group ace_player;
+    };
+    case (2): { // Players on Side
+        _proximityPlayers append (allUnits select {side (group _x) == side (group ace_player)});
+    };
+    case (3): { // Proximity
+        [[ace_player, GVAR(maxRange)]] call _fnc_getProximitsPlayers;
+    };
+    case (4): {}; // Disabled
+    default {
+        _this call _fnc_getProximitsPlayers;
+    };
+};
+
+_proximityPlayers = _proximityPlayers arrayIntersect _proximityPlayers;
+_proximityPlayers = _proximityPlayers select { [_x, false] call EFUNC(common,isPlayer); };
 _proximityPlayers

--- a/addons/map_gestures/functions/fnc_initDisplayCurator.sqf
+++ b/addons/map_gestures/functions/fnc_initDisplayCurator.sqf
@@ -17,4 +17,7 @@
 params ["_mapCtrl"];
 TRACE_1("initDisplayCurator",_mapCtrl);
 
-_mapCtrl ctrlAddEventHandler ["Draw", { [_this select 0, [ACE_player, positionCameraToWorld [0, 0, 0]]] call FUNC(drawMapGestures);}];
+_mapCtrl ctrlAddEventHandler ["Draw", {
+    if (!GVAR(allowCurator)) exitWith {};
+    [_this select 0, [[ACE_player, GVAR(maxRange)], [positionCameraToWorld [0, 0, 0], GVAR(maxRangeCamera)]]] call FUNC(drawMapGestures);
+}];

--- a/addons/map_gestures/functions/fnc_initDisplayDiary.sqf
+++ b/addons/map_gestures/functions/fnc_initDisplayDiary.sqf
@@ -17,39 +17,44 @@
 params ["_mapCtrl"];
 TRACE_1("initDisplayDiary",_mapCtrl);
 
-_mapCtrl ctrlAddEventHandler ["Draw", { [_this select 0, [ACE_player]] call FUNC(drawMapGestures); }];
+_mapCtrl ctrlAddEventHandler ["Draw", {
+    if (!GVAR(enabled)) exitWith {};
+    if (getClientStateNumber < 10) then {
+        [_this select 0, GVAR(briefingMode)] call FUNC(drawMapGestures);
+    } else {
+        [_this select 0, [[ACE_player, GVAR(maxRange)]]] call FUNC(drawMapGestures);
+    };
+}];
 
 // MouseMoving EH.
 _mapCtrl ctrlAddEventHandler ["MouseMoving", {
     if (!GVAR(enabled)) exitWith {};
     params ["_control", "_posX", "_posY"];
-    private _position = _control ctrlMapScreenToWorld [_posX, _posY];
-    GVAR(cursorPosition) = _position;
+    GVAR(cursorPosition) = _control ctrlMapScreenToWorld [_posX, _posY];
+
     // Don't transmit any data if we're using the map tools
     if (!GVAR(EnableTransmit) || {(["ace_maptools"] call EFUNC(common,isModLoaded)) && {EGVAR(maptools,mapTool_isDragging) || EGVAR(maptools,mapTool_isRotating)}}) exitWith {};
-    if (_position distance2D (ACE_player getVariable [QGVAR(pointPosition), [0, 0, 0]]) >= 1) then {
-        [ACE_player, QGVAR(pointPosition), _position, GVAR(interval)] call EFUNC(common,setVariablePublic);
+    if (GVAR(cursorPosition) distance2D (ACE_player getVariable [QGVAR(pointPosition), [0, 0, 0]]) >= 1) then {
+        [ACE_player, QGVAR(pointPosition), GVAR(cursorPosition), GVAR(interval)] call EFUNC(common,setVariablePublic);
     };
 }];
 
 // MouseDown EH
 _mapCtrl ctrlAddEventHandler ["MouseButtonDown", {
-    if (getClientStateNumber < 10) exitWith {};
     if (!GVAR(enabled)) exitWith {};
         params ["", "_button", "_x", "_y", "_shift", "_ctrl", "_alt"];
         if (_button == 0 && {[_shift, _ctrl, _alt] isEqualTo [false, false, false]}) then {
             GVAR(EnableTransmit) = true;
+            [ACE_player, QGVAR(pointPosition), GVAR(cursorPosition), GVAR(interval)] call EFUNC(common,setVariablePublic);
         };
 }];
 
 // MouseUp EH
 _mapCtrl ctrlAddEventHandler ["MouseButtonUp", {
-    if (getClientStateNumber < 10) exitWith {};
     if (!GVAR(enabled)) exitWith {};
     params ["", "_button"];
     if (_button == 0) then {
         GVAR(EnableTransmit) = false;
         ACE_player setVariable [QGVAR(pointPosition), nil, true]; // Instantly transmit nil to stop drawing icon
-        GVAR(cursorPosition) = nil;
     };
 }];

--- a/addons/map_gestures/functions/fnc_initDisplaySpectator.sqf
+++ b/addons/map_gestures/functions/fnc_initDisplaySpectator.sqf
@@ -18,15 +18,16 @@ params ["_mapCtrl"];
 TRACE_1("initDisplaySpectator",_mapCtrl);
 
 _mapCtrl ctrlAddEventHandler ["Draw", {
-    private _targets = [positionCameraToWorld [0, 0, 0]];
+    if (!GVAR(allowSpectator)) exitWith {};
+    private _targets = [[positionCameraToWorld [0, 0, 0], GVAR(maxRangeCamera)]];
 
     private _aceSpectatorFocus = missionNamespace getVariable [QEGVAR(spectator,camFocus), objNull];
     if (!isNull _aceSpectatorFocus) then {
-        _targets pushback _aceSpectatorFocus;
+        _targets pushback [_aceSpectatorFocus, GVAR(maxRange)];
     };
     private _vanillaSpectatorFocus = uiNamespace getVariable ["RscEGSpectator_focus", objNull];
     if (!isNull _vanillaSpectatorFocus) then {
-        _targets pushback _vanillaSpectatorFocus;
+        _targets pushback [_vanillaSpectatorFocus, GVAR(maxRange)];
     };
     [_this select 0, _targets] call FUNC(drawMapGestures);
 }];

--- a/addons/map_gestures/initSettings.sqf
+++ b/addons/map_gestures/initSettings.sqf
@@ -40,7 +40,7 @@
     QGVAR(briefingMode), "LIST",
     [LSTRING(allowCurator_displayName), LSTRING(allowCurator_description)],
     LSTRING(mapGestures_category),
-    [[0, 1, 2, 3, 4], [LSTRING(briefingMode_All) ,LSTRING(briefingMode_Group) ,LSTRING(briefingMode_Side) ,LSTRING(briefingMode_Proximity) ,LSTRING(briefingMode_Disabled)], 0]
+    [[0, 1, 2, 3, 4], [LSTRING(briefingMode_All), LSTRING(briefingMode_Group), LSTRING(briefingMode_Side), LSTRING(briefingMode_Proximity), LSTRING(briefingMode_Disabled)], 0]
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/map_gestures/initSettings.sqf
+++ b/addons/map_gestures/initSettings.sqf
@@ -15,6 +15,35 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(maxRangeCamera), "SLIDER",
+    [LSTRING(maxRangeCamera_displayName), LSTRING(maxRangeCamera_description)],
+    LSTRING(mapGestures_category),
+    [0,50,14,1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(allowSpectator), "CHECKBOX",
+    [LSTRING(allowSpectator_displayName), LSTRING(allowSpectator_description)],
+    LSTRING(mapGestures_category),
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(allowCurator), "CHECKBOX",
+    [LSTRING(allowCurator_displayName), LSTRING(allowCurator_description)],
+    LSTRING(mapGestures_category),
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(briefingMode), "LIST",
+    [LSTRING(allowCurator_displayName), LSTRING(allowCurator_description)],
+    LSTRING(mapGestures_category),
+    [[0, 1, 2, 3, 4], [LSTRING(briefingMode_All) ,LSTRING(briefingMode_Group) ,LSTRING(briefingMode_Side) ,LSTRING(briefingMode_Proximity) ,LSTRING(briefingMode_Disabled)], 0]
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(onlyShowFriendlys),
     "CHECKBOX",
     [LSTRING(onlyShowFriendlys_displayName), LSTRING(onlyShowFriendlys_description)],
@@ -34,7 +63,7 @@
 [
     QGVAR(nameTextColor), "COLOR",
     [LSTRING(nameTextColor_displayName), LSTRING(nameTextColor_description)],
-    LSTRING(mapGestures_category),
+    [LSTRING(mapGestures_category), LSTRING(mapGestures_subcategory_colors)],
     [0.2,0.2,0.2,0.3],
     false
 ] call CBA_fnc_addSetting;
@@ -42,7 +71,7 @@
 [
     QGVAR(defaultLeadColor), "COLOR",
     [LSTRING(defaultLeadColor_displayName), LSTRING(defaultLeadColor_description)],
-    LSTRING(mapGestures_category),
+    [LSTRING(mapGestures_category), LSTRING(mapGestures_subcategory_colors)],
     [1,0.88,0,0.95],
     false
 ] call CBA_fnc_addSetting;
@@ -50,7 +79,7 @@
 [
     QGVAR(defaultColor), "COLOR",
     [LSTRING(defaultColor_displayName), LSTRING(defaultColor_description)],
-    LSTRING(mapGestures_category),
+    [LSTRING(mapGestures_category), LSTRING(mapGestures_subcategory_colors)],
     [1,0.88,0,0.7],
     false
 ] call CBA_fnc_addSetting;

--- a/addons/map_gestures/script_component.hpp
+++ b/addons/map_gestures/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_MAP_GESTURES

--- a/addons/map_gestures/script_component.hpp
+++ b/addons/map_gestures/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_MAP_GESTURES

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -66,19 +66,19 @@
             <Turkish>Harita Hareketi Max Uzaklık</Turkish>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_maxRange_description">
-            <English>Max range between players to show the map gesture indicator [default: 7 meters]</English>
-            <Portuguese>Distância max. entre os jogadores para mostrar o indicador de gesto no mapa [padrão: 7 metros]</Portuguese>
-            <Polish>Maksymalny zasięg, w obrębie którego gesty będą widoczne dla graczy [domyślnie: 7 metrów]</Polish>
-            <Russian>Макс. дистанция между игроками для отображения жестов на карте [по-умолчанию: 7 метров]</Russian>
-            <Czech>Maximální vzdálenost mezi hráči pro zobrazení indikátoru ukázání v mapě [výchozí: 7 metrů] </Czech>
-            <Italian>Distanza massima tra giocatori per mostrare i gesti in mappa [default: 7 metri]</Italian>
-            <German>Maximale Reichweite zwischen Spielern um Kartenzeichen anzuzeigen (Standard: 7 Meter)</German>
-            <Spanish>Máxima distancia a la cual pueden verse el indicador de gestos [defecto: 7 m]</Spanish>
-            <French>Définit le rayon au-delà duquel les joueurs ne verront plus l'indicateur de pointage de leurs alliés. Valeur par défaut : 7 mètres.</French>
-            <Japanese>プレイヤーによるマップ ジェスチャーの表示範囲を設定します [標準：7 メートル]</Japanese>
-            <Korean>플레이어간에 지도 신호 표시거리를 설정합니다. [기본: 7 미터]</Korean>
-            <Chinesesimp>设定地图标识器显示的最大范围距离 [预设: 7公尺]</Chinesesimp>
-            <Chinese>設定地圖指示器顯示的最大範圍距離 [預設: 7公尺]</Chinese>
+            <English>Max range between players to show the map gesture indicator</English>
+            <Portuguese>Distância max. entre os jogadores para mostrar o indicador de gesto no mapa</Portuguese>
+            <Polish>Maksymalny zasięg, w obrębie którego gesty będą widoczne dla graczy</Polish>
+            <Russian>Макс. дистанция между игроками для отображения жестов на карте</Russian>
+            <Czech>Maximální vzdálenost mezi hráči pro zobrazení indikátoru ukázání v mapě</Czech>
+            <Italian>Distanza massima tra giocatori per mostrare i gesti in mappa</Italian>
+            <German>Maximale Reichweite zwischen Spielern um Kartenzeichen anzuzeigen</German>
+            <Spanish>Máxima distancia a la cual pueden verse el indicador de gestos</Spanish>
+            <French>Définit le rayon au-delà duquel les joueurs ne verront plus l'indicateur de pointage de leurs alliés.</French>
+            <Japanese>プレイヤーによるマップ ジェスチャーの表示範囲を設定します</Japanese>
+            <Korean>플레이어간에 지도 신호 표시거리를 설정합니다.</Korean>
+            <Chinesesimp>设定地图标识器显示的最大范围距离</Chinesesimp>
+            <Chinese>設定地圖指示器顯示的最大範圍距離</Chinese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_interval_displayName">
             <English>Update Interval</English>
@@ -276,6 +276,45 @@
             <Russian>Показывать жесты только от игроков союзной стороны.</Russian>
             <French>Affiche uniquement les pointages effectués par des unités qui sont du même camp, ou d'un camp allié.</French>
         </Key>
+        <Key ID="STR_ACE_Map_Gestures_maxRangeCamera_displayName">
+            <English>Max range Camera</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_maxRangeCamera_description">
+            <English>Max range between a Camera and players to show the map gesture indicator</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_allowSpectator_displayName">
+            <English>Allow Spectator</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_allowSpectator_description">
+            <English>Allows Spectator to See Map Gestures</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_allowCurator_displayName">
+            <English>Allow Curator</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_allowCurator_description">
+            <English>Allows Curator to See Map Gestures</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_displayName">
+            <English>Briefing Mode</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_description">
+            <English>What player can see what</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_Disabled">
+            <English>Disabled</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_Group">
+            <English>Group</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_Side">
+            <English>Side</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_Proximity">
+            <English>Proximity</English>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_briefingMode_All">
+            <English>All</English>
+        </Key>
         <Key ID="STR_ACE_Map_Gestures_moduleGroupSettings_displayName">
             <English>Map Gestures - Group Settings</English>
             <Portuguese>Gestos no mapa - Definições de Grupo</Portuguese>
@@ -306,6 +345,9 @@
             <Chinesesimp>ACE 地图标识器</Chinesesimp>
             <Chinese>ACE 地圖指示器</Chinese>
             <Turkish>ACE Harita Hareketleri</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Map_Gestures_mapGestures_subcategory_colors">
+            <English>Colors</English>
         </Key>
     </Package>
 </Project>

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -305,15 +305,39 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_Group">
             <English>Group</English>
+            <Czech>Skupina</Czech>
+            <French>Groupement</French>
+            <German>Gruppe</German>
+            <Italian>Gruppo</Italian>
+            <Polish>Grupa</Polish>
+            <Portuguese>Grupo</Portuguese>
+            <Russian>Группа</Russian>
+            <Spanish>Grupo</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_Side">
             <English>Side</English>
+            <Czech>Strana</Czech>
+            <French>Camp</French>
+            <German>Seite</German>
+            <Italian>Fazione</Italian>
+            <Polish>Strona</Polish>
+            <Portuguese>Lado</Portuguese>
+            <Russian>Сторона</Russian>
+            <Spanish>Bando</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_Proximity">
             <English>Proximity</English>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_All">
             <English>All</English>
+            <Czech>Vše</Czech>
+            <French>Tous</French>
+            <German>Alle</German>
+            <Italian>Tutte</Italian>
+            <Polish>Wszystko</Polish>
+            <Portuguese>Tudo</Portuguese>
+            <Russian>Все</Russian>
+            <Spanish>Todas</Spanish>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_moduleGroupSettings_displayName">
             <English>Map Gestures - Group Settings</English>
@@ -348,6 +372,14 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_mapGestures_subcategory_colors">
             <English>Colors</English>
+            <Czech>Barvy</Czech>
+            <French>Couleurs</French>
+            <German>Farben</German>
+            <Italian>Colori</Italian>
+            <Polish>Kolory</Polish>
+            <Portuguese>Cores</Portuguese>
+            <Russian>Цвета</Russian>
+            <Spanish>Colores</Spanish>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
 - Add Variable Range for Camera Users (Zeus, Spectator) + Settings  
 - Add Setting to Disable Zeus and/or Spectator Map Draws  
 - Add Ability to use Map Gestures on Briefing screen  
 - Add Setting for Briefing Screen mode (All, Only Group, Only Side, Proximity, Disabled)
 - Improve Responsiveness of Transmission. Transmission of the position is now started as soon as clicked

Todo:
- [ ] ~~Find good Text for Briefing Screen mode Description~~
- [ ] Test on Dedicated server in Briefing Screen