### PR TITLE
Advanced Vehicle Damage - Change default setting to disabled

### DIFF
--- a/addons/vehicle_damage/initSettings.sqf
+++ b/addons/vehicle_damage/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(enabled), "CHECKBOX",
     [ELSTRING(common,Enabled), LSTRING(setting_description)],
     LSTRING(category_displayName),
-    true, // default value
+    false, // default value
     true, // isGlobal
     {[QGVAR(enabled), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart


### PR DESCRIPTION
As stated in https://github.com/acemod/ACE3/pull/8734#discussion_r787918244, Maintainers have decided that Advanced Vehicle Damage should disabled by default.

**When merged this pull request will:**
- Change default setting of advanced vehicle damage to false
- Allow https://github.com/acemod/ACE3/pull/8734 to be merged