### PR TITLE
Changes A-10 gun poisson disc to centered random.

### DIFF
--- a/addons/aircraft/CfgAmmo.hpp
+++ b/addons/aircraft/CfgAmmo.hpp
@@ -64,7 +64,7 @@ class CfgAmmo {
    class ACE_Gatling_30mm_Sub_HEI: SubmunitionBullet {
        submunitionAmmo = "Gatling_30mm_HE_Plane_CAS_01_F";
        weaponType = "cannon";
-       submunitionConeType[] = {"poissondisccenter", 3};
+       submunitionConeType[] = {"randomcenter", 3};
        submunitionConeAngle = 0.056; // in degrees, 0.055 ~= 0.001 mils minute, but present
        model = "\A3\Weapons_f\Data\bullettracer\tracer_red.p3d";
        triggerTime = 0.005;


### PR DESCRIPTION
It looks nicer and distributes more realistically. I don't know what I was thinking when I first put in poisson disc.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](https://ace3mod.com/wiki/development/)
- Follow title standard `Component - Add|Fix|Improve|Change|Make|Remove bananas`
