### PR TITLE
Arsenal - Improve `addWeaponItem` usage

### DIFF
--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -61,7 +61,7 @@ switch (GVAR(currentLeftPanel)) do {
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
                 if (_compatibleMags isNotEqualTo []) then {
-                    GVAR(center) addWeaponItem [_item, [_compatibleMags select 0]];
+                    GVAR(center) addWeaponItem [_item, [_compatibleMags select 0], true];
                 };
 
                 {
@@ -103,7 +103,7 @@ switch (GVAR(currentLeftPanel)) do {
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
                 if (_compatibleMags isNotEqualTo []) then {
-                    GVAR(center) addWeaponItem [_item, [_compatibleMags select 0]];
+                    GVAR(center) addWeaponItem [_item, [_compatibleMags select 0], true];
                 };
 
                 {
@@ -144,7 +144,7 @@ switch (GVAR(currentLeftPanel)) do {
                 private _compatibleMags = ([_item, true] call CBA_fnc_compatibleMagazines) select { getNumber (_cfgMags >> _x >> "scope") == 2 };
                 GVAR(center) addWeapon _item;
                 if (_compatibleMags isNotEqualTo []) then {
-                    GVAR(center) addWeaponItem [_item, [_compatibleMags select 0]];
+                    GVAR(center) addWeaponItem [_item, [_compatibleMags select 0], true];
                 };
 
                 {

--- a/addons/arsenal/functions/fnc_onSelChangedRight.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedRight.sqf
@@ -33,7 +33,7 @@ private _fnc_selectItem = {
                 private _primaryMags = primaryWeaponMagazine GVAR(center);
                 GVAR(currentItems) set [18, (primaryWeaponItems GVAR(center)) + ([_primaryMags + [""], _primaryMags] select (count _primaryMags > 1))];
             } else {
-                GVAR(center) addPrimaryWeaponItem _item;
+                GVAR(center) addWeaponItem [primaryWeapon GVAR(center), _item, true];
                 private _primaryMags = primaryWeaponMagazine GVAR(center);
                 GVAR(currentItems) set [18, (primaryWeaponItems GVAR(center)) + ([_primaryMags + [""], _primaryMags] select (count _primaryMags > 1))];
             };
@@ -47,7 +47,7 @@ private _fnc_selectItem = {
                 private _secondaryMags = secondaryWeaponMagazine GVAR(center);
                 GVAR(currentItems) set [19, (secondaryWeaponItems GVAR(center)) + ([_secondaryMags + [""], _secondaryMags] select (count _secondaryMags > 1))];
             } else {
-                GVAR(center) addSecondaryWeaponItem _item;
+                GVAR(center) addWeaponItem [secondaryWeapon GVAR(center), _item, true];
                 private _secondaryMags = secondaryWeaponMagazine GVAR(center);
                 GVAR(currentItems) set [19, (secondaryWeaponItems GVAR(center)) + ([_secondaryMags + [""], _secondaryMags] select (count _secondaryMags > 1))];
             };
@@ -60,7 +60,7 @@ private _fnc_selectItem = {
                 private _handgunMags = handgunMagazine GVAR(center);
                 GVAR(currentItems) set [20, (handgunItems GVAR(center)) + ([_handgunMags + [""], _handgunMags] select (count _handgunMags > 1))];
             } else {
-                GVAR(center) addHandgunItem _item;
+                GVAR(center) addWeaponItem [handgunWeapon GVAR(center), _item, true];
                 private _handgunMags = handgunMagazine GVAR(center);
                 GVAR(currentItems) set [20, (handgunItems GVAR(center)) + ([_handgunMags + [""], _handgunMags] select (count _handgunMags > 1))];
             };

--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -26,5 +26,4 @@ _target selectWeapon _weapon;
 if (currentWeapon _target != _weapon) exitWith {};
 if (currentMagazine _target != "") exitWith {};
 
-// command is wip, reload time for launchers is not intended.
 _target addWeaponItem [_weapon, _magazine, true];


### PR DESCRIPTION
**When merged this pull request will:**
- Add `instant` param to addWeaponItem usage in arsenal so magazine is reloaded instantly. This was particularly noticeable with launchers.
- Remove obsolete comment in `reloadlaunchers` that implied reloading time was still being used.
- Change some `addXWeaponItem` usage to straight `addWeaponItem` so animations are skipped as well.

See: https://community.bistudio.com/wiki/addWeaponItem

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
