### PR TITLE
Quick Mount: Check vehicle simulation

### DIFF
--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -30,6 +30,7 @@ GVAR(enabled)
 }
 && {alive _vehicle}
 && {2 > locked _vehicle}
+&& {simulationEnabled _vehicle}
 && {
     -1 == crew _vehicle findIf {alive _x}
     || {0.6 <= side group _unit getFriend side group _vehicle}

--- a/addons/quickmount/functions/fnc_getInNearest.sqf
+++ b/addons/quickmount/functions/fnc_getInNearest.sqf
@@ -37,7 +37,7 @@ if ((isNull _target) && {alive _interactionTarget}) then {
     _target = (_objects param [0, []]) param [2, objNull];
 };
 
-if (locked _target in [2,3]) exitWith {
+if (locked _target in [2,3] || {!simulationEnabled _target}) exitWith {
     [localize LSTRING(VehicleLocked)] call EFUNC(common,displayTextStructured);
     true
 };


### PR DESCRIPTION
**Stops players getting to vehicles with simulation disabled**
- You can currently mount in a vehicle witih sim disabled and you get "stuck" inside. Vanilla addActions allow this too (I've asked Ded to see if he can fix). For now this at leasts stops people accidentally getting in to something they shouldn't with a bad key press.
- Reusing the locked message as the player doesn't need to know the difference between locked/sim disabled, they just need to know they can't get in.
- Possibly warrants an RPT line so if you get people complaining they cannot get in a vehicle, RPT shows why (#blamethemissionmaker) - Thoughts?
