### PR TITLE
[Attach] Add event property to detect temporary detach/reattach

### DIFF
--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -44,7 +44,7 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
         [_onAttachText, 2] call EFUNC(common,displayTextStructured);
     };
     _unit setVariable [QGVAR(attached), [[_attachedItem, _itemClassname]], true];
-    [QGVAR(attached), [_attachedItem, _itemClassname]] call CBA_fnc_localEvent;
+    [QGVAR(attached), [_attachedItem, _itemClassname, _silentScripted]] call CBA_fnc_localEvent;
 } else {
     GVAR(placeAction) = PLACE_WAITING;
 

--- a/addons/attach/functions/fnc_detach.sqf
+++ b/addons/attach/functions/fnc_detach.sqf
@@ -50,7 +50,7 @@ if (!([_unit, _itemName] call CBA_fnc_canAddItem) && {!_isChemlight}) exitWith {
     [LELSTRING(common,Inventory_Full)] call EFUNC(common,displayTextStructured);
 };
 
-[QGVAR(detaching), [_attachedObject, _itemName]] call CBA_fnc_localEvent;
+[QGVAR(detaching), [_attachedObject, _itemName, false]] call CBA_fnc_localEvent;
 
 // Add item to inventory (unless it's a chemlight)
 if (!_isChemlight) then {

--- a/addons/attach/functions/fnc_handleGetIn.sqf
+++ b/addons/attach/functions/fnc_handleGetIn.sqf
@@ -25,9 +25,10 @@ if (!local _unit) exitWith {};
 private _attachedList = _unit getVariable [QGVAR(attached), []];
 if (_attachedList isEqualTo []) exitWith {};
 
-(_attachedList select 0) params ["_xObject"];
+(_attachedList select 0) params ["_xObject", "_xItemName"];
 if (!isNull _xObject) then {
     TRACE_1("detaching and moving attached light",_xObject);
+    [QGVAR(detaching), [_xObject, _xItemName, true]] call CBA_fnc_localEvent;
     detach _xObject;
     _xObject setPos ((getPos _unit) vectorAdd [0, 0, -1000]);
     [{

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -100,6 +100,6 @@ _unit removeItem _itemClassname;
 private _attachList = _attachToVehicle getVariable [QGVAR(attached), []];
 _attachList pushBack [_attachedObject, _itemClassname];
 _attachToVehicle setVariable [QGVAR(attached), _attachList, true];
-[QGVAR(attached), [_attachedObject, _itemClassname]] call CBA_fnc_localEvent;
+[QGVAR(attached), [_attachedObject, _itemClassname, false]] call CBA_fnc_localEvent;
 
 [_onAttachText, 2] call EFUNC(common,displayTextStructured);

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -113,8 +113,8 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 
 | Event Key | Parameters | Locality | Type | Description |
 |----------|---------|---------|---------|---------|---------|
-|`ace_attach_attached` | [_attachedObject, _itemClassname] | Local | Listen | After an item was attached to a unit/vehicle
-|`ace_attach_detaching` | [_attachedObject, _itemName] | Local | Listen | Just before an item gets detached/removed from a unit/vehicle
+|`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | After an item was attached to a unit/vehicle. _temporary flag means a item is being re-attached after the player exits a vehicle
+|`ace_attach_detaching` | [_attachedObject, _itemName, _temporary] | Local | Listen | Just before an item gets detached/removed from a unit/vehicle. _temporary flag means its detached because the player unit entered a vehicle.
 
 ## 3. Usage
 Also Reference [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} documentation.


### PR DESCRIPTION
I need this for GPS trackers on the player.
I want the tracker to be moved over to the vehicle instead of being deleted, for that I need to know when that happens.