### PR TITLE
Grenades - Use fnc_addToInventory

### DIFF
--- a/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
+++ b/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
@@ -34,8 +34,8 @@
         ],
         {
             params ["_unit", "", "", "_slot", "_magArr"];
-            private _containerStr = toLower ((_slot splitString "_") select 0);
-            [_unit, (_magArr select 1), _containerStr, -1] call ace_common_fnc_addToInventory;
+            private _containerStr = toLower (_slot splitString "_" select 0);
+            [_unit, _magArr select 1, _containerStr] call EFUNC(common,addToInventory);
             false;
         },
         true,

--- a/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
+++ b/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
@@ -57,8 +57,8 @@
         ],
         {
             params ["_unit", "", "", "_slot", "_magArr"];
-            private _containerStr = toLower ((_slot splitString "_") select 0);
-            [_unit, (_magArr select 0), _containerStr, -1] call ace_common_fnc_addToInventory;
+            private _containerStr = toLower (_slot splitString "_" select 0);
+            [_unit, _magArr select 0, _containerStr] call EFUNC(common,addToInventory);
             false;
         },
         true,

--- a/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
+++ b/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
@@ -33,8 +33,9 @@
             }
         ],
         {
-            params ["_unit", "", "", "", "_magArr"];
-            _unit addMagazine (_magArr select 1);
+            params ["_unit", "", "", "_slot", "_magArr"];
+            private _containerStr = toLower ((_slot splitString "_") select 0);
+            [_unit, (_magArr select 1), _containerStr, -1] call ace_common_fnc_addToInventory;
             false;
         },
         true,
@@ -55,8 +56,9 @@
             }
         ],
         {
-            params ["_unit", "", "", "", "_magArr"];
-            _unit addMagazine (_magArr select 0);
+            params ["_unit", "", "", "_slot", "_magArr"];
+            private _containerStr = toLower ((_slot splitString "_") select 0);
+            [_unit, (_magArr select 0), _containerStr, -1] call ace_common_fnc_addToInventory;
             false;
         },
         true,

--- a/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
+++ b/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
@@ -34,8 +34,23 @@
         ],
         {
             params ["_unit", "", "", "_slot", "_magArr"];
-            private _containerStr = toLower (_slot splitString "_" select 0);
-            [_unit, _magArr select 1, _containerStr] call EFUNC(common,addToInventory);
+            private _container = "";
+            switch _slot do {
+                case "UNIFORM_CONTAINER": {
+                    _container = "uniform";
+                };
+                case "VEST_CONTAINER": {
+                    _container = "vest";
+                };
+                case "BACKPACK_CONTAINER": {
+                    _container = "backpack";
+                };
+            };
+
+            if (_container != "") then {
+                [_unit, _magArr select 1, _container] call EFUNC(common,addToInventory);
+            };
+
             false;
         },
         true,
@@ -57,8 +72,23 @@
         ],
         {
             params ["_unit", "", "", "_slot", "_magArr"];
-            private _containerStr = toLower (_slot splitString "_" select 0);
-            [_unit, _magArr select 0, _containerStr] call EFUNC(common,addToInventory);
+            private _container = "";
+            switch _slot do {
+                case "UNIFORM_CONTAINER": {
+                    _container = "uniform";
+                };
+                case "VEST_CONTAINER": {
+                    _container = "vest";
+                };
+                case "BACKPACK_CONTAINER": {
+                    _container = "backpack";
+                };
+            };
+
+            if (_container != "") then {
+                [_unit, _magArr select 0, _container] call EFUNC(common,addToInventory);
+            };
+
             false;
         },
         true,

--- a/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
+++ b/addons/grenades/functions/fnc_addChangeFuseItemContextMenuOptions.sqf
@@ -51,7 +51,7 @@
                 [_unit, _magArr select 1, _container] call EFUNC(common,addToInventory);
             };
 
-            false;
+            false
         },
         true,
         [_mag,_throwableMag]
@@ -89,7 +89,7 @@
                 [_unit, _magArr select 0, _container] call EFUNC(common,addToInventory);
             };
 
-            false;
+            false
         },
         true,
         [_mag,_throwableMag]


### PR DESCRIPTION
**Make use of fnc_addToInventory:**
- When you convert an explosive to a grenade, it'll try and go back in to the same container to stop it magically jumping from backpack to vest etc.

If there is a better way to get the original container rather than abusing `splitString` let me know

