### PR TITLE
Medical - Change - Pain level affects stability

### DIFF
--- a/addons/medical_status/functions/fnc_hasStableVitals.sqf
+++ b/addons/medical_status/functions/fnc_hasStableVitals.sqf
@@ -31,4 +31,7 @@ if (_bloodPressureL < 50 || {_bloodPressureH < 60}) exitWith { false };
 private _heartRate = GET_HEART_RATE(_unit);
 if (_heartRate < 40) exitWith { false };
 
+private _painLevel = GET_PAIN(_unit);
+if (_painLevel > PAIN_UNCONSCIOUS) exitWith { false };
+
 true


### PR DESCRIPTION
**When merged this pull request will:**
- Make it so that units are not stable unless their pain level is managed
Stability is a prerequisite for becoming conscious. With this: https://github.com/acemod/ACE3/pull/8092 Pain can be more important incapacitor.
Things affected that need to be checked:

I think FullHealLocal is not an issue since pain is set to 0 in it:
https://github.com/acemod/ACE3/blob/8e7f9b6db53a279432a2372c04be311807d1193b/addons/medical_treatment/functions/fnc_fullHealLocal.sqf#L35

Setting uncon. by script ?:
https://github.com/acemod/ACE3/blob/8e7f9b6db53a279432a2372c04be311807d1193b/addons/medical/functions/fnc_setUnconscious.sqf

And pain supression should be considered in some way?
https://github.com/acemod/ACE3/blob/8e7f9b6db53a279432a2372c04be311807d1193b/addons/medical_vitals/functions/fnc_updatePainSuppress.sqf

PAK treatment prerequisite are effected:
https://github.com/acemod/ACE3/blob/171fbf1e9ec3ee593ee0fc9e5c04b1270db4d01f/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
