### PR TITLE
Fastroping - Add Auto add FRIES setting

### DIFF
--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -36,7 +36,7 @@ if (isServer) then {
     ["Helicopter", "init", {
         if (!GVAR(autoAddFRIES)) exitWith {};
         params ["_vehicle"];
-        if (!isNumber (configOf _vehicle >> QGVAR(enabled)) && {isNil {_vehicle getVariable [QGVAR(FRIES), nil]}}) then {
+        if (isNumber (configOf _vehicle >> QGVAR(enabled)) && {isNil {_vehicle getVariable [QGVAR(FRIES), nil]}}) then {
             [_vehicle] call FUNC(equipFRIES);
         };
     }, true, ["ACE_friesBase"], true] call CBA_fnc_addClassEventHandler;

--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -32,6 +32,17 @@
 }, {false}] call CBA_fnc_addKeybind;
 
 
+if (isServer) then {
+    ["Helicopter", "init", {
+        if (!GVAR(autoAddFRIES)) exitWith {};
+        params ["_vehicle"];
+        if (!isNumber (configOf _vehicle >> QGVAR(enabled)) && {isNil {_vehicle getVariable [QGVAR(FRIES), nil]}}) then {
+            [_vehicle] call FUNC(equipFRIES);
+        };
+    }, true, ["ACE_friesBase"], true] call CBA_fnc_addClassEventHandler;
+};
+
+
 #ifdef DRAW_FASTROPE_INFO
 addMissionEventHandler ["Draw3D", {
     if (!(cursorObject isKindOf "Helicopter")) exitWith {};

--- a/addons/fastroping/config.cpp
+++ b/addons/fastroping/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction","ace_logistics_rope"};
         author = ECSTRING(common,ACETeam);
-        authors[] = {"KoffeinFlummi", "BaerMitUmlaut", "Pokertour"};
+        authors[] = {"KoffeinFlummi", "BaerMitUmlaut", "Pokertour", "veteran29"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };

--- a/addons/fastroping/initSettings.sqf
+++ b/addons/fastroping/initSettings.sqf
@@ -12,7 +12,7 @@ private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(setting_c
 
 [
     QGVAR(autoAddFRIES), "CHECKBOX",
-    [LSTRING(setting_autoAddFRIES_displayName), LSTRING(setting_autoAddFRIES_description],
+    [LSTRING(setting_autoAddFRIES_displayName), LSTRING(setting_autoAddFRIES_description)],
     _category,
     false, // default value
     true, // isGlobal

--- a/addons/fastroping/initSettings.sqf
+++ b/addons/fastroping/initSettings.sqf
@@ -15,5 +15,5 @@ private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(setting_c
     [LSTRING(setting_autoAddFRIES_displayName), LSTRING(setting_autoAddFRIES_description)],
     _category,
     false, // default value
-    true, // isGlobal
+    true // isGlobal
 ] call CBA_fnc_addSetting;

--- a/addons/fastroping/initSettings.sqf
+++ b/addons/fastroping/initSettings.sqf
@@ -9,3 +9,11 @@ private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(setting_c
     {[QGVAR(requireRopeItems), _this] call EFUNC(common,cbaSettings_settingChanged)},
     false // needRestart
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(autoAddFRIES), "CHECKBOX",
+    [LSTRING(setting_autoAddFRIES_displayName), LSTRING(setting_autoAddFRIES_description],
+    _category,
+    false, // default value
+    true, // isGlobal
+] call CBA_fnc_addSetting;

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -315,8 +315,8 @@
             <Korean>줄이 필요합니다</Korean>
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_displayName">
-            <English>Auto add FRIES</English>
-            <Polish>Auto dodawanie FRIES</Polish>
+            <English>Auto-Equip FRIES</English>
+            <Polish>Automatyczne Zamontuj FRIES</Polish>
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_displayName">
             <English>Automatically add FRIES to helicopters that support them.</English>

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -316,7 +316,7 @@
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_displayName">
             <English>Auto-Equip FRIES</English>
-            <Polish>Automatyczne Zamontuj FRIES</Polish>
+            <Polish>Automatycznie Zamontuj FRIES</Polish>
         </Key>
         <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_description">
             <English>Automatically add FRIES to helicopters that support them.</English>

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -318,7 +318,7 @@
             <English>Auto-Equip FRIES</English>
             <Polish>Automatyczne Zamontuj FRIES</Polish>
         </Key>
-        <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_displayName">
+        <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_description">
             <English>Automatically add FRIES to helicopters that support them.</English>
             <Polish>Automatycznie dodawaj FRIES do śmigłowców które je wspierają.</Polish>
         </Key>

--- a/addons/fastroping/stringtable.xml
+++ b/addons/fastroping/stringtable.xml
@@ -314,5 +314,13 @@
             <Turkish>Halatla kaymak için halat gerekli</Turkish>
             <Korean>줄이 필요합니다</Korean>
         </Key>
+        <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_displayName">
+            <English>Auto add FRIES</English>
+            <Polish>Auto dodawanie FRIES</Polish>
+        </Key>
+        <Key ID="STR_ACE_Fastroping_setting_autoAddFRIES_displayName">
+            <English>Automatically add FRIES to helicopters that support them.</English>
+            <Polish>Automatycznie dodawaj FRIES do śmigłowców które je wspierają.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/docs/wiki/feature/fastroping.md
+++ b/docs/wiki/feature/fastroping.md
@@ -1,8 +1,8 @@
 ---
 layout: wiki
-title: Fast-Roping
+title: Fastroping
 component: fastroping
-description: System for adding fast roping capabilities to helicopters.
+description: System for adding fastroping capabilities to helicopters.
 group: feature
 category: realism
 parent: wiki
@@ -14,10 +14,10 @@ version:
 ---
 
 ## 1. Overview
-The fast roping module adds the possibility to do fast roping insertions from helicopters.
+The fast roping module adds the possibility to do fastroping insertions from helicopters.
 
 ## 2. Usage
-If you are sitting in the back of a helicopter that has fast roping capabilities, open your interaction menu to deploy the ropes. Depending on the helicopter and its FRIES (abbr. for Fast Rope Insertion Extraction System) the deployment of the ropes is a two step process:
+If you are sitting in the back of a helicopter that has fastroping capabilities, open your interaction menu to deploy the ropes. Depending on the helicopter and its FRIES (abbr. for FastRope Insertion Extraction System) the deployment of the ropes is a two step process:
 
 1. FRIES preparation, usually consisting of opening the helicopters doors and the extension of the hooks (not necessary for some helicopters)
 2. Rope deployment

--- a/docs/wiki/framework/fastroping-framework.md
+++ b/docs/wiki/framework/fastroping-framework.md
@@ -1,7 +1,7 @@
 ---
 layout: wiki
-title: Fast Roping Framework
-description: Explains the config values and functions used for making a helicopter fast roping capable.
+title: Fastroping Framework
+description: Explains the config values and functions used for making a helicopter fastroping capable.
 group: framework
 order: 5
 parent: wiki
@@ -12,7 +12,7 @@ version:
   patch: 0
 ---
 
-If you want to prepare a helicopter from your addon for fast roping, there's a few ways to do that.
+If you want to prepare a helicopter from your addon for fastroping, there's a few ways to do that.
 
 ## 1. Using simple rope origin points
 
@@ -37,7 +37,7 @@ You can also use more or less than two rope origins. You can additionally execut
 
 ## 2. Using a FRIES
 
-If your helicopter is not fast roping capable by default, you can make it take a FRIES. A FRIES is just a simple model that gets attached to the helicopter with its own rope origin points. ACE3 already includes two FRIES that are used in real life and can be attached to most helicopters.
+If your helicopter is not fastroping capable by default, you can make it take a FRIES. A FRIES is just a simple model that gets attached to the helicopter with its own rope origin points. ACE3 already includes two FRIES that are used in real life and can be attached to most helicopters.
 
 To make your helicopter FRIES capable, you need to add the following config entries:
 
@@ -52,10 +52,10 @@ ace_fastroping_ropeOrigins[] = {"ropeOriginLeft", "ropeOriginRight"};
 
 Let us go through each of them:
 
-- `ace_fastroping_enabled = 2` tells ACE that your helicopter is fast roping capabale but needs a FRIES for that.
+- `ace_fastroping_enabled = 2` tells ACE that your helicopter is fastroping capabale but needs a FRIES for that.
 - `ace_fastroping_friesType` defines the object that will be used as a FRIES on your helicopter
 - `ace_fastroping_friesAttachmentPoint` defines the coordinates at which the FRIES will be attached to.
-- See 3.3 for more information about `ace_fastroping_onCut` and `ace_fastroping_onPrepare`. Note: These two entries are necessary for fast roping with a FRIES.
+- See 3.3 for more information about `ace_fastroping_onCut` and `ace_fastroping_onPrepare`. Note: These two entries are necessary for fastroping with a FRIES.
 - `ace_fastroping_ropeOrigins` defines the memory points or coordinates from the FRIES where the ropes will be attached to.
 
 ## 2.1 Using one of the given FRIES


### PR DESCRIPTION
Integrated ArmaForces/Mods component

**When merged this pull request will:**
- Integrate https://github.com/ArmaForces/Mods/tree/aaaa420df0fecc0ff996dbb5e92e1f9b629b5c57/addons/fries (https://github.com/ArmaForces/Mods/pull/40)
  - Add "Auto add FRIES" setting which is just a global version of the per-object property.
- Streamline component name documentation (same as component now)

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
