### PR TITLE
Fastroping - Improve FRIES macro and fix UBC issues in RHS Compats

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -1,16 +1,3 @@
-#define EQUIP_FRIES_ATTRIBUTE class Attributes { \
-    class GVAR(equipFRIES) { \
-        property = QGVAR(equipFRIES); \
-        control = "Checkbox"; \
-        displayName = CSTRING(Eden_equipFRIES); \
-        tooltip = CSTRING(Eden_equipFRIES_Tooltip); \
-        expression = QUOTE(if (_value) then {[_this] call FUNC(equipFRIES)}); \
-        typeName = "BOOL"; \
-        condition = "objectVehicle"; \
-        defaultValue = "(false)"; \
-    }; \
-}
-
 class CfgVehicles {
     class Logic;
     class Module_F: Logic {
@@ -221,7 +208,9 @@ class CfgVehicles {
         GVAR(friesAttachmentPoint)[] = {0.035, 2.2, -0.15};
         GVAR(onPrepare) = QFUNC(onPrepareCommon);
         GVAR(onCut) = QFUNC(onCutCommon);
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
     class Heli_Transport_02_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
@@ -254,14 +243,19 @@ class CfgVehicles {
         GVAR(ropeOrigins)[] = {"ropeOriginRight", "ropeOriginLeft"};
         GVAR(friesType) = "ACE_friesGantryReverse";
         GVAR(friesAttachmentPoint)[] = {-1.04, 2.5, -0.34};
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
     class Heli_light_03_unarmed_base_F: Heli_light_03_base_F {
         GVAR(enabled) = 2;
         GVAR(ropeOrigins)[] = {"ropeOriginRight", "ropeOriginLeft"};
         GVAR(friesType) = "ACE_friesGantry";
         GVAR(friesAttachmentPoint)[] = {1.07, 2.5, -0.5};
-        EQUIP_FRIES_ATTRIBUTE;
+
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
     class Heli_Transport_04_base_F: Helicopter_Base_H {
         class UserActions;

--- a/addons/fastroping/script_component.hpp
+++ b/addons/fastroping/script_component.hpp
@@ -16,6 +16,7 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
+#include "script_macros.hpp"
 
 #define DEFAULT_ROPE_LENGTH 34.5
 

--- a/addons/fastroping/script_macros.hpp
+++ b/addons/fastroping/script_macros.hpp
@@ -1,0 +1,10 @@
+#define EQUIP_FRIES_ATTRIBUTE class EGVAR(fastroping,equipFRIES) { \
+    property = QEGVAR(fastroping,equipFRIES); \
+    control = "Checkbox"; \
+    displayName = ECSTRING(fastroping,Eden_equipFRIES); \
+    tooltip = ECSTRING(fastroping,Eden_equipFRIES_Tooltip); \
+    expression = QUOTE(if (_value) then {[_this] call EFUNC(fastroping,equipFRIES)}); \
+    typeName = "BOOL"; \
+    condition = "objectVehicle"; \
+    defaultValue = false; \
+}

--- a/optionals/compat_rhs_gref3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_gref3/CfgVehicles.hpp
@@ -1,16 +1,3 @@
-#define EQUIP_FRIES_ATTRIBUTE class Attributes { \
-    class EGVAR(fastroping,equipFRIES) { \
-        property = QEGVAR(fastroping,equipFRIES); \
-        control = "Checkbox"; \
-        displayName = ECSTRING(fastroping,Eden_equipFRIES); \
-        tooltip = ECSTRING(fastroping,Eden_equipFRIES_Tooltip); \
-        expression = QUOTE([_this] call EFUNC(fastroping,equipFRIES)); \
-        typeName = "BOOL"; \
-        condition = "objectVehicle"; \
-        defaultValue = false; \
-    }; \
-}
-
 class CfgVehicles {
     class Rubber_duck_base_F;
     class rhsgref_canoe_base: Rubber_duck_base_F {
@@ -61,7 +48,9 @@ class CfgVehicles {
     };
 
     class rhs_uh1h_hidf: rhs_uh1h_base {
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
 
     class rhs_uh1h_hidf_unarmed: rhs_uh1h_hidf {
@@ -75,7 +64,9 @@ class CfgVehicles {
             };
         };
 
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes: Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
 
     class rhs_uh1h_idap: rhs_uh1h_base {
@@ -89,7 +80,9 @@ class CfgVehicles {
             };
         };
 
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
 
     class rhs_uh1h_un: rhs_uh1h_base {
@@ -103,7 +96,9 @@ class CfgVehicles {
             };
         };
 
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
 
     // ACE Explosives

--- a/optionals/compat_rhs_gref3/script_component.hpp
+++ b/optionals/compat_rhs_gref3/script_component.hpp
@@ -4,3 +4,4 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 #include "\z\ace\addons\main\script_macros.hpp"
+#include "\z\ace\addons\fastroping\script_macros.hpp"

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -1,16 +1,3 @@
-#define EQUIP_FRIES_ATTRIBUTE class Attributes { \
-    class EGVAR(fastroping,equipFRIES) { \
-        property = QEGVAR(fastroping,equipFRIES); \
-        control = "Checkbox"; \
-        displayName = ECSTRING(fastroping,Eden_equipFRIES); \
-        tooltip = ECSTRING(fastroping,Eden_equipFRIES_Tooltip); \
-        expression = QUOTE([_this] call EFUNC(fastroping,equipFRIES)); \
-        typeName = "BOOL"; \
-        condition = "objectVehicle"; \
-        defaultValue = false; \
-    }; \
-}
-
 class CfgVehicles {
     class LandVehicle;
     class Car: LandVehicle {
@@ -54,7 +41,9 @@ class CfgVehicles {
     };
 
     class RHS_UH1Y_base: RHS_UH1_Base {
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
     class RHS_UH1Y_US_base: RHS_UH1Y_base {};
     class RHS_UH1Y: RHS_UH1Y_US_base {
@@ -80,8 +69,6 @@ class CfgVehicles {
                 condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
             };
         };
-        
-        EQUIP_FRIES_ATTRIBUTE;
     };
 
     class Helicopter_Base_H: Helicopter_Base_F {
@@ -100,7 +87,11 @@ class CfgVehicles {
         EGVAR(refuel,fuelCapacity) = 1360;
     };
 
-    class RHS_UH60M_base: RHS_UH60_Base {};
+    class RHS_UH60M_base: RHS_UH60_Base {
+        class Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
+    };
     class RHS_UH60M_US_base: RHS_UH60M_base {};
     class RHS_UH60M: RHS_UH60M_US_base {
         EGVAR(fastroping,enabled) = 2;
@@ -119,20 +110,28 @@ class CfgVehicles {
                 condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
             };
         };
+    };
+    class RHS_UH60M2: RHS_UH60M {};
 
-        EQUIP_FRIES_ATTRIBUTE;
+    class RHS_UH60M_ESSS: RHS_UH60M2 {
+        EGVAR(fastroping,enabled) = 0;
+        class Attributes: Attributes {
+            delete EGVAR(fastroping,equipFRIES);
+        };
     };
 
     class RHS_UH60M_MEV: RHS_UH60M {
         EGVAR(fastroping,enabled) = 0;
-        class Attributes {
+        class Attributes: Attributes {
             delete EGVAR(fastroping,equipFRIES);
         };
     };
 
     class RHS_UH60M_MEV2: RHS_UH60M_MEV {
         EGVAR(fastroping,enabled) = 2;
-        EQUIP_FRIES_ATTRIBUTE;
+        class Attributes: Attributes {
+            EQUIP_FRIES_ATTRIBUTE;
+        };
     };
 
     class Heli_Transport_02_base_F;

--- a/optionals/compat_rhs_usf3/script_component.hpp
+++ b/optionals/compat_rhs_usf3/script_component.hpp
@@ -4,3 +4,4 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 #include "\z\ace\addons\main\script_macros.hpp"
+#include "\z\ace\addons\fastroping\script_macros.hpp"

--- a/optionals/compat_sog/CfgVehicles.hpp
+++ b/optionals/compat_sog/CfgVehicles.hpp
@@ -1,16 +1,3 @@
-#define EQUIP_FRIES_ATTRIBUTE class Attributes { \
-    class EGVAR(fastroping,equipFRIES) { \
-        property = QEGVAR(fastroping,equipFRIES); \
-        control = "Checkbox"; \
-        displayName = ECSTRING(fastroping,Eden_equipFRIES); \
-        tooltip = ECSTRING(fastroping,Eden_equipFRIES_Tooltip); \
-        expression = QUOTE([_this] call EFUNC(fastroping,equipFRIES)); \
-        typeName = "BOOL"; \
-        condition = "objectVehicle"; \
-        defaultValue = false; \
-    }; \
-}
-
 class CfgVehicles {
     #include "CfgVehicles\boxes.hpp"
     #include "CfgVehicles\explosives.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Cleanup copypasted FRIES macro
- Remove unused FRIES macro from SOG PF compat
- Fix UBC issues in RHS compats due to overriden Attributes classes

### TODO
- Test in game
- Verify UBC issues are fixed

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [ ] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [ ] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
