### PR TITLE
Cookoff - Tweaked effects cleanup to work in dedicated environment

### DIFF
--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -20,7 +20,7 @@
         private _deletedEH = _vehicle addEventHandler ["Deleted", {
             params ["_vehicle"];
             
-            [QGVAR(cleanupEffects), [_vehicle]] call CBA_fnc_globalEvent;
+            [QGVAR(cleanupEffects), [_vehicle]] call CBA_fnc_localEvent;
         }];
     
         _vehicle setVariable [QGVAR(deletedEH), _deletedEH];

--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -30,7 +30,7 @@ TRACE_9("cooking off",_vehicle,_intensity,_instigator,_smokeDelayEnabled,_ammoDe
 if (_vehicle getVariable [QGVAR(isCookingOff), false]) exitWith {};
 _vehicle setVariable [QGVAR(isCookingOff), true, true];
 
-[QGVAR(addCleanupHandlers), [_vehicle]] call CBA_fnc_serverEvent;
+[QGVAR(addCleanupHandlers), [_vehicle]] call CBA_fnc_globalEvent;
 
 // limit maximum value of intensity to prevent very long cook-off times
 _intensity = _intensity min _maxIntensity;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix cookoff effects cleanup not working in a dedicated environment

Previous method assumed the vehicle entity would still exist by the time the CBA global event was received by clients but in testing it becomes NULL and the local effects variables are unable to be retrieved.

Refactor switches to adding the Deleted EH on globally when a cookoff occurs and the EH triggers a local event for cleanup allowing for use of vehicle entity and access to the local effects variable stored on the vehicle.