### PR TITLE
Map - Use getLightingAt

### DIFF
--- a/addons/map/XEH_postInitClient.sqf
+++ b/addons/map/XEH_postInitClient.sqf
@@ -94,9 +94,12 @@ GVAR(vehicleLightColor) = [1,1,1,0];
     private _vehicleLightCondition = getText (_cfg >> QGVAR(vehicleLightCondition));
     if (_vehicleLightCondition == "") then {
         private _userAction = toLower getText (_cfg >> "UserActions" >> "ToggleLight" >> "statement");
-        switch (true) do {
-            case ((_userAction find "cabinlights_hide") > 0): {_vehicleLightCondition = "(_vehicle animationSourcePhase 'cabinlights_hide') == 1";};
-            case ((_userAction find "cargolights_hide") > 0): {_vehicleLightCondition = "(_vehicle animationSourcePhase 'cargolights_hide') == 1";};
+        if (
+            isClass (_cfg >> "compartmentsLights")
+            || {_userAction find "cabinlights_hide" > 0}
+            || {_userAction find "cargolights_hide" > 0}
+        ) then {
+            _vehicleLightCondition = "false";
         };
     };
 
@@ -109,7 +112,7 @@ GVAR(vehicleLightColor) = [1,1,1,0];
     } else {
         switch (true) do {
             case (_vehicle isKindOf "Tank");
-            case (_vehicle isKindOf "Wheeled_APC"): { {true} };
+            case (_vehicle isKindOf "Wheeled_APC_F"): { {true} };
             case (_vehicle isKindOf "ParachuteBase"): { {false} };
             case (_vehicle isKindOf "Helicopter");
             case (_vehicle isKindOf "Plane"): { {(driver _vehicle == _unit) || {gunner _vehicle == _unit}} };
@@ -117,3 +120,17 @@ GVAR(vehicleLightColor) = [1,1,1,0];
         };
     };
 }, true] call CBA_fnc_addPlayerEventHandler;
+
+// compartmentsLights work only when cameraView == "INTERNAL" so we switch it on map opening
+["visibleMap", {
+    params ["_player", "_mapOn"];
+    if (_mapOn) then {
+        if (!isClass (configOf vehicle _player >> "compartmentsLights") || {cameraView == "INTERNAL"}) exitWith {};
+        GVAR(cameraViewLast) = cameraView;
+        vehicle _player switchCamera "INTERNAL";
+    } else {
+        if (isNil QGVAR(cameraViewLast)) exitWith {};
+        vehicle _player switchCamera GVAR(cameraViewLast);
+        GVAR(cameraViewLast) = nil;
+    };
+}] call CBA_fnc_addPlayerEventHandler;

--- a/addons/map/functions/fnc_simulateMapLight.sqf
+++ b/addons/map/functions/fnc_simulateMapLight.sqf
@@ -41,12 +41,15 @@ _lightLevel params ["_r", "_g", "_b", "_a"];
 private _colourAlpha = (_r + _g + _b) min _a;
 private _shadeAlpha = _a;
 
-private _colourList = [_r, _g, _b];
-_colourList sort false;
-private _maxColour = _colourList select 0;
+private _maxColour = selectMax [_r, _g, _b];
+private _ambientColor = if (_maxColour == 0) then {
+    [1, 1, 1, _colourAlpha];
+} else {
+    [_r / _maxColour, _g / _maxColour, _b / _maxColour, _colourAlpha];
+};
 
 //ambient colour fill
-_mapCtrl drawIcon ["#(rgb,8,8,3)color(1,1,1,1)", [_r / _maxColour, _g / _maxColour, _b / _maxColour, _colourAlpha], _mapCentre, _screenSize, _screenSize, 0, "", 0];
+_mapCtrl drawIcon ["#(rgb,8,8,3)color(1,1,1,1)", _ambientColor, _mapCentre, _screenSize, _screenSize, 0, "", 0];
 
 if (_flashlight == "") then {
     //ambient shade fill

--- a/addons/map/functions/fnc_updateMapEffects.sqf
+++ b/addons/map/functions/fnc_updateMapEffects.sqf
@@ -4,13 +4,13 @@
  * On map draw, updates the effects
  *
  * Arguments:
- * None
+ * 0: Map control <CONTROL>
  *
  * Return Value:
  * None
  *
  * Example:
- * call ACE_map_fnc_updateMapEffects
+ * _mapControl call ACE_map_fnc_updateMapEffects
  *
  * Public: No
  */


### PR DESCRIPTION
**When merged this pull request will:**
- replace color/brightness calculation to `getLightingAt`-based (thank you @dedmen);
- get rid of cabin light animation check (not necessary anymore);
- consider `compartmentsLights` if they exist (most vanilla armored vehicles and some CUP/RHS do);
- fix wrong `Wheeled_APC_F` parent check;
- fix `[0,0,0]` color handling in `fnc_simulateMapLight`;
- fix `fnc_updateMapEffects` header.

With this PR these light sources will also illuminate map:
- burning vehicles;
- flares;
- weapon fire;
- IR grenade / IR flare.

Light colors will be also calculated correctly for several sources.

IR grenade/flare map illuminating is doubtful but we can't disable it and it's better to think that map luminesces by IR light.

I can't explain math for `_alfa` and `_finalColor` calculating, I just sorted values out. Also I'm not sure about ambient and dynamic brightness/color summarizing but it looks quite good.

<details>
<summary>You can use this code to create map snippet on screen to test effects (splendid camera handled)</summary>

```
with uiNamespace do {
    disableSerialization;
    private _display = findDisplay ([314,46] select isNull findDisplay 314);
    map = _display ctrlCreate ["RscMapControl", -420];
    map ctrlSetPosition [1, 0.3, 0.6, 0.8];
    map ctrlCommit 0;
    map ctrlMapAnimAdd [0, 0.05, player];
    ctrlMapAnimCommit map;
    map ctrlAddEventHandler ["Draw", {_this call ace_map_fnc_updateMapEffects}];
};
```
</details>

