### PR TITLE
Repair - Fix spare wheels receiving fall damage

### DIFF
--- a/addons/repair/CfgVehicles.hpp
+++ b/addons/repair/CfgVehicles.hpp
@@ -377,13 +377,14 @@ class CfgVehicles {
         // can not take damage individually though, because of limitations of the thingX simulation type
         class HitPoints {
             class HitBody {
-                armor = 0.6;
+                armor = 1;
                 material = -1;
                 name = "mat_rim";
                 visual = "mat_rim";
                 passThrough = 1;
                 radius = 0.1;
                 explosionShielding = 1;
+                minimalHit = 1;
             };
         };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #6142

The hitpoint is only used for visual effects but causes the tire to receive fall damage. Setting `minimalDamage` to 1 basically disables it taking damage on its own and thus disables fall damage completely. Other damage still works fine.