### PR TITLE
Interact Menu - Add blocking while editing CT_EDIT

### DIFF
--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -15,18 +15,14 @@
  * Public: No
  */
 
+#define CT_EDIT 2
+
 params ["_menuType"];
 
 if (GVAR(openedMenuType) == _menuType) exitWith {true};
 
 // Conditions: Don't open when editing a text box
-private _isTextEditing = false;
-{
-    if (ctrlType (focusedCtrl _x) == 2) then {
-        _isTextEditing = true;
-        break;
-    };
-} forEach (allDisplays select {!isNull (focusedCtrl _x)});
+private _isTextEditing = (allDisplays findIf {(ctrlType (focusedCtrl _x)) == CT_EDIT}) != -1;
 
 // Conditions: canInteract (these don't apply to zeus)
 if (

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-#define CT_EDIT 2
+#include "\a3\ui_f\hpp\defineResincl.inc"
 
 params ["_menuType"];
 

--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -19,9 +19,21 @@ params ["_menuType"];
 
 if (GVAR(openedMenuType) == _menuType) exitWith {true};
 
+// Conditions: Don't open when editing a text box
+private _isTextEditing = false;
+{
+    if (ctrlType (focusedCtrl _x) == 2) then {
+        _isTextEditing = true;
+        break;
+    };
+} forEach (allDisplays select {!isNull (focusedCtrl _x)});
+
 // Conditions: canInteract (these don't apply to zeus)
-if ((isNull curatorCamera) && {
-    !([ACE_player, objNull, ["isNotInside","isNotDragging", "isNotCarrying", "isNotSwimming", "notOnMap", "isNotEscorting", "isNotSurrendering", "isNotSitting", "isNotOnLadder", "isNotRefueling"]] call EFUNC(common,canInteractWith))
+if (
+    _isTextEditing ||
+    {(isNull curatorCamera) && {
+        !([ACE_player, objNull, ["isNotInside","isNotDragging", "isNotCarrying", "isNotSwimming", "notOnMap", "isNotEscorting", "isNotSurrendering", "isNotSitting", "isNotOnLadder", "isNotRefueling"]] call EFUNC(common,canInteractWith))
+    }
 }) exitWith {false};
 
 while {dialog} do {


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent the interaction menu from activating if currently focused control on any display is of type CT_EDIT.

My interaction keys are in E and F, and the interact menu opens while searching in ZEN. This blocks that.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
