### PR TITLE
Explosives - Add "ace_explosives_setup" CBA Event

### DIFF
--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -187,6 +187,7 @@ GVAR(TweakedAngle) = 0;
             _unit setVariable [QGVAR(PlantingExplosive), true];
             [{_this setVariable [QGVAR(PlantingExplosive), false]}, _unit, 1.5] call CBA_fnc_waitAndExecute;
 
+            [QGVAR(setup), [_expSetupVehicle, _magClassname, _unit]] call CBA_fnc_globalEvent;
         };
     } else {
         private _screenPos = worldToScreen (_virtualPosASL call EFUNC(common,ASLToPosition));

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -87,6 +87,8 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 |`ace_allowDefuse` | [_mine, _allow] | Global or Target | Callable | Set allowance of the dynamic defusal action on a mine
 |`ace_tripflareTriggered` | [_flareObject, [_posX, _posY, _posZ]] | Global | Listen | Tripflare triggered
 |`ace_explosives_clackerAdded` | [_unit, _explosive, _id] | Local | Listen | Clacker added to explosive
+|`ace_explosives_setup` | [_explosive, _dir, _pitch, _unit] | Global | Listen | Explosive is placed in the world
+|`ace_explosives_place` | [_explosiveVehicle, _magClassname, _unit] | Global | Listen | Explosive is armed
 
 ### 2.9 Logistics Wirecutter (`ace_logistics`)
 

--- a/docs/wiki/framework/events-framework.md
+++ b/docs/wiki/framework/events-framework.md
@@ -87,8 +87,8 @@ MenuType: 0 = Interaction, 1 = Self Interaction
 |`ace_allowDefuse` | [_mine, _allow] | Global or Target | Callable | Set allowance of the dynamic defusal action on a mine
 |`ace_tripflareTriggered` | [_flareObject, [_posX, _posY, _posZ]] | Global | Listen | Tripflare triggered
 |`ace_explosives_clackerAdded` | [_unit, _explosive, _id] | Local | Listen | Clacker added to explosive
-|`ace_explosives_setup` | [_explosive, _dir, _pitch, _unit] | Global | Listen | Explosive is placed in the world
-|`ace_explosives_place` | [_explosiveVehicle, _magClassname, _unit] | Global | Listen | Explosive is armed
+|`ace_explosives_place` | [_explosive, _dir, _pitch, _unit] | Global | Listen | Explosive is armed
+|`ace_explosives_setup` | [_explosiveVehicle, _magClassname, _unit] | Global | Listen | Explosive is placed in the world
 
 ### 2.9 Logistics Wirecutter (`ace_logistics`)
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add an event to the "fnc_setupExplosive" for when an explosive is successfully placed down.

Currently, the "ace_explosives_place" event only triggers when a "trigger" is added to the explosive. This adds an event that passes in the placed explosive's vehicle, the mag class and the unit that placed the explosive.

Personally, the current event should be renamed and this one should be named "place" however, to avoid fallout with other mods that depend on this one, I've simply created a new one to keep the two separate and not cause other mods to need to be updated.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.