### PR TITLE
Parachute - Fix Broken Altimeter PerFrameHandler removal

### DIFF
--- a/addons/parachute/functions/fnc_showAltimeter.sqf
+++ b/addons/parachute/functions/fnc_showAltimeter.sqf
@@ -32,12 +32,12 @@ private _TimeText = _display displayCtrl 1001;
     _args params ["_unit", "_oldHeight", "_prevTime", "_HeightText", "_DecendRate", "_TimeText"];
 
     if !(GVAR(AltimeterActive)) exitWith {
-        _pfhID call CBA_fnc_removePerFrameEventHandler;
+        _pfhID call CBA_fnc_removePerFrameHandler;
     };
 
     if !("ACE_Altimeter" in assignedItems _unit) exitWith {
         call FUNC(hideAltimeter);
-        _pfhID call CBA_fnc_removePerFrameEventHandler;
+        _pfhID call CBA_fnc_removePerFrameHandler;
     };
 
     private _hour = floor daytime;


### PR DESCRIPTION
Bug fix
CBA_fnc_removePerFrameEventHandler was used to remove the calculations for the altimeter, but does not exist. Replaced with CBA_fnc_removePerFrameHandler to rectify this issue.

**When merged this pull request will:**
- Fix a bug with the perframehandler never being removed.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
