### PR TITLE
SOG Compat - Add support for M63A belt linking

### DIFF
--- a/optionals/compat_sog/CfgMagazines/belts.hpp
+++ b/optionals/compat_sog/CfgMagazines/belts.hpp
@@ -8,3 +8,7 @@ class vn_pk_100_mag: vn_lmgmag_base {
 class vn_rpd_100_mag: vn_lmgmag_base {
     ACE_isBelt = 1;
 };
+class vn_m16_mag_base;
+class vn_m63a_100_mag: vn_m16_mag_base {
+    ACE_isBelt = 1;
+};


### PR DESCRIPTION
When merged this pull request will:
set ACE_isBelt to 1 for all magazines for the M63A Commando and LMG