### PR TITLE
Fix Multiple Issues With Timestamps

### DIFF
--- a/addons/markers/XEH_PREP.hpp
+++ b/addons/markers/XEH_PREP.hpp
@@ -17,3 +17,4 @@ PREP(movePFH);
 PREP(canTimestamp);
 PREP(onButtonClickConfirm);
 PREP(onCheckedChangedTimestamp);
+PREP(removeTimestamp);

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -1,5 +1,4 @@
 #include "script_component.hpp"
-#include "\A3\ui_f\hpp\defineResincl.inc"
 /*
  * Author: BIS, commy2, Timi007
  * Sets up the marker placement
@@ -26,30 +25,28 @@
 
     //Can't place markers when can't interact
     if !([ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {
-        _display closeDisplay 2;  //emulate "Cancel" button
+        _display closeDisplay 2; //emulate "Cancel" button
     };
 
     //BIS Controls:
-    private _text =                 _display displayctrl IDC_INSERT_MARKER;
-    private _picture =              _display displayctrl IDC_INSERT_MARKER_PICTURE;
-    private _channel =              _display displayctrl IDC_INSERT_MARKER_CHANNELS;
-    private _buttonOK =             _display displayctrl IDC_OK;
-    private _buttonCancel =         _display displayctrl IDC_CANCEL;
-    private _description =          _display displayctrl 1100;
-    private _title =                _display displayctrl 1001;
-    private _descriptionChannel =   _display displayctrl 1101;
+    private _text = _display displayctrl IDC_INSERT_MARKER;
+    private _picture = _display displayctrl IDC_INSERT_MARKER_PICTURE;
+    private _channel = _display displayctrl IDC_INSERT_MARKER_CHANNELS;
+    private _buttonOK = _display displayctrl IDC_OK;
+    private _buttonCancel = _display displayctrl IDC_CANCEL;
+    private _description = _display displayctrl 1100;
+    private _title = _display displayctrl 1001;
+    private _descriptionChannel = _display displayctrl 1101;
 
     //ACE Controls:
-    // _sizeX =                     _display displayctrl 1200;
-    // _sizeY =                     _display displayctrl 1201;
-    private _aceTimestamp =         _display displayCtrl IDC_ACE_INSERT_MARKER_TIMESTAMP;
-    private _aceTimestampText =     _display displayCtrl IDC_ACE_INSERT_MARKER_TIMESTAMP_TEXT;
-    private _aceShapeLB =           _display displayctrl IDC_ACE_INSERT_MARKER_SHAPE;
-    private _aceColorLB =           _display displayctrl IDC_ACE_INSERT_MARKER_COLOR;
-    private _aceAngleSlider =       _display displayctrl IDC_ACE_INSERT_MARKER_ANGLE;
-    private _aceAngleSliderText =   _display displayctrl IDC_ACE_INSERT_MARKER_ANGLE_TEXT;
+    private _ctrlTimestamp = _display displayCtrl IDC_ACE_INSERT_MARKER_TIMESTAMP;
+    private _ctrlTimestampText = _display displayCtrl IDC_ACE_INSERT_MARKER_TIMESTAMP_TEXT;
+    private _aceShapeLB = _display displayctrl IDC_ACE_INSERT_MARKER_SHAPE;
+    private _aceColorLB = _display displayctrl IDC_ACE_INSERT_MARKER_COLOR;
+    private _aceAngleSlider = _display displayctrl IDC_ACE_INSERT_MARKER_ANGLE;
+    private _aceAngleSliderText = _display displayctrl IDC_ACE_INSERT_MARKER_ANGLE_TEXT;
 
-    private _mapDisplay =           displayParent _display;
+    private _mapDisplay = displayParent _display;
     if (isNull _mapDisplay) exitWith {ERROR("No Map");};
     private _mapCtrl = _mapDisplay displayCtrl IDC_MAP;
 
@@ -93,17 +90,9 @@
     _display displayAddEventHandler ["KeyDown", {(_this select 1) in [200, 208]}];
 
     private _hasTimestamp = false;
-    if !((markerText GVAR(editingMarker)) isEqualTo "") then {
+    if !(markerText GVAR(editingMarker) isEqualTo "") then {
         // fill text input with text from marker which is being edited
-
-        private _originalText = markerText GVAR(editingMarker);
-        private _timeIndex = _originalText find (TIMESTAMP_SPACE + "[");
-        if (_timeIndex > 0 ) then {
-            // Shave off timestamp
-            _hasTimestamp = true;
-            _originalText = _originalText select [0,_timeIndex];
-        };
-
+        private _originalText = markerText GVAR(editingMarker) call FUNC(removeTimestamp);
         _text ctrlSetText _originalText;
     };
 
@@ -114,7 +103,7 @@
     private _pos = ctrlposition _text;
     _pos params ["_posX", "_posY", "_posW", "_posH"];
     _posX = _posX + 0.01;
-    _posY = _posY min ((safeZoneH + safeZoneY) - (8 * _posH + 8 * BORDER));  //prevent buttons being placed below bottom edge of screen
+    _posY = _posY min ((safeZoneH + safeZoneY) - (8 * _posH + 8 * BORDER)); //prevent buttons being placed below bottom edge of screen
     _pos set [0, _posX];
     _pos set [1, _posY];
     _text ctrlSetPosition _pos;
@@ -143,31 +132,33 @@
     if (GVAR(timestampEnabled)) then {
         _timestampOffset = _posH + BORDER;
 
-        _pos set [0, _posX];
-        _pos set [1, _posY + 1 * _posH + 2 * BORDER];
-        _pos set [2, _posW - _posH];
-        _pos set [3, _posH];
-        _aceTimestampText ctrlSetStructuredText parseText format ["<t size='0.8'>%1</t>", LLSTRING(Timestamp)];
-        _aceTimestampText ctrlSetPosition _pos;
-        _aceTimestampText ctrlCommit 0;
+        private _left = _posX;
+        private _top = _posY + 1 * _posH + 2 * BORDER;
+        private _width = _posH * safeZoneH / safeZoneW;
+        private _height = _posH;
 
-        _pos set [0, _posX + _posW - _posH];
-        _pos set [2, _posH];
-        _pos set [3, _posH];
-        _aceTimestamp ctrlSetPosition _pos;
-        _aceTimestamp ctrlCommit 0;
+        _ctrlTimestamp ctrlSetPosition [_left, _top, _width, _height];
+        _ctrlTimestamp ctrlCommit 0;
+
+        _ctrlTimestampText ctrlSetStructuredText parseText format ["<t size='0.8'>%1</t>", LLSTRING(Timestamp)];
+
+        _left = _left + _width;
+        _width = _posW - _width;
+        _top = _top + 0.1 * _height;
+        _ctrlTimestampText ctrlSetPosition [_left, _top, _width, _height];
+        _ctrlTimestampText ctrlCommit 0;
 
         if !([ACE_player] call FUNC(canTimestamp)) then {
-            _aceTimestamp ctrlEnable false;
-            _aceTimestamp ctrlSetTooltip LLSTRING(TimestampTooltipNoWatch);
+            _ctrlTimestamp ctrlEnable false;
+            _ctrlTimestamp ctrlSetTooltip LLSTRING(TimestampTooltipNoWatch);
         } else {
-            _aceTimestamp cbSetChecked (GETUVAR(GVAR(timestampChecked),false) || _hasTimestamp);
+            _ctrlTimestamp cbSetChecked (GETUVAR(GVAR(timestampChecked),false) || _hasTimestamp);
         };
     } else {
-        _aceTimestampText ctrlEnable false;
-        _aceTimestampText ctrlShow false;
-        _aceTimestamp ctrlEnable false;
-        _aceTimestamp ctrlShow false;
+        _ctrlTimestampText ctrlEnable false;
+        _ctrlTimestampText ctrlShow false;
+        _ctrlTimestamp ctrlEnable false;
+        _ctrlTimestamp ctrlShow false;
     };
 
     //--- Shape
@@ -268,9 +259,8 @@
 
     ////////////////////
     // init marker timestamp cb
-
-    _buttonOK ctrlAddEventHandler ['ButtonClick', FUNC(onButtonClickConfirm)];
-    _aceTimestamp ctrlAddEventHandler ['CheckedChanged', FUNC(onCheckedChangedTimestamp)];
+    _buttonOK ctrlAddEventHandler ["ButtonClick", FUNC(onButtonClickConfirm)];
+    _ctrlTimestamp ctrlAddEventHandler ["CheckedChanged", FUNC(onCheckedChangedTimestamp)];
 
     ////////////////////
     // init marker shape lb

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -89,11 +89,11 @@
     // prevent vanilla key input
     _display displayAddEventHandler ["KeyDown", {(_this select 1) in [200, 208]}];
 
-    private _hasTimestamp = false;
-    if !(markerText GVAR(editingMarker) isEqualTo "") then {
+    private _markerText = markerText GVAR(editingMarker);
+    if (_markerText != "") then {
         // fill text input with text from marker which is being edited
-        private _originalText = markerText GVAR(editingMarker) call FUNC(removeTimestamp);
-        _text ctrlSetText _originalText;
+        _markerText = _markerText call FUNC(removeTimestamp);
+        _text ctrlSetText _markerText;
     };
 
     //Focus on the text input
@@ -152,7 +152,7 @@
             _ctrlTimestamp ctrlEnable false;
             _ctrlTimestamp ctrlSetTooltip LLSTRING(TimestampTooltipNoWatch);
         } else {
-            _ctrlTimestamp cbSetChecked (GETUVAR(GVAR(timestampChecked),false) || _hasTimestamp);
+            _ctrlTimestamp cbSetChecked (uiNamespace getVariable [QGVAR(timestampChecked), false]);
         };
     } else {
         _ctrlTimestampText ctrlEnable false;

--- a/addons/markers/functions/fnc_onButtonClickConfirm.sqf
+++ b/addons/markers/functions/fnc_onButtonClickConfirm.sqf
@@ -1,5 +1,4 @@
 #include "script_component.hpp"
-#include "\a3\ui_f\hpp\defineResincl.inc"
 /*
  * Author: Freddo
  * When the confirm button is pressed.
@@ -21,22 +20,34 @@ private _display = ctrlParent _buttonOk;
 private _description = _display displayctrl IDC_INSERT_MARKER;
 private _aceTimestamp = _display displayCtrl IDC_ACE_INSERT_MARKER_TIMESTAMP;
 
-// Handle timestamp
-if (cbChecked _aceTimestamp && {[ACE_player] call FUNC(canTimestamp)}) then {
+// handle timestamp
+if (cbChecked _aceTimestamp && {ACE_player call FUNC(canTimestamp)}) then {
     private _time = daytime;
-    private _ampm = switch (true) do {
-        case (GVAR(timestampHourFormat) == 24): {""};
-        case (_time < 12): {" am"};
-        case (_time > 12): {SUB(_time,12); " pm"};
+
+    // add timestamp suffix
+    private _periodPostfix = "";
+    if (GVAR(timestampHourFormat) == 12) then {
+        if (floor _time == 0) exitWith {
+            _time = _time + 12;
+            _periodPostfix = " am";
+        };
+
+        if (floor _time == 12) exitWith {
+            _periodPostfix = " pm";
+        };
+
+        if (_time < 12) then {
+            _periodPostfix = " am";
+        } else {
+            _time = _time - 12;
+            _periodPostfix = " pm";
+        };
     };
 
-    _description ctrlSetText format [ // Add timestamp suffix
-        "%1%2[%2%3]",
+    _description ctrlSetText format [
+        "%1 [%2%3]",
         ctrlText _description,
-        TIMESTAMP_SPACE,
         [_time, GVAR(timestampFormat)] call BIS_fnc_timeToString,
-        _ampm
+        _periodPostfix
     ];
 };
-
-nil

--- a/addons/markers/functions/fnc_onCheckedChangedTimestamp.sqf
+++ b/addons/markers/functions/fnc_onCheckedChangedTimestamp.sqf
@@ -1,8 +1,7 @@
 #include "script_component.hpp"
-#include "\a3\ui_f\hpp\defineResincl.inc"
 /*
- * Author: Freddo
- * When the timestamp checkbox is toggled
+ * Author: Freddo, commy2
+ * When the timestamp checkbox is toggled.
  *
  * Arguments:
  * 0: Checkbox <CONTROL>
@@ -12,12 +11,10 @@
  * None
  *
  * Example:
- * [_cbTimestamp,1] call ACE_markers_fnc_onCheckedChangedTimestamp
+ * [controlNull, 1] call ACE_markers_fnc_onCheckedChangedTimestamp;
  *
  * Public: No
  */
-params ["_cbTimestamp", "_checked"];
+params ["", "_checked"];
 
-SETUVAR(GVAR(timestampChecked),(_checked == 1));
-
-nil
+uiNamespace setVariable [QGVAR(timestampChecked), _checked == 1]

--- a/addons/markers/functions/fnc_onLBSelChangedColor.sqf
+++ b/addons/markers/functions/fnc_onLBSelChangedColor.sqf
@@ -1,5 +1,4 @@
 #include "script_component.hpp"
-#include "\a3\ui_f\hpp\defineResincl.inc"
 /*
  * Author: commy2
  * When the color list box is changed.

--- a/addons/markers/functions/fnc_onLBSelChangedShape.sqf
+++ b/addons/markers/functions/fnc_onLBSelChangedShape.sqf
@@ -1,5 +1,4 @@
 #include "script_component.hpp"
-#include "\a3\ui_f\hpp\defineResincl.inc"
 /*
  * Author: commy2
  * When the shape list box is changed.

--- a/addons/markers/functions/fnc_removeTimestamp.sqf
+++ b/addons/markers/functions/fnc_removeTimestamp.sqf
@@ -1,0 +1,46 @@
+#include "script_component.hpp"
+/*
+ * Author: commy2
+ * Removes timestamp from end of a string.
+ *
+ * Arguments:
+ * 0: Marker text string <STRING>
+ *
+ * Return Value:
+ * Input with timestamp removed <STRING>
+ *
+ * Example:
+ * "abc [12:00 am]" call ace_markers_fnc_removeTimestamp // "abc"
+ * "[13:37]" call ace_markers_fnc_removeTimestamp // ""
+ * "xyz [123]" call ace_markers_fnc_removeTimestamp // "xyz [123]"
+ *
+ * Public: No
+ */
+#define DIGITS "0123456789"
+
+params ["_original"];
+
+// @todo, 2.02 reverse command will support STRING types
+private _string = toArray _original;
+reverse _string;
+_string = toString _string;
+
+if (_string select [0, 1] != "]") exitWith {_original};
+
+private _timestampLength = (_string find "[") + 1;
+_string = _string select [0, _timestampLength];
+
+// @todo
+_string = toArray _string;
+reverse _string;
+_string = toString _string;
+
+if (_string select [0, 1] != "[") exitWith {_original};
+
+if !(_string select [1, 1] in DIGITS) exitWith {_original};
+if !(_string select [2, 1] in DIGITS) exitWith {_original};
+if (_string select [3, 1] != ":") exitWith {_original};
+if !(_string select [4, 1] in DIGITS) exitWith {_original};
+if !(_string select [5, 1] in DIGITS) exitWith {_original};
+
+[_original select [0, count _original - _timestampLength], " "] call CBA_fnc_rightTrim // return

--- a/addons/markers/initSettings.sqf
+++ b/addons/markers/initSettings.sqf
@@ -37,14 +37,8 @@ private _categoryName = format ["ACE %1", localize ELSTRING(map,Module_DisplayNa
     [LSTRING(TimestampHourFormat), LSTRING(TimestampHourFormatDescription)],
     [_categoryName, LLSTRING(Module_DisplayName)],
     [
-        [
-            24,
-            12
-        ],
-        [
-            LSTRING(TimestampHourFormat24),
-            LSTRING(TimestampHourFormat12)
-        ],
+        [24, 12],
+        [LSTRING(TimestampHourFormat24), LSTRING(TimestampHourFormat12)],
         0
     ]
 ] call CBA_fnc_addSetting;
@@ -55,25 +49,15 @@ private _formatDescription = [
     LLSTRING(TimestampFormatDescription2),
     LLSTRING(TimestampFormatDescription3),
     LLSTRING(TimestampFormatDescription4)
-] joinString "\n";
+] joinString endl;
 
 [
     QGVAR(timestampFormat), "LIST",
     [LSTRING(timestampFormat), _formatDescription],
     [_categoryName, LLSTRING(Module_DisplayName)],
     [
-        [
-            "HH",
-            "HH:MM",
-            "HH:MM:SS",
-            "HH:MM:SS:MM"
-        ],
-        [
-            "HH",
-            "HH:MM",
-            "HH:MM:SS",
-            "HH:MM:SS:MM"
-        ],
+        ["HH", "HH:MM", "HH:MM:SS", "HH:MM:SS:MM"],
+        ["HH", "HH:MM", "HH:MM:SS", "HH:MM:SS:MM"],
         1
     ]
 ] call CBA_fnc_addSetting;

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -15,6 +15,7 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+#include "\a3\ui_f\hpp\defineResincl.inc"
 
 #define CHANNEL_NAMES [ \
     localize "str_channel_global", \
@@ -24,19 +25,16 @@
     localize "str_channel_vehicle" \
 ]
 
-// 129 just looks like a space
-#define TIMESTAMP_SPACE (toString [129])
+#define MOVE_RESTRICTION_NOBODY -1
+#define MOVE_RESTRICTION_ALL 0
+#define MOVE_RESTRICTION_ADMINS 1
+#define MOVE_RESTRICTION_GROUP_LEADERS 2
+#define MOVE_RESTRICTION_GROUP_LEADERS_ADMINS 3
+#define MOVE_RESTRICTION_OWNER 4
 
-#define MOVE_RESTRICTION_NOBODY                -1
-#define MOVE_RESTRICTION_ALL                    0
-#define MOVE_RESTRICTION_ADMINS                 1
-#define MOVE_RESTRICTION_GROUP_LEADERS          2
-#define MOVE_RESTRICTION_GROUP_LEADERS_ADMINS   3
-#define MOVE_RESTRICTION_OWNER                  4
-
-#define IDC_ACE_INSERT_MARKER_TIMESTAMP         1210
-#define IDC_ACE_INSERT_MARKER_TIMESTAMP_TEXT    1211
-#define IDC_ACE_INSERT_MARKER_SHAPE             1220
-#define IDC_ACE_INSERT_MARKER_COLOR             1221
-#define IDC_ACE_INSERT_MARKER_ANGLE             1230
-#define IDC_ACE_INSERT_MARKER_ANGLE_TEXT        1231
+#define IDC_ACE_INSERT_MARKER_TIMESTAMP 1210
+#define IDC_ACE_INSERT_MARKER_TIMESTAMP_TEXT 1211
+#define IDC_ACE_INSERT_MARKER_SHAPE 1220
+#define IDC_ACE_INSERT_MARKER_COLOR 1221
+#define IDC_ACE_INSERT_MARKER_ANGLE 1230
+#define IDC_ACE_INSERT_MARKER_ANGLE_TEXT 1231

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -159,8 +159,8 @@
             <French>Active une interface permettant d'apposer un horodatage sur les marqueurs.</French>
         </Key>
         <Key ID="STR_ACE_Markers_Timestamp">
-            <English>Add Timestamp:</English>
-            <French>Ajouter l'horodatage</French>
+            <English>Timestamp</English>
+            <French>Horodatage</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampTooltipNoWatch">
             <English>Watch Required</English>


### PR DESCRIPTION
The pull request that added the auto timestamping to the marker menu was incredibly rushed and broken.

**When merged this pull request will:**
- properly aligns text with "Timestamp" checkbox vertically
- makes checkbox a square instead of a fucking rectangle
- fixes completely broken 12-hour clock
- properly handles 12:xx am (after noon) and 12:xx pm (after midnight); 00:00 am/pm is not a thing...
- avoids the broken space character, because it is not a space in most fonts, bad workaround
- instead, adds ace_marker_fnc_removeTimestamp function
- removes bad code formatting changes with mid line whitespace
- includes the vanilla header file in the common component header file instead of in 5 different functions...

before
![https://i.imgur.com/B7X0tOB.png](https://i.imgur.com/B7X0tOB.png)
![https://i.imgur.com/mQCaqM8.png](https://i.imgur.com/mQCaqM8.png)

after:
![https://i.imgur.com/vkOuOiZ.png](https://i.imgur.com/vkOuOiZ.png)
