### PR TITLE
ACEX Merge - Make ACEX-prefixed functions proxies

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -48,7 +48,7 @@
 #define QEXGVAR(var1,var2) QUOTE(EXGVAR(var1,var2))
 #define QQXGVAR(var) QUOTE(QXGVAR(var))
 #define QQEXGVAR(var1,var2) QUOTE(QEXGVAR(var1,var2))
-#define ACEX_PREP(func) PREP(func); TRIPLES(XADDON,fnc,func) = call DFUNC(func)
+#define ACEX_PREP(func) PREP(func); TRIPLES(XADDON,fnc,func) = DFUNC(func)
 
 
 #define MACRO_ADDWEAPON(WEAPON,COUNT) class _xx_##WEAPON { \


### PR DESCRIPTION
**When merged this pull request will:**
- Title

We don't want to deprecate old ACEX things this late, so just make old functions proxies. @BaerMitUmlaut's idea.