### PR TITLE
Medical Engine - Prevent issues with respawning and ragdoll animations

### DIFF
--- a/addons/medical_engine/XEH_preInit.sqf
+++ b/addons/medical_engine/XEH_preInit.sqf
@@ -64,12 +64,12 @@ addMissionEventHandler ["Loaded", {
 ["ace_unconscious", {
     params ["_unit", "_active"];
     if (_active) then {
-        if (_unit getVariable [QGVAR(waitForAnim), true]) then {
-            [{(animationState _this) find QGVAR(face) != -1}, {
-                [_this, animationState _this] call FUNC(applyAnimAfterRagdoll);
-            }, _unit, 20] call CBA_fnc_waitUntilAndExecute;
-            _unit setVariable [QGVAR(waitForAnim), false];
-        };
+        // Use object reference to indicate the waitUnit is already running (this prevents issues with respawning units keeping SetVars)
+        if ((_unit getVariable [QGVAR(waitForAnim), objNull]) == _unit) exitWith {};
+        _unit setVariable [QGVAR(waitForAnim), _unit];
+        [{(animationState _this) find QGVAR(face) != -1}, {
+            [_this, animationState _this] call FUNC(applyAnimAfterRagdoll);
+        }, _unit, 20] call CBA_fnc_waitUntilAndExecute;
     } else {
         _unit setVariable [QGVAR(waitForAnim), nil];
         if (local _unit) then {

--- a/addons/medical_engine/functions/fnc_applyAnimAfterRagdoll.sqf
+++ b/addons/medical_engine/functions/fnc_applyAnimAfterRagdoll.sqf
@@ -17,6 +17,8 @@
  */
 
 params ["_unit", "_anim"];
+TRACE_2("applyAnimAfterRagdoll",_unit,_unconsciousAnimation);
+
 if !(IS_UNCONSCIOUS(_unit) &&                   // do not run if unit is conscious
     {alive _unit &&                             // do not run if unit is dead
     {isNull objectParent _unit}}) exitWith {};  // do not run if unit in any vehicle
@@ -25,7 +27,7 @@ private _unconsciousAnimation = selectRandom (GVAR(animations) getVariable [_ani
 
 if (_unconsciousAnimation isEqualTo "") exitWith {
     // not a valid animation found
-    ERROR("No valid animation found!");
+    ERROR_1("No valid animation found! [from anim: %1]",_anim);
 };
 
 // Apply the animation only locally on the machine and do not broadcast it to others


### PR DESCRIPTION
If unit was killed while unconc it will keep `QGVAR(waitForAnim), true])` setVars