### PR TITLE
RHS Compats - Fix various UBCs

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -187,7 +187,7 @@ class CfgVehicles {
         ace_rearm_defaultSupply = 1200;
     };
 
-    class rhs_kamaz5350: rhs_truck {};
+    class rhs_kamaz5350;
     class rhs_kamaz5350_ammo_base: rhs_kamaz5350 {
         transportAmmo = 0;
         ace_rearm_defaultSupply = 1200;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -126,7 +126,8 @@ class CfgWeapons {
         HEARING_PROTECTION_VICCREW
     };
 
-    class rhs_6b48: H_HelmetB {
+    class rhs_6b47_bare;
+    class rhs_6b48: rhs_6b47_bare {
         HEARING_PROTECTION_VICCREW
     };
 

--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -240,7 +240,8 @@ class CfgAmmo {
         EGVAR(vehicle_damage,incendiary) = 0.8;
     };
 
-    class rhs_ammo_mk19m3_M430I_penetrator: rhsusf_ammo_basic_penetrator {
+    class rhsusf_ammo_reduced_penetrator;
+    class rhs_ammo_mk19m3_M430I_penetrator: rhsusf_ammo_reduced_penetrator {
         EGVAR(vehicle_damage,incendiary) = 0.8;
     };
 


### PR DESCRIPTION
Fix
```
Updating base class rhs_6b47_bare->H_HelmetB, by z\ace\addons\compat_rhs_afrf3\config.cpp/CfgWeapons/rhs_6b48/ (original rhsafrf\addons\rhs_c_troops\config.bin)
Updating base class O_Truck_02_covered_F->rhs_truck, by z\ace\addons\compat_rhs_afrf3\config.cpp/CfgVehicles/rhs_kamaz5350/ (original (rhsafrf\addons\rhs_c_kamaz\config.bin - no unload))
Updating base class rhsusf_ammo_reduced_penetrator->rhsusf_ammo_basic_penetrator, by z\ace\addons\compat_rhs_usf3\config.cpp/CfgAmmo/rhs_ammo_mk19m3_M430I_penetrator/ (original rhsusf\addons\rhsusf_c_heavyweapons\config.bin)

```