### PR TITLE
Common - Fix added throwables not being throwable

### DIFF
--- a/addons/common/functions/fnc_addToInventory.sqf
+++ b/addons/common/functions/fnc_addToInventory.sqf
@@ -112,13 +112,13 @@ switch (_type select 0) do {
 
             switch (_container) do {
                 case "vest": {
-                    (vestContainer _unit) addMagazineCargoGlobal [_classname, 1/*_ammoCount*/]; //@todo Bug! This isn't really the ammo, but magazine count. No such command.
+                    _unit addItemToVest _classname; //@todo Bug! A full magazine, ignoring ammo. No such command.
                 };
                 case "backpack": {
-                    (backpackContainer _unit) addMagazineCargoGlobal [_classname, 1/*_ammoCount*/]; //@todo Bug! This isn't really the ammo, but magazine count. No such command.
+                    _unit addItemToBackpack _classname; //@todo Bug! A full magazine, ignoring ammo. No such command.
                 };
                 case "uniform": {
-                    (uniformContainer _unit) addMagazineCargoGlobal [_classname, 1/*_ammoCount*/]; //@todo Bug! This isn't really the ammo, but magazine count. No such command.
+                    _unit addItemToUniform _classname; //@todo Bug! A full magazine, ignoring ammo. No such command.
                 };
                 default {
                     _unit addMagazine [_classname, _ammoCount];


### PR DESCRIPTION
- Replace [addMagazineCargoGlobal](https://community.bistudio.com/wiki/addMagazineCargoGlobal) with [addItemToUniform](https://community.bistudio.com/wiki/addItemToUniform)/[addItemToVest](https://community.bistudio.com/wiki/addItemToVest)/[addItemToBackpack](https://community.bistudio.com/wiki/addItemToBackpack) when adding magazines to units to make added throwables throwable.
- Closes #9185.