### PR TITLE
Laser/Laserpointer - Fix localization of laser

### DIFF
--- a/addons/laser/initSettings.sqf
+++ b/addons/laser/initSettings.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), localize "str_a3_itemtype_laser"];
+private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(laser)];
 
 [
     QGVAR(dispersionCount),  "SLIDER",

--- a/addons/laser/stringtable.xml
+++ b/addons/laser/stringtable.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Laser">
+        <Key ID="STR_ACE_Laser_laser">
+            <English>Laser</English>
+            <German>Laser</German>
+            <Polish>Laser</Polish>
+            <French>Laser</French>
+            <Russian>Лазер</Russian>
+            <Portuguese>Laser</Portuguese>
+            <Hungarian>Lézer</Hungarian>
+            <Spanish>Láser</Spanish>
+            <Czech>Laser</Czech>
+            <Italian>Laser</Italian>
+            <Japanese>レーザー</Japanese>
+            <Korean>레이저</Korean>
+            <Chinesesimp>激光</Chinesesimp>
+            <Chinese>雷射</Chinese>
+            <Turkish>Lazer</Turkish>
+        </Key>
         <Key ID="STR_ACE_Laser_dispersionCount_displayName">
             <English>Laser Dispersion Simulation Count</English>
             <Japanese>レーザーの分散シミュレート数</Japanese>

--- a/addons/laserpointer/stringtable.xml
+++ b/addons/laserpointer/stringtable.xml
@@ -97,7 +97,7 @@
             <Hungarian>Lézer</Hungarian>
             <Czech>Laser</Czech>
             <Portuguese>Laser</Portuguese>
-            <Japanese>レーザ</Japanese>
+            <Japanese>レーザー</Japanese>
             <Korean>레이저</Korean>
             <Chinesesimp>激光</Chinesesimp>
             <Chinese>雷射</Chinese>


### PR DESCRIPTION
Add
- `laser`: Add missing Hungarian translation of laser (BI doesn't have it translated).

Change
- `laser`: Change `localize` to `LLSTRING`.

Fix
- `laser`: Fix capitalization of laser. It's used in settings and looks off with only "laser" but no other setting in lowercase.
- `laserpointer`: Fix Japanese translation of "Laser" to match the one in the `laser` module.

Note
- The same translation of "Laser" now exists in both the `laser` and `laserpointer` modules. Maybe it should be put in `common`?
- "レーザー" and "レーザ" are mixed in the aforementioned modules. I guess the former should be used: a Japanese person I asked said the former is correct and the latter wrong, BI uses the former, Wikipedia redirects to the former, most dictionaries I've looked in translates "laser" to the former, but for some reason Google translates it to the latter.