### PR TITLE
Speed limiter utalizes setCruiseControl

### DIFF
--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -21,6 +21,7 @@ params ["_driver", "_vehicle"];
 if (GVAR(isSpeedLimiter)) exitWith {
     [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
     playSound "ACE_Sound_Click";
+    _vehicle setCruiseControl [0, false];
     GVAR(isSpeedLimiter) = false;
 };
 
@@ -38,21 +39,25 @@ GVAR(speedLimit) = speed _vehicle max 5;
         private _uavControll = UAVControl _vehicle;
         if ((_uavControll select 0) != _driver || _uavControll select 1 != "DRIVER") then {
             GVAR(isSpeedLimiter) = false;
+            _vehicle setCruiseControl [0, false];
         };
     } else {
         if (_driver != driver _vehicle) then {
             GVAR(isSpeedLimiter) = false;
+            _vehicle setCruiseControl [0, false];
         };
     };
 
     if (!GVAR(isSpeedLimiter)) exitWith {
+        _vehicle setCruiseControl [0, false];
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 
+    _vehicle setCruiseControl [GVAR(speedLimit), false];
+
     private _speed = speed _vehicle;
 
-    if (_speed > GVAR(speedLimit)) then {
+    if (_speed > GVAR(speedLimit)+2) then {
         _vehicle setVelocity ((velocity _vehicle) vectorMultiply ((GVAR(speedLimit) / _speed) - 0.00001));  // fix 1.42-hotfix PhysX libraries applying force in previous direction when turning
     };
-
 }, 0, [_driver, _vehicle]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Change speed limiter to utalize setCruiseControl

**Adjustments and code of note:**
- Kept setVelocity with a +2 to speed check to make vehicle slow down downhill and to slow it down when enabled.
- Still use the per frame due to ctrl+scroll adjustment check and active breake.
