### PR TITLE
Overheating - Use `select` instead of `params`

### DIFF
--- a/addons/overheating/functions/fnc_coolWeaponWithItem.sqf
+++ b/addons/overheating/functions/fnc_coolWeaponWithItem.sqf
@@ -61,7 +61,7 @@ private _fnc_onSuccess = {
     };
 
     // cool the weapon
-    ([_weapon] call FUNC(getWeaponData)) params ["", "", "", "", "", "", "", "_barrelMass"];
+    private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
     _temperature = [_temperature, _barrelMass, _liquidAmount * 10] call FUNC(calculateCooling);
     [_target, _tempVarName, _temperature, TEMP_TOLERANCE] call EFUNC(common,setApproximateVariablePublic);
 };

--- a/addons/overheating/functions/fnc_coolWeaponWithWaterSource.sqf
+++ b/addons/overheating/functions/fnc_coolWeaponWithWaterSource.sqf
@@ -59,7 +59,7 @@ private _fnc_condition = {
         };
 
         //Cool the weapon down
-        ([_weapon] call FUNC(getWeaponData)) params ["", "", "", "", "", "", "", "_barrelMass"];
+        private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
         _temperature = [_temperature, _barrelMass, 20] call FUNC(calculateCooling);
         [_player, _tempVarName, _temperature, TEMP_TOLERANCE] call EFUNC(common,setApproximateVariablePublic);
 

--- a/addons/overheating/functions/fnc_getBarrelMass.sqf
+++ b/addons/overheating/functions/fnc_getBarrelMass.sqf
@@ -17,6 +17,6 @@
 
 params ["_weapon"];
 
-([_weapon] call FUNC(getWeaponData)) params ["", "", "", "", "", "", "", "_barrelMass"];
+private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
 
 _barrelMass

--- a/addons/overheating/functions/fnc_swapBarrelCallback.sqf
+++ b/addons/overheating/functions/fnc_swapBarrelCallback.sqf
@@ -34,7 +34,7 @@ if (GVAR(unJamOnSwapBarrel) && {[_gunner] call FUNC(canUnjam)}) then {
 [localize LSTRING(SwappedBarrel), QPATHTOF(UI\spare_barrel_ca.paa)] call EFUNC(common,displayTextPicture);
 
 private _temp = _gunner getVariable [format [QGVAR(%1_temp), _weapon], 0];
-([_weapon] call FUNC(getWeaponData)) params ["", "", "", "", "", "", "", "_barrelMass"];
+private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
 
 // Instruct the server to load the coolest spare barrel into the weapon and
 // store the removed barrel with the former weapon temperature. The server

--- a/addons/overheating/functions/fnc_updateAmmoTemperature.sqf
+++ b/addons/overheating/functions/fnc_updateAmmoTemperature.sqf
@@ -20,7 +20,7 @@
 params ["_unit", "_weapon", "_barrelTemperature"];
 TRACE_3("params",_unit,_weapon,_barrelTemperature);
 
-([_weapon] call FUNC(getWeaponData)) params ["", "", "", "", "", "", "_closedBolt"];
+private _closedBolt = ([_weapon] call FUNC(getWeaponData)) select 6;
 private _canUnjam = [_unit] call FUNC(canUnjam);
 private _jamType = _unit getVariable [format [QGVAR(%1_jamType), _weapon], "None"];
 

--- a/addons/overheating/functions/fnc_updateTemperature.sqf
+++ b/addons/overheating/functions/fnc_updateTemperature.sqf
@@ -33,7 +33,7 @@ _trackedWeapons pushBackUnique _tempVarName;
 _unit setVariable [QGVAR(trackedWeapons), _trackedWeapons];
 
 // Calculate cooling
-([_weapon] call FUNC(getWeaponData)) params ["", "", "", "", "", "", "", "_barrelMass"];
+private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
 _temperature = [_temperature, _barrelMass, CBA_missionTime - _lastTime] call FUNC(calculateCooling);
 
 TRACE_1("cooledTo",_temperature);


### PR DESCRIPTION
**When merged this pull request will:**
- switch from params to select for single value returns when calling getWeaponData