### PR TITLE
WIP: Night Vision - Add scotopic effects to normal vision when dark

### DIFF
--- a/addons/nightvision/XEH_PREP.hpp
+++ b/addons/nightvision/XEH_PREP.hpp
@@ -9,4 +9,5 @@ PREP(onVisionModeChanged);
 PREP(pfeh);
 PREP(refreshGoggleType);
 PREP(scaleCtrl);
+PREP(scotopicEffects);
 PREP(setupDisplayEffects);

--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -24,7 +24,7 @@ GVAR(ppeffectBlur) = -1;
 GVAR(isUsingMagnification) = false;
 
 ["ace_settingsInitialized", {
-    TRACE_4("settingsInitialized",GVAR(disableNVGsWithSights),GVAR(fogScaling),GVAR(noiseScaling),GVAR(effectScaling));
+    TRACE_5("settingsInitialized",GVAR(disableNVGsWithSights),GVAR(fogScaling),GVAR(noiseScaling),GVAR(effectScaling),GVAR(scotopicEffects));
 
     ["visionMode", LINKFUNC(onVisionModeChanged), false] call CBA_fnc_addPlayerEventHandler;
     ["loadout", LINKFUNC(onLoadoutChanged), true] call CBA_fnc_addPlayerEventHandler;
@@ -46,6 +46,19 @@ GVAR(isUsingMagnification) = false;
             [true] call FUNC(setupDisplayEffects);
         };
     }];
+
+    if (GVAR(scotopicEffects)) then {
+
+GVAR(scoTestToggle) = true;
+["test", "test", "test", {
+    GVAR(scoTestToggle) = !GVAR(scoTestToggle);
+}, {false}, [0x21, [false, false, false]], false] call CBA_fnc_addKeybind; // F Key
+
+
+        GVAR(scotopicCC) = ppEffectCreate ["colorCorrections", 1502];
+        GVAR(scotopicCC) ppEffectForceInNVG false;
+        [FUNC(scotopicEffects), [], 1] call CBA_fnc_waitAndExecute;
+    };
 }] call CBA_fnc_addEventHandler;
 
 

--- a/addons/nightvision/functions/fnc_scotopicEffects.sqf
+++ b/addons/nightvision/functions/fnc_scotopicEffects.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Adjusts color and luminosity when in dark conditions. 
+ * Simulates rod and cones vision by decreasing color intensity when dark.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call ace_nightvision_fnc_scotopicEffects
+ *
+ * Public: No
+ */
+private _unit = ACE_player;
+
+if (EGVAR(common,OldIsCamera) || {!alive _unit} || {currentVisionMode _unit != 0}) exitWith {
+    GVAR(scotopicCC) ppEffectEnable false;
+    [FUNC(scotopicEffects), [], 0.1] call CBA_fnc_waitAndExecute;
+};
+
+getLighting params ["", "_ambientLightBrightness"];
+(getLightingAt _unit) params ["", "", "", "_dynamiclightBrightness"];
+
+private _light = _ambientLightBrightness + 5 * _dynamiclightBrightness;
+if (_light > 30) exitWith {   
+    GVAR(scotopicCC) ppEffectEnable false;
+    // if it's day, we can go to sleep for a long while (but won't be responsive to skipTime?)
+    [FUNC(scotopicEffects), [], [1, 120] select (_ambientLightBrightness > 100)] call CBA_fnc_waitAndExecute;
+};
+
+private _intensity = if (_light > 5) then {
+    linearConversion [5, 30, _light, 0.3, 0, true]; // Mesopic
+} else {
+    linearConversion [0, 5, _light, 0.6, 0.3, true]; // Scotopic
+};
+
+systemChat format ["%1 - %2", _light, _intensity];
+
+GVAR(scotopicCC) ppEffectEnable GVAR(scoTestToggle) && true;
+// "players like the night blue"
+GVAR(scotopicCC) ppEffectAdjust  [1,1,0,[1,1,1,0],[_intensity*.95, _intensity*.95,_intensity*1.1, 1-_intensity], [0.15, 1.0, 1.50, 1]];
+GVAR(scotopicCC) ppEffectCommit 1;
+
+[FUNC(scotopicEffects), [], 1] call CBA_fnc_waitAndExecute;

--- a/addons/nightvision/initSettings.sqf
+++ b/addons/nightvision/initSettings.sqf
@@ -84,3 +84,11 @@
     true, // default value
     false // isGlobal
 ] call CBA_settings_fnc_init;
+
+[
+    QGVAR(scotopicEffects), "CHECKBOX",
+    [LSTRING(scotopicEffects_DisplayName), LSTRING(scotopicEffects_description)],
+    localize LSTRING(Category),
+    false, // default value
+    true // isGlobal
+] call CBA_settings_fnc_init;


### PR DESCRIPTION
As it gets darker human vision switches from cones to rods, 
losing the ability to see specific colors ("black and white vision")
as well as having a different luminosity function (rods are much less sensitive to red light)

This uses the new `getLighting` commands with a color correction to approximate this effect.
It should be somewhat similar to Arma2's night lighting.

 