### PR TITLE
[WIP] Overheating - Add rate of fire feature and additional customization settings

### DIFF
--- a/addons/overheating/ACE_Settings.hpp
+++ b/addons/overheating/ACE_Settings.hpp
@@ -43,7 +43,7 @@ class ACE_Settings {
         value = 1;
         displayName = CSTRING(jamChanceCoef_displayName);
         description = CSTRING(jamChanceCoef_description);
-        sliderSettings[] = {0, 10, 1, 2};
+        sliderSettings[] = {0, 5, 1, 2};
     };
     class GVAR(unJamOnreload) {
         category = CSTRING(DisplayName);

--- a/addons/overheating/ACE_Settings.hpp
+++ b/addons/overheating/ACE_Settings.hpp
@@ -33,7 +33,7 @@ class ACE_Settings {
         category = CSTRING(DisplayName);
         typeName = "SCALAR";
         isClientSettable = 1;
-        value = 1;
+        value = 3000;
         displayName = CSTRING(particleEffectsAndDispersionDistance_displayName);
         description = CSTRING(particleEffectsAndDispersionDistance_description);
         sliderSettings[] = {1, 5000, 3000, 0};

--- a/addons/overheating/ACE_Settings.hpp
+++ b/addons/overheating/ACE_Settings.hpp
@@ -37,6 +37,14 @@ class ACE_Settings {
         displayName = CSTRING(DisplayTextOnJam_displayName);
         description = CSTRING(DisplayTextOnJam_description);
     };
+    class GVAR(jamChanceCoef) {
+        category = CSTRING(DisplayName);
+        typeName = "SCALAR";
+        value = 1;
+        displayName = CSTRING(jamChanceCoef_displayName);
+        description = CSTRING(jamChanceCoef_description);
+        sliderSettings[] = {0, 10, 1, 2};
+    };
     class GVAR(unJamOnreload) {
         category = CSTRING(DisplayName);
         typeName = "BOOL";

--- a/addons/overheating/ACE_Settings.hpp
+++ b/addons/overheating/ACE_Settings.hpp
@@ -29,6 +29,22 @@ class ACE_Settings {
         displayName = CSTRING(overheatingDispersion_displayName);
         description = CSTRING(overheatingDispersion_description);
     };
+    class GVAR(particleEffectsAndDispersionDistance) {
+        category = CSTRING(DisplayName);
+        typeName = "SCALAR";
+        isClientSettable = 1;
+        value = 1;
+        displayName = CSTRING(particleEffectsAndDispersionDistance_displayName);
+        description = CSTRING(particleEffectsAndDispersionDistance_description);
+        sliderSettings[] = {1, 5000, 3000, 0};
+    };
+    class GVAR(overheatingRateOfFire) {
+        category = CSTRING(DisplayName);
+        typeName = "BOOL";
+        value = 1;
+        displayName = CSTRING(overheatingRateOfFire_displayName);
+        description = CSTRING(overheatingRateOfFire_description);
+    };
     class GVAR(displayTextOnJam) {
         category = CSTRING(DisplayName);
         typeName = "BOOL";
@@ -45,12 +61,19 @@ class ACE_Settings {
         description = CSTRING(jamChanceCoef_description);
         sliderSettings[] = {0, 5, 1, 2};
     };
-    class GVAR(unJamOnreload) {
+    class GVAR(unJamOnReload) {
         category = CSTRING(DisplayName);
         typeName = "BOOL";
         value = 0;
-        displayName = CSTRING(unJamOnreload_displayName);
-        description = CSTRING(unJamOnreload_description);
+        displayName = CSTRING(unJamOnReload_displayName);
+        description = CSTRING(unJamOnReload_description);
+    };
+    class GVAR(unJamOnSwapBarrel) {
+        category = CSTRING(DisplayName);
+        typeName = "BOOL";
+        value = 0;
+        displayName = CSTRING(unJamOnSwapBarrel_displayName);
+        description = CSTRING(unJamOnSwapBarrel_description);
     };
     class GVAR(unJamFailChance) {
         category = CSTRING(DisplayName);

--- a/addons/overheating/XEH_postInit.sqf
+++ b/addons/overheating/XEH_postInit.sqf
@@ -51,7 +51,7 @@ if (hasInterface) then {
     // Register fire event handler
     ["ace_firedPlayer", DFUNC(firedEH)] call CBA_fnc_addEventHandler;
     // Only add eh to non local players if dispersion is enabled
-    if (GVAR(overheatingDispersion)) then {
+    if (GVAR(overheatingDispersion) || GVAR(showParticleEffectsForEveryone)) then {
         ["ace_firedPlayerNonLocal", DFUNC(firedEH)] call CBA_fnc_addEventHandler;
     };
 

--- a/addons/overheating/functions/fnc_firedEH.sqf
+++ b/addons/overheating/functions/fnc_firedEH.sqf
@@ -20,7 +20,7 @@ TRACE_10("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectil
 
 BEGIN_COUNTER(firedEH);
 
-if ((_unit distance ACE_player) > 3000
+if ((_unit distance ACE_player) > GVAR(particleEffectsAndDispersionDistance)
     || {(_muzzle != (primaryWeapon _unit)) && {_muzzle != (handgunWeapon _unit)}}) exitWith { // Only rifle or pistol muzzles (ignore grenades / GLs)
     END_COUNTER(firedEH);
 };
@@ -94,7 +94,13 @@ if ((_unit ammo _weapon) % 3 == 0) then {
     _this call FUNC(overheat);
 };
 
-//Don't bother with jamming when weapons can never jam.
+// decrease time to next shot as heat increases, value is a coef where 1 is unchanged and 0 is instant, 0.8 is a 25% faster ROF.
+// this could be filtered by weapon type, but I think the heat gain and rate of fire on non-automatic weapons is low enough not to bother
+if (GVAR(overheatingRateOfFire)) then {
+    _unit setWeaponReloadingTime [_unit, _muzzle, linearConversion [0, 1, _scaledTemperature, 1, 0.8, true]];
+};
+
+//Don't bother with jamming if coef makes the chance 0.
 if (GVAR(jamChanceCoef) == 0) exitWith {END_COUNTER(firedEH);};
 
 private _value = 5 * _scaledTemperature;

--- a/addons/overheating/functions/fnc_firedEH.sqf
+++ b/addons/overheating/functions/fnc_firedEH.sqf
@@ -54,12 +54,12 @@ if (_scaledTemperature > 0.1) then {
         [_projectile, _dispersionX * _dispersion, _dispersionY * _dispersion, _slowdownFactor * vectorMagnitude (velocity _projectile)] call EFUNC(common,changeProjectileDirection);
         TRACE_PROJECTILE_INFO(_projectile);
     };
-    
+
     // Particle Effects
     if (GVAR(showParticleEffects)
         && {GVAR(showParticleEffectsForEveryone) || {_unit == ACE_player} || {_unit distance ACE_player <= 20}}
         && {CBA_missionTime > (_unit getVariable [QGVAR(lastDrop), -1000]) + 0.40}) then {
-        
+
         _unit setVariable [QGVAR(lastDrop), CBA_missionTime];
 
         private _direction = (_unit weaponDirection _weapon) vectorMultiply 0.25;
@@ -94,9 +94,12 @@ if ((_unit ammo _weapon) % 3 == 0) then {
     _this call FUNC(overheat);
 };
 
+//Don't bother with jamming when weapons can never jam.
+if (GVAR(jamChanceCoef) == 0) exitWith {END_COUNTER(firedEH);};
+
 private _value = 5 * _scaledTemperature;
 private _array = [0.5, 1, 2, 8, 20, 150];
-_jamChance = _jamChance * linearConversion [0, 1, _value % 1, _array select floor _value, _array select ceil _value];
+_jamChance = _jamChance * GVAR(jamChanceCoef) * linearConversion [0, 1, _value % 1, _array select floor _value, _array select ceil _value];
 
 TRACE_3("check for random jam",_unit,_weapon,_jamChance);
 

--- a/addons/overheating/functions/fnc_firedEH.sqf
+++ b/addons/overheating/functions/fnc_firedEH.sqf
@@ -97,7 +97,7 @@ if ((_unit ammo _weapon) % 3 == 0) then {
 // decrease time to next shot as heat increases, value is a coef where 1 is unchanged and 0 is instant, 0.8 is a 25% faster ROF.
 // this could be filtered by weapon type, but I think the heat gain and rate of fire on non-automatic weapons is low enough not to bother
 if (GVAR(overheatingRateOfFire)) then {
-    _unit setWeaponReloadingTime [_unit, _muzzle, linearConversion [0, 1, _scaledTemperature, 1, 0.8, true]];
+    _unit setWeaponReloadingTime [_unit, _muzzle, linearConversion [0, 0.5, _scaledTemperature, 1, 0.8, true]];
 };
 
 //Don't bother with jamming if coef makes the chance 0.

--- a/addons/overheating/functions/fnc_handleTakeEH.sqf
+++ b/addons/overheating/functions/fnc_handleTakeEH.sqf
@@ -18,14 +18,15 @@
  * Public: No
  */
 
-if !(GVAR(unJamOnreload)) exitWith {};
+if !(GVAR(unJamOnReload)) exitWith {};
 
 params ["_unit", "_container", "_item"];
 TRACE_3("params",_unit,_container,_item);
 
 if ((_unit == ACE_player)
-        && {_container in [uniformContainer _unit, vestContainer _unit, backpackContainer _unit]}
-        && {_item == currentMagazine _unit}) then { //Todo: should this be any valid magazine for any jammed gun?
+    && {_container in [uniformContainer _unit, vestContainer _unit, backpackContainer _unit]}
+    && {_item == currentMagazine _unit}
+) then { //Todo: should this be any valid magazine for any jammed gun?
 
     TRACE_1("clearing jam",currentWeapon _unit);
     [_unit, currentWeapon _unit, true] call FUNC(clearJam)

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -28,8 +28,6 @@ _jammedWeapons pushBack _weapon;
 
 _unit setVariable [QGVAR(jammedWeapons), _jammedWeapons];
 
-
-
 // Stop current burst
 if (_ammo > 0) then {
     _unit setAmmo [_weapon, 0];

--- a/addons/overheating/functions/fnc_swapBarrelCallback.sqf
+++ b/addons/overheating/functions/fnc_swapBarrelCallback.sqf
@@ -26,7 +26,7 @@ if (_assistant isEqualTo _gunner) then {
     playSound "ACE_BarrelSwap";
 };
 
-if (GVAR(unJamOnSwapBarrel)) then {
+if (GVAR(unJamOnSwapBarrel) && {[_gunner] call FUNC(canUnjam)}) then {
     [ARR_3(_gunner, currentMuzzle _gunner, true)] call FUNC(clearJam);
 };
 

--- a/addons/overheating/functions/fnc_swapBarrelCallback.sqf
+++ b/addons/overheating/functions/fnc_swapBarrelCallback.sqf
@@ -26,6 +26,10 @@ if (_assistant isEqualTo _gunner) then {
     playSound "ACE_BarrelSwap";
 };
 
+if (GVAR(unJamOnSwapBarrel)) then {
+    [ARR_3(_gunner, currentMuzzle _gunner, true)] call FUNC(clearJam);
+};
+
 // don't consume the barrel, but rotate through them.
 [localize LSTRING(SwappedBarrel), QPATHTOF(UI\spare_barrel_ca.paa)] call EFUNC(common,displayTextPicture);
 

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -144,6 +144,12 @@
             <Chinese>過熱的武器將會有打不準和減少射擊初速的情況。適用於所有玩家</Chinese>
             <Hungarian>A túlmelegedett fegyverek kevésbé lesznek pontosak és csökkent a lövés sebessége. Minden játékosra vonatkozik.</Hungarian>
         </Key>
+        <Key ID="STR_ACE_Overheating_jamChanceCoef_displayName">
+            <English>Jam Chance Coefficient</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_jamChanceCoef_description">
+            <English>Modifier for the chance that weapon will jam from overheating [Setting to 0 will disable jamming].</English>
+        </Key>
         <Key ID="STR_ACE_Overheating_unJamOnreload_displayName">
             <English>Unjam weapon on reload</English>
             <German>Behebt Ladehemmung beim Nachladen</German>

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -145,7 +145,7 @@
             <Hungarian>A túlmelegedett fegyverek kevésbé lesznek pontosak és csökkent a lövés sebessége. Minden játékosra vonatkozik.</Hungarian>
         </Key>
         <Key ID="STR_ACE_Overheating_particleEffectsAndDispersionDistance_displayName">
-            <English>Distance for Particle Effect and Overheating Dispersion</English>
+            <English>Distance for Effects and Dispersion</English>
         </Key>
         <Key ID="STR_ACE_Overheating_particleEffectsAndDispersionDistance_description">
             <English>Overheating particle effects and dispersion will only be show for other player units closer than this. Value is in metres.</English>

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -144,13 +144,25 @@
             <Chinese>過熱的武器將會有打不準和減少射擊初速的情況。適用於所有玩家</Chinese>
             <Hungarian>A túlmelegedett fegyverek kevésbé lesznek pontosak és csökkent a lövés sebessége. Minden játékosra vonatkozik.</Hungarian>
         </Key>
+        <Key ID="STR_ACE_Overheating_particleEffectsAndDispersionDistance_displayName">
+            <English>Distance for Particle Effect and Overheating Dispersion</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_particleEffectsAndDispersionDistance_description">
+            <English>Overheating particle effects and dispersion will only be show for other player units closer than this. Value is in metres.</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_overheatingRateOfFire_displayName">
+            <English>Increase rate of fire with heat</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_overheatingRateOfFire_description">
+            <English>As weapons heat up their rate of fire increases up to 20%.</English>
+        </Key>
         <Key ID="STR_ACE_Overheating_jamChanceCoef_displayName">
             <English>Jam Chance Coefficient</English>
         </Key>
         <Key ID="STR_ACE_Overheating_jamChanceCoef_description">
             <English>Modifier for the chance that weapon will jam from overheating [Setting to 0 will disable jamming].</English>
         </Key>
-        <Key ID="STR_ACE_Overheating_unJamOnreload_displayName">
+        <Key ID="STR_ACE_Overheating_unJamOnReload_displayName">
             <English>Unjam weapon on reload</English>
             <German>Behebt Ladehemmung beim Nachladen</German>
             <Spanish>Desencasquillar el arma al recargar.</Spanish>
@@ -166,7 +178,7 @@
             <Chinese>重裝彈匣以解決卡彈</Chinese>
             <Hungarian>Távolítsa el az akadályt újratöltéskor</Hungarian>
         </Key>
-        <Key ID="STR_ACE_Overheating_unJamOnreload_description">
+        <Key ID="STR_ACE_Overheating_unJamOnReload_description">
             <English>Reloading clears a weapon jam.</English>
             <German>Nachladen behebt eine Ladehemmung.</German>
             <Spanish>Recargar el arma la desencasquilla.</Spanish>
@@ -181,6 +193,12 @@
             <Chinesesimp>利用重装弹匣来解决卡弹</Chinesesimp>
             <Chinese>利用重裝彈匣來解決卡彈</Chinese>
             <Hungarian>Az újratöltés megszünteti a fegyver elakadását.</Hungarian>
+        </Key>
+        <Key ID="STR_ACE_Overheating_unJamOnSwapBarrel_displayName">
+            <English>Unjam weapon on barrel swap</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_unJamOnSwapBarrel_description">
+            <English>Swapping barrels clears a weapon jam.</English>
         </Key>
         <Key ID="STR_ACE_Overheating_unJamFailChance_displayName">
             <English>Chance of unjam failing</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add feature to increase rate of fire with heat, with setting
- Add feature to unjam on barrel swap, with setting
- Add setting for jamming coefficient to change or disable jamming chance
- Add setting for particle effects and dispersion distance
- Add setting for overheating effects distance

Things I would like to add/improve before merge:
- Math for rate of fire increase.
The numbers I'm using in the linear conversion feel good, but if someone has the math for heat transfer from the gun to the ammo that'd be better.
- Cookoff from heat for closed barrel firearms
I'd like to add this as a feature.
It would need a gvar for each weapon to indicate if it's open or closed bolt. Any fancy math for the rate of fire increase could probably be reused.
Info for both could be taken from this or other research.
https://www.researchgate.net/publication/262880619_Experimental_investigation_of_a_cook-off_temperature_in_a_hot_barrel
![](https://www.researchgate.net/publication/262880619/figure/fig1/AS:267472821551108@1440781898196/Key-features-of-characteristics-curves.png)
