### PR TITLE
Fire - Fix incorrect mempoint for sound source

### DIFF
--- a/addons/fire/functions/fnc_burn.sqf
+++ b/addons/fire/functions/fnc_burn.sqf
@@ -289,7 +289,7 @@ if (_isBurning) exitWith {};
 
     if (isServer) then {
         _fireSound = createSoundSource ["Sound_Fire", _unitPos, [], 0];
-        _fireSound attachTo [_unit, [0, 0, 0], "destructionEffect1"];
+        _fireSound attachTo [_unit, [0, 0, 0], "Head"];
     };
 
     _unit setVariable [QGVAR(burning), true];


### PR DESCRIPTION
**When merged this pull request will:**
- Change mempoint used for fire sound source to avoid RPT errors

Removes the current RPT error:
```13:51:29 Error: Invalid memory point 'destructionEffect1' provided to attachTo on shape 'a3\characters_f\blufor\b_soldier_01.p3d'```

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
