### PR TITLE
Cargo - Remove the ability to load cooked-off items

### DIFF
--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -35,7 +35,8 @@ if (_item  isEqualType "") then {
 } else {
     _validItem =
         (alive _item) &&
-        {_ignoreInteraction || {([_item, _vehicle] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}};
+        {_ignoreInteraction || {([_item, _vehicle] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE}} &&
+        {!(_item getVariable [QEGVAR(cookoff,isCookingOff), false])};
 };
 
 _validItem &&


### PR DESCRIPTION
Loading a cooked-off item and waiting until it is no longer cooked-off will allow you to unload it in a state in which it cannot be interacted with. The proposed commit prevents you from being able to do that. If trying it will just say for example `Basic Ammo [NATO] could not be loaded`. This does not remove the `Load` action on the item however. Maybe someone else can add that.