### PR TITLE
Killtracker - Remove medical from required addons

### DIFF
--- a/addons/killtracker/README.md
+++ b/addons/killtracker/README.md
@@ -1,7 +1,8 @@
 ace_killtracker
 ============
 
-Tracks deaths/kills and logs to the end mission disaplay. Attemps to log kills from Medical by using `ace_medical_lastDamageSource`.
+Tracks deaths/kills and logs to the end mission disaplay. 
+Show detailed info from player kills from ACE Medical by using `ace_killed` event.
 
 Note: Requires config setup in a mission, see `killtracker.inc` - has no effect if mission is not setup correctly.
 

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -19,6 +19,10 @@
 if ((getText (missionconfigfile >> "CfgDebriefingSections" >> QUOTE(XADDON) >> "variable")) != QXGVAR(outputText)) exitWith {
     TRACE_1("no mission debriefing config",_this);
 };
+if (!(["ACE_Medical"] call EFUNC(common,isModLoaded))) exitWith {
+    WARNING("No ACE-Medical");
+    XGVAR(outputText) = "No ACE-Medical";
+};
 
 private _global = missionNamespace getVariable [QGVAR(globalSync), false];  // Global Sync (e.g. for spectator)
 INFO_1("Running Kill Tracking [Global: %1]",_global);

--- a/addons/killtracker/config.cpp
+++ b/addons/killtracker/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_medical"};
+        requiredAddons[] = {"ace_common"};
         author = ECSTRING(common,ACETeam);
         authors[]= {"PabstMirror"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
Removes `ace_medical` from `requiredAddons`
