### PR TITLE
Medical - Fix wound hashmaps deserialized as CBA_namespaces

### DIFF
--- a/addons/medical/functions/fnc_deserializeState.sqf
+++ b/addons/medical/functions/fnc_deserializeState.sqf
@@ -56,6 +56,13 @@ private _state = [_json] call CBA_fnc_parseJSON;
     _x params ["_var", "_default"];
     private _value = _state getVariable _x;
 
+    // Handle wound hashmaps deserialized as CBA_namespaces
+    if (typeName _value == "LOCATION") then {
+        private _keys = allVariables _value;
+        private _values = _keys apply {_value getVariable _x};
+        _value = _keys createHashMapFromArray _values;
+    };
+
     // Treat null as nil
     if (_value isEqualTo objNull) then {
         _value = _default;


### PR DESCRIPTION
**When merged this pull request will:**
- Handle wound hashmaps being deserialized as CBA_namepsaces in medical deserialization
- Fixes #9244 

*Note*
- This has the least surface area of changes
- I also have a version where `[_json, 2] call CBA_fnc_parseJSON` is used, which creates native hashmaps instead of CBA_namespaces for the deserialized object types, however this also required updating every state read and using `toLower` for the keys as hashmap keys are [case sensitive](https://community.bistudio.com/wiki/get#:~:text=key%3A%20HashMapKey%20%2D-,Case%20sensitive%20key,-Return%20Value%3A) and the serialization produces all lower case keys
- Let me know if that [version](https://github.com/tbeswick96/ACE3/commit/ffc5acafcd9f6124e4739b257b1ec32fb8166da6) would be preferred and I'll update accordingly
