### PR TITLE
RHSUSF Compat - Fix A-10A 30mm 5:1 DU:HEI mag rearm

### DIFF
--- a/optionals/compat_rhs_usf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_usf3/CfgAmmo.hpp
@@ -250,6 +250,11 @@ class CfgAmmo {
         EGVAR(vehicle_damage,incendiary) = 0.8;
     };
 
+    class SubmunitionBase;
+    class rhs_ammo_30x173mm_GAU8_mixed: SubmunitionBase {
+        EGVAR(rearm,caliber) = 30;
+    };
+
     class M_Titan_AT;
     class rhs_ammo_TOW_AT: M_Titan_AT {
         EGVAR(vehicle_damage,incendiary) = 1.0;


### PR DESCRIPTION
**When merged this pull request will:**
- Add missing `ace_rearm_caliber` attribute to `rhs_ammo_30x173mm_GAU8_mixed`

![image](https://user-images.githubusercontent.com/20744006/179870327-2afd3637-53ad-45f1-8b40-9dcf9bb3ee5e.png)


Fix https://github.com/acemod/ACE3/issues/8860