### PR TITLE
Ballistics - Fix wrong shot size in birdshot strings

### DIFF
--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -171,30 +171,30 @@
             <Russian>#4 Картечь</Russian>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Bird_NameShort">
-            <English>#7 Birdshot</English>
-            <Spanish>Perdigones #7</Spanish>
-            <German>#7 Vogelschrot</German>
-            <Chinese>#7 鹿彈</Chinese>
-            <Italian>#7 Birdshot</Italian>
-            <Japanese>#7 バックショット</Japanese>
+            <English>#4 Birdshot</English>
+            <Spanish>Perdigones #4</Spanish>
+            <German>#4 Vogelschrot</German>
+            <Chinese>#4 鹿彈</Chinese>
+            <Italian>#4 Birdshot</Italian>
+            <Japanese>#4 バックショット</Japanese>
             <French>Grenaille No.4</French>
-            <Czech>#7 Broky malé</Czech>
-            <Polish>#7 Śrut Drobny</Polish>
-            <Turkish>#7 Küçük saçma</Turkish>
-            <Russian>#7 Дробь</Russian>
+            <Czech>#4 Broky malé</Czech>
+            <Polish>#4 Śrut Drobny</Polish>
+            <Turkish>#4 Küçük saçma</Turkish>
+            <Russian>#4 Дробь</Russian>
         </Key>
         <Key ID="STR_ACE_Ballistics_12Gauge_Pellets_No4_Bird_Description">
-            <English>#7 Birdshot</English>
-            <Spanish>Perdigones #7</Spanish>
-            <German>#7 Vogelschrot</German>
-            <Chinese>#7 鹿彈</Chinese>
-            <Italian>#7 Birdshot</Italian>
-            <Japanese>#7 バックショット</Japanese>
+            <English>#4 Birdshot</English>
+            <Spanish>Perdigones #4</Spanish>
+            <German>#4 Vogelschrot</German>
+            <Chinese>#4 鹿彈</Chinese>
+            <Italian>#4 Birdshot</Italian>
+            <Japanese>#4 バックショット</Japanese>
             <French>Grenaille No.4</French>
-            <Czech>#7 Broky malé - kalibr 2.54 mm</Czech>
-            <Polish>#7 Śrut Drobny (Birdshot)</Polish>
-            <Turkish>#7 Küçük saçma</Turkish>
-            <Russian>#7 Дробь</Russian>
+            <Czech>#4 Broky malé - kalibr 3.3 mm</Czech>
+            <Polish>#4 Śrut Drobny (Birdshot)</Polish>
+            <Turkish>#4 Küçük saçma</Turkish>
+            <Russian>#4 Дробь</Russian>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 2Rnd #00 Buckshot</English>
@@ -281,18 +281,18 @@
             <Turkish>12 kalibre 2 mermi #4 İrisaçma</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_2Rnd_12Gauge_Pellets_No4_Bird_Name">
-            <English>12 Gauge 2Rnd #7 Birdshot</English>
-            <Spanish>2 Cartuchos de Perdigones Calibre 12 #7</Spanish>
-            <German>12 Gauge 2Schuss #7 Schrotmunition</German>
-            <Chinese>12鉛徑 2發  #7 鹿彈</Chinese>
-            <Italian>12 Gauge 2Rnd #7 Birdshot</Italian>
-            <Japanese>12 ゲージ 2 発入り #7 バックショット</Japanese>
+            <English>12 Gauge 2Rnd #4 Birdshot</English>
+            <Spanish>2 Cartuchos de Perdigones Calibre 12 #4</Spanish>
+            <German>12 Gauge 2Schuss #4 Schrotmunition</German>
+            <Chinese>12鉛徑 2發  #4 鹿彈</Chinese>
+            <Italian>12 Gauge 2Rnd #4 Birdshot</Italian>
+            <Japanese>12 ゲージ 2 発入り #4 バックショット</Japanese>
             <French>2 balles cal. 12 Grenaille No.4</French>
-            <Czech>2x #7 Broky malé (kalibr 2.54 mm)</Czech>
-            <Polish>12 Gauge 2 naboje #7 Śrut</Polish>
-            <Portuguese>Chumbo #7 Calibre Doze 2 Tiros</Portuguese>
-            <Russian>12 Калибр 2 патр. #7 Дробь</Russian>
-            <Turkish>12 kalibre 2 mermi #5 İrisaçma</Turkish>
+            <Czech>2x #4 Broky malé (kalibr 3.3 mm)</Czech>
+            <Polish>12 Gauge 2 naboje #4 Śrut</Polish>
+            <Portuguese>Chumbo #4 Calibre Doze 2 Tiros</Portuguese>
+            <Russian>12 Калибр 2 патр. #4 Дробь</Russian>
+            <Turkish>12 kalibre 2 mermi #4 İrisaçma</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 6Rnd #00 Buckshot</English>
@@ -379,17 +379,17 @@
             <Turkish>12 kalibre 6 mermi #4 İrisaçma</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_6Rnd_12Gauge_Pellets_No4_Bird_Name">
-            <English>12 Gauge 6Rnd #7 Birdshot</English>
-            <Spanish>6 Cartuchos de Perdigones Calibre 12 #7</Spanish>
-            <German>12 Gauge 6Schuss #7 Schrotmunition</German>
-            <Chinese>12鉛徑 6發  #7 鹿彈</Chinese>
-            <Italian>12 Gauge 6Rnd #7 Birdshot</Italian>
-            <Japanese>12 ゲージ 6 発入り #7 バックショット</Japanese>
+            <English>12 Gauge 6Rnd #4 Birdshot</English>
+            <Spanish>6 Cartuchos de Perdigones Calibre 12 #4</Spanish>
+            <German>12 Gauge 6Schuss #4 Schrotmunition</German>
+            <Chinese>12鉛徑 6發  #4 鹿彈</Chinese>
+            <Italian>12 Gauge 6Rnd #4 Birdshot</Italian>
+            <Japanese>12 ゲージ 6 発入り #4 バックショット</Japanese>
             <French>6 balles cal. 12 Grenaille No.4</French>
-            <Czech>6x #7 Broky malé (kalibr 2.54 mm)</Czech>
-            <Polish>12 Gauge 6 naboi #7 Śrut</Polish>
-            <Russian>12 Калибр 6 патр. #7 Дробь</Russian>
-            <Turkish>12 kalibre 6 mermi #7 İrisaçma</Turkish>
+            <Czech>6x #4 Broky malé (kalibr 3.3 mm)</Czech>
+            <Polish>12 Gauge 6 naboi #4 Śrut</Polish>
+            <Russian>12 Калибр 6 патр. #4 Дробь</Russian>
+            <Turkish>12 kalibre 6 mermi #4 İrisaçma</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_15Rnd_12Gauge_Pellets_No00_Buck_Name">
             <English>12 Gauge 15Rnd #00 Buckshot</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Correct the birdshot pellet size in stringtable
- These were originally intended to be No. 7 size shot, but the number of pellets was too high so I changed it to No. 4 size bird shot to reduce the pellet count. I guess I forgot to update the strings at that time.