### PR TITLE
Medical - Add check to FullHealLocal in case unit is burning then extinguish before healing

### DIFF
--- a/addons/medical_treatment/functions/fnc_fullHealLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_fullHealLocal.sqf
@@ -21,7 +21,7 @@ TRACE_1("fullHealLocal",_patient);
 if (!alive _patient) exitWith {};
 
 // check if on fire, then put out the fire before healing
-if ([_patient] call EFUNC(fire,isBurning)) then {
+if ((["ace_fire"] call EFUNC(common,isModLoaded)) && {[_patient] call EFUNC(fire,isBurning)}) then {
     _patient setVariable [QEGVAR(fire,intensity), 0, true];
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
This will fix the issue described in https://github.com/acemod/ACE3/issues/8621. It makes full heal extinguish the unit if on fire before healing it. This avoids the issue of a unit on fire that can't be put out by Zeus. 

It adds a check to the full heal, if unit is on fire, it sets intensity to 0, which stops the fire. 
