### PR TITLE
Common/Medical - Change `vehicle` checks to `objectParent`

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -402,11 +402,11 @@ addMissionEventHandler ["PlayerViewChanged", {
     params ["_unit", "_target"];
 
     // Players can always interact with himself if not boarded
-    vehicle _unit == _unit ||
+    isNull objectParent _unit ||
     // Players can always interact with his vehicle
-    {vehicle _unit == _target} ||
+    {objectParent _unit isEqualTo _target} ||
     // Players can always interact with passengers of the same vehicle
-    {_unit != _target && {vehicle _unit == vehicle _target}} ||
+    {_unit isNotEqualTo _target && {!isNull objectParent _target} && {objectParent _unit isEqualTo objectParent _target}} ||
     // Players can always interact with connected UAV
     {!(isNull (ACE_controlledUAV select 0))}
 }] call FUNC(addCanInteractWithCondition);
@@ -415,7 +415,7 @@ addMissionEventHandler ["PlayerViewChanged", {
 
 ["isNotUnconscious", {
     params ["_unit"];
-    lifeState _unit != "INCAPACITATED"
+    lifeState _unit isNotEqualTo "INCAPACITATED"
 }] call FUNC(addCanInteractWithCondition);
 
 //////////////////////////////////////////////////

--- a/addons/medical_gui/CfgVehicles.hpp
+++ b/addons/medical_gui/CfgVehicles.hpp
@@ -38,7 +38,7 @@ class CfgVehicles {
                 };
                 class ACE_Medical_Radial {
                     displayName = CSTRING(Medical);
-                    condition = QUOTE((GVAR(enableActions) == 1 || {GVAR(enableActions) != 2 && {vehicle _target != _target && {vehicle _target == vehicle _player}}}));
+                    condition = QUOTE((GVAR(enableActions) == 1 || {GVAR(enableActions) != 2 && {!isNull objectParent _target && {objectParent _target isEqualTo objectParent _player}}}));
                     exceptions[] = {"isNotInside", "isNotSitting"};
                     statement = QUOTE([ARR_2(_target,0)] call FUNC(displayPatientInformation));
                     runOnHover = 1;
@@ -49,7 +49,7 @@ class CfgVehicles {
                 };
                 class ACE_LoadPatient {
                     displayName = CSTRING(LoadPatient);
-                    condition = QUOTE(_target getVariable [ARR_2('ACE_isUnconscious',false)] && {alive _target} && {vehicle _target == _target});
+                    condition = QUOTE(_target getVariable [ARR_2('ACE_isUnconscious',false)] && {alive _target} && {isNull objectParent _target} && {(_target call EFUNC(common,nearestVehiclesFreeSeat)) isNotEqualTo []});
                     exceptions[] = {"isNotDragging", "isNotCarrying"};
                     statement = QUOTE([ARR_2(_player, _target)] call EFUNC(medical_treatment,loadUnit));
                     icon = QPATHTOF(ui\cross.paa);
@@ -57,7 +57,7 @@ class CfgVehicles {
                 };
                 class ACE_UnloadPatient {
                     displayName = CSTRING(UnloadPatient);
-                    condition = QUOTE(_target getVariable [ARR_2('ACE_isUnconscious',false)] && {vehicle _target != _target} && {vehicle _player == _player});
+                    condition = QUOTE(_target getVariable [ARR_2('ACE_isUnconscious',false)] && {!isNull objectParent _target} && {isNull objectParent _player});
                     exceptions[] = {"isNotDragging", "isNotCarrying", "isNotInside"};
                     statement = QUOTE([ARR_2(_player, _target)] call EFUNC(medical_treatment,unloadUnit));
                     icon = QPATHTOF(ui\cross.paa);

--- a/addons/medical_gui/CfgVehicles.hpp
+++ b/addons/medical_gui/CfgVehicles.hpp
@@ -57,7 +57,7 @@ class CfgVehicles {
                 };
                 class ACE_UnloadPatient {
                     displayName = CSTRING(UnloadPatient);
-                    condition = QUOTE(_target getVariable [ARR_2('ACE_isUnconscious',false)] && {!isNull objectParent _target} && {isNull objectParent _player});
+                    condition = QUOTE((_target getVariable [ARR_2('ACE_isUnconscious',false)] || {!alive _target}) && {!isNull objectParent _target} && {isNull objectParent _player});
                     exceptions[] = {"isNotDragging", "isNotCarrying", "isNotInside"};
                     statement = QUOTE([ARR_2(_player, _target)] call EFUNC(medical_treatment,unloadUnit));
                     icon = QPATHTOF(ui\cross.paa);

--- a/addons/medical_treatment/functions/fnc_unloadUnit.sqf
+++ b/addons/medical_treatment/functions/fnc_unloadUnit.sqf
@@ -19,7 +19,7 @@
 params ["_medic", "_patient"];
 TRACE_2("unloadUnit",_medic,_patient);
 
-if (vehicle _patient == _patient) exitWith {
+if (isNull objectParent _patient) exitWith {
     ERROR_1("Unit %1 is not in a vehicle",_patient);
 };
 
@@ -27,18 +27,18 @@ if (_patient call EFUNC(common,isAwake)) exitWith {
     ERROR_1("Unit %1 is awake",_patient);
 };
 
-["ace_unloadPersonEvent", [_patient, vehicle _patient, _medic], _patient] call CBA_fnc_targetEvent;
+["ace_unloadPersonEvent", [_patient, objectParent _patient, _medic], _patient] call CBA_fnc_targetEvent;
 
 [{
     params ["_unit", "_vehicle"];
-    (alive _unit) && {alive _vehicle} && {(vehicle _unit) != _vehicle}
+    (alive _unit) && {alive _vehicle} && {isNull objectParent _patient}
 }, {
     params ["_unit", "_vehicle"];
     TRACE_2("success",_unit,_vehicle);
     private _patientName = [_unit, false, true] call EFUNC(common,getName);
     private _vehicleName = getText (configOf _vehicle >> "displayName");
     [[LSTRING(UnloadedFrom), _patientName, _vehicleName], 3] call EFUNC(common,displayTextStructured);
-}, [_patient, vehicle _patient], 3, {
+}, [_patient, objectParent _patient], 3, {
     params ["_unit", "_vehicle"];
     WARNING_3("unloadPerson failed to unload %1[local %2] -> %3 ",_unit,local _unit,_vehicle);
 }] call CBA_fnc_waitUntilAndExecute;

--- a/addons/medical_treatment/functions/fnc_unloadUnit.sqf
+++ b/addons/medical_treatment/functions/fnc_unloadUnit.sqf
@@ -30,8 +30,8 @@ if (_patient call EFUNC(common,isAwake)) exitWith {
 ["ace_unloadPersonEvent", [_patient, objectParent _patient, _medic], _patient] call CBA_fnc_targetEvent;
 
 [{
-    params ["_unit", "_vehicle"];
-    (alive _unit) && {alive _vehicle} && {isNull objectParent _patient}
+    params ["_unit"];
+    isNull objectParent _unit
 }, {
     params ["_unit", "_vehicle"];
     TRACE_2("success",_unit,_vehicle);


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Change one string comparison to `isNotEqualTo`.
- Change Medical's "Load Patient" interaction to only show if there is a vehicle nearby.
- Allow using Medical's "Unload Patient" interaction on dead units.
- Close #8001.

Behavior is maintained. Ref https://github.com/acemod/ACE3/pull/7959#issuecomment-1646452185.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [ ] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
