### PR TITLE
Advanced Fatigue - Add cap to muscle damage

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
+++ b/addons/advanced_fatigue/functions/fnc_mainLoop.sqf
@@ -38,7 +38,7 @@ if ((vehicle ACE_player == ACE_player) && {_currentSpeed > 0.1} && {isTouchingGr
 
 // Calculate muscle damage increase
 // Note: Muscle damage recovery is ignored as it takes multiple days
-GVAR(muscleDamage) = GVAR(muscleDamage) + (_currentWork / GVAR(peakPower)) ^ 3.2 * 0.00004;
+GVAR(muscleDamage) = (GVAR(muscleDamage) + (_currentWork / GVAR(peakPower)) ^ 3.2 * 0.00004) min 1;
 private _muscleIntegritySqrt = sqrt (1 - GVAR(muscleDamage));
 
 // Calculate available power


### PR DESCRIPTION
**When merged this pull request will:**
- Previously, muscle damage could go above 1 and [cause issues with stamina calculation](https://github.com/acemod/ACE3/blob/628d62d329a7550053c359bcb7c8ced2c6eba2e7/addons/advanced_fatigue/functions/fnc_mainLoop.sqf#L42). Realistically this could probably never happen, as getting muscle damage up to 1 is quite a challenge, but I think it's best to be cautious nonetheless.

TODO: Implement muscle damage recovery, as it could technically pose a problem, although practically I don't know if it does.

I'm hoping to be able to fix advanced fatigue with high performance factor and recovery factor values, but so far I haven't had any luck in reproducing any errors. Any help is appreciated.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
