### PR TITLE
WIP - Arsenal - Optimizations & Improved CBA Accessory Support

### DIFF
--- a/addons/arsenal/defines.hpp
+++ b/addons/arsenal/defines.hpp
@@ -402,28 +402,28 @@ if (!isNil QGVAR(customRightPanelButtons)) then {\
 ]
 
 #define CHECK_WEAPON_OR_ACC\
-    (_weaponsArray select 0) findIf {_x == _item} > -1 ||\
-    {(_weaponsArray select 1) findIf {_x == _item} > -1} ||\
-    {(_weaponsArray select 2)  findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 9) findIf {_x == _item} > -1} ||\
-    {(_accsArray select 0) findIf {_x == _item} > -1} ||\
-    {(_accsArray select 1 findIf {_x == _item} > -1)} ||\
-    {(_accsArray select 2) findIf {_x == _item} > -1} ||\
-    {(_accsArray select 3) findIf {_x == _item} > -1}
+    _item in (_weaponsArray select 0) ||\
+    {_item in (_weaponsArray select 1)} ||\
+    {_item in (_weaponsArray select 2)} ||\
+    {_item in (GVAR(virtualItems) select 9)} ||\
+    {_item in (_accsArray select 0)} ||\
+    {_item in (_accsArray select 1)} ||\
+    {_item in (_accsArray select 2)} ||\
+    {_item in (_accsArray select 3)}
 
 // PboProject 2.45 has problems with these macros for some reason, adding a single space before the \ fixes
 #define CHECK_ASSIGNED_ITEMS \
-    (GVAR(virtualItems) select 10) findIf {_x == _item} > -1 ||\
-    {(GVAR(virtualItems) select 11) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 12) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 13) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 14) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 8) findIf {_x == _item} > -1}
+    _item in (GVAR(virtualItems) select 10) ||\
+    {_item in (GVAR(virtualItems) select 11)} ||\
+    {_item in (GVAR(virtualItems) select 12)} ||\
+    {_item in (GVAR(virtualItems) select 13)} ||\
+    {_item in (GVAR(virtualItems) select 14)} ||\
+    {_item in (GVAR(virtualItems) select 8)}
 
 #define CHECK_CONTAINER \
-    (GVAR(virtualItems) select 4) findIf {_x == _item} > -1 ||\
-    {(GVAR(virtualItems) select 5) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 6) findIf {_x == _item} > -1}
+    _item in (GVAR(virtualItems) select 4) ||\
+    {_item in (GVAR(virtualItems) select 5)} ||\
+    {_item in (GVAR(virtualItems) select 6)}
 
 #define CLASS_CHECK_ITEM\
     isClass (_weaponCfg >> _item) ||\
@@ -432,24 +432,23 @@ if (!isNil QGVAR(customRightPanelButtons)) then {\
     {isClass (_magCfg >> _item)}
 
 #define CHECK_CONTAINER_ITEMS \
-    (GVAR(virtualItems) select 3) findIf {_x == _item} > -1 ||\
-    {(_accsArray select 0) findIf {_x == _item} > -1} ||\
-    {(_accsArray select 1) findIf {_x == _item} > -1} ||\
-    {(_accsArray select 2) findIf {_x == _item} > -1} ||\
-    {(_accsArray select 3) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 4) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 5) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 6) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 7) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 8) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 10) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 11) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 12) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 13) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 14) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 15) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 16) findIf {_x == _item} > -1} ||\
-    {(GVAR(virtualItems) select 17) findIf {_x == _item} > -1}
+    _item in (GVAR(virtualItems) select 3) ||\
+    {_item in (_accsArray select 0)} ||\
+    {_item in (_accsArray select 1)} ||\
+    {_item in (_accsArray select 2)} ||\
+    {_item in (_accsArray select 3)} ||\
+    {_item in (GVAR(virtualItems) select 4)} ||\
+    {_item in (GVAR(virtualItems) select 5)} ||\
+    {_item in (GVAR(virtualItems) select 6)} ||\
+    {_item in (GVAR(virtualItems) select 7)} ||\
+    {_item in (GVAR(virtualItems) select 8)} ||\
+    {_item in (GVAR(virtualItems) select 11)} ||\
+    {_item in (GVAR(virtualItems) select 12)} ||\
+    {_item in (GVAR(virtualItems) select 13)} ||\
+    {_item in (GVAR(virtualItems) select 14)} ||\
+    {_item in (GVAR(virtualItems) select 15)} ||\
+    {_item in (GVAR(virtualItems) select 16)} ||\
+    {_item in (GVAR(virtualItems) select 17)}
 
 #define ADD_LOADOUTS_LIST_PICTURES\
     _contentPanelCtrl lnbSetPicture [[_newRow, 2], getText (configFile >> "cfgWeapons" >> ((_loadout select 0) select 0) >> "picture")];\

--- a/addons/arsenal/defines.hpp
+++ b/addons/arsenal/defines.hpp
@@ -459,3 +459,6 @@ if (!isNil QGVAR(customRightPanelButtons)) then {\
     _contentPanelCtrl lnbSetPicture [[_newRow, 7], getText (configFile >> "cfgVehicles" >> ((_loadout select 5) select 0) >> "picture")];\
     _contentPanelCtrl lnbSetPicture [[_newRow, 8], getText (configFile >> "cfgWeapons" >> (_loadout select 6) >> "picture")];\
     _contentPanelCtrl lnbSetPicture [[_newRow, 9], getText (configFile >> "cfgGlasses" >> (_loadout select 7) >> "picture")];
+
+#define ALL_BOX_VIRTUAL_ITEMS\
+    (flatten (GVAR(currentBox) getVariable [QGVAR(virtualItems),[]]))

--- a/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
+++ b/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
@@ -23,21 +23,36 @@ if (isNil QGVAR(defaultLoadoutsList)) then {
     GVAR(defaultLoadoutsList) = [];
 };
 
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+private _cfgVehicles = configFile >> "CfgVehicles";
+private _cfgGlasses = configFile >> "CfgGlasses";
+
 for "_dataIndex" from 0 to 10 do {
     switch (_dataIndex) do {
 
         case 0;
         case 1;
         case 2;
-        case 8: {
+        case 8: { // Primary, secondary, handgun, binocular
             if (count (_loadout select _dataIndex) > 0) then {
 
-                private _weapon = (_loadout select _dataIndex) select 0;
-                if (_weapon != "") then {
+                for "_subIndex" from 0 to 6 do {
+                    private _weapon = (_loadout select _dataIndex) select _subIndex;
 
-                    private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                     if (_weapon != _baseWeapon) then {
-                        (_loadout select _dataIndex) set [0, _baseWeapon];
+                    // Magazines
+                    if (_weapon isEqualType []) then {
+                        private _magazine = _weapon select 0;
+                        _magazine = configName (_cfgMagazines >> _magazine);
+                        (_loadout select _dataIndex select _subIndex) set [0, _magazine];
+                        continue
+                    };
+
+                    if (_weapon != "") then {
+                        _weapon = configName (_cfgWeapons >> _weapon);
+                        private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
+                        if (_weapon != _baseWeapon) then { _weapon = _baseWeapon };
+                        (_loadout select _dataIndex) set [_subIndex, _weapon];
                     };
                 };
             };
@@ -45,53 +60,81 @@ for "_dataIndex" from 0 to 10 do {
 
         case 3;
         case 4;
-        case 5: {
+        case 5: { // Uniform, Vest, Backpack
             if (count (_loadout select _dataIndex) > 0) then {
                 private _containerContents = (_loadout select _dataIndex) select 1;
 
                 if (count _containerContents > 0) then {
-
                     {
-                        if (count _x == 2) then {
-
+                        if (count _x == 2) then { //Misc Items and Weapons
                                 if ((_x select 0) isEqualType "") then {
 
                                     private _item = (_x select 0);
                                     if (_item != "") then {
-
-                                        private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
-                                        if (_uniqueBaseCfgText != "") then {
-
-                                            _x set [0, _uniqueBaseCfgText];
+                                        switch (true) do {
+                                            case (isClass (_cfgWeapons >> _item)): {_item = configName (_cfgWeapons >> _item)};
+                                            case (isClass (_cfgVehicles >> _item)): {_item = configName (_cfgVehicles >> _item)};
+                                            case (isClass (_cfgGlasses >> _item)): {_item = configName (_cfgGlasses >> _item)};
                                         };
+                                        private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
+                                        if (_uniqueBaseCfgText != "") then { _item = _uniqueBaseCfgText };
+                                        _x set [0, _item];
                                     };
                                 } else {
-                                    private _weapon = (_x select 0) select 0;
-                                    if (_weapon != "") then {
+                                    for "_subIndex" from 0 to 6 do {
+                                        private _weapon = (_x select 0) select _subIndex;
 
-                                        private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                                        if (_weapon != _baseWeapon) then {
-                                            (_x select 0)set [0, _baseWeapon];
+                                        // Magazines
+                                        if (_weapon isEqualType []) then {
+                                            private _magazine = _weapon select 0;
+                                            _magazine = configName (_cfgMagazines >> _magazine);
+                                            (_x select 0 select _subIndex) set [0, _magazine];
+                                            continue
+                                        };
+
+                                        if (_weapon != "") then {
+                                            _weapon = configName (_cfgWeapons >> _weapon);
+                                            private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
+                                            if (_weapon != _baseWeapon) then { _weapon = _baseWeapon };
+                                            (_x select 0) set [_subIndex, _weapon];
                                         };
                                     };
                                 };
+                            };
+                            if (count _x == 3) then { // Magazines
+                                private _magazine = _x select 0;
+                                _magazine = configName (_cfgMagazines >> _magazine);
+                                _x set [0, _magazine];
                             };
                     } foreach _containerContents;
                 };
             };
         };
 
-        case 9: {
+        case 6: { // Headgear
+            private _item = _loadout select _dataIndex;
+            if (_item != "") then {
+                _item = configName (_cfgWapons >> _item);
+                _loadout set [_dataIndex, _item];
+            };
+        };
+        case 7: { // Facewear
+            private _item = _loadout select _dataIndex;
+            if (_item != "") then {
+                _item = configName (_cfgGlasses >> _item);
+                _loadout set [_dataIndex, _item];
+            };
+        };
+
+        case 9: { // Assigned Items
             for "_subIndex" from 0 to 4 do {
                 private _item = (_loadout select _dataIndex) select _subIndex;
 
                 if (_item != "") then {
-
+                    _item = configName (_cfgWeapons >> _item);
                     private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
-                    if (_uniqueBaseCfgText != "") then {
-
-                        (_loadout select _dataIndex) set [_subIndex, _uniqueBaseCfgText];
-                    };
+                    if (_uniqueBaseCfgText != "") then { _item = _uniqueBaseCfgText };
+                    (_loadout select _dataIndex) set [_subIndex, _item];
                 };
             };
         };

--- a/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
+++ b/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
@@ -44,12 +44,12 @@ for "_dataIndex" from 0 to 10 do {
                     if (_weapon isEqualType []) then {
                         private _magazine = _weapon select 0;
                         _magazine = configName (_cfgMagazines >> _magazine);
+                        if (_magazine == "") then {continue}; // Skip null class
                         (_loadout select _dataIndex select _subIndex) set [0, _magazine];
                         continue
                     };
-
+                    _weapon = configName (_cfgWeapons >> _weapon);
                     if (_weapon != "") then {
-                        _weapon = configName (_cfgWeapons >> _weapon);
                         private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
                         if (_weapon != _baseWeapon) then { _weapon = _baseWeapon };
                         (_loadout select _dataIndex) set [_subIndex, _weapon];
@@ -104,7 +104,10 @@ for "_dataIndex" from 0 to 10 do {
                             if (count _x == 3) then { // Magazines
                                 private _magazine = _x select 0;
                                 _magazine = configName (_cfgMagazines >> _magazine);
+                                if (_magazine == "") then {continue}; // Skip null class
+                                systemChat _magazine;
                                 _x set [0, _magazine];
+                                systemChat str (_x);
                             };
                     } foreach _containerContents;
                 };
@@ -113,15 +116,15 @@ for "_dataIndex" from 0 to 10 do {
 
         case 6: { // Headgear
             private _item = _loadout select _dataIndex;
+            _item = configName (_cfgWapons >> _item);
             if (_item != "") then {
-                _item = configName (_cfgWapons >> _item);
                 _loadout set [_dataIndex, _item];
             };
         };
         case 7: { // Facewear
             private _item = _loadout select _dataIndex;
+            _item = configName (_cfgGlasses >> _item);
             if (_item != "") then {
-                _item = configName (_cfgGlasses >> _item);
                 _loadout set [_dataIndex, _item];
             };
         };
@@ -129,9 +132,8 @@ for "_dataIndex" from 0 to 10 do {
         case 9: { // Assigned Items
             for "_subIndex" from 0 to 4 do {
                 private _item = (_loadout select _dataIndex) select _subIndex;
-
+                _item = configName (_cfgWeapons >> _item);
                 if (_item != "") then {
-                    _item = configName (_cfgWeapons >> _item);
                     private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
                     if (_uniqueBaseCfgText != "") then { _item = _uniqueBaseCfgText };
                     (_loadout select _dataIndex) set [_subIndex, _item];

--- a/addons/arsenal/functions/fnc_addListBoxItem.sqf
+++ b/addons/arsenal/functions/fnc_addListBoxItem.sqf
@@ -20,10 +20,11 @@ private _cacheNamespace = _ctrlPanel; //For better readability.
 
 private _cachedItemInfo = _cacheNamespace getVariable [_configCategory+_className, []];
 
+private _configPath = configFile >> _configCategory >> _className;
+private _className = configName _configPath;
+
 //_cachedItemInfo == [_displayName, _itemPicture, _modPicture]
 if (_cachedItemInfo isEqualTo []) then {//Not in cache. So get info and put into cache.
-
-    private _configPath = configFile >> _configCategory >> _className;
 
     _cachedItemInfo set [0, getText (_configPath >> "displayName")];
     //if _pictureEntryName is empty then this item has no Icons. (Faces)

--- a/addons/arsenal/functions/fnc_addRightPanelButton.sqf
+++ b/addons/arsenal/functions/fnc_addRightPanelButton.sqf
@@ -42,14 +42,14 @@ if (_position >= 0 && _position <= 9) then {
     private _cfgWeapons = configFile >> "CfgWeapons";
     _items = _items select {
         private _configItemInfo = _cfgWeapons >> _x >> "ItemInfo";
-           
+
         _x isKindOf ["CBA_MiscItem", _cfgWeapons] && {getNumber (_configItemInfo >> "type") in [TYPE_MUZZLE, TYPE_OPTICS, TYPE_FLASHLIGHT, TYPE_BIPOD]} ||
         {getNumber (_configItemInfo >> "type") in [TYPE_FIRST_AID_KIT, TYPE_MEDIKIT, TYPE_TOOLKIT]} ||
         {getText (_cfgWeapons >> _x >> "simulation") == "ItemMineDetector"}
     };
-    
+
     _return = _position;
-    GVAR(customRightPanelButtons) set [_position, [_items apply {toLower _x}, _picture, _tooltip]];
+    GVAR(customRightPanelButtons) set [_position, [_items, _picture, _tooltip]];
 };
 
 _return

--- a/addons/arsenal/functions/fnc_addRightPanelButton.sqf
+++ b/addons/arsenal/functions/fnc_addRightPanelButton.sqf
@@ -47,6 +47,7 @@ if (_position >= 0 && _position <= 9) then {
         {getNumber (_configItemInfo >> "type") in [TYPE_FIRST_AID_KIT, TYPE_MEDIKIT, TYPE_TOOLKIT]} ||
         {getText (_cfgWeapons >> _x >> "simulation") == "ItemMineDetector"}
     };
+    _items apply {configName (_cfgWeapons >> _x)};
 
     _return = _position;
     GVAR(customRightPanelButtons) set [_position, [_items, _picture, _tooltip]];

--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -46,6 +46,8 @@ private _cargo = _object getVariable [QGVAR(virtualItems), [
 ]];
 
 private _configCfgWeapons = configFile >> "CfgWeapons"; //Save this lookup in variable for perf improvement
+private _configCfgMagazines = configFile >> "CfgMagazines";
+private _configCfgVehicles = configFile >> "CfgVehicles";
 
 if (_items isEqualType true) then {
     if (_items) then {
@@ -77,6 +79,7 @@ if (_items isEqualType true) then {
             private _simulationType = getText (_configCfgWeapons >> _x >> "simulation");
             switch true do {
                 case (isClass (_configCfgWeapons >> _x)): {
+                    _x = configName (_configCfgWeapons >> _x);
                     switch true do {
                         /* Weapon acc */
                         case (
@@ -175,7 +178,8 @@ if (_items isEqualType true) then {
                         };
                     };
                 };
-                case (isClass (configFile >> "CfgMagazines" >> _x)): {
+                case (isClass (_configCfgMagazines >> _x)): {
+                    _x = configName (_configCfgMagazines >> _x);
                     // Lists to check against
                     private _grenadeList = [];
                     {
@@ -191,15 +195,6 @@ if (_items isEqualType true) then {
 
                     // Check what the magazine actually is
                     switch true do {
-                        // Rifle, handgun, secondary weapons mags
-                        case (
-                                ((getNumber (configFile >> "CfgMagazines" >> _x >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL]) ||
-                                {(getNumber (configFile >> "CfgMagazines" >> _x >> QGVAR(hide))) == -1}) &&
-                                {!(_x in _grenadeList)} &&
-                                {!(_x in _putList)}
-                            ): {
-                            (_cargo select 2) pushBackUnique _x;
-                        };
                         // Grenades
                         case (_x in _grenadeList): {
                             (_cargo select 15) pushBackUnique _x;
@@ -208,14 +203,23 @@ if (_items isEqualType true) then {
                         case (_x in _putList): {
                             (_cargo select 16) pushBackUnique _x;
                         };
+                        // Rifle, handgun, secondary weapons mags
+                        case (
+                                ((getNumber (_configCfgMagazines >> _x >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL]) ||
+                                {(getNumber (_configCfgMagazines >> _x >> QGVAR(hide))) == -1})
+                            ): {
+                            (_cargo select 2) pushBackUnique _x;
+                        };
                     };
                 };
-                case (isClass (configFile >> "CfgVehicles" >> _x)): {
-                    if (getNumber (configFile >> "CfgVehicles" >> _x >> "isBackpack") == 1) then {
+                case (isClass (_configCfgVehicles >> _x)): {
+                    _x = configName (_configCfgVehicles >> _x);
+                    if (getNumber (_configCfgVehicles >> _x >> "isBackpack") == 1) then {
                         (_cargo select 6) pushBackUnique _x;
                     };
                 };
                 case (isClass (configFile >> "CfgGlasses" >> _x)): {
+                    _x = configName (configFile >> "CfgGlasses" >> _x);
                     (_cargo select 7) pushBackUnique _x;
                 };
             };

--- a/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
@@ -51,7 +51,7 @@ if (_category == 8) then {
             _itemsToAdd append _magazines;
 
             {
-                _itemsToAdd append ([_magazineGroups, _x] call CBA_fnc_hashGet);
+                _itemsToAdd append (_magazineGroups get _x);
             } forEach getArray (_muzzleConfig >> "magazineWell");
         } forEach getArray (_weaponConfig >> "muzzles");
     } forEach _attributeWeapons;

--- a/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
@@ -51,7 +51,7 @@ if (_category == 8) then {
             _itemsToAdd append _magazines;
 
             {
-                _itemsToAdd append ([_magazineGroups, toLower _x] call CBA_fnc_hashGet);
+                _itemsToAdd append ([_magazineGroups, _x] call CBA_fnc_hashGet);
             } forEach getArray (_muzzleConfig >> "magazineWell");
         } forEach getArray (_weaponConfig >> "muzzles");
     } forEach _attributeWeapons;

--- a/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
@@ -38,6 +38,7 @@ private _itemsToAdd = [];
 if (_category == 8) then {
     private _magazineGroups = uiNamespace getVariable QGVAR(magazineGroups);
     private _cfgMagazines = configFile >> "CfgMagazines";
+    private _cfgMagazineWells = configFile >> "CfgMagazineWells";
 
     {
         private _weaponConfig = _cfgWeapons >> _x;
@@ -52,7 +53,7 @@ if (_category == 8) then {
 
             {
                 _itemsToAdd append (_magazineGroups get _x);
-            } forEach getArray ((_muzzleConfig >> "magazineWell") apply {configName (_cfgMagazines >> _x)});
+            } forEach getArray ((_muzzleConfig >> "magazineWell") apply {configName (_cfgMagazineWells >> _x)});
         } forEach getArray (_weaponConfig >> "muzzles");
     } forEach _attributeWeapons;
 } else {

--- a/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddCompatible.sqf
@@ -52,7 +52,7 @@ if (_category == 8) then {
 
             {
                 _itemsToAdd append (_magazineGroups get _x);
-            } forEach getArray (_muzzleConfig >> "magazineWell");
+            } forEach getArray ((_muzzleConfig >> "magazineWell") apply {configName (_cfgMagazines >> _x)});
         } forEach getArray (_weaponConfig >> "muzzles");
     } forEach _attributeWeapons;
 } else {

--- a/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
@@ -58,12 +58,17 @@ switch (GVAR(currentLoadoutsTab)) do {
                 case 8: {
                     if (count (_loadout select _dataIndex) > 0) then {
 
-                        private _weapon = (_loadout select _dataIndex) select 0;
-                        if (_weapon != "") then {
+                        for "_subIndex" from 0 to 6 do {
+                            private _weapon = (_loadout select _dataIndex) select _subIndex;
+                            if (_weapon isEqualType []) then {continue};
+                            systemChat str _weapon;
+                            if (_weapon != "") then {
 
-                            private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                             if (_weapon != _baseWeapon) then {
-                                (_loadout select _dataIndex) set [0, _baseWeapon];
+                                private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
+                                systemChat str _baseWeapon;
+                                 if (_weapon != _baseWeapon) then {
+                                    (_loadout select _dataIndex) set [_subIndex, _baseWeapon];
+                                };
                             };
                         };
                     };

--- a/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
@@ -85,28 +85,38 @@ switch (GVAR(currentLoadoutsTab)) do {
                             {
                                 if (count _x == 2) then {
 
-                                        if ((_x select 0) isEqualType "") then {
+                                    if ((_x select 0) isEqualType "") then {
 
-                                            private _item = (_x select 0);
-                                            if (_item != "") then {
+                                        private _item = (_x select 0);
+                                        if (_item != "") then {
 
-                                                private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
-                                                if (_uniqueBaseCfgText != "") then {
-
-                                                    _x set [0, _uniqueBaseCfgText];
-                                                };
+                                            private _baseWeapon = _item call BIS_fnc_baseWeapon;
+                                            if (_item != _baseWeapon) then {
+                                                _x set [0, _baseWeapon];
                                             };
-                                        } else {
-                                            private _weapon = (_x select 0) select 0;
-                                            if (_weapon != "") then {
 
+                                            private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
+                                            if (_uniqueBaseCfgText != "") then {
+                                                _x set [0, _uniqueBaseCfgText];
+                                            };
+                                        };
+                                    } else {
+                                        for "_subIndex" from 0 to 6 do {
+                                            private _weapon = (_x select 0) select _subIndex;
+
+                                            // skip magazines
+                                            if (_weapon isEqualType []) then {continue};
+
+                                            if (_weapon != "") then {
                                                 private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
+
                                                 if (_weapon != _baseWeapon) then {
-                                                    (_x select 0)set [0, _baseWeapon];
+                                                    (_x select 0) set [_subIndex, _baseWeapon];
                                                 };
                                             };
                                         };
                                     };
+                                };
                             } foreach _containerContents;
                         };
                     };
@@ -213,19 +223,29 @@ switch (GVAR(currentLoadoutsTab)) do {
                                             private _item = (_x select 0);
                                             if (_item != "") then {
 
+                                                private _baseWeapon = _item call BIS_fnc_baseWeapon;
+                                                if (_item != _baseWeapon) then {
+                                                    _x set [0, _baseWeapon];
+                                                };
+
                                                 private _uniqueBaseCfgText = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
                                                 if (_uniqueBaseCfgText != "") then {
-
                                                     _x set [0, _uniqueBaseCfgText];
                                                 };
                                             };
                                         } else {
-                                            private _weapon = (_x select 0) select 0;
-                                            if (_weapon != "") then {
+                                            for "_subIndex" from 0 to 6 do {
+                                                private _weapon = (_x select 0) select _subIndex;
 
-                                                private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                                                if (_weapon != _baseWeapon) then {
-                                                    (_x select 0)set [0, _baseWeapon];
+                                                // skip magazines
+                                                if (_weapon isEqualType []) then {continue};
+
+                                                if (_weapon != "") then {
+                                                    private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
+
+                                                    if (_weapon != _baseWeapon) then {
+                                                        (_x select 0) set [_subIndex, _baseWeapon];
+                                                    };
                                                 };
                                             };
                                         };

--- a/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
@@ -60,13 +60,13 @@ switch (GVAR(currentLoadoutsTab)) do {
 
                         for "_subIndex" from 0 to 6 do {
                             private _weapon = (_loadout select _dataIndex) select _subIndex;
-                            if (_weapon isEqualType []) then {continue};
-                            systemChat str _weapon;
-                            if (_weapon != "") then {
 
+                            // skip magazines
+                            if (_weapon isEqualType []) then {continue};
+
+                            if (_weapon != "") then {
                                 private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                                systemChat str _baseWeapon;
-                                 if (_weapon != _baseWeapon) then {
+                                if (_weapon != _baseWeapon) then {
                                     (_loadout select _dataIndex) set [_subIndex, _baseWeapon];
                                 };
                             };
@@ -181,12 +181,17 @@ switch (GVAR(currentLoadoutsTab)) do {
                     case 8: {
                         if (count (_loadout select _dataIndex) > 0) then {
 
-                            private _weapon = (_loadout select _dataIndex) select 0;
-                            if (_weapon != "") then {
+                            for "_subIndex" from 0 to 6 do {
+                                private _weapon = (_loadout select _dataIndex) select _subIndex;
 
-                                private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                                if (_weapon != _baseWeapon) then {
-                                    (_loadout select _dataIndex) set [0, _baseWeapon];
+                                // skip magazines
+                                if (_weapon isEqualType []) then {continue};
+
+                                if (_weapon != "") then {
+                                    private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
+                                     if (_weapon != _baseWeapon) then {
+                                        (_loadout select _dataIndex) set [_subIndex, _baseWeapon];
+                                    };
                                 };
                             };
                         };

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -194,12 +194,12 @@ GVAR(currentLeftPanel) = _ctrlIDC;
 [_sortLeftCtrl] call FUNC(sortPanel);
 
 //Select current item
-private _itemsToCheck = ((GVAR(currentItems) select [0,15]) + [GVAR(currentFace), GVAR(currentVoice), GVAR(currentInsignia)]) apply {tolower _x};
+private _itemsToCheck = ((GVAR(currentItems) select [0,15]) + [GVAR(currentFace), GVAR(currentVoice), GVAR(currentInsignia)]);
 
 for "_lbIndex" from 0 to (lbSize _ctrlPanel - 1) do {
     private _currentData = _ctrlPanel lbData _lbIndex;
 
-    if ((_currentData isNotEqualTo "") && {tolower _currentData in _itemsToCheck}) exitWith {
+    if ((_currentData isNotEqualTo "") && {_currentData in _itemsToCheck}) exitWith {
         _ctrlPanel lbSetCurSel _lbIndex;
     };
 };

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -45,6 +45,10 @@ private _fnc_fill_right_Container = {
     private _cacheNamespace = _ctrlPanel;
     private _cachedItemInfo = _cacheNamespace getVariable [_configCategory+_className, []];
 
+    if (!(_className in ALL_BOX_VIRTUAL_ITEMS)) then {
+        _isUnique = true;
+    };
+
     // Not in cache. So get info and put into cache
     if (_cachedItemInfo isEqualTo []) then {
         private _configPath = configFile >> _configCategory >> _className;

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -86,7 +86,7 @@ private _compatibleMagazines = [[[], []], [[], []], [[], []]];
             // Magazine groups
             {
                 private _magazineGroups = uiNamespace getVariable [QGVAR(magazineGroups),["#CBA_HASH#",[],[],[]]];
-                private _magArray = [_magazineGroups, toLower _x] call CBA_fnc_hashGet;
+                private _magArray = [_magazineGroups, _x] call CBA_fnc_hashGet;
                 {((_compatibleMagazines select _index) select _subIndex) pushBackUnique _x} forEach _magArray;
             } foreach ([getArray (_weaponConfig >> _x >> "magazineWell"), getArray (_weaponConfig >> "magazineWell")] select (_x == "this"));
 
@@ -142,8 +142,8 @@ _ctrlPanel ctrlCommit 0;
 _ctrlPanel ctrlSetFade 0;
 _ctrlPanel ctrlCommit FADE_DELAY;
 
-_itemsToCheck = _itemsToCheck apply {toLower _x};
-_compatibleItems =  _compatibleItems apply {toLower _x};
+_itemsToCheck = _itemsToCheck;
+_compatibleItems =  _compatibleItems;
 
 lbClear (_display displayCtrl IDC_rightTabContentListnBox);
 lbClear (_display displayCtrl IDC_rightTabContent);
@@ -164,7 +164,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 0) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect ((GVAR(virtualItems) select 1) select 0));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -179,7 +179,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 1) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect ((GVAR(virtualItems) select 1) select 1));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -194,7 +194,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 2) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect ((GVAR(virtualItems) select 1) select 2));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -209,7 +209,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 3) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect ((GVAR(virtualItems) select 1) select 3));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -285,17 +285,17 @@ switch (_ctrlIDC) do {
 
         {
             ["CfgWeapons", _x, false]  call _fnc_fill_right_Container;
-        } forEach ((GVAR(virtualItems) select 17) select {!((toLower _x) in _blockItems)});
+        } forEach ((GVAR(virtualItems) select 17) select {!(_x in _blockItems)});
 
         {
             ["CfgWeapons", _x, false, true]  call _fnc_fill_right_Container;
-        } foreach ((GVAR(virtualItems) select 18) select {!((toLower _x) in _blockItems)});
+        } foreach ((GVAR(virtualItems) select 18) select {!(_x in _blockItems)});
         {
             ["CfgVehicles", _x, false, true]  call _fnc_fill_right_Container;
-        } foreach ((GVAR(virtualItems) select 23) select {!((toLower _x) in _blockItems)});
+        } foreach ((GVAR(virtualItems) select 23) select {!(_x in _blockItems)});
         {
             ["CfgGlasses", _x, false, true]  call _fnc_fill_right_Container;
-        } foreach ((GVAR(virtualItems) select 24) select {!((toLower _x) in _blockItems)});
+        } foreach ((GVAR(virtualItems) select 24) select {!(_x in _blockItems)});
     };
 
     default {
@@ -307,17 +307,17 @@ switch (_ctrlIDC) do {
                 private _items = _data select 0;
                 {
                     ["CfgWeapons", _x, true] call _fnc_fill_right_Container;
-                } foreach ((GVAR(virtualItems) select 17) select {(toLower _x) in _items});
+                } foreach ((GVAR(virtualItems) select 17) select {_x in _items});
 
                 {
                     ["CfgWeapons", _x, false, true]  call _fnc_fill_right_Container;
-                } foreach ((GVAR(virtualItems) select 18) select {(toLower _x) in _items});
+                } foreach ((GVAR(virtualItems) select 18) select {_x in _items});
                 {
                     ["CfgVehicles", _x, false, true]  call _fnc_fill_right_Container;
-                } foreach ((GVAR(virtualItems) select 23) select {(toLower _x) in _items});
+                } foreach ((GVAR(virtualItems) select 23) select {_x in _items});
                 {
                     ["CfgGlasses", _x, false, true]  call _fnc_fill_right_Container;
-                } foreach ((GVAR(virtualItems) select 24) select {(toLower _x) in _items});
+                } foreach ((GVAR(virtualItems) select 24) select {_x in _items});
             };
         };
     };
@@ -370,7 +370,7 @@ if (_itemsToCheck isNotEqualTo []) then {
     for "_lbIndex" from 0 to (lbSize _ctrlPanel - 1) do {
         private _currentData = _ctrlPanel lbData _lbIndex;
 
-        if ((_currentData != "") && {tolower _currentData in _itemsToCheck}) exitWith {
+        if ((_currentData != "") && {_currentData in _itemsToCheck}) exitWith {
             _ctrlPanel lbSetCurSel _lbIndex;
         };
     };

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -73,12 +73,13 @@ private _fnc_fill_right_Container = {
     _ctrlPanel lbSetTooltip [_lbAdd * _columns,format ["%1\n%2", _displayName, _x]];
 };
 
+private _cfgWeapons = configFile >> "CfgWeapons";
 // Retrieve compatible mags
 private _compatibleItems = [];
 private _compatibleMagazines = [[[], []], [[], []], [[], []]];
 {
     if (_x != "") then {
-        private _weaponConfig = (configFile >> "CfgWeapons" >> _x);
+        private _weaponConfig = (_cfgWeapons >> _x);
         private _index = _forEachIndex;
 
         {
@@ -116,6 +117,7 @@ switch (GVAR(currentLeftPanel)) do {
         _compatibleMagsPrimaryMuzzle = _compatibleMagazines select 0 select 0;
         _compatibleMagsSecondaryMuzzle = _compatibleMagazines select 0 select 1;
         _compatibleItems = (primaryWeapon GVAR(center)) call bis_fnc_compatibleItems;
+        _compatibleItems apply {configName (_cfgWeapons >> _x)};
         _itemsToCheck = GVAR(currentItems) select 18;
     };
 
@@ -123,6 +125,7 @@ switch (GVAR(currentLeftPanel)) do {
         _compatibleMagsPrimaryMuzzle = _compatibleMagazines select 1 select 0;
         _compatibleMagsSecondaryMuzzle = _compatibleMagazines select 1 select 1;
         _compatibleItems = (handgunWeapon GVAR(center)) call bis_fnc_compatibleItems;
+        _compatibleItems apply {configName (_cfgWeapons >> _x)};
         _itemsToCheck = GVAR(currentItems) select 20;
     };
 
@@ -130,6 +133,7 @@ switch (GVAR(currentLeftPanel)) do {
         _compatibleMagsPrimaryMuzzle = _compatibleMagazines select 2 select 0;
         _compatibleMagsSecondaryMuzzle = _compatibleMagazines select 2 select 1;
         _compatibleItems = (secondaryWeapon GVAR(center)) call bis_fnc_compatibleItems;
+        _compatibleItems apply {configName (_cfgWeapons >> _x)};
         _itemsToCheck = GVAR(currentItems) select 19;
     };
 

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -74,6 +74,8 @@ private _fnc_fill_right_Container = {
 };
 
 private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+private _cfgMagazineWells = configFile >> "CfgMagazineWells";
 // Retrieve compatible mags
 private _compatibleItems = [];
 private _compatibleMagazines = [[[], []], [[], []], [[], []]];
@@ -85,16 +87,21 @@ private _compatibleMagazines = [[[], []], [[], []], [[], []]];
         {
             private _subIndex = _forEachIndex min 1;
             {
-                ((_compatibleMagazines select _index) select _subIndex) pushBackUnique (configName (configFile >> "CfgMagazines" >> _x))
-            } foreach ([getArray (_weaponConfig >> _x >> "magazines"), getArray (_weaponConfig >> "magazines")] select (_x == "this"));
+                ((_compatibleMagazines select _index) select _subIndex) pushBackUnique (configName (_cfgMagazines >> _x))
+            } foreach ([
+                getArray (_weaponConfig >> _x >> "magazines") apply {configName (_cfgMagazines >> _x)},
+                getArray (_weaponConfig >> "magazines") apply {configName (_cfgMagazines >> _x)}
+            ] select (_x == "this"));
 
             // Magazine groups
             {
                 private _magazineGroups = uiNamespace getVariable QGVAR(magazineGroups);
                 private _magArray = _magazineGroups get _x;
                 {((_compatibleMagazines select _index) select _subIndex) pushBackUnique _x} forEach _magArray;
-            } foreach ([getArray (_weaponConfig >> _x >> "magazineWell"), getArray (_weaponConfig >> "magazineWell")] select (_x == "this"));
-
+            } foreach ([
+                getArray (_weaponConfig >> _x >> "magazineWell") apply {configName (_cfgMagazineWells >> _x)},
+                getArray (_weaponConfig >> "magazineWell") apply {configName (_cfgMagazineWells >> _x)}
+            ] select (_x == "this"));
 
         } foreach getArray (_weaponConfig >> "muzzles");
     };

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -89,8 +89,8 @@ private _compatibleMagazines = [[[], []], [[], []], [[], []]];
 
             // Magazine groups
             {
-                private _magazineGroups = uiNamespace getVariable [QGVAR(magazineGroups),["#CBA_HASH#",[],[],[]]];
-                private _magArray = [_magazineGroups, _x] call CBA_fnc_hashGet;
+                private _magazineGroups = uiNamespace getVariable QGVAR(magazineGroups);
+                private _magArray = _magazineGroups get _x;
                 {((_compatibleMagazines select _index) select _subIndex) pushBackUnique _x} forEach _magArray;
             } foreach ([getArray (_weaponConfig >> _x >> "magazineWell"), getArray (_weaponConfig >> "magazineWell")] select (_x == "this"));
 

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -56,7 +56,7 @@ switch (GVAR(currentLeftPanel)) do {
             if ((GVAR(currentItems) select 0) != _item && {_baseWeapon != _item}) then {
                 call _fnc_clearPreviousWepMags;
 
-                private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
+                private _compatibleItems = _item call bis_fnc_compatibleItems;
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
@@ -65,7 +65,7 @@ switch (GVAR(currentLeftPanel)) do {
                 };
 
                 {
-                    if (tolower _x in _compatibleItems || {_x in _compatibleMags}) then {
+                    if (_x in _compatibleItems || {_x in _compatibleMags}) then {
                         GVAR(center) addPrimaryWeaponItem _x;
                     };
                 } foreach (GVAR(currentItems) select 18);
@@ -98,7 +98,7 @@ switch (GVAR(currentLeftPanel)) do {
             if ((GVAR(currentItems) select 2) != _item && {_baseWeapon != _item}) then {
                 call _fnc_clearPreviousWepMags;
 
-                private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
+                private _compatibleItems = _item call bis_fnc_compatibleItems;
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
@@ -107,7 +107,7 @@ switch (GVAR(currentLeftPanel)) do {
                 };
 
                 {
-                    if (tolower _x in _compatibleItems || {_x in _compatibleMags}) then {
+                    if (_x in _compatibleItems || {_x in _compatibleMags}) then {
                         GVAR(center) addHandgunItem _x;
                     };
                 } foreach (GVAR(currentItems) select 20);
@@ -139,7 +139,7 @@ switch (GVAR(currentLeftPanel)) do {
             if ((GVAR(currentItems) select 1) != _item && {_baseWeapon != _item}) then {
                 call _fnc_clearPreviousWepMags;
 
-                private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
+                private _compatibleItems = _item call bis_fnc_compatibleItems;
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
@@ -148,7 +148,7 @@ switch (GVAR(currentLeftPanel)) do {
                 };
 
                 {
-                    if (tolower _x in _compatibleItems || {_x in _compatibleMags}) then {
+                    if (_x in _compatibleItems || {_x in _compatibleMags}) then {
                         GVAR(center) addSecondaryWeaponItem _x;
                     };
                 } foreach (GVAR(currentItems) select 19);

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -28,8 +28,10 @@ private _selectCorrectPanelWeapon = [_weaponDefaultRightPanel, _display displayC
 private _containerDefaultRightPanel = _display displayCtrl IDC_buttonMisc;
 private _selectCorrectPanelContainer = [_containerDefaultRightPanel, _display displayCtrl GVAR(currentRightPanel)] select (!isNil QGVAR(currentRightPanel) && {GVAR(currentRightPanel) in [RIGHT_PANEL_ITEMS_IDCS]});
 
+private _cfgWeapons = configFile >> "CfgWeapons";
+
 private _fnc_clearPreviousWepMags = {
-    private _compatibleMags = getArray (configfile >> "cfgweapons" >> _baseWeapon >> "magazines");
+    private _compatibleMags = getArray (_cfgWeapons >> _baseWeapon >> "magazines");
     {
         GVAR(center) removeMagazines _x;
     } foreach _compatibleMags;
@@ -57,6 +59,7 @@ switch (GVAR(currentLeftPanel)) do {
                 call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = _item call bis_fnc_compatibleItems;
+                _compatibleItems apply {configName (_cfgWeapons >> _x)};
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
@@ -99,6 +102,7 @@ switch (GVAR(currentLeftPanel)) do {
                 call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = _item call bis_fnc_compatibleItems;
+                _compatibleItems apply {configName (_cfgWeapons >> _x)};
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
@@ -140,6 +144,7 @@ switch (GVAR(currentLeftPanel)) do {
                 call _fnc_clearPreviousWepMags;
 
                 private _compatibleItems = _item call bis_fnc_compatibleItems;
+                _compatibleItems apply {configName (_cfgWeapons >> _x)};
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -182,7 +182,7 @@ private _cfgMagazines = configFile >> "CfgMagazines";
         _magList append _magazines;
     } foreach configProperties [_x, "isArray _x", true];
 
-    [_magazineGroups, toLower configName _x, _magList arrayIntersect _magList] call CBA_fnc_hashSet;
+    [_magazineGroups, configName _x, _magList arrayIntersect _magList] call CBA_fnc_hashSet;
 } foreach configProperties [(configFile >> "CfgMagazineWells"), "isClass _x", true];
 
 uiNamespace setVariable [QGVAR(configItems), _cargo];

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -101,15 +101,16 @@ private _configCfgWeapons = configFile >> "CfgWeapons"; //Save this lookup in va
         /* Weapon, at the bottom to avoid adding binos */
         case (isClass (_x >> "WeaponSlotsInfo") &&
             {getNumber (_x >> 'type') != TYPE_BINOCULAR_AND_NVG}): {
+            private _baseWeapon = _className call bis_fnc_baseWeapon;
             switch (getNumber (_x >> "type")) do {
                 case TYPE_WEAPON_PRIMARY: {
-                    (_cargo select 0) select 0 pushBackUnique (_className call bis_fnc_baseWeapon);
+                    (_cargo select 0) select 0 pushBackUnique ([_baseWeapon, _className] select (_className == _baseWeapon));
                 };
                 case TYPE_WEAPON_HANDGUN: {
-                    (_cargo select 0) select 2 pushBackUnique (_className call bis_fnc_baseWeapon);
+                    (_cargo select 0) select 2 pushBackUnique ([_baseWeapon, _className] select (_className == _baseWeapon));
                 };
                 case TYPE_WEAPON_SECONDARY: {
-                    (_cargo select 0) select 1 pushBackUnique (_className call bis_fnc_baseWeapon);
+                    (_cargo select 0) select 1 pushBackUnique ([_baseWeapon, _className] select (_className == _baseWeapon));
                 };
             };
         };

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -141,15 +141,6 @@ private _putList = [];
     private _className = configName _x;
 
     switch true do {
-        // Rifle, handgun, secondary weapons mags
-        case (
-                ((getNumber (_x >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL,TYPE_MAGAZINE_MISSILE]) ||
-                {(getNumber (_x >> QGVAR(hide))) == -1}) &&
-                {!(_className in _grenadeList)} &&
-                {!(_className in _putList)}
-            ): {
-            (_cargo select 2) pushBackUnique _className;
-        };
         // Grenades
         case (_className in _grenadeList): {
             (_cargo select 15) pushBackUnique _className;
@@ -157,6 +148,13 @@ private _putList = [];
         // Put
         case (_className in _putList): {
             (_cargo select 16) pushBackUnique _className;
+        };
+        // Rifle, handgun, secondary weapons mags
+        case (
+                (getNumber (_x >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL,TYPE_MAGAZINE_MISSILE]) ||
+                {getNumber (_x >> QGVAR(hide)) isEqualTo -1}
+            ): {
+            (_cargo select 2) pushBackUnique _className;
         };
     };
 } foreach configProperties [(configFile >> "CfgMagazines"), "isClass _x && {(if (isNumber (_x >> 'scopeArsenal')) then {getNumber (_x >> 'scopeArsenal')} else {getNumber (_x >> 'scope')}) == 2} && {getNumber (_x >> 'ace_arsenal_hide') != 1}", true];

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -151,7 +151,13 @@ private _putList = [];
         };
         // Rifle, handgun, secondary weapons mags
         case (
-                (getNumber (_x >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL,TYPE_MAGAZINE_MISSILE]) ||
+                (getNumber (_x >> "type") in [
+                    TYPE_MAGAZINE_PRIMARY_AND_THROW,
+                    TYPE_MAGAZINE_SECONDARY_AND_PUT,
+                    1536, // Magic number, bad touch
+                    TYPE_MAGAZINE_HANDGUN_AND_GL,
+                    TYPE_MAGAZINE_MISSILE
+                ]) ||
                 {getNumber (_x >> QGVAR(hide)) isEqualTo -1}
             ): {
             (_cargo select 2) pushBackUnique _className;

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -169,7 +169,7 @@ private _putList = [];
     (_cargo select 7) pushBackUnique (configName _x);
 } foreach configProperties [(configFile >> "CfgGlasses"), "isClass _x && {(if (isNumber (_x >> 'scopeArsenal')) then {getNumber (_x >> 'scopeArsenal')} else {getNumber (_x >> 'scope')}) == 2} && {getNumber (_x >> 'ace_arsenal_hide') != 1}", true];
 
-private _magazineGroups = [[],[]] call CBA_fnc_hashCreate;
+private _magazineGroups = createHashMap;
 
 private _cfgMagazines = configFile >> "CfgMagazines";
 
@@ -181,7 +181,7 @@ private _cfgMagazines = configFile >> "CfgMagazines";
         _magList append _magazines;
     } foreach configProperties [_x, "isArray _x", true];
 
-    [_magazineGroups, configName _x, _magList arrayIntersect _magList] call CBA_fnc_hashSet;
+    _magazineGroups set [configName _x, _magList arrayIntersect _magList];
 } foreach configProperties [(configFile >> "CfgMagazineWells"), "isClass _x", true];
 
 uiNamespace setVariable [QGVAR(configItems), _cargo];

--- a/addons/laserpointer/CfgWeapons.hpp
+++ b/addons/laserpointer/CfgWeapons.hpp
@@ -15,6 +15,7 @@ class CfgWeapons {
 
         displayName = CSTRING(red);
         descriptionUse = CSTRING(useLaser);
+        baseWeapon = "acc_pointer_IR";
     };
 
     class ACE_acc_pointer_red: ItemCore {
@@ -29,6 +30,7 @@ class CfgWeapons {
         scope = 1;
         displayName = CSTRING(red);
         descriptionUse = CSTRING(useLaser);
+        baseWeapon = "acc_pointer_IR";
         picture = "\A3\weapons_F\Data\UI\gear_accv_pointer_CA.paa";
         model = "\A3\weapons_f\acc\accv_pointer_F";
         descriptionShort = CSTRING(Description);
@@ -82,6 +84,7 @@ class CfgWeapons {
         _generalMacro = "ACE_acc_pointer_green";
         scope = 1;
         displayName = CSTRING(green);
+        baseWeapon = "ACE_acc_pointer_green";
     };
 
     class ACE_acc_pointer_green: ACE_acc_pointer_red {
@@ -95,5 +98,6 @@ class CfgWeapons {
         _generalMacro = "ACE_acc_pointer_green";
         scope = 2;
         displayName = CSTRING(green);
+        baseWeapon = "ACE_acc_pointer_green";
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Remove excessive use of toLower everywhere.
- Optimize loadout verification macros to use in instead of findIf.
- Prioritize classname casing over baseWeapon casing in case of matching case-insensitive strings.
- Add better support for CBA Accessories.
- Add baseWeapon config property to ACE laser pointers.

Use of toLower on classnames can be troublesome for third-party arsenal hooks, potentially causing duplicate classnames in arrays and other complications. Since all functions used return case-sensitive classnames of items, best to get rid of it. Also faster.

Use of `in` instead of `findIf` greatly reduces stutter when opening loadouts tab on slower CPUs. (Personally went from a 4s freeze to less than a second).

Better support for CBA Accessories via checking attachments' baseWeapon config property when saving loadouts. This'll allow, for example, for a loadout saved with ACE_acc_pointer_green_IR attachment to still be loaded despite having that item having scope = 1, as the loadout will save its baseWeapon property instead.
