### PR TITLE
Overpressure - Fix invulnerable units taking backblast damage when firing launchers

### DIFF
--- a/addons/overpressure/functions/fnc_firedEHBB.sqf
+++ b/addons/overpressure/functions/fnc_firedEHBB.sqf
@@ -41,18 +41,23 @@ private _distance = 2 * ([_position, _direction, _backblastRange, _unit] call FU
 TRACE_1("Distance",_distance);
 
 if (_distance < _backblastRange) then {
-    private _alpha = sqrt (1 - _distance / _backblastRange);
-    private _beta = sqrt 0.5;
+    TRACE_2("",isDamageAllowed _unit,_unit getVariable [ARR_2(QEGVAR(medical,allowDamage),true)]);
 
-    private _damage = _alpha * _beta * _backblastDamage;
-    [_damage * 100] call BIS_fnc_bloodEffect;
+    // Skip damage if not allowed
+    if (isDamageAllowed _unit && {_unit getVariable [QEGVAR(medical,allowDamage), true]}) then {
+        private _alpha = sqrt (1 - _distance / _backblastRange);
+        private _beta = sqrt 0.5;
 
-    if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
-        [_unit, _damage, "body", "backblast", _unit] call EFUNC(medical,addDamageToUnit);
-    } else {
-        TRACE_1("",isDamageAllowed _unit);
-        if (!isDamageAllowed _unit) exitWith {}; // Skip damage if not allowed
-        _unit setDamage (damage _unit + _damage);
+        private _damage = _alpha * _beta * _backblastDamage;
+        TRACE_1("",_damage);
+
+        [_damage * 100] call BIS_fnc_bloodEffect;
+
+        if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
+            [_unit, _damage, "body", "backblast", _unit] call EFUNC(medical,addDamageToUnit);
+        } else {
+            _unit setDamage (damage _unit + _damage);
+        };
     };
 };
 

--- a/addons/overpressure/functions/fnc_overpressureDamage.sqf
+++ b/addons/overpressure/functions/fnc_overpressureDamage.sqf
@@ -42,19 +42,21 @@ TRACE_3("cache",_overpressureAngle,_overpressureRange,_overpressureDamage);
         TRACE_4("Affected:",_x,_axisDistance,_distance,_angle);
 
         if (_angle < _overpressureAngle && {_distance < _overpressureRange} && {!lineIntersects _line} && {!terrainIntersectASL _line2}) then {
+            TRACE_2("",isDamageAllowed _unit,_unit getVariable [ARR_2(QEGVAR(medical,allowDamage),true)]);
 
-            private _alpha = sqrt (1 - _distance / _overpressureRange);
-            private _beta = sqrt (1 - _angle / _overpressureAngle);
-
-            private _damage = _alpha * _beta * _overpressureDamage;
-            TRACE_1("",_damage);
-
-            TRACE_1("",isDamageAllowed _x);
+            // Skip damage if not allowed
             if (isDamageAllowed _x && {_x getVariable [QEGVAR(medical,allowDamage), true]}) then {
+                private _alpha = sqrt (1 - _distance / _overpressureRange);
+                private _beta = sqrt (1 - _angle / _overpressureAngle);
+
+                private _damage = _alpha * _beta * _overpressureDamage;
+                TRACE_1("",_damage);
+
                 // If the target is the ACE_player
                 if (_x isEqualTo ACE_player) then {
-                    [_damage * 100] call BIS_fnc_bloodEffect
+                    [_damage * 100] call BIS_fnc_bloodEffect;
                 };
+
                 if (["ACE_Medical"] call EFUNC(common,isModLoaded)) then {
                     [_x, _damage, "body", "backblast", _firer] call EFUNC(medical,addDamageToUnit);
                 } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- If you go into the ACE arsenal mission and fire the MAAWS with some of the virtual blocks/barriers to your back, you will take backblast damage. This PR addresses such unintended behaviour.
- Includes some very minor cleanup.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
