### PR TITLE
Logistics wirecutter - Add wirecutter stats to ACE arsenal

### DIFF
--- a/addons/logistics_wirecutter/ACE_Arsenal_Stats.hpp
+++ b/addons/logistics_wirecutter/ACE_Arsenal_Stats.hpp
@@ -6,7 +6,7 @@ class EGVAR(arsenal,stats) {
         stats[] = {QGVAR(hasWirecutter)};
         displayName = CSTRING(wirecutterName);
         showText = 1;
-        textStatement = QUOTE(localize 'STR_ACE_Common_Yes'); // using localization macros in QUOTE is a PITA
+        textStatement = QUOTE(localize QUOTE(ELSTRING(common,yes)));
         condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
         tabs[] = {{4,5}, {}};
     };

--- a/addons/logistics_wirecutter/ACE_Arsenal_Stats.hpp
+++ b/addons/logistics_wirecutter/ACE_Arsenal_Stats.hpp
@@ -1,0 +1,23 @@
+class EGVAR(arsenal,stats) {
+    class statBase;
+    class GVAR(wireCutter): statBase {
+        scope = 2;
+        priority = -1;
+        stats[] = {QGVAR(hasWirecutter)};
+        displayName = CSTRING(wirecutterName);
+        showText = 1;
+        textStatement = QUOTE(localize 'STR_ACE_Common_Yes'); // using localization macros in QUOTE is a PITA
+        condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
+        tabs[] = {{4,5}, {}};
+    };
+    class GVAR(wireCutterItem): statBase {
+        scope = 2;
+        priority = -1;
+        stats[] = {"ACE_isWirecutter"};
+        displayName = CSTRING(wirecutterName);
+        showText = 1;
+        textStatement = QUOTE(localize 'STR_ACE_Common_Yes'); // using localization macros in QUOTE is a PITA
+        condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
+        tabs[] = {{}, {7}};
+    };
+};

--- a/addons/logistics_wirecutter/ACE_Arsenal_Stats.hpp
+++ b/addons/logistics_wirecutter/ACE_Arsenal_Stats.hpp
@@ -16,7 +16,7 @@ class EGVAR(arsenal,stats) {
         stats[] = {"ACE_isWirecutter"};
         displayName = CSTRING(wirecutterName);
         showText = 1;
-        textStatement = QUOTE(localize 'STR_ACE_Common_Yes'); // using localization macros in QUOTE is a PITA
+        textStatement = QUOTE(localize QUOTE(ELSTRING(common,yes)));
         condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
         tabs[] = {{}, {7}};
     };

--- a/addons/logistics_wirecutter/config.cpp
+++ b/addons/logistics_wirecutter/config.cpp
@@ -17,3 +17,4 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
+#include "ACE_Arsenal_Stats.hpp"

--- a/addons/trenches/ACE_Arsenal_Stats.hpp
+++ b/addons/trenches/ACE_Arsenal_Stats.hpp
@@ -6,7 +6,7 @@ class EGVAR(arsenal,stats) {
         stats[] = {QGVAR(entrenchingTool)};
         displayName = CSTRING(EntrenchingToolName);
         showText = 1;
-        textStatement = QUOTE(localize 'STR_ACE_Common_Yes'); // using localization macros in QUOTE is a PITA
+        textStatement = QUOTE(localize QUOTE(ELSTRING(common,yes)));
         condition = QUOTE(getNumber (_this select 1 >> (_this select 0) select 0) > 0);
         tabs[] = {{0,1,5}, {7}};
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- The config is based off of the entrenching tool stat.
- Brought macro usage to entrenching tool stat (seeing as this PR was based off of the entrenching tool stat).

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
