### PR TITLE
Towing - Fix you can still tow wreck even if you shouldn't

### DIFF
--- a/addons/towing/functions/fnc_towStateMachinePFH.sqf
+++ b/addons/towing/functions/fnc_towStateMachinePFH.sqf
@@ -20,7 +20,7 @@ _args params ["_state", "_unit", "_parent", "_rope", "_length", "_ropeClass"];
 
 private _exitCondition = !(
     (alive GVAR(attachHelper)) &&
-    { alive _target } &&
+    { alive _parent } &&
     { alive _unit } &&
     { "" isEqualTo currentWeapon _unit || { _unit call EFUNC(common,isSwimming) }} &&
     { [_unit, objNull, [INTERACTION_EXCEPTIONS]] call EFUNC(common,canInteractWith) } &&


### PR DESCRIPTION
You can still try to attach rope on wreck which you shouldn't be allow according to the current implementation

**When merged this pull request will:**
- Little typo: `_target` is not define
- Change `_target` to `_parent`
