### PR TITLE
Arsenal - Add and Improve stats

### DIFF
--- a/addons/arsenal/ACE_Arsenal_Stats.hpp
+++ b/addons/arsenal/ACE_Arsenal_Stats.hpp
@@ -144,4 +144,12 @@ class GVAR(stats) {
         textStatement = QUOTE(call FUNC(statTextStatement_explosionTime));
         tabs[] = {{}, {5}};
     };
+    class ACE_magCount: statBase {
+        scope = 2;
+        priority = 1;
+        displayName = CSTRING(statMagCount);
+        showText = 1;
+        textStatement = QUOTE(call FUNC(statTextStatement_magCount));
+        tabs[] = {{}, {4}};
+    };
 };

--- a/addons/arsenal/ACE_Arsenal_Stats.hpp
+++ b/addons/arsenal/ACE_Arsenal_Stats.hpp
@@ -75,6 +75,14 @@ class GVAR(stats) {
         textStatement = QUOTE(call FUNC(statTextStatement_scopeMag));
         tabs[] = {{}, {0}};
     };
+    class ACE_binoMagnification: statBase {
+        scope = 2;
+        priority = 2;
+        displayName = CSTRING(statMagnification);
+        showText = 1;
+        textStatement = QUOTE(call FUNC(statTextStatement_binoMag));
+        tabs[] = {{9}, {}};
+    };
     class ACE_scopeVisionMode: statBase {
         scope = 2;
         priority = 1.6;
@@ -82,6 +90,14 @@ class GVAR(stats) {
         showText = 1;
         textStatement = QUOTE(call FUNC(statTextStatement_scopeVisionMode));
         tabs[] = {{}, {0}};
+    };
+    class ACE_binoVisionMode: statBase {
+        scope = 2;
+        priority = 1.6;
+        displayName = CSTRING(statVisionModeGeneric);
+        showText = 1;
+        textStatement = QUOTE(call FUNC(statTextStatement_binoVisionMode));
+        tabs = {{8,9}, {}};
     };
     class ACE_ballisticProtection: statBase {
         scope = 2;

--- a/addons/arsenal/ACE_Arsenal_Stats.hpp
+++ b/addons/arsenal/ACE_Arsenal_Stats.hpp
@@ -97,7 +97,7 @@ class GVAR(stats) {
         displayName = CSTRING(statVisionModeGeneric);
         showText = 1;
         textStatement = QUOTE(call FUNC(statTextStatement_binoVisionMode));
-        tabs = {{8,9}, {}};
+        tabs[] = {{8,9}, {}};
     };
     class ACE_ballisticProtection: statBase {
         scope = 2;

--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -85,6 +85,7 @@ PREP(statBarStatement_impact);
 PREP(statBarStatement_rateOfFIre);
 PREP(statTextStatement_accuracy);
 PREP(statTextStatement_explosionTime);
+PREP(statTextStatement_magCount);
 PREP(statTextStatement_mass);
 PREP(statTextStatement_rateOfFire);
 PREP(statTextStatement_scopeMag);

--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -70,6 +70,8 @@ PREP(scanConfig);
 PREP(showItem);
 PREP(sortPanel);
 PREP(sortStatement_accuracy);
+PREP(statTextStatement_binoMag);
+PREP(statTextStatement_binoVisionMode);
 PREP(sortStatement_amount);
 PREP(sortStatement_magCount);
 PREP(sortStatement_mass);

--- a/addons/arsenal/functions/fnc_statTextStatement_binoMag.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_binoMag.sqf
@@ -14,7 +14,7 @@
  */
 
 params ["", "_config"];
-TRACE_1("statTextStatement_scopeMag",_config);
+TRACE_1("statTextStatement_binoMag",_config);
 
 _minZoom = getNumber (_config >> "opticsZoomMin"); // FOV, so smaller is more zoomed in
 _maxZoom = getNumber (_config >> "opticsZoomMax");

--- a/addons/arsenal/functions/fnc_statTextStatement_binoMag.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_binoMag.sqf
@@ -1,0 +1,35 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror, LinkIsGrim
+ * Text statement for the binocular magnification stat.
+ *
+ * Arguments:
+ * 0: Not used
+ * 1: Item config path <CONFIG>
+ *
+ * Return Value:
+ * Stat Text <STRING>
+ *
+ * Public: No
+ */
+
+params ["", "_config"];
+TRACE_1("statTextStatement_scopeMag",_config);
+
+_minZoom = getNumber (_config >> "opticsZoomMin"); // FOV, so smaller is more zoomed in
+_maxZoom = getNumber (_config >> "opticsZoomMax");
+
+if (_minZoom == 0) exitWith {"?"};
+
+private _maxMagnification = (0.25 / _minZoom) toFixed 1;
+private _minMagnification = (0.25 / _maxZoom);
+if (_minMagnification < 1) then {
+    _minMagnification = 1;
+};
+_minMagnification = _minMagnification toFixed 1;
+
+if (_minMagnification == _maxMagnification) exitWith {
+    format ["%1x", _maxMagnification]
+};
+
+format ["%1x-%2x", _minMagnification, _maxMagnification]

--- a/addons/arsenal/functions/fnc_statTextStatement_binoVisionMode.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_binoVisionMode.sqf
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+/*
+ * Author: Dedmen, johnb43, LinkIsGrim
+ * Text statement for the scope Night vision support stat.
+ *
+ * Arguments:
+ * 0: Not used
+ * 1: Item config path <CONFIG>
+ *
+ * Return Value:
+ * Stat Text <STRING>
+ *
+ * Public: No
+ */
+
+params ["", "_config"];
+TRACE_1("statTextStatement_scopeVisionMode",_config);
+
+private _text = [];
+private _visionModes = getArray (_config >> "visionMode") apply {toLower _x};
+{
+    if (_x in _visionModes) then {
+        _text pushBack (localize ([LSTRING(VisionNormal), LSTRING(VisionNight), LSTRING(VisionThermal)] select _forEachIndex));
+    };
+} forEach ["normal", "nvg", "ti"];
+
+_text joinString ", "

--- a/addons/arsenal/functions/fnc_statTextStatement_binoVisionMode.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_binoVisionMode.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: Dedmen, johnb43, LinkIsGrim
- * Text statement for the scope Night vision support stat.
+ * Text statement for the binocular/NVG vision mode stat.
  *
  * Arguments:
  * 0: Not used
@@ -14,7 +14,7 @@
  */
 
 params ["", "_config"];
-TRACE_1("statTextStatement_scopeVisionMode",_config);
+TRACE_1("statTextStatement_binoVisionMode",_config);
 
 private _text = [];
 private _visionModes = getArray (_config >> "visionMode") apply {toLower _x};

--- a/addons/arsenal/functions/fnc_statTextStatement_magCount.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_magCount.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+/*
+ * Author: LinkIsGrim
+ * Text statement for the magazine capacity stat.
+ *
+ * Arguments:
+ * 0: Stats Array <ARRAY> (not used)
+ * 1: Item config path <CONFIG>
+ *
+ * Return Value:
+ * String to display
+ *
+ * Public: No
+*/
+
+params ["", "_config"];
+
+getNumber (_config >> "count");

--- a/addons/arsenal/functions/fnc_statTextStatement_magCount.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_magCount.sqf
@@ -14,5 +14,6 @@
 */
 
 params ["", "_config"];
+TRACE_1("statTextStatement_magCount",_config)
 
 getNumber (_config >> "count");

--- a/addons/arsenal/functions/fnc_statTextStatement_scopeMag.sqf
+++ b/addons/arsenal/functions/fnc_statTextStatement_scopeMag.sqf
@@ -17,11 +17,31 @@ params ["", "_config"];
 TRACE_1("statTextStatement_scopeMag",_config);
 
 private _minZoom = 999; // FOV, so smaller is more zoomed in
+private _maxZoom = 1.25; // Cap at 1x zoomed out
 
+private _opticsModes = "true" configClasses (_config >> "ItemInfo" >> "OpticsModes");
 {
+    // If there is a primary mode then just use that
+    if (getNumber (_x >> "useModelOptics") == 1 || {count _opticsModes == 1}) exitWith {
+        _minZoom = getNumber (_x >> "opticsZoomMin");
+        _maxZoom = getNumber (_x >> "opticsZoomMax");
+    };
+    // Otherwise go through the optic's modes
     _minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin"));
-} forEach configProperties [_config >> "ItemInfo" >> "OpticsModes"];
+    _maxZoom = _maxZoom max (getNumber (_x >> "opticsZoomMax"));
+} forEach _opticsModes;
 
 if (_minZoom in [0, 999]) exitWith {"?"};
 
-format ["%1x", (0.25 / _minZoom) toFixed 1]
+private _maxMagnification = (0.25 / _minZoom) toFixed 1;
+private _minMagnification = (0.25 / _maxZoom);
+if (_minMagnification < 1) then {
+    _minMagnification = 1;
+};
+_minMagnification = _minMagnification toFixed 1;
+
+if (_minMagnification == _maxMagnification) exitWith {
+    format ["%1x", _maxMagnification]
+};
+
+format ["%1x-%2x", _minMagnification, _maxMagnification]

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -1569,5 +1569,8 @@
             <Chinesesimp>工具</Chinesesimp>
             <Turkish>Araçlar</Turkish>
         </Key>
+        <Key ID="STR_ACE_Arsenal_statMagCount">
+            <English>Ammo count</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -1240,6 +1240,70 @@
             <Turkish>Desteklenmiyor</Turkish>
             <Korean>지원되지 않음</Korean>
         </Key>
+        <Key ID="STR_ACE_Arsenal_statVisionModeGeneric">
+            <English>Vision Mode</English>
+            <German>Sichtmodus</German>
+            <Japanese>ビジョン モード</Japanese>
+            <Italian>Modalità Visiva</Italian>
+            <Chinese>視覺模式</Chinese>
+            <Chinesesimp>视觉模式</Chinesesimp>
+            <Korean>보기 모드</Korean>
+            <French>Mode de vision</French>
+            <Polish>Tryb Wizji</Polish>
+            <Russian>Режим видения</Russian>
+            <Portuguese>Modo de Visão</Portuguese>
+            <Czech>Režim sledování</Czech>
+            <Turkish>Görüş Modu</Turkish>
+            <Spanish>Modo de visión</Spanish>
+        </Key>
+        <Key ID="STR_ACE_Arsenal_VisionNormal">
+            <English>Normal</English>
+            <German>Normal</German>
+            <Polish>Normalna</Polish>
+            <Portuguese>Normal</Portuguese>
+            <Russian>Нормальное</Russian>
+            <Czech>Normální</Czech>
+            <Spanish>Normal</Spanish>
+            <Italian>Normale</Italian>
+            <French>Normale</French>
+            <Japanese>通常</Japanese>
+            <Korean>일반</Korean>
+            <Chinesesimp>正常</Chinesesimp>
+            <Chinese>正常</Chinese>
+            <Turkish>Normal</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Arsenal_VisionNight">
+            <English>Night</English>
+            <German>Nacht</German>
+            <Polish>Noc</Polish>
+            <Portuguese>Visão Norturna</Portuguese>
+            <Russian>Ночное</Russian>
+            <Czech>Noční</Czech>
+            <Spanish>Nocturna</Spanish>
+            <Italian>Notturno</Italian>
+            <French>Nocturne</French>
+            <Japanese>暗視装置</Japanese>
+            <Korean>야간</Korean>
+            <Chinesesimp>夜视</Chinesesimp>
+            <Chinese>夜視</Chinese>
+            <Turkish>Gece</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Arsenal_VisionThermal">
+            <English>Thermal</English>
+            <German>Wärme</German>
+            <Polish>Termo</Polish>
+            <Portuguese>Térmica</Portuguese>
+            <Russian>Тепловизор</Russian>
+            <Czech>Termální</Czech>
+            <Spanish>Térmica</Spanish>
+            <Italian>Termico</Italian>
+            <French>Thermique</French>
+            <Japanese>熱源画像</Japanese>
+            <Korean>열상</Korean>
+            <Chinesesimp>热成像</Chinesesimp>
+            <Chinese>熱成像</Chinese>
+            <Turkish>Termal</Turkish>
+        </Key>
         <Key ID="STR_ACE_Arsenal_page">
             <English>Page</English>
             <Spanish>Página</Spanish>

--- a/addons/ballistics/ACE_Arsenal_Stats.hpp
+++ b/addons/ballistics/ACE_Arsenal_Stats.hpp
@@ -24,6 +24,7 @@ class EGVAR(arsenal,stats) {
         stats[] = {"ammo", "displayName"};
         displayName = "$STR_dn_ammo";
         showText = 1;
+        condition = QUOTE(getText (_this select 1 >> _this select 0 select 0) isNotEqualTo '');
         textStatement = QUOTE(params [ARR_2('_stat', '_config')]; private _ammoDisplayName = getText (configFile >> 'CfgAmmo' >> (getText (_config >> 'ammo')) >> _stat select 1); [ARR_2(_ammoDisplayName, getText (_config >> _stat select 0))] select (_ammoDisplayName == ''));
         tabs[] = {{}, {4}};
     };
@@ -50,11 +51,11 @@ class EGVAR(arsenal,stats) {
     class ACE_magMuzzleVelocity: statBase {
         scope = 2;
         priority = 3;
-        stats[] = {"initSpeed"};
+        stats[] = {"initSpeed", "ammo"};
         displayName= CSTRING(statMuzzleVelocity);
         showText= 1;
         textStatement = QUOTE([ARR_2(_this select 0, _this select 1)] call FUNC(statTextStatement_magazineMuzzleVelocity));
-        condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
+        condition = QUOTE(getText (_this select 1 >> _this select 0 select 1) isNotEqualTo '' && {getNumber (_this select 1 >> (_this select 0) select 0) > 0});
         tabs[] = {{}, {4}};
     };
     class ACE_weaponMuzzleVelocity: statBase {

--- a/addons/nightvision/ACE_Arsenal_Stats.hpp
+++ b/addons/nightvision/ACE_Arsenal_Stats.hpp
@@ -7,6 +7,6 @@ class EGVAR(arsenal,stats) {
         displayName = CSTRING(NVGeneration);
         showText = 1;
         textStatement = QUOTE(call FUNC(statTextStatement_NVGeneration));
-        tabs = {{8}, {}};
+        tabs[] = {{8}, {}};
     };
 };

--- a/addons/nightvision/ACE_Arsenal_Stats.hpp
+++ b/addons/nightvision/ACE_Arsenal_Stats.hpp
@@ -1,0 +1,12 @@
+class EGVAR(arsenal,stats) {
+    class statBase;
+    class GVAR(generation): statBase {
+        scope = 2;
+        priority = 1.6;
+        condition = QUOTE('nvg' in (getArray ((_this select 1) >> 'visionMode') apply {toLower _x}));
+        displayName = CSTRING(NVGeneration);
+        showText = 1;
+        textStatement = QUOTE(call FUNC(statTextStatement_NVGeneration));
+        tabs = {{8}, {}};
+    };
+};

--- a/addons/nightvision/XEH_PREP.hpp
+++ b/addons/nightvision/XEH_PREP.hpp
@@ -10,3 +10,4 @@ PREP(pfeh);
 PREP(refreshGoggleType);
 PREP(scaleCtrl);
 PREP(setupDisplayEffects);
+PREP(statTextStatement_NVGeneration);

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -34,3 +34,4 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 #include "ACE_Settings.hpp"
 #include "RscTitles.hpp"
+#include "ACE_Arsenal_Stats.hpp"

--- a/addons/nightvision/functions/fnc_statTextStatement_NVGeneration.sqf
+++ b/addons/nightvision/functions/fnc_statTextStatement_NVGeneration.sqf
@@ -14,7 +14,7 @@
  */
 
 params ["", "_config"];
-TRACE_1("statTextStatement_scopeMag",_config);
+TRACE_1("statTextStatement_nvGeneration",_config);
 
 private _gen = 3; // Default
 if (isNumber (_config >> QGVAR(generation))) then {

--- a/addons/nightvision/functions/fnc_statTextStatement_NVGeneration.sqf
+++ b/addons/nightvision/functions/fnc_statTextStatement_NVGeneration.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/*
+ * Author: LinkIsGrim
+ * Text statement for the NV Generation stat.
+ *
+ * Arguments:
+ * 0: Not used
+ * 1: Item config path <CONFIG>
+ *
+ * Return Value:
+ * Stat Text <STRING>
+ *
+ * Public: No
+ */
+
+params ["", "_config"];
+TRACE_1("statTextStatement_scopeMag",_config);
+
+private _gen = 3; // Default
+if (isNumber (_config >> QGVAR(generation))) then {
+    _gen = getNumber (_config >> QGVAR(generation));
+};
+
+format [localize LSTRING(statGen), _gen];

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -466,5 +466,11 @@
             <Spanish>Efecto obturador por los fogonazos de la boca del cañón</Spanish>
             <Korean>총구화염에 의한 셔터효과를 구현합니다</Korean>
         </Key>
+        <Key ID="STR_ACE_NightVision_NVGeneration">
+            <English>Night Vision Generation</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_statGen">
+            <English>Gen %1</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add magnification stat for binoculars.
- Improve magnification stat for optics: shows magnification range of primary optic mode if detected, otherwise minimum and maximum magnification between all optics modes.
- Add vision mode stat for binoculars and NVGs.
- Add night vision generation stat for NVGs.
- Add ammo count stat for magazines.
- Improve conditions on ballistics stats.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
