### PR TITLE
Gunbag - Fix arsenal caching conflicting with CBA_fnc_setLoadout

### DIFF
--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -49,6 +49,9 @@ PREP_RECOMPILE_END;
     private _gunbagWeapon = _extendedInfo getOrDefault [QGVAR(gunbagWeapon), []];
     if (_gunbagWeapon isNotEqualTo []) then {
         (backpackContainer _unit) setVariable [QGVAR(gunbagWeapon), _gunbagWeapon, true];
+
+        // Prevent the arsenal closed event from overwriting new info
+        GVAR(arsenalCache) = nil;
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -51,7 +51,9 @@ PREP_RECOMPILE_END;
         (backpackContainer _unit) setVariable [QGVAR(gunbagWeapon), _gunbagWeapon, true];
 
         // Prevent the arsenal closed event from overwriting new info
-        GVAR(arsenalCache) = nil;
+        if (!isNil QGVAR(arsenalCache)) then {
+            GVAR(arsenalCache) = _gunbagWeapon;
+        };
     };
 }] call CBA_fnc_addEventHandler;
 


### PR DESCRIPTION
**When merged this pull request will:**
- [This](https://github.com/acemod/ACE3/blob/ab2207924f6311fcb15dd6372cccc27ca1db682d/addons/gunbag/XEH_preInit.sqf#L38) line overwrites the gunbag that was loaded within the arsenal using `CBA_fnc_setLoadout`. This PR fixes this issue.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
