### PR TITLE
Medical Vitals - Add event to vitals loop

### DIFF
--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -165,4 +165,7 @@ if (!isPlayer _unit) then {
 
 END_COUNTER(Vitals);
 
+//placed outside the counter as 3rd-party code may be called from this event
+[QEGVAR(medical,handleUnitVitals), _unit] call CBA_fnc_localEvent;
+
 true

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -166,6 +166,6 @@ if (!isPlayer _unit) then {
 END_COUNTER(Vitals);
 
 //placed outside the counter as 3rd-party code may be called from this event
-[QEGVAR(medical,handleUnitVitals), _unit] call CBA_fnc_localEvent;
+[QEGVAR(medical,handleUnitVitals), [_unit, _deltaT]] call CBA_fnc_localEvent;
 
 true

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -40,6 +40,7 @@ The vehicle events will also have the following local variables available `_gunn
 |`ace_treatmentStarted` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action has started (local on the _caller)
 |`ace_treatmentSucceded` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action is completed (local on the _caller)
 |`ace_treatmentFailed` | [_caller, _target, _selectionName, _className, _itemUser, _usedItem] | Local | Listen | Treatment action has been interrupted (local on the _caller)
+|`ace_medical_handleUnitVitals` | [_unit, _deltaT] | Local | Listen | Vitals update ran for unit, _deltaT is the time elapsed since the previous vitals update (local to _unit)
 
 ### 2.3 Interaction Menu (`ace_interact_menu`)
 MenuType: 0 = Interaction, 1 = Self Interaction


### PR DESCRIPTION
**When merged this pull request will:**
- Add a local event in the main vitals loop so that extension mods can run updates in-sync without having to write their own loop.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
