### PR TITLE
Interact Menu - Ignore text controls from invisible map

### DIFF
--- a/addons/interact_menu/functions/fnc_keyDown.sqf
+++ b/addons/interact_menu/functions/fnc_keyDown.sqf
@@ -22,7 +22,15 @@ params ["_menuType"];
 if (GVAR(openedMenuType) == _menuType) exitWith {true};
 
 // Conditions: Don't open when editing a text box
-private _isTextEditing = (allDisplays findIf {(ctrlType (focusedCtrl _x)) == CT_EDIT}) != -1;
+private _focusedTextIndex = allDisplays findIf {(ctrlType (focusedCtrl _x)) == CT_EDIT};
+private _isTextEditing = _focusedTextIndex != -1;
+
+// Map's controls remain open and focused despite map not being visible, workaround
+if (_isTextEditing) then {
+    if (ctrlIDD (allDisplays select _focusedTextIndex) == IDD_MAIN_MAP) then {
+        _isTextEditing = visibleMap;
+    };
+};
 
 // Conditions: canInteract (these don't apply to zeus)
 if (


### PR DESCRIPTION
**When merged this pull request will:**
- Fix losing ability to interact if you close the map while having an open notepad from Intel Items

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
