### PR TITLE
Goggles - Fix APR and Regulator mask overlays being flipped

### DIFF
--- a/addons/goggles/config.cpp
+++ b/addons/goggles/config.cpp
@@ -235,12 +235,15 @@ class CfgGlasses {
         ACE_OverlayCracked = "";
         ACE_Resistance = 2;
         ACE_Protection = 1;
+        ACE_Overlay_Angle = 180;
     };
     class G_AirPurifyingRespirator_02_base_F: G_AirPurifyingRespirator_01_base_F {
         ACE_Overlay = "a3\ui_f_enoch\data\objects\data\optics_APR_02_CA.paa";
     };
     class G_RegulatorMask_base_F: None {
         ACE_Overlay = "a3\ui_f_enoch\data\objects\data\optics_regulator_ca.paa";
+        ACE_OverlayCracked = "";
+        ACE_Overlay_Angle = 180;
     };
 };
 

--- a/addons/goggles/functions/fnc_applyGlassesEffect.sqf
+++ b/addons/goggles/functions/fnc_applyGlassesEffect.sqf
@@ -44,10 +44,16 @@ if (_postProcessTintAmount != 0 && {GVAR(UsePP)} && GVAR(effects) in [1, 2]) the
 };
 
 private _imagePath = getText (_config >> ["ACE_Overlay", "ACE_OverlayCracked"] select GETBROKEN);
+private _angle = getNumber (_config >> "ACE_Overlay_Angle");
 
 if (_imagePath != "") then {
     GVAR(GogglesLayer) cutRsc ["RscACE_Goggles", "PLAIN", 1, false];
-    (GLASSDISPLAY displayCtrl 10650) ctrlSetText _imagePath;
+    private _overlay = (GLASSDISPLAY displayCtrl 10650);
+    _overlay ctrlSetText _imagePath;
+
+    if ((_angle != 0) && {((ctrlAngle _overlay) # 0) != _angle}) then {
+        _overlay ctrlSetAngle [_angle, 0.5, 0.5, true];
+    };
 };
 
 if (GVAR(effects) in [2, 3]) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Flip the Enoch `G_AirPurifyingRespirator_*` and `G_RegulatorMask_F` overlays according to their `RcsTitles` angle

Close https://github.com/acemod/ACE3/issues/8127