### PR TITLE
Small Arms - Fix for FN Minimi SPW reload

### DIFF
--- a/addons/smallarms/CfgWeapons.hpp
+++ b/addons/smallarms/CfgWeapons.hpp
@@ -186,6 +186,12 @@ class CfgWeapons {
         };
     };
 
+    class LMG_03_Base_F;
+
+    class LMG_03_F: LMG_03_Base_F {
+        magazineReloadTime = 0; // Fix for reloading every time weapon is equipped
+    };
+
     // Sniper and anti-materiel rifles /////////////////////////////////
 
     class EBR_base_F: Rifle_Long_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**
- Stop FN Minimi SPW and derivatives from reloading every time weapon is equipped.

This was particularly noticeable in the arsenal, but would also manifest any time the weapon was added to inventory or upon exiting a vehicle.