### PR TITLE
CSW - Fix mag multiplication in multiplayer

### DIFF
--- a/addons/csw/XEH_postInit.sqf
+++ b/addons/csw/XEH_postInit.sqf
@@ -4,7 +4,10 @@ GVAR(vehicleMagCache) = createHashMap;
 
 ["CBA_settingsInitialized", {
     TRACE_3("settingsInit",GVAR(defaultAssemblyMode),GVAR(handleExtraMagazines),GVAR(ammoHandling));
-    ["StaticWeapon", "init", LINKFUNC(staticWeaponInit), true, [], true] call CBA_fnc_addClassEventHandler;
+    ["StaticWeapon", "Init", {
+        // needs a small delay for network syncing, or we end up with duplicate mags with ammo handling
+        [LINKFUNC(staticWeaponInit), _this] call CBA_fnc_execNextFrame;
+    }, true, [], true] call CBA_fnc_addClassEventHandler;
 }] call CBA_fnc_addEventHandler;
 
 

--- a/addons/csw/XEH_postInit.sqf
+++ b/addons/csw/XEH_postInit.sqf
@@ -6,7 +6,7 @@ GVAR(vehicleMagCache) = createHashMap;
     TRACE_3("settingsInit",GVAR(defaultAssemblyMode),GVAR(handleExtraMagazines),GVAR(ammoHandling));
     ["StaticWeapon", "Init", {
         // needs a small delay for network syncing, or we end up with duplicate mags with ammo handling
-        [LINKFUNC(staticWeaponInit), _this] call CBA_fnc_execNextFrame;
+        [LINKFUNC(staticWeaponInit), _this, 1] call CBA_fnc_waitAndExecute;
     }, true, [], true] call CBA_fnc_addClassEventHandler;
 }] call CBA_fnc_addEventHandler;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

`turretLocal` is used to check who handles the extra mags, but that returns true for all clients on Init, resulting in mags being multiplied by the number of players on the server.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
