### PR TITLE
Medical Treatment - Allow variable CPR chance based on blood volume (invalidates old setting)

### DIFF
--- a/addons/medical_treatment/functions/fnc_cprLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_cprLocal.sqf
@@ -22,7 +22,7 @@ TRACE_2("cprLocal",_medic,_patient);
 [_patient, "activity", LSTRING(Activity_CPR), [[_medic, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
 
 private _bloodVolume = GET_BLOOD_VOLUME(_patient);
-private _successChance = linearConversion [BLOOD_VOLUME_CLASS_4_HEMORRHAGE, BLOOD_VOLUME_CLASS_1_HEMORRHAGE, _bloodVolume, GVAR(cprSuccessChanceMin), GVAR(cprSuccessChanceMax), true];
+private _successChance = linearConversion [BLOOD_VOLUME_CLASS_4_HEMORRHAGE, BLOOD_VOLUME_CLASS_2_HEMORRHAGE, _bloodVolume, GVAR(cprSuccessChanceMin), GVAR(cprSuccessChanceMax), true];
 if ((random 1) < _successChance) then {
     TRACE_2("CPR random success",_bloodVolume,_successChance);
     [QEGVAR(medical,CPRSucceeded), _patient] call CBA_fnc_localEvent;

--- a/addons/medical_treatment/functions/fnc_cprLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_cprLocal.sqf
@@ -21,10 +21,12 @@ TRACE_2("cprLocal",_medic,_patient);
 
 [_patient, "activity", LSTRING(Activity_CPR), [[_medic, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
 
-if ((random 1) < GVAR(cprSuccessChance)) then {
-    TRACE_1("CPR random success",GVAR(cprSuccessChance));
+private _bloodVolume = GET_BLOOD_VOLUME(_patient);
+private _successChance = linearConversion [BLOOD_VOLUME_FATAL, DEFAULT_BLOOD_VOLUME, _bloodVolume, GVAR(cprSuccessChanceMin), GVAR(cprSuccessChanceMax), true];
+if ((random 1) < _successChance) then {
+    TRACE_2("CPR random success",_bloodVolume,_successChance);
     [QEGVAR(medical,CPRSucceeded), _patient] call CBA_fnc_localEvent;
 } else {
-    TRACE_1("CPR random fail",GVAR(cprSuccessChance));
+    TRACE_2("CPR random fail",_bloodVolume,_successChance);
 };
 

--- a/addons/medical_treatment/functions/fnc_cprLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_cprLocal.sqf
@@ -22,7 +22,7 @@ TRACE_2("cprLocal",_medic,_patient);
 [_patient, "activity", LSTRING(Activity_CPR), [[_medic, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);
 
 private _bloodVolume = GET_BLOOD_VOLUME(_patient);
-private _successChance = linearConversion [BLOOD_VOLUME_FATAL, DEFAULT_BLOOD_VOLUME, _bloodVolume, GVAR(cprSuccessChanceMin), GVAR(cprSuccessChanceMax), true];
+private _successChance = linearConversion [BLOOD_VOLUME_CLASS_4_HEMORRHAGE, BLOOD_VOLUME_CLASS_1_HEMORRHAGE, _bloodVolume, GVAR(cprSuccessChanceMin), GVAR(cprSuccessChanceMax), true];
 if ((random 1) < _successChance) then {
     TRACE_2("CPR random success",_bloodVolume,_successChance);
     [QEGVAR(medical,CPRSucceeded), _patient] call CBA_fnc_localEvent;

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -252,9 +252,18 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(cprSuccessChance),
+    QGVAR(cprSuccessChanceMin),
     "SLIDER",
-    [LSTRING(CPRSuccessChance_DisplayName), LSTRING(CPRSuccessChance_Description)],
+    [LSTRING(CPRSuccessChanceMin_DisplayName), LSTRING(CPRSuccessChanceMin_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0, 1, 0.4, 2, true],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(cprSuccessChanceMax),
+    "SLIDER",
+    [LSTRING(CPRSuccessChanceMax_DisplayName), LSTRING(CPRSuccessChanceMax_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
     [0, 1, 0.4, 2, true],
     true

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -947,10 +947,10 @@
             <Spanish>Probabilidad de que el RCP sea exitoso restaurando el ritmo cardíaco.</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMin_Description">
-            <English>Minimum probability that CPR will be successful in restoring heart rhythm. Actual probability is interpolated based on blood volume.</English>
+            <English>Lowest probability that CPR will restore heart rhythm, when blood loss is greater.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMax_Description">
-            <English>Maximum probability that CPR will be successful in restoring heart rhythm. Actual probability is interpolated based on blood volume.</English>
+            <English>Highest probability that CPR will restore heart rhythm, when blood loss is less.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPR_DisplayName">
             <English>CPR Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -926,6 +926,12 @@
             <Turkish>CPR Başarı Şansı</Turkish>
             <Spanish>Probabilidad de éxito del RCP</Spanish>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMin_DisplayName">
+            <English>CPR Success Chance Minimum</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMax_DisplayName">
+            <English>CPR Success Chance Maximum</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChance_Description">
             <English>Probability that CPR will be successful in restoring heart rhythm.</English>
             <Japanese>心肺蘇生によって心拍を戻せる確率を決定できます。</Japanese>
@@ -939,6 +945,12 @@
             <German>Wahrscheinlichkeit, dass HLW bei der Wiederherstellung des Herzrhythmus erfolgreich sein wird.</German>
             <Turkish>Kalp ritmini geri kazanmada CPR'nin başarılı olma olasılığı.</Turkish>
             <Spanish>Probabilidad de que el RCP sea exitoso restaurando el ritmo cardíaco.</Spanish>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMin_Description">
+            <English>Minimum probability that CPR will be successful in restoring heart rhythm. Actual probability is interpolated based on blood volume.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMax_Description">
+            <English>Maximum probability that CPR will be successful in restoring heart rhythm. Actual probability is interpolated based on blood volume.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPR_DisplayName">
             <English>CPR Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -912,39 +912,11 @@
             <Turkish>Araçlar ve Tesisler</Turkish>
             <Spanish>Vehículos e instalaciones médicas</Spanish>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChance_DisplayName">
-            <English>CPR Success Chance</English>
-            <Japanese>心肺蘇生の成功率</Japanese>
-            <French>Chance de réussite de la RCP</French>
-            <Russian>Шанс успешной реанимации</Russian>
-            <Portuguese>Chance de ter sucesso com SBV</Portuguese>
-            <Chinese>心肺復甦術成功率</Chinese>
-            <Czech>Pravděpodobnost úspěchu CPR</Czech>
-            <Italian>Possibilità di successo della RCP</Italian>
-            <Polish>Szansa powodzenia RKO</Polish>
-            <German>HLW Erfolgsrate</German>
-            <Turkish>CPR Başarı Şansı</Turkish>
-            <Spanish>Probabilidad de éxito del RCP</Spanish>
-        </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMin_DisplayName">
             <English>CPR Success Chance Minimum</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMax_DisplayName">
             <English>CPR Success Chance Maximum</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChance_Description">
-            <English>Probability that CPR will be successful in restoring heart rhythm.</English>
-            <Japanese>心肺蘇生によって心拍を戻せる確率を決定できます。</Japanese>
-            <French>Probabilité de rétablir un rythme cardiaque suite à une RCP.</French>
-            <Russian>Вероятность успешного проведения сердечно-лёгочной реанимации (СЛР).</Russian>
-            <Portuguese>Probabilidade que um SBV restaurará o batimento cardíaco.</Portuguese>
-            <Chinese>心肺復甦術恢復心率的機率。</Chinese>
-            <Czech>Pravděpodobnost, že CPR obnoví srdeční tep.</Czech>
-            <Italian>E' probabile che la rianimazione RCP abbia successo nel ripristinare il ritmo cardiaco.</Italian>
-            <Polish>Prawdopodobieństwo przwyrócenia akcji serca poprzez wykonanie RKO</Polish>
-            <German>Wahrscheinlichkeit, dass HLW bei der Wiederherstellung des Herzrhythmus erfolgreich sein wird.</German>
-            <Turkish>Kalp ritmini geri kazanmada CPR'nin başarılı olma olasılığı.</Turkish>
-            <Spanish>Probabilidad de que el RCP sea exitoso restaurando el ritmo cardíaco.</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMin_Description">
             <English>Lowest probability that CPR will restore heart rhythm, when blood loss is greater.</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -919,10 +919,10 @@
             <English>CPR Success Chance Maximum</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMin_Description">
-            <English>Lowest probability that CPR will restore heart rhythm, when blood loss is greater.</English>
+            <English>Minimum probability that performing CPR will restore heart rhythm.\nThis minimum value is used when the patient has at least "Lost a fatal amount of blood".\nAn interpolated probability is used when the patient's blood volume is between the minimum and maximum thresholds.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_CPRSuccessChanceMax_Description">
-            <English>Highest probability that CPR will restore heart rhythm, when blood loss is less.</English>
+            <English>Maximum probability that performing CPR will restore heart rhythm.\nThis maximum value is used when the patient has at most "Lost some blood".\nAn interpolated probability is used when the patient's blood volume is between the minimum and maximum thresholds.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPR_DisplayName">
             <English>CPR Treatment Time</English>


### PR DESCRIPTION
**When merged this pull request will:**
- CPR success chance is interpolated between two settings, based on current blood volume
- Default values are the same to maintain current behaviour

I've left the old stringtable entries in for reference - is this a bad idea?

Interpolates based on blood volume between 60% (below this value you would immediately arrest again) and 85% (minimum threshold for waking up)