### PR TITLE
Finger - Add scaling settings

### DIFF
--- a/addons/finger/functions/fnc_incomingFinger.sqf
+++ b/addons/finger/functions/fnc_incomingFinger.sqf
@@ -27,7 +27,7 @@ private _fingerPos = if (_sourceUnit == ACE_player) then {
 
 TRACE_3("incoming finger:", _sourceUnit, _fingerPosPrecise, _fingerPos);
 
-private _data = [diag_tickTime, _fingerPos, ([_sourceUnit, false, true] call EFUNC(common,getName))];
+private _data = [diag_tickTime, _fingerPos, ([_sourceUnit, false, true] call EFUNC(common,getName)), _sourceUnit];
 GVAR(fingersHash) set [hashValue _sourceUnit, _data];
 
 if (GVAR(pfeh_id) == -1) then {

--- a/addons/finger/functions/fnc_perFrameEH.sqf
+++ b/addons/finger/functions/fnc_perFrameEH.sqf
@@ -21,7 +21,7 @@ if !([ACE_player, ACE_player, ["isNotInside", "isNotSwimming"]] call EFUNC(commo
 // Make sure player is dismounted or in a static weapon:
 if ((ACE_player != vehicle ACE_player) && {!((vehicle ACE_player) isKindOf "StaticWeapon")}) then {GVAR(fingersHash) = createHashMap};
 
-private _iconBaseSize = GVAR(size) * BASE_SIZE * 0.10713 * (call EFUNC(common,getZoom));
+private _iconBaseSize = GVAR(sizeCoef) * BASE_SIZE * 0.10713 * (call EFUNC(common,getZoom));
 
 {
     //IGNORE_PRIVATE_WARNING ["_x", "_y"];
@@ -38,6 +38,7 @@ private _iconBaseSize = GVAR(size) * BASE_SIZE * 0.10713 * (call EFUNC(common,ge
         if (GVAR(proximityScaling)) then {
             _iconSize = _iconSize * linearConversion [0, GVAR(maxRange), (getPosASL ACE_player) vectorDistance (getPosASL _sourceUnit), 0.25, 2, true];
         };
+
         drawIcon3D [QPATHTOF(UI\fp_icon2.paa), _drawColor, ASLtoAGL _pos, _iconSize, _iconSize, 0, _name, 1, 0.03, "RobotoCondensed"];
     };
 } forEach GVAR(fingersHash);

--- a/addons/finger/functions/fnc_perFrameEH.sqf
+++ b/addons/finger/functions/fnc_perFrameEH.sqf
@@ -21,11 +21,11 @@ if !([ACE_player, ACE_player, ["isNotInside", "isNotSwimming"]] call EFUNC(commo
 // Make sure player is dismounted or in a static weapon:
 if ((ACE_player != vehicle ACE_player) && {!((vehicle ACE_player) isKindOf "StaticWeapon")}) then {GVAR(fingersHash) = createHashMap};
 
-private _iconSize = BASE_SIZE * 0.10713 * (call EFUNC(common,getZoom));
+private _iconBaseSize = GVAR(size) * BASE_SIZE * 0.10713 * (call EFUNC(common,getZoom));
 
 {
     //IGNORE_PRIVATE_WARNING ["_x", "_y"];
-    _y params ["_lastTime", "_pos", "_name"];
+    _y params ["_lastTime", "_pos", "_name", "_sourceUnit"];
     private _timeLeftToShow = _lastTime + FP_TIMEOUT - diag_tickTime;
     if (_timeLeftToShow <= 0) then {
         GVAR(fingersHash) deleteAt _x;
@@ -34,6 +34,10 @@ private _iconSize = BASE_SIZE * 0.10713 * (call EFUNC(common,getZoom));
         // Fade out:
         _drawColor set [3, ((_drawColor select 3) * ((_timeLeftToShow min 0.5) / 0.5))];
 
+        private _iconSize = _iconBaseSize;
+        if (GVAR(proximityScaling)) then {
+            _iconSize = _iconSize * linearConversion [0, GVAR(maxRange), (getPosASL ACE_player) vectorDistance (getPosASL _sourceUnit), 0.25, 2, true];
+        };
         drawIcon3D [QPATHTOF(UI\fp_icon2.paa), _drawColor, ASLtoAGL _pos, _iconSize, _iconSize, 0, _name, 1, 0.03, "RobotoCondensed"];
     };
 } forEach GVAR(fingersHash);

--- a/addons/finger/initSettings.sqf
+++ b/addons/finger/initSettings.sqf
@@ -20,7 +20,7 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     QGVAR(sizeCoef), "SLIDER",
     [LSTRING(sizeCoef_displayName), LSTRING(sizeCoef_description)],
     _category,
-    [0.1, 5, 1, 0.1],
+    [0.1, 5, 1, 2],
     1
 ] call CBA_fnc_addSetting;
 

--- a/addons/finger/initSettings.sqf
+++ b/addons/finger/initSettings.sqf
@@ -17,6 +17,22 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(sizeCoef), "SLIDER",
+    [LSTRING(sizeCoef_displayName), LSTRING(sizeCoef_description)],
+    _category,
+    [0.1, 5, 1, 0.1],
+    1
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(proximityScaling), "CHECKBOX",
+    [LSTRING(proximityScaling_displayName), LSTRING(proximityScaling_description)],
+    _category,
+    false,
+    1
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(indicatorForSelf), "CHECKBOX",
     [LSTRING(indicatorForSelf_name), LSTRING(indicatorForSelf_description)],
     _category,

--- a/addons/finger/stringtable.xml
+++ b/addons/finger/stringtable.xml
@@ -85,6 +85,18 @@
             <Chinese>設定指向指示器最大顯示距離。[預設: 4公尺]</Chinese>
             <Turkish>Hangi uzaklıktakilerin sanal daireyi görmesini seçin. [Varsayılan : 4 metre] </Turkish>
         </Key>
+        <Key ID="STR_ACE_Finger_sizeCoef_displayName">
+            <English>Visual Marker Size Coefficient</English>
+        </Key>
+        <Key ID="STR_ACE_Finger_sizeCoef_description">
+            <English>Adjusts the size of the visual marker.</English>
+        </Key>
+        <Key ID="STR_ACE_Finger_proximityScaling_displayName">
+            <English>Proximity Scaling</English>
+        </Key>
+        <Key ID="STR_ACE_Finger_proximityScaling_description">
+            <English>Scales the size of the visual marker based on the distance between the player observing and the player pointing.</English>
+        </Key>
         <Key ID="STR_ACE_Finger_indicatorForSelf_name">
             <English>Show pointing indicator to self</English>
             <German>Zeigersymbol einem selbst anzeigen</German>


### PR DESCRIPTION
**When merged this pull request will:**
- add two settings to scale the size of the visual marker; `sizeCoef` will scale the size directly from the setting value, default 1x is the same as the current size; `proximityScaling` will scale the size based on the distance between the observer and the pointer, 2x the size at `maxRange`, 0.25x at 0m, interpolated in between.