### PR TITLE
Interact Menu - Make List default

### DIFF
--- a/addons/interact_menu/initSettings.sqf
+++ b/addons/interact_menu/initSettings.sqf
@@ -39,7 +39,7 @@
     "CHECKBOX",
     LSTRING(UseListMenu),
     [format ["ACE %1", LLSTRING(Category_InteractionMenu)], LLSTRING(Category_InteractionMenu)],
-    false,
+    true,
     false
 ] call CBA_fnc_addSetting;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Reimplement #6656 by just changing the default setting.

A majority agreed with this change in the old PR, I think that just got more support in the last years, I don't know when I've last seen radial used by not-completely-new players.