### PR TITLE
Arsenal - GM Compat - Add uniform details support

### DIFF
--- a/optionals/compat_gm/XEH_preinit.sqf
+++ b/optionals/compat_gm/XEH_preinit.sqf
@@ -7,7 +7,7 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 // handle GM uniform additonal insignia
-["ace_arsenal_displayClosed", {
+[QEGVAR(arsenal,displayClosed), {
     ACE_arsenal_center call gm_core_characters_fnc_updateUniformDetails;
 }] call CBA_fnc_addEventHandler;
 

--- a/optionals/compat_gm/XEH_preinit.sqf
+++ b/optionals/compat_gm/XEH_preinit.sqf
@@ -6,4 +6,9 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+// handle GM uniform additonal insignia
+["ace_arsenal_displayClosed", {
+    ACE_arsenal_center call gm_core_characters_fnc_updateUniformDetails;
+}] call CBA_fnc_addEventHandler;
+
 ADDON = true;

--- a/optionals/compat_gm/XEH_preinit.sqf
+++ b/optionals/compat_gm/XEH_preinit.sqf
@@ -8,7 +8,7 @@ PREP_RECOMPILE_END;
 
 // handle GM uniform additional insignia
 [QEGVAR(arsenal,displayClosed), {
-    ACE_arsenal_center call gm_core_characters_fnc_updateUniformDetails;
+    EGVAR(arsenal,center) call gm_core_characters_fnc_updateUniformDetails;
 }] call CBA_fnc_addEventHandler;
 
 ADDON = true;

--- a/optionals/compat_gm/XEH_preinit.sqf
+++ b/optionals/compat_gm/XEH_preinit.sqf
@@ -6,7 +6,7 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-// handle GM uniform additonal insignia
+// handle GM uniform additional insignia
 [QEGVAR(arsenal,displayClosed), {
     ACE_arsenal_center call gm_core_characters_fnc_updateUniformDetails;
 }] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- title
- handle additional insignia and player/character name on the front pocket

### IMPORTANT

- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

GM does it like this:
```sqf
[missionNamespace, "arsenalClosed", {player call gm_core_characters_fnc_updateUniformDetails}] call bis_fnc_addScriptedEventhandler;
```