### PR TITLE
Documentation - Use title instead of name

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-name: ACE3
+title: ACE3
 description: ACE3 is a joint effort by the teams behind ACE 2, AGM and CSE to improve the realism and authenticity of Arma 3.
 keywords: Advanced Combat Enhancement 3, ACE, ACE3, Arma, Arma 3, Mod, Modification, Realism, AGM, CSE, Bohemia, Interactive
 

--- a/docs/_config_dev.yml
+++ b/docs/_config_dev.yml
@@ -1,4 +1,4 @@
-name: ACE3
+title: ACE3
 description: ACE3 is a joint effort by the teams behind ACE 2, AGM and CSE to improve the realism and authenticity of Arma 3.
 keywords: Advanced Combat Enhancement 3, ACE, ACE3, Arma, Arma 3, Mod, Modification, Realism, AGM, CSE, Bohemia, Interactive
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `GitHub Metadata: site.name is set in _config.yml, but many plugins and themes expect site.title to be used instead. To avoid potential inconsistency, Jekyll GitHub Metadata will not set site.title to the repository's name.`