### PR TITLE
General - Setting category cleanup

### DIFF
--- a/addons/artillerytables/initSettings.sqf
+++ b/addons/artillerytables/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_artillerytables]:
-
 private _categoryName = [format ["ACE %1", localize "str_a3_cfgmarkers_nato_art"], LLSTRING(rangetable_displayName)];
 
 [

--- a/addons/common/initSettings.sqf
+++ b/addons/common/initSettings.sqf
@@ -1,4 +1,5 @@
-private _category = localize LSTRING(ACEKeybindCategoryCommon);
+private _category = LLSTRING(ACEKeybindCategoryCommon);
+private _categoryColors = [_category, format ["| %1 |", LELSTRING(common,subcategory_colors)]];
 
 [
     QGVAR(checkPBOsAction),
@@ -49,7 +50,7 @@ private _category = localize LSTRING(ACEKeybindCategoryCommon);
     QGVAR(displayTextColor),
     "COLOR",
     [LSTRING(SettingDisplayTextColorName),LSTRING(SettingDisplayTextColorDesc)],
-    _category,
+    _categoryColors,
     [0, 0, 0, 0.1],
     0
 ] call CBA_fnc_addSetting;
@@ -58,7 +59,7 @@ private _category = localize LSTRING(ACEKeybindCategoryCommon);
     QGVAR(displayTextFontColor),
     "COLOR",
     [LSTRING(SettingDisplayTextFontColorName),LSTRING(SettingDisplayTextFontColorDesc)],
-    _category,
+    _categoryColors,
     [1, 1, 1, 1],
     0
 ] call CBA_fnc_addSetting;

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -677,6 +677,18 @@
             <Chinese>設定ACE提示文字的顏色。若提示字體並無指定其他顏色，將會自動選用ACE系統的預設顏色</Chinese>
             <Chinesesimp>设定ACE提示文字的颜色。若提示字体并无指定其他颜色，将会自动选用ACE系统的预设颜色。</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Common_subcategory_colors">
+            <English>Colors</English>
+            <Czech>Barvy</Czech>
+            <French>Couleurs</French>
+            <German>Farben</German>
+            <Italian>Colori</Italian>
+            <Polish>Kolory</Polish>
+            <Portuguese>Cores</Portuguese>
+            <Russian>Цвета</Russian>
+            <Spanish>Colores</Spanish>
+            <Japanese>色</Japanese>
+        </Key>
         <Key ID="STR_ACE_Common_SettingPersistentLaserName">
             <English>Persistent weapon laserpointer/flashlight</English>
             <Russian>Автоматический ЛЦУ/тактический фонарь</Russian>
@@ -1280,6 +1292,9 @@
             <Chinese>ACE 載具按鍵</Chinese>
             <Chinesesimp>ACE 载具按键</Chinesesimp>
             <Turkish>ACE Araçlar</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Common_categoryUncategorized">
+            <English>ACE Uncategorized</English>
         </Key>
         <Key ID="STR_ACE_Common_NoRoomToUnload">
             <English>No Room to unload</English>

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_cookoff]:
-
 [
     QGVAR(enable), "LIST",
     [LSTRING(enable_hd_name), LSTRING(enable_hd_tooltip)],

--- a/addons/csw/initSettings.sqf
+++ b/addons/csw/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_csw]:
-
 private _categoryArray = [format ["ACE %1", localize LSTRING(DisplayName)]];
 
 [

--- a/addons/fastroping/initSettings.sqf
+++ b/addons/fastroping/initSettings.sqf
@@ -1,6 +1,4 @@
-// CBA Settings [ADDON: ace_fastroping]:
-
-private _category = ["ACE Uncategorized", LLSTRING(setting_categoryMenu_displayName)];
+private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(setting_categoryMenu_displayName)];
 
 [
     QGVAR(requireRopeItems), "CHECKBOX",

--- a/addons/gunbag/initSettings.sqf
+++ b/addons/gunbag/initSettings.sqf
@@ -1,9 +1,9 @@
-// CBA Settings [ADDON: ace_gunbag]:
+private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(DisplayName_Settings)];
 
 [
     QGVAR(swapGunbagEnabled), "CHECKBOX",
     [LSTRING(SwapGunbagEnabled_DisplayName), LSTRING(SwapGunbagEnabled_Description)],
-    ["ACE Uncategorized", LLSTRING(DisplayName_Settings)],
+    _category,
     true, // default value
     true // isGlobal
 ] call CBA_fnc_addSetting;

--- a/addons/hitreactions/initSettings.sqf
+++ b/addons/hitreactions/initSettings.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,categoryUncategorized), QUOTE(COMPONENT_BEAUTIFIED)];
+
 [
     QGVAR(minDamageToTrigger), "SLIDER",
     LSTRING(minDamageToTrigger_displayName),
-    "ACE Uncategorized",
+    _category,
     [-1, 1, 0.1, 1],
     1
 ] call CBA_fnc_addSetting;

--- a/addons/interact_menu/initSettings.sqf
+++ b/addons/interact_menu/initSettings.sqf
@@ -1,9 +1,10 @@
 private _category = format ["ACE %1", LLSTRING(Category_InteractionMenu)];
+private _categoryColors = [_category, format ["| %1 |", LELSTRING(common,subcategory_colors)]];
 
 [
     QGVAR(selectorColor), "COLOR",
     LSTRING(SelectorColor),
-    _category,
+    _categoryColors,
     [1, 0, 0],
     false,
     {GVAR(selectorColorHex) = _this call BIS_fnc_colorRGBtoHTML} // Stored in Hex to avoid constant conversion
@@ -12,7 +13,7 @@ private _category = format ["ACE %1", LLSTRING(Category_InteractionMenu)];
 [
     QGVAR(colorTextMax), "COLOR",
     LSTRING(ColorTextMax),
-    _category,
+    _categoryColors,
     [1, 1, 1, 1],
     0
 ] call CBA_fnc_addSetting;
@@ -20,7 +21,7 @@ private _category = format ["ACE %1", LLSTRING(Category_InteractionMenu)];
 [
     QGVAR(colorTextMin), "COLOR",
     LSTRING(ColorTextMin),
-    _category,
+    _categoryColors,
     [1, 1, 1, 0.25],
     0
 ] call CBA_fnc_addSetting;
@@ -28,7 +29,7 @@ private _category = format ["ACE %1", LLSTRING(Category_InteractionMenu)];
 [
     QGVAR(colorShadowMax), "COLOR",
     LSTRING(ColorShadowMax),
-    _category,
+    _categoryColors,
     [0, 0, 0, 1],
     0
 ] call CBA_fnc_addSetting;
@@ -36,7 +37,7 @@ private _category = format ["ACE %1", LLSTRING(Category_InteractionMenu)];
 [
     QGVAR(colorShadowMin), "COLOR",
     LSTRING(ColorShadowMin),
-    _category,
+    _categoryColors,
     [0, 0, 0, 0.25],
     0
 ] call CBA_fnc_addSetting;

--- a/addons/inventory/initSettings.sqf
+++ b/addons/inventory/initSettings.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,categoryUncategorized), localize "str_a3_gear1"];
+
 [
     QGVAR(inventoryDisplaySize), "LIST",
     [LSTRING(SettingName), LSTRING(SettingDescription)],
-    "ACE Uncategorized",
+    _category,
     [[0, 1, 2], ["str_medium", "str_large", "str_very_large"], 0],
     0
 ] call CBA_fnc_addSetting;

--- a/addons/laser/initSettings.sqf
+++ b/addons/laser/initSettings.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,categoryUncategorized), localize "str_a3_itemtype_laser"];
+
 [
     QGVAR(dispersionCount),  "SLIDER",
     LSTRING(dispersionCount_displayName),
-    "ACE Uncategorized",
+    _category,
     [0, 5, 2, -1],
     1
 ] call CBA_fnc_addSetting;

--- a/addons/map_gestures/initSettings.sqf
+++ b/addons/map_gestures/initSettings.sqf
@@ -1,7 +1,10 @@
+private _category = LLSTRING(mapGestures_category);
+private _categoryColors = [_category, format ["| %1 |", LELSTRING(common,subcategory_colors)]];
+
 [
     QGVAR(enabled), "CHECKBOX",
     [LSTRING(enabled_displayName), LSTRING(enabled_description)],
-    LSTRING(mapGestures_category),
+    _category,
     true,
     true
 ] call CBA_fnc_addSetting;
@@ -9,7 +12,7 @@
 [
     QGVAR(maxRange), "SLIDER",
     [LSTRING(maxRange_displayName), LSTRING(maxRange_description)],
-    LSTRING(mapGestures_category),
+    _category,
     [0,50,7,1],
     true
 ] call CBA_fnc_addSetting;
@@ -17,7 +20,7 @@
 [
     QGVAR(maxRangeCamera), "SLIDER",
     [LSTRING(maxRangeCamera_displayName), LSTRING(maxRangeCamera_description)],
-    LSTRING(mapGestures_category),
+    _category,
     [0,50,14,1],
     true
 ] call CBA_fnc_addSetting;
@@ -25,21 +28,21 @@
 [
     QGVAR(allowSpectator), "CHECKBOX",
     [LSTRING(allowSpectator_displayName), LSTRING(allowSpectator_description)],
-    LSTRING(mapGestures_category),
+    _category,
     true
 ] call CBA_fnc_addSetting;
 
 [
     QGVAR(allowCurator), "CHECKBOX",
     [LSTRING(allowCurator_displayName), LSTRING(allowCurator_description)],
-    LSTRING(mapGestures_category),
+    _category,
     true
 ] call CBA_fnc_addSetting;
 
 [
     QGVAR(briefingMode), "LIST",
     [LSTRING(briefingMode_displayName), LSTRING(briefingMode_description)],
-    LSTRING(mapGestures_category),
+    _category,
     [[0, 1, 2, 3, 4], [LSTRING(briefingMode_All), LSTRING(briefingMode_Group), LSTRING(briefingMode_Side), LSTRING(briefingMode_Proximity), LSTRING(briefingMode_Disabled)], 0]
 ] call CBA_fnc_addSetting;
 
@@ -47,7 +50,7 @@
     QGVAR(onlyShowFriendlys),
     "CHECKBOX",
     [LSTRING(onlyShowFriendlys_displayName), LSTRING(onlyShowFriendlys_description)],
-    LSTRING(mapGestures_category),
+    _category,
     false,
     1
 ] call CBA_fnc_addSetting;
@@ -55,7 +58,7 @@
 [
     QGVAR(interval), "SLIDER",
     [LSTRING(interval_displayName), LSTRING(interval_description)],
-    LSTRING(mapGestures_category),
+    _category,
     [0,1,0.03,2],
     true
 ] call CBA_fnc_addSetting;
@@ -63,7 +66,7 @@
 [
     QGVAR(nameTextColor), "COLOR",
     [LSTRING(nameTextColor_displayName), LSTRING(nameTextColor_description)],
-    [LSTRING(mapGestures_category), LSTRING(mapGestures_subcategory_colors)],
+    _categoryColors,
     [0.2,0.2,0.2,0.3],
     false
 ] call CBA_fnc_addSetting;
@@ -71,7 +74,7 @@
 [
     QGVAR(defaultLeadColor), "COLOR",
     [LSTRING(defaultLeadColor_displayName), LSTRING(defaultLeadColor_description)],
-    [LSTRING(mapGestures_category), LSTRING(mapGestures_subcategory_colors)],
+    _categoryColors,
     [1,0.88,0,0.95],
     false
 ] call CBA_fnc_addSetting;
@@ -79,7 +82,7 @@
 [
     QGVAR(defaultColor), "COLOR",
     [LSTRING(defaultColor_displayName), LSTRING(defaultColor_description)],
-    [LSTRING(mapGestures_category), LSTRING(mapGestures_subcategory_colors)],
+    _categoryColors,
     [1,0.88,0,0.7],
     false
 ] call CBA_fnc_addSetting;

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -428,17 +428,5 @@
             <Chinese>ACE 地圖指示器</Chinese>
             <Turkish>ACE Harita Hareketleri</Turkish>
         </Key>
-        <Key ID="STR_ACE_Map_Gestures_mapGestures_subcategory_colors">
-            <English>Colors</English>
-            <Czech>Barvy</Czech>
-            <French>Couleurs</French>
-            <German>Farben</German>
-            <Italian>Colori</Italian>
-            <Polish>Kolory</Polish>
-            <Portuguese>Cores</Portuguese>
-            <Russian>Цвета</Russian>
-            <Spanish>Colores</Spanish>
-            <Japanese>色</Japanese>
-        </Key>
     </Package>
 </Project>

--- a/addons/medical_ai/initSettings.sqf
+++ b/addons/medical_ai/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_medical_ai]:
-
 private _categoryArray = [ELSTRING(medical,Category), "STR_TEAM_SWITCH_AI"];
 
 [

--- a/addons/medical_gui/initSettings.sqf
+++ b/addons/medical_gui/initSettings.sqf
@@ -86,12 +86,13 @@ private _damageColors = [
     [0.00, 0.00, 1.00, 1]
 ];
 
+private _categoryColors = [ELSTRING(medical,Category), format ["| %1 |", LELSTRING(common,subcategory_colors)]];
 {
     [
         format ["%1_%2", QGVAR(bloodLossColor), _forEachIndex], 
         "COLOR",
         [format [localize LSTRING(BloodLossColorX_DisplayName), _forEachIndex], LSTRING(BloodLossColor_Description)],
-        [ELSTRING(medical,Category), LSTRING(BloodLossColors)],
+        _categoryColors,
         _x,
         false // isGlobal
     ] call CBA_fnc_addSetting;
@@ -102,7 +103,7 @@ private _damageColors = [
         format ["%1_%2", QGVAR(damageColor), _forEachIndex],
         "COLOR",
         [format [localize LSTRING(DamageColorX_DisplayName), _forEachIndex], LSTRING(DamageColor_Description)],
-        [ELSTRING(medical,Category), LSTRING(DamageColors)],
+        _categoryColors,
         _x,
         false // isGlobal
     ] call CBA_fnc_addSetting;

--- a/addons/microdagr/initSettings.sqf
+++ b/addons/microdagr/initSettings.sqf
@@ -1,9 +1,9 @@
-// CBA Settings [ADDON: ace_microdagr]:
+private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(itemName)];
 
 [
     QGVAR(mapDataAvailable), "LIST",
     [LSTRING(MapDataAvailable_DisplayName), LSTRING(MapDataAvailable_Description)],
-    ["ACE Uncategorized", "MicroDAGR"],
+    _category,
     [[0,1,2],[LSTRING(MapFill_None), LSTRING(MapFill_OnlyRoads), LSTRING(MapFill_Full)],2], // [values, titles, defaultIndex]
     true, // isGlobal
     {[QGVAR(mapDataAvailable), _this] call EFUNC(common,cbaSettings_settingChanged)},
@@ -13,7 +13,7 @@
 [
     QGVAR(waypointPrecision), "LIST",
     [LSTRING(WaypointPrecision_DisplayName), LSTRING(WaypointPrecision_Description)],
-    ["ACE Uncategorized", "MicroDAGR"],
+    _category,
     [[1, 2, 3], [LSTRING(WaypointPrecision_medium), LSTRING(WaypointPrecision_close), LSTRING(WaypointPrecision_exact)], 2],  // [values, titles, defaultIndex]
     true, // isGlobal
     {[QGVAR(waypointPrecision), _this] call EFUNC(common,cbaSettings_settingChanged)},

--- a/addons/mk6mortar/initSettings.sqf
+++ b/addons/mk6mortar/initSettings.sqf
@@ -1,4 +1,3 @@
-// CBA Settings [ADDON: ace_mk6mortar]:
 // These settings effect gameplay difficutly:  defaults will leave the mortar the same as vanilla
 
 private _category = [format ["ACE %1", localize "str_a3_cfgmarkers_nato_art"], localize LSTRING(DisplayName)];

--- a/addons/nametags/initSettings.sqf
+++ b/addons/nametags/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_nametags]:
-
 [
     QGVAR(showPlayerNames), "LIST",
     [LSTRING(ShowPlayerNames), LSTRING(ShowPlayerNames_Desc)],

--- a/addons/nightvision/initSettings.sqf
+++ b/addons/nightvision/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_nightVision]:
-
 [
     QGVAR(effectScaling), "SLIDER",
     [LSTRING(effectScaling_DisplayName), LSTRING(effectScaling_Description)],

--- a/addons/noradio/XEH_preInit.sqf
+++ b/addons/noradio/XEH_preInit.sqf
@@ -27,13 +27,4 @@ if (hasInterface) then {
     }, true] call CBA_fnc_addPlayerEventHandler;
 };
 
-[QGVAR(enabled), "CHECKBOX", [LSTRING(setting), LSTRING(setting_tooltip)], format ["ACE %1", localize ELSTRING(common,DisplayName)], true, true, {
-    params ["_enabled"];
-
-    if (_enabled) then {
-        [ACE_player, "isPlayer"] call EFUNC(common,muteUnit);
-    } else {
-        [ACE_player, "isPlayer"] call EFUNC(common,unmuteUnit);
-    };
-}, true // Needs mission restart
-] call CBA_fnc_addSetting;
+#include "initSettings.sqf"

--- a/addons/noradio/initSettings.sqf
+++ b/addons/noradio/initSettings.sqf
@@ -1,0 +1,17 @@
+private _category = [LELSTRING(common,ACEKeybindCategoryCommon), QUOTE(COMPONENT_BEAUTIFIED)];
+
+[
+    QGVAR(enabled), "CHECKBOX", 
+    [LSTRING(setting), LSTRING(setting_tooltip)], 
+    _category,
+    true, 
+    true, {
+    params ["_enabled"];
+
+    if (_enabled) then {
+        [ACE_player, "isPlayer"] call EFUNC(common,muteUnit);
+    } else {
+        [ACE_player, "isPlayer"] call EFUNC(common,unmuteUnit);
+    };
+}, true // Needs mission restart
+] call CBA_fnc_addSetting;

--- a/addons/optionsmenu/initSettings.sqf
+++ b/addons/optionsmenu/initSettings.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(aceNews)];
+
 [
     QGVAR(showNewsOnMainMenu), "CHECKBOX",
     LSTRING(showNewsOnMainMenu_name),
-    "ACE Uncategorized",
+    _category,
     true,
     0
 ] call CBA_fnc_addSetting;

--- a/addons/overpressure/initSettings.sqf
+++ b/addons/overpressure/initSettings.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,categoryUncategorized), QUOTE(COMPONENT_BEAUTIFIED)];
+
 [
     QGVAR(distanceCoefficient), "SLIDER",
     [LSTRING(distanceCoefficient_displayName), LSTRING(distanceCoefficient_toolTip)],
-    "ACE Uncategorized",
+    _category,
     [-1, 10, 5, 1],
     1
 ] call CBA_fnc_addSetting;

--- a/addons/parachute/XEH_preInit.sqf
+++ b/addons/parachute/XEH_preInit.sqf
@@ -8,23 +8,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-[
-    QGVAR(hideAltimeter),
-    "CHECKBOX",
-    [LSTRING(HideAltimeter), LSTRING(HideAltimeter_tooltip)],
-    ["ACE Uncategorized", localize "str_dn_parachute"],
-    true,
-    false,
-    {[QGVAR(hideAltimeter), _this, false] call EFUNC(common,cbaSettings_settingChanged)}
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(failureChance),
-    "SLIDER",
-    LSTRING(FailureChance),
-    ["ACE Uncategorized", localize "str_dn_parachute"],
-    [0, 1, 0, 2, true],
-    1
-] call CBA_fnc_addSetting;
+#include "initSettings.sqf"
 
 ADDON = true;

--- a/addons/parachute/initSettings.sqf
+++ b/addons/parachute/initSettings.sqf
@@ -1,0 +1,20 @@
+private _category = [LELSTRING(common,categoryUncategorized), localize "str_dn_parachute"];
+
+[
+    QGVAR(hideAltimeter),
+    "CHECKBOX",
+    [LSTRING(HideAltimeter), LSTRING(HideAltimeter_tooltip)],
+    _category,
+    true,
+    false,
+    {[QGVAR(hideAltimeter), _this, false] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(failureChance),
+    "SLIDER",
+    LSTRING(FailureChance),
+    _category,
+    [0, 1, 0, 2, true],
+    1
+] call CBA_fnc_addSetting;

--- a/addons/rearm/initSettings.sqf
+++ b/addons/rearm/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_rearm]:
-
 [
     QGVAR(level), "LIST",
     [LSTRING(RearmSettings_level_DisplayName), LSTRING(RearmSettings_level_Description)],

--- a/addons/refuel/initSettings.sqf
+++ b/addons/refuel/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_refuel]:
-
 [
     QGVAR(rate), "SLIDER",
     [LSTRING(RefuelSettings_speed_DisplayName), LSTRING(RefuelSettings_speed_Description)],

--- a/addons/tagging/initSettings.sqf
+++ b/addons/tagging/initSettings.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(Tagging)];
+
 [
     QGVAR(quickTag), "LIST",
     [LLSTRING(QuickTag), LLSTRING(QuickTagDesc)],
-    ["ACE Uncategorized", LLSTRING(Tagging)],
+    _category,
     [[0,1,2,3], [LELSTRING(Common,Disabled), LLSTRING(LastUsed), LLSTRING(RandomX), LLSTRING(Random)], 1], // [values, titles, defaultIndex]
     false, // isGlobal
     {[QGVAR(quickTag), _this] call EFUNC(common,cbaSettings_settingChanged)},

--- a/addons/vehiclelock/initSettings.sqf
+++ b/addons/vehiclelock/initSettings.sqf
@@ -1,5 +1,3 @@
-// CBA Settings [ADDON: ace_vehicleLock]:
-
 [
     QGVAR(defaultLockpickStrength), "SLIDER",
     [LSTRING(DefaultLockpickStrength_DisplayName), LSTRING(DefaultLockpickStrength_Description)],

--- a/addons/viewdistance/initSettings.sqf
+++ b/addons/viewdistance/initSettings.sqf
@@ -10,7 +10,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
 
 [
     QGVAR(viewDistanceOnFoot), "SLIDER",
-    [LSTRING(onFoot_DisplayName), LSTRING(onFoot_Description)],
+    [LSTRING(onFoot_DisplayName), format ["%1\n%2", LLSTRING(onFoot_Description), LLSTRING(sliderExtraDescription)]],
     _category,
     [0, 10000, 0, -1],
     0,
@@ -19,7 +19,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
 
 [
     QGVAR(viewDistanceLandVehicle), "SLIDER",
-    [LSTRING(landVehicle_DisplayName), LSTRING(landVehicle_Description)],
+    [LSTRING(landVehicle_DisplayName), format ["%1\n%2", LLSTRING(airVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
     [0, 10000, 0, -1],
     0,
@@ -28,7 +28,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
 
 [
     QGVAR(viewDistanceAirVehicle), "SLIDER",
-    [LSTRING(airVehicle_DisplayName), LSTRING(airVehicle_Description)],
+    [LSTRING(airVehicle_DisplayName), format ["%1\n%2", LLSTRING(airVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
     [0, 10000, 0, -1],
     0,

--- a/addons/viewdistance/initSettings.sqf
+++ b/addons/viewdistance/initSettings.sqf
@@ -19,7 +19,7 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
 
 [
     QGVAR(viewDistanceLandVehicle), "SLIDER",
-    [LSTRING(landVehicle_DisplayName), format ["%1\n%2", LLSTRING(airVehicle_Description), LLSTRING(sliderExtraDescription)]],
+    [LSTRING(landVehicle_DisplayName), format ["%1\n%2", LLSTRING(landVehicle_Description), LLSTRING(sliderExtraDescription)]],
     _category,
     [0, 10000, 0, -1],
     0,

--- a/addons/viewdistance/stringtable.xml
+++ b/addons/viewdistance/stringtable.xml
@@ -118,6 +118,9 @@
             <Chinesesimp>玩家的视距限制可在此设定，也可透过模块改写</Chinesesimp>
             <Chinese>玩家的視距限制可在此設定，也可透過模塊改寫</Chinese>
         </Key>
+        <Key ID="STR_ACE_ViewDistance_sliderExtraDescription">
+            <English>Setting to 0 will use default video settings</English>
+        </Key>
         <Key ID="STR_ACE_ViewDistance_onFoot_DisplayName">
             <English>Client View Distance (On Foot)</English>
             <Polish>Zasięg widzenia (piechota)</Polish>

--- a/addons/weaponselect/initSettings.sqf
+++ b/addons/weaponselect/initSettings.sqf
@@ -1,8 +1,8 @@
-// CBA Settings [ADDON: ace_weaponselect]:
-
-[QGVAR(displayText), "CHECKBOX",
-[LSTRING(SettingDisplayTextName), LSTRING(SettingDisplayTextDesc)],
-localize ELSTRING(common,ACEKeybindCategoryWeapons),
-true, // default value
-false, // isGlobal
-{[QGVAR(displayText), _this] call EFUNC(common,cbaSettings_settingChanged)}] call CBA_fnc_addSetting;
+[
+    QGVAR(displayText), "CHECKBOX",
+    [LSTRING(SettingDisplayTextName), LSTRING(SettingDisplayTextDesc)],
+    localize ELSTRING(common,ACEKeybindCategoryWeapons),
+    true, // default value
+    false, // isGlobal
+    {[QGVAR(displayText), _this] call EFUNC(common,cbaSettings_settingChanged)}
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
- Localize ACE Uncategorized
- Add subcategories for everything in Uncategorized
Helps to organize and give context to setting
- Put colors in subCategory (alphabetically last) 
For example half of the verticle height of medical setting category is color settings, so I think it's best to group together
- Add extra info on ViewDistance settings descriptions
- Move all settings to initSettings.sqf
