### PR TITLE
SOG Compat - Fix M1919 ammo not showing in arsenal

### DIFF
--- a/optionals/compat_sog/CfgMagazines/csw.hpp
+++ b/optionals/compat_sog/CfgMagazines/csw.hpp
@@ -11,6 +11,7 @@ class GVAR(tow_missile): vn_missile_tow_mag_x1 {
 class vn_m1919_v_250_mag;
 class GVAR(m1919_250): vn_m1919_v_250_mag {
     scope = 2;
+    scopeArsenal = 2;
     type = 256;
     count = 250;
     model = "\vn\objects_f_vietnam\supply\a2_ammo\macv\vn_us_30cal.p3d";


### PR DESCRIPTION
vn_m1919_v_250_mag magazine has scopeArsenal attribute set to 0 so compat needs to address it.

**When merged this pull request will:**
 - Make CSW ammo for M1919 show up in arsenal

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
