### PR TITLE
RHS AFRF Compat - Add hearing protection to 6M2 and 6B47

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgWeapons.hpp
+++ b/optionals/compat_rhs_afrf3/CfgWeapons.hpp
@@ -184,6 +184,18 @@ class CfgWeapons {
         HEARING_PROTECTION_EARMUFF
     };
 
+    class rhs_6b47;
+    class rhs_6b47_6m2: rhs_6b47 {
+        HEARING_PROTECTION_PELTOR
+    };
+    class rhs_6b47_6m2_1: rhs_6b47 {
+        HEARING_PROTECTION_PELTOR
+    };
+
+    class rhs_6m2: H_HelmetB {
+        HEARING_PROTECTION_PELTOR
+    };
+
     class rhs_weap_d81;
     class rhs_weap_2a70: rhs_weap_d81 { // "Low pressure" 100mm cannon
         ace_overpressure_range = 15;


### PR DESCRIPTION
**When merged this pull request will:**
- Add hearing protection to 6M2, 6M2-1, 6B47 (6M2) and 6B47 (6M2-1)

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
