### PR TITLE
xm157 - Fix latitude calc for maps not in `getMapData`

### DIFF
--- a/addons/xm157/XEH_postInit.sqf
+++ b/addons/xm157/XEH_postInit.sqf
@@ -3,8 +3,7 @@
 
 GVAR(shown) = false;
 GVAR(data) = createHashMap;
-([worldName] call EFUNC(common,getMapData)) params ["_latitude"];
-GVAR(data) set ["latitude", _latitude];
+GVAR(data) set ["latitude", EGVAR(common,mapLatitude)];
 
 
 // Add Keybinds


### PR DESCRIPTION
`EFUNC(common,getMapData)` can return `[]`