### PR TITLE
UAVs - Add Pilot Camera/Sane Solo Use Capability

### DIFF
--- a/addons/uav/$PBOPREFIX$
+++ b/addons/uav/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\uav

--- a/addons/uav/CfgEventHandlers.hpp
+++ b/addons/uav/CfgEventHandlers.hpp
@@ -1,0 +1,12 @@
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/uav/CfgVehicles.hpp
+++ b/addons/uav/CfgVehicles.hpp
@@ -1,0 +1,151 @@
+class GVAR(UAVPod) {
+    class OpticsIn {
+        class Wide {
+            opticsDisplayName = "WFOV";
+            initAngleX=0; minAngleX=0; maxAngleX=0;
+            initAngleY=0; minAngleY=0; maxAngleY=0;
+            initFov = 0.5;
+            minFov = 0.5;
+            maxFov = 0.5;
+            visionMode[] = {"Normal","NVG","Ti"};
+            thermalMode[] = {0,1};
+            gunnerOpticsModel = "\A3\Drones_F\Weapons_F_Gamma\Reticle\UAV_Optics_Gunner_wide_F.p3d";
+            //gunnerOpticsModel = "\A3\Weapons_F\Reticle\Optics_Gunship_wide_F.p3d";
+            opticsPPEffects[] = {"OpticsCHAbera2","OpticsBlur2"};
+        };
+        
+        class Medium: Wide {
+            opticsDisplayName = "MFOV";
+            initFov = 0.125;
+            minFov = 0.125;
+            maxFov = 0.125;
+            gunnerOpticsModel = "\A3\Drones_F\Weapons_F_Gamma\Reticle\UAV_Optics_Gunner_medium_F.p3d";
+            //gunnerOpticsModel = "\A3\Weapons_F\Reticle\Optics_Gunship_medium_F.p3d";
+        };
+        
+        class Narrow: Wide {
+            opticsDisplayName = "NFOV";
+            initFov = 0.03125;
+            minFov = 0.03125;
+            maxFov = 0.03125;
+            gunnerOpticsModel = "\A3\Drones_F\Weapons_F_Gamma\Reticle\UAV_Optics_Gunner_narrow_F.p3d";
+            //gunnerOpticsModel = "\A3\Weapons_F\Reticle\Optics_Gunship_narrow_F.p3d";
+        };
+
+        showMiniMapInOptics = true;
+        showUAVViewInOptics= false;
+        showSlingLoadManagerInOptics= false;
+    };
+
+    minTurn = -180;
+    maxTurn  = +180;
+    initTurn = 0;
+    minElev = -10;
+    maxElev = 90;
+    initElev = 0;
+    maxXRotSpeed = 0.75;
+    maxYRotSpeed = 0.75;
+    pilotOpticsShowCursor = 1;
+    controllable = true;
+};
+
+class GVAR(UAVOptics) {
+    initAngleX = 0;
+    initAngleY = 0;
+    initFov = 1.25;
+    maxAngleX = 0;
+    maxAngleY = 0;
+    maxFov = 1.25;
+    maxMoveX = 0;
+    maxMoveY = 0;
+    maxMoveZ = 0;
+    minAngleX = 0;
+    minAngleY = 0;
+    minFov = 1.25;
+    minMoveX = 0;
+    minMoveY = 0;
+    minMoveZ = 0;
+    speedZoomMaxFOV = 0;
+    speedZoomMaxSpeed = 1e+010;
+    thermalMode[] = {0, 1};
+    visionMode[] = {"Normal", "NVG", "Ti"};
+};
+
+
+class CfgVehicles {
+    class UAV_01_Base_F;
+    class B_UAV_01_F: UAV_01_Base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+    
+    class O_UAV_01_F: UAV_01_Base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+    
+    class I_UAV_01_F: UAV_01_Base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+    
+    class I_E_UAV_01_F: UAV_01_Base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+    
+    class UAV_02_dynamicLoadout_base_F;
+    class B_UAV_02_dynamicLoadout_F: UAV_02_dynamicLoadout_base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+    
+    class O_UAV_02_dynamicLoadout_F: UAV_02_dynamicLoadout_base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+
+    class I_UAV_02_dynamicLoadout_F: UAV_02_dynamicLoadout_base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+
+    class UAV_03_dynamicLoadout_base_F;
+    class B_T_UAV_03_dynamicLoadout_F: UAV_03_dynamicLoadout_base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+
+    class UAV_04_base_F;
+    class O_T_UAV_04_CAS_F: UAV_04_base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+
+    class UAV_05_Base_F;
+    class B_UAV_05_F: UAV_05_Base_F {
+        driverWeaponsInfoType = "ACE_RscOptics_UAVPod"; //rsc with Weapon elements
+
+        class Viewoptics: GVAR(UAVOptics){};
+        class PilotCamera: GVAR(UAVPod){};
+    };
+   
+};

--- a/addons/uav/README.md
+++ b/addons/uav/README.md
@@ -1,0 +1,4 @@
+ace_uav
+===============
+
+Adds single-person usability to UAVs.

--- a/addons/uav/RscInGameUI.hpp
+++ b/addons/uav/RscInGameUI.hpp
@@ -1,0 +1,51 @@
+
+//Big thanks to commy2
+class RscControlsGroup;
+class RscPicture;
+class RscInGameUI {
+    class RscUnitInfo;
+    class RscOptics_CAS_01_TGP: RscUnitInfo {
+        class CA_IGUI_elements_group: RscControlsGroup {
+            class controls {
+                class ValueDistance;
+                class ValueGrid;
+                class TextGrid;
+                class CA_VisionMode;
+                class CA_FlirMode;
+                class CA_Laser;
+                class TextTrackArea;
+                class TextTrackPoint;
+            };
+        };
+    };
+    class ACE_RscOptics_UAVPod: RscOptics_CAS_01_TGP {
+        class CA_IGUI_elements_group: CA_IGUI_elements_group {
+            class controls: controls {
+                class ValueDistance: ValueDistance {};
+                class ValueGrid: ValueGrid {};
+                class TextGrid: TextGrid {};
+                class CA_VisionMode: CA_VisionMode {};
+                class CA_FlirMode: CA_FlirMode {};
+                class CA_Laser: CA_Laser {};
+                class TextTrackArea: TextTrackArea {};
+                class TextTrackPoint: TextTrackPoint {};
+                class ACE_HorizontalCompass: RscPicture {
+                    idc = 207;
+                    type = 105;
+                    font = "EtelkaMonospacePro";
+                    textSize = "0.02*SafezoneH";
+                    style = 1;
+                    color[] = {1,1,1,1};
+                    x = "6.0 *      (0.01875 * SafezoneH)";
+                    y = "1.75 *         (0.025 * SafezoneH)";
+                    w = "41.3 *         (0.01875 * SafezoneH)";
+                    h = "1 *        (0.025 * SafezoneH)";
+                    imageHull = "A3\Ui_f\data\IGUI\RscIngameUI\RscOptics\horizontalCompassHull.paa";
+                    imageTurret = "A3\Ui_f\data\IGUI\RscIngameUI\RscOptics\horizontalCompassTurret.paa";
+                    imageObsTurret = "A3\Ui_f\data\IGUI\RscIngameUI\RscOptics\horizontalCompassObsTurret.paa";
+                    imageGun = "#(rgb,8,8,3)color(0,0,0,0)";
+                };
+            };
+        };
+    };
+};

--- a/addons/uav/XEH_postInit.sqf
+++ b/addons/uav/XEH_postInit.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+
+["Air", "init", {
+    params ["_vehicle"];
+    if (!unitIsUAV _vehicle) exitWith {};
+    if (!hasPilotCamera _vehicle) exitWith {};
+
+    GVAR(pfehID) = [{
+        params ["_args", "_pfID"];
+        _args params ["_vehicle"];
+
+        if (isNull _vehicle) exitWith {
+            [_pfID] call CBA_fnc_removePerFrameHandler;
+        };
+        if (!alive _vehicle) exitWith {
+            [_pfID] call CBA_fnc_removePerFrameHandler;
+        };
+        if ("GUNNER" in (UAVControl _vehicle)) exitWith {
+            _vehicle lockCameraTo [objNull, [0]];
+        };
+        if ((getPilotCameraTarget _vehicle) select 0) then {
+            _vehicle lockCameraTo [getPilotCameraTarget _vehicle select 1, [0]]; 
+        } else {
+            _vehicle lockCameraTo [objNull, [0]];
+        };
+
+    }, 0.1, [_vehicle]] call CBA_fnc_addPerFrameHandler;
+}, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/addons/uav/XEH_preInit.sqf
+++ b/addons/uav/XEH_preInit.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+ADDON = true;

--- a/addons/uav/config.cpp
+++ b/addons/uav/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_interaction"};
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"LorenLuke"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"
+#include "RscInGameUI.hpp"

--- a/addons/uav/script_component.hpp
+++ b/addons/uav/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT uav
+#define COMPONENT_BEAUTIFIED UAV
+#include "\z\ace\addons\main\script_mod.hpp"
+
+//#define DEBUG_MODE_FULL
+//#define DISABLE_COMPILE_CACHE
+//#define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_UAV
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_UAV
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_UAV
+#endif
+
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
Ultra-lightweight reimagining of #7485.

**When merged this pull request will:**
- Add pilot cameras to vanilla UAVs.
- Provide additional UI to UAV usage, including horizontal compass
- Slave UAV turret and designator to tracked pilot camera point when locked (Ctrl+T), as long as its gunner position is not occupied by a player.

**Known Issues:**
- UAV Pilot camera shares the same location with the regular internal camera, meaning the UAV body obscures the view when looking backwards. (Solution unknown at this time)