### PR TITLE
Medical - Add arsenal category

### DIFF
--- a/addons/medical_treatment/CfgWeapons.hpp
+++ b/addons/medical_treatment/CfgWeapons.hpp
@@ -8,12 +8,14 @@ class CfgWeapons {
 
     class FirstAidKit: ItemCore {
         type = 0;
+        ACE_isMedicalItem = 1;
         class ItemInfo: InventoryFirstAidKitItem_Base_F {
             mass = 4;
         };
     };
     class Medikit: ItemCore {
         type = 0;
+        ACE_isMedicalItem = 1;
         class ItemInfo: MedikitItem {
             mass = 60;
         };
@@ -27,6 +29,7 @@ class CfgWeapons {
         displayName = CSTRING(Bandage_Basic_Display);
         descriptionShort = CSTRING(Bandage_Basic_Desc_Short);
         descriptionUse = CSTRING(Bandage_Basic_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -39,6 +42,7 @@ class CfgWeapons {
         model = QPATHTOF(data\packingbandage.p3d);
         descriptionShort = CSTRING(Packing_Bandage_Desc_Short);
         descriptionUse = CSTRING(Packing_Bandage_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -51,6 +55,7 @@ class CfgWeapons {
         model = "\A3\Structures_F_EPA\Items\Medical\Bandage_F.p3d";
         descriptionShort = CSTRING(Bandage_Elastic_Desc_Short);
         descriptionUse = CSTRING(Bandage_Elastic_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -63,6 +68,7 @@ class CfgWeapons {
         model = QPATHTOF(data\tourniquet.p3d);
         descriptionShort = CSTRING(Tourniquet_Desc_Short);
         descriptionUse = CSTRING(Tourniquet_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -74,6 +80,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\splint_ca.paa);
         model = QPATHTOF(data\splint.p3d);
         descriptionShort = CSTRING(splint_Desc_Short);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 2;
         };
@@ -86,6 +93,7 @@ class CfgWeapons {
         model = QPATHTOF(data\morphine.p3d);
         descriptionShort = CSTRING(Morphine_Desc_Short);
         descriptionUse = CSTRING(Morphine_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -98,6 +106,7 @@ class CfgWeapons {
         model = QPATHTOF(data\adenosine.p3d);
         descriptionShort = CSTRING(adenosine_Desc_Short);
         descriptionUse = CSTRING(adenosine_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -110,6 +119,7 @@ class CfgWeapons {
         model = QPATHTOF(data\atropine.p3d);
         descriptionShort = CSTRING(Atropine_Desc_Short);
         descriptionUse = CSTRING(Atropine_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -122,6 +132,7 @@ class CfgWeapons {
         model = QPATHTOF(data\epinephrine.p3d);
         descriptionShort = CSTRING(Epinephrine_Desc_Short);
         descriptionUse = CSTRING(Epinephrine_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -137,6 +148,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\plasmaIV_ca.paa);
         descriptionShort = CSTRING(Plasma_IV_Desc_Short);
         descriptionUse = CSTRING(Plasma_IV_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
@@ -167,6 +179,7 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_blood_1000ml_ca.paa)};
         descriptionShort = CSTRING(Blood_IV_Desc_Short);
         descriptionUse = CSTRING(Blood_IV_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
@@ -197,6 +210,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\salineIV_ca.paa);
         descriptionShort = CSTRING(Saline_IV_Desc_Short);
         descriptionUse = CSTRING(Saline_IV_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
@@ -225,6 +239,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\quickclot_ca.paa);
         descriptionShort = CSTRING(QuikClot_Desc_Short);
         descriptionUse = CSTRING(QuikClot_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -236,6 +251,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\personal_aid_kit_ca.paa);
         descriptionShort = CSTRING(Aid_Kit_Desc_Short);
         descriptionUse = CSTRING(Aid_Kit_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 10;
         };
@@ -248,6 +264,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\surgicalKit_ca.paa);
         descriptionShort = CSTRING(SurgicalKit_Desc_Short);
         descriptionUse = CSTRING(SurgicalKit_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 15;
         };
@@ -260,6 +277,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\suture_ca.paa);
         descriptionShort = CSTRING(Suture_Desc_Short);
         descriptionUse = CSTRING(Suture_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 1;
         };
@@ -272,6 +290,7 @@ class CfgWeapons {
         picture = QPATHTOF(ui\bodybag_ca.paa);
         descriptionShort = CSTRING(Bodybag_Desc_Short);
         descriptionUse = CSTRING(Bodybag_Desc_Use);
+        ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 7;
         };

--- a/addons/medical_treatment/XEH_PREP.hpp
+++ b/addons/medical_treatment/XEH_PREP.hpp
@@ -49,6 +49,7 @@ PREP(medicationLocal);
 PREP(onMedicationUsage);
 PREP(placeInBodyBag);
 PREP(removeBody);
+PREP(scanMedicalItems);
 PREP(setTriageStatus);
 PREP(splint);
 PREP(splintLocal);

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -1,5 +1,7 @@
 #include "script_component.hpp"
 
+#define ARSENAL_CATEGORY_ICON (["\A3\ui_f\data\igui\cfg\actions\heal_ca.paa", QPATHTOEF(medical_gui,data\categories\bandage_fracture.paa)] select (["ace_medical_gui"] call EFUNC(common,isModLoaded)))
+
 [QEGVAR(medical_status,initialized), {
     params ["_unit"];
 
@@ -61,3 +63,8 @@ if (isServer) then {
         [_toReplace, _replacements] call EFUNC(common,registerItemReplacement);
     } forEach (configProperties [configFile >> QEGVAR(medical,replacementItems), "isArray _x"]);
 }] call CBA_fnc_addEventHandler;
+
+// Custom Arsenal tab
+if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
+    [uiNamespace getVariable [QGVAR(treatmentItems), []], localize ELSTRING(medical,Category), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
+};

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -1,7 +1,5 @@
 #include "script_component.hpp"
 
-#define ARSENAL_CATEGORY_ICON (["\A3\ui_f\data\igui\cfg\actions\heal_ca.paa", QPATHTOEF(medical_gui,data\categories\bandage_fracture.paa)] select (["ace_medical_gui"] call EFUNC(common,isModLoaded)))
-
 [QEGVAR(medical_status,initialized), {
     params ["_unit"];
 
@@ -63,8 +61,3 @@ if (isServer) then {
         [_toReplace, _replacements] call EFUNC(common,registerItemReplacement);
     } forEach (configProperties [configFile >> QEGVAR(medical,replacementItems), "isArray _x"]);
 }] call CBA_fnc_addEventHandler;
-
-// Custom Arsenal tab
-if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
-    [uiNamespace getVariable [QGVAR(treatmentItems), []], localize ELSTRING(medical,Category), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
-};

--- a/addons/medical_treatment/XEH_preInit.sqf
+++ b/addons/medical_treatment/XEH_preInit.sqf
@@ -8,6 +8,8 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+#define ARSENAL_CATEGORY_ICON (["\A3\ui_f\data\igui\cfg\actions\heal_ca.paa", QPATHTOEF(medical_gui,data\categories\bandage_fracture.paa)] select (["ace_medical_gui"] call EFUNC(common,isModLoaded)))
+
 // config to determine animation acceleration coefficient
 // adjusting these is trail and error
 // if the animation is cut of ingame, increase these values
@@ -43,5 +45,10 @@ GVAR(facilityClasses) = [];
         if (_name != "") then { GVAR(facilityClasses) pushBackUnique _name; };
     } forEach getArray _x;
 } forEach configProperties [configFile >> QEGVAR(medical,facilities), "isArray _x"];
+
+// Custom Arsenal tab
+if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
+    [call MEDICAL_TREATMENT_ITEMS, LELSTRING(medical,Category), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
+};
 
 ADDON = true;

--- a/addons/medical_treatment/XEH_preInit.sqf
+++ b/addons/medical_treatment/XEH_preInit.sqf
@@ -48,7 +48,7 @@ GVAR(facilityClasses) = [];
 
 // Custom Arsenal tab
 if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
-    [call MEDICAL_TREATMENT_ITEMS, LELSTRING(medical,Category), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
+    [MEDICAL_TREATMENT_ITEMS, LELSTRING(medical,Category), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
 };
 
 ADDON = true;

--- a/addons/medical_treatment/XEH_preStart.sqf
+++ b/addons/medical_treatment/XEH_preStart.sqf
@@ -1,3 +1,5 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.hpp"
+
+call FUNC(scanMedicalItems)

--- a/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
+++ b/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
@@ -31,4 +31,9 @@ private _fnc_isMedicalItem = toString {
     _list pushBack (configName _x);
 } forEach (_fnc_isMedicalItem configClasses (configFile >> "CfgWeapons"));
 
+// Some third-party mods use magazines as medical items
+{
+    _list pushBack (configName _x);
+} forEach (_fnc_isMedicalItem configClasses (configFile >> "CfgMagazines"));
+
 uiNamespace setVariable [QGVAR(treatmentItems), compileFinal str (_list arrayIntersect _list)]

--- a/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
+++ b/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: Salluci
+ * Caches all item classnames used in ACE_Medical_Treatment_Actions
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call ace_medical_treatment_fnc_getAllMedicalItems
+ *
+ * Public: No
+ */
+
+private _list = ["ACE_suture"]; // ugly workaround for sutures
+private _config = configFile >> QGVAR(actions);
+{
+    _list append (getArray (_x >> "items"));
+} forEach ("true" configClasses _config);
+
+uiNamespace setVariable [QGVAR(treatmentItems), _list arrayIntersect _list]

--- a/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
+++ b/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * call ace_medical_treatment_fnc_getAllMedicalItems
+ * call ace_medical_treatment_fnc_scanMedicalItems
  *
  * Public: No
  */

--- a/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
+++ b/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
@@ -15,10 +15,20 @@
  * Public: No
  */
 
-private _list = ["ACE_suture"]; // ugly workaround for sutures
-private _config = configFile >> QGVAR(actions);
+private _list = [];
+private _cfgActions = configFile >> QGVAR(actions);
+
+private _fnc_isMedicalItem = toString {
+    getNumber (_x >> "ACE_isMedicalItem") isEqualTo 1
+};
+
+// get items in ACE_Medical_Treament_Actions, fallback for items without API config property
 {
     _list append (getArray (_x >> "items"));
-} forEach ("true" configClasses _config);
+} forEach ("true" configClasses _cfgActions);
+
+{
+    _list pushBack (configName _x);
+} forEach (_fnc_isMedicalItem configClasses (configFile >> "CfgWeapons"));
 
 uiNamespace setVariable [QGVAR(treatmentItems), compileFinal str (_list arrayIntersect _list)]

--- a/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
+++ b/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
@@ -21,4 +21,4 @@ private _config = configFile >> QGVAR(actions);
     _list append (getArray (_x >> "items"));
 } forEach ("true" configClasses _config);
 
-uiNamespace setVariable [QGVAR(treatmentItems), _list arrayIntersect _list]
+uiNamespace setVariable [QGVAR(treatmentItems), compileFinal str (_list arrayIntersect _list)]

--- a/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
+++ b/addons/medical_treatment/functions/fnc_scanMedicalItems.sqf
@@ -31,9 +31,4 @@ private _fnc_isMedicalItem = toString {
     _list pushBack (configName _x);
 } forEach (_fnc_isMedicalItem configClasses (configFile >> "CfgWeapons"));
 
-// Some third-party mods use magazines as medical items
-{
-    _list pushBack (configName _x);
-} forEach (_fnc_isMedicalItem configClasses (configFile >> "CfgMagazines"));
-
 uiNamespace setVariable [QGVAR(treatmentItems), compileFinal str (_list arrayIntersect _list)]

--- a/addons/medical_treatment/script_component.hpp
+++ b/addons/medical_treatment/script_component.hpp
@@ -55,4 +55,4 @@
 // Animations that would be played faster than this are instead skipped. (= Progress bar too quick for animation).
 #define ANIMATION_SPEED_MAX_COEFFICIENT 2.5
 
-#define MEDICAL_TREATMENT_ITEMS (uiNamespace getVariable [QGVAR(treatmentItems), {[]}])
+#define MEDICAL_TREATMENT_ITEMS (call (uiNamespace getVariable [QGVAR(treatmentItems), {[]}]))

--- a/addons/medical_treatment/script_component.hpp
+++ b/addons/medical_treatment/script_component.hpp
@@ -54,3 +54,5 @@
 
 // Animations that would be played faster than this are instead skipped. (= Progress bar too quick for animation).
 #define ANIMATION_SPEED_MAX_COEFFICIENT 2.5
+
+#define MEDICAL_TREATMENT_ITEMS (uiNamespace getVariable [QGVAR(treatmentItems), {[]}])

--- a/docs/wiki/framework/medical-treatment-framework.md
+++ b/docs/wiki/framework/medical-treatment-framework.md
@@ -38,3 +38,21 @@ class CfgVehicles {
     };
 };
 ```
+### 1.3 Treatment Items
+
+Items in `CfgWeapons` with `ACE_isMedicalItem` property will be added to the ACE Medical category in the ACE Arsenal.
+```cpp
+class CfgWeapons {
+    class MyMedicalItem {
+        ACE_isMedicalItem = 1;
+    };
+};
+```
+Required items in `ACE_Medical_Treatment_Actions` will also be added as a fallback.
+```cpp
+class ACE_Medical_Treatment_Actions {
+    class MyCustomTreatment {
+        items[] = {"MyMedicalItem"};
+    };
+};
+```

--- a/docs/wiki/framework/medical-treatment-framework.md
+++ b/docs/wiki/framework/medical-treatment-framework.md
@@ -40,15 +40,10 @@ class CfgVehicles {
 ```
 ### 1.3 Treatment Items
 
-Items in `CfgWeapons` and `CfgMagazines` with `ACE_isMedicalItem` property will be added to the ACE Medical category in the ACE Arsenal.
+Items in `CfgWeapons` with `ACE_isMedicalItem` property will be added to the ACE Medical category in the ACE Arsenal.
 ```cpp
 class CfgWeapons {
     class MyMedicalItem {
-        ACE_isMedicalItem = 1;
-    };
-};
-class CfgMagazines {
-    class MyOtherMedicalitem {
         ACE_isMedicalItem = 1;
     };
 };

--- a/docs/wiki/framework/medical-treatment-framework.md
+++ b/docs/wiki/framework/medical-treatment-framework.md
@@ -40,10 +40,15 @@ class CfgVehicles {
 ```
 ### 1.3 Treatment Items
 
-Items in `CfgWeapons` with `ACE_isMedicalItem` property will be added to the ACE Medical category in the ACE Arsenal.
+Items in `CfgWeapons` and `CfgMagazines` with `ACE_isMedicalItem` property will be added to the ACE Medical category in the ACE Arsenal.
 ```cpp
 class CfgWeapons {
     class MyMedicalItem {
+        ACE_isMedicalItem = 1;
+    };
+};
+class CfgMagazines {
+    class MyOtherMedicalitem {
         ACE_isMedicalItem = 1;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Add "ACE Medical" category to ACE Arsenal through API function

Contains all items in ACE_Medical_Treatment_Actions, compatible with third party mods that add medical items (OPTRE, KAM (though not all items from KAM are added apparently? This should be fixed on their end with API)). Should clean up Misc Items a bit.

Uses Medical GUI icon if that's available. Vanilla medical icon is ugly.

See also #9221.

![image](https://github.com/acemod/ACE3/assets/69561145/96e4057f-0f17-42b2-8f98-6cd66801bec0)


### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
