### PR TITLE
General - Empty units/weapons arryas in ACEX `CfgPatches` and add `acex_main`

### DIFF
--- a/addons/field_rations/config.cpp
+++ b/addons/field_rations/config.cpp
@@ -51,7 +51,10 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 
-    class XADDON: ADDON {};
+    class XADDON: ADDON {
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 #include "CfgEventHandlers.hpp"

--- a/addons/fortify/config.cpp
+++ b/addons/fortify/config.cpp
@@ -12,7 +12,10 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 
-    class XADDON: ADDON {};
+    class XADDON: ADDON {
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 #include "Cfg3DEN.hpp"

--- a/addons/headless/config.cpp
+++ b/addons/headless/config.cpp
@@ -13,7 +13,10 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 
-    class XADDON: ADDON {};
+    class XADDON: ADDON {
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 #include "ACE_Settings.hpp"

--- a/addons/intelitems/config.cpp
+++ b/addons/intelitems/config.cpp
@@ -17,7 +17,10 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 
-    class XADDON: ADDON {};
+    class XADDON: ADDON {
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 #include "CfgEventHandlers.hpp"

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -11,6 +11,11 @@ class CfgPatches {
         url = CSTRING(URL);
         VERSION_CONFIG;
     };
+
+    class XADDON: ADDON { // just in-case anything requires "acex_main"
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 class CfgMods {

--- a/addons/sitting/config.cpp
+++ b/addons/sitting/config.cpp
@@ -13,7 +13,10 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 
-    class XADDON: ADDON {};
+    class XADDON: ADDON {
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 #include "ACE_Settings.hpp"

--- a/addons/viewrestriction/config.cpp
+++ b/addons/viewrestriction/config.cpp
@@ -13,7 +13,10 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 
-    class XADDON: ADDON {};
+    class XADDON: ADDON {
+        units[] = {};
+        weapons[] = {};
+    };
 };
 
 #include "CfgEventHandlers.hpp"


### PR DESCRIPTION
- Add acex_main in case something required it
- Prevent cfgVehicles being listed in 2 different cfgPatches (I think this makes sense?)