### PR TITLE
Cargo - Improve config and `fnc_getNameItem`

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -320,14 +320,12 @@ class CfgVehicles {
     class StaticWeapon: LandVehicle {
         GVAR(size) = 2; // 1 = small, 2 = large
         GVAR(canLoad) = 1;
-        GVAR(noRename) = 1;
     };
 
     class StaticMortar;
     class Mortar_01_base_F: StaticMortar {
         GVAR(size) = 2; // 1 = small, 2 = large
         GVAR(canLoad) = 1;
-        GVAR(noRename) = 1;
     };
 
     // Ammo boxes

--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -320,12 +320,14 @@ class CfgVehicles {
     class StaticWeapon: LandVehicle {
         GVAR(size) = 2; // 1 = small, 2 = large
         GVAR(canLoad) = 1;
+        GVAR(noRename) = 1;
     };
 
     class StaticMortar;
     class Mortar_01_base_F: StaticMortar {
         GVAR(size) = 2; // 1 = small, 2 = large
         GVAR(canLoad) = 1;
+        GVAR(noRename) = 1;
     };
 
     // Ammo boxes
@@ -426,20 +428,21 @@ class CfgVehicles {
     class Land_CanisterFuel_F: Items_base_F {
         GVAR(size) = 1;
         GVAR(canLoad) = 1;
-        EGVAR(cargo,noRename) = 1;
+        GVAR(noRename) = 1;
     };
 
     // Flexible Fuel tanks, 300L
     class FlexibleTank_base_F: ThingX {
         GVAR(size) = 3;
         GVAR(canLoad) = 1;
+        GVAR(noRename) = 1;
     };
 
     // objects
     class RoadCone_F: ThingX {
         GVAR(size) = 1;
         GVAR(canLoad) = 1;
-        EGVAR(cargo,noRename) = 1;
+        GVAR(noRename) = 1;
     };
     class RoadBarrier_F: RoadCone_F {
         GVAR(size) = 2;
@@ -449,18 +452,18 @@ class CfgVehicles {
     class Land_PortableLight_single_F: Lamps_base_F {
         GVAR(size) = 2;
         GVAR(canLoad) = 1;
-        EGVAR(cargo,noRename) = 1;
+        GVAR(noRename) = 1;
     };
     class FloatingStructure_F;
     class Land_Camping_Light_F: FloatingStructure_F {
         GVAR(size) = 0.2;
         GVAR(canLoad) = 1;
-        EGVAR(cargo,noRename) = 1;
+        GVAR(noRename) = 1;
     };
     class Land_Camping_Light_off_F: ThingX {
         GVAR(size) = 0.2;
         GVAR(canLoad) = 1;
-        EGVAR(cargo,noRename) = 1;
+        GVAR(noRename) = 1;
     };
 
 

--- a/addons/cargo/functions/fnc_getNameItem.sqf
+++ b/addons/cargo/functions/fnc_getNameItem.sqf
@@ -18,8 +18,10 @@
 
 params ["_object", ["_addCustomPart", false]];
 
-private _displayName = if (_object isEqualType "") then {_object} else {
-    getText ((configOf _object) >> "_displayName");
+private _displayName = if (_object isEqualType "") then {
+    getText (configFile >> "CfgVehicles" >> _object >> "displayName")
+} else {
+    getText ((configOf _object) >> "displayName")
 };
 
 if (_addCustomPart && {!(_object isEqualType "")}) then {

--- a/addons/cargo/functions/fnc_getNameItem.sqf
+++ b/addons/cargo/functions/fnc_getNameItem.sqf
@@ -18,8 +18,9 @@
 
 params ["_object", ["_addCustomPart", false]];
 
-private _class = if (_object isEqualType "") then {_object} else {typeOf _object};
-private _displayName = getText (configFile >> "CfgVehicles" >> _class >> "displayName");
+private _displayName = if (_object isEqualType "") then {_object} else {
+    getText ((configOf _object) >> "_displayName");
+};
 
 if (_addCustomPart && {!(_object isEqualType "")}) then {
     private _customPart = _object getVariable [QGVAR(customName), ""];

--- a/addons/fire/stringtable.xml
+++ b/addons/fire/stringtable.xml
@@ -22,14 +22,14 @@
             <Chinesesimp>灭火</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Fire_Actions_PerformingPatDown">
-            <English>Patting Down Fire</English>
-            <Japanese>火を叩き消しています</Japanese>
+            <English>Patting down fire...</English>
+            <Japanese>火を叩き消しています・・・</Japanese>
             <French>Feu en cours d'extinction...</French>
-            <Russian>Тушение</Russian>
+            <Russian>Тушение...</Russian>
             <German>Feuer wird gelöscht...</German>
-            <Polish>Gaszenie ognia</Polish>
-            <Spanish>Extinguiendo el Fuego</Spanish>
-            <Chinesesimp>正在灭火</Chinesesimp>
+            <Polish>Gaszenie ognia...</Polish>
+            <Spanish>Extinguiendo el fuego...</Spanish>
+            <Chinesesimp>正在灭火...</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Fire_Setting_Description">
             <English>Allow units to catch fire</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Block renaming 300l fuel container.
- Change config macro to GVAR from EGVAR.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
