### PR TITLE
Cookoff - Add setting to destroy vehicle after cooking off

### DIFF
--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -69,8 +69,8 @@ if (_smokeDelayEnabled) then {
             _vehicle setVariable [QGVAR(isCookingOff), false, true];
             [_pfh] call CBA_fnc_removePerFrameHandler;
 
-            if (_detonateAfterCookoff) then {
-                _vehicle setDamage 1;
+            if (GVAR(destroyVehicleAfterCookoff) || _detonateAfterCookoff) then {
+                _vehicle setDamage [1, _detonateAfterCookoff];
             };
         };
 

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -19,6 +19,16 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(destroyVehicleAfterCookoff), "CHECKBOX",
+    [LSTRING(destroyVehicleAfterCookoff_name), LSTRING(destroyVehicleAfterCookoff_tooltip)],
+    LSTRING(category_displayName),
+    true, // default value
+    true, // isGlobal
+    {[QGVAR(destroyVehicleAfterCookoff), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    false // Needs mission restart
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(enableAmmoCookoff), "CHECKBOX",
     [LSTRING(enableAmmoCookoff_name), LSTRING(enableAmmoCookoff_tooltip)],
     LSTRING(category_displayName),

--- a/addons/cookoff/initSettings.sqf
+++ b/addons/cookoff/initSettings.sqf
@@ -22,7 +22,7 @@
     QGVAR(destroyVehicleAfterCookoff), "CHECKBOX",
     [LSTRING(destroyVehicleAfterCookoff_name), LSTRING(destroyVehicleAfterCookoff_tooltip)],
     LSTRING(category_displayName),
-    true, // default value
+    false, // default value
     true, // isGlobal
     {[QGVAR(destroyVehicleAfterCookoff), _this] call EFUNC(common,cbaSettings_settingChanged)},
     false // Needs mission restart

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -163,7 +163,7 @@
         <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_name">
             <English>Destroy Vehicles After Cook-Off</English>
         </Key>
-        <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_tooltip	">
+        <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_tooltip">
             <English>Vehicles will be destroyed after cooking off</English>
         </Key>
         <Key ID="STR_ACE_CookOff_enableFire_name">

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -160,6 +160,12 @@
             <Portuguese>Multiplicador para a chance de cozinhamento. Valores mais altos aumentam as chances de ocorrer.</Portuguese>
             <Czech>Multiplikátor pro pravděpodobnost vznícení munice. Vyšší hodnota znamená vyšší šanci vznícení munice.</Czech>
         </Key>
+        <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_name">
+            <English>Destroy Vehicles After Cook-Off</English>
+        </Key>
+        <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_tooltip	">
+            <English>Vehicles will be destroyed after cooking off</English>
+        </Key>
         <Key ID="STR_ACE_CookOff_enableFire_name">
             <English>Enable Cook-Off Vehicle Fire</English>
             <Japanese>誘爆火災を有効化</Japanese>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -164,7 +164,7 @@
             <English>Destroy Vehicles After Cook-Off</English>
         </Key>
         <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_tooltip">
-            <English>Whether or not vehicles will always be destroyed after cooking off. Depending on the cookoff the vehicle may explode, or may simply be killed without effects</English>
+            <English>Controls whether vehicles will always be destroyed after cooking off. Depending on the cookoff, the vehicle may explode or may simply be killed without effects.</English>
         </Key>
         <Key ID="STR_ACE_CookOff_enableFire_name">
             <English>Enable Cook-Off Vehicle Fire</English>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -161,7 +161,7 @@
             <Czech>Multiplikátor pro pravděpodobnost vznícení munice. Vyšší hodnota znamená vyšší šanci vznícení munice.</Czech>
         </Key>
         <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_name">
-            <English>Destroy Vehicles After Cook-Off</English>
+            <English>Destroy Vehicles After Cook-off</English>
         </Key>
         <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_tooltip">
             <English>Controls whether vehicles will always be destroyed after cooking off. Depending on the cookoff, the vehicle may explode or may simply be killed without effects.</English>

--- a/addons/cookoff/stringtable.xml
+++ b/addons/cookoff/stringtable.xml
@@ -164,7 +164,7 @@
             <English>Destroy Vehicles After Cook-Off</English>
         </Key>
         <Key ID="STR_ACE_CookOff_destroyVehicleAfterCookoff_tooltip">
-            <English>Vehicles will be destroyed after cooking off</English>
+            <English>Whether or not vehicles will always be destroyed after cooking off. Depending on the cookoff the vehicle may explode, or may simply be killed without effects</English>
         </Key>
         <Key ID="STR_ACE_CookOff_enableFire_name">
             <English>Enable Cook-Off Vehicle Fire</English>


### PR DESCRIPTION
When merged this pull request will:
- Add a setting to always destroy vehicles after cooking off
- The vehicle will be destroyed without explosion
- Catastrophic kill effect will trigger if `_detonateAfterCookoff` is true
- Addresses https://github.com/acemod/ACE3/issues/8715