### PR TITLE
Repair - Use callback functions directly

### DIFF
--- a/addons/repair/ACE_Repair.hpp
+++ b/addons/repair/ACE_Repair.hpp
@@ -9,11 +9,11 @@ class ACE_Repair {
             repairingTime = 10;
             repairingTimeSelfCoef = 1;
             items = QGVAR(wheelRepairRequiredItems);
-            condition = QUOTE(call FUNC(canReplaceWheel));
+            condition = QFUNC(canReplaceWheel);
             itemConsumed = 0;
             claimObjects[] = {{"ACE_Wheel"}};
 
-            callbackSuccess = QUOTE(call FUNC(doReplaceWheel));
+            callbackSuccess = QFUNC(doReplaceWheel);
             callbackFailure = "";
             callbackProgress = "";
 
@@ -26,17 +26,17 @@ class ACE_Repair {
         class RemoveWheel: ReplaceWheel {
             displayName = CSTRING(RemoveWheel);
             displayNameProgress = CSTRING(RemovingWheel);
-            condition = QUOTE(call FUNC(canRemove));
-            callbackSuccess = QUOTE(call FUNC(doRemoveWheel));
+            condition = QFUNC(canRemove);
+            callbackSuccess = QFUNC(doRemoveWheel);
             claimObjects[] = {};
         };
         class MiscRepair: ReplaceWheel {
             displayName = CSTRING(Repairing); // let's make empty string an auto generated string
             displayNameProgress = CSTRING(RepairingHitPoint);
-            condition = QUOTE(call FUNC(canMiscRepair));
+            condition = QFUNC(canMiscRepair);
             requiredEngineer = QGVAR(engineerSetting_Repair);
             repairingTime = 15;
-            callbackSuccess = QUOTE(call FUNC(doRepair));
+            callbackSuccess = QFUNC(doRepair);
             items = QGVAR(miscRepairRequiredItems);
             itemConsumed = QGVAR(consumeItem_ToolKit);
             claimObjects[] = {};
@@ -44,8 +44,8 @@ class ACE_Repair {
         class RepairTrack: MiscRepair {
             displayName = CSTRING(Repairing);
             displayNameProgress = CSTRING(RepairingHitPoint);
-            condition = QUOTE(call FUNC(canRepairTrack));
-            callbackSuccess = QUOTE(call FUNC(doRepairTrack));
+            condition = QFUNC(canRepairTrack);
+            callbackSuccess = QFUNC(doRepairTrack);
             requiredEngineer = QGVAR(engineerSetting_Wheel);
             claimObjects[] = {{"ACE_Track"}};
             itemConsumed = 0;
@@ -53,16 +53,16 @@ class ACE_Repair {
         class RemoveTrack: MiscRepair {
             displayName = CSTRING(RemoveTrack);
             displayNameProgress = CSTRING(RemovingTrack);
-            condition = QUOTE(call FUNC(canRemove));
-            callbackSuccess = QUOTE(call FUNC(doRemoveTrack));
+            condition = QFUNC(canRemove);
+            callbackSuccess = QFUNC(doRemoveTrack);
             requiredEngineer = QGVAR(engineerSetting_Wheel);
             itemConsumed = 0;
         };
         class ReplaceTrack: RemoveTrack {
             displayName = CSTRING(ReplaceTrack);
             displayNameProgress = CSTRING(ReplacingTrack);
-            condition = QUOTE(call FUNC(canReplaceTrack));
-            callbackSuccess = QUOTE(call FUNC(doReplaceTrack));
+            condition = QFUNC(canReplaceTrack);
+            callbackSuccess = QFUNC(doReplaceTrack);
             requiredEngineer = QGVAR(engineerSetting_Wheel);
             claimObjects[] = {{"ACE_Track"}};
         };
@@ -73,7 +73,7 @@ class ACE_Repair {
             repairLocations[] = {QGVAR(fullRepairLocation)};
             repairingTime = 30;
             condition = "-1 != ((getAllHitPointsDamage _target param [2,[]]) findIf {_x > 0})";
-            callbackSuccess = QUOTE(call FUNC(doFullRepair));
+            callbackSuccess = QFUNC(doFullRepair);
             items = QGVAR(fullRepairRequiredItems);
             itemConsumed = QGVAR(consumeItem_ToolKit);
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Switch callback lines in `ACE_Repair.hpp` to use functions directly in `fnc_repair` instead of call statement that'll need to be recompiled.
