### PR TITLE
Repair - Add Locations Boost Training Setting

### DIFF
--- a/addons/repair/functions/fnc_isEngineer.sqf
+++ b/addons/repair/functions/fnc_isEngineer.sqf
@@ -25,4 +25,11 @@ private _class = _unit getVariable ["ACE_IsEngineer", _unit getUnitTrait "engine
 if (_class isEqualType false) then {_class = [0, 1] select _class};
 
 TRACE_3("isEngineer",_unit,_engineerN,_class);
-_class >= _engineerN;
+if (_class >= _engineerN) exitWith {true};
+if (!GVAR(locationsBoostTraining)) exitWith {false};
+
+if ([_unit] call FUNC(isInRepairFacility) || {[_unit] call FUNC(isNearRepairVehicle)}) then {
+    _class = _class + 1; // Boost engineer training by one: untrained becomes engineer, engineer becomes advanced engineer
+};
+
+_class >= _engineerN

--- a/addons/repair/initSettings.sqf
+++ b/addons/repair/initSettings.sqf
@@ -53,6 +53,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(locationsBoostTraining),
+    "CHECKBOX",
+    [LSTRING(LocationsBoostTraining_DisplayName), LSTRING(LocationsBoostTraining_Description)],
+    [localize ELSTRING(OptionsMenu,CategoryLogistics), localize "str_state_repair"],
+    false,
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(fullRepairLocation), "LIST",
     [LSTRING(fullRepairLocation), LSTRING(fullRepairLocation_description)],
     [localize ELSTRING(OptionsMenu,CategoryLogistics), localize "str_state_repair"],

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -261,6 +261,12 @@
             <Chinese>維修載具中...</Chinese>
             <Turkish>Tamir Ediliyor...</Turkish>
         </Key>
+        <Key ID="STR_ACE_Repair_LocationsBoostTraining_DisplayName">
+            <English>Locations Boost Training</English>
+        </Key>
+        <Key ID="STR_ACE_Repair_LocationsBoostTraining_Description">
+            <English>Boost engineer training when in repair vehicles or facilities. Untrained becomes engineer, engineer becomes advanced engineer.</English>
+        </Key>
         <Key ID="STR_ACE_Repair_fullRepairLocation">
             <English>Full Repair Locations</English>
             <German>Möglichkeit zur vollständigen Reperatur</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Add Locations Boost Training Setting for Repair.

Works the same way as in Medical Treatment component. Just for consistency.
