### PR TITLE
Medical Treatment - Add treatment time multipliers & restructure settings

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -79,7 +79,7 @@ class GVAR(actions) {
         icon = QPATHTOEF(medical_gui,ui\tourniquet.paa);
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         items[] = {"ACE_tourniquet"};
-        treatmentTime = QGVAR(treatmentTimeTourniquet);
+        treatmentTime = QUOTE(([ARR_2(_medic, 'tourniquet')] call FUNC(getTreatmentTimeMult)) * GVAR(treatmentTimeTourniquet));
         condition = QUOTE(!([ARR_2(_patient,_bodyPart)] call FUNC(hasTourniquetAppliedTo)));
         callbackSuccess = QFUNC(tourniquet);
         litter[] = {};
@@ -100,7 +100,7 @@ class GVAR(actions) {
         icon = QPATHTOEF(medical_gui,ui\splint.paa);
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         items[] = {"ACE_splint"};
-        treatmentTime = QGVAR(treatmentTimeSplint);
+        treatmentTime = QUOTE(([ARR_2(_medic, 'splint')] call FUNC(getTreatmentTimeMult)) * GVAR(treatmentTimeSplint));
         callbackSuccess = QFUNC(splint);
         condition = QFUNC(canSplint);
         litter[] = {
@@ -117,7 +117,7 @@ class GVAR(actions) {
         category = "medication";
         items[] = {"ACE_morphine"};
         condition = "";
-        treatmentTime = QGVAR(treatmentTimeAutoinjector);
+        treatmentTime = QUOTE(([ARR_2(_medic, 'autoinjector')] call FUNC(getTreatmentTimeMult)) * GVAR(treatmentTimeAutoinjector));
         callbackSuccess = QFUNC(medication);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
         sounds[] = {{QPATHTO_R(sounds\Inject.ogg),1,1,50}};
@@ -148,7 +148,7 @@ class GVAR(actions) {
         allowSelfTreatment = QGVAR(allowSelfIV);
         category = "advanced";
         medicRequired = QGVAR(medicIV);
-        treatmentTime = QGVAR(treatmentTimeIV);
+        treatmentTime = QUOTE(([ARR_2(_medic, 'IV')] call FUNC(getTreatmentTimeMult)) * GVAR(treatmentTimeIV));
         items[] = {"ACE_bloodIV"};
         treatmentLocations = QGVAR(locationIV);
         condition = "";
@@ -244,7 +244,7 @@ class GVAR(actions) {
         treatmentLocations = TREATMENT_LOCATIONS_ALL;
         allowSelfTreatment = 0;
         medicRequired = 0;
-        treatmentTime = QGVAR(treatmentTimeBodyBag);
+        treatmentTime = QUOTE(([ARR_2(_medic, 'bodybag')] call FUNC(getTreatmentTimeMult)) * GVAR(treatmentTimeBodyBag));
         items[] = {"ACE_bodyBag"};
         condition = QFUNC(canPlaceInBodyBag);
         callbackSuccess = QFUNC(placeInBodyBag);
@@ -260,7 +260,7 @@ class GVAR(actions) {
         allowedSelections[] = {"Body"};
         allowSelfTreatment = 0;
         medicRequired = 0;
-        treatmentTime = QGVAR(treatmentTimeCPR);
+        treatmentTime = QUOTE(([ARR_2(_medic, 'cpr')] call FUNC(getTreatmentTimeMult)) * GVAR(treatmentTimeCPR));
         items[] = {};
         condition = QFUNC(canCPR);
         callbackSuccess = QFUNC(cprSuccess);

--- a/addons/medical_treatment/XEH_PREP.hpp
+++ b/addons/medical_treatment/XEH_PREP.hpp
@@ -32,6 +32,7 @@ PREP(getBandageTime);
 PREP(getHealTime);
 PREP(getStitchableWounds);
 PREP(getStitchTime);
+PREP(getTreatmentTimeMult);
 PREP(getTriageStatus);
 PREP(handleBandageOpening);
 PREP(hasItem);

--- a/addons/medical_treatment/functions/fnc_getHealTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getHealTime.sqf
@@ -18,7 +18,7 @@
 
 #define DAMAGE_SCALING_FACTOR 5
 
-params ["", "_patient"];
+params ["_medic", "_patient"];
 
 private _bodyPartDamage = 0;
 
@@ -26,4 +26,6 @@ private _bodyPartDamage = 0;
     _bodyPartDamage = _bodyPartDamage + _x;
 } forEach (_patient getVariable [QEGVAR(medical,bodyPartDamage), []]);
 
-10 max (((_bodyPartDamage * DAMAGE_SCALING_FACTOR) min 180) * GVAR(timeCoefficientPAK))
+private _mult = [_medic, "PAK"] call FUNC(getTreatmentTimeMult);
+
+10 max (((_bodyPartDamage * DAMAGE_SCALING_FACTOR) min 180) * GVAR(timeCoefficientPAK) * _mult)

--- a/addons/medical_treatment/functions/fnc_getStitchTime.sqf
+++ b/addons/medical_treatment/functions/fnc_getStitchTime.sqf
@@ -16,6 +16,8 @@
  * Public: No
  */
 
-params ["", "_patient"];
+params ["_medic", "_patient"];
 
-count (_patient call FUNC(getStitchableWounds)) * GVAR(woundStitchTime)
+private _mult = [_medic, "stitch"] call FUNC(getTreatmentTimeMult);
+
+count (_patient call FUNC(getStitchableWounds)) * GVAR(woundStitchTime) * _mult

--- a/addons/medical_treatment/functions/fnc_getTreatmentTimeMult.sqf
+++ b/addons/medical_treatment/functions/fnc_getTreatmentTimeMult.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*
+ * Author: Pterolatypus
+ * Gets multiplier for time taken to apply a particular treatment based on user's medic level
+ *
+ * Arguments:
+ * 0: Medic <OBJECT>
+ * 1: Treatment <String>
+ *
+ * Return Value:
+ * Multiplier <NUMBER>
+ *
+ * Example:
+ * [player, "PAK"] call ace_medical_treatment_fnc_getTreatmentTimeMult
+ *
+ * Public: No
+ */
+
+params ["_medic", "_treatment"];
+
+//doctor
+if ([_medic, 2] call FUNC(isMedic)) exitwith {
+	missionNamespace getVariable [format [QGVAR(treatmentTime%1MultDoctor), _treatment], 1] //return
+};
+
+//medic
+if ([_medic, 1] call FUNC(isMedic)) exitwith {
+	missionNamespace getVariable [format [QGVAR(treatmentTime%1MultMedic), _treatment], 1] //return
+};
+
+1 //return default

--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -20,15 +20,16 @@
  */
 
 params ["_args", "_elapsedTime", "_totalTime"];
-_args params ["", "_patient"];
+_args params ["_medic", "_patient"];
 
 private _stitchableWounds = _patient call FUNC(getStitchableWounds);
 
 // Stop treatment if there are no wounds that can be stitched remaining
 if (_stitchableWounds isEqualTo []) exitWith {false};
 
+private _mult = [_medic, "stitch"] call FUNC(getTreatmentTimeMult);
 // Not enough time has elapsed to stitch a wound
-if (_totalTime - _elapsedTime > (count _stitchableWounds - 1) * GVAR(woundStitchTime)) exitWith {true};
+if (_totalTime - _elapsedTime > (count _stitchableWounds - 1) * GVAR(woundStitchTime) * _mult) exitWith {true};
 
 private _bandagedWounds = GET_BANDAGED_WOUNDS(_patient);
 private _stitchedWounds = GET_STITCHED_WOUNDS(_patient);

--- a/addons/medical_treatment/initSettings.sqf
+++ b/addons/medical_treatment/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(advancedDiagnose),
     "LIST",
     [LSTRING(AdvancedDiagnose_DisplayName), LSTRING(AdvancedDiagnose_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(AdvancedDiagnose_DiagnoseCardiacArrest)], 1],
     true
 ] call CBA_fnc_addSetting;
@@ -11,7 +11,7 @@
     QGVAR(advancedMedication),
     "CHECKBOX",
     [LSTRING(AdvancedMedication_DisplayName), LSTRING(AdvancedMedication_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     true,
     true
 ] call CBA_fnc_addSetting;
@@ -20,7 +20,7 @@
     QGVAR(advancedBandages),
     "LIST",
     [LSTRING(AdvancedBandages_DisplayName), LSTRING(AdvancedBandages_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(AdvancedBandages_EnabledCanReopen)], 1],
     true
 ] call CBA_fnc_addSetting;
@@ -29,7 +29,7 @@
     QGVAR(woundReopenChance),
     "SLIDER",
     [LSTRING(WoundReopenChance_DisplayName), LSTRING(WoundReopenChance_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [0, 5, 1, 2],
     true
 ] call CBA_fnc_addSetting;
@@ -38,7 +38,7 @@
     QGVAR(clearTrauma),
     "LIST",
     [LSTRING(ClearTrauma_DisplayName), LSTRING(ClearTrauma_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [ELSTRING(common,Never),  LSTRING(ClearTrauma_AfterStitch), LSTRING(ClearTrauma_AfterBandage)], 1],
     true
 ] call CBA_fnc_addSetting;
@@ -48,7 +48,7 @@
     QGVAR(locationsBoostTraining),
     "CHECKBOX",
     [ELSTRING(common,LocationsBoostTraining_DisplayName), LSTRING(LocationsBoostTraining_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     false,
     true
 ] call CBA_fnc_addSetting;
@@ -57,7 +57,7 @@
     QGVAR(allowSharedEquipment),
     "LIST",
     [LSTRING(AllowSharedEquipment_DisplayName), LSTRING(AllowSharedEquipment_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [LSTRING(AllowSharedEquipment_PriorityPatient), LSTRING(AllowSharedEquipment_PriorityMedic), ELSTRING(common,No)], 0],
     true
 ] call CBA_fnc_addSetting;
@@ -66,44 +66,8 @@
     QGVAR(convertItems),
     "LIST",
     [LSTRING(ConvertItems_DisplayName), LSTRING(ConvertItems_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [ELSTRING(common,Enabled), LSTRING(ConvertItems_RemoveOnly), ELSTRING(common,Disabled)], 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(treatmentTimeAutoinjector),
-    "SLIDER",
-    [LSTRING(TreatmentTimeAutoinjector_DisplayName), LSTRING(TreatmentTimeAutoinjector_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 5, 1],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(treatmentTimeTourniquet),
-    "SLIDER",
-    [LSTRING(TreatmentTimeTourniquet_DisplayName), LSTRING(TreatmentTimeTourniquet_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 7, 1],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(treatmentTimeSplint),
-    "SLIDER",
-    [LSTRING(TreatmentTimeSplint_DisplayName), LSTRING(TreatmentTimeSplint_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 7, 1],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(treatmentTimeBodyBag),
-    "SLIDER",
-    [LSTRING(TreatmentTimeBodyBag_DisplayName), LSTRING(TreatmentTimeBodyBag_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 15, 1],
     true
 ] call CBA_fnc_addSetting;
 
@@ -111,7 +75,7 @@
     QGVAR(medicEpinephrine),
     "LIST",
     [LSTRING(MedicEpinephrine_DisplayName), LSTRING(MedicEpinephrine_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 0],
     true
 ] call CBA_fnc_addSetting;
@@ -120,7 +84,7 @@
     QGVAR(locationEpinephrine),
     "LIST",
     [LSTRING(LocationEpinephrine_DisplayName), LSTRING(LocationEpinephrine_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
     true
 ] call CBA_fnc_addSetting;
@@ -129,7 +93,7 @@
     QGVAR(medicPAK),
     "LIST",
     [LSTRING(MedicPAK_DisplayName), LSTRING(MedicPAK_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 1],
     true
 ] call CBA_fnc_addSetting;
@@ -138,7 +102,7 @@
     QGVAR(locationPAK),
     "LIST",
     [LSTRING(LocationPAK_DisplayName), LSTRING(LocationPAK_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 3],
     true
 ] call CBA_fnc_addSetting;
@@ -147,7 +111,7 @@
     QGVAR(consumePAK),
     "LIST",
     [LSTRING(ConsumePAK_DisplayName), LSTRING(ConsumePAK_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 0],
     true
 ] call CBA_fnc_addSetting;
@@ -156,17 +120,8 @@
     QGVAR(allowSelfPAK),
     "LIST",
     [LSTRING(AllowSelfPAK_DisplayName), LSTRING(AllowSelfPAK_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(timeCoefficientPAK),
-    "SLIDER",
-    [LSTRING(TimeCoefficientPAK_DisplayName), LSTRING(TimeCoefficientPAK_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0, 5, 1, 1],
     true
 ] call CBA_fnc_addSetting;
 
@@ -174,7 +129,7 @@
     QGVAR(medicSurgicalKit),
     "LIST",
     [LSTRING(MedicSurgicalKit_DisplayName), LSTRING(MedicSurgicalKit_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 1],
     true
 ] call CBA_fnc_addSetting;
@@ -183,7 +138,7 @@
     QGVAR(locationSurgicalKit),
     "LIST",
     [LSTRING(LocationSurgicalKit_DisplayName), LSTRING(LocationSurgicalKit_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 2],
     true
 ] call CBA_fnc_addSetting;
@@ -192,7 +147,7 @@
     QGVAR(consumeSurgicalKit),
     "LIST",
     [LSTRING(ConsumeSurgicalKit_DisplayName), LSTRING(ConsumeSurgicalKit_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 0],
     true
 ] call CBA_fnc_addSetting;
@@ -201,17 +156,8 @@
     QGVAR(allowSelfStitch),
     "LIST",
     [LSTRING(AllowSelfStitch_DisplayName), LSTRING(AllowSelfStitch_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(woundStitchTime),
-    "SLIDER",
-    [LSTRING(WoundStitchTime_DisplayName), LSTRING(WoundStitchTime_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 5, 1],
     true
 ] call CBA_fnc_addSetting;
 
@@ -219,7 +165,7 @@
     QGVAR(medicIV),
     "LIST",
     [LSTRING(MedicIV_DisplayName), LSTRING(MedicIV_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 1],
     true
 ] call CBA_fnc_addSetting;
@@ -228,7 +174,7 @@
     QGVAR(locationIV),
     "LIST",
     [LSTRING(LocationIV_DisplayName), LSTRING(LocationIV_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
     1
 ] call CBA_fnc_addSetting;
@@ -237,44 +183,8 @@
     QGVAR(allowSelfIV),
     "LIST",
     [LSTRING(AllowSelfIV_DisplayName), LSTRING(AllowSelfIV_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 1],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(treatmentTimeIV),
-    "SLIDER",
-    [LSTRING(TreatmentTimeIV_DisplayName), LSTRING(TreatmentTimeIV_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 12, 1],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(cprSuccessChanceMin),
-    "SLIDER",
-    [LSTRING(CPRSuccessChanceMin_DisplayName), LSTRING(CPRSuccessChanceMin_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0, 1, 0.4, 2, true],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(cprSuccessChanceMax),
-    "SLIDER",
-    [LSTRING(CPRSuccessChanceMax_DisplayName), LSTRING(CPRSuccessChanceMax_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0, 1, 0.4, 2, true],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(treatmentTimeCPR),
-    "SLIDER",
-    [LSTRING(TreatmentTimeCPR_DisplayName), LSTRING(TreatmentTimeCPR_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0.1, 60, 15, 1],
     true
 ] call CBA_fnc_addSetting;
 
@@ -282,7 +192,7 @@
     QGVAR(allowBodyBagUnconscious),
     "CHECKBOX",
     [LSTRING(AllowBodyBagUnconscious_DisplayName), LSTRING(AllowBodyBagUnconscious_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     false,
     true
 ] call CBA_fnc_addSetting;
@@ -291,7 +201,7 @@
     QGVAR(holsterRequired),
     "LIST",
     [LSTRING(HolsterRequired_DisplayName), LSTRING(HolsterRequired_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [LSTRING(Category_Treatment), ELSTRING(common,Basic)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Disabled), LSTRING(HolsterRequired_Lowered), LSTRING(HolsterRequired_LoweredExam), LSTRING(HolsterRequired_Holstered), LSTRING(HolsterRequired_HolsteredExam)], 0],
     true
 ] call CBA_fnc_addSetting;
@@ -300,7 +210,7 @@
     QGVAR(allowLitterCreation),
     "CHECKBOX",
     [LSTRING(AllowLitterCreation_DisplayName), LSTRING(AllowLitterCreation_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Litter)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Litter)],
     true,
     true
 ] call CBA_fnc_addSetting;
@@ -309,7 +219,7 @@
     QGVAR(maxLitterObjects),
     "LIST",
     [LSTRING(MaxLitterObjects_DisplayName), LSTRING(MaxLitterObjects_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Litter)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Litter)],
     [[50, 100, 200, 300, 400, 500, 1000, 2000, 3000, 4000, 5000], [/* settings function will auto create names */], 5],
     true
 ] call CBA_fnc_addSetting;
@@ -318,7 +228,242 @@
     QGVAR(litterCleanupDelay),
     "SLIDER",
     [LSTRING(LitterCleanupDelay_DisplayName), LSTRING(LitterCleanupDelay_Description)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Litter)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Litter)],
     [-1, 3600, 600, 0],
+    true
+] call CBA_fnc_addSetting;
+
+//"tweaks" are more advanced settings that most users will ignore
+[
+    QGVAR(treatmentTimeAutoinjector),
+    "SLIDER",
+    [LSTRING(TreatmentTimeAutoinjector_DisplayName), LSTRING(TreatmentTimeAutoinjector_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeAutoinjectorMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeAutoinjectorMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeAutoinjectorMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeAutoinjectorMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeTourniquet),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTourniquet_DisplayName), LSTRING(TreatmentTimeTourniquet_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 7, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeTourniquetMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTourniquetMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeTourniquetMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTourniquetMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeSplint),
+    "SLIDER",
+    [LSTRING(TreatmentTimeSplint_DisplayName), LSTRING(TreatmentTimeSplint_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 7, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeSplintMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeSplintMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeSplintMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeSplintMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeBodyBag),
+    "SLIDER",
+    [LSTRING(TreatmentTimeBodyBag_DisplayName), LSTRING(TreatmentTimeBodyBag_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 15, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeBodyBagMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeBodyBagMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeBodyBagMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeBodyBagMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(timeCoefficientPAK),
+    "SLIDER",
+    [LSTRING(TimeCoefficientPAK_DisplayName), LSTRING(TimeCoefficientPAK_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimePAKMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimePAKMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimePAKMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimePAKMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(woundStitchTime),
+    "SLIDER",
+    [LSTRING(WoundStitchTime_DisplayName), LSTRING(WoundStitchTime_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeStitchMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeStitchMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeStitchMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeStitchMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeIV),
+    "SLIDER",
+    [LSTRING(TreatmentTimeIV_DisplayName), LSTRING(TreatmentTimeIV_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 12, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeIVMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeIVMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeIVMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeIVMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(cprSuccessChanceMin),
+    "SLIDER",
+    [LSTRING(CPRSuccessChanceMin_DisplayName), LSTRING(CPRSuccessChanceMin_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 1, 0.4, 2, true],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(cprSuccessChanceMax),
+    "SLIDER",
+    [LSTRING(CPRSuccessChanceMax_DisplayName), LSTRING(CPRSuccessChanceMax_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 1, 0.4, 2, true],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeCPR),
+    "SLIDER",
+    [LSTRING(TreatmentTimeCPR_DisplayName), LSTRING(TreatmentTimeCPR_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0.1, 60, 15, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeCPRMultMedic),
+    "SLIDER",
+    [LSTRING(TreatmentTimeCPRMultMedic_DisplayName), LSTRING(TreatmentTimeMultMedic_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeCPRMultDoctor),
+    "SLIDER",
+    [LSTRING(TreatmentTimeCPRMultDoctor_DisplayName), LSTRING(TreatmentTimeMultDoctor_Description)],
+    [LSTRING(Category_Treatment), LSTRING(SubCategory_Tweaks)],
+    [0, 5, 1, 1],
     true
 ] call CBA_fnc_addSetting;

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Medical_Treatment">
+        <Key ID="STR_ACE_Medical_Treatment_Category_Treatment">
+            <English>ACE Medical - Treatment</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_SubCategory_Tweaks">
+            <English>Tweaks</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_SubCategory_Treatment">
             <English>Treatment</English>
             <German>Behandlung</German>
@@ -319,6 +325,18 @@
             <Chinesesimp>使用自动注射器给药所需的时间（秒）</Chinesesimp>
             <Korean>초 단위로 주사기를 사용하는데 걸리는 시간을 정합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeAutoinjectorMultMedic_DisplayName">
+            <English>Autoinjector Treatment Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeAutoinjectorMultDoctor_DisplayName">
+            <English>Autoinjector Treatment Time Multiplier (Doctor)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeMultMedic_Description">
+            <English>Multiplier applied to treatment time for medics (not doctors).</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeMultDoctor_Description">
+            <English>Multiplier applied to treatment time for doctors.</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquet_DisplayName">
             <English>Tourniquet Treatment Time</English>
             <French>Durée d'interaction - Garrots</French>
@@ -340,6 +358,12 @@
             <Polish>Czas w sekundach potrzebny do założenia/zdjęcia stazy.</Polish>
             <Chinesesimp>使用/移除止血带所需的时间（秒）</Chinesesimp>
             <Korean>초 단위로 지혈대를 사용/제거하는 데 걸리는 시간을 정합니다.</Korean>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquetMultMedic_DisplayName">
+            <English>Tourniquet Treatment Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquetMultDoctor_DisplayName">
+            <English>Tourniquet Treatment Time Multiplier (Doctor)</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIV_DisplayName">
             <English>IV Bag Treatment Time</English>
@@ -363,6 +387,12 @@
             <Chinesesimp>使用静脉输液所需的时间（秒）</Chinesesimp>
             <Korean>초 단위로 수액용기를 사용하는 데 걸리는 시간을 정합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIVMultMedic_DisplayName">
+            <English>IV Bag Treatment Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeIVMultDoctor_DisplayName">
+            <English>IV Bag Treatment Time Multiplier (Doctor)</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplint_DisplayName">
             <English>Splint Treatment Time</English>
             <French>Durée d'interaction - Attelles</French>
@@ -385,6 +415,12 @@
             <Chinesesimp>使用夹板所需的时间（秒）</Chinesesimp>
             <Korean>초 단위로 부목을 사용하는데 걸리는 시간을 정합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplintMultMedic_DisplayName">
+            <English>Splint Treatment Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplintMultDoctor_DisplayName">
+            <English>Splint Treatment Time Multiplier (Doctor)</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodyBag_DisplayName">
             <English>Body Bag Use Time</English>
             <French>Durée d'interaction - Housses mortuaires</French>
@@ -406,6 +442,12 @@
             <Polish>Czas w sekundach potrzebny na spakowanie ciała do worka na ciało.</Polish>
             <Chinesesimp>装入裹尸袋时间</Chinesesimp>
             <Korean>초 단위로 시체 운반용 부대를 사용하는데 걸리는 시간을 정합니다.</Korean>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodybagMultMedic_DisplayName">
+            <English>Body Bag Use Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodybagMultDoctor_DisplayName">
+            <English>Body Bag Use Time Multiplier (Doctor)</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicEpinephrine_DisplayName">
             <English>Allow Epinephrine</English>
@@ -631,6 +673,12 @@
             <Spanish>Modifica el tiempo que tarda en aplicarse un EPA. \n El tiempo de tratamiento se basa en el daño total de la parte del cuerpo multiplicado por este coeficiente, con un mínimo de 10 segundos.</Spanish>
             <Korean>개인응급키트를 사용하는데 걸리는 시간의 계수을 정합니다.\n최소 10초를 기준으로 몸 전체 피해량과 계수를 합산하여 계산합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimePAKMultMedic_DisplayName">
+            <English>PAK Treatment Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimePAKMultDoctor_DisplayName">
+            <English>PAK Treatment Time Multiplier (Doctor)</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicSurgicalKit_DisplayName">
             <English>Allow Surgical Kit</English>
             <Japanese>縫合キットを許可</Japanese>
@@ -776,6 +824,12 @@
             <German>Zeit in Sekunden, um eine einzelne Wunde zu nähen.</German>
             <Chinesesimp>缝合一个伤口所需的时间（秒）</Chinesesimp>
             <Korean>초 단위로, 한 상처를 봉합하는데 걸리는 시간을 설정합니다.</Korean>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeStitchMultMedic_DisplayName">
+            <English>Wound Stitch Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeStitchMultDoctor_DisplayName">
+            <English>Wound Stitch Time Multiplier (Doctor)</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AllowSelfIV_DisplayName">
             <English>Self IV Transfusion</English>
@@ -1158,6 +1212,12 @@
             <German>Zeit in Sekunden, die benötigt wird, um eine HLW durzuführen.</German>
             <Chinesesimp>对伤员实施心肺复苏所需的时间（秒）</Chinesesimp>
             <Korean>초 단위로, 심폐소생술을 진행하는 시간을 결정합니다.</Korean>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPRMultMedic_DisplayName">
+            <English>CPR Treatment Time Multiplier (Medic)</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeCPRMultDoctor_DisplayName">
+            <English>CPR Treatment Time Multiplier (Doctor)</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_HolsterRequired_DisplayName">
             <English>Holster Required</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add multipliers to treatment time based on medic level for all treatments whose base time is currently configurable
- Move medical_treatment settings to their own category, as the other was getting a bit full
- Move treatment time settings to a "tweaks" subcategory for tidiness
- No change to bandages yet but I'd like to include them

I'm torn on whether it makes more sense to have one category for the whole component like this, or separate _all_ the medical settings into a normal and "advanced" category for all this fine-grained stuff that most people won't bother changing.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
