### PR TITLE
Arsenal - Restore curator camera state when exiting

### DIFF
--- a/addons/arsenal/functions/fnc_onArsenalClose.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalClose.sqf
@@ -72,8 +72,15 @@ if (!isNil QGVAR(moduleUsed)) then {
 
 ACE_player switchCamera GVAR(cameraView);
 
-if (isMultiplayer) then {
+// Restore curator camera state
+if (!isNull curatorCamera) then {
+    GVAR(curatorCameraData) params ["_position", "_dirAndUp"];
 
+    curatorCamera setPosASL _position;
+    curatorCamera setVectorDirAndUp _dirAndUp;
+};
+
+if (isMultiplayer) then {
     [QGVAR(broadcastFace), [GVAR(center), GVAR(currentFace)], QGVAR(center) + "_face"] call CBA_fnc_globalEventJIP;
     [QGVAR(center) + "_face", GVAR(center)] call CBA_fnc_removeGlobalEventJIP;
 
@@ -85,6 +92,8 @@ GVAR(currentBox) = objNull;
 
 GVAR(camera) = nil;
 GVAR(cameraHelper) = nil;
+
+GVAR(curatorCameraData) = nil;
 
 GVAR(mouseButtonState) = nil;
 GVAR(currentLeftPanel) = nil;

--- a/addons/arsenal/functions/fnc_onArsenalOpen.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalOpen.sqf
@@ -334,6 +334,11 @@ if (isNil QGVAR(cameraPosition)) then {
     GVAR(cameraPosition) = [5,0,0,[0,0,0.85]];
 };
 
+// Save curator camera state so camera position and direction is not modified while using arsenal
+if (!isNull curatorCamera) then {
+    GVAR(curatorCameraData) = [getPosASL curatorCamera, [vectorDir curatorCamera, vectorUp curatorCamera]];
+};
+
 GVAR(cameraHelper) = createAgent ["Logic", position GVAR(center) ,[] ,0 ,"none"];
 GVAR(cameraHelper) attachTo [GVAR(center), GVAR(cameraPosition) select 3, ""];
 

--- a/addons/arsenal/functions/fnc_onArsenalOpen.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalOpen.sqf
@@ -334,7 +334,7 @@ if (isNil QGVAR(cameraPosition)) then {
     GVAR(cameraPosition) = [5,0,0,[0,0,0.85]];
 };
 
-// Save curator camera state so camera position and direction is not modified while using arsenal
+// Save curator camera state so camera position and direction are not modified while using arsenal
 if (!isNull curatorCamera) then {
     GVAR(curatorCameraData) = [getPosASL curatorCamera, [vectorDir curatorCamera, vectorUp curatorCamera]];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Preserve the curator camera's state while using arsenal
- Small QOL improvement since Zeus camera should not move unexpectedly when modifying a unit's loadout
    - Happens because mouse movement and scroll wheel still move curator camera while using the arsenal