### PR TITLE
Hearing - Fix: CBA Extended Loadouts do not catch earplugs server side

### DIFF
--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -1,5 +1,20 @@
 #include "script_component.hpp"
 
+["CBA_loadoutSet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
+        _unit setVariable ["ACE_hasEarPlugsIn", true, true];
+        [[true]] remoteExec [QFUNC(updateVolume), _unit];
+    };
+}] call CBA_fnc_addEventHandler;
+
+["CBA_loadoutGet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    if (_unit getVariable ["ACE_hasEarPlugsin", false]) then {
+        _extendedInfo set ["ace_earplugs", true]
+    };
+}] call CBA_fnc_addEventHandler;
+
 if (!hasInterface) exitWith {};
 
 GVAR(cacheAmmoLoudness) = call CBA_fnc_createNamespace;
@@ -78,19 +93,4 @@ GVAR(lastPlayerVehicle) = objNull;
 
     // Update protection on possible helmet change
     ["loadout", LINKFUNC(updateHearingProtection), false] call CBA_fnc_addPlayerEventHandler;
-}] call CBA_fnc_addEventHandler;
-
-["CBA_loadoutSet", {
-    params ["_unit", "_loadout", "_extendedInfo"];
-    if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
-        _unit setVariable ["ACE_hasEarPlugsIn", true, true];
-        [[true]] remoteExec [QFUNC(updateVolume), _unit];
-    };
-}] call CBA_fnc_addEventHandler;
-
-["CBA_loadoutGet", {
-    params ["_unit", "_loadout", "_extendedInfo"];
-    if (_unit getVariable ["ACE_hasEarPlugsin", false]) then {
-        _extendedInfo set ["ace_earplugs", true]
-    };
 }] call CBA_fnc_addEventHandler;

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -1,20 +1,5 @@
 #include "script_component.hpp"
 
-["CBA_loadoutSet", {
-    params ["_unit", "_loadout", "_extendedInfo"];
-    if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
-        _unit setVariable ["ACE_hasEarPlugsIn", true, true];
-        [[true]] remoteExec [QFUNC(updateVolume), _unit];
-    };
-}] call CBA_fnc_addEventHandler;
-
-["CBA_loadoutGet", {
-    params ["_unit", "_loadout", "_extendedInfo"];
-    if (_unit getVariable ["ACE_hasEarPlugsin", false]) then {
-        _extendedInfo set ["ace_earplugs", true]
-    };
-}] call CBA_fnc_addEventHandler;
-
 if (!hasInterface) exitWith {};
 
 GVAR(cacheAmmoLoudness) = call CBA_fnc_createNamespace;

--- a/addons/hearing/XEH_preInit.sqf
+++ b/addons/hearing/XEH_preInit.sqf
@@ -8,4 +8,19 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+["CBA_loadoutSet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
+        _unit setVariable ["ACE_hasEarPlugsIn", true, true];
+        [[true]] remoteExec [QFUNC(updateVolume), _unit];
+    };
+}] call CBA_fnc_addEventHandler;
+
+["CBA_loadoutGet", {
+    params ["_unit", "_loadout", "_extendedInfo"];
+    if (_unit getVariable ["ACE_hasEarPlugsin", false]) then {
+        _extendedInfo set ["ace_earplugs", true]
+    };
+}] call CBA_fnc_addEventHandler;
+
 ADDON = true;


### PR DESCRIPTION

**When merged this pull request will:**
- Add `CBA_loadoutSet` event and `CBA_loadoutGet` event server and player side

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
