### PR TITLE
Advanced Ballistics - Fix `_maxRange` in `handleFired`

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_handleFired.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFired.sqf
@@ -38,6 +38,7 @@ if (_abort) then {
         } else {
             _vanillaInitialSpeed * getNumber(configFile >> "CfgAmmo" >> _ammo >> "tracerEndTime")
         };
+        _maxRange = _maxRange * 1.3; // Adding 30% more to range just to be safe
         uiNamespace setVariable [format[QGVAR(maxRange_%1), _ammo], _maxRange];
     };
     if (ACE_player distance _unit > _maxRange && {ACE_player distance ((getPosASL _unit) vectorAdd ((vectorNormalized _bulletVelocity) vectorMultiply _maxRange)) > _maxRange}) exitWith {};


### PR DESCRIPTION
`_vanillaInitialSpeed` was never defined so `_maxRange` was always nil
inner `_maxRange` was private, (would be nil only on first run, afterwords it would use the getVar)

the only effect these had was the exitWith would always fail
https://github.com/acemod/ACE3/blob/dc6ce6a88bf57bc9c32841cf00357481423f0735/addons/advanced_ballistics/functions/fnc_handleFired.sqf#L43

I was getting range of about 1000 for a sniper rifle which almost seem a little low?