### PR TITLE
Cookoff - Limit maximum cook intensity/duration

### DIFF
--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -16,7 +16,7 @@
  * Public: No
  */
 
-params ["_vehicle", "_intensity", ["_instigator", objNull], ["_smokeDelayEnabled", true], ["_ammoDetonationChance", 0], ["_detonateAfterCookoff", false], ["_fireSource", ""], ["_canRing", true]];
+params ["_vehicle", "_intensity", ["_instigator", objNull], ["_smokeDelayEnabled", true], ["_ammoDetonationChance", 0], ["_detonateAfterCookoff", false], ["_fireSource", ""], ["_canRing", true], ["_maxIntensity", MAX_COOKOFF_INTENSITY, [0]]];
 
 if (GVAR(enable) == 0) exitWith {};
 if !(GVAR(enableFire)) exitWith {};
@@ -24,10 +24,13 @@ if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] in [0, false]) exitWith {
 if (_vehicle getVariable [QGVAR(enable), GVAR(enable)] isEqualTo 2 && {fullCrew [_vehicle, "", false] findIf {isPlayer (_x select 0)} == -1}) exitWith {};
 
 
-TRACE_8("cooking off",_vehicle,_intensity,_instigator,_smokeDelayEnabled,_ammoDetonationChance,_detonateAfterCookoff,_fireSource,_canRing);
+TRACE_9("cooking off",_vehicle,_intensity,_instigator,_smokeDelayEnabled,_ammoDetonationChance,_detonateAfterCookoff,_fireSource,_canRing,_maxIntensity);
 
 if (_vehicle getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _vehicle setVariable [QGVAR(isCookingOff), true, true];
+
+// limit maximum value of intensity
+_intensity = _intensity min _maxIntensity;
 
 private _config = _vehicle call CBA_fnc_getObjectConfig;
 private _positions = getArray (_config >> QGVAR(cookoffSelections)) select {!((_vehicle selectionPosition _x) isEqualTo [0,0,0])};
@@ -39,7 +42,7 @@ if (_positions isEqualTo []) then {
         if (_pos isEqualTo [0, 0, 0]) exitWith {};
         _positions pushBack _x;
     } forEach DEFAULT_COMMANDER_HATCHES;
-    
+
     if (_positions isEqualTo []) then {
         _positions pushBack "#noselection";
     };
@@ -64,15 +67,15 @@ if (_smokeDelayEnabled) then {
             [QGVAR(cleanupEffects), [_vehicle, _smokeEffects]] call CBA_fnc_globalEvent;
             _vehicle setVariable [QGVAR(isCookingOff), false, true];
             [_pfh] call CBA_fnc_removePerFrameHandler;
-            
+
             if (_detonateAfterCookoff) then {
                 _vehicle setDamage 1;
             };
         };
-        
+
         private _lastFlameTime = _vehicle getVariable [QGVAR(lastFlame), 0];
         private _nextFlameTime = _vehicle getVariable [QGVAR(nextFlame), 0];
-        
+
         // Wait until we are ready for the next flame
         // dt = Tcurrent - Tlast
         // dt >= Tnext
@@ -81,39 +84,39 @@ if (_smokeDelayEnabled) then {
             if (!_ring && _intensity >= 2) then {
                 _ring = (0.7 > random 1);
             };
-            
+
             if !(_canRing) then {
                 _ring = false;
             };
-        
+
             private _time = linearConversion [0, 10, _intensity, 3, 20] + random COOKOFF_TIME;
-            
+
             if (_fireSource isEqualTo "") then {
                 _fireSource = selectRandom _positions;
             };
-            
+
             [QGVAR(cookOffEffect), [_vehicle, true, _ring, _time, _fireSource]] call CBA_fnc_globalEvent;
-            
+
             _intensity = _intensity - (0.5 max random 1);
             _vehicle setVariable [QGVAR(intensity), _intensity];
             _vehicle setVariable [QGVAR(lastFlame), CBA_missionTime];
             _vehicle setVariable [QGVAR(nextFlame), _time + (MIN_TIME_BETWEEN_FLAMES max random MAX_TIME_BETWEEN_FLAMES)];
-            
+
             {
                 [QEGVAR(fire,burn), [_x, _intensity * 1.5, _instigator]] call CBA_fnc_globalEvent;
             } forEach crew _vehicle
         };
-        
+
         if (_ammoDetonationChance > random 1) then {
             private _lastExplosiveDetonationTime = _vehicle getVariable [QGVAR(lastExplosiveDetonation), 0];
             private _nextExplosiveDetonation = _vehicle getVariable [QGVAR(nextExplosiveDetonation), 0];
-                        
+
             if ((CBA_missionTime - _lastExplosiveDetonationTime) > _nextExplosiveDetonation) then {
                 if (_fireSource isEqualTo "") then {
                     _fireSource = selectRandom _positions;
                 };
                 createVehicle ["ACE_ammoExplosionLarge", (_vehicle modelToWorld (_vehicle selectionPosition _fireSource)), [], 0 , "CAN_COLLIDE"];
-                
+
                 _vehicle setVariable [QGVAR(lastExplosiveDetonation), CBA_missionTime];
                 _vehicle setVariable [QGVAR(nextExplosiveDetonation), random 60];
             };

--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -29,7 +29,7 @@ TRACE_9("cooking off",_vehicle,_intensity,_instigator,_smokeDelayEnabled,_ammoDe
 if (_vehicle getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _vehicle setVariable [QGVAR(isCookingOff), true, true];
 
-// limit maximum value of intensity
+// limit maximum value of intensity to prevent very long cook-off times
 _intensity = _intensity min _maxIntensity;
 
 private _config = _vehicle call CBA_fnc_getObjectConfig;

--- a/addons/cookoff/script_component.hpp
+++ b/addons/cookoff/script_component.hpp
@@ -27,6 +27,7 @@
 #define MIN_TIME_BETWEEN_FLAMES 5
 #define MAX_TIME_BETWEEN_FLAMES 15
 #define MAX_TIME_BETWEEN_AMMO_DET 25
+#define MAX_COOKOFF_INTENSITY 10
 
 // Delay between flame effect for players in a cooking off vehicle
 #define FLAME_EFFECT_DELAY 0.4


### PR DESCRIPTION
**When merged this pull request will:**
- title

**Reasoning:**
Advanced vehicle damage calculates the intensity (which indirectly also means duration) of the cook-off by getting the amount of the explosive ammo. This can result in ridiculously long cook-offs for vehicles that have autocannons with HE ammunition.

I've decided to use 10 intensity as maximum which roughly should limit it to ~7.5min (the intervals between cook-offs are randomised).

We could consider making this a setting but I'm not sure how to properly tell the user what it does.
  
  
**Reproduction of the issue:**
- spawn `O_APC_Tracked_02_cannon_F`
- spawn 'B_MBT_01_TUSK_F`
- shot IFV in the turret with the Tank Heat round
- ~15min cook-off