### PR TITLE
Field Rations - Basic CfgMagazines support

### DIFF
--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -89,7 +89,8 @@ if !(hasInterface) exitWith {};
         ],
         {
             params ["_unit", "", "_item"];
-            [objNull, _unit, _item] call FUNC(consumeItem);
+            private _itemConfig = configFile >> "CfgWeapons" >> _item;
+            [objNull, _unit, [_item, _itemConfig, false]] call FUNC(consumeItem);
             false
         }
     ] call CBA_fnc_addItemContextMenuOption;

--- a/addons/field_rations/functions/fnc_canRefillItem.sqf
+++ b/addons/field_rations/functions/fnc_canRefillItem.sqf
@@ -17,12 +17,16 @@
  * Public: No
  */
 
-params ["_source", "_player", "_item"];
+params ["_source", "_player", "_itemData"];
+_itemData params ["_item", "_itemConfig", "_isMagazine"];
 
 alive _source
 && {XGVAR(waterSourceActions) != 0}
-&& {_item in (_player call EFUNC(common,uniqueItems))}
+&& {
+    (_isMagazine && {_item in magazines _player})
+    || {_item in (_player call EFUNC(common,uniqueItems))}
+}
 && {
     private _water = _source call FUNC(getRemainingWater);
-    _water == REFILL_WATER_INFINITE || {_water >= getNumber (configFile >> "CfgWeapons" >> _item >> QXGVAR(refillAmount))}
+    _water == REFILL_WATER_INFINITE || {_water >= getNumber (_itemConfig >> QXGVAR(refillAmount))}
 }

--- a/addons/field_rations/functions/fnc_canRefillItem.sqf
+++ b/addons/field_rations/functions/fnc_canRefillItem.sqf
@@ -6,13 +6,16 @@
  * Arguments:
  * 0: Water source <OBJECT>
  * 1: Player <OBJECT>
- * 2: Item classname <STRING>
+ * 2: Item data <ARRAY>
+ *    0: Item classname <STRING>
+ *    1: Item config <CONFIG>
+ *    2: Is item magazine <BOOL>
  *
  * Return Value:
  * Can refill item <BOOL>
  *
  * Example:
- * [_source, _player, "ACE_WaterBottle_Empty"] call ace_field_rations_fnc_canRefillItem
+ * [_source, _player, ["ACE_WaterBottle_Empty", configFile >> "CfgWeapons" >> "ACE_WaterBottle_Empty", false]] call ace_field_rations_fnc_canRefillItem
  *
  * Public: No
  */

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -6,13 +6,16 @@
  * Arguments:
  * 0: Target (not used) <OBJECT>
  * 1: Player <OBJECT>
- * 2: Item classname <STRING>
+ * 2: Item data <ARRAY>
+ *    0: Item classname <STRING>
+ *    1: Item config <CONFIG>
+ *    2: Is item magazine <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [objNull, ACE_player, "ACE_WaterBottle"] call ace_field_rations_fnc_consumeItem
+ * [objNull, ACE_player, "["ACE_WaterBottle_Empty", configFile >> "CfgWeapons" >> "ACE_WaterBottle_Empty", false]] call ace_field_rations_fnc_consumeItem
  *
  * Public: No
  */

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -24,7 +24,7 @@ params ["", "_player", "_consumeData"];
 _consumeData params ["_consumeItem", "_config", ["_isMagazine", false]];
 // backward compatiblity
 if (isNil "_config") then {
-    WARNING_1("No config specified, falling back to CfgWeapons",_consumeItem);
+    WARNING_1("No config specified, falling back to CfgWeapons - %1",_consumeItem);
     _config = configFile >> "CfgWeapons" >> _consumeItem;
 };
 

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -21,7 +21,13 @@
  */
 
 params ["", "_player", "_consumeData"];
-_consumeData params ["_consumeItem", "_config", "_isMagazine"];
+_consumeData params ["_consumeItem", "_config", ["_isMagazine", false]];
+// backward compatiblity
+if (isNil "_config") then {
+    WARNING_1("No config specified, falling back to CfgWeapons",_consumeItem);
+    _config = configFile >> "CfgWeapons" >> _consumeItem;
+};
+
 TRACE_3("Consume item started",_player,_consumeItem,_config);
 
 // Get consume time for item

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -17,10 +17,9 @@
  * Public: No
  */
 
-params ["", "_player", "_consumeItem"];
-TRACE_2("Consume item started",_player,_consumeItem);
-
-private _config = configFile >> "CfgWeapons" >> _consumeItem;
+params ["", "_player", "_consumeData"];
+_consumeData params ["_consumeItem", "_config", "_isMagazine"];
+TRACE_3("Consume item started",_player,_consumeItem,_config);
 
 // Get consume time for item
 private _consumeTime = getNumber (_config >> QXGVAR(consumeTime));
@@ -70,11 +69,15 @@ private _soundPlayed = if (_consumeAnim != "" && {vehicle _player == _player && 
 
 private _fnc_onSuccess = {
     params ["_args"];
-    _args params ["_player", "_consumeItem", "_replacementItem", "_thirstQuenched", "_hungerSatiated"];
+    _args params ["_player", "_consumeItem", "_replacementItem", "_thirstQuenched", "_hungerSatiated", "", "", "", "_isMagazine"];
     TRACE_1("Consume item successful",_args);
 
     // Remove consumed item
-    _player removeItem _consumeItem;
+    if (_isMagazine) then {
+        _player removeMagazineGlobal _consumeItem;
+    } else {
+        _player removeItem _consumeItem;
+    };
 
     // Add replacement item if needed
     if (_replacementItem != "") then {
@@ -92,7 +95,7 @@ private _fnc_onSuccess = {
         _player setVariable [QXGVAR(hunger), (_hunger - _hungerSatiated) max 0];
     };
 
-    ["acex_rationConsumed", [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated]] call CBA_fnc_localEvent;
+    ["acex_rationConsumed", [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated, _isMagazine]] call CBA_fnc_localEvent;
 
     _player setVariable [QGVAR(previousAnim), nil];
 };
@@ -115,7 +118,7 @@ private _fnc_onFailure = {
 
 private _fnc_condition = {
     params ["_args"];
-    _args params ["_player", "_consumeItem", "", "", "", "_consumeAnim", "_consumeSound", "_soundPlayed"];
+    _args params ["_player", "_consumeItem", "", "", "", "_consumeAnim", "_consumeSound", "_soundPlayed", "_isMagazine"];
 
     // Attempt to sync sound with animation start
     if (!_soundPlayed && {_consumeSound != "" && {_consumeAnim == "" || {animationState _player == _consumeAnim}}}) then {
@@ -123,7 +126,10 @@ private _fnc_condition = {
         _args set [7, true];
     };
 
-    _consumeItem in (_player call EFUNC(common,uniqueItems))
+    if (_isMagazine) exitWith {
+        _consumeItem in magazines _player // return
+    };
+    _consumeItem in (_player call EFUNC(common,uniqueItems)) // return
 };
 
 [
@@ -136,7 +142,8 @@ private _fnc_condition = {
         _hungerSatiated,
         _consumeAnim,
         _consumeSound,
-        _soundPlayed
+        _soundPlayed,
+        _isMagazine
     ],
     _fnc_onSuccess,
     _fnc_onFailure,

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -21,13 +21,7 @@
  */
 
 params ["", "_player", "_consumeData"];
-_consumeData params ["_consumeItem", "_config", ["_isMagazine", false]];
-// backward compatiblity
-if (isNil "_config") then {
-    WARNING_1("No config specified, falling back to CfgWeapons - %1",_consumeItem);
-    _config = configFile >> "CfgWeapons" >> _consumeItem;
-};
-
+_consumeData params ["_consumeItem", "_config", "_isMagazine"];
 TRACE_3("Consume item started",_player,_consumeItem,_config);
 
 // Get consume time for item

--- a/addons/field_rations/functions/fnc_getConsumableChildren.sqf
+++ b/addons/field_rations/functions/fnc_getConsumableChildren.sqf
@@ -22,18 +22,26 @@ private _fnc_getActions = {
 
     private _actions = [];
     private _cfgWeapons = configFile >> "CfgWeapons";
+    private _cfgMagazines = configFile >> "CfgMagazines";
 
     {
-        private _config = _cfgWeapons >> _x;
-        if (getNumber (_config >> QXGVAR(thirstQuenched)) > 0 || {getNumber (_config >> QXGVAR(hungerSatiated)) > 0}) then {
-            private _displayName = getText (_config >> "displayName");
-            private _picture = getText (_config >> "picture");
+        _x params ["_config", "_items"];
+        private _isMagazine = _config == _cfgMagazines;
+        {
+            private _itemConfig = _config >> _x;
+            if (getNumber (_itemConfig >> QXGVAR(thirstQuenched)) > 0 || {getNumber (_itemConfig >> QXGVAR(hungerSatiated)) > 0}) then {
+                private _displayName = getText (_itemConfig >> "displayName");
+                private _picture = getText (_itemConfig >> "picture");
 
-            // Exec next frame so closing interaction menu doesn't block progressBar
-            private _action = [_x, _displayName, _picture, {[FUNC(consumeItem), _this] call CBA_fnc_execNextFrame}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
-            _actions pushBack [_action, [], _player];
-        };
-    } forEach (_player call EFUNC(common,uniqueItems));
+                // Exec next frame so closing interaction menu doesn't block progressBar
+                private _action = [_x, _displayName, _picture, {[FUNC(consumeItem), _this] call CBA_fnc_execNextFrame}, {true}, {}, [_x, _itemConfig, _isMagazine]] call EFUNC(interact_menu,createAction);
+                _actions pushBack [_action, [], _player];
+            };
+        } forEach _items;
+    } forEach [
+        [_cfgWeapons, _player call EFUNC(common,uniqueItems)],
+        [_cfgMagazines, [magazines _player] call EFUNC(common,uniqueElements)]
+    ];
 
     _actions
 };

--- a/addons/field_rations/functions/fnc_getRefillChildren.sqf
+++ b/addons/field_rations/functions/fnc_getRefillChildren.sqf
@@ -24,15 +24,23 @@ if (_water == 0 || {_water == REFILL_WATER_DISABLED}) exitWith {[]};
 
 private _actions = [];
 private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
 
 {
-    private _config = _cfgWeapons >> _x;
-    if (getText (_config >> QXGVAR(refillItem)) != "" && {_water == REFILL_WATER_INFINITE || {getNumber (_config >> QXGVAR(refillAmount)) <= _water}}) then {
-        private _displayName = format ["%1: %2", LLSTRING(Refill), getText (_config >> "displayName")];
-        private _picture = getText (_config >> "picture");
-        private _action = [_x, _displayName, _picture, FUNC(refillItem), FUNC(canRefillItem), {}, _x] call EFUNC(interact_menu,createAction);
-        _actions pushBack [_action, [], _source];
-    };
-} forEach (_player call EFUNC(common,uniqueItems));
+    _x params ["_config", "_items"];
+    private _isMagazine = _config == _cfgMagazines;
+    {
+        private _itemConfig = _config >> _x;
+        if (getText (_itemConfig >> QXGVAR(refillItem)) != "" && {_water == REFILL_WATER_INFINITE || {getNumber (_itemConfig >> QXGVAR(refillAmount)) <= _water}}) then {
+            private _displayName = format ["%1: %2", LLSTRING(Refill), getText (_itemConfig >> "displayName")];
+            private _picture = getText (_itemConfig >> "picture");
+            private _action = [_x, _displayName, _picture, FUNC(refillItem), FUNC(canRefillItem), {}, [_x, _itemConfig, _isMagazine]] call EFUNC(interact_menu,createAction);
+            _actions pushBack [_action, [], _source];
+        };
+    } forEach _items;
+} forEach [
+    [_cfgWeapons, _player call EFUNC(common,uniqueItems)],
+    [_cfgMagazines, [magazines _player] call EFUNC(common,uniqueElements)]
+];
 
 _actions

--- a/addons/field_rations/functions/fnc_refillItem.sqf
+++ b/addons/field_rations/functions/fnc_refillItem.sqf
@@ -17,10 +17,9 @@
  * Public: No
  */
 
-params ["_source", "_player", "_item"];
+params ["_source", "_player", "_itemData"];
+_itemData params ["_item", "_config", "_isMagazine"];
 TRACE_3("Item refill started",_source,_player,_item);
-
-private _config = configFile >> "CfgWeapons" >> _item;
 
 // Get config values for refill
 private _refillItem = getText (_config >> QXGVAR(refillItem));
@@ -29,11 +28,15 @@ private _refillTime = getNumber (_config >> QXGVAR(refillTime));
 
 private _fnc_onSuccess = {
     params ["_args"];
-    _args params ["_source", "_player", "_item", "_refillItem", "_refillAmount"];
+    _args params ["_source", "_player", "_item", "_refillItem", "_refillAmount", "_isMagazine"];
     TRACE_1("Refill item successful",_args);
 
     // Replace item with refilled one
-    _player removeItem _item;
+    if (_isMagazine) then {
+        _player removeMagazineGlobal _item;
+    } else {
+        _player removeItem _item;
+    };
     [_player, _refillItem] call EFUNC(common,addToInventory);
 
     // Update remaining water in source
@@ -43,7 +46,7 @@ private _fnc_onSuccess = {
         [_source, _waterInSource] call FUNC(setRemainingWater);
     };
 
-    ["acex_rationRefilled", [_source, _player, _item, _refillItem, _refillAmount]] call CBA_fnc_localEvent;
+    ["acex_rationRefilled", [_source, _player, _item, _refillItem, _refillAmount, _isMagazine]] call CBA_fnc_localEvent;
 
     // Show refilled item hint
     private _picture = getText (configFile >> "CfgWeapons" >> _refillItem >> "picture");
@@ -66,7 +69,8 @@ private _fnc_condition = {
         _player,
         _item,
         _refillItem,
-        _refillAmount
+        _refillAmount,
+        _isMagazine
     ],
     _fnc_onSuccess,
     _fnc_onFailure,

--- a/addons/field_rations/functions/fnc_refillItem.sqf
+++ b/addons/field_rations/functions/fnc_refillItem.sqf
@@ -31,7 +31,8 @@ private _refillTime = getNumber (_config >> QXGVAR(refillTime));
 
 private _fnc_onSuccess = {
     params ["_args"];
-    _args params ["_source", "_player", "_item", "_refillItem", "_refillAmount", "_isMagazine"];
+    _args params ["_source", "_player", "_itemData", "_refillItem", "_refillAmount", "_itemData"];
+    _itemData params ["_item", "", "_isMagazine"];
     TRACE_1("Refill item successful",_args);
 
     // Replace item with refilled one
@@ -70,10 +71,9 @@ private _fnc_condition = {
     [
         _source,
         _player,
-        _item,
+        _itemData,
         _refillItem,
-        _refillAmount,
-        _isMagazine
+        _refillAmount
     ],
     _fnc_onSuccess,
     _fnc_onFailure,

--- a/addons/field_rations/functions/fnc_refillItem.sqf
+++ b/addons/field_rations/functions/fnc_refillItem.sqf
@@ -6,13 +6,16 @@
  * Arguments:
  * 0: Water source <OBJECT>
  * 1: Player <OBJECT>
- * 2: Item classname <STRING>
+ * 2: Item data <ARRAY>
+ *    0: Item classname <STRING>
+ *    1: Item config <CONFIG>
+ *    2: Is item magazine <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * [_source, _player, "ACE_WaterBottle_Empty"] call ace_field_rations_fnc_refillItem
+ * [_source, _player, ["ACE_WaterBottle_Empty", configFile >> "CfgWeapons" >> "ACE_WaterBottle_Empty", false]] call ace_field_rations_fnc_refillItem
  *
  * Public: No
  */

--- a/docs/wiki/framework/field-rations-framework.md
+++ b/docs/wiki/framework/field-rations-framework.md
@@ -45,8 +45,8 @@ Config Name | Type | Description
 
 Event Name | Passed Parameter(s) | Locality | Description
 ---------- | ------------------- | -------- | -----------
-`acex_rationConsumed` | [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated] | Local | Item consumed
-`acex_rationRefilled` | [_source, _player, _item, _refillItem, _refillAmount] | Local | Item refilled
+`acex_rationConsumed` | [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated, _isMagazine] | Local | Item consumed
+`acex_rationRefilled` | [_source, _player, _item, _refillItem, _refillAmount, _isMagazine] | Local | Item refilled
 
 ## 3. Scripting
 


### PR DESCRIPTION
**When merged this pull request will:**
- Basic support of CfgMagazine items for field rations
- No additional features

Adding this so I can use CfgMagazines SOG:PF food props with field rations. In the future, the system could be expanded with the feature of refilling/draining the magazine "rounds" (eg. SOG:PF food mags have 100 "rounds" each)