### PR TITLE
Arsenal - Remove launcher sorts

### DIFF
--- a/addons/arsenal/ACE_Arsenal_Sorts.hpp
+++ b/addons/arsenal/ACE_Arsenal_Sorts.hpp
@@ -37,14 +37,14 @@ class GVAR(sorts) {
     class ACE_accuracy: sortBase {
         scope = 2;
         displayName = CSTRING(sortByAccuracyText);
-        tabs[] = {{0,1,2}, {}};
+        tabs[] = {{0,1}, {}};
         statement = QUOTE(_this call FUNC(sortStatement_accuracy));
     };
 
     class ACE_rateOfFire: sortBase {
         scope = 2;
         displayName = CSTRING(sortByRateOfFireText);
-        tabs[] = {{0,1,2}, {}};
+        tabs[] = {{0,1}, {}};
         statement = QUOTE(_this call FUNC(sortStatement_rateOfFire));
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Remove `Sort by accuracy` and `Sort by rate of fire` from launcher tab as they didn't provide anything useful
