### PR TITLE
Ballistics - Improve B_127x108_Ball values

### DIFF
--- a/addons/atragmx/functions/fnc_initGunList.sqf
+++ b/addons/atragmx/functions/fnc_initGunList.sqf
@@ -32,7 +32,7 @@ if ((profileNamespace getVariable ["ACE_ATragMX_profileNamespaceVersion", 0]) ==
 if (_resetGunList) then {
     WARNING("Reseting Profile Gunlist");
     // Profile Name, Muzzle Velocity, Zero Range, Scope Base Angle, AirFriction, Bore Height, Scope Unit, Scope Click Unit, Scope Click Number, Maximum Elevation, Dialed Elevation, Dialed Windage, Mass, Bullet Diameter, Rifle Twist, BC, Drag Model, Atmosphere Model, Muzzle Velocity vs. Temperature Interpolation, C1 Ballistic Coefficient vs. Distance Interpolation, Persistent
-    GVAR(gunList) =  [["12.7x108mm"        ,  812, 100, 0.0958029, -0.00063800, 8.89, 0, 2, 10, 120, 0, 0, 48.28, 12.7, 38.10, 0.630, 1, "ASM" , [[-15,793],[0,800],[10,807],[15,812],[25,826],[30,835],[35,846]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],
+    GVAR(gunList) =  [["12.7x108mm"        ,  820, 100, 0.0946366, -0.00065098, 8.89, 0, 2, 10, 120, 0, 0, 48.28, 12.7, 38.10, 0.630, 1, "ASM" , [[-15,801],[0,808],[10,815],[15,820],[25,834],[30,843],[35,854]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],
 
                       ["12.7x99mm AMAX"    ,  852, 100, 0.0907214, -0.00037397, 8.89, 0, 2, 10, 120, 0, 0, 48.60, 12.7, 38.10, 1.050, 1, "ASM" , [[-15,833],[0,840],[10,847],[15,852],[25,866],[30,875],[35,886]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],
                       ["12.7x99mm"         ,  892, 100, 0.0879633, -0.00058679, 8.89, 0, 2, 10, 120, 0, 0, 41.92, 12.7, 38.10, 0.670, 1, "ASM" , [[-15,873],[0,880],[10,887],[15,892],[25,906],[30,915],[35,926]]       , [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]], true],

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -695,19 +695,19 @@ class CfgAmmo {
         ACE_barrelLengths[]={736.6};
     };
     class B_127x108_Ball: BulletBase {
-        timeToLive=10;
-        airFriction=-0.00065098;
+        timeToLive = 10;
+        airFriction = -0.00065098;
         tracerScale = 1.3; //1.5;
-        ACE_caliber=12.979;
-        ACE_bulletLength=64.008;
-        ACE_bulletMass=48.276;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.63};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={820};
-        ACE_barrelLengths[]={728.98};
+        ACE_caliber = 12.979;
+        ACE_bulletLength = 64.008;
+        ACE_bulletMass = 48.276;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19}; // Muzzle Velocity shift 0 at 70°F (21°C), -8m/s at 15°C
+        ACE_ballisticCoefficients[] = {0.63};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {828}; // muzzle velocity 828 m/s at 21°C (70°F: Temp vs MV chart zero), 820 m/s at 15°C (ASM: 15°C, 999,916 hPa, 78%) according to 5Rnd_127x108_Mag initSpeed
+        ACE_barrelLengths[] = {730}; // GM6 Lynx barrel length https://gm6lynx.com/
     };
     class B_127x108_APDS: B_127x108_Ball {
         typicalSpeed = 820;

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -9,7 +9,7 @@ class CfgWeapons {
     // GM6 Lynx
     class GM6_base_F: Rifle_Long_Base_F {};
     class srifle_GM6_F: GM6_base_F {
-        ACE_barrelLength = 730;
+        ACE_barrelLength = 730; // GM6 Lynx barrel length https://gm6lynx.com/
         ACE_barrelTwist = 381.0;
         initSpeed = -1.0;
         magazineWell[] += {


### PR DESCRIPTION
**When merged this pull request will:**
- Update 12.7x108mm `ACE_muzzleVelocities` according to `5Rnd_127x108_Mag` `initSpeed` 820 m/s (ASM standard conditions).
- AtragMx preset 12.7x108mm: Fix `airFriction`, update `Scope Base Angle` and `Muzzle Velocities vs. Temperature Interpolation` .

AtragMx GunList will need to be refreshed with the Eden Editor Debug Console, execute:
- `call ace_atragmx_fnc_clear_user_data` (LOCAL EXEC)
or
- `call ace_atragmx_fnc_initGunList` (LOCAL EXEC)

**/!\ All private AtragMx GunList values must be saved manually before.**

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
