### PR TITLE
Common - Add cache to `fnc_isModLoaded`

### DIFF
--- a/addons/advanced_ballistics/XEH_postInit.sqf
+++ b/addons/advanced_ballistics/XEH_postInit.sqf
@@ -28,7 +28,7 @@ if (!hasInterface) exitWith {};
     //Add warnings for missing compat PBOs (only if AB is on)
     {
         _x params ["_modPBO", "_compatPBO"];
-        if ((isClass (configFile >> "CfgPatches" >> _modPBO)) && {!isClass (configFile >> "CfgPatches" >> _compatPBO)}) then {
+        if ([_modPBO] call EFUNC(common,isModLoaded) && {!([_compatPBO] call EFUNC(common,isModLoaded))}) then {
             WARNING_2("Weapon Mod [%1] missing ace compat pbo [%2] (from @ace\optionals)",_modPBO,_compatPBO);
         };
     } forEach [

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -78,10 +78,10 @@
     if (_object isEqualTo ACE_Player && {_set > 0}) then {
         call FUNC(endRadioTransmission);
     };
-    if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
+    if (["task_force_radio"] call FUNC(isModLoaded)) then {
         _object setVariable ["tf_unable_to_use_radio", _set > 0, true];
     };
-    if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {
+    if (["acre_main"] call FUNC(isModLoaded)) then {
         _object setVariable ["acre_sys_core_isDisabled", _set > 0, true];
     };
 }] call CBA_fnc_addEventHandler;
@@ -107,6 +107,9 @@
     params ["_object", "_mass"];
     _object setMass _mass;
 }] call CBA_fnc_addEventHandler;
+
+// Cache for FUNC(isModLoaded)
+GVAR(isModLoadedCache) = createHashMap;
 
 //Add a fix for BIS's zeus remoteControl module not reseting variables on DC when RC a unit
 //This variable is used for isPlayer checks

--- a/addons/common/functions/fnc_deprecateComponent.sqf
+++ b/addons/common/functions/fnc_deprecateComponent.sqf
@@ -22,7 +22,7 @@ params ["_oldComponent", "_newComponent", "_version"];
 _oldComponent params ["_oldComponentName", "_oldSettingName"];
 _newComponent params ["_newComponentName", "_newSettingName"];
 
-private _isReplacementAvailable = isClass (configFile >> "CfgPatches" >> _newComponentName);
+private _isReplacementAvailable = [_newComponentName] call FUNC(isModLoaded);
 private _isDeprecatedLoaded = missionNamespace getvariable [_oldSettingName, false];
 private _isReplacementLoaded = missionNamespace getvariable [_newSettingName, false];
 

--- a/addons/common/functions/fnc_endRadioTransmission.sqf
+++ b/addons/common/functions/fnc_endRadioTransmission.sqf
@@ -19,7 +19,7 @@
 ["ace_endRadioTransmissions"] call CBA_fnc_localEvent;
 
 // ACRE
-if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {
+if (["acre_main"] call FUNC(isModLoaded)) then {
     [-1] call acre_sys_core_fnc_handleMultiPttKeyPressUp;
     [0] call acre_sys_core_fnc_handleMultiPttKeyPressUp;
     [1] call acre_sys_core_fnc_handleMultiPttKeyPressUp;
@@ -27,8 +27,8 @@ if (isClass (configFile >> "CfgPatches" >> "acre_main")) then {
 };
 
 // TFAR
-if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
-    if (isClass (configFile >> "CfgPatches" >> "tfar_core")) exitWith { // Beta TFAR, exit to avoid script errors from legacy functions not existing
+if (["task_force_radio"] call FUNC(isModLoaded)) then {
+    if (["tfar_core"] call FUNC(isModLoaded)) exitWith { // Beta TFAR, exit to avoid script errors from legacy functions not existing
         ACE_Player call TFAR_fnc_releaseAllTangents;
     };
     call TFAR_fnc_onSwTangentReleased;

--- a/addons/common/functions/fnc_isModLoaded.sqf
+++ b/addons/common/functions/fnc_isModLoaded.sqf
@@ -1,10 +1,10 @@
 #include "script_component.hpp"
 /*
  * Author: Glowbal
- * Check in cfgPatches if modification is loaded
+ * Check in CfgPatches if modification is loaded
  *
  * Arguments:
- * 0: Mod Name or Classname of the mod in cfgPatches <STRING>
+ * 0: Mod Name or Classname of the mod in CfgPatches <STRING>
  *
  * Return Value:
  * if modification is loaded <BOOL>
@@ -17,4 +17,11 @@
 
 params [["_modName", "", [""]]];
 
-isClass (configFile >> "CfgPatches" >> _modName) // return
+private _return = GVAR(isModLoadedCache) get _modName;
+
+if (isNil "_return") then {
+    _return = isClass (configFile >> "CfgPatches" >> _modName);
+    GVAR(isModLoadedCache) set [_modName, _return];
+};
+
+_return

--- a/addons/common/functions/fnc_isModLoaded.sqf
+++ b/addons/common/functions/fnc_isModLoaded.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: Glowbal
+ * Author: Glowbal, GhostIsSpooky
  * Check in CfgPatches if modification is loaded
  *
  * Arguments:

--- a/addons/gforces/functions/fnc_pfhUpdateGForces.sqf
+++ b/addons/gforces/functions/fnc_pfhUpdateGForces.sqf
@@ -61,7 +61,7 @@ if (_count > 0) then {
 };
 
 private _classCoef = (ACE_player getVariable ["ACE_GForceCoef",
-    getNumber (configFile >> "CfgVehicles" >> (typeOf ACE_player) >> "ACE_GForceCoef")]) max 0.001;
+    getNumber ((configOf ACE_player) >> "ACE_GForceCoef")]) max 0.001;
 private _suitCoef = if ((uniform ACE_player) != "") then {
     (getNumber (configFile >> "CfgWeapons" >> (uniform ACE_player) >> "ACE_GForceCoef")) max 0.001
 } else {
@@ -71,7 +71,7 @@ private _suitCoef = if ((uniform ACE_player) != "") then {
 private _gBlackOut = MAXVIRTUALG / _classCoef + MAXVIRTUALG / _suitCoef - MAXVIRTUALG;
 
 // Unconsciousness
-if ((_average > _gBlackOut) and {isClass (configFile >> "CfgPatches" >> "ACE_Medical") and {!(ACE_player getVariable ["ACE_isUnconscious", false])}}) then {
+if ((_average > _gBlackOut) && {["ACE_Medical"] call EFUNC(common,isModLoaded) && {!(ACE_player getVariable ["ACE_isUnconscious", false])}}) then {
     [ACE_player, true, (10 + floor(random 5)), true] call EFUNC(medical,setUnconscious);
 };
 

--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -110,14 +110,14 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
     _strength = _strength * _losCoefficient;
 
     // Add ace_hearing ear ringing sound effect
-    if (isClass (configFile >> "CfgPatches" >> "ACE_Hearing") && {_strength > 0 && {EGVAR(hearing,damageCoefficent) > 0.25}}) then {
+    if (["ACE_Hearing"] call EFUNC(common,isModLoaded) && {_strength > 0 && {EGVAR(hearing,damageCoefficent) > 0.25}}) then {
         private _earringingStrength = 40 * _strength;
         [_earringingStrength] call EFUNC(hearing,earRinging);
         TRACE_1("Earringing Strength",_earringingStrength);
     };
 
     // add ace_medical pain effect:
-    if (isClass (configFile >> "CfgPatches" >> "ACE_Medical") && {_strength > 0.1}) then {
+    if (["ACE_Medical"] call EFUNC(common,isModLoaded) && {_strength > 0.1}) then {
         [ACE_player, _strength / 2] call EFUNC(medical,adjustPainLevel);
     };
 

--- a/addons/nametags/functions/fnc_initIsSpeaking.sqf
+++ b/addons/nametags/functions/fnc_initIsSpeaking.sqf
@@ -37,14 +37,14 @@ if (!hasInterface) exitWith {};
 }] call CBA_fnc_addPlayerEventHandler;
 
 switch (true) do {
-    case (["acre_api"] call EFUNC(common,isModLoaded): {
+    case (["acre_api"] call EFUNC(common,isModLoaded)): {
         INFO("ACRE Detected.");
         DFUNC(isSpeaking) = {
             params ["_unit"];
             ([_unit] call acre_api_fnc_isSpeaking) && {!(_unit getVariable ["ACE_isUnconscious", false])}
         };
     };
-    case (["task_force_radio"] call EFUNC(common,isModLoaded): {
+    case (["task_force_radio"] call EFUNC(common,isModLoaded)): {
         INFO("TFAR Detected.");
         DFUNC(isSpeaking) =     {
             params ["_unit"];

--- a/addons/nametags/functions/fnc_initIsSpeaking.sqf
+++ b/addons/nametags/functions/fnc_initIsSpeaking.sqf
@@ -36,20 +36,22 @@ if (!hasInterface) exitWith {};
     };
 }] call CBA_fnc_addPlayerEventHandler;
 
-if (isClass (configFile >> "CfgPatches" >> "acre_api")) then {
-    INFO("ACRE Detected.");
-    DFUNC(isSpeaking) = {
-        params ["_unit"];
-        ([_unit] call acre_api_fnc_isSpeaking) && {!(_unit getVariable ["ACE_isUnconscious", false])}
+switch (true) do {
+    case (["acre_api"] call EFUNC(common,isModLoaded): {
+        INFO("ACRE Detected.");
+        DFUNC(isSpeaking) = {
+            params ["_unit"];
+            ([_unit] call acre_api_fnc_isSpeaking) && {!(_unit getVariable ["ACE_isUnconscious", false])}
+        };
     };
-} else {
-    if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
+    case (["task_force_radio"] call EFUNC(common,isModLoaded): {
         INFO("TFAR Detected.");
         DFUNC(isSpeaking) =     {
             params ["_unit"];
             (_unit getVariable ["tf_isSpeaking", false]) && {!(_unit getVariable ["ACE_isUnconscious", false])}
         };
-    } else {
+    };
+    default {
         //No Radio Mod - Start a PFEH to watch the internal VON icon
         //Note: class RscDisplayVoiceChat {idd = 55} - only present when talking
 

--- a/addons/overheating/XEH_postInit.sqf
+++ b/addons/overheating/XEH_postInit.sqf
@@ -92,7 +92,7 @@ if (hasInterface) then {
     [QGVAR(initiateSwapBarrelAssisted), DFUNC(swapBarrel)] call CBA_fnc_addEventHandler;
 
     // Add an action to allow hot weapons to be cooled off in AceX Field Rations water sources
-    if (isClass (configfile >> "CfgPatches" >> "acex_field_rations")) then {
+    if (["acex_field_rations"] call EFUNC(common,isModLoaded)) then {
         [
             {EXGVAR(field_rations,enabled) || CBA_missionTime > 1},
             {

--- a/addons/overheating/functions/fnc_canCoolWeaponWithItem.sqf
+++ b/addons/overheating/functions/fnc_canCoolWeaponWithItem.sqf
@@ -20,7 +20,7 @@ params ["_unit", "_player"];
 TRACE_2("canCoolWeaponWithItem",_unit,_player);
 
 GVAR(enabled)
-&& {isClass (configfile >> "CfgPatches" >> "acex_field_rations")}
+&& {["acex_field_rations"] call EFUNC(common,isModLoaded)}
 && {!(_unit getVariable [QEGVAR(captives,isSurrendering), false])} // interaction point will overlap with ace_captives
 && {!(_unit getVariable [QEGVAR(captives,isHandcuffed), false])}
 && {[_unit, currentWeapon _unit] call FUNC(getWeaponTemperature) > (ambientTemperature select 0)}

--- a/addons/overpressure/functions/fnc_firedEHBB.sqf
+++ b/addons/overpressure/functions/fnc_firedEHBB.sqf
@@ -51,7 +51,7 @@ if (_distance < _backblastRange) then {
     private _damage = _alpha * _beta * _backblastDamage;
     [_damage * 100] call BIS_fnc_bloodEffect;
 
-    if (isClass (configFile >> "CfgPatches" >> "ACE_Medical")) then {
+    if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
         [_unit, _damage, "body", "backblast", _unit] call EFUNC(medical,addDamageToUnit);
     } else {
         TRACE_1("",isDamageAllowed _unit);

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -53,12 +53,13 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
             private _damage = _alpha * _beta * _overpressureDamage;
             TRACE_1("",_damage);
 
-            // If the target is the ACE_player
-            if (_x == ACE_player) then {[_damage * 100] call BIS_fnc_bloodEffect};
-
             TRACE_1("",isDamageAllowed _x);
             if (isDamageAllowed _x && {_x getVariable [QEGVAR(medical,allowDamage), true]}) then {
-                if (isClass (configFile >> "CfgPatches" >> "ACE_Medical")) then {
+                // If the target is the ACE_player
+                if (_x isEqualTo ACE_player) then {
+                    [_damage * 100] call BIS_fnc_bloodEffect
+                };
+                if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
                     [_x, _damage, "body", "backblast", _firer] call EFUNC(medical,addDamageToUnit);
                 } else {
                     _x setDamage (damage _x + _damage);

--- a/addons/zeus/functions/fnc_handleZeusUnitAssigned.sqf
+++ b/addons/zeus/functions/fnc_handleZeusUnitAssigned.sqf
@@ -30,14 +30,14 @@ private _removeAddons = [];
     private _addon = _x;
     if (isArray _addon) then {
         {
-            if !(isClass (configFile >> "CfgPatches" >> _x)) exitWith {
+            if !([_x] call EFUNC(common,isModLoaded)) exitWith {
                 _removeAddons pushBack (configName _addon);
             };
         } forEach (getArray _addon);
     };
 
     if (isText _addon) then {
-        if !(isClass (configFile >> "CfgPatches" >> getText _addon)) then {
+        if !([getText _addon] call EFUNC(common,isModLoaded)) then {
             _removeAddons pushBack (configName _addon);
         };
     };

--- a/optionals/compat_sog/functions/fnc_handlePunjiTrapDamage.sqf
+++ b/optionals/compat_sog/functions/fnc_handlePunjiTrapDamage.sqf
@@ -16,7 +16,7 @@
  */
 params ["_trap"];
 
-if (isNull (configFile >> "CfgPatches" >> "ace_medical")) exitWith {};
+if (!(["ACE_Medical"] call EFUNC(common,isModLoaded))) exitWith {};
 
 private _radius = getNumber (configOf _trap >> "indirectHitRange");
 private _affectedUnits = (_trap nearEntities ["CAManBase", _radius]) select {local _x} select {isDamageAllowed _x};


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Move remaining manual CfgPatches lookups to use the function.
- Change a CfgVehicles >> typeOf lookup to configOf.
- Change overpressure damage to only show blood effect if damage is enabled.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
