### PR TITLE
Ballistics - Update the B 556x45 dual

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -130,6 +130,14 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[]={210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
+
+    class B_556x45_dual: B_556x45_Ball {
+        airFriction = -0.00055;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_muzzleVelocities[] = {268}; // at 21°C, at 15°C 267 m/s according with the 20Rnd_556x45_UW_mag initSpeed
+        ACE_barrelLengths[] = {457.2}; // according with the SDAR barrel length: https://en.wikipedia.org/wiki/Kel-Tec_RFB
+    };
+
     class ACE_556x45_Ball_Mk262 : B_556x45_Ball {
         airFriction=-0.00111805;
         ACE_caliber=5.69;

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -340,7 +340,7 @@ class CfgWeapons {
     
     class arifle_SDAR_F: SDAR_base_F {
         ACE_RailHeightAboveBore = 0;
-        ACE_IronSightBaseAngle = -0.037242;
+        ACE_IronSightBaseAngle = -0.042972;
     };
 
     class SMG_01_Base: Rifle_Short_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix https://github.com/acemod/ACE3/issues/7832

Without real datas about underwater ammo, the airFriction is basically calculated with the Ruthberg values: the `20Rnd_556x45_UW_mag` `initSpeed` and a subsonic 5.56 from the [CfgAmmoReference](https://github.com/acemod/ACE3/blob/master/extras/CfgAmmoReference.hpp#L2760):

> ##########################################
Ammo Class: B_556x45_dual
_drag model 7_
_ballistic coefficient 0.151_
MaxRanges (m): [250, 250]
MuzzleVelocities (m/s): [262, 272]
Max. Velocity diff (m/s): 0.19
Max. Drop diff (cm): 0.44
Max. Tof diff (ms): 0.5
Optimal airFriction: 0.00054976

The goal is something coherent between the both ballistics: [in-game Range cards](https://steamuserimages-a.akamaihd.net/ugc/1680366675632031238/66705BE979A09E8280C5BF700AAAAF1ABAF92C40/).
As reference, [this article with a DSG Technology underwater 5.56x45 super and subsonic bullets](https://www.thefirearmblog.com/blog/2017/04/20/dsg-technology-underwater-ammo/).

_- The `arifle_SDAR_F` `ACE_IronSightBaseAngle` value is a compromise between the default `discreteDistance` 30 m (`20Rnd_556x45_UW_mag`) and the `discreteDistance` 100 m (`30Rnd_556x45_Stanag`)._

All kudos to @BaerMitUmlaut, as mentioned it was an `airFriction` issue.