### PR TITLE
Hearing - Remove outdated 12.7x108mm audibleFire value

### DIFF
--- a/addons/hearing/CfgAmmo.hpp
+++ b/addons/hearing/CfgAmmo.hpp
@@ -1,7 +1,0 @@
-// Setting up old stuff for A3
-class CfgAmmo {
-    class BulletBase;
-    class B_127x108_Ball: BulletBase {
-        audibleFire = 15;
-    };
-};

--- a/addons/hearing/config.cpp
+++ b/addons/hearing/config.cpp
@@ -18,6 +18,5 @@ class CfgPatches {
 #include "CfgVehicles.hpp"
 #include "CfgSounds.hpp"
 #include "CfgWeapons.hpp"
-#include "CfgAmmo.hpp"
 #include "ACE_Settings.hpp"
 #include "ACE_Arsenal_Stats.hpp"


### PR DESCRIPTION
**When` merged this pull request will:**
- Remove outdated 2015 `B_127x108_Ball` `audibleFire = 15;`.

All 12.7x99 and 108mm have now an `audibleFire=120;`.
Probably missed something but that makes sense to keep `15` only for 12.7x108 ammunitions ?

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
