### PR TITLE
Cookoff - Delay full vehicle destruction

### DIFF
--- a/addons/cookoff/functions/fnc_cookOff.sqf
+++ b/addons/cookoff/functions/fnc_cookOff.sqf
@@ -16,7 +16,7 @@
  * Public: No
  */
 
-params ["_vehicle", "_intensity", ["_instigator", objNull], ["_smokeDelayEnabled", true], ["_ammoDetonationChance", 0], ["_detonateAfterCookoff", false], ["_fireSource", ""], ["_canRing", true], ["_canJet", true], ["_maxIntensity", MAX_COOKOFF_INTENSITY, [0]]];
+params ["_vehicle", "_intensity", ["_instigator", objNull], ["_smokeDelayEnabled", true], ["_ammoDetonationChance", 0], ["_detonateAfterCookoff", false], ["_fireSource", ""], ["_canRing", true], ["_maxIntensity", MAX_COOKOFF_INTENSITY, [0]], ["_canJet", true, [true]]];
 
 if (GVAR(enable) == 0) exitWith {};
 if !(GVAR(enableFire)) exitWith {};

--- a/addons/vehicle_damage/functions/fnc_handleCookoff.sqf
+++ b/addons/vehicle_damage/functions/fnc_handleCookoff.sqf
@@ -44,7 +44,8 @@ if (!_alreadyCookingOff && { _chanceOfFire >= random 1 }) exitWith {
         _source = ["hit_engine_point", "HitPoints"];
     };
 
-    [QEGVAR(cookOff,cookOff), [_vehicle, _intensity, _injurer, _delayWithSmoke, _fireDetonateChance, _detonateAfterCookoff, _source, _canRing, _canJet]] call CBA_fnc_localEvent;
+    // sending nil for _maxIntensity (9th param) to use default value in ace_cookoff_fnc_cookOff
+    [QEGVAR(cookOff,cookOff), [_vehicle, _intensity, _injurer, _delayWithSmoke, _fireDetonateChance, _detonateAfterCookoff, _source, _canRing, nil, _canJet]] call CBA_fnc_localEvent;
     _vehicle setVariable [QGVAR(cookingOff), true];
     LOG_4("Cooking-off [%1] with a chance-of-fire [%2] - Delayed Smoke | Detonate after cookoff [%3 | %4]",_vehicle,_chanceOfFire,_delayWithSmoke,_detonateAfterCookoff);
     [_vehicle] spawn FUNC(abandon);


### PR DESCRIPTION
**When merged this pull request will:**

- Delay final explosion.

<details>
<summary>Old description</summary>

- _Restricted cookoff jet/ring flame effects to a single execution_
- _After the cookoff jet/ring flame effects have finished a finale can happen (based on random roll) that results in catastrophic destruction of the vehicle (ex. https://youtu.be/qfldUOrXCGk)_
  - _Adds `Destruction Finale Chance` CBA setting to adjust the random roll chance of finale_
  - _Adds `ace_vehicle_damage_canHaveFinale` to disable feature via configs_

Depends upon https://github.com/acemod/ACE3/pull/9060
</details>