### PR TITLE
Parachute - Add failure chance

### DIFF
--- a/addons/parachute/CfgVehicles.hpp
+++ b/addons/parachute/CfgVehicles.hpp
@@ -21,6 +21,7 @@ class CfgVehicles {
             };
         };
         MACRO_HASRESERVE
+        GVAR(failureDelay) = 2;
     };
     class ParachuteWest: ParachuteBase {
         MACRO_HASRESERVE

--- a/addons/parachute/XEH_PREP.hpp
+++ b/addons/parachute/XEH_PREP.hpp
@@ -1,4 +1,5 @@
 PREP(cutParachute);
+PREP(handleFailureChance);
 PREP(handleInfoDisplayChanged);
 PREP(handleReserve);
 PREP(hideAltimeter);

--- a/addons/parachute/XEH_postInit.sqf
+++ b/addons/parachute/XEH_postInit.sqf
@@ -38,3 +38,5 @@ if (!hasInterface) exitWith {};
 
 // Don't show vanilla speed and height when in expert mode
 ["ace_infoDisplayChanged", {_this call FUNC(handleInfoDisplayChanged)}] call CBA_fnc_addEventHandler;
+
+["vehicle", {_this call FUNC(handleFailureChance)}] call CBA_fnc_addPlayerEventHandler;

--- a/addons/parachute/XEH_preInit.sqf
+++ b/addons/parachute/XEH_preInit.sqf
@@ -18,4 +18,13 @@ PREP_RECOMPILE_END;
     {[QGVAR(hideAltimeter), _this, false] call EFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(failureChance),
+    "SLIDER",
+    LSTRING(FailureChance),
+    ["ACE Uncategorized", localize "str_dn_parachute"],
+    [0, 1, 0, 2, true],
+    1
+] call CBA_fnc_addSetting;
+
 ADDON = true;

--- a/addons/parachute/functions/fnc_handleFailureChance.sqf
+++ b/addons/parachute/functions/fnc_handleFailureChance.sqf
@@ -11,16 +11,16 @@
  * None
  *
  * Example:
- * [player, vehicle player] call FUNC(handleFailureChance);
+ * [player, vehicle player] call FUNC(handleFailureChance)
  *
  * Public: No
  */
 
 params ["_unit", "_vehicle"];
 
-if !(_vehicle isKindOf "ParachuteBase" || {GVAR(failureChance) > 0}) exitWith {};
+if !(GVAR(failureChance) > 0 || {_vehicle isKindOf "ParachuteBase"}) exitWith {};
 
 if (random 1 < GVAR(failureChance)) then {
-    private _failureDelay = getNumber (configFile >> "CfgVehicles" >> str typeOf _vehicle >> QGVAR(failureDelay))
+    private _failureDelay = getNumber (configOf _vehicle >> QGVAR(failureDelay));
     [{[(_this select 0), (_this select 1)] call FUNC(cutParachute)}, [_unit, _vehicle], _failureDelay] call cba_fnc_waitAndExecute;
 };

--- a/addons/parachute/functions/fnc_handleFailureChance.sqf
+++ b/addons/parachute/functions/fnc_handleFailureChance.sqf
@@ -5,22 +5,22 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 0: Vehicle <OBJECT>
+ * 1: Vehicle <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, vehicle player] call FUNC(handleFailureChance)
+ * [player, vehicle player] call ace_parachute_handleFailureChance
  *
  * Public: No
  */
 
 params ["_unit", "_vehicle"];
 
-if !(GVAR(failureChance) > 0 || {_vehicle isKindOf "ParachuteBase"}) exitWith {};
+if !(_vehicle isKindOf "ParachuteBase") exitWith {};
 
 if (random 1 < GVAR(failureChance)) then {
     private _failureDelay = getNumber (configOf _vehicle >> QGVAR(failureDelay));
-    [{[(_this select 0), (_this select 1)] call FUNC(cutParachute)}, [_unit, _vehicle], _failureDelay] call cba_fnc_waitAndExecute;
+    [FUNC(cutParachute), [_unit, _vehicle], _failureDelay] call CBA_fnc_waitAndExecute;
 };

--- a/addons/parachute/functions/fnc_handleFailureChance.sqf
+++ b/addons/parachute/functions/fnc_handleFailureChance.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: JoramD
+ * Handles percentage chance parachute failure.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, vehicle player] call FUNC(handleFailureChance);
+ *
+ * Public: No
+ */
+
+params ["_unit", "_vehicle"];
+
+if !(_vehicle isKindOf "ParachuteBase" && {GVAR(failureChance) > 0}) exitWith {};
+
+if (random 1 < GVAR(failureChance)) then {
+    private _failureDelay = getNumber (configFile >> "CfgVehicles" >> str typeOf _vehicle >> QGVAR(failureDelay))
+    [{[(_this select 0), (_this select 1)] call FUNC(cutParachute)}, [_unit, _vehicle], _failureDelay] call cba_fnc_waitAndExecute;
+};

--- a/addons/parachute/functions/fnc_handleFailureChance.sqf
+++ b/addons/parachute/functions/fnc_handleFailureChance.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [player, vehicle player] call ace_parachute_handleFailureChance
+ * [player, vehicle player] call ace_parachute_fnc_handleFailureChance
  *
  * Public: No
  */

--- a/addons/parachute/functions/fnc_handleFailureChance.sqf
+++ b/addons/parachute/functions/fnc_handleFailureChance.sqf
@@ -18,7 +18,7 @@
 
 params ["_unit", "_vehicle"];
 
-if !(_vehicle isKindOf "ParachuteBase" && {GVAR(failureChance) > 0}) exitWith {};
+if !(_vehicle isKindOf "ParachuteBase" || {GVAR(failureChance) > 0}) exitWith {};
 
 if (random 1 < GVAR(failureChance)) then {
     private _failureDelay = getNumber (configFile >> "CfgVehicles" >> str typeOf _vehicle >> QGVAR(failureDelay))

--- a/addons/parachute/script_component.hpp
+++ b/addons/parachute/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_PARACHUTE

--- a/addons/parachute/script_component.hpp
+++ b/addons/parachute/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_PARACHUTE

--- a/addons/parachute/stringtable.xml
+++ b/addons/parachute/stringtable.xml
@@ -133,5 +133,8 @@
             <Spanish>Oculta la altitud y la velocidad que se muestran en caída libre o en paracaídas.</Spanish>
             <Turkish>Serbest düşme veya paraşütle atlama sırasında gösterilen yüksekliği ve hızı gizler.</Turkish>
         </Key>
+        <Key ID="STR_ACE_Parachute_FailureChance">
+            <English>Parachute Failure Chance</English>
+        </Key>
     </Package>
 </Project>

--- a/docs/wiki/framework/parachute-framework.md
+++ b/docs/wiki/framework/parachute-framework.md
@@ -27,7 +27,8 @@ class CfgVehicles {
 
 ```cpp
 class CfgVehicles {
-    class BananaParachute {
+    class ParachuteBase;
+    class BananaParachute: ParachuteBase {
         ace_parachute_failureDelay = 2;  // Add delay before parachute fails (time in seconds)
     };
 };

--- a/docs/wiki/framework/parachute-framework.md
+++ b/docs/wiki/framework/parachute-framework.md
@@ -16,7 +16,8 @@ version:
 
 ```cpp
 class CfgVehicles {
-    class BananaParachute {
+    class ParachuteBase;
+    class BananaParachute: ParachuteBase {
         ace_hasReserveParachute = 1;  // Add reserve parachute (1-enabled, 0-disabled)
         ace_reserveParachute = "ACE_ReserveParachute";  // Classname of the reserve parachute
     };

--- a/docs/wiki/framework/parachute-framework.md
+++ b/docs/wiki/framework/parachute-framework.md
@@ -22,3 +22,13 @@ class CfgVehicles {
     };
 };
 ```
+
+## 2. Adding failure cut delay
+
+```cpp
+class CfgVehicles {
+    class BananaParachute {
+        ace_parachute_failureDelay = 2;  // Add delay before parachute fails (time in seconds)
+    };
+};
+```


### PR DESCRIPTION
**When merged this pull request will:**
- Add setting to enable percentage based failing of parachutes (0% chance by default).
- Add config value to `ParachuteBase` to set the failure delay.
- Add documentation for the config value mentioned above.

This was [a request](https://github.com/acemod/ACE3/issues/3594#issuecomment-546740178) from @DevastatorCM

[A small demo](https://youtu.be/nrmtXdw9ooU)