### PR TITLE
Spottingscope - Fix destruction of Spotting Scope

### DIFF
--- a/addons/spottingscope/XEH_preInit.sqf
+++ b/addons/spottingscope/XEH_preInit.sqf
@@ -11,7 +11,7 @@ PREP_RECOMPILE_END;
 
     private _tube = "ACE_SpottingScope_tube" createVehicle [0,0,0];
     _tube setDir (getDir _wreck - 180);
-    _tube setPosASL _wreck modelToWorldWorld (_wreck selectionPosition "destructionEffect");
+    _tube setPosASL (_wreck modelToWorldWorld (_wreck selectionPosition "destructionEffect"));
     _tube setVelocity [1 - random 2, 1 - random 2, 4];
     _tube addTorque (vectorNormalized [1 - random 2, 1 - random 2, 1 - random 2] vectorMultiply 4);
 }] call CBA_fnc_addClassEventHandler;


### PR DESCRIPTION
Fix `Error setposasl: Type Object, expected Array` when destroying Spotting Scope.