### PR TITLE
Vector - Disable tilting the reticule when zoomed

### DIFF
--- a/addons/vector/CfgWeapons.hpp
+++ b/addons/vector/CfgWeapons.hpp
@@ -19,6 +19,7 @@ class CfgWeapons {
             reticleSafezoneSize = 1;
             hidePeripheralVision = 1;
             opticsPPEffects[] = {QGVAR(OpticsRadBlur1)};
+            disableTilt = 1;
         };
         weaponInfoType = "ACE_RscOptics_vector";
     };


### PR DESCRIPTION
We don't rotate the numbers, so it doesn't make sense to rotate the reticule.