### PR TITLE
Medical Treatment - Change stitching when wound reopening disabled

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -285,7 +285,7 @@ class GVAR(actions) {
         medicRequired = QGVAR(medicSurgicalKit);
         treatmentTime = QFUNC(getStitchTime);
         condition = QFUNC(canStitch);
-        callbackSuccess = "";
+        callbackSuccess = QFUNC(surgicalKitSuccess);
         callbackProgress = QFUNC(surgicalKitProgress);
         consumeItem = QGVAR(consumeSurgicalKit);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";

--- a/addons/medical_treatment/XEH_PREP.hpp
+++ b/addons/medical_treatment/XEH_PREP.hpp
@@ -53,6 +53,7 @@ PREP(setTriageStatus);
 PREP(splint);
 PREP(splintLocal);
 PREP(surgicalKitProgress);
+PREP(surgicalKitSuccess);
 PREP(tourniquet);
 PREP(tourniquetLocal);
 PREP(tourniquetRemove);

--- a/addons/medical_treatment/functions/fnc_canStitch.sqf
+++ b/addons/medical_treatment/functions/fnc_canStitch.sqf
@@ -18,4 +18,13 @@
 
 params ["", "_patient"];
 
-(_patient call FUNC(getStitchableWounds) isNotEqualTo [])
+(_patient call FUNC(getStitchableWounds) isNotEqualTo []) ||
+{   // Allow stitching if "Clear Trauma" is set to "After Stitch",
+    // but wound reopening is disabled
+    GVAR(clearTrauma) isEqualTo 1 &&
+    {!IS_BLEEDING(_patient)} &&
+    {(_patient getVariable [
+        QEGVAR(medical,bodyPartDamage),
+        [0,0,0,0,0,0]
+    ]) isNotEqualTo [0,0,0,0,0,0]}
+}

--- a/addons/medical_treatment/functions/fnc_getStitchTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getStitchTime.sqf
@@ -17,5 +17,26 @@
  */
 
 params ["", "_patient"];
+private _time = 0;
 
-count (_patient call FUNC(getStitchableWounds)) * GVAR(woundStitchTime)
+if (GVAR(advancedBandages) == 2) then {
+    _time = count (_patient call FUNC(getStitchableWounds)) * GVAR(woundStitchTime)
+} else {
+    // Allow stitching if "Clear Trauma" is set to "After Stitch",
+    // but wound reopening is disabled
+    if (GVAR(clearTrauma) == 1) then {
+        private _bodyPartDamage = _patient getVariable [
+            QEGVAR(medical,bodyPartDamage),
+            [0,0,0,0,0,0]
+        ];
+
+        {
+            ADD(_time, _x * GVAR(woundStitchTime));
+        } forEach _bodyPartDamage;
+
+        _time = _time max GVAR(woundStitchTime);
+    };
+};
+
+_time
+

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -24,8 +24,9 @@ _args params ["", "_patient"];
 
 private _stitchableWounds = _patient call FUNC(getStitchableWounds);
 
-// Stop treatment if there are no wounds that can be stitched remaining
-if (_stitchableWounds isEqualTo []) exitWith {false};
+// Stop treatment if there are no wounds that can be stitched remaining,
+// except when clear trauma on stitch is enabled
+if (_stitchableWounds isEqualTo []) exitWith {GVAR(clearTrauma) == 1};
 
 // Not enough time has elapsed to stitch a wound
 if (_totalTime - _elapsedTime > (count _stitchableWounds - 1) * GVAR(woundStitchTime)) exitWith {true};

--- a/addons/medical_treatment/functions/fnc_surgicalKitSuccess.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitSuccess.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+/*
+ * Author: Freddo
+ * Handles the surgical kit treatment by resetting bodypart damage.
+ *
+ * Arguments:
+ * 0: Medic (not used) <OBJECT>
+ * 1: Patient <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, player] call ace_medical_treatment_fnc_surgicalKitSuccess
+ *
+ * Public: No
+ */
+
+params ["_medic", "_patient"];
+
+if (GVAR(clearTrauma) == 1 && {GVAR(advancedBandages) != 2}) then {
+    TRACE_2("clearTrauma - clearing trauma after stitching (no reopening)",_medic,_patient);
+    _patient setVariable [QEGVAR(medical,bodyPartDamage), [0,0,0,0,0,0], true];
+
+    [_patient, true, true, true, true] call EFUNC(medical_engine,updateBodyPartVisuals);
+};
+
+
+nil


### PR DESCRIPTION
**When merged this pull request will:**
- Allow stitching when "Clear Trauma" is set to "On Stitch".
- This changes behaviour as such that trauma is cleared upon finishing stitching, instead of periodically, with time calculation based on `ΣbodyPartDamage * GVAR(woundStitchTime)`. This is due to some of the values otherwise used for stitching are only available when wound reopening is enabled.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
