### PR TITLE
Update stringtable_validator.py

### DIFF
--- a/tools/stringtable_validator.py
+++ b/tools/stringtable_validator.py
@@ -129,7 +129,7 @@ def check_stringtable(filepath):
            if line_clean.startswith("</key") or line_clean.startswith("</package") or line_clean.startswith("</project") or line_clean.startswith("</container"):
                spacing_depth -= 4
 
-           line_spacing = len(line) - len(line_clean)
+           line_spacing = len(line.lower()) - len(line_clean)
 
            if line_spacing != spacing_depth:
                print("  ERROR: Incorrect number of indenting spaces on line {}, currently {}, should be {}.".format(line_number, line_spacing, spacing_depth))
@@ -162,13 +162,11 @@ def main():
     bad_count = 0
 
     for filepath in stringtable_files:
-        print("\nChecking {}:".format(os.path.relpath(filepath, root_dir)))
+        print("Checking {}:".format(os.path.relpath(filepath, root_dir)))
 
         errors = check_stringtable(filepath)
 
-        if errors == 0:
-            print("No errors found.")
-        else:
+        if errors != 0:
             print("Found {} error(s).".format(errors))
             bad_count += 1
 


### PR DESCRIPTION
Fix odd unicode bug in string validator
(causing false positives in #7823)

```
            <Turkish>.45 ACP 25 Merm.İzli</Turkish>
```
Failed with `ERROR: Incorrect number of indenting spaces on line 45, currently 11, should be 12.`

it seems to be because `toLower()` changes the length of the string (the İ expands to 2 chars?)
```
52 =             <Turkish>.45 ACP 25 Merm.İzli</Turkish>
53 =             <turkish>.45 acp 25 merm.i̇zli</turkish>
```
looks the same in my browser, but my terminal kinda shows what's happening
![image](https://user-images.githubusercontent.com/9376747/89478719-6cc17b00-d756-11ea-8316-5abcbc743efd.png)
