### PR TITLE
Refuel - Add events for fuel source and jerry can creation

### DIFF
--- a/addons/refuel/functions/fnc_initSource.sqf
+++ b/addons/refuel/functions/fnc_initSource.sqf
@@ -15,12 +15,14 @@
  * Public: No
  */
 
-if (!hasInterface) exitWith {};
-
 params ["_source"];
 TRACE_2("init",_source,typeOf _source);
 
-[_source, 0, ["ACE_MainActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
-{
-    [_source, 0, ["ACE_MainActions", QGVAR(Refuel)], _x] call EFUNC(interact_menu,addActionToObject);
-} forEach GVAR(actions);
+if (hasInterface) then {
+	[_source, 0, ["ACE_MainActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
+    {
+        [_source, 0, ["ACE_MainActions", QGVAR(Refuel)], _x] call EFUNC(interact_menu,addActionToObject);
+    } forEach GVAR(actions);
+};
+
+[QGVAR(fuelSourceInitialized), [_source]] call CBA_fnc_localEvent;

--- a/addons/refuel/functions/fnc_initSource.sqf
+++ b/addons/refuel/functions/fnc_initSource.sqf
@@ -15,14 +15,12 @@
  * Public: No
  */
 
+if (!hasInterface) exitWith {};
+
 params ["_source"];
 TRACE_2("init",_source,typeOf _source);
 
-if (hasInterface) then {
-	[_source, 0, ["ACE_MainActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
-    {
-        [_source, 0, ["ACE_MainActions", QGVAR(Refuel)], _x] call EFUNC(interact_menu,addActionToObject);
-    } forEach GVAR(actions);
-};
-
-[QGVAR(fuelSourceInitialized), [_source]] call CBA_fnc_localEvent;
+[_source, 0, ["ACE_MainActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
+{
+    [_source, 0, ["ACE_MainActions", QGVAR(Refuel)], _x] call EFUNC(interact_menu,addActionToObject);
+} forEach GVAR(actions);

--- a/addons/refuel/functions/fnc_makeJerryCan.sqf
+++ b/addons/refuel/functions/fnc_makeJerryCan.sqf
@@ -27,7 +27,7 @@ _target setVariable [QGVAR(source), _target];
 _target setVariable [QGVAR(capacity), _fuelAmount];
 
 if (isServer) then {
-    [_target, _fuelAmount] call FUNC(setFuel);  // has global effects
+    [_target, _fuelAmount] call FUNC(setFuel); // has global effects
     [QVAR(jerryCanInitalized), [_target]] call CBA_fnc_globalevent;
 };
 

--- a/addons/refuel/functions/fnc_makeJerryCan.sqf
+++ b/addons/refuel/functions/fnc_makeJerryCan.sqf
@@ -31,9 +31,6 @@ if (isServer) then {
     [QVAR(jerryCanInitalized), [_target]] call CBA_fnc_globalevent;
 };
 
-
-if (isServer) then { [_target, _fuelAmount] call FUNC(setFuel); };
-
 // Main Action
 private _action = [QGVAR(Refuel),
     localize LSTRING(Refuel),

--- a/addons/refuel/functions/fnc_makeJerryCan.sqf
+++ b/addons/refuel/functions/fnc_makeJerryCan.sqf
@@ -24,8 +24,14 @@ if (isNull _target ||
 
 _target setVariable [QGVAR(jerryCan), true];
 _target setVariable [QGVAR(source), _target];
-
 _target setVariable [QGVAR(capacity), _fuelAmount];
+
+if (isServer) then {
+    [_target, _fuelAmount] call FUNC(setFuel);  // has global effects
+    [QVAR(jerryCanInitalized), [_target]] call CBA_fnc_globalevent;
+};
+
+
 if (isServer) then { [_target, _fuelAmount] call FUNC(setFuel); };
 
 // Main Action

--- a/addons/refuel/functions/fnc_makeSource.sqf
+++ b/addons/refuel/functions/fnc_makeSource.sqf
@@ -56,9 +56,11 @@ if (
     _source setVariable [QGVAR(hooks), _hooks, true];
 };
 
-// check if menu already exists
-if (_fuelCargoConfig != 0 || {!isNil {_source getVariable QGVAR(initSource_jipID)}}) exitWith {};
+// only add if menu doesn't already exist
+if (!(_fuelCargoConfig != 0 && {!isNil {_source getVariable QGVAR(initSource_jipID)}})) then {
+    private _jipID = [QGVAR(initSource), [_source]] call CBA_fnc_globalEventJIP;
+    [_jipID, _source] call CBA_fnc_removeGlobalEventJIP;
+    _source setVariable [QGVAR(initSource_jipID), _jipID];
+};
 
-private _jipID = [QGVAR(initSource), [_source]] call CBA_fnc_globalEventJIP;
-[_jipID, _source] call CBA_fnc_removeGlobalEventJIP;
-_source setVariable [QGVAR(initSource_jipID), _jipID];
+[QGVAR(sourceInitialized), [_source]] call CBA_fnc_globalEvent;

--- a/docs/wiki/framework/refuel-framework.md
+++ b/docs/wiki/framework/refuel-framework.md
@@ -130,5 +130,5 @@ The jerry can will now have a volume of 200 liters.
 
 | Name  | Arguments | Global? | Added in |
 | ------------- | ------------- | ------------- |
-| ace_refuel_fuelSourceInitialized | Fuel source (OBJECT), items (BOOL or ARRAY) | No | 3.16.0 |
+| ace_refuel_sourceInitialized | Fuel source (OBJECT), items (BOOL or ARRAY) | Yes | 3.16.0 |
 | ace_refuel_jerryCanInitalized | Jerry can (OBJECT) | Yes | 3.16.0 |

--- a/docs/wiki/framework/refuel-framework.md
+++ b/docs/wiki/framework/refuel-framework.md
@@ -125,3 +125,10 @@ The jerry can will now have a volume of 200 liters.
 ---| --------- | -----------
 0  | `cursorObject` | Fuel source object
 1  | `100` | Fuel supply
+
+## 3. Events
+
+| Name  | Arguments | Global? | Added in |
+| ------------- | ------------- | ------------- |
+| ace_refuel_fuelSourceInitialized | Fuel source (OBJECT), items (BOOL or ARRAY) | No | 3.16.0 |
+| ace_refuel_jerryCanInitalized | Jerry can (OBJECT) | Yes | 3.16.0 |


### PR DESCRIPTION
**When merged this pull request will:**
- Add ´ace_refuel_fuelSourceInitialized´ and `ace_refuel_jerryCanInitalized´ events
- Update documentation accordingly

Depending on whether this or #9122 get merged first, the documentation of the other needs to be updated.

Analog to #9134 

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
