### PR TITLE
Medical GUI - Fix portuguese translation of "head"

### DIFF
--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -548,7 +548,7 @@
             <Spanish>Cabeza</Spanish>
             <French>Tête</French>
             <Polish>Głowa</Polish>
-            <Portuguese>Caebça</Portuguese>
+            <Portuguese>Cabeça</Portuguese>
             <Czech>Hlava</Czech>
             <Italian>Testa</Italian>
             <Japanese>頭部</Japanese>


### PR DESCRIPTION
**When merged this pull request will:**
- _Replace "Caebça" with "Cabeça", the correct translation of "head"_
