### PR TITLE
Overpressure - Change overpressure vs. distance falloff curve and override damage scaling (WIP)

### DIFF
--- a/addons/overpressure/CfgWeapons.hpp
+++ b/addons/overpressure/CfgWeapons.hpp
@@ -41,6 +41,13 @@ class CfgWeapons {
         GVAR(damage) = 0.7;
     };
 
+    class launch_MRAWS_base_F: Launcher_Base_F {
+        GVAR(priority) = 1;
+        GVAR(angle) = 70;
+        GVAR(range) = 15;
+        GVAR(damage) = 0.75;
+    };
+
     class CannonCore;
     class cannon_120mm: CannonCore {
         GVAR(priority) = 1;

--- a/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
+++ b/addons/overpressure/functions/fnc_cacheOverPressureValues.sqf
@@ -15,7 +15,7 @@
  *  1: Range <Number>
  *  2: Damage <Number>
  *
- * Example: 
+ * Example:
  * ["cannon_125mm","Sh_125mm_APFSDS_T_Green","24Rnd_125mm_APFSDS_T_Green"] call ace_overpressure_fnc_cacheOverPressureValues
  *
  * Public: No
@@ -44,10 +44,14 @@ private _config = [
 TRACE_1("ConfigPath",_config);
 
 // get the Variables out of the Configes and create a array with then
+private _angle = getNumber (_config >> QGVAR(angle));
+private _range = getNumber (_config >> QGVAR(range));
+private _damage = getNumber (_config >> QGVAR(damage));
+
 private _return = [
-    (getNumber (_config >> QGVAR(angle))),
-    (getNumber (_config >> QGVAR(range))) * GVAR(distanceCoefficient),
-    (getNumber (_config >> QGVAR(damage)))
+    _angle,
+    _range * GVAR(distanceCoefficient),
+    _damage * _range ^ 0.1
 ];
 
 private _varName = format [QGVAR(values%1%2%3), _weapon, _ammo, _magazine];

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -46,11 +46,12 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
         TRACE_4("Affected:",_x,_axisDistance,_distance,_angle);
 
         if (_angle < _overpressureAngle && {_distance < _overpressureRange} && {!lineIntersects _line} && {!terrainIntersectASL _line2}) then {
-
-            private _alpha = sqrt (1 - _distance / _overpressureRange);
-            private _beta = sqrt (1 - _angle / _overpressureAngle);
-
-            private _damage = _alpha * _beta * _overpressureDamage;
+            // Distance factor follow the curve that has slight plateau between 50% and 80%
+            private _distanceFactor = 1 - _distance / _overpressureRange;
+            private _distanceFactor1 = 0.65 * _distanceFactor^6;
+            private _distanceFactor2 = 0.35 * sqrt _distanceFactor;
+            private _angleFactor = sqrt (1 - _angle / _overpressureAngle);
+            private _damage = (_distanceFactor1 + _distanceFactor2) * _angleFactor * _overpressureDamage;
             TRACE_1("",_damage);
 
             // If the target is the ACE_player


### PR DESCRIPTION
**When merged this pull request will:**
- Change overpressure vs. distance falloff curve to a more reasonable one, as shown in the picture: ![image](https://user-images.githubusercontent.com/2622874/113358915-f1e14c00-9346-11eb-93e0-cf2155507f4b.png)
The new curve (blue) vs old curve (red)
- Make it possible to have a lethal backblast damage when standing next to a firing launcher and not killl people passing by a couple of meters away.
- Also increase MAAWS backblast to 15m, 70 degrees, 0.75