### PR TITLE
Map Tools - Use polyline marker for straight lines

### DIFF
--- a/addons/maptools/functions/fnc_handleMouseButton.sqf
+++ b/addons/maptools/functions/fnc_handleMouseButton.sqf
@@ -40,18 +40,11 @@ if ((_button == 0) && {GVAR(freedrawing) || _ctrlKey}) exitWith {
             if ((count GVAR(freeDrawingData)) != 3) exitWith {TRACE_1("never touched roamer",GVAR(freeDrawingData));};
 
             GVAR(freeDrawingData) params ["", "_startStraightPos", "_endStraightPos"];
-           _startStraightPos set [2, 0];
-            _endStraightPos set [2, 0];
 
-            // Convert marker to rectangle and change it's pos/size/dir
-            _markerName setMarkerShape "RECTANGLE";
-
-            private _difPos = _endStraightPos vectorDiff _startStraightPos;
-            private _mag = vectorMagnitude _difPos;
-            _markerName setMarkerPos (_startStraightPos vectorAdd (_difPos vectorMultiply 0.5));
-            _markerName setMarkerSize [10, _mag / 2];
-            _markerName setMarkerDir (_difPos call CBA_fnc_vectDir);
-
+            _markerName setMarkerPolyline [
+                _startStraightPos#0, _startStraightPos#1,
+                _endStraightPos#0, _endStraightPos#1
+            ];
         }, []] call CBA_fnc_execNextFrame;
     } else {
         if (_ctrlKey && {_dir == 1}) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Use polyline instead of rectangular marker for drawing straight lines

![grafik](https://user-images.githubusercontent.com/9693842/227611158-42998757-9f0c-4fbc-bf15-c728685190bc.png)


### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
