### PR TITLE
Map Gestures: Fix Briefing Mode setting strings

### DIFF
--- a/addons/map_gestures/initSettings.sqf
+++ b/addons/map_gestures/initSettings.sqf
@@ -38,7 +38,7 @@
 
 [
     QGVAR(briefingMode), "LIST",
-    [LSTRING(allowCurator_displayName), LSTRING(allowCurator_description)],
+    [LSTRING(briefingMode_displayName), LSTRING(briefingMode_description)],
     LSTRING(mapGestures_category),
     [[0, 1, 2, 3, 4], [LSTRING(briefingMode_All), LSTRING(briefingMode_Group), LSTRING(briefingMode_Side), LSTRING(briefingMode_Proximity), LSTRING(briefingMode_Disabled)], 0]
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
The `briefingMode` setting displayed the name and the tooltip of the `allowCurator` setting.