### PR TITLE
Revert "Vehicles - Utilize `setCruiseControl` for speed limiter (#8273)"

### DIFF
--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -21,12 +21,8 @@ params ["_driver", "_vehicle"];
 if (GVAR(isSpeedLimiter)) exitWith {
     [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
     playSound "ACE_Sound_Click";
-    _vehicle setCruiseControl [0, false];
     GVAR(isSpeedLimiter) = false;
 };
-
-(getCruiseControl _vehicle) params ["_speedLimit"];
-if (_speedLimit != 0) exitWith { TRACE_1("speed limit set by external source",_speedLimit); };
 
 [localize LSTRING(On)] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";
@@ -42,24 +38,21 @@ GVAR(speedLimit) = speed _vehicle max 5;
         private _uavControll = UAVControl _vehicle;
         if ((_uavControll select 0) != _driver || _uavControll select 1 != "DRIVER") then {
             GVAR(isSpeedLimiter) = false;
-            _vehicle setCruiseControl [0, false];
         };
     } else {
         if (_driver != driver _vehicle) then {
             GVAR(isSpeedLimiter) = false;
-            _vehicle setCruiseControl [0, false];
         };
     };
 
     if (!GVAR(isSpeedLimiter)) exitWith {
-        _vehicle setCruiseControl [0, false];
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 
-    getCruiseControl _vehicle params ["_currentSpeedLimit"];
-    if (_currentSpeedLimit != GVAR(speedLimit)) then {
-        _vehicle setCruiseControl [GVAR(speedLimit), false];
-    };
+    private _speed = speed _vehicle;
 
+    if (_speed > GVAR(speedLimit)) then {
+        _vehicle setVelocity ((velocity _vehicle) vectorMultiply ((GVAR(speedLimit) / _speed) - 0.00001));  // fix 1.42-hotfix PhysX libraries applying force in previous direction when turning
+    };
 
 }, 0, [_driver, _vehicle]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
The change of PR-#8273 does not work, at least not for specific vehicles. It makes them completely uncontrollable.

I see no reason to use this new script command here. This is a speed limiter, and not "cruise control". Please add your own feature if you want that, and leave this one alone. It has been tested and tweaked alot, and has been used for years, and nobody ever complained. The players in my comm like how it worked, and the new one not in a usable state.

Thank you.