### PR TITLE
Cargo - paradrop fixes

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -37,10 +37,6 @@
 
     [[_hint, _itemName, _vehicleName], 3.0] call EFUNC(common,displayTextStructured);
 
-    if (_unloaded) then {
-        // Invoke listenable event
-        ["ace_cargoUnloaded", [_item, _vehicle]] call CBA_fnc_globalEvent;
-    };
 
     // TOOO maybe drag/carry the unloaded item?
 }] call CBA_fnc_addEventHandler;

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -38,7 +38,7 @@ TRACE_1("",_distBehind);
 private _posBehindVehicleAGL = _vehicle modelToWorld [0, _distBehind, -2];
 
 
-private _object=_item;
+private _object = _item;
 if (_item isEqualType objNull) then {
     detach _item;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -107,6 +107,6 @@ if (_showHint) then {
 };
 
 // Invoke listenable event
-["ace_cargoUnloaded", [_item, _vehicle, "paradrop"]] call CBA_fnc_globalEvent;
+["ace_cargoUnloaded", [_itemObject, _vehicle, "paradrop"]] call CBA_fnc_globalEvent;
 
 true

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -38,19 +38,18 @@ TRACE_1("",_distBehind);
 private _posBehindVehicleAGL = _vehicle modelToWorld [0, _distBehind, -2];
 
 
-private _itemObject = if (_item isEqualType objNull) then {
+private _object=_item;
+if (_item isEqualType objNull) then {
     detach _item;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
     // do both on server to ensure they are executed in the correct order
     [QGVAR(serverUnload), [_item, _posBehindVehicleAGL]] call CBA_fnc_serverEvent;
-    _item
 } else {
-    private _newItem = createVehicle [_item, _posBehindVehicleAGL, [], 0, "NONE"];
-    _newItem setPosASL (AGLtoASL _posBehindVehicleAGL);
-    _newItem
+    _object = createVehicle [_item, _posBehindVehicleAGL, [], 0, "NONE"];
+    _object setPosASL (AGLtoASL _posBehindVehicleAGL);
 };
 
-_itemObject setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
+_object setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
 
 // open parachute and ir light effect
 [{
@@ -74,7 +73,7 @@ _itemObject setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vecto
         _light attachTo [_item, [0,0,0]];
     };
 
-}, [_itemObject], 0.7] call CBA_fnc_waitAndExecute;
+}, [_object], 0.7] call CBA_fnc_waitAndExecute;
 
 // smoke effect when crate landed
 [{
@@ -93,7 +92,7 @@ _itemObject setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vecto
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };
 
-}, 1, [_itemObject]] call CBA_fnc_addPerFrameHandler;
+}, 1, [_object]] call CBA_fnc_addPerFrameHandler;
 
 if (_showHint) then {
     [
@@ -107,6 +106,6 @@ if (_showHint) then {
 };
 
 // Invoke listenable event
-["ace_cargoUnloaded", [_itemObject, _vehicle, "paradrop"]] call CBA_fnc_globalEvent;
+["ace_cargoUnloaded", [_object, _vehicle, "paradrop"]] call CBA_fnc_globalEvent;
 
 true

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -40,10 +40,10 @@ private _posBehindVehicleAGL = _vehicle modelToWorld [0, _distBehind, -2];
 
 private _object = _item;
 if (_item isEqualType objNull) then {
-    detach _item;
+    detach _object;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
     // do both on server to ensure they are executed in the correct order
-    [QGVAR(serverUnload), [_item, _posBehindVehicleAGL]] call CBA_fnc_serverEvent;
+    [QGVAR(serverUnload), [_object, _posBehindVehicleAGL]] call CBA_fnc_serverEvent;
 } else {
     _object = createVehicle [_item, _posBehindVehicleAGL, [], 0, "NONE"];
     _object setPosASL (AGLtoASL _posBehindVehicleAGL);

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -48,8 +48,8 @@ if (_item isEqualType objNull) then {
     _object = createVehicle [_item, _posBehindVehicleAGL, [], 0, "NONE"];
     _object setPosASL (AGLtoASL _posBehindVehicleAGL);
 };
-private _velocity((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
-[QEGVAR(common,setVelocity), [_object, _velocity],_object] call CBA_fnc_targetEvent;
+
+_object setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
 
 // open parachute and ir light effect
 [{

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -53,40 +53,40 @@ _object setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir
 
 // open parachute and ir light effect
 [{
-    params ["_item"];
+    params ["_object"];
 
-    if (isNull _item || {getPos _item select 2 < 1}) exitWith {};
+    if (isNull _object || {getPos _object select 2 < 1}) exitWith {};
 
     private _parachute = createVehicle ["B_Parachute_02_F", [0,0,0], [], 0, "CAN_COLLIDE"];
 
     // cannot use setPos on parachutes without them closing down
-    _parachute attachTo [_item, [0,0,0]];
+    _parachute attachTo [_object, [0,0,0]];
     detach _parachute;
 
-    private _velocity = velocity _item;
+    private _velocity = velocity _object;
 
-    _item attachTo [_parachute, [0,0,1]];
+    _object attachTo [_parachute, [0,0,1]];
     _parachute setVelocity _velocity;
 
-    if ((GVAR(disableParadropEffectsClasstypes) findIf {_item isKindOf _x}) == -1) then {
+    if ((GVAR(disableParadropEffectsClasstypes) findIf {_object isKindOf _x}) == -1) then {
         private _light = "Chemlight_yellow" createVehicle [0,0,0];
-        _light attachTo [_item, [0,0,0]];
+        _light attachTo [_object, [0,0,0]];
     };
 
 }, [_object], 0.7] call CBA_fnc_waitAndExecute;
 
 // smoke effect when crate landed
 [{
-    (_this select 0) params ["_item"];
+    (_this select 0) params ["_object"];
 
-    if (isNull _item) exitWith {
+    if (isNull _object) exitWith {
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };
 
-    if (getPos _item select 2 < 1) then {
-        if ((GVAR(disableParadropEffectsClasstypes) findIf {_item isKindOf _x}) == -1) then {
+    if (getPos _object select 2 < 1) then {
+        if ((GVAR(disableParadropEffectsClasstypes) findIf {_object isKindOf _x}) == -1) then {
             private _smoke = "SmokeshellYellow" createVehicle [0,0,0];
-            _smoke attachTo [_item, [0,0,0]];
+            _smoke attachTo [_object, [0,0,0]];
         };
 
         [_this select 1] call CBA_fnc_removePerFrameHandler;

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -48,8 +48,8 @@ if (_item isEqualType objNull) then {
     _object = createVehicle [_item, _posBehindVehicleAGL, [], 0, "NONE"];
     _object setPosASL (AGLtoASL _posBehindVehicleAGL);
 };
-
-_object setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
+private _velocity((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
+[QEGVAR(common,setVelocity), [_object, _velocity],_object] call CBA_fnc_targetEvent;
 
 // open parachute and ir light effect
 [{

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -98,7 +98,7 @@ if (_showHint) then {
     [
         [
             LSTRING(UnloadedItem),
-            getText (configOf _itemObject >> "displayName"),
+            getText (configOf _object >> "displayName"),
             getText (configOf _vehicle >> "displayName")
         ],
         3

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -47,7 +47,7 @@ private _space = [_vehicle] call FUNC(getCargoSpaceLeft);
 private _itemSize = [_item] call FUNC(getSizeItem);
 _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
-private _object=_item;
+private _object = _item;
 if (_item isEqualType objNull) then {
     detach _item;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -47,17 +47,16 @@ private _space = [_vehicle] call FUNC(getCargoSpaceLeft);
 private _itemSize = [_item] call FUNC(getSizeItem);
 _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
-private _itemObject = if (_item isEqualType objNull) then {
+private _object=_item;
+if (_item isEqualType objNull) then {
     detach _item;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
     // do both on server to ensure they are executed in the correct order
     [QGVAR(serverUnload), [_item, _emptyPosAGL]] call CBA_fnc_serverEvent;
-    _item;
 } else {
-    private _newItem = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
-    _newItem setPosASL (AGLtoASL _emptyPosAGL);
-    _newItem;
+    _object = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
+    _object setPosASL (AGLtoASL _emptyPosAGL);
 };
 // Invoke listenable event
-["ace_cargoUnloaded", [_itemObject, _vehicle, "unload"]] call CBA_fnc_globalEvent;
+["ace_cargoUnloaded", [_object, _vehicle, "unload"]] call CBA_fnc_globalEvent;
 true

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -48,11 +48,11 @@ private _itemSize = [_item] call FUNC(getSizeItem);
 _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
 private _object = _item;
-if (_item isEqualType objNull) then {
-    detach _item;
+if (_object isEqualType objNull) then {
+    detach _object;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
     // do both on server to ensure they are executed in the correct order
-    [QGVAR(serverUnload), [_item, _emptyPosAGL]] call CBA_fnc_serverEvent;
+    [QGVAR(serverUnload), [_object, _emptyPosAGL]] call CBA_fnc_serverEvent;
 } else {
     _object = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
     _object setPosASL (AGLtoASL _emptyPosAGL);

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -47,14 +47,17 @@ private _space = [_vehicle] call FUNC(getCargoSpaceLeft);
 private _itemSize = [_item] call FUNC(getSizeItem);
 _vehicle setVariable [QGVAR(space), (_space + _itemSize), true];
 
-if (_item isEqualType objNull) then {
+private _itemObject = if (_item isEqualType objNull) then {
     detach _item;
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
     // do both on server to ensure they are executed in the correct order
     [QGVAR(serverUnload), [_item, _emptyPosAGL]] call CBA_fnc_serverEvent;
+    _item;
 } else {
     private _newItem = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
     _newItem setPosASL (AGLtoASL _emptyPosAGL);
+    _newItem;
 };
-
+// Invoke listenable event
+["ace_cargoUnloaded", [_itemObject, _vehicle, "unload"]] call CBA_fnc_globalEvent;
 true


### PR DESCRIPTION
**When merged this pull request will:**
- Cargo - Improve make event "ace_cargoUnloaded" always pass object instead of sometimes passing classname.
- Cargo - Change move "ace_cargoUnloaded" event invocation from "ace_unloadItem" eh to function unloadItem to facilitate aforementioned change.

Fixes #8200 