### PR TITLE
Medical - Add treatment status events

### DIFF
--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -147,6 +147,8 @@ if (_callbackProgress isEqualTo {}) then {
 
 [_medic, _patient, _bodyPart, _classname, _itemUser, _usedItem] call _callbackStart;
 
+["ace_treatmentStarted", [_medic, _patient, _bodyPart, _classname, _itemUser, _usedItem]] call CBA_fnc_localEvent;
+
 [
     _treatmentTime,
     [_medic, _patient, _bodyPart, _classname, _itemUser, _usedItem],

--- a/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentFailure.sqf
@@ -48,3 +48,5 @@ if (!isNil QEGVAR(advanced_fatigue,setAnimExclusions)) then {
 GET_FUNCTION(_callbackFailure,configFile >> QGVAR(actions) >> _classname >> "callbackFailure");
 
 _args call _callbackFailure;
+
+["ace_treatmentFailed", [_medic, _patient, _bodyPart, _classname, _itemUser, _usedItem]] call CBA_fnc_localEvent;

--- a/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
+++ b/addons/medical_treatment/functions/fnc_treatmentSuccess.sqf
@@ -19,7 +19,7 @@
  */
 
 params ["_args"];
-_args params ["_medic", "_patient", "_bodyPart", "_classname"];
+_args params ["_medic", "_patient", "_bodyPart", "_classname", "_itemUser", "_usedItem"];
 
 // Switch medic to end animation immediately
 private _endInAnim = _medic getVariable QGVAR(endInAnim);
@@ -48,4 +48,4 @@ _args call _callbackSuccess;
 _args call FUNC(createLitter);
 
 // Emit local event for medical API
-["ace_treatmentSucceded", [_medic, _patient, _bodyPart, _classname]] call CBA_fnc_localEvent;
+["ace_treatmentSucceded", [_medic, _patient, _bodyPart, _classname, _itemUser, _usedItem]] call CBA_fnc_localEvent;

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -37,7 +37,9 @@ The vehicle events will also have the following local variables available `_gunn
 |----------|---------|---------|---------|---------|---------|
 |`ace_unconscious` | [_unit, _state(BOOL)] | Global | Listen | Unit's unconscious state changed
 |`ace_placedInBodyBag` | [_target, _bodyBag] | Global | Listen | Target placed into a bodybag Note: (Target will soon be deleted)
+|`ace_treatmentStarted` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action is completed (local on the _caller)
 |`ace_treatmentSucceded` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action is completed (local on the _caller)
+|`ace_treatmentFailed` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action is completed (local on the _caller)
 
 ### 2.3 Interaction Menu (`ace_interact_menu`)
 MenuType: 0 = Interaction, 1 = Self Interaction

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -37,7 +37,7 @@ The vehicle events will also have the following local variables available `_gunn
 |----------|---------|---------|---------|---------|---------|
 |`ace_unconscious` | [_unit, _state(BOOL)] | Global | Listen | Unit's unconscious state changed
 |`ace_placedInBodyBag` | [_target, _bodyBag] | Global | Listen | Target placed into a bodybag Note: (Target will soon be deleted)
-|`ace_treatmentSucceded` | [_caller, _target, _selectionName, _className] | Local | Listen | Treatment action is completed (local on the _caller)
+|`ace_treatmentSucceded` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action is completed (local on the _caller)
 
 ### 2.3 Interaction Menu (`ace_interact_menu`)
 MenuType: 0 = Interaction, 1 = Self Interaction


### PR DESCRIPTION
Adds
- `ace_medical_treatment_treatmentStartedLocal`
- `ace_medical_treatment_treatmentSucceededLocal`, and
- `ace_medical_treatment_treatmentFailedLocal`
CBA events. All of them have the same six parameters passed unchanged from the treatment action:
`_medic`, `_patient`, `_bodyPart`, `_classname`, `_itemUser`, `_usedItem`.

Rationale:
I've been trying to write a ShackTac-style medical extension without forking ACE. When trying to add a "PlayerName is bandaging you"/"You are being assisted" hint, I've been stopped by the following drawbacks in existing `ace_medical_treatment_{TREATMENT}Local` (e.g. `ace_medical_treatment_bandageLocal`) events:
1) They are not a single convenient entry point;
2) They do not carry a `_medic` parameter.

[Here's an example of someone else trying to do this kind of hint with the existing API](https://github.com/fparma/fparma-mods/blob/6ffd86e17be98b4474f12fac453c21b1a73d322d/addons/common/XEH_postInitClient.sqf#L47-L53). I think this PR would improve the situation.

Existing "ace_treatmentSucceded" event seems grandfathered in from before the medical rewrite, so I'm leaving it alone.