### PR TITLE
Dragging - Fix unintended Cargo dependency and improve ragdoll/disconnection handling

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1661,5 +1661,21 @@
             <Russian>Разрядить оружие</Russian>
             <Spanish>Descargar arma</Spanish>
         </Key>
+        <Key ID="STR_ACE_common_loadObject">
+            <English>Load</English>
+            <German>Beladen</German>
+            <Polish>Załaduj</Polish>
+            <Portuguese>Carregar</Portuguese>
+            <Russian>Загрузить</Russian>
+            <Czech>Naložit</Czech>
+            <Spanish>Cargar</Spanish>
+            <Italian>Carica</Italian>
+            <French>Charger</French>
+            <Japanese>積み込む</Japanese>
+            <Korean>싣기</Korean>
+            <Chinese>裝載</Chinese>
+            <Chinesesimp>装载</Chinesesimp>
+            <Turkish>Yükle</Turkish>
+        </Key>
     </Package>
 </Project>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1661,7 +1661,7 @@
             <Russian>Разрядить оружие</Russian>
             <Spanish>Descargar arma</Spanish>
         </Key>
-        <Key ID="STR_ACE_common_loadObject">
+        <Key ID="STR_ACE_Common_loadObject">
             <English>Load</English>
             <German>Beladen</German>
             <Polish>Załaduj</Polish>

--- a/addons/dragging/XEH_postInit.sqf
+++ b/addons/dragging/XEH_postInit.sqf
@@ -2,8 +2,12 @@
 #include "script_component.hpp"
 
 if (isServer) then {
-    // release object on hard disconnection. Function is identical to killed
-    addMissionEventHandler ["HandleDisconnect", {_this call FUNC(handleKilled)}];
+    // 'HandleDisconnect' EH triggers too late
+    addMissionEventHandler ["PlayerDisconnected", {
+        private _unit = (getUserInfo (_this select 5)) select 10;
+
+        _unit call FUNC(handleKilled);
+    }];
 };
 
 if (!hasInterface) exitWith {};

--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interaction"};
+        requiredAddons[] = {"ace_interaction","ace_cargo"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet", "commy2", "PiZZADOX", "Malbryn"};
         url = ECSTRING(main,URL);

--- a/addons/dragging/config.cpp
+++ b/addons/dragging/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_interaction","ace_cargo"};
+        requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Garth 'L-H' de Wet", "commy2", "PiZZADOX", "Malbryn"};
         url = ECSTRING(main,URL);

--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -31,10 +31,11 @@ if (_target isKindOf "StaticWeapon") exitWith {
     crew _target findIf {getText (configOf _x >> "simulation") != "UAVPilot"} == -1
 };
 
-// Units need to be unconscious or limping
+// Units need to be unconscious or limping; Units also need to not be in ragdoll, as that causes desync issues
 if (_target isKindOf "CAManBase") exitWith {
-    lifeState _target isEqualTo "INCAPACITATED"
-    || {_target getHitPointDamage "HitLegs" >= 0.5}
+    !(alive _target != isAwake _target) &&
+    {lifeState _target isEqualTo "INCAPACITATED" ||
+    {_target getHitPointDamage "HitLegs" >= 0.5}}
 };
 
 // Check max items for WeaponHolders

--- a/addons/dragging/functions/fnc_canDrag.sqf
+++ b/addons/dragging/functions/fnc_canDrag.sqf
@@ -27,10 +27,11 @@ if (_target isKindOf "StaticWeapon") exitWith {
     crew _target findIf {getText (configOf _x >> "simulation") != "UAVPilot"} == -1
 };
 
-// Units need to be unconscious or limping
+// Units need to be unconscious or limping; Units also need to not be in ragdoll, as that causes desync issues
 if (_target isKindOf "CAManBase") exitWith {
-    lifeState _target isEqualTo "INCAPACITATED"
-    || {_target getHitPointDamage "HitLegs" >= 0.5}
+    !(alive _target != isAwake _target) &&
+    {lifeState _target isEqualTo "INCAPACITATED" ||
+    {_target getHitPointDamage "HitLegs" >= 0.5}}
 };
 
 // Check max items for WeaponHolders

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -58,11 +58,12 @@ if (
         if (_target isKindOf "CAManBase") then {
             [_cursorObject, 0, true] call EFUNC(common,nearestVehiclesFreeSeat) isNotEqualTo []
         } else {
-            [_target, _cursorObject] call EFUNC(cargo,canLoadItemIn)
+            ["ace_cargo"] call EFUNC(common,isModLoaded) &&
+            {[_target, _cursorObject] call EFUNC(cargo,canLoadItemIn)}
         }
     }
 ) then {
-    _hintLMB = localize ELSTRING(Cargo,loadObject);
+    _hintLMB = localize ELSTRING(common,loadObject);
 };
 
 private _hintMMB = localize LSTRING(RaiseLowerRotate);

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -91,7 +91,7 @@ if (_mass != 0) then {
 _target setVariable [QGVAR(carryDirection_temp), nil];
 
 // try loading into vehicle
-if (_tryLoad && {!isNull cursorObject} && {([ACE_player, cursorObject, []] call EFUNC(common,canInteractWith))}) then {
+if (_tryLoad && {!isNull cursorObject} && {([ACE_player, cursorObject, ["isNotCarrying"]] call EFUNC(common,canInteractWith))}) then {
     if (_target isKindOf "CAManBase") then {
         private _vehicles = [cursorObject, 0, true] call EFUNC(common,nearestVehiclesFreeSeat);
         if ([cursorObject] isEqualTo _vehicles) then {
@@ -102,7 +102,10 @@ if (_tryLoad && {!isNull cursorObject} && {([ACE_player, cursorObject, []] call 
             };
         };
     } else {
-        if ([_target, cursorObject] call EFUNC(cargo,canLoadItemIn)) then {
+        if (
+            ["ace_cargo"] call EFUNC(common,isModLoaded) &&
+            {[_target, cursorObject] call EFUNC(cargo,canLoadItemIn)}
+        ) then {
             [player, _target, cursorObject] call EFUNC(cargo,startLoadIn);
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- The improvement part of https://github.com/acemod/ACE3/pull/9269, plius a third one (last in the list below).

1. Makes `ace_dragging` depend on `ace_cargo`. There are functions and stringtable entries from `ace_cargo` that are called, see [here](https://github.com/acemod/ACE3/blob/aead9a8eb4949714ddcb5d7b07b57f0c798a4ea0/addons/dragging/functions/fnc_dropObject_carry.sqf#L105), [here](https://github.com/acemod/ACE3/blob/aead9a8eb4949714ddcb5d7b07b57f0c798a4ea0/addons/dragging/functions/fnc_carryObjectPFH.sqf#L61) and [here](https://github.com/acemod/ACE3/blob/aead9a8eb4949714ddcb5d7b07b57f0c798a4ea0/addons/dragging/functions/fnc_carryObjectPFH.sqf#L65). If `ace_dragging` isn't supposed to be dependent on `ace_cargo`, then `ace_dragging` will need to be adjusted accordingly.
2. Disconnection detection for units carrying or dragging was done previously with the `HandleDisconnect` mission EH. In my testing (self-hosted MP) `HandleDisconnect` fires too late and when trying to read the `QGVAR(isCarrying)/QGVAR(isDragging)` variables, it just returns `false`, regardless if a unit if carrying/dragging something or not. This makes it impossible for carried/dragged objects to be dropped properly.
`PlayerDisconnected` fires before and therefore makes it possible to drop carried/dragged objects correctly. However, I'm unsure if there are any disadvantages to `PlayerDisconnected`.
3. Added a check to `FUNC(canDrag)` and `FUNC(canCarry)`, where it disables dragging/carrying if a unit is in ragdoll animation. This is to prevent odd behaviour. As it is now, you can try to drag a unit in ragdoll, but they stay in place while you go into the drag animation.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
