### PR TITLE
Repair - Skip destruction effects

### DIFF
--- a/addons/repair/functions/fnc_setDamage.sqf
+++ b/addons/repair/functions/fnc_setDamage.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Local Vehicle to Damage <OBJECT>
  * 1: Total Damage <NUMBER>
+ # 2: Use destruction effects <BOOL>
  *
  * Return Value:
  * None
@@ -16,7 +17,7 @@
  * Public: No
  */
 
-params ["_vehicle", "_damage"];
+params ["_vehicle", "_damage", ["_useEffects", false]];
 TRACE_2("params",_vehicle,_damage);
 
 // can't execute all commands if the vehicle isn't local. exit here.
@@ -31,7 +32,7 @@ if (_damageDisabled) then {
     _vehicle allowDamage true;
 };
 
-_vehicle setDamage _damage;
+_vehicle setDamage [_damage, _useEffects];
 
 // restore original hitpoint damage values
 {

--- a/addons/repair/functions/fnc_setHitPointDamage.sqf
+++ b/addons/repair/functions/fnc_setHitPointDamage.sqf
@@ -8,7 +8,7 @@
  * 0: Local Vehicle to Damage <OBJECT>
  * 1: Selected hitpoint INDEX <NUMBER>
  * 2: Total Damage <NUMBER>
- * 3: Skip destruction effects <BOOL>
+ * 3: Use destruction effects <BOOL>
  *
  * Return Value:
  * None
@@ -19,7 +19,7 @@
  * Public: No
  */
 
-params ["_vehicle", "_hitPointIndex", "_hitPointDamage", ["_useEffects", true]];
+params ["_vehicle", "_hitPointIndex", "_hitPointDamage", ["_useEffects", false]];
 TRACE_4("params",_vehicle,typeOf _vehicle,_hitPointIndex,_hitPointDamage);
 
 // can't execute all commands if the vehicle isn't local. exit here.


### PR DESCRIPTION
_useEffects was probably inverted. Makes ERA/SLAT not explode when repairing unrelated hitpoints. See #7452.

**When merged this pull request will:**
- Close #7452.
- Change fnc_setHitPointDamage default value for destruction effects to false.
- Add _useEffects parameter to fnc_setDamage.
- Prevent destruction effects from being played when doing partial repair on vehicles.

This was _probably_ an oversight, given that previous description of _useEffects parameter said it skipped destruction effects rather than use them. See [setDamage](https://community.bistudio.com/wiki/setDamage) syntax.