### PR TITLE
#9027 Gives back ability to put AI unconscious by shooting at limbs

### DIFF
--- a/addons/medical_damage/initSettings.sqf
+++ b/addons/medical_damage/initSettings.sqf
@@ -30,7 +30,7 @@
     "SLIDER",
     [LSTRING(PainUnconsciousChance_DisplayName), LSTRING(PainUnconsciousChance_Description)],
     ELSTRING(medical,Category),
-    [0, 1, 0.1, 2, true],
+    [0, 1, 0.3, 2, true],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -74,7 +74,7 @@
 
 // --- pain
 #define PAIN_UNCONSCIOUS EGVAR(medical,const_painUnconscious)
-#define PAIN_UNCONSCIOUS_DEFAULT 0.5
+#define PAIN_UNCONSCIOUS_DEFAULT 0.35
 
 // Pain fade out time (time it takes until pain is guaranteed to be completly gone)
 #define PAIN_FADE_TIME EGVAR(medical,const_painFadeTime)


### PR DESCRIPTION
Fix related to #9027 

**When merged this pull request will:**
- Gives back ability to put AI unconscious by shooting at limbs with painUnconsciousChance setting. 
- Change `ace_medical_const_painUnconscious `to 0.35 (from 0.5).
- Change default `painUnconsciousChance `to 0.3 (from 0.1) to add a little dose of variation.

TIP: If you want your AI to keep being limbs insensitive:
- Just set force `ace_medical_fatalDamageSource` to 0 (head and so called "heart") which is exactly the goal of that setting already.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [ ] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
