### PR TITLE
Medical - Add Treatment Time Addon Settings

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -79,7 +79,7 @@ class GVAR(actions) {
         icon = QPATHTOEF(medical_gui,ui\tourniquet.paa);
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         items[] = {"ACE_tourniquet"};
-        treatmentTime = 7;
+        treatmentTime = QGVAR(treatmentTimeTourniquet);
         condition = QUOTE(!([ARR_2(_patient,_bodyPart)] call FUNC(hasTourniquetAppliedTo)));
         callbackSuccess = QFUNC(tourniquet);
         litter[] = {};
@@ -100,7 +100,7 @@ class GVAR(actions) {
         icon = QPATHTOEF(medical_gui,ui\splint.paa);
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         items[] = {"ACE_splint"};
-        treatmentTime = 7;
+        treatmentTime = QGVAR(treatmentTimeSplint);
         callbackSuccess = QFUNC(splint);
         condition = QFUNC(canSplint);
         litter[] = {
@@ -117,7 +117,7 @@ class GVAR(actions) {
         category = "medication";
         items[] = {"ACE_morphine"};
         condition = "";
-        treatmentTime = 5;
+        treatmentTime = QGVAR(treatmentTimeSyringe);
         callbackSuccess = QFUNC(medication);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
         sounds[] = {{QPATHTO_R(sounds\Inject.ogg),1,1,50}};
@@ -148,7 +148,7 @@ class GVAR(actions) {
         allowSelfTreatment = QGVAR(allowSelfIV);
         category = "advanced";
         medicRequired = QGVAR(medicIV);
-        treatmentTime = 12;
+        treatmentTime = QGVAR(treatmentTimeIV);
         items[] = {"ACE_bloodIV"};
         condition = "";
         callbackSuccess = QFUNC(ivBag);
@@ -243,7 +243,7 @@ class GVAR(actions) {
         treatmentLocations = TREATMENT_LOCATIONS_ALL;
         allowSelfTreatment = 0;
         medicRequired = 0;
-        treatmentTime = 15;
+        treatmentTime = QGVAR(treatmentTimeBodyBag);
         items[] = {"ACE_bodyBag"};
         // 'vehicle _patient' always returns the body
         // '_patient in _patient' always false for body

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -35,6 +35,52 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(treatmentTimeTourniquet),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTourniquet_DisplayName), LSTRING(TreatmentTimeTourniquet_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0.1, 30, 7, 2],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(treatmentTimeSplint),
+    "SLIDER",
+    [LSTRING(TreatmentTimeSplint_DisplayName), LSTRING(TreatmentTimeSplint_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0.1, 30, 7, 2],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(treatmentTimeIV),
+    "SLIDER",
+    [LSTRING(TreatmentTimeIV_DisplayName), LSTRING(TreatmentTimeIV_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0.1, 36, 12, 2],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(treatmentTimeSyringe),
+    "SLIDER",
+    [LSTRING(TreatmentTimeSyringe_DisplayName), LSTRING(TreatmentTimeSyringe_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0.1, 30, 5, 2],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(treatmentTimeBodyBag),
+    "SLIDER",
+    [LSTRING(TreatmentTimeBodyBag_DisplayName), LSTRING(TreatmentTimeBodyBag_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0.1, 60, 15, 2],
+    true
+] call CBA_settings_fnc_init;
+
+
+[
     QGVAR(clearTraumaAfterBandage),
     "CHECKBOX",
     [LSTRING(ClearTraumaAfterBandage_DisplayName), LSTRING(ClearTraumaAfterBandage_Description)],

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -126,6 +126,57 @@
             <Polish>Współczynnik kontroluje szanse na ponowne otworzenie rany. Końcowa szansa na otworzenie jest ustalana przez pomnożenie tej wartości z wartością szansy na otworzenie rany dla typu rany oraz typu bandaża.</Polish>
             <Japanese>傷が再開放する確率の係数を設定できます。再開放は、この数値と傷の種類、そして使用した包帯に応じて左右されます。</Japanese>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquet_DisplayName">
+            <English>Tourniquet Treatment Time</English>
+            <French>Temps de traitement du tourniquet</French>
+            <German>Tourniquet-Behandlungszeit</German>
+
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquet_Description">
+            <English>Time in seconds it takes to apply a tourniquet.</English>
+            <French>Temps en secondes nécessaire pour appliquer un garrot.</French>
+            <German>Zeit in Sekunden, die benötigt wird, um ein Tourniquet anzuwenden.</German>
+        </Key>
+             <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSyringe_DisplayName">
+            <English>Syringe Treatment Time</English>
+            <French>Temps de traitement de la seringue</French>
+            <German>Spritzenbehandlungszeit</German>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSyringe_Description">
+            <English>Time in seconds it takes to apply a syringe.</English>
+            <French>Temps en secondes nécessaire pour appliquer une seringue.</French>
+            <German>Zeit in Sekunden, die zum Auftragen einer Spritze benötigt wird.</German>
+        </Key>
+            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIV_DisplayName">
+            <English>IV Bag Treatment Time</English>
+            <French>Temps de traitement du sac IV</French>
+            <German>IV Beutelbehandlungszeit</German>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIV_Description">
+            <English>Time in seconds it takes to apply an IV bag.</English>
+            <French>Temps en secondes nécessaire pour appliquer un sac IV.</French>
+            <German>Zeit in Sekunden, die benötigt wird, um einen Infusionsbeutel aufzutragen.</German>
+        </Key>
+            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplint_DisplayName">
+            <English>Splint Treatment Time</English>
+            <French>Temps de traitement de l'attelle</French>
+            <German>Schienenbehandlungszeit</German>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplint_Description">
+            <English>Time in seconds it takes to apply a splint.</English>
+            <French>Temps en secondes nécessaire pour appliquer une attelle.</French>
+            <German>Zeit in Sekunden, die zum Anbringen einer Schiene benötigt wird.</German>
+        </Key>
+            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodyBag_DisplayName">
+            <English>Body Bag Use Time</English>
+            <French>Temps d'utilisation du sac mortuaire</French>
+            <German>Anwendungszeit für Leichensack</German>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodyBag_Description">
+            <English>Time in seconds it takes to apply a body bag.</English>
+            <French>Temps en secondes qu'il faut pour appliquer un sac mortuaire.</French>
+            <German>Zeit in Sekunden, die benötigt wird, um einen Leichensack aufzutragen.</German>
+       </Key>
         <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
             <English>Clear Trauma After Bandage</English>
             <Japanese>治療後に外傷を削除</Japanese>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -136,7 +136,7 @@
             <French>Temps en secondes nécessaire pour appliquer un garrot.</French>
             <German>Zeit in Sekunden, die benötigt wird, um ein Tourniquet anzuwenden.</German>
         </Key>
-            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSyringe_DisplayName">
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSyringe_DisplayName">
             <English>Syringe Treatment Time</English>
             <French>Temps de traitement de la seringue</French>
             <German>Spritzenbehandlungszeit</German>
@@ -146,7 +146,7 @@
             <French>Temps en secondes nécessaire pour appliquer une seringue.</French>
             <German>Zeit in Sekunden, die zum Auftragen einer Spritze benötigt wird.</German>
         </Key>
-            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIV_DisplayName">
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIV_DisplayName">
             <English>IV Bag Treatment Time</English>
             <French>Temps de traitement du sac IV</French>
             <German>IV Beutelbehandlungszeit</German>
@@ -156,7 +156,7 @@
             <French>Temps en secondes nécessaire pour appliquer un sac IV.</French>
             <German>Zeit in Sekunden, die benötigt wird, um einen Infusionsbeutel aufzutragen.</German>
         </Key>
-            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplint_DisplayName">
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplint_DisplayName">
             <English>Splint Treatment Time</English>
             <French>Temps de traitement de l'attelle</French>
             <German>Schienenbehandlungszeit</German>
@@ -166,7 +166,7 @@
             <French>Temps en secondes nécessaire pour appliquer une attelle.</French>
             <German>Zeit in Sekunden, die zum Anbringen einer Schiene benötigt wird.</German>
         </Key>
-            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodyBag_DisplayName">
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodyBag_DisplayName">
             <English>Body Bag Use Time</English>
             <French>Temps d'utilisation du sac mortuaire</French>
             <German>Anwendungszeit für Leichensack</German>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -130,14 +130,13 @@
             <English>Tourniquet Treatment Time</English>
             <French>Temps de traitement du tourniquet</French>
             <German>Tourniquet-Behandlungszeit</German>
-
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquet_Description">
             <English>Time in seconds it takes to apply a tourniquet.</English>
             <French>Temps en secondes nécessaire pour appliquer un garrot.</French>
             <German>Zeit in Sekunden, die benötigt wird, um ein Tourniquet anzuwenden.</German>
         </Key>
-             <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSyringe_DisplayName">
+            <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSyringe_DisplayName">
             <English>Syringe Treatment Time</English>
             <French>Temps de traitement de la seringue</French>
             <German>Spritzenbehandlungszeit</German>
@@ -176,7 +175,7 @@
             <English>Time in seconds it takes to apply a body bag.</English>
             <French>Temps en secondes qu'il faut pour appliquer un sac mortuaire.</French>
             <German>Zeit in Sekunden, die benötigt wird, um einen Leichensack aufzutragen.</German>
-       </Key>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
             <English>Clear Trauma After Bandage</English>
             <Japanese>治療後に外傷を削除</Japanese>


### PR DESCRIPTION
Adds treatment time addon settings for Tourniquets, IV Bags, Syringes, Splints, and Body Bags.

Each value has been defaulted to the current default time for each type, and has been set in a range [0.1,  (currentDefault * 4)].

I have tested all 5 of these new settings without issue.

![image](https://user-images.githubusercontent.com/22088666/92492391-4b263a00-f1c1-11ea-9b71-0ab156216f3c.png)


Thank you.