### PR TITLE
Dragging - Add limping check to carrier and improve limping check for target unit

### DIFF
--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -31,10 +31,10 @@ if (_target isKindOf "StaticWeapon") exitWith {
     crew _target findIf {getText (configOf _x >> "simulation") != "UAVPilot"} == -1
 };
 
-// Units need to be unconscious or be limping
+// Units need to be unconscious or limping
 if (_target isKindOf "CAManBase") exitWith {
     lifeState _target isEqualTo "INCAPACITATED"
-    || {_target getHitPointDamage "HitLegs" > 0.4}
+    || {_target getHitPointDamage "HitLegs" >= 0.5}
 };
 
 // Check max items for WeaponHolders

--- a/addons/dragging/functions/fnc_canDrag.sqf
+++ b/addons/dragging/functions/fnc_canDrag.sqf
@@ -27,10 +27,10 @@ if (_target isKindOf "StaticWeapon") exitWith {
     crew _target findIf {getText (configOf _x >> "simulation") != "UAVPilot"} == -1
 };
 
-// Units need to be unconscious or be limping
+// Units need to be unconscious or limping
 if (_target isKindOf "CAManBase") exitWith {
     lifeState _target isEqualTo "INCAPACITATED"
-    || {_target getHitPointDamage "HitLegs" > 0.4}
+    || {_target getHitPointDamage "HitLegs" >= 0.5}
 };
 
 // Check max items for WeaponHolders

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -33,8 +33,8 @@ if !(_unit getVariable [QGVAR(isCarrying), false]) exitWith {
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 };
 
-// drop if the crate is destroyed OR (target moved away from carrier (weapon disasembled))
-if (!alive _target || {_unit distance _target > 10}) exitWith {
+// drop if the crate is destroyed OR target moved away from carrier (weapon disassembled) OR carrier starts limping
+if !(alive _target && {_unit distance _target <= 10} && {_unit getHitPointDamage "HitLegs" < 0.5}) exitWith {
     TRACE_2("dead/distance",_unit,_target);
     if ((_unit distance _target > 10) && {(CBA_missionTime - _startTime) < 1}) exitWith {
         //attachTo seems to have some kind of network delay and target can return an odd position during the first few frames,


### PR DESCRIPTION
**When merged this pull request will:**
- Change the limping damage threshold in `FUNC(canCarry)` and `FUNC(canDrag)` to use the actual point at which a unit starts limping.
- Add a check for carrier limping `FUNC(carryObjectPFH)`. Previously if the carrier started limping after picking up an object they wouldn't drop it.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
