### PR TITLE
Javelin - Fix weapon being in top-attack when loading AP magazine

### DIFF
--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -56,7 +56,7 @@ if ((_ammoCount == 0) || // No ammo loaded
     _this set [0, diag_frameno];
     _this set [4, _fireDisabledEH];
 
-    // Fix weapon being in top-attack when loading AP magazine (vanilla bug)
+    // Fix weapon being in top-attack when loading AP magazine (https://feedback.bistudio.com/T171012)
     if ((_currentShooter == ACE_player) && {_currentMagazine == "Titan_AP"} && {currentWeaponMode ACE_player == "TopDown"}) then {
         {
             _x params ["_xIndex", "", "", "", "_xMode"];

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -55,6 +55,19 @@ if ((_ammoCount == 0) || // No ammo loaded
     _fireDisabledEH = [_fireDisabledEH] call FUNC(enableFire);
     _this set [0, diag_frameno];
     _this set [4, _fireDisabledEH];
+
+    // Fix weapon being in top-attack when loading AP magazine (vanilla bug)
+    if ((_currentShooter == ACE_player) && {_currentMagazine == "Titan_AP"} && {currentWeaponMode ACE_player == "TopDown"}) then {
+        {
+            _x params ["_xIndex", "", "", "", "_xMode"];
+            if (_xMode == "Single") exitWith {
+                ACE_player action ["SwitchWeapon", _currentShooter, ACE_player, _xIndex];
+                __JavelinIGUITop ctrlSetTextColor __ColorGray;
+                __JavelinIGUIDir ctrlSetTextColor __ColorGreen;
+                TRACE_2("fix top-attack for AP",weaponState _currentShooter,_x);
+            };
+        } forEach (ACE_player weaponsInfo [_currentWeapon, true]);
+    };
 };
 
 


### PR DESCRIPTION
>load an AT missile and switch to top-down, then reload an AP missile, you can't de-activate top-down mode and the missile guidance stops working for the AP missile

happens in vanilla, but it's something we can easily fix???
issue https://feedback.bistudio.com/T171012