### PR TITLE
Scopes - Weapons IronSightBaseAngle updated

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -188,9 +188,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {743, 848, 891, 900}; // at 21°C, at 15°C {735, 840, 883, 892} according with the AKS initSpeed
         ACE_barrelLengths[] = {210, 314, 415, 508.0}; // respectively {AKS74U / AK105,AK12K / AK74 / default}
     };
-    class B_56x15_dual: BulletBase {
-        tracerScale = 0.5;
-    };
+
     class B_580x42_Ball_F: BulletBase { // DBP87
         airFriction = -0.00121087;
         ACE_caliber = 6;

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -243,11 +243,11 @@ class CfgWeapons {
 
     class arifle_SPAR_01_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.20768;
-        ACE_IronSightBaseAngle = -0.166678;
+        ACE_IronSightBaseAngle = 0.002856;
     };
     class arifle_SPAR_02_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.22175;
-        ACE_IronSightBaseAngle = -0.184641;
+        ACE_IronSightBaseAngle = -0.018908;
     };
     class arifle_SPAR_03_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.71491;

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -219,13 +219,13 @@ class CfgWeapons {
     class Rifle_Long_Base_F: Rifle_Base_F {};
 
     class DMR_06_base_F: Rifle_Long_Base_F {
-        ACE_IronSightBaseAngle = 0.018227;
+        ACE_IronSightBaseAngle = 0.010313;
         ACE_RailHeightAboveBore = 3.27488;
     };
 
     class DMR_07_base_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 5.07109;
-        ACE_IronSightBaseAngle = -0.00160721;
+        ACE_IronSightBaseAngle = 0;
     };
 
     class arifle_MX_Base_F: Rifle_Base_F {
@@ -234,11 +234,11 @@ class CfgWeapons {
     };
     class arifle_MX_SW_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.40874;
-        ACE_IronSightBaseAngle = 0.216372;
+        ACE_IronSightBaseAngle = -0.004011;
     };
     class arifle_MXM_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.40323;
-        ACE_IronSightBaseAngle = 0.157545;
+        ACE_IronSightBaseAngle = -0.004011;
     };
 
     class arifle_SPAR_01_base_F: Rifle_Base_F {
@@ -251,141 +251,153 @@ class CfgWeapons {
     };
     class arifle_SPAR_03_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.71491;
-        ACE_IronSightBaseAngle = -0.134908;
+        ACE_IronSightBaseAngle = 0;
     };
 
     class LMG_Mk200_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 2.68925;
-        ACE_IronSightBaseAngle = 0.0182228;
+        ACE_IronSightBaseAngle = 0.001719;
     };
     class LMG_Zafir_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 0.996651;
-        ACE_IronSightBaseAngle = 0.19812212;
+        ACE_IronSightBaseAngle = 0.004584;
     };
     class LMG_03_base_F: Rifle_Long_Base_F {
         ACE_RailHeightAboveBore = 4.24282;
-        ACE_IronSightBaseAngle = 0.00181939;
+        ACE_IronSightBaseAngle = 0.008021;
     };
 
     class pdw2000_base_F: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 3.08883;
         ACE_RailBaseAngle = 0.019366;
-        ACE_IronSightBaseAngle = 0.0399664;
+        ACE_IronSightBaseAngle = 0.009740;
     };
 
     class arifle_AKS_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 0;
-        ACE_IronSightBaseAngle = 0.00574991;
+        ACE_IronSightBaseAngle = 0;
     };
     class arifle_AKM_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 0;
-        ACE_IronSightBaseAngle = 0.006273;
+        ACE_IronSightBaseAngle = 0.014897;
     };
     class arifle_AK12_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.82508;
-        ACE_IronSightBaseAngle = 0.0276926;
+        ACE_IronSightBaseAngle = 0.025210;
+    };
+    class arifle_AK12_GL_base_F: arifle_AK12_base_F {
+        ACE_IronSightBaseAngle = 0.017189;
+    };
+    class arifle_AK12U_base_F: arifle_AK12_base_F {
+        ACE_IronSightBaseAngle = 0.002865;
+    };
+    class arifle_RPK12_base_F: arifle_AK12_base_F {
+        ACE_IronSightBaseAngle = 0.003438;
     };
     class arifle_CTAR_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 6.07588;
-        ACE_IronSightBaseAngle = 0.0151815;
+        ACE_IronSightBaseAngle = 0.004584;
     };
     class arifle_CTARS_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 6.0787;
-        ACE_IronSightBaseAngle = 0.0125245;
+        ACE_IronSightBaseAngle = 0.022918;
     };
     class arifle_ARX_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.81635;
-        ACE_IronSightBaseAngle = 0.113024;
+        ACE_IronSightBaseAngle = 0.016043;
     };
 
     class arifle_katiba_Base_F: Rifle_Base_F {};
     
     class arifle_Katiba_F: arifle_katiba_Base_F {
         ACE_RailHeightAboveBore = 5.75468;
-        ACE_IronSightBaseAngle = 0.0863227;
+        ACE_IronSightBaseAngle = 0.011459;
     };
     class arifle_Katiba_C_F: arifle_katiba_Base_F {
         ACE_RailHeightAboveBore = 5.75468;
-        ACE_IronSightBaseAngle = 0.083419;
+        ACE_IronSightBaseAngle = 0.011459;
     };
     class arifle_Katiba_GL_F: arifle_katiba_Base_F {
         ACE_RailHeightAboveBore = 5.75468;
-        ACE_IronSightBaseAngle = 0.0863227;
+        ACE_IronSightBaseAngle = 0.011459;
     };
 
     class arifle_MX_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.80201;
-        ACE_IronSightBaseAngle = 0.19502;
+        ACE_IronSightBaseAngle = -0.005157;
     };
     class arifle_MX_GL_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.80201;
-        ACE_IronSightBaseAngle = 0.17142857;
+        ACE_IronSightBaseAngle = -0.005730;
     };
 
     class arifle_MXC_F: arifle_MX_Base_F {
         ACE_RailHeightAboveBore = 2.40874;
-        ACE_IronSightBaseAngle = 0.0154129;
+        ACE_IronSightBaseAngle = -0.005157;
     };
 
     class SDAR_base_F: Rifle_Base_F {};
     
     class arifle_SDAR_F: SDAR_base_F {
         ACE_RailHeightAboveBore = 0;
-        ACE_IronSightBaseAngle = -0.0237516;
+        ACE_IronSightBaseAngle = -0.037242;
     };
 
     class SMG_01_Base: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 4.85355;
         ACE_RailBaseAngle = 0.0250956;
-        ACE_IronSightBaseAngle = -0.159239;
+        ACE_IronSightBaseAngle = 0.018908;
     };
     class SMG_02_base_F: Rifle_Short_Base_F  {
         ACE_RailHeightAboveBore = 4.41831;
         ACE_RailBaseAngle = 0.0217724;
-        ACE_IronSightBaseAngle = 0.434847;
+        ACE_IronSightBaseAngle = 0.022918;
+    };
+    class SMG_03_TR_BASE: Rifle_Base_F {
+        ACE_IronSightBaseAngle = -0.011459;
     };
     class SMG_05_base_F: Rifle_Short_Base_F {
         ACE_RailHeightAboveBore = 4.05169;
         ACE_RailBaseAngle = 0.019366;
-        ACE_IronSightBaseAngle = -0.122823;
+        ACE_IronSightBaseAngle = 0.027502;
     };
 
     class Tavor_base_F: Rifle_Base_F {};
 
     class arifle_TRG20_F: Tavor_base_F {
         ACE_RailHeightAboveBore = 4.30954;
-        ACE_IronSightBaseAngle = 0.0338428;
+        ACE_IronSightBaseAngle = 0.002292;
     };
     class arifle_TRG21_F: Tavor_base_F {
         ACE_RailHeightAboveBore = 4.30954;
-        ACE_IronSightBaseAngle = 0.0317759;
+        ACE_IronSightBaseAngle = 0.002292;
     };
     class arifle_TRG21_GL_F: arifle_TRG21_F {
         ACE_RailHeightAboveBore = 4.30954;
-        ACE_IronSightBaseAngle = -0.03428571;
+        ACE_IronSightBaseAngle = -0.014424;
     };
 
     class mk20_base_F: Rifle_Base_F {};
 
     class arifle_Mk20_F: mk20_base_F {
         ACE_RailHeightAboveBore = 4.57255;
-        ACE_IronSightBaseAngle = -0.153292;
+        ACE_IronSightBaseAngle = 0.006303;
     };
     class arifle_Mk20C_F: mk20_base_F {
         ACE_RailHeightAboveBore = 4.41539;
-        ACE_IronSightBaseAngle = -0.137835;
+        ACE_IronSightBaseAngle = 0.001146;
     };
     class arifle_Mk20_GL_F: mk20_base_F {
         ACE_RailHeightAboveBore = 4.41539;
-        ACE_IronSightBaseAngle = -0.1532926;
+        ACE_IronSightBaseAngle = 0.005730;
     };
 
     class arifle_MSBS65_base_F: Rifle_Base_F {
         ACE_RailHeightAboveBore = 5.2;
-        ACE_IronSightBaseAngle = -0.028648;
+        ACE_IronSightBaseAngle = 0.001719;
     };
     class arifle_MSBS65_Mark_base_F: arifle_MSBS65_base_F {
-        ACE_IronSightBaseAngle = -0.045837;
+        ACE_IronSightBaseAngle = 0.002292;
     };
 
     class EBR_base_F: Rifle_Long_Base_F {};
@@ -399,35 +411,35 @@ class CfgWeapons {
 
     class srifle_EBR_F: EBR_base_F {
         ACE_RailHeightAboveBore = 1.98812;
-        ACE_IronSightBaseAngle = -0.00601782;
+        ACE_IronSightBaseAngle = 0.007448;
     };
     class srifle_LRR_F: LRR_base_F {
         ACE_RailHeightAboveBore = 3.20864;
-        ACE_IronSightBaseAngle = -0.0302847;
+        ACE_IronSightBaseAngle = 0.004011;
     };
     class srifle_GM6_F: GM6_base_F {
         ACE_RailHeightAboveBore = 4.75572;
-        ACE_IronSightBaseAngle = -0.165062;
+        ACE_IronSightBaseAngle = 0.001146;
     };
     class srifle_DMR_01_F: DMR_01_base_F {
         ACE_RailHeightAboveBore = 2.83284;
-        ACE_IronSightBaseAngle = 0.234393;
+        ACE_IronSightBaseAngle = 0.005730;
     };
     class srifle_DMR_02_F: DMR_02_base_F {
         ACE_RailHeightAboveBore = 3.43913;
-        ACE_IronSightBaseAngle = 0.013878;
+        ACE_IronSightBaseAngle = 0.015470;
     };
     class srifle_DMR_03_F: DMR_03_base_F {
         ACE_RailHeightAboveBore = 4.0795;
-        ACE_IronSightBaseAngle = 0.0138099;
+        ACE_IronSightBaseAngle = 0.005730;
     };
     class srifle_DMR_04_F: DMR_04_base_F {
         ACE_RailHeightAboveBore = 2.38022;
-        ACE_RailBaseAngle = 0.0171842;
+        ACE_RailBaseAngle = 0.019481;
     };
     class srifle_DMR_05_blk_F: DMR_05_base_F {
         ACE_RailHeightAboveBore = 3.91334;
-        ACE_IronSightBaseAngle = 0.0123425;
+        ACE_IronSightBaseAngle = 0.012605;
     };
 
     class MMG_01_base_F;
@@ -435,10 +447,10 @@ class CfgWeapons {
 
     class MMG_01_hex_F: MMG_01_base_F {
         ACE_RailHeightAboveBore = 4.73961;
-        ACE_IronSightBaseAngle = -0.0101613;
+        ACE_IronSightBaseAngle = -0.003438;
     };    
     class MMG_02_camo_F: MMG_02_base_F {
         ACE_RailHeightAboveBore = 5.01913;
-        ACE_IronSightBaseAngle = 0.0136377;
+        ACE_IronSightBaseAngle = 0.010886;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**

- update all weapons `ACE_IronSightBaseAngle` according with the last Ama3 v2.00 (both ballistics checked).

- remove the unused `B_56x15_dual` changed by the `B_556x45_dual` (underwater bullets).

> Tweaked: SPAR rifle series iron sights - FT-T149711

> Fixed: Zeroed ironsights on MX, Katiba, TRG, Mk20, Zafir, M320, GM6, Mk18, Rahim, Protector, Sting, Vermin, Zafir and Mk200

_- The `arifle_SDAR_F` `ACE_IronSightBaseAngle` value is a compromise between the default `discreteDistance` 30 m (`20Rnd_556x45_UW_mag`) and the `discreteDistance` 100 m (`30Rnd_556x45_Stanag`)._

_- The green dot of the `SMG_03` variants (ADR-97 or P90) is not centered correctly : POI approximately 0.7 mRad up and right of the POA._

_- **Test conditions** : no saw, `dispersion=0;`, `opticsZoomMin=0.025;` (10x), POA=POI at the top of all front sights (center of the monitor), flat map, barrel axis at the same level of the target center, axis targets North - South (no Eötvös), latitude 0° (no Coriolis), ICAO condition, no wind._ 