### PR TITLE
Logistics Rope - Use generic model instead of one linked to DLC

### DIFF
--- a/addons/logistics_rope/CfgWeapons.hpp
+++ b/addons/logistics_rope/CfgWeapons.hpp
@@ -4,7 +4,7 @@ class CfgWeapons {
     class ACE_ropeBase: ACE_ItemCore {
         scope = 1;
         picture = QPATHTOF(data\m_rope_ca);
-        model = "\A3\Structures_F_Heli\Items\Tools\Rope_01_F.p3d";
+        // model = "\A3\Structures_F_Heli\Items\Tools\Rope_01_F.p3d"; // model is Locked to Helicopter DLC
         descriptionShort = CSTRING(descriptionShort);
     };
 


### PR DESCRIPTION
model p3d is linked to Helicopter DLC
Apparently those who don't own the dlc cannot pickup item