### PR TITLE
Medical - Fix respawn when letting AI take over playable units

### DIFF
--- a/addons/medical_status/functions/fnc_initUnit.sqf
+++ b/addons/medical_status/functions/fnc_initUnit.sqf
@@ -74,10 +74,10 @@ if (_isRespawn) then {
     _unit setVariable [VAR_MEDICATIONS, [], true];
 
     // Unconscious spontanious wake up chance
-    _unit setVariable [QEGVAR(medical,lastWakeUpCheck), nil];
+    _unit setVariable [QEGVAR(medical,lastWakeUpCheck), nil, true];
 
     // Cause of death
-    _unit setVariable [QEGVAR(medical,causeOfDeath), nil];
+    _unit setVariable [QEGVAR(medical,causeOfDeath), nil, true];
 };
 
 [{


### PR DESCRIPTION
**When merged this pull request will:**
- Reset `causeOfDeath` and `lastWakeUpCheck` on respawn

Because `causeOfDeath` was only reset locally, letting AI take over a unit after it respawned caused the `causeOfDeath` on the server being the new truth, which persisted even when reslotting as that unit. This in turn caused `fnc_enteredStateDeath` to fail and exit early. TBH, that [`exitWith`](https://github.com/acemod/ACE3/blob/master/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf#L19) seems unnecessary to me, but I don't know what the original intention was. I think `setDead` should always be called.