### PR TITLE
Cargo - Fix collision when unloading a IDAP 20m long container from HEMTT

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -636,6 +636,14 @@ class CfgVehicles {
         GVAR(space) = 49;
         GVAR(size) = 50;
     };
+    class Land_Cargo20_IDAP_F: Cargo_base_F {
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+        };
+
+        GVAR(space) = 49;
+        GVAR(size) = 50;
+    };
 
     class Land_Cargo40_blue_F: Cargo_base_F {
         class EventHandlers {


### PR DESCRIPTION
Each time you unload `Land_Cargo20_IDAP_F` from a HEMTT, the container collide with the vehicle and go in space 
This is due to `[cursorObject, a, player, 10, true] call ace_common_fnc_findUnloadPosition` whitch return a too close position for this container. The calculation of that position mainly depend on this:
```
getNumber (configFile >> "CfgVehicles" >> "Land_Cargo20_IDAP_F" >> "ace_cargo_size")
````
return `4`

```
getNumber (configFile >> "CfgVehicles" >> "Land_Cargo20_military_green_F" >> "ace_cargo_size")
````
return `50`

As we notice there is a big difference between a Land_Cargo20_military_green_F and Land_Cargo20_IDAP_F

**When merged this pull request will:**
- Use the same value as `Land_Cargo20_military_green_F` cargo variant as they have the same size
- change config `ace_cargo_size` and `ace_cargo_space` for `Land_Cargo20_IDAP_F`
- fix https://github.com/Vdauphin/HeartsAndMinds/issues/1153 and https://github.com/Vdauphin/HeartsAndMinds/discussions/1148#discussioncomment-1095089

