### PR TITLE
Compats - Fix RHSUSF UH-1Y F.R.I.E.S options

### DIFF
--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -53,7 +53,9 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 1447;
     };
 
-    class RHS_UH1Y_base: RHS_UH1_Base {};
+    class RHS_UH1Y_base: RHS_UH1_Base {
+        EQUIP_FRIES_ATTRIBUTE;
+    };
     class RHS_UH1Y_US_base: RHS_UH1Y_base {};
     class RHS_UH1Y: RHS_UH1Y_US_base {
         EGVAR(fastroping,enabled) = 2;
@@ -67,8 +69,6 @@ class CfgVehicles {
         class EventHandlers: EventHandlers {
             class RHSUSF_EventHandlers;
         };
-
-        EQUIP_FRIES_ATTRIBUTE;
     };
     class RHS_UH1Y_FFAR: RHS_UH1Y {
         class UserActions: UserActions {
@@ -80,6 +80,8 @@ class CfgVehicles {
                 condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
             };
         };
+        
+        EQUIP_FRIES_ATTRIBUTE;
     };
 
     class Helicopter_Base_H: Helicopter_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix 3DEN `Equip FRIES` attribute for RHS:USAF UH-1Y

Partially fixes https://github.com/acemod/ACE3/issues/6068.

Not sure about the other issues mentioned in the ticket: 
- Non pylon choppers not having the option to equip F.R.I.E.S through `Edit Pylons` (obviously)
- Can't really see any issues with where the F.R.I.E.S is attached to the UH-60's
- UH-60 MEV (ESSS) explicitly having it disabled (by design)
