### PR TITLE
Hit Reactions - Add check for disabled damage

### DIFF
--- a/addons/hitreactions/functions/fnc_fallDown.sqf
+++ b/addons/hitreactions/functions/fnc_fallDown.sqf
@@ -22,6 +22,9 @@ params ["_unit", "_firer", "_damage"];
 // exit if system is disabled
 if (GVAR(minDamageToTrigger) == -1) exitWith {};
 
+// exit if damage is disabled on unit
+if !(isDamageAllowed _unit && {_unit getVariable [QEGVAR(medical,allowDamage), true]}) exitWith {};
+
 // don't fall after minor damage
 if (_damage < GVAR(minDamageToTrigger)) exitWith {};
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add check to exit fnc_fallDown if damage is disabled on a unit.
