### PR TITLE
RHS ARF Compat - Add ammo URAL & Kamaz, wirecutter backpacks and crew helmet

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -163,6 +163,10 @@ class CfgVehicles {
         transportRepair = 0;
         EGVAR(repair,canRepair) = 1;
     };
+    class RHS_Ural_Ammo_Base: RHS_Ural_Base {
+        transportAmmo = 0;
+        ace_rearm_defaultSupply = 1200;
+    };
 
     class rhs_truck: Truck_F {
         EGVAR(refuel,fuelCapacity) = 210;
@@ -175,6 +179,12 @@ class CfgVehicles {
     };
 
     class rhs_gaz66_ammo_base: rhs_gaz66_vmf {
+        transportAmmo = 0;
+        ace_rearm_defaultSupply = 1200;
+    };
+
+    class rhs_kamaz5350: rhs_truck {};
+    class rhs_kamaz5350_ammo_base: rhs_kamaz5350 {
         transportAmmo = 0;
         ace_rearm_defaultSupply = 1200;
     };

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -281,12 +281,12 @@ class CfgVehicles {
     };
     
     class rhs_rk_sht_30_emr;
-    class rhs_rk_sht_30_emr_engineer: rhs {
+    class rhs_rk_sht_30_emr_engineer: rhs_rk_sht_30_emr {
         EGVAR(logistics_wirecutter,hasWirecutter) = 1;
     };
     
     class rhs_rk_sht_30_olive;
-    class rhs_rk_sht_30_olive_engineer: rhs {
+    class rhs_rk_sht_30_olive_engineer: rhs_rk_sht_30_olive {
         EGVAR(logistics_wirecutter,hasWirecutter) = 1;
     };
 

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -279,6 +279,16 @@ class CfgVehicles {
     class rhs_assault_umbts_engineer: rhs_assault_umbts {
         EGVAR(logistics_wirecutter,hasWirecutter) = 1;
     };
+    
+    class rhs_rk_sht_30_emr;
+    class rhs_rk_sht_30_emr_engineer: rhs {
+        EGVAR(logistics_wirecutter,hasWirecutter) = 1;
+    };
+    
+    class rhs_rk_sht_30_olive;
+    class rhs_rk_sht_30_olive_engineer: rhs {
+        EGVAR(logistics_wirecutter,hasWirecutter) = 1;
+    };
 
     class StaticMortar: StaticWeapon {};
     class rhs_2b14_82mm_Base: StaticMortar {

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -125,6 +125,10 @@ class CfgWeapons {
     class rhs_tsh4: H_HelmetB {
         HEARING_PROTECTION_VICCREW
     };
+    
+    class rhs_6b48: H_HelmetB {
+        HEARING_PROTECTION_VICCREW
+    };
 
     class rhs_zsh7a: H_HelmetB {
         HEARING_PROTECTION_VICCREW


### PR DESCRIPTION
**When merged this pull request will:**
- Add the RHS_Ural_Ammo_Base and rhs_kamaz5350_ammo_base into the config to allow them to be used for ACE rearming (which were added in RHS AFRF update 0.5.6).
- Add the rhs_rk_sht_30_olive_engineer and rhs_rk_sht_30_emr_engineer (which both have wirecutters on their model) to the wirecutting list.
- Add sound muffling to the new tank crew helmet, 6b48.