### PR TITLE
Tools - Update sqf_linter.py to ignore parse/macro errors

### DIFF
--- a/tools/sqf_linter.py
+++ b/tools/sqf_linter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Requires: https://github.com/LordGolias/sqf
 
 import os


### PR DESCRIPTION
tool has limited use because it struggles with macro usage and has many false positives, 
this limits the errors it reports to just local/private diagnostic