### PR TITLE
Remove "ACE" prefix for the Gunbag category in Uncategorized menu

### DIFF
--- a/addons/gunbag/stringtable.xml
+++ b/addons/gunbag/stringtable.xml
@@ -34,20 +34,20 @@
             <Spanish>Funda de arma (Tan)</Spanish>
         </Key>
         <Key ID="STR_ACE_Gunbag_DisplayName_Settings">
-            <English>ACE Gunbag</English>
-            <German>ACE Waffentasche</German>
-            <French>ACE Housse d'arme</French>
-            <Russian>ACE Чехол</Russian>
-            <Czech>ACE Pouzdro na zbraň</Czech>
-            <Japanese>ACE ガンバッグ</Japanese>
-            <Polish>ACE Torba na broń</Polish>
-            <Korean>ACE 총가방</Korean>
-            <Italian>ACE Borsa per Armi</Italian>
-            <Chinesesimp>ACE 枪袋</Chinesesimp>
-            <Chinese>ACE 槍袋</Chinese>
-            <Portuguese>ACE Bolsa de Arma</Portuguese>
-            <Turkish>ACE Silah Çantası</Turkish>
-            <Spanish>ACE Funda de arma</Spanish>
+            <English>Gunbag</English>
+            <German>Waffentasche</German>
+            <French>Housse d'arme</French>
+            <Russian>Чехол</Russian>
+            <Czech>Pouzdro na zbraň</Czech>
+            <Japanese>ガンバッグ</Japanese>
+            <Polish>Torba na broń</Polish>
+            <Korean>총가방</Korean>
+            <Italian>Borsa per Armi</Italian>
+            <Chinesesimp>枪袋</Chinesesimp>
+            <Chinese>槍袋</Chinese>
+            <Portuguese>Bolsa de Arma</Portuguese>
+            <Turkish>Silah Çantası</Turkish>
+            <Spanish>Funda de arma</Spanish>
         </Key>
         <Key ID="STR_ACE_Gunbag_ToGunbag">
             <English>Put weapon into gunbag</English>
@@ -81,7 +81,7 @@
             <English>Allows interaction to directly swap the primary weapon and stored weapon.</English>
             <Polish>Pozwala na interakcje do wymiany broni głównej na bron schowaną.</Polish>
             <Russian>Разрешает действие прямого обмена основного оружия и спрятанного в чехле.</Russian>
-            <French>Permet d'échanger directement l'arme primaire et l'arme stockée dans la housse, via le menu d'interaction personnelle.</French>
+            <French>Active le menu d'interaction personnelle permettant d'échanger directement l'arme primaire et l'arme rangée dans la housse.</French>
         </Key>
         <Key ID="STR_ACE_Gunbag_OffGunbag">
             <English>Get weapon out of gunbag</English>


### PR DESCRIPTION
**When merged this pull request will:**
- For better consistency with the rest of the mod, the "ACE" prefix has been removed for the Gunbag category in Uncategorized menu.
![20200823130049_1](https://user-images.githubusercontent.com/22501336/90977973-4408f600-e54a-11ea-80ad-e23ab6852eb0.jpg)
