### PR TITLE
Towing - Add CBA event for towing start and cancel

### DIFF
--- a/addons/towing/functions/fnc_startTow.sqf
+++ b/addons/towing/functions/fnc_startTow.sqf
@@ -17,7 +17,7 @@
  * Public: No
  */
 params ["_unit", "_target", "_ropeClass"];
-[QGVAR(ropeDeployed), [_unit, _target, _ropeClass]] call CBA_fnc_localEvent;
+
 
 GVAR(attachHelper) = "Sign_Sphere10cm_F" createVehicleLocal [0, 0, 0];
 [_unit] call EFUNC(weaponselect,putWeaponAway);
@@ -32,4 +32,4 @@ _unit removeItem _ropeClass;
 GVAR(cancel) = false;
 GVAR(canAttach) = false;
 [LINKFUNC(towStateMachinePFH), 0, [TOW_STATE_ATTACH_PARENT, _unit, _target, objNull, _ropeLength, _ropeClass]] call CBA_fnc_addPerFrameHandler;
-
+[QGVAR(ropeDeployed), [_unit, _target, _ropeClass]] call CBA_fnc_localEvent;

--- a/addons/towing/functions/fnc_startTow.sqf
+++ b/addons/towing/functions/fnc_startTow.sqf
@@ -33,3 +33,4 @@ GVAR(cancel) = false;
 GVAR(canAttach) = false;
 [LINKFUNC(towStateMachinePFH), 0, [TOW_STATE_ATTACH_PARENT, _unit, _target, objNull, _ropeLength, _ropeClass]] call CBA_fnc_addPerFrameHandler;
 [QGVAR(ropeDeployed), [_unit, _target, _ropeClass]] call CBA_fnc_localEvent;
+

--- a/addons/towing/functions/fnc_startTow.sqf
+++ b/addons/towing/functions/fnc_startTow.sqf
@@ -17,6 +17,7 @@
  * Public: No
  */
 params ["_unit", "_target", "_ropeClass"];
+[QGVAR(ropeDeployed), [_unit, _target, _ropeClass]] call CBA_fnc_localEvent;
 
 GVAR(attachHelper) = "Sign_Sphere10cm_F" createVehicleLocal [0, 0, 0];
 [_unit] call EFUNC(weaponselect,putWeaponAway);

--- a/addons/towing/functions/fnc_towStateMachinePFH.sqf
+++ b/addons/towing/functions/fnc_towStateMachinePFH.sqf
@@ -140,7 +140,7 @@ switch (_state) do {
         [_unit, _ropeClass, true] call CBA_fnc_addItem;
         _args set [0, TOW_STATE_CLEANUP];
         GVAR(cancel) = false;
-
+        [QGVAR(ropeDeployedCanceled), [_unit, _ropeClass]] call CBA_fnc_localEvent;
         (localize LSTRING(canceled)) call CBA_fnc_notify;
     };
     case TOW_STATE_CLEANUP: {

--- a/addons/towing/functions/fnc_towStateMachinePFH.sqf
+++ b/addons/towing/functions/fnc_towStateMachinePFH.sqf
@@ -140,7 +140,7 @@ switch (_state) do {
         [_unit, _ropeClass, true] call CBA_fnc_addItem;
         _args set [0, TOW_STATE_CLEANUP];
         GVAR(cancel) = false;
-        [QGVAR(ropeDeployedCanceled), [_unit, _ropeClass]] call CBA_fnc_localEvent;
+        [QGVAR(ropeDeployCancelled), [_unit, _ropeClass]] call CBA_fnc_localEvent;
         (localize LSTRING(canceled)) call CBA_fnc_notify;
     };
     case TOW_STATE_CLEANUP: {

--- a/addons/towing/functions/fnc_towStateMachinePFH.sqf
+++ b/addons/towing/functions/fnc_towStateMachinePFH.sqf
@@ -140,7 +140,7 @@ switch (_state) do {
         [_unit, _ropeClass, true] call CBA_fnc_addItem;
         _args set [0, TOW_STATE_CLEANUP];
         GVAR(cancel) = false;
-        [QGVAR(ropeDeployCancelled), [_unit, _ropeClass]] call CBA_fnc_localEvent;
+        [QGVAR(ropeDeployCanceled), [_unit, _ropeClass]] call CBA_fnc_localEvent;
         (localize LSTRING(canceled)) call CBA_fnc_notify;
     };
     case TOW_STATE_CLEANUP: {


### PR DESCRIPTION
Adds a tow rope deploy event.
Adds a tow rope deploy cancel event.
Antistasi currently needs these events for removing undercover mode for towing. 


- ropeDeployed event:
params:
<object>_unit - unit that deployed the ropes/ started towing
<object> _target  - target object for towing
<string> _ropeClass - rope className


- ropeDeployedCanceled event:
params:
<object>_unit - unit that deployed the ropes/ started towing
<string> _ropeClass - rope className