### PR TITLE
Refuel - Fix warnings when building with latest pboProject

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -38,7 +38,7 @@
                 icon = QPATHTOF(ui\icon_refuel_interact.paa); \
             }; \
         }; \
-    };
+    }
 
 class CBA_Extended_EventHandlers;
 
@@ -92,7 +92,7 @@ class CfgVehicles {
             class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
         };
 
-        MACRO_NOZZLE_ACTIONS
+        MACRO_NOZZLE_ACTIONS;
         displayName = QGVAR(fuelNozzle);
         scope = 1;
         scopeCurator = 1;

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -44,7 +44,6 @@ class CBA_Extended_EventHandlers;
 
 class CfgNonAIVehicles {
     class GVAR(fuelHoseSegment) {
-        access = 0;
         scope = 2;
         displayName = "Fuel Hose";
         simulation = "ropesegment";


### PR DESCRIPTION
**When merged this pull request will:**
- Fix macro and access property in refuel addon causing warnings with latest pboProject

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
