### PR TITLE
Medical - Fix stuck in uncon animation after CfgExtendedAnimation change

### DIFF
--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -66,7 +66,7 @@
 // Fixes units being stuck in unconscious animation when being knocked over by a PhysX object
 ["CAManBase", "AnimDone", {
     params ["_unit", "_anim"];
-    if (local _unit && {_anim find QGVAR(face) != -1 && {lifeState _unit != "INCAPACITATED"}}) then {
+    if (local _unit && {_anim find QUNCON_ANIM(face) != -1 && {lifeState _unit != "INCAPACITATED"}}) then {
         [_unit, false] call FUNC(setUnconsciousAnim);
     };
 }] call CBA_fnc_addClassEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**

Fixes being stuck in the uncon animation when hit by a car but not really being unconscious. This happened after the change inside the CfgExtendedAnimation class for 3.14.1 RC0.