### PR TITLE
Fastroping - Disable destruction for helper object

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -177,6 +177,7 @@ class CfgVehicles {
         author = "KoffeinFlummi";
         scope = 1;
         model = QPATHTOF(data\helper.p3d);
+        destrType = "DestructNo";
         class ACE_Actions {};
         class Turrets {};
         class TransportItems {};


### PR DESCRIPTION
**When merged this pull request will:**
- title, previously when the helper was destroyed it would create an explosion
