### PR TITLE
RHS Compats - Use RHS loadorder CfgPatches for compats

### DIFF
--- a/optionals/compat_rhs_afrf3/config.cpp
+++ b/optionals/compat_rhs_afrf3/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_explosives", "ace_csw", "ace_rearm", "ace_refuel", "ace_repair", "rhs_c_weapons", "rhs_c_airweapons", "rhs_c_troops", "rhs_c_bmd", "rhs_c_bmp", "rhs_c_bmp3", "rhs_c_a2port_armor", "rhs_c_btr", "rhs_c_sprut", "rhs_c_t72", "rhs_c_tanks", "rhs_c_a2port_air", "rhs_c_a2port_car", "rhs_c_cars", "rhs_c_trucks", "rhs_c_2s3", "rhs_c_rva", "rhs_c_heavyweapons"};
+        requiredAddons[] = {"ace_explosives", "ace_csw", "ace_rearm", "ace_refuel", "ace_repair", "rhs_main_loadorder"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "commy2", "Skengman2"};
         url = ECSTRING(main,URL);

--- a/optionals/compat_rhs_gref3/config.cpp
+++ b/optionals/compat_rhs_gref3/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_explosives", "ace_csw", "rhsgref_main", "rhsgref_c_weapons"};
+        requiredAddons[] = {"ace_explosives", "ace_csw", "rhsgref_main_loadorder"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror", "Ruthberg", "Anton"};
         url = ECSTRING(main,URL);

--- a/optionals/compat_rhs_saf3/config.cpp
+++ b/optionals/compat_rhs_saf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_explosives", "rhssaf_c_weapons", "rhssaf_main"};
+        requiredAddons[] = {"ace_explosives", "rhssaf_main_loadorder"};
         author = ECSTRING(common,ACETeam);
         authors[] = {};
         url = ECSTRING(main,URL);

--- a/optionals/compat_rhs_usf3/config.cpp
+++ b/optionals/compat_rhs_usf3/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_explosives", "ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "ace_csw", "rhsusf_c_weapons", "rhsusf_c_troops", "rhsusf_c_m1a1", "rhsusf_c_m1a2", "RHS_US_A2_AirImport", "rhsusf_c_m109", "rhsusf_c_HEMTT_A4", "rhsusf_c_hmmwv", "rhsusf_c_rg33", "rhsusf_c_fmtv", "rhsusf_c_m113", "RHS_US_A2Port_Armor", "rhsusf_c_melb"};
+        requiredAddons[] = {"ace_explosives", "ace_javelin", "ace_rearm", "ace_refuel", "ace_repair", "ace_csw", "rhsusf_main_loadorder"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "Fyuran"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
Finally getting rid of my todo entry from august 2019 :D 
This just simplifies the requiredAddons, and we don't need to update anything in case RHS decides to move things around.