### PR TITLE
Map - Fix stuck map compass size (add 0.1 zoom duration)

### DIFF
--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -100,7 +100,7 @@ class RscDisplayMainMap {
     class objects {
         class Compass: RscObject {
             scale = 0.7;
-            zoomDuration = 0.1;
+            zoomDuration = 0.1; // 0 (instant transition) breaks Arma saving position/size
         };
     };
 };

--- a/addons/map/config.cpp
+++ b/addons/map/config.cpp
@@ -100,7 +100,7 @@ class RscDisplayMainMap {
     class objects {
         class Compass: RscObject {
             scale = 0.7;
-            zoomDuration = 0;
+            zoomDuration = 0.1;
         };
     };
 };


### PR DESCRIPTION
See #6200

* This PR changes `zoomDuration = 0;` to `zoomDuration = 0.1;` in map config.
