### PR TITLE
SOG Compat - Change mass of CSW TOW missile

### DIFF
--- a/optionals/compat_sog/CfgMagazines/csw.hpp
+++ b/optionals/compat_sog/CfgMagazines/csw.hpp
@@ -5,7 +5,7 @@ class GVAR(tow_missile): vn_missile_tow_mag_x1 {
     count = 1;
     model = "\vn\static_f_vietnam\tow\vn_static_tow_mag.p3d";
     picture = QPATHTOF(UI\ammo_1rnd_tow_ca.paa);
-    mass = 563;
+    mass = 220;  // to Arma, weight and volume are all the same which makes real life values unusable
 };
 
 class vn_m1919_v_250_mag;


### PR DESCRIPTION
Changes the mass of CSW TOW missile to 220, as current value is over twice the largest backpack's in the game capacity (it's impossible to reload the weapon). New value is the same as in RHS compatibility addon.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
