### PR TITLE
Fix vanilla NV Marker lifetime

### DIFF
--- a/addons/attach/CfgVehicles.hpp
+++ b/addons/attach/CfgVehicles.hpp
@@ -112,8 +112,6 @@ class CfgVehicles {
         };
     };
 
-
-
     class NATO_Box_Base;
     class Box_NATO_Support_F: NATO_Box_Base {
         class TransportItems {

--- a/addons/attach/CfgVehicles.hpp
+++ b/addons/attach/CfgVehicles.hpp
@@ -106,6 +106,14 @@ class CfgVehicles {
         brightness = 10;
     };
 
+    class NVG_TargetBase : All {
+        class NVGMarker {
+            maxLifetime = "8 * 60 * 60";
+        };
+    };
+
+
+
     class NATO_Box_Base;
     class Box_NATO_Support_F: NATO_Box_Base {
         class TransportItems {


### PR DESCRIPTION
We fixed the lifetime for our ACE IRStrobe item in #8283, but we didn't fix the liftimes when attaching the vanilla strobes.

I thought about updating the blinking pattern too. But I think its better to have separate blinking patterns so player can choose what they want.

This updates the lifetime for attached IRStrobe (NVG_TargetC) and thrown IRStrobe (NVG_TargetW).
