### PR TITLE
Common - Add separate blockSpeaking status for acre direct

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -27,6 +27,7 @@
 ["blockThrow", false, ["ACE_Attach", "ACE_concertina_wire", "ACE_dragging", "ACE_Explosives", "ACE_Ladder", "ACE_rearm", "ACE_refuel", "ACE_Sandbag", "ACE_Trenches", "ACE_tripod"]] call FUNC(statusEffect_addType);
 ["setHidden", true, ["ace_unconscious"]] call FUNC(statusEffect_addType);
 ["blockRadio", false, [QEGVAR(captives,Handcuffed), QEGVAR(captives,Surrendered), "ace_unconscious"]] call FUNC(statusEffect_addType);
+["blockSpeaking", false, ["ace_unconscious"]] call FUNC(statusEffect_addType);
 
 [QGVAR(forceWalk), {
     params ["_object", "_set"];
@@ -83,6 +84,14 @@
     };
     if (["acre_main"] call FUNC(isModLoaded)) then {
         _object setVariable ["acre_sys_core_isDisabledRadio", _set > 0, true];
+    };
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(blockSpeaking), {
+    params ["_object", "_set"];
+    TRACE_2("blockSpeaking EH",_object,_set);
+    if (["acre_main"] call FUNC(isModLoaded)) then {
+        _object setVariable ["acre_sys_core_isDisabled", _set > 0, true];
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -93,6 +93,9 @@
     if (["acre_main"] call FUNC(isModLoaded)) then {
         _object setVariable ["acre_sys_core_isDisabled", _set > 0, true];
     };
+    if (["task_force_radio"] call FUNC(isModLoaded)) then {
+        _object setVariable ["tf_voiceVolume", [1, 0] select (_set > 0), true];
+    };
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(blockDamage), { //Name reversed from `allowDamage` because we want NOR logic

--- a/addons/common/functions/fnc_setVolume.sqf
+++ b/addons/common/functions/fnc_setVolume.sqf
@@ -31,7 +31,6 @@ if (_setVolume) then {
     2 fadeSound NORMAL_LEVEL;
 
     // TFAR
-    _unit setVariable ["tf_voiceVolume", NORMAL_LEVEL, true];
     _unit setVariable ["tf_globalVolume", NORMAL_LEVEL];
 
     // ACRE2
@@ -42,7 +41,6 @@ if (_setVolume) then {
     2 fadeSound MUTED_LEVEL;
 
     // TFAR
-    _unit setVariable ["tf_voiceVolume", NO_SOUND, true];
     _unit setVariable ["tf_globalVolume", MUTED_LEVEL];
 
     // ACRE2

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -34,6 +34,9 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Block radio on unconsciousness for compatibility with captive module
 [_unit, "blockRadio", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
 
+// Block speaking on unconsciousness
+[_unit, "blockSpeaking", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
+
 if (_active) then {
     // Don't bother setting this if not used
     if (EGVAR(medical,spontaneousWakeUpChance) > 0) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Add new status effect `blockSpeaking` to block acre direct voice
- Set `blockSpeaking` in `setUnconsciousState`

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
