### PR TITLE
Towing - Add rope to vehicle inventory

### DIFF
--- a/addons/towing/XEH_PREP.hpp
+++ b/addons/towing/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addRopeToVehicle);
 PREP(attachRopePFH);
 PREP(canStartTow);
 PREP(detach);

--- a/addons/towing/XEH_preInit.sqf
+++ b/addons/towing/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/towing/functions/fnc_addRopeToVehicle.sqf
+++ b/addons/towing/functions/fnc_addRopeToVehicle.sqf
@@ -15,6 +15,7 @@
  * Public: No
  */
 
+if (!GVAR(addRopeToVehicleInventory)) exitWith {};
 params ["_vehicle"];
 
 if (0 == getNumber (configOf _vehicle >> QEGVAR(cargo,hasCargo))) exitWith {};

--- a/addons/towing/functions/fnc_addRopeToVehicle.sqf
+++ b/addons/towing/functions/fnc_addRopeToVehicle.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: Dystopian
+ * Adds rope to vehicle inventory.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * cursorObject call ace_towing_fnc_addRopeToVehicle
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+if (0 == getNumber (configOf _vehicle >> QEGVAR(cargo,hasCargo))) exitWith {};
+
+private _ropeType = if (
+    -1 < ["Tank", "Wheeled_APC_F", "Truck_F"] findIf {_vehicle isKindOf _x}
+) then {"ACE_rope12"} else {"ACE_rope6"};
+
+_vehicle addItemCargoGlobal [_ropeType, 1];

--- a/addons/towing/initSettings.sqf
+++ b/addons/towing/initSettings.sqf
@@ -1,0 +1,17 @@
+[
+    QGVAR(addRopeToVehicleInventory), "CHECKBOX",
+    LSTRING(Setting_addRopeToVehicleInventory_DisplayName),
+    LELSTRING(OptionsMenu,CategoryLogistics),
+    true,
+    true,
+    {
+        if (!_this) exitWith {
+            [QGVAR(addRopeToVehicleInventory), _this] call EFUNC(common,cbaSettings_settingChanged);
+        };
+        if (!isServer || {!isNil QGVAR(addRopeToVehicleInventory_initialized)}) exitWith {};
+        GVAR(addRopeToVehicleInventory_initialized) = true;
+        ["Tank", "initPost", {call FUNC(addRopeToVehicle)}, true, [], true] call CBA_fnc_addClassEventHandler;
+        ["Car", "initPost", {call FUNC(addRopeToVehicle)}, true, [], true] call CBA_fnc_addClassEventHandler;
+    },
+    true // needs restart only on disabling
+] call CBA_fnc_addSetting;

--- a/addons/towing/initSettings.sqf
+++ b/addons/towing/initSettings.sqf
@@ -5,13 +5,9 @@
     true,
     true,
     {
-        if (!_this) exitWith {
-            [QGVAR(addRopeToVehicleInventory), _this] call EFUNC(common,cbaSettings_settingChanged);
-        };
-        if (!isServer || {!isNil QGVAR(addRopeToVehicleInventory_initialized)}) exitWith {};
+        if !(_this && {isServer} && {isNil QGVAR(addRopeToVehicleInventory_initialized)}) exitWith {};
         GVAR(addRopeToVehicleInventory_initialized) = true;
         ["Tank", "initPost", LINKFUNC(addRopeToVehicle), true, [], true] call CBA_fnc_addClassEventHandler;
         ["Car", "initPost", LINKFUNC(addRopeToVehicle), true, [], true] call CBA_fnc_addClassEventHandler;
-    },
-    true // needs restart only on disabling
+    }
 ] call CBA_fnc_addSetting;

--- a/addons/towing/initSettings.sqf
+++ b/addons/towing/initSettings.sqf
@@ -10,8 +10,8 @@
         };
         if (!isServer || {!isNil QGVAR(addRopeToVehicleInventory_initialized)}) exitWith {};
         GVAR(addRopeToVehicleInventory_initialized) = true;
-        ["Tank", "initPost", {call FUNC(addRopeToVehicle)}, true, [], true] call CBA_fnc_addClassEventHandler;
-        ["Car", "initPost", {call FUNC(addRopeToVehicle)}, true, [], true] call CBA_fnc_addClassEventHandler;
+        ["Tank", "initPost", LINKFUNC(addRopeToVehicle), true, [], true] call CBA_fnc_addClassEventHandler;
+        ["Car", "initPost", LINKFUNC(addRopeToVehicle), true, [], true] call CBA_fnc_addClassEventHandler;
     },
     true // needs restart only on disabling
 ] call CBA_fnc_addSetting;

--- a/addons/towing/stringtable.xml
+++ b/addons/towing/stringtable.xml
@@ -111,5 +111,9 @@
             <Chinesesimp>解开牵引绳</Chinesesimp>
             <Korean>견인줄 분리</Korean>
         </Key>
+        <Key ID="STR_ACE_Towing_Setting_addRopeToVehicleInventory_DisplayName">
+            <English>Add Tow Rope to Vehicle Inventory</English>
+            <Russian>Добавить буксировочный трос в инвентарь машин</Russian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- add setting to add rope to all `Car` and `Tank` vehicles inventory.

Cars get 6m rope; tanks, APCs and trucks get 12m rope. There is `ace_cargo_hasCargo` config value check to handle all those quadbike/cart/etc vehicles.

Setting needs restart only on disabling.

Not completely sure about:
- default setting value (enabled now);
- setting category (`Logistics` now, can be `Vehicles`);
- should add caching for vehicle classes (I don't think it's worth it);

At least some CUP trucks have `Car_F` parent instead of `Truck_F` so they get 6m rope but I don't think it's a big problem.
