### PR TITLE
Rearm - Fix rearming turrets comprised of multiple magazines of the same type

### DIFF
--- a/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
+++ b/addons/rearm/functions/fnc_rearmSuccessLocal.sqf
@@ -74,7 +74,7 @@ while {((count _ammoCounts) < _maxMagazines) && {_ammoToAdd > 0}} do {
     _ammoToAdd = _ammoToAdd - _xAdd;
     _ammoAdded = _ammoAdded + _xAdd;
     _ammoCounts pushBack _xAdd;
-    if (!_arrayModified) then {
+    if (_arrayModified) then {
         TRACE_1("adding new mag to array",_xAdd);
     } else {
         TRACE_1("adding new mag directly",_xAdd);


### PR DESCRIPTION
**When merged this pull request will:**

-  Fix Rearming so that turrets that are comprised of multiple magazines of the same type, of which each existing one may be full, or each one may only have a max count of 1: will be properly rearmed by properly adding the missing magazines directly to the turret

Please see #8286 for a breakdown of the current problem.

Fixes #8286 
Fixes #8166