### PR TITLE
cookOff - Fix: Disable ammunition cookoff and turret effect when skipping destruction effects

### DIFF
--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -73,8 +73,11 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // secondary explosions
 ["AllVehicles", "killed", {
-    params ["_vehicle"];
-    if (_vehicle getVariable [QGVAR(enableAmmoCookoff), GVAR(enableAmmoCookoff)]) then {
+    params ["_vehicle", "", "", "_useEffects"];
+    if (
+        _vehicle getVariable [QGVAR(enableAmmoCookoff), GVAR(enableAmmoCookoff)] &&
+        _useEffects
+    ) then {
         if (GVAR(ammoCookoffDuration) == 0) exitWith {};
         ([_vehicle] call FUNC(getVehicleAmmo)) params ["_mags", "_total"];
         [_vehicle, _mags, _total] call FUNC(detonateAmmunition);
@@ -83,9 +86,13 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 
 // blow off turret effect
 ["Tank", "killed", {
-    if ((_this select 0) getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]) then {
+    params ["_vehicle", "", "", "_useEffects"];
+    if (
+        _vehicle getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true] &&
+        _useEffects
+    ) then {
         if (random 1 < 0.15) then {
-            (_this select 0) call FUNC(blowOffTurret);
+            _vehicle call FUNC(blowOffTurret);
         };
     };
 }] call CBA_fnc_addClassEventHandler;

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -75,8 +75,8 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 ["AllVehicles", "killed", {
     params ["_vehicle", "", "", "_useEffects"];
     if (
-        _vehicle getVariable [QGVAR(enableAmmoCookoff), GVAR(enableAmmoCookoff)] &&
-        _useEffects
+        _useEffects &&
+        _vehicle getVariable [QGVAR(enableAmmoCookoff), GVAR(enableAmmoCookoff)]
     ) then {
         if (GVAR(ammoCookoffDuration) == 0) exitWith {};
         ([_vehicle] call FUNC(getVehicleAmmo)) params ["_mags", "_total"];
@@ -88,8 +88,8 @@ GVAR(cacheTankDuplicates) = call CBA_fnc_createNamespace;
 ["Tank", "killed", {
     params ["_vehicle", "", "", "_useEffects"];
     if (
-        _vehicle getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true] &&
-        _useEffects
+        _useEffects &&
+        _vehicle getVariable [QGVAR(enable), GVAR(enable)] in [1, 2, true]
     ) then {
         if (random 1 < 0.15) then {
             _vehicle call FUNC(blowOffTurret);


### PR DESCRIPTION
**When merged this pull request will:**
- When you apply `cursorObject setDamage [1, false]` to destroy an object by skipping destruction effects the ammunition still cookoff
- So now we check if we want to skip destruction effects or not before calling cookoff ammunition 