### PR TITLE
CSW - Fix missing magazine on assembling

### DIFF
--- a/addons/csw/functions/fnc_assemble_deployTripod.sqf
+++ b/addons/csw/functions/fnc_assemble_deployTripod.sqf
@@ -21,12 +21,14 @@
 
     // Remove the tripod from the launcher slot
     private _secondaryWeaponClassname = secondaryWeapon _player;
+    // handle loaded launchers which can become csw like CUP Metis
+    private _secondaryWeaponMagazine = secondaryWeaponMagazine _player param [0, ""];
     _player removeWeaponGlobal (secondaryWeapon _player);
 
     private _onFinish = {
         params ["_args"];
-        _args params ["_player", "_secondaryWeaponClassname"];
-        TRACE_2("deployTripod finish",_player,_secondaryWeaponClassname);
+        _args params ["_player", "_secondaryWeaponClassname", "_secondaryWeaponMagazine"];
+        TRACE_3("deployTripod finish",_player,_secondaryWeaponClassname,_secondaryWeaponMagazine);
 
         private _tripodClassname = getText(configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deploy");
 
@@ -34,6 +36,9 @@
         private _cswTripod = createVehicle [_tripodClassname, [0, 0, 0], [], 0, "NONE"];
         // Because the tripod can be a "full weapon" we disable any data that will allow it to be loaded
         _cswTripod setVariable [QGVAR(assemblyMode), 2, true]; // Explicitly set enabled&unload assembly mode and broadcast
+        if (_secondaryWeaponMagazine isNotEqualTo "") then {
+            _cswTripod setVariable [QGVAR(secondaryWeaponMagazine), _secondaryWeaponMagazine];
+        };
         if (!GVAR(defaultAssemblyMode)) then {
             TRACE_1("global disableVanillaAssembly event",_cswTripod); // handles it being assembled when setting is disabled
             [QGVAR(disableVanillaAssembly), [_cswTripod]] call CBA_fnc_globalEvent;
@@ -61,12 +66,15 @@
 
     private _onFailure = {
         params ["_args"];
-        _args params ["_player", "_secondaryWeaponClassname"];
-        TRACE_2("deployTripod failure",_player,_secondaryWeaponClassname);
+        _args params ["_player", "_secondaryWeaponClassname", "_secondaryWeaponMagazine"];
+        TRACE_3("deployTripod failure",_player,_secondaryWeaponClassname,_secondaryWeaponMagazine);
 
         _player addWeaponGlobal _secondaryWeaponClassname;
+        if (_secondaryWeaponMagazine isNotEqualTo "") then {
+            _player addWeaponItem [_secondaryWeaponClassname, _secondaryWeaponMagazine, true];
+        };
     };
 
     private _deployTime = getNumber(configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deployTime");
-    [TIME_PROGRESSBAR(_deployTime), [_player, _secondaryWeaponClassname], _onFinish, _onFailure, localize LSTRING(PlaceTripod_progressBar)] call EFUNC(common,progressBar);
+    [TIME_PROGRESSBAR(_deployTime), [_player, _secondaryWeaponClassname, _secondaryWeaponMagazine], _onFinish, _onFailure, localize LSTRING(PlaceTripod_progressBar)] call EFUNC(common,progressBar);
 }, _this] call CBA_fnc_execNextFrame;

--- a/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
@@ -81,7 +81,11 @@
             private _weaponHolder = createVehicle ["groundWeaponHolder", [0, 0, 0], [], 0, "NONE"];
             _weaponHolder setDir random [0, 180, 360];
             _weaponHolder setPosATL [_weaponRelPos select 0, _weaponRelPos select 1, _weaponPos select 2];
-            _weaponHolder addWeaponCargoGlobal [_carryWeaponClassname, 1];
+            if (_carryWeaponMag isEqualTo "") then {
+                _weaponHolder addWeaponCargoGlobal [_carryWeaponClassname, 1];
+            } else {
+                _weaponHolder addWeaponWithAttachmentsCargoGlobal [[_carryWeaponClassname, "", "", "", [_carryWeaponMag, 1], [], ""], 1];
+            };
         }, [_player, _weaponPos, _carryWeaponClassname, _carryWeaponMag]] call CBA_fnc_execNextFrame;
 
         LOG("delete weapon");

--- a/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
@@ -37,6 +37,8 @@
         _weaponPos set [2, (_weaponPos select 2) + 0.1];
         private _weaponDir = getDir _staticWeapon;
 
+        private _carryWeaponMag = "";
+        private _carryWeaponMags = getArray (configFile >> "CfgWeapons" >> _carryWeaponClassname >> "magazines") apply {toLower _x};
         LOG("remove ammo");
         {
             _x params ["_xMag", "", "_xAmmo"];
@@ -47,6 +49,11 @@
                 _carryMag = configName (_groups param [0, configNull]);
                 GVAR(vehicleMagCache) set [_xMag, _carryMag];
                 TRACE_2("setting cache",_xMag,_carryMag);
+            };
+            if (_carryWeaponMag isEqualTo "" && {toLower _carryMag in _carryWeaponMags}) then {
+                TRACE_3("Adding mag to secondary weapon",_xMag,_xAmmo,_carryMag);
+                _carryWeaponMag = _carryMag;
+                DEC(_xAmmo);
             };
             if ((_xAmmo > 0) && {_carryMag != ""}) then {
                 TRACE_2("Removing ammo",_xMag,_carryMag);
@@ -68,16 +75,19 @@
         };
 
         [{
-            params ["_player", "_weaponPos", "_carryWeaponClassname"];
+            params ["_player", "_weaponPos", "_carryWeaponClassname", "_carryWeaponMag"];
             if ((alive _player) && {(secondaryWeapon _player) == ""}) exitWith {
                 _player addWeapon _carryWeaponClassname;
+                if (_carryWeaponMag isNotEqualTo "") then {
+                    _player addWeaponItem [_carryWeaponClassname, _carryWeaponMag, true];
+                };
             };
             private _weaponRelPos = _weaponPos getPos RELATIVE_DIRECTION(90);
             private _weaponHolder = createVehicle ["groundWeaponHolder", [0, 0, 0], [], 0, "NONE"];
             _weaponHolder setDir random [0, 180, 360];
             _weaponHolder setPosATL [_weaponRelPos select 0, _weaponRelPos select 1, _weaponPos select 2];
             _weaponHolder addWeaponCargoGlobal [_carryWeaponClassname, 1];
-        }, [_player, _weaponPos, _carryWeaponClassname]] call CBA_fnc_execNextFrame;
+        }, [_player, _weaponPos, _carryWeaponClassname, _carryWeaponMag]] call CBA_fnc_execNextFrame;
 
         LOG("delete weapon");
         deleteVehicle _staticWeapon;

--- a/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
@@ -42,6 +42,7 @@
         LOG("remove ammo");
         {
             _x params ["_xMag", "", "_xAmmo"];
+            if (_xAmmo == 0) then {continue};
 
             private _carryMag = GVAR(vehicleMagCache) get _xMag;
             if (isNil "_carryMag") then {

--- a/addons/csw/functions/fnc_reload_getVehicleMagazine.sqf
+++ b/addons/csw/functions/fnc_reload_getVehicleMagazine.sqf
@@ -4,8 +4,9 @@
  * Finds the best vehicle magazines to create from a carryable magazine for a given weapon.
  *
  * Arguments:
- * 0: Weapon <STRING>
- * 1: Magazine that is carryable <STRING>
+ * 0: Vehicle <OBJECT>
+ * 1: Turret <ARRAY>
+ * 2: Magazine that is carryable <STRING>
  *
  * Return Value:
  * Vehicle Magazine <STRING>

--- a/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
@@ -74,6 +74,15 @@ TRACE_1("Remove all loaded magazines",_magsToRemove);
     };
 } forEach _magsToRemove;
 
+if (_staticWeapon getVariable [QGVAR(secondaryWeaponMagazine), ""] isNotEqualTo "") then {
+    private _secondaryWeaponMagazine = _staticWeapon getVariable QGVAR(secondaryWeaponMagazine);
+    private _turret = allTurrets _staticWeapon param [0, []];
+    private _vehicleMag = [_staticWeapon, _turret, _secondaryWeaponMagazine] call FUNC(reload_getVehicleMagazine);
+    TRACE_3("Re-add previous mag",_secondaryWeaponMagazine,_turret,_vehicleMag);
+    if (!isClass (configFile >> "CfgMagazines" >> _vehicleMag)) exitWith {};
+    _staticWeapon addMagazineTurret [_vehicleMag, _turret, 1];
+    _staticWeapon setVariable [QGVAR(secondaryWeaponMagazine), nil];
+};
 
 if (_storeExtraMagazines) then {
     TRACE_1("saving extra mags to container",_containerMagazineCount);


### PR DESCRIPTION
**When merged this pull request will:**
- fix missing magazine on assembling some launchers (I know only about CUP Metis);
- fix `fnc_reload_getVehicleMagazine` header arguments.

When you place loaded with rocket CUP Metis to its internal tripod (you don't need an external one) it's assembled but without rocket in it. Rocket is just disappeared from your inventory. Also when you disassemble static Metis to portable launcher it's empty and rocket(s) is placed near you. This PR makes new launcher loaded if it was loaded before (dis)assembling.