### PR TITLE
Javelin - Reduce soft-launch motor delay

### DIFF
--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -63,7 +63,7 @@ class CfgAmmo {
         //trackOversteer = 1;
         //trackLead = 0;
 
-        initTime = 2;
+        initTime = 0.5;
 
         // Begin ACE guidance Configs
         class ADDON {


### PR DESCRIPTION
there is a delay between initial push and main rocket firing,
but we had it set at 2 seconds which looks very odd, the missile is just hovering in mid-air

based on https://www.youtube.com/watch?v=0HbtJfKzpec
it should be much more brief
vanilla is 0.25 