### PR TITLE
Advanced Throwing - Add Throwing Arc Range setting

### DIFF
--- a/addons/advanced_throwing/functions/fnc_drawArc.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawArc.sqf
@@ -40,12 +40,14 @@ private _initialVelocity = (vectorNormalized (_viewEnd vectorDiff _viewStart)) v
 private _prevTrajASL = getPosASLVisual _activeThrowable;
 
 private _pathData = [];
+private _pathRange = GVAR(arcMaxDist);
+private _pathNodes = parseNumber ((GVAR(arcMaxDist) * 0.0725) toFixed 2);
 
-for "_i" from 0.05 to 1.45 step 0.1 do {
+for "_i" from 0.05 to _pathNodes step 0.1 do {
     private _newTrajASL = (getPosASLVisual _activeThrowable) vectorAdd (_initialVelocity vectorMultiply _i) vectorAdd ([0, 0, -4.9] vectorMultiply (_i * _i));
     private _cross = 0;
 
-    if (_newTrajASL distance (getPosASLVisual ACE_player) <= 20) then {
+    if (_newTrajASL distance (getPosASLVisual ACE_player) <= _pathRange) then {
         if ((ASLToATL _newTrajASL) select 2 <= 0) then {
             _cross = 1; // 1: Distance Limit (Green)
         } else {
@@ -59,8 +61,8 @@ for "_i" from 0.05 to 1.45 step 0.1 do {
             };
         };
 
-        private _iDim = linearConversion [20, 0, _newTrajASL distance (getPosASLVisual ACE_player), 0.3, 2.5, true];
-        private _alpha = linearConversion [20, 0, _newTrajASL distance (getPosASLVisual ACE_player), 0.05, 0.7, true];
+        private _iDim = linearConversion [_pathRange, 0, _newTrajASL distance (getPosASLVisual ACE_player), 0.3, 2.5, true];
+        private _alpha = linearConversion [_pathRange, 0, _newTrajASL distance (getPosASLVisual ACE_player), 0.05, 0.7, true];
         private _movePerc = linearConversion [3, 0, vectorMagnitude (velocity ACE_player), 0, 1, true];
         _alpha = _alpha * _movePerc;
 

--- a/addons/advanced_throwing/initSettings.sqf
+++ b/addons/advanced_throwing/initSettings.sqf
@@ -18,6 +18,15 @@ private _category = format ["ACE %1", localize LSTRING(Category)];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(arcMaxDist),
+    "SLIDER",
+    [LSTRING(ArcMaxDist_DisplayName), LSTRING(ArcMaxDist_Description)],
+    _category,
+    [1, 250, 20, 0],
+    0
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(showMouseControls), "CHECKBOX",
     [LSTRING(ShowMouseControls_DisplayName), LSTRING(ShowMouseControls_Description)],
     _category,

--- a/addons/advanced_throwing/initSettings.sqf
+++ b/addons/advanced_throwing/initSettings.sqf
@@ -23,7 +23,8 @@ private _category = format ["ACE %1", localize LSTRING(Category)];
     [LSTRING(ArcMaxDist_DisplayName), LSTRING(ArcMaxDist_Description)],
     _category,
     [1, 250, 20, 0],
-    0
+    0,
+    {[QGVAR(arcMaxDist), _this, true] call EFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/advanced_throwing/stringtable.xml
+++ b/addons/advanced_throwing/stringtable.xml
@@ -95,6 +95,12 @@
             <Portuguese>Permite a visualização do Arco de Arremesso por onde o objeto será jogado.</Portuguese>
             <Czech>Zapíná vizualizaci oblouku vrhu (kam bude předmět hozen).</Czech>
         </Key>
+        <Key ID="STR_ACE_Advanced_Throwing_ArcMaxDist_DisplayName">
+            <English>Throw Arc Distance</English>
+        </Key>
+        <Key ID="STR_ACE_Advanced_Throwing_ArcMaxDist_Description">
+            <English>Maximum distance the throw arc can project.</English>
+        </Key>
         <Key ID="STR_ACE_Advanced_Throwing_ShowMouseControls_DisplayName">
             <English>Show Throwing Mouse Controls</English>
             <Spanish>Mostrar controles de ratón de lanzamiento</Spanish>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a setting for the range the throwing arc displays.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
