### PR TITLE
Medical Treatment - Allow diagnosing death/CA (invalidates old setting)

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -204,7 +204,7 @@ class GVAR(actions) {
         medicRequired = 0;
         treatmentTime = 2.5;
         items[] = {};
-        condition = QUOTE(!GVAR(advancedDiagnose));
+        condition = QUOTE(GVAR(advancedDiagnose) == 0);
         callbackSuccess = QFUNC(diagnose);
         callbackFailure = "";
         callbackProgress = "";
@@ -216,7 +216,7 @@ class GVAR(actions) {
         displayName = CSTRING(Actions_CheckPulse);
         displayNameProgress = CSTRING(Check_Pulse_Content);
         allowedSelections[] = {"All"};
-        condition = QGVAR(advancedDiagnose);
+        condition = QUOTE(GVAR(advancedDiagnose) != 0);
         callbackSuccess = QFUNC(checkPulse);
         animationMedicProne = "";
         animationMedicSelfProne = "";

--- a/addons/medical_treatment/functions/fnc_canCPR.sqf
+++ b/addons/medical_treatment/functions/fnc_canCPR.sqf
@@ -19,5 +19,5 @@
 params ["", "_patient"];
 
 !(_patient call EFUNC(common,isAwake))
-&& {GVAR(advancedDiagnose) || {IN_CRDC_ARRST(_patient)}} // if basic diagnose, then only show action if appropriate (they can't tell difference between uncon/ca)
+&& {(GVAR(advancedDiagnose) != 0) || {IN_CRDC_ARRST(_patient)}} // if basic diagnose, then only show action if appropriate (they can't tell difference between uncon/ca)
 && {isNull (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])}

--- a/addons/medical_treatment/functions/fnc_checkResponse.sqf
+++ b/addons/medical_treatment/functions/fnc_checkResponse.sqf
@@ -18,7 +18,15 @@
 
 params ["_medic", "_patient"];
 
-private _output = [LSTRING(Check_Response_Unresponsive), LSTRING(Check_Response_Responsive)] select (_patient call EFUNC(common,isAwake));
+
+private _output = if (_patient call EFUNC(common,isAwake)) then {
+     LSTRING(Check_Response_Responsive)
+} else {
+    if ((GVAR(advancedDiagnose) == 2) && {IN_CRDC_ARRST(_patient)}) exitWith { LSTRING(Check_Response_CardiacArrest) };
+    if ((GVAR(advancedDiagnose) == 2) && {!alive _patient}) exitWith { LSTRING(Check_Response_Dead) };
+    LSTRING(Check_Response_Unresponsive)
+};
+
 [[_output, _patient call EFUNC(common,getName)], 2] call EFUNC(common,displayTextStructured);
 
 [_patient, "quick_view", _output, [[_patient, false, true] call EFUNC(common,getName)]] call FUNC(addToLog);

--- a/addons/medical_treatment/functions/fnc_cprProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_cprProgress.sqf
@@ -23,5 +23,5 @@ _args params ["_medic", "_patient"];
 // Cancel CPR if patient wakes up
 
 !(_patient call EFUNC(common,isAwake))
-&& {(GVAR(advancedDiagnose)) || {IN_CRDC_ARRST(_patient)}} // if basic diagnose, then only show action if appropriate (they can't tell difference between uncon/ca)
+&& {(GVAR(advancedDiagnose) != 0) || {IN_CRDC_ARRST(_patient)}} // if basic diagnose, then only show action if appropriate (they can't tell difference between uncon/ca)
 && {_medic == (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])}

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -1,9 +1,9 @@
 [
     QGVAR(advancedDiagnose),
-    "CHECKBOX",
+    "LIST",
     [LSTRING(AdvancedDiagnose_DisplayName), LSTRING(AdvancedDiagnose_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    true,
+    [[0, 1, 2], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(AdvancedDiagnose_DiagnoseCardiacArrest)], 1],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -3703,7 +3703,7 @@
             <Turkish>%1 tepki vermiyor</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Response_CardiacArrest">
-            <English>%1 is not responsive, taking shallow gasps and seizuring</English>
+            <English>%1 is not responsive, taking shallow gasps and convulsing</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Response_Dead">
             <English>%1 is not responsive, motionless and cold</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -58,7 +58,7 @@
             <Spanish>Habilita la comprobación del pulso, presión sanguinea y rsepuesta a las acciones del tratamiento en lugar de la acción de diagnóstico genérico. \n Cuando se deshabilita, la acción RCP solo se mostrará cuando realizar un RCP sea apropiado. \n Las acciones activadas de este ajuste son necesarias para determinar si una persona está inconsciente o en parada cardiaca.</Spanish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_DiagnoseCardiacArrest">
-            <English>Enabled + Can diagnose Death/Cardiac Arrest</English>
+            <English>Enabled &amp; Can Diagnose Death/Cardiac Arrest</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedMedication_DisplayName">
             <English>Advanced Medication</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -57,6 +57,9 @@
             <Turkish>Genel Teşhis eylemi yerine Nabzı Kontrol Et, Kan Basıncını Kontrol Et ve Yanıtı Kontrol Et tedavi eylemlerini etkinleştirir. \ Devre dışı bırakıldığında, CPR eylemi yalnızca CPR gerçekleştirilmesi uygun olduğunda gösterilecektir.</Turkish>
             <Spanish>Habilita la comprobación del pulso, presión sanguinea y rsepuesta a las acciones del tratamiento en lugar de la acción de diagnóstico genérico. \n Cuando se deshabilita, la acción RCP solo se mostrará cuando realizar un RCP sea apropiado. \n Las acciones activadas de este ajuste son necesarias para determinar si una persona está inconsciente o en parada cardiaca.</Spanish>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_DiagnoseCardiacArrest">
+            <English>Enabled + Can diagnose Death/Cardiac Arrest</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedMedication_DisplayName">
             <English>Advanced Medication</English>
             <German>Erweiterte Medikation</German>
@@ -3698,6 +3701,12 @@
             <Chinesesimp>%1 没有反应</Chinesesimp>
             <Chinese>%1 沒有反應</Chinese>
             <Turkish>%1 tepki vermiyor</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Check_Response_CardiacArrest">
+            <English>%1 is not responsive, taking shallow gasps and seizuring</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Check_Response_Dead">
+            <English>%1 is not responsive, motionless and cold</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Response_You_Checked">
             <English>You checked %1</English>

--- a/docs/wiki/feature/medical-system.md
+++ b/docs/wiki/feature/medical-system.md
@@ -211,7 +211,7 @@ force ace_medical_fractures = 0; // Disabled Fractures
 force ace_medical_limping = 0; // Disabled Limping
 force ace_medical_statemachine_fatalInjuriesPlayer = 2; // Disabled fatal injuries by damage to head or torso
 force ace_medical_treatment_advancedBandages = 0; // Disabled advanced bandages
-force ace_medical_treatment_advancedDiagnose = false; // Disabled advanced diagnose
+force ace_medical_treatment_advancedDiagnose = 0; // Disabled advanced diagnose
 force ace_medical_treatment_advancedMedication = false; // Disabled advanced medication
 ```
 
@@ -224,7 +224,7 @@ force ace_medical_spontaneousWakeUpChance = 0.15; // 15% chance of waking up fro
 force ace_medical_spontaneousWakeUpEpinephrineBoost = 1; // Epinephrine boosts wake up chance
 force ace_medical_statemachine_fatalInjuriesPlayer = 1; // Fatal injuries only occur in Cardiac Arrest
 force ace_medical_treatment_advancedBandages = 2; // Wounds can re-open until stitched.
-force ace_medical_treatment_advancedDiagnose = true; // Enabled Advanced Diagnosis
+force ace_medical_treatment_advancedDiagnose = 1; // Enabled Advanced Diagnosis
 force ace_medical_treatment_advancedMedication = true; // Enabled Advanced Medication
 force ace_medical_treatment_allowSelfIV = 1; // Medics can Self-IV
 force ace_medical_treatment_allowSelfPAK = 1; // Medics can Self-PAK


### PR DESCRIPTION
Adds a 3rd setting level to advancedDiagnose that shows death/CA state

Doing CPR for 5 minutes on your buddy, not sure if he's alive or dead, might be heartbreakingly realistic
but I feel like some players will want a way to diagnose their state easily without having to drop down to basic diagnose
