### PR TITLE
Fixed casting const char* to char* in extension

### DIFF
--- a/extensions/common/pbo/search.cpp
+++ b/extensions/common/pbo/search.cpp
@@ -97,7 +97,7 @@ typedef struct _OBJECT_TYPE_INFORMATION
     ULONG NonPagedPoolUsage;
 } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
 
-PVOID GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName)
+PVOID GetLibraryProcAddress(LPCSTR LibraryName, LPCSTR ProcName)
 {
     return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
 }


### PR DESCRIPTION
**When merged this pull request will:**
- GetLibraryProcAddress is called with const char* arguments, but PSTR is char*, casting const char* to char* won't be allowed anymore in C++20