### PR TITLE
Medical Treatment - Settings to limit IVs to certain locations

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -150,7 +150,7 @@ class GVAR(actions) {
         medicRequired = QGVAR(medicIV);
         treatmentTime = QGVAR(treatmentTimeIV);
         items[] = {"ACE_bloodIV"};
-        treatmentLocations = QGVAR(locationPlasmaBlood);
+        treatmentLocations = QGVAR(locationIV);
         condition = "";
         callbackSuccess = QFUNC(ivBag);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
@@ -182,7 +182,6 @@ class GVAR(actions) {
         displayName = CSTRING(Actions_Saline4_1000);
         displayNameProgress = CSTRING(Transfusing_Saline);
         items[] = {"ACE_salineIV"};
-        treatmentLocations = QGVAR(locationSaline);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
     };
     class SalineIV_500: SalineIV {

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -150,6 +150,7 @@ class GVAR(actions) {
         medicRequired = QGVAR(medicIV);
         treatmentTime = QGVAR(treatmentTimeIV);
         items[] = {"ACE_bloodIV"};
+        treatmentLocations = QGVAR(locationPlasmaBlood);
         condition = "";
         callbackSuccess = QFUNC(ivBag);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
@@ -181,6 +182,7 @@ class GVAR(actions) {
         displayName = CSTRING(Actions_Saline4_1000);
         displayNameProgress = CSTRING(Transfusing_Saline);
         items[] = {"ACE_salineIV"};
+        treatmentLocations = QGVAR(locationSaline);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
     };
     class SalineIV_500: SalineIV {

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -225,22 +225,13 @@
 ] call CBA_settings_fnc_init;
 
 [
-    QGVAR(locationSaline),
+    QGVAR(locationIV),
     "LIST",
-    [LSTRING(LocationSaline_DisplayName), LSTRING(LocationSaline_Description)],
+    [LSTRING(LocationIV_DisplayName), LSTRING(LocationIV_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
-    true
-] call CBA_settings_fnc_init;
-
-[
-    QGVAR(locationPlasmaBlood),
-    "LIST",
-    [LSTRING(LocationPlasmaBlood_DisplayName), LSTRING(LocationPlasmaBlood_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
-    true
-] call CBA_settings_fnc_init;
+    1
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(allowSelfIV),

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -225,6 +225,24 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(locationSaline),
+    "LIST",
+    [LSTRING(LocationSaline_DisplayName), LSTRING(LocationSaline_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(locationPlasmaBlood),
+    "LIST",
+    [LSTRING(LocationPlasmaBlood_DisplayName), LSTRING(LocationPlasmaBlood_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
+    true
+] call CBA_settings_fnc_init;
+
+[
     QGVAR(allowSelfIV),
     "LIST",
     [LSTRING(AllowSelfIV_DisplayName), LSTRING(AllowSelfIV_Description)],

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -640,6 +640,18 @@
             <Czech>Úroveň výcviku nutná pro IV transfuzi.</Czech>
             <Russian>Уровень навыка требуемый для переливания крови IV группы.</Russian>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationSaline_DisplayName">
+            <English>Locations Saline</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationSaline_Description">
+            <English>Controls where IV saline can be used.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationPlasmaBlood_DisplayName">
+            <English>Locations Plasma and Blood</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationPlasmaBlood_Description">
+            <English>Controls where IV plasma and blood can be used.</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">
             <English>Convert Vanilla Items</English>
             <German>Standard Arma-Equipment in ACE-Items umwandeln</German>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -641,10 +641,10 @@
             <Russian>Уровень навыка требуемый для переливания крови IV группы.</Russian>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_LocationIV_DisplayName">
-            <English>Locations IV</English>
+            <English>Locations IV Transfusion</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_LocationIV_Description">
-            <English>Controls where IV fluids can be used.</English>
+            <English>Controls where IV transfusions can be performed.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">
             <English>Convert Vanilla Items</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -640,17 +640,11 @@
             <Czech>Úroveň výcviku nutná pro IV transfuzi.</Czech>
             <Russian>Уровень навыка требуемый для переливания крови IV группы.</Russian>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_LocationSaline_DisplayName">
-            <English>Locations Saline</English>
+        <Key ID="STR_ACE_Medical_Treatment_LocationIV_DisplayName">
+            <English>Locations IV</English>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_LocationSaline_Description">
-            <English>Controls where IV saline can be used.</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_LocationPlasmaBlood_DisplayName">
-            <English>Locations Plasma and Blood</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_LocationPlasmaBlood_Description">
-            <English>Controls where IV plasma and blood can be used.</English>
+        <Key ID="STR_ACE_Medical_Treatment_LocationIV_Description">
+            <English>Controls where IV fluids can be used.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_ConvertItems_DisplayName">
             <English>Convert Vanilla Items</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds two settings to limit use of a) saline and b) blood and plasma to specific locations
- Settings are separate to allow more differentiation of the IV types in the future
- Needs translations

Additionally, I noticed that the Treatment subcategory in settings is getting pretty big. Would it be worth moving this to its own category?
