### PR TITLE
Dragging - Fix unknown DIK key in dragging code

### DIFF
--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -45,7 +45,7 @@ _unit setVariable [QGVAR(draggedObject), _target, true];
 // add drop action
 GVAR(unit) = _unit;
 
-GVAR(releaseActionID) = [0xF1, [false, false, false], {
+GVAR(releaseActionID) = [0x01, [false, false, false], {
     [GVAR(unit), GVAR(unit) getVariable [QGVAR(draggedObject), objNull]] call FUNC(dropObject);
 }, "keydown", "", false, 0] call CBA_fnc_addKeyHandler;
 


### PR DESCRIPTION
**When merged this pull request will:**
#7950 introduce a unknown DIK for dropping objects, this pr reassigns that value to be the Escape Key

