### PR TITLE
Explosives - Fix Dial Tone Sound Position

### DIFF
--- a/addons/explosives/functions/fnc_dialingPhone.sqf
+++ b/addons/explosives/functions/fnc_dialingPhone.sqf
@@ -22,7 +22,8 @@ params ["_args", "_pfID"];
 _args params ["_unit", "_i", "_arr", "_code"];
 
 if ((_i mod 4) == 0) then {
-    playSound3D [QUOTE(PATHTO_R(Data\Audio\DialTone.wss)), objNull, false, (_unit modelToWorldVisualWorld [0,0.2,2]), 5,1,5];
+    private _pos = _unit modelToWorldVisualWorld (_unit selectionPosition "RightHand");
+    playSound3D [QUOTE(PATHTO_R(Data\Audio\DialTone.wss)), objNull, false, _pos, 5, 1, 5];
 };
 ctrlSetText [1400,format["Calling%1",_arr select (_i - 4)]];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Replace `modelToWorldVisual` with `modelToWorldVisualWorld` so that `playSound3D` plays the dial sound at the correct position.

I wanted to implement dialing as requested [here](https://github.com/acemod/ACE3/issues/3594#issuecomment-919802127), but to my surprise there was already dial tone functionality in the module!

A quick search shows every other code that uses `playSound3D` with `modelToWorldVisual` first runs it through `AGLToASL`, so this bug was unique. **Edit:** I've made another PR (#8489) to get rid of this ambiguity everywhere else.