### PR TITLE
Tools - Fix make.py temp files cleanup

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -592,7 +592,9 @@ def get_project_version(version_increments=[]):
 
 
 def replace_file(filePath, oldSubstring, newSubstring):
-    fh, absPath = mkstemp()
+    global work_drive
+    fh, absPath = mkstemp(None, None, work_drive + "temp")
+    os.close(fh)
     with open(absPath, "w", encoding="utf-8") as newFile:
         with open(filePath, encoding="utf-8") as oldFile:
             for line in oldFile:


### PR DESCRIPTION
**When merged this pull request will:**
- title;
- make make.py `mkstemp` create temp files in `P:\temp` instead of system temp folder.

I found many `tmpXXXXXXXX` files in my system temp folder. They were created by `mkstemp` function. Files were not moved because they are somewhat opened right after `mkstemp` call. So `shutil.move` just copies file and doesn't remove it. Simple `os.close` call fixes this problem. Maybe this exception was made for this (I'm not python programmer so don't know): https://github.com/acemod/ACE3/blob/76676eee462cb0bbe400a482561c148d8652b550/tools/make.py#L647-L649

Also there is no sense to use system temp folder when there is build temp folder.