### PR TITLE
Medical Damage - Improve custom wound handling

### DIFF
--- a/addons/medical_damage/functions/fnc_parseWoundHandlersCfg.sqf
+++ b/addons/medical_damage/functions/fnc_parseWoundHandlersCfg.sqf
@@ -19,6 +19,7 @@ params ["_config"];
 // Read all valid entries from config and store
 private _entries = [];
 private _entryResult = "";
+private _function = "";
 
 {
     _entryResult = getText _x;

--- a/addons/medical_damage/functions/fnc_woundReceived.sqf
+++ b/addons/medical_damage/functions/fnc_woundReceived.sqf
@@ -20,16 +20,22 @@
 params ["_unit", "_allDamages", "_shooter", "_ammo"];
 
 private _typeOfDamage = _ammo call FUNC(getTypeOfDamage);
+
 if (_typeOfDamage in GVAR(damageTypeDetails)) then {
     (GVAR(damageTypeDetails) get _typeOfDamage) params ["", "", "_woundHandlers"];
-    
+
     private _damageData = [_unit, _allDamages, _typeOfDamage];
+    private _damageDataTemp = [];
+
     {
-        _damageData = _damageData call _x;
-        TRACE_1("Wound handler returned", _damageData);
-        if !(_damageData isEqualType [] && {(count _damageData) >= 3}) exitWith {
-            TRACE_1("Return invalid, terminating wound handling", _damageData);
+        _damageDataTemp = _damageData call _x;
+        TRACE_2("Wound handler returned",_damageData,_damageDataTemp);
+
+        // If invalid return, skip
+        if (isNil "_damageData" || {!(_damageDataTemp isEqualType [])} || {(count _damageDataTemp) < 3}) then {
+            TRACE_2("Return invalid, skipping wound handling",_damageData,_damageDataTemp);
+        } else {
+            _damageData = _damageDataTemp;
         };
     } forEach _woundHandlers;
-    
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Addresses #8927 by wrapping entry in `call _fnc` block if `_fnc` does not exist when config is parsed.
I'm not sure how well this new way can account for code (see example below), but I'm not sure if this system was ever meant for handling code directly.

```cpp
class ACE_Medical_Injuries {
    class damageTypes {
        class woundHandlers;
        class bullet {
            class woundHandlers: woundHandlers {
                ADDON = QUOTE(systemChat str _damageData; _damageData);
            };
        };
    };
};
```

- If a wound handler returns an invalid return, it will be ignored. However it will no longer stop checking other wound handlers; it will continue on until it has gone through all wound handlers.
- Invalid wound handler return now includes `nil`.
- Minor code cleanup.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
