### PR TITLE
GM Compat - Jam types and Open bolts

### DIFF
--- a/optionals/compat_gm/CfgWeapons.hpp
+++ b/optionals/compat_gm/CfgWeapons.hpp
@@ -40,19 +40,19 @@ class CfgWeapons {
     
     // GRENADE LAUNCHERS
     class gm_hk69a1_base: gm_rifle_base {
-        EGVAR(overheating,jamTypesAllowed) = ["Fire","Dud"];
+        EGVAR(overheating,jamTypesAllowed)[] = {"Fire", "Dud"};
     };
     class gm_pallad_d_base: gm_rifle_base {
-        EGVAR(overheating,jamTypesAllowed) = ["Fire","Dud"];
+        EGVAR(overheating,jamTypesAllowed)[] = {"Fire", "Dud"};
     };
     
     // FLARE GUNS
     class gm_pistol_base;
     class gm_lp1_base: gm_pistol_base {
-        EGVAR(overheating,jamTypesAllowed) = ["Fire","Dud"];
+        EGVAR(overheating,jamTypesAllowed)[] = {"Fire", "Dud"};
     };
     class gm_p2a1_base: gm_pistol_base {
-        EGVAR(overheating,jamTypesAllowed) = ["Fire","Dud"];
+        EGVAR(overheating,jamTypesAllowed)[] = {"Fire", "Dud"};
     };
     
     // HELMETS


### PR DESCRIPTION
When merged this pull request will:
- Configure Belt-fed Machineguns and older SMGs as open bolts
- Restrict Jam types for Grenade Launchers and Flare Guns to "Fire" and "Dud"