### PR TITLE
Captives - Disallow ACRE/TFAR radio usage on surrender/handcuff

### DIFF
--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -41,6 +41,7 @@ if ((_unit getVariable [QGVAR(isHandcuffed), false]) isEqualTo _state) exitWith 
 if (_state) then {
     _unit setVariable [QGVAR(isHandcuffed), true, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
+    [_unit, "blockRadio", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
 
     if (_unit getVariable [QGVAR(isSurrendering), false]) then {  //If surrendering, stop
         [_unit, false] call FUNC(setSurrendered);
@@ -81,6 +82,7 @@ if (_state) then {
 } else {
     _unit setVariable [QGVAR(isHandcuffed), false, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), false] call EFUNC(common,statusEffect_set);
+    [_unit, "blockRadio", QGVAR(Handcuffed), false] call EFUNC(common,statusEffect_set);
 
     //remove AnimChanged EH
     private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];

--- a/addons/captives/functions/fnc_setSurrendered.sqf
+++ b/addons/captives/functions/fnc_setSurrendered.sqf
@@ -45,6 +45,7 @@ if (_state) then {
     _unit setVariable [QGVAR(isSurrendering), true, true];
 
     [_unit, "setCaptive", QGVAR(Surrendered), true] call EFUNC(common,statusEffect_set);
+    [_unit, "blockRadio", QGVAR(Surrendered), true] call EFUNC(common,statusEffect_set);
 
     if (_unit == ACE_player) then {
         ["captive", [false, false, false, false, false, false, false, false, false, true]] call EFUNC(common,showHud);
@@ -71,6 +72,7 @@ if (_state) then {
 } else {
     _unit setVariable [QGVAR(isSurrendering), false, true];
     [_unit, "setCaptive", QGVAR(Surrendered), false] call EFUNC(common,statusEffect_set);
+    [_unit, "blockRadio", QGVAR(Surrendered), false] call EFUNC(common,statusEffect_set);
 
     //remove AnimChanged EH
     private _animChangedEHID = _unit getVariable [QGVAR(surrenderAnimEHID), -1];

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -26,6 +26,7 @@
 ["blockEngine", false, ["ACE_Refuel"]] call FUNC(statusEffect_addType);
 ["blockThrow", false, ["ACE_Attach", "ACE_concertina_wire", "ACE_dragging", "ACE_Explosives", "ACE_Ladder", "ACE_rearm", "ACE_refuel", "ACE_Sandbag", "ACE_Trenches", "ACE_tripod"]] call FUNC(statusEffect_addType);
 ["setHidden", true, ["ace_unconscious"]] call FUNC(statusEffect_addType);
+["blockRadio", false, [QEGVAR(captives,Handcuffed), QEGVAR(captives,Surrendered), "ace_unconscious"]] call FUNC(statusEffect_addType);
 
 [QGVAR(forceWalk), {
     params ["_object", "_set"];
@@ -69,6 +70,16 @@
         _vis = _object getVariable [QGVAR(oldVisibility), _vis];
         _object setUnitTrait ["camouflageCoef", _vis];
     };
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(blockRadio), {
+    params ["_object", "_set"]
+    TRACE_2("blockRadio EH",_object,_set);
+    if (_object isEqualTo ACE_Player && {_set > 0}) then {
+        call FUNC(endRadioTransmission);
+    };
+    _object setVariable ["tf_unable_to_use_radio", _set > 0, true];
+    _object setVariable ["acre_sys_core_isDisabled", _set > 0, true];
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(blockDamage), { //Name reversed from `allowDamage` because we want NOR logic

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -73,7 +73,7 @@
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(blockRadio), {
-    params ["_object", "_set"]
+    params ["_object", "_set"];
     TRACE_2("blockRadio EH",_object,_set);
     if (_object isEqualTo ACE_Player && {_set > 0}) then {
         call FUNC(endRadioTransmission);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -78,8 +78,12 @@
     if (_object isEqualTo ACE_Player && {_set > 0}) then {
         call FUNC(endRadioTransmission);
     };
-    _object setVariable ["tf_unable_to_use_radio", _set > 0, true];
-    _object setVariable ["acre_sys_core_isDisabled", _set > 0, true];
+    if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
+        _object setVariable ["tf_unable_to_use_radio", _set > 0, true];
+    };
+    if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {
+        _object setVariable ["acre_sys_core_isDisabled", _set > 0, true];
+    };
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(blockDamage), { //Name reversed from `allowDamage` because we want NOR logic

--- a/addons/common/functions/fnc_setVolume.sqf
+++ b/addons/common/functions/fnc_setVolume.sqf
@@ -33,11 +33,9 @@ if (_setVolume) then {
     // TFAR
     _unit setVariable ["tf_voiceVolume", NORMAL_LEVEL, true];
     _unit setVariable ["tf_globalVolume", NORMAL_LEVEL];
-    _unit setVariable ["tf_unable_to_use_radio", false];
 
     // ACRE2
     if (!isNil "acre_api_fnc_setGlobalVolume") then { [NORMAL_LEVEL^0.33] call acre_api_fnc_setGlobalVolume; };
-    _unit setVariable ["acre_sys_core_isDisabled", false, true];
 
 } else {
     // Vanilla Game
@@ -46,9 +44,7 @@ if (_setVolume) then {
     // TFAR
     _unit setVariable ["tf_voiceVolume", NO_SOUND, true];
     _unit setVariable ["tf_globalVolume", MUTED_LEVEL];
-    _unit setVariable ["tf_unable_to_use_radio", true];
 
     // ACRE2
     if (!isNil "acre_api_fnc_setGlobalVolume") then { [MUTED_LEVEL^0.33] call acre_api_fnc_setGlobalVolume; };
-    _unit setVariable ["acre_sys_core_isDisabled", true, true];
 };

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -31,6 +31,9 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Stop AI firing at unconscious units in most situations (global effect)
 [_unit, "setHidden", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
 
+// Block radio on unconsciousness for compatibility with captive module
+[_unit, "blockRadio", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
+
 if (_active) then {
     // Don't bother setting this if not used
     if (EGVAR(medical,spontaneousWakeUpChance) > 0) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Supersedes #4334.
- Remove setting of master radio control variable from common_fnc_setVolume.

If it's still necessary to have setVolume control radio transmission allowance, I can edit that to call the status effect instead.