### PR TITLE
RHSAFRF Compat - Fix subsonic ammo ballistic attributes

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgAmmo.hpp
+++ b/optionals/compat_rhs_afrf3/CfgAmmo.hpp
@@ -113,27 +113,38 @@ class CfgAmmo {
         ACE_barrelLengths[]={96.52, 127.0, 228.6};
     };
     class rhs_B_545x39_7U1_Ball: rhs_B_545x39_Ball {
-        // @todo: Provide accurate coefficients for this subsonic ammo
-        // In the meantime, prevent it inheriting from its supersonic parent
-        // ammoTempMuzzleVelocityShifts scaled down from normal
-        ACE_ammoTempMuzzleVelocityShifts[]={-8.85,-8.49,-7.61667,-6.70667,-5.66,-4.26667,-2.54667,-0.51,1.98667,5.05667,8.73};
-        ACE_muzzleVelocities[] = {};
-        ACE_barrelLengths[] = {};
+        ACE_caliber = 5.67;
+        ACE_bulletLength = 24.3;
+        ACE_bulletMass = 5.2;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-8.85,-8.49,-7.61667,-6.70667,-5.66,-4.26667,-2.54667,-0.51,1.98667,5.05667,8.73};
+        ACE_muzzleVelocities[] = {300, 320, 335};
+        ACE_barrelLengths[] = {200, 300, 400};
     };
     class rhs_B_762x39_U_Ball: rhs_B_762x39_Ball {
-        // @todo: Provide accurate coefficients for this subsonic ammo
-        // In the meantime, prevent it inheriting from its supersonic parent
-        // ammoTempMuzzleVelocityShifts scaled down from normal
-        ACE_ammoTempMuzzleVelocityShifts[]={-8.85,-8.49,-7.61667,-6.70667,-5.66,-4.26667,-2.54667,-0.51,1.98667,5.05667,8.73}; //Just Scaled Down Normal?
-        ACE_muzzleVelocities[] = {};
-        ACE_barrelLengths[] = {};
+        ACE_caliber = 7.94;
+        ACE_bulletLength = 33.62;
+        ACE_bulletMass = 12.5;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-8.85,-8.49,-7.61667,-6.70667,-5.66,-4.26667,-2.54667,-0.51,1.98667,5.05667,8.73}; //Just Scaled Down Normal?
+        ACE_muzzleVelocities[]= {270, 290, 320};
+        ACE_barrelLengths[]= {254.0, 414.02, 508.0};
     };
     class rhs_B_9x39_SP5: rhs_B_762x39_Ball {
-        // @todo: Provide accurate coefficients for this subsonic ammo
-        // In the meantime, prevent it inheriting from its supersonic parent
-        ACE_ammoTempMuzzleVelocityShifts[]={};
-        ACE_muzzleVelocities[]={};
-        ACE_barrelLengths[]={};
+        ACE_caliber = 9.246;
+        ACE_bulletLength = 31.496;
+        ACE_bulletMass = 16.1;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655,-2.547,-2.285,-2.012,-1.698,-1.28,-0.764,-0.153,0.596,1.517,2.619};
+        ACE_ballisticCoefficients[] = {0.275};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_muzzleVelocities[] = {280, 300, 320};
+        ACE_barrelLengths[] = {254.0, 414.02, 508.0};
+    };
+    class rhs_B_9x39_SP6: rhs_B_9x39_SP5 {
+        ACE_caliber = 9.26;
+        ACE_bulletMass = 16.2;
+        ACE_ballisticCoefficients[] = {0.225};
+        ACE_muzzleVelocities[] = {290, 310, 335};
+        ACE_barrelLengths[] = {254.0, 414.02, 508.0};
     };
 
     class SubmunitionBase;

--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -41,6 +41,10 @@ class CfgWeapons {
         ACE_barrelTwist = 160.02;
         ACE_barrelLength = 210.82;
     };
+    class rhs_weap_asval: rhs_weap_ak74m {
+        ACE_barrelTwist = 210.82;
+        ACE_barrelLength = 200.66;
+    };
     class rhs_weap_svd: rhs_weap_ak74m {
         ACE_RailHeightAboveBore = -0.617396;
         ACE_barrelTwist = 238.76;


### PR DESCRIPTION
**When merged this pull request will:**
- Add missing ballistic attributes for ammo: `rhs_B_545x39_7U1_Ball`, `rhs_B_762x39_U_Ball`, `rhs_B_9x39_SP5` and `rhs_B_9x39_SP6`
- Add missing barrel attributes for weapons: `rhs_weap_asval` and `rhs_weap_vss`

_Note: Values taken from various sources and extrapolated when data points were missing. Current values seems to be within the envelope when testing though, so I'm hoping best effort is better than nothing._

Fix #8940