### PR TITLE
Medical Engine - Ignore Reflector Hitpoints

### DIFF
--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -13,6 +13,7 @@
     // Check if last hit point is our dummy.
     private _allHitPoints = getAllHitPointsDamage _unit param [0, []];
     reverse _allHitPoints;
+    while {(_allHitPoints param [0, ""]) select [0,1] == "#"} do { WARNING_1("Ignoring Reflector hitpoint %1", _allHitPoints deleteAt 0); };
 
     if (_allHitPoints param [0, ""] != "ACE_HDBracket") then {
         private _config = configOf _unit;


### PR DESCRIPTION
Issue:
```
class class CAManBase: Man {
  class Reflectors {
      class CustomLight_1 {
          hitpoint         = "Light";
```
will cause
```
getAllHitPointsDamage player param [0, []]; ->
[..."hitrightleg","ace_hdbracket","#light"]
```
and break medical completely, this pr should at least allow medical to add the EH and the results seem normal
But I'm not really sure if this is a good fix, I don't have much experience working with `class Reflectors`

