### PR TITLE
Medical - Add dropping weapons on unconsciousness

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -182,6 +182,7 @@ PREP(toBin);
 PREP(toBitmask);
 PREP(toHex);
 PREP(toNumber);
+PREP(throwWeapon)
 PREP(unhideUnit);
 PREP(uniqueElements);
 PREP(uniqueItems);

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -182,7 +182,7 @@ PREP(toBin);
 PREP(toBitmask);
 PREP(toHex);
 PREP(toNumber);
-PREP(throwWeapon)
+PREP(throwWeapon);
 PREP(unhideUnit);
 PREP(uniqueElements);
 PREP(uniqueItems);

--- a/addons/common/functions/fnc_throwWeapon.sqf
+++ b/addons/common/functions/fnc_throwWeapon.sqf
@@ -11,7 +11,7 @@
  * Weapon Holder
  *
  * Example:
- * player call ace_hitreactions_fnc_throwWeapon
+ * player call ace_common_fnc_throwWeapon
  *
  * Public: No
  */

--- a/addons/fire/functions/fnc_burnReaction.sqf
+++ b/addons/fire/functions/fnc_burnReaction.sqf
@@ -21,7 +21,7 @@ if (
     && {_unit in _unit && { !(currentWeapon _unit isEqualTo "") }}
     && {!isPlayer _unit || GVAR(dropWeapon >= 2)}
 ) then {
-    [_unit] call EFUNC(hitreactions,throwWeapon);
+    [_unit] call EFUNC(common,throwWeapon);
 };
 
 if (_unit isKindOf "CAManBase") then {

--- a/addons/hitreactions/XEH_PREP.hpp
+++ b/addons/hitreactions/XEH_PREP.hpp
@@ -1,4 +1,3 @@
 
 PREP(fallDown);
 PREP(getRandomAnimation);
-PREP(throwWeapon);

--- a/addons/medical_status/config.cpp
+++ b/addons/medical_status/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_medical_engine"};
+        requiredAddons[] = {"ace_medical_engine", "ace_hitreactions"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal", "KoffeinFlummi"};
         url = ECSTRING(main,URL);

--- a/addons/medical_status/config.cpp
+++ b/addons/medical_status/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_medical_engine", "ace_hitreactions"};
+        requiredAddons[] = {"ace_medical_engine"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Glowbal", "KoffeinFlummi"};
         url = ECSTRING(main,URL);

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -42,6 +42,11 @@ if (_active) then {
         _unit setVariable [QEGVAR(medical,lastWakeUpCheck), _lastWakeUpCheck max CBA_missionTime];
     };
 
+    // Player drop weapon chanse
+    if (EGVAR(medical,dropWeaponUnconsciousChanse) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChanse)}}) then {
+        _unit call EFUNC(hitreactions,throwWeapon);
+    };
+
     if (_unit == ACE_player) then {
         if (visibleMap) then {openMap false};
 

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -44,7 +44,7 @@ if (_active) then {
 
     // Player drop weapon chanse
     if (EGVAR(medical,dropWeaponUnconsciousChanse) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChanse)}}) then {
-        _unit call EFUNC(hitreactions,throwWeapon);
+        _unit call EFUNC(common,throwWeapon);
     };
 
     if (_unit == ACE_player) then {

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -42,7 +42,7 @@ if (_active) then {
         _unit setVariable [QEGVAR(medical,lastWakeUpCheck), _lastWakeUpCheck max CBA_missionTime];
     };
 
-    // Player drop weapon channe
+    // Player drop weapon chance
     if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChance)}}) then {
         _unit call EFUNC(common,throwWeapon);
     };

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -42,8 +42,8 @@ if (_active) then {
         _unit setVariable [QEGVAR(medical,lastWakeUpCheck), _lastWakeUpCheck max CBA_missionTime];
     };
 
-    // Player drop weapon chanse
-    if (EGVAR(medical,dropWeaponUnconsciousChanse) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChanse)}}) then {
+    // Player drop weapon channe
+    if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChance)}}) then {
         _unit call EFUNC(common,throwWeapon);
     };
 

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -42,16 +42,15 @@ if (_active) then {
         _unit setVariable [QEGVAR(medical,lastWakeUpCheck), _lastWakeUpCheck max CBA_missionTime];
     };
 
-    // Chance for player to drop weapon
-    if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChance)}}) then {
-        _unit call EFUNC(common,throwWeapon);
-    };
-
     if (_unit == ACE_player) then {
         if (visibleMap) then {openMap false};
 
         while {dialog} do {
             closeDialog 0;
+        };
+
+        if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {random 1 < EGVAR(medical,dropWeaponUnconsciousChance)}) then {
+            _unit call EFUNC(common,throwWeapon);
         };
     };
     // Unlock controls for copilot if unit is pilot of aircraft

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -42,7 +42,7 @@ if (_active) then {
         _unit setVariable [QEGVAR(medical,lastWakeUpCheck), _lastWakeUpCheck max CBA_missionTime];
     };
 
-    // Player drop weapon chance
+    // Chance for player to drop weapon
     if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {_unit == ACE_player && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChance)}}) then {
         _unit call EFUNC(common,throwWeapon);
     };

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -49,7 +49,7 @@ if (_active) then {
             closeDialog 0;
         };
 
-        if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {random 1 < EGVAR(medical,dropWeaponUnconsciousChance)}) then {
+        if (EGVAR(medical,dropWeaponUnconsciousChance) != 0 && {random 1 <= EGVAR(medical,dropWeaponUnconsciousChance)}) then {
             _unit call EFUNC(common,throwWeapon);
         };
     };

--- a/addons/medical_status/initSettings.sqf
+++ b/addons/medical_status/initSettings.sqf
@@ -24,3 +24,12 @@
     [0, 25, 1, 1],
     true
 ] call CBA_fnc_addSetting;
+
+[
+    QEGVAR(medical,dropWeaponUnconsciousChanse),
+    "SLIDER",
+    [LSTRING(DropWeaponUnconsciousChanse_DisplayName), LSTRING(DropWeaponUnconsciousChanse_Description)],
+    ELSTRING(medical,Category),
+    [0, 1, 0, 2, true],
+    true
+] call CBA_fnc_addSetting;

--- a/addons/medical_status/initSettings.sqf
+++ b/addons/medical_status/initSettings.sqf
@@ -26,9 +26,9 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QEGVAR(medical,dropWeaponUnconsciousChanse),
+    QEGVAR(medical,dropWeaponUnconsciousChance),
     "SLIDER",
-    [LSTRING(DropWeaponUnconsciousChanse_DisplayName), LSTRING(DropWeaponUnconsciousChanse_Description)],
+    [LSTRING(DropWeaponUnconsciousChance_DisplayName), LSTRING(DropWeaponUnconsciousChance_Description)],
     ELSTRING(medical,Category),
     [0, 1, 0, 2, true],
     true

--- a/addons/medical_status/stringtable.xml
+++ b/addons/medical_status/stringtable.xml
@@ -111,5 +111,11 @@
             <Spanish>Controla la rapidez con que fluye el líquido de las bolsas intravenosas. El cambio de volumen de la bolsa IV se calcula como: \n intervalo (s) de tiempo * cambio iv por segundo (4.1667 mL/s) * velocidad de flujo (este coeficiente).</Spanish>
             <Turkish>IV Torbalardan sıvının ne kadar hızlı aktığını kontrol eder. IV Torba hacim değişikliği şu şekilde hesaplanır: zaman aralıkları iv saniye başına değişim (4.1667 mL / s) akış hızı (bu katsayı).</Turkish>
         </Key>
+        <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChanse_DisplayName">
+            <English>Chance to Drop Weapon On Loss of Consciousness</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChanse_Description">
+            <English>The probability of a person of dropping their weapon on loss of concussion.</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/medical_status/stringtable.xml
+++ b/addons/medical_status/stringtable.xml
@@ -111,11 +111,11 @@
             <Spanish>Controla la rapidez con que fluye el líquido de las bolsas intravenosas. El cambio de volumen de la bolsa IV se calcula como: \n intervalo (s) de tiempo * cambio iv por segundo (4.1667 mL/s) * velocidad de flujo (este coeficiente).</Spanish>
             <Turkish>IV Torbalardan sıvının ne kadar hızlı aktığını kontrol eder. IV Torba hacim değişikliği şu şekilde hesaplanır: zaman aralıkları iv saniye başına değişim (4.1667 mL / s) akış hızı (bu katsayı).</Turkish>
         </Key>
-        <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChanse_DisplayName">
-            <English>Chance to Drop Weapon On Loss of Consciousness</English>
+        <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChance_DisplayName">
+            <English>Unconscious Drop Weapon</English>
         </Key>
-        <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChanse_Description">
-            <English>The probability of a person of dropping their weapon on loss of consciousness.</English>
+        <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChance_Description">
+            <English>The probability of a player dropping their weapon on loss of consciousness.</English>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_status/stringtable.xml
+++ b/addons/medical_status/stringtable.xml
@@ -115,7 +115,7 @@
             <English>Chance to Drop Weapon On Loss of Consciousness</English>
         </Key>
         <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChanse_Description">
-            <English>The probability of a person of dropping their weapon on loss of concussion.</English>
+            <English>The probability of a person of dropping their weapon on loss of consciousness.</English>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_status/stringtable.xml
+++ b/addons/medical_status/stringtable.xml
@@ -112,7 +112,7 @@
             <Turkish>IV Torbalardan sıvının ne kadar hızlı aktığını kontrol eder. IV Torba hacim değişikliği şu şekilde hesaplanır: zaman aralıkları iv saniye başına değişim (4.1667 mL / s) akış hızı (bu katsayı).</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChance_DisplayName">
-            <English>Unconscious Drop Weapon</English>
+            <English>Weapon Drop Chance</English>
         </Key>
         <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChance_Description">
             <English>Chance for a player to drop their weapon when going unconscious.\nHas no effect on AI.</English>

--- a/addons/medical_status/stringtable.xml
+++ b/addons/medical_status/stringtable.xml
@@ -115,7 +115,7 @@
             <English>Unconscious Drop Weapon</English>
         </Key>
         <Key ID="STR_ACE_Medical_Status_DropWeaponUnconsciousChance_Description">
-            <English>The probability of a player dropping their weapon on loss of consciousness.</English>
+            <English>Chance for a player to drop their weapon when going unconscious.\nHas no effect on AI.</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Added setting to allow a change of dropping held weapon when going unconscious (Default 0% chance / off)
- Moved `throwWeapon` function from `hitreactions` to `common`.