### PR TITLE
Tools - Fix make after hemtt pack

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -366,7 +366,7 @@ def copy_important_files(source_dir,destination_dir):
 
 
 def copy_optionals_for_building(mod,pbos):
-    src_directories = os.listdir(optionals_root)
+    src_directories = next(os.walk(optionals_root))[1]
     current_dir = os.getcwd()
 
     print_blue("\nChecking optionals folder...")


### PR DESCRIPTION
`build.py` and `hemtt pack` create pbo files in `optionals` dir. `make.py` needs only dirs to copy and stops with error.