### PR TITLE
Zeus - Fix group players disembarking on garrison module

### DIFF
--- a/addons/zeus/functions/fnc_moduleGarrison.sqf
+++ b/addons/zeus/functions/fnc_moduleGarrison.sqf
@@ -51,7 +51,7 @@ switch (false) do {
 private _units = units _unit;
 // Make sure all units are disembarked
 {
-    if (vehicle _x != _x) then {
+    if (vehicle _x != _x && {!isPlayer _x}) then {
         moveOut _x;
     };
 } forEach _units;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix an edge case where garrisoning a group with player units would cause the players to involuntarily disembark their vehicles.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
