### PR TITLE
Small Arms - Fix FNX-45 magazine round count

### DIFF
--- a/addons/smallarms/CfgMagazines.hpp
+++ b/addons/smallarms/CfgMagazines.hpp
@@ -76,4 +76,10 @@ class CfgMagazines {
 
         count = 8;
     };
+
+    class 11Rnd_45ACP_Mag : CA_Magazine {
+      displayname = CSTRING(15Rnd_45_Name);
+
+      count = 15;
+    };
 };

--- a/addons/smallarms/stringtable.xml
+++ b/addons/smallarms/stringtable.xml
@@ -72,5 +72,16 @@
             <Turkish>.45 ACP 8 Merm. Şarjör</Turkish>
             <Japanese>.45 ACP 8Rnd マガジン</Japanese>
         </Key>
+        <Key ID="STR_ACE_SmallArms_15Rnd_45_Name">
+            <English>.45 ACP 15Rnd Mag</English>
+            <Polish>15-nab. mag. .45 ACP </Polish>
+            <Russian>Магазин, 15 патр. .45 ACP</Russian>
+            <French>Mag. 15 balles .45 ACP</French>
+            <Spanish>Cargador de 15 proyectiles de .45 ACP</Spanish>
+            <German>15-Schuss-.45-ACP-Magazin</German>
+            <Czech>.45 ACP, 15ks zásobník</Czech>
+            <Turkish>.45 ACP 15 Merm. Şarjör</Turkish>
+            <Japanese>.45 ACP 15Rnd マガジン</Japanese>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Changes FNX-45 magazine round count to 15 rounds.

See [FNX-45 product description ](https://fnamerica.com/products/pistols/fnx-45-tactical/). Magazine modeled ingame is the 15Rnd extended base pad version.
