### PR TITLE
Arsenal - Fix items in custom panels having mass of zero

### DIFF
--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -306,7 +306,7 @@ switch (_ctrlIDC) do {
             if (!isNil "_data") then {
                 private _items = _data select 0;
                 {
-                    ["CfgWeapons", _x, true] call _fnc_fill_right_Container;
+                    ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
                 } foreach ((GVAR(virtualItems) select 17) select {(toLower _x) in _items});
 
                 {


### PR DESCRIPTION
**When merged this pull request will:**
- title, items were incorrectly considered as magazines since 3rd parameter to `_fnc_fill_right_Container` was `true`
