### PR TITLE
Replace CPP highlighting with SQF highlighting

### DIFF
--- a/docs/wiki/development/arma-3-scheduler-and-our-practices.md
+++ b/docs/wiki/development/arma-3-scheduler-and-our-practices.md
@@ -45,7 +45,7 @@ It means we need to live outside of the spawn execution as much as possible. The
 
 The scheduler will also actually halt your script mid-execution, usually at the end of a given control block, and pause you to yield to other scripts. This can lead to drastically incorrect results when performing calculations and unexpected behaviours. For example, try the following code. Even though it doesn't seem logical, it will show a hint.
 
-```cpp
+```sqf
 myVar = true;
 0 spawn {
     while {true} do {
@@ -90,7 +90,7 @@ These rules follow from the rules of thumb above:
 #### 3.3.1 Per Frame Handler
 See: [https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_addPerFrameHandler.sqf](https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_addPerFrameHandler.sqf) for more details.
 
-```cpp
+```sqf
 [{code} , delay, [params]] call CBA_fnc_addPerFrameHandler;
 ```
 
@@ -98,7 +98,7 @@ See: [https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_addPerFram
 #### 3.3.2 WaitAndExecute
 See: [https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_waitAndExecute.sqf](https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_waitAndExecute.sqf) for more details.
 
-```cpp
+```sqf
 [{delayed code}, [params], delay] call CBA_fnc_waitAndExecute;
 ```
 
@@ -106,6 +106,6 @@ See: [https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_waitAndExe
 #### 3.3.3 WaitUntilAndExecute
 See: [https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_waitUntilAndExecute.sqf](https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_waitUntilAndExecute.sqf) for more details.
 
-```cpp
+```sqf
 [{condition}, {code}, [params]] call CBA_fnc_waitUntilAndExecute;
 ```

--- a/docs/wiki/development/coding-guidelines.md
+++ b/docs/wiki/development/coding-guidelines.md
@@ -181,7 +181,7 @@ This ensures every function starts off in an uniform way and enforces function d
 ### 3.2 Headers
 Every function should have a header of the following format appear before any code:
 
-```cpp
+```sqf
 /*
  * Author: [Name of Author(s)]
  * [Description]
@@ -260,7 +260,7 @@ class Something : Or {
 
 When using `if`/`else`, it is encouraged to put `else` on the same line as the closing brace to save space:
 
-```cpp
+```sqf
 if (alive player) then {
     player setDamage 1;
 } else {
@@ -284,7 +284,7 @@ Every new scope should be on a new indent. This will make the code easier to und
 
 Good:
 
-```cpp
+```sqf
 call {
     call {
         if (/* condition */) then {
@@ -296,7 +296,7 @@ call {
 
 Bad:
 
-```cpp
+```sqf
 call {
         call {
         if (/* condition */) then {
@@ -311,7 +311,7 @@ Inline comments should use `//`. Usage of `/* */` is allowed for larger comment 
 
 Example:
 
-```cpp
+```sqf
 //// Comment   // < incorrect
 // Comment     // < correct
 /* Comment */  // < correct
@@ -324,7 +324,7 @@ Comments within the code shall be used when they are describing a complex and cr
 
 Good:
 
-```cpp
+```sqf
 // find the object with the most blood loss
 _highestObj = objNull;
 _highestLoss = -1;
@@ -338,28 +338,28 @@ _highestLoss = -1;
 
 Good:
 
-```cpp
+```sqf
 // Check if the unit is an engineer
 (_obj getvariable [QGVAR(engineerSkill), 0] >= 1);
 ```
 
 Bad:
 
-```cpp
+```sqf
 // Get the engineer skill and check if it is above 1
 (_obj getvariable [QGVAR(engineerSkill), 0] >= 1);
 ```
 
 Bad:
 
-```cpp
+```sqf
 // Get the variable myValue from the object
 _myValue = _obj getvariable [QGVAR(myValue), 0];
 ```
 
 Bad:
 
-```cpp
+```sqf
 // Loop through all units to increase the myvalue variable
 {
     _x setvariable [QGVAR(myValue), (_x getvariable [QGVAR(myValue), 0]) + 1];
@@ -369,19 +369,19 @@ Bad:
 ### 5.5 Brackets around code
 When making use of brackets `( )`, use as few as possible, unless doing so decreases readability of the code. Avoid statements such as:
 
-```cpp
+```sqf
 if (!(_value)) then { };
 ```
 
 However the following is allowed:
 
-```cpp
+```sqf
 _value = (_array select 0) select 1;
 ```
 
 Any conditions in statements shall always be wrapped around brackets.
 
-```cpp
+```sqf
 if (!_value) then {};
 if (_value) then {};
 ```
@@ -402,14 +402,14 @@ When using array notation `[]`, always use a space between elements to improve c
 
 Good:
 
-```cpp
+```sqf
 params ["_unit", "_vehicle"];
 private _pos = [0, 0, 0];
 ```
 
 Bad:
 
-```cpp
+```sqf
 params ["_unit","_vehicle"];
 private _pos = [0,0,0];
 ```
@@ -436,19 +436,19 @@ All private variables shall make use of the `private` keyword on initialization.
 
 Good:
 
-```cpp
+```sqf
 private _myVariable = "hello world";
 ```
 
 Good:
 
-```cpp
+```sqf
 _myArray params ["_elementOne", "_elementTwo"];
 ```
 
 Bad:
 
-```cpp
+```sqf
 _elementOne = _myArray select 0;
 _elementTwo = _myArray select 1;
 ```
@@ -461,7 +461,7 @@ Declarations should be at the smallest feasible scope.
 
 Good:
 
-```cpp
+```sqf
 if (call FUNC(myCondition)) then {
     private _areAllAboveTen = true; // <- smallest feasable scope
 
@@ -479,7 +479,7 @@ if (call FUNC(myCondition)) then {
 
 Bad:
 
-```cpp
+```sqf
 private _areAllAboveTen = true; // <- this is bad, because it can be initialized in the if statement
 if (call FUNC(myCondition)) then {
     {
@@ -499,7 +499,7 @@ Private variables will not be introduced until they can be initialized with mean
 
 Good:
 
-```cpp
+```sqf
 private _myVariable = 0; // good because the value will be used
 {
     _x params ["_value", "_amount"];
@@ -511,7 +511,7 @@ private _myVariable = 0; // good because the value will be used
 
 Bad:
 
-```cpp
+```sqf
 private _myvariable = 0; // Bad because it is initialized with a zero, but this value does not mean anything
 if (_condition) then {
     _myVariable = 1;
@@ -522,7 +522,7 @@ if (_condition) then {
 
 Good:
 
-```cpp
+```sqf
 private _myvariable = [1, 2] select _condition;
 ```
 
@@ -537,20 +537,20 @@ When using `getVariable`, there shall either be a default value given in the sta
 
 Bad:
 
-```cpp
+```sqf
 _return = obj getvariable "varName";
-if (isnil "_return") then {_return = 0 };
+if (isnil "_return") then { _return = 0 };
 ```
 
 Good:
 
-```cpp
+```sqf
 _return = obj getvariable ["varName", 0];
 ```
 
 Good:
 
-```cpp
+```sqf
 _return = obj getvariable "varName";
 if (isnil "_return") exitwith {};
 ```
@@ -560,27 +560,27 @@ Global variables should not be used to pass along information from one function 
 
 Bad:
 
-```cpp
+```sqf
 fnc_example = {
     hint GVAR(myVariable);
 };
 ```
 
-```cpp
+```sqf
 GVAR(myVariable) = "hello my variable";
 call fnc_example;
 ```
 
 Good:
 
-```cpp
+```sqf
 fnc_example = {
     params ["_content"];
     hint _content;
 };
 ```
 
-```cpp
+```sqf
 ["hello my variable"] call fnc_example;
 ```
 
@@ -625,7 +625,7 @@ More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wi
 
 **Warning about BIS event handlers:**
 BIS's event handlers (`addEventHandler`, `addMissionEventHandler`) are slow when passing a large code variable. Use a short code block that calls the function you want.
-```cpp
+```sqf
 player addEventHandler ["Fired", FUNC(handleFired)]; // bad
 player addEventHandler ["Fired", {call FUNC(handleFired)}]; // good
 ```
@@ -638,7 +638,7 @@ Hashes are a variable type that store key value pairs. They are not implemented 
 
 The following example is a simple usage using our macros which will be explained further below.
 
-```cpp
+```sqf
 _hash = HASHCREATE;
 HASH_SET(_hash,"key","value");
 if (HASH_HASKEY(_hash,"key")) then {
@@ -664,7 +664,7 @@ A description of the above macros is below.
 
 A hashlist is an extension of a hash. It is a list of hashes! The reason for having this special type of storage container rather than using a normal array is that an array of normal hashes that are similar will duplicate a large amount of data in their storage of keys. A hashlist on the other hand uses a common list of keys and an array of unique value containers. The following will demonstrate its usage.
 
-```cpp
+```sqf
 _defaultKeys = ["key1", "key2", "key3"];
 // create a new hashlist using the above keys as default
 _hashList = HASHLIST_CREATELIST(_defaultKeys);
@@ -712,19 +712,19 @@ When adding new elements to an array, `pushBack` shall be used instead of the bi
 
 Good:
 
-```cpp
+```sqf
 _a pushBack _value;
 ```
 
 Also good:
 
-```cpp
+```sqf
 _a append [1, 2, 3];
 ```
 
 Bad:
 
-```cpp
+```sqf
 _a set [ count _a, _value];
 _a = a + _[value];
 ```
@@ -742,14 +742,14 @@ Where possible `[0, 0, 0]` position shall be used, except on `#` objects (e.g. `
 
 This code requires ~1.00ms and will be higher with more objects near wanted position:
 
-```cpp
+```sqf
 _vehicle = _type createVehicleLocal _posATL;
 _vehicle setposATL _posATL;
 ```
 
 While this one requires ~0.04ms:
 
-```cpp
+```sqf
 _vehicle = _type createVehicleLocal [0, 0, 0];
 _vehicle setposATL _posATL;
 ```
@@ -765,13 +765,13 @@ When checking if an array is empty `isEqualTo` shall be used.
 
 ### 8.7 `for` Loops
 
-```cpp
+```sqf
 for "_y" from # to # step # do { ... }
 ```
 
 shall be used instead of
 
-```cpp
+```sqf
 for [{ ... },{ ... },{ ... }] do { ... };
 ```
 
@@ -782,7 +782,7 @@ While is only allowed when used to perform a unknown finite amount of steps with
 
 Good:
 
-```cpp
+```sqf
 _original = _obj getvariable [QGVAR(value), 0];
 while {_original < _weaponThreshold} do {
     _original = [_original, _weaponClass] call FUNC(getNewValue);
@@ -791,7 +791,7 @@ while {_original < _weaponThreshold} do {
 
 Bad:
 
-```cpp
+```sqf
 while {true} do {
     // anything
 };
@@ -799,7 +799,7 @@ while {true} do {
 
 ### 8.9 `waitUntil`
 The `waitUntil` command shall not be used. Instead, make use of CBA's `CBA_fnc_waitUntilAndExecute`
-```cpp
+```sqf
 [{
     params ["_unit"];
     _unit getVariable [QGVAR(myVariable), false]

--- a/docs/wiki/development/setting-up-the-development-environment.md
+++ b/docs/wiki/development/setting-up-the-development-environment.md
@@ -125,7 +125,7 @@ class CfgSettings {
 
 - To only disable caching for a single module, hence greatly improving mission restart time, add the following line to the `script_component.hpp` file of said module (prepared in each ACE3 component, simply uncomment):
 
-```cpp
+```sqf
 #define DISABLE_COMPILE_CACHE
 ```
 

--- a/docs/wiki/feature/hellfire.md
+++ b/docs/wiki/feature/hellfire.md
@@ -54,7 +54,7 @@ This and the attack profile used will effect missile's flight and max altitude.
 ### 3.2 Script Example
 - Adding hellfires to the Cessna Civilian Plane:
 
-```
+```sqf
 if (local this) then {
     this addWeaponTurret ["ace_hellfire_launcher", [-1]];
     this addMagazineTurret ["6Rnd_ACE_Hellfire_AGM114K", [-1]];

--- a/docs/wiki/feature/hot.md
+++ b/docs/wiki/feature/hot.md
@@ -53,7 +53,7 @@ There are 4 HOT missiles included
 
 - Adding HOT to e.g. a Cessna Civilian Plane:
 
-```cpp
+```sqf
 if (local this) then {
     this addWeaponTurret ["ace_hot_generic_launcher", [-1]];
     this addMagazineTurret ["ace_hot_2mp_6Rnd", [-1]];

--- a/docs/wiki/feature/refuel.md
+++ b/docs/wiki/feature/refuel.md
@@ -61,7 +61,7 @@ Please check the framework description for more details.
 
 ### How do I increase the length of the hose?
 There is a global setting that will effect all vehicles and static pumps. To only effect a specific vehicle put the following in it's init box:
-```cpp
+```sqf
 this setVariable ["ace_refuel_hoseLength", 30];
 ```
 

--- a/docs/wiki/framework/advanced-throwing-framework.md
+++ b/docs/wiki/framework/advanced-throwing-framework.md
@@ -15,6 +15,6 @@ version:
 
 Pick-up interaction can be disabled for ammo (e.g. chemlights) attached to an object.
 
-```cpp
+```sqf
 OBJECT setVariable ["ace_advanced_throwing_disablePickUp", true, true];
 ```

--- a/docs/wiki/framework/cargo-framework.md
+++ b/docs/wiki/framework/cargo-framework.md
@@ -65,7 +65,7 @@ If you wish to enable loading for an object/vehicle which does not have these ed
 
 To disable cargo for a mission object use:
 
-```cpp
+```sqf
 [this, -1] call ace_cargo_fnc_setSize;
 ```
 
@@ -74,7 +74,7 @@ To disable cargo for a mission object use:
 `ace_cargo_fnc_setSize`
 Note that this function can be used to make objects loadable/unloadable (set to `-1` for unloadable).
 
-```cpp
+```sqf
  * Set the cargo size of any object. Has global effect.
  * Adds the load action menu if necessary.
  * Negative size makes unloadable.
@@ -95,7 +95,7 @@ Note that this function can be used to make objects loadable/unloadable (set to 
 `ace_cargo_fnc_setSpace`
 Note that this function can be used to enable/disable a vehicle's cargo space (set to `0` to disable).
 
-```cpp
+```sqf
  * Set the cargo space of any object. Has global effect.
  * Adds the cargo action menu if necessary.
  *
@@ -115,7 +115,7 @@ Note that this function can be used to enable/disable a vehicle's cargo space (s
 `ace_cargo_fnc_loadItem` (Also callable from cba event `ace_loadCargo`)
 Note first arg can be a in-game object or a classname of an object type.
 
-```cpp
+```sqf
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Vehicle <OBJECT>
@@ -132,7 +132,7 @@ Note first arg can be a in-game object or a classname of an object type.
 
 `ace_cargo_fnc_unloadItem` (Also callable from cba event `ace_unloadCargo`)
 
-```cpp
+```sqf
  * Arguments:
  * 0: Item <OBJECT or STRING>
  * 1: Vehicle <OBJECT>
@@ -149,7 +149,7 @@ Note first arg can be a in-game object or a classname of an object type.
 
 `ace_cargo_fnc_removeCargoItem`
 
-```cpp
+```sqf
  * Arguments:
  * 0: Item <STRING> or <OBJECT>
  * 1: Vehicle <OBJECT>

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -228,7 +228,7 @@ Calls a globally synchronized event, which will also be run on JIP players unles
 
 ### 3.4 Example
 
-```cpp
+```sqf
 // Event handler added on a target machine
 ["ace_interact_tapShoulder", ace_example_fnc_onTapShoulder] call CBA_fnc_addEventHandler;
 

--- a/docs/wiki/framework/explosives-framework.md
+++ b/docs/wiki/framework/explosives-framework.md
@@ -190,7 +190,7 @@ CODE will be passed `[Unit<OBJECT>, MaxRange <NUMBER>, Explosive <OBJECT>, FuzeT
 
 Jammer that blocks RF triggers:
 
-```cpp
+```sqf
 [{
     params ["_unit", "_range", "_explosive", "_fuzeTime", "_triggerItem"];
     if (_triggerItem == "ace_cellphone") exitWith { systemChat "Blocking Cell Phone"; false };  // always block cell phones

--- a/docs/wiki/framework/field-rations-framework.md
+++ b/docs/wiki/framework/field-rations-framework.md
@@ -54,7 +54,7 @@ Event Name | Passed Parameter(s) | Locality | Description
 
 `ace_field_rations_fnc_getRemainingWater`
 
-```cpp
+```sqf
 * Returns the remaining water in a source.
 *
 * Arguments:
@@ -71,7 +71,7 @@ Event Name | Passed Parameter(s) | Locality | Description
 
 `ace_field_rations_fnc_setRemainingWater`
 
-```cpp
+```sqf
 * Sets the remaining water supply for given water source.
 *
 * Arguments:
@@ -89,7 +89,7 @@ Event Name | Passed Parameter(s) | Locality | Description
 
 `ace_field_rations_fnc_addStatusModifier`
 
-```cpp
+```sqf
 * Adds a status modifier. Should be called on all machines.
 * Code must return a NUMBER which will be applied additively with other status changes.
 *

--- a/docs/wiki/framework/fortify-framework.md
+++ b/docs/wiki/framework/fortify-framework.md
@@ -34,7 +34,7 @@ There are two ways of adding custom presets to your mission, either via code or 
 
 To add a preset via code you use the function `call ace_fortify_fnc_registerObjects`. Also enables Fortify.
 
-```cpp
+```sqf
 * Registers the given objects in the given side's player interaction menu.
 * Players on that side must have the `Fortify Tool` item in their inventory to access the menu.
 * Classnames must be in the format [<classname>, <cost>]
@@ -74,7 +74,7 @@ A custom deploy handler allows missions makers to decide if an object can be pla
 
 To verify that an object isn't above a certain terrain height we can check the height of the object before it is confirmed as placed. Returning `false` from the code block means that placement is not allowed.
 
-```cpp
+```sqf
 [{
     params ["_unit", "_object", "_cost"];
     private _return = (getPosATL _object) select 2 < 1;

--- a/docs/wiki/framework/headless-framework.md
+++ b/docs/wiki/framework/headless-framework.md
@@ -34,7 +34,7 @@ As of ACEX v3.2.0 _(before merge into ACE3)_ this feature can also be enabled wi
 
 To prevent a group from transferring to a Headless Client use the following line on a group leader (or every unit in a group in case group leader may not spawn):
 
-```cpp
+```sqf
 this setVariable ["acex_headless_blacklist", true];
 ```
 

--- a/docs/wiki/framework/interactionMenu-framework.md
+++ b/docs/wiki/framework/interactionMenu-framework.md
@@ -74,7 +74,7 @@ Important: `ace_common_fnc_canInteractWith` is not automatically checked and nee
 
 `ace_interact_menu_fnc_createAction`
 
-```cpp
+```sqf
 /*
  * Argument:
  * 0: Action name <STRING>
@@ -95,7 +95,7 @@ Important: `ace_common_fnc_canInteractWith` is not automatically checked and nee
 
 `ace_interact_menu_fnc_addActionToClass`
 
-```cpp
+```sqf
 /*
  * Argument:
  * 0: TypeOf of the class <STRING>
@@ -111,7 +111,7 @@ By default this function will not use inheritance, so actions will only be added
 
 `ace_interact_menu_fnc_addActionToObject`
 
-```cpp
+```sqf
 /*
  * Argument:
  * 0: Object the action should be assigned to <OBJECT>
@@ -125,7 +125,7 @@ By default this function will not use inheritance, so actions will only be added
 
 `ace_interact_menu_fnc_addActionToZeus`
 
-```cpp
+```sqf
 /*
  * Argument:
  * 0: Parent path of the new action <ARRAY> (Example: `["ACE_ZeusActions"]`)
@@ -137,14 +137,14 @@ By default this function will not use inheritance, so actions will only be added
 
 External:
 
-```cpp
+```sqf
 _action = ["VulcanPinch","Vulcan Pinch","",{_target setDamage 1;},{true},{},[parameters], [0,0,0], 100] call ace_interact_menu_fnc_createAction;
 [cursorTarget, 0, ["ACE_TapShoulderRight"], _action] call ace_interact_menu_fnc_addActionToObject;
 ```
 
 Self:
 
-```cpp
+```sqf
 _condition = {
     (!pabst_radioFinder_on) && {(backpack _player) in pabst_radioFinder_backpacks} && {[_player, _target, []] call ace_common_fnc_canInteractWith}
 };
@@ -157,7 +157,7 @@ _action = ["Open RDF","Radio Direction Finder","pabst\RDF.jpg",_statement,_condi
 
 Using `addActionToClass` inheritance:
 
-```cpp
+```sqf
 // Adds action to check fuel levels for all land vehicles
 _action = ["CheckFuel", "Check Fuel", "", {hint format ["Fuel: %1", fuel _target]}, {true}] call ace_interact_menu_fnc_createAction;
 ["LandVehicle", 0, ["ACE_MainActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
@@ -169,7 +169,7 @@ _action = ["CheckExtTank","Check External Tank","",{hint format ["Ext Tank: %1",
 
 Zeus:
 
-```cpp
+```sqf
 _statement = {
     playSound3D ["alarm.ogg", theBase]
 };
@@ -185,7 +185,7 @@ This adds an interaction to a unit that allows passing items that the player is 
 - The parent action's display name is modified based on the item count.
 - When hovering on the action, a hint text is sent to the target.
 
-```cpp
+```sqf
 _condition = {
     true
 };
@@ -227,7 +227,7 @@ _action = ["GiveItems", "?","",_statement,_condition,_insertChildren,[123],"",4,
 CBA event `ace_interact_menu_newControllableObject` fires only once the first time the player controls a new object (new man, vehicle or controlled UAV)
 This is the ideal way to add self interaction actions, as adding them via `addActionToClass` will force self interaction actions to be compiled for classes that may never be used.
 
-```cpp
+```sqf
 // Example: Add radio self-action to all civilian cars
 ["ace_interact_menu_newControllableObject", {
     params ["_type"]; // string of the object's classname

--- a/docs/wiki/framework/respawn-framework.md
+++ b/docs/wiki/framework/respawn-framework.md
@@ -47,7 +47,7 @@ To enable other units to move them reference [Scripting](#allow-units-to-move-ra
 
 To change the texture of the flag use the following line on the rally point object:
 
-```cpp
+```sqf
 this setFlagTexture 'path\to\my\texture\my_awesome_clan_logo.paa';
 ```
 
@@ -55,6 +55,6 @@ this setFlagTexture 'path\to\my\texture\my_awesome_clan_logo.paa';
 
 To enable other units to move rally points, such as JIP units, use the following line on the units:
 
-```cpp
+```sqf
 _unit setVariable ["ACE_canMoveRallypoint", true, true];
 ```

--- a/docs/wiki/framework/spectator-framework.md
+++ b/docs/wiki/framework/spectator-framework.md
@@ -65,7 +65,7 @@ If the interface is not forced then the player can close spectator with the <kbd
 
 If the player is hidden they will become invisible, invulnerable and removed from their group until they exit spectator.
 
-```cpp
+```sqf
  * Arguments:
  * 0: Spectator state of local client <BOOL> (default: true)
  * 1: Force interface <BOOL> (default: true)
@@ -85,7 +85,7 @@ Whitelisted units will always show in the unit list regardless of the usual filt
 
 Note that this function takes local effect, so only the local player will see these changes.
 
-```cpp
+```sqf
  * Arguments:
  * 0: Units to show in the list <ARRAY>
  * 1: Units to hide in the list <ARRAY>
@@ -104,7 +104,7 @@ By default, units on all 4 sides (`west`, `east`, `independent` and `civilian`) 
 
 Note that this function takes local effect, so only the local player will see these changes.
 
-```cpp
+```sqf
  * Arguments:
  * 0: Sides to add <ARRAY>
  * 1: Sides to remove <ARRAY>
@@ -123,7 +123,7 @@ You can change the spectator camera modes available at any point during the miss
 
 Note that this function takes local effect, so only the local player will experience these changes.
 
-```cpp
+```sqf
  * Possible camera modes are:
  *   - 0: Free
  *   - 1: First person
@@ -147,7 +147,7 @@ You can change the spectator vision modes available at any point during the miss
 
 Note that this function takes local effect, so only the local player will experience these changes.
 
-```cpp
+```sqf
  * Possible vision modes are:
  *   - -2: Normal
  *   - -1: Night vision
@@ -178,7 +178,7 @@ You can change any of the listed camera attributes at any time during a mission 
 
 Note that this function takes local effect, so only the local player will experience these changes.
 
-```cpp
+```sqf
  * Arguments:
  * 0: Camera mode <NUMBER>
  *   - 0: Free
@@ -211,7 +211,7 @@ Note that this function takes local effect, so only the local player will experi
 `ace_spectator_fnc_getCameraAttributes`
 Returns an array of the listed camera attributes (see `setCameraAttributes` for more details) for the local player. If the spectator camera is not currently active any pre-set attributes will be returned (otherwise default values will be returned - position will be `[0,0,0]` if unset).
 
-```cpp
+```sqf
  * Arguments:
  * None
  *
@@ -227,7 +227,7 @@ Returns an array of the listed camera attributes (see `setCameraAttributes` for 
 `ace_spectator_fnc_players`
 Will return both alive and dead players (note that dead player corpses are never deleted until the player has respawned - even when `deleteVehicle` is used on them).
 
-```cpp
+```sqf
  * Arguments:
  * None
  *

--- a/docs/wiki/framework/switchunits-framework.md
+++ b/docs/wiki/framework/switchunits-framework.md
@@ -26,6 +26,6 @@ The module settings define which side a player can control or how big the radius
 
 To enable a player to control AI execute the following on it:
 
-```cpp
+```sqf
 this setVariable ["ACE_CanSwitchUnits", true];
 ```

--- a/docs/wiki/framework/vehiclelock-framework.md
+++ b/docs/wiki/framework/vehiclelock-framework.md
@@ -52,7 +52,7 @@ Sync the module with vehicles and players. Custom keys will be handed to players
 
 To override a vehicle's side, allowing locking and unlocking using a different side's key, use the following on that vehicle (use wanted side instead of `west`):
 
-```cpp
+```sqf
 this setVariable ["ace_vehiclelock_lockSide", west];
 ```
 
@@ -60,6 +60,6 @@ this setVariable ["ace_vehiclelock_lockSide", west];
 
 To override default lock pick strength for a vehicle, that is how long lock picking will take, use the following on that vehicle (use wanted time in seconds instead of `5`):
 
-```cpp
+```sqf
 this setVariable ["ace_vehiclelock_lockpickStrength", 5];
 ```


### PR DESCRIPTION
**When merged this pull request will:**
- Make use of the SQF highlighting

Jekyll uses Rouge for highlighting and I added SQF highlighting to it a while ago (rouge-ruby/rouge#761). I've already replaced the tags for it on the arsenal framework page in #8650.