### PR TITLE
Overheating - Add barrel mass config value

### DIFF
--- a/addons/overheating/functions/fnc_getWeaponData.sqf
+++ b/addons/overheating/functions/fnc_getWeaponData.sqf
@@ -81,7 +81,10 @@ private _reloadTime = getNumber (configfile >> "CfgWeapons" >> _weapon >> (_mode
 
 private _closedBolt = getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(closedBolt));
 
-private _barrelMass = METAL_MASS_RATIO * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
+private _barrelMass = getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(barrelMass));
+if (_barrelMass <= 0) then {
+    _barrelMass = METAL_MASS_RATIO * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
+};
 
 // Cache the values
 _weaponData = [_dispersion, _slowdownFactor, _jamChance, _modes, _muzzle, _reloadTime, _closedBolt, _barrelMass];

--- a/docs/wiki/framework/overheating-framework.md
+++ b/docs/wiki/framework/overheating-framework.md
@@ -53,10 +53,16 @@ class CfgWeapons {
 
 ```cpp
 class CfgWeapons {
-    class Rifle_Long_Base_F ;
+    class Rifle_Base_F;
+    class Rifle_Long_Base_F;
+
+    class MyRifle: Rifle_Base_F {
+        ace_overheating_closedBolt = 1; // Closed bolt, can cook off from barrel heat.
+        ace_overheating_barrelMass = 1.5895; // Mass of the area heated by firing, not strictly just the barrel. Higher mass gives slower heat buildup and faster cooling. Default estimation is 55% of weapon weight in kg.
+    };
 
     class MySniper: Rifle_Long_Base_F {
-        ace_overheating_closedBolt = 1; // Closed bolt, can cook off from barrel heat.
+        ace_overheating_closedBolt = 1;
     };
 
     class MyMG: Rifle_Long_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**
- Add an optional config value for barrel mass to overheating.
This is intended to allow mod makers to individually tweak the heating and cooling potential of their weapons to better reflect their actual ability.

### IMPORTANT

- [X] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [X] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [X] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
