### PR TITLE
Interaction - Fix door opening for buildings with 10+ doors

### DIFF
--- a/addons/interaction/functions/fnc_getDoorAnimations.sqf
+++ b/addons/interaction/functions/fnc_getDoorAnimations.sqf
@@ -23,10 +23,13 @@ params ["_house", "_door"];
 private _animate = animationNames _house;
 private _animations = [];
 private _lockedVariable = [];
+private _numberStrings = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
 {
     private _animName = toLower _x;
-    if ((_animName find (toLower _door)) != -1) then {
+    private _index = _animName find toLower _door;
+
+    if (_index != -1 && {!(_animName select [_index + count _door, 1] in _numberStrings)}) then {
         if (((_animName find "disabled") != -1) || ((_animName find "locked") != -1)) then {
             _lockedVariable pushBack _animName;
         } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #7707

The door in that issue is door_1, but the animation search previously returned all animations for door_1 and door_10 to door_15.
This fix assumes that other buildings also put an underscore after the door name, so if someone could verify this for CUP that would be great.