### PR TITLE
CSW - use preferred XEH format

### DIFF
--- a/addons/csw/CfgEventHandlers.hpp
+++ b/addons/csw/CfgEventHandlers.hpp
@@ -10,6 +10,6 @@ class Extended_PreInit_EventHandlers {
 };
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        init = QUOTE( call COMPILE_FILE(XEH_postInit) );
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };


### PR DESCRIPTION
Small diff but formatting actually matters to CBA_fnc_compileEventHandlers
```
//Optimize "QUOTE(call COMPILE_FILE(XEH_preInit));" down to just the content of the EH script
if (toLower (_eventFunc select [0,40]) isEqualTo "call compile preprocessfilelinenumbers '" && {(_eventFunc select [count _eventFunc - 1]) isEqualTo "'"}) then {
```