### PR TITLE
Attach - Add child options

### DIFF
--- a/addons/attach/CfgVehicles.hpp
+++ b/addons/attach/CfgVehicles.hpp
@@ -105,6 +105,267 @@ class CfgVehicles {
         destrType = "DestructNo";
         brightness = 10;
     };
+    class ACE_IR_Strobe_one_Effect: All {
+        scope = 1;
+        displayName = "IR Strobe";
+        model = "\A3\Weapons_F\empty.p3d";
+        simulation = "nvmarker";
+
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.45;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {1,0.1};
+        };
+
+        side = 7;//-1=NO_SIDE yellow box,3=CIV grey box,4=NEUTRAL yellow box,6=FRIENDLY green box,7=LOGIC no radar signature
+        accuracy = 1000;
+        cost = 0;
+        armor = 500;
+        threat[] = {0,0,0};
+        nameSound = "";
+        type = 0;
+        weapons[] = {};
+        magazines[] = {};
+        nvTarget = 1;
+        destrType = "DestructNo";
+        brightness = 10;
+    };
+    class ACE_IR_Strobe_one_medium_Effect:ACE_IR_Strobe_one_Effect{
+        brightness = 6;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.1;
+            name = "pozicni blik";
+            activeLight = 1;
+            blinking=1;
+            dayLight = 1;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {1,0.1};
+        };
+    };
+    class ACE_IR_Strobe_one_low_Effect:ACE_IR_Strobe_one_Effect{
+        brightness = 2;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.05;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {1,0.1};
+        };
+    };
+    
+    class ACE_IR_Strobe_two_Effect: All {
+        scope = 1;
+        displayName = "IR Strobe";
+        model = "\A3\Weapons_F\empty.p3d";
+        simulation = "nvmarker";
+
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.45;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {1,0.1,0.1,0.1};
+        };
+
+        side = 7;//-1=NO_SIDE yellow box,3=CIV grey box,4=NEUTRAL yellow box,6=FRIENDLY green box,7=LOGIC no radar signature
+        accuracy = 1000;
+        cost = 0;
+        armor = 500;
+        threat[] = {0,0,0};
+        nameSound = "";
+        type = 0;
+        weapons[] = {};
+        magazines[] = {};
+        nvTarget = 1;
+        destrType = "DestructNo";
+        brightness = 10;
+    };
+    class ACE_IR_Strobe_two_medium_Effect:ACE_IR_Strobe_two_Effect{
+        brightness = 6;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.1;
+            name = "pozicni blik";
+            activeLight = 1;
+            blinking=1;
+            dayLight = 1;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {1,0.1,0.1,0.1};
+        };
+    };
+    class ACE_IR_Strobe_two_low_Effect:ACE_IR_Strobe_two_Effect{
+        brightness = 2;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.05;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {1,0.1,0.1,0.1};
+        };
+    };
+
+    
+    class ACE_IR_Strobe_three_Effect: All {
+        scope = 1;
+        displayName = "IR Strobe";
+        model = "\A3\Weapons_F\empty.p3d";
+        simulation = "nvmarker";
+
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.45;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {0.7,0.2,0.7,0.1,0.1,0.1};
+        };
+
+        side = 7;//-1=NO_SIDE yellow box,3=CIV grey box,4=NEUTRAL yellow box,6=FRIENDLY green box,7=LOGIC no radar signature
+        accuracy = 1000;
+        cost = 0;
+        armor = 500;
+        threat[] = {0,0,0};
+        nameSound = "";
+        type = 0;
+        weapons[] = {};
+        magazines[] = {};
+        nvTarget = 1;
+        destrType = "DestructNo";
+        brightness = 10;
+    };
+
+    class ACE_IR_Strobe_three_medium_Effect:ACE_IR_Strobe_three_Effect {
+        brightness = 6;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.1;
+            name = "pozicni blik";
+            activeLight = 1;
+            blinking=1;
+            dayLight = 1;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {0.7,0.2,0.7,0.1,0.1,0.1};
+        };
+    };
+
+    class ACE_IR_Strobe_three_low_Effect: ACE_IR_Strobe_three_Effect {
+        brightness = 2;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.05;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {0.7,0.2,0.7,0.1,0.1,0.1};
+        };
+    };
+
+    
+
+    
+    class ACE_IR_Strobe_four_Effect: All {
+        scope = 1;
+        displayName = "IR Strobe";
+        model = "\A3\Weapons_F\empty.p3d";
+        simulation = "nvmarker";
+
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.45;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {0.7,0.2,0.7,0.2,0.7,0.1,0.1,0.1};
+        };
+
+        side = 7;//-1=NO_SIDE yellow box,3=CIV grey box,4=NEUTRAL yellow box,6=FRIENDLY green box,7=LOGIC no radar signature
+        accuracy = 1000;
+        cost = 0;
+        armor = 500;
+        threat[] = {0,0,0};
+        nameSound = "";
+        type = 0;
+        weapons[] = {};
+        magazines[] = {};
+        nvTarget = 1;
+        destrType = "DestructNo";
+        brightness = 10;
+    };
+
+    class ACE_IR_Strobe_four_medium_Effect:ACE_IR_Strobe_four_Effect {
+        brightness = 6;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.1;
+            name = "pozicni blik";
+            activeLight = 1;
+            blinking=1;
+            dayLight = 1;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {0.7,0.2,0.7,0.2,0.7,0.1,0.1,0.1};
+        };
+    };
+
+    class ACE_IR_Strobe_four_low_Effect: ACE_IR_Strobe_four_Effect {
+        brightness = 2;
+        class NVGMarker {
+            diffuse[]={0.015,0.015,0.015};
+            ambient[]={0.001,0.001,0.001};
+            brightness=0.05;
+            name = "pozicni blik";
+            activeLight = 0;
+            blinking=1;
+            dayLight = 0;
+            onlyInNvg = 1;
+            useFlare = 0;
+            blinkingPattern[] = {0.7,0.2,0.7,0.2,0.7,0.1,0.1,0.1};
+        };
+    };
+
+    
 
     class NATO_Box_Base;
     class Box_NATO_Support_F: NATO_Box_Base {

--- a/addons/attach/CfgWeapons.hpp
+++ b/addons/attach/CfgWeapons.hpp
@@ -2,17 +2,92 @@ class CfgWeapons {
     class ACE_ItemCore;
     class CBA_MiscItem_ItemInfo;
 
-    class ACE_IR_Strobe_Item: ACE_ItemCore {
-        ACE_attachable = "ACE_IR_Strobe_Effect";
+    class ACE_IR_Strobe_Base: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
-        scope = 2;
+        scope = 1;
         displayName = CSTRING(IrStrobe_Name);
         descriptionShort = CSTRING(IrStrobe_Description);
         model = QPATHTOF(data\ace_IRStrobe.p3d);
         picture = QPATHTOF(UI\irstrobe_item.paa);
-
+        ACE_AttachToLocation[] = {{-0.05,-0.2,0.2}, "head"};
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
+        ACE_ItemUsed = "ACE_IR_Strobe_Item";
+
+    };
+    class ACE_IR_Strobe_Item: ACE_IR_Strobe_Base {
+        ACE_attachable_children[] = {"ACE_IR_Strobe_Item_One", "ACE_IR_Strobe_Item_Two","ACE_IR_Strobe_Item_Three","ACE_IR_Strobe_Item_Four"};
+        // ACE_attachable_children[] = {"ACE_IR_Strobe_Item_One"};
+        ACE_attachable = "ACE_IR_Strobe_one_Effect";
+        scope = 2;
+    };
+    class ACE_IR_Strobe_Item_One : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 1";
+        ACE_attachable_children[] = { "ACE_IR_Strobe_Item_One_High","ACE_IR_Strobe_Item_One_Medium","ACE_IR_Strobe_Item_One_Low"};
+        ACE_attachable = "ACE_IR_Strobe_one_Effect";
+    };
+    class ACE_IR_Strobe_Item_One_High : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 1 - High";
+        ACE_attachable = "ACE_IR_Strobe_one_Effect";
+    };
+    class ACE_IR_Strobe_Item_One_Medium : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 1 - Medium";
+        ACE_attachable = "ACE_IR_Strobe_one_medium_Effect";
+    };
+    class ACE_IR_Strobe_Item_One_Low : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 1 - Low";
+        ACE_attachable = "ACE_IR_Strobe_one_low_Effect";
+    };
+    class ACE_IR_Strobe_Item_Two : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 2";
+        ACE_attachable_children[] = {"ACE_IR_Strobe_Item_Two_High","ACE_IR_Strobe_Item_Two_Medium","ACE_IR_Strobe_Item_Two_Low"};
+        ACE_attachable = "ACE_IR_Strobe_two_Effect";
+    };
+    class ACE_IR_Strobe_Item_Two_High : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 2 - High";
+        ACE_attachable = "ACE_IR_Strobe_two_Effect";
+    };
+    class ACE_IR_Strobe_Item_Two_Medium : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 2 - Medium";
+        ACE_attachable = "ACE_IR_Strobe_two_medium_Effect";
+    };
+    class ACE_IR_Strobe_Item_Two_Low : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 2 - Low";
+        ACE_attachable = "ACE_IR_Strobe_two_low_Effect";
+    };
+    class ACE_IR_Strobe_Item_Three : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 3";
+        ACE_attachable_children[] = {"ACE_IR_Strobe_Item_Three_High","ACE_IR_Strobe_Item_Three_Medium","ACE_IR_Strobe_Item_Three_Low"};
+        ACE_attachable = "ACE_IR_Strobe_three_Effect";
+    };
+    class ACE_IR_Strobe_Item_Three_High : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 3 - High";
+        ACE_attachable = "ACE_IR_Strobe_three_Effect";
+    };
+    class ACE_IR_Strobe_Item_Three_Medium : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 3 - Medium";
+        ACE_attachable = "ACE_IR_Strobe_three_medium_Effect";
+    };
+    class ACE_IR_Strobe_Item_Three_Low : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 3 - Low";
+        ACE_attachable = "ACE_IR_Strobe_three_low_Effect";
+    };
+    class ACE_IR_Strobe_Item_Four : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 3";
+        ACE_attachable_children[] = {"ACE_IR_Strobe_Item_Four_High","ACE_IR_Strobe_Item_Four_Medium","ACE_IR_Strobe_Item_Four_Low"};
+        ACE_attachable = "ACE_IR_Strobe_four_Effect";
+    };
+    class ACE_IR_Strobe_Item_Four_High : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 4 - High";
+        ACE_attachable = "ACE_IR_Strobe_four_Effect";
+    };
+    class ACE_IR_Strobe_Item_Four_Medium : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 4 - Medium";
+        ACE_attachable = "ACE_IR_Strobe_four_medium_Effect";
+    };
+    class ACE_IR_Strobe_Item_Four_Low : ACE_IR_Strobe_Base{
+        selectName = "IR Mode 4 - Low";
+        ACE_attachable = "ACE_IR_Strobe_four_low_Effect";
     };
 };

--- a/addons/attach/XEH_PREP.hpp
+++ b/addons/attach/XEH_PREP.hpp
@@ -7,3 +7,4 @@ PREP(handleGetIn);
 PREP(handleGetOut);
 PREP(handleKilled);
 PREP(placeApprove);
+PREP(getSubChildrenActions);

--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -26,21 +26,37 @@ if ((_itemClassname == "") || {(!_silentScripted) && {!(_this call FUNC(canAttac
 
 private _itemVehClass = getText (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_Attachable");
 private _onAttachText = getText (configFile >> "CfgWeapons" >> _itemClassname >> "displayName");
+private _attachToLocation = getArray (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_AttachToLocation");
 
 if (_itemVehClass == "") then {
     _itemVehClass = getText (configFile >> "CfgMagazines" >> _itemClassname >> "ACE_Attachable");
     _onAttachText = getText (configFile >> "CfgMagazines" >> _itemClassname >> "displayName");
+    _attachToLocation = getArray (configFile >> "CfgMagazines" >> _itemClassname >> "ACE_AttachToLocation");
 };
-
+if (_attachToLocation isEqualTo []) then {
+    _attachToLocation = [[0.05, -0.09, 0.1],"leftshoulder"];
+};
+_coords = _attachToLocation select 0;
+_bone = _attachToLocation select 1;
 if (_itemVehClass == "") exitWith {ERROR("no ACE_Attachable for Item");};
 
 private _onAttachText = format [localize LSTRING(Item_Attached), _onAttachText];
 
+
+private _itemUsedClass = getText (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_ItemUsed");
+
+if (_itemUsedClass == "") then {
+    _itemUsedClass = getText (configFile >> "CfgMagazines" >> _itemClassname >> "ACE_ItemUsed");
+};
+
 if (_unit == _attachToVehicle) then {  //Self Attachment
     private _attachedItem = _itemVehClass createVehicle [0,0,0];
-    _attachedItem attachTo [_unit, [0.05, -0.09, 0.1], "leftshoulder"];
+    _attachedItem attachTo [_unit, _coords, _bone, true];
     if (!_silentScripted) then {
-        _unit removeItem _itemClassname;  // Remove item
+        if (_itemUsedClass != "") then {
+            _itemClassname = _itemUsedClass;
+        };
+        _unit removeItem _itemClassname;
         [_onAttachText, 2] call EFUNC(common,displayTextStructured);
     };
     _unit setVariable [QGVAR(attached), [[_attachedItem, _itemClassname]], true];

--- a/addons/attach/functions/fnc_canAttach.sqf
+++ b/addons/attach/functions/fnc_canAttach.sqf
@@ -23,9 +23,11 @@ TRACE_3("params",_attachToVehicle,_player,_itemClassname);
 
 private _attachLimit = [6, 1] select (_player == _attachToVehicle);
 private _attachedObjects = _attachToVehicle getVariable [QGVAR(attached), []];
+private _itemUsedClass = getText (configFile >> "CfgWeapons" >> _itemName >> "ACE_ItemUsed");
 
-((_player == _attachToVehicle) || {canStand _player}) &&
-{(_attachToVehicle distance _player) < 10} &&
-{alive _attachToVehicle} &&
-{(count _attachedObjects) < _attachLimit} &&
-{_itemClassname in ((itemsWithMagazines _player) + [""])};
+if (_itemUsedClass == "") then {
+    _itemUsedClass = getText (configFile >> "CfgMagazines" >> _itemName >> "ACE_ItemUsed");
+};
+_canAttach = false;
+_canAttach =( ((_player == _attachToVehicle) || {canStand _player}) && {(_attachToVehicle distance _player) < 10} && {alive _attachToVehicle} && {(count _attachedObjects) < _attachLimit} && {(_itemClassname in ((itemsWithMagazines _player) + [""])) || (_itemUsedClass in ((itemsWithMagazines _player) + [""])) });
+_canAttach

--- a/addons/attach/functions/fnc_detach.sqf
+++ b/addons/attach/functions/fnc_detach.sqf
@@ -45,6 +45,15 @@ if (isNull _attachedObject || {_itemName == ""}) exitWith {ERROR("Could not find
 // Check if item is a chemlight
 private _isChemlight = _attachedObject isKindOf "Chemlight_base";
 
+// check if attached item is created from another itemCargo
+
+
+private _itemUsedClass = getText (configFile >> "CfgWeapons" >> _itemName >> "ACE_ItemUsed");
+
+if (_itemUsedClass == "") then {
+    _itemUsedClass = getText (configFile >> "CfgMagazines" >> _itemName >> "ACE_ItemUsed");
+};
+
 // Exit if can't add the item
 if (!([_unit, _itemName] call CBA_fnc_canAddItem) && {!_isChemlight}) exitWith {
     [LELSTRING(common,Inventory_Full)] call EFUNC(common,displayTextStructured);
@@ -54,6 +63,9 @@ if (!([_unit, _itemName] call CBA_fnc_canAddItem) && {!_isChemlight}) exitWith {
 
 // Add item to inventory (unless it's a chemlight)
 if (!_isChemlight) then {
+    if (_itemUsedClass != "") then {
+        _itemName = _itemUsedClass;
+    };
     _unit addItem _itemName;
 };
 

--- a/addons/attach/functions/fnc_getChildrenActions.sqf
+++ b/addons/attach/functions/fnc_getChildrenActions.sqf
@@ -30,7 +30,7 @@ private _magazines = magazines _player;
     if (getText (_config >> "ACE_Attachable") != "") then {
         private _displayName = getText (_config >> "displayName");
         private _picture = getText (_config >> "picture");
-        private _action = [_x, _displayName, _picture, {[{_this call FUNC(attach)}, _this] call CBA_fnc_execNextFrame}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+        private _action = [_x, _displayName, _picture, {[{_this call FUNC(attach)}, _this] call CBA_fnc_execNextFrame}, {true}, {_this call FUNC(getSubChildrenActions)}, _x] call EFUNC(interact_menu,createAction);
         _actions pushBack [_action, [], _target];
     };
 } forEach (_magazines arrayIntersect _magazines);
@@ -40,7 +40,7 @@ private _magazines = magazines _player;
     if (getText (_config >> "ACE_Attachable") != "") then {
         private _displayName = getText (_config >> "displayName");
         private _picture = getText (_config >> "picture");
-        private _action = [_x, _displayName, _picture, {[{_this call FUNC(attach)}, _this] call CBA_fnc_execNextFrame}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+        private _action = [_x, _displayName, _picture, {[{_this call FUNC(attach)}, _this] call CBA_fnc_execNextFrame}, {true}, {_this call FUNC(getSubChildrenActions)}, _x] call EFUNC(interact_menu,createAction);
         _actions pushBack [_action, [], _target];
     };
 } forEach (_player call EFUNC(common,uniqueItems));

--- a/addons/attach/functions/fnc_getSubChildrenActions.sqf
+++ b/addons/attach/functions/fnc_getSubChildrenActions.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+/*
+ * Author: Slatery
+ * Returns Sub actions for attachable items.
+ *
+ * Arguments:
+ * 0: Target <OBJECT>
+ * 1: Player <OBJECT>
+ * 3: ClassName <STRING>
+ *
+ * Return Value:
+ * Actions <ARRAY>
+ *
+ * Example:
+ * [_target, _player,"ACE_IR_Strobe_Item"] call ace_attach_fnc_getSubChildrenActions
+ *
+ * Public: No
+ */
+
+params ["_target", "_player", "_configClass"];
+_childactions = [];
+if (isArray (configFile >> "CfgWeapons" >> _configClass >> "ACE_attachable_children")) then {
+	{
+		private _configstring = _x;
+		if (gettext (configFile >> "CfgWeapons" >> _configstring >> "ACE_Attachable") != "") then {
+			private _info = [_target, _player, _configstring];
+			private _displayname = gettext (configFile >> "CfgWeapons" >> _configstring >> "selectname");
+			private _picture = gettext (configFile >> "CfgWeapons" >> _configstring >> "picture");
+			
+			private _statement = {
+				[{
+					_this call FUNC(attach);
+				}, _this] call CBA_fnc_execNextFrame;
+			};
+			private _childExtra = {
+				_this call FUNC(getSubChildrenActions);
+			};
+			private _childaction = [_configstring, _displayname, _picture, _statement, {true}, _childExtra, _x] call EFUNC(interact_menu,createAction);
+			_childactions pushBack [_childaction, [], _target];
+		};
+	} forEach (getArray (configFile >> "CfgWeapons" >> _configClass >> "ACE_attachable_children"));
+};
+_childactions

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -92,8 +92,16 @@ private _endPosTestOffset = _startingOffset vectorAdd (_closeInUnitVector vector
 _endPosTestOffset set [2, (_startingOffset select 2)];
 private _attachedObject = _itemVehClass createVehicle (getPos _unit);
 _attachedObject attachTo [_attachToVehicle, _endPosTestOffset];
+private _itemUsedClass = getText (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_ItemUsed");
+
+if (_itemUsedClass == "") then {
+    _itemUsedClass = getText (configFile >> "CfgMagazines" >> _itemClassname >> "ACE_ItemUsed");
+};
 
 //Remove Item from inventory
+if (_itemUsedClass != "") then {
+    _itemClassname = _itemUsedClass;
+};
 _unit removeItem _itemClassname;
 
 //Add Object to attached array


### PR DESCRIPTION
Reason - clean up the attach item menu to allow for multiple similar items, or the same item with different options, to be attached, without having to have multiple different items in a player's inventory, and not cluttering the interaction tree

**When merged this pull request will:**
- adds child actions to attaching items
- allow for multiple effects to be attached from a single item in inventory
