### PR TITLE
R3F Compat - Update to the R3F weapons 3.7.1

### DIFF
--- a/optionals/compat_r3f/CfgAmmo.hpp
+++ b/optionals/compat_r3f/CfgAmmo.hpp
@@ -1,9 +1,7 @@
 class CfgAmmo {
     class Default;
     class BulletBase;
-    class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L370
-        hit = 6; // R3F default value 13, BI default value 5
-        typicalSpeed = 350; // R3F config
+    class R3F_9x19_Ball: BulletBase { // https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L495
         airFriction = -0.00201185; // ACE3 value, default -0.001413
         ACE_caliber = 9.017;
         ACE_bulletLength = 15.494;
@@ -13,12 +11,10 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {340, 370, 400};
-        ACE_barrelLengths[] = {101.6, 127.0, 228.6};
+        ACE_muzzleVelocities[] = {341, 371, 401}; // at 21°C, at 15°C 400 m/s according with the R3F_MP5A5 initSpeed
+        ACE_barrelLengths[] = {101.6, 127, 225};
     };
-    class R3F_556x45_Ball: BulletBase { // M855 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L9
-        typicalSpeed = 930; // R3F config
-        airFriction = -0.00130094; // ACE3 value, default -0.001625
+    class R3F_556x45_Ball: BulletBase { // M855 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L117
         ACE_caliber = 5.69;
         ACE_bulletLength = 23.012;
         ACE_bulletMass = 4.0176;
@@ -30,12 +26,10 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
-    class R3F_762x51_Ball: BulletBase { // M80 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L155
-        typicalSpeed = 820; // R3F config
-        airFriction = -0.00103711; // ACE3 value, default -0.00095
-        ACE_caliber = 7.823;
-        ACE_bulletLength = 28.956;
-        ACE_bulletMass = 9.4608;
+    class R3F_762x51_Ball: BulletBase { // M80 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L280
+        ACE_caliber = 7.82;
+        ACE_bulletLength = 28.96;
+        ACE_bulletMass = 9.46;
         ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.2};
         ACE_velocityBoundaries[] = {};
@@ -44,12 +38,10 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {700, 800, 820, 833, 845};
         ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
-    class R3F_762x51_Ball2: R3F_762x51_Ball { // M993 AP https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L226
-        typicalSpeed = 850; // R3F config
-        airFriction = -0.00110718; // ACE3 value, default -0.00095
-        ACE_caliber = 7.823;
-        ACE_bulletLength = 31.496;
-        ACE_bulletMass = 8.22946157;
+    class R3F_762x51_Ball2: R3F_762x51_Ball { // M993 AP https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L351
+        ACE_caliber = 7.82;
+        ACE_bulletLength = 31.5;
+        ACE_bulletMass = 8.23;
         ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.359};
         ACE_velocityBoundaries[] = {};
@@ -58,15 +50,22 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {650};
     };
-    class R3F_762x51_Minimi_Ball: R3F_762x51_Ball { // M80 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L155
-        airFriction = -0.00103711; // ACE3 value, default -0.002000
+    class R3F_762x51_Ball_SCAR: BulletBase { // M80 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L280
+        ACE_caliber = 7.82;
+        ACE_bulletLength = 28.96;
+        ACE_bulletMass = 9.46;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.8, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.2};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_dragModel = 7;
+        ACE_muzzleVelocities[] = {708, 808, 828, 841, 853}; // at 21°C, at 15°C 820 m/s according with the R3F SCAR-H initSpeed
+        ACE_barrelLengths[] = {254.0, 406.4, 508.0, 609.6, 660.4};
     };
-    class R3F_127x99_Ball: BulletBase { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
-        typicalSpeed = 780; // R3F config
-        airFriction = -0.00062115; // ACE3 value, default -0.00086
-        ACE_caliber = 12.954;
-        ACE_bulletLength = 58.674;
-        ACE_bulletMass = 41.9256;
+    class R3F_127x99_Ball: BulletBase { // PGM Hécate 2 M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L635
+        ACE_caliber = 12.95;
+        ACE_bulletLength = 58.67;
+        ACE_bulletMass = 41.93;
         ACE_muzzleVelocityVariationSD = 0.35;
         ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
@@ -76,27 +75,11 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {780};
         ACE_barrelLengths[] = {700};
     };
-    class R3F_127x99_PEI: R3F_127x99_Ball { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
-        typicalSpeed = 780; // R3F config
-        airFriction = -0.00062115; // ACE3 value, default -0.00086
-        ACE_caliber = 12.954;
-        ACE_bulletLength = 58.674;
-        ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD = 0.4;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
-        ACE_ballisticCoefficients[] = {0.670};
-        ACE_velocityBoundaries[] = {};
-        ACE_standardAtmosphere = "ASM";
-        ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {780};
-        ACE_barrelLengths[] = {700};
-    };
-    class R3F_127x99_Ball2: BulletBase { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
-        typicalSpeed = 850; // R3F config
-        airFriction = -0.000601; // ACE3 value, default -0.00086
-        ACE_caliber = 12.954;
-        ACE_bulletLength = 58.674;
-        ACE_bulletMass = 41.9256;
+    class R3F_127x99_Ball2: BulletBase { // BARRETT M107 M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L635
+        airFriction = -0.000618; // ACE3 value, default -0.00086
+        ACE_caliber = 12.95;
+        ACE_bulletLength = 58.67;
+        ACE_bulletMass = 41.93;
         ACE_muzzleVelocityVariationSD = 0.35;
         ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
         ACE_ballisticCoefficients[] = {0.670};
@@ -106,34 +89,19 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = {850};
         ACE_barrelLengths[] = {736.6};
     };
-    class R3F_127x99_PEI2: R3F_127x99_Ball2 { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
-        typicalSpeed = 850; // R3F config
-        airFriction = -0.000601; // ACE3 value, default -0.00086
-        ACE_caliber = 12.954;
-        ACE_bulletLength = 58.674;
-        ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD = 0.4;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
-        ACE_ballisticCoefficients[] = {0.670};
+    class R3F_127x99_Ball3: BulletBase { //  McMillan TAC-50 AMAX https://web.archive.org/web/20080527201619/http://mcmfamily.com/pdfs/Tac-50%20Technical%20Data.pdf
+        typicalSpeed = 823; // R3F default value 820
+        airFriction = -0.000388; // R3F default value -0.00086
+        ACE_caliber = 12.98;
+        ACE_bulletLength = 64.52;
+        ACE_bulletMass = 48.6;
+        ACE_muzzleVelocityVariationSD = 0.2;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.8, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {1.05};
         ACE_velocityBoundaries[] = {};
-        ACE_standardAtmosphere = "ASM";
+        ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {850};
-        ACE_barrelLengths[] = {736.6};
-    };
-    class R3F_127x99_Ball3: BulletBase { // M33 https://github.com/acemod/ACE3/blob/master/addons/ballistics/CfgAmmo.hpp#L510
-        typicalSpeed = 820; // R3F config
-        airFriction = -0.00060964; // ACE3 value, default -0.00086
-        ACE_caliber = 12.954;
-        ACE_bulletLength = 58.674;
-        ACE_bulletMass = 41.9256;
-        ACE_muzzleVelocityVariationSD = 0.35;
-        ACE_ammoTempMuzzleVelocityShifts[] = {-18.91, -17.83, -15.21, -12.48, -09.34, -05.16, 0, 6.11, 13.60, 22.81, 33.83};
-        ACE_ballisticCoefficients[] = {0.670};
-        ACE_velocityBoundaries[] = {};
-        ACE_standardAtmosphere = "ASM";
-        ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {820};
+        ACE_muzzleVelocities[] = {831}; // at 21°C, at 15°C 823 m/s (2700 fps) according with the R3F_TAC50 initSpeed
         ACE_barrelLengths[] = {736.6};
     };
 };

--- a/optionals/compat_r3f/CfgMagazines.hpp
+++ b/optionals/compat_r3f/CfgMagazines.hpp
@@ -4,59 +4,15 @@ class CfgMagazines {
         scope = 1; // Game Update 1.84: "Tweaked: Magazines can now be hidden in Virtual Arsenal by setting their scope to 1", R3F default value 2
     };
     class R3F_15Rnd_9x19_PAMAS: CA_magazine {
-        initSpeed = 350; // R3F config
+        initSpeed = 368; // according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C), R3F default value 350
     };
     class R3F_15Rnd_9x19_HKUSP: CA_magazine {
-        initSpeed = 350; // R3F config
+        initSpeed = 363; // according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C), R3F default value 350
     };
     class R3F_17Rnd_9x19_G17: CA_magazine {
-        initSpeed = 350; // R3F config
+        initSpeed = 355; // according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C), R3F default value 350
     };
-    class R3F_30Rnd_9x19_MP5: CA_magazine {
-        initSpeed = 400; // R3F config
-    };
-    class R3F_25Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-        initSpeed = 960; // R3F config
-    };
-    class R3F_25Rnd_556x45_TRACER_FAMAS: R3F_25Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
-    class R3F_30Rnd_556x45_FAMAS: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-        initSpeed = 925; // R3F config
-    };
-    class R3F_30Rnd_556x45_TRACER_FAMAS: R3F_30Rnd_556x45_FAMAS {}; // AtragMx GunList: 5.56x45mm M855
-    class R3F_30Rnd_556x45_HK416: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-        initSpeed = 850; // R3F config
-    };
-    class R3F_30Rnd_556x45_TRACER_HK416: R3F_30Rnd_556x45_HK416 {}; // AtragMx GunList: 5.56x45mm M855
-    class R3F_30Rnd_556x45_SIG551: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-        initSpeed = 850; // R3F config
-    };
-    class R3F_30Rnd_556x45_TRACER_SIG551: R3F_30Rnd_556x45_SIG551 {}; // AtragMx GunList: 5.56x45mm M855
-    class R3F_10Rnd_762x51_FRF2: CA_magazine { // AtragMx GunList: R3F FRF2 M993
-        initSpeed = 850; // R3F config
-    };
-    class R3F_200Rnd_556x45_MINIMI: CA_magazine { // AtragMx GunList: 5.56x45mm M855
-        initSpeed = 915; // R3F config
-    };
-    class R3F_100Rnd_762x51_MINIMI: CA_magazine { // AtragMx GunList: 7.62x51mm M80
-        initSpeed = 820; // R3F config
-    };
-    class R3F_20Rnd_762x51_HK417: CA_magazine { // AtragMx GunList: 7.62x51mm M80 / HK417L 20": R3F HK417L M80
-        initSpeed = 820; // R3F config
-    };
-    class R3F_20Rnd_762x51_TRACER_HK417: R3F_20Rnd_762x51_HK417 {}; // AtragMx GunList: 7.62x51mm M80 / HK417L 20": R3F HK417L M80
-    class R3F_7Rnd_127x99_PGM: CA_magazine { // AtragMx GunList: R3F PGM M33
-        initSpeed = 780; // R3F config
-    };
-    class R3F_7Rnd_127x99_PEI_PGM: R3F_7Rnd_127x99_PGM { // AtragMx GunList: R3F PGM M33
-        initSpeed = 780; // R3F config
-    };
-    class R3F_10Rnd_127x99_M107: CA_magazine { // AtragMx GunList: R3F M107 M33
-        initSpeed = 850; // R3F config
-    };
-    class R3F_10Rnd_127x99_PEI_M107: R3F_10Rnd_127x99_M107 { // AtragMx GunList: R3F M107 M33
-        initSpeed = 850; // R3F config
-    };
-    class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: R3F TAC50 M33
-        initSpeed = 820; // R3F config
+    class R3F_5Rnd_127x99_TAC50: CA_magazine { // AtragMx GunList: R3F TAC50 AMAX
+        initSpeed = 823; // 2700 fps according with the McMillan Tactical Products specification and the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C), R3F default value 820
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -122,6 +122,7 @@ class CfgWeapons {
     };
     class R3F_MP5A5: R3F_MP5SD { // https://www.heckler-koch.com/en/products/military/submachine-guns/mp5/mp5/overview.html
         ACE_barrelLength = 225;
+        initSpeed = -1; // 400 m/s according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C), R3F default value 0
         muzzles[] = {"this"};
     };
     class R3F_M4S90: Rifle_Base_F { // https://www.benelli.it

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -497,11 +497,11 @@ class CfgWeapons {
 class ACE_ATragMX_Presets {
     class R3F_PGM_Hecate_II {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F PGM M33", 780, 100, 0.0845596, -0.00086, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F PGM M33", 780, 100, 0.0845596, -0.00086, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.18, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_M107 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F M107 M33", 850, 100, 0.0841653, -0.00061813, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F M107 M33", 850, 100, 0.0841653, -0.00061813, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.19, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_TAC50 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
@@ -509,10 +509,10 @@ class ACE_ATragMX_Presets {
     };
     class R3F_FRF2 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F FRF2 M993", 850, 100, 0.0783702, -0.00095, 6.35, 0, 2, 10, 120, 0, 0, 8.23, 7.82, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
+        preset[] = {"R3F FRF2 M993", 850, 100, 0.0783702, -0.00095, 6.35, 0, 2, 10, 120, 0, 0, 8.23, 7.35, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
     };
     class R3F_HK417L {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F HK417L M80", 820, 100, 0.0884448, -0.00095, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 27.94, 0.398, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{200, 0.398}, {400, 0.398}, {600, 0.398}, {800, 0.39}, {1000, 0.383}, {1200, 0.379}, {1400, 0.378}}};
+        preset[] = {"R3F HK417L M80", 820, 100, 0.0884758, -0.00095, 7.62, 0, 2, 10, 120, 0, 0, 9.46, 8.02, 27.94, 0.394, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0.394}, {700, 0.394}, {800, 0.391}, {900, 0.386}, {1000, 0.383}, {1100, 0.381}, {1300, 0.379}}};
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -1,31 +1,21 @@
 class Mode_SemiAuto;
-class Mode_Burst;
-class Mode_FullAuto;
 
 class CfgWeapons {
     class Pistol_Base_F;
     class Rifle_Base_F;
+    class Rifle_Long_Base_F;
     class R3F_Famas_F1: Rifle_Base_F {
         ACE_RailHeightAboveBore = 10.1796;
         ACE_barrelTwist = 304.8; // 1:12"
         ACE_barrelLength = 488.0;
         muzzles[] = {"this"};
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
-        };
-        class Burst: Mode_Burst {
-            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.0035 (12 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.005 (17.2 MOA)
-        };
     };
     class R3F_Famas_F1_M203: R3F_Famas_F1 {
         muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_Famas_surb: R3F_Famas_F1 { // R3F FAMAS Surbaissé, should be FAMAS Valorisé : http://narval34.free.fr/fiche_tech_famas.pdf
         ACE_RailHeightAboveBore = 5.08219;
-        ACE_barrelTwist = 228.6; // 1:9" FAMAS Surbaissé, should be 1:7" FAMAS Valorisé
+        ACE_barrelTwist = 177.8; // 1:7" FAMAS Valorisé
         ACE_barrelLength = 450.0; // 3D model with Beretta barrel : FAMAS Valorisé
     };
     class R3F_Famas_surb_M203: R3F_Famas_surb {
@@ -35,15 +25,6 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 10.1808;
         ACE_barrelTwist = 228.6; // 1:9"
         ACE_barrelLength = 488.0;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
-        };
-        class Burst: Mode_Burst {
-            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.0035 (12 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.74); // 3.1 MOA*0.562, R3F default value 0.005 (17.2 MOA)
-        };
     };
     class R3F_Famas_G2_M203: R3F_Famas_G2 {
         muzzles[] = {"this","Lance_Grenades"};
@@ -70,160 +51,123 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 1.79013;
         ACE_barrelTwist = 294.6;
         ACE_barrelLength = 650.0;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.88); // 1.56 MOA*0.562, R3F default value 9.9999997e-005 (0.34 MOA)
-        };
         muzzles[] = {"this"};
     };
     class R3F_PGM_Hecate_II: Rifle_Base_F {
         ACE_RailHeightAboveBore = 1.84858;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 700.0;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.58); // 1.04 MOA*0.562, R3F default value 0.00018 (0.62 MOA)
-        };
         muzzles[] = {"this"};
     };
     class R3F_M107: Rifle_Base_F {
         ACE_RailHeightAboveBore = 3.13099;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.5); // 0.9 MOA*0.562, R3F default value 0.00030 (1.03 MOA)
-        };
         muzzles[] = {"this"};
     };
     class R3F_TAC50: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.99563;
         ACE_barrelTwist = 381.0;
         ACE_barrelLength = 736.6;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.53); // 0.95 MOA*0.562, R3F default value 0.00015 (0.52 MOA)
-        };
         muzzles[] = {"this"};
     };
-    class R3F_Minimi: Rifle_Base_F {
+    class R3F_Minimi: Rifle_Base_F { // FN HERSTAL Minimi 5.56 Mk3 https://www.fnherstal.com/sites/default/files/2020-06/technical-data-fn-minimi-556-mk3.pdf
         ACE_RailHeightAboveBore = 3.81385;
         ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 347.98;
+        ACE_barrelLength = 349;
         muzzles[] = {"this"};
-        initSpeed = 915; // R3F config
-        class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.92); // 3.41 MOA*0.562, R3F default value 0.0008 (2.75 MOA)
-        };
     };
-    class R3F_Minimi_HG: R3F_Minimi {
-        class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.92); // 3.41 MOA*0.562, R3F default value 0.0008 (2.75 MOA)
-        };
-    };
-    class R3F_Minimi_762: R3F_Minimi {
+    class R3F_Minimi_762: R3F_Minimi { // FN HERSTAL Minimi 7.62 Mk3 https://www.fnherstal.com/sites/default/files/2020-06/technical-data-fn-minimi-762-mk3.pdf
         ACE_RailHeightAboveBore = 3.80834;
         ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 502.92;
-        initSpeed = 820; // R3F config
-        class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.56); // 2.77 MOA*0.562, R3F default value 0.002 (6.88 MOA)
-        };
+        ACE_barrelLength = 422;
     };
-    class R3F_Minimi_762_HG: R3F_Minimi_762 {
-        class manual: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.56); // 2.77 MOA*0.562, R3F default value 0.002 (6.88 MOA)
-        };
-    };
-    class R3F_HK417M: Rifle_Base_F {
+    class R3F_HK417M: Rifle_Base_F { // https://www.heckler-koch.com/
         ACE_RailHeightAboveBore = 3.23377;
         ACE_barrelTwist = 279.4;
-        ACE_barrelLength = 406.0;
+        ACE_barrelLength = 406.4;
         muzzles[] = {"this"};
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.62); // 2.89 MOA*0.562, R3F default value 0.001 (3.44 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.62); // 2.89 MOA*0.562, R3F default value 0.0025 (8.6 MOA)
-        };
     };
     class R3F_HK417S_HG: R3F_HK417M {
-        ACE_barrelLength = 305.0;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.9); // 3.4 MOA*0.562, R3F default value 0.002 (6.88 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.9); // 3.4 MOA*0.562, R3F default value 0.007 (24.06 MOA)
-        };
+        ACE_barrelLength = 304.8;
     };
     class R3F_HK417L: R3F_HK417M {
         ACE_barrelLength = 508.0;
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(0.93); // 1.66 MOA*0.562, R3F default value 0.0002 (0.69 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(0.93); // 1.66 MOA*0.562, R3F default value 0.0025 (8.6 MOA)
-        };
     };
     class R3F_HK416M: Rifle_Base_F {
         ACE_RailHeightAboveBore = 2.84776;
         ACE_barrelTwist = 177.8;
         ACE_barrelLength = 368.3;
         muzzles[] = {"this"};
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.87); // 3.32 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.87); // 3.32 MOA*0.562, R3F default value 0.005 (17.2 MOA)
-        };
     };
     class R3F_HK416M_M203: R3F_HK416M {
         muzzles[] = {"this","Lance_Grenades"};
     };
     class R3F_HK416S_HG: R3F_HK416M {
         ACE_barrelLength = 279.4;
-        class Single: Single {
-            dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
-        };
-        class FullAuto: FullAuto {
-            dispersion = MOA_TO_RAD(2.12); // 3.78 MOA*0.562, R3F default value 0.005 (17.2 MOA)
-        };
     };
-    class R3F_SIG551: Rifle_Base_F {
+    class R3F_SIG551: Rifle_Base_F { // http://www.sigsauer.swiss
         ACE_RailHeightAboveBore = 3.95288;
         ACE_barrelTwist = 177.8;
-        ACE_barrelLength = 363.0;
+        ACE_barrelLength = 363.5; // SG551 SB http://www.sigsauer.swiss/en/accessories-conversion-kits.php
         muzzles[] = {"this"};
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(1.88); // 3.34 MOA*0.562, R3F default value 0.00087 (2.99 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(1.88); // 3.34 MOA*0.562, R3F default value 0.005 (17.2 MOA)
-        };
     };
-    class R3F_MP5SD: Rifle_Base_F {
+    class R3F_MP5SD: Rifle_Base_F { // https://www.heckler-koch.com/en/products/military/submachine-guns/mp5/mp5sd/overview.html
         ACE_RailHeightAboveBore = 4.21816;
         ACE_barrelTwist = 254.0;
-        ACE_barrelLength = 144.78;
+        ACE_barrelLength = 146;
         muzzles[] = {"this"};
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.004 (13.75 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.007 (24.06 MOA)
-        };
     };
-    class R3F_MP5A5: R3F_MP5SD {
-        ACE_barrelLength = 226.06;
+    class R3F_MP5A5: R3F_MP5SD { // https://www.heckler-koch.com/en/products/military/submachine-guns/mp5/mp5/overview.html
+        ACE_barrelLength = 225;
         muzzles[] = {"this"};
-        class Single: Mode_SemiAuto {
-            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.004 (13.75 MOA)
-        };
-        class FullAuto: Mode_FullAuto {
-            dispersion = MOA_TO_RAD(7.73); // 13.75 MOA*0.562 (a square of 10/10cm at 50 meters), R3F default value 0.007 (24.06 MOA)
-        };
     };
-    class R3F_M4S90: Rifle_Base_F {
+    class R3F_M4S90: Rifle_Base_F { // https://www.benelli.it
         ACE_RailHeightAboveBore = 1.86213;
         ACE_twistDirection = 0;
         ACE_barrelTwist = 0;
-        ACE_barrelLength = 144.78;
+        ACE_barrelLength = 470;
+    };
+    class R3F_SCAR_H_PR_20cps_base: Rifle_Base_F { // FN HERSTAL https://www.fnherstal.com/sites/default/files/2020-06/technical-data-fn-scar-h-pr_0.pdf
+        ACE_barrelTwist = 279.4;
+        ACE_barrelLength = 508;
+        muzzles[] = {"this"};
+    };
+    class R3F_SCAR_H_PR_20cps_recup_base: Rifle_Base_F {
+        ACE_barrelTwist = 279.4;
+        ACE_barrelLength = 508;
+        muzzles[] = {"this"};
+    };
+    class R3F_SCAR_H_CAM_base: Rifle_Base_F { // FN HERSTAL https://www.fnherstal.com/sites/default/files/2020-06/technical-data-fn-scar-h_0.pdf
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 330.2;
+        muzzles[] = {"this"};
+    };
+    class R3F_SCAR_H_CAM_LG_GHILLIE: R3F_SCAR_H_CAM_base {
+        muzzles[] = {"this", "EGLM"};
+    };
+    class R3F_SCAR_H_CAM_LG: R3F_SCAR_H_CAM_base {
+        muzzles[] = {"this", "EGLM"};
+    };
+    class R3F_SCAR_L_CAM_base: Rifle_Base_F { // FN HERSTAL https://www.fnherstal.com/sites/default/files/2020-06/technical-data-fn-scar-l_1.pdf
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 368.3;
+        muzzles[] = {"this"};
+    };
+    class R3F_SCAR_L_CAM_ghillie_LG: R3F_SCAR_L_CAM_base {
+        muzzles[] = {"this", "EGLM"};
+    };
+    class R3F_SCAR_L_CQC_CAM: R3F_SCAR_L_CAM_base {
+        ACE_barrelLength = 254;
+    };
+    class R3F_SCAR_L_CQC_LG_CAM: R3F_SCAR_L_CAM_base {
+        ACE_barrelLength = 254;
+        muzzles[] = {"this", "EGLM"};
+    };
+    class R3F_FN_MAG58: Rifle_Long_Base_F { // FN HERSTAL https://www.fnherstal.com/sites/default/files/2020-10/technical-data-fn-mag-1.pdf
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 630;
+        muzzles[] = {"this"};
     };
     class R3F_PAMAS: Pistol_Base_F {
         ACE_barrelTwist = 250.0;
@@ -248,9 +192,6 @@ class CfgWeapons {
         ACE_barrelLength = 114.0;
         muzzles[] = {"this"};
         initSpeed = -1.0; // default 410
-        class Single: Mode_SemiAuto {
-            dispersion=0.0029; // R3F default value, 9.97 MOA (a square of 7.25/7.25cm at 25 meters)
-        };
     };
     class ItemCore;
     class InventoryOpticsItem_Base_F;
@@ -284,48 +225,38 @@ class CfgWeapons {
             class OpticsModes {
                 class Felin {};
                 class Oeilleton: Felin {
-                    opticsID=2;
-                    opticsDisplayName="";
-                    useModelOptics=0;
-                    opticsPPEffects[]={};
-                    opticsFlare=0;
-                    opticsDisablePeripherialVision=0;
-                    opticsZoomMin=0.25;
-                    opticsZoomMax=1.25;
-                    opticsZoomInit=0.75;
-                    memoryPointCamera="eye_Oeilleton";
-                    visionMode[]={};
-                    discretefov[]={};
-                    discreteDistance[]={200};
-                    discreteDistanceInitIndex=0;
-                    distanceZoomMin=200;
-                    distanceZoomMax=200;
-                    discreteInitIndex=0;
-                    cameraDir="";
+                    opticsID = 2;
+                    opticsDisplayName = "";
+                    useModelOptics = 0;
+                    opticsPPEffects[] = {};
+                    opticsFlare = 0;
+                    opticsDisablePeripherialVision = 0;
+                    opticsZoomMin = 0.25;
+                    opticsZoomMax = 1.25;
+                    opticsZoomInit = 0.75;
+                    memoryPointCamera = "eye_Oeilleton";
+                    visionMode[] = {};
+                    discretefov[] = {};
+                    discreteDistance[] = {200};
+                    discreteDistanceInitIndex = 0;
+                    distanceZoomMin = 200;
+                    distanceZoomMax = 200;
+                    discreteInitIndex = 0;
+                    cameraDir = "";
                 };
             };
         };
     };
     class R3F_J8: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
-        ACE_ScopeHeightAboveRail = 4.474; // Inaccurate BDC reticle, designed to work with the vanilla ballistic and R3F values.
+        ACE_ScopeHeightAboveRail = -2.237; // Off-center BDC reticle designed to work with the vanilla ballistic and R3F values only.
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo: InventoryOpticsItem_Base_F {
-            class OpticsModes {
-                class J8 {
-                    discreteDistance[] = {100};
-                    discreteDistanceInitIndex = 0;
-                };
-            };
-        };
     };
     class R3F_J8_MILDOT: R3F_J8 {
+        ACE_ScopeHeightAboveRail = 4.474;
         ACE_ScopeAdjust_Vertical[] = {0, 20};
-        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
-        ACE_ScopeAdjust_VerticalIncrement = 0.1;
-        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J8_MILDOT {
@@ -336,27 +267,14 @@ class CfgWeapons {
         };
     };
     class R3F_J10: ItemCore { // http://www.scrome.com/assets/templates/flexibility/pdf/Scrome_Marksman_Scope_LTE_Datasheet_GB.pdf
-        ACE_ScopeZeroRange = 1400; // Inaccurate BDC reticle, designed to work with the vanilla ballistic and R3F values.
-        ACE_ScopeHeightAboveRail = 4.474;
+        ACE_ScopeHeightAboveRail = 4.474; // BDC reticle designed to work with the vanilla ballistic and R3F values only.
         ACE_ScopeAdjust_Vertical[] = {-10, 10};
         ACE_ScopeAdjust_Horizontal[] = {-10, 10};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo: InventoryOpticsItem_Base_F {
-            class OpticsModes {
-                class J10 {
-                    discreteDistance[] = {100};
-                    discreteDistanceInitIndex = 0;
-                };
-            };
-        };
     };
     class R3F_J10_MILDOT: R3F_J10 {
-        ACE_ScopeZeroRange = 100;
         ACE_ScopeAdjust_Vertical[] = {0, 20};
-        ACE_ScopeAdjust_Horizontal[] = {-10, 10};
-        ACE_ScopeAdjust_VerticalIncrement = 0.1;
-        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo: InventoryOpticsItem_Base_F {
             class OpticsModes {
                 class J10_MILDOT {
@@ -413,6 +331,34 @@ class CfgWeapons {
     };
     class R3F_OB50: ItemCore {
         ACE_ScopeHeightAboveRail = 4.13217;
+    };
+    class R3F_SB_PM: ItemCore { // Off-center BDC reticle designed to work with the vanilla ballistic and R3F values only.
+        ACE_ScopeAdjust_Vertical[] = {0, 12}; // https://www.schmidtundbender.de/en/products/police-military-forces/1-8x24-pm-ii-shortdot-dual-cc.html
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo: InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class SB_PM {
+                    discreteDistance[] = {100};
+                    discreteDistanceInitIndex = 0;
+                    distanceZoomMin = 100;
+                    distanceZoomMax = 1200;
+                };
+            };
+        };
+    };
+    class R3F_SB_PM_BLACK: R3F_SB_PM {
+        class ItemInfo: InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class SB_PM {
+                    discreteDistance[] = {100};
+                    discreteDistanceInitIndex = 0;
+                    distanceZoomMin = 100;
+                    distanceZoomMax = 1200;
+                };
+            };
+        };
     };
     class InventoryMuzzleItem_Base_F;
     class R3F_SILENCIEUX_HK416: ItemCore {
@@ -511,27 +457,59 @@ class CfgWeapons {
             };
         };
     };
+    class R3F_SILENCIEUX_SCAR_H_PR: ItemCore {
+        class ItemInfo: InventoryMuzzleItem_Base_F {
+            class MagazineCoef {
+                initSpeed = 1.0;
+            };
+
+            class AmmoCoef {
+                hit = 1.0;
+                visibleFire = 0.5;
+                audibleFire = 0.1;
+                visibleFireTime = 0.5;
+                audibleFireTime = 0.5;
+                cost = 1.0;
+                typicalSpeed = 1.0;
+                airFriction = 1.0;
+            };
+
+            class MuzzleCoef {
+                dispersionCoef = "0.95f";
+                artilleryDispersionCoef = "1.0f";
+                fireLightCoef = "0.5f";
+                recoilCoef = "0.95f";
+                recoilProneCoef = "0.95f";
+                minRangeCoef = "1.0f";
+                minRangeProbabCoef = "1.0f";
+                midRangeCoef = "1.0f";
+                midRangeProbabCoef = "1.0f";
+                maxRangeCoef = "1.0f";
+                maxRangeProbabCoef = "1.0f";
+            };
+        };
+    };
 };
 
 class ACE_ATragMX_Presets {
     class R3F_PGM_Hecate_II {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F PGM M33", 780, 100, 0.0845596, -0.00062115, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F PGM M33", 780, 100, 0.0845596, -0.00086, 6.35, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 761},{0, 768},{10, 775},{15, 780},{25, 794},{30, 803},{35, 814}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_M107 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F M107 M33", 850, 100, 0.0841653, -0.000601, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F M107 M33", 850, 100, 0.0841653, -0.00061813, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_TAC50 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F TAC50 M33", 820, 100, 0.0872461, -0.00060964, 7.62, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
+        preset[] = {"R3F TAC50 AMAX", 823, 100, 0.0848384, -0.00038793, 7.37, 0, 2, 10, 120, 0, 0, 48.6, 12.44, 38.10, 1.050, 1, "ICAO", {{-15, 804},{0, 811},{10, 818},{15, 823},{25, 837},{30, 846},{35, 857}}, {{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0},{0, 0}}};
     };
     class R3F_FRF2 {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F FRF2 M993", 850, 100, 0.0783702, -0.00110718, 6.35, 0, 2, 10, 120, 0, 0, 8.230, 7.82, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
+        preset[] = {"R3F FRF2 M993", 850, 100, 0.0783702, -0.00095, 6.35, 0, 2, 10, 120, 0, 0, 8.23, 7.82, 29.46, 0.359, 1, "ICAO", {{-15, 831},{0, 838},{10, 845},{15, 850},{25, 864},{30, 873},{35, 884}}, {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}};
     };
     class R3F_HK417L {
         // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation
-        preset[] = {"R3F HK417L M80", 820, 100, 0.0884448, -0.00103711, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 27.94, 0.398, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{200, 0.398}, {400, 0.398}, {600, 0.398}, {800, 0.39}, {1000, 0.383}, {1200, 0.379}, {1400, 0.378}}};
+        preset[] = {"R3F HK417L M80", 820, 100, 0.0884448, -0.00095, 7.62, 0, 2, 10, 120, 0, 0, 9.461, 7.82, 27.94, 0.398, 1, "ICAO", {{-15, 801},{0, 808},{10, 815},{15, 820},{25, 834},{30, 843},{35, 854}}, {{200, 0.398}, {400, 0.398}, {600, 0.398}, {800, 0.39}, {1000, 0.383}, {1200, 0.379}, {1400, 0.378}}};
     };
 };

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -103,7 +103,8 @@ class CfgWeapons {
     class R3F_HK416M_M203: R3F_HK416M {
         muzzles[] = {"this","Lance_Grenades"};
     };
-    class R3F_HK416S_HG: R3F_HK416M {
+    class R3F_HK416M_HG: R3F_HK416M {};
+    class R3F_HK416S_HG: R3F_HK416M_HG {
         ACE_barrelLength = 279.4;
     };
     class R3F_SIG551: Rifle_Base_F { // http://www.sigsauer.swiss

--- a/optionals/compat_r3f/CfgWeapons.hpp
+++ b/optionals/compat_r3f/CfgWeapons.hpp
@@ -117,6 +117,7 @@ class CfgWeapons {
         ACE_RailHeightAboveBore = 4.21816;
         ACE_barrelTwist = 254.0;
         ACE_barrelLength = 146;
+        initSpeed = -0.94; // 400*0.94= 376 m/s according with the ACE_ammoTempMuzzleVelocityShifts at the normal conditions (15°C), R3F default value 0
         muzzles[] = {"this"};
     };
     class R3F_MP5A5: R3F_MP5SD { // https://www.heckler-koch.com/en/products/military/submachine-guns/mp5/mp5/overview.html

--- a/optionals/compat_r3f/config.cpp
+++ b/optionals/compat_r3f/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"r3f_armes_c", "R3F_G17_addons", "r3f_acc"};
+        requiredAddons[] = {"r3f_armes_c", "r3f_acc", "R3F_G17_addons", "R3F_G_SCAR", "R3F_SCAR_H", "R3F_SCAR_L", "R3F_FN_MAG"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
**When merged this pull request will:**
- Update for a better compatibility with the new R3F 5.56 and 7.62 BDC reticles and to fit with the R3F 3.7.1 values.

For example, the R3F J8 and J10 reticles work now, but only with the default ballistic (not designed to work with AB).

