### PR TITLE
Documentation - Fix Viewports versions

### DIFF
--- a/docs/wiki/feature/viewports.md
+++ b/docs/wiki/feature/viewports.md
@@ -8,8 +8,8 @@ parent: wiki
 mod: ace
 version:
   major: 3
-  minor: x
-  patch: y
+  minor: 15
+  patch: 0
 ---
 
 ## 1. Overview

--- a/docs/wiki/framework/viewports-framework.md
+++ b/docs/wiki/framework/viewports-framework.md
@@ -8,8 +8,8 @@ parent: wiki
 mod: ace
 version:
   major: 3
-  minor: x
-  patch: y
+  minor: 15
+  patch: 0
 ---
 
 ## 1. Config Values
@@ -18,10 +18,10 @@ Reference [ace_viewports_fnc_getViewports](https://github.com/acemod/ACE3/blob/m
 
 ```cpp
 class myVehicle {
-    class ace_viewports {            
+    class ace_viewports {
         class Template {
             // type [STRING] - Optional
-            type = ""; 
+            type = "";
              // camLocation [ARRAY or STRING] - Required
             camLocation = "memoryPointP1";
             camLocation[] = {1,2,3}; // model offset


### PR DESCRIPTION
**When merged this pull request will:**
- Fix documentation failing to build regression from #8480.

Used 3.15.0, but we can change to 3.14.x later if necessary.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
