### PR TITLE
fix missing return in d2d_display::init_input

### DIFF
--- a/extensions/common/directx/d3d_display.cpp
+++ b/extensions/common/directx/d3d_display.cpp
@@ -198,6 +198,7 @@ namespace ace {
                 LOG(ERROR) << "Could not register raw input devices. ";
                 exit(1);
             }
+            return true;
         }
 
         bool d3d_display::create(uint32_t width = 1024, uint32_t height = 768, bool fullscreen = false) {


### PR DESCRIPTION
**When merged this pull request will:**

`bool d3d_display::init_input()` was missing a return statement. I'm not entirely sure if this code is in use, but found it while looking through the code base.
