### PR TITLE
Arsenal - Stop deleting unique belt items

### DIFF
--- a/addons/arsenal/defines.hpp
+++ b/addons/arsenal/defines.hpp
@@ -176,6 +176,13 @@
 #define IDX_VIRT_VEST 5
 #define IDX_VIRT_BACKPACK 6
 #define IDX_VIRT_GOGGLES 7
+#define IDX_VIRT_NVG 8
+#define IDX_VIRT_BINO 9
+#define IDX_VIRT_MAP 10
+#define IDX_VIRT_COMPASS 11
+#define IDX_VIRT_RADIO 12
+#define IDX_VIRT_WATCH 13
+#define IDX_VIRT_COMMS 14
 
 #define SYMBOL_ITEM_NONE "−"
 #define SYMBOL_ITEM_REMOVE "×"

--- a/addons/arsenal/functions/fnc_onArsenalOpen.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalOpen.sqf
@@ -61,7 +61,7 @@ GVAR(statsPagesRight) =  [0, 0, 0, 0, 0, 0, 0, 0];
 GVAR(statsInfo) = [true, 0, controlNull, nil, nil];
 
 // Add the items the player has to virtualItems
-for "_index" from 0 to 10 do {
+for "_index" from 0 to 14 do {
     switch (_index) do {
         // primary, secondary, handgun weapons
         case IDX_VIRT_WEAPONS: {
@@ -107,6 +107,16 @@ for "_index" from 0 to 10 do {
                     };
                 };
             } forEach _magsArray;
+        };
+
+        // Assigned items
+        case IDX_VIRT_MAP;
+        case IDX_VIRT_COMPASS;
+        case IDX_VIRT_RADIO;
+        case IDX_VIRT_WATCH;
+        case IDX_VIRT_COMMS: {
+            private _item = (assignedItems GVAR(center)) select (_index - 10);
+            (GVAR(virtualItems) select _index) pushBackUnique (_item);
         };
 
         // Inventory items


### PR DESCRIPTION
**When merged this pull request will:**
- Add center's belt items (map, compass, radio, watch, GPS) to virtualItems array, preventing them from being deleted if accessed on a box where those items are unique.
