### PR TITLE
Name Tags - Add ability to set custom rank icon

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -71,6 +71,7 @@ Dharma Bellamkonda <dharma.bellamkonda@gmail.com>
 Dimaslg <dimaslg@telecable.es>
 diwako
 dixon13 <dixonbegay@gmail.com>
+Drift_91
 Drill <drill87@gmail.com>
 Dudakov aka [OMCB]Kaban <dudakov.s@gmail.com>
 Drofseh <drofseh@gmail.com>

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2, esteldunedain
+ * Author: commy2, esteldunedain, Drift_91
  * Draw the nametag and rank icon.
  *
  * Arguments:
@@ -33,12 +33,15 @@ _fnc_parameters = {
     if (_drawSoundwave) then {
         _icon = format [QPATHTOF(UI\soundwave%1.paa), floor random 10];
     } else {
-        if (_drawRank && {rank _target != ""}) then {
-            _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
-            if (!isNil "_icon") then {
-                _icon = _icon param [ALL_RANKS find rank _target, ""];
-            } else {
-                _icon = format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target];
+        if (_drawRank) then {
+            _icon = _target getVariable "ace_nametags_customRankIcon";
+            if (isNil "_icon" && {rank _target != ""}) then {
+                _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
+                if (!isNil "_icon") then {
+                    _icon = _icon param [ALL_RANKS find rank _target, ""];
+                } else {
+                    _icon = format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target];
+                };
             };
         };
     };

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -34,7 +34,7 @@ _fnc_parameters = {
         _icon = format [QPATHTOF(UI\soundwave%1.paa), floor random 10];
     } else {
         if (_drawRank) then {
-            _icon = _target getVariable "ace_nametags_customRankIcon";
+            _icon = _target getVariable "ace_nametags_rankIcon";
             if (isNil "_icon" && {rank _target != ""}) then {
                 _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
                 if (!isNil "_icon") then {


### PR DESCRIPTION
**When merged this pull request will:**
- This pull request adds the ability to set custom rank icons on an individual unit via `setVariable`.
- Usage: `_unit setVariable ["ace_nametags_rankIcon", "<path to .paa file>"]`
- This should override the faction rank icons if set, otherwise the faction icons or defaults will be used as appropriate.
- An advantage to using the direct path to the .paa file is that it should allow loading from both addons and the mission file, if I'm not mistaken.