### PR TITLE
Magazine Repack - Add idle animation when a player starts repacking magazines

### DIFF
--- a/addons/magazinerepack/functions/fnc_startRepackingMagazine.sqf
+++ b/addons/magazinerepack/functions/fnc_startRepackingMagazine.sqf
@@ -61,6 +61,8 @@ if (count _startingAmmoCounts < 2) exitWith {ERROR("Not Enough Mags to Repack");
 private _simEvents = [_fullMagazineCount, _startingAmmoCounts, _isBelt] call FUNC(simulateRepackEvents);
 private _totalTime = _simEvents select (count _simEvents - 1) select 0;
 
+[_player, "Gear", 1] call EFUNC(common,doGesture);
+
 [
     _totalTime,
     [_magazineClassname, _startingAmmoCounts, _simEvents],

--- a/addons/magazinerepack/functions/fnc_startRepackingMagazine.sqf
+++ b/addons/magazinerepack/functions/fnc_startRepackingMagazine.sqf
@@ -61,7 +61,9 @@ if (count _startingAmmoCounts < 2) exitWith {ERROR("Not Enough Mags to Repack");
 private _simEvents = [_fullMagazineCount, _startingAmmoCounts, _isBelt] call FUNC(simulateRepackEvents);
 private _totalTime = _simEvents select (count _simEvents - 1) select 0;
 
-[_player, "Gear", 1] call EFUNC(common,doGesture);
+if (GVAR(repackAnimation)) then {
+    [_player, "Gear"] call EFUNC(common,doGesture);
+};
 
 [
     _totalTime,

--- a/addons/magazinerepack/initSettings.sqf
+++ b/addons/magazinerepack/initSettings.sqf
@@ -31,3 +31,11 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     true,
     0
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(repackAnimation), "CHECKBOX",
+    LSTRING(repackAnimation),
+    _category,
+    true,
+    0
+] call CBA_fnc_addSetting;

--- a/addons/magazinerepack/stringtable.xml
+++ b/addons/magazinerepack/stringtable.xml
@@ -186,5 +186,11 @@
             <Chinesesimp>重新整理弹匣，武器未上膛</Chinesesimp>
             <Korean>탄창 다시 채우는 중, 무기에서 탄창 뺌</Korean>
         </Key>
+        <Key ID="STR_ACE_MagazineRepack_repackAnimation">
+            <English>Repack Animation</English>
+            <French>Remplir l'animation</French>
+            <German>Animation umpacken</German>
+            <Polish>Przepakuj animację</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/magazinerepack/stringtable.xml
+++ b/addons/magazinerepack/stringtable.xml
@@ -189,7 +189,7 @@
         <Key ID="STR_ACE_MagazineRepack_repackAnimation">
             <English>Repack Animation</English>
             <French>Remplir l'animation</French>
-            <German>Animation umpacken</German>
+            <German>Animation für Umpacken</German>
             <Polish>Animacja przepakowywania</Polish>
         </Key>
     </Package>

--- a/addons/magazinerepack/stringtable.xml
+++ b/addons/magazinerepack/stringtable.xml
@@ -190,7 +190,7 @@
             <English>Repack Animation</English>
             <French>Remplir l'animation</French>
             <German>Animation umpacken</German>
-            <Polish>Przepakuj animację</Polish>
+            <Polish>Animacja przepakowywania</Polish>
         </Key>
     </Package>
 </Project>

--- a/addons/magazinerepack/stringtable.xml
+++ b/addons/magazinerepack/stringtable.xml
@@ -188,7 +188,6 @@
         </Key>
         <Key ID="STR_ACE_MagazineRepack_repackAnimation">
             <English>Repack Animation</English>
-            <French>Remplir l'animation</French>
             <German>Animation für Umpacken</German>
             <Polish>Animacja przepakowywania</Polish>
         </Key>


### PR DESCRIPTION
Previously you'd just sit there doing nothing for X seconds and at times people can question why you're just sitting still for 10 seconds doing apparently nothing.

Needs some translation help because I can only google translate and I do not trust its handling of the excluded languages in this PR.

**When merged this pull request will:**
- _Adds the 'Gear' idle animation when a player starts repacking magazines_
- _Adds an ACE setting to allow for disabling of the new animation_
