### PR TITLE
WIP - Ballistics - Cleanup magazines and magazineWells

### DIFF
--- a/addons/ballistics/CfgMagazineWells.hpp
+++ b/addons/ballistics/CfgMagazineWells.hpp
@@ -155,15 +155,16 @@ class CfgMagazineWells {
             "ACE_10Rnd_338_API526_Mag",
             "ACE_20Rnd_762x67_Mk248_Mod_0_Mag",
             "ACE_20Rnd_762x67_Mk248_Mod_1_Mag",
-            "ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag"
+            "ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag",
+            "ACE_10Rnd_762x67_Mk248_Mod_0_Mag",
+            "ACE_10Rnd_762x67_Mk248_Mod_1_Mag",
+            "ACE_10Rnd_762x67_Berger_Hybrid_OTM_Mag"
         };
     };
 
     class CBA_65C_AR10 {
         ADDON[] = {
-            "ACE_30Rnd_65_Creedmor_mag",
             "ACE_20Rnd_65_Creedmor_mag",
-            "ACE_30Rnd_65x47_Scenar_mag",
             "ACE_20Rnd_65x47_Scenar_mag"
         };
     };
@@ -174,11 +175,19 @@ class CfgMagazineWells {
         };
     };
 
-    class CBA_50BMG_M107 {
+    class CBA_50BMG_AS50 {
         ADDON[] = {
             "ACE_5Rnd_127x99_Mag",
             "ACE_5Rnd_127x99_API_Mag",
             "ACE_5Rnd_127x99_AMAX_Mag"
+        };
+    };
+
+    class CBA_50BMG_M107 {
+        ADDON[] = {
+            "ACE_10Rnd_127x99_Mag",
+            "ACE_10Rnd_127x99_API_Mag",
+            "ACE_10Rnd_127x99_AMAX_Mag"
         };
     };
 

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -260,6 +260,8 @@ class CfgMagazines {
         initSpeed = 827;
     };
 
+    class 10Rnd_Mk14_762x51_Mag;
+
     class 10Rnd_762x51_Mag: 20Rnd_762x51_Mag {
         initSpeed = 833;
     };
@@ -298,7 +300,7 @@ class CfgMagazines {
         initSpeed = 330;
     };
 
-    class ACE_10Rnd_762x51_M118LR_Mag: 10Rnd_762x51_Mag {
+    class ACE_10Rnd_762x51_M118LR_Mag: 10Rnd_Mk14_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_M118LR";
         count = 10;
@@ -308,7 +310,7 @@ class CfgMagazines {
         initSpeed = 780;
     };
 
-    class ACE_10Rnd_762x51_Mk316_Mod_0_Mag: 10Rnd_762x51_Mag {
+    class ACE_10Rnd_762x51_Mk316_Mod_0_Mag: 10Rnd_Mk14_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_Mk316_Mod_0";
         count = 10;
@@ -318,7 +320,7 @@ class CfgMagazines {
         initSpeed = 790;
     };
 
-    class ACE_10Rnd_762x51_Mk319_Mod_0_Mag: 10Rnd_762x51_Mag {
+    class ACE_10Rnd_762x51_Mk319_Mod_0_Mag: 10Rnd_Mk14_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_Mk319_Mod_0";
         count = 10;
@@ -328,7 +330,7 @@ class CfgMagazines {
         initSpeed = 900;
     };
 
-    class ACE_10Rnd_762x51_M993_AP_Mag: 10Rnd_762x51_Mag {
+    class ACE_10Rnd_762x51_M993_AP_Mag: 10Rnd_Mk14_762x51_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "ACE_762x51_Ball_M993_AP";
         count = 10;
@@ -374,33 +376,6 @@ class CfgMagazines {
         displayNameShort = CSTRING(20Rnd_762x51_M993_AP_Mag_NameShort);
         descriptionShort = CSTRING(20Rnd_762x51_M993_AP_Mag_Description);
         initSpeed = 930;
-    };
-
-    class ACE_20Rnd_762x67_Mk248_Mod_0_Mag: 20Rnd_762x51_Mag {
-        author = ECSTRING(common,ACETeam);
-        ammo = "ACE_762x67_Ball_Mk248_Mod_0";
-        displayName = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_Name);
-        displayNameShort = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_NameShort);
-        descriptionShort = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_Description);
-        initSpeed = 865;
-    };
-
-    class ACE_20Rnd_762x67_Mk248_Mod_1_Mag: 20Rnd_762x51_Mag {
-        author = ECSTRING(common,ACETeam);
-        ammo = "ACE_762x67_Ball_Mk248_Mod_1";
-        displayName = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_Name);
-        displayNameShort = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_NameShort);
-        descriptionShort = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_Description);
-        initSpeed = 847;
-    };
-
-    class ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag: 20Rnd_762x51_Mag {
-        author = ECSTRING(common,ACETeam);
-        ammo = "ACE_762x67_Ball_Berger_Hybrid_OTM";
-        displayName = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_Name);
-        displayNameShort = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_NameShort);
-        descriptionShort = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_Description);
-        initSpeed = 800;
     };
 
     class ACE_30Rnd_65x47_Scenar_mag: 30Rnd_65x39_caseless_mag {
@@ -461,6 +436,69 @@ class CfgMagazines {
         initSpeed = 880;
     };
 
+    class ACE_20Rnd_762x67_Mk248_Mod_0_Mag: 10Rnd_338_Mag {
+        author = ECSTRING(common,ACETeam);
+        ammo = "ACE_762x67_Ball_Mk248_Mod_0";
+        count = 20;
+        scope = 1; // backwards compatibility only
+        mass = 28; // 10Rnd_338_Mag mass * 2
+        displayName = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_Name);
+        displayNameShort = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_NameShort);
+        descriptionShort = CSTRING(20Rnd_762x67_Mk248_Mod_0_Mag_Description);
+        initSpeed = 865;
+    };
+
+    class ACE_20Rnd_762x67_Mk248_Mod_1_Mag: 10Rnd_338_Mag {
+        author = ECSTRING(common,ACETeam);
+        ammo = "ACE_762x67_Ball_Mk248_Mod_1";
+        count = 20;
+        scope = 1;
+        mass = 28;
+        displayName = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_Name);
+        displayNameShort = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_NameShort);
+        descriptionShort = CSTRING(20Rnd_762x67_Mk248_Mod_1_Mag_Description);
+        initSpeed = 847;
+    };
+
+    class ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag: 10Rnd_338_Mag {
+        author = ECSTRING(common,ACETeam);
+        ammo = "ACE_762x67_Ball_Berger_Hybrid_OTM";
+        count = 20;
+        scope = 1;
+        mass = 28;
+        displayName = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_Name);
+        displayNameShort = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_NameShort);
+        descriptionShort = CSTRING(20Rnd_762x67_Berger_Hybrid_OTM_Mag_Description);
+        initSpeed = 800;
+    };
+
+    class ACE_10Rnd_762x67_Mk248_Mod_0_Mag: ACE_20Rnd_762x67_Mk248_Mod_0_Mag {
+        scope = 2;
+        count = 10;
+        mass = 14; // same as 10Rnd_338_Mag
+        displayName = CSTRING(10Rnd_762x67_Mk248_Mod_0_Mag_Name);
+        displayNameShort = CSTRING(10Rnd_762x67_Mk248_Mod_0_Mag_NameShort);
+        descriptionShort = CSTRING(10Rnd_762x67_Mk248_Mod_0_Mag_Description);
+    };
+
+    class ACE_10Rnd_762x67_Mk248_Mod_1_Mag: ACE_20Rnd_762x67_Mk248_Mod_1_Mag {
+        scope = 2;
+        count = 10;
+        mass = 14;
+        displayName = CSTRING(10Rnd_762x67_Mk248_Mod_1_Mag_Name);
+        displayNameShort = CSTRING(10Rnd_762x67_Mk248_Mod_1_Mag_NameShort);
+        descriptionShort = CSTRING(10Rnd_762x67_Mk248_Mod_1_Mag_Description);
+    };
+
+    class ACE_10Rnd_762x67_Berger_Hybrid_OTM_Mag: ACE_20Rnd_762x67_Berger_Hybrid_OTM_Mag {
+        scope = 2;
+        count = 10;
+        mass = 14;
+        displayName = CSTRING(10Rnd_762x67_Berger_Hybrid_OTM_Mag_Name);
+        displayNameShort = CSTRING(10Rnd_762x67_Berger_Hybrid_OTM_Mag_NameShort);
+        descriptionShort = CSTRING(10Rnd_762x67_Berger_Hybrid_OTM_Mag_Description);
+    };
+
     class 7Rnd_408_Mag: CA_Magazine {
         initSpeed = 867;
     };
@@ -504,6 +542,30 @@ class CfgMagazines {
         displayNameShort = CSTRING(5Rnd_127x99_AMAX_Mag_NameShort);
         descriptionShort = CSTRING(5Rnd_127x99_AMAX_Mag_Description);
         initSpeed = 860;
+    };
+
+    class ACE_10Rnd_127x99_Mag: ACE_5Rnd_127x99_Mag {
+        count = 10;
+        mass = 32; // 5Rnd_127x108_Mag mass * 2
+        displayName = CSTRING(5Rnd_127x99_Mag_Name);
+        displayNameShort = CSTRING(5Rnd_127x99_Mag_NameShort);
+        descriptionShort = CSTRING(5Rnd_127x99_Mag_Description);
+    };
+
+    class ACE_10Rnd_127x99_API_Mag: ACE_5Rnd_127x99_API_Mag {
+        count = 10;
+        mass = 32;
+        displayName = CSTRING(5Rnd_127x99_API_Mag_Name);
+        displayNameShort = CSTRING(5Rnd_127x99_API_Mag_NameShort);
+        descriptionShort = CSTRING(5Rnd_127x99_API_Mag_Description);
+    };
+
+    class ACE_10Rnd_127x99_AMAX_Mag: ACE_5Rnd_127x99_AMAX_Mag {
+        count = 10;
+        mass = 32;
+        displayName = CSTRING(5Rnd_127x99_AMAX_Mag_Name);
+        displayNameShort = CSTRING(5Rnd_127x99_AMAX_Mag_NameShort);
+        descriptionShort = CSTRING(5Rnd_127x99_AMAX_Mag_Description);
     };
 
     class 30Rnd_9x21_Mag: CA_Magazine {

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -13,7 +13,7 @@ class CfgWeapons {
         ACE_barrelTwist = 381.0;
         initSpeed = -1.0;
         magazineWell[] += {
-            "CBA_50BMG_M107"
+            "CBA_50BMG_AS50"
         }; // empty in vanilla
     };
 

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -1116,7 +1116,7 @@
             <Spanish>Calibre: .338 Norma Magnum trazadora&lt;br /&gt;Balas: 130&lt;br /&gt;Se usa en: SPMG</Spanish>
             <Russian>Калибр: .338 Norma Magnum трассирующие&lt;br /&gt;Патронов: 130&lt;br /&gt;Используются в: SPMG</Russian>
             <Italian>Calibro: .338 Norma Magnum Tracciante&lt;br /&gt;Munizioni: 130&lt;br /&gt;In uso su: SPMG</Italian>
-            <Czech>Ráže: .338 Noma Magnum Svítící&lt;br /&gt;Nábojů: 130&lt;br /&gt;Použití u: LWMMG</Czech>
+            <Czech>Ráže: .338 Norma Magnum Svítící&lt;br /&gt;Nábojů: 130&lt;br /&gt;Použití u: LWMMG</Czech>
             <Portuguese>Calibre: .338 Norma Magnum Traçante&lt;br /&gt;Cartuchos: 130&lt;br /&gt;Usado em: SPMG</Portuguese>
             <Hungarian>Kaliber: .338 Norma Magnum nyomkövető&lt;br /&gt;Lövedékek: 130&lt;br /&gt;Használható: SPMG</Hungarian>
             <Japanese>口径: .338 Norma Magnum 曳光弾&lt;br /&gt;装填数: 130&lt;br /&gt;次で使用: SPMG</Japanese>
@@ -1144,7 +1144,7 @@
         </Key>
         <Key ID="STR_ACE_Ballistics_130Rnd_338_Mag_Tracer_DimNameShort">
             <English>.338 NM IR-DIM</English>
-            <German>.338 LM IR-DIM</German>
+            <German>.338 NM IR-DIM</German>
             <Polish>.338 NM IR-DIM</Polish>
             <Czech>.338 NM IR-DIM</Czech>
             <French>.338 NM IR-DIM</French>
@@ -2301,157 +2301,157 @@
             <Turkish>Kalibre: 7.62x51mm NATO (M993 AP)&lt;br /&gt;Mermi: 20</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Mk248_Mod_0_Mag_Name">
-            <English>7.62mm 20Rnd Mag (Mk248 Mod 0)</English>
-            <Polish>Magazynek 7,62mm 20rd (Mk248 Mod 0)</Polish>
-            <French>Ch. 7,62mm 20Cps (Mk248 Mod 0)</French>
-            <Spanish>Cargador de 20 balas de 7.62mm (Mk248 Mod 0)</Spanish>
-            <Russian>Магазин из 20-ти 7,62 мм (Mk248 Mod 0)</Russian>
-            <German>7,62mm 20-Patronen-Magazin (Mk248 Mod 0)</German>
-            <Italian>7.62mm 20Rnd Mag (Mk248 Mod 0)</Italian>
-            <Czech>7.62mm 20náb. Zásobník (Mk248 Mod 0)</Czech>
-            <Portuguese>Carregador 7.62mm com 20 cartuchos (Mk248 Mod 0)</Portuguese>
-            <Hungarian>7,62mm 20-lövedékes tár (Mk248 Mod 0)</Hungarian>
-            <Japanese>7.62mm 20発入り 弾倉 (Mk248 Mod 0)</Japanese>
-            <Korean>20발들이 7.62mm 탄창 (Mk248 Mod 0)</Korean>
-            <Chinese>7.62毫米 20發 彈匣 (Mk248 Mod 0 狙擊專用彈)</Chinese>
-            <Chinesesimp>7.62mm 20发 弹匣 (Mk248 Mod 0 狙击专用弹)</Chinesesimp>
-            <Turkish>7.62mm 20Rnd Mag (Mk248 Mod 0)</Turkish>
+            <English>.300 WM 20Rnd Mag (Mk248 Mod 0)</English>
+            <Polish>Magazynek .300 WM 20rd (Mk248 Mod 0)</Polish>
+            <French>Ch. .300 WM 20Cps (Mk248 Mod 0)</French>
+            <Spanish>Cargador de 20 balas de .300 WM (Mk248 Mod 0)</Spanish>
+            <Russian>Магазин из 20-ти .300 WM (Mk248 Mod 0)</Russian>
+            <German>.300 WM 20-Patronen-Magazin (Mk248 Mod 0)</German>
+            <Italian>.300 WM 20Rnd Mag (Mk248 Mod 0)</Italian>
+            <Czech>.300 WM 20náb. Zásobník (Mk248 Mod 0)</Czech>
+            <Portuguese>Carregador .300 WM com 20 cartuchos (Mk248 Mod 0)</Portuguese>
+            <Hungarian>.300 WM 20-lövedékes tár (Mk248 Mod 0)</Hungarian>
+            <Japanese>.300 WM 20発入り 弾倉 (Mk248 Mod 0)</Japanese>
+            <Korean>20발들이 .300 WM 탄창 (Mk248 Mod 0)</Korean>
+            <Chinese>.300 萬能(WM) 20發 彈匣 (Mk248 Mod 0 狙擊專用彈)</Chinese>
+            <Chinesesimp>.300 WM 20发 弹匣 (Mk248 Mod 0 狙击专用弹)</Chinesesimp>
+            <Turkish>.300 WM 20Rnd Mag (Mk248 Mod 0)</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Mk248_Mod_0_Mag_NameShort">
-            <English>7.62mm Mk248</English>
-            <Polish>7,62mm Mk248</Polish>
-            <French>7,62mm Mk248</French>
-            <Spanish>7.62mm Mk248</Spanish>
-            <Russian>7,62 мм Mk248</Russian>
-            <German>7,62mm Mk248</German>
-            <Italian>7.62mm Mk248</Italian>
-            <Czech>7.62mm Mk248</Czech>
-            <Portuguese>7.62mm Mk248</Portuguese>
-            <Hungarian>7,62mm Mk248</Hungarian>
-            <Japanese>7.62mm Mk248</Japanese>
-            <Korean>7.62mm Mk248</Korean>
-            <Chinese>7.62毫米 Mk248 狙擊專用彈</Chinese>
-            <Chinesesimp>7.62mm Mk248 狙击专用弹</Chinesesimp>
-            <Turkish>7.62mm Mk248</Turkish>
+            <English>.300 WM Mk248</English>
+            <Polish>.300 WM Mk248</Polish>
+            <French>.300 WM Mk248</French>
+            <Spanish>.300 WM Mk248</Spanish>
+            <Russian>.300 WM Mk248</Russian>
+            <German>.300 WM Mk248</German>
+            <Italian>.300 WM Mk248</Italian>
+            <Czech>.300 WM Mk248</Czech>
+            <Portuguese>.300 WM Mk248</Portuguese>
+            <Hungarian>.300 WM Mk248</Hungarian>
+            <Japanese>.300 WM Mk248</Japanese>
+            <Korean>.300 WM Mk248</Korean>
+            <Chinese>.300 西米 Mk248 狙擊專用彈</Chinese>
+            <Chinesesimp>.300 WM Mk248 狙击专用弹</Chinesesimp>
+            <Turkish>.300 WM Mk248</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Mk248_Mod_0_Mag_Description">
-            <English>Caliber: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Rounds: 20</English>
-            <Polish>Kaliber: 7,62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Pociski: 20</Polish>
-            <French>Calibre: 7,62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Cartouches: 20</French>
-            <Spanish>Calibre: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
-            <Russian>Калибр: 7,62x67 мм NATO (Mk248 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7,62x51mm NATO (Mk248 Mod 0)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x67 mm NATO (Mk248 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
-            <Czech>Ráže: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Nábojů: 20</Czech>
-            <Portuguese>Calibre: 7.26x67mm NATO (Mk248 Mod 0)&lt;br/&gt;Cartuchos: 20</Portuguese>
-            <Hungarian>Kaliber: 7,62x51mm NATO (Mk248 Mod 0)&lt;br /&gt;Lövedékek: 20</Hungarian>
-            <Japanese>口径: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;装填数: 20</Japanese>
-            <Korean>구경: 7.62x51mm NATO (Mk248 Mod 0)&lt;br /&gt;장탄수: 20</Korean>
-            <Chinese>口徑: 7.62x67毫米 NATO標準 (Mk248 Mod 0 狙擊專用彈)&lt;br /&gt;發數: 20</Chinese>
-            <Chinesesimp>口径: 7.62x67mm NATO标准 (Mk248 Mod 0 狙击专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
-            <Turkish>Kalibre: 7.62x67mm NATO (Mk248 Mod 0)&lt;br /&gt;Mermi: 20</Turkish>
+            <English>Caliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Rounds: 20</English>
+            <Polish>Kaliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Pociski: 20</Polish>
+            <French>Calibre: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Cartouches: 20</French>
+            <Spanish>Calibre: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Balas: 20</Spanish>
+            <Russian>Калибр: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Патронов: 20</Russian>
+            <German>Kaliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Patronen: 20</German>
+            <Italian>Calibro: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Munizioni: 20</Italian>
+            <Czech>Ráže: .300 WM (Mk248 Mod 0)&lt;br /&gt;Nábojů: 20</Czech>
+            <Portuguese>Calibre: .300 WM NATO (Mk248 Mod 0)&lt;br/&gt;Cartuchos: 20</Portuguese>
+            <Hungarian>Kaliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Lövedékek: 20</Hungarian>
+            <Japanese>口径: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;装填数: 20</Japanese>
+            <Korean>구경: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;장탄수: 20</Korean>
+            <Chinese>口徑: .300 西米 NATO標準 (Mk248 Mod 0 狙擊專用彈)&lt;br /&gt;發數: 20</Chinese>
+            <Chinesesimp>口径: .300 WM NATO标准 (Mk248 Mod 0 狙击专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
+            <Turkish>Kalibre: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Mermi: 20</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Mk248_Mod_1_Mag_Name">
-            <English>7.62mm 20Rnd Mag (Mk248 Mod 1)</English>
-            <Polish>Magazynek 7,62mm 20rd (Mk248 Mod 1)</Polish>
-            <French>Ch. 7,62mm 20Cps (Mk248 Mod 1)</French>
-            <Spanish>Cargador de 20 balas de 7.62mm (Mk248 Mod 1)</Spanish>
-            <Russian>Магазин из 20-ти 7,62 мм (Mk248 Mod 1)</Russian>
-            <German>7,62mm 20-Patronen-Magazin (Mk248 Mod 1)</German>
-            <Italian>7.62mm 20Rnd Mag (Mk248 Mod 1)</Italian>
-            <Czech>7.62mm 20náb. Zásobník (Mk248 Mod 1)</Czech>
-            <Portuguese>Carregador 7.62mm com 20 cartuchos (Mk248 Mod 1)</Portuguese>
-            <Hungarian>7,62mm 20-lövedékes tár (Mk248 Mod 1)</Hungarian>
-            <Japanese>7.62mm 20発入り 弾倉 (Mk248 Mod 1)</Japanese>
-            <Korean>20발들이 7.62mm 탄창 (Mk248 Mod 1)</Korean>
-            <Chinese>7.62毫米 20發 彈匣 (Mk248 Mod 1 狙擊專用彈)</Chinese>
-            <Chinesesimp>7.62mm 20发 弹匣 (Mk248 Mod 1 狙击专用弹)</Chinesesimp>
-            <Turkish>7.62mm 20Rnd Mag (Mk248 Mod 1)</Turkish>
+            <English>.300 WM 20Rnd Mag (Mk248 Mod 1)</English>
+            <Polish>Magazynek .300 WM 20rd (Mk248 Mod 1)</Polish>
+            <French>Ch. .300 WM 20Cps (Mk248 Mod 1)</French>
+            <Spanish>Cargador de 20 balas de .300 WM (Mk248 Mod 1)</Spanish>
+            <Russian>Магазин из 20-ти .300 WM (Mk248 Mod 1)</Russian>
+            <German>.300 WM 20-Patronen-Magazin (Mk248 Mod 1)</German>
+            <Italian>.300 WM 20Rnd Mag (Mk248 Mod 1)</Italian>
+            <Czech>.300 WM 20náb. Zásobník (Mk248 Mod 1)</Czech>
+            <Portuguese>Carregador .300 WM com 20 cartuchos (Mk248 Mod 1)</Portuguese>
+            <Hungarian>.300 WM 20-lövedékes tár (Mk248 Mod 1)</Hungarian>
+            <Japanese>.300 WM 20発入り 弾倉 (Mk248 Mod 1)</Japanese>
+            <Korean>20발들이 .300 WM 탄창 (Mk248 Mod 1)</Korean>
+            <Chinese>.300 西米 20發 彈匣 (Mk248 Mod 1 狙擊專用彈)</Chinese>
+            <Chinesesimp>.300 WM 20发 弹匣 (Mk248 Mod 1 狙击专用弹)</Chinesesimp>
+            <Turkish>.300 WM 20Rnd Mag (Mk248 Mod 1)</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Mk248_Mod_1_Mag_NameShort">
-            <English>7.62mm Mk248</English>
-            <Polish>7,62mm Mk248</Polish>
-            <French>7,62mm Mk248</French>
-            <Spanish>7.62mm Mk248</Spanish>
-            <Russian>7,62 мм Mk248</Russian>
-            <German>7,62mm Mk248</German>
-            <Italian>7.62mm Mk248</Italian>
-            <Czech>7.62mm Mk248</Czech>
-            <Portuguese>7.62mm Mk248</Portuguese>
-            <Hungarian>7,62mm Mk248</Hungarian>
-            <Japanese>7.62mm Mk248</Japanese>
-            <Korean>7.62mm Mk248</Korean>
-            <Chinese>7.62毫米 Mk248 狙擊專用彈</Chinese>
-            <Chinesesimp>7.62mm Mk248 狙击专用弹</Chinesesimp>
-            <Turkish>7.62mm Mk248</Turkish>
+            <English>.300 WM Mk248</English>
+            <Polish>.300 WM Mk248</Polish>
+            <French>.300 WM Mk248</French>
+            <Spanish>.300 WM Mk248</Spanish>
+            <Russian>.300 WM Mk248</Russian>
+            <German>.300 WM Mk248</German>
+            <Italian>.300 WM Mk248</Italian>
+            <Czech>.300 WM Mk248</Czech>
+            <Portuguese>.300 WM Mk248</Portuguese>
+            <Hungarian>.300 WM Mk248</Hungarian>
+            <Japanese>.300 WM Mk248</Japanese>
+            <Korean>.300 WM Mk248</Korean>
+            <Chinese>.300 西米 Mk248 狙擊專用彈</Chinese>
+            <Chinesesimp>.300 WM Mk248 狙击专用弹</Chinesesimp>
+            <Turkish>.300 WM Mk248</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Mk248_Mod_1_Mag_Description">
-            <English>Caliber: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Rounds: 20</English>
-            <Polish>Kaliber: 7,62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Pociski: 20</Polish>
-            <French>Calibre: 7,62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Cartouches: 20</French>
-            <Spanish>Calibre: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Balas: 20</Spanish>
-            <Russian>Калибр: 7,62x67 мм NATO (Mk248 Mod 1)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7,62x51mm NATO (Mk248 Mod 1)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x67 mm NATO (Mk248 Mod 1)&lt;br /&gt;Munizioni: 20</Italian>
-            <Czech>Ráže: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Nábojů: 20</Czech>
-            <Portuguese>Calibre: 7.26x67mm NATO (Mk248 Mod 1)&lt;br/&gt;Cartuchos: 20</Portuguese>
-            <Hungarian>Kaliber: 7,62x51mm NATO (Mk248 Mod 1)&lt;br /&gt;Lövedékek: 20</Hungarian>
-            <Japanese>口径: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;装填数: 20</Japanese>
-            <Korean>구경: 7.62x51mm NATO (Mk248 Mod 1)&lt;br /&gt;장탄수: 20</Korean>
-            <Chinese>口徑: 7.62x67毫米 NATO標準 (Mk248 Mod 1 狙擊專用彈)&lt;br /&gt;發數: 20</Chinese>
-            <Chinesesimp>口径: 7.62x67mm NATO标准 (Mk248 Mod 1 狙击专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
-            <Turkish>Kalibre: 7.62x67mm NATO (Mk248 Mod 1)&lt;br /&gt;Mermi: 20</Turkish>
+            <English>Caliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Rounds: 20</English>
+            <Polish>Kaliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Pociski: 20</Polish>
+            <French>Calibre: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Cartouches: 20</French>
+            <Spanish>Calibre: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Balas: 20</Spanish>
+            <Russian>Калибр: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Патронов: 20</Russian>
+            <German>Kaliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Patronen: 20</German>
+            <Italian>Calibro: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Munizioni: 20</Italian>
+            <Czech>Ráže: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Nábojů: 20</Czech>
+            <Portuguese>Calibre: .300 WM NATO (Mk248 Mod 1)&lt;br/&gt;Cartuchos: 20</Portuguese>
+            <Hungarian>Kaliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Lövedékek: 20</Hungarian>
+            <Japanese>口径: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;装填数: 20</Japanese>
+            <Korean>구경: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;장탄수: 20</Korean>
+            <Chinese>口徑: .300 西米 NATO標準 (Mk248 Mod 1 狙擊專用彈)&lt;br /&gt;發數: 20</Chinese>
+            <Chinesesimp>口径: .300 WM NATO标准 (Mk248 Mod 1 狙击专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
+            <Turkish>Kalibre: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Mermi: 20</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Berger_Hybrid_OTM_Mag_Name">
-            <English>7.62mm 20Rnd Mag (Berger Hybrid OTM)</English>
-            <Polish>Magazynek 7,62mm 20rd (Berger Hybrid OTM)</Polish>
-            <French>Ch. 7,62 20Cps (Berger Hybrid OTM)</French>
-            <Spanish>Cargador de 20 balas de 7.62mm (Berger Hybrid OTM)</Spanish>
-            <Russian>Магазин из 20-ти 7,62 мм (Berger Hybrid OTM)</Russian>
-            <German>7,62mm 20-Patronen-Magazin (Berger Hybrid OTM)</German>
-            <Italian>7.62mm 20Rnd Mag (Berger Hybrid OTM)</Italian>
-            <Czech>7.62mm 20náb. Zásobník (Berger Hybrid OTM)</Czech>
-            <Portuguese>Carregador 7.62mm com 20 cartuchos (Berger Hybrid OTM)</Portuguese>
-            <Hungarian>7,62mm 20-lövedékes tár (Berger Hybrid OTM)</Hungarian>
-            <Japanese>7.62mm 20発入り 弾倉 (Berger Hybrid OTM)</Japanese>
-            <Korean>20발들이 7.62mm 탄창 (Berger Hybrid OTM)</Korean>
-            <Chinese>7.62毫米 20發 彈匣 (Berger Hybrid 空尖比賽專用彈)</Chinese>
-            <Chinesesimp>7.62mm 20发 弹匣 (Berger Hybrid 空尖比赛专用弹)</Chinesesimp>
-            <Turkish>7.62mm 20Rnd Mag (Berger Hybrid OTM)</Turkish>
+            <English>.300 WM 20Rnd Mag (Berger Hybrid OTM)</English>
+            <Polish>Magazynek .300 WM 20rd (Berger Hybrid OTM)</Polish>
+            <French>Ch. .300 WM 20Cps (Berger Hybrid OTM)</French>
+            <Spanish>Cargador de 20 balas de .300 WM (Berger Hybrid OTM)</Spanish>
+            <Russian>Магазин из 20-ти .300 WM (Berger Hybrid OTM)</Russian>
+            <German>.300 WM 20-Patronen-Magazin (Berger Hybrid OTM)</German>
+            <Italian>.300 WM 20Rnd Mag (Berger Hybrid OTM)</Italian>
+            <Czech>.300 WM 20náb. Zásobník (Berger Hybrid OTM)</Czech>
+            <Portuguese>Carregador .300 WM com 20 cartuchos (Berger Hybrid OTM)</Portuguese>
+            <Hungarian>.300 WM 20-lövedékes tár (Berger Hybrid OTM)</Hungarian>
+            <Japanese>.300 WM 20発入り 弾倉 (Berger Hybrid OTM)</Japanese>
+            <Korean>20발들이 .300 WM 탄창 (Berger Hybrid OTM)</Korean>
+            <Chinese>.300 西米 20發 彈匣 (Berger Hybrid 空尖比賽專用彈)</Chinese>
+            <Chinesesimp>.300 WM 20发 弹匣 (Berger Hybrid 空尖比赛专用弹)</Chinesesimp>
+            <Turkish>.300 WM 20Rnd Mag (Berger Hybrid OTM)</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Berger_Hybrid_OTM_Mag_NameShort">
-            <English>7.62mm OTM</English>
-            <Polish>7,62mm OTM</Polish>
-            <French>7,62mm OTM</French>
-            <Spanish>7.62mm OTM</Spanish>
-            <Russian>7,62 мм OTM</Russian>
-            <German>7,62mm OTM</German>
-            <Italian>7.62mm OTM</Italian>
-            <Czech>7.62mm OTM</Czech>
-            <Portuguese>7.62mm OTM</Portuguese>
-            <Hungarian>7,62mm OTM</Hungarian>
-            <Japanese>7.62mm OTM</Japanese>
-            <Korean>7.62mm OTM</Korean>
-            <Chinese>7.62毫米  空尖比賽專用彈</Chinese>
-            <Chinesesimp>7.62mm 空尖比赛专用弹</Chinesesimp>
-            <Turkish>7.62mm OTM</Turkish>
+            <English>.300 WM OTM</English>
+            <Polish>.300 WM OTM</Polish>
+            <French>.300 WM OTM</French>
+            <Spanish>.300 WM OTM</Spanish>
+            <Russian>.300 WM OTM</Russian>
+            <German>.300 WM OTM</German>
+            <Italian>.300 WM OTM</Italian>
+            <Czech>.300 WM OTM</Czech>
+            <Portuguese>.300 WM OTM</Portuguese>
+            <Hungarian>.300 WM OTM</Hungarian>
+            <Japanese>.300 WM OTM</Japanese>
+            <Korean>.300 WM OTM</Korean>
+            <Chinese>.300 西米  空尖比賽專用彈</Chinese>
+            <Chinesesimp>.300 WM 空尖比赛专用弹</Chinesesimp>
+            <Turkish>.300 WM OTM</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_20Rnd_762x67_Berger_Hybrid_OTM_Mag_Description">
-            <English>Caliber: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Rounds: 20</English>
-            <Polish>Kaliber: 7,62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Pociski: 20</Polish>
-            <French>Calibre: 7,62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Cartouches: 20</French>
-            <Spanish>Calibre: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Balas: 20</Spanish>
-            <Russian>Калибр: 7,62x67 мм NATO (Berger Hybrid OTM)&lt;br /&gt;Патронов: 20</Russian>
-            <German>Kaliber: 7,62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Patronen: 20</German>
-            <Italian>Calibro: 7.62x67 mm NATO (Berger Hybrid OTM)&lt;br /&gt;Munizioni: 20</Italian>
-            <Czech>Ráže: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Nábojů: 20</Czech>
-            <Portuguese>Calibre: 7.26x67mm NATO (Berger Hybrid OTM)&lt;br/&gt;Cartuchos: 20</Portuguese>
-            <Hungarian>Kaliber: 7,62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Lövedékek: 20</Hungarian>
-            <Japanese>口径: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;装填数: 20</Japanese>
-            <Korean>구경: 7.62x51mm NATO (Berger Hybrid OTM)&lt;br /&gt;장탄수: 20</Korean>
-            <Chinese>口徑: 7.62x67毫米 NATO標準 (Berger Hybrid 空尖比賽專用彈)&lt;br /&gt;發數: 20</Chinese>
-            <Chinesesimp>口径: 7.62x67mm NATO标准 (Berger Hybrid 空尖比赛专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
-            <Turkish>Kalibre: 7.62x67mm NATO (Berger Hybrid OTM)&lt;br /&gt;Mermi: 20</Turkish>
+            <English>Caliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Rounds: 20</English>
+            <Polish>Kaliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Pociski: 20</Polish>
+            <French>Calibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Cartouches: 20</French>
+            <Spanish>Calibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Balas: 20</Spanish>
+            <Russian>Калибр: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Патронов: 20</Russian>
+            <German>Kaliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Patronen: 20</German>
+            <Italian>Calibro: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Munizioni: 20</Italian>
+            <Czech>Ráže: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Nábojů: 20</Czech>
+            <Portuguese>Calibre: .300 WM OTM NATO (Berger Hybrid OTM)&lt;br/&gt;Cartuchos: 20</Portuguese>
+            <Hungarian>Kaliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Lövedékek: 20</Hungarian>
+            <Japanese>口径: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;装填数: 20</Japanese>
+            <Korean>구경: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;장탄수: 20</Korean>
+            <Chinese>口徑: .300 西米 NATO標準 (Berger Hybrid 空尖比賽專用彈)&lt;br /&gt;發數: 20</Chinese>
+            <Chinesesimp>口径: .300 WM NATO标准 (Berger Hybrid 空尖比赛专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
+            <Turkish>Kalibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Mermi: 20</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_30Rnd_65x47_Scenar_mag_Name">
             <English>6.5x47mm 30Rnd Mag (HPBT Scenar)</English>

--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -2453,6 +2453,159 @@
             <Chinesesimp>口径: .300 WM NATO标准 (Berger Hybrid 空尖比赛专用弹)&lt;br /&gt;发数: 20</Chinesesimp>
             <Turkish>Kalibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Mermi: 20</Turkish>
         </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Mk248_Mod_0_Mag_Name">
+            <English>.300 WM 10Rnd Mag (Mk248 Mod 0)</English>
+            <Polish>Magazynek .300 WM 10rd (Mk248 Mod 0)</Polish>
+            <French>Ch. .300 WM 10Cps (Mk248 Mod 0)</French>
+            <Spanish>Cargador de 10 balas de .300 WM (Mk248 Mod 0)</Spanish>
+            <Russian>Магазин из 10-ти .300 WM (Mk248 Mod 0)</Russian>
+            <German>.300 WM 10-Patronen-Magazin (Mk248 Mod 0)</German>
+            <Italian>.300 WM 10Rnd Mag (Mk248 Mod 0)</Italian>
+            <Czech>.300 WM 10náb. Zásobník (Mk248 Mod 0)</Czech>
+            <Portuguese>Carregador .300 WM com 10 cartuchos (Mk248 Mod 0)</Portuguese>
+            <Hungarian>.300 WM 10-lövedékes tár (Mk248 Mod 0)</Hungarian>
+            <Japanese>.300 WM 10発入り 弾倉 (Mk248 Mod 0)</Japanese>
+            <Korean>10발들이 .300 WM 탄창 (Mk248 Mod 0)</Korean>
+            <Chinese>.300 萬能(WM) 10發 彈匣 (Mk248 Mod 0 狙擊專用彈)</Chinese>
+            <Chinesesimp>.300 WM 10发 弹匣 (Mk248 Mod 0 狙击专用弹)</Chinesesimp>
+            <Turkish>.300 WM 10Rnd Mag (Mk248 Mod 0)</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Mk248_Mod_0_Mag_NameShort">
+            <English>.300 WM Mk248</English>
+            <Polish>.300 WM Mk248</Polish>
+            <French>.300 WM Mk248</French>
+            <Spanish>.300 WM Mk248</Spanish>
+            <Russian>.300 WM Mk248</Russian>
+            <German>.300 WM Mk248</German>
+            <Italian>.300 WM Mk248</Italian>
+            <Czech>.300 WM Mk248</Czech>
+            <Portuguese>.300 WM Mk248</Portuguese>
+            <Hungarian>.300 WM Mk248</Hungarian>
+            <Japanese>.300 WM Mk248</Japanese>
+            <Korean>.300 WM Mk248</Korean>
+            <Chinese>.300 西米 Mk248 狙擊專用彈</Chinese>
+            <Chinesesimp>.300 WM Mk248 狙击专用弹</Chinesesimp>
+            <Turkish>.300 WM Mk248</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Mk248_Mod_0_Mag_Description">
+            <English>Caliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Rounds: 10</English>
+            <Polish>Kaliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Pociski: 10</Polish>
+            <French>Calibre: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Cartouches: 10</French>
+            <Spanish>Calibre: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Balas: 10</Spanish>
+            <Russian>Калибр: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Патронов: 10</Russian>
+            <German>Kaliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Patronen: 10</German>
+            <Italian>Calibro: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Munizioni: 10</Italian>
+            <Czech>Ráže: .300 WM (Mk248 Mod 0)&lt;br /&gt;Nábojů: 10</Czech>
+            <Portuguese>Calibre: .300 WM NATO (Mk248 Mod 0)&lt;br/&gt;Cartuchos: 10</Portuguese>
+            <Hungarian>Kaliber: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Lövedékek: 10</Hungarian>
+            <Japanese>口径: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;装填数: 10</Japanese>
+            <Korean>구경: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;장탄수: 10</Korean>
+            <Chinese>口徑: .300 西米 NATO標準 (Mk248 Mod 0 狙擊專用彈)&lt;br /&gt;發數: 10</Chinese>
+            <Chinesesimp>口径: .300 WM NATO标准 (Mk248 Mod 0 狙击专用弹)&lt;br /&gt;发数: 10</Chinesesimp>
+            <Turkish>Kalibre: .300 WM NATO (Mk248 Mod 0)&lt;br /&gt;Mermi: 10</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Mk248_Mod_1_Mag_Name">
+            <English>.300 WM 10Rnd Mag (Mk248 Mod 1)</English>
+            <Polish>Magazynek .300 WM 10rd (Mk248 Mod 1)</Polish>
+            <French>Ch. .300 WM 10Cps (Mk248 Mod 1)</French>
+            <Spanish>Cargador de 10 balas de .300 WM (Mk248 Mod 1)</Spanish>
+            <Russian>Магазин из 10-ти .300 WM (Mk248 Mod 1)</Russian>
+            <German>.300 WM 10-Patronen-Magazin (Mk248 Mod 1)</German>
+            <Italian>.300 WM 10Rnd Mag (Mk248 Mod 1)</Italian>
+            <Czech>.300 WM 10náb. Zásobník (Mk248 Mod 1)</Czech>
+            <Portuguese>Carregador .300 WM com 10 cartuchos (Mk248 Mod 1)</Portuguese>
+            <Hungarian>.300 WM 10-lövedékes tár (Mk248 Mod 1)</Hungarian>
+            <Japanese>.300 WM 10発入り 弾倉 (Mk248 Mod 1)</Japanese>
+            <Korean>10발들이 .300 WM 탄창 (Mk248 Mod 1)</Korean>
+            <Chinese>.300 西米 10發 彈匣 (Mk248 Mod 1 狙擊專用彈)</Chinese>
+            <Chinesesimp>.300 WM 10发 弹匣 (Mk248 Mod 1 狙击专用弹)</Chinesesimp>
+            <Turkish>.300 WM 10Rnd Mag (Mk248 Mod 1)</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Mk248_Mod_1_Mag_NameShort">
+            <English>.300 WM Mk248</English>
+            <Polish>.300 WM Mk248</Polish>
+            <French>.300 WM Mk248</French>
+            <Spanish>.300 WM Mk248</Spanish>
+            <Russian>.300 WM Mk248</Russian>
+            <German>.300 WM Mk248</German>
+            <Italian>.300 WM Mk248</Italian>
+            <Czech>.300 WM Mk248</Czech>
+            <Portuguese>.300 WM Mk248</Portuguese>
+            <Hungarian>.300 WM Mk248</Hungarian>
+            <Japanese>.300 WM Mk248</Japanese>
+            <Korean>.300 WM Mk248</Korean>
+            <Chinese>.300 西米 Mk248 狙擊專用彈</Chinese>
+            <Chinesesimp>.300 WM Mk248 狙击专用弹</Chinesesimp>
+            <Turkish>.300 WM Mk248</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Mk248_Mod_1_Mag_Description">
+            <English>Caliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Rounds: 10</English>
+            <Polish>Kaliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Pociski: 10</Polish>
+            <French>Calibre: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Cartouches: 10</French>
+            <Spanish>Calibre: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Balas: 10</Spanish>
+            <Russian>Калибр: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Патронов: 10</Russian>
+            <German>Kaliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Patronen: 10</German>
+            <Italian>Calibro: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Munizioni: 10</Italian>
+            <Czech>Ráže: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Nábojů: 10</Czech>
+            <Portuguese>Calibre: .300 WM NATO (Mk248 Mod 1)&lt;br/&gt;Cartuchos: 10</Portuguese>
+            <Hungarian>Kaliber: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Lövedékek: 10</Hungarian>
+            <Japanese>口径: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;装填数: 10</Japanese>
+            <Korean>구경: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;장탄수: 10</Korean>
+            <Chinese>口徑: .300 西米 NATO標準 (Mk248 Mod 1 狙擊專用彈)&lt;br /&gt;發數: 10</Chinese>
+            <Chinesesimp>口径: .300 WM NATO标准 (Mk248 Mod 1 狙击专用弹)&lt;br /&gt;发数: 10</Chinesesimp>
+            <Turkish>Kalibre: .300 WM NATO (Mk248 Mod 1)&lt;br /&gt;Mermi: 10</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Berger_Hybrid_OTM_Mag_Name">
+            <English>.300 WM 10Rnd Mag (Berger Hybrid OTM)</English>
+            <Polish>Magazynek .300 WM 10rd (Berger Hybrid OTM)</Polish>
+            <French>Ch. .300 WM 10Cps (Berger Hybrid OTM)</French>
+            <Spanish>Cargador de 10 balas de .300 WM (Berger Hybrid OTM)</Spanish>
+            <Russian>Магазин из 10-ти .300 WM (Berger Hybrid OTM)</Russian>
+            <German>.300 WM 10-Patronen-Magazin (Berger Hybrid OTM)</German>
+            <Italian>.300 WM 10Rnd Mag (Berger Hybrid OTM)</Italian>
+            <Czech>.300 WM 10náb. Zásobník (Berger Hybrid OTM)</Czech>
+            <Portuguese>Carregador .300 WM com 10 cartuchos (Berger Hybrid OTM)</Portuguese>
+            <Hungarian>.300 WM 10-lövedékes tár (Berger Hybrid OTM)</Hungarian>
+            <Japanese>.300 WM 10発入り 弾倉 (Berger Hybrid OTM)</Japanese>
+            <Korean>10발들이 .300 WM 탄창 (Berger Hybrid OTM)</Korean>
+            <Chinese>.300 西米 10發 彈匣 (Berger Hybrid 空尖比賽專用彈)</Chinese>
+            <Chinesesimp>.300 WM 10发 弹匣 (Berger Hybrid 空尖比赛专用弹)</Chinesesimp>
+            <Turkish>.300 WM 10Rnd Mag (Berger Hybrid OTM)</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Berger_Hybrid_OTM_Mag_NameShort">
+            <English>.300 WM OTM</English>
+            <Polish>.300 WM OTM</Polish>
+            <French>.300 WM OTM</French>
+            <Spanish>.300 WM OTM</Spanish>
+            <Russian>.300 WM OTM</Russian>
+            <German>.300 WM OTM</German>
+            <Italian>.300 WM OTM</Italian>
+            <Czech>.300 WM OTM</Czech>
+            <Portuguese>.300 WM OTM</Portuguese>
+            <Hungarian>.300 WM OTM</Hungarian>
+            <Japanese>.300 WM OTM</Japanese>
+            <Korean>.300 WM OTM</Korean>
+            <Chinese>.300 西米  空尖比賽專用彈</Chinese>
+            <Chinesesimp>.300 WM 空尖比赛专用弹</Chinesesimp>
+            <Turkish>.300 WM OTM</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Ballistics_10Rnd_762x67_Berger_Hybrid_OTM_Mag_Description">
+            <English>Caliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Rounds: 10</English>
+            <Polish>Kaliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Pociski: 10</Polish>
+            <French>Calibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Cartouches: 10</French>
+            <Spanish>Calibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Balas: 10</Spanish>
+            <Russian>Калибр: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Патронов: 10</Russian>
+            <German>Kaliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Patronen: 10</German>
+            <Italian>Calibro: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Munizioni: 10</Italian>
+            <Czech>Ráže: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Nábojů: 10</Czech>
+            <Portuguese>Calibre: .300 WM OTM NATO (Berger Hybrid OTM)&lt;br/&gt;Cartuchos: 10</Portuguese>
+            <Hungarian>Kaliber: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Lövedékek: 10</Hungarian>
+            <Japanese>口径: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;装填数: 10</Japanese>
+            <Korean>구경: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;장탄수: 10</Korean>
+            <Chinese>口徑: .300 西米 NATO標準 (Berger Hybrid 空尖比賽專用彈)&lt;br /&gt;發數: 10</Chinese>
+            <Chinesesimp>口径: .300 WM NATO标准 (Berger Hybrid 空尖比赛专用弹)&lt;br /&gt;发数: 10</Chinesesimp>
+            <Turkish>Kalibre: .300 WM NATO (Berger Hybrid OTM)&lt;br /&gt;Mermi: 10</Turkish>
+        </Key>
         <Key ID="STR_ACE_Ballistics_30Rnd_65x47_Scenar_mag_Name">
             <English>6.5x47mm 30Rnd Mag (HPBT Scenar)</English>
             <French>Ch. 6,5x47mm 30Cps (HPBT Scenar)</French>


### PR DESCRIPTION
**When merged this pull request will:**
- Change base class of ACE 10Rnd 7.62x51 magazines to use Contact added 10Rnd Mk14 magazine with new model and icon.
- Switch GM6 Lynx magazine well from M107 to AS50. GM6 Lynx uses single stack magazines, M107 uses double stack.
- Remove 30Rnd MX 6.5 Creedmoor magazines from CBA 6.5C AR10 magazine well. MX magazines won't fit the average AR-10.
- Close #8355 by changing base class of ACE .300 WM magazines and adding new 10Rnd magazines.
- Add 10Rnd .50BMG magazines for the CBA_M107 magazine well.

TODO:

- [ ] Add color variants for MX magazines

- [ ] Remove 6.5 creedmoor magazines from MX series OR

- [ ] Add 6.5 creedmoor for Katiba/MSBS series
