### PR TITLE
User Interface - Add setting for Development Build watermark

### DIFF
--- a/addons/ui/ACE_Settings.hpp
+++ b/addons/ui/ACE_Settings.hpp
@@ -45,14 +45,6 @@ class ACE_Settings {
     };
 
 // ADVANCED
-    // general
-    class GVAR(devWatermark) {
-        category = CSTRING(Category);
-        displayName = CSTRING(devWatermark);
-        typeName = "BOOL";
-        value = 1;
-        isClientSettable = 1;
-    };
     // Soldier
     class GVAR(weaponName) {
         category = CSTRING(Category);

--- a/addons/ui/ACE_Settings.hpp
+++ b/addons/ui/ACE_Settings.hpp
@@ -45,6 +45,14 @@ class ACE_Settings {
     };
 
 // ADVANCED
+    // general
+    class GVAR(devWatermark) {
+        category = CSTRING(Category);
+        displayName = CSTRING(devWatermark);
+        typeName = "BOOL";
+        value = 1;
+        isClientSettable = 1;
+    };
     // Soldier
     class GVAR(weaponName) {
         category = CSTRING(Category);

--- a/addons/ui/ACE_UI.hpp
+++ b/addons/ui/ACE_UI.hpp
@@ -1,174 +1,179 @@
 class ACE_UI {
+    class devWatermark {
+        idd = IDD_MISSION;
+        elements[] = {11400};
+        location = ANYWHERE;
+    };
     class weaponName {
-        idd = 300;
-        elements[] = {118};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON};
         location = GROUND_ONLY;
         class conditions {};
     };
     class weaponNameBackground {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {1001, 1008};
         location = GROUND_ONLY;
         class conditions {};
     };
     class firingMode {
-        idd = 300;
-        elements[] = {187, 1203};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON_MODE_TEXTURE, 1203};
         location = GROUND_ONLY;
         class conditions {};
     };
     class ammoType {
-        idd = 300;
-        elements[] = {155};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON_AMMO};
         location = GROUND_ONLY;
         class conditions {};
     };
     class ammoCount {
-        idd = 300;
-        elements[] = {184};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_AMMOCOUNT};
         location = GROUND_ONLY;
         class conditions {};
     };
     class magCount {
-        idd = 300;
-        elements[] = {185};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_MAGCOUNT};
         location = GROUND_ONLY;
         class conditions {};
     };
     class throwableName {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {152};
         location = GROUND_ONLY;
         class conditions {};
     };
     class throwableCount {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {151};
         location = GROUND_ONLY;
         class conditions {};
     };
     class zeroing {
-        idd = 300;
-        elements[] = {168};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON_ELEVATION};
         location = GROUND_ONLY;
         class conditions {};
     };
     class weaponLowerInfoBackground {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {1202};
         location = GROUND_ONLY;
         class conditions {};
     };
     class staminaBar {
-        idd = 305;
-        elements[] = {193};
+        idd = IDD_STAMINA_BAR;
+        elements[] = {IDC_IGUI_STAMINA_BAR};
         location = GROUND_ONLY;
         class conditions {};
     };
     class stance {
-        idd = 303;
-        elements[] = {188, 1201};
+        idd = IDD_STANCEINFO;
+        elements[] = {IDC_IGUI_STANCE_INDICATOR, 1201};
         location = GROUND_ONLY;
         class conditions {};
     };
     class gunnerWeaponName {
-        idd = 300;
-        elements[] = {118};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerWeaponNameBackground {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {1001, 1008};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerFiringMode {
-        idd = 300;
-        elements[] = {187, 1203};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON_MODE_TEXTURE, 1203};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerAmmoType {
-        idd = 300;
-        elements[] = {155};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON_AMMO};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerAmmoCount {
-        idd = 300;
-        elements[] = {184};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_AMMOCOUNT};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerMagCount {
-        idd = 300;
-        elements[] = {185};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_MAGCOUNT};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerLaunchableName {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {152};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerLaunchableCount {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {151};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerZeroing {
-        idd = 300;
-        elements[] = {168};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_WEAPON_ELEVATION};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class gunnerWeaponLowerInfoBackground {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {1202};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleName {
-        idd = 300;
-        elements[] = {120};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_VEHICLE};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleNameBackground {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {1000, 1013};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleFuelBar {
-        idd = 300;
-        elements[] = {113, 1202};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_VALUE_FUEL, 1202};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleSpeed {
-        idd = 300;
-        elements[] = {121, 1004, 1006};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_SPEED, 1004, 1006};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleAltitude {
-        idd = 300;
-        elements[] = {122, 1005, 1014};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_ALT, 1005, 1014};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleDamage {
-        idd = 300;
-        elements[] = {111};
+        idd = IDD_UNITINFO;
+        elements[] = {IDC_IGUI_HITZONES};
         location = VEHICLE_ONLY;
         class conditions {};
     };
     class vehicleInfoBackground {
-        idd = 300;
+        idd = IDD_UNITINFO;
         elements[] = {1200};
         location = VEHICLE_ONLY;
         class conditions {};

--- a/addons/ui/ACE_UI.hpp
+++ b/addons/ui/ACE_UI.hpp
@@ -3,6 +3,9 @@ class ACE_UI {
         idd = IDD_MISSION;
         elements[] = {11400};
         location = ANYWHERE;
+        class conditions {
+            isDevelopmentBranch = QUOTE(productVersion select 4 == 'Development');
+        };
     };
     class weaponName {
         idd = IDD_UNITINFO;

--- a/addons/ui/XEH_clientInit.sqf
+++ b/addons/ui/XEH_clientInit.sqf
@@ -36,10 +36,13 @@ GVAR(elementsSet) = call CBA_fnc_createNamespace;
     ["ace_settingChanged", {
         params ["_name"];
 
+        private _delimPos = count QUOTE(DOUBLES(ADDON,));
+        if (_name select [0, _delimPos] != QUOTE(DOUBLES(ADDON,))) exitWith {};
+
         if (_name in ELEMENTS_BASIC) then {
             [true] call FUNC(setElements);
         } else {
-            private _nameNoPrefix = toLower (_name select [7]);
+            private _nameNoPrefix = toLower (_name select [_delimPos]);
             private _cachedElement = GVAR(configCache) getVariable _nameNoPrefix;
             if (!isNil "_cachedElement") then {
                 [_nameNoPrefix, missionNamespace getVariable _name, true] call FUNC(setAdvancedElement);

--- a/addons/ui/XEH_clientInit.sqf
+++ b/addons/ui/XEH_clientInit.sqf
@@ -33,8 +33,8 @@ GVAR(elementsSet) = call CBA_fnc_createNamespace;
     }] call CBA_fnc_addEventHandler;
 
     // On changing settings
-    ["ace_settingChanged", {
-        params ["_name"];
+    ["CBA_SettingChanged", {
+        params ["_name", "_value"];
 
         private _delimPos = count QUOTE(DOUBLES(ADDON,));
         if (_name select [0, _delimPos] != QUOTE(DOUBLES(ADDON,))) exitWith {};
@@ -45,7 +45,7 @@ GVAR(elementsSet) = call CBA_fnc_createNamespace;
             private _nameNoPrefix = toLower (_name select [_delimPos]);
             private _cachedElement = GVAR(configCache) getVariable _nameNoPrefix;
             if (!isNil "_cachedElement") then {
-                [_nameNoPrefix, missionNamespace getVariable _name, true] call FUNC(setAdvancedElement);
+                [_nameNoPrefix, _value, true] call FUNC(setAdvancedElement);
             };
         };
     }] call CBA_fnc_addEventHandler;

--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -8,4 +8,6 @@ PREP_RECOMPILE_END;
 
 GVAR(interfaceInitialized) = false;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -76,18 +76,15 @@ private _success = false;
 
     // Loop through IGUI displays as they can be present several times for some reason
     {
+        _success = true;
+
         private _control = _x displayCtrl _idc;
-        if (ctrlFade _control == _fade) then {
-            _success = true;
-            continue;
-        };
+        if (ctrlFade _control == _fade) then {continue};
 
         TRACE_4("Setting Element Visibility",_element,_fade,_idd,_idc);
 
         _control ctrlSetFade _fade;
         _control ctrlCommit 0;
-
-        _success = true;
     } count _displays;
     nil
 } count _elements;

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -66,6 +66,7 @@ if (!_force) then {
     };
 };
 
+private _displays = (uiNamespace getVariable "IGUI_displays") + [findDisplay IDD_MISSION] select {_idd == ctrlIDD _x};
 private _fade = [1, 0] select _show;
 
 // Disable/Enable elements
@@ -75,15 +76,13 @@ private _success = false;
 
     // Loop through IGUI displays as they can be present several times for some reason
     {
-        if (_idd == ctrlIDD _x) then {
-            TRACE_4("Setting Element Visibility",_element,_fade,_idd,_idc);
+        TRACE_4("Setting Element Visibility",_element,_fade,_idd,_idc);
 
-            (_x displayCtrl _idc) ctrlSetFade _fade;
-            (_x displayCtrl _idc) ctrlCommit 0;
+        (_x displayCtrl _idc) ctrlSetFade _fade;
+        (_x displayCtrl _idc) ctrlCommit 0;
 
-            _success = true;
-        };
-    } count (uiNamespace getVariable "IGUI_displays");
+        _success = true;
+    } count _displays;
     nil
 } count _elements;
 

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -66,7 +66,7 @@ if (!_force) then {
     };
 };
 
-private _displays = (uiNamespace getVariable "IGUI_displays") + [findDisplay IDD_MISSION] select {_idd == ctrlIDD _x};
+private _displays = ((uiNamespace getVariable "IGUI_displays") + [findDisplay IDD_MISSION]) select {_idd == ctrlIDD _x};
 private _fade = [1, 0] select _show;
 
 // Disable/Enable elements

--- a/addons/ui/functions/fnc_setAdvancedElement.sqf
+++ b/addons/ui/functions/fnc_setAdvancedElement.sqf
@@ -76,10 +76,16 @@ private _success = false;
 
     // Loop through IGUI displays as they can be present several times for some reason
     {
+        private _control = _x displayCtrl _idc;
+        if (ctrlFade _control == _fade) then {
+            _success = true;
+            continue;
+        };
+
         TRACE_4("Setting Element Visibility",_element,_fade,_idd,_idc);
 
-        (_x displayCtrl _idc) ctrlSetFade _fade;
-        (_x displayCtrl _idc) ctrlCommit 0;
+        _control ctrlSetFade _fade;
+        _control ctrlCommit 0;
 
         _success = true;
     } count _displays;

--- a/addons/ui/initSettings.sqf
+++ b/addons/ui/initSettings.sqf
@@ -1,0 +1,9 @@
+if (productVersion select 4 == 'Development') then {
+    [
+        QGVAR(devWatermark),
+        "CHECKBOX",
+        LSTRING(devWatermark),
+        "ACE " + LLSTRING(Category),
+        true
+    ] call CBA_fnc_addSetting;
+};

--- a/addons/ui/script_component.hpp
+++ b/addons/ui/script_component.hpp
@@ -16,6 +16,7 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
+#include "\a3\ui_f\hpp\defineResincl.inc"
 
 // Basic Elements
 #define ELEMENTS_BASIC [QGVAR(soldierVehicleWeaponInfo), QGVAR(vehicleRadar), QGVAR(vehicleCompass), QGVAR(commandMenu), QGVAR(groupBar)]

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -157,7 +157,7 @@
             <Turkish>Grup Göstergesi</Turkish>
         </Key>
         <Key ID="STR_ACE_UI_devWatermark">
-            <English>Development Build watermark</English>
+            <English>Development Build Watermark</English>
             <Russian>Водяной знак Development Build</Russian>
         </Key>
         <Key ID="STR_ACE_UI_WeaponName">

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -156,6 +156,10 @@
             <Spanish>Barra de grupo</Spanish>
             <Turkish>Grup Göstergesi</Turkish>
         </Key>
+        <Key ID="STR_ACE_UI_devWatermark">
+            <English>Development Build watermark</English>
+            <Russian>Водяной знак Development Build</Russian>
+        </Key>
         <Key ID="STR_ACE_UI_WeaponName">
             <English>Weapon Name</English>
             <Czech>Název zbraně</Czech>


### PR DESCRIPTION
**When merged this pull request will:**
- title;
- replace some numeric idcs with macro from `defineResincl.inc`;
- add addon name check and replace magic variable in setting handler;
- optimize a little `fnc_setAdvancedElement` (move idd check out of loop).

The setting appears on dev branch only. It hides `11400` control group (`class BcgWIP: RscWIP`) which contains 2 controls: `WIP_VersionText` (`idc = 1001`) and `WIP_VersionNumber` (`idc = 1000`). KK wrote about more controls [here](http://killzonekid.com/arma-scripting-tutorials-how-to-remove-beta-watermark-other-things/) but I think it was about A3 beta watermark.