### PR TITLE
WIP: interaction_menu - Change vehicleSelfInteraction to allow base level actions

### DIFF
--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -109,6 +109,14 @@ private _fnc_renderSelfActions = {
         _action = _x;
         [_target, _action, _pos] call FUNC(renderBaseMenu);
     } forEach _classActions;
+
+    // Iterate through object actions, find base level actions and render them if appropiate
+    {
+        // Only render them directly if they are base level actions
+        if (_x select 1 isNotEqualTo []) then {continue};
+        private _action = _x;
+        [_target, _action] call FUNC(renderBaseMenu);
+    } forEach GVAR(objectActionList);
 };
 
 private _fnc_renderZeusActions = {

--- a/addons/interact_menu/functions/fnc_renderActionPoints.sqf
+++ b/addons/interact_menu/functions/fnc_renderActionPoints.sqf
@@ -109,14 +109,28 @@ private _fnc_renderSelfActions = {
         _action = _x;
         [_target, _action, _pos] call FUNC(renderBaseMenu);
     } forEach _classActions;
+    
+};
+
+private _fnc_renderVehicleSelfActions = {
+    private _target = _this;
 
     // Iterate through object actions, find base level actions and render them if appropiate
+    GVAR(objectActionList) = _target getVariable [QGVAR(selfActions), []];
     {
         // Only render them directly if they are base level actions
         if (_x select 1 isNotEqualTo []) then {continue};
         private _action = _x;
         [_target, _action] call FUNC(renderBaseMenu);
     } forEach GVAR(objectActionList);
+
+
+    // Iterate through class actions
+    private _classActions = GVAR(ActNamespace) getVariable [typeOf _target, []];
+    {
+        private _action = _x;
+        [_target, _action, [0.5,0.5]] call FUNC(renderBaseMenu);
+    } forEach _classActions;
 };
 
 private _fnc_renderZeusActions = {
@@ -146,7 +160,7 @@ if (GVAR(openedMenuType) == 0) then {
                 };
             } else {
                 // Render vehicle self actions when in vehicle
-                (vehicle ACE_player) call _fnc_renderSelfActions;
+                (vehicle ACE_player) call _fnc_renderVehicleSelfActions;
             };
         };
     } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Edit `renderActionPoints` to properly pass base-level vehicle-object-actions to `renderBaseMenu`

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
