### PR TITLE
Common - switch getTurretConfigPath to use cba func

### DIFF
--- a/addons/common/functions/fnc_getTurretConfigPath.sqf
+++ b/addons/common/functions/fnc_getTurretConfigPath.sqf
@@ -16,27 +16,4 @@
  * Public: Yes
  */
 
-params ["_config", "_turretIndex"];
-
-for "_index" from 0 to (count _turretIndex - 1) do {
-    _config = _config >> "Turrets";
-
-    private _offset = 0;
-    private _config2 = _config select 0;
-    private _foundClasses = 0;
-
-    for "_a" from 0 to (count _config - 1) do {
-        if (isClass _config2) then {
-            _foundClasses = _foundClasses + 1;
-        } else {
-            _offset = _offset + 1;
-        };
-        _config2 = _config select (_turretIndex select _index) + _offset;
-
-        if (_foundClasses == _turretIndex select _index) exitWith {};
-    };
-
-    _config = _config2;
-};
-
-_config
+call CBA_fnc_getTurret


### PR DESCRIPTION
cwr british fv4030

```
class Turrets: Turrets {  
  particlesPos = "usti hlavne"; 
  particlesDir = "konec hlavne"; 
  class CommanderOptics: CommanderOptics {
```
`["cwr3_b_uk_fv4030", [0,0]] call BIS_fnc_turretConfig` 
returns `bin\config.bin/CfgVehicles/cwr3_challenger1_base/Turrets/MainTurret/Turrets/particlesPos`
should be `bin\config.bin/CfgVehicles/cwr3_challenger1_base/Turrets/MainTurret/Turrets/CommanderOptics`

`BIS_fnc_turretConfig` and `ace_common_fnc_getTurretConfigPath` both parse it wrong and ends up causing
```
Warning Message: 'particlesDir/' is not a class ('ace_fcs_Enabled' accessed)
```

I think the config is bad but `CBA_fnc_getTurret` handles it right 
and is slightly faster (0.018 vs 0.012) so I don't see any reason not to switch over

ref https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_getTurret.sqf