### PR TITLE
Fix AI Targeting Unconscious Enemies

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -53,12 +53,18 @@
 [QGVAR(setHidden), {
     params ["_object", "_set"];
     TRACE_2("setHidden EH",_object,_set);
+
     // May report nil. Default to factor 1.
     private _vis = [_object getUnitTrait "camouflageCoef"] param [0, 1];
+    private _aud = [_object getUnitTrait "audibleCoef"] param [0, 1];
+
     if (_set > 0) then {
-        if (_vis != 0) then {
+        if (_vis != 0 || _aud != 0) then {
             _object setVariable [QGVAR(oldVisibility), _vis];
             _object setUnitTrait ["camouflageCoef", 0];
+            _object setVariable [QGVAR(oldAudibleCoef), _aud];
+            _object setUnitTrait ["audibleCoef", 0];
+
             {
                 if (side _x != side group _object) then {
                     _x forgetTarget _object;
@@ -68,6 +74,8 @@
     } else {
         _vis = _object getVariable [QGVAR(oldVisibility), _vis];
         _object setUnitTrait ["camouflageCoef", _vis];
+        _aud = _object getVariable [QGVAR(oldAudibleCoef), _aud];
+        _object setUnitTrait ["audibleCoef", _vis];
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -21,7 +21,7 @@
 [QGVAR(setStatusEffect), {_this call FUNC(statusEffect_set)}] call CBA_fnc_addEventHandler;
 ["forceWalk", false, ["ace_advanced_fatigue", "ACE_SwitchUnits", "ACE_Attach", "ACE_dragging", "ACE_Explosives", "ACE_Ladder", "ACE_Sandbag", "ACE_refuel", "ACE_rearm", "ACE_Trenches", "ace_medical_fracture"]] call FUNC(statusEffect_addType);
 ["blockSprint", false, ["ace_advanced_fatigue", "ace_medical_fracture"]] call FUNC(statusEffect_addType);
-["setCaptive", true, [QEGVAR(captives,Handcuffed), QEGVAR(captives,Surrendered)]] call FUNC(statusEffect_addType);
+["setCaptive", true, [QEGVAR(captives,Handcuffed), QEGVAR(captives,Surrendered), QEGVAR(medical_status,Unconscious)]] call FUNC(statusEffect_addType);
 ["blockDamage", false, ["fixCollision", "ACE_cargo"]] call FUNC(statusEffect_addType);
 ["blockEngine", false, ["ACE_Refuel"]] call FUNC(statusEffect_addType);
 ["blockThrow", false, ["ACE_Attach", "ACE_concertina_wire", "ACE_dragging", "ACE_Explosives", "ACE_Ladder", "ACE_rearm", "ACE_refuel", "ACE_Sandbag", "ACE_Trenches", "ACE_tripod"]] call FUNC(statusEffect_addType);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -358,6 +358,14 @@ addMissionEventHandler ["PlayerViewChanged", {
 [QGVAR(displayTextStructured), {_this call FUNC(displayTextStructured)}] call CBA_fnc_addEventHandler;
 [QGVAR(displayTextPicture), {_this call FUNC(displayTextPicture)}] call CBA_fnc_addEventHandler;
 
+["ace_unconscious", {
+    params ["_unit", "_isUnconscious"];
+
+    if (local _unit && {!_isUnconscious}) then {
+        [_unit, false, QFUNC(loadPerson), west /* dummy side */] call FUNC(switchToGroupSide);
+    };
+}] call CBA_fnc_addEventHandler;
+
 ["ace_useItem", DFUNC(useItem)] call CBA_fnc_addEventHandler;
 
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -75,7 +75,7 @@
         _vis = _object getVariable [QGVAR(oldVisibility), _vis];
         _object setUnitTrait ["camouflageCoef", _vis];
         _aud = _object getVariable [QGVAR(oldAudibleCoef), _aud];
-        _object setUnitTrait ["audibleCoef", _vis];
+        _object setUnitTrait ["audibleCoef", _aud];
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -358,14 +358,6 @@ addMissionEventHandler ["PlayerViewChanged", {
 [QGVAR(displayTextStructured), {_this call FUNC(displayTextStructured)}] call CBA_fnc_addEventHandler;
 [QGVAR(displayTextPicture), {_this call FUNC(displayTextPicture)}] call CBA_fnc_addEventHandler;
 
-["ace_unconscious", {
-    params ["_unit", "_isUnconscious"];
-
-    if (local _unit && {!_isUnconscious}) then {
-        [_unit, false, QFUNC(loadPerson), west /* dummy side */] call FUNC(switchToGroupSide);
-    };
-}] call CBA_fnc_addEventHandler;
-
 ["ace_useItem", DFUNC(useItem)] call CBA_fnc_addEventHandler;
 
 

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -28,12 +28,8 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
-// Change unit's side to civilian. We use switchToGroupSide over setCaptive to avoid handcuffed units
-// changing faction on reanimation.
-[_unit, _active, GROUP_SWITCH_ID, civilian] call EFUNC(common,switchToGroupSide);
-
-// Stop AI firing at unconscious units in most situations (global effect)
-[_unit, "setHidden", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
+// Stop enemy AI targeting the unit
+[_unit, "setCaptive", QGVAR(Unconscious), _active] call EFUNC(common,statusEffect_set);
 
 if (_active) then {
     // Don't bother setting this if not used

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -28,6 +28,10 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
+// Change unit's side to civilian. We use switchToGroupSide over setCaptive to avoid handcuffed units
+// changing faction on reanimation.
+[_unit, _active, GROUP_SWITCH_ID, civilian] call EFUNC(common,switchToGroupSide);
+
 // Stop AI firing at unconscious units in most situations (global effect)
 [_unit, "setHidden", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #8041 (AI targeting unconscious enemies), by adding extra side-switching logic
- Remove antiquated wake-up logic from old medical
- Update `setHidden` status effect to make unit inaudible as well as invisible

The current system for stopping AI engaging unconscious units relies on the vanilla `setUnconscious` command, which is very buggy. For some reason, it fails to change the side of the unit to civilian despite ragdolling them in certain circumstances (see procedure at bottom). To resolve this, this PR adds redundant side-switching logic following `setUnconscious`. This is done using `switchToGroupSide` rather than `setCaptive` to avoid possible issues arising with unconscious handcuffed units.

The logic around https://github.com/acemod/ACE3/blob/fe544a274d043480e557903a891f6bfe02277d3e/addons/common/XEH_postInit.sqf#L353
 appears to be a holdover from the old medical and so has been removed for the risk of it interfering with the new medical system and to consolidate the code around unconsciousness logic to solely the medical modules.

In addition, this PR makes the `setHidden` status effect make the player inaudible as well as invisible. If a unit was moving when downed, they could still be detected by the enemy, undermining https://github.com/acemod/ACE3/blob/8e7f9b6db53a279432a2372c04be311807d1193b/addons/common/XEH_postInit.sqf#L64 I think the use of the `setHidden` status effect in relation to unconsciousness was originally added to help mitigate the issue when `setUnconscious` had failed, so this could likely be removed now.

A comprehensive reproduction procedure for the issue is as follows:
1. Start mission as zeus (with zeus module name `zeus`), with instant death disabled for AI and a single BLUFOR rifleman named `inf` and init field `zeus addCuratorEditableObjects [[this], true];`
2. Spawn REDFOR rifleman in front of BLUFOR rifleman
3. Wait for BLUFOR rifleman to neutralize REDFOR rifleman
4. Run `[inf, true] call ace_medical_fnc_setUnconscious;` in console
5. Observe that the faction of the BLUFOR rifleman does not change

Intended behaviour can be observed by not completing steps 2 and 3. The underlying issue with `setUnconscious` can be seen by running the game without mods and then executing `inf setUnconscious true;` in place of the command in step 4.