### PR TITLE
Dragging - Fix mass synchronization

### DIFF
--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -84,5 +84,5 @@ if (_target getVariable [QGVAR(isUAV), false]) then {
 private _mass = _target getVariable [QGVAR(originalMass), 0];
 
 if (_mass != 0) then {
-    [QEGVAR(common,setMass), [_target, _mass], _target] call CBA_fnc_globalEvent; // force global sync
+    [QEGVAR(common,setMass), [_target, _mass]] call CBA_fnc_globalEvent; // force global sync
 };

--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -84,5 +84,5 @@ if (_target getVariable [QGVAR(isUAV), false]) then {
 private _mass = _target getVariable [QGVAR(originalMass), 0];
 
 if (_mass != 0) then {
-    [QEGVAR(common,setMass), [_target, _mass], _target] call CBA_fnc_targetEvent;
+    [QEGVAR(common,setMass), [_target, _mass], _target] call CBA_fnc_globalEvent; // force global sync
 };

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -81,7 +81,7 @@ if (_target getVariable [QGVAR(isUAV), false]) then {
 private _mass = _target getVariable [QGVAR(originalMass), 0];
 
 if (_mass != 0) then {
-    [QEGVAR(common,setMass), [_target, _mass], _target] call CBA_fnc_globalEvent; // force global sync
+    [QEGVAR(common,setMass), [_target, _mass]] call CBA_fnc_globalEvent; // force global sync
 };
 
 // reset temp direction

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -81,7 +81,7 @@ if (_target getVariable [QGVAR(isUAV), false]) then {
 private _mass = _target getVariable [QGVAR(originalMass), 0];
 
 if (_mass != 0) then {
-    [QEGVAR(common,setMass), [_target, _mass], _target] call CBA_fnc_targetEvent;
+    [QEGVAR(common,setMass), [_target, _mass], _target] call CBA_fnc_globalEvent; // force global sync
 };
 
 // reset temp direction

--- a/addons/dragging/functions/fnc_startCarry.sqf
+++ b/addons/dragging/functions/fnc_startCarry.sqf
@@ -79,5 +79,5 @@ private _mass = getMass _target;
 
 if (_mass > 1) then {
     _target setVariable [QGVAR(originalMass), _mass, true];
-    [QEGVAR(common,setMass), [_target, 1e-12], _target] call CBA_fnc_targetEvent;
+    [QEGVAR(common,setMass), [_target, 1e-12], _target] call CBA_fnc_globalEvent; // force global sync
 };

--- a/addons/dragging/functions/fnc_startCarry.sqf
+++ b/addons/dragging/functions/fnc_startCarry.sqf
@@ -79,5 +79,5 @@ private _mass = getMass _target;
 
 if (_mass > 1) then {
     _target setVariable [QGVAR(originalMass), _mass, true];
-    [QEGVAR(common,setMass), [_target, 1e-12], _target] call CBA_fnc_globalEvent; // force global sync
+    [QEGVAR(common,setMass), [_target, 1e-12]] call CBA_fnc_globalEvent; // force global sync
 };

--- a/addons/dragging/functions/fnc_startDrag.sqf
+++ b/addons/dragging/functions/fnc_startDrag.sqf
@@ -67,5 +67,5 @@ private _mass = getMass _target;
 
 if (_mass > 1) then {
     _target setVariable [QGVAR(originalMass), _mass, true];
-    [QEGVAR(common,setMass), [_target, 1e-12], _target] call CBA_fnc_targetEvent;
+    [QEGVAR(common,setMass), [_target, 1e-12], _target] call CBA_fnc_globalEvent; // force global sync
 };

--- a/addons/dragging/functions/fnc_startDrag.sqf
+++ b/addons/dragging/functions/fnc_startDrag.sqf
@@ -67,5 +67,5 @@ private _mass = getMass _target;
 
 if (_mass > 1) then {
     _target setVariable [QGVAR(originalMass), _mass, true];
-    [QEGVAR(common,setMass), [_target, 1e-12], _target] call CBA_fnc_globalEvent; // force global sync
+    [QEGVAR(common,setMass), [_target, 1e-12]] call CBA_fnc_globalEvent; // force global sync
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Force `setMass` synchronization in dragging/carrying
- Prevent collision damage with dragged/carried objects in the first few seconds after performing the action

Mass synchronization in Arma is delayed, this forces synchronization.

Tested on multiplayer dedicated, a few times to confirm, manually executing global event in debug console on object carry/drag. Can also observe results with `getMass`.