### PR TITLE
Docs/Cargo - Include missing "unload type" param

### DIFF
--- a/docs/wiki/framework/cargo-framework.md
+++ b/docs/wiki/framework/cargo-framework.md
@@ -50,7 +50,7 @@ class CfgVehicles {
 Event Name | Passed Parameter(s) | Locality | Description
 ---------- | ----------- | ------------------- | --------
 `ace_cargoLoaded` | [_item, _vehicle] | Global | Cargo has been Loaded into vehicle
-`ace_cargoUnloaded` | [_item, _vehicle] | Global | Cargo has been Unloaded from vehicle
+`ace_cargoUnloaded` | [_item, _vehicle, _unloadType] | Global | Cargo has been Unloaded from vehicle
 `ace_cargoRemoved` | [_itemClass, _vehicle, _amountRequested, _amountRemoved] | Global | Cargo has been removed (deleted) from vehicle
 
 ## 3. Editor Attributes

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -57,7 +57,7 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 |----------|---------|---------|---------|---------|---------|
 |`ace_addCargo` | [_item (CLASSNAME or OBJECT), _vehicle, _cargoCount] | Target | Callable | Scripted way to add cargo to vehicle
 |`ace_cargoLoaded` | [_item, _vehicle] | Global | Listen | Cargo has been Loaded into vehicle
-|`ace_cargoUnloaded` | [_item, _vehicle] | Global | Listen | Cargo has been Unloaded from vehicle
+|`ace_cargoUnloaded` | [_item, _vehicle, _unloadType] | Global | Listen | Cargo has been Unloaded from vehicle
 
 ### 2.5 Captives (`ace_captives`)
 


### PR DESCRIPTION
**When merged this pull request will:**
- Added missing "unload type" param from the Cargo Framework documentation.