### PR TITLE
Logistics Wirecutter - Add new fences models for the wirecutter

### DIFF
--- a/addons/logistics_wirecutter/script_component.hpp
+++ b/addons/logistics_wirecutter/script_component.hpp
@@ -74,7 +74,13 @@
     "netfence_03_m_3m_corner_f.p3d",\
     "netfence_03_m_9m_f.p3d",\
     "vineyardfence_01_f.p3d",\
-    "gameprooffence_01_l_5m_f.p3d"\
+    "gameprooffence_01_l_5m_f.p3d",\
+    "netfence_01_m_gate_f.p3d",\
+    "netfence_02_m_2m_f.p3d",\
+    "netfence_02_m_4m_f.p3d",\
+    "netfence_02_m_8m_f.p3d",\
+    "net_fence_gate_f.p3d",\
+    "new_wiredfence_10m_dam_f.p3d"\
 ]
 
 #define SOUND_CLIP_TIME_SPACING 1.5


### PR DESCRIPTION
**When merged this pull request will:**
- make the wirecutter able to cut through all new wire fences. (there was some addition to the fences of vanilla ArmA (e.g. at the airport on Altis).
- fences for @cup_terrains_core are also included.
