### PR TITLE
Common - Use hashmap variable for canDig surfaces

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -59,6 +59,16 @@ GVAR(hexArray) = [
 "F0","F1","F2","F3","F4","F5","F6","F7","F8","F9","FA","FB","FC","FD","FE","FF"
 ];
 
+GVAR(canDigSurfaces) = createHashMapFromArray [
+    ["int_concrete",false],["int_pavement_exp",false],["int_solidwood_exp",false],["tiling",false],["roof_tiles",false],["stony",false],
+    ["wavymetal",false],["int_wood",false],["int_tiles",false],["softwood_exp",false],["int_concrete_exp",false],["tiles_int",false],
+    ["metalplate_exp",false],["int_metalplate_exp",false],["steel_exp",false],["metal",false],["int_lino_exp",false],["metal_int",false],
+    ["wavymetal_exp",false],["int_metal",false],["forest_exp",true],["snow",true],["asphalt_exp",false],["pavement_exp",false],
+    ["rooftiles_exp",false],["rock",false],["int_mat_exp",false],["wood_int",false],["concrete_int",false],["tarmac",false],["wood",false],
+    ["grasstall_exp",true],["roof_tin",false],["lino_exp",false],["concrete",false],["int_softwood_exp",false],["grass",true],
+    ["concrete_exp",false],["stones_exp",false],["gridmetal_exp",false]
+];
+
 isHC = !hasInterface && !isDedicated; // deprecated because no tag
 missionNamespace setVariable ["ACE_isHC", ACE_isHC];
 uiNamespace setVariable ["ACE_isHC", ACE_isHC];

--- a/addons/common/functions/fnc_canDig.sqf
+++ b/addons/common/functions/fnc_canDig.sqf
@@ -33,5 +33,5 @@ TRACE_2("Surface",_surfaceType,_surfaceDust);
 if (isNumber (_config >> "ACE_canDig")) then {
     (getNumber (_config >> "ACE_canDig")) == 1 // return
 } else {
-    !(_surfaceType in DIG_SURFACE_BLACKLIST) && {(_surfaceDust >= 0.1) || {_surfaceType in DIG_SURFACE_WHITELIST}} // return
+    GVAR(canDigSurfaces) getOrDefault [_surfaceType, _surfaceDust >= 0.1] // return
 };

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -15,18 +15,3 @@
 #endif
 
 #include "\z\ace\addons\main\script_macros.hpp"
-
-
-#define DIG_SURFACE_BLACKLIST [ \
-    "concrete", "concrete_exp", "concrete_int", "int_concrete", "int_concrete_exp", \
-    "pavement_exp", "int_pavement_exp", \
-    "tiling", "tiles_int", "int_tiles", \
-    "roof_tin", "roof_tiles", "rooftiles_exp", \
-    "tarmac", "asphalt_exp", \
-    "stones_exp", "rock", "stony", \
-    "metal", "gridmetal_exp", "metalplate_exp", "int_metalplate_exp", "metal_int", "wavymetal", "wavymetal_exp", "int_metal", "steel_exp", \
-    "lino_exp", "int_lino_exp", "int_mat_exp", \
-    "wood", "wood_int", "int_wood", "softwood_exp", "int_softwood_exp", "int_solidwood_exp" \
-]
-
-#define DIG_SURFACE_WHITELIST ["grass", "grasstall_exp", "forest_exp", "snow"]


### PR DESCRIPTION
can be edited by mission makers to block/allow