### PR TITLE
Tools - Make.py don't Binarise ANY configs

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -1268,7 +1268,7 @@ See the make.cfg file for additional build options.
                         cmd = [makepboTool, "-P","-A","-X=*.backup", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"addons")]
 
                     else:
-                        cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
+                        cmd = [pboproject, "-B", "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
 
                     color("grey")
                     if quiet:


### PR DESCRIPTION
On current tools (pboProject 2.89/dePbo7.97)
Project built successfully but has significant errors in-game

ace_rearm:
```
#define GET_NUMBER(config,default) (if (isNumber (config)) then {getNumber (config)} else {default})
#define DEFAULT_REARMCARGO GET_NUMBER(configFile >> 'CfgVehicles' >> typeOf _this >> QQGVAR(defaultSupply),-1)
defaultValue = QUOTE(DEFAULT_REARMCARGO);
// mikro: Missing else statement
defaultValue = "(if (isNumber (configFile >> 'CfgVehicles' >> typeOf _this >> ""ace_rearm_defaultSupply"")) then {getNumber (configFile >> 'CfgVehicles' >> typeOf _this >> ""ace_rearm_defaultSupply"")}";
// expected
defaultValue = "(if (isNumber (configFile >> 'CfgVehicles' >> typeOf _this >> ""ace_rearm_defaultSupply"")) then {getNumber (configFile >> 'CfgVehicles' >> typeOf _this >> ""ace_rearm_defaultSupply"")} else {-1})";
```
ace_zeus:
```
condition = QUOTE(!(isNil QQGVAR(zeus) || {isNull GVAR(zeus)}));
// mikro: missing ) at end
condition = "!(isNil ""ace_zeus_zeus"" || {isNull ace_zeus_zeus}";
// expected
condition = "!(isNil ""ace_zeus_zeus"" || {isNull ace_zeus_zeus})";
```

I don't feel like we can trust this tool anymore
This PR should disable binarization and pack raw configs.
Only downside I know of might be a trivial increase to loading speed 