### PR TITLE
Arsenal - Improved some case sensitivity for arsenal

### DIFF
--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -71,6 +71,9 @@ if (_items isEqualType true) then {
     };
 
 } else {
+    // Convert items to their config names (which is used by the arsenal system)
+    _items = _items apply {configName (_x call CBA_fnc_getItemConfig)};
+
     {
         if (_x isEqualType "") then {
             private _configItemInfo = _configCfgWeapons >> _x >> "ItemInfo";

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -146,8 +146,7 @@ _ctrlPanel ctrlCommit 0;
 _ctrlPanel ctrlSetFade 0;
 _ctrlPanel ctrlCommit FADE_DELAY;
 
-_itemsToCheck = _itemsToCheck apply {toLower _x};
-_compatibleItems =  _compatibleItems apply {toLower _x};
+_compatibleItems = _compatibleItems apply {configName (_x call CBA_fnc_getItemConfig)};
 
 lbClear (_display displayCtrl IDC_rightTabContentListnBox);
 lbClear (_display displayCtrl IDC_rightTabContent);
@@ -168,7 +167,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 0) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 0)));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -183,7 +182,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 1) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 1)));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -198,7 +197,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 2) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 2)));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -213,7 +212,7 @@ switch (_ctrlIDC) do {
         if (_leftPanelState) then {
             {
                 ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 3) apply {toLower _x}));
+            } foreach (_compatibleItems arrayIntersect (((GVAR(virtualItems) select 1) select 3)));
         } else {
             {
                 ["CfgWeapons", _x, false] call _fnc_fill_right_Container;
@@ -372,7 +371,7 @@ if (_itemsToCheck isNotEqualTo []) then {
     for "_lbIndex" from 0 to (lbSize _ctrlPanel - 1) do {
         private _currentData = _ctrlPanel lbData _lbIndex;
 
-        if ((_currentData != "") && {tolower _currentData in _itemsToCheck}) exitWith {
+        if ((_currentData != "") && {_currentData in _itemsToCheck}) exitWith {
             _ctrlPanel lbSetCurSel _lbIndex;
         };
     };

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -146,8 +146,6 @@ _ctrlPanel ctrlCommit 0;
 _ctrlPanel ctrlSetFade 0;
 _ctrlPanel ctrlCommit FADE_DELAY;
 
-_compatibleItems = _compatibleItems apply {configName (_x call CBA_fnc_getItemConfig)};
-
 lbClear (_display displayCtrl IDC_rightTabContentListnBox);
 lbClear (_display displayCtrl IDC_rightTabContent);
 

--- a/addons/arsenal/functions/fnc_removeVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_removeVirtualItems.sqf
@@ -54,6 +54,9 @@ if (_items isEqualType true) then {
     // Make sure all items are in string form
     _items = _items select {_x isEqualType "" && {_x != ""}};
 
+    // Convert items to their config names (which is used by the arsenal system)
+    _items = _items apply {configName (_x call CBA_fnc_getItemConfig)};
+
     {
         if (_forEachIndex isEqualTo 0) then {
             _cargo set [_forEachIndex, [(_x select 0) - _items, (_x select 1) - _items, (_x select 2) - _items]];


### PR DESCRIPTION
**When merged this pull request will:**
- Make right side panels for choosing weapon attachments (when a weapon selected) case sensitive.
- `ace_arsenal_fnc_removeVirtualItems` & `ace_arsenal_fnc_addVirtualItems` are no longer case sensitive.

`bis_fnc_compatibleItems` already returns case sensitive names, so no need to go find the config names of the items again.

Addresses #8844.

Thanks @commy2 for helping!

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3mod.com/).
- [x] [Development Guidelines](https://ace3mod.com/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
