### PR TITLE
Map Tools - Improve modded maps support

### DIFF
--- a/addons/maptools/functions/fnc_canUseMapTools.sqf
+++ b/addons/maptools/functions/fnc_canUseMapTools.sqf
@@ -17,13 +17,7 @@
 
 visibleMap &&
 {alive ACE_player} &&
-{
-    scopeName "hasMap";
-    {
-        if (_x isKindOf ["ItemMap", configFile >> "CfgWeapons"]) exitWith {true breakOut "hasMap"};
-    } forEach (assignedItems ACE_player);
-    false
-} &&
+{getText (configFile >> "CfgWeapons" >> (assignedItems ACE_player param [0, ""]) >> "simulation") == "ItemMap"} &&
 {"ACE_MapTools" in (ACE_player call EFUNC(common,uniqueItems))} &&
 {!GVAR(mapTool_isDragging)} &&
 {!GVAR(mapTool_isRotating)}


### PR DESCRIPTION
**When merged this pull request will:**
- title

Reasoning:
Modded maps are not required to inherit from `ItemMap` class, but only items with `simulation` equal to `ItemMap` can be put into map slot.