### PR TITLE
Arsenal - Improve magazine removal after weapon switch

### DIFF
--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -29,10 +29,15 @@ private _containerDefaultRightPanel = _display displayCtrl IDC_buttonMisc;
 private _selectCorrectPanelContainer = [_containerDefaultRightPanel, _display displayCtrl GVAR(currentRightPanel)] select (!isNil QGVAR(currentRightPanel) && {GVAR(currentRightPanel) in [RIGHT_PANEL_ITEMS_IDCS]});
 
 private _fnc_clearPreviousWepMags = {
-    private _compatibleMags = getArray (configfile >> "cfgweapons" >> _baseWeapon >> "magazines");
+    private _compatibleMagsBaseWeapon = [_baseWeapon, true] call CBA_fnc_compatibleMagazines;
+
+    if (_item != "") then {
+        _compatibleMagsBaseWeapon = _compatibleMagsBaseWeapon select {!(_x in _compatibleMags)};
+    };
+
     {
         GVAR(center) removeMagazines _x;
-    } foreach _compatibleMags;
+    } foreach _compatibleMagsBaseWeapon;
 
     GVAR(currentItems) set [15, uniformItems GVAR(center)];
     GVAR(currentItems) set [16, vestItems GVAR(center)];
@@ -54,12 +59,13 @@ switch (GVAR(currentLeftPanel)) do {
             TOGGLE_RIGHT_PANEL_HIDE
         } else {
             if ((GVAR(currentItems) select 0) != _item && {_baseWeapon != _item}) then {
-                call _fnc_clearPreviousWepMags;
-
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
-                GVAR(center) addWeapon _item;
+
+                call _fnc_clearPreviousWepMags;
+
+                [GVAR(center), _item] call CBA_fnc_addWeaponWithoutItems;
                 if (_compatibleMags isNotEqualTo []) then {
                     GVAR(center) addWeaponItem [_item, [_compatibleMags select 0]];
                 };
@@ -96,12 +102,13 @@ switch (GVAR(currentLeftPanel)) do {
             TOGGLE_RIGHT_PANEL_HIDE
         } else {
             if ((GVAR(currentItems) select 2) != _item && {_baseWeapon != _item}) then {
-                call _fnc_clearPreviousWepMags;
-
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
-                GVAR(center) addWeapon _item;
+
+                call _fnc_clearPreviousWepMags;
+
+                [GVAR(center), _item] call CBA_fnc_addWeaponWithoutItems;
                 if (_compatibleMags isNotEqualTo []) then {
                     GVAR(center) addWeaponItem [_item, [_compatibleMags select 0]];
                 };
@@ -137,12 +144,13 @@ switch (GVAR(currentLeftPanel)) do {
             TOGGLE_RIGHT_PANEL_HIDE
         } else {
             if ((GVAR(currentItems) select 1) != _item && {_baseWeapon != _item}) then {
-                call _fnc_clearPreviousWepMags;
-
                 private _compatibleItems = (_item call bis_fnc_compatibleItems) apply {tolower _x};
                 private _cfgMags = configFile >> "CfgMagazines";
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
-                GVAR(center) addWeapon _item;
+
+                call _fnc_clearPreviousWepMags;
+
+                [GVAR(center), _item] call CBA_fnc_addWeaponWithoutItems;
                 if (_compatibleMags isNotEqualTo []) then {
                     GVAR(center) addWeaponItem [_item, [_compatibleMags select 0]];
                 };


### PR DESCRIPTION
**When merged this pull request will:**
Improve the removal of magazines when switching weapons in the arsenal.

Current behaviour:
- When a new weapon is selected, only magazines defined in the "magazines" attribute of the old weapon's class were deleted.
See [here](https://github.com/acemod/ACE3/blob/936dd5d9786cd32b3061cf702f9ce45b45fa852a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf#L32).
This leads to inconsistent and unnecessary magazine removal upon weapon switching.
- When a new weapon is selected, it would consume a magazine from the loadout.
See [here](https://github.com/acemod/ACE3/blob/936dd5d9786cd32b3061cf702f9ce45b45fa852a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf#L62).

Improved behaviour:
- When a new weapon is selected, it will remove all magazines from the previous weapon that are not compatible with the new weapon.
See [here](https://github.com/johnb432/ACE3/blob/43494d24bec80cae911ccbca0e2699a6b065ffe6/addons/arsenal/functions/fnc_onSelChangedLeft.sqf#L32).
This is also valid when selecting no weapon: It will remove all magazines of the previous weapon.

On a personal note, I think the above can be seen as good and bad behaviour: When selecting launcher ammunition when you have a launcher equipped means that when you unequip the launcher in the arsenal, it will delete the launcher magazines.
However for other weapon types, especially side arms in my opinion, it can be very handy to remove all of the side arm magazines along with the unequipped weapon.
This behaviour can be circumvented by selecting the desired magazines via the all magazines tab in the arsenal, but it might pose an inconvenience for some.
Either way, I'm open for discussion - a CBA setting could be added if needed.
- When a new weapon is selected, it does not consume a magazine from the loadout.
See [here](https://github.com/johnb432/ACE3/blob/43494d24bec80cae911ccbca0e2699a6b065ffe6/addons/arsenal/functions/fnc_onSelChangedLeft.sqf#L68).

-----
What *hasn't* changed is if you have magazines from a weapon that isn't involved in switching process, it still won't affect those magazines.
E.g: If you have an RPG-7 and you switch your primary weapon (e.g. basegame HK416), it will not remove the RPG-7 rounds you have in your loadout.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
