### PR TITLE
Vehiclelock - Improve setting name

### DIFF
--- a/addons/vehiclelock/initSettings.sqf
+++ b/addons/vehiclelock/initSettings.sqf
@@ -23,7 +23,7 @@
     QGVAR(vehicleStartingLockState), "LIST",
     [LSTRING(VehicleStartingLockState_DisplayName), LSTRING(VehicleStartingLockState_Description)],
     LSTRING(DisplayName),
-    [[-1,0,1,2],["str_cfg_envsounds_default", LSTRING(VehicleStartingLockState_AsIs), LSTRING(VehicleStartingLockState_Locked), LSTRING(VehicleStartingLockState_Unlocked)], 0], // [values, titles, defaultIndex]
+    [[-1,0,1,2],[LSTRING(VehicleStartingLockState_AsIs), LSTRING(VehicleStartingLockState_RemoveAmbiguousLockState), LSTRING(VehicleStartingLockState_Locked), LSTRING(VehicleStartingLockState_Unlocked)], 0], // [values, titles, defaultIndex]
     true, // isGlobal
     {[QGVAR(vehicleStartingLockState), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart

--- a/addons/vehiclelock/stringtable.xml
+++ b/addons/vehiclelock/stringtable.xml
@@ -276,6 +276,9 @@
             <Chinesesimp>设定所有载具的初始上锁状态 (移除不明确的锁定状态)</Chinesesimp>
             <Chinese>設定所有載具的初始上鎖狀態 (移除不明確的鎖定狀態)</Chinese>
         </Key>
+        <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_RemoveAmbiguousLockState">
+            <English>Remove Ambiguous Lock State</English>
+        </Key>
         <Key ID="STR_ACE_VehicleLock_VehicleStartingLockState_AsIs">
             <English>As Is</English>
             <Polish>Jak jest</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- Improve `Vehicle Starting Lock State` setting names.

Renamed the "Default" setting to "As Is" and changed the current "As Is" to "Remove Ambiguous Lock State" to avoid confusion.

closes #6828 