### PR TITLE
RHS Compat - Add RHS:SAF compat

### DIFF
--- a/addons/main/CfgSettings.hpp
+++ b/addons/main/CfgSettings.hpp
@@ -11,6 +11,7 @@ class CfgSettings {
                     compat_rhs_afrf3[] = {"ace_compat_rhs_afrf3", {VERSION_AR}, "isClass (configFile >> 'CfgPatches' >> 'rhs_main')"};
                     compat_rhs_usf3[] = {"ace_compat_rhs_usf3", {VERSION_AR}, "isClass (configFile >> 'CfgPatches' >> 'rhsusf_main')"};
                     compat_rhs_gref3[] = {"ace_compat_rhs_gref3", {VERSION_AR}, "isClass (configFile >> 'CfgPatches' >> 'rhsgref_main')"};
+                    compat_rhs_saf3[] = {"ace_compat_rhs_saf3", {VERSION_AR}, "isClass (configFile >> 'CfgPatches' >> 'rhssaf_main')"};
                 };
             };
         };

--- a/optionals/compat_rhs_saf3/$PBOPREFIX$
+++ b/optionals/compat_rhs_saf3/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_rhs_saf3

--- a/optionals/compat_rhs_saf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_saf3/CfgAmmo.hpp
@@ -1,5 +1,20 @@
 class CfgAmmo {
 
+    // ACE Ballistics
+    class BulletBase;
+    class rhs_ammo_792x57_Ball: BulletBase {
+        ACE_caliber = 8.077;
+        ACE_bulletLength = 28.651;
+        ACE_bulletMass = 12.7008;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.315};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel=1;
+        ACE_muzzleVelocities[] = {785, 800, 815};
+        ACE_barrelLengths[] = {508.0, 599.948, 660.4};
+    };
+
     // ACE Explosives
     class DirectionalBombBase;
     class rhssaf_mine_mrud_a_ammo: DirectionalBombBase {

--- a/optionals/compat_rhs_saf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_saf3/CfgAmmo.hpp
@@ -18,4 +18,17 @@ class CfgAmmo {
     class rhssaf_mine_tma4_ammo: MineBase {
         ace_explosives_defuseObjectPosition[] = {0, 0, 0.045};
     };
+
+    class PipeBombBase;
+    class rhssaf_tm100_ammo: PipeBombBase {
+        ace_explosives_defuseObjectPosition[] = {-0.055, 0, 0.014};
+    };
+
+    class rhssaf_tm200_ammo: rhssaf_tm100_ammo {
+        ace_explosives_defuseObjectPosition[] = {-0.055, 0, 0.018};
+    };
+
+    class rhssaf_tm500_ammo: rhssaf_tm100_ammo {
+        ace_explosives_defuseObjectPosition[] = {-0.056, 0, 0.032};
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_saf3/CfgAmmo.hpp
@@ -10,7 +10,7 @@ class CfgAmmo {
         ACE_ballisticCoefficients[] = {0.315};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
-        ACE_dragModel=1;
+        ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {785, 800, 815};
         ACE_barrelLengths[] = {508.0, 599.948, 660.4};
     };

--- a/optionals/compat_rhs_saf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_saf3/CfgAmmo.hpp
@@ -9,4 +9,13 @@ class CfgAmmo {
     class rhssaf_mine_mrud_d_ammo: rhssaf_mine_mrud_a_ammo {
         ace_explosives_defuseObjectPosition[] = {0.0325, 0, 0.18};
     };
+
+    class MineBase;
+    class rhssaf_mine_pma3_ammo: MineBase {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.025};
+    };
+
+    class rhssaf_mine_tma4_ammo: MineBase {
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.045};
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_saf3/CfgAmmo.hpp
@@ -15,6 +15,15 @@ class CfgAmmo {
         ACE_barrelLengths[] = {508.0, 599.948, 660.4};
     };
 
+    class rhs_B_762x39_Ball;
+    class rhssaf_ammo_762x39_m82_api: rhs_B_762x39_Ball {
+        ACE_Caliber = 7.8994;
+        ACE_bulletMass = 7.6074;
+        ACE_bulletLength = 27.2796;
+        ACE_muzzleVelocities[] = {650, 700, 748};
+        ACE_barrelLengths[] = {206.85, 329.62, 412.75};
+    };
+
     // ACE Explosives
     class DirectionalBombBase;
     class rhssaf_mine_mrud_a_ammo: DirectionalBombBase {

--- a/optionals/compat_rhs_saf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_saf3/CfgAmmo.hpp
@@ -1,0 +1,12 @@
+class CfgAmmo {
+
+    // ACE Explosives
+    class DirectionalBombBase;
+    class rhssaf_mine_mrud_a_ammo: DirectionalBombBase {
+        ace_explosives_defuseObjectPosition[] = {-0.034, 0, 0.202};
+    };
+
+    class rhssaf_mine_mrud_d_ammo: rhssaf_mine_mrud_a_ammo {
+        ace_explosives_defuseObjectPosition[] = {0.0325, 0, 0.18};
+    };
+};

--- a/optionals/compat_rhs_saf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_saf3/CfgMagazines.hpp
@@ -27,4 +27,24 @@ class CfgMagazines {
             class MK16_Transmitter: Command {};
         };
     };
+
+    class rhssaf_mine_pma3_mag: ATMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_mine_pma3";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.026;
+            };
+        };
+    };
+
+    class rhssaf_mine_tma4_mag: ATMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_mine_tma4";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"PressurePlate"};
+            class PressurePlate {
+                digDistance = 0.05;
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_saf3/CfgMagazines.hpp
@@ -47,4 +47,29 @@ class CfgMagazines {
             };
         };
     };
+
+    class CA_Magazine;
+    class rhssaf_tm100_mag: CA_Magazine {
+        ace_explosives_DelayTime = 1;
+        ace_explosives_Placeable = 1;
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_tm100";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter"};
+            class Timer {
+                FuseTime = 0.5;
+            };
+            class Command {
+                FuseTime = 0.5;
+            };
+            class MK16_Transmitter: Command {};
+        };
+    };
+
+    class rhssaf_tm200_mag: rhssaf_tm100_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_tm200";
+    };
+
+    class rhssaf_tm500_mag: rhssaf_tm100_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_tm500";
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgMagazines.hpp
+++ b/optionals/compat_rhs_saf3/CfgMagazines.hpp
@@ -1,0 +1,30 @@
+class CfgMagazines {
+
+    // ACE Explosives
+    class ATMine_Range_Mag;
+    class rhssaf_mine_mrud_a_mag: ATMine_Range_Mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_mine_mrud_a";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Tripwire"};
+        };
+    };
+
+    class rhssaf_mine_mrud_b_mag: rhssaf_mine_mrud_a_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_mine_mrud_b";
+    };
+
+    class rhssaf_mine_mrud_c_mag: rhssaf_mine_mrud_a_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_mine_mrud_c";
+    };
+
+    class rhssaf_mine_mrud_d_mag: rhssaf_mine_mrud_a_mag {
+        ace_explosives_SetupObject = "ACE_Explosives_Place_rhssaf_mine_mrud_d";
+        class ACE_Triggers {
+            SupportedTriggers[] = {"Command", "MK16_Transmitter"};
+            class Command {
+                FuseTime = 0.5;
+            };
+            class MK16_Transmitter: Command {};
+        };
+    };
+};

--- a/optionals/compat_rhs_saf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_saf3/CfgVehicles.hpp
@@ -1,0 +1,40 @@
+class CfgVehicles {
+
+    //ACE Explosives
+    class Items_base_F;
+    class ACE_Explosives_Place: Items_base_F {
+        class ACE_Actions {
+            class ACE_MainActions;
+        };
+    };
+
+    class ACE_Explosives_Place_rhssaf_mine_mrud_a: ACE_Explosives_Place {
+        displayName = $STR_RHSSAF_MRUD_A_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\mines_ap\mrud\rhssaf_mrud_a_e";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0.034, 0, 0.202]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhssaf_mine_mrud_b: ACE_Explosives_Place_rhssaf_mine_mrud_a {
+        displayName = $STR_RHSSAF_MRUD_B_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\mines_ap\mrud\rhssaf_mrud_b_e";
+    };
+
+    class ACE_Explosives_Place_rhssaf_mine_mrud_c: ACE_Explosives_Place_rhssaf_mine_mrud_a {
+        displayName = $STR_RHSSAF_MRUD_C_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\mines_ap\mrud\rhssaf_mrud_c_e";
+    };
+
+    class ACE_Explosives_Place_rhssaf_mine_mrud_d: ACE_Explosives_Place_rhssaf_mine_mrud_a {
+        displayName = $STR_RHSSAF_MRUD_D_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\mines_ap\mrud\rhssaf_mrud_d_e";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[-0.0325, 0, 0.18]";
+            };
+        };
+    };
+};

--- a/optionals/compat_rhs_saf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_saf3/CfgVehicles.hpp
@@ -57,4 +57,34 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhssaf_tm100: ACE_Explosives_Place {
+        displayName = $STR_RHSSAF_TM100_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\tm500\rhssaf_tm100_e";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0.055, 0, 0.014]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhssaf_tm200: ACE_Explosives_Place {
+        displayName = $STR_RHSSAF_TM200_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\tm500\rhssaf_tm200_e";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0.055, 0, 0.018]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhssaf_tm500: ACE_Explosives_Place {
+        displayName = $STR_RHSSAF_TM500_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\tm500\rhssaf_tm500_e";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0.056, 0, 0.028]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_saf3/CfgVehicles.hpp
@@ -37,4 +37,24 @@ class CfgVehicles {
             };
         };
     };
+
+    class ACE_Explosives_Place_rhssaf_mine_pma3: ACE_Explosives_Place {
+        displayName = $STR_RHSSAF_PMA3_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\mines_ap\pma\rhssaf_pma3_d";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.02]";
+            };
+        };
+    };
+
+    class ACE_Explosives_Place_rhssaf_mine_tma4: ACE_Explosives_Place {
+        displayName = $STR_RHSSAF_TMA4_DISPLAYNAME;
+        model = "\rhssaf\addons\rhssaf_m_explosives\mines_at\tma4\rhssaf_tma4_d";
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "[0, 0, 0.024]";
+            };
+        };
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_saf3/CfgVehicles.hpp
@@ -1,6 +1,6 @@
 class CfgVehicles {
 
-    //ACE Explosives
+    // ACE Explosives
     class Items_base_F;
     class ACE_Explosives_Place: Items_base_F {
         class ACE_Actions {

--- a/optionals/compat_rhs_saf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_saf3/CfgWeapons.hpp
@@ -58,4 +58,9 @@ class CfgWeapons {
         ACE_barrelTwist = 240;
         ACE_Overheating_allowSwapBarrel = 1;
     };
+
+    class hgun_P07_F;
+    class rhs_weap_cz99: hgun_P07_F {
+        ACE_barrelLength = 108;
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_saf3/CfgWeapons.hpp
@@ -1,0 +1,61 @@
+class CfgWeapons {
+
+    // ACE Ballistics
+    class rhs_weap_g36_base;
+    class rhs_weap_g36c: rhs_weap_g36_base {
+        ACE_barrelLength = 228;
+        ACE_barrelTwist = 178;
+    };
+
+    class rhs_weap_g36kv: rhs_weap_g36_base {
+        ACE_barrelLength = 318;
+        ACE_barrelTwist = 178;
+    };
+
+    class rhs_weap_m21_base;
+    class rhs_weap_m21a: rhs_weap_m21_base {
+        ACE_barrelLength = 460;
+        ACE_barrelTwist = 177.8;
+    };
+
+    class rhs_weap_m21a_pr: rhs_weap_m21_base {
+        ACE_barrelLength = 460;
+        ACE_barrelTwist = 177.8;
+    };
+
+    class rhs_weap_m21a_pr_pbg40: rhs_weap_m21_base {
+        ACE_barrelLength = 460;
+        ACE_barrelTwist = 177.8;
+    };
+
+    class rhs_weap_m21s: rhs_weap_m21_base {
+        ACE_barrelLength = 375;
+        ACE_barrelTwist = 177.8;
+    };
+
+    class rhs_weap_m21s_pr: rhs_weap_m21a_pr {
+        ACE_barrelLength = 375;
+        ACE_barrelTwist = 177.8;
+    };
+
+    class Rifle_Base_F;
+    class rhs_weap_m70_base: Rifle_Base_F {
+        ACE_barrelLength = 415;
+        ACE_barrelTwist = 240;
+    };
+
+    class rhs_weap_m92: rhs_weap_m70_base {
+        ACE_barrelLength = 254;
+    };
+
+    class rhs_weap_m76: rhs_weap_m70_base {
+        ACE_barrelLength = 550;
+    };
+
+    class Rifle_Long_Base_F;
+    class rhs_weap_m84: Rifle_Long_Base_F {
+        ACE_barrelLength = 658;
+        ACE_barrelTwist = 240;
+        ACE_Overheating_allowSwapBarrel = 1;
+    };
+};

--- a/optionals/compat_rhs_saf3/config.cpp
+++ b/optionals/compat_rhs_saf3/config.cpp
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"rhssaf_main"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};

--- a/optionals/compat_rhs_saf3/config.cpp
+++ b/optionals/compat_rhs_saf3/config.cpp
@@ -6,10 +6,14 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhssaf_main"};
+        requiredAddons[] = {"ace_explosives", "rhssaf_c_weapons", "rhssaf_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };
 };
+
+#include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_saf3/config.cpp
+++ b/optionals/compat_rhs_saf3/config.cpp
@@ -16,4 +16,5 @@ class CfgPatches {
 
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"

--- a/optionals/compat_rhs_saf3/script_component.hpp
+++ b/optionals/compat_rhs_saf3/script_component.hpp
@@ -1,0 +1,6 @@
+#define COMPONENT compat_rhs_saf3
+#define COMPONENT_BEAUTIFIED RHS SAF Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**

- Add optional RHS:SAF compat

Addresses issue #7785

- [x] `Explosives`
- [x] `Ballistics`