### PR TITLE
Interaction - Add interaction with terrain objects

### DIFF
--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -29,6 +29,8 @@ private _fnc_renderNearbyActions = {
     GVAR(foundActions) = [];
     GVAR(lastTimeSearchedActions) = diag_tickTime;
 
+    QGVAR(renderNearbyActions) call CBA_fnc_localEvent;
+
     private _numInteractObjects = 0;
     private _nearestObjects = nearestObjects [ACE_player, ["All"], 13];
     {

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -44,4 +44,6 @@ PREP(openDoor);
 PREP(canPush);
 PREP(push);
 
+// misc
 PREP(canFlip);
+PREP(replaceTerrainObject);

--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -77,7 +77,24 @@ ACE_Modifier = 0;
     };
 }] call CBA_fnc_addEventHandler;
 
+if (isServer) then {
+    [QGVAR(replaceTerrainObject), FUNC(replaceTerrainObject)] call CBA_fnc_addEventHandler;
+};
+
 if (!hasInterface) exitWith {};
+
+[QEGVAR(interact_menu,renderNearbyActions), {
+    if !GVAR(interactWithTerrainObjects) exitWith {};
+    {
+        if (!isObjectHidden _x && {_x getVariable [QGVAR(terrainObjectNotReplaced), true]} && {typeOf _x isEqualTo ""}) then {
+            private _model = getModelInfo _x select 1;
+            private _class = GVAR(replaceTerrainClasses) getVariable [_model, ""];
+            if (_class isEqualTo "") exitWith {};
+            _x setVariable [QGVAR(terrainObjectNotReplaced), false];
+            [QGVAR(replaceTerrainObject), [_x, _class]] call CBA_fnc_serverEvent;
+        };
+    } forEach nearestTerrainObjects [ACE_player, [], 5, false];
+}] call CBA_fnc_addEventHandler;
 
 GVAR(isOpeningDoor) = false;
 

--- a/addons/interaction/XEH_preInit.sqf
+++ b/addons/interaction/XEH_preInit.sqf
@@ -6,11 +6,22 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 DFUNC(repair_Statement) = { // moved from config because of build problems
     TRACE_1("repair_Statement",_this);
     {
         if (_x isKindOf 'AllVehicles' && {!(_x isKindOf 'Man')}) then { _x setDamage 0; };
     } forEach (curatorSelected select 0)
+};
+
+if hasInterface then {
+    GVAR(replaceTerrainClasses) = call CBA_fnc_createNamespace;
+    private _cacheReplaceTerrainArray = call (uiNamespace getVariable [QGVAR(cacheReplaceTerrainClasses), {[[],[]]}]);
+    _cacheReplaceTerrainArray params ["_cacheReplaceTerrainModels", "_cacheReplaceTerrainClasses"];
+    {
+        GVAR(replaceTerrainClasses) setVariable [_x, _cacheReplaceTerrainClasses select _forEachIndex];
+    } forEach _cacheReplaceTerrainModels;
 };
 
 ADDON = true;

--- a/addons/interaction/XEH_preStart.sqf
+++ b/addons/interaction/XEH_preStart.sqf
@@ -1,3 +1,27 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.hpp"
+
+if !hasInterface exitWith {};
+
+private _replaceTerrainClasses = QUOTE( \
+    getNumber (_x >> 'scope') == 2 \
+    && {getNumber (_x >> QQGVAR(replaceTerrainObject)) > 0} \
+) configClasses (configFile >> "CfgVehicles");
+
+private _cacheReplaceTerrainModels = [];
+private _cacheReplaceTerrainClasses = [];
+{
+    private _model = toLower getText (_x >> "model");
+    if (_model select [0, 1] == "\") then {
+        _model = _model select [1];
+    };
+    if ((_model select [count _model - 4]) != ".p3d") then {
+        _model = _model + ".p3d"
+    };
+    if (-1 < _cacheReplaceTerrainModels pushBackUnique _model) then {
+        _cacheReplaceTerrainClasses pushBack configName _x;
+    };
+} forEach _replaceTerrainClasses;
+
+uiNamespace setVariable [QGVAR(cacheReplaceTerrainClasses), compileFinal str [_cacheReplaceTerrainModels, _cacheReplaceTerrainClasses]];

--- a/addons/interaction/dev/initReplaceTerrainCursorObject.sqf
+++ b/addons/interaction/dev/initReplaceTerrainCursorObject.sqf
@@ -1,0 +1,54 @@
+// execVM "z\ace\addons\interaction\dev\initReplaceTerrainCursorObject.sqf";
+// use "J" key to replace terrain object and add dragging actions to cursorObject
+
+#include "\z\ace\addons\interaction\script_component.hpp"
+
+DFUNC(replaceTerrainClassesAdd) = {
+    params ["_model", ["_class", ""]];
+    if (_model isEqualType objNull) then {
+        _model = getModelInfo _model select 1;
+    };
+    if (_model isEqualTo "") exitWith {systemChat "fail model"; false};
+
+    private _savedClass = GVAR(replaceTerrainClasses) getVariable [_model, ""];
+    if (_savedClass != "") exitWith {systemChat ("was " + _savedClass); true};
+
+    private _parent = "";
+    if (_class isEqualTo "") then {
+        private _configClasses = QUOTE(getNumber (_x >> 'scope') == 2 && {!(configName _x isKindOf 'AllVehicles')}) configClasses (configFile >> "CfgVehicles");
+        {
+            private _xmodel = toLower getText (_x >> "model");
+            if (_xmodel select [0, 1] == "\") then {
+                _xmodel = _xmodel select [1];
+            };
+            if ((_xmodel select [count _xmodel - 4]) != ".p3d") then {
+                _xmodel = _xmodel + ".p3d"
+            };
+            if (_model == _xmodel) exitWith {_class = configName _x; _parent = configName inheritsFrom _x;}
+        } forEach _configClasses;
+    };
+    if (_class isEqualTo "") exitWith {systemChat "fail class"; false};
+    GVAR(replaceTerrainClasses) setVariable [_model, _class];
+    QEGVAR(interact_menu,renderNearbyActions) call CBA_fnc_localEvent;
+    systemChat ("found " + _class);
+    diag_log format ["replaceTerrain: class %1: %2", _class, _parent];
+    true
+};
+
+// DIK_J
+[0x24, [false, false, false], {
+    if (
+        cursorObject call FUNC(replaceTerrainClassesAdd)
+        && {["ace_dragging"] call EFUNC(common,isModLoaded)}
+    ) then {
+        [{
+            if (typeOf cursorObject == "") exitwith {};
+            [cursorObject, {
+                if !hasInterface exitWith {};
+                [_this, true] call EFUNC(dragging,setDraggable);
+                [_this, true] call EFUNC(dragging,setCarryable);
+            }] remoteExec ["call", 0];
+        }, [], 1] call CBA_fnc_waitAndExecute;
+    };
+    true
+}, nil, nil, false] call CBA_fnc_addKeyHandler;

--- a/addons/interaction/functions/fnc_replaceTerrainObject.sqf
+++ b/addons/interaction/functions/fnc_replaceTerrainObject.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+/*
+ * Author: Dystopian
+ * Replaces terrain object with created one.
+ * Run on server only.
+ *
+ * Arguments:
+ * 0: Terrain object <OBJECT>
+ * 1: New object class <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject, "Land_Bucket_F"] call ace_interaction_fnc_replaceTerrainObject
+ *
+ * Public: No
+ */
+
+params ["_terrainObject", "_class"];
+TRACE_2("",_terrainObject,_class);
+
+if (isObjectHidden _terrainObject) exitWith {};
+
+private _position = getPosATL _terrainObject;
+private _vectorDirAndUp = [vectorDir _terrainObject, vectorUp _terrainObject];
+
+hideObjectGlobal _terrainObject;
+// prevent new object clipping with old one
+_terrainObject setDamage [1, false];
+
+private _newObject = createVehicle [_class, [0,0,0]];
+_newObject setVectorDirAndUp _vectorDirAndUp;
+_newObject setPosATL _position;

--- a/addons/interaction/initSettings.sqf
+++ b/addons/interaction/initSettings.sqf
@@ -1,0 +1,7 @@
+[
+    QGVAR(interactWithTerrainObjects), "CHECKBOX",
+    "str_a3_modules_moduleomquest_defend_f_attributes_useterrainobject0",
+    "ACE " + LLSTRING(DisplayName),
+    false,
+    true
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
**When merged this pull request will:**
- title;
- add dev function for replacing any terrain object with hotkey.

Terrain objects with `ace_interaction_replaceTerrainObject` config value == 1 are replaced with created object when interaction menu is being opened near them. This feature can be useful at least for `dragging`, `acex sitting` and `acex field_rations`.
