### PR TITLE
RHS Compat - Add ACE_GForceCoef value for DF-15 uniforms

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -332,13 +332,14 @@ class CfgWeapons {
         modes[] = {};
         picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_Kornet_9M133_2_msv_ca.paa";
     };
+    
     class rhs_uniform_flora;
-	class rhs_uniform_df15: rhs_uniform_flora
-	{
-		ACE_GForceCoef=0.80000001;
-	};
-	class rhs_uniform_df15_tan: rhs_uniform_df15
-	{
-		ACE_GForceCoef=0.80000001;
-	};
+    class rhs_uniform_df15: rhs_uniform_flora
+    {
+        ACE_GForceCoef=0.8;
+    };
+    class rhs_uniform_df15_tan: rhs_uniform_df15
+    {
+        ACE_GForceCoef=0.8;
+    };
 };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -332,4 +332,13 @@ class CfgWeapons {
         modes[] = {};
         picture = "\rhsafrf\addons\rhs_heavyweapons\data\ico\rhs_Kornet_9M133_2_msv_ca.paa";
     };
+    class rhs_uniform_flora;
+	class rhs_uniform_df15: rhs_uniform_flora
+	{
+		ACE_GForceCoef=0.80000001;
+	};
+	class rhs_uniform_df15_tan: rhs_uniform_df15
+	{
+		ACE_GForceCoef=0.80000001;
+	};
 };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -334,12 +334,10 @@ class CfgWeapons {
     };
     
     class rhs_uniform_flora;
-    class rhs_uniform_df15: rhs_uniform_flora
-    {
-        ACE_GForceCoef=0.8;
+    class rhs_uniform_df15: rhs_uniform_flora {
+        ACE_GForceCoef = 0.8;
     };
-    class rhs_uniform_df15_tan: rhs_uniform_df15
-    {
-        ACE_GForceCoef=0.8;
+    class rhs_uniform_df15_tan: rhs_uniform_df15 {
+        ACE_GForceCoef = 0.8;
     };
 };

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -337,7 +337,4 @@ class CfgWeapons {
     class rhs_uniform_df15: rhs_uniform_flora {
         ACE_GForceCoef = 0.8;
     };
-    class rhs_uniform_df15_tan: rhs_uniform_df15 {
-        ACE_GForceCoef = 0.8;
-    };
 };

--- a/optionals/compat_rhs_saf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_saf3/CfgWeapons.hpp
@@ -63,13 +63,14 @@ class CfgWeapons {
     class rhs_weap_cz99: hgun_P07_F {
         ACE_barrelLength = 108;
     };
+
     class Uniform_Base;
-	class rhssaf_uniform_mig29_pilot: Uniform_Base
-	{
-		ACE_GForceCoef=0.80000001;
-	};
-	class rhssaf_uniform_heli_pilot: Uniform_Base
-	{
-		ACE_GForceCoef=0.80000001;
-	};
+    class rhssaf_uniform_mig29_pilot: Uniform_Base
+    {
+        ACE_GForceCoef=0.8;
+    };
+    class rhssaf_uniform_heli_pilot: Uniform_Base
+    {
+        ACE_GForceCoef=0.8;
+    };
 };

--- a/optionals/compat_rhs_saf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_saf3/CfgWeapons.hpp
@@ -63,4 +63,13 @@ class CfgWeapons {
     class rhs_weap_cz99: hgun_P07_F {
         ACE_barrelLength = 108;
     };
+    class Uniform_Base;
+	class rhssaf_uniform_mig29_pilot: Uniform_Base
+	{
+		ACE_GForceCoef=0.80000001;
+	};
+	class rhssaf_uniform_heli_pilot: Uniform_Base
+	{
+		ACE_GForceCoef=0.80000001;
+	};
 };

--- a/optionals/compat_rhs_saf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_saf3/CfgWeapons.hpp
@@ -65,12 +65,10 @@ class CfgWeapons {
     };
 
     class Uniform_Base;
-    class rhssaf_uniform_mig29_pilot: Uniform_Base
-    {
-        ACE_GForceCoef=0.8;
+    class rhssaf_uniform_mig29_pilot: Uniform_Base {
+        ACE_GForceCoef = 0.8;
     };
-    class rhssaf_uniform_heli_pilot: Uniform_Base
-    {
-        ACE_GForceCoef=0.8;
+    class rhssaf_uniform_heli_pilot: Uniform_Base {
+        ACE_GForceCoef = 0.8;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**

- Add missing ACE_GForceCoef value for DF-15 uniforms.
- ACE_GForceCoef value is the same as for Vanilla counterparts(Many other mods are using these values for their uniforms as well) 

