### PR TITLE
Respawn - fix script error

### DIFF
--- a/addons/respawn/functions/fnc_updateRallypoint.sqf
+++ b/addons/respawn/functions/fnc_updateRallypoint.sqf
@@ -17,7 +17,8 @@
  * Public: No
  */
 
-params ["_rallypoint", "_side", "_position"];
+params ["_rallypoint", "_side"];
+private _position = param [2, getpos _rallypoint];
 
 if (!hasInterface) exitWith {};
 


### PR DESCRIPTION
initRallypoint calls `["ace_rallypointMoved", [_rallypoint, _side]] call CBA_fnc_globalEvent;`
which calls `ace_respawn_fnc_updateRallypoint` but it's missing 3rd arg

causes (in spawned code) `Error Undefined variable in expression: _position`