### PR TITLE
Wirecutter - Replace fences with destroyed models when cut

### DIFF
--- a/addons/logistics_wirecutter/CfgEventHandlers.hpp
+++ b/addons/logistics_wirecutter/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_FILE(XEH_clientInit));
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };

--- a/addons/logistics_wirecutter/CfgVehicles.hpp
+++ b/addons/logistics_wirecutter/CfgVehicles.hpp
@@ -80,4 +80,19 @@ class CfgVehicles {
     class Land_BackAlley_01_l_1m_F: Wall_F {
         GVAR(isFence) = 1;
     };
+    class Land_GameProofFence_01_l_5m_F: Wall_F {
+        GVAR(isFence) = 1;
+    };
+    class Land_NetFence_03_m_3m_F: Wall_F {
+        GVAR(isFence) = 1;
+    };
+    class Land_NetFence_03_m_3m_corner_F: Wall_F {
+        GVAR(isFence) = 1;
+    };
+    class Land_NetFence_03_m_3m_hole_F: Wall_F {
+        GVAR(isFence) = 1;
+    };
+    class Land_NetFence_03_m_9m_F: Wall_F {
+        GVAR(isFence) = 1;
+    };
 };

--- a/addons/logistics_wirecutter/XEH_PREP.hpp
+++ b/addons/logistics_wirecutter/XEH_PREP.hpp
@@ -1,3 +1,4 @@
 PREP(cutDownFence);
+PREP(destroyFence);
 PREP(interactEH);
 PREP(isFence);

--- a/addons/logistics_wirecutter/XEH_clientInit.sqf
+++ b/addons/logistics_wirecutter/XEH_clientInit.sqf
@@ -1,5 +1,0 @@
-#include "script_component.hpp"
-
-if (!hasInterface) exitWith {};
-
-["ace_interactMenuOpened", {_this call FUNC(interactEH)}] call CBA_fnc_addEventHandler;

--- a/addons/logistics_wirecutter/XEH_postInit.sqf
+++ b/addons/logistics_wirecutter/XEH_postInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+if (hasInterface) then {
+    ["ace_interactMenuOpened", {_this call FUNC(interactEH)}] call CBA_fnc_addEventHandler;
+};
+
+if (isServer) then {
+    [QGVAR(destroyFence), {_this call FUNC(destroyFence)}] call CBA_fnc_addEventHandler;
+};

--- a/addons/logistics_wirecutter/XEH_preInit.sqf
+++ b/addons/logistics_wirecutter/XEH_preInit.sqf
@@ -6,26 +6,28 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-GVAR(replacements) = createHashMapFromArray [
-    ["gameprooffence_01_l_5m_f.p3d", [["Land_GameProofFence_01_l_d_F", [0, 0, 0], 0]]],
-    ["indfnc_3_f.p3d", [["Land_IndFnc_3_D_F", [0.039, -0.221, 0], 0]]],
-    ["indfnc_3_hole_f.p3d", [["Land_IndFnc_3_D_F", [0.042, -0.252, 0], 0]]],
-    ["indfnc_9_f.p3d", [["Land_IndFnc_3_F", [-3, -0.06, 0], 0], ["Land_IndFnc_3_D_F", [0.039, -0.281, 0], 0], ["Land_IndFnc_3_F", [3, -0.06, 0], 0]]],
-    ["indfnc_corner_f.p3d", [["Land_IndFnc_3_D_F", [0.116, -0.223, 0], 0]]],
-    ["mil_wiredfence_f.p3d", [["Land_Mil_WiredFenceD_F", [0, 0, 0], 0]]],
-    ["net_fence_8m_f.p3d", [["Land_Net_FenceD_8m_F", [0, 0.1, 0], 0]]],
-    ["netfence_01_m_4m_f.p3d", [["Land_NetFence_01_m_d_F", [0, 0, 0], 0]]],
-    ["netfence_01_m_8m_f.p3d", [["Land_NetFence_01_m_4m_F", [-2, 0, 0], 0], ["Land_NetFence_01_m_d_F", [2, 0, 0], 0]]],
-    ["netfence_03_m_3m_corner_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.104, -0.183, 0], 0]]],
-    ["netfence_03_m_3m_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.042, -0.236, 0], 0]]],
-    ["netfence_03_m_3m_hole_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.045, -0.273, 0], 0]]],
-    ["netfence_03_m_9m_f.p3d", [["Land_NetFence_03_m_3m_F", [-3.006, -0.073, 0], 0], ["Land_NetFence_03_m_3m_d_F", [0.038, -0.309, 0], 0], ["Land_NetFence_03_m_3m_F", [2.995, -0.073, 0], 0]]],
-    ["plasticnetfence_01_long_f.p3d", [["Land_PlasticNetFence_01_long_d_F", [0, 0, -0.1], 0]]],
-    ["wired_fence_4m_f.p3d", [["Land_Wired_Fence_4mD_F", [0, 0, 0], 0]]],
-    ["wired_fence_8m_f.p3d", [["Land_Wired_Fence_4m_F", [-2, 0, 0], 0], ["Land_Wired_Fence_4mD_F", [3, 0, 0], 0]]],
-    ["wiredfence_01_16m_f.p3d", [["Land_WiredFence_01_4m_F", [-6, 0, 0], 0], ["Land_WiredFence_01_8m_d_F", [0.34, -0.1, 0], 0]]],
-    ["wiredfence_01_4m_f.p3d", [["Land_WiredFence_01_pole_F", [-2, 0, 0], 150]]],
-    ["wiredfence_01_8m_f.p3d", [["Land_WiredFence_01_4m_F", [-2, 0, 0], 0], ["Land_WiredFence_01_pole_F", [0, 0, 0], 0]]]
-];
+if (isServer) then {
+    GVAR(replacements) = createHashMapFromArray [
+        ["gameprooffence_01_l_5m_f.p3d", [["Land_GameProofFence_01_l_d_F", [0, 0, 0], 0]]],
+        ["indfnc_3_f.p3d", [["Land_IndFnc_3_D_F", [0.039, -0.221, 0], 0]]],
+        ["indfnc_3_hole_f.p3d", [["Land_IndFnc_3_D_F", [0.042, -0.252, 0], 0]]],
+        ["indfnc_9_f.p3d", [["Land_IndFnc_3_F", [-3, -0.06, 0], 0], ["Land_IndFnc_3_D_F", [0.039, -0.281, 0], 0], ["Land_IndFnc_3_F", [3, -0.06, 0], 0]]],
+        ["indfnc_corner_f.p3d", [["Land_IndFnc_3_D_F", [0.116, -0.223, 0], 0]]],
+        ["mil_wiredfence_f.p3d", [["Land_Mil_WiredFenceD_F", [0, 0, 0], 0]]],
+        ["net_fence_8m_f.p3d", [["Land_Net_FenceD_8m_F", [0, 0.1, 0], 0]]],
+        ["netfence_01_m_4m_f.p3d", [["Land_NetFence_01_m_d_F", [0, 0, 0], 0]]],
+        ["netfence_01_m_8m_f.p3d", [["Land_NetFence_01_m_4m_F", [-2, 0, 0], 0], ["Land_NetFence_01_m_d_F", [2, 0, 0], 0]]],
+        ["netfence_03_m_3m_corner_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.104, -0.183, 0], 0]]],
+        ["netfence_03_m_3m_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.042, -0.236, 0], 0]]],
+        ["netfence_03_m_3m_hole_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.045, -0.273, 0], 0]]],
+        ["netfence_03_m_9m_f.p3d", [["Land_NetFence_03_m_3m_F", [-3.006, -0.073, 0], 0], ["Land_NetFence_03_m_3m_d_F", [0.038, -0.309, 0], 0], ["Land_NetFence_03_m_3m_F", [2.995, -0.073, 0], 0]]],
+        ["plasticnetfence_01_long_f.p3d", [["Land_PlasticNetFence_01_long_d_F", [0, 0, -0.1], 0]]],
+        ["wired_fence_4m_f.p3d", [["Land_Wired_Fence_4mD_F", [0, 0, 0], 0]]],
+        ["wired_fence_8m_f.p3d", [["Land_Wired_Fence_4m_F", [-2, 0, 0], 0], ["Land_Wired_Fence_4mD_F", [3, 0, 0], 0]]],
+        ["wiredfence_01_16m_f.p3d", [["Land_WiredFence_01_4m_F", [-6, 0, 0], 0], ["Land_WiredFence_01_8m_d_F", [0.34, -0.1, 0], 0]]],
+        ["wiredfence_01_4m_f.p3d", [["Land_WiredFence_01_pole_F", [-2, 0, 0], 150]]],
+        ["wiredfence_01_8m_f.p3d", [["Land_WiredFence_01_4m_F", [-2, 0, 0], 0], ["Land_WiredFence_01_pole_F", [0, 0, 0], 0]]]
+    ];
+};
 
 ADDON = true;

--- a/addons/logistics_wirecutter/XEH_preInit.sqf
+++ b/addons/logistics_wirecutter/XEH_preInit.sqf
@@ -6,4 +6,26 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+GVAR(replacements) = createHashMapFromArray [
+    ["gameprooffence_01_l_5m_f.p3d", [["Land_GameProofFence_01_l_d_F", [0, 0, 0], 0]]],
+    ["indfnc_3_f.p3d", [["Land_IndFnc_3_D_F", [0.039, -0.221, 0], 0]]],
+    ["indfnc_3_hole_f.p3d", [["Land_IndFnc_3_D_F", [0.042, -0.252, 0], 0]]],
+    ["indfnc_9_f.p3d", [["Land_IndFnc_3_F", [-3, -0.06, 0], 0], ["Land_IndFnc_3_D_F", [0.039, -0.281, 0], 0], ["Land_IndFnc_3_F", [3, -0.06, 0], 0]]],
+    ["indfnc_corner_f.p3d", [["Land_IndFnc_3_D_F", [0.116, -0.223, 0], 0]]],
+    ["mil_wiredfence_f.p3d", [["Land_Mil_WiredFenceD_F", [0, 0, 0], 0]]],
+    ["net_fence_8m_f.p3d", [["Land_Net_FenceD_8m_F", [0, 0.1, 0], 0]]],
+    ["netfence_01_m_4m_f.p3d", [["Land_NetFence_01_m_d_F", [0, 0, 0], 0]]],
+    ["netfence_01_m_8m_f.p3d", [["Land_NetFence_01_m_4m_F", [-2, 0, 0], 0], ["Land_NetFence_01_m_d_F", [2, 0, 0], 0]]],
+    ["netfence_03_m_3m_corner_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.104, -0.183, 0], 0]]],
+    ["netfence_03_m_3m_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.042, -0.236, 0], 0]]],
+    ["netfence_03_m_3m_hole_f.p3d", [["Land_NetFence_03_m_3m_d_F", [0.045, -0.273, 0], 0]]],
+    ["netfence_03_m_9m_f.p3d", [["Land_NetFence_03_m_3m_F", [-3.006, -0.073, 0], 0], ["Land_NetFence_03_m_3m_d_F", [0.038, -0.309, 0], 0], ["Land_NetFence_03_m_3m_F", [2.995, -0.073, 0], 0]]],
+    ["plasticnetfence_01_long_f.p3d", [["Land_PlasticNetFence_01_long_d_F", [0, 0, -0.1], 0]]],
+    ["wired_fence_4m_f.p3d", [["Land_Wired_Fence_4mD_F", [0, 0, 0], 0]]],
+    ["wired_fence_8m_f.p3d", [["Land_Wired_Fence_4m_F", [-2, 0, 0], 0], ["Land_Wired_Fence_4mD_F", [3, 0, 0], 0]]],
+    ["wiredfence_01_16m_f.p3d", [["Land_WiredFence_01_4m_F", [-6, 0, 0], 0], ["Land_WiredFence_01_8m_d_F", [0.34, -0.1, 0], 0]]],
+    ["wiredfence_01_4m_f.p3d", [["Land_WiredFence_01_pole_F", [-2, 0, 0], 150]]],
+    ["wiredfence_01_8m_f.p3d", [["Land_WiredFence_01_4m_F", [-2, 0, 0], 0], ["Land_WiredFence_01_pole_F", [0, 0, 0], 0]]]
+];
+
 ADDON = true;

--- a/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
@@ -35,7 +35,7 @@ if !(_unit call EFUNC(common,isSwimming)) then {
         TRACE_1("Fence cutting successful",_this);
         (_this select 0) params ["_unit", "_fence"];
 
-        _fence setDamage 1;
+        [_fence] call FUNC(destroyFence);
         if !(_unit call EFUNC(common,isSwimming)) then {
             [_unit, "AmovPknlMstpSrasWrflDnon", 1] call EFUNC(common,doAnimation);
         };

--- a/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
@@ -35,7 +35,7 @@ if !(_unit call EFUNC(common,isSwimming)) then {
         TRACE_1("Fence cutting successful",_this);
         (_this select 0) params ["_unit", "_fence"];
 
-        [_fence] call FUNC(destroyFence);
+        [QGVAR(destroyFence), [_fence]] call CBA_fnc_serverEvent;
         if !(_unit call EFUNC(common,isSwimming)) then {
             [_unit, "AmovPknlMstpSrasWrflDnon", 1] call EFUNC(common,doAnimation);
         };

--- a/addons/logistics_wirecutter/functions/fnc_destroyFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_destroyFence.sqf
@@ -14,6 +14,7 @@
  *
  * Public: No
  */
+
 params ["_fence"];
 
 private _fenceModel = toLower ((getModelInfo _fence)#0);

--- a/addons/logistics_wirecutter/functions/fnc_destroyFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_destroyFence.sqf
@@ -1,0 +1,41 @@
+#include "script_component.hpp"
+/*
+ * Author: BaerMitUmlaut
+ * Destroys the given fence and replaces it with a destroyed fence if possible.
+ *
+ * Arguments:
+ * 0: Fence <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [fence] call ace_logistics_wirecutter_fnc_destroyFence
+ *
+ * Public: No
+ */
+params ["_fence"];
+
+private _fenceModel = toLower ((getModelInfo _fence)#0);
+
+// If fence cannot be replaced with destroyed model, just knock it over
+if !(_fenceModel in GVAR(replacements)) exitWith {
+    _fence setDamage 1;
+};
+
+// Remove old fence
+if ([_fence] call CBA_fnc_isTerrainObject) then {
+    _fence setDamage 1;
+    _fence hideObjectGlobal true;
+} else {
+    deleteVehicle _fence;
+};
+
+// Create replacement(s)
+{
+    _x params ["_type", "_position", "_dir"];
+
+    private _replacement = _type createVehicle [0, 0, 0];
+    _replacement setPosWorld (_fence modelToWorldWorld _position);
+    _replacement setDir (direction _fence + _dir);
+} forEach (GVAR(replacements) get _fenceModel);

--- a/addons/logistics_wirecutter/script_component.hpp
+++ b/addons/logistics_wirecutter/script_component.hpp
@@ -70,6 +70,7 @@
     "gm_gc_g501_sm70_02.p3d",\
     "gm_gc_g501_sm70_03.p3d",\
     "netfence_03_m_3m_f.p3d",\
+    "netfence_03_m_3m_hole_f.p3d",\
     "netfence_03_m_3m_corner_f.p3d",\
     "netfence_03_m_9m_f.p3d",\
     "vineyardfence_01_f.p3d",\


### PR DESCRIPTION
**When merged this pull request will:**
- Add some more fence types for wirecutting
- Replace fences with destroyed models when cut where possible

Some large fences are replaced by multiple smaller fences, sometimes the whole net is removed and just a pole remains - I tried to make it look as realistic as possible. Unfortunately I could not find a suitable replacement model for one of the most used fences on Altis and Stratis (the razor wire fence just in front of the radar dome in the screenshots below).

Before             |  After
:-:|:-:
![20210211233540_1](https://user-images.githubusercontent.com/9693842/107708642-19f7eb80-6cc4-11eb-8207-227ed66a8b17.jpg) | ![20210211233558_1](https://user-images.githubusercontent.com/9693842/107708645-1a908200-6cc4-11eb-833d-39a1235a2a26.jpg)
![20210211233928_1](https://user-images.githubusercontent.com/9693842/107708485-de5d2180-6cc3-11eb-84e3-ff50afd8d9bd.jpg) | ![20210211233945_1](https://user-images.githubusercontent.com/9693842/107708487-df8e4e80-6cc3-11eb-8617-9b40b9cf3510.jpg)

