### PR TITLE
Change hemorrhage text colors

### DIFF
--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -41,13 +41,13 @@ if (IS_BLEEDING(_target)) then {
 // Give a qualitative description of the blood volume lost
 switch (GET_HEMORRHAGE(_target)) do {
     case 1: {
-        _entries pushBack [localize LSTRING(Lost_Blood1), [1, 0, 0, 1]];
+        _entries pushBack [localize LSTRING(Lost_Blood1), [1, 1, 0, 1]];
     };
     case 2: {
-        _entries pushBack [localize LSTRING(Lost_Blood2), [1, 0, 0, 1]];
+        _entries pushBack [localize LSTRING(Lost_Blood2), [1, 0.67, 0, 1]];
     };
     case 3: {
-        _entries pushBack [localize LSTRING(Lost_Blood3), [1, 0, 0, 1]];
+        _entries pushBack [localize LSTRING(Lost_Blood3), [1, 0.33, 0, 1]];
     };
     case 4: {
         _entries pushBack [localize LSTRING(Lost_Blood4), [1, 0, 0, 1]];


### PR DESCRIPTION
**When merged this pull request will:**
- Change hemorrhage text color from always red to yellow-red grade.

There was feature request to change `Lost some blood` text color from red to white. I think yellow is better to show that there is some loss but not so "screaming" as red.

https://gka.github.io/palettes/#/4|s|ffff00,ff0000|ffffe0,ff005e,93003a|0|0
```
#ffff00
#ffaa00
#ff5500
#ff0000
```