### PR TITLE
Arsenal - Fix non-local loop variable use in fnc_fillRightPanel.sqf

### DIFF
--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -65,12 +65,12 @@ private _fnc_fill_right_Container = {
     private _lbAdd = _ctrlPanel lnbAddRow ["", _displayName, "0"];
     private _columns = count lnbGetColumnsPosition _ctrlPanel;
 
-    _ctrlPanel lnbSetData [[_lbAdd, 0], _x];
+    _ctrlPanel lnbSetData [[_lbAdd, 0], _className];
     _ctrlPanel lnbSetPicture [[_lbAdd, 0], _picture];
     _ctrlPanel lnbSetValue [[_lbAdd, 0], _mass];
-    _ctrlPanel setVariable [_x, _mass];
+    _ctrlPanel setVariable [_className, _mass];
     _ctrlPanel lnbSetValue [[_lbAdd, 2], [0, 1] select (_isUnique)];
-    _ctrlPanel lbSetTooltip [_lbAdd * _columns,format ["%1\n%2", _displayName, _x]];
+    _ctrlPanel lbSetTooltip [_lbAdd * _columns,format ["%1\n%2", _displayName, _className]];
 };
 
 // Retrieve compatible mags

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -70,7 +70,7 @@ private _fnc_fill_right_Container = {
     _ctrlPanel lnbSetValue [[_lbAdd, 0], _mass];
     _ctrlPanel setVariable [_className, _mass];
     _ctrlPanel lnbSetValue [[_lbAdd, 2], [0, 1] select (_isUnique)];
-    _ctrlPanel lbSetTooltip [_lbAdd * _columns,format ["%1\n%2", _displayName, _className]];
+    _ctrlPanel lbSetTooltip [_lbAdd * _columns, format ["%1\n%2", _displayName, _className]];
 };
 
 // Retrieve compatible mags


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the use of the loop variable `_x` in a function and instead use the local variable holding the same value

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
