### PR TITLE
Common - Fix `arithmeticGetResult` hash values extraction

### DIFF
--- a/addons/common/functions/fnc_arithmeticGetResult.sqf
+++ b/addons/common/functions/fnc_arithmeticGetResult.sqf
@@ -21,7 +21,8 @@
 params ["_namespace", "_setID", "_operation"];
 TRACE_3("arithmeticGetResult",_namespace,_setID,_operation);
 
-private _data = (_namespace getVariable _setID) param [2, [{0}]];
+private _hash = _namespace getVariable [_setID, createHashMapFromArray [["empty", {0}]]];
+private _data = values _hash;
 
 switch (_operation) do {
     case "max": {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `ace_common_fnc_arithmeticGetResult` hash values extraction

Close https://github.com/acemod/ACE3/issues/8502