### PR TITLE
Medical - Add multiple uses to consumable Surgical Kit

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -279,7 +279,7 @@ class GVAR(actions) {
         displayNameProgress = CSTRING(Stitching);
         icon = QPATHTOEF(medical_gui,ui\surgical_kit.paa);
         category = "advanced";
-        items[] = {"ACE_surgicalKit"};
+        items[] = {"ACE_surgicalKit_mag"};
         treatmentLocations = QGVAR(locationSurgicalKit);
         allowSelfTreatment = QGVAR(allowSelfStitch);
         medicRequired = QGVAR(medicSurgicalKit);
@@ -287,7 +287,7 @@ class GVAR(actions) {
         condition = QFUNC(canStitch);
         callbackSuccess = "";
         callbackProgress = QFUNC(surgicalKitProgress);
-        consumeItem = QGVAR(consumeSurgicalKit);
+        consumeItem = 0;
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
         litter[] = {{"ACE_MedicalLitter_gloves"}};
     };

--- a/addons/medical_treatment/CfgMagazines.hpp
+++ b/addons/medical_treatment/CfgMagazines.hpp
@@ -7,7 +7,7 @@ class CfgMagazines {
         model = QPATHTOF(data\surgical_kit.p3d);
         picture = QPATHTOF(ui\surgicalKit_ca.paa);
         descriptionShort = CSTRING(SurgicalKit_Desc_Short);
-        descriptionUse = CSTRING(SurgicalKit_Desc_Use);
+        deleteIfEmpty = 1;
         mass = 15;
     };
 };

--- a/addons/medical_treatment/CfgMagazines.hpp
+++ b/addons/medical_treatment/CfgMagazines.hpp
@@ -7,6 +7,7 @@ class CfgMagazines {
         model = QPATHTOF(data\surgical_kit.p3d);
         picture = QPATHTOF(ui\surgicalKit_ca.paa);
         descriptionShort = CSTRING(SurgicalKit_Desc_Short);
+        count = SURGICAL_KIT_USES;
         deleteIfEmpty = 1;
         mass = 15;
     };

--- a/addons/medical_treatment/CfgMagazines.hpp
+++ b/addons/medical_treatment/CfgMagazines.hpp
@@ -1,0 +1,13 @@
+class CfgMagazines {
+    class CA_Magazine;
+    class ACE_surgicalKit_mag: CA_Magazine {
+        scope = 2;
+        author = ECSTRING(common,ACETeam);
+        displayName= CSTRING(SurgicalKit_Display);
+        model = QPATHTOF(data\surgical_kit.p3d);
+        picture = QPATHTOF(ui\surgicalKit_ca.paa);
+        descriptionShort = CSTRING(SurgicalKit_Desc_Short);
+        descriptionUse = CSTRING(SurgicalKit_Desc_Use);
+        mass = 15;
+    };
+};

--- a/addons/medical_treatment/CfgReplacementItems.hpp
+++ b/addons/medical_treatment/CfgReplacementItems.hpp
@@ -21,6 +21,6 @@ class EGVAR(medical,replacementItems) {
         {"ACE_adenosine", 1}
     };
     ACE_surgicalKit[] = {
-        {"ACE_surgicalKit_mag", 1};
+        {"ACE_surgicalKit_mag", 1}
     };
 };

--- a/addons/medical_treatment/CfgReplacementItems.hpp
+++ b/addons/medical_treatment/CfgReplacementItems.hpp
@@ -20,4 +20,7 @@ class EGVAR(medical,replacementItems) {
     ACE_atropine[] = {
         {"ACE_adenosine", 1}
     };
+    ACE_surgicalKit[] = {
+        {"ACE_surgicalKit_mag", 1};
+    };
 };

--- a/addons/medical_treatment/config.cpp
+++ b/addons/medical_treatment/config.cpp
@@ -21,4 +21,5 @@ class CfgPatches {
 #include "CfgReplacementItems.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgMagazines.hpp"
 #include "Cfg3DEN.hpp"

--- a/addons/medical_treatment/functions/fnc_getStitchTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getStitchTime.sqf
@@ -18,4 +18,12 @@
 
 params ["", "_patient"];
 
-count (_patient call FUNC(getStitchableWounds)) * GVAR(woundStitchTime)
+private _stitchableWounds = _patient call FUNC(getStitchableWounds);
+
+private _woundCount = 0;
+{
+    _x params ["_woundID", "_bodyPartN", "_amountOf"];
+    _woundCount = _woundCount + (ceil _amountOf);
+} forEach _stitchableWounds;
+
+_woundCount * GVAR(woundStitchTime)

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -68,7 +68,7 @@ _treatedWound set [2, _treatedAmountOf];
 private _woundIndex = _stitchedWounds findIf {
     _x params ["_classID", "_bodyPartN"];
 
-    _classID == _treatedID && {_bodyPartN == _treatedBodyPartN}
+    [_classID, _bodyPartN] isEqualTo [_treatedID, _treatedBodyPartN]
 };
 
 if (_woundIndex == -1) then {

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -53,7 +53,7 @@ private _stitchedWounds = GET_STITCHED_WOUNDS(_patient);
 private _treatedWoundIndex = _bandagedWounds find (_stitchableWounds select 0);
 private _bandagedWound = (_bandagedWounds select _treatedWoundIndex);
 _bandagedWound params ["_bandagedID", "_bandagedBodyPartN", "_bandagedAmountOf"];
-private _treatedWound = +_bandagedWound;
+private _treatedWound = +_bandagedWound; // need a copy so we don't alter the original
 _treatedWound params ["_treatedID", "_treatedBodyPartN", "_treatedAmountOf"];
 
 if (_bandagedAmountOf - 1 <= 0) then {
@@ -63,6 +63,7 @@ if (_bandagedAmountOf - 1 <= 0) then {
     _bandagedWounds set [_treatedWoundIndex, _bandagedWound];
 };
 
+// Can be lazy here, _treatedWound is only used in its entirety when a new wound is being added
 _treatedAmountOf = _treatedAmountOf min 1;
 _treatedWound set [2, _treatedAmountOf];
 

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -31,11 +31,8 @@ if (_stitchableWounds isEqualTo []) exitWith {false};
 private _allMedicMagazines = magazinesAmmo _medic;
 private _hasUsesLeft = _allMedicMagazines findIf {(_x select 0) isEqualTo "ACE_surgicalKit_mag"} != -1;
 
-// Stop treatment & remove empty magazines if there are no more surgical kit uses
-if ((GVAR(consumeSurgicalKit) > 0) && {!_hasUsesLeft}) exitWith {
-    [_medic, "ACE_surgicalKit_mag", 0] call EFUNC(common,removeSpecificMagazine);
-    false
-};
+// Stop treatment if there are no more surgical kit uses
+if ((GVAR(consumeSurgicalKit) > 0) && {!_hasUsesLeft}) exitWith {false};
 
 private _woundCount = 0;
 {

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Arguments <ARRAY>
- *   0: Medic (not used) <OBJECT>
+ *   0: Medic <OBJECT>
  *   1: Patient <OBJECT>
  * 1: Elapsed Time <NUMBER>
  * 2: Total Time <NUMBER>
@@ -20,22 +20,51 @@
  */
 
 params ["_args", "_elapsedTime", "_totalTime"];
-_args params ["", "_patient"];
+_args params ["_medic", "_patient"];
 
 private _stitchableWounds = _patient call FUNC(getStitchableWounds);
 
 // Stop treatment if there are no wounds that can be stitched remaining
 if (_stitchableWounds isEqualTo []) exitWith {false};
 
+// magazinesAmmo only returns magazines with ammo, so can check for uses this way
+private _allMedicMagazines = magazinesAmmo _medic;
+private _hasUsesLeft = _allMedicMagazines findIf {(_x select 0) isEqualTo "ACE_surgicalKit_mag"} != -1;
+
+// Stop treatment & remove empty magazines if there are no more surgical kit uses
+if ((GVAR(consumeSurgicalKit) > 0) && {!_hasUsesLeft}) exitWith {
+    [_medic, "ACE_surgicalKit_mag", 0] call EFUNC(common,removeSpecificMagazine);
+    false
+};
+
+private _woundCount = 0;
+{
+    _x params ["_woundID", "_bodyPartN", "_amountOf"];
+    _woundCount = _woundCount + (ceil _amountOf);
+} forEach _stitchableWounds;
+
 // Not enough time has elapsed to stitch a wound
-if (_totalTime - _elapsedTime > (count _stitchableWounds - 1) * GVAR(woundStitchTime)) exitWith {true};
+if (_totalTime - _elapsedTime > (_woundCount - 1) * GVAR(woundStitchTime)) exitWith {true};
 
 private _bandagedWounds = GET_BANDAGED_WOUNDS(_patient);
 private _stitchedWounds = GET_STITCHED_WOUNDS(_patient);
 
-// Remove the first stitchable wound from the bandaged wounds
-private _treatedWound = _bandagedWounds deleteAt (_bandagedWounds find (_stitchableWounds select 0));
+// Reduce stitched wound amount from bandaged wounds and delete when empty
+private _treatedWoundIndex = _bandagedWounds find (_stitchableWounds select 0);
+private _bandagedWound = (_bandagedWounds select _treatedWoundIndex);
+_bandagedWound params ["_bandagedID", "_bandagedBodyPartN", "_bandagedAmountOf"];
+private _treatedWound = +_bandagedWound;
 _treatedWound params ["_treatedID", "_treatedBodyPartN", "_treatedAmountOf"];
+
+if (_bandagedAmountOf - 1 <= 0) then {
+    _bandagedWounds deleteAt _treatedWoundIndex;
+} else {
+    _bandagedWound set [2, _bandagedAmountOf - 1];
+    _bandagedWounds set [_treatedWoundIndex, _bandagedWound];
+};
+
+_treatedAmountOf = _treatedAmountOf min 1;
+_treatedWound set [2, _treatedAmountOf];
 
 // Check if we need to add a new stitched wound or increase the amount of an existing one
 private _woundIndex = _stitchedWounds findIf {
@@ -53,6 +82,17 @@ if (_woundIndex == -1) then {
 
 _patient setVariable [VAR_BANDAGED_WOUNDS, _bandagedWounds, true];
 _patient setVariable [VAR_STITCHED_WOUNDS, _stitchedWounds, true];
+
+if (GVAR(consumeSurgicalKit) > 0) then {
+    private _allSurgicalKits = _allMedicMagazines select {(_x select 0) isEqualTo "ACE_surgicalKit_mag"};
+    private _ammo = (_allSurgicalKits select 0) select 1;
+    _allSurgicalKits deleteAt 0;
+    _medic removeMagazines "ACE_surgicalKit_mag";
+    _medic addMagazine ["ACE_surgicalKit_mag", _ammo - 1];
+    {
+        _medic addMagazine ["ACE_surgicalKit_mag", _x select 1];
+    } forEach _allSurgicalKits;
+};
 
 // Check if we fixed limping by stitching this wound (only for leg wounds)
 if (EGVAR(medical,limping) == 2 && {_patient getVariable [QEGVAR(medical,isLimping), false]} && {_treatedBodyPartN > 3}) then {

--- a/addons/medical_treatment/script_component.hpp
+++ b/addons/medical_treatment/script_component.hpp
@@ -54,3 +54,6 @@
 
 // Animations that would be played faster than this are instead skipped. (= Progress bar too quick for animation).
 #define ANIMATION_SPEED_MAX_COEFFICIENT 2.5
+
+// Number of wounds a single surgical kit can close if consume setting is enabled
+#define SURGICAL_KIT_USES 50


### PR DESCRIPTION
**When merged this pull request will:**

- Add magazine version of surgical kit that has its ammo decreased by one with every wound closed.
- Refactor surgicalKitProgress and getStitchTime to use actual wound count instead of count of wound arrays.
- Change stitching to close one wound instead of one wound conglomerate every GVAR(woundStitchTime) seconds.

Charge system has no influence on non-consumable Surgical Kit. Needs #8362 (and by consequence, v2.06) or more specifically the ability to check for magazines as required items for medical treatment.

New stitching will close one wound every GVAR(woundStitchTime) seconds. Previous behaviour was to close every set of same ID wounds on same limb instead, so if patient had 4x Medium Avulsions on their left leg, the 4 would be closed at once. Now, 1 is closed and array is only deleted when post-stitch amount would be negative or 0.