### PR TITLE
Nametags - Fix names jump when no ranks shown and talking

### DIFF
--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -30,10 +30,8 @@ _fnc_parameters = {
 
     //Set Icon:
     private _icon = "";
-    private _size = 0;
     if (_drawSoundwave) then {
         _icon = format [QPATHTOF(UI\soundwave%1.paa), floor random 10];
-        _size = 1;
     } else {
         if (_drawRank && {rank _target != ""}) then {
             _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
@@ -42,7 +40,6 @@ _fnc_parameters = {
             } else {
                 _icon = format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target];
             };
-            _size = 1;
         };
     };
 
@@ -76,8 +73,8 @@ _fnc_parameters = {
         _icon,
         _color,
         [],
-        (_size * _scale),
-        (_size * _scale),
+        _scale,
+        _scale,
         0,
         _name,
         2,


### PR DESCRIPTION
**When merged this pull request will:**
- Fix names jump on nametags when no ranks shown and talking on ACRE/TFAR

When no ranks are shown nametag jumps up and down when player talks on ACRE/TFAR due to soundwave icon pushing the name down. This can be fixed by not scaling the icon to 0 when no icon shown (no icon still takes space).

https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=92429296-c375-11ea-bf88-a15b6c7adf9a
