### PR TITLE
Interact Menu - Optimize interaction menu conditions

### DIFF
--- a/addons/interact_menu/functions/fnc_compileMenu.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenu.sqf
@@ -69,11 +69,14 @@ private _recurseFnc = {
             };
 
             private _condition = getText (_entryCfg >> "condition");
-            if (_condition == "") then {_condition = "true"};
 
-            // Add canInteract (including exceptions) and canInteractWith to condition
-            if ((configName _entryCfg) != "ACE_MainActions") then {
-                _condition = _condition + format [QUOTE( && {[ARR_3(ACE_player, _target, %1)] call EFUNC(common,canInteractWith)} ), getArray (_entryCfg >> "exceptions")];
+            if (configName _entryCfg == "ACE_MainActions") then {
+                if (_condition isEqualTo "") then {_condition = "true"};
+            } else {
+                // Add canInteract (including exceptions) and canInteractWith to condition
+                private _canInteractCondition = format [QUOTE([ARR_3(ACE_player,_target,%1)] call EFUNC(common,canInteractWith)), getArray (_entryCfg >> "exceptions")];
+                private _conditionFormatPattern = ["%1 && {%2}", "%2"] select (_condition isEqualTo "" || {_condition == "true"});
+                _condition = format [_conditionFormatPattern, _condition, _canInteractCondition];
             };
 
             private _insertChildren = compile (getText (_entryCfg >> "insertChildren"));

--- a/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuSelfAction.sqf
@@ -45,10 +45,11 @@ private _recurseFnc = {
             private _statement = compile (getText (_entryCfg >> "statement"));
 
             private _condition = getText (_entryCfg >> "condition");
-            if (_condition == "") then {_condition = "true"};
 
             // Add canInteract (including exceptions) and canInteractWith to condition
-            _condition = _condition + format [QUOTE( && {[ARR_3(ACE_player, _target, %1)] call EFUNC(common,canInteractWith)} ), getArray (_entryCfg >> "exceptions")];
+            private _canInteractCondition = format [QUOTE([ARR_3(ACE_player,_target,%1)] call EFUNC(common,canInteractWith)), getArray (_entryCfg >> "exceptions")];
+            private _conditionFormatPattern = ["%1 && {%2}", "%2"] select (_condition isEqualTo "" || {_condition == "true"});
+            _condition = compile format [_conditionFormatPattern, _condition, _canInteractCondition];
 
             private _insertChildren = compile (getText (_entryCfg >> "insertChildren"));
             private _modifierFunction = compile (getText (_entryCfg >> "modifierFunction"));
@@ -63,7 +64,6 @@ private _recurseFnc = {
                 _runOnHover = (getNumber (_entryCfg >> "runOnHover")) > 0;
             };
 
-            _condition = compile _condition;
             private _children = [_entryCfg] call _recurseFnc;
 
             private _entry = [

--- a/addons/interact_menu/functions/fnc_compileMenuZeus.sqf
+++ b/addons/interact_menu/functions/fnc_compileMenuZeus.sqf
@@ -35,7 +35,11 @@ private _recurseFnc = {
             private _statement = compile (getText (_entryCfg >> "statement"));
 
             private _condition = getText (_entryCfg >> "condition");
-            if (_condition == "") then {_condition = "true"};
+            if (_condition == "") then {
+                _condition = {true};
+            } else {
+                _condition = compile _condition;
+            };
 
             private _insertChildren = compile (getText (_entryCfg >> "insertChildren"));
             private _modifierFunction = compile (getText (_entryCfg >> "modifierFunction"));
@@ -50,7 +54,6 @@ private _recurseFnc = {
                 _runOnHover = (getNumber (_entryCfg >> "runOnHover")) > 0;
             };
 
-            private _condition = compile _condition;
             private _children = [_entryCfg] call _recurseFnc;
 
             private _entry = [


### PR DESCRIPTION
**When merged this pull request will:**
- remove useless `true && {` code from empy/`true` interaction conditions;
- optimize `fnc_compileMenuZeus` a little.

Before:
```
        true && {
            [ACE_player, _target, ["isNotInside", "isNotSwimming", "isNotSitting"]] call ace_common_fnc_canInteractWith
        }
```
After:
```
        [ACE_player, _target, ["isNotInside", "isNotSwimming", "isNotSitting"]] call ace_common_fnc_canInteractWith
```