### PR TITLE
Vehicles - Add cruise control

### DIFF
--- a/addons/vehicles/XEH_postInit.sqf
+++ b/addons/vehicles/XEH_postInit.sqf
@@ -19,6 +19,31 @@ GVAR(isSpeedLimiter) = false;
         // Conditions: specific
         if !(ACE_player == driver vehicle ACE_player &&
             {vehicle ACE_player isKindOf 'Car' ||
+            {vehicle ACE_player isKindOf 'Tank'}}) exitWith {false};
+
+            GVAR(isUAV) = false;
+        // Statement
+        [ACE_player, vehicle ACE_player] call FUNC(speedLimiter);
+        true
+    };
+},
+{false},
+[DIK_DELETE, [false, false, false]], false] call CBA_fnc_addKeybind;
+
+["ACE3 Vehicles", QGVAR(cruiseControl), localize LSTRING(CruiseControl), {
+    private _connectedUAV = getConnectedUAV ACE_player;
+    private _uavControll = UAVControl _connectedUAV;
+    if ((_uavControll select 1) == "DRIVER") then {
+        if !(_connectedUAV isKindOf "UGV_01_base_F") exitWith {false};
+        GVAR(isUAV) = true;
+        [_uavControll select 0, _connectedUAV, true] call FUNC(speedLimiter);
+        true
+    } else {
+        // Conditions: canInteract
+        if !([ACE_player, objNull, ["isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
+        // Conditions: specific
+        if !(ACE_player == driver vehicle ACE_player &&
+            {vehicle ACE_player isKindOf 'Car' ||
             {vehicle ACE_player isKindOf 'Tank'} ||
             {vehicle ACE_player isKindOf 'Plane'}}) exitWith {false};
 
@@ -27,14 +52,13 @@ GVAR(isSpeedLimiter) = false;
         if (vehicle ACE_player isKindOf 'Plane') then {
             [ACE_player, vehicle ACE_player] call FUNC(autoThrottle);
         } else {
-            [ACE_player, vehicle ACE_player] call FUNC(speedLimiter);
+            [ACE_player, vehicle ACE_player, true] call FUNC(speedLimiter);
         };
         true
     };
-
 },
 {false},
-[211, [false, false, false]], false] call CBA_fnc_addKeybind; //DELETE Key
+[DIK_INSERT, [false, false, false]], false] call CBA_fnc_addKeybind;
 
 ["ACE3 Vehicles", QGVAR(scrollUp), localize LSTRING(IncreaseSpeedLimit), {
     if (GVAR(isSpeedLimiter)) then {

--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -53,7 +53,7 @@ if (GVAR(isSpeedLimiter)) exitWith {
 if (_speedLimit != 0) exitWith { TRACE_1("speed limit set by external source",_speedLimit); };
 
 [localize (
-    if (_cruiseControl) then { LSTRING(OnCruise) } else { LSTRING(On) }
+    [LSTRING(On), LSTRING(OnCruise)] select _cruiseControl
 )] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;

--- a/addons/vehicles/functions/fnc_speedLimiter.sqf
+++ b/addons/vehicles/functions/fnc_speedLimiter.sqf
@@ -6,33 +6,61 @@
  * Arguments:
  * 0: Driver <OBJECT>
  * 1: Vehicle <OBJECT>
+ * 2: Cruise Control <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, car] call ace_vehicles_fnc_speedLimiter
+ * [player, car, true] call ace_vehicles_fnc_speedLimiter
  *
  * Public: No
  */
 
-params ["_driver", "_vehicle"];
+params ["_driver", "_vehicle", ["_cruiseControl", false]];
 
 if (GVAR(isSpeedLimiter)) exitWith {
-    [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
-    playSound "ACE_Sound_Click";
-    _vehicle setCruiseControl [0, false];
-    GVAR(isSpeedLimiter) = false;
+    switch ([GVAR(isCruiseControl), _cruiseControl]) do {
+        case [true, true]: {
+            [localize LSTRING(OffCruise)] call EFUNC(common,displayTextStructured);
+            playSound "ACE_Sound_Click";
+            _vehicle setCruiseControl [0, false];
+            GVAR(isSpeedLimiter) = false;
+            GVAR(isCruiseControl) = false;
+        };
+        case [true, false]: {
+            [localize LSTRING(On)] call EFUNC(common,displayTextStructured);
+            playSound "ACE_Sound_Click";
+            _vehicle setCruiseControl [GVAR(speedLimit), false];
+            GVAR(isCruiseControl) = false;
+        };
+        case [false, true]: {
+            [localize LSTRING(OnCruise)] call EFUNC(common,displayTextStructured);
+            playSound "ACE_Sound_Click";
+            _vehicle setCruiseControl [GVAR(speedLimit), true];
+            GVAR(isCruiseControl) = true;
+        };
+        case [false, false]: {
+            [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
+            playSound "ACE_Sound_Click";
+            _vehicle setCruiseControl [0, false];
+            GVAR(isSpeedLimiter) = false;
+        };
+    };
 };
 
 (getCruiseControl _vehicle) params ["_speedLimit"];
 if (_speedLimit != 0) exitWith { TRACE_1("speed limit set by external source",_speedLimit); };
 
-[localize LSTRING(On)] call EFUNC(common,displayTextStructured);
+[localize (
+    if (_cruiseControl) then { LSTRING(OnCruise) } else { LSTRING(On) }
+)] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";
 GVAR(isSpeedLimiter) = true;
+GVAR(isCruiseControl) = _cruiseControl;
 
 GVAR(speedLimit) = round (speed _vehicle max 5);
+GVAR(speedLimitInit) = true;
 
 [{
     params ["_args", "_idPFH"];
@@ -58,11 +86,16 @@ GVAR(speedLimit) = round (speed _vehicle max 5);
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 
-    getCruiseControl _vehicle params ["_currentSpeedLimit"];
+    getCruiseControl _vehicle params ["_currentSpeedLimit", "_cruiseControlActive"];
+    if (GVAR(isCruiseControl) && {!GVAR(speedLimitInit) && {!_cruiseControlActive}}) exitWith {
+        [_idPFH] call CBA_fnc_removePerFrameHandler;
+        GVAR(isSpeedLimiter) = false;
+        [localize LSTRING(OffCruise)] call EFUNC(common,displayTextStructured);
+        playSound "ACE_Sound_Click";
+    };
     if (round _currentSpeedLimit != GVAR(speedLimit)) then {
         TRACE_2("Updating speed limit",GVAR(speedLimit),_vehicle);
-        _vehicle setCruiseControl [GVAR(speedLimit), false];
+        _vehicle setCruiseControl [GVAR(speedLimit), GVAR(isCruiseControl)];
+        GVAR(speedLimitInit) = false;
     };
-
-
 }, 0, [_driver, _vehicle]] call CBA_fnc_addPerFrameHandler;

--- a/addons/vehicles/script_component.hpp
+++ b/addons/vehicles/script_component.hpp
@@ -6,6 +6,8 @@
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
 #ifdef DEBUG_ENABLED_VEHICLES
     #define DEBUG_MODE_FULL
 #endif

--- a/addons/vehicles/stringtable.xml
+++ b/addons/vehicles/stringtable.xml
@@ -18,6 +18,10 @@
             <Chinese>啟用速度限制</Chinese>
             <Turkish>Hız Sabitleyeciı Açık</Turkish>
         </Key>
+        <Key ID="STR_ACE_Vehicles_OnCruise">
+            <English>Cruise control on</English>
+            <German>Tempomat an</German>
+        </Key>
         <Key ID="STR_ACE_Vehicles_Off">
             <English>Speed Limiter off</English>
             <German>Geschwindigkeitsbegrenzer aus</German>
@@ -34,6 +38,10 @@
             <Chinesesimp>停用速度限制</Chinesesimp>
             <Chinese>停用速度限制</Chinese>
             <Turkish>Hız Sabitleyeci Kapalı</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Vehicles_OffCruise">
+            <English>Cruise control off</English>
+            <German>Tempomat aus</German>
         </Key>
         <Key ID="STR_ACE_Vehicles_SpeedLimit">
             <English>Speed Limit</English>
@@ -67,6 +75,10 @@
             <Chinesesimp>速度限制器</Chinesesimp>
             <Chinese>速度限制器</Chinese>
             <Turkish>Hız Sabitleyici</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Vehicles_CruiseControl">
+            <English>Cruise Control</English>
+            <German>Tempomat</German>
         </Key>
         <Key ID="STR_ACE_Vehicles_IncreaseSpeedLimit">
             <English>Increase Speed Limit</English>

--- a/docs/wiki/feature/vehicles.md
+++ b/docs/wiki/feature/vehicles.md
@@ -15,8 +15,8 @@ version:
 
 ## 1. Overview
 
-### 1.1 Speed limiter
-Adds ability to limit the max. speed of any vehicle.
+### 1.1 Speed limiter & Cruise Control
+Adds ability to limit the max speed of any vehicle, or enable cruise control.
 
 ### 1.2 Engine start delay
 The engine has to be started before the vehicle can move. Starting the engine takes aprox. 1 to 2 seconds.
@@ -56,3 +56,7 @@ Adds the ability to prevent the automatic shut-off of the engine when exiting ve
 ### 2.2 Turning the speed limiter on / off
 - To turn the speed limiter on press <kbd>Del</kbd>.
 - To turn it off press <kbd>Del</kbd> again.
+
+### 2.3 Turning cruise control on / off
+- To turn cruise control on press <kbd>Ins</kbd>.
+- To turn it off press <kbd>Ins</kbd> again.


### PR DESCRIPTION
**When merged this pull request will:**
- Adds cruise control by pressing `Insert`
- Interacts smoothly with the speed limiter

Example:

- Player is driving 30 km/h
- Enables speed limiter, set to 30 km/h
- Player slows to 15 km/h
- Enables cruise control, vehicle will accelerate to 30 km/h
- Player increases the speed limit to 50 km/h, cruise control will accelerate to 50 km/h
- Player enables speed limiter, cruise control will disable, speed limit still set to 50 km/h
