### PR TITLE
Typo in usage example

### DIFF
--- a/addons/captives/functions/fnc_doEscortCaptive.sqf
+++ b/addons/captives/functions/fnc_doEscortCaptive.sqf
@@ -12,7 +12,7 @@
  * The return value <BOOL>
  *
  * Example:
- * [player, bob, true] call ACE_captives_fnc_doEscorteCaptive;
+ * [player, bob, true] call ACE_captives_fnc_doEscortCaptive;
  *
  * Public: No
  */


### PR DESCRIPTION
**When merged this pull request will:**
- Fix typo in ACE_captives_fnc_doEscortCaptive usage example