### PR TITLE
Compats - Fix RHS LMGs being classed as closed bolt systems

### DIFF
--- a/optionals/compat_rhs_gref3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_gref3/CfgWeapons.hpp
@@ -87,7 +87,8 @@ class CfgWeapons {
     };
 
     class rhs_weap_mg42_base: Rifle_Base_F {
-        ACE_Overheating_allowSwapBarrel = 1;
+        EGVAR(overheating,closedBolt) = 0;
+        EGVAR(overheating,allowSwapBarrel) = 1;
         ACE_barrelTwist = 305.0;
         ACE_barrelLength = 530.0;
     };

--- a/optionals/compat_rhs_usf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_usf3/CfgWeapons.hpp
@@ -70,7 +70,8 @@ class CfgWeapons {
         ACE_barrelLength = 508.0;
     };
     class rhs_weap_saw_base: Rifle_Base_F { // Base class for all Minimi
-        ACE_Overheating_allowSwapBarrel = 1;
+        EGVAR(overheating,allowSwapBarrel) = 1;
+        EGVAR(overheating,closedBolt) = 0;
     };
     class rhs_weap_lmg_minimi_railed;
     class rhs_weap_m249_pip_S: rhs_weap_lmg_minimi_railed {


### PR DESCRIPTION
**When merged this pull request will:**

Fix some overheating issues with RHS M249 and MG42, since they had the `ace_overheating_closedBolt` set to `1` through inheriting from `Rifle_Base_F`.

- Fix RHS:USF M249/MiniMi having closed bolt
- Fix RHS:GREF MG42 having closed bolt

Partially fixes https://github.com/acemod/ACE3/issues/8790