### PR TITLE
Frag - Fix fuse-arming distance calculation

### DIFF
--- a/addons/frag/functions/fnc_addPfhRound.sqf
+++ b/addons/frag/functions/fnc_addPfhRound.sqf
@@ -60,7 +60,7 @@ if (alive _round) then {
     private _spallTrackID = [];
 
     private _args = [
-        _round, getPosASL _round, velocity _round, _type, diag_frameno, _gun, _doSpall, _spallTrack, _spallTrackID,
+        _round, getPosASL _round, velocity _round, _type, diag_frameno, getPosASL _gun, _doSpall, _spallTrack, _spallTrackID,
         getNumber (configFile >> "CfgAmmo" >> _type >> QGVAR(skip)),
         getNumber (configFile >> "CfgAmmo" >> _type >> "explosive"),
         getNumber (configFile >> "CfgAmmo" >> _type >> "indirectHitRange"),

--- a/addons/frag/functions/fnc_addPfhRound.sqf
+++ b/addons/frag/functions/fnc_addPfhRound.sqf
@@ -60,7 +60,7 @@ if (alive _round) then {
     private _spallTrackID = [];
 
     private _args = [
-        _round, getPosASL _round, velocity _round, _type, diag_frameno, getPosASL _gun, _doSpall, _spallTrack, _spallTrackID,
+        _round, getPosASL _round, velocity _round, _type, diag_frameno, getPosASL _round, _doSpall, _spallTrack, _spallTrackID,
         getNumber (configFile >> "CfgAmmo" >> _type >> QGVAR(skip)),
         getNumber (configFile >> "CfgAmmo" >> _type >> "explosive"),
         getNumber (configFile >> "CfgAmmo" >> _type >> "indirectHitRange"),

--- a/addons/frag/functions/fnc_pfhRound.sqf
+++ b/addons/frag/functions/fnc_pfhRound.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-params ["_round", "_lastPos", "_lastVel", "_shellType", "_firedFrame", "_gunPos", "_doSpall", "_spallTrack", "_foundObjectHPIds", "_skip", "_explosive", "_indirectRange", "_force", "_fragPower"];
+params ["_round", "_lastPos", "_lastVel", "_shellType", "_firedFrame", "_firedPos", "_doSpall", "_spallTrack", "_foundObjectHPIds", "_skip", "_explosive", "_indirectRange", "_force", "_fragPower"];
 
 if (_round in GVAR(blackList)) exitWith {
     false
@@ -26,13 +26,10 @@ if (!alive _round) exitWith {
         if (_skip == 0) then {
             if ((_explosive > 0.5 && {_indirectRange >= 4.5} && {_fragPower >= 35}) || {_force == 1}) then {
                 // shotbullet, shotShell don't seem to explode when touching water, so don't create frags
-                if (((_lastPos select 2) < 0) && {(toLower getText (configFile >> "CfgAmmo" >> _shellType >> "simulation")) in ["shotbullet", "shotshell"]}) exitWith {};
-                private _isArmed = true;
-                if (!isNil "_gunPos") then {
-                    private _fuseDist = getNumber(configFile >> "CfgAmmo" >> _shellType >> "fuseDistance");
-                    _isArmed =  (_gunPos distance _lastPos > _fuseDist);
-                    TRACE_2("",_fuseDist,_isArmed);
-                };
+                if ((surfaceIsWater _lastPos) && {(toLower getText (configFile >> "CfgAmmo" >> _shellType >> "simulation")) in ["shotbullet", "shotshell"]}) exitWith {};
+                private _fuseDist = getNumber(configFile >> "CfgAmmo" >> _shellType >> "fuseDistance");
+                private _isArmed =  _firedPos distance _lastPos >= _fuseDist; // rounds explode at exactly fuseDistance, so check inclusive
+                TRACE_2("",_fuseDist,_isArmed);
                 if (!_isArmed) exitWith {TRACE_1("round not armed",_this);};
                 TRACE_3("Sending frag event to server",_lastPos,_lastVel,_shellType);
                 [QGVAR(frag_eh), [_lastPos,_lastVel,_shellType]] call CBA_fnc_serverEvent;

--- a/addons/frag/functions/fnc_pfhRound.sqf
+++ b/addons/frag/functions/fnc_pfhRound.sqf
@@ -28,7 +28,7 @@ if (!alive _round) exitWith {
                 // shotbullet, shotShell don't seem to explode when touching water, so don't create frags
                 if ((surfaceIsWater _lastPos) && {(toLower getText (configFile >> "CfgAmmo" >> _shellType >> "simulation")) in ["shotbullet", "shotshell"]}) exitWith {};
                 private _fuseDist = getNumber(configFile >> "CfgAmmo" >> _shellType >> "fuseDistance");
-                private _isArmed =  _firedPos distance _lastPos >= _fuseDist; // rounds explode at exactly fuseDistance, so check inclusive
+                private _isArmed =  _firedPos vectorDistance _lastPos >= _fuseDist; // rounds explode at exactly fuseDistance, so check inclusive
                 TRACE_2("",_fuseDist,_isArmed);
                 if (!_isArmed) exitWith {TRACE_1("round not armed",_this);};
                 TRACE_3("Sending frag event to server",_lastPos,_lastVel,_shellType);

--- a/addons/frag/functions/fnc_pfhRound.sqf
+++ b/addons/frag/functions/fnc_pfhRound.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-params ["_round", "_lastPos", "_lastVel", "_shellType", "_firedFrame", "_gun", "_doSpall", "_spallTrack", "_foundObjectHPIds", "_skip", "_explosive", "_indirectRange", "_force", "_fragPower"];
+params ["_round", "_lastPos", "_lastVel", "_shellType", "_firedFrame", "_gunPos", "_doSpall", "_spallTrack", "_foundObjectHPIds", "_skip", "_explosive", "_indirectRange", "_force", "_fragPower"];
 
 if (_round in GVAR(blackList)) exitWith {
     false
@@ -28,9 +28,9 @@ if (!alive _round) exitWith {
                 // shotbullet, shotShell don't seem to explode when touching water, so don't create frags
                 if (((_lastPos select 2) < 0) && {(toLower getText (configFile >> "CfgAmmo" >> _shellType >> "simulation")) in ["shotbullet", "shotshell"]}) exitWith {};
                 private _isArmed = true;
-                if (!isNil "_gun") then {
+                if (!isNil "_gunPos") then {
                     private _fuseDist = getNumber(configFile >> "CfgAmmo" >> _shellType >> "fuseDistance");
-                    _isArmed = ((getPosASL _gun) distance _lastPos > _fuseDist);
+                    _isArmed =  (_gunPos distance _lastPos > _fuseDist);
                     TRACE_2("",_fuseDist,_isArmed);
                 };
                 if (!_isArmed) exitWith {TRACE_1("round not armed",_this);};


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Close #8073.

Current position of shooter was used instead of round's original position. If shooter moved beyond fuse distance, round would create fragmentation without any effects.
