### PR TITLE
Interaction - Fix opening locked doors for GM buildings

### DIFF
--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -34,9 +34,14 @@ _getDoorAnimations params ["_animations"];
 if (_animations isEqualTo []) exitWith {};
 
 private _lockedVariable = format ["bis_disabled_%1", _door];
+private _lockedVariableAlt = _lockedVariable; // GM Buildings may have door names like door_01 but locking expects door_1
+if ((count _door == 7) && {(_door select [0, 6]) == "door_0"}) then { 
+    _lockedVariableAlt = format ["bis_disabled_door_%1", _door select [6, 1]]; // stip off the leading zero, the check both vars
+};
 
 // Check if the door can be locked aka have locked variable, otherwhise cant lock it
-if ((_house animationPhase (_animations select 0) <= 0) && {_house getVariable [_lockedVariable, 0] == 1}) exitWith {
+if ((_house animationPhase (_animations select 0) <= 0) && 
+    {(_house getVariable [_lockedVariable, 0] == 1) || {_house getVariable [_lockedVariableAlt, 0] == 1}}) exitWith {
     private _lockedAnimation = format ["%1_locked_source", _door];
     TRACE_3("locked",_house,_lockedAnimation,isClass (configOf _house >> "AnimationSources" >> _lockedAnimation));
     if (isClass (configOf _house >> "AnimationSources" >> _lockedAnimation)) then {

--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -36,7 +36,7 @@ if (_animations isEqualTo []) exitWith {};
 private _lockedVariable = format ["bis_disabled_%1", _door];
 private _lockedVariableAlt = _lockedVariable; // GM Buildings may have door names like door_01 but locking expects door_1
 if ((count _door == 7) && {(_door select [0, 6]) == "door_0"}) then { 
-    _lockedVariableAlt = format ["bis_disabled_door_%1", _door select [6, 1]]; // stip off the leading zero, the check both vars
+    _lockedVariableAlt = format ["bis_disabled_door_%1", _door select [6, 1]]; // stip off the leading zero then check both vars
 };
 
 // Check if the door can be locked aka have locked variable, otherwhise cant lock it


### PR DESCRIPTION
Fix #9143


e.g. land_gm_euro_house_11_wL
```
_door = "door_01"; // from getDoor
class openDoor_1 {
    condition = "this animationSourcePhase 'door_1_sound_source' <= 0.5";
    statement = "([this, 1, 1] call BIS_fnc_Door);";
```

bis_fnc_door checks
```
// _door is a number
if ((_structure getVariable [format ["bis_disabled_Door_%1", _door], 0]) != 1) 
```

so if we get a "door_0X" then we just check both vars