### PR TITLE
Ballistics - Add 127x108mm APDS AB values

### DIFF
--- a/addons/atragmx/functions/fnc_initGunList.sqf
+++ b/addons/atragmx/functions/fnc_initGunList.sqf
@@ -33,6 +33,7 @@ if (_resetGunList) then {
     WARNING("Reseting Profile Gunlist");
     // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation, Persistent
     GVAR(gunList) =  [["12.7x108mm"        ,  812, 100, 0.0958029, -0.00063800, 8.89, 0, 2, 10, 120, 0, 0, 48.28, 12.7, 38.10, 0.630, 1, "ASM" , [[-15,793],[0,800],[10,807],[15,812],[25,826],[30,835],[35,846]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],
+                      ["12.7x108mm APDS"   , 1060, 100, 0.0766151, -0.00036000, 8.89, 0, 2, 10, 120, 0, 0, 27.95, 11.08, 38.10, 1.052, 1, "ICAO" , [[-15,1041],[0,1048],[10,1055],[15,1060],[25,1074],[30,1083],[35,1094]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],
 
                       ["12.7x99mm AMAX"    ,  852, 100, 0.0907214, -0.00037397, 8.89, 0, 2, 10, 120, 0, 0, 48.60, 12.7, 38.10, 1.050, 1, "ASM" , [[-15,833],[0,840],[10,847],[15,852],[25,866],[30,875],[35,886]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],
                       ["12.7x99mm"         ,  892, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM" , [[-15,873],[0,880],[10,887],[15,892],[25,906],[30,915],[35,926]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -709,10 +709,20 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={820};
         ACE_barrelLengths[]={728.98};
     };
+
     class B_127x108_APDS: B_127x108_Ball {
-        typicalSpeed = 820;
-        airFriction = -0.00065098;
+        ACE_caliber = 7.13; // Chinese 12.7x108mm APDS (Armour Piercing Discarding Sabot) https://i.imgur.com/8mlXD0e.png
+        ACE_bulletLength = 34.08 // Chinese 12.7x108mm APDS (Armour Piercing Discarding Sabot) https://i.imgur.com/8mlXD0e.png
+        ACE_bulletMass = 27.95; // Average value from "Norinco 2017 Weapon Systems", Type 54 12.7x108 mm Tungsten APDS https://i-com.cdn.gaijin.net/monthly_2023_03/image.png.5e6ae14e7b69a610c716872abea1061e.png
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.8, -7.64, -1.53, 5.96, 15.17, 26.19}; // Muzzle Velocity shift 0 at 70°F (21°C), -8m/s at 15°C
+        ACE_ballisticCoefficients[] = {1.052}; // Compromise based on bullet drops, times of flight and remaining velocities according to vanilla B_127x108_APDS airFriction -0.00036
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {1068}; // muzzle velocity 1068 m/s at 21°C (70°F: Temp vs MV chart zero), 1060 m/s at 15°C (ICAO: 15°C, 1013.25 hPa, 0%) according to 5Rnd_127x108_APDS_Mag initSpeed
+        ACE_barrelLengths[] = {730}; // GM6 Lynx barrel length https://gm6lynx.com/
     };
+
     class B_45ACP_Ball: BulletBase {
         airFriction=-0.00082143;
         tracerScale = 0.6;

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -591,11 +591,6 @@ class CfgMagazines {
         initSpeed = 1067;
     };
 
-    class 5Rnd_127x108_Mag;
-    class 5Rnd_127x108_APDS_Mag: 5Rnd_127x108_Mag {
-        initSpeed = 820;
-    };
-
     class ACE_5Rnd_127x99_Mag: 5Rnd_127x108_Mag {
         author = ECSTRING(common,ACETeam);
         ammo = "B_127x99_Ball";


### PR DESCRIPTION
**When merged this pull request will:**
- Add 127x108mm APDS advanced ballistics values based on Chinese 127x108mm APDS Type 54.
- Without real datas, G1 ICAO ballistic coefficient according to vanilla `B_127x108_APDS` `airFriction` `-0.00036`, elevation gap 0.1 - 0.2 mRad until 2700 meters: [Range Cards in-game](https://steamuserimages-a.akamaihd.net/ugc/2048617897926993023/ED37FAB28C24DE6DC1B2572222427BD58C0EF822/?imw=5000&imh=5000&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=false).
- Add 127x108mm APDS AtragMx preset calibrated with Strelok Pro.

AtragMx GunList will need to be refreshed with the Eden Editor Debug Console, execute:
- `call ace_atragmx_fnc_clear_user_data` (LOCAL EXEC)
or
- `call ace_atragmx_fnc_initGunList` (LOCAL EXEC)

**/!\ All private AtragMx GunList values must be saved manually before.**

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
