### PR TITLE
Vehicle Damage - Fix blank hit selections resulting in absurd damage to the driver

### DIFF
--- a/addons/vehicle_damage/functions/fnc_handleDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_handleDamage.sqf
@@ -22,7 +22,15 @@
  * Public: No
  */
 
-params ["_vehicle", "", "_damage", "", "_projectile", "_hitIndex", "", "_hitPoint"];
+params ["_vehicle", "_hitSelection", "_damage", "", "_projectile", "_hitIndex", "", "_hitPoint"];
+TRACE_6("HandleDamage event inputs",_vehicle,_hitSelection,_damage,_projectile,_hitIndex,_hitPoint);
+
+private _returnHit = if (_hitSelection isNotEqualTo "") then {
+    _vehicle getHitIndex _hitIndex
+} else {
+    damage _vehicle
+};
+
 if !(_projectile in ["ace_ammoExplosion", "ACE_ammoExplosionLarge"]) then {
     if (local _vehicle) then {
         // set up hit array so we can execute all damage next frame. Always in order of hit done.
@@ -47,8 +55,15 @@ if !(_projectile in ["ace_ammoExplosion", "ACE_ammoExplosionLarge"]) then {
                     TRACE_3("processing data from old frame",diag_frameNo,_processingFrame,_hitArray);
                     {
                         _x params ["_vehicle", "_selection", "_damage", "_injurer", "_projectile", "_hitIndex", "", "_hitPoint"];
-                        private _newDamage = _damage - (_vehicle getHitIndex _hitIndex);
-                        if !([_vehicle, _hitPoint, _hitIndex, _injurer, _vehicle getHitIndex _hitIndex, _newDamage, _projectile, _selection] call FUNC(handleVehicleDamage)) exitWith {
+
+                        private _returnHit = if (_selection isNotEqualTo "") then {
+                            _vehicle getHitIndex _hitIndex
+                        } else {
+                            damage _vehicle
+                        };
+
+                        private _newDamage = _damage - _returnHit;
+                        if !([_vehicle, _hitPoint, _hitIndex, _injurer, _returnHit, _newDamage, _projectile, _selection] call FUNC(handleVehicleDamage)) exitWith {
                             LOG_2("cancelling rest of vehicle damage queue ( [%1] items left out of [%2] )",(count (_hitArray#1)) - _forEachIndex,count (_hitArray#1))
                         };
                     } forEach _hitArray;
@@ -67,7 +82,6 @@ if !(_projectile in ["ace_ammoExplosion", "ACE_ammoExplosionLarge"]) then {
 
 // damage is never to be handled in-engine. Always handle out of engine with this event handler
 // don't return 0 or else old parts will be reset in damage
-private _returnHit = _vehicle getHitIndex _hitIndex;
 private _criticalDamageIndex = (CRITICAL_HITPOINTS findIf { _x isEqualTo _hitPoint }) + 1;
 if (_criticalDamageIndex > 0) then {
     _returnHit = (_returnHit min (CRITICAL_HITPOINTS select _criticalDamageIndex));


### PR DESCRIPTION
**When merged this pull request will:**
- _Change damage handling get the overall damage from the vehicle if the hit selection is blank_

**Repro steps**

Using `CUP_B_BMP2_CZ` for testing, some observations: 
- I can drive full-speed into pretty much anything without consequence, very rarely take a wound from a head-on collision with a tree, rock, or building 
- Those collisions will cause track damage usually, but they also damage the front lights (#l svetlo/#p svetlo)
- At some point after enough collisions I'll start taking damage, sometimes quite catastrophically, sometimes less so

I iterated on all kinds of different damage combinations and eventually discovered what seems to be one cause (I'm sure the logic means it applies in other ways as well): 
- If those front lights mentioned above are at damage state 1 (there are seemingly four selections, I only was able to damage two of them via scripting and did the other two via running into things), there's a very high chance that the driver will take a lot of damage from driving through bushes and similar obstacles

It may not happen on the first bush you go through, but it'll happen soon enough. It's probably just dependent on whatever you hit managing to hit one of those obliterated lights to trigger it.

Go into a mission, create the BMP with the following snippet
```sqf
private _bmp = "CUP_B_BMP2_CZ" createVehicle (getPos player);
player moveInDriver _bmp;
```
Damage the lights (this only damages some of the selections, the others need to be damaged by driving into a building)
```sqf
{(vehicle player) setHitpointDamage [_x, 1]} forEach ["#l svetlo","#p svetlo"];
```
Now drive into a building a few times to damage the other selections, after doing so drive over a bush or crash through a small wall and watch as the driver recieves a bunch of wounds.

If you need to repair the vehicle after slamming into a building too many times (resulting in disabled tracks/engine)
```sqf
{(vehicle player) setHitpointDamage [_x, 0]} forEach ["hithull", "hitturret", "hitengine", "hitfuel","hitrtrack","hitltrack"];
```

Here is a video of repro showing toggling the fix on/off: https://youtu.be/KNprZ4aezRY