### PR TITLE
Convert all true/false in configs to 0/1

### DIFF
--- a/addons/cargo/menu.hpp
+++ b/addons/cargo/menu.hpp
@@ -2,7 +2,7 @@
 
 class GVAR(menu) {
     idd = 314614;
-    movingEnable = true;
+    movingEnable = 1;
     onLoad = QUOTE([_this select 0] call FUNC(onMenuOpen));
     onUnload = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuDisplay)),nil)];);
     class controlsBackground {

--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -8,14 +8,12 @@ class Extended_PreStart_EventHandlers {
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
-        disableModuload = true;
     };
 };
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_postInit));
-        disableModuload = true;
     };
 };
 

--- a/addons/common/HintConfig.hpp
+++ b/addons/common/HintConfig.hpp
@@ -23,7 +23,7 @@ class RscTitles {
     class ACE_RscHint {
         idd = -1;
         onLoad = "uiNamespace setVariable ['ACE_ctrlHint', (_this select 0) displayCtrl 1];";
-        movingEnable = false;
+        movingEnable = 0;
         duration = 4;
         fadeIn = 0.2;
         fadeOut = 0.2;
@@ -48,7 +48,7 @@ class RscTitles {
     class ACE_RscErrorHint {
         idd = -1;
         onLoad = "uiNamespace setVariable ['ACE_ctrlErrorHint', (_this select 0) displayCtrl 1];";
-        movingEnable = false;
+        movingEnable = 0;
         duration = 999999;
         fadeIn = 0.2;
         fadeOut = 0.2;

--- a/addons/common/ProgressScreen.hpp
+++ b/addons/common/ProgressScreen.hpp
@@ -1,6 +1,6 @@
 class GVAR(ProgressBar_Dialog) {
     idd = -1;
-    movingEnable = false;
+    movingEnable = 0;
     onLoad = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(ctrlProgressBG)),(_this select 0) displayCtrl 1)]; uiNamespace setVariable [ARR_2(QUOTE(QGVAR(ctrlProgressBar)),(_this select 0) displayCtrl 2)]; uiNamespace setVariable [ARR_2(QUOTE(QGVAR(ctrlProgressBarTitle)),(_this select 0) displayCtrl 3)];);
     objects[] = {};
 
@@ -52,7 +52,7 @@ class GVAR(ProgressBar_Dialog) {
 
 class GVAR(DisableMouse_Dialog) {
     idd = -1;
-    movingEnable = false;
+    movingEnable = 0;
     onLoad = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(dlgDisableMouse)),_this select 0)];);
     objects[] = {};
     class controlsBackground {

--- a/addons/common/define.hpp
+++ b/addons/common/define.hpp
@@ -159,7 +159,7 @@ class ACE_gui_buttonBase {
   colorBackgroundFocused[] = {1,1,1,1};
   periodFocus = 1.2;
   periodOver = 0.8;
-  default = false;
+  default = 0;
   class HitZone {
     left = 0.00;
     top = 0.00;

--- a/addons/dagr/Dialog.hpp
+++ b/addons/dagr/Dialog.hpp
@@ -139,7 +139,7 @@ class DAGR_Menu_Text {
 
 class DAGR_Menu {
     idd = 266860;
-    movingEnable = false;
+    movingEnable = 0;
     duration = 100000;
     fadein = 0;
     fadeout = 0;

--- a/addons/dagr/RscTitles.hpp
+++ b/addons/dagr/RscTitles.hpp
@@ -32,7 +32,7 @@ class RscTitles {
 
     class DAGR_Display {
         idd = 266850;
-        movingEnable = false;
+        movingEnable = 0;
         duration = 100000;
         fadein = 0;
         fadeout = 0;

--- a/addons/goggles/RscTitles.hpp
+++ b/addons/goggles/RscTitles.hpp
@@ -7,7 +7,7 @@ class RscTitles{
         onUnload = "uiNamespace setVariable ['ACE_Goggles_Display', displayNull]";
         fadeIn=0.5;
         fadeOut=0.5;
-        movingEnable = false;
+        movingEnable = 0;
         duration = 10e10;
         name = "RscACE_Goggles_BaseTitle";
         class controls;

--- a/addons/huntir/Dialog.hpp
+++ b/addons/huntir/Dialog.hpp
@@ -60,7 +60,7 @@
 
 class GVAR(cam_dialog) {
     idd = 18880;
-    movingEnable = true;
+    movingEnable = 1;
     controlsBackground[] = { };
     objects[] = { };
     controls[] = {

--- a/addons/huntir/RscTitles.hpp
+++ b/addons/huntir/RscTitles.hpp
@@ -3,7 +3,7 @@
 class RscTitles {
     class GVAR(cam_rose) {
         idd=-1;
-        movingEnable = true;
+        movingEnable = 1;
         fadein = 0;
         fadeout = 1;
         duration = 1e+011;

--- a/addons/interact_menu/CursorMenus.hpp
+++ b/addons/interact_menu/CursorMenus.hpp
@@ -12,7 +12,7 @@ class RscTitles {
         onUnload = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuBackground)),displayNull)]);
         fadeIn = 0.25;
         fadeOut = 0.25;
-        movingEnable = false;
+        movingEnable = 0;
         duration = 10e10;
         name = QGVAR(menuBackground);
         class controls {};


### PR DESCRIPTION
mikro would convert these to 1/0, hemmt doesn't and makes them quotes
It's not really necessary because `getNumber (..."false")` = 0 and  `getNumber (..."true")` = 1
but I think it's best to be explicit

`disableModuload` is from some old abandoned mod that can be cleaned up as well