### PR TITLE
Pylons - Show ammo description in pylon loadout tooltips

### DIFF
--- a/addons/pylons/functions/fnc_showDialog.sqf
+++ b/addons/pylons/functions/fnc_showDialog.sqf
@@ -93,7 +93,8 @@ GVAR(comboBoxes) = [];
     {
         _combo lbAdd getText (configFile >> "CfgMagazines" >> _x >> "displayName");
         _combo lbSetData [_forEachIndex + 1, _x];
-        _combo lbSetTooltip [_forEachIndex + 1, getText (configFile >> "CfgMagazines" >> _x >> "descriptionShort")];
+        private _description = getText (configFile >> "CfgMagazines" >> _x >> "descriptionShort");
+        _combo lbSetTooltip [_forEachIndex + 1, _description];
 
         if (_x == _mag) then {
             _index = _forEachIndex + 1;

--- a/addons/pylons/functions/fnc_showDialog.sqf
+++ b/addons/pylons/functions/fnc_showDialog.sqf
@@ -93,6 +93,7 @@ GVAR(comboBoxes) = [];
     {
         _combo lbAdd getText (configFile >> "CfgMagazines" >> _x >> "displayName");
         _combo lbSetData [_forEachIndex + 1, _x];
+        _combo lbSetTooltip [_forEachIndex + 1, getText (configFile >> "CfgMagazines" >> _x >> "descriptionShort")];
 
         if (_x == _mag) then {
             _index = _forEachIndex + 1;


### PR DESCRIPTION
Same as vanilla does in Eden editor.
![Arma3Retail_DX11_x64_2022-04-20_17-58-52](https://user-images.githubusercontent.com/3768165/164273324-cd1b1834-f467-4bb3-97b8-0f1d056a3e76.png)
