### PR TITLE
Overpressure - Add support for funnel shape backblast

### DIFF
--- a/addons/overpressure/CfgWeapons.hpp
+++ b/addons/overpressure/CfgWeapons.hpp
@@ -7,6 +7,7 @@ class CfgWeapons {
         GVAR(angle) = 60;
         GVAR(range) = 10;
         GVAR(damage) = 0.7;
+        GVAR(funnel) = 0; // Funnel means that rocket engine exhaust does not affect units standing directly behind the launcher. Example: RPG-76 Komar
     };
 
     class Launcher_Base_F: Launcher {};

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -14,8 +14,9 @@
  *  0: Angle <Number>
  *  1: Range <Number>
  *  2: Damage <Number>
+ *  3: Funnel <Number>
  *
- * Example: 
+ * Example:
  * ["cannon_125mm","Sh_125mm_APFSDS_T_Green","24Rnd_125mm_APFSDS_T_Green"] call ace_overpressure_fnc_cacheOverPressureValues
  *
  * Public: No
@@ -47,7 +48,8 @@ TRACE_1("ConfigPath",_config);
 private _return = [
     (getNumber (_config >> QGVAR(angle))),
     (getNumber (_config >> QGVAR(range))) * GVAR(distanceCoefficient),
-    (getNumber (_config >> QGVAR(damage)))
+    (getNumber (_config >> QGVAR(damage))),
+    (getNumber (_config >> QGVAR(funnel)))
 ];
 
 private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -30,8 +30,8 @@ private _var = if (isNil _varName) then {
 } else {
     missionNameSpace getVariable _varName;
 };
-_var params ["_overpressureAngle","_overpressureRange","_overpressureDamage"];
-TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
+_var params ["_overpressureAngle","_overpressureRange","_overpressureDamage","_overpressureFunnel"];
+TRACE_4("cache",_overpressureAngle,_overpressureRange,_overpressureDamage,_overpressureFunnel);
 
 {
     if (local _x && {_x != _firer} && {vehicle _x == _x}) then {
@@ -45,10 +45,9 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
         private _line2 = [_posASL, _targetPositionASL];
         TRACE_4("Affected:",_x,_axisDistance,_distance,_angle);
 
-        if (_angle < _overpressureAngle && {_distance < _overpressureRange} && {!lineIntersects _line} && {!terrainIntersectASL _line2}) then {
-
+        if (_angle < _overpressureAngle && _angle >= _overpressureFunnel && _distance < _overpressureRange && {!lineIntersects _line && {!terrainIntersectASL _line2}}) then {
             private _alpha = sqrt (1 - _distance / _overpressureRange);
-            private _beta = sqrt (1 - _angle / _overpressureAngle);
+            private _beta = sqrt (1 - _angle - _overpressureFunnel / (_overpressureAngle - _overpressureFunnel));
 
             private _damage = _alpha * _beta * _overpressureDamage;
             TRACE_1("",_damage);


### PR DESCRIPTION
**When merged this pull request will:**
- Add support for weapon attribute **ace_overpressure_funnel**, which will allow people standing directly behind the launcher to be unaffected, if this is how given launcher works IRL.
- ace_overpressure_funnel is added to Launcher base class and set to 0 (not used).
- Small proposed optimization change, can be reverted given there is evidence that lazy eval of separate code blocks is faster than nested code blocks.