### PR TITLE
Cargo - Fix can't load `Slingload_01_Base_F`

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -356,8 +356,8 @@ class CfgVehicles {
 
      //Huron 20ft containers
     class Slingload_01_Base_F: Slingload_base_F {
-        GVAR(canLoad) = 0;
-        GVAR(size) = -1;
+        GVAR(canLoad) = 1;
+        GVAR(size) = 50;
     };
     class B_Slingload_01_Cargo_F: Slingload_01_Base_F { // Huron Cargo
         GVAR(space) = 20;

--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -357,7 +357,7 @@ class CfgVehicles {
      //Huron 20ft containers
     class Slingload_01_Base_F: Slingload_base_F {
         GVAR(canLoad) = 1;
-        GVAR(size) = 50;
+        GVAR(size) = 50; // Use same size value from 20ft containers for consistancy
     };
     class B_Slingload_01_Cargo_F: Slingload_01_Base_F { // Huron Cargo
         GVAR(space) = 20;


### PR DESCRIPTION
20ft containers (`Land_Cargo20_military_green_F`) can be loaded. But all children from `Slingload_01_Base_F` which share the same real size of a 20ft container can't be loaded (ex: `B_Slingload_01_Ammo_F`)

**When merged this pull request will:**
- This pull request enable the loading of  `Slingload_01_Base_F` childrens. It follow the current behavior of all 20 ft containers (https://github.com/acemod/ACE3/blob/e6a0772adb86d6d4d4ee038570326625e48ccdd3/addons/cargo/CfgVehicles.hpp#L534-L647)