### PR TITLE
Allow AI to Fastrope from VTOLs with FRIES

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -161,3 +161,4 @@ xrufix
 Zakant <Zakant@gmx.de>
 zGuba
 Fyuran <dankemedic@hotmail.com>
+JWatt <bluroffense@gmail.com

--- a/addons/fastroping/functions/fnc_deployAI.sqf
+++ b/addons/fastroping/functions/fnc_deployAI.sqf
@@ -18,7 +18,7 @@
  */
 params [["_vehicle", objNull, [objNull]], ["_deploySpecial", false, [true]], ["_createDeploymentGroup", true, [true]]];
 
-if (isNull _vehicle || {!(_vehicle isKindOf "Helicopter")}) exitWith {
+if (isNull _vehicle || {!((_vehicle isKindOf "Helicopter") || (_vehicle isKindOf "Plane"))}) exitWith {
     if (hasInterface) then {
         // Note: BIS_fnc_guiMessage causes a CTD with call, so spawn is used instead.
         ["deployAI was called with an invalid or non-existant vehicle.", QFUNC(deployAI)] spawn BIS_fnc_guiMessage;

--- a/addons/fastroping/functions/fnc_deployAI.sqf
+++ b/addons/fastroping/functions/fnc_deployAI.sqf
@@ -18,7 +18,7 @@
  */
 params [["_vehicle", objNull, [objNull]], ["_deploySpecial", false, [true]], ["_createDeploymentGroup", true, [true]]];
 
-if (isNull _vehicle || {!((_vehicle isKindOf "Helicopter") || (_vehicle isKindOf "Plane"))}) exitWith {
+if (isNull _vehicle || {!((_vehicle isKindOf "Helicopter") || {_vehicle isKindOf "Plane"})}) exitWith {
     if (hasInterface) then {
         // Note: BIS_fnc_guiMessage causes a CTD with call, so spawn is used instead.
         ["deployAI was called with an invalid or non-existant vehicle.", QFUNC(deployAI)] spawn BIS_fnc_guiMessage;


### PR DESCRIPTION
**Description:**

I am part of the dev team for the [Project Future Vertical Lift](https://steamcommunity.com/sharedfiles/filedetails/?id=1686321576) mod. We are in process of releasing an ACE compatabiltity mod that adds ACE fastroping capability to the V-280 Valor VTOL aircraft that we made. This works great with human-controlled passengers. 
However, the waypoints that ace fastroping uses to allow AI to fastrope from vehicles requires that the vehicle be of type "Helicopter". Since VTOLs are of type "Plane", it does not allow AI to fastrope from the V-280. This change will fix that and prevent this from being a barrier to fully enabling fastroping on other VTOLs.

**When merged this pull request will:**
- Allow AI to fastrope from vehicles of type"Plane"
