### PR TITLE
CSW - Add variable to disable for individual weapons

### DIFF
--- a/addons/csw/functions/fnc_ai_handleFired.sqf
+++ b/addons/csw/functions/fnc_ai_handleFired.sqf
@@ -16,6 +16,7 @@ params ["_staticWeapon", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_
 TRACE_8("firedEH:",_staticWeapon,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile,_gunner);
 
 if ((!local _gunner) || {[_gunner] call EFUNC(common,isPlayer)}) exitWith {};
+if (_staticWeapon getVariable [QGVAR(disabled), false]) exitWith {};
 if (someAmmo _staticWeapon) exitWith {};
 
 TRACE_2("need ammo",someAmmo _staticWeapon,magazinesAllTurrets _staticWeapon);

--- a/addons/csw/functions/fnc_ai_handleGetIn.sqf
+++ b/addons/csw/functions/fnc_ai_handleGetIn.sqf
@@ -15,6 +15,7 @@ params ["_staticWeapon", "_role", "_gunner"];
 TRACE_3("getInEH:",_staticWeapon,_role,_gunner);
 
 if ((!local _gunner) || {[_gunner] call EFUNC(common,isPlayer)}) exitWith {};
+if (_staticWeapon getVariable [QGVAR(disabled), false]) exitWith {};
 if (someAmmo _staticWeapon) exitWith {};
 
 TRACE_2("need ammo",someAmmo _staticWeapon,magazinesAllTurrets _staticWeapon);

--- a/addons/csw/functions/fnc_reload_actionsLoad.sqf
+++ b/addons/csw/functions/fnc_reload_actionsLoad.sqf
@@ -32,7 +32,8 @@ private _condition = {
     params ["_target", "_player", "_params"];
     _params params ["_carryMag", "_turretPath", "", "_magSource"];
 
-    ([_target, _turretPath, _carryMag, _magSource] call FUNC(reload_canLoadMagazine)) select 0
+    !(_target getVariable [QGVAR(disabled), false]) &&
+    {([_target, _turretPath, _carryMag, _magSource] call FUNC(reload_canLoadMagazine)) select 0}
 };
 
 private _cfgMagazines = configFile >> "CfgMagazines"; // micro-optimization

--- a/addons/csw/functions/fnc_reload_actionsUnload.sqf
+++ b/addons/csw/functions/fnc_reload_actionsUnload.sqf
@@ -46,7 +46,8 @@ private _statement = {
 private _condition = {
     params ["_target", "_player", "_params"];
     _params params ["_vehMag", "_turretPath", "_carryMag"];
-    [_target, _turretPath, _player, _carryMag, _vehMag] call FUNC(reload_canUnloadMagazine)
+    !(_target getVariable [QGVAR(disabled), false]) &&
+    {[_target, _turretPath, _player, _carryMag, _vehMag] call FUNC(reload_canUnloadMagazine)}
 };
 
 private _actions = [];

--- a/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
@@ -19,6 +19,7 @@
 params ["_staticWeapon", "_assemblyMode", "_emptyWeapon"];
 TRACE_3("staticWeaponInit_unloadExtraMags",_staticWeapon,_assemblyMode,_emptyWeapon);
 if (!_assemblyMode) exitWith {};
+if (_staticWeapon getVariable [QGVAR(disabled), false]) exitWith {};
 
 private _desiredAmmo = getNumber (configOf _staticWeapon >> QUOTE(ADDON) >> "desiredAmmo");
 private _storeExtraMagazines = GVAR(handleExtraMagazines);

--- a/addons/mk6mortar/XEH_preInit.sqf
+++ b/addons/mk6mortar/XEH_preInit.sqf
@@ -8,4 +8,17 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.sqf"
 
+["Mortar_01_base_F", "Init", { // override CSW's ammo handling with Mk6 setting
+    params ["_mortar"];
+    _mortar setVariable [QEGVAR(csw,disabled), !GVAR(useAmmoHandling)];
+}] call CBA_fnc_addClassEventHandler;
+
+GVAR(ammoHandlingMagazineReplacement) = createHashMapFromArray [
+    ["8Rnd_82mm_Mo_shells", "ACE_1Rnd_82mm_Mo_HE"],
+    ["8Rnd_82mm_Mo_Smoke_white", "ACE_1Rnd_82mm_Mo_Smoke"],
+    ["8Rnd_82mm_Mo_Flare_white", "ACE_1Rnd_82mm_Mo_Illum"],
+    ["8Rnd_82mm_Mo_guided", "ACE_1Rnd_82mm_Mo_HE_Guided"],
+    ["8Rnd_82mm_Mo_LG", "ACE_1Rnd_82mm_Mo_HE_LaserGuided"]
+];
+
 ADDON = true;

--- a/addons/mk6mortar/functions/fnc_csw_getProxyWeapon.sqf
+++ b/addons/mk6mortar/functions/fnc_csw_getProxyWeapon.sqf
@@ -22,9 +22,9 @@
 params ["_mortar", "_turret", "_currentWeapon", "_proxyWeaponNeeded"];
 TRACE_4("csw_getProxyWeapon",_mortar,_turret,_currentWeapon,_proxyWeaponNeeded);
 
-private _newWeapon = "";
+private _newWeapon = _currentWeapon;
 
-if (_proxyWeaponNeeded || GVAR(useAmmoHandling)) then {
+if (GVAR(useAmmoHandling)) then {
     if (_currentWeapon != "mortar_82mm") exitWith { ERROR_2("unknown weapon [%1 - %2]",typeOf _mortar,_currentWeapon); };
 
     // Replace weapon with fast reloading version
@@ -36,23 +36,13 @@ if (_proxyWeaponNeeded || GVAR(useAmmoHandling)) then {
     private _convertedMags = [];
     {
         _x params ["_xMag", "_xTurret", "_xAmmo"];
-
         if (_xTurret isEqualTo _turret) then {
-            private _replaceMag = switch (true) do {
-            case (_xMag == "8Rnd_82mm_Mo_shells"): {"ACE_1Rnd_82mm_Mo_HE"};
-            case (_xMag == "8Rnd_82mm_Mo_Smoke_white"): {"ACE_1Rnd_82mm_Mo_Smoke"};
-            case (_xMag == "8Rnd_82mm_Mo_Flare_white"): {"ACE_1Rnd_82mm_Mo_Illum"};
-            case (_xMag == "8Rnd_82mm_Mo_guided"): {"ACE_1Rnd_82mm_Mo_HE_Guided"};
-            case (_xMag == "8Rnd_82mm_Mo_LG"): {"ACE_1Rnd_82mm_Mo_HE_LaserGuided"};
-                default {""};
-            };
+            private _replaceMag = GVAR(ammoHandlingMagazineReplacement) getOrDefault [_xMag, ""];
             if (_replaceMag != "") then {
                 _magsToRemove pushBackUnique [_xMag, _xTurret];
-                if (!GVAR(useAmmoHandling)) then {
-                    TRACE_3("replacing",_xMag,_replaceMag,_xAmmo);
-                    for "_i" from 1 to _xAmmo do {
-                        _convertedMags pushBack [_replaceMag, _xTurret, 1];
-                    };
+                TRACE_3("replacing",_xMag,_replaceMag,_xAmmo);
+                for "_i" from 1 to _xAmmo do {
+                    _convertedMags pushBack [_replaceMag, _xTurret, 1];
                 };
             } else {
                 WARNING_1("unknown mag %1", _xMag);

--- a/addons/mk6mortar/stringtable.xml
+++ b/addons/mk6mortar/stringtable.xml
@@ -218,7 +218,7 @@
             <Chinese>這個模塊允許你設定MK6迫擊砲的相關功能</Chinese>
         </Key>
         <Key ID="STR_ACE_Mk6Mortar_useAmmoHandling_DisplayName">
-            <English>Use Ammunition handling</English>
+            <English>Use Ammunition Handling</English>
             <German>Aktiviere Munitionshandhabung</German>
             <Spanish>Usar manejo de munición.</Spanish>
             <Polish>Aktywuj obsługę amunicji</Polish>
@@ -233,19 +233,7 @@
             <Czech>Používat ruční manipulaci s municí</Czech>
         </Key>
         <Key ID="STR_ACE_Mk6Mortar_useAmmoHandling_Description">
-            <English>Removes mortar magazines, requiring individual rounds to be loaded by the gunner or loader. Does not affect AI mortars.</English>
-            <German>Enfernt das Magzin des Mörsers. Es ist nun erforderlich, die einzelnen Patronen manuell zu laden. Dies beeinflusst nicht die KI-Truppen.</German>
-            <Spanish>Elimina los cargadores del mortero, requiriendo al artillero o cargador la carga manual de cada rondas. No afecta morteros controlados por IA.</Spanish>
-            <Polish>Usuwa magazynki moździerza, wymagając ładowania pojedynczych pocisków przez strzelca lub ładowniczego. Nie dotyczy moździerzy AI.</Polish>
-            <French>Enlève les chargeurs de mortier, ce qui oblige le tireur ou le servant à charger les obus manuellement. N'affecte pas les mortiers IA.</French>
-            <Italian>Toglie i proiettili dal mortaio. I colpi singoli devono essere caricati dall'operatore. Non cambia quado l'IA spara.</Italian>
-            <Portuguese>Elimina os carregadores do morteiro, requerendo que o atirador ou carregador utilize de forma individual a munição. Não afeta os morteiros controlados pela IA.</Portuguese>
-            <Russian>Удаляет артиллерийские магазины, требует загрузку отдельных снарядов стрелком или заряжающим. Не влияет на артиллерию ИИ.</Russian>
-            <Japanese>迫撃砲から弾薬を除去します。射手か装填手により予め装填されている必要があります。AI 迫撃砲へ影響を与えません。</Japanese>
-            <Korean>박격포 탄창을 제거합니다, 사수나 장전수가 개별적으로 탄환을 넣어줘야 합니다. 인공지능은 영향을 받지 않습니다.</Korean>
-            <Chinesesimp>开启此功能时。迫击炮的弹药需由炮手与装填手共同合作来进行装填。此功能并不影响由 AI 射击的迫击炮</Chinesesimp>
-            <Chinese>開啟此功能時。迫擊砲的彈藥需由砲手與裝填手共同合作來進行裝填。此功能並不影響由AI射擊的迫擊砲</Chinese>
-            <Czech>Odstraní z minometu zásobník a vynucuje nabíjení po každém výstřelu buď mířičem nebo nabíječem. Tato možnost neovlivňuje AI posádky.</Czech>
+            <English>Converts mortar magazines into their single round versions, requiring individual rounds to be loaded by the crew.\nOverrides Crew Served Weapon's Ammo Handling.</English>
         </Key>
         <Key ID="STR_ACE_Mk6Mortar_unloadMortar">
             <English>Remove Round</English>

--- a/docs/wiki/framework/crew-served-weapons-framework.md
+++ b/docs/wiki/framework/crew-served-weapons-framework.md
@@ -102,12 +102,12 @@ class ACE_CSW_Groups {
     class prefix_100rnd_hmg_csw_mag { // Same name as the carryable magazine
         prefix_100rnd_hmg_mag = 1;    // Vehicle magazine that will be loaded when loading this magazine
     };
-    
+
     // Using an existing CSW magazine
     class ace_csw_100Rnd_127x99_mag {
         banana_dummy_ammo = 1;
     };
-    
+
     /*
         Carryable magazines already defined by ACE:
         - ace_csw_100Rnd_127x99_mag
@@ -134,12 +134,12 @@ class CfgVehicles {
     class StaticMGWeapon;
     class prefix_hmg: StaticMGWeapon {
         class ACE_CSW {
-            enabled = 1; // Enables ACE CSW for this weapon              
+            enabled = 1; // Enables ACE CSW for this weapon
             proxyWeapon = "prefix_hmg_weapon_proxy"; // The proxy weapon created above
             magazineLocation = "_target selectionPosition 'magazine'"; // Ammo handling interaction point location
             disassembleWeapon = "prefix_hmg_carry";  // Carryable weapon created above
             disassembleTurret = "ace_csw_m3Tripod";  // Which static tripod will appear when weapon is disassembled
-            ammoLoadTime = 7;   // How long it takes in seconds to load ammo into the weapon           
+            ammoLoadTime = 7;   // How long it takes in seconds to load ammo into the weapon
             ammoUnloadTime = 5; // How long it takes in seconds to unload ammo from the weapon
             desiredAmmo = 100;  // When the weapon is reloaded it will try and reload to this ammo capacity
             // Optional callback function for when the CSW gets disassembled, called with [tripod, staticWeapon]
@@ -147,6 +147,17 @@ class CfgVehicles {
         };
     };
 };
+```
+
+### 1.5 Custom Ammo Handling
+
+ACE's ammo handling (including AI reloading, and initial unloading and conversion of the weapon's magazines) can be blocked by setting the `ace_csw_disabled` variable on init.
+This will also block reloading and unloading the weapon manually through ACE.
+This variable needs to be set where the weapon is local.
+
+```sqf
+myCustomStaticWeapon = createVehicle ["B_Mortar_01_F", [0, 0, 0]];
+myCustomStaticWeapon setVariable ["ace_csw_disabled", true, true]; // blocks ammo handling
 ```
 
 ## 2. Making a new Tripod


### PR DESCRIPTION
**When merged this pull request will:**
- Add `ace_csw_disabled` variable. Disables AI reloading, magazine replacement on init, and loading/unloading.
- Make Mk6 Ammo Handling setting overrides CSW's.
- Change mortar magazine replacement into hashmap, to be documented later. First step for finishing #4080.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
