### PR TITLE
Medical - Clean up namespaces used by (de-)serializing functions

### DIFF
--- a/addons/medical/functions/fnc_deserializeState.sqf
+++ b/addons/medical/functions/fnc_deserializeState.sqf
@@ -96,3 +96,5 @@ private _targetState = _state getVariable [QGVAR(statemachineState), "Default"];
 if (_currentState in ["Unconscious", "CardiacArrest"] && {_targetState in ["Default", "Injured"]}) then {
     [_unit, false] call EFUNC(medical_status,setUnconsciousState);
 };
+
+_state call CBA_fnc_deleteNamespace;

--- a/addons/medical/functions/fnc_serializeState.sqf
+++ b/addons/medical/functions/fnc_serializeState.sqf
@@ -61,4 +61,6 @@ private _currentState = [_unit, GVAR(STATE_MACHINE)] call CBA_statemachine_fnc_g
 _state setVariable [QGVAR(statemachineState), _currentState];
 
 // Serialize & return
-[_state] call CBA_fnc_encodeJSON
+private _json = [_state] call CBA_fnc_encodeJSON;
+_state call CBA_fnc_deleteNamespace;
+_json


### PR DESCRIPTION
**When merged this pull request will:**
- title, using these functions would result in a lot of temporary namespaces that were never cleaned up
