### PR TITLE
Goggles - Add effects only option

### DIFF
--- a/addons/goggles/ACE_Settings.hpp
+++ b/addons/goggles/ACE_Settings.hpp
@@ -4,9 +4,9 @@ class ACE_Settings {
         category = CSTRING(DisplayName);
         displayName = CSTRING(effects_displayName);
         typeName = "SCALAR";
-        value = 2;
+        value = 3;
         isClientSettable = 1;
-        values[] = {ECSTRING(common,Disabled), CSTRING(effects_tintOnly), CSTRING(enabled_tintAndEffects)};
+        values[] = {ECSTRING(common,Disabled), CSTRING(effects_tintOnly), CSTRING(enabled_tintAndEffects), CSTRING(effects_effectsOnly)};
     };
     class GVAR(showInThirdPerson) {
         category = CSTRING(DisplayName);

--- a/addons/goggles/ACE_Settings.hpp
+++ b/addons/goggles/ACE_Settings.hpp
@@ -4,7 +4,7 @@ class ACE_Settings {
         category = CSTRING(DisplayName);
         displayName = CSTRING(effects_displayName);
         typeName = "SCALAR";
-        value = 3;
+        value = 2;
         isClientSettable = 1;
         values[] = {ECSTRING(common,Disabled), CSTRING(effects_tintOnly), CSTRING(enabled_tintAndEffects), CSTRING(effects_effectsOnly)};
     };

--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -85,7 +85,7 @@ if (!hasInterface) exitWith {};
 
 
     // // ---Add the Dust/Dirt/Rain Effects---
-    if (GVAR(effects) == 2) then {
+    if (GVAR(effects) in [2, 3]) then {
 
         // Register fire event handler
         ["ace_firedPlayer", DFUNC(handleFired)] call CBA_fnc_addEventHandler;

--- a/addons/goggles/functions/fnc_applyGlassesEffect.sqf
+++ b/addons/goggles/functions/fnc_applyGlassesEffect.sqf
@@ -33,7 +33,7 @@ private _config = configFile >> "CfgGlasses" >> _glasses;
 private _postProcessColour = getArray (_config >> "ACE_Color");
 private _postProcessTintAmount = getNumber (_config >> "ACE_TintAmount");
 
-if (_postProcessTintAmount != 0 && {GVAR(UsePP)}) then {
+if (_postProcessTintAmount != 0 && {GVAR(UsePP)} && GVAR(effects) in [1, 2]) then {
     _postProcessColour set [3, _postProcessTintAmount/100];
     GVAR(PostProcess) ppEffectAdjust[0.9, 1.1, 0.004, _postProcessColour, [0,0,0,1],[0,0,0,0]];
     GVAR(PostProcess) ppEffectCommit 0;
@@ -50,7 +50,7 @@ if (_imagePath != "") then {
     (GLASSDISPLAY displayCtrl 10650) ctrlSetText _imagePath;
 };
 
-if (GVAR(effects) == 2) then {
+if (GVAR(effects) in [2, 3]) then {
     if (GETDIRT) then {
         call FUNC(applyDirtEffect);
     };

--- a/addons/goggles/functions/fnc_canWipeGlasses.sqf
+++ b/addons/goggles/functions/fnc_canWipeGlasses.sqf
@@ -15,4 +15,4 @@
  * Public: No
  */
 
-GVAR(effects) == 2 && {!GETVAR(ACE_player,ACE_isUnconscious,false)} // return
+GVAR(effects) in [2, 3] && {!GETVAR(ACE_player,ACE_isUnconscious,false)} // return

--- a/addons/goggles/functions/fnc_handleKilled.sqf
+++ b/addons/goggles/functions/fnc_handleKilled.sqf
@@ -22,7 +22,7 @@ if (GVAR(effects) == 0) exitWith {true};
 
 call FUNC(removeGlassesEffect);
 
-if (GVAR(effects) == 2) then {
+if (GVAR(effects) in [2, 3]) then {
     GVAR(PostProcessEyes) ppEffectEnable false;
 
     SETGLASSES(_unit,GLASSESDEFAULT);

--- a/addons/goggles/functions/fnc_removeGlassesEffect.sqf
+++ b/addons/goggles/functions/fnc_removeGlassesEffect.sqf
@@ -22,7 +22,7 @@ if (!isNull (GLASSDISPLAY)) then {
     GLASSDISPLAY closeDisplay 0;
 };
 
-if (GVAR(effects) == 2) then {
+if (GVAR(effects) in [2, 3]) then {
     call FUNC(removeDirtEffect);
     call FUNC(removeRainEffect);
     call FUNC(removeDustEffect);

--- a/addons/goggles/stringtable.xml
+++ b/addons/goggles/stringtable.xml
@@ -99,6 +99,22 @@
             <Spanish>Tinte</Spanish>
             <Turkish>Ton</Turkish>
         </Key>
+        <Key ID="STR_ACE_Goggles_effects_effectsOnly">
+            <English>Effects</English>
+            <Russian>эффекты</Russian>
+            <Japanese>効果</Japanese>
+            <Polish>Efekty</Polish>
+            <German>Effekte</German>
+            <Korean>효과</Korean>
+            <French>Effets</French>
+            <Italian>Effetti</Italian>
+            <Chinesesimp>影响</Chinesesimp>
+            <Chinese>影響</Chinese>
+            <Portuguese>Efeitos</Portuguese>
+            <Czech>Efekty</Czech>
+            <Spanish>Efectos</Spanish>
+            <Turkish>Efektler</Turkish>
+        </Key>
         <Key ID="STR_ACE_Goggles_enabled_tintAndEffects">
             <English>Tint + Effects</English>
             <Russian>Тонировка + эффекты</Russian>


### PR DESCRIPTION
**When merged this pull request will:**
- As the title says, adds an effects only option for goggles.

Translations are from `STR_ACE_Goggles_enabled_tintAndEffects`, they _should_ be accurate