### PR TITLE
Logistics Wirecutter - Check if fence model is in `FENCE_P3DS` even if config check fails.

### DIFF
--- a/addons/logistics_wirecutter/functions/fnc_isFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_isFence.sqf
@@ -22,8 +22,8 @@ TRACE_1("Checking if fence",_object);
 private _configOf = configOf _object;
 if !(isNull _configOf) then {
     // Check for isFence entry since we have valid configOf
-    getNumber (_configOf >> QGVAR(isFence)) == 1 // return
-} else {
-    // Check the p3d name against list (in script_component.hpp)
-    (getModelInfo _object select 0) in FENCE_P3DS // return
+    if (getNumber (_configOf >> QGVAR(isFence)) == 1) exitWith { true };
 };
+
+// Check the p3d name against list (in script_component.hpp)
+(getModelInfo _object select 0) in FENCE_P3DS // return

--- a/addons/logistics_wirecutter/functions/fnc_isFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_isFence.sqf
@@ -20,10 +20,14 @@ params ["_object"];
 TRACE_1("Checking if fence",_object);
 
 private _configOf = configOf _object;
-if !(isNull _configOf) then {
+private _isConfigFence = if !(isNull _configOf) then {
     // Check for isFence entry since we have valid configOf
-    if (getNumber (_configOf >> QGVAR(isFence)) == 1) exitWith { true };
+    getNumber (_configOf >> QGVAR(isFence)) == 1
+} else {
+    false
 };
 
-// Check the p3d name against list (in script_component.hpp)
-(getModelInfo _object select 0) in FENCE_P3DS // return
+_isConfigFence || {
+    // Check the p3d name against list (in script_component.hpp)
+    (getModelInfo _object select 0) in FENCE_P3DS
+}

--- a/addons/logistics_wirecutter/functions/fnc_isFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_isFence.sqf
@@ -19,15 +19,4 @@
 params ["_object"];
 TRACE_1("Checking if fence",_object);
 
-private _configOf = configOf _object;
-private _isConfigFence = if !(isNull _configOf) then {
-    // Check for isFence entry since we have valid configOf
-    getNumber (_configOf >> QGVAR(isFence)) == 1
-} else {
-    false
-};
-
-_isConfigFence || {
-    // Check the p3d name against list (in script_component.hpp)
-    (getModelInfo _object select 0) in FENCE_P3DS
-}
+getNumber (configOf _object >> QGVAR(isFence)) == 1 || {(getModelInfo _object select 0) in FENCE_P3DS}


### PR DESCRIPTION
**When merged this pull request will:**
- Change the behavior of `ace_logistics_wirecutter_fnc_isFence` to check the `FENCE_P3DS` list even if `isFence` is unset (or set to 0) in the object's config.
   - It seems unlikely that `isFence` would get set to 0 on an object _and_ its model would be added to `FENCE_P3DS`. We don't even explicitly set this value to 0 anywhere anyways...

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

closes https://github.com/acemod/ACE3/issues/9165
