### PR TITLE
Weapon Select - Remove vehicle smoke selection key

### DIFF
--- a/addons/weaponselect/XEH_postInit.sqf
+++ b/addons/weaponselect/XEH_postInit.sqf
@@ -183,18 +183,18 @@ if (!hasInterface) exitWith {};
 {false},
 [0, [false, false, false]], false] call CBA_fnc_addKeybind; //Unbound (was 5 Key)
 
-["ACE3 Vehicles", QGVAR(FireSmokeLauncher), localize LSTRING(FireSmokeLauncher), {
-    // Conditions: canInteract
-    if !([ACE_player, vehicle ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
-    // Conditions: specific
-    if !(ACE_player != vehicle ACE_player && {ACE_player == commander vehicle ACE_player}) exitWith {false};
+// ["ACE3 Vehicles", QGVAR(FireSmokeLauncher), localize LSTRING(FireSmokeLauncher), {
+//     // Conditions: canInteract
+//     if !([ACE_player, vehicle ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
+//     // Conditions: specific
+//     if !(ACE_player != vehicle ACE_player && {ACE_player == commander vehicle ACE_player}) exitWith {false};
 
-    // Statement
-    [vehicle ACE_player] call FUNC(fireSmokeLauncher);
-    true
-},
-{false},
-[10, [false, false, false]], false] call CBA_fnc_addKeybind; //9 Key
+//     // Statement
+//     [vehicle ACE_player] call FUNC(fireSmokeLauncher);
+//     true
+// },
+// {false},
+// [10, [false, false, false]], false] call CBA_fnc_addKeybind; //9 Key
 
 ["ACE3 Vehicles", QGVAR(CollisionLights), localize LSTRING(CollisionLights), {
     // Conditions: canInteract


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/issues/5591#issuecomment-334680323
I don't think this keybind makes sense any more
There is a dedicated vanilla counter-measure keybind that works
I think the game used to require you to select "smoke" as a weapon but that isn't the case anymore??

the while loop https://github.com/acemod/ACE3/blob/master/addons/weaponselect/functions/fnc_fireSmokeLauncher.sqf#L34
never exits normally, and only continues when it hits the 10k limit

