### PR TITLE
Explosives - Fix missing action name for setup helper object

### DIFF
--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -78,6 +78,7 @@ class CfgVehicles {
         vehicleClass = "Cargo";
         class ACE_Actions {
             class ACE_MainActions {
+                displayName = ECSTRING(interaction,MainAction);
                 selection = "";
                 distance = 1.5;
                 condition = "true";


### PR DESCRIPTION
**When merged this pull request will:**
- title, "Interactions" text on the main action node was missing