### PR TITLE
Weather - Add more exceptions for checking wind info

### DIFF
--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -4,7 +4,7 @@ GVAR(WindInfo) = false;
 ["ACE3 Common", QGVAR(WindInfoKey), localize LSTRING(WindInfoKeyToggle),
 {
     // Conditions: canInteract
-    if !([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, ACE_player, ["notOnMap", "isNotInside", "isNotSitting", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
     // Statement
     [] call FUNC(displayWindInfo);
@@ -15,7 +15,7 @@ GVAR(WindInfo) = false;
 ["ACE3 Common", QGVAR(WindInfoKey_hold), localize LSTRING(WindInfoKeyHold),
 {
     // Conditions: canInteract
-    if !([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, ACE_player, ["notOnMap", "isNotInside", "isNotSitting", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
     // Statement
     [] call FUNC(displayWindInfo);

--- a/addons/weather/functions/fnc_displayWindInfo.sqf
+++ b/addons/weather/functions/fnc_displayWindInfo.sqf
@@ -35,7 +35,7 @@ TRACE_1("Starting Wind Info PFEH", GVAR(WindInfo));
     disableSerialization;
     params ["", "_pfID"];
 
-    if ((!GVAR(WindInfo)) || {!([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith))}) exitWith {
+    if ((!GVAR(WindInfo)) || {!([ACE_player, ACE_player, ["notOnMap", "isNotInside", "isNotSitting", "isNotSwimming"]] call EFUNC(common,canInteractWith))}) exitWith {
         TRACE_1("Ending Wind Info PFEH", GVAR(WindInfo));
         GVAR(WindInfo) = false;
         (["RscWindIntuitive"] call BIS_fnc_rscLayer) cutText ["", "PLAIN"];


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Doesn't make a lot of sense not being to check wind while sitting on an open helicopter or swimming. Obstacles check still handles occlusion properly.
