### PR TITLE
maptools - Improve behaviour upon first open (show under mouse position instead of bottom-left corner)

### DIFF
--- a/addons/maptools/CfgVehicles.hpp
+++ b/addons/maptools/CfgVehicles.hpp
@@ -32,14 +32,14 @@ class CfgVehicles {
                 class ACE_MapToolsShowNormal {
                     displayName = CSTRING(MapToolsShowNormal);
                     condition = QUOTE(GVAR(mapTool_Shown) != 1);
-					statement = QUOTE(if (GVAR(mapTool_Shown) == 0) then {GVAR(mapTool_moveToMouse) = true}; GVAR(mapTool_Shown) = 1;);
+                    statement = QUOTE(if (GVAR(mapTool_Shown) == 0) then {GVAR(mapTool_moveToMouse) = true}; GVAR(mapTool_Shown) = 1;);
                     exceptions[] = {"isNotDragging", "notOnMap", "isNotInside", "isNotSitting"};
                     showDisabled = 1;
                 };
                 class ACE_MapToolsShowSmall {
                     displayName = CSTRING(MapToolsShowSmall);
                     condition = QUOTE(GVAR(mapTool_Shown) != 2);
-					statement = QUOTE(if (GVAR(mapTool_Shown) == 0) then {GVAR(mapTool_moveToMouse) = true}; GVAR(mapTool_Shown) = 2;);
+                    statement = QUOTE(if (GVAR(mapTool_Shown) == 0) then {GVAR(mapTool_moveToMouse) = true}; GVAR(mapTool_Shown) = 2;);
                     exceptions[] = {"isNotDragging", "notOnMap", "isNotInside", "isNotSitting"};
                     showDisabled = 1;
                 };

--- a/addons/maptools/CfgVehicles.hpp
+++ b/addons/maptools/CfgVehicles.hpp
@@ -32,14 +32,14 @@ class CfgVehicles {
                 class ACE_MapToolsShowNormal {
                     displayName = CSTRING(MapToolsShowNormal);
                     condition = QUOTE(GVAR(mapTool_Shown) != 1);
-                    statement = QUOTE(GVAR(mapTool_Shown) = 1;);
+					statement = QUOTE(if (GVAR(mapTool_Shown) == 0) then {GVAR(mapTool_moveToMouse) = true}; GVAR(mapTool_Shown) = 1;);
                     exceptions[] = {"isNotDragging", "notOnMap", "isNotInside", "isNotSitting"};
                     showDisabled = 1;
                 };
                 class ACE_MapToolsShowSmall {
                     displayName = CSTRING(MapToolsShowSmall);
                     condition = QUOTE(GVAR(mapTool_Shown) != 2);
-                    statement = QUOTE(GVAR(mapTool_Shown) = 2;);
+					statement = QUOTE(if (GVAR(mapTool_Shown) == 0) then {GVAR(mapTool_moveToMouse) = true}; GVAR(mapTool_Shown) = 2;);
                     exceptions[] = {"isNotDragging", "notOnMap", "isNotInside", "isNotSitting"};
                     showDisabled = 1;
                 };

--- a/addons/maptools/XEH_postInitClient.sqf
+++ b/addons/maptools/XEH_postInitClient.sqf
@@ -13,7 +13,7 @@ GVAR(mapTool_pos) = [0,0];
 GVAR(mapTool_angle) = 0;
 GVAR(mapTool_isDragging) = false;
 GVAR(mapTool_isRotating) = false;
-GVAR(mapTool_isFirstShown) = true;  // used to display it in center of screen when first opened
+GVAR(mapTool_moveToMouse) = true;  // used to display it in center of screen when opened
 
 //Install the event handers for the map tools on the main in-game map
 [{!isNull findDisplay 12},

--- a/addons/maptools/XEH_postInitClient.sqf
+++ b/addons/maptools/XEH_postInitClient.sqf
@@ -13,6 +13,7 @@ GVAR(mapTool_pos) = [0,0];
 GVAR(mapTool_angle) = 0;
 GVAR(mapTool_isDragging) = false;
 GVAR(mapTool_isRotating) = false;
+GVAR(mapTool_isFirstShown) = true;  // used to display it in center of screen when first opened
 
 //Install the event handers for the map tools on the main in-game map
 [{!isNull findDisplay 12},

--- a/addons/maptools/functions/fnc_handleMouseMove.sqf
+++ b/addons/maptools/functions/fnc_handleMouseMove.sqf
@@ -29,10 +29,10 @@ if (GVAR(mapTool_Shown) == 0) exitWith {false};
 
 private _mousePosition = _control ctrlMapScreenToWorld [_mousePosX, _mousePosY];
 
-// open map tools in center of screen upon first open
-if (GVAR(mapTool_isFirstShown)) then {
+// open map tools in center of screen when toggled to be shown
+if (GVAR(mapTool_moveToMouse)) then {
     GVAR(mapTool_pos) = _mousePosition;
-    GVAR(mapTool_isFirstShown) = false;  // we only need to do this once
+    GVAR(mapTool_moveToMouse) = false;  // we only need to do this once	after opening the map tool
 };
 
 // Translation

--- a/addons/maptools/functions/fnc_handleMouseMove.sqf
+++ b/addons/maptools/functions/fnc_handleMouseMove.sqf
@@ -29,6 +29,12 @@ if (GVAR(mapTool_Shown) == 0) exitWith {false};
 
 private _mousePosition = _control ctrlMapScreenToWorld [_mousePosX, _mousePosY];
 
+// open map tools in center of screen upon first open
+if (GVAR(mapTool_isFirstShown)) then {
+    GVAR(mapTool_pos) = _mousePosition;
+    GVAR(mapTool_isFirstShown) = false;  // we only need to do this once
+};
+
 // Translation
 if (GVAR(mapTool_isDragging)) exitWith {
     GVAR(mapTool_pos) set [0, (GVAR(mapTool_startPos) select 0) + (_mousePosition select 0) - (GVAR(mapTool_startDragPos) select 0)];

--- a/addons/maptools/functions/fnc_handleMouseMove.sqf
+++ b/addons/maptools/functions/fnc_handleMouseMove.sqf
@@ -29,12 +29,6 @@ if (GVAR(mapTool_Shown) == 0) exitWith {false};
 
 private _mousePosition = _control ctrlMapScreenToWorld [_mousePosX, _mousePosY];
 
-// open map tools in center of screen when toggled to be shown
-if (GVAR(mapTool_moveToMouse)) then {
-    GVAR(mapTool_pos) = _mousePosition;
-    GVAR(mapTool_moveToMouse) = false;  // we only need to do this once	after opening the map tool
-};
-
 // Translation
 if (GVAR(mapTool_isDragging)) exitWith {
     GVAR(mapTool_pos) set [0, (GVAR(mapTool_startPos) select 0) + (_mousePosition select 0) - (GVAR(mapTool_startDragPos) select 0)];

--- a/addons/maptools/functions/fnc_updateMapToolMarkers.sqf
+++ b/addons/maptools/functions/fnc_updateMapToolMarkers.sqf
@@ -19,6 +19,13 @@ params ["_theMap"];
 
 if ((GVAR(mapTool_Shown) == 0) || {!("ACE_MapTools" in (ACE_player call EFUNC(common,uniqueItems)))}) exitWith {};
 
+// open map tools in center of screen when toggled to be shown
+if (GVAR(mapTool_moveToMouse)) then {
+    private _mousePosition = _theMap ctrlMapScreenToWorld getMousePosition;
+    GVAR(mapTool_pos) = _mousePosition;
+    GVAR(mapTool_moveToMouse) = false;  // we only need to do this once	after opening the map tool
+};
+
 private _rotatingTexture = "";
 private _textureWidth = 0;
 if (GVAR(mapTool_Shown) == 1) then {


### PR DESCRIPTION

**When merged this pull request will:**
- Show the Map Tools not in the bottom-left corner of the map when first opened, but right where your mouse is (as soon as mouse is moved slightly; might need further improvement here) 
  - see https://youtu.be/pjgQJSyNKTs for a quick demo of the new behaviour

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
      - does not affect the documentation of Map Tools
- [ ] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
      - sorry no; such a small change does not justify reading through all of that :-/
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
