### PR TITLE
Western Sahara Compatibility

### DIFF
--- a/optionals/compat_ws/$PBOPREFIX$
+++ b/optionals/compat_ws/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_ws

--- a/optionals/compat_ws/CfgWeapons.hpp
+++ b/optionals/compat_ws/CfgWeapons.hpp
@@ -1,0 +1,79 @@
+class CfgWeapons {
+    // AA40
+    class Rifle_Base_F;
+    class sgun_aa40_base_lxWS: Rifle_Base_F {
+        ACE_barrelLength = 457;
+        ACE_barrelTwist = 0.0;
+        ACE_twistDirection = 0;
+    };
+
+    // Galat Arm
+    class arifle_Galat_base_lxWS: Rifle_Base_F {
+        ACE_barrelLength = 535;
+        ACE_barrelTwist = 304.8;
+        ACE_twistDirection = 1;
+    };
+
+    // SA-77
+    class Rifle_Long_Base_F;
+    class LMG_S77_base_lxWS: Rifle_Long_Base_F {
+        ACE_barrelLength = 550;
+        ACE_barrelTwist = 304.8;
+        ACE_twistDirection = 1;
+    };
+    class LMG_S77_Compact_base_lxWS: LMG_S77_base_lxWS {
+        ACE_barrelLength = 500;
+        ACE_barrelTwist = 304.8;
+        ACE_twistDirection = 1;
+    };
+
+    // SLR
+    class DMR_06_base_F;
+    class arifle_SLR_lxWS: DMR_06_base_F {
+        ACE_barrelLength = 533;
+        ACE_barrelTwist = 279.4;
+        ACE_twistDirection = 1;
+    };
+
+    // Velko R4/R5
+    class arifle_Velko_base_lxWS: arifle_Galat_base_lxWS {
+        ACE_barrelLength = 460;
+        ACE_barrelTwist = 304.8;
+        ACE_twistDirection = 1;
+    };
+    class arifle_VelkoR5_lxWS: arifle_Velko_base_lxWS {
+        ACE_barrelLength = 332;
+        ACE_barrelTwist = 304.8;
+        ACE_twistDirection = 1;
+    };
+
+    // XMS
+    class arifle_SPAR_01_base_F;
+    class arifle_XMS_Base_lxWS: arifle_SPAR_01_base_F {
+        ACE_barrelLength = 406.4;
+        ACE_barrelTwist = 178.0;
+        ACE_twistDirection = 1;
+    };
+
+    // Headgear
+    // ION Cap (Headphones)
+    class lxWS_H_CapB_rvs_blk;
+    class lxWS_H_CapB_rvs_blk_ION: lxWS_H_CapB_rvs_blk {
+        ace_hearing_protection = 0.75;
+        ace_hearing_lowerVolume = 0.2;
+    };
+
+    // Tank helmet
+    class HelmetBase;
+    class lxWS_H_Tank_tan_F: HelmetBase {
+        ace_hearing_protection = 0.85;
+        ace_hearing_lowerVolume = 0.6;
+    };
+
+    // Headphones, inherited hearing protection
+    class H_Cap_headphones;
+    class lxWS_H_Headset: H_Cap_headphones {
+        ace_hearing_protection = 0;
+        ace_hearing_lowerVolume = 0;
+    };
+};

--- a/optionals/compat_ws/CfgWeapons.hpp
+++ b/optionals/compat_ws/CfgWeapons.hpp
@@ -47,7 +47,7 @@ class CfgWeapons {
         ACE_twistDirection = 1;
     };
 
-    // XMS
+    // XMS - Weird off-shoot from the XM8 rifles so there is no data for barrel lengths or twists. Used the vanilla CTAR as a baseline for the values.
     class arifle_SPAR_01_base_F;
     class arifle_XMS_Base_lxWS: arifle_SPAR_01_base_F {
         ACE_barrelLength = 406.4;

--- a/optionals/compat_ws/config.cpp
+++ b/optionals/compat_ws/config.cpp
@@ -6,11 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {
-            "Weapons_F_lxWS",
-            "Weapons_1_F_lxWS",
-            "Characters_f_lxWS_headgear"
-        };
+        requiredAddons[] = {"data_f_lxWS_Loadorder"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Mike"};
         url = ECSTRING(main,URL);

--- a/optionals/compat_ws/config.cpp
+++ b/optionals/compat_ws/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "Weapons_F_lxWS",
+            "Weapons_1_F_lxWS",
+            "Characters_f_lxWS_headgear"
+        };
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Mike"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/optionals/compat_ws/script_component.hpp
+++ b/optionals/compat_ws/script_component.hpp
@@ -1,0 +1,6 @@
+#define COMPONENT compat_ws
+#define COMPONENT_BEAUTIFIED Western Sahara Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add a compatibility addon for the Western Sahara CDLC
- Mostly just adds ballistics values to weapons and hearing protection to helmets that need it.

- Sidenote: the XMS rifles are a weird off-shoot of the XM8 rifles and there is no data to use for barrel lengths, compared to the vanilla CTAR it's around the same length barrel so the values are matched from that.
