### PR TITLE
Common - Add epilepsy friendly mode

### DIFF
--- a/addons/common/functions/fnc_moduleLSDVehicles.sqf
+++ b/addons/common/functions/fnc_moduleLSDVehicles.sqf
@@ -17,7 +17,7 @@
 
 params ["", "_units", "_activated"];
 
-if !(_activated) exitWith {};
+if (!_activated || {GVAR(epilepsyFriendlyMode)}) exitWith {};
 
 if (isNil QGVAR(LSD_Vehicles)) then {
     GVAR(LSD_Vehicles) = [];

--- a/addons/common/initSettings.sqf
+++ b/addons/common/initSettings.sqf
@@ -16,3 +16,12 @@
     true,
     true
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(epilepsyFriendlyMode),
+    "CHECKBOX",
+    [LSTRING(EpilepsyFriendlyMode), LSTRING(EpilepsyFriendlyModeTooltip)],
+    format ["ACE %1", localize LSTRING(DisplayName)],
+    false,
+    2
+] call CBA_fnc_addSetting;

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1379,6 +1379,14 @@
             <Spanish>Permitir a los scripts de ACE reducir el volumen la música</Spanish>
             <Turkish>ACE scripti müziği kısmana izin verir</Turkish>
         </Key>
+        <Key ID="STR_ACE_Common_EpilepsyFriendlyMode">
+            <English>Epilepsy friendly mode</English>
+            <German>Epilepsiefreundlicher Modus</German>
+        </Key>
+        <Key ID="STR_ACE_Common_EpilepsyFriendlyModeTooltip">
+            <English>Disables some flashing light effects to reduce seizure risk.</English>
+            <German>Deaktiviert einige Lichtflackereffekte um das Risiko von Epilepsieanfällen zu reduzieren.</German>
+        </Key>
         <Key ID="STR_ACE_Common_FlagBlack">
             <English>Flag (ACE - Black)</English>
             <German>Flagge (Ace - Schwarz)</German>

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -122,8 +122,10 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
 
     // Blind player
     if (_strength > 0.1) then {
+        private _blend = [[1,1,1,0], [0.3,0.3,0.3,1]] select EGVAR(common,epilepsyFriendlyMode);
+
         GVAR(flashbangPPEffectCC) ppEffectEnable true;
-        GVAR(flashbangPPEffectCC) ppEffectAdjust [1,1,(0.8 + _strength) min 1,[1,1,1,0],[0,0,0,1],[0,0,0,0]];
+        GVAR(flashbangPPEffectCC) ppEffectAdjust [1, 1, (0.8 + _strength) min 1, _blend, [0,0,0,1], [0,0,0,0]];
         GVAR(flashbangPPEffectCC) ppEffectCommit 0.01;
 
         //PARTIALRECOVERY - start decreasing effect over time

--- a/addons/nightvision/functions/fnc_onFiredPlayer.sqf
+++ b/addons/nightvision/functions/fnc_onFiredPlayer.sqf
@@ -18,7 +18,12 @@
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
 TRACE_7("firedEH:",_unit, _weapon, _muzzle, _mode, _ammo, _magazine, _projectile);
 
-if ((!GVAR(running)) || {!GVAR(shutterEffects)} || {_weapon == "throw"} || {_weapon == "put"}) exitWith {};
+if ((!GVAR(running))
+    || {!GVAR(shutterEffects)}
+    || {EGVAR(common,epilepsyFriendlyMode)}
+    || {_weapon == "throw"}
+    || {_weapon == "put"}
+) exitWith {};
 
 private _visibleFireCoef = 1;
 if (_unit == ace_player) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Add a setting in Common for an epilepsy friendly mode

This mode will currently:
- Disable the NVG shutter effects (see #6119)
- Make the flashbang effect a dark shade of gray instead of bright white (inspired by [this reddit post](https://www.reddit.com/r/Rainbow6/comments/oudmii/hey_i_am_a_player_with_sensitivity_to_flashes_in/))

I also plan to integrate it into #7761. That's just three uses of it for now, but I believe it's a simple change that could help a few people.