### PR TITLE
Arsenal - Fix sort running twice

### DIFF
--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -37,10 +37,6 @@ _ctrlPanel ctrlCommit FADE_DELAY;
 
 _ctrlPanel lbSetCurSel -1;
 
-// Fill sort options
-private _sortLeftCtrl = _display displayCtrl IDC_sortLeftTab;
-[_display, _control, _sortLeftCtrl] call FUNC(fillSort);
-
 // Handle icons and filling
 switch true do {
     case (_ctrlIDC in [IDC_buttonPrimaryWeapon, IDC_buttonHandgun, IDC_buttonSecondaryWeapon]) : {
@@ -191,7 +187,8 @@ GVAR(currentLeftPanel) = _ctrlIDC;
 [QGVAR(leftPanelFilled), [_display, _ctrlIDC, GVAR(currentRightPanel)]] call CBA_fnc_localEvent;
 
 // Sort
-[_sortLeftCtrl] call FUNC(sortPanel);
+private _sortLeftCtrl = _display displayCtrl IDC_sortLeftTab;
+[_display, _control, _sortLeftCtrl] call FUNC(fillSort);
 
 //Select current item
 private _itemsToCheck = ((GVAR(currentItems) select [0,15]) + [GVAR(currentFace), GVAR(currentVoice), GVAR(currentInsignia)]) apply {tolower _x};

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -363,8 +363,6 @@ if (GVAR(currentLeftPanel) in [IDC_buttonUniform, IDC_buttonVest, IDC_buttonBack
 private _sortRightCtrl = _display displayCtrl IDC_sortRightTab;
 [_display, _control, _sortRightCtrl] call FUNC(fillSort);
 
-[_sortRightCtrl] call FUNC(sortPanel);
-
 // Select current data if not in a container
 if (_itemsToCheck isNotEqualTo []) then {
     for "_lbIndex" from 0 to (lbSize _ctrlPanel - 1) do {


### PR DESCRIPTION
**When merged this pull request will:**
- title, remove unnecessary call to `sortPanel` in fill panel functions which would perform sorting twice
- When panels are filled they also fill the sort options list boxes by calling `fillSort`
- `fillSort` uses `lbSetCurSel` to select the current sort mode which triggers the `LBSelChanged` event handler which calls `sortPanel`
