### PR TITLE
Medical Treatment - Remove early exit when stitching with sutures

### DIFF
--- a/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
+++ b/addons/medical_treatment/functions/fnc_surgicalKitProgress.sqf
@@ -83,9 +83,7 @@ if (
 };
 
 // Consume a suture for the next wound if one exists, stop stitching if none are left
-if (GVAR(consumeSurgicalKit) == 2) then {
-    // Don't consume a suture if there are no more wounds to stitch
-    if (_bandagedWoundsOnPart isEqualTo []) exitWith {false};
+if (GVAR(consumeSurgicalKit) == 2 && {_bandagedWoundsOnPart isNotEqualTo []}) then {
     ([_medic, _patient, ["ACE_suture"]] call FUNC(useItem)) params ["_user"];
     !isNull _user
 } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Early exit meant callbackSuccess wasn't called and Medical Menu wouldn't reopen. Suture consumption remains unchanged.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
