### PR TITLE
General - Format config classes with consistent spacing

### DIFF
--- a/addons/aircraft/RscInGameUI.hpp
+++ b/addons/aircraft/RscInGameUI.hpp
@@ -1,6 +1,6 @@
 class RscControlsGroup;
 class RscText;
-class RangeText: RscText{};
+class RangeText: RscText {};
 class RscPicture;
 class RscOpticsText;
 class RscIGProgress;

--- a/addons/artillerytables/RscRangeTable.hpp
+++ b/addons/artillerytables/RscRangeTable.hpp
@@ -42,7 +42,7 @@ class GVAR(rangeTableDialog) {
             colorSelectBackground[] = {0, 0, 0, 0.025};
             colorSelectBackground2[] = {0, 0, 0, 0.025};
             colorScrollbar[] = {0.95,0,0.95,1};
-            class ListScrollBar: ScrollBar{
+            class ListScrollBar: ScrollBar {
                 color[] = {0,0,0,0.6};
             };
         };

--- a/addons/cargo/menu.hpp
+++ b/addons/cargo/menu.hpp
@@ -6,7 +6,7 @@ class GVAR(menu) {
     onLoad = QUOTE([_this select 0] call FUNC(onMenuOpen));
     onUnload = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuDisplay)),nil)];);
     class controlsBackground {
-        class HeaderBackground: ACE_gui_backgroundBase{
+        class HeaderBackground: ACE_gui_backgroundBase {
             idc = -1;
             SizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
             x = "13 * (((safezoneW / safezoneH) min 1.2) / 40) + (safezoneX + (safezoneW - ((safezoneW / safezoneH) min 1.2))/2)";

--- a/addons/cargo/renameMenu.hpp
+++ b/addons/cargo/renameMenu.hpp
@@ -6,7 +6,7 @@ class GVAR(renameMenu) {
     onLoad = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuDisplay)),_this select 0)];);
     onUnload = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuDisplay)),nil)];);
     class controlsBackground {
-        class HeaderBackground: ACE_gui_backgroundBase{
+        class HeaderBackground: ACE_gui_backgroundBase {
             idc = -1;
             SizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 1)";
             x = "13 * (((safezoneW / safezoneH) min 1.2) / 40) + (safezoneX + (safezoneW - ((safezoneW / safezoneH) min 1.2))/2)";

--- a/addons/concertina_wire/CfgVehicles.hpp
+++ b/addons/concertina_wire/CfgVehicles.hpp
@@ -34,22 +34,22 @@ class CfgVehicles {
                 source = "user";
                 animPeriod = 1e-007;
             };
-            class wire_3: wire_2{};
-            class wire_4: wire_2{};
-            class wire_5: wire_2{};
-            class wire_6: wire_2{};
-            class wire_7: wire_2{};
-            class wire_8: wire_2{};
-            class wire_9: wire_2{};
-            class wire_10: wire_2{};
-            class wire_11: wire_2{};
-            class wire_12: wire_2{};
-            class wire_13: wire_2{};
-            class wire_14: wire_2{};
-            class wire_15: wire_2{};
-            class wire_16: wire_2{};
-            class wire_17: wire_2{};
-            class wire_18: wire_2{};
+            class wire_3: wire_2 {};
+            class wire_4: wire_2 {};
+            class wire_5: wire_2 {};
+            class wire_6: wire_2 {};
+            class wire_7: wire_2 {};
+            class wire_8: wire_2 {};
+            class wire_9: wire_2 {};
+            class wire_10: wire_2 {};
+            class wire_11: wire_2 {};
+            class wire_12: wire_2 {};
+            class wire_13: wire_2 {};
+            class wire_14: wire_2 {};
+            class wire_15: wire_2 {};
+            class wire_16: wire_2 {};
+            class wire_17: wire_2 {};
+            class wire_18: wire_2 {};
 
             class wire_2_1: wire_2 {
                 animPeriod = 8;

--- a/addons/csw/Cfg3den.hpp
+++ b/addons/csw/Cfg3den.hpp
@@ -9,7 +9,7 @@ class Cfg3DEN {
         };
         class Combo: Title {
            class Controls: Controls {
-                class Title: Title{};
+                class Title: Title {};
                 class Value;
             };
         };

--- a/addons/explosives/CfgMagazines.hpp
+++ b/addons/explosives/CfgMagazines.hpp
@@ -86,13 +86,13 @@ class CfgMagazines {
         GVAR(SetupObject) = "ACE_Explosives_Place_SLAM";
         class ACE_Triggers {
             SupportedTriggers[] = {"IRSensor", "PressurePlate", "Timer", "Command", "MK16_Transmitter"};
-            class PressurePlate{
+            class PressurePlate {
                 displayName = CSTRING(SLAME_Magnetic);
                 digDistance = 0;
                 ammo = "ACE_SLAMDirectionalMine_Magnetic_Ammo";
                 pitch = 90;
             };
-            class IRSensor{
+            class IRSensor {
                 displayName = CSTRING(SLAME_IRSensor);
             };
             class Timer {

--- a/addons/explosives/CfgWeapons.hpp
+++ b/addons/explosives/CfgWeapons.hpp
@@ -2,7 +2,7 @@ class CfgWeapons {
     class Default;
     class Put: Default {
         muzzles[] += {QGVAR(muzzle)};
-        class PutMuzzle: Default{};
+        class PutMuzzle: Default {};
         class GVAR(muzzle): PutMuzzle {
             magazines[] = {"ACE_FlareTripMine_Mag"};
         };

--- a/addons/explosives/config.cpp
+++ b/addons/explosives/config.cpp
@@ -41,10 +41,10 @@ class CfgActions {
     class ActivateMine: None {
         show = 0;
     };
-    class Deactivate:None {
+    class Deactivate: None {
         show = 0;
     };
-    class DeactivateMine:None {
+    class DeactivateMine: None {
         show = 0;
     };
     class UseContainerMagazine: None {

--- a/addons/goggles/RscTitles.hpp
+++ b/addons/goggles/RscTitles.hpp
@@ -1,7 +1,7 @@
-class RscTitles{
+class RscTitles {
     #include "define.hpp"
 
-    class RscACE_Goggles_BaseTitle{
+    class RscACE_Goggles_BaseTitle {
         idd = -1;
         onLoad = "uiNamespace setVariable ['ACE_Goggles_Display', _this select 0]";
         onUnload = "uiNamespace setVariable ['ACE_Goggles_Display', displayNull]";
@@ -13,25 +13,25 @@ class RscTitles{
         class controls;
     };
 
-    class RscACE_Goggles:RscACE_Goggles_BaseTitle{
+    class RscACE_Goggles: RscACE_Goggles_BaseTitle {
         idd = 1044;
         name = "RscACE_Goggles";
-        class controls{
-            class gogglesImage: RscPicture{
+        class controls {
+            class gogglesImage: RscPicture {
                 idc = 10650;
             };
         };
     };
 
-    class RscACE_GogglesEffects:RscACE_Goggles_BaseTitle{
+    class RscACE_GogglesEffects: RscACE_Goggles_BaseTitle {
         idd = 1045;
         onLoad = "uiNamespace setVariable ['ACE_Goggles_DisplayEffects', _this select 0]";
         onUnload = "uiNamespace setVariable ['ACE_Goggles_DisplayEffects', displayNull]";
         name = "RscACE_GogglesEffects";
         fadeIn=0;
         fadeOut=0.5;
-        class controls{
-            class dirtImage: RscPicture    {
+        class controls {
+            class dirtImage: RscPicture {
                 idc = 10660;
             };
             class dustImage: RscPicture {

--- a/addons/goggles/config.cpp
+++ b/addons/goggles/config.cpp
@@ -42,7 +42,7 @@ class CfgGlasses {
         ACE_Protection = 1;
     };
 
-    class G_Combat:None {
+    class G_Combat: None {
         COMBAT_GOGGLES
     };
 
@@ -57,135 +57,135 @@ class CfgGlasses {
         ACE_Protection = 1;
     };
 
-    class G_Lowprofile:None {
+    class G_Lowprofile: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 2;
         ACE_Protection = 1;
     };
 
-    class G_Shades_Black:None {
+    class G_Shades_Black: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
     };
 
-    class G_Shades_Blue:None{
+    class G_Shades_Blue: None {
         ACE_Color[] = {0,0,1};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Shades_Green:None{
+    class G_Shades_Green: None {
         ACE_Color[] = {0,1,0};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Shades_Red:None{
+    class G_Shades_Red: None {
         ACE_Color[] = {1,0,0};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Spectacles:None{
+    class G_Spectacles: None {
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Spectacles_Tinted:None{
+    class G_Spectacles_Tinted: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
     };
 
-    class G_Sport_Blackred:None{
+    class G_Sport_Blackred: None {
         ACE_Color[] = {1,0,0};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Sport_BlackWhite:None{
+    class G_Sport_BlackWhite: None {
         ACE_Color[] = {0,0,1};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Sport_Blackyellow:None{
+    class G_Sport_Blackyellow: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
     };
 
-    class G_Sport_Checkered:None{
+    class G_Sport_Checkered: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
     };
 
-    class G_Sport_Greenblack:None{
+    class G_Sport_Greenblack: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
     };
 
-    class G_Sport_Red:None{
+    class G_Sport_Red: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Color[] = {0,0,0};
         ACE_Resistance = 1;
     };
 
-    class G_Squares:None{
+    class G_Squares: None {
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Squares_Tinted:None{
+    class G_Squares_Tinted: None {
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Tactical_Black:None{
+    class G_Tactical_Black: None {
         ACE_TintAmount=COLOUR;
         ACE_Color[] = {0,0,-1.5};
         ACE_Resistance = 1;
     };
 
-    class G_Tactical_Clear:None{
+    class G_Tactical_Clear: None {
         ACE_TintAmount=COLOUR;
         ACE_Color[] = {0,0,-1};
         ACE_Resistance = 1;
     };
 
-    class G_Aviator:None{
+    class G_Aviator: None {
         ACE_Color[] = {0,0,-1};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Lady_Blue:None{
+    class G_Lady_Blue: None {
         ACE_Color[] = {0,0,1};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Lady_Red:None{
+    class G_Lady_Red: None {
         ACE_Color[] = {1,0,0};
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
-    class G_Lady_Dark:None{
+    class G_Lady_Dark: None {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
     };
 
-    class G_Lady_Mirror:None{
+    class G_Lady_Mirror: None {
         ACE_TintAmount=COLOUR;
         ACE_Resistance = 1;
     };
 
     class G_Balaclava_blk;
 
-    class G_Balaclava_combat:G_Balaclava_blk {
+    class G_Balaclava_combat: G_Balaclava_blk {
         COMBAT_GOGGLES
     };
 
-    class G_Balaclava_lowprofile:G_Balaclava_blk {
+    class G_Balaclava_lowprofile: G_Balaclava_blk {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 2;
         ACE_Protection = 1;
@@ -202,7 +202,7 @@ class CfgGlasses {
     };
 
     class G_Bandanna_blk;
-    class G_Bandanna_shades:G_Bandanna_blk {
+    class G_Bandanna_shades: G_Bandanna_blk {
         ACE_TintAmount=COLOUR*2;
         ACE_Resistance = 1;
         ACE_Protection = 1;
@@ -265,13 +265,13 @@ class CfgGesturesMale {
 class CfgWeapons {
     class H_HelmetB;
 
-    class H_CrewHelmetHeli_B:H_HelmetB {
+    class H_CrewHelmetHeli_B: H_HelmetB {
         ACE_Protection = 1;
     };
-    class H_PilotHelmetHeli_B:H_HelmetB {
+    class H_PilotHelmetHeli_B: H_HelmetB {
         ACE_Protection = 1;
     };
-    class H_PilotHelmetFighter_B:H_HelmetB {
+    class H_PilotHelmetFighter_B: H_HelmetB {
         ACE_Protection = 1;
     };
 };
@@ -290,7 +290,7 @@ class SniperCloud {
 
 class CfgCloudlets {
     class Default;
-    class ACERainEffect:Default {
+    class ACERainEffect: Default {
         interval = 0.001;
         particleShape = "\A3\data_f\ParticleEffects\Universal\Refract";
         particleFSNtieth = 1;

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -365,7 +365,7 @@ class CfgVehicles {
         };
     };
 
-    class Car_F: Car{};
+    class Car_F: Car {};
     class Quadbike_01_base_F: Car_F {
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {

--- a/addons/interaction/RscTitles.hpp
+++ b/addons/interaction/RscTitles.hpp
@@ -57,7 +57,7 @@ class RscACE_SelectAnItem {
             h = 0.71;
             colorBackground[] = {0, 0, 0, 0.2};
         };
-        class header: RscText{
+        class header: RscText {
             idc = 8870;
             x = X_OFFSET + 0.005;
             y = 0.005;

--- a/addons/maptools/RscDisplayMainMap.hpp
+++ b/addons/maptools/RscDisplayMainMap.hpp
@@ -51,7 +51,7 @@ class RscDisplayMainMap {
                             shadow = 0;
                             sizeEx = 0.18;
                         };
-                        class altitude: RscText{
+                        class altitude: RscText {
                             idc = 913591;
                             x = 0.5;
                             y = 0;
@@ -66,7 +66,7 @@ class RscDisplayMainMap {
                             shadow = 0;
                             sizeEx = 0.18;
                         };
-                        class coordinates: RscText{
+                        class coordinates: RscText {
                             idc = 913592;
                             x = 0;
                             y = 0.225;

--- a/addons/maverick/CfgMagazines.hpp
+++ b/addons/maverick/CfgMagazines.hpp
@@ -8,7 +8,7 @@ class CfgMagazines {
     
     class 6Rnd_Missile_AGM_02_F: VehicleMagazine {};
     class PylonRack_1Rnd_Missile_AGM_02_F: 6Rnd_Missile_AGM_02_F {};
-    class PylonRack_3Rnd_Missile_AGM_02_F: PylonRack_1Rnd_Missile_AGM_02_F{};
+    class PylonRack_3Rnd_Missile_AGM_02_F: PylonRack_1Rnd_Missile_AGM_02_F {};
     
     class PylonRack_Missile_AGM_02_x1: magazine_Missile_AGM_02_x1 {};
     class PylonRack_Missile_AGM_02_x2: magazine_Missile_AGM_02_x1 {};

--- a/addons/maverick/CfgWeapons.hpp
+++ b/addons/maverick/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 class CfgWeapons {
     class LauncherCore;
     class RocketPods: LauncherCore {};
-    class weapon_AGM_65Launcher: RocketPods{};
+    class weapon_AGM_65Launcher: RocketPods {};
 
     class MissileLauncher: LauncherCore {};
     class Missile_AGM_02_Plane_CAS_01_F: MissileLauncher {};

--- a/addons/parachute/CfgVehicles.hpp
+++ b/addons/parachute/CfgVehicles.hpp
@@ -57,7 +57,7 @@ class CfgVehicles {
         MACRO_HASRESERVE
     };
     class Bag_Base;
-    class B_Parachute:Bag_Base {
+    class B_Parachute: Bag_Base {
         MACRO_HASRESERVE
     };
     class B_B_Parachute_02_F: B_Parachute {

--- a/addons/rearm/CfgVehicles.hpp
+++ b/addons/rearm/CfgVehicles.hpp
@@ -143,17 +143,17 @@ class CfgVehicles {
     };
 
     class ReammoBox_F;
-    class NATO_Box_Base: ReammoBox_F{};
+    class NATO_Box_Base: ReammoBox_F {};
     class Box_NATO_AmmoVeh_F: NATO_Box_Base {
         transportAmmo = 0;
         GVAR(defaultSupply) = 1200;
     };
-    class EAST_Box_Base: ReammoBox_F{};
+    class EAST_Box_Base: ReammoBox_F {};
     class Box_East_AmmoVeh_F: EAST_Box_Base {
         transportAmmo = 0;
         GVAR(defaultSupply) = 1200;
     };
-    class IND_Box_Base: ReammoBox_F{};
+    class IND_Box_Base: ReammoBox_F {};
     class Box_IND_AmmoVeh_F: IND_Box_Base {
         transportAmmo = 0;
         GVAR(defaultSupply) = 1200;

--- a/addons/repair/CfgEden.hpp
+++ b/addons/repair/CfgEden.hpp
@@ -17,7 +17,7 @@ class Cfg3DEN {
             attributeLoad = "(_this controlsGroupCtrl 100) lbSetCurSel (((_value + 1) min 3) max 0);";
             attributeSave = "(lbCurSel (_this controlsGroupCtrl 100)) - 1";
             class Controls: Controls {
-                class Title: Title{};
+                class Title: Title {};
                 class Value: ctrlToolbox {
                     idc = 100;
                     style = "0x02";

--- a/addons/spottingscope/CfgVehicles.hpp
+++ b/addons/spottingscope/CfgVehicles.hpp
@@ -41,7 +41,7 @@ class CfgVehicles {
         EGVAR(dragging,dragPosition)[] = {0,1,0};
         EGVAR(dragging,dragDirection) = 0;
 
-        class ACE_Actions: ACE_Actions{
+        class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 selection = "main_turret_axis";
                 class ACE_Pickup {

--- a/optionals/compat_gm/CfgVehicles.hpp
+++ b/optionals/compat_gm/CfgVehicles.hpp
@@ -397,7 +397,7 @@ class CfgVehicles {
         EGVAR(fastroping,onPrepare) = QFUNC(onPrepare);
     };
 
-    class gm_ch53_base:gm_helicopter_base {
+    class gm_ch53_base: gm_helicopter_base {
         EGVAR(map,vehicleLightColor)[] = {1,0,0,0.1};
         EGVAR(fastroping,enabled) = 1;
         EGVAR(fastroping,ropeOrigins)[] = {{0.6, -5.2, -0.8},{-0.6, -5.2, -0.8}};
@@ -411,7 +411,7 @@ class CfgVehicles {
     };
 
     // EAST
-    class gm_mi2_base:gm_helicopter_base {
+    class gm_mi2_base: gm_helicopter_base {
         EGVAR(map,vehicleLightColor)[] = {1,0,0,0.1};
         EGVAR(fastroping,enabled) = 1;
         EGVAR(fastroping,ropeOrigins)[] = {{-1.17969,0.0205078,-0.178533}};
@@ -433,7 +433,7 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 1076;
     };
 
-    class gm_mi2platan_base: gm_mi2_base{
+    class gm_mi2platan_base: gm_mi2_base {
         EGVAR(refuel,fuelCapacity) = 1076;
     };
 

--- a/optionals/compat_gm/CfgWeapons.hpp
+++ b/optionals/compat_gm/CfgWeapons.hpp
@@ -41,7 +41,7 @@ class CfgWeapons {
     };
     
     class gm_ge_headgear_sph4_base;
-    class gm_ge_headgear_sph4_oli: gm_ge_headgear_sph4_base{
+    class gm_ge_headgear_sph4_oli: gm_ge_headgear_sph4_base {
         HEARING_PROTECTION_PELTOR
     };
     

--- a/tools/config_style_checker.py
+++ b/tools/config_style_checker.py
@@ -17,7 +17,11 @@ def check_config_style(filepath):
         closing << closingStack.pop()
 
     reIsClass = re.compile(r'^\s*class(.*)')
+    reIsClassInherit = re.compile(r'^\s*class(.*):')
+    reIsClassBody = re.compile(r'^\s*class(.*){')
     reBadColon = re.compile(r'\s*class (.*) :')
+    reSpaceAfterColon = re.compile(r'\s*class (.*): ')
+    reSpaceBeforeCurly = re.compile(r'\s*class (.*) {')
     reClassSingleLine = re.compile(r'\s*class (.*)[{;]')
 
     with open(filepath, 'r', encoding='utf-8', errors='ignore') as file:
@@ -127,8 +131,14 @@ def check_config_style(filepath):
         for lineNumber, line in enumerate(file.readlines()):
             if reIsClass.match(line):
                 if reBadColon.match(line):
-                    print(f"WARNING: bad class colon {filepath} Line number: {lineNumber}")
+                    print(f"WARNING: bad class colon {filepath} Line number: {lineNumber+1}")
                     # bad_count_file += 1
+                if reIsClassInherit.match(line):
+                    if not reSpaceAfterColon.match(line):
+                        print(f"WARNING: bad class missing space after colon {filepath} Line number: {lineNumber+1}")
+                if reIsClassBody.match(line):
+                    if not reSpaceBeforeCurly.match(line):
+                        print(f"WARNING: bad class inherit missing space before curly braces {filepath} Line number: {lineNumber+1}")
                 if not reClassSingleLine.match(line):
                     print(f"WARNING: bad class braces placement {filepath} Line number: {lineNumber+1}")
                     # bad_count_file += 1


### PR DESCRIPTION
**When merged this pull request will:**
- Show warning for classes in configs with missing space after colon and before curly braces
- Fix current warnings