### PR TITLE
Common - Add CBA extended loadout

### DIFF
--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -34,6 +34,7 @@ PREP(fillLeftPanel);
 PREP(fillLoadoutsList);
 PREP(fillRightPanel);
 PREP(fillSort);
+PREP(getLoadout);
 PREP(handleLoadoutsSearchbar);
 PREP(handleMouse);
 PREP(handleScrollWheel);

--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -59,10 +59,11 @@ GVAR(lastSortRight) = "";
     if (!isNil QGVAR(currentLoadoutsTab) && {GVAR(currentLoadoutsTab) == IDC_buttonSharedLoadouts}) then {
 
         private _curSelData =_contentPanelCtrl lnbData [(lnbCurSelRow _contentPanelCtrl), 1];
-        ([_loadoutData] call FUNC(verifyLoadout)) params ["_loadout", "_nullItemsAmount", "_unavailableItemsAmount"];
+        ([_loadoutData] call FUNC(verifyLoadout)) params ["_extendedLoadout", "_nullItemsAmount", "_unavailableItemsAmount"];
 
         private _newRow = _contentPanelCtrl lnbAddRow [_playerName, _loadoutName];
 
+        _extendedLoadout params ["_loadout"];
         ADD_LOADOUTS_LIST_PICTURES
 
         _contentPanelCtrl lnbSetData [[_newRow, 1], _playerName + _loadoutName];
@@ -83,5 +84,22 @@ GVAR(lastSortRight) = "";
         for '_i' from 0 to (((lnbsize _contentPanelCtrl) select 0) - 1) do {
             if ((_contentPanelCtrl lnbText [_i, 1]) == _curSelData) exitwith {_contentPanelCtrl lnbSetCurSelRow _i};
         };
+    };
+}] call CBA_fnc_addEventHandler;
+
+["CBA_loadoutSet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    private _face = _extendedInfo getOrDefault [QGVAR(face), ""];
+    if (_face != "") then {
+        _unit setFace _face;
+    };
+    private _voice = _extendedInfo getOrDefault [QGVAR(voice), ""];
+    if (_voice != "") then {
+        _unit setSpeaker _voice;
+    };
+    private _insignia = _extendedInfo getOrDefault [QGVAR(insignia), ""];
+    if (_insignia != "") then {
+        _unit setVariable ["BIS_fnc_setUnitInsignia_class", nil];
+        [_unit, _insignia] call bis_fnc_setUnitInsignia;
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -14,9 +14,13 @@ PREP_RECOMPILE_END;
 [QGVAR(enableIdentityTabs), "CHECKBOX", localize LSTRING(enableIdentityTabsSettings), localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
 
 // Arsenal loadouts
-[QGVAR(allowDefaultLoadouts), "CHECKBOX", [LSTRING(allowDefaultLoadoutsSetting), LSTRING(defaultLoadoutsTooltip)], localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
-[QGVAR(allowSharedLoadouts), "CHECKBOX", localize LSTRING(allowSharingSetting), localize LSTRING(settingCategory), true, true] call CBA_fnc_addSetting;
-[QGVAR(EnableRPTLog), "CHECKBOX", [LSTRING(printToRPTSetting), LSTRING(printToRPTTooltip)], localize LSTRING(settingCategory), false, false] call CBA_fnc_addSetting;
+[QGVAR(allowDefaultLoadouts), "CHECKBOX", [LSTRING(allowDefaultLoadoutsSetting), LSTRING(defaultLoadoutsTooltip)], [localize LSTRING(settingCategory), localize LSTRING(loadoutSubcategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(allowSharedLoadouts), "CHECKBOX", localize LSTRING(allowSharingSetting), [localize LSTRING(settingCategory), localize LSTRING(loadoutSubcategory)], true, true] call CBA_fnc_addSetting;
+[QGVAR(EnableRPTLog), "CHECKBOX", [LSTRING(printToRPTSetting), LSTRING(printToRPTTooltip)], [localize LSTRING(settingCategory), localize LSTRING(loadoutSubcategory)], false, false] call CBA_fnc_addSetting;
+
+[QGVAR(loadoutsSaveFace), "CHECKBOX", localize LSTRING(loadoutsSaveFaceSetting), [localize LSTRING(settingCategory), localize LSTRING(loadoutSubcategory)], false] call CBA_fnc_addSetting;
+[QGVAR(loadoutsSaveVoice), "CHECKBOX", localize LSTRING(loadoutsSaveVoiceSetting), [localize LSTRING(settingCategory), localize LSTRING(loadoutSubcategory)], false] call CBA_fnc_addSetting;
+[QGVAR(loadoutsSaveInsignia), "CHECKBOX", localize LSTRING(loadoutsSaveInsigniaSetting), [localize LSTRING(settingCategory), localize LSTRING(loadoutSubcategory)], true] call CBA_fnc_addSetting;
 
 [QGVAR(statsToggle), {
     params ["_display", "_showStats"];

--- a/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
+++ b/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
@@ -6,7 +6,7 @@
  *
  * Arguments:
  * 0: Name of loadout <STRING>
- * 1: getUnitLoadout array <ARRAY>
+ * 1: CBA extended loadout or getUnitLoadout array <ARRAY>
  *
  * Return Value:
  * None
@@ -17,7 +17,13 @@
  * Public: Yes
 */
 
-params [["_name", "", [""]], ["_loadout", [], [[]], 10]];
+params [["_name", "", [""]], ["_loadout", [], [[]]]];
+
+private _extendedInfo = createHashMap;
+if (count _loadout == 2) then {
+    _extendedInfo = _loadout select 1;
+    _loadout = _loadout select 0;
+};
 
 if (isNil QGVAR(defaultLoadoutsList)) then {
     GVAR(defaultLoadoutsList) = [];
@@ -36,7 +42,7 @@ for "_dataIndex" from 0 to 10 do {
                 if (_weapon != "") then {
 
                     private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                     if (_weapon != _baseWeapon) then {
+                    if (_weapon != _baseWeapon) then {
                         (_loadout select _dataIndex) set [0, _baseWeapon];
                     };
                 };
@@ -71,7 +77,7 @@ for "_dataIndex" from 0 to 10 do {
 
                                         private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
                                         if (_weapon != _baseWeapon) then {
-                                            (_x select 0)set [0, _baseWeapon];
+                                            (_x select 0) set [0, _baseWeapon];
                                         };
                                     };
                                 };
@@ -100,7 +106,7 @@ for "_dataIndex" from 0 to 10 do {
 
 private _loadoutIndex = (+(GVAR(defaultLoadoutsList))) findIf {(_x select 0) == _name};
 if (_loadoutIndex == -1) then {
-    GVAR(defaultLoadoutsList) pushBack [_name, _loadout];
+    GVAR(defaultLoadoutsList) pushBack [_name, [_loadout, _extendedInfo]];
 } else {
-    GVAR(defaultLoadoutsList) set [_loadoutIndex, [_name, _loadout]];
+    GVAR(defaultLoadoutsList) set [_loadoutIndex, [_name, [_loadout, _extendedInfo]]];
 };

--- a/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
+++ b/addons/arsenal/functions/fnc_addDefaultLoadout.sqf
@@ -25,6 +25,8 @@ if (count _loadout == 2) then {
     _loadout = _loadout select 0;
 };
 
+if (count _loadout != 10) exitWith {};
+
 if (isNil QGVAR(defaultLoadoutsList)) then {
     GVAR(defaultLoadoutsList) = [];
 };

--- a/addons/arsenal/functions/fnc_buttonExport.sqf
+++ b/addons/arsenal/functions/fnc_buttonExport.sqf
@@ -43,7 +43,7 @@ if (GVAR(shiftState)) then {
     [_display, localize LSTRING(exportDefault)] call FUNC(message);
 } else {
 
-    private _export = str getUnitLoadout GVAR(center);
+    private _export = str ([GVAR(center)] call FUNC(getLoadout));
     "ace_clipboard" callExtension (_export + ";");
     "ace_clipboard" callExtension "--COMPLETE--";
 

--- a/addons/arsenal/functions/fnc_buttonImport.sqf
+++ b/addons/arsenal/functions/fnc_buttonImport.sqf
@@ -39,8 +39,9 @@ if (GVAR(shiftState) && {is3DEN}) then {
     set3DENMissionAttributes [[QGVAR(DummyCategory), QGVAR(DefaultLoadoutsListAttribute), GVAR(defaultLoadoutsList)]];
 
 } else {
-    if (count _data == 10) then {
-        GVAR(center) setUnitLoadout _data;
+    private _count = count _data;
+    if (_count == 10 || { _count == 2 }) then {
+        [GVAR(center), _data] call CBA_fnc_setLoadout;
 
         GVAR(currentItems) = ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", [], [], [], [], [], []];
         for "_index" from 0 to 15 do {
@@ -92,8 +93,19 @@ if (GVAR(shiftState) && {is3DEN}) then {
         call FUNC(updateUniqueItemsList);
 
         // Reapply insignia
-        [GVAR(center), ""] call bis_fnc_setUnitInsignia;
-        [GVAR(center), GVAR(currentInsignia)] call bis_fnc_setUnitInsignia;
+        if (QGVAR(insignia) in _loadout#1) then {
+            GVAR(currentInsignia) = _loadout#1 getOrDefault [QGVAR(insignia), ""];
+        } else {
+            [GVAR(center), ""] call bis_fnc_setUnitInsignia;
+            [GVAR(center), GVAR(currentInsignia)] call bis_fnc_setUnitInsignia;
+        };
+
+        if (QGVAR(face) in _loadout#1) then {
+            GVAR(currentFace) = _loadout#1 getOrDefault [QGVAR(face), GVAR(currentFace)];
+        };
+        if (QGVAR(voice) in _loadout#1) then {
+            GVAR(currentVoice) = _loadout#1 getOrDefault [QGVAR(voice), GVAR(currentVoice)];
+        };
 
         [_display, _display displayCtrl GVAR(currentLeftPanel)] call FUNC(fillLeftPanel);
 

--- a/addons/arsenal/functions/fnc_buttonLoadoutsLoad.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsLoad.sqf
@@ -34,7 +34,7 @@ private _loadout = switch GVAR(currentLoadoutsTab) do {
     };
 };
 
-GVAR(center) setUnitLoadout [_loadout, true];
+[GVAR(center), _loadout, true] call CBA_fnc_setLoadout;
 
 GVAR(currentItems) = ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", [], [], [], [], [], []];
 for "_index" from 0 to 15 do {
@@ -91,9 +91,21 @@ for "_index" from 0 to 15 do {
 call FUNC(updateUniqueItemsList);
 
 // Reapply insignia
-[GVAR(center), ""] call bis_fnc_setUnitInsignia;
-[GVAR(center), GVAR(currentInsignia)] call bis_fnc_setUnitInsignia;
+if (QGVAR(insignia) in _loadout#1) then {
+    GVAR(currentInsignia) = _loadout#1 getOrDefault [QGVAR(insignia), ""];
+} else {
+    [GVAR(center), ""] call bis_fnc_setUnitInsignia;
+    [GVAR(center), GVAR(currentInsignia)] call bis_fnc_setUnitInsignia;
+};
+
+if (QGVAR(face) in _loadout#1) then {
+    GVAR(currentFace) = _loadout#1 getOrDefault [QGVAR(face), GVAR(currentFace)];
+};
+if (QGVAR(voice) in _loadout#1) then {
+    GVAR(currentVoice) = _loadout#1 getOrDefault [QGVAR(voice), GVAR(currentVoice)];
+};
 
 [(findDisplay IDD_ace_arsenal), [localize LSTRING(loadoutLoaded), _loadoutName] joinString " "] call FUNC(message);
 
-[QGVAR(onLoadoutLoad), [_loadout, _loadoutName]] call CBA_fnc_localEvent;
+[QGVAR(onLoadoutLoad), [_loadout#0, _loadoutName]] call CBA_fnc_localEvent;
+[QGVAR(onLoadoutLoadExtended), [_loadout, _loadoutName]] call CBA_fnc_localEvent;

--- a/addons/arsenal/functions/fnc_buttonLoadoutsRename.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsRename.sqf
@@ -35,16 +35,17 @@ if (count _similarLoadouts > 0) exitWith {
 
 // Update loadout info in profile / 3DEN and list namespaces
 private _loadoutToRename = (_data select {_x select 0 == _loadoutName}) select 0;
-(_contentPanelCtrl getVariable (_loadoutName + str GVAR(currentLoadoutsTab))) params ["_loadout", "_nullItemsAmount", "_unavailableItemsAmount", "_nullItemsList", "_unavailableItemsList"];
+(_contentPanelCtrl getVariable (_loadoutName + str GVAR(currentLoadoutsTab))) params ["_extendedLoadout", "_nullItemsAmount", "_unavailableItemsAmount", "_nullItemsList", "_unavailableItemsList"];
 
 _data set [_data find _loadoutToRename, [_editBoxContent, (_loadoutToRename select 1)]];
 _contentPanelCtrl setVariable [_loadoutName + str GVAR(currentLoadoutsTab), nil];
-_contentPanelCtrl setVariable [_editBoxContent + str GVAR(currentLoadoutsTab), [_loadout, _nullItemsAmount, _unavailableItemsAmount, _nullItemsList, _unavailableItemsList]];
+_contentPanelCtrl setVariable [_editBoxContent + str GVAR(currentLoadoutsTab), [_extendedLoadout, _nullItemsAmount, _unavailableItemsAmount, _nullItemsList, _unavailableItemsList]];
 
 // Add new row
 _contentPanelCtrl lnbDeleteRow _curSelRow;
 private _newRow = _contentPanelCtrl lnbAddRow ["",_editBoxContent];
 
+_extendedLoadout params ["_loadout"];
 ADD_LOADOUTS_LIST_PICTURES
 
 if (_nullItemsAmount > 0) then {

--- a/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsSave.sqf
@@ -31,7 +31,8 @@ private _cursSelRow = lnbCurSelRow _contentPanelCtrl;
 
 private _loadoutName = _contentPanelCtrl lnbText [_cursSelRow, 1];
 private _curSelLoadout = (_contentPanelCtrl getVariable (_loadoutName + str GVAR(currentLoadoutsTab))) select 0;
-private _loadout = getUnitLoadout GVAR(center);
+private _extendedLoadout = GVAR(center) call FUNC(getLoadout);
+private _loadout = _loadout select 0;
 
 private _loadoutIndex = _data findIf {(_x select 0) == _editBoxContent};
 private _sharedLoadoutsVars = GVAR(sharedLoadoutsNamespace) getVariable QGVAR(sharedLoadoutsVars);
@@ -62,7 +63,7 @@ switch (GVAR(currentLoadoutsTab)) do {
                         if (_weapon != "") then {
 
                             private _baseWeapon = _weapon call BIS_fnc_baseWeapon;
-                             if (_weapon != _baseWeapon) then {
+                            if (_weapon != _baseWeapon) then {
                                 (_loadout select _dataIndex) set [0, _baseWeapon];
                             };
                         };
@@ -135,9 +136,9 @@ switch (GVAR(currentLoadoutsTab)) do {
         };
 
         if (_loadoutIndex isEqualto -1) then {
-            _data pushBack [_editBoxContent, _loadout];
+            _data pushBack [_editBoxContent, _extendedLoadout];
         } else {
-            _data set [_loadoutIndex, [[_editBoxContent, _loadoutName] select (_loadoutName isEqualTo _editBoxContent), _loadout]];
+            _data set [_loadoutIndex, [[_editBoxContent, _loadoutName] select (_loadoutName isEqualTo _editBoxContent), _extendedLoadout]];
         };
 
         // Delete "old" loadout row
@@ -149,7 +150,7 @@ switch (GVAR(currentLoadoutsTab)) do {
 
         ADD_LOADOUTS_LIST_PICTURES
 
-        _contentPanelCtrl setVariable [_editBoxContent + str GVAR(currentLoadoutsTab), [_loadout] call FUNC(verifyLoadout)];
+        _contentPanelCtrl setVariable [_editBoxContent + str GVAR(currentLoadoutsTab), [_extendedLoadout] call FUNC(verifyLoadout)];
 
         _contentPanelCtrl lnbSort [1, false];
 
@@ -243,9 +244,9 @@ switch (GVAR(currentLoadoutsTab)) do {
             };
 
             if (_loadoutIndex == -1) then {
-                GVAR(defaultLoadoutsList) pushBack [_editBoxContent, _loadout];
+                GVAR(defaultLoadoutsList) pushBack [_editBoxContent, _extendedLoadout];
             } else {
-                GVAR(defaultLoadoutsList) set [_loadoutIndex, [[_editBoxContent, _loadoutName] select (_loadoutName isEqualTo _editBoxContent), _loadout]];
+                GVAR(defaultLoadoutsList) set [_loadoutIndex, [[_editBoxContent, _loadoutName] select (_loadoutName isEqualTo _editBoxContent), _extendedLoadout]];
             };
 
             for '_i' from 0 to (((lnbsize _contentPanelCtrl) select 0) - 1) do {
@@ -256,7 +257,7 @@ switch (GVAR(currentLoadoutsTab)) do {
 
             ADD_LOADOUTS_LIST_PICTURES
 
-            _contentPanelCtrl setVariable [_editBoxContent + str GVAR(currentLoadoutsTab), [_loadout] call FUNC(verifyLoadout)];
+            _contentPanelCtrl setVariable [_editBoxContent + str GVAR(currentLoadoutsTab), [_extendedLoadout] call FUNC(verifyLoadout)];
 
             _contentPanelCtrl lnbSort [1, false];
 
@@ -295,4 +296,5 @@ switch (GVAR(currentLoadoutsTab)) do {
 };
 [(findDisplay IDD_ace_arsenal), [localize LSTRING(loadoutSaved), _editBoxContent] joinString " "] call FUNC(message);
 private _savedLoadout = (_data select {_x select 0 == _editBoxContent}) select 0;
-[QGVAR(onLoadoutSave), [_data find _savedLoadout, _savedLoadout]] call CBA_fnc_localEvent;
+[QGVAR(onLoadoutSave), [_data find _savedLoadout, _savedLoadout#0]] call CBA_fnc_localEvent;
+[QGVAR(onLoadoutSaveExtended), [_data find _savedLoadout, _savedLoadout]] call CBA_fnc_localEvent;

--- a/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
+++ b/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
@@ -44,7 +44,7 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
             [_loadoutData] call FUNC(verifyLoadout)
         } else {
             _loadoutCachedInfo
-        } params ["_loadout", "_nullItemsAmount", "_unavailableItemsAmount", "_nullItemsList", "_unavailableItemsList"];
+        } params ["_extendedLoadout", "_nullItemsAmount", "_unavailableItemsAmount", "_nullItemsList", "_unavailableItemsList"];
 
         // Log missing / nil items to RPT
         if (GVAR(EnableRPTLog) && {isNil "_loadoutCachedInfo"} && {(_nullItemsAmount > 0) || {_unavailableItemsAmount > 0}}) then {
@@ -64,6 +64,7 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
 
         private _newRow = _contentPanelCtrl lnbAddRow ["",_loadoutName];
 
+        _extendedLoadout params ["_loadout"];
         ADD_LOADOUTS_LIST_PICTURES
 
         if (_nullItemsAmount > 0) then {
@@ -76,7 +77,7 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
             };
         };
 
-        _contentPanelCtrl setVariable [_loadoutName + str GVAR(currentLoadoutsTab), [_loadout, _nullItemsAmount, _unavailableItemsAmount, _nullItemsList, _unavailableItemsList]];
+        _contentPanelCtrl setVariable [_loadoutName + str GVAR(currentLoadoutsTab), [_extendedLoadout, _nullItemsAmount, _unavailableItemsAmount, _nullItemsList, _unavailableItemsList]];
 
         if ((profileName + _loadoutName) in _sharedLoadoutsVars && {GVAR(currentLoadoutsTab) == IDC_buttonMyLoadouts}) then {
             _contentPanelCtrl lnbSetPicture [[_newRow, 0], QPATHTOF(data\iconPublic.paa)];
@@ -99,11 +100,12 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
             [QGVAR(loadoutUnshared), [_contentPanelCtrl, profileName, _loadoutName]] call CBA_fnc_remoteEvent;
         } else {
 
-            ([_loadoutData] call FUNC(verifyLoadout)) params ["_loadout", "_nullItemsAmount", "_unavailableItemsAmount"];
+            ([_loadoutData] call FUNC(verifyLoadout)) params ["_extendedLoadout", "_nullItemsAmount", "_unavailableItemsAmount"];
 
             _contentPanelCtrl lnbSetColumnsPos [0, 0.15, 0.40, 0.50, 0.60, 0.70, 0.75, 0.80, 0.85, 0.90];
             private _newRow = _contentPanelCtrl lnbAddRow [_playerName, _loadoutName];
 
+            _extendedLoadout params ["_loadout"];
             ADD_LOADOUTS_LIST_PICTURES
 
             _contentPanelCtrl lnbSetData [[_newRow, 1], _playerName + _loadoutName];

--- a/addons/arsenal/functions/fnc_getLoadout.sqf
+++ b/addons/arsenal/functions/fnc_getLoadout.sqf
@@ -10,7 +10,7 @@
  * CBA Extended Loadout <ARRAY>
  *
  * Example:
- * [_box, player] call ace_arsenal_fnc_openBox
+ * [_unit] call ace_arsenal_fnc_getLoadout
  *
  * Public: Yes
 */

--- a/addons/arsenal/functions/fnc_getLoadout.sqf
+++ b/addons/arsenal/functions/fnc_getLoadout.sqf
@@ -1,0 +1,37 @@
+#include "script_component.hpp"
+/*
+ * Author: Brett Mayson
+ * Get the extended loadout of a unit, including identity options if enabled
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * CBA Extended Loadout <ARRAY>
+ *
+ * Example:
+ * [_box, player] call ace_arsenal_fnc_openBox
+ *
+ * Public: Yes
+*/
+
+params [["_unit", objNull, [objNull]]];
+
+if (isNull _unit) exitWith {};
+
+([_unit] call CBA_fnc_getLoadout) params ["_loadout", "_extendedInfo"];
+
+if (GVAR(loadoutsSaveFace)) then {
+    _extendedInfo set [QGVAR(face), face _unit];
+};
+if (GVAR(loadoutsSaveVoice)) then {
+    _extendedInfo set [QGVAR(voice), speaker _unit];
+};
+if (GVAR(loadoutsSaveInsignia)) then {
+    private _insignia = _unit getVariable ["BIS_fnc_setUnitInsignia_class", ""];
+    if (_insignia != "") then {
+        _extendedInfo set [QGVAR(insignia), _insignia];
+    };
+};
+
+[_loadout, _extendedInfo]

--- a/addons/arsenal/functions/fnc_onArsenalClose.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalClose.sqf
@@ -32,7 +32,7 @@ if (is3DEN) then {
     // Apply the loadout from the dummy to all selected units
     if (_exitCode == 1) then {
         {
-            _x setUnitLoadout (getUnitLoadout GVAR(center));
+            [_x, GVAR(center) call FUNC(getLoadout)] call CBA_fnc_setLoadout;
         } foreach (get3DENSelected "object");
 
         save3DENInventory (get3DENSelected "object");

--- a/addons/arsenal/functions/fnc_onArsenalOpen.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalOpen.sqf
@@ -79,7 +79,7 @@ for "_index" from 0 to 14 do {
             };
 
             if ((_array select 2) isNotEqualTo "") then {
-                 ((GVAR(virtualItems) select _index) select 2) pushBackUnique (_array select 2);
+                ((GVAR(virtualItems) select _index) select 2) pushBackUnique (_array select 2);
             };
         };
 

--- a/addons/arsenal/functions/fnc_verifyLoadout.sqf
+++ b/addons/arsenal/functions/fnc_verifyLoadout.sqf
@@ -5,7 +5,7 @@
  * Verify the provided loadout.
  *
  * Arguments:
- * 0: Loadout <ARRAY> (getUnitLoadout format)
+ * 0: Loadout <ARRAY> (CBA Extended Loadout or getUnitLoadout format)
  *
  * Return Value:
  * Verified loadout and missing / unavailable items list and count <ARRAY>
@@ -14,6 +14,14 @@
 */
 
 params ["_loadout"];
+
+private _extendedInfo = createHashMap;
+
+// Check if the provided loadout is a CBA extended loadout
+if (count _loadout == 2) then {
+    _extendedInfo = _loadout select 1;
+    _loadout = _loadout select 0;
+};
 
 private _weaponCfg = configFile >> "CfgWeapons";
 private _magCfg = configFile >> "CfgMagazines";
@@ -236,4 +244,4 @@ for "_dataIndex" from 0 to 9 do {
     };
 };
 
-[_loadout, _nullItemsAmount, _unavailableItemsAmount, _nullItemsList, _unavailableItemsList]
+[[_loadout, _extendedInfo], _nullItemsAmount, _unavailableItemsAmount, _nullItemsList, _unavailableItemsList]

--- a/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
@@ -54,7 +54,7 @@ cba_diagnostic_projectileMaxLines = 10;
                     ] call BIS_fnc_GUImessage;
 
                     if (_return) then {
-                        profileNamespace setVariable [QGVAR(missionLastLoadout), getUnitLoadout player];
+                        profileNamespace setVariable [QGVAR(missionLastLoadout), [player] call CBA_fnc_getLoadout];
                         _display closeDisplay 2;
                         findDisplay 46 closeDisplay 0;
                     };

--- a/addons/arsenal/missions/Arsenal.VR/initPlayerLocal.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/initPlayerLocal.sqf
@@ -5,7 +5,7 @@ params ["_unit"];
 private _loadout = profileNamespace getVariable QGVAR(missionLastLoadout);
 
 if (!isNil "_loadout") then {
-    _unit setUnitLoadout _loadout;
+    [_unit, _loadout] call CBA_fnc_setLoadout;
 };
 
 _unit allowDamage false;

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -881,6 +881,22 @@
             <Czech>ACE Arzenál</Czech>
             <Turkish>ACE Arsenal</Turkish>
         </Key>
+        <Key ID="STR_ACE_Arsenal_loadoutSubcategory">
+            <English>Loadouts</English>
+            <Spanish>Equipamiento</Spanish>
+            <French>Sets d'équipement</French>
+            <German>Ausrüstungen</German>
+            <Polish>Zestawy wyposażenia</Polish>
+            <Japanese>装備</Japanese>
+            <Italian>Equipaggiamenti</Italian>
+            <Korean>로드아웃</Korean>
+            <Chinese>裝備</Chinese>
+            <Chinesesimp>负载</Chinesesimp>
+            <Russian>Комплекты</Russian>
+            <Portuguese>Loadouts</Portuguese>
+            <Czech>Sady vybavení</Czech>
+            <Turkish>Kıyafetler</Turkish>
+        </Key>
         <Key ID="STR_ACE_Arsenal_defaultLoadoutsTooltip">
             <English>Allow the use of the default loadouts tab</English>
             <Spanish>Permitir el uso de la pestaña de equipamientos por defecto</Spanish>
@@ -1448,6 +1464,15 @@
             <Spanish>Detona mediante impacto</Spanish>
             <Chinesesimp>碰炸引信</Chinesesimp>
             <Korean>충격 신관</Korean>
+        </Key>
+        <Key ID="STR_ACE_Arsenal_loadoutsSaveFaceSetting">
+            <English>Save Face</English>
+        </Key>
+        <Key ID="STR_ACE_Arsenal_loadoutsSaveVoiceSetting">
+            <English>Save Voice</English>
+        </Key>
+        <Key ID="STR_ACE_Arsenal_loadoutsSaveInsigniaSetting">
+            <English>Save Insignia</English>
         </Key>
     </Package>
 </Project>

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -556,4 +556,17 @@ GVAR(deviceKeyCurrentIndex) = -1;
     true
 }, {false}, [19, [false, false, true]], false] call CBA_fnc_addKeybind; //ALT + R Key
 
+["CBA_loadoutSet", {
+    params ["_unit", "_loadout"];
+    // remove if with https://github.com/CBATeam/CBA_A3/pull/1548
+    if (count _loadout == 2) then {
+        _loadout = _loadout select 0;
+    };
+    _loadout params ["_primaryWeaponArray"];
+    if ((_primaryWeaponArray param [0, ""]) == "ACE_FakePrimaryWeapon") then {
+        TRACE_1("Ignoring fake gun",_primaryWeaponArray);
+        _loadout set [0, []];
+    };
+}] call CBA_fnc_addEventHandler;
+
 GVAR(commonPostInited) = true;

--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -44,4 +44,20 @@ PREP_RECOMPILE_END;
     GVAR(arsenalCache) = nil;
 }] call CBA_fnc_addEventHandler;
 
+["CBA_loadoutSet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    private _gunbagWeapon = _extendedInfo getOrDefault [QGVAR(gunbagWeapon), []];
+    if (_gunbagWeapon isNotEqualTo []) then {
+        (backpackContainer _unit) setVariable [QGVAR(gunbagWeapon), _gunbagWeapon, true];
+    };
+}] call CBA_fnc_addEventHandler;
+
+["CBA_loadoutGet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    private _gunbagWeapon = (backpackContainer _unit) getVariable [QGVAR(gunbagWeapon), []];
+    if (_gunbagWeapon isNotEqualTo []) then {
+        _extendedInfo set [QGVAR(gunbagWeapon), _gunbagWeapon];
+    };
+}] call CBA_fnc_addEventHandler;
+
 ADDON = true;

--- a/addons/headless/XEH_postInit.sqf
+++ b/addons/headless/XEH_postInit.sqf
@@ -22,14 +22,17 @@
 
                 // Check if naked unit bug happened
                 if (_local && {uniform _unit == ""}) then {
+                    scopeName QGVAR(applyLoadout);
                     INFO_1("Unit [%1] became local with broken loadout - attempting to fix",_unit);
                     if (XGVAR(transferLoadout) == 1) then {
                         // Transferred loadout, if unavailable reset to config default (still better than naked)
-                        _unit setUnitLoadout (_unit getVariable [QGVAR(loadout), typeOf _unit]);
-                    } else {
-                        // Config default loadout
-                        _unit setUnitLoadout (typeOf _unit);
+                        private _loadout = _unit getVariable [QGVAR(loadout), []];
+                        if (_loadout isNotEqualTo []) then {
+                            [_unit, _loadout] call CBA_fnc_setLoadout;
+                            breakOut QGVAR(applyLoadout);
+                        };
                     };
+                    _unit setUnitLoadout (typeOf _unit);
                 };
             }] call CBA_fnc_addClassEventHandler;
         };

--- a/addons/headless/XEH_postInit.sqf
+++ b/addons/headless/XEH_postInit.sqf
@@ -32,6 +32,7 @@
                             breakOut QGVAR(applyLoadout);
                         };
                     };
+                    // Config default loadout
                     _unit setUnitLoadout (typeOf _unit);
                 };
             }] call CBA_fnc_addClassEventHandler;

--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -96,7 +96,7 @@ private _numTransferredHC3 = 0;
 
             // Save gear if unit about to be transferred with current loadout (naked unit work-around)
             if (XGVAR(transferLoadout) == 1) then {
-                _x setVariable [QGVAR(loadout), getUnitLoadout _x, true];
+                _x setVariable [QGVAR(loadout), [_x] call CBA_fnc_getLoadout, true];
             };
         } forEach (units _x);
     };

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -79,3 +79,18 @@ GVAR(lastPlayerVehicle) = objNull;
     // Update protection on possible helmet change
     ["loadout", LINKFUNC(updateHearingProtection), false] call CBA_fnc_addPlayerEventHandler;
 }] call CBA_fnc_addEventHandler;
+
+["CBA_loadoutSet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
+        _unit setVariable ["ACE_hasEarPlugsIn", true, true];
+        [[true]] remoteExec [QFUNC(updateVolume), _unit];
+    };
+}] call CBA_fnc_addEventHandler;
+
+["CBA_loadoutGet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    if (_unit getVariable ["ACE_hasEarPlugsin", false]) then {
+        _extendedInfo set ["ace_earplugs", true]
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/respawn/functions/fnc_handleKilled.sqf
+++ b/addons/respawn/functions/fnc_handleKilled.sqf
@@ -20,7 +20,7 @@ params ["_unit"];
 
 // Saves the gear when the player! (and only him) is killed
 if (ACE_player == _unit && {GVAR(SavePreDeathGear)}) then {
-    _unit setVariable [QGVAR(unitGear), getUnitLoadout _unit];
+    _unit setVariable [QGVAR(unitGear), [_unit] call CBA_fnc_getLoadout];
     _unit setVariable [QGVAR(activeWeaponAndMuzzle), [currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit]];
     [QGVAR(saveGear), _unit] call CBA_fnc_localEvent;
 };

--- a/addons/respawn/functions/fnc_restoreGear.sqf
+++ b/addons/respawn/functions/fnc_restoreGear.sqf
@@ -21,13 +21,7 @@ TRACE_3("restoreGear",_unit, count _allGear, _activeWeaponAndMuzzle);
 
 // restore all gear
 if (!isNil "_allGear") then {
-    _allGear params ["_primaryWeaponArray"];
-    if ((_primaryWeaponArray param [0, ""]) == "ACE_FakePrimaryWeapon") then {
-        TRACE_1("Ignoring fake gun",_primaryWeaponArray);
-        _allGear set [0, []];
-        _activeWeaponAndMuzzle = nil;
-    };
-    _unit setUnitLoadout _allGear;
+    [_unit, _allGear] call CBA_fnc_setLoadout;
 };
 
 // restore the last active weapon, muzzle and weaponMode

--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -289,7 +289,9 @@ All are local.
 | ace_arsenal_leftPanelFilled | Arsenal display (DISPLAY), current left panel IDC (SCALAR), current right panel IDC (SCALAR) |
 | ace_arsenal_rightPanelFilled | Arsenal display (DISPLAY), current left panel IDC (SCALAR), current right panel IDC (SCALAR) |
 | ace_arsenal_onLoadoutSave | Loadout index (SCALAR), [loadout name (STRING), loadout data (ARRAY)] |
+| ace_arsenal_onLoadoutSaveExtended | Loadout index (SCALAR), [loadout name (STRING), CBA extended loadout data (ARRAY)] |
 | ace_arsenal_onLoadoutLoad | loadout data (ARRAY), loadout name (STRING) |
+| ace_arsenal_onLoadoutLoadExtended | CBA extended loadout data (ARRAY), loadout name (STRING) |
 | ace_arsenal_onLoadoutDelete | loadout name (STRING) |
 |  ace_arsenal_loadoutShared | Loadouts list listnBox control (CONTROL),, [loadout author (STRING), loadout name (STRING), loadout data (ARRAY)]  |
 |  ace_arsenal_loadoutUnshared | Loadouts list listnBox control (CONTROL), loadout name (STRING) |


### PR DESCRIPTION
Doesn't require this, it is compatible before and after the CBA PR is merged. There is an if statement that can be removed after the linked CBA PR is merged.
- https://github.com/CBATeam/CBA_A3/pull/1548

**When merged this pull request will:**
- Add earplugs to CBA extended loadouts
- Add gunbag weapon to CBA extended loadouts
- Add face and speaker to loadouts saved in the ACE arsenal (default off)
- Add insignia to loadouts saved in the ACE arsenal (default on)
- Respawn keep gear uses CBA extended loadouts
- Headless naked fix uses CBA extended loadouts (not sure about this one, may not be needed)

<details>
<summary>Settings Changes</summary>

![image](https://user-images.githubusercontent.com/3946739/170151128-45cdf866-66c9-4c92-a098-ec9f492f496e.png)

</details>

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
