### PR TITLE
Interact Menu - Combine parent menu with single child

### DIFF
--- a/addons/chemlights/CfgVehicles.hpp
+++ b/addons/chemlights/CfgVehicles.hpp
@@ -9,11 +9,8 @@ class CfgVehicles {
                 class ACE_Chemlights {
                     displayName = CSTRING(Action_Chemlights);
                     icon = "\a3\ui_f\data\gui\cfg\Hints\chemlights_ca.paa";
-                    condition = QUOTE(count ([ACE_player] call FUNC(getShieldComponents)) > 0);
-                    statement = "true";
                     exceptions[] = {"isNotDragging", "isNotSwimming", "notOnMap", "isNotInside", "isNotSitting"};
-                    insertChildren = QUOTE(_this call DFUNC(compileChemlightMenu));
-                    showDisabled = 0;
+                    insertChildren = QUOTE(call DFUNC(compileChemlightMenu));
                 };
             };
         };

--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -76,7 +76,7 @@ class CfgVehicles {
             class ACE_cutRopes {
                 displayName = CSTRING(Interaction_cutRopes);
                 condition = QUOTE([_target] call FUNC(canCutRopes));
-                // should not be empty to work with EGVAR(interact_menu,combineParentWithSingleChild) setting
+                // should not be empty to work with EGVAR(interact_menu,consolidateSingleChild) setting
                 statement = QUOTE(true);
                 class confirmCutRopes {
                     displayName = ECSTRING(common,confirm);

--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -75,8 +75,9 @@ class CfgVehicles {
             };
             class ACE_cutRopes {
                 displayName = CSTRING(Interaction_cutRopes);
-                condition = QUOTE(true);
-                statement = "";
+                condition = QUOTE([_target] call FUNC(canCutRopes));
+                // should not be empty to work with EGVAR(interact_menu,combineParentWithSingleChild) setting
+                statement = QUOTE(true);
                 class confirmCutRopes {
                     displayName = ECSTRING(common,confirm);
                     condition = QUOTE([_target] call FUNC(canCutRopes));

--- a/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
+++ b/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
@@ -102,7 +102,7 @@ if ((_activeChildren isEqualTo []) && {_statementCode isEqualTo {}}) exitWith {
 };
 
 if (GVAR(consolidateSingleChild) && {count _activeChildren == 1} && {_statementCode isEqualTo {}}) then {
-    _activeChildren select 0 params ["_childActionData", "_childChildren"];
+    _activeChildren select 0 params ["_childActionData", "_childChildren", "_childObject"];
     _childActionData params ["", "_displayNameChild", "_iconChild", "_statementChild", "", "", "_customParamsChild", "", "", "_paramsChild"];
     _origActionData = [
         _actionName,
@@ -117,6 +117,7 @@ if (GVAR(consolidateSingleChild) && {count _activeChildren == 1} && {_statementC
         _paramsChild
     ];
     _activeChildren = _childChildren;
+    _object = _childObject;
 };
 
 [_origActionData, _activeChildren, _object]

--- a/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
+++ b/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
@@ -13,7 +13,7 @@
  * Active children <ARRAY>
  *
  * Example:
- * [bob, [array], [array], 5] call ACE_interact_menu_fnc_collectActoveActionTree
+ * [bob, [array], [array], 5] call ACE_interact_menu_fnc_collectActiveActionTree
  *
  * Public: No
  */
@@ -31,7 +31,17 @@ if !((_origActionData select 10) isEqualTo {}) then {
     [_target, ACE_player, _origActionData select 6, _origActionData] call (_origActionData select 10);
 };
 
-_origActionData params ["_actionName", "", "", "_statementCode", "_conditionCode", "_insertChildrenCode", "_customParams", "", "_distance"];
+_origActionData params [
+    "_actionName",
+    "_displayName",
+    "",
+    "_statementCode",
+    "_conditionCode",
+    "_insertChildrenCode",
+    "_customParams",
+    "_position",
+    "_distance"
+];
 
 // Return nothing if the action itself is not active
 if !([_target, ACE_player, _customParams] call _conditionCode) exitWith {
@@ -91,5 +101,22 @@ if ((_activeChildren isEqualTo []) && {_statementCode isEqualTo {}}) exitWith {
     []
 };
 
+if (GVAR(combineParentWithSingleChild) && {count _activeChildren == 1} && {_statementCode isEqualTo {}}) then {
+    _activeChildren select 0 params ["_childActionData", "_childChildren"];
+    _childActionData params ["", "_displayNameChild", "_iconChild", "_statementChild", "", "", "_customParamsChild", "", "", "_paramsChild"];
+    _origActionData = [
+        _actionName,
+        format ["%1 > %2", _displayName, _displayNameChild],
+        _iconChild,
+        _statementChild,
+        _conditionCode,
+        _insertChildrenCode,
+        _customParamsChild,
+        _position,
+        _distance,
+        _paramsChild
+    ];
+    _activeChildren = _childChildren;
+};
 
 [_origActionData, _activeChildren, _object]

--- a/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
+++ b/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
@@ -101,7 +101,7 @@ if ((_activeChildren isEqualTo []) && {_statementCode isEqualTo {}}) exitWith {
     []
 };
 
-if (GVAR(combineParentWithSingleChild) && {count _activeChildren == 1} && {_statementCode isEqualTo {}}) then {
+if (GVAR(consolidateSingleChild) && {count _activeChildren == 1} && {_statementCode isEqualTo {}}) then {
     _activeChildren select 0 params ["_childActionData", "_childChildren"];
     _childActionData params ["", "_displayNameChild", "_iconChild", "_statementChild", "", "", "_customParamsChild", "", "", "_paramsChild"];
     _origActionData = [

--- a/addons/interact_menu/initSettings.sqf
+++ b/addons/interact_menu/initSettings.sqf
@@ -9,9 +9,9 @@
 ] call CBA_settings_fnc_init;
 
 [
-    QGVAR(combineParentWithSingleChild),
+    QGVAR(consolidateSingleChild),
     "CHECKBOX",
-    [LSTRING(combineParentWithSingleChild), LSTRING(combineParentWithSingleChild)],
+    [LSTRING(consolidateSingleChild), LSTRING(consolidateSingleChild_Description)],
     format ["ACE %1", LLSTRING(Category_InteractionMenu)],
     false
 ] call CBA_fnc_addSetting;

--- a/addons/interact_menu/initSettings.sqf
+++ b/addons/interact_menu/initSettings.sqf
@@ -9,6 +9,14 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(combineParentWithSingleChild),
+    "CHECKBOX",
+    [LSTRING(combineParentWithSingleChild), LSTRING(combineParentWithSingleChild)],
+    format ["ACE %1", LLSTRING(Category_InteractionMenu)],
+    false
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(alwaysUseCursorInteraction),
     "CHECKBOX",
     LSTRING(AlwaysUseCursorInteraction),

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -489,9 +489,13 @@
             <Spanish>Selector de color</Spanish>
             <Turkish>Seçici Renk</Turkish>
         </Key>
-        <Key ID="STR_ACE_Interact_Menu_combineParentWithSingleChild">
-            <English>Combine parent menu with single child item</English>
-            <Russian>Объединять родительское меню с единственным дочерним меню</Russian>
+        <Key ID="STR_ACE_Interact_Menu_consolidateSingleChild">
+            <English>Consolidate single child actions</English>
+            <Russian>Объединять с единственным дочерним действием</Russian>
+        </Key>
+        <Key ID="STR_ACE_Interact_Menu_consolidateSingleChild_Description">
+            <English>Combines parent action with only one child action together.</English>
+            <Russian>Объединять родительское действие с единственным дочерним действием в одно.</Russian>
         </Key>
     </Package>
 </Project>

--- a/addons/interact_menu/stringtable.xml
+++ b/addons/interact_menu/stringtable.xml
@@ -489,5 +489,9 @@
             <Spanish>Selector de color</Spanish>
             <Turkish>Seçici Renk</Turkish>
         </Key>
+        <Key ID="STR_ACE_Interact_Menu_combineParentWithSingleChild">
+            <English>Combine parent menu with single child item</English>
+            <Russian>Объединять родительское меню с единственным дочерним меню</Russian>
+        </Key>
     </Package>
 </Project>

--- a/addons/map/CfgVehicles.hpp
+++ b/addons/map/CfgVehicles.hpp
@@ -5,11 +5,9 @@ class CfgVehicles {
             class ACE_MapFlashlight {
                 displayName = CSTRING(Action_Flashlights);
                 icon = QUOTE(\a3\ui_f\data\IGUI\Cfg\VehicleToggles\lightsiconon_ca.paa);
-                condition = QUOTE(GVAR(mapIllumination) && visibleMap && {!([] isEqualTo (_player call FUNC(getUnitFlashlights)))});
-                statement = "true";
+                condition = QUOTE(GVAR(mapIllumination) && visibleMap);
                 exceptions[] = {"isNotDragging", "notOnMap", "isNotInside", "isNotSitting"};
-                insertChildren = QUOTE(_this call DFUNC(compileFlashlightMenu));
-                showDisabled = 0;
+                insertChildren = QUOTE(call DFUNC(compileFlashlightMenu));
             };
         };
     };

--- a/addons/quickmount/CfgVehicles.hpp
+++ b/addons/quickmount/CfgVehicles.hpp
@@ -51,8 +51,7 @@ class CfgVehicles {
             class GVAR(ChangeSeat) { \
                 displayName = CSTRING(ChangeSeat); \
                 condition = QUOTE(call DFUNC(canShowFreeSeats)); \
-                statement = ""; \
-                insertChildren = QUOTE((_this select 2) param [ARR_2(0, [])]); \
+                insertChildren = QUOTE(call DFUNC(addFreeSeatsActions)); \
             }; \
         }
 

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -19,7 +19,6 @@
 
 params ["_vehicle", "_unit", "_args"];
 
-_args set [0, []];
 private _isInVehicle = _unit in _vehicle;
 
 GVAR(enabled)
@@ -40,7 +39,12 @@ GVAR(enabled)
     || {_vehicle isKindOf "Air"} // except Air
 }
 && {
-    private _subActions = _this call FUNC(addFreeSeatsActions);
-    _args set [0, _subActions];
-    !([] isEqualTo _subActions)
+    _isInVehicle
+    || {
+        // because Get In action has its own statement
+        // we have to cache subactions in args and reuse them in insertChildren code
+        private _subActions = _this call FUNC(addFreeSeatsActions);
+        _args set [0, _subActions];
+        !([] isEqualTo _subActions)
+    }
 }


### PR DESCRIPTION
**When merged this pull request will:**
- add setting to combine parent menu with single child;
- adapt `fastroping` `Cut ropes` action for the setting;
- clean up `chemlights` and `map` menu configs a little.

Setting is disabled by default. ~Still not sure about setting name and description.~

![3](https://user-images.githubusercontent.com/3867143/103810966-90764d80-5075-11eb-895b-1f4eb2b2ea71.jpg)