### PR TITLE
Cookoff - Removed references to unused ignoreTurret parameter in code and docs

### DIFF
--- a/addons/cookoff/CfgVehicles.hpp
+++ b/addons/cookoff/CfgVehicles.hpp
@@ -35,13 +35,6 @@ class CfgVehicles {
         explosionEffect = "FuelExplosionBig";
     };
 
-    class APC_Wheeled_02_base_F: Wheeled_APC_F { // Otokar ARMA - RCWS Turret
-        GVAR(ignoreTurret) = 1;
-    };
-    class APC_Tracked_01_base_F: Tank_F { // Namera, Nemmera - RCWS Turret
-        GVAR(ignoreTurret) = 1;
-    };
-
 
     class MRAP_01_base_F: Car_F {
         GVAR(engineSmokeOffset)[] = {0,-2,0};

--- a/docs/wiki/framework/cookoff-framework.md
+++ b/docs/wiki/framework/cookoff-framework.md
@@ -49,6 +49,6 @@ e.g. RCWS turrets
 
 ```
 class MyVehicle {
-    ace_cookoff_ignoreTurret = 1;
+    ace_vehicle_damage_turretFireProb = 0;
 };
 ```


### PR DESCRIPTION
Ref issue https://github.com/acemod/ACE3/issues/8952

**When merged this pull request will:**
- Removes CfgVehicles changes to dead `ace_cookoff_ignoreTurret` parameter that has since been replaced with `ace_vehicle_damage_turretFireProb`
- Updates cookoff doc's `Ignore damage to turret` reference to the correct `ace_vehicle_damage_turretFireProb` variable.