### PR TITLE
Medical Engine - Hide actions that have ACE interactions

### DIFF
--- a/addons/medical_engine/CfgActions.hpp
+++ b/addons/medical_engine/CfgActions.hpp
@@ -13,4 +13,32 @@ class CfgActions {
     class FirstAid: None {
         show = 0;
     };
+    class UnloadUnconsciousUnits: None
+    {
+        show = 0;
+    };
+    class UnloadFromDriver: None
+    {
+        show = 0;
+    };
+    class UnloadFromPilot: None
+    {
+        show = 0;
+    };
+    class UnloadFromCargo: None
+    {
+        show = 0;
+    };
+    class UnloadFromCommander: None
+    {
+        show = 0;
+    };
+    class UnloadFromGunner: None
+    {
+        show = 0;
+    };
+    class UnloadFromTurret: None
+    {
+        show = 0;
+    };
 };

--- a/addons/medical_engine/CfgActions.hpp
+++ b/addons/medical_engine/CfgActions.hpp
@@ -13,32 +13,25 @@ class CfgActions {
     class FirstAid: None {
         show = 0;
     };
-    class UnloadUnconsciousUnits: None
-    {
+    class UnloadUnconsciousUnits: None {
         show = 0;
     };
-    class UnloadFromDriver: None
-    {
+    class UnloadFromDriver: None {
         show = 0;
     };
-    class UnloadFromPilot: None
-    {
+    class UnloadFromPilot: None {
         show = 0;
     };
-    class UnloadFromCargo: None
-    {
+    class UnloadFromCargo: None {
         show = 0;
     };
-    class UnloadFromCommander: None
-    {
+    class UnloadFromCommander: None {
         show = 0;
     };
-    class UnloadFromGunner: None
-    {
+    class UnloadFromGunner: None {
         show = 0;
     };
-    class UnloadFromTurret: None
-    {
+    class UnloadFromTurret: None {
         show = 0;
     };
 };


### PR DESCRIPTION
**Remove the vanilla actions to unload unconcious**
- People seem to accidentally hit this when trying to mount up (I know they should be using quickmount...)
- ACE adds it's own interaction to unload people

Needs MP test (hence draft)
