### PR TITLE
Dragging - Fix keyhandler removing when drop

### DIFF
--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -20,7 +20,7 @@ params ["_unit", "_target"];
 TRACE_2("params",_unit,_target);
 
 // remove drop action
-[QGVAR(releaseActionID), "keydown"] call CBA_fnc_removeKeyHandler;
+[GVAR(releaseActionID), "keydown"] call CBA_fnc_removeKeyHandler;
 
 // stop blocking
 if !(GVAR(dragAndFire)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- title.

This var should not be qouted when removing:
https://github.com/acemod/ACE3/blob/58730b82fd831783bcf97f2b3dc3f6268ba4c3d3/addons/dragging/functions/fnc_dragObject.sqf#L48-L50
https://github.com/acemod/ACE3/blob/58730b82fd831783bcf97f2b3dc3f6268ba4c3d3/addons/dragging/functions/fnc_dropObject.sqf#L23