### PR TITLE
Nametags - Fix ACE nametag drawIcon3D parameter error when player controlled unit dies

### DIFF
--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -42,6 +42,8 @@ _fnc_parameters = {
                 } else {
                     _icon = format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target];
                 };
+            } else {
+                _icon = "";
             };
         };
     };

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -38,7 +38,7 @@ _fnc_parameters = {
 
         case !_drawRank: {""};
         case !isNil "_targetIcon": {_targetIcon};
-        case rank _target == "": {""};
+        case (rank _target == ""): {""};
 
         default {
             private _targetFaction = _target getVariable [QGVAR(faction), faction _target];

--- a/addons/nametags/functions/fnc_drawNameTagIcon.sqf
+++ b/addons/nametags/functions/fnc_drawNameTagIcon.sqf
@@ -29,21 +29,26 @@ _fnc_parameters = {
     params ["_player", "_target", "_alpha", "_heightOffset", "_drawName", "_drawRank", "_drawSoundwave"];
 
     //Set Icon:
-    private _icon = "";
-    if (_drawSoundwave) then {
-        _icon = format [QPATHTOF(UI\soundwave%1.paa), floor random 10];
-    } else {
-        if (_drawRank) then {
-            _icon = _target getVariable "ace_nametags_rankIcon";
-            if (isNil "_icon" && {rank _target != ""}) then {
-                _icon = GVAR(factionRanks) getVariable (_target getVariable [QGVAR(faction), faction _target]);
-                if (!isNil "_icon") then {
-                    _icon = _icon param [ALL_RANKS find rank _target, ""];
-                } else {
-                    _icon = format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target];
-                };
+    private _targetIcon = _target getVariable QGVAR(rankIcon);
+
+    private _icon = switch true do {
+        case _drawSoundwave: {
+            format [QPATHTOF(UI\soundwave%1.paa), floor random 10]
+        };
+
+        case !_drawRank: {""};
+        case !isNil "_targetIcon": {_targetIcon};
+        case rank _target == "": {""};
+
+        default {
+            private _targetFaction = _target getVariable [QGVAR(faction), faction _target];
+            private _customRankIcons = GVAR(factionRanks) getVariable _targetFaction;
+
+            if (!isNil "_customRankIcons") then {
+                _customRankIcons param [ALL_RANKS find rank _target, ""] // return
             } else {
-                _icon = "";
+                // default rank icons
+                format ["\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa", rank _target] // return
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- fix #8719 
- Make sure `_icon` is never `nil`
- Looks like when a unit (player or IA) is killed, the `rank` return `""` just before the ACE nametags disappear

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
