### PR TITLE
Medical Feedback - Fix pain effects when set to `Only high pain effect`

### DIFF
--- a/addons/medical_feedback/functions/fnc_effectPain.sqf
+++ b/addons/medical_feedback/functions/fnc_effectPain.sqf
@@ -19,10 +19,10 @@
 params ["_enable", "_intensity"];
 
 if (!_enable || {_intensity == 0}) exitWith {
-    GVAR(ppPain) ppEffectEnable false;
+    if (GVAR(ppPain) != -1) then { GVAR(ppPain) ppEffectEnable false; };
     GVAR(ppPainBlur) ppEffectEnable false;
 };
-GVAR(ppPain) ppEffectEnable true;
+if (GVAR(ppPain) != -1) then { GVAR(ppPain) ppEffectEnable true; };
 GVAR(ppPainBlur) ppEffectEnable true;
 
 // Trigger effect every 2s

--- a/addons/medical_feedback/functions/fnc_initEffects.sqf
+++ b/addons/medical_feedback/functions/fnc_initEffects.sqf
@@ -33,7 +33,7 @@ private _fnc_createEffect = {
 // - Pain ---------------------------------------------------------------------
 if (!isNil QGVAR(ppPain)) then {
     TRACE_1("delete pain",GVAR(ppPain));
-    ppEffectDestroy GVAR(ppPain)
+    if (GVAR(ppPain) != -1) then { ppEffectDestroy GVAR(ppPain); };
 };
 switch (GVAR(painEffectType)) do {
     case FX_PAIN_WHITE_FLASH: {
@@ -57,6 +57,7 @@ switch (GVAR(painEffectType)) do {
             [0, 0, false]
         ] call _fnc_createEffect;
     };
+    default { GVAR(ppPain) = -1; };
 };
 // Base blur on high pain
 if (isNil QGVAR(ppPainBlur)) then {


### PR DESCRIPTION
Close #8533

on setting 3, the `GVAR(ppPain)` would be left `nil`