### PR TITLE
Mk6 Mortar - Fix AI firing and doArtilleryFire

### DIFF
--- a/addons/mk6mortar/CfgWeapons.hpp
+++ b/addons/mk6mortar/CfgWeapons.hpp
@@ -16,15 +16,18 @@ class CfgWeapons {
     class CannonCore;
     class mortar_82mm: CannonCore {
         class Single1;
+        class Burst1;
     };
     class ACE_mortar_82mm: mortar_82mm {
         author = ECSTRING(common,ACETeam);
         magazines[] = {"ACE_1Rnd_82mm_Mo_HE","ACE_1Rnd_82mm_Mo_Smoke","ACE_1Rnd_82mm_Mo_Illum",
             "ACE_1Rnd_82mm_Mo_HE_Guided","ACE_1Rnd_82mm_Mo_HE_LaserGuided"};
-        modes[] = {"Single1","Single2","Single3"};
         reloadTime = 0.5;
         magazineReloadTime = 0.5;
         class Single1: Single1 {
+            reloadTime = 0.5;
+        };
+        class Burst1: Burst1 {
             reloadTime = 0.5;
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Removing the burst modes breaks `doArtilleryFire` and AI firing the weapon. No reason to do that anymore as we just replace the whole weapon.

I don't know how many issues this closes. Probably a few. I'll track them down later.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
