### PR TITLE
Medical - Disable blood spurts for fire, burn and drown damage types

### DIFF
--- a/addons/medical_blood/XEH_preInit.sqf
+++ b/addons/medical_blood/XEH_preInit.sqf
@@ -8,6 +8,9 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+// Damage types which do not cause blood spurts
+GVAR(noBloodDamageTypes) = createHashMapFromArray (call (uiNamespace getVariable QGVAR(noBloodDamageTypes)));
+
 // blood object model namespace
 GVAR(models) = [] call CBA_fnc_createNamespace;
 

--- a/addons/medical_blood/XEH_preStart.sqf
+++ b/addons/medical_blood/XEH_preStart.sqf
@@ -1,3 +1,10 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.hpp"
+
+// Damage types which do not cause blood spurts
+private _noBloodDamageTypes = "getNumber (_x >> 'noBlood') == 1" configClasses (configFile >> "ACE_Medical_Injuries" >> "damageTypes");
+uiNamespace setVariable [
+    QGVAR(noBloodDamageTypes),
+    compileFinal str (_noBloodDamageTypes apply {[configName _x, true]})
+];

--- a/addons/medical_blood/XEH_preStart.sqf
+++ b/addons/medical_blood/XEH_preStart.sqf
@@ -6,5 +6,5 @@
 private _noBloodDamageTypes = "getNumber (_x >> 'noBlood') == 1" configClasses (configFile >> "ACE_Medical_Injuries" >> "damageTypes");
 uiNamespace setVariable [
     QGVAR(noBloodDamageTypes),
-    compileFinal str (_noBloodDamageTypes apply {[configName _x, true]})
+    compileFinal str (_noBloodDamageTypes apply {[configName _x, nil]})
 ];

--- a/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
+++ b/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
@@ -18,8 +18,11 @@
  * Public: No
  */
 
-params ["_unit", "_allDamages", "_shooter"];
-(_allDamages select 0) params ["_damage", ""];
+params ["_unit", "_allDamages", "_shooter", "_damageType"];
+(_allDamages select 0) params ["_damage"];
+
+// Don't bleed if damage type does not cause bleeding
+if (getNumber (configFile >> "ACE_Medical_Injuries" >> "damageTypes" >> _damageType >> "noBlood") == 1) exitWith {};
 
 // Don't bleed when players only and a non-player unit is wounded
 if (GVAR(enabledFor) == BLOOD_ONLY_PLAYERS && {!isPlayer _unit && {_unit != ACE_player}}) exitWith {};

--- a/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
+++ b/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
@@ -22,7 +22,7 @@ params ["_unit", "_allDamages", "_shooter", "_damageType"];
 (_allDamages select 0) params ["_damage"];
 
 // Don't bleed if damage type does not cause bleeding
-if (getNumber (configFile >> "ACE_Medical_Injuries" >> "damageTypes" >> _damageType >> "noBlood") == 1) exitWith {};
+if (GVAR(noBloodDamageTypes) getOrDefault [_damageType, false]) exitWith {};
 
 // Don't bleed when players only and a non-player unit is wounded
 if (GVAR(enabledFor) == BLOOD_ONLY_PLAYERS && {!isPlayer _unit && {_unit != ACE_player}}) exitWith {};

--- a/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
+++ b/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
@@ -22,7 +22,7 @@ params ["_unit", "_allDamages", "_shooter", "_damageType"];
 (_allDamages select 0) params ["_damage"];
 
 // Don't bleed if damage type does not cause bleeding
-if (GVAR(noBloodDamageTypes) getOrDefault [_damageType, false]) exitWith {};
+if (_damageType in GVAR(noBloodDamageTypes)) exitWith {};
 
 // Don't bleed when players only and a non-player unit is wounded
 if (GVAR(enabledFor) == BLOOD_ONLY_PLAYERS && {!isPlayer _unit && {_unit != ACE_player}}) exitWith {};

--- a/addons/medical_damage/ACE_Medical_Injuries.hpp
+++ b/addons/medical_damage/ACE_Medical_Injuries.hpp
@@ -68,7 +68,7 @@ class ACE_Medical_Injuries {
 
         // if 1, wounds are only applied to the hitpoint that took the most damage. othewrise, wounds are applied to all damaged hitpoints
         selectionSpecific = 1;
-        
+
         // list of damage handlers, which will be called in reverse order
         // each entry should be a SQF expression that returns a function
         // this can also be overridden for each damage type
@@ -80,7 +80,7 @@ class ACE_Medical_Injuries {
             // bullets only create multiple wounds when the damage is very high
             thresholds[] = {{20, 10}, {4.5, 2}, {3, 1}, {0, 1}};
             selectionSpecific = 1;
-            
+
             class Avulsion {
                 // at damage, weight. between points, weight is interpolated then wound is chosen by weighted random.
                 // as with thresholds, but result is not rounded (decimal values used as-is)
@@ -268,6 +268,7 @@ class ACE_Medical_Injuries {
         class ropeburn {
             thresholds[] = {{0.1, 1}, {0.1, 0}};
             selectionSpecific = 1;
+            noBlood = 1;
             class Abrasion {
                 weighting[] = {{0.30, 1}};
             };
@@ -275,9 +276,11 @@ class ACE_Medical_Injuries {
         class drowning {
             //No related wounds as drowning should not cause wounds/bleeding. Can be extended for internal injuries if they are added.
             thresholds[] = {{0, 0}};
+            noBlood = 1;
             class woundHandlers {};
         };
         class fire {
+            noBlood = 1;
             // custom handling for environmental fire sources
             // passes damage to "burn" so doesn't need its own wound stats
             class woundHandlers {
@@ -287,6 +290,7 @@ class ACE_Medical_Injuries {
         class burn {
             thresholds[] = {{0, 1}};
             selectionSpecific = 0;
+            noBlood = 1;
             class ThermalBurn {
                 weighting[] = {{0, 1}};
             };

--- a/docs/wiki/framework/medical-framework.md
+++ b/docs/wiki/framework/medical-framework.md
@@ -171,6 +171,9 @@ class ACE_Medical_Injuries {
             // if 1, wounds are only applied to the most-damaged body part. if 0, wounds are applied to all damaged parts
             selectionSpecific = 1;
 
+            // if 1, wounds do not produce blood spurts
+            noBlood = 0;
+
             // custom handling for this damage type
             // inherits from the default handlers - the function(s) defined here will be called first, then the default one(s)
             class woundHandlers: woundHandlers {


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Added `noBlood` config param to the damageTypes configs in ACE_Medical_Injuries
- Docs