### PR TITLE
Medical Feedback - Fix Injured Sounds Not Playing At Altitudes Above 70

### DIFF
--- a/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
+++ b/addons/medical_feedback/functions/fnc_playInjuredSound.sqf
@@ -33,7 +33,7 @@ private _distance = if (_type == "hit") then {
 } else {
     [10, 15, 20] select _severity;
 };
-private _targets = allPlayers inAreaArray [getPosWorld _unit, _distance, _distance, 0, false, _distance];
+private _targets = allPlayers inAreaArray [ASLToAGL getPosASL _unit, _distance, _distance, 0, false, _distance];
 if (_targets isEqualTo []) exitWith {};
 
 // Handle timeout


### PR DESCRIPTION
**When merged this pull request will:**
- `inAreaArray` takes AGL if z-value is provided.
- `playInjuredSound` gives it ASL, which means only units above z/2 sea level are detected as nearby.
- This PR changes the provided position from ASL to AGL in the most straight forward way possible.
- fix #8208

As an aside, this should've never checked the z in the first place. You're wasting more cycles than you will ever save iterating over units 3 stories above you. Just let the distance attenuation handle heights...
