### PR TITLE
Hearing - Add hearing protection to LDF and Spetsnaz helmets

### DIFF
--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -88,4 +88,19 @@ class CfgWeapons {
     class H_HelmetO_ViperSP_hex_f: H_HelmetB {
         HEARING_PROTECTION_PELTOR
     };
+
+    class H_HelmetAggressor_base_F: HelmetBase {
+        HEARING_PROTECTION_PELTOR
+    };
+
+    class H_HelmetHBK_base_F;
+    class H_HelmetHBK_chops_base_F: H_HelmetHBK_base_F {
+        HEARING_PROTECTION_PELTOR
+    };
+    class H_HelmetHBK_ear_base_F: H_HelmetHBK_base_F {
+        HEARING_PROTECTION_PELTOR
+    };
+    class H_HelmetHBK_headset_base_F: H_HelmetHBK_base_F {
+        HEARING_PROTECTION_PELTOR
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Adds 75% (peltor) hearing protection to the Advanced Modular Helmets (except the base "(Olive)" helmet which doesn't have a headset).
- And adds the same to the Avenger Helmet (the covered helmets inherit).