### PR TITLE
GPS inaccuracy

### DIFF
--- a/addons/gps/$PBOPREFIX$
+++ b/addons/gps/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\gps

--- a/addons/gps/CfgEventHandlers.hpp
+++ b/addons/gps/CfgEventHandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/gps/XEH_PREP.hpp
+++ b/addons/gps/XEH_PREP.hpp
@@ -1,0 +1,4 @@
+PREP(getError);
+PREP(getOffset);
+PREP(getPos);
+PREP(getSatLocations);

--- a/addons/gps/XEH_postInit.sqf
+++ b/addons/gps/XEH_postInit.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};

--- a/addons/gps/XEH_preInit.sqf
+++ b/addons/gps/XEH_preInit.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+// #include "initSettings.sqf"
+
+ADDON = true;

--- a/addons/gps/XEH_preStart.sqf
+++ b/addons/gps/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/gps/config.cpp
+++ b/addons/gps/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+#define COLOUR 8.0
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_common"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Brett Mayson"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/gps/functions/fnc_getError.sqf
+++ b/addons/gps/functions/fnc_getError.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+/*
+ * Author: Brett Mayson
+ * Get GPS error level
+ *
+ * This number does not have any real world correlation
+ *
+ * Arguments:
+ * Object with GPS <OBJECT>
+ *
+ * Return Value:
+ * Error <NUMBER>
+ *
+ * Example:
+ * [_unit] call ace_gps_fnc_getError
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_object", ACE_player, [objNull]]
+];
+
+if (time < (_object getVariable [QGVAR(errorCacheExpire), -1])) exitWith {
+    _object getVariable [QGVAR(errorCache), 0];
+};
+
+private _points = [_object] call FUNC(getSatLocations);
+private _src = getPos _object;
+_src set [2, 1.3];
+_src = AGLtoASL _src;
+private _error = 0;
+{
+    _error = _error + count lineIntersectsSurfaces [_src, AGLtoASL _x, _object, objNull, true, 3];
+} forEach _points;
+
+_object setVariable [QGVAR(errorCache), _error];
+_object setVariable [QGVAR(errorCacheExpire), time + 0.5];
+
+_error

--- a/addons/gps/functions/fnc_getOffset.sqf
+++ b/addons/gps/functions/fnc_getOffset.sqf
@@ -1,0 +1,44 @@
+#include "script_component.hpp"
+/*
+ * Author: Brett Mayson
+ * Get GPS position with random error
+ *
+ * This number does not have any real world correlation
+ *
+ * Arguments:
+ * Object with GPS <OBJECT>
+ *
+ * Return Value:
+ * Error <NUMBER>
+ *
+ * Example:
+ * [_unit] call ace_gps_fnc_getPos
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_object", ACE_player, [objNull]]
+];
+
+if (time < (_object getVariable [QGVAR(offsetCacheExpire), -1])) exitWith {
+    _object getVariable [QGVAR(offsetCache), [0, 0]];
+};
+
+private _error = [_object] call FUNC(getError);
+if (_error == 0) exitWith { [0,0] };
+
+private _seed = floor (dayTime * 10);
+
+private _pos = getPos _object;
+_pos deleteAt 2;
+_pos set [0, floor (_pos#0 / 100)];
+_pos set [1, floor (_pos#1 / 100)];
+
+private _distance = (_seed random _pos) * _error;
+private _direction = (_error random _pos) * 360;
+
+_object setVariable [QGVAR(offsetCache), [_distance, _direction]];
+_object setVariable [QGVAR(offsetCacheExpire), time + 3];
+
+[_distance, _direction]

--- a/addons/gps/functions/fnc_getPos.sqf
+++ b/addons/gps/functions/fnc_getPos.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: Brett Mayson
+ * Get GPS position with random error
+ *
+ * This number does not have any real world correlation
+ *
+ * Arguments:
+ * Object with GPS <OBJECT>
+ *
+ * Return Value:
+ * Error <NUMBER>
+ *
+ * Example:
+ * [_unit] call ace_gps_fnc_getPos
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_object", ACE_player, [objNull]]
+];
+
+_object getPos ([_object] call FUNC(getOffset));

--- a/addons/gps/functions/fnc_getSatLocations.sqf
+++ b/addons/gps/functions/fnc_getSatLocations.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/*
+ * Author: Brett Mayson
+ * Get "satellite" locations for simulating gps inaccuracy
+ *
+ * Arguments:
+ * Object with GPS <OBJECT>
+ *
+ * Return Value:
+ * Locations <ARRAY>
+ *
+ * Example:
+ * [_unit] call ace_gps_fnc_getSatLocations
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_object", ACE_player, [objNull]]
+];
+
+private _points = [];
+for "_i" from 0 to 5 do {
+    private _point = _object getPos [800, _i * 60];
+    _point set [2, 500];
+    _points pushBack _point;
+};
+_points

--- a/addons/gps/functions/script_component.hpp
+++ b/addons/gps/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\ace\addons\gps\script_component.hpp"

--- a/addons/gps/script_component.hpp
+++ b/addons/gps/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT gps
+#define COMPONENT_BEAUTIFIED GPS
+#include "\z\ace\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_GPS
+  #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_GPS
+  #define DEBUG_SETTINGS DEBUG_SETTINGS_GPS
+#endif
+
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
Note sure if there is interest in ACE for this, or if I should just do this in-house or as a standalone mod.

**When merged this pull request will:**
- Add a function to get the position of the player, but with an offset depending on view of the "satellites"

Some future notes:
- Would be disabled by default
- Would be disabled if the vanilla blufor tracking is on
- When disabled, the function would just return `getPos _object`

Compatibility:
- Not sure how / if I'll be able to get the vanilla GPS minimap to co-operate
- Mods like cTab or [FriendlyTracker](https://github.com/ArmaForces/FriendlyTracker) would have to choose to call the function when ACE is loaded