### PR TITLE
Medical - Refactor Clear Trauma Setting

### DIFF
--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -35,7 +35,7 @@ private _stitchedWounds = GET_STITCHED_WOUNDS(_patient);
 
 // Remove the first stitchable wound from the bandaged wounds
 private _treatedWound = _bandagedWounds deleteAt (_bandagedWounds find (_stitchableWounds select 0));
-_treatedWound params ["_treatedID", "_treatedBodyPartN", "_treatedAmountOf"];
+_treatedWound params ["_treatedID", "_treatedBodyPartN", "_treatedAmountOf", "", "_treatedDamageOf"];
 
 // Check if we need to add a new stitched wound or increase the amount of an existing one
 private _woundIndex = _stitchedWounds findIf {
@@ -49,6 +49,22 @@ if (_woundIndex == -1) then {
 } else {
     private _wound = _stitchedWounds select _woundIndex;
     _wound set [2, (_wound select 2) + _treatedAmountOf];
+};
+
+if (GVAR(clearTrauma == 1)) then {
+    TRACE_2("clearTrauma - clearing trauma after stitching",_partIndex,_treatedWound);
+    private _bodyPartDamage = _patient getVariable [QEGVAR(medical,bodyPartDamage), []];
+    _bodyPartDamage set [_treatedBodyPartN, (_bodyPartDamage select _treatedBodyPartN) - _treatedDamageOf];
+    _patient setVariable [QEGVAR(medical,bodyPartDamage), _bodyPartDamage, true];
+    TRACE_2("clearTrauma - healed damage",_partIndex,_treatedDamageOf);
+
+    switch (_treatedBodyPartN) do {
+        case 0: { [_patient, true, false, false, false] call EFUNC(medical_engine,updateBodyPartVisuals); };
+        case 1: { [_patient, false, true, false, false] call EFUNC(medical_engine,updateBodyPartVisuals); };
+        case 2;
+        case 3: { [_patient, false, false, true, false] call EFUNC(medical_engine,updateBodyPartVisuals); };
+        default { [_patient, false, false, false, true] call EFUNC(medical_engine,updateBodyPartVisuals); };
+    };
 };
 
 _patient setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -35,11 +35,11 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(clearTraumaAfterBandage),
-    "CHECKBOX",
-    [LSTRING(ClearTraumaAfterBandage_DisplayName), LSTRING(ClearTraumaAfterBandage_Description)],
+    QGVAR(clearTrauma),
+    "LIST",
+    [LSTRING(ClearTrauma_DisplayName), LSTRING(ClearTrauma_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    false,
+    [[0, 1, 2], [ELSTRING(common,Never),  LSTRING(ClearTrauma_AfterStitch), LSTRING(ClearTrauma_AfterBandage)], 1],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -144,31 +144,17 @@
             <Turkish>Yaranın yeniden açılma şansını kontrol etme katsayısı. Son yeniden açılma şansı, bu değerin kullanılan yara tipi ve bandaj için spesifik yeniden açılma şansı ile çarpılmasıyla belirlenir.</Turkish>
             <Spanish>Coeficiente que controla la probabilidad de reapertura de heridas. La probabilidad final de reapertura de heridas queda determinada multiplicando este valor por la probabilidad específica del tipo de herida y venda usada.</Spanish>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_DisplayName">
-            <English>Clear Trauma After Bandage</English>
-            <Japanese>治療後に外傷を削除</Japanese>
-            <Chinese>包紮即痊癒</Chinese>
-            <French>Guérir les blessures pansées</French>
-            <Czech>Odebrat úraz po obvázání</Czech>
-            <Polish>Usuń uraz po zabandażowaniu</Polish>
-            <Italian>Rimozione ferite bendate</Italian>
-            <German>Entferne Trauma nach Bandagierung.</German>
-            <Russian>Удалять травму после перевязки</Russian>
-            <Turkish>Bandaj Sonrası Travmayı Temizle</Turkish>
-            <Spanish>Quitar trauma despues de vendaje</Spanish>
+        <Key ID="STR_ACE_Medical_Treatment_ClearTrauma_DisplayName">
+            <English>Clear Trauma</English>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_ClearTraumaAfterBandage_Description">
-            <English>Controls whether fully bandaged body parts are healed.</English>
-            <Japanese>全ての傷に対して包帯を巻いた部分を治癒するかどうかを決定します。</Japanese>
-            <Polish>Kontroluje czy w pełni zabandażowane części ciała są uleczone.</Polish>
-            <French>Définit s'il faut guérir les parties du corps entièrement bandées.</French>
-            <Italian>Controlla se le parti del corpo completamente bendate sono guarite.</Italian>
-            <German>Kontrolliert, ob voll bandagierte Körperteile geheilt werden.</German>
-            <Chinese>控制說當傷口處理好的時候是否直接痊癒。</Chinese>
-            <Czech>Nastavuje zda jsou plně obvázané části těla vyléčena.</Czech>
-            <Russian>Контролирует то, что полностью перевязанные раны целиком исцеляют часть тела.</Russian>
-            <Turkish>Tamamen sargılı vücut kısımlarının iyileşip iyileşmediğini kontrol eder.</Turkish>
-            <Spanish>Controla si las partes del cuerpo completamente vendadas se curan.</Spanish>
+        <Key ID="STR_ACE_Medical_Treatment_ClearTrauma_Description">
+            <English>Controls when hitpoint damage from wounds is healed.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_ClearTrauma_AfterBandage">
+            <English>After Bandage</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_ClearTrauma_AfterStitch">
+            <English>After Stitch</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_LocationsBoostTraining_DisplayName">
             <English>Locations Boost Training</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add in a setting for clearing trauma after stitching a wound.
- Refactor clearing trauma after bandage to clear trauma for individual wounds as they're bandaged.
- Previous behaviour was to set damage on body part to 0 after all wounds on it were bandaged.