### PR TITLE
Explosives - SOG Compat - Fix Spiked ammo box placing wrong ammo type

### DIFF
--- a/optionals/compat_sog/CfgMagazines/explosives.hpp
+++ b/optionals/compat_sog/CfgMagazines/explosives.hpp
@@ -171,6 +171,18 @@ class vn_mine_m112_remote_mag: vn_mine_m18_mag {
     };
 };
 
+// Spiked ammo box
+class vn_mine_ammobox_range_mag: vn_mine_m18_mag {
+    EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(ammobox_range);
+
+    class ACE_Triggers {
+        SupportedTriggers[] = {"PressurePlate"};
+        class PressurePlate {
+            digDistance = 0.01;
+        };
+    };
+};
+
 // Punji large
 class vn_mine_punji_01_mag: vn_mine_m18_mag {
     EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(punji_01);

--- a/optionals/compat_sog/CfgVehicles/explosives.hpp
+++ b/optionals/compat_sog/CfgVehicles/explosives.hpp
@@ -111,6 +111,18 @@ class EXPLOSIVES_PLACE(m112): EGVAR(explosives,Place) {
     model = "\vn\weapons_f_vietnam\mines\m112\vn_mine_m112_mag";
 };
 
+// Spiked ammo box
+class EXPLOSIVES_PLACE(ammobox_range): EGVAR(explosives,Place) {
+    displayName = "$STR_VN_MINE_AMMOBOX_RANGE_MAG_DN";
+    model = "\vn\objects_f_vietnam\supply\a2_ammo\pavn\vn_pavn_ammo";
+
+    class ACE_Actions: ACE_Actions {
+        class ACE_MainActions: ACE_MainActions {
+            position = "[0, 0, 0.3]";
+        };
+    };
+};
+
 // Punji large
 class EXPLOSIVES_PLACE(punji_01): EGVAR(explosives,Place) {
     displayName = "$STR_VN_MINE_PUNJI_01_MAG_DN";


### PR DESCRIPTION
**When merged this pull request will:**
- Fix spiked ammo box not setup for ace explosives
- Closes #8886