### PR TITLE
Documentation - Fixed wrong CBA location

### DIFF
--- a/docs/wiki/development/setting-up-the-development-environment.md
+++ b/docs/wiki/development/setting-up-the-development-environment.md
@@ -58,7 +58,7 @@ mklink /J "[Arma 3 installation folder]\z\ace" "[location of the ACE3 project]"
 mklink /J "P:\z\ace" "[location of the ACE3 project]"
 ```
 
-Then, copy the `cba` folder from the `tools` folder to `P:\x\cba`. Create the `x` folder if needed. That folder contains the parts of the CBA source code that are required for the macros to work.
+Then, copy the `cba` folder from the `include\x` folder to `P:\x\cba`. Create the `x` folder if needed. That folder contains the parts of the CBA source code that are required for the macros to work.
 
 
 ## 4.2 Creating a Test Build


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the wrong foldername that the CBA files are located in

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
