### PR TITLE
Refuel - Fix refuel nozzle getting stuck in destroyed vehicles

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -80,6 +80,7 @@ class CfgVehicles {
         scope = 1;
         scopeCurator = 1;
         model = QPATHTOF(data\nozzle.p3d);
+        destrType = "DestructNo";
     };
 
     class All;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #7861

Handling of destroyed vehicles was fine, however interacting with the nozzle was not possible because it was destroyed with the vehicle (although it visually seemed to be fine).

The rope might still break and cannot be made invincible, but that's more of a visual problem than a gameplay problem.