### PR TITLE
User Interface - Add ability to hide Default Action Icon

### DIFF
--- a/addons/ui/CfgInGameUI.hpp
+++ b/addons/ui/CfgInGameUI.hpp
@@ -1,0 +1,5 @@
+class CfgInGameUI {
+    class DefaultAction {
+        size = QUOTE(profileNamespace getVariable [ARR_2('GVAR(hideDefaultActionIcon)', (((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) * 0.8))]);
+    };
+};

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
+#include "CfgInGameUI.hpp"
 #include "CfgVehicles.hpp"
 #include "ACE_Settings.hpp"
 #include "ACE_UI.hpp"

--- a/addons/ui/initSettings.sqf
+++ b/addons/ui/initSettings.sqf
@@ -294,7 +294,7 @@ if (productVersion select 4 == 'Development') then {
     QGVAR(enableSpeedIndicator),
     "CHECKBOX",
     [LSTRING(EnableSpeedIndicator), LSTRING(EnableSpeedIndicator_Description)],
-    "ACE " + LLSTRING(Category),
+    _category,
     true,
     true, {
         if (!_this) then {
@@ -302,4 +302,17 @@ if (productVersion select 4 == 'Development') then {
             _speedIndicator ctrlSetText "";
         };
     }
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(hideDefaultActionIcon),
+    "CHECKBOX",
+    [LSTRING(HideDefaultActionIcon), LSTRING(HideDefaultActionIcon_Description)],
+    _category,
+    false,
+    2, {
+        profileNamespace setVariable [QGVAR(hideDefaultActionIcon), [nil, 0] select _this];
+        saveProfileNamespace;
+    },
+    true // needs restart
 ] call CBA_fnc_addSetting;

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -688,5 +688,11 @@
             <Chinesesimp>为玩家角色启用移动速度指示器。</Chinesesimp>
             <Korean>플레이어 캐릭터를 위한 이동속도 표시기를 활성화 합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_UI_HideDefaultActionIcon">
+            <English>Hide Default Action Icon</English>
+        </Key>
+        <Key ID="STR_ACE_UI_HideDefaultActionIcon_Description">
+            <English>Hides the icon shown automatically when something is in front of the cursor. Requires a game restart.\nWarning: Does not remove the action itself! It is advisable to unbind 'Use default action' key to prevent unwanted interactions.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Implement #6193 with a setting.

Tested the setting in config, works nicely, and even defaults to the default value correctly (copied from vanilla config).