### PR TITLE
DAGR / Kestrel - Fix deviceKey condition

### DIFF
--- a/addons/dagr/CfgVehicles.hpp
+++ b/addons/dagr/CfgVehicles.hpp
@@ -9,7 +9,7 @@ class CfgVehicles {
                     statement = QUOTE(call FUNC(menuInit));
                     showDisabled = 0;
                     icon = QPATHTOF(UI\DAGR_Icon.paa);
-                    exceptions[] = {"isNotInside", "isNotSitting"};
+                    exceptions[] = {"notOnMap", "isNotInside", "isNotSitting"};
                     class GVAR(toggle) {
                         displayName = CSTRING(ToggleDAGR);
                         condition = QUOTE([ARR_2(_player,'ACE_DAGR')] call EFUNC(common,hasItem));

--- a/addons/dagr/initKeybinds.sqf
+++ b/addons/dagr/initKeybinds.sqf
@@ -31,10 +31,11 @@
 
 //Add deviceKey entry:
 private _conditonCode = {
-    ([ACE_player, "ACE_DAGR"] call EFUNC(common,hasItem)) &&
-    {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
+    ([ACE_player, "ACE_DAGR"] call EFUNC(common,hasItem));
 };
 private _toggleCode = {
+    // Conditions: canInteract
+    if !([ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
     // Statement
     [] call FUNC(toggleOverlay);

--- a/addons/dagr/initKeybinds.sqf
+++ b/addons/dagr/initKeybinds.sqf
@@ -31,11 +31,10 @@
 
 //Add deviceKey entry:
 private _conditonCode = {
-    ([ACE_player, "ACE_DAGR"] call EFUNC(common,hasItem));
+    ([ACE_player, "ACE_DAGR"] call EFUNC(common,hasItem)) &&
+    {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
 };
 private _toggleCode = {
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {};
 
     // Statement
     [] call FUNC(toggleOverlay);

--- a/addons/kestrel4500/initKeybinds.sqf
+++ b/addons/kestrel4500/initKeybinds.sqf
@@ -28,10 +28,11 @@
 
 //Add deviceKey entry:
 private _conditonCode = {
-    ([] call FUNC(canShow)) &&
-    {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
+    [] call FUNC(canShow);
 };
 private _toggleCode = {
+    // Conditions: canInteract
+    if !([ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
     // Statement
     if (!GVAR(Overlay)) then {

--- a/addons/kestrel4500/initKeybinds.sqf
+++ b/addons/kestrel4500/initKeybinds.sqf
@@ -28,11 +28,10 @@
 
 //Add deviceKey entry:
 private _conditonCode = {
-    [] call FUNC(canShow);
+    ([] call FUNC(canShow)) &&
+    {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
 };
 private _toggleCode = {
-    // Conditions: canInteract
-    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {};
 
     // Statement
     if (!GVAR(Overlay)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Allow configure DAGR self action to be shown while map is open. Consistency with all other condition checks.
- Close #8272.
- Allow Kestrel to be opened with deviceKey keybind while in a vehicle as well.
