### PR TITLE
Cargo - Add BI Vehicle in vehicle support

### DIFF
--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -35,11 +35,13 @@ _vehicle setVariable [QGVAR(space), _space - _itemSize, true];
 
 if (_item isEqualType objNull) then {
     detach _item;
-    _item attachTo [_vehicle,[0,0,-100]];
-    [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
+    if !(_vehicle setVehicleCargo _item) then {
+        _item attachTo [_vehicle,[0,0,-100]];
+        [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
 
-    // Some objects below water will take damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
-    [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
+        // Some objects below water will take damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
+        [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
+    };
 };
 
 true

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -48,10 +48,15 @@ private _itemSize = [_item] call FUNC(getSizeItem);
 _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
 if (_item isEqualType objNull) then {
-    detach _item;
-    // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
-    // do both on server to ensure they are executed in the correct order
-    [QGVAR(serverUnload), [_item, _emptyPosAGL]] call CBA_fnc_serverEvent;
+    if (isVehicleCargo _item) then {
+        objNull setVehicleCargo _item;
+        _item setPosASL (AGLtoASL _emptyPosAGL);
+    } else {
+        detach _item;
+        // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
+        // do both on server to ensure they are executed in the correct order
+        [QGVAR(serverUnload), [_item, _emptyPosAGL]] call CBA_fnc_serverEvent;
+    };
 } else {
     private _newItem = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
     _newItem setPosASL (AGLtoASL _emptyPosAGL);


### PR DESCRIPTION
**When merged this pull request will:**
- This PR choose when possible to use the BI Vehicle in Vehicle feature (ViV)
- When loading an item, the function check if it is possible to load it with ViV
- When unloading an iten, the function check if the item has been loaded with ViV and spawn it accordingly 
- [ ] Need to handle the case where player unload a ViV item without ACE Cargo. ie: As driver, you can unload all ViV item