### PR TITLE
Medical Engine - Disable third party medical systems

### DIFF
--- a/addons/medical_engine/CfgFunctions.hpp
+++ b/addons/medical_engine/CfgFunctions.hpp
@@ -1,0 +1,10 @@
+class CfgFunctions {
+    class A3_Mark {
+        class Revive {
+            class reviveInit {
+                // Disable BI medical system
+                postInit = 0;
+            };
+        };
+    };
+};

--- a/addons/medical_engine/XEH_PREP.hpp
+++ b/addons/medical_engine/XEH_PREP.hpp
@@ -1,9 +1,10 @@
-PREP(handleDamage);
+PREP(applyAnimAfterRagdoll);
 PREP(damageBodyPart);
-PREP(updateBodyPartVisuals);
-PREP(updateDamageEffects);
-PREP(setStructuralDamage);
-PREP(setUnconsciousAnim);
+PREP(disableThirdParty);
 PREP(getHitpointArmor);
 PREP(getItemArmor);
-PREP(applyAnimAfterRagdoll);
+PREP(handleDamage);
+PREP(setStructuralDamage);
+PREP(setUnconsciousAnim);
+PREP(updateBodyPartVisuals);
+PREP(updateDamageEffects);

--- a/addons/medical_engine/XEH_preInit.sqf
+++ b/addons/medical_engine/XEH_preInit.sqf
@@ -78,4 +78,6 @@ addMissionEventHandler ["Loaded", {
     };
 }] call CBA_fnc_addEventhandler;
 
+[] call FUNC(disableThirdParty);
+
 ADDON = true;

--- a/addons/medical_engine/config.cpp
+++ b/addons/medical_engine/config.cpp
@@ -14,10 +14,10 @@ class CfgPatches {
     };
 };
 
-#include "CfgEventHandlers.hpp"
-
 #include "CfgActions.hpp"
-#include "CfgMoves.hpp"
+#include "CfgEventHandlers.hpp"
 #include "CfgExtendedAnimation.hpp"
+#include "CfgFunctions.hpp"
+#include "CfgMoves.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/medical_engine/functions/fnc_disableThirdParty.sqf
+++ b/addons/medical_engine/functions/fnc_disableThirdParty.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*
+ * Author: BaerMitUmlaut
+ * Detects and disables third party medical systems.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call ace_medical_engine_fnc_disableThirdParty;
+ *
+ * Public: No
+ */
+
+// SOG:PF CDLC revive system
+// Pretend revive system was alread initialized.
+// See: vn_fnc_module_advancedrevive
+vn_advanced_revive_started = true;
+
+// Farooq Revive
+// Overwrite player initialization.
+far_player_init = compileFinal "";
+[{!isNil "far_debugging"}, {
+    far_isDragging = nil;  // Disable "Drag & Carry animation fix" loop - cannot be killed because spawned while true.
+    far_muteRadio = nil;   // Disable initialization hint.
+    far_muteACRE = nil;    // Same, but for very old versions.
+    far_debugging = false; // Disable adding event handlers to AI in SP.
+}, [], 5] call CBA_fnc_waitUntilAndExecute;

--- a/addons/medical_engine/functions/fnc_disableThirdParty.sqf
+++ b/addons/medical_engine/functions/fnc_disableThirdParty.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * [] call ace_medical_engine_fnc_disableThirdParty;
+ * [] call ace_medical_engine_fnc_disableThirdParty
  *
  * Public: No
  */

--- a/addons/medical_engine/functions/fnc_disableThirdParty.sqf
+++ b/addons/medical_engine/functions/fnc_disableThirdParty.sqf
@@ -16,7 +16,7 @@
  */
 
 // SOG:PF CDLC revive system
-// Pretend revive system was alread initialized.
+// Pretend revive system was already initialized.
 // See: vn_fnc_module_advancedrevive
 vn_advanced_revive_started = true;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Automatically disable third party medical systems. Currently supported:
  - Vanilla revive system
  - SOG:PF advanced revive system
  - Farooq revive (https://github.com/farooqaaa/far_revive)

This would allow you to play missions not made with ACE in mind at least to some degree (like SOG:PF's Mike Force).
Suggestions for other systems welcome, these are just the ones I know of.