### PR TITLE
Missile Guidance - Fix attack profile and laser code variable

### DIFF
--- a/addons/laser/functions/fnc_addLaserTarget.sqf
+++ b/addons/laser/functions/fnc_addLaserTarget.sqf
@@ -20,9 +20,9 @@ params ["_targetObject", "_vehicle"];
 TRACE_2("params",_targetObject,_vehicle);
 
 // Get the designator variables, or use defaults
-private _waveLength = _vehicle getVariable [QEGVAR(laser,waveLength), ACE_DEFAULT_LASER_WAVELENGTH];
-private _laserCode = _vehicle getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
-private _beamSpread = _vehicle getVariable [QEGVAR(laser,beamSpread), ACE_DEFAULT_LASER_BEAMSPREAD];
+private _waveLength = _vehicle getVariable [QGVAR(waveLength), ACE_DEFAULT_LASER_WAVELENGTH];
+private _laserCode = _vehicle getVariable [QGVAR(code), ACE_DEFAULT_LASER_CODE];
+private _beamSpread = _vehicle getVariable [QGVAR(beamSpread), ACE_DEFAULT_LASER_BEAMSPREAD];
 TRACE_3("codes",_waveLength,_laserCode,_beamSpread);
 
 // Laser method is the method ACE_Laser will use to determine from where to where it should project the designator cone

--- a/addons/laser/functions/fnc_laserTargetPFH.sqf
+++ b/addons/laser/functions/fnc_laserTargetPFH.sqf
@@ -29,7 +29,7 @@ GVAR(trackedLaserTargets) = GVAR(trackedLaserTargets) select {
         TRACE_1("Laser off:", _laserUuid);
         false
     } else {
-        private _newCode = _owner getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
+        private _newCode = _owner getVariable [QGVAR(code), ACE_DEFAULT_LASER_CODE];
         if (_laserCode != _newCode) then {
             TRACE_2("code change",_newCode,_laserCode);
             [QGVAR(updateCode), [_laserUuid, _newCode]] call CBA_fnc_globalEvent;

--- a/addons/laser/functions/fnc_showVehicleHud.sqf
+++ b/addons/laser/functions/fnc_showVehicleHud.sqf
@@ -91,10 +91,10 @@ GVAR(pfID) = [{
     // Do Laser Scan:
     private _ammo = getText (configFile >> "CfgMagazines" >> _vehicle currentMagazineTurret _turretPath >> "ammo");
     private _laserSource = AGLtoASL (_vehicle modelToWorld (_vehicle selectionPosition _seekerSource));
-    private _laserCode = _vehicle getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
+    private _laserCode = _vehicle getVariable [QGVAR(code), ACE_DEFAULT_LASER_CODE];
     private _seekerAngle = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ace_missileguidance" >> "seekerAngle");
     private _seekerMaxRange = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ace_missileguidance" >> "seekerMaxRange");
-    private _laserResult = [_laserSource, vectorDir _vehicle, _seekerAngle, _seekerMaxRange, [ACE_DEFAULT_LASER_WAVELENGTH,ACE_DEFAULT_LASER_WAVELENGTH], _laserCode, _vehicle] call EFUNC(laser,seekerFindLaserSpot);
+    private _laserResult = [_laserSource, vectorDir _vehicle, _seekerAngle, _seekerMaxRange, [ACE_DEFAULT_LASER_WAVELENGTH,ACE_DEFAULT_LASER_WAVELENGTH], _laserCode, _vehicle] call FUNC(seekerFindLaserSpot);
     private _foundTargetPos = _laserResult select 0;
     private _haveLock = !isNil "_foundTargetPos";
 

--- a/addons/missileguidance/functions/fnc_ahr_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_ahr_onFired.sqf
@@ -24,6 +24,10 @@ _target = missileTarget _projectile;
 if (isNull _target && isVehicleRadarOn vehicle _shooter) then {
     _target = cursorTarget;
 };
+private _isRemoteTarget = ((listRemoteTargets side _shooter) findIf {_x#0 == cursorTarget}) != -1;
+if (isNull _target && _isRemoteTarget) then {
+    _target = cursorTarget;
+};
 if !(_target isKindOf "AllVehicles") then {
     _target = nil;
 };
@@ -56,7 +60,7 @@ private _shooterHasActiveRadar = {
     false
 } forEach listVehicleSensors vehicle _shooter;
 
-if !(isVehicleRadarOn vehicle _shooter) then {
+if (!(isVehicleRadarOn vehicle _shooter) && !_isRemoteTarget) then {
     _isActive = true;
 };
 

--- a/addons/missileguidance/functions/fnc_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_onFired.sqf
@@ -43,13 +43,13 @@ private _config = configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON);
 private _target = _shooter getVariable [QGVAR(target), nil];
 private _targetPos = _shooter getVariable [QGVAR(targetPosition), nil];
 private _seekerType = _shooter getVariable [QGVAR(seekerType), nil];
-private _attackProfile = _shooter getVariable [QGVAR(attackProfile), nil];
+private _attackProfile = (vehicle _shooter) getVariable [QGVAR(attackProfile), nil];
 if ((getNumber (configFile >> "CfgAmmo" >> _ammo >> QUOTE(ADDON) >> "useModeForAttackProfile")) == 1) then {
     _attackProfile = getText (configFile >> "CfgWeapons" >> _weapon >> _mode >> QGVAR(attackProfile))
 };
-private _lockMode = _shooter getVariable [QGVAR(lockMode), nil];
 
-private _laserCode = _shooter getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
+private _lockMode = _shooter getVariable [QGVAR(lockMode), nil];
+private _laserCode = (vehicle _shooter) getVariable [QEGVAR(laser,code), ACE_DEFAULT_LASER_CODE];
 private _laserInfo = [_laserCode, ACE_DEFAULT_LASER_WAVELENGTH, ACE_DEFAULT_LASER_WAVELENGTH];
 
 TRACE_6("getVars",_target,_targetPos,_seekerType,_attackProfile,_lockMode,_laserCode);


### PR DESCRIPTION
**When merged this pull request will:**
- Use shooter vehicle for attack profile and laser code (both set on vehicle, currently retrieved from player)
- Don't use `E` variant macros inside laser for own variables and functions
- Check list of remote targets for the locked target as one of the fallbacks for hellfire ARH onFired, to enable firing on datalink track files without needing LOS on the target or radar sensor on
  - If target is a remote track, the missile isn't set as active off the rail so it doesn't go maddog
