### PR TITLE
Explosives - Fix `objNull` reported as source and instigator in BI `handleDamage` event for explosive triggered by timer

### DIFF
--- a/addons/explosives/ACE_Triggers.hpp
+++ b/addons/explosives/ACE_Triggers.hpp
@@ -56,7 +56,7 @@ class ACE_Triggers {
         isAttachable = 1;
         displayName = CSTRING(timerName);
         picture = QPATHTOF(data\UI\Timer.paa);
-        onPlace = QUOTE([ARR_4(_this select 1, _this select 3 select 0, '#timer', _this select 0)] call FUNC(startTimer); false);
+        onPlace = QUOTE([ARR_4(_this select 1, _this select 3 select 0, nil, _this select 0)] call FUNC(startTimer); false);
         onSetup = QUOTE(_this call FUNC(openTimerUI));
     };
     class Tripwire {

--- a/addons/explosives/functions/fnc_startTimer.sqf
+++ b/addons/explosives/functions/fnc_startTimer.sqf
@@ -24,6 +24,6 @@ TRACE_3("Starting timer",_explosive,_delay,_trigger);
     params ["_explosive", "_trigger"];
     TRACE_1("Explosive detonating from timer",_explosive);
     if (!isNull _explosive) then {
-        [_explosive, -1, [_explosive, 0], _trigger] call FUNC(detonateExplosive);
+        [player, -1, [_explosive, 0], _trigger] call FUNC(detonateExplosive);
     };
 }, [_explosive, _trigger], _delay] call CBA_fnc_waitAndExecute;

--- a/addons/explosives/functions/fnc_startTimer.sqf
+++ b/addons/explosives/functions/fnc_startTimer.sqf
@@ -24,6 +24,6 @@ TRACE_3("Starting timer",_explosive,_delay,_trigger);
     params ["_explosive", "_trigger"];
     TRACE_1("Explosive detonating from timer",_explosive);
     if (!isNull _explosive) then {
-        [player, -1, [_explosive, 0], _trigger] call FUNC(detonateExplosive);
+        [ACE_Player, -1, [_explosive, 0], _trigger] call FUNC(detonateExplosive);
     };
 }, [_explosive, _trigger], _delay] call CBA_fnc_waitAndExecute;

--- a/addons/overpressure/initSettings.sqf
+++ b/addons/overpressure/initSettings.sqf
@@ -2,6 +2,6 @@
     QGVAR(distanceCoefficient), "SLIDER",
     [LSTRING(distanceCoefficient_displayName), LSTRING(distanceCoefficient_toolTip)],
     "ACE Uncategorized",
-    [-1, 10, 5, 1],
+    [-1, 10, 1, 1],
     1
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
title

~~This fix only works on client. I don't know if this function is supposed to be call server side.~~
~~As workaround, we could check if player is not null and pass _explosive as instigator.~~

**When merged this pull request will:**
- Pass the player setting the timer as instigator
- relevent function: 
  - https://github.com/acemod/ACE3/blob/06336b8dcfa8128b37ecb0ffb9961def8e02c22f/addons/explosives/functions/fnc_detonateExplosive.sqf#L58
  - https://github.com/acemod/ACE3/blob/87cfd9632e369dcd7529700f0f2e5bdd332697ab/addons/explosives/XEH_postInit.sqf#L28