### PR TITLE
Maverick - Change displayShortName to MAVL for Maverick L

### DIFF
--- a/addons/maverick/stringtable.xml
+++ b/addons/maverick/stringtable.xml
@@ -63,19 +63,7 @@
                 <Turkish>3x AGM-65 Maverick L [ACE]</Turkish>
             </Key>
             <Key ID="STR_ACE_Maverick_l_mag_short">
-                <English>Laser Guided</English>
-                <German>Lasergelenkt</German>
-                <Italian>Guida Laser</Italian>
-                <Japanese>レーザー誘導</Japanese>
-                <Chinese>雷射導引</Chinese>
-                <Chinesesimp>雷射导引</Chinesesimp>
-                <Korean>레이저 유도</Korean>
-                <Polish>Kierowany laserowo</Polish>
-                <Russian>С лазерным наведением</Russian>
-                <Portuguese>Guiado a laser</Portuguese>
-                <French>Guidage Laser</French>
-                <Czech>Laserem naváděná</Czech>
-                <Turkish>Lazer Güdümlü</Turkish>
+                <English>MAVL</English>
             </Key>
             <Key ID="STR_ACE_Maverick_kh25ml_mag_descr">
                 <English>Kh-25ML, Laser Guided Air-to-Ground-Missile</English>


### PR DESCRIPTION
**When merged this pull request will:**
- it will change the short name for the magazine of Maverick L to MAVL for consumption by the F/A-18EF MFD
- Change the stringtable.xml to return MAVL
