### PR TITLE
Overpressure - Add support for funnel shaped backblast

### DIFF
--- a/addons/overpressure/CfgWeapons.hpp
+++ b/addons/overpressure/CfgWeapons.hpp
@@ -7,6 +7,7 @@ class CfgWeapons {
         GVAR(angle) = 60;
         GVAR(range) = 10;
         GVAR(damage) = 0.7;
+        GVAR(funnel) = 0; // Funnel shaped backblast does not affect units standing directly behind the launcher. Example: RPG-76 Komar
     };
 
     class Launcher_Base_F: Launcher {};

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -14,8 +14,9 @@
  *  0: Angle <Number>
  *  1: Range <Number>
  *  2: Damage <Number>
+ *  3: Funnel <Number>
  *
- * Example: 
+ * Example:
  * ["cannon_125mm","Sh_125mm_APFSDS_T_Green","24Rnd_125mm_APFSDS_T_Green"] call ace_overpressure_fnc_cacheOverPressureValues
  *
  * Public: No
@@ -47,7 +48,8 @@ TRACE_1("ConfigPath",_config);
 private _return = [
     (getNumber (_config >> QGVAR(angle))),
     (getNumber (_config >> QGVAR(range))) * GVAR(distanceCoefficient),
-    (getNumber (_config >> QGVAR(damage)))
+    (getNumber (_config >> QGVAR(damage))),
+    (getNumber (_config >> QGVAR(funnel)))
 ];
 
 private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -41,8 +41,8 @@ TRACE_4("cache",_overpressureAngle,_overpressureRange,_overpressureDamage,_overp
         private _distance = vectorMagnitude _relativePosition;
         private _angle = acos (_axisDistance / _distance);
 
-        private _line = [_posASL, _targetPositionASL];
-        private _line2 = [_posASL, _targetPositionASL, _firer, _x];
+        private _line = [_posASL, _targetPositionASL, _firer, _x];
+        private _line2 = [_posASL, _targetPositionASL];
         TRACE_4("Affected:",_x,_axisDistance,_distance,_angle);
 
         // Funnel determines offset angle from the _direction.
@@ -51,7 +51,7 @@ TRACE_4("cache",_overpressureAngle,_overpressureRange,_overpressureDamage,_overp
             _angle = abs (_angle - _overpressureFunnel);
         };
 
-        if (_angle < _overpressureAngle && _distance < _overpressureRange && {!terrainIntersectASL _line && {!lineIntersects _line2}}) then {
+        if (_angle < _overpressureAngle && {_distance < _overpressureRange} && {!lineIntersects _line} && {!terrainIntersectASL _line2}) then {
             private _alpha = sqrt (1 - _distance / _overpressureRange);
             private _beta = sqrt (1 - _angle / _overpressureAngle);
 

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -47,7 +47,9 @@ TRACE_4("cache",_overpressureAngle,_overpressureRange,_overpressureDamage,_overp
 
         // Funnel determines offset angle from the _direction.
         // Absolute value is needed to make it symmetrical towards and outwards the _direction.
-        if (_overpressureFunnel > 0) then {_angle = abs (_angle - _overpressureFunnel)};
+        if (_overpressureFunnel > 0) then {
+            _angle = abs (_angle - _overpressureFunnel);
+        };
 
         if (_angle < _overpressureAngle && _distance < _overpressureRange && {!terrainIntersectASL _line && {!lineIntersects _line2}}) then {
             private _alpha = sqrt (1 - _distance / _overpressureRange);

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -30,8 +30,8 @@ private _var = if (isNil _varName) then {
 } else {
     missionNameSpace getVariable _varName;
 };
-_var params ["_overpressureAngle","_overpressureRange","_overpressureDamage"];
-TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
+_var params ["_overpressureAngle","_overpressureRange","_overpressureDamage","_overpressureFunnel"];
+TRACE_4("cache",_overpressureAngle,_overpressureRange,_overpressureDamage,_overpressureFunnel);
 
 {
     if (local _x && {_x != _firer} && {vehicle _x == _x}) then {
@@ -41,12 +41,15 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
         private _distance = vectorMagnitude _relativePosition;
         private _angle = acos (_axisDistance / _distance);
 
-        private _line = [_posASL, _targetPositionASL, _firer, _x];
-        private _line2 = [_posASL, _targetPositionASL];
+        private _line = [_posASL, _targetPositionASL];
+        private _line2 = [_posASL, _targetPositionASL, _firer, _x];
         TRACE_4("Affected:",_x,_axisDistance,_distance,_angle);
 
-        if (_angle < _overpressureAngle && {_distance < _overpressureRange} && {!lineIntersects _line} && {!terrainIntersectASL _line2}) then {
+        // Funnel determines offset angle from the _direction.
+        // Absolute value is needed to make it symmetrical towards and outwards the _direction.
+        if (_overpressureFunnel > 0) then {_angle = abs (_angle - _overpressureFunnel)};
 
+        if (_angle < _overpressureAngle && _distance < _overpressureRange && {!terrainIntersectASL _line && {!lineIntersects _line2}}) then {
             private _alpha = sqrt (1 - _distance / _overpressureRange);
             private _beta = sqrt (1 - _angle / _overpressureAngle);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add support for weapon attribute **ace_overpressure_funnel**, which will allow people standing directly behind the launcher to be unaffected, if this is how given launcher works IRL. Example: RPG-76 Komar
![image](https://user-images.githubusercontent.com/2622874/86668158-a76ab300-bff2-11ea-9b2a-04a0f2feb2c8.png)
- ace_overpressure_funnel is added to Launcher base class and set to 0 (not used).
- Small proposed optimization change