### PR TITLE
Docs - Fix inconsistencies in coding guidelines

### DIFF
--- a/docs/wiki/development/coding-guidelines.md
+++ b/docs/wiki/development/coding-guidelines.md
@@ -463,17 +463,17 @@ Good:
 
 ```js
 if (call FUNC(myCondition)) then {
-   private _areAllAboveTen = true; // <- smallest feasable scope
+    private _areAllAboveTen = true; // <- smallest feasable scope
 
-   {
-      if (_x >= 10) then {
-         _areAllAboveTen = false;
-      };
-   } forEach _anArray;
+    {
+        if (_x >= 10) then {
+            _areAllAboveTen = false;
+        };
+    } forEach _anArray;
 
-   if (_areAllAboveTen) then {
-       hint "all values are above ten!";
-   };
+    if (_areAllAboveTen) then {
+        hint "all values are above ten!";
+    };
 }
 ```
 
@@ -482,15 +482,15 @@ Bad:
 ```js
 private _areAllAboveTen = true; // <- this is bad, because it can be initialized in the if statement
 if (call FUNC(myCondition)) then {
-   {
-      if (_x >= 10) then {
-         _areAllAboveTen = false;
-      };
-   } forEach _anArray;
+    {
+        if (_x >= 10) then {
+            _areAllAboveTen = false;
+        };
+    } forEach _anArray;
 
-   if (_areAllAboveTen) then {
-       hint "all values are above ten!";
-   };
+    if (_areAllAboveTen) then {
+        hint "all values are above ten!";
+    };
 };
 ```
 
@@ -575,8 +575,8 @@ Good:
 
 ```js
 fnc_example = {
-   params ["_content"];
-   hint _content;
+    params ["_content"];
+    hint _content;
 };
 ```
 
@@ -719,7 +719,7 @@ _a pushBack _value;
 Also good:
 
 ```js
-_a append [1,2,3];
+_a append [1, 2, 3];
 ```
 
 Bad:


### PR DESCRIPTION
**When merged this pull request will:**
- Fix some minor example inconsistencies in `Development/Coding guidelines`


### Indentations consist of 4 spaces

https://github.com/acemod/ACE3/blob/66ce0ba5ff79c9b43dea37b06b71649b720595b6/docs/wiki/development/coding-guidelines.md#L465-L477
https://github.com/acemod/ACE3/blob/66ce0ba5ff79c9b43dea37b06b71649b720595b6/docs/wiki/development/coding-guidelines.md#L484-L494



### When using array notation `[]`, always use a space between elements to improve code readability.
https://github.com/acemod/ACE3/blob/66ce0ba5ff79c9b43dea37b06b71649b720595b6/docs/wiki/development/coding-guidelines.md#L722