### PR TITLE
Tagging - Remove useless isClass check in configClasses

### DIFF
--- a/addons/tagging/XEH_preStart.sqf
+++ b/addons/tagging/XEH_preStart.sqf
@@ -4,7 +4,7 @@
 
 private _cacheStaticModels = [];
 
-private _vehicleClasses = "isClass _x && (configName _x) isKindOf 'Static'" configClasses (configFile >> "CfgVehicles");
+private _vehicleClasses = "(configName _x) isKindOf 'Static'" configClasses (configFile >> "CfgVehicles");
 
 // Consider static everything vehicle that inherit from Static
 // This include houses (which we don't need), but also walls, that we do
@@ -16,7 +16,7 @@ private _vehicleClasses = "isClass _x && (configName _x) isKindOf 'Static'" conf
     };
 } forEach _vehicleClasses;
 
-private _nonAIVehicleClasses = "isClass _x" configClasses (configFile >> "CfgNonAIVehicles");
+private _nonAIVehicleClasses = "true" configClasses (configFile >> "CfgNonAIVehicles");
 
 // Also consider static all object inheriting from bridges
 private _cfgBase = configFile >> "CfgNonAIVehicles";


### PR DESCRIPTION
Why? Because engine already checks
![firefox_2020-11-26_11-23-41](https://user-images.githubusercontent.com/3768165/100339320-00ef7080-2fda-11eb-9655-33b957fee113.png)

Also engine will get optimization for when condition == "true", so we'll benefit from that here too when it arrives