### PR TITLE
Weather - Fix `calculateRoughnessLength` detecting buildings above sea level

### DIFF
--- a/addons/weather/functions/fnc_calculateRoughnessLength.sqf
+++ b/addons/weather/functions/fnc_calculateRoughnessLength.sqf
@@ -19,18 +19,18 @@
 #define ROUGHNESS_LENGTHS [0.0002, 0.0005, 0.0024, 0.03, 0.055, 0.1, 0.2, 0.4, 0.8, 1.6]
 
 private _windSource = _this vectorDiff ((vectorNormalized wind) vectorMultiply 25);
-private _nearBuildings = {
+private _nearBuildingCount = {
     // Filter lights - fixes high roughness on airports (#6602)
     str _x find "light" == -1
-} count (_windSource nearObjects ["Building", 50]);
+} count (ASLToAGL _windSource nearObjects ["Building", 50]);
 private _isWater = surfaceIsWater _windSource;
 
-if (_nearBuildings == 0 && _isWater) exitWith {
+if (_nearBuildingCount == 0 && _isWater) exitWith {
     0.0005
 };
 
-if (_nearBuildings >= 10) exitWith {
+if (_nearBuildingCount >= 10) exitWith {
     1.6
 };
 
-ROUGHNESS_LENGTHS select (2 + (_nearBuildings min 6))
+ROUGHNESS_LENGTHS select (2 + (_nearBuildingCount min 6))


### PR DESCRIPTION
**When merged this pull request will:**
- fix https://github.com/acemod/ACE3/issues/8705

`nearObjects` apparenlty takes PosAGL, while the functions takes PosASL.

I am pretty sure it actually doesn't matter which position you provide and `nearObjects` actually ignores z entirely.

This would mean being 1000 meters above a town would give you high "roughness", even though you are well above the buildings.
Seems like the function is half assed and does not take building height into account at all. Could add a distance check to the buildings, but to be completely sure, you likely have to take building geometry into account.

Ngl, I am salty that half-assed stuff like this is in ACE. Would appreciate if anyone has a solution for this.