### PR TITLE
Cookoff - Fix ammo not being removed from turrets with additional FFV

### DIFF
--- a/addons/cookoff/functions/fnc_getVehicleAmmo.sqf
+++ b/addons/cookoff/functions/fnc_getVehicleAmmo.sqf
@@ -24,21 +24,18 @@ TRACE_1("getVehicleAmmo",_vehicle);
 private _ammoToDetonate = [];
 private _totalAmmo = 0;
 
-// from ace_common, tweaked becasue command is busted
-private _ffvTurrets = fullCrew [_vehicle, "", true] select {_x select 4} apply {_x select 3};
-
 // Get ammo from turrets
 {
     _x params ["_mag", "_turret", "_count"];
     // if the turret is an FFV seat, it takes magazines from the soldier
-    if (!(_turret in _ffvTurrets) && {_count > 0}) then {
+    if (_count > 0) then {
         private _ammo = getText (configFile >> "CfgMagazines" >> _mag >> "ammo");
         private _model = getText (configFile >> "CfgAmmo" >> _ammo >> "model");
         if (_model == "\A3\weapons_f\empty") exitWith {TRACE_3("skipping",_mag,_ammo,_model);};
         _ammoToDetonate pushBack [_mag, _count];
         _totalAmmo = _totalAmmo + _count;
     };
-} forEach (magazinesAllTurrets _vehicle);
+} forEach (magazinesAllTurrets [_vehicle, true]);
 
 // Get ammo from cargo space
 {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix ammo not being removed from turrets which have "additional" FFV, eg. in tanks after turning out from gunner pos
