### PR TITLE
Safety - Add optional flag to hide hint

### DIFF
--- a/addons/safemode/functions/fnc_lockSafety.sqf
+++ b/addons/safemode/functions/fnc_lockSafety.sqf
@@ -7,6 +7,7 @@
  * 0: Unit <OBJECT>
  * 1: Weapon <STRING>
  * 2: Muzzle <STRING>
+ * 3: Show hint <BOOL>
  *
  * Return Value:
  * None
@@ -17,7 +18,7 @@
  * Public: No
  */
 
-params ["_unit", "_weapon", "_muzzle"];
+params ["_unit", "_weapon", "_muzzle", "_hint"];
 
 private _safedWeapons = _unit getVariable [QGVAR(safedWeapons), []];
 
@@ -75,6 +76,9 @@ if (_muzzle isEqualType "") then {
 // play fire mode selector sound
 [_unit, _weapon, _muzzle] call FUNC(playChangeFiremodeSound);
 
-// show info box
-private _picture = getText (configFile >> "CfgWeapons" >> _weapon >> "picture");
-[localize LSTRING(PutOnSafety), _picture] call EFUNC(common,displayTextPicture);
+// show info box unless disabled
+if (_hint) then {
+    private _picture = getText (configFile >> "CfgWeapons" >> _weapon >> "picture");
+    [localize LSTRING(PutOnSafety), _picture] call EFUNC(common,displayTextPicture);
+};
+

--- a/addons/safemode/functions/fnc_lockSafety.sqf
+++ b/addons/safemode/functions/fnc_lockSafety.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_unit", "_weapon", "_muzzle", "_hint"];
+params ["_unit", "_weapon", "_muzzle", ["_hint", true, [true]]];
 
 private _safedWeapons = _unit getVariable [QGVAR(safedWeapons), []];
 

--- a/addons/safemode/functions/fnc_setWeaponSafety.sqf
+++ b/addons/safemode/functions/fnc_setWeaponSafety.sqf
@@ -7,7 +7,7 @@
  * 0: Unit <OBJECT>
  * 1: Weapon <STRING>
  * 2: State <BOOL>
- * 3: Show hint <BOOL> (Optional)
+ * 3: Show hint <BOOL> (default: true)
  *
  * Return Value:
  * None

--- a/addons/safemode/functions/fnc_setWeaponSafety.sqf
+++ b/addons/safemode/functions/fnc_setWeaponSafety.sqf
@@ -7,6 +7,7 @@
  * 0: Unit <OBJECT>
  * 1: Weapon <STRING>
  * 2: State <BOOL>
+ * 3: Show hint <BOOL> (Optional)
  *
  * Return Value:
  * None
@@ -20,7 +21,8 @@
 params [
     ["_unit", objNull, [objNull]],
     ["_weapon", "", [""]],
-    ["_state", true, [true]]
+    ["_state", true, [true]],
+    ["_hint", true, [true]]
 ];
 
 if (_weapon == "") exitWith {};
@@ -32,5 +34,5 @@ _weapon = configName (configFile >> "CfgWeapons" >> _weapon);
 private _muzzle = currentMuzzle _unit;
 
 if (_state isNotEqualTo (_weapon in _safedWeapons)) then {
-    [_unit, _weapon, _muzzle] call FUNC(lockSafety);
+    [_unit, _weapon, _muzzle, _hint] call FUNC(lockSafety);
 };

--- a/addons/safemode/functions/fnc_unlockSafety.sqf
+++ b/addons/safemode/functions/fnc_unlockSafety.sqf
@@ -7,6 +7,7 @@
  * 0: Unit <OBJECT>
  * 1: Weapon <STRING>
  * 2: Muzzle <STRING>
+ * 3: Show hint <BOOL>
  *
  * Return Value:
  * None
@@ -17,7 +18,7 @@
  * Public: No
  */
 
-params ["_unit", "_weapon", "_muzzle"];
+params ["_unit", "_weapon", "_muzzle", "_hint"];
 
 private _safedWeapons = _unit getVariable [QGVAR(safedWeapons), []];
 _safedWeapons deleteAt (_safedWeapons find _weapon);
@@ -77,6 +78,8 @@ if (inputAction "nextWeapon" > 0) then {
 // player hud
 [true] call FUNC(setSafeModeVisual);
 
-// show info box
-private _picture = getText (configFile >> "CfgWeapons" >> _weapon >> "picture");
-[localize LSTRING(TookOffSafety), _picture] call EFUNC(common,displayTextPicture);
+// show info box unless disabled
+if (_hint) then {
+    private _picture = getText (configFile >> "CfgWeapons" >> _weapon >> "picture");
+    [localize LSTRING(TookOffSafety), _picture] call EFUNC(common,displayTextPicture);
+};

--- a/addons/safemode/functions/fnc_unlockSafety.sqf
+++ b/addons/safemode/functions/fnc_unlockSafety.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_unit", "_weapon", "_muzzle", "_hint"];
+params ["_unit", "_weapon", "_muzzle", ["_hint", true, [true]]];
 
 private _safedWeapons = _unit getVariable [QGVAR(safedWeapons), []];
 _safedWeapons deleteAt (_safedWeapons find _weapon);


### PR DESCRIPTION
**When merged this pull request will:**
- Adds an optional flag (to public fnc) to suppress the hint for safety on/off

I figure a lot of peoples frameworks use this fnc to auto-safety weapons at game start and it's just one less pop up to have. It defaults to true and works with the arg omitted so shouldn't impact any existing missions or change current behaviour.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
