### PR TITLE
Medical Treatment: Adding splints + torniquets to simple crate

### DIFF
--- a/addons/medical_treatment/CfgVehicles.hpp
+++ b/addons/medical_treatment/CfgVehicles.hpp
@@ -267,6 +267,8 @@ class CfgVehicles {
             MACRO_ADDITEM(ACE_bloodIV,15);
             MACRO_ADDITEM(ACE_bloodIV_500,15);
             MACRO_ADDITEM(ACE_bloodIV_250,15);
+            MACRO_ADDITEM(ACE_tourniquet,10);
+            MACRO_ADDITEM(ACE_splint,10);
             MACRO_ADDITEM(ACE_bodyBag,10);
         };
         class AnimationSources {


### PR DESCRIPTION
**Adds splints + torniquets to simple crate**
- Since the basic/advanced split was removed with the rewrite you now (likely) have use for both of these items in the "simple" version of the crate too
