### PR TITLE
Cookoff - Fix smoke effects not getting cleaned up

### DIFF
--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -11,6 +11,16 @@
 [QGVAR(smoke), FUNC(smoke)] call CBA_fnc_addEventHandler;
 [QGVAR(cookOffBox), FUNC(cookOffBox)] call CBA_fnc_addEventHandler;
 
+// handle cleaning up effects when vehicle is deleted mid-cookoff 
+[QGVAR(addCleanupHandlers), {
+    params ["_vehicle"];
+
+    _vehicle addEventHandler ["Deleted", {
+        params ["_vehicle"];
+        [QGVAR(cleanupEffects), [_vehicle]] call CBA_fnc_globalEvent;
+    }];
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(cleanupEffects), {
     params ["_vehicle", ["_effects", []]];
 

--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -30,6 +30,8 @@ TRACE_9("cooking off",_vehicle,_intensity,_instigator,_smokeDelayEnabled,_ammoDe
 if (_vehicle getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _vehicle setVariable [QGVAR(isCookingOff), true, true];
 
+[QGVAR(addCleanupHandlers), [_vehicle]] call CBA_fnc_localEvent;
+
 // limit maximum value of intensity to prevent very long cook-off times
 _intensity = _intensity min _maxIntensity;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a `Deleted` EH to vehicles such that any children effects get cleaned up if it's being removed mid-cookoff