### PR TITLE
RHS Compat - Fix RHS:GREF M21/G36 weapons

### DIFF
--- a/optionals/compat_rhs_gref3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_gref3/CfgAmmo.hpp
@@ -3,30 +3,32 @@ class CfgAmmo {
     class rhsgref_ammo_rkg3em: GrenadeHand { // Scripted shaped charge
         ace_frag_force = 0;
     };
+
     class BulletBase;
     class rhs_ammo_762x25_Ball: BulletBase {
-        ACE_caliber=7.874;
-        ACE_bulletLength=13.856;
-        ACE_bulletMass=5.5728;
-        ACE_ammoTempMuzzleVelocityShifts[]={-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
-        ACE_ballisticCoefficients[]={0.17};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={360, 380, 400};
-        ACE_barrelLengths[]={101.6, 152.4, 228.6};
+        ACE_caliber = 7.874;
+        ACE_bulletLength = 13.856;
+        ACE_bulletMass = 5.5728;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {0.17};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {360, 380, 400};
+        ACE_barrelLengths[] = {101.6, 152.4, 228.6};
     };
+
     class rhs_ammo_792x57_Ball: BulletBase {
-        ACE_caliber=8.077;
-        ACE_bulletLength=28.651;
-        ACE_bulletMass=12.7008;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.315};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={785, 800, 815};
-        ACE_barrelLengths[]={508.0, 599.948, 660.4};
+        ACE_caliber = 8.077;
+        ACE_bulletLength = 28.651;
+        ACE_bulletMass = 12.7008;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.315};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {785, 800, 815};
+        ACE_barrelLengths[] = {508.0, 599.948, 660.4};
     };
 
     // ACE Explosives

--- a/optionals/compat_rhs_gref3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_gref3/CfgWeapons.hpp
@@ -61,13 +61,6 @@ class CfgWeapons {
         ACE_barrelLength = 583;
     };
 
-    class Rifle_Long_Base_F;
-    class rhs_weap_m84: Rifle_Long_Base_F {
-        ACE_Overheating_allowSwapBarrel = 1;
-        ACE_barrelTwist = 240;
-        ACE_barrelLength = 658;
-    };
-
     class rhs_weap_vhs2_base;
     class rhs_weap_vhsd2: rhs_weap_vhs2_base {
         ACE_barrelTwist = 177.8;

--- a/optionals/compat_rhs_gref3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_gref3/CfgWeapons.hpp
@@ -1,117 +1,116 @@
 class CfgWeapons {
+
+    // ACE Ballistics
     class rhs_weap_kar98k_Base_F;
     class rhs_weap_kar98k: rhs_weap_kar98k_Base_F {
         ACE_barrelTwist = 240;
         ACE_barrelLength = 600;
     };
+
     class rhs_weap_m38_Base_F;
     class rhs_weap_m38: rhs_weap_m38_Base_F {
         ACE_barrelTwist = 250;
         ACE_barrelLength = 315;
     };
+
     class rhs_weap_m38_rail;
     class rhs_weap_mosin_sbr: rhs_weap_m38_rail {
         ACE_barrelTwist = 240;
         ACE_barrelLength = 254;
     };
+
     class rhs_weap_m70_base;
     class rhs_weap_m70ab2: rhs_weap_m70_base {
         ACE_barrelTwist = 240;
         ACE_barrelLength = 415;
     };
+
     class rhs_weap_m92: rhs_weap_m70_base {
         ACE_barrelTwist = 240;
         ACE_barrelLength = 254;
     };
+
     class rhs_weap_m76: rhs_weap_m70_base {
         ACE_barrelTwist = 250;
         ACE_barrelLength = 200;
     };
-    class rhs_weap_m21_base;
-    class rhs_weap_m21: rhs_weap_m21_base {
-        ACE_barrelTwist = 177.8;
+
+    class rhs_weap_m21_base: rhs_weap_m70_base {
         ACE_barrelLength = 460;
-    };
-    class rhs_weap_m21a: rhs_weap_m21_base {
         ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 290;
     };
-    class rhs_weap_m21a_pr: rhs_weap_m21_base {
-        ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 290;
-    };
-    class rhs_weap_m21a_pr_pbg40: rhs_weap_m21_base {
-        ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 290;
-    };
+
     class rhs_weap_m21s: rhs_weap_m21_base {
-        ACE_barrelTwist = 177.8;
         ACE_barrelLength = 375;
     };
+
+    class rhs_weap_m21a_pr;
     class rhs_weap_m21s_pr: rhs_weap_m21a_pr {
-        ACE_barrelTwist = 177.8;
         ACE_barrelLength = 375;
     };
+
     class Rifle_Base_F;
     class rhs_weap_savz58_base: Rifle_Base_F {
         ACE_barrelTwist = 240;
         ACE_barrelLength = 390;
     };
+
     class rhs_weap_stgw57_base;
     class rhs_weap_stgw57: rhs_weap_stgw57_base {
         ACE_barrelTwist = 270;
         ACE_barrelLength = 583;
     };
-    class rhs_weap_g36_base;
-    class rhs_weap_g36c: rhs_weap_g36_base {
-        ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 228.6;
-    };
-    class rhs_weap_g36kv: rhs_weap_g36_base {
-        ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 317.5;
-    };
+
     class Rifle_Long_Base_F;
     class rhs_weap_m84: Rifle_Long_Base_F {
         ACE_Overheating_allowSwapBarrel = 1;
         ACE_barrelTwist = 240;
         ACE_barrelLength = 658;
     };
+
     class rhs_weap_vhs2_base;
     class rhs_weap_vhsd2: rhs_weap_vhs2_base {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 500.0;
     };
+
     class rhs_weap_vhsk2: rhs_weap_vhsd2 {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 410.0;
     };
+
     class rhs_weap_vhsd2_ct15x: rhs_weap_vhsk2 {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 500.0;
     };
+
     class rhs_weap_vhsd2_bg: rhs_weap_vhsd2_ct15x {
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 500.0;
     };
+
     class rhs_weap_fnfal_base;
     class rhs_weap_l1a1_base: rhs_weap_fnfal_base {
         ACE_barrelTwist = 302.26;
         ACE_barrelLength = 554.4;
     };
+
     class rhs_weap_mg42_base: Rifle_Base_F {
         ACE_Overheating_allowSwapBarrel = 1;
         ACE_barrelTwist = 305.0;
         ACE_barrelLength = 530.0;
     };
+
     class rhs_weap_MP44_base: Rifle_Base_F {
         ACE_barrelTwist = 240.0;
         ACE_barrelLength = 420.0;
     };
+
     class rhs_weap_m3a1_base: Rifle_Base_F {
         ACE_barrelTwist = 406.0;
         ACE_barrelLength = 203.2;
     };
+
     class rhs_weap_M1garand_Base_F: Rifle_Base_F {
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 610.0;


### PR DESCRIPTION
**When merged this pull request will:**
- Update M21 rifles
- Remove G36 rifles _(moved to SAF compat)_
- Remove M84 MG _(moved to SAF compat)_
- General cosmetics

Related to issue https://github.com/acemod/ACE3/issues/7785 and PR https://github.com/acemod/ACE3/pull/7793

Merge after https://github.com/acemod/ACE3/pull/7784 to avoid potential conflicts ....