### PR TITLE
Scopes - Add tool to diagnose scope height

### DIFF
--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -54,6 +54,10 @@ class CfgWeapons {
         ACE_ScopeHeightAboveRail = 3.88405;
     };
 
+    class optic_ico_01_base_f: ItemCore {
+        ACE_ScopeHeightAboveRail = 5.41148;
+    };
+
     class optic_Nightstalker: ItemCore {
         ACE_ScopeHeightAboveRail = 5.54325;
         ACE_ScopeAdjust_Vertical[] = {-4, 30};
@@ -87,6 +91,21 @@ class CfgWeapons {
     };
 
     class optic_TWS: ItemCore {
+        ACE_ScopeHeightAboveRail = 5.52874;
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0.1;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
+        class ItemInfo: InventoryOpticsItem_Base_F {
+            class OpticsModes {
+                class TWS {
+                    discreteDistance[] = {300};
+                    discreteDistanceInitIndex = 0;
+                };
+            };
+        };
+    };
+    class optic_tws_mg: ItemCore {
         ACE_ScopeHeightAboveRail = 5.52874;
         ACE_ScopeAdjust_Vertical[] = {-4, 30};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};

--- a/addons/scopes/dev/checkScopes.sqf
+++ b/addons/scopes/dev/checkScopes.sqf
@@ -1,22 +1,22 @@
 // [] call compileScript ["\z\ace\addons\scopes\dev\checkScopes.sqf"];
 
 
-private _optics = "getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons"); 
+private _optics = "getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons");
 _optics = _optics select {(getNumber (_x >> 'ItemInfo' >> 'type')) == 201};
 diag_log text format ["** Checking %1 scopes **", count _optics];
 
 private _fnc_checkConfig = {
     params ["_config", ["_diag", false]];
 
-    private _model = getText (_config >> "model"); 
-    private _weaponObj = createSimpleObject [_model, [0, 0, 0], true]; 
+    private _model = getText (_config >> "model");
+    private _weaponObj = createSimpleObject [_model, [0, 0, 0], true];
     private _bestZoom = 1e6;
     private _bestOffset = 0;
     {
         private _xZoom = getNumber (_x >> "opticsZoomMin");
         private _xMem = getText (_x >> "memoryPointCamera");
         private _xOffset = 100 * ((_weaponObj selectionPosition _xMem) select 2); // convert to centimeters
-        if (_xZoom < _bestZoom) then {
+        if (_xZoom < _bestZoom) then { // get offset for optic with highest magnification (lowest fov)
             _bestZoom = _xZoom;
             _bestOffset = _xOffset;
         };
@@ -41,30 +41,34 @@ private _fnc_checkConfig = {
 
 
 
-private _rifles = "getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons"); 
+private _rifles = "getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons");
 _rifles = _rifles select {(getNumber (_x >> 'type')) == 1};
 _rifles = _rifles select {(configName _x) == (getText (_x >> 'baseWeapon'))};
 diag_log text format ["** Checking %1 weapons **", count _rifles];
 
 private _fnc_checkConfig = {
     params ["_config", ["_diag", false]];
-    private _model = getText (_config >> "model"); 
-    private _weaponObj = createSimpleObject [_model, [0, 0, 0], true]; 
+    private _model = getText (_config >> "model");
+    private _weaponObj = createSimpleObject [_model, [0, 0, 0], true];
+    private _lod = (allLODs _weaponObj) # 0 # 2;
     private _xMemMuzzle = getText (_config >> "muzzlePos");
     private _xMemOptic = "proxy:\a3\data_f\proxies\weapon_slots\top.001";
     private _xPosMuzzle = _weaponObj selectionPosition _xMemMuzzle;
-    private _xPosOptic = _weaponObj selectionPosition [_xMemOptic, 1];
+    private _xPosOptic = _weaponObj selectionPosition [_xMemOptic, _lod];
+    if (_xPosOptic isEqualTo [0,0,0]) exitWith { -999 }; // e.g. akm has no proxy
 
     private _xOffset = 100 * ((_xPosOptic vectorDiff _xPosMuzzle) select 2);
     if (_diag) then {
-        diag_log text format ["Muzzle %1 - Top %2", _xPosMuzzle, _xPosOptic];
+        diag_log text format [" Muzzle %1 - Top %2", _xPosMuzzle, _xPosOptic];
     };
     deleteVehicle _weaponObj;
     _xOffset
 };
 {
     private _config = _x;
+    if ((compatibleItems [configName _config, "CowsSlot"]) isEqualTo []) then { continue }; // e.g. arifle_SDAR_F has no scopes
     private _actualOffset = [_config, false] call _fnc_checkConfig;
+    if (_actualOffset == -999) then { continue };
     private _configOffset = getNumber (_config >> "ACE_RailHeightAboveBore");
 
     if ((abs (_actualOffset - _configOffset)) > 0.1) then {

--- a/addons/scopes/dev/checkScopes.sqf
+++ b/addons/scopes/dev/checkScopes.sqf
@@ -1,0 +1,74 @@
+// [] call compileScript ["\z\ace\addons\scopes\dev\checkScopes.sqf"];
+
+
+private _optics = "getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons"); 
+_optics = _optics select {(getNumber (_x >> 'ItemInfo' >> 'type')) == 201};
+diag_log text format ["** Checking %1 scopes **", count _optics];
+
+private _fnc_checkConfig = {
+    params ["_config", ["_diag", false]];
+
+    private _model = getText (_config >> "model"); 
+    private _weaponObj = createSimpleObject [_model, [0, 0, 0], true]; 
+    private _bestZoom = 1e6;
+    private _bestOffset = 0;
+    {
+        private _xZoom = getNumber (_x >> "opticsZoomMin");
+        private _xMem = getText (_x >> "memoryPointCamera");
+        private _xOffset = 100 * ((_weaponObj selectionPosition _xMem) select 2); // convert to centimeters
+        if (_xZoom < _bestZoom) then {
+            _bestZoom = _xZoom;
+            _bestOffset = _xOffset;
+        };
+        if (_diag) then {
+            diag_log text format [" %1[%2] = %3 (%4)",configName _x, _xZoom, _xMem, _xOffset];
+        };
+    } forEach configProperties [_config >> "ItemInfo" >> "OpticsModes", "isClass _x"];
+    deleteVehicle _weaponObj;
+    _bestOffset
+};
+{
+    private _config = _x;
+    private _actualOffset = [_config, false] call _fnc_checkConfig;
+    private _configOffset = getNumber (_config >> "ACE_ScopeHeightAboveRail");
+
+    if ((abs (_actualOffset - _configOffset)) > 0.1) then {
+        diag_log text format ["Mismatch %1 - Actual %2 vs Config %3", configName _config, _actualOffset, _configOffset];
+        [_config, true] call _fnc_checkConfig;
+    };
+} forEach _optics;
+
+
+
+
+private _rifles = "getNumber (_x >> 'scope') > 0" configClasses (configFile >> "CfgWeapons"); 
+_rifles = _rifles select {(getNumber (_x >> 'type')) == 1};
+_rifles = _rifles select {(configName _x) == (getText (_x >> 'baseWeapon'))};
+diag_log text format ["** Checking %1 weapons **", count _rifles];
+
+private _fnc_checkConfig = {
+    params ["_config", ["_diag", false]];
+    private _model = getText (_config >> "model"); 
+    private _weaponObj = createSimpleObject [_model, [0, 0, 0], true]; 
+    private _xMemMuzzle = getText (_config >> "muzzlePos");
+    private _xMemOptic = "proxy:\a3\data_f\proxies\weapon_slots\top.001";
+    private _xPosMuzzle = _weaponObj selectionPosition _xMemMuzzle;
+    private _xPosOptic = _weaponObj selectionPosition [_xMemOptic, 1];
+
+    private _xOffset = 100 * ((_xPosOptic vectorDiff _xPosMuzzle) select 2);
+    if (_diag) then {
+        diag_log text format ["Muzzle %1 - Top %2", _xPosMuzzle, _xPosOptic];
+    };
+    deleteVehicle _weaponObj;
+    _xOffset
+};
+{
+    private _config = _x;
+    private _actualOffset = [_config, false] call _fnc_checkConfig;
+    private _configOffset = getNumber (_config >> "ACE_RailHeightAboveBore");
+
+    if ((abs (_actualOffset - _configOffset)) > 0.1) then {
+        diag_log text format ["Mismatch %1 - Actual %2 vs Config %3", configName _config, _actualOffset, _configOffset];
+        [_config, true] call _fnc_checkConfig;
+    };
+} forEach _rifles;

--- a/addons/xm157/CfgWeapons.hpp
+++ b/addons/xm157/CfgWeapons.hpp
@@ -10,6 +10,7 @@ class CfgWeapons {
         picture = "\a3\Weapons_F\acc\Data\UI\icon_optic_tws_ca.paa";
         model = "\A3\weapons_f\acc\acco_tws_F";
         inertia = 0.3;
+        ACE_ScopeHeightAboveRail = 5.52874;
         
         class CBA_ScriptedOptic {
             bodyTexture = QPATHTOF(data\ace_vector_body_co.paa);


### PR DESCRIPTION
I think this is close but could use another look, I'm not positive the results are correct

```
** Checking 67 scopes **
Mismatch optic_MRD - Actual 1.94867 vs Config 2.8
 ACO[0.25] = eye (1.94867)
Mismatch optic_MRD_black - Actual 1.94867 vs Config 2.8
 ACO[0.25] = eye (1.94867)
 
** Checking 103 weapons **
Mismatch LMG_Zafir_F - Actual 1.12161 vs Config 0.996651
 Muzzle [-0.517082,4.34779e-005,0.0894913] - Top [0.123988,-0.00138879,0.100707]
Mismatch arifle_SPAR_01_blk_F - Actual 2.96535 vs Config 3.20768
 Muzzle [-0.335041,6.07815e-005,0.061947] - Top [-0.000982652,2.00588e-005,0.0916006]
```