### PR TITLE
Refuel - Fix Endless Jerry Cans

### DIFF
--- a/addons/refuel/functions/fnc_refuel.sqf
+++ b/addons/refuel/functions/fnc_refuel.sqf
@@ -74,13 +74,19 @@ if (_maxFuel == 0) then {
         private _rateTime = _rate * (CBA_missionTime - (_nozzle getVariable [QGVAR(lastTickMissionTime), CBA_missionTime]));
         _nozzle setVariable [QGVAR(lastTickMissionTime), CBA_missionTime];
 
-        if !(_fuelInSource == REFUEL_INFINITE_FUEL) then {
-            _fuelInSource = _fuelInSource - _rateTime;
+        if (_fuelInSource != REFUEL_INFINITE_FUEL) then {
+            if (_rateTime > _fuelInSource) then {
+                _rateTime = _fuelInSource;
+                _fuelInSource = 0;
+            } else {
+                _fuelInSource = _fuelInSource - _rateTime;
+            };
         } else {
             _source setVariable [QGVAR(fuelCounter), (_source getVariable [QGVAR(fuelCounter), 0]) + _rateTime, true];
         };
-        if (_fuelInSource < 0 && {_fuelInSource > REFUEL_INFINITE_FUEL}) then {
+        if (_fuelInSource <= 0 && {_fuelInSource != REFUEL_INFINITE_FUEL}) then {
             _fuelInSource = 0;
+            [_source, _fuelInSource] call FUNC(setFuel);
             _finished = true;
             [LSTRING(Hint_SourceEmpty), 2, _unit] call EFUNC(common,displayTextStructured);
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Close #8301.
- Fix refueling for sinks with high input rates being fueled by sources with low fuel capacity.

Previous behaviour: no check was made if _rateTime > _fuelInSource, potentially causing _fuelInSource to have negative values. Manifested primarily when fueling large vehicles with jerry cans or other sources with low capacity.
