### PR TITLE
Translations - Add missing german translations

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -491,6 +491,7 @@
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsActionDesc">
             <English>Defines the action to be taken if a player does not have the correct PBOs.</English>
+            <German>Definiert die Aktion die ausgeführt werden soll, falls ein Spieler nicht die richtigen PBOs hat.</German>
             <French>Définit l'action à effectuer si un joueur n'a pas les bons PBOs.</French>
             <Chinese>設定當玩家有錯誤的PBO檔案時要如何處置。</Chinese>
             <Czech>Nastavuje jakou akci provést pokud hráč nemá správné PBO.</Czech>
@@ -516,6 +517,7 @@
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsCheckAllDesc">
             <English>Check all addons, not only those of ACE.</English>
+            <German>Alle Addons überprüfen, nicht nur die von ACE</German>
             <French>Vérifie tous les addons, même ceux qui ne sont pas liés à ACE.</French>
             <Chinese>檢查全部的插件而非只有ACE。</Chinese>
             <Czech>Zkontrolovat všechny addony a ne jenom ACE.</Czech>
@@ -541,6 +543,7 @@
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsWhitelistDesc">
             <English>Define a list of regardless allowed addons.</English>
+            <German>Definiere eine Liste der erlaubten Addons</German>
             <French>Permet de définir une liste d'addons autorisés systématiquement.</French>
             <Chinese>定義哪些插件是允許使用的。</Chinese>
             <Czech>Nastavte seznam addonů, které jsou povolené.</Czech>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -517,7 +517,7 @@
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsCheckAllDesc">
             <English>Check all addons, not only those of ACE.</English>
-            <German>Alle Addons überprüfen, nicht nur die von ACE</German>
+            <German>Alle Addons überprüfen, nicht nur die von ACE.</German>
             <French>Vérifie tous les addons, même ceux qui ne sont pas liés à ACE.</French>
             <Chinese>檢查全部的插件而非只有ACE。</Chinese>
             <Czech>Zkontrolovat všechny addony a ne jenom ACE.</Czech>
@@ -543,7 +543,7 @@
         </Key>
         <Key ID="STR_ACE_Common_CheckPBOsWhitelistDesc">
             <English>Define a list of regardless allowed addons.</English>
-            <German>Definiere eine Liste der erlaubten Addons</German>
+            <German>Definiere eine Liste der erlaubten Addons.</German>
             <French>Permet de définir une liste d'addons autorisés systématiquement.</French>
             <Chinese>定義哪些插件是允許使用的。</Chinese>
             <Czech>Nastavte seznam addonů, které jsou povolené.</Czech>

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -404,6 +404,7 @@
         </Key>
         <Key ID="STR_ACE_CSW_StaticM2ShieldBag_displayName">
             <English>[CSW] Static M2 w/ Shield</English>
+            <German>[CSW] Statische M2 mit Schild</German>
             <Spanish>[CSW] M2 estática con escudo</Spanish>
             <Czech>[CSW] Statická zbraň M2 se štítem</Czech>
             <French>[CSW] Mitrailleuse statique M2 ac. bouclier</French>

--- a/addons/dragging/stringtable.xml
+++ b/addons/dragging/stringtable.xml
@@ -54,7 +54,7 @@
         </Key>
         <Key ID="STR_ACE_Dragging_CarryKeybind">
             <English>Carry/Release Object</English>
-            <German>Objekt Tragen/hinlegen</German>
+            <German>Objekt tragen/hinlegen</German>
             <French>Porter/Lâcher un objet</French>
             <Russian>Нести/Отпустить Объект</Russian>
             <Polish>Nieś/Puść objekt</Polish>

--- a/addons/dragging/stringtable.xml
+++ b/addons/dragging/stringtable.xml
@@ -54,6 +54,7 @@
         </Key>
         <Key ID="STR_ACE_Dragging_CarryKeybind">
             <English>Carry/Release Object</English>
+            <German>Objekt Tragen/hinlegen</German>
             <French>Porter/Lâcher un objet</French>
             <Russian>Нести/Отпустить Объект</Russian>
             <Polish>Nieś/Puść objekt</Polish>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -1114,26 +1114,32 @@
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMin_DisplayName">
             <English>Minimum Time</English>
+            <German>Minimale Zeit</German>
             <French>Durée minimale</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMax_DisplayName">
             <English>Maximum Time</English>
+            <German>Maximale Zeit</German>
             <French>Durée maximale</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerDefault_DisplayName">
             <English>Default Time</English>
+            <German>Standard Zeit</German>
             <French>Durée par défaut</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMin_Description">
             <English>Minimum time value (in seconds) for the explosive timer.</English>
+            <German>Minimaler Wert (in Sekunden) für die Detonationszeit.</German>
             <French>Définit la durée minimale paramétrable sur le minuteur.</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMax_Description">
             <English>Maximum time value (in seconds) for the explosive timer.</English>
+            <German>Maximaler Wert (in Sekunden) für die Detonationszeit.</German>
             <French>Définit la durée maximale paramétrable sur le minuteur.</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerDefault_Description">
             <English>Default time value (in seconds) for the explosive timer.</English>
+            <German>Standard Wert (in Sekunden) für die Detonationszeit.</German>
             <French>Définit la durée paramétrée par défaut sur le minuteur.</French>
         </Key>
     </Package>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -1114,32 +1114,32 @@
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMin_DisplayName">
             <English>Minimum Time</English>
-            <German>Minimale Zeit</German>
+            <German>Minimalzeit</German>
             <French>Durée minimale</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMax_DisplayName">
             <English>Maximum Time</English>
-            <German>Maximale Zeit</German>
+            <German>Maximalzeit</German>
             <French>Durée maximale</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerDefault_DisplayName">
             <English>Default Time</English>
-            <German>Standard Zeit</German>
+            <German>Standardzeit</German>
             <French>Durée par défaut</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMin_Description">
             <English>Minimum time value (in seconds) for the explosive timer.</English>
-            <German>Minimaler Wert (in Sekunden) für die Detonationszeit.</German>
+            <German>Minimalwert (in Sekunden) für die Detonationszeit.</German>
             <French>Définit la durée minimale paramétrable sur le minuteur.</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerMax_Description">
             <English>Maximum time value (in seconds) for the explosive timer.</English>
-            <German>Maximaler Wert (in Sekunden) für die Detonationszeit.</German>
+            <German>Maximalwert (in Sekunden) für die Detonationszeit.</German>
             <French>Définit la durée maximale paramétrable sur le minuteur.</French>
         </Key>
         <Key ID="STR_ACE_Explosives_TimerDefault_Description">
             <English>Default time value (in seconds) for the explosive timer.</English>
-            <German>Standard Wert (in Sekunden) für die Detonationszeit.</German>
+            <German>Standardwert (in Sekunden) für die Detonationszeit.</German>
             <French>Définit la durée paramétrée par défaut sur le minuteur.</French>
         </Key>
     </Package>

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -325,7 +325,7 @@
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_categoryMenu_displayName">
             <English>Fast-roping</English>
-            <German>Abseilung</German>
+            <German>Abseilen</German>
             <French>Hélicordage</French>
             <Chinese>快速繩降</Chinese>
             <Japanese>ファスト ロープ</Japanese>

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -325,6 +325,7 @@
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_categoryMenu_displayName">
             <English>Fast-roping</English>
+            <German>Abseilung</German>
             <French>Hélicordage</French>
             <Chinese>快速繩降</Chinese>
             <Japanese>ファスト ロープ</Japanese>

--- a/addons/gforces/stringtable.xml
+++ b/addons/gforces/stringtable.xml
@@ -59,7 +59,7 @@
         </Key>
         <Key ID="STR_ACE_GForces_Coefficient_DisplayName">
             <English>G-Force Coefficient</English>
-            <German>G-Kraft Koeffizient</German>
+            <German>G-Kraft-Koeffizient</German>
             <Polish>Współczynnk przeciążenia</Polish>
             <French>Coefficient de force gravitationnelle</French>
             <Russian>Коэффициент перегрузки</Russian>
@@ -68,7 +68,7 @@
         </Key>
         <Key ID="STR_ACE_GForces_Coefficient_Description">
             <English>Controls strength of G-Force affecting players.</English>
-            <German>Kontrolliert die Stärke der Einwirkung der G-Kräfte auf die Spieler.</German>
+            <German>Kontrolliert die Stärke der G-Kräfte auf die Spieler.</German>
             <Polish>Wpływa na siłe przeciążeń oddziałujących na graczy</Polish>
             <French>Coefficient permettant d'ajuster le niveau de force gravitationnelle affectant les joueurs.</French>
             <Russian>Определяет силу перегрузок, влияющих на игроков.</Russian>

--- a/addons/gforces/stringtable.xml
+++ b/addons/gforces/stringtable.xml
@@ -3,6 +3,7 @@
     <Package name="GForces">
         <Key ID="STR_ACE_GForces_Category">
             <English>ACE G-Forces</English>
+            <German>ACE G-Kräfte</German>
             <Polish>ACE Przeciążenia</Polish>
             <French>ACE Force gravitationnelle</French>
             <Russian>ACE Перегрузки</Russian>
@@ -58,6 +59,7 @@
         </Key>
         <Key ID="STR_ACE_GForces_Coefficient_DisplayName">
             <English>G-Force Coefficient</English>
+            <German>G-Kraft Koeffizient</German>
             <Polish>Współczynnk przeciążenia</Polish>
             <French>Coefficient de force gravitationnelle</French>
             <Russian>Коэффициент перегрузки</Russian>
@@ -66,6 +68,7 @@
         </Key>
         <Key ID="STR_ACE_GForces_Coefficient_Description">
             <English>Controls strength of G-Force affecting players.</English>
+            <German>Kontrolliert die Stärke der Einwirkung der G-Kräfte auf die Spieler.</German>
             <Polish>Wpływa na siłe przeciążeń oddziałujących na graczy</Polish>
             <French>Coefficient permettant d'ajuster le niveau de force gravitationnelle affectant les joueurs.</French>
             <Russian>Определяет силу перегрузок, влияющих на игроков.</Russian>

--- a/addons/grenades/stringtable.xml
+++ b/addons/grenades/stringtable.xml
@@ -513,36 +513,43 @@
         </Key>
         <Key ID="STR_ACE_Grenades_SatchelCharge_Remote_Mag_Throwable">
             <English>Explosive Satchel (Throwable)</English>
+            <German>Rucksackladung (Werfbar)</German>
             <French>Charge en sacoche (lançable)</French>
             <Japanese>梱包爆薬 (投てき仕様)</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_SatchelCharge_Description">
             <English>Type: Charge&lt;br /&gt;Rounds: 1&lt;br /&gt;Used on: Things that need to die</English>
+            <German>Typ: Ladung&lt;br /&gt;Ladungen: 1&lt;br /&gt;Anwendbar für: Dinge die sterben sollen</German>
             <French>Type : Charge&lt;br /&gt;Munitions : 1&lt;br /&gt;Application : à balancer sur des trucs qui doivent mourir</French>
             <Japanese>種類: 爆薬&lt;br /&gt;弾数: 1&lt;br /&gt;次で使用: 破壊すべき物に</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_SatchelCharge_LibText">
             <English>An explosive satchel that is throwable. 7 second fixed fuse</English>
+            <German>Eine werfbare Rucksackladung, 7 Sekunden Zünder</German>
             <French>Charge explosive lançable. Détonation après 7 secondes.</French>
             <Japanese>投げられる梱包爆薬。起爆までの時間は 7 秒間</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_DemoCharge_Remote_Mag_Throwable">
             <English>Explosive Charge (Throwable)</English>
+            <German>Sprengladung (Werfbar)</German>
             <French>Charge explosive (lançable)</French>
             <Japanese>爆薬ブロック (投てき仕様)</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_DemoCharge_LibText">
             <English>An explosive charge that is throwable. 7 second fixed fuse</English>
+            <German>Eine werfbare Sprengladung, 7 Sekunden Zünder</German>
             <French>Bloc explosif lançable. Détonation après 7 secondes.</French>
             <Japanese>投げられる爆薬ブロック。起爆までの時間は 7 秒間</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_Convert_Fuse">
             <English>Convert to short fuse</English>
+            <German>Zu Kurzzünder konvertieren</German>
             <French>Appliquer une mèche</French>
             <Japanese>短信管へ変更</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_Remove_Fuse">
             <English>Remove short fuse</English>
+            <German>Kurzzünder entfernen</German>
             <French>Retirer la mèche</French>
             <Japanese>短信管を削除</Japanese>
         </Key>
@@ -564,11 +571,13 @@
         </Key>
         <Key ID="STR_ACE_Grenades_convertExplosives_DisplayName">
             <English>Allow Explosive Conversion</English>
+            <German>Erlaube Sprengstoff Konvertierungen</German>
             <French>Autoriser les mèches (charges lançables)</French>
             <Japanese>爆薬変更を許可</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_convertExplosives_Description">
             <English>Allow converting explosives to throwables</English>
+            <German>Erlaubt das konvertieren von Sprengstoff zu Wurfgegenständen</German>
             <French>Cette option permet de rendre les charges explosives lançables, à la manière des grenades.\nPour celà, ouvrir l'inventaire et double-cliquer sur les charges, afin de leur appliquer une mèche.\nLa mèche peut se retirer en suivant la même procédure.</French>
             <Japanese>爆発物を投てき仕様へ交換できるようにします。</Japanese>
         </Key>

--- a/addons/grenades/stringtable.xml
+++ b/addons/grenades/stringtable.xml
@@ -513,31 +513,31 @@
         </Key>
         <Key ID="STR_ACE_Grenades_SatchelCharge_Remote_Mag_Throwable">
             <English>Explosive Satchel (Throwable)</English>
-            <German>Rucksackladung (Werfbar)</German>
+            <German>Rucksackladung (werfbar)</German>
             <French>Charge en sacoche (lançable)</French>
             <Japanese>梱包爆薬 (投てき仕様)</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_SatchelCharge_Description">
             <English>Type: Charge&lt;br /&gt;Rounds: 1&lt;br /&gt;Used on: Things that need to die</English>
-            <German>Typ: Ladung&lt;br /&gt;Ladungen: 1&lt;br /&gt;Anwendbar für: Dinge die sterben sollen</German>
+            <German>Typ: Rucksackladung&lt;br /&gt;Patronen: 1&lt;br /&gt;Anwendbar für: Dinge die sterben sollen</German>
             <French>Type : Charge&lt;br /&gt;Munitions : 1&lt;br /&gt;Application : à balancer sur des trucs qui doivent mourir</French>
             <Japanese>種類: 爆薬&lt;br /&gt;弾数: 1&lt;br /&gt;次で使用: 破壊すべき物に</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_SatchelCharge_LibText">
             <English>An explosive satchel that is throwable. 7 second fixed fuse</English>
-            <German>Eine werfbare Rucksackladung, 7 Sekunden Zünder</German>
+            <German>Eine werfbare Rucksackladung, 7 Sekunden Zünder.</German>
             <French>Charge explosive lançable. Détonation après 7 secondes.</French>
             <Japanese>投げられる梱包爆薬。起爆までの時間は 7 秒間</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_DemoCharge_Remote_Mag_Throwable">
             <English>Explosive Charge (Throwable)</English>
-            <German>Sprengladung (Werfbar)</German>
+            <German>Sprengladung (werfbar)</German>
             <French>Charge explosive (lançable)</French>
             <Japanese>爆薬ブロック (投てき仕様)</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_DemoCharge_LibText">
             <English>An explosive charge that is throwable. 7 second fixed fuse</English>
-            <German>Eine werfbare Sprengladung, 7 Sekunden Zünder</German>
+            <German>Eine werfbare Sprengladung, 7 Sekunden Zünder.</German>
             <French>Bloc explosif lançable. Détonation après 7 secondes.</French>
             <Japanese>投げられる爆薬ブロック。起爆までの時間は 7 秒間</Japanese>
         </Key>
@@ -571,13 +571,13 @@
         </Key>
         <Key ID="STR_ACE_Grenades_convertExplosives_DisplayName">
             <English>Allow Explosive Conversion</English>
-            <German>Erlaube Sprengstoff Konvertierungen</German>
+            <German>Erlaube Sprengstoffkonvertierungen</German>
             <French>Autoriser les mèches (charges lançables)</French>
             <Japanese>爆薬変更を許可</Japanese>
         </Key>
         <Key ID="STR_ACE_Grenades_convertExplosives_Description">
             <English>Allow converting explosives to throwables</English>
-            <German>Erlaubt das konvertieren von Sprengstoff zu Wurfgegenständen</German>
+            <German>Erlaubt das konvertieren von Sprengstoff zu Wurfgegenständen.</German>
             <French>Cette option permet de rendre les charges explosives lançables, à la manière des grenades.\nPour celà, ouvrir l'inventaire et double-cliquer sur les charges, afin de leur appliquer une mèche.\nLa mèche peut se retirer en suivant la même procédure.</French>
             <Japanese>爆発物を投てき仕様へ交換できるようにします。</Japanese>
         </Key>

--- a/addons/gunbag/stringtable.xml
+++ b/addons/gunbag/stringtable.xml
@@ -67,6 +67,7 @@
         </Key>
         <Key ID="STR_ACE_Gunbag_SwapGunbag">
             <English>Exchange weapon in gunbag</English>
+            <German>Waffe in Waffentasche austauschen</German>
             <Polish>Wymień broń w torbie</Polish>
             <Russian>Заменить оружие в чехле</Russian>
             <French>Échanger les armes</French>
@@ -75,6 +76,7 @@
         </Key>
         <Key ID="STR_ACE_Gunbag_SwapGunbagEnabled_DisplayName">
             <English>Enable Weapon Swap</English>
+            <German>Waffentausch aktivieren</German>
             <Polish>Aktywuj wymianę broni</Polish>
             <Russian>Включить обмен оружием</Russian>
             <French>Activer l'échange d'arme</French>
@@ -83,6 +85,7 @@
         </Key>
         <Key ID="STR_ACE_Gunbag_SwapGunbagEnabled_Description">
             <English>Allows interaction to directly swap the primary weapon and stored weapon.</English>
+            <German>Erlaubt das direkte Tauschen, der Primären- und gelagerten Waffe durch eine Interaktion.</German>
             <Polish>Pozwala na interakcje do wymiany broni głównej na bron schowaną.</Polish>
             <Russian>Разрешает действие прямого обмена основного оружия и спрятанного в чехле.</Russian>
             <French>Active le menu d'interaction personnelle permettant d'échanger directement l'arme primaire et l'arme rangée dans la housse.</French>

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -267,6 +267,7 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_onlyShowFriendlys_displayName">
             <English>Only Show Friendly Gestures</English>
+            <German>Zeige nur freundliche Gesten</German>
             <Russian>Показывать только союзные жесты</Russian>
             <Polish>Pokazuj jedynie sojusznicze gesty</Polish>
             <French>Afficher uniquement le pointage des alliés</French>
@@ -274,52 +275,62 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_onlyShowFriendlys_description">
             <English>Shows only Gestures from Units that are from the same side or a Friendly side.</English>
+            <German>Zeige nur Gesten von Einheiten, die der gleichen oder einer Freundlichen Seite angehören.</German>
             <Russian>Показывать жесты только от игроков союзной стороны.</Russian>
             <French>Affiche uniquement les pointages effectués par des unités qui sont du même camp, ou d'un camp allié.</French>
             <Japanese>友軍ユニットのみからジェスチャーを表示します。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_maxRangeCamera_displayName">
             <English>Max range Camera</English>
+            <German>Maxmimale Kamera Reichweite</German>
             <French>Portée de la caméra</French>
             <Japanese>カメラ最大範囲</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_maxRangeCamera_description">
             <English>Max range between a Camera and players to show the map gesture indicator</English>
+            <German>Maximale Reichweite zwischen einer Kamera und einem Spieler, um die Kartengesten zu zeigen.</German>
             <French>Définit le rayon au-delà duquel une caméra ne verra plus l'indicateur de pointage des autres joueurs.</French>
             <Japanese>プレイヤーが行うマップ ジェスチャーをカメラから確認できる最大範囲を設定します。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowSpectator_displayName">
             <English>Allow Spectator</English>
+            <German>Erlaube Zuschauer</German>
             <French>Autoriser les spectateurs</French>
             <Japanese>スペクテイターに許可</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowSpectator_description">
             <English>Allows Spectator to See Map Gestures</English>
+            <German>Erlaube Zuschauern, die Kartengesten zu sehen</German>
             <French>Permet aux spectateurs de voir le pointage des autres joueurs.</French>
             <Japanese>スペクテイターからマップ ジェスチャーを表示できるようにします。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowCurator_displayName">
             <English>Allow Curator</English>
+            <German>Erlaube Kurator</German>
             <French>Autoriser les curateurs</French>
             <Japanese>キュレーターに許可</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowCurator_description">
             <English>Allows Curator to See Map Gestures</English>
+            <German>Erlaube Kuratoren, die Kartengesten zu sehen</German>
             <French>Permet aux curateurs de voir le pointage des autres joueurs.</French>
             <Japanese>キュレーターからマップ ジェスチャーを表示できるようにします。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_displayName">
             <English>Briefing Mode</English>
+            <German>Briefing Modus</German>
             <French>Visibilité lors du briefing</French>
             <Japanese>ブリーフィング モード</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_description">
             <English>What player can see what</English>
+            <German>Welche Spieler was sehen können</German>
             <French>Définit quels pointages les joueurs peuvent voir lors du briefing.</French>
             <Japanese>プレイヤーが見ることができる対象を決定します。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_Disabled">
             <English>Disabled</English>
+            <German>Deaktiviert</German>
             <French>Pointage désactivé</French>
             <Japanese>無効化</Japanese>
         </Key>
@@ -349,6 +360,7 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_Proximity">
             <English>Proximity</English>
+            <German>Umgebung</German>
             <French>Proximité</French>
             <Japanese>付近のみ</Japanese>
         </Key>

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -275,14 +275,14 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_onlyShowFriendlys_description">
             <English>Shows only Gestures from Units that are from the same side or a Friendly side.</English>
-            <German>Zeige nur Gesten von Einheiten, die der gleichen oder einer Freundlichen Seite angehören.</German>
+            <German>Zeige nur Gesten von Einheiten, die der gleichen oder einer freundlichen Seite angehören.</German>
             <Russian>Показывать жесты только от игроков союзной стороны.</Russian>
             <French>Affiche uniquement les pointages effectués par des unités qui sont du même camp, ou d'un camp allié.</French>
             <Japanese>友軍ユニットのみからジェスチャーを表示します。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_maxRangeCamera_displayName">
             <English>Max range Camera</English>
-            <German>Maxmimale Kamera Reichweite</German>
+            <German>Maxmimale Kamerareichweite</German>
             <French>Portée de la caméra</French>
             <Japanese>カメラ最大範囲</Japanese>
         </Key>
@@ -294,31 +294,31 @@
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowSpectator_displayName">
             <English>Allow Spectator</English>
-            <German>Erlaube Zuschauer</German>
+            <German>Zuschauer erlauben</German>
             <French>Autoriser les spectateurs</French>
             <Japanese>スペクテイターに許可</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowSpectator_description">
             <English>Allows Spectator to See Map Gestures</English>
-            <German>Erlaube Zuschauern, die Kartengesten zu sehen</German>
+            <German>Erlaube Zuschauern, die Kartengesten zu sehen.</German>
             <French>Permet aux spectateurs de voir le pointage des autres joueurs.</French>
             <Japanese>スペクテイターからマップ ジェスチャーを表示できるようにします。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowCurator_displayName">
             <English>Allow Curator</English>
-            <German>Erlaube Kurator</German>
+            <German>Kuratoren erlauben</German>
             <French>Autoriser les curateurs</French>
             <Japanese>キュレーターに許可</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_allowCurator_description">
             <English>Allows Curator to See Map Gestures</English>
-            <German>Erlaube Kuratoren, die Kartengesten zu sehen</German>
+            <German>Erlaube Kuratoren, die Kartengesten zu sehen.</German>
             <French>Permet aux curateurs de voir le pointage des autres joueurs.</French>
             <Japanese>キュレーターからマップ ジェスチャーを表示できるようにします。</Japanese>
         </Key>
         <Key ID="STR_ACE_Map_Gestures_briefingMode_displayName">
             <English>Briefing Mode</English>
-            <German>Briefing Modus</German>
+            <German>Briefing-Modus</German>
             <French>Visibilité lors du briefing</French>
             <Japanese>ブリーフィング モード</Japanese>
         </Key>

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -152,12 +152,12 @@
         </Key>
         <Key ID="STR_ACE_Markers_TimestampEnabled">
             <English>Allow Timestamps</English>
-            <German>Erlaube Zeitstempel</German>
+            <German>Zeitstempel erlauben</German>
             <French>Permettre l'horodatage</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampEnabledDescription">
             <English>Whether to allow timestamps to be automatically applied to markers</English>
-            <German>Erlaubt das automatische Anwenden von Zeitstempeln, auf Markierungen</German>
+            <German>Erlaubt das automatische Anwenden von Zeitstempeln auf Markierungen.</German>
             <French>Active une interface permettant d'apposer un horodatage sur les marqueurs.</French>
         </Key>
         <Key ID="STR_ACE_Markers_Timestamp">
@@ -172,12 +172,12 @@
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormat">
             <English>Timestamp Format</English>
-            <German>Zeitstempel Format</German>
+            <German>Zeitstempelformat</German>
             <French>Horodatage - Format</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription0">
             <English>Changes the timestamp format</English>
-            <German>Ändert das Zeitstempel Format</German>
+            <German>Ändert das Zeitstempelformat</German>
             <French>Modifie le format de l'horodatage.</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription1">
@@ -202,22 +202,22 @@
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat">
             <English>Timestamp Hour Format</English>
-            <German>Zeitstempel Stunden Format</German>
+            <German>Zeitstempel Stundenformat</German>
             <French>Horodatage - Système horaire</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat24">
             <English>24-Hour Clock</English>
-            <German>24 Stunden Uhr</German>
+            <German>24-Stunden Uhr</German>
             <French>Format 24 heures</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat12">
             <English>12-Hour Clock</English>
-            <German>12 Stunden Uhr</German>
+            <German>12-Stunden Uhr</German>
             <French>Format 12 heures</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormatDescription">
             <English>Changes timestamp to use either 24-hour or 12-hour clock format</English>
-            <German>Ändert das Zeitstempel Format, um entweder das 24 Stunden oder 12 Stunden Format zu benutzen.</German>
+            <German>Ändert das Zeitstempelformat, um entweder das 24-Stunden oder 12-Stunden Format zu benutzen.</German>
             <French>Permet de choisir le système d'horodatage souhaité, au format 12 ou 24 heures.</French>
         </Key>
     </Package>

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -152,58 +152,72 @@
         </Key>
         <Key ID="STR_ACE_Markers_TimestampEnabled">
             <English>Allow Timestamps</English>
+            <German>Erlaube Zeitstempel</German>
             <French>Permettre l'horodatage</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampEnabledDescription">
             <English>Whether to allow timestamps to be automatically applied to markers</English>
+            <German>Erlaubt das automatische Anwenden von Zeitstempeln, auf Markierungen</German>
             <French>Active une interface permettant d'apposer un horodatage sur les marqueurs.</French>
         </Key>
         <Key ID="STR_ACE_Markers_Timestamp">
             <English>Add Timestamp:</English>
+            <German>Zeitstempel einfügen:</German>
             <French>Ajouter l'horodatage</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampTooltipNoWatch">
             <English>Watch Required</English>
+            <German>Uhr benötigt</German>
             <French>Une montre est requise.</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormat">
             <English>Timestamp Format</English>
+            <German>Zeitstempel Format</German>
             <French>Horodatage - Format</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription0">
             <English>Changes the timestamp format</English>
+            <German>Ändert das Zeitstempel Format</German>
             <French>Modifie le format de l'horodatage.</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription1">
             <English>"HH" - Hour</English>
+            <German>"HH" - Stunde</German>
             <French>"HH" - Heures</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription2">
             <English>"MM" - Minute</English>
+            <German>"MM" - Minute</German>
             <French>"MM" - Minutes</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription3">
             <English>"SS" - Seconds</English>
+            <German>"SS" - Sekunden</German>
             <French>"SS" - Secondes</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription4">
             <English>"MM" - Milliseconds</English>
+            <German>"MM" - Millisekunden</German>
             <French>"MS" - Millisecondes</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat">
             <English>Timestamp Hour Format</English>
+            <German>Zeitstempel Stunden Format</German>
             <French>Horodatage - Système horaire</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat24">
             <English>24-Hour Clock</English>
+            <German>24 Stunden Uhr</German>
             <French>Format 24 heures</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat12">
             <English>12-Hour Clock</English>
+            <German>12 Stunden Uhr</German>
             <French>Format 12 heures</French>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormatDescription">
             <English>Changes timestamp to use either 24-hour or 12-hour clock format</English>
+            <German>Ändert das Zeitstempel Format, um entweder das 24 Stunden oder 12 Stunden Format zu benutzen.</German>
             <French>Permet de choisir le système d'horodatage souhaité, au format 12 ou 24 heures.</French>
         </Key>
     </Package>

--- a/addons/medical/stringtable.xml
+++ b/addons/medical/stringtable.xml
@@ -197,12 +197,14 @@
         </Key>
         <Key ID="STR_ACE_Medical_Fractures_SplintHealsNoJog">
             <English>Splints Heal, but Cannot Jog</English>
+            <German>Schinen heilen Knochenbrüche, erlauben aber nicht das laufen</German>
             <French>Les attelles guérissent les fractures, mais empêchent de courir</French>
             <Japanese>添え木で治癒可能、駆け足できないように</Japanese>
             <Turkish>Ateller İyileştirir, Ama Koşu Yapamaz</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_FractureChance_DisplayName">
             <English>Fracture Chance</English>
+            <German>Knochenbruch Chance</German>
             <French>Chance de fracture</French>
             <Japanese>骨折確率</Japanese>
             <Chinesesimp>骨折概率</Chinesesimp>

--- a/addons/medical_feedback/stringtable.xml
+++ b/addons/medical_feedback/stringtable.xml
@@ -106,7 +106,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_DisplayName">
             <English>Low Blood Volume Effect Type</English>
-            <German>Niedriger Blutstand Effekt Typ</German>
+            <German>Niedriger Blutstand Effekttyp</German>
             <Russian>Визуальный эффект низкого объема крови</Russian>
             <French>Effet de faible volume sanguin</French>
             <Japanese>低血液量時の効果種類</Japanese>

--- a/addons/medical_feedback/stringtable.xml
+++ b/addons/medical_feedback/stringtable.xml
@@ -106,6 +106,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_DisplayName">
             <English>Low Blood Volume Effect Type</English>
+            <German>Niedriger Blutstand Effekt Typ</German>
             <Russian>Визуальный эффект низкого объема крови</Russian>
             <French>Effet de faible volume sanguin</French>
             <Japanese>低血液量時の効果種類</Japanese>
@@ -115,6 +116,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_Description">
             <English>Selects the used low blood volume effect type.</English>
+            <German>Wähle den Effekt, der bei einem niedrigen Blutstand verwendet wird.</German>
             <Russian>Выбирает тип визуализации эффекта низкого объема крови.</Russian>
             <French>Permet de choisir quel effet provoque un faible volume sanguin.</French>
             <Japanese>低血液量時の効果を選択できます。</Japanese>
@@ -124,6 +126,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_colorCorrection">
             <English>Color Fading</English>
+            <German>Farbverblassung</German>
             <Russian>Потеря цветности</Russian>
             <French>Atténuation des couleurs</French>
             <Japanese>退色</Japanese>
@@ -133,6 +136,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_icon">
             <English>Icon</English>
+            <German>Bild</German>
             <Russian>Иконка</Russian>
             <French>Icône</French>
             <Japanese>アイコン</Japanese>
@@ -142,6 +146,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Feedback_BloodVolumeEffectType_both">
             <English>Icon + Color Fading</English>
+            <German>Bild + Farbverblassung</German>
             <Russian>Иконка + Потеря цветности</Russian>
             <French>Icône + Atténuation des couleurs</French>
             <Japanese>アイコンと退色</Japanese>

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -191,7 +191,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_GUI_InteractionMenuShowTriage_DisplayName">
             <English>Show Triage Level in Interaction Menu</English>
-            <German>Triage Stufe im Interaktions Menü anzeigen</German>
+            <German>Triagestufe im Interaktionsmenü anzeigen.</German>
             <French>Couleur de triage dans le menu d'interaction</French>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_InteractionMenuShowTriage_Description">
@@ -1114,7 +1114,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_GUI_IGUI_PatientInfo">
             <English>Patient Info</English>
-            <German>Patienten Information</German>
+            <German>Patienteninformation</German>
             <Polish>Informacje o pacjencie</Polish>
             <French>Informations patient</French>
             <Russian>Информация о пациенте</Russian>

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -191,10 +191,12 @@
         </Key>
         <Key ID="STR_ACE_Medical_GUI_InteractionMenuShowTriage_DisplayName">
             <English>Show Triage Level in Interaction Menu</English>
+            <German>Triage Stufe im Interaktions Menü anzeigen</German>
             <French>Couleur de triage dans le menu d'interaction</French>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_InteractionMenuShowTriage_Description">
             <English>Shows the patient's triage level by changing the color of the main and medical menu actions.</English>
+            <German>Zeigt die Triage Stufe des Patienten, durch das Ändern der Farbe der Haupt- und Sanitätsmenü-Aktionen.</German>
             <French>Modifie la couleur du menu d'interactions et du sous-menu médical en fonction de la fiche de triage du patient.</French>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_Medical">
@@ -955,6 +957,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_GUI_Status_Fractured">
             <English>Fractured</English>
+            <German>Gebrochen</German>
             <Russian>Перелом</Russian>
             <Japanese>骨折している</Japanese>
             <French>Fracturé</French>
@@ -969,6 +972,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_GUI_Status_SplintApplied">
             <English>Splint Applied</English>
+            <German>Schiene angewendet</German>
             <Russian>Наложена шина</Russian>
             <Japanese>添え木を当てている</Japanese>
             <French>Attelle appliquée</French>
@@ -1110,6 +1114,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_GUI_IGUI_PatientInfo">
             <English>Patient Info</English>
+            <German>Patienten Information</German>
             <Polish>Informacje o pacjencie</Polish>
             <French>Informations patient</French>
             <Russian>Информация о пациенте</Russian>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -106,6 +106,8 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_EnabledCanReopen">
             <English>Enabled &amp; Can Reopen</English>
+            <German>Aktiviert &amp; Wundwiederöffnung aktiviert</German>
+			//meh translation
             <French>Activé &amp; peuvent se rouvrir</French>
             <Japanese>有効 &amp; 再開放</Japanese>
             <Czech>Zapnuto &amp; Úrazy se mohou znovu otevřít</Czech>
@@ -240,10 +242,12 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeAutoinjector_DisplayName">
             <English>Autoinjector Treatment Time</English>
+            <German>Autoinjektor Behandlungszeit</German>
             <French>Durée d'interaction - Auto-injecteurs</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeAutoinjector_Description">
             <English>Time, in seconds, required to administer medication using an autoinjector.</English>
+            <German>Zeit, in Sekunden, benötigt um Medizin mit einem Autoinjektor zu verabreichen.</German>
             <French>Définit le temps nécessaire à l'administration d'une substance auto-injectable (en secondes).</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquet_DisplayName">
@@ -582,10 +586,12 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_WoundStitchTime_DisplayName">
             <English>Wound Stitch Time</English>
+            <German>Zeit benötigt um Wunden zu nähen</German>
             <French>Durée d'interaction - Sutures</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_WoundStitchTime_Description">
             <English>Time, in seconds, required to stitch a single wound.</English>
+            <German>Zeit, in Sekunden, die benötigt wird um eine Wunden zu nähen.</German>
             <French>Définit le temps nécessaire à la suture d'une plaie (en secondes).</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AllowSelfIV_DisplayName">
@@ -614,10 +620,13 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AllowBodyBagUnconscious_DisplayName">
             <English>Allow Unconscious Body Bag</English>
+            <German>Platzieren von Bewustlosen Personen in Leichensäcken erlauben</German>
+            //too long?
             <French>Housse mortuaire - Autoriser patients inconscients</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AllowBodyBagUnconscious_Description">
             <English>Enables placing an unconscious patient in a body bag.</English>
+            <German>Erlaubt das platzieren von Bewustlosen Personen in Leichensäcken.</German>
             <French>Active la possibilité de placer des patients inconscients dans les housses mortuaires.\nAttention : le cas échéant cela provoquera la mort du patient.</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicIV_DisplayName">
@@ -850,10 +859,12 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPR_DisplayName">
             <English>CPR Treatment Time</English>
+            <German>HLW Behandlungszeit</German>
             <French>Durée d'interaction - RCP</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPR_Description">
             <English>Time, in seconds, required to perform CPR on a patient.</English>
+            <German>Zeit, in Sekunden, die benötigt wird um Herz-Lungen-Wiederbelebung duchzuführen.</German>
             <French>Définit le temps nécessaire à la mise en œuvre d'une RCP (en secondes).</French>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_HolsterRequired_DisplayName">
@@ -4306,6 +4317,7 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_bodybagWhileStillAlive">
             <English>The body twitched and may not be dead!</English>
+            <German>Der Körper hat gezuckt, und ist vielleicht nicht tot!</German>
             <French>L'unité a bougé et n'est peut-être pas morte !</French>
         </Key>
     </Package>

--- a/addons/quickmount/stringtable.xml
+++ b/addons/quickmount/stringtable.xml
@@ -61,6 +61,7 @@
         </Key>
         <Key ID="STR_ACE_QuickMount_EnabledDescription">
             <English>This option allows quick entry into the vehicle you are directly looking at.</English>
+            <German>Diese Option erlaubt den schnellen Einstieg, in das Fahrzeug, welches angeschaut wird.</German>
             <French>Cette option permet d'entrer rapidement dans les véhicules que vous regardez.</French>
             <Chinese>這個選項允許你能快速進入你直視的載具</Chinese>
             <Polish>Ta opcja umożliwia szybkie wsiadanie do pojazdu na który patrzysz.</Polish>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -1325,6 +1325,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_SatchelChargeThrowable_Name">
             <English>M183 Demolition Charge (Throwable)</English>
+            <German>M183 Sprengladung (Werfbar)</German>
             <French>M183 Charge de démolition (lançable)</French>
             <Japanese>M183 梱包爆薬 (投てき仕様)</Japanese>
             <Turkish>M183 Demolition Charge (Throwable)</Turkish>
@@ -1348,6 +1349,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_DemoChargeThrowable_Name">
             <English>M112 Demolition Charge (Throwable)</English>
+            <German>M112 Sprengladung (Werfbar)</German>
             <French>M112 Bloc de démolition (lançable)</French>
             <Japanese>M112 爆薬ブロック (投てき仕様)</Japanese>
             <Turkish>M112 Demolition Charge (Throwable)</Turkish>
@@ -3760,6 +3762,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_arco_ghex">
             <English>ELCAN SpecterOS (Green Hex)</English>
+            <German>ELCAN SpecterOS (Grün Hex)</German>
             <Chinese>ELCAN SpecterOS (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>ELCAN SpecterOS (绿色数位蜂巢迷彩)</Chinesesimp>
             <Japanese>ELCAN SpecterOS (緑ヘックス)</Japanese>
@@ -3829,6 +3832,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_lrps">
             <English>Nightforce NXS</English>
+            <German>Nightforce NXS</German>
             <Chinese>Nightforce NXS</Chinese>
             <Chinesesimp>Nightforce NXS</Chinesesimp>
             <Japanese>Nightforce NXS</Japanese>
@@ -3842,6 +3846,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_lrps_ghex">
             <English>Nightforce NXS (Green Hex)</English>
+            <German>Nightforce NXS (Grün Hex)</German>
             <Chinese>Nightforce NXS (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>Nightforce NXS (绿色数位蜂巢迷彩)</Chinesesimp>
             <Japanese>Nightforce NXS (緑ヘックス)</Japanese>
@@ -3869,6 +3874,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_lrps_2d">
             <English>Nightforce NXS (2D)</English>
+            <German>Nightforce NXS (2D)</German>
             <Chinese>Nightforce NXS (2D)</Chinese>
             <Chinesesimp>Nightforce NXS (2D)</Chinesesimp>
             <Japanese>Nightforce NXS (2D)</Japanese>
@@ -3882,6 +3888,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_ams">
             <English>US Optics MR-10 (Black)</English>
+            <German>US Optics MR-10 (Schwarz)</German>
             <Chinese>US Optics MR-10 (Black)</Chinese>
             <Chinesesimp>US Optics MR-10 (Black)</Chinesesimp>
             <Japanese>US Optics MR-10 (ブラック)</Japanese>
@@ -3895,6 +3902,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_ams_khk">
             <English>US Optics MR-10 (Khaki)</English>
+            <German>US Optics MR-10 (Khaki)</German>
             <Chinese>US Optics MR-10 (Khaki)</Chinese>
             <Chinesesimp>US Optics MR-10 (Khaki)</Chinesesimp>
             <Japanese>US Optics MR-10 (カーキ)</Japanese>
@@ -3908,6 +3916,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_ams_snd">
             <English>US Optics MR-10 (Sand)</English>
+            <German>US Optics MR-10 (Sand)</German>
             <Chinese>US Optics MR-10 (Sand)</Chinese>
             <Chinesesimp>US Optics MR-10 (Sand)</Chinesesimp>
             <Japanese>US Optics MR-10 (サンド)</Japanese>
@@ -3921,6 +3930,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_blk">
             <English>KAHLES Helia (Black)</English>
+            <German>KAHLES Helia (Schwarz)</German>
             <Chinese>KAHLES Helia (Black)</Chinese>
             <Chinesesimp>KAHLES Helia (Black)</Chinesesimp>
             <Japanese>KAHLES ヘリア (ブラック)</Japanese>
@@ -3934,6 +3944,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_hex">
             <English>KAHLES Helia (Hex)</English>
+            <German>KAHLES Helia (Hex)</German>
             <Chinese>KAHLES Helia (Hex)</Chinese>
             <Chinesesimp>KAHLES Helia (Hex)</Chinesesimp>
             <Japanese>KAHLES ヘリア (ヘックス)</Japanese>
@@ -3947,6 +3958,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_old">
             <English>KAHLES Helia (Old)</English>
+            <German>KAHLES Helia (Alt)</German>
             <Chinese>KAHLES Helia (Old)</Chinese>
             <Chinesesimp>KAHLES Helia (Old)</Chinesesimp>
             <Japanese>KAHLES ヘリア (使い古し)</Japanese>
@@ -3960,6 +3972,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_khs_tan">
             <English>KAHLES Helia (Tan)</English>
+            <German>KAHLES Helia (Beige)</German>
             <Chinese>KAHLES Helia (Tan)</Chinese>
             <Chinesesimp>KAHLES Helia (Tan)</Chinesesimp>
             <Japanese>KAHLES Helia (タン)</Japanese>
@@ -3973,6 +3986,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_dms">
             <English>Burris XTR II</English>
+            <German>Burris XTR II</German>
             <Chinese>Burris XTR II</Chinese>
             <Chinesesimp>Burris XTR II</Chinesesimp>
             <Japanese>Burris XTR II</Japanese>
@@ -3986,6 +4000,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_dms_ghex">
             <English>Burris XTR II (Green Hex)</English>
+            <German>Burris XTR II (Grün Hex)</German>
             <Chinese>Burris XTR II (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>Burris XTR II (绿色数位蜂巢迷彩)</Chinesesimp>
             <Japanese>Burris XTR II (緑ヘックス)</Japanese>
@@ -4083,6 +4098,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_mrco">
             <English>IOR-Valdada Pitbull 2</English>
+            <German>IOR-Valdada Pitbull 2</German>
             <Chinese>IOR-Valdada Pitbull 2</Chinese>
             <Chinesesimp>IOR-Valdada Pitbull 2</Chinesesimp>
             <Japanese>IOR-Valdada ピットブル 2</Japanese>
@@ -4096,6 +4112,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_mrco_2d">
             <English>IOR-Valdada Pitbull 2 (2D)</English>
+            <German>IOR-Valdada Pitbull 2 (2D)</German>
             <Chinese>IOR-Valdada Pitbull 2 (2D)</Chinese>
             <Chinesesimp>IOR-Valdada Pitbull 2 (2D)</Chinesesimp>
             <Japanese>IOR-Valdada ピットブル 2 (2D)</Japanese>
@@ -4109,6 +4126,7 @@
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_Yorris">
             <English>Burris FastFire 2</English>
+            <German>Burris FastFire 2</German>
             <Chinese>Burris FastFire 2</Chinese>
             <Chinesesimp>Burris FastFire 2</Chinesesimp>
             <Japanese>Burris ファストファイア 2</Japanese>

--- a/addons/reload/stringtable.xml
+++ b/addons/reload/stringtable.xml
@@ -35,6 +35,7 @@
         </Key>
         <Key ID="STR_ACE_Reload_SettingShowCheckAmmoSelf">
             <English>Always show check ammo self interaction</English>
+            <German>'Prüfe Munition' Selbstinterkation immer anzeigen</German>
             <Polish>Zawsze pokazuj interakcję od sprawdzania amunicji</Polish>
             <Italian>Mostra sempre l'interazione di autocontrollo delle munizioni</Italian>
             <Czech>Vždy zobrazit kontrolu munice v menu vlastní interakce</Czech>
@@ -46,6 +47,7 @@
         </Key>
         <Key ID="STR_ACE_Reload_SettingShowCheckAmmoSelfDesc">
             <English>Shows check ammo self interaction even when not in static weapons.</English>
+            <German>'Prüfe Munition' Selbstinterkation anzeigen, auch wenn nicht in einem statischen Geschütz.</German>
             <Polish>Pokazuje interakcję od sprawdzania amunicji poza bronią statyczną.</Polish>
             <Italian>Mostra il controllo dell'interazione tra le munizioni anche quando non sono in armi statiche.</Italian>
             <Czech>Zobrazuje kontrolu munice v menu vlastní interakce i pokud hráč nepoužívá statickou zbraň.</Czech>

--- a/addons/trenches/stringtable.xml
+++ b/addons/trenches/stringtable.xml
@@ -241,46 +241,55 @@
         </Key>
         <Key ID="STR_ACE_Trenches_Category">
             <English>ACE Trenches</English>
+            <German>ACE Schützengraben</German>
             <French>ACE Tranchées</French>
             <Japanese>ACE 塹壕</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_SmallEnvelopeDigDuration_DisplayName">
             <English>Small Trench Dig Duration</English>
+            <German>Kleiner Schützengraben Baudauer</German>
             <French>Petites tranchées - durée d'excavation</French>
             <Japanese>小型塹壕の完成時間</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_SmallEnvelopeDigDuration_Description">
             <English>Time, in seconds, required to dig a small trench.</English>
+            <German>Zeit, in Sekunden, die benötigt wird um einen kleinen Schützengraben zu bauen</German>
             <French>Définit le temps nécessaire au déploiement des petites tranchées (en secondes).</French>
             <Japanese>小型塹壕が完成するまでの時間 (秒) を設定できます。</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_SmallEnvelopeRemoveDuration_DisplayName">
             <English>Small Trench Remove Duration</English>
+            <German>Kleiner Schützengraben Entfernungsdauer</German>
             <French>Petites tranchées - durée de retrait</French>
             <Japanese>小型塹壕の削除時間</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_SmallEnvelopeRemoveDuration_Description">
             <English>Time, in seconds, required to remove a small trench.</English>
+            <German>Zeit, in Sekunden, die benötigt wird um einen kleinen Schützengraben zu entfernen.</German>
             <French>Définit le temps nécessaire pour le retrait des petites tranchées (en secondes).</French>
             <Japanese>小型塹壕が削除されるまでの時間 (秒) を設定できます。</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_BigEnvelopeDigDuration_DisplayName">
             <English>Big Trench Dig Duration</English>
+            <German>Großer Schützengraben Baudauer</German>
             <French>Grandes tranchées - durée d'excavation</French>
             <Japanese>大型塹壕の完成時間</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_BigEnvelopeDigDuration_Description">
             <English>Time, in seconds, required to dig a big trench.</English>
+            <German>Zeit, in Sekunden, die benötigt wird um einen großen Schützengraben zu bauen.</German>
             <French>Définit le temps nécessaire au déploiement des grandes tranchées (en secondes).</French>
             <Japanese>大型塹壕が完成するまでの時間 (秒) を設定できます。</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_BigEnvelopeRemoveDuration_DisplayName">
             <English>Big Trench Remove Duration</English>
+            <German>Großer Schützengraben Entfernungsdauer</German>
             <French>Grandes tranchées - durée de retrait</French>
             <Japanese>大型塹壕の削除時間</Japanese>
         </Key>
         <Key ID="STR_ACE_Trenches_BigEnvelopeRemoveDuration_Description">
             <English>Time, in seconds, required to remove a big trench.</English>
+            <German>Zeit, in Sekunden, die benötigt wird um einen großen Schützengraben zu entfernen.</German>
             <French>Définit le temps nécessaire pour le retrait des grandes tranchées (en secondes).</French>
             <Japanese>大型塹壕が削除されるまでの時間 (秒) を設定できます。</Japanese>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**

- Add german translations in `common` module,
- Add german translations in `csw` module,
- Add german translations in `dragging` module,
- Add german translations in `explosives` module,
- Add german translations in `fastroping` module,
- Add german translations in `gforces` module,
- Add german translations in `grenades` module,
- Add german translations in `gunbag` module,
- Add german translations in `map_gestures` module,
- Add german translations in `markers` module,
- Add german translations in `medical` module,
- Add german translations in `medical_feedback` module,
- Add german translations in `medical_gui` module,
- Add german translations in `medical_treatment` module,
- Add german translations in `quickmount` module,
- Add german translations in `realisticnames` module,
- Add german translations in `reload` module,
- Add german translations in `trenches` module

Please do provide feedback on the translations!

I added 2 comments in `medical_treatment`, since I'm not quite happy with those translations.
It'd be good if someone can provide any ideas to improve those two translations.