### PR TITLE
Common - Fix undefined variable for isModLoadedCache

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -108,9 +108,6 @@
     _object setMass _mass;
 }] call CBA_fnc_addEventHandler;
 
-// Cache for FUNC(isModLoaded)
-GVAR(isModLoadedCache) = createHashMap;
-
 //Add a fix for BIS's zeus remoteControl module not reseting variables on DC when RC a unit
 //This variable is used for isPlayer checks
 if (isServer) then {

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -11,6 +11,9 @@ GVAR(syncedEvents) = createHashMap;
 GVAR(showHudHash) = createHashMap;
 GVAR(vehicleIconCache) = createHashMap; // for getVehicleIcon
 
+// Cache for FUNC(isModLoaded)
+GVAR(isModLoadedCache) = createHashMap;
+
 GVAR(settingsInitFinished) = false;
 GVAR(runAtSettingsInitialized) = [];
 


### PR DESCRIPTION
Moved ace_common_isModLoadedCache from postinit to preinit. The hash object can be used before post init which then produces errors.

