### PR TITLE
Interaction - Add Plastic Case Open Box interaction

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -643,6 +643,26 @@ class CfgVehicles {
         };
         class ACE_SelfActions {};
     };
+
+    class PlasticCase_01_base_F: ThingX {
+        class ACE_Actions {
+            class ACE_MainActions {
+                displayName = CSTRING(MainAction);
+                selection = "";
+                distance = 2;
+                condition = "true";
+                class ACE_OpenBox {
+                    displayName = CSTRING(OpenBox);
+                    condition = QUOTE(alive _target && {!lockedInventory _target} && {getNumber (configOf _target >> 'disableInventory') == 0});
+                    statement = QUOTE(_player action [ARR_2(QUOTE(QUOTE(Gear)), _target)]);
+                    showDisabled = 0;
+                };
+            };
+        };
+        class ACE_SelfActions {};
+    };
+
+
     class Slingload_base_F: ReammoBox_F {};
     class Slingload_01_Base_F: Slingload_base_F {
         class ACE_Actions: ACE_Actions {


### PR DESCRIPTION
Plastic cases (small, medium, large) all didn't support the "Open" Interaction.
Because they don't inherit from ReammoBox_f

wasn't sure if it was worth to just put the actions thing into a macro and reuse that macro.
If we just copy-paste this once for this class its still acceptable to have duplicate code I guess


We might need to add this to more boxes.
With #7984 this is really important as you sometimes cannot access boxes with normal inventory action.
See video for a example where its required here: https://github.com/acemod/ACE3/discussions/8606