### PR TITLE
Fire - Adding option to disable screaming for units on fire

### DIFF
--- a/addons/fire/XEH_postInit.sqf
+++ b/addons/fire/XEH_postInit.sqf
@@ -3,7 +3,10 @@
 [QGVAR(burn), FUNC(burn)] call CBA_fnc_addEventHandler;
 [QGVAR(playScream), {
     params ["_scream", "_source"];
-    _source say3D _scream;
+    // only play sound if enabled in settings
+    if (GVAR(enableScreams)) then {
+        _source say3D _scream;
+    };
 }] call CBA_fnc_addEventHandler;
 
 ["ace_settingsInitialized", {

--- a/addons/fire/initSettings.sqf
+++ b/addons/fire/initSettings.sqf
@@ -29,3 +29,11 @@
     ],
     true // isGlobal
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(enableScreams), "CHECKBOX",
+    [LSTRING(Setting_EnableScreams), LSTRING(Setting_EnableScreamsDescription)],
+    LSTRING(Category_DisplayName),
+    true,
+    false // isGlobal
+] call CBA_fnc_addSetting;

--- a/addons/fire/initSettings.sqf
+++ b/addons/fire/initSettings.sqf
@@ -37,3 +37,4 @@
     true,
     false // isGlobal
 ] call CBA_fnc_addSetting;
+

--- a/addons/fire/initSettings.sqf
+++ b/addons/fire/initSettings.sqf
@@ -32,7 +32,7 @@
 
 [
     QGVAR(enableScreams), "CHECKBOX",
-    [LSTRING(Setting_EnableScreams), LSTRING(Setting_EnableScreamsDescription)],
+    [LSTRING(Setting_EnableScreams), LSTRING(Setting_EnableScreams_Description)],
     LSTRING(Category_DisplayName),
     true,
     false // isGlobal

--- a/addons/fire/stringtable.xml
+++ b/addons/fire/stringtable.xml
@@ -52,7 +52,7 @@
         <Key ID="STR_ACE_Fire_Setting_EnableScreams">
             <English>Enable screams by units on fire</English>
         </Key>
-        <Key ID="STR_ACE_Fire_Setting_EnableScreamsDescription">
+        <Key ID="STR_ACE_Fire_Setting_EnableScreams_Description">
             <English>Enables if units on fire will play the screaming sound</English>
         </Key>
         <Key ID="STR_ACE_Fire_Setting_DropWeapon">

--- a/addons/fire/stringtable.xml
+++ b/addons/fire/stringtable.xml
@@ -49,6 +49,12 @@
             <German>Benutzt einen Feuerschein-Effekt um die Intensität des Feuers bei Nacht zu verstärken.</German>
             <Polish>Używa efektu flary, aby zwiększyć jasność w nocy</Polish>
         </Key>
+        <Key ID="STR_ACE_Fire_Setting_EnableScreams">
+            <English>Enable screams by units on fire</English>
+        </Key>
+        <Key ID="STR_ACE_Fire_Setting_EnableScreamsDescription">
+            <English>Enables if units on fire will play the screaming sound</English>
+        </Key>
         <Key ID="STR_ACE_Fire_Setting_DropWeapon">
             <English>Drop Weapons When on Fire</English>
             <Polish>Włącz wyrzucanie broni podczas płonięcia</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
Add a CBA setting that can disable/enable the screaming sounds when units are on fire. fixes https://github.com/acemod/ACE3/issues/8664 

Adds a CBA setting.
Adds check in "playScream" event before playing the screams. 