### PR TITLE
Medical - Improve keybind to open med menu for vehicle occupant under cursor

### DIFF
--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -33,13 +33,24 @@ GVAR(selfInteractionActions) = [];
 }] call CBA_fnc_addEventHandler;
 
 ["ACE3 Common", QGVAR(openMedicalMenuKey), localize LSTRING(OpenMedicalMenu), {
-    // Get target (cursorTarget and cursorObject), if not valid then target is ACE_player
+    // Get target (cursorTarget, cursorObject, and lineIntersectsSurfaces along camera to maxDistance), if not valid then target is ACE_player
     TRACE_3("Open menu key",cursorTarget,cursorObject,ACE_player);
     private _target = cursorTarget;
     if !(_target isKindOf "CAManBase" && {[ACE_player, _target] call FUNC(canOpenMenu)}) then {
         _target = cursorObject;
         if !(_target isKindOf "CAManBase" && {[ACE_player, _target] call FUNC(canOpenMenu)}) then {
-            _target = ACE_player;
+            private _start = AGLToASL positionCameraToWorld [0, 0, 0];
+            private _end = AGLToASL positionCameraToWorld [0, 0, GVAR(maxDistance)];
+            private _intersections = lineIntersectsSurfaces [_start, _end, ACE_player, objNull, true, -1, "FIRE"];
+            _target = {
+                _x params ["", "", "_intersectObject"];
+                if (_intersectObject != ACE_player && {_intersectObject isKindOf "CAManBase" && {[ACE_player, _intersectObject] call FUNC(canOpenMenu)}}) exitWith {
+                    _intersectObject
+                };
+            } forEach _intersections;
+            if !(_target isKindOf "CAManBase" && {[ACE_player, _target] call FUNC(canOpenMenu)}) then {
+                _target = ACE_player;
+            };
         };
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add lineIntersectsSurfaces check to medical menu keybind
- Allows it to be used to open medical menu for vehicle occupant being looked at
- https://youtu.be/noIHrXAi8qc