### PR TITLE
Overheating / Nametags - Fix Global / Default settings

### DIFF
--- a/addons/nametags/initSettings.sqf
+++ b/addons/nametags/initSettings.sqf
@@ -68,7 +68,7 @@
     QGVAR(tagSize), "LIST",
     [LSTRING(TagSize_Name), LSTRING(TagSize_Description)],
     format ["ACE %1", localize LSTRING(Module_DisplayName)],
-    [[0, 1, 2, 3, 4], ["str_very_small", "str_small", "str_medium", "str_large", "str_very_large"], 1],
+    [[0, 1, 2, 3, 4], ["str_very_small", "str_small", "str_medium", "str_large", "str_very_large"], 2],
     0
 ] call CBA_fnc_addSetting;
 

--- a/addons/overheating/initSettings.sqf
+++ b/addons/overheating/initSettings.sqf
@@ -75,7 +75,7 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     [LSTRING(jamChanceCoef_displayName), LSTRING(jamChanceCoef_description)],
     _category,
     [0, 5, 1, 2],
-    0
+    1
 ] call CBA_fnc_addSetting;
 
 [


### PR DESCRIPTION
- Sets ACE Nametag size back to "Normal" as the default.
- Changes Jam chance coef to a global setting.
