### PR TITLE
Arsenal - Fix adding inventory item with empty name to dummies

### DIFF
--- a/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
@@ -88,29 +88,29 @@ cba_diagnostic_projectileMaxLines = 10;
     {
         _unit = _x;
 
-        if (vest _player != "") then { _target addVest vest _player; };
+        if (vest _player != "") then { _unit addVest vest _player; };
 
         removeBackpack _unit;
-        if (backpack _player != "") then { _target addBackpack backpack _player; };
+        if (backpack _player != "") then { _unit addBackpack backpack _player; };
         removeHeadgear _unit;
-        if (headgear _player != "") then { _target addHeadgear headgear _player; };
+        if (headgear _player != "") then { _unit addHeadgear headgear _player; };
         removeGoggles _unit;
-        if (goggles _player != "") then { _target addGoggles goggles _player; };
+        if (goggles _player != "") then { _unit addGoggles goggles _player; };
 
         removeAllWeapons _unit;
-        if (primaryWeapon _player != "") then { _target addWeapon primaryWeapon _player; };
+        if (primaryWeapon _player != "") then { _unit addWeapon primaryWeapon _player; };
 
         {
             _unit addPrimaryWeaponItem _x;
         } forEach primaryWeaponItems _player;
 
-        if (secondaryWeapon _player != "") then { _target addWeapon secondaryWeapon _player; };
+        if (secondaryWeapon _player != "") then { _unit addWeapon secondaryWeapon _player; };
 
         {
             _unit addSecondaryWeaponItem _x;
         } forEach secondaryWeaponItems _player;
 
-        if (handgunWeapon _player != "") then { _target addWeapon handgunWeapon _player; };
+        if (handgunWeapon _player != "") then { _unit addWeapon handgunWeapon _player; };
 
         {
             _unit addHandgunItem _x;

--- a/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/XEH_postInit.sqf
@@ -88,29 +88,29 @@ cba_diagnostic_projectileMaxLines = 10;
     {
         _unit = _x;
 
-        _unit addVest vest _player;
+        if (vest _player != "") then { _target addVest vest _player; };
 
         removeBackpack _unit;
-        _unit addBackpack backpack _player;
-
-        _unit addHeadgear headgear _player;
-
-        _unit addGoggles goggles _player;
+        if (backpack _player != "") then { _target addBackpack backpack _player; };
+        removeHeadgear _unit;
+        if (headgear _player != "") then { _target addHeadgear headgear _player; };
+        removeGoggles _unit;
+        if (goggles _player != "") then { _target addGoggles goggles _player; };
 
         removeAllWeapons _unit;
-        _unit addWeapon primaryWeapon _player;
+        if (primaryWeapon _player != "") then { _target addWeapon primaryWeapon _player; };
 
         {
             _unit addPrimaryWeaponItem _x;
         } forEach primaryWeaponItems _player;
 
-        _unit addWeapon secondaryWeapon _player;
+        if (secondaryWeapon _player != "") then { _target addWeapon secondaryWeapon _player; };
 
         {
             _unit addSecondaryWeaponItem _x;
         } forEach secondaryWeaponItems _player;
 
-        _unit addWeapon handgunWeapon _player;
+        if (handgunWeapon _player != "") then { _target addWeapon handgunWeapon _player; };
 
         {
             _unit addHandgunItem _x;

--- a/addons/arsenal/missions/Arsenal.VR/fnc_createTarget.sqf
+++ b/addons/arsenal/missions/Arsenal.VR/fnc_createTarget.sqf
@@ -47,13 +47,13 @@ _target setSpeaker "BASE";
 _player reveal [_target, 4];
 
 // Copy player's gear onto target
-_target addVest vest _player;
-_target addBackpack backpack _player;
-_target addHeadgear headgear _player;
-_target addGoggles goggles _player;
-_target addWeapon primaryWeapon _player;
-_target addWeapon secondaryWeapon _player;
-_target addWeapon handgunWeapon _player;
+if (vest _player != "") then { _target addVest vest _player; };
+if (backpack _player != "") then { _target addBackpack backpack _player; };
+if (headgear _player != "") then { _target addHeadgear headgear _player; };
+if (goggles _player != "") then { _target addGoggles goggles _player; };
+if (primaryWeapon _player != "") then { _target addWeapon primaryWeapon _player; };
+if (secondaryWeapon _player != "") then { _target addWeapon secondaryWeapon _player; };
+if (handgunWeapon _player != "") then { _target addWeapon handgunWeapon _player; };
 
 // Save AI for respawn
 _target setVehicleVarName _varName;


### PR DESCRIPTION
fix 
```
Trying to add inventory item with empty name to object [VR Entity]
 âž¥ Context: 	[] L18 (z\ace\addons\arsenal\missions\Arsenal.VR\initPlayerLocal.sqf)
	[] L17 (z\ace\addons\arsenal\missions\Arsenal.VR\initPlayerLocal.sqf)
	[] L55 (z\ace\addons\arsenal\missions\Arsenal.VR\fnc_createTarget.sqf)
```
and
```
Trying to add inventory item with empty name to object [VR Entity]
 âž¥ Context: 	[] L1 ()
	[] L20 (z\ace\addons\arsenal\functions\fnc_onArsenalClose.sqf)
	[] L27 (x\cba\addons\events\fnc_localEvent.sqf)
	[] L27 (x\cba\addons\events\fnc_localEvent.sqf)
	[] L27 (x\cba\addons\events\fnc_localEvent.sqf)
	[] L118 (z\ace\addons\arsenal\missions\Arsenal.VR\XEH_postInit.sqf)
	[] L96 (z\ace\addons\arsenal\missions\Arsenal.VR\XEH_postInit.sqf)
```
unrelated to anything recent
this might only show in dev branch??
