### PR TITLE
Compats - Fix RHSUSF water Jerry Can having refuel actions

### DIFF
--- a/optionals/compat_rhs_usf3/CfgEventHandlers.hpp
+++ b/optionals/compat_rhs_usf3/CfgEventHandlers.hpp
@@ -11,7 +11,7 @@ class Extended_PreInit_EventHandlers {
 };
 
 class Extended_InitPost_EventHandlers {
-    class rhsusf_props_JerryCan_Base {
+    class rhsusf_props_ScepterMFC_Base {
         class ADDON {
             init = QUOTE(call EFUNC(refuel,makeJerryCan));
         };

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -577,5 +577,11 @@ class CfgVehicles {
     class rhsusf_props_JerryCan_Base: Items_base_F {
         EGVAR(cargo,canLoad) = 1;
         EGVAR(cargo,size) = 1;
+        EGVAR(dragging,canCarry) = 1;
+    };
+
+    class rhsusf_props_ScepterMWC_Base: rhsusf_props_JerryCan_Base {
+        EXGVAR(field_rations,waterSupply) = 20;
+        EXGVAR(field_rations,offset)[] = {-0.13, 0, 0.2};
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Only make the fuel jerrycans to, well, fuel jerrycans
- Adjust `Water source` interaction position for water jerrycans
- Make the them all carryable

![image](https://user-images.githubusercontent.com/20744006/144070480-cff1bcde-c560-40a9-94ec-f335a17f22cb.png)
![image](https://user-images.githubusercontent.com/20744006/144070531-e8dd6a40-d6e0-4a79-b3be-d6e02ef2ddee.png)


Close https://github.com/acemod/ACE3/issues/8710
