### PR TITLE
Cookoff - Randomized the delay from start of cookoff and ammunition detonation

### DIFF
--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -55,8 +55,6 @@
         ([_vehicle] call FUNC(getVehicleAmmo)) params ["_mags", "_total"];
 
         private _delay = (random MAX_AMMO_DETONATION_START_DELAY) max MIN_AMMO_DETONATION_START_DELAY;
-        [{
-            _this call FUNC(detonateAmmunition);
-        }, [_vehicle, _mags, _total], _delay] call CBA_fnc_waitAndExecute;
+        [FUNC(detonateAmmunition), [_vehicle, _mags, _total], _delay] call CBA_fnc_waitAndExecute;
     };
 }, nil, ["Man","StaticWeapon"]] call CBA_fnc_addClassEventHandler;

--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -53,6 +53,10 @@
     ) then {
         if (GVAR(ammoCookoffDuration) == 0) exitWith {};
         ([_vehicle] call FUNC(getVehicleAmmo)) params ["_mags", "_total"];
-        [_vehicle, _mags, _total] call FUNC(detonateAmmunition);
+
+        private _delay = (random MAX_AMMO_DETONATION_START_DELAY) max MIN_AMMO_DETONATION_START_DELAY;
+        [{
+            _this call FUNC(detonateAmmunition);
+        }, [_vehicle, _mags, _total], _delay] call CBA_fnc_waitAndExecute;
     };
 }, nil, ["Man","StaticWeapon"]] call CBA_fnc_addClassEventHandler;

--- a/addons/cookoff/script_component.hpp
+++ b/addons/cookoff/script_component.hpp
@@ -24,6 +24,8 @@
 #define SMOKE_TIME 10.5
 #define COOKOFF_TIME 14 // Cook off time should be 20s at most due to length of sound files
 #define COOKOFF_TIME_BOX 82.5 // Cook off time for boxes should be significant to allow time for ammo to burn
+#define MIN_AMMO_DETONATION_START_DELAY 2 // Min time to wait before a vehicle's ammo starts to cookoff
+#define MAX_AMMO_DETONATION_START_DELAY 6 // Max time to wait before a vehicle's ammo starts to cookoff
 #define MIN_TIME_BETWEEN_FLAMES 5
 #define MAX_TIME_BETWEEN_FLAMES 15
 #define MAX_TIME_BETWEEN_AMMO_DET 25

--- a/addons/cookoff/script_component.hpp
+++ b/addons/cookoff/script_component.hpp
@@ -24,12 +24,13 @@
 #define SMOKE_TIME 10.5
 #define COOKOFF_TIME 14 // Cook off time should be 20s at most due to length of sound files
 #define COOKOFF_TIME_BOX 82.5 // Cook off time for boxes should be significant to allow time for ammo to burn
-#define MIN_AMMO_DETONATION_START_DELAY 1 // Min time to wait before a vehicle's ammo starts to cookoff
-#define MAX_AMMO_DETONATION_START_DELAY 6 // Max time to wait before a vehicle's ammo starts to cookoff
 #define MIN_TIME_BETWEEN_FLAMES 5
 #define MAX_TIME_BETWEEN_FLAMES 15
 #define MAX_TIME_BETWEEN_AMMO_DET 25
 #define MAX_COOKOFF_INTENSITY 10
+
+#define MIN_AMMO_DETONATION_START_DELAY 1 // Min time to wait before a vehicle's ammo starts to cookoff
+#define MAX_AMMO_DETONATION_START_DELAY 6 // Max time to wait before a vehicle's ammo starts to cookoff
 
 // Delay between flame effect for players in a cooking off vehicle
 #define FLAME_EFFECT_DELAY 0.4

--- a/addons/cookoff/script_component.hpp
+++ b/addons/cookoff/script_component.hpp
@@ -24,7 +24,7 @@
 #define SMOKE_TIME 10.5
 #define COOKOFF_TIME 14 // Cook off time should be 20s at most due to length of sound files
 #define COOKOFF_TIME_BOX 82.5 // Cook off time for boxes should be significant to allow time for ammo to burn
-#define MIN_AMMO_DETONATION_START_DELAY 2 // Min time to wait before a vehicle's ammo starts to cookoff
+#define MIN_AMMO_DETONATION_START_DELAY 1 // Min time to wait before a vehicle's ammo starts to cookoff
 #define MAX_AMMO_DETONATION_START_DELAY 6 // Max time to wait before a vehicle's ammo starts to cookoff
 #define MIN_TIME_BETWEEN_FLAMES 5
 #define MAX_TIME_BETWEEN_FLAMES 15


### PR DESCRIPTION
**When merged this pull request will:**
- _Randomize the delay from start of cookoff and ammunition detonation_

Something I've noticed with cookoff is in certain circumstances almost at the exact same time that a vehicle is hit with AT you'll hear the ammo detonation cookoff sound effects, this seems quite odd as you'd expect the hit to have a short delay of 1+ seconds before the ammo would even begin to cookoff, give it a bit of time to for the "fire" to be lit.

I'm open to more modular ways to handle this (as cookoff in general isn't very tweakable at runtime)