### PR TITLE
Medical - Add multiple uses to consumable Surgical Kit

### DIFF
--- a/addons/arsenal/functions/fnc_onArsenalClose.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalClose.sqf
@@ -70,6 +70,9 @@ if (!isNil QGVAR(moduleUsed)) then {
     objNull remoteControl GVAR(center);
 };
 
+// Update player unique items cache
+ACE_player call EFUNC(common,uniqueItems);
+
 ACE_player switchCamera GVAR(cameraView);
 
 if (isMultiplayer) then {

--- a/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
+++ b/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
@@ -96,7 +96,7 @@ TRACE_2("searching for new vehicles",_vehicleAdded,_rangeTablesShown);
             };
             private _condition = {
                 //IGNORE_PRIVATE_WARNING ["_player"];
-                ([_player, "ACE_artilleryTable"] call EFUNC(common, hasItem)) && {[_player, objNull, ["notOnMap", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)}
+                ([_player, "ACE_artilleryTable"] call EFUNC(common,hasItem)) && {[_player, objNull, ["notOnMap", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)}
             };
             private _displayName = format ["%1%2", getText (_vehicleCfg >> "displayName"),["","*"] select _advCorrection];
             private _action = [format ['QGVAR(%1)',_index], _displayName, QPATHTOF(UI\icon_rangeTable.paa), _statement, _condition, {}, _info] call EFUNC(interact_menu,createAction);

--- a/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
+++ b/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
@@ -19,7 +19,7 @@ params ["_menuType"];
 TRACE_1("interactMenuOpened",_menuType);
 
 if (_menuType != 1) exitWith {};
-if (!("ACE_artilleryTable" in (ace_player call EFUNC(common,uniqueItems)))) exitWith {};
+if !([ace_player, "ACE_artilleryTable"] call EFUNC(common,hasItem)) exitWith {};
 
 private _vehicleAdded = ace_player getVariable [QGVAR(vehiclesAdded), []];
 private _rangeTablesShown = ace_player getVariable [QGVAR(rangeTablesShown), []];
@@ -96,7 +96,7 @@ TRACE_2("searching for new vehicles",_vehicleAdded,_rangeTablesShown);
             };
             private _condition = {
                 //IGNORE_PRIVATE_WARNING ["_player"];
-                ("ACE_artilleryTable" in (_player call EFUNC(common,uniqueItems))) && {[_player, objNull, ["notOnMap", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)}
+                ([_player, "ACE_artilleryTable"] call EFUNC(common, hasItem)) && {[_player, objNull, ["notOnMap", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)}
             };
             private _displayName = format ["%1%2", getText (_vehicleCfg >> "displayName"),["","*"] select _advCorrection];
             private _action = [format ['QGVAR(%1)',_index], _displayName, QPATHTOF(UI\icon_rangeTable.paa), _statement, _condition, {}, _info] call EFUNC(interact_menu,createAction);

--- a/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
+++ b/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
@@ -19,7 +19,7 @@ params ["_menuType"];
 TRACE_1("interactMenuOpened",_menuType);
 
 if (_menuType != 1) exitWith {};
-if !([ace_player, "ACE_artilleryTable"] call EFUNC(common,hasItem)) exitWith {};
+if !([ACE_player, "ACE_artilleryTable"] call EFUNC(common,hasItem)) exitWith {};
 
 private _vehicleAdded = ace_player getVariable [QGVAR(vehiclesAdded), []];
 private _rangeTablesShown = ace_player getVariable [QGVAR(rangeTablesShown), []];

--- a/addons/atragmx/functions/fnc_can_show.sqf
+++ b/addons/atragmx/functions/fnc_can_show.sqf
@@ -16,4 +16,4 @@
  */
 
 !underwater ACE_player &&
-{[ACE_Player, "ACE_ATragMX"] call EFUNC(common, hasItem)}
+{[ACE_Player, "ACE_ATragMX"] call EFUNC(common,hasItem)}

--- a/addons/atragmx/functions/fnc_can_show.sqf
+++ b/addons/atragmx/functions/fnc_can_show.sqf
@@ -16,4 +16,4 @@
  */
 
 !underwater ACE_player &&
-{"ACE_ATragMX" in ([ACE_player] call EFUNC(common,uniqueItems))}
+{[ACE_Player, "ACE_ATragMX"] call EFUNC(common, hasItem)}

--- a/addons/captives/functions/fnc_canApplyHandcuffs.sqf
+++ b/addons/captives/functions/fnc_canApplyHandcuffs.sqf
@@ -20,7 +20,7 @@ params ["_unit", "_target"];
 //Check sides, Player has cableTie, target is alive and not already handcuffed
 
 (GVAR(allowHandcuffOwnSide) || {(side _unit) != (side _target)}) &&
-{"ACE_CableTie" in (_unit call EFUNC(common,uniqueItems))} &&
+{[_unit, "ACE_CableTie"] call EFUNC(common,hasItem)} &&
 {alive _target} &&
 {!(_target getVariable [QGVAR(isHandcuffed), false])} &&
 {

--- a/addons/common/functions/fnc_hasItem.sqf
+++ b/addons/common/functions/fnc_hasItem.sqf
@@ -23,7 +23,7 @@ if (_item isEqualType "") then {
 };
 
 private _return = false;
-private _unitItems = _unit call EFUNC(common,uniqueItems);
+private _unitItems = _unit call FUNC(uniqueItems);
 {
     _return = _x in _unitItems;
     if (!_return) then {break};

--- a/addons/common/functions/fnc_hasItem.sqf
+++ b/addons/common/functions/fnc_hasItem.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: Item Classname <STRING>
+ * 1: Item Classname <STRING or ARRAY of STRING>
  *
  * Return Value:
  * Unit has Item <BOOL>
@@ -16,6 +16,17 @@
  * Public: Yes
  */
 
-params [["_unit", objNull, [objNull]], ["_item", "", [""]]];
+params [["_unit", objNull, [objNull]], ["_item", "", ["", [""]]]];
 
-_item in (_unit call EFUNC(common,uniqueItems))
+if (_item isEqualType "") then {
+    _item = [_item];
+};
+
+private _return = false;
+private _unitItems = _unit call EFUNC(common,uniqueItems);
+{
+    _return = _x in _unitItems;
+    if (!_return) then {break};
+} forEach _item;
+
+_return

--- a/addons/common/functions/fnc_hasItem.sqf
+++ b/addons/common/functions/fnc_hasItem.sqf
@@ -17,7 +17,7 @@
  * Public: Yes
  */
 
-params [["_unit", objNull, [objNull]], ["_item", "", ["", [""], ["_checkAll", false, [false]]]]];
+params [["_unit", objNull, [objNull]], ["_item", "", ["", [""]]], ["_checkAll", false, [false]]];
 
 if (_item isEqualType "") then {
     _item = [_item];
@@ -25,10 +25,10 @@ if (_item isEqualType "") then {
 
 private _return = false;
 private _unitItems = _unit call FUNC(uniqueItems);
+
 {
     _return = _x in _unitItems;
-    if (_return) then {[break, continue] select _checkAll};
-    break
+    if ([_return, !_return] select _checkAll) then {break};
 } forEach _item;
 
 _return

--- a/addons/common/functions/fnc_hasItem.sqf
+++ b/addons/common/functions/fnc_hasItem.sqf
@@ -19,16 +19,10 @@
 
 params [["_unit", objNull, [objNull]], ["_item", "", ["", [""]]], ["_checkAll", false, [false]]];
 
-if (_item isEqualType "") then {
-    _item = [_item];
-};
-
-private _return = false;
 private _unitItems = _unit call FUNC(uniqueItems);
 
-{
-    _return = _x in _unitItems;
-    if ([_return, !_return] select _checkAll) then {break};
-} forEach _item;
+if (_item isEqualType "") exitWith { _item in _unitItems };
 
-_return
+if (_checkAll) exitWith { _item findIf {!(_x in _unitItems)} == -1 };
+
+_item findIf {_x in _unitItems} != -1

--- a/addons/common/functions/fnc_hasItem.sqf
+++ b/addons/common/functions/fnc_hasItem.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Unit <OBJECT>
  * 1: Item Classname <STRING or ARRAY of STRING>
+ * 2: Check all items in array (Optional, default: false) <BOOL>
  *
  * Return Value:
  * Unit has Item <BOOL>
@@ -16,7 +17,7 @@
  * Public: Yes
  */
 
-params [["_unit", objNull, [objNull]], ["_item", "", ["", [""]]]];
+params [["_unit", objNull, [objNull]], ["_item", "", ["", [""], ["_checkAll", false, [false]]]]];
 
 if (_item isEqualType "") then {
     _item = [_item];
@@ -26,7 +27,8 @@ private _return = false;
 private _unitItems = _unit call FUNC(uniqueItems);
 {
     _return = _x in _unitItems;
-    if (!_return) then {break};
+    if (_return) then {[break, continue] select _checkAll};
+    break
 } forEach _item;
 
 _return

--- a/addons/common/functions/fnc_uniqueItems.sqf
+++ b/addons/common/functions/fnc_uniqueItems.sqf
@@ -18,20 +18,12 @@
 
 params ["_unit"];
 
-private _fnc_getItems = {
-    private _items = (getItemCargo uniformContainer _unit) select 0;
-    _items append ((getItemCargo vestContainer _unit) select 0);
-    _items append ((getItemCargo backpackContainer _unit) select 0);
-
-    _items arrayIntersect _items
-};
-
 // Use cached items list if unit is ACE_player
 if (_unit isEqualTo ACE_player) then {
     if (isNil QGVAR(uniqueItemsCache)) then {
-        GVAR(uniqueItemsCache) = call _fnc_getItems;
+        GVAR(uniqueItemsCache) = keys uniqueUnitItems _unit;
     };
     +GVAR(uniqueItemsCache)
 } else {
-    call _fnc_getItems;
+    keys uniqueUnitItems _unit;
 };

--- a/addons/common/functions/fnc_useItem.sqf
+++ b/addons/common/functions/fnc_useItem.sqf
@@ -23,13 +23,9 @@ private _return = false;
 if !(_vehicleUsage) then {
     if (_item != "") then {
         if (_item in (_unit call EFUNC(common,uniqueItems))) then {
+            _unit unassignItem _item;
             _unit removeItem _item;
             _return = true;
-        } else {
-            if (_item in assignedItems _unit) then {
-                _unit unlinkItem _item;
-                _return = true;
-            };
         };
     };
 //} else {

--- a/addons/common/functions/fnc_useItem.sqf
+++ b/addons/common/functions/fnc_useItem.sqf
@@ -22,7 +22,7 @@ private _return = false;
 
 if !(_vehicleUsage) then {
     if (_item != "") then {
-        if (_item in (_unit call EFUNC(common,uniqueItems))) then {
+        if ([_unit, _item] call FUNC(hasItem)) then {
             _unit unassignItem _item;
             _unit removeItem _item;
             _return = true;

--- a/addons/common/functions/fnc_useMagazine.sqf
+++ b/addons/common/functions/fnc_useMagazine.sqf
@@ -21,7 +21,7 @@ params ["_unit", "_magazine", ["_vehicleUsage", false]];
 private _return = false;
 
 if !(_vehicleUsage) then {
-    if (_magazine != "") then {
+    if (_magazine != "" && {_magazine in magazines _unit}) then {
         _unit removeMagazine _magazine;
         _return = true;
     };

--- a/addons/disarming/functions/fnc_getAllGearUnit.sqf
+++ b/addons/disarming/functions/fnc_getAllGearUnit.sqf
@@ -18,36 +18,6 @@
 
 params ["_target"];
 
-private _allItems = (((items _target) + (assignedItems _target)) - (weapons _target)) + (weapons _target) + (magazines _target);
+private _uniqueItems = uniqueUnitItems [_target, 1, 2, 2, 2, true];
 
-if ((backpack _target) != "") then {
-    _allItems pushBack (backpack _target);
-};
-if ((vest _target) != "") then {
-    _allItems pushBack (vest _target);
-};
-if ((uniform _target) != "") then {
-    _allItems pushBack (uniform _target);
-};
-if ((headgear _target) != "") then {
-    _allItems pushBack (headgear _target);
-};
-//What kind of asshole takes a man's glasses?
-if ((goggles _target) != "") then {
-    _allItems pushBack (goggles _target);
-};
-
-private _uniqueClassnames = [];
-private _classnamesCount = [];
-//Filter unique and count
-{
-    private _index = _uniqueClassnames find _x;
-    if (_index != -1) then {
-        _classnamesCount set [_index, ((_classnamesCount select _index) + 1)];
-    } else {
-        _uniqueClassnames pushBack _x;
-        _classnamesCount pushBack 1;
-    };
-} forEach _allItems;
-
-[_uniqueClassnames, _classnamesCount]
+[keys _uniqueItems, values _uniqueItems]

--- a/addons/disarming/functions/fnc_getAllGearUnit.sqf
+++ b/addons/disarming/functions/fnc_getAllGearUnit.sqf
@@ -18,6 +18,4 @@
 
 params ["_target"];
 
-private _uniqueItems = uniqueUnitItems [_target, 1, 2, 2, 2, true];
-
-[keys _uniqueItems, values _uniqueItems]
+toArray uniqueUnitItems [_target, 1, 2, 2, 2, true]

--- a/addons/explosives/functions/fnc_canDefuse.sqf
+++ b/addons/explosives/functions/fnc_canDefuse.sqf
@@ -24,7 +24,7 @@ if (isNull _explosive) exitWith {
     deleteVehicle _target;
     false
 };
-if (vehicle _unit != _unit || {!("ACE_DefusalKit" in (_unit call EFUNC(common,uniqueItems)))}) exitWith {false};
+if (vehicle _unit != _unit || {!([_unit, "ACE_DefusalKit"] call EFUNC(common,hasItem))}) exitWith {false};
 
 if (GVAR(RequireSpecialist) && {!([_unit] call EFUNC(Common,isEOD))}) exitWith {false};
 

--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -25,7 +25,7 @@ TRACE_1("Explosives interactEH",_interactionType);
 if (
     _interactionType != 0
     || {vehicle ACE_player != ACE_player}
-    || {!("ACE_DefusalKit" in (ACE_player call EFUNC(common,uniqueItems)))}
+    || {!([ACE_Player, "ACE_DefusalKit"] call EFUNC(common,hasItem))}
 ) exitWith {};
 
 [{

--- a/addons/explosives/functions/fnc_onIncapacitated.sqf
+++ b/addons/explosives/functions/fnc_onIncapacitated.sqf
@@ -25,7 +25,7 @@ if (_unit == ace_player) then {
 };
 
 // Exit if no item
-if !("ACE_DeadManSwitch" in (_unit call EFUNC(common,uniqueItems))) exitWith {};
+if !([_unit, "ACE_DeadManSwitch"]call EFUNC(common,hasItem)) exitWith {};
 
 private _range = getNumber (configFile >> "CfgWeapons" >> "ACE_DeadManSwitch" >> QGVAR(range));
 private _deadman = [_unit, "DeadManSwitch"] call FUNC(getPlacedExplosives);

--- a/addons/fastroping/functions/fnc_canDeployRopes.sqf
+++ b/addons/fastroping/functions/fnc_canDeployRopes.sqf
@@ -29,5 +29,5 @@ private _config = configOf _vehicle;
     private _deploymentStage = _vehicle getVariable [QGVAR(deploymentStage), 0];
     if (getText (_config >> QGVAR(onPrepare)) == "") then { _deploymentStage == 0 } else { _deploymentStage == 2 };
 } && {
-    (_defaultOption && {!GVAR(requireRopeItems)}) || {(_ropeClass in (_player call EFUNC(common,uniqueItems))) || {_ropeClass in (itemCargo _vehicle)}}
+    (_defaultOption && {!GVAR(requireRopeItems)}) || {[_player, _ropeClass] call EFUNC(common,hasItem) || {_ropeClass in (itemCargo _vehicle)}}
 }

--- a/addons/fastroping/functions/fnc_deployRopes.sqf
+++ b/addons/fastroping/functions/fnc_deployRopes.sqf
@@ -35,7 +35,7 @@ if (_ropeLength <= 0) then {
 TRACE_3("",_ropeClass,_ropeLength,GVAR(requireRopeItems));
 
 if (GVAR(requireRopeItems) && {_ropeClass != ""}) then {
-    if (_ropeClass in (_player call EFUNC(common,uniqueItems))) then {
+    if ([_player, _ropeClass] call EFUNC(common,hasItem)) then {
         _player removeItem _ropeClass;
     } else {
         _vehicle removeItem _ropeClass;

--- a/addons/kestrel4500/functions/fnc_canShow.sqf
+++ b/addons/kestrel4500/functions/fnc_canShow.sqf
@@ -15,4 +15,4 @@
  * Public: No
  */
 
-"ACE_Kestrel4500" in ([ACE_player] call EFUNC(common,uniqueItems))
+[ACE_player, "ACE_Kestrel4500"] call EFUNC(common,hasItem)

--- a/addons/logistics_uavbattery/functions/fnc_canRefuelUAV.sqf
+++ b/addons/logistics_uavbattery/functions/fnc_canRefuelUAV.sqf
@@ -18,4 +18,4 @@
 
 params ["_caller", "_target"];
 
-("ACE_UAVBattery" in (_caller call EFUNC(common,uniqueItems))) && {(fuel _target) < 1} && {(speed _target) < 1} && {!(isEngineOn _target)} && {(_target distance _caller) <= 4}
+([_caller, "ACE_UAVBattery"] call EFUNC(common,hasItem)) && {(fuel _target) < 1} && {(speed _target) < 1} && {!(isEngineOn _target)} && {(_target distance _caller) <= 4}

--- a/addons/logistics_wirecutter/script_component.hpp
+++ b/addons/logistics_wirecutter/script_component.hpp
@@ -82,7 +82,7 @@
 #define CUT_TIME_ENGINEER 7.5
 
 #define HAS_WIRECUTTER(unit) (\
-    "ACE_wirecutter" in (unit call EFUNC(common,uniqueItems)) \
+    ([unit, "ACE_wirecutter"] call EFUNC(common,hasItem)) \
     || {1 == getNumber (configFile >> "CfgVehicles" >> (backpack unit) >> QGVAR(hasWirecutter))} \
     || {1 == getNumber (configFile >> "CfgWeapons" >> (vest unit) >> QGVAR(hasWirecutter))} \
 )

--- a/addons/maptools/functions/fnc_canUseMapTools.sqf
+++ b/addons/maptools/functions/fnc_canUseMapTools.sqf
@@ -24,6 +24,6 @@ visibleMap &&
     } forEach (assignedItems ACE_player);
     false
 } &&
-{"ACE_MapTools" in (ACE_player call EFUNC(common,uniqueItems))} &&
+{[ACE_player, "ACE_MapTools"] call EFUNC(common,hasItem)} &&
 {!GVAR(mapTool_isDragging)} &&
 {!GVAR(mapTool_isRotating)}

--- a/addons/maptools/functions/fnc_handleMouseMove.sqf
+++ b/addons/maptools/functions/fnc_handleMouseMove.sqf
@@ -20,7 +20,7 @@ params ["_control", "_mousePosX", "_mousePosY"];
 TRACE_3("params",_control,_mousePosX,_mousePosY);
 
 // If have no map tools, then exit
-if (((isNull ACE_player) || {!("ACE_MapTools" in (ACE_player call EFUNC(common,uniqueItems)))})) exitWith {
+if (((isNull ACE_player) || {!([ACE_player, "ACE_MapTools"] call EFUNC(common,hasItem)))}) exitWith {
     false
 };
 

--- a/addons/maptools/functions/fnc_updateMapToolMarkers.sqf
+++ b/addons/maptools/functions/fnc_updateMapToolMarkers.sqf
@@ -17,7 +17,7 @@
 
 params ["_theMap"];
 
-if ((GVAR(mapTool_Shown) == 0) || {!("ACE_MapTools" in (ACE_player call EFUNC(common,uniqueItems)))}) exitWith {};
+if ((GVAR(mapTool_Shown) == 0) || {!([ACE_player, "ACE_MapTools"] call EFUNC(common,hasItem))}) exitWith {};
 
 private _rotatingTexture = "";
 private _textureWidth = 0;

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -279,7 +279,7 @@ class GVAR(actions) {
         displayNameProgress = CSTRING(Stitching);
         icon = QPATHTOEF(medical_gui,ui\surgical_kit.paa);
         category = "advanced";
-        items[] = {"ACE_surgicalKit"};
+        items[] = {"ACE_surgicalKit_mag"};
         treatmentLocations = QGVAR(locationSurgicalKit);
         allowSelfTreatment = QGVAR(allowSelfStitch);
         medicRequired = QGVAR(medicSurgicalKit);
@@ -287,7 +287,7 @@ class GVAR(actions) {
         condition = QFUNC(canStitch);
         callbackSuccess = "";
         callbackProgress = QFUNC(surgicalKitProgress);
-        consumeItem = QGVAR(consumeSurgicalKit);
+        consumeItem = 0;
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
         litter[] = {{"ACE_MedicalLitter_gloves"}};
     };

--- a/addons/medical_treatment/CfgMagazines.hpp
+++ b/addons/medical_treatment/CfgMagazines.hpp
@@ -1,0 +1,13 @@
+class CfgMagazines {
+    class CA_Magazine;
+    class ACE_surgicalKit_mag: CA_Magazine {
+        scope = 2;
+        author = ECSTRING(common,ACETeam);
+        displayName= CSTRING(SurgicalKit_Display);
+        model = QPATHTOF(data\surgical_kit.p3d);
+        picture = QPATHTOF(ui\surgicalKit_ca.paa);
+        descriptionShort = CSTRING(SurgicalKit_Desc_Short);
+        descriptionUse = CSTRING(SurgicalKit_Desc_Use);
+        mass = 15;
+    };
+};

--- a/addons/medical_treatment/CfgReplacementItems.hpp
+++ b/addons/medical_treatment/CfgReplacementItems.hpp
@@ -20,4 +20,7 @@ class EGVAR(medical,replacementItems) {
     ACE_atropine[] = {
         {"ACE_adenosine", 1}
     };
+    ACE_surgicalKit[] = {
+        {"ACE_surgicalKit_mag", 1};
+    };
 };

--- a/addons/medical_treatment/config.cpp
+++ b/addons/medical_treatment/config.cpp
@@ -21,4 +21,5 @@ class CfgPatches {
 #include "CfgReplacementItems.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgMagazines.hpp"
 #include "Cfg3DEN.hpp"

--- a/addons/medical_treatment/functions/fnc_getStitchTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getStitchTime.sqf
@@ -18,4 +18,12 @@
 
 params ["", "_patient"];
 
-count (_patient call FUNC(getStitchableWounds)) * GVAR(woundStitchTime)
+private _stitchableWounds = _patient call FUNC(getStitchableWounds);
+
+private _woundCount = 0;
+{
+    _x params ["_woundID", "_bodyPartN", "_amountOf"];
+    _woundCount = _woundCount + (ceil _amountOf);
+} forEach _stitchableWounds;
+
+_woundCount * GVAR(woundStitchTime)

--- a/addons/medical_treatment/functions/fnc_hasItem.sqf
+++ b/addons/medical_treatment/functions/fnc_hasItem.sqf
@@ -21,4 +21,12 @@
 
 params ["_medic", "_patient", "_items"];
 
-[_medic, _items] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _items] call EFUNC(common,hasItem)}}
+
+private _return = false;
+{
+    if ([_medic, _x] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _x] call EFUNC(common,hasItem)}}) exitWith {
+        _return = true;
+    };
+} forEach _items;
+
+_return

--- a/addons/medical_treatment/functions/fnc_hasItem.sqf
+++ b/addons/medical_treatment/functions/fnc_hasItem.sqf
@@ -21,11 +21,4 @@
 
 params ["_medic", "_patient", "_items"];
 
-private _fnc_checkItems = {
-    params ["_unit"];
-
-    private _unitItems = _unit call EFUNC(common,uniqueItems);
-    _items findIf {_x in _unitItems} != -1
-};
-
-_medic call _fnc_checkItems || {GVAR(allowSharedEquipment) != 2 && {_patient call _fnc_checkItems}}
+[_medic, _items] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _items] call EFUNC(common,hasItem)}}

--- a/addons/medical_treatment/functions/fnc_hasItem.sqf
+++ b/addons/medical_treatment/functions/fnc_hasItem.sqf
@@ -22,11 +22,4 @@
 params ["_medic", "_patient", "_items"];
 
 
-private _return = false;
-{
-    if ([_medic, _x] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _x] call EFUNC(common,hasItem)}}) exitWith {
-        _return = true;
-    };
-} forEach _items;
-
-_return
+[_medic, _items, false] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _items, false] call EFUNC(common,hasItem)}}

--- a/addons/medical_treatment/functions/fnc_hasItem.sqf
+++ b/addons/medical_treatment/functions/fnc_hasItem.sqf
@@ -22,4 +22,4 @@
 params ["_medic", "_patient", "_items"];
 
 
-[_medic, _items, false] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _items, false] call EFUNC(common,hasItem)}}
+[_medic, _items] call EFUNC(common,hasItem) || {GVAR(allowSharedEquipment) != 2 && {[_patient, _items] call EFUNC(common,hasItem)}}

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Arguments <ARRAY>
- *   0: Medic (not used) <OBJECT>
+ *   0: Medic <OBJECT>
  *   1: Patient <OBJECT>
  * 1: Elapsed Time <NUMBER>
  * 2: Total Time <NUMBER>
@@ -20,22 +20,51 @@
  */
 
 params ["_args", "_elapsedTime", "_totalTime"];
-_args params ["", "_patient"];
+_args params ["_medic", "_patient"];
 
 private _stitchableWounds = _patient call FUNC(getStitchableWounds);
 
 // Stop treatment if there are no wounds that can be stitched remaining
 if (_stitchableWounds isEqualTo []) exitWith {false};
 
+// magazinesAmmo only returns magazines with ammo, so can check for uses this way
+private _allMedicMagazines = magazinesAmmo _medic;
+private _hasUsesLeft = _allMedicMagazines findIf {(_x select 0) isEqualTo "ACE_surgicalKit_mag"} != -1;
+
+// Stop treatment & remove empty magazines if there are no more surgical kit uses
+if ((GVAR(consumeSurgicalKit) > 0) && {!_hasUsesLeft}) exitWith {
+    [_medic, "ACE_surgicalKit_mag", 0] call EFUNC(common,removeSpecificMagazine);
+    false
+};
+
+private _woundCount = 0;
+{
+    _x params ["_woundID", "_bodyPartN", "_amountOf"];
+    _woundCount = _woundCount + (ceil _amountOf);
+} forEach _stitchableWounds;
+
 // Not enough time has elapsed to stitch a wound
-if (_totalTime - _elapsedTime > (count _stitchableWounds - 1) * GVAR(woundStitchTime)) exitWith {true};
+if (_totalTime - _elapsedTime > (_woundCount - 1) * GVAR(woundStitchTime)) exitWith {true};
 
 private _bandagedWounds = GET_BANDAGED_WOUNDS(_patient);
 private _stitchedWounds = GET_STITCHED_WOUNDS(_patient);
 
-// Remove the first stitchable wound from the bandaged wounds
-private _treatedWound = _bandagedWounds deleteAt (_bandagedWounds find (_stitchableWounds select 0));
+// Reduce stitched wound amount from bandaged wounds and delete when empty
+private _treatedWoundIndex = _bandagedWounds find (_stitchableWounds select 0);
+private _bandagedWound = (_bandagedWounds select _treatedWoundIndex);
+_bandagedWound params ["_bandagedID", "_bandagedBodyPartN", "_bandagedAmountOf"];
+private _treatedWound = +_bandagedWound;
 _treatedWound params ["_treatedID", "_treatedBodyPartN", "_treatedAmountOf"];
+
+if (_bandagedAmountOf - 1 <= 0) then {
+    _bandagedWounds deleteAt _treatedWoundIndex;
+} else {
+    _bandagedWound set [2, _bandagedAmountOf - 1];
+    _bandagedWounds set [_treatedWoundIndex, _bandagedWound];
+};
+
+_treatedAmountOf = _treatedAmountOf min 1;
+_treatedWound set [2, _treatedAmountOf];
 
 // Check if we need to add a new stitched wound or increase the amount of an existing one
 private _woundIndex = _stitchedWounds findIf {
@@ -53,6 +82,17 @@ if (_woundIndex == -1) then {
 
 _patient setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
 _patient setVariable [VAR_STITCHED_WOUNDS, _stitchedWounds, true];
+
+if (GVAR(consumeSurgicalKit) > 0) then {
+    private _allSurgicalKits = _allMedicMagazines select {(_x select 0) isEqualTo "ACE_surgicalKit_mag"};
+    private _ammo = (_allSurgicalKits select 0) select 1;
+    _allSurgicalKits deleteAt 0;
+    _medic removeMagazines "ACE_surgicalKit_mag";
+    _medic addMagazine ["ACE_surgicalKit_mag", _ammo - 1];
+    {
+        _medic addMagazine ["ACE_surgicalKit_mag", _x select 1];
+    } forEach _allSurgicalKits;
+};
 
 // Check if we fixed limping by stitching this wound (only for leg wounds)
 if (EGVAR(medical,limping) == 2 && {_patient getVariable [QEGVAR(medical,isLimping), false]} && {_treatedBodyPartN > 3}) then {

--- a/addons/medical_treatment/functions/fnc_useItem.sqf
+++ b/addons/medical_treatment/functions/fnc_useItem.sqf
@@ -24,13 +24,11 @@ scopeName "Main";
 private _useOrder = [[_patient, _medic], [_medic, _patient], [_medic]] select GVAR(allowSharedEquipment);
 
 {
-    private _unit      = _x;
-    private _unitItems = _x call EFUNC(common,uniqueItems);
-
+    params ["_unit"];
     {
-        if (_x in _unitItems) then {
-            _unit removeItem _x;
-            [_unit, _x] breakOut "Main";
+        if ([_unit, _x] call EFUNC(common,hasItem)) then {
+          _unit removeItem _x;
+          [_unit, _x] breakOut "Main";
         };
     } forEach _items;
 } forEach _useOrder;

--- a/addons/medical_treatment/functions/fnc_useItem.sqf
+++ b/addons/medical_treatment/functions/fnc_useItem.sqf
@@ -24,7 +24,7 @@ scopeName "Main";
 private _useOrder = [[_patient, _medic], [_medic, _patient], [_medic]] select GVAR(allowSharedEquipment);
 
 {
-    params ["_unit"];
+    private _unit = _x;
     {
         if ([_unit, _x] call EFUNC(common,hasItem)) then {
           _unit removeItem _x;

--- a/addons/medical_treatment/script_component.hpp
+++ b/addons/medical_treatment/script_component.hpp
@@ -54,3 +54,6 @@
 
 // Animations that would be played faster than this are instead skipped. (= Progress bar too quick for animation).
 #define ANIMATION_SPEED_MAX_COEFFICIENT 2.5
+
+// Number of wounds a single surgical kit can close if consume setting is enabled
+#define SURGICAL_KIT_USES 50

--- a/addons/microdagr/XEH_clientInit.sqf
+++ b/addons/microdagr/XEH_clientInit.sqf
@@ -5,7 +5,7 @@ if (!hasInterface) exitWith {};
 
 //Add deviceKey entry:
 private _conditonCode = {
-    "ACE_microDAGR" in (ACE_player call EFUNC(common,uniqueItems))
+    [ACE_player, "ACE_microDAGR"] call EFUNC(common,hasItem)
 };
 private _toggleCode = {
     if !([ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};

--- a/addons/microdagr/functions/fnc_canShow.sqf
+++ b/addons/microdagr/functions/fnc_canShow.sqf
@@ -22,12 +22,12 @@ _returnValue = switch (_showType) do {
     case (DISPLAY_MODE_CLOSED): { true }; //Can always close
     case (DISPLAY_MODE_HIDDEN): { true }; //Can always hide
     case (DISPLAY_MODE_DIALOG): {
-         ("ACE_microDAGR" in (ACE_player call EFUNC(common,uniqueItems))) && {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
+         ([ACE_player, "ACE_microDAGR"] call EFUNC(common,hasItem)) && {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
     };
     case (DISPLAY_MODE_DISPLAY): {
         //Can't have minimap up while zoomed in on foot, but allow drivers to use while in "Gunner" to handle non-3d vehicles like most tanks
         ((cameraView != "GUNNER") || {(vehicle ACE_player != ACE_player) && {driver vehicle ACE_player == ACE_player}}) &&
-        {"ACE_microDAGR" in (ACE_player call EFUNC(common,uniqueItems))} &&
+        {[ACE_player, "ACE_microDAGR"] call EFUNC(common,hasItem)} &&
         {[ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)}
     };
     default { false };

--- a/addons/microdagr/functions/fnc_openDisplay.sqf
+++ b/addons/microdagr/functions/fnc_openDisplay.sqf
@@ -73,7 +73,7 @@ if ((_oldShowMode == DISPLAY_MODE_CLOSED) && {GVAR(currentShowMode) != DISPLAY_M
     [{
         params ["_args", "_idPFH"];
         _args params ["_player"];
-        if ((isNull ACE_player) || {!alive ACE_player} || {ACE_player != _player} || {!("ACE_microDAGR" in (ACE_player call EFUNC(common,uniqueItems)))} || {GVAR(currentShowMode) == DISPLAY_MODE_CLOSED}) then {
+        if ((isNull ACE_player) || {!alive ACE_player} || {ACE_player != _player} || {!([ACE_player, "ACE_microDAGR"] call EFUNC(common,hasItem))} || {GVAR(currentShowMode) == DISPLAY_MODE_CLOSED}) then {
             //Close Display if still open:
             if (GVAR(currentShowMode) != DISPLAY_MODE_CLOSED) then {
                 [DISPLAY_MODE_CLOSED] call FUNC(openDisplay);

--- a/addons/mk6mortar/functions/fnc_rangeTableCanUse.sqf
+++ b/addons/mk6mortar/functions/fnc_rangeTableCanUse.sqf
@@ -18,4 +18,4 @@
 
 params ["_vehicle", "_player"];
 
-"ACE_RangeTable_82mm" in (_player call EFUNC(common,uniqueItems));
+[_player, "ACE_RangeTable_82mm"] call EFUNC(common,hasItem)

--- a/addons/rangecard/functions/fnc_canShow.sqf
+++ b/addons/rangecard/functions/fnc_canShow.sqf
@@ -16,7 +16,7 @@
  */
 
 GVAR(ammoClass) != "" &&
-GVAR(magazineClass) != "" &&
-GVAR(weaponClass) != "" &&
-!GVAR(RangeCardOpened) &&
-"ACE_RangeCard" in ([ACE_player] call EFUNC(common,uniqueItems))
+{GVAR(magazineClass) != ""} &&
+{GVAR(weaponClass) != ""} &&
+{!GVAR(RangeCardOpened)} &&
+{[_player, "ACE_RangeCard"] call EFUNC(common,hasItem)}

--- a/addons/rangecard/functions/fnc_canShowCopy.sqf
+++ b/addons/rangecard/functions/fnc_canShowCopy.sqf
@@ -15,8 +15,8 @@
  * Public: No
  */
 
-GVAR(ammoClassCopy) != "" &&
-GVAR(magazineClassCopy) != "" &&
-GVAR(weaponClassCopy) != "" &&
-!GVAR(RangeCardOpened) &&
-"ACE_RangeCard" in ([ACE_player] call EFUNC(common,uniqueItems))
+ GVAR(ammoClassCopy) != "" &&
+ {GVAR(magazineClassCopy) != ""} &&
+ {GVAR(weaponClassCopy) != ""} &&
+ {!GVAR(RangeCardOpened)} &&
+ {[_player, "ACE_RangeCard"] call EFUNC(common,hasItem)}

--- a/addons/repair/functions/fnc_hasItems.sqf
+++ b/addons/repair/functions/fnc_hasItems.sqf
@@ -19,4 +19,4 @@
 params ["_unit", "_items"];
 TRACE_2("params",_unit,_items);
 
-[_unit, _items] call EFUNC(common, hasItem);
+[_unit, _items] call EFUNC(common,hasItem);

--- a/addons/repair/functions/fnc_hasItems.sqf
+++ b/addons/repair/functions/fnc_hasItems.sqf
@@ -19,4 +19,4 @@
 params ["_unit", "_items"];
 TRACE_2("params",_unit,_items);
 
-[_unit, _items] call EFUNC(common,hasItem);
+[_unit, _items, true] call EFUNC(common,hasItem);

--- a/addons/repair/functions/fnc_hasItems.sqf
+++ b/addons/repair/functions/fnc_hasItems.sqf
@@ -19,14 +19,4 @@
 params ["_unit", "_items"];
 TRACE_2("params",_unit,_items);
 
-private _return = true;
-{
-    if ((_x isEqualType []) && {({[_unit, _x] call EFUNC(common,hasItem)} count _x == 0)}) exitWith {
-        _return = false;
-    };
-    if ((_x isEqualType "") && {!([_unit, _x] call EFUNC(common,hasItem))}) exitWith {
-        _return = false;
-    };
-} forEach _items;
-
-_return;
+[_unit, _items] call EFUNC(common, hasItem);

--- a/addons/sandbag/functions/fnc_canDeploy.sqf
+++ b/addons/sandbag/functions/fnc_canDeploy.sqf
@@ -17,6 +17,6 @@
 
 params ["_unit"];
 
-if !("ACE_Sandbag_empty" in (_unit call EFUNC(common,uniqueItems))) exitWith {false};
+if !([_unit, "ACE_Sandbag_empty"] call EFUNC(common,hasItem)) exitWith {false};
 
 _unit call EFUNC(common,canDig)

--- a/addons/sandbag/functions/fnc_handlePlayerInventoryChanged.sqf
+++ b/addons/sandbag/functions/fnc_handlePlayerInventoryChanged.sqf
@@ -19,7 +19,7 @@
 params ["_unit"];
 
 if (_unit getVariable [QGVAR(isDeploying), false]) then {
-    if !("ACE_Sandbag_empty" in (_unit call EFUNC(common,uniqueItems))) then {
+    if !([_unit, "ACE_Sandbag_empty"] call EFUNC(common,hasItem)) then {
         [_unit] call FUNC(deployCancel);
     };
 };

--- a/addons/tagging/functions/fnc_addTagActions.sqf
+++ b/addons/tagging/functions/fnc_addTagActions.sqf
@@ -43,7 +43,7 @@ private _actions = [];
             },
             {
                 (_this select 2) params ["_unit", "", "", "_requiredItem"];
-                _requiredItem in (_unit call EFUNC(common,uniqueItems))
+                [_unit, _requiredItem] call EFUNC(common,hasItem)
             },
             {},
             [_unit, _class, _textures, _requiredItem, _materials]

--- a/addons/trenches/functions/fnc_canContinueDiggingTrench.sqf
+++ b/addons/trenches/functions/fnc_canContinueDiggingTrench.sqf
@@ -18,7 +18,7 @@
 
 params ["_trench", "_unit"];
 
-if !("ACE_EntrenchingTool" in (_unit call EFUNC(common,uniqueItems))) exitWith {false};
+if !([_unit, "ACE_EntrenchingTool"] call EFUNC(common,hasItem)) exitWith {false};
 if ((_trench getVariable [QGVAR(progress), 1]) >= 1) exitWith {false};
 
 // Prevent removing/digging trench by more than one person

--- a/addons/trenches/functions/fnc_canDigTrench.sqf
+++ b/addons/trenches/functions/fnc_canDigTrench.sqf
@@ -17,6 +17,6 @@
 
 params ["_unit"];
 
-if !("ACE_EntrenchingTool" in (_unit call EFUNC(common,uniqueItems))) exitWith {false};
+if !([_unit, "ACE_EntrenchingTool"] call EFUNC(common,hasItem)) exitWith {false};
 
 _unit call EFUNC(common,canDig)

--- a/addons/trenches/functions/fnc_canRemoveTrench.sqf
+++ b/addons/trenches/functions/fnc_canRemoveTrench.sqf
@@ -18,7 +18,7 @@
 
 params ["_trench", "_unit"];
 
-if !("ACE_EntrenchingTool" in (_unit call EFUNC(common,uniqueItems))) exitWith {false};
+if !([_unit, "ACE_EntrenchingTool"] call EFUNC(common,hasItem)) exitWith {false};
 
 // Prevent removing/digging trench by more than one person
 if (_trench getVariable [QGVAR(digging), false]) exitWith {false};

--- a/addons/trenches/functions/fnc_continueDiggingTrench.sqf
+++ b/addons/trenches/functions/fnc_continueDiggingTrench.sqf
@@ -65,7 +65,7 @@ private _fnc_onFailure = {
 };
 private _fnc_condition = {
     (_this select 0) params ["_unit"];
-    "ACE_EntrenchingTool" in (_unit call EFUNC(common,uniqueItems))
+    [_unit, "ACE_EntrenchingTool"] call EFUNC(common,hasItem)
 };
 [(_digTimeLeft + 0.5), [_unit, _trench], _fnc_onFinish, _fnc_onFailure, localize LSTRING(DiggingTrench), _fnc_condition] call EFUNC(common,progressBar);
 

--- a/addons/trenches/functions/fnc_handlePlayerInventoryChanged.sqf
+++ b/addons/trenches/functions/fnc_handlePlayerInventoryChanged.sqf
@@ -19,7 +19,7 @@
 params ["_unit"];
 
 if (_unit getVariable [QGVAR(isPlacing), false]) then {
-    if !("ACE_EntrenchingTool" in (_unit call EFUNC(common,uniqueItems))) then {
+    if !([_unit, "ACE_EntrenchingTool"] call EFUNC(common,hasItem)) then {
         [_unit] call FUNC(placeCancel);
     };
 };

--- a/addons/trenches/functions/fnc_removeTrench.sqf
+++ b/addons/trenches/functions/fnc_removeTrench.sqf
@@ -66,7 +66,7 @@ private _fnc_onFailure = {
 };
 private _fnc_condition = {
     (_this select 0) params ["_unit"];
-    "ACE_EntrenchingTool" in (_unit call EFUNC(common,uniqueItems))
+    [_unit, "ACE_EntrenchingTool"] call EFUNC(common,hasItem)
 };
 [(_removeTimeLeft + 0.5), [_unit, _trench], _fnc_onFinish, _fnc_onFailure, localize LSTRING(RemovingTrench), _fnc_condition] call EFUNC(common,progressBar);
 

--- a/addons/vehiclelock/functions/fnc_lockpick.sqf
+++ b/addons/vehiclelock/functions/fnc_lockpick.sqf
@@ -30,7 +30,7 @@ if (isNull _veh) exitWith {ERROR("null vehicle"); false};
 if ((locked _veh) == 0) exitWith {false};
 
 //need lockpick item
-if !("ACE_key_lockpick" in (_unit call EFUNC(common,uniqueItems))) exitWith {false};
+if !([_unit, "ACE_key_lockpick"] call EFUNC(common,hasItem)) exitWith {false};
 
 private _vehLockpickStrength = _veh getVariable[QGVAR(lockpickStrength), GVAR(DefaultLockpickStrength)];
 if (!(_vehLockpickStrength isEqualType 0)) exitWith {ERROR("ACE_vehicleLock_LockpickStrength invalid"); false};


### PR DESCRIPTION
**When merged this pull request will:**
- Add magazine version of surgical kit that has its ammo decreased by one with every wound closed.
- Refactor surgicalKitProgress and getStitchTime to use actual wound count instead of count of wound arrays.

Has no influence on non-consumable Surgical Kit. Needs #8362 (and by consequence, v2.06) or more specifically the ability to check for magazines as required items for medical treatment.