### PR TITLE
Field Rations - Add arsenal category

### DIFF
--- a/addons/field_rations/CfgWeapons.hpp
+++ b/addons/field_rations/CfgWeapons.hpp
@@ -40,6 +40,7 @@ class CfgWeapons {
         XGVAR(replacementItem) = "ACE_WaterBottle_Half";
         XGVAR(consumeAnims)[] = {QGVAR(drinkStand), QGVAR(drinkCrouch), QGVAR(drinkProne)};
         XGVAR(consumeSounds)[] = {QGVAR(drink1), QGVAR(drink1), QGVAR(drink2)};
+        ACE_isFieldRationItem = 1;
     };
 
     class ACE_WaterBottle_Half: ACE_WaterBottle {
@@ -87,6 +88,7 @@ class CfgWeapons {
         XGVAR(replacementItem) = "ACE_Canteen_Half";
         XGVAR(consumeAnims)[] = {QGVAR(drinkStand), QGVAR(drinkCrouch), QGVAR(drinkProne)};
         XGVAR(consumeSounds)[] = {QGVAR(drink1), QGVAR(drink1), QGVAR(drink2)};
+        ACE_isFieldRationItem = 1;
     };
 
     class ACE_Canteen_Half: ACE_Canteen {
@@ -132,6 +134,7 @@ class CfgWeapons {
         XGVAR(consumeText) = CSTRING(DrinkingX);
         XGVAR(consumeAnims)[] = {QGVAR(drinkStandCan), QGVAR(drinkCrouchCan), QGVAR(drinkProneCan)};
         XGVAR(consumeSounds)[] = {QGVAR(drinkCan1), QGVAR(drinkCan1), QGVAR(drinkCan2)};
+        ACE_isFieldRationItem = 1;
     };
 
     class ACE_Can_Franta: ACE_Can_Spirit {
@@ -164,6 +167,7 @@ class CfgWeapons {
         XGVAR(consumeTime) = 10;
         XGVAR(hungerSatiated) = 20;
         XGVAR(consumeText) = CSTRING(EatingX);
+        ACE_isFieldRationItem = 1;
     };
 
     class ACE_MRE_BeefStew: ACE_MRE_LambCurry {
@@ -225,7 +229,7 @@ class CfgWeapons {
         model = QPATHTOF(data\mre_human.p3d);
         picture = QPATHTOF(ui\item_mre_human_co.paa);
     };
-    
+
     // - Misc Food ------------------------------------------------------------
     class ACE_Sunflower_Seeds: ACE_ItemCore {
         author = ECSTRING(common,ACETeam);
@@ -240,5 +244,6 @@ class CfgWeapons {
         XGVAR(consumeTime) = 10;
         XGVAR(hungerSatiated) = 10;
         XGVAR(consumeText) = CSTRING(EatingX);
+        ACE_isFieldRationItem = 1;
     };
 };

--- a/addons/field_rations/XEH_PREP.hpp
+++ b/addons/field_rations/XEH_PREP.hpp
@@ -14,5 +14,6 @@ ACEX_PREP(handleEffects);
 ACEX_PREP(handleHUD);
 ACEX_PREP(handleRespawn);
 ACEX_PREP(refillItem);
+ACEX_PREP(scanFieldRations);
 ACEX_PREP(setRemainingWater);
 ACEX_PREP(update);

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -2,8 +2,6 @@
 
 if !(hasInterface) exitWith {};
 
-#define ARSENAL_CATEGORY_ICON QPATHTOF(ui\icon_survival.paa)
-
 ["ace_settingsInitialized", {
     // Exit if not enabled
     if (!XGVAR(enabled)) exitWith {};
@@ -143,8 +141,3 @@ if !(hasInterface) exitWith {};
         ["ACE_player hunger", {ACE_player getVariable [QXGVAR(hunger), 0]}, [true, 0, 100]] call EFUNC(common,watchVariable);
     #endif
 }] call CBA_fnc_addEventHandler;
-
-// Custom Arsenal Tab
-if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
-    [keys FIELD_RATIONS_ITEMS, LLSTRING(DisplayName), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
-};

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -2,6 +2,8 @@
 
 if !(hasInterface) exitWith {};
 
+#define ARSENAL_CATEGORY_ICON QPATHTOF(ui\icon_survival.paa)
+
 ["ace_settingsInitialized", {
     // Exit if not enabled
     if (!XGVAR(enabled)) exitWith {};
@@ -141,3 +143,8 @@ if !(hasInterface) exitWith {};
         ["ACE_player hunger", {ACE_player getVariable [QXGVAR(hunger), 0]}, [true, 0, 100]] call EFUNC(common,watchVariable);
     #endif
 }] call CBA_fnc_addEventHandler;
+
+// Custom Arsenal Tab
+if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
+    [keys FIELD_RATIONS_ITEMS, localize LSTRING(DisplayName), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
+};

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -146,5 +146,5 @@ if !(hasInterface) exitWith {};
 
 // Custom Arsenal Tab
 if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
-    [keys FIELD_RATIONS_ITEMS, localize LSTRING(DisplayName), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
+    [keys FIELD_RATIONS_ITEMS, LLSTRING(DisplayName), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
 };

--- a/addons/field_rations/XEH_preInit.sqf
+++ b/addons/field_rations/XEH_preInit.sqf
@@ -8,6 +8,8 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+#define ARSENAL_CATEGORY_ICON QPATHTOF(ui\icon_survival.paa)
+
 // Init arrays of status modifiers
 GVAR(thirstModifiers) = [];
 GVAR(hungerModifiers) = [];
@@ -17,5 +19,10 @@ private _cache = call (uiNamespace getVariable [QGVAR(cacheP3Ds), {ERROR("no cac
 GVAR(waterSourceP3Ds) = _cache select 0;
 // List of refill action offsets corresponding to the p3ds in the array above
 GVAR(waterSourceOffsets) = _cache select 1;
+
+// Custom Arsenal Tab
+if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
+    [keys FIELD_RATIONS_ITEMS, LLSTRING(DisplayName), ARSENAL_CATEGORY_ICON] call EFUNC(arsenal,addRightPanelButton);
+};
 
 ADDON = true;

--- a/addons/field_rations/XEH_preStart.sqf
+++ b/addons/field_rations/XEH_preStart.sqf
@@ -30,3 +30,5 @@ private _waterSourceOffsets = [
 
 uiNamespace setVariable [QGVAR(cacheP3Ds), compileFinal str [_waterSourceP3Ds, _waterSourceOffsets]];
 TRACE_1("compiled",count _waterSourceP3Ds);
+
+call FUNC(scanFieldRations);

--- a/addons/field_rations/functions/fnc_scanFieldRations.sqf
+++ b/addons/field_rations/functions/fnc_scanFieldRations.sqf
@@ -19,16 +19,16 @@ private _list = createHashMap;
 private _cfgWeapons = configFile >> "CfgWeapons";
 private _cfgMagazines = configFile >> "CfgMagazines";
 
-private _fnc_isFieldRationItem = {
-    ((getNumber (_x >> QXGVAR(thirstQuenched))) > 0) || {(getNumber (_x >> QXGVAR(hungerSatiated))) > 0}
+private _fnc_isFieldRationItem = toString {
+    ((getNumber (_x >> QXGVAR(thirstQuenched))) > 0) || {(getNumber (_x >> QXGVAR(hungerSatiated))) > 0} || {(getText (_x >> QXGVAR(refillItem))) isNotEqualTo ""}
 };
 
 {
     _list set [configName _x, ""];
-} forEach (configProperties [_cfgWeapons, toString _fnc_isFieldRationItem, true]);
+} forEach (configProperties [_cfgWeapons, _fnc_isFieldRationItem]);
 
 {
     _list set [configName _x, ""];
-} forEach (configProperties [_cfgMagazines, toString _fnc_isFieldRationItem, true]);
+} forEach (configProperties [_cfgMagazines, _fnc_isFieldRationItem]);
 
 uiNamespace setVariable [QXGVAR(fieldRationItems), compileFinal str _list];

--- a/addons/field_rations/functions/fnc_scanFieldRations.sqf
+++ b/addons/field_rations/functions/fnc_scanFieldRations.sqf
@@ -31,4 +31,4 @@ private _fnc_isFieldRationItem = {
     _list set [configName _x, ""];
 } forEach (configProperties [_cfgMagazines, toString _fnc_isFieldRationItem, true]);
 
-uiNamespace setVariable [QXGVAR(fieldRationItems), _list];
+uiNamespace setVariable [QXGVAR(fieldRationItems), compileFinal str _list];

--- a/addons/field_rations/functions/fnc_scanFieldRations.sqf
+++ b/addons/field_rations/functions/fnc_scanFieldRations.sqf
@@ -25,10 +25,10 @@ private _fnc_isFieldRationItem = toString {
 
 {
     _list set [configName _x, ""];
-} forEach (configProperties [_cfgWeapons, _fnc_isFieldRationItem]);
+} forEach (_fnc_isFieldRationItem configClasses _cfgWeapons);
 
 {
     _list set [configName _x, ""];
-} forEach (configProperties [_cfgMagazines, _fnc_isFieldRationItem]);
+} forEach (_fnc_isFieldRationItem configClasses _cfgMagazines);
 
 uiNamespace setVariable [QXGVAR(fieldRationItems), compileFinal str _list];

--- a/addons/field_rations/functions/fnc_scanFieldRations.sqf
+++ b/addons/field_rations/functions/fnc_scanFieldRations.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+/*
+ * Author: Salluci
+ * Caches all item classnames used as field rations, their thirst/hunger values, and whether they are treated as magazines
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call acex_field_rations_fnc_scanFieldRations
+ *
+ * Public: No
+ */
+
+private _list = createHashMap;
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+
+private _fnc_isFieldRationItem = {
+    ((getNumber (_x >> QXGVAR(thirstQuenched))) > 0) || {(getNumber (_x >> QXGVAR(hungerSatiated))) > 0}
+};
+
+{
+    _list set [configName _x, ""];
+} forEach (configProperties [_cfgWeapons, toString _fnc_isFieldRationItem, true]);
+
+{
+    _list set [configName _x, ""];
+} forEach (configProperties [_cfgMagazines, toString _fnc_isFieldRationItem, true]);
+
+uiNamespace setVariable [QXGVAR(fieldRationItems), _list];

--- a/addons/field_rations/functions/fnc_scanFieldRations.sqf
+++ b/addons/field_rations/functions/fnc_scanFieldRations.sqf
@@ -20,7 +20,7 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 private _cfgMagazines = configFile >> "CfgMagazines";
 
 private _fnc_isFieldRationItem = toString {
-    ((getNumber (_x >> QXGVAR(thirstQuenched))) > 0) || {(getNumber (_x >> QXGVAR(hungerSatiated))) > 0} || {(getText (_x >> QXGVAR(refillItem))) isNotEqualTo ""}
+    (getNumber (_x >> "ACE_isFieldRationItem") isEqualTo 1) || {(getNumber (_x >> QXGVAR(thirstQuenched))) > 0} || {(getNumber (_x >> QXGVAR(hungerSatiated))) > 0} || {(getText (_x >> QXGVAR(refillItem))) isNotEqualTo ""}
 };
 
 {

--- a/addons/field_rations/script_component.hpp
+++ b/addons/field_rations/script_component.hpp
@@ -33,3 +33,5 @@
 #define IDC_DRAINING_HUD_THIRST_ICON  7750
 #define IDC_DRAINING_HUD_HUNGER_GROUP 7840
 #define IDC_DRAINING_HUD_HUNGER_ICON  7850
+
+#define FIELD_RATIONS_ITEMS (uiNamespace getVariable [QXGVAR(fieldRationItems), createHashMap])

--- a/addons/field_rations/script_component.hpp
+++ b/addons/field_rations/script_component.hpp
@@ -34,4 +34,4 @@
 #define IDC_DRAINING_HUD_HUNGER_GROUP 7840
 #define IDC_DRAINING_HUD_HUNGER_ICON  7850
 
-#define FIELD_RATIONS_ITEMS (uiNamespace getVariable [QXGVAR(fieldRationItems), createHashMap])
+#define FIELD_RATIONS_ITEMS (createHashMapFromArray (call (uiNamespace getVariable [QXGVAR(fieldRationItems), {createHashMap}])))

--- a/docs/wiki/framework/field-rations-framework.md
+++ b/docs/wiki/framework/field-rations-framework.md
@@ -28,7 +28,7 @@ Config Name | Type | Description
 `acex_field_rations_refillItem` | String | Makes an item refillable, class name of item added when refilled (OPTIONAL)
 `acex_field_rations_refillAmount` | Number | Amount of water required to refill item (OPTIONAL)
 `acex_field_rations_refillTime` | Number | Time required to refill item (in seconds) (OPTIONAL)
-`ACE_isFieldRationItem` | Number | Adds the item to the ACE Field Rations category in ACE Arsenal (OPTIONAL)
+`ACE_isFieldRationItem` | Number | Force adds the item to the ACE Field Rations category in ACE Arsenal (OPTIONAL)
 
 
 _* Value range is 0 to 100 and can be modified by the corresponding coefficient setting._

--- a/docs/wiki/framework/field-rations-framework.md
+++ b/docs/wiki/framework/field-rations-framework.md
@@ -28,6 +28,7 @@ Config Name | Type | Description
 `acex_field_rations_refillItem` | String | Makes an item refillable, class name of item added when refilled (OPTIONAL)
 `acex_field_rations_refillAmount` | Number | Amount of water required to refill item (OPTIONAL)
 `acex_field_rations_refillTime` | Number | Time required to refill item (in seconds) (OPTIONAL)
+`ACE_isFieldRationItem` | Number | Adds the item to the ACE Field Rations category in ACE Arsenal (OPTIONAL)
 
 
 _* Value range is 0 to 100 and can be modified by the corresponding coefficient setting._


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Same deal as #9220. This also caches the items in UI namespace in case anyone wants to take a crack at reducing the footprint on `fnc_createConsumableChildren` and `fnc_consumeItem`. I tried but I don't want more migraines today.

![20230619040919_1](https://github.com/acemod/ACE3/assets/69561145/422b68b8-83de-4463-bdf1-edb6df0b2141)


### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
