### PR TITLE
Interaction Menu - Fix black screen option not removing background properly

### DIFF
--- a/addons/interact_menu/CursorMenus.hpp
+++ b/addons/interact_menu/CursorMenus.hpp
@@ -9,11 +9,10 @@ class RscTitles {
     class GVAR(menuBackground) {
         idd = -1;
         onLoad = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuBackground)),_this select 0)]);
-        onUnload = QUOTE(uiNamespace setVariable [ARR_2(QUOTE(QGVAR(menuBackground)),displayNull)]);
         fadeIn = 0.25;
         fadeOut = 0.25;
         movingEnable = 0;
-        duration = 10e10;
+        duration = QUOTE(10e10);
         name = QGVAR(menuBackground);
         class controls {};
         class controlsBackground {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix closing the display for the black screen option on Profiling branch and Arma 2.10
- Removed the "unset" on display unload as it created a race condition when a new display was opened
