### PR TITLE
Medical Statemachine - Ensure bleedout condition string is code

### DIFF
--- a/addons/medical_statemachine/Statemachine.hpp
+++ b/addons/medical_statemachine/Statemachine.hpp
@@ -103,7 +103,7 @@ class ACE_Medical_StateMachine {
         };
         class Bleedout {
             targetState = "Dead";
-            condition = QGVAR(cardiacArrestBleedoutEnabled);
+            condition = QUOTE((GVAR(cardiacArrestBleedoutEnabled))); // wrap to ensure cba uses this as code and not a direct variable
             events[] = {QEGVAR(medical,Bleedout)};
         };
     };


### PR DESCRIPTION
Fix
```
 Error Params: Type Bool, expected String,code
 File x\cba\addons\statemachine\fnc_addEventTransition.sqf, line 38
```
tested with filepatching and with pboProject