### PR TITLE
Medical - Change default spontaneous wake up chance & epinephrine boost settings

### DIFF
--- a/addons/medical/initSettings.sqf
+++ b/addons/medical/initSettings.sqf
@@ -34,7 +34,7 @@
     "SLIDER",
     [LSTRING(SpontaneousWakeUpChance_DisplayName), LSTRING(SpontaneousWakeUpChance_Description)],
     LSTRING(Category),
-    [0, 1, 0.05, 2, true],
+    [0, 1, 0.1, 2, true],
     true
 ] call CBA_fnc_addSetting;
 
@@ -43,6 +43,6 @@
     "SLIDER",
     [LSTRING(spontaneousWakeUpEpinephrineBoost_DisplayName), LSTRING(spontaneousWakeUpEpinephrineBoost_Description)],
     LSTRING(Category),
-    [1, 30, 1, 1],
+    [1, 30, 1.5, 1],
     true
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Epinephrine does nothing with default settings. This is counter-productive for understanding of that mechanic.

Some math for unconsciousness: on average, a stable, unconscious patient will take 3.5 minutes (0.95^14) to reach 50% chance to wake up. Bell curve means this will usually be higher. Setting to 10% halves this without making things easy.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
