### PR TITLE
Arsenal - Show attached objects in arsenal mission

### DIFF
--- a/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
@@ -27,7 +27,7 @@ cba_diagnostic_projectileMaxLines = 10;
     {
         _x enableSimulation false;
         _x hideObject true;
-    } forEach (allMissionObjects "" - [_player]);
+    } forEach (allMissionObjects "" - [_player] - attachedObjects _player);
 
     if ((_player getVariable ["cba_projectile_firedEhId", -1]) != -1) then {
         _player call CBA_fnc_removeUnitTrackProjectiles;


### PR DESCRIPTION
**When merged this pull request will:**
- Shows attached objects when in the ACE Arsenal mission

Allows mods like <https://github.com/gruppe-adler/grad_slingHelmet/> using extended loadouts to appear correctly
