### PR TITLE
Headless - Fix no rebalance of units spawned after headless joined

### DIFF
--- a/addons/headless/XEH_postInit.sqf
+++ b/addons/headless/XEH_postInit.sqf
@@ -6,7 +6,7 @@
         if (isServer) then {
             // Request rebalance on any unit spawn (only if distribution enabled)
             if (XGVAR(enabled)) then {
-                ["AllVehicles", "init", FUNC(handleSpawn), nil, nil, true] call CBA_fnc_addClassEventHandler;
+                ["AllVehicles", "initPost", FUNC(handleSpawn), nil, nil, true] call CBA_fnc_addClassEventHandler;
             };
             // Add disconnect EH
             addMissionEventHandler ["HandleDisconnect", {call FUNC(handleDisconnect)}];


### PR DESCRIPTION
```sqf
["AllVehicles", "init", {
    (format ["init %1 %2", _this#0, _this#0 in allUnits]) remoteExecCall ["systemChat", 0];
}] call CBA_fnc_addClassEventHandler;

["AllVehicles", "InitPost", {
    (format ["InitPost %1 %2", _this#0, _this#0 in allUnits]) remoteExecCall ["systemChat", 0];
}] call CBA_fnc_addClassEventHandler;

private _group = createGroup west;
_group createUnit ["B_officer_F", player getPos [5, 0], [], 0, "CAN_COLLIDE"];
```
![20211021211915_1](https://user-images.githubusercontent.com/14364400/138342947-573885eb-593c-4e0a-926e-7f5879edb081.jpg)

https://github.com/acemod/ACE3/blob/285c44bf1582982e4d706a06205795c0eef0b653/addons/headless/functions/fnc_handleSpawn.sqf#L22

_object is NEVER in allUnits array during "init"

**When merged this pull request will:**
- Use initPost event instead of init event
- Replace `init`by `initPost`