### PR TITLE
Cargo - Update VTOL Cargo sizes

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -265,11 +265,11 @@ class CfgVehicles {
     };
     class VTOL_Base_F;
     class VTOL_01_base_F: VTOL_Base_F {
-        GVAR(space) = 4;
+        GVAR(space) = 20;
         GVAR(hasCargo) = 1;
     };
     class VTOL_02_base_F: VTOL_Base_F {
-        GVAR(space) = 4;
+        GVAR(space) = 10;
         GVAR(hasCargo) = 1;
     };
 


### PR DESCRIPTION
- Updates both the V-44 Blackfish & Y-32 Xi'an VTOLs cargo sizes to fit the size of the vehicle.
- Blackfish is now at 20
- Xi'an is at 10.
Resolves #9031 
