### PR TITLE
Quickmount - Fix teleport bug in UAV through change seat

### DIFF
--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -29,7 +29,7 @@ GVAR(enabled)
 }
 && {alive _vehicle}
 && {2 > locked _vehicle}
-&& {isnull getConnectedUAVUnit _unit}
+&& {isNull getConnectedUAVUnit _unit}
 && {simulationEnabled _vehicle}
 && {
     -1 == crew _vehicle findIf {alive _x}

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -29,6 +29,7 @@ GVAR(enabled)
 }
 && {alive _vehicle}
 && {2 > locked _vehicle}
+&& {isnull getConnectedUAVUnit _unit}
 && {simulationEnabled _vehicle}
 && {
     -1 == crew _vehicle findIf {alive _x}


### PR DESCRIPTION
**When merged this pull request will:**
- Fix an bug where you could teleport to an  UAV with an free seat, through the change seat action while controlling it with the UAV terminal (for example the UGV Stomper).  

### IMPORTANT
- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
