### PR TITLE
Medical Status - Remove status effects upon death/featureCamera

### DIFF
--- a/addons/medical_status/XEH_PREP.hpp
+++ b/addons/medical_status/XEH_PREP.hpp
@@ -14,5 +14,6 @@ PREP(isBeingDragged);
 PREP(isInStableCondition);
 PREP(setCardiacArrestState);
 PREP(setDead);
+PREP(setStatusEffects);
 PREP(setUnconsciousState);
 PREP(updateWoundBloodLoss);

--- a/addons/medical_status/XEH_postInit.sqf
+++ b/addons/medical_status/XEH_postInit.sqf
@@ -2,3 +2,18 @@
 
 // Handle pain changes on injury
 [QEGVAR(medical,injured), LINKFUNC(adjustPainLevel)] call CBA_fnc_addEventHandler;
+
+// Handle comms status effects for spectator
+// Separate from medical_feedback as these affect unit behavior rather than what the player sees
+["featureCamera", {
+    params ["_unit", "_newCamera"];
+
+    if (_unit isNotEqualTo ACE_player) exitWith {};
+
+    if (_newCamera == "") then { // switched back to player view
+        private _status = IS_UNCONSCIOUS(_unit);
+        [_unit, _status, true] call FUNC(setStatusEffects);
+    } else {
+        [_unit, false, true] call FUNC(setStatusEffects);
+    };
+}] call CBA_fnc_addPlayerEventHandler;

--- a/addons/medical_status/XEH_postInit.sqf
+++ b/addons/medical_status/XEH_postInit.sqf
@@ -10,10 +10,10 @@
 
     if (_unit isNotEqualTo ACE_player) exitWith {};
 
-    if (_newCamera == "") then { // Switched back to player view
+    if (_newCamera == "") then { // switched back to player view
         private _status = IS_UNCONSCIOUS(_unit);
-        [_unit, _status] call FUNC(setStatusEffects);
+        [_unit, _status, true] call FUNC(setStatusEffects);
     } else {
-        [_unit, false] call FUNC(setStatusEffects);
+        [_unit, false, true] call FUNC(setStatusEffects);
     };
 }] call CBA_fnc_addPlayerEventHandler;

--- a/addons/medical_status/XEH_postInit.sqf
+++ b/addons/medical_status/XEH_postInit.sqf
@@ -10,10 +10,10 @@
 
     if (_unit isNotEqualTo ACE_player) exitWith {};
 
-    if (_newCamera == "") then { // switched back to player view
+    if (_newCamera == "") then { // Switched back to player view
         private _status = IS_UNCONSCIOUS(_unit);
-        [_unit, _status, true] call FUNC(setStatusEffects);
+        [_unit, _status] call FUNC(setStatusEffects);
     } else {
-        [_unit, false, true] call FUNC(setStatusEffects);
+        [_unit, false] call FUNC(setStatusEffects);
     };
 }] call CBA_fnc_addPlayerEventHandler;

--- a/addons/medical_status/XEH_postInit.sqf
+++ b/addons/medical_status/XEH_postInit.sqf
@@ -12,7 +12,7 @@
 
     if (_newCamera == "") then { // switched back to player view
         private _status = IS_UNCONSCIOUS(_unit);
-        [_unit, _status, true] call FUNC(setStatusEffects);
+        [_unit, _status] call FUNC(setStatusEffects);
     } else {
         [_unit, false, true] call FUNC(setStatusEffects);
     };

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -53,13 +53,7 @@ if (_unit == player) then {
     ["unconscious", false] call EFUNC(common,setDisableUserInputStatus);
 };
 
-// Let AI resume firing at dead units in most situations (global effect) (which was blocked upon unconsciouness)
-[_unit, "setHidden", "ace_unconscious", false] call EFUNC(common,statusEffect_set);
-
-// Unblock radio on dead for compatibility with captive module (which was blocked upon unconsciouness)
-[_unit, "blockRadio", "ace_unconscious", false] call EFUNC(common,statusEffect_set);
-
-// Unblock speaking on death (which was blocked upon unconsciouness)
-[_unit, "blockSpeaking", "ace_unconscious", false] call EFUNC(common,statusEffect_set);
+// Remove status effects before respawn, in case mission is using spectator
+[_unit, false] call FUNC(setStatusEffects);
 
 ["ace_killed", [_unit, _causeOfDeath, _killer, _instigator]] call CBA_fnc_globalEvent;

--- a/addons/medical_status/functions/fnc_handleKilled.sqf
+++ b/addons/medical_status/functions/fnc_handleKilled.sqf
@@ -53,4 +53,13 @@ if (_unit == player) then {
     ["unconscious", false] call EFUNC(common,setDisableUserInputStatus);
 };
 
+// Let AI resume firing at dead units in most situations (global effect) (which was blocked upon unconsciouness)
+[_unit, "setHidden", "ace_unconscious", false] call EFUNC(common,statusEffect_set);
+
+// Unblock radio on dead for compatibility with captive module (which was blocked upon unconsciouness)
+[_unit, "blockRadio", "ace_unconscious", false] call EFUNC(common,statusEffect_set);
+
+// Unblock speaking on death (which was blocked upon unconsciouness)
+[_unit, "blockSpeaking", "ace_unconscious", false] call EFUNC(common,statusEffect_set);
+
 ["ace_killed", [_unit, _causeOfDeath, _killer, _instigator]] call CBA_fnc_globalEvent;

--- a/addons/medical_status/functions/fnc_setStatusEffects.sqf
+++ b/addons/medical_status/functions/fnc_setStatusEffects.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+/*
+ * Author: LinkIsGrim
+ * Sets status effects for a unit.
+ * For Internal Use: Called by FUNC(setUnconsciousState), FUNC(handleKilled), and on featureCamera changes.
+ *
+ * Arguments:
+ * 0: The unit <OBJECT>
+ * 1: Status effects value <BOOL>
+ * 2: Skip setHidden <BOOL> (default: false)
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_unit", "_set", ["_skipSetHidden", false]];
+TRACE_3("setStatusEffect",_unit,_set,_skipSetHidden);
+
+// Block radio on unconsciousness for compatibility with captive module
+[_unit, "blockRadio", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
+
+// Block speaking on unconsciousness
+[_unit, "blockSpeaking", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
+
+if (_skipSetHidden) exitWith {};
+
+// Stop AI firing at unconscious units in most situations (global effect)
+[_unit, "setHidden", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);

--- a/addons/medical_status/functions/fnc_setStatusEffects.sqf
+++ b/addons/medical_status/functions/fnc_setStatusEffects.sqf
@@ -7,7 +7,6 @@
  * Arguments:
  * 0: The unit <OBJECT>
  * 1: Status effects value <BOOL>
- * 2: Skip setHidden <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -15,16 +14,14 @@
  * Public: No
  */
 
-params ["_unit", "_set", ["_skipSetHidden", false]];
-TRACE_3("setStatusEffect",_unit,_set,_skipSetHidden);
+params ["_unit", "_set"];
+TRACE_2("setStatusEffect",_unit,_set);
 
 // Block radio on unconsciousness for compatibility with captive module
 [_unit, "blockRadio", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
 
 // Block speaking on unconsciousness
 [_unit, "blockSpeaking", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
-
-if (_skipSetHidden) exitWith {};
 
 // Stop AI firing at unconscious units in most situations (global effect)
 [_unit, "setHidden", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);

--- a/addons/medical_status/functions/fnc_setStatusEffects.sqf
+++ b/addons/medical_status/functions/fnc_setStatusEffects.sqf
@@ -7,6 +7,7 @@
  * Arguments:
  * 0: The unit <OBJECT>
  * 1: Status effects value <BOOL>
+ * 2: Skip setHidden <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -14,14 +15,16 @@
  * Public: No
  */
 
-params ["_unit", "_set"];
-TRACE_2("setStatusEffect",_unit,_set);
+params ["_unit", "_set", ["_skipSetHidden", false]];
+TRACE_3("setStatusEffect",_unit,_set,_skipSetHidden);
 
 // Block radio on unconsciousness for compatibility with captive module
 [_unit, "blockRadio", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
 
 // Block speaking on unconsciousness
 [_unit, "blockSpeaking", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
+
+if (_skipSetHidden) exitWith {};
 
 // Stop AI firing at unconscious units in most situations (global effect)
 [_unit, "setHidden", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -28,14 +28,7 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
-// Stop AI firing at unconscious units in most situations (global effect)
-[_unit, "setHidden", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
-
-// Block radio on unconsciousness for compatibility with captive module
-[_unit, "blockRadio", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
-
-// Block speaking on unconsciousness
-[_unit, "blockSpeaking", "ace_unconscious", _active] call EFUNC(common,statusEffect_set);
+[_unit, _active] call FUNC(setStatusEffects);
 
 if (_active) then {
     // Don't bother setting this if not used

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -28,7 +28,6 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
-// Set status effects for comms
 [_unit, _active] call FUNC(setStatusEffects);
 
 if (_active) then {

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -28,6 +28,7 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
+// Set status effects for comms
 [_unit, _active] call FUNC(setStatusEffects);
 
 if (_active) then {

--- a/addons/medical_status/functions/fnc_setUnconsciousState.sqf
+++ b/addons/medical_status/functions/fnc_setUnconsciousState.sqf
@@ -28,6 +28,7 @@ _unit setVariable [VAR_UNCON, _active, true];
 // Toggle unit ragdoll state
 [_unit, _active] call EFUNC(medical_engine,setUnconsciousAnim);
 
+// Handle hiding from AI and talking blocks.
 [_unit, _active] call FUNC(setStatusEffects);
 
 if (_active) then {


### PR DESCRIPTION
**When merged this pull request will:**
- If a unit was unconscious and then died, they would have the `setHidden`, `blockRadio` and `blockSpeaking` status effects still applied. The first is not important, but the two others are, especially `blockSpeaking`, which (I believe) prevented spectators talking in the spectator view when using TFAR.

This PR reverses those status effects upon death.
Unsure if ACRE is affected in any negative way.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
