### PR TITLE
Advanced Throwing - Add object variable to disable pick up of attached throwables

### DIFF
--- a/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
+++ b/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
@@ -31,7 +31,7 @@
             _nearThrowables append (ACE_player nearObjects ["ACE_Chemlight_IR_Dummy", PICK_UP_DISTANCE]);
 
             {
-                if (!(_x in _throwablesHelped) &&
+                if (!(_x in _throwablesHelped) && {!(_x getVariable [QGVAR(disablePickUp), false])} &&
                     {!(_x isKindOf "SmokeShellArty")} && {!(_x isKindOf "G_40mm_Smoke")} && // All smokes inherit from "GrenadeHand" >> "SmokeShell"
                     {GVAR(enablePickUpAttached) || {!GVAR(enablePickUpAttached) && {isNull (attachedTo _x)}}}
                 ) then {

--- a/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
+++ b/addons/advanced_throwing/functions/fnc_renderPickUpInteraction.sqf
@@ -31,7 +31,7 @@
             _nearThrowables append (ACE_player nearObjects ["ACE_Chemlight_IR_Dummy", PICK_UP_DISTANCE]);
 
             {
-                if (!(_x in _throwablesHelped) && {!(_x getVariable [QGVAR(disablePickUp), false])} &&
+                if (!(_x in _throwablesHelped) && {!((attachedTo _x) getVariable [QGVAR(disablePickUp), false])} &&
                     {!(_x isKindOf "SmokeShellArty")} && {!(_x isKindOf "G_40mm_Smoke")} && // All smokes inherit from "GrenadeHand" >> "SmokeShell"
                     {GVAR(enablePickUpAttached) || {!GVAR(enablePickUpAttached) && {isNull (attachedTo _x)}}}
                 ) then {

--- a/docs/wiki/framework/advanced-throwing-framework.md
+++ b/docs/wiki/framework/advanced-throwing-framework.md
@@ -11,10 +11,10 @@ version:
   patch: 0
 ---
 
-## 1. Disabling pick up of specific ammo
+## 1. Disabling pick up of ammo attached to an object
 
-Pick-up interaction can be disabled for specific ammo. Use settings to disable it globally.
+Pick-up interaction can be disabled for ammo (e.g. chemlights) attached to an object.
 
 ```js
-AMMO setVariable ["ace_advanced_throwing_disablePickUp", true, true];
+OBJECT setVariable ["ace_advanced_throwing_disablePickUp", true, true];
 ```

--- a/docs/wiki/framework/advanced-throwing-framework.md
+++ b/docs/wiki/framework/advanced-throwing-framework.md
@@ -1,0 +1,20 @@
+---
+layout: wiki
+title: Advanced Throwing Framework
+description: Explains how to interact with the Advanced Throwing API.
+group: framework
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 7
+  patch: 0
+---
+
+## 1. Disabling pick up of specific ammo
+
+Pick-up interaction can be disabled for specific ammo. Use settings to disable it globally.
+
+```js
+AMMO setVariable ["ace_advanced_throwing_disablePickUp", true, true];
+```


### PR DESCRIPTION
**When merged this pull request will:**
- Close #8030 
- Usage: `OBJECT setVariable ["ace_advanced_throwing_disablePickUp", true, true]`