### PR TITLE
Update fnc_getNeedRearmMagazines.sqf

### DIFF
--- a/addons/rearm/functions/fnc_getNeedRearmMagazines.sqf
+++ b/addons/rearm/functions/fnc_getNeedRearmMagazines.sqf
@@ -58,10 +58,19 @@ private _pylonConfigs = configProperties [configOf _vehicle >> "Components" >> "
 private _turrets = [_vehicle] call FUNC(getAllRearmTurrets);
 {
     private _turretPath = _x;
-    private _magazines = [_vehicle, _turretPath] call FUNC(getTurretConfigMagazines);
+    private _magazineClasses = [];
 
-    // _magazines without duplicates
-    private _magazineClasses = _magazines arrayIntersect _magazines;
+    if (_vehicle getVariable [QGVAR(scriptedLoadout), false]) then {
+        {
+            _x params ["_className", "_turretCurrent"];
+            if (_turretPath isEqualTo _turretCurrent) then {
+                _magazineClasses pushBackUnique _className;
+            };
+        } forEach (magazinesAllTurrets _vehicle); 
+    } else {
+        _magazineClasses = [_vehicle, _turretPath] call FUNC(getTurretConfigMagazines);
+        _magazineClasses = _magazineClasses arrayIntersect _magazineClasses;
+    };
 
     {
         private _magazineClass = _x;


### PR DESCRIPTION
**When merged this pull request will:**
- Allow rearming magazines added through script, rather than only config `magazines[]`
- Not sure if the check for a scripted loadout is really needed, or if this method should just completely replace the orignal method with fnc_getTurretConfigMagazines that only allows config magazines.