### PR TITLE
MissileGuidance - Add config option for using pilot camera as primary SACLOS control method

### DIFF
--- a/addons/missileguidance/functions/fnc_SACLOS_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_SACLOS_onFired.sqf
@@ -18,16 +18,18 @@ params ["_firedEH", "", "", "", "_stateParams"];
 _firedEH params ["_shooter","_weapon","","","","","_projectile"];
 _stateParams params ["", "_seekerStateParams"];
 
-private _config = ([_projectile] call CBA_fnc_getObjectConfig) >> "ace_missileguidance";
-
-if (_shooter isKindOf "Plane" && { !hasPilotCamera _shooter }) exitWith { WARNING("SACLOS fired from planes without camera unsupported"); };
+private _usePilotCamera = getNumber (([_shooter] call CBA_fnc_getObjectConfig) >> "pilotCamera" >> QGVAR(usePilotCameraForTargeting)) == 1;
 
 private _turretPath = [_shooter, _weapon] call CBA_fnc_turretPathWeapon;
 private _turretConfig = [_shooter, _turretPath] call CBA_fnc_getTurret;
 private _memoryPointGunnerOptics = getText(_turretConfig >> "memoryPointGunnerOptics");
 private _animationSourceBody = getText(_turretConfig >> "animationSourceBody");
 private _animationSourceGun = getText(_turretConfig >> "animationSourceGun");
+
 _seekerStateParams set [0, _memoryPointGunnerOptics];
 _seekerStateParams set [1, _animationSourceBody];
 _seekerStateParams set [2, _animationSourceGun];
+_seekerStateParams set [3, _usePilotCamera || { (_shooter isKindOf "Plane") && hasPilotCamera _shooter }];
+
+if ((_shooter isKindOf "Plane") && !hasPilotCamera _shooter) then { WARNING("SACLOS fired from planes without pilot camera unsupported!"); };
 

--- a/addons/missileguidance/functions/fnc_seekerType_SACLOS.sqf
+++ b/addons/missileguidance/functions/fnc_seekerType_SACLOS.sqf
@@ -20,13 +20,13 @@ _args params ["_firedEH", "", "", "_seekerParams", "_stateParams"];
 _firedEH params ["_shooter","_weapon","","","","","_projectile"];
 _seekerParams params ["_seekerAngle"];
 _stateParams params ["", "_seekerStateParams"];
-_seekerStateParams params ["_memoryPointGunnerOptics", "_animationSourceBody", "_animationSourceGun"];
+_seekerStateParams params ["_memoryPointGunnerOptics", "_animationSourceBody", "_animationSourceGun", "_usePilotCamera"];
 
 private _shooterPos = AGLToASL (_shooter modelToWorld(_shooter selectionPosition _memoryPointGunnerOptics));
 private _projPos = getPosASL _projectile;
 
 private _lookDirection = if !(_shooter isKindOf "CAManBase" || {_shooter isKindOf "StaticWeapon"}) then {
-    private _finalLookDirection = if (_shooter isKindOf "Plane") then {
+    private _finalLookDirection = if (_usePilotCamera) then {
         _shooterPos = _shooter modelToWorldVisualWorld getPilotCameraPosition _shooter;
         private _trackingTarget = getPilotCameraTarget _shooter;
         _trackingTarget params ["_isTracking", "_trackingPos"];


### PR DESCRIPTION
fix #7811 
doesn't automatically apply to vehicles that want to use the camera since that would require information that we can't infer. All vanilla helicopters use other means for turrets so I am still assuming that to be the default.