### PR TITLE
Common - Fix loading units into FFV cargo seats

### DIFF
--- a/addons/common/functions/fnc_loadPersonLocal.sqf
+++ b/addons/common/functions/fnc_loadPersonLocal.sqf
@@ -38,6 +38,10 @@ if ((_vehicle emptyPositions "cargo" > 0) && {!(_unit getVariable ['ACE_isUncons
     };
     if (!_slotsOpen) then {
         private _cargoSeats = fullCrew [_vehicle, "cargo", true];
+        // FFV cargo seats are empty cargo positions but are not returned by fullCrew "cargo"
+        if (_cargoSeats isEqualTo []) then {
+            _cargoSeats = (fullCrew [_vehicle, "turret", true]) select {_x select 4};
+        };
         if (_reverseFill) then {
             reverse _cargoSeats;
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Close #9257.
- Fix script error when loading captive/unconscious patient into a FFV cargo seat.

Side-effect: unconscious enemies can and will fire upon waking up in an FFV seat.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
