### PR TITLE
medical_treatment - Fix medic falling unconscious can provide CPR

### DIFF
--- a/addons/medical_treatment/functions/fnc_cprProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_cprProgress.sqf
@@ -23,5 +23,6 @@ _args params ["_medic", "_patient"];
 // Cancel CPR if patient wakes up
 
 !(_patient call EFUNC(common,isAwake))
+&& {_medic call EFUNC(common,isAwake)}
 && {(GVAR(advancedDiagnose)) || {IN_CRDC_ARRST(_patient)}} // if basic diagnose, then only show action if appropriate (they can't tell difference between uncon/ca)
 && {_medic == (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])}


### PR DESCRIPTION
While reading ACE Medical, I noticed the [fnc_cprProgress.sqf](https://github.com/acemod/ACE3/blob/de13ab0f47ef7a0d7bdc9b2f942869185217ac93/addons/medical_treatment/functions/fnc_cprProgress.sqf#L23) doesn't check if `_medic` is awake while CPR is in progress. And [`ace_common_fnc_progressBar`](https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_progressBar.sqf#L56) only check if player is alive

- [x] Need to investigate what is happening when a medic, providing CPR, fall unconscious.

After investigation, while medic fall unconscious the [fnc_setUnconsciousState.sqf#L45-L47](https://github.com/acemod/ACE3/blob/d27122fa16c66f3166656785c0f56324953d513b/addons/medical_status/functions/fnc_setUnconsciousState.sqf#L45-L47) close all dialog so [fnc_progressBar.sqf#L53](https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_progressBar.sqf#L53) fail safely I guess.
Don't know if that PR is necessary then.

**When merged this pull request will:**
- Check if `_medic` is awake while CPR is in progress.
- Add a `EFUNC(common,isAwake)` for `_medic`