### PR TITLE
Vehicles - Add configurable engine startup delay

### DIFF
--- a/addons/vehicles/CfgVehicles.hpp
+++ b/addons/vehicles/CfgVehicles.hpp
@@ -16,7 +16,9 @@ class CfgVehicles {
         class CommanderOptics;//: NewTurret {};
     };
 
-    class Car: LandVehicle {};
+    class Car: LandVehicle {
+        GVAR(engineStartDelay) = 1.3;
+    };
 
     class Tank: LandVehicle {
         class Turrets {

--- a/addons/vehicles/XEH_PREP.hpp
+++ b/addons/vehicles/XEH_PREP.hpp
@@ -1,3 +1,4 @@
 
 PREP(speedLimiter);
 PREP(startEngine);
+PREP(addStartupDelayToObject);

--- a/addons/vehicles/XEH_PREP.hpp
+++ b/addons/vehicles/XEH_PREP.hpp
@@ -1,4 +1,4 @@
 
 PREP(speedLimiter);
 PREP(startEngine);
-PREP(addStartupDelayToObject);
+PREP(setVehicleStartDelay);

--- a/addons/vehicles/functions/fnc_addStartupDelayToObject.sqf
+++ b/addons/vehicles/functions/fnc_addStartupDelayToObject.sqf
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+/*
+ * Author: severgun
+ * Add engine startup delay to specific vehicle.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ * 1: Delay (seconds) <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [hemmt, 3.2] call ace_vehicles_fnc_addStartupDelayToObject
+ *
+ * Public: Yes
+ */
+
+params [["_veh", objNull, [objNull]], ["_delay", 0, [99]]];
+
+if (isNull _veh || {!(_veh isKindOf "AllVehicles")}) exitWith {};
+
+_veh setVariable [QGVAR(engineStartDelay), _delay max 0, true];

--- a/addons/vehicles/functions/fnc_setVehicleStartDelay.sqf
+++ b/addons/vehicles/functions/fnc_setVehicleStartDelay.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: severgun
- * Add engine startup delay to specific vehicle.
+ * Set engine startup delay to specific vehicle.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [hemmt, 3.2] call ace_vehicles_fnc_addStartupDelayToObject
+ * [hemmt, 3.2] call ace_vehicles_fnc_setVehicleStartDelay
  *
  * Public: Yes
  */

--- a/addons/vehicles/functions/fnc_startEngine.sqf
+++ b/addons/vehicles/functions/fnc_startEngine.sqf
@@ -20,6 +20,8 @@ params ["_vehicle", "_isEngineOn"];
 
 if (!_isEngineOn || {floor abs speed _vehicle > 0 || {!isNull isVehicleCargo _vehicle}}) exitWith {};
 
+private _startupDelay = getNumber(configOf _vehicle >> QGVAR(engineStartDelay));
+
 [{
     params ["_args", "_idPFH"];
     _args params ["_vehicle", "_time", "_direction"];
@@ -29,4 +31,4 @@ if (!_isEngineOn || {floor abs speed _vehicle > 0 || {!isNull isVehicleCargo _ve
     _vehicle setVelocity [0, 0, 0];
     _vehicle setVectorDirAndUp _direction;
 
-} , 0, [_vehicle, CBA_missionTime + STARTUP_DELAY, [vectorDir _vehicle, vectorUp _vehicle]]] call CBA_fnc_addPerFrameHandler;
+} , 0, [_vehicle, CBA_missionTime + _startupDelay, [vectorDir _vehicle, vectorUp _vehicle]]] call CBA_fnc_addPerFrameHandler;

--- a/addons/vehicles/functions/fnc_startEngine.sqf
+++ b/addons/vehicles/functions/fnc_startEngine.sqf
@@ -20,7 +20,7 @@ params ["_vehicle", "_isEngineOn"];
 
 if (!_isEngineOn || {floor abs speed _vehicle > 0 || {!isNull isVehicleCargo _vehicle}}) exitWith {};
 
-private _startupDelay = getNumber(configOf _vehicle >> QGVAR(engineStartDelay));
+private _startupDelay = getNumber (configOf _vehicle >> QGVAR(engineStartDelay));
 
 [{
     params ["_args", "_idPFH"];

--- a/addons/vehicles/functions/fnc_startEngine.sqf
+++ b/addons/vehicles/functions/fnc_startEngine.sqf
@@ -20,7 +20,7 @@ params ["_vehicle", "_isEngineOn"];
 
 if (!_isEngineOn || {floor abs speed _vehicle > 0 || {!isNull isVehicleCargo _vehicle}}) exitWith {};
 
-private _startupDelay = getNumber (configOf _vehicle >> QGVAR(engineStartDelay));
+private _startupDelay = _vehicle getVariable [QGVAR(engineStartDelay), getNumber (configOf _vehicle >> QGVAR(engineStartDelay))];
 
 [{
     params ["_args", "_idPFH"];

--- a/addons/vehicles/functions/fnc_startEngine.sqf
+++ b/addons/vehicles/functions/fnc_startEngine.sqf
@@ -21,6 +21,7 @@ params ["_vehicle", "_isEngineOn"];
 if (!_isEngineOn || {floor abs speed _vehicle > 0 || {!isNull isVehicleCargo _vehicle}}) exitWith {};
 
 private _startupDelay = _vehicle getVariable [QGVAR(engineStartDelay), getNumber (configOf _vehicle >> QGVAR(engineStartDelay))];
+if (_startupDelay <= 0) exitWith {};
 
 [{
     params ["_args", "_idPFH"];

--- a/addons/vehicles/script_component.hpp
+++ b/addons/vehicles/script_component.hpp
@@ -20,4 +20,3 @@
 #define MOUSE_SCROLL_DOWN 0xF9
 
 #define FUEL_FACTOR 0.165    // fuel capacity = range in km * FUEL_FACTOR
-#define STARTUP_DELAY 1.3

--- a/docs/wiki/framework/vehicles-framework.md
+++ b/docs/wiki/framework/vehicles-framework.md
@@ -1,0 +1,34 @@
+---
+layout: wiki
+title: Vehicles Framework
+description: Explains how to set-up vehicles startup delay.
+group: framework
+order: 5
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 14
+  patch: 0
+---
+
+## 1. Engine startup delay
+
+The engine has to be started before the vehicle can move. Delay can be configured per vehicle via config.
+By default starting the engine takes aprox. 1 to 2 seconds.
+
+{% raw %}
+```cpp
+class CfgVehicles {
+    class MyFuelTruck {
+        ace_vehicles_engineStartDelay = 3; // Startup delay in seconds
+    };
+    class MyCar {
+        ace_vehicles_engineStartDelay = 2.2;
+    };
+    class MyElectricCar {
+        ace_vehicles_engineStartDelay = 0.1;
+    };
+};
+```
+{% endraw %}

--- a/docs/wiki/framework/vehicles-framework.md
+++ b/docs/wiki/framework/vehicles-framework.md
@@ -35,7 +35,7 @@ class CfgVehicles {
 
 ### 1.2 Setting the startup delay by script
 
-`ace_vehicles_fnc_addStartupDelayToObject`
+`ace_vehicles_fnc_setVehicleStartDelay`
 
    | Arguments | Type | Optional (default value)
 ---| --------- | ---- | ------------------------
@@ -46,7 +46,7 @@ class CfgVehicles {
 
 #### 1.2.1 Example
 
-`[myCar, 2.2] call ace_vehicles_fnc_addStartupDelayToObject;`
+`[myCar, 2.2] call ace_vehicles_fnc_setVehicleStartDelay;`
 
    | Arguments | Explanation
 ---| --------- | -----------

--- a/docs/wiki/framework/vehicles-framework.md
+++ b/docs/wiki/framework/vehicles-framework.md
@@ -14,10 +14,11 @@ version:
 
 ## 1. Engine startup delay
 
-The engine has to be started before the vehicle can move. Delay can be configured per vehicle via config.
+The engine has to be started before the vehicle can move. Delay can be configured per class via config or per vehicle via script.
 By default starting the engine takes aprox. 1 to 2 seconds.
 
-{% raw %}
+### 1.1 Setting the startup delay by config
+
 ```cpp
 class CfgVehicles {
     class MyFuelTruck {
@@ -31,4 +32,23 @@ class CfgVehicles {
     };
 };
 ```
-{% endraw %}
+
+### 1.2 Setting the startup delay by script
+
+`ace_vehicles_fnc_addStartupDelayToObject`
+
+   | Arguments | Type | Optional (default value)
+---| --------- | ---- | ------------------------
+0  | Vehicle | Object | Required
+1  | Delay (in seconds) | Number | Required
+**R** | None | None | Return value
+
+
+#### 1.2.1 Example
+
+`[myCar, 2.2] call ace_vehicles_fnc_addStartupDelayToObject;`
+
+   | Arguments | Explanation
+---| --------- | -----------
+0  | `myCar` | My car object
+1  | `2.2` | New startup delay

--- a/docs/wiki/framework/vehicles-framework.md
+++ b/docs/wiki/framework/vehicles-framework.md
@@ -36,6 +36,7 @@ class CfgVehicles {
 ### 1.2 Setting the startup delay by script
 
 `ace_vehicles_fnc_setVehicleStartDelay`
+Has global effects.
 
    | Arguments | Type | Optional (default value)
 ---| --------- | ---- | ------------------------


### PR DESCRIPTION
**When merged this pull request will:**
- Add configurable engine startup delay by config and script
- Add function to set delay per vehicle
- Set default delay to 1.3 as it was before
- Add vehicles framework wiki page
