### PR TITLE
Interaction Menu/Medical GUI - Add triage colors to icons at passengers list

### DIFF
--- a/addons/interaction/functions/fnc_addPassengersActions.sqf
+++ b/addons/interaction/functions/fnc_addPassengersActions.sqf
@@ -40,7 +40,7 @@ private _actions = [];
             [
                 format ["%1", _unit],
                 [_unit, true] call EFUNC(common,getName),
-                _icon,
+                [_icon, "#FFFFFF"],
                 { 
                     //statement (Run on hover) - reset the cache so we will insert actions immedietly when hovering over new unit
                     TRACE_2("Cleaning Cache",_target,vehicle _target);
@@ -57,7 +57,8 @@ private _actions = [];
                 [_unit],
                 {[0, 0, 0]},
                 2,
-                [false,false,false,true,false] //add run on hover (4th bit true)
+                [false,false,false,true,false], //add run on hover (4th bit true)
+                {call EFUNC(medical_gui,modifyActionTriageLevel)}
                 ] call EFUNC(interact_menu,createAction),
                 [],
                 _unit

--- a/addons/medical_gui/functions/fnc_modifyActionTriageLevel.sqf
+++ b/addons/medical_gui/functions/fnc_modifyActionTriageLevel.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * [cursorObject, player, [], []] call ace_interaction_fnc_modifyActionTriageLevel
+ * [cursorObject, player, [], []] call ace_medical_gui_fnc_modifyActionTriageLevel
  *
  * Public: No
  */


### PR DESCRIPTION
**When merged this pull request will:**
- Add triage colors to icons at passengers list
- Fix header in `fnc_modifyActionTriageLevel.sqf`

There was feature request to add triage colors to passenger names. So there is no need to dig into sub menus to check.
Let's say this is some kind of implementation but with icons color. 