### PR TITLE
Nightvision - Add White Phosphor NVGs

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,6 +44,7 @@ aeroson
 Aggr094 <bastards4glory@gmail.com>
 alef <alefor@gmail.com>
 Aleksey EpMAK Yermakov <epmak777@gmail.com>
+AleM
 Alganthe <alganthe@live.fr>
 Andrea "AtixNeon" Verano <veranoandrea88@gmail.com>
 Anthariel <Contact@storm-simulation.com>
@@ -113,6 +114,7 @@ Hawkins
 Head <brobergsebastian@gmail.com>
 Hybrid V
 JasperRab <jasper@jasperrab.eu>
+JDT
 john681611 <john681611@hotmail.com>
 JoramD
 Karneck <dschultz26@hotmail.com>
@@ -131,6 +133,7 @@ MarcBook
 meat <p.humberdroz@gmail.com>
 Michail Nikolaev
 MikeMatrix <m.braun92@gmail.com>
+MikeMF
 mjc4wilton <mjc4wilton@gmail.com>
 Mysteryjuju
 nic547 <nic547@outlook.com>
@@ -174,7 +177,6 @@ Toaster <jonathan.pereira@gmail.com>
 Tonic
 Tourorist <tourorist@gmail.com>
 Tuupertunut
-TyroneMF <TyroneMF@hotmail.com>
 Valentin Torikian <valentin.torikian@gmail.com>
 voiper
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -5,6 +5,12 @@ class CfgWeapons {
         modelOptics = "";
         GVAR(border) = QPATHTOF(data\nvg_mask_binos_4096.paa);
         GVAR(bluRadius) = 0.15;
+        NVG_GREEN_PRESET;
+    };
+    class NVGoggles_WP: NVGoggles {
+        displayName = CSTRING(NVG_Gen3_brown_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
     };
     class O_NVGoggles_hex_F: NVGoggles { // APEX NVG with multiple lenses (spider eyes)
         modelOptics = "";
@@ -21,9 +27,19 @@ class CfgWeapons {
         modelOptics = "";
         displayName = CSTRING(NVG_Gen3_black);
     };
+    class NVGoggles_OPFOR_WP: NVGoggles_OPFOR {
+        displayName = CSTRING(NVG_Gen3_black_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
+    };
     class NVGoggles_INDEP: NVGoggles {
         modelOptics = "";
         displayName = CSTRING(NVG_Gen3_green);
+    };
+    class NVGoggles_INDEP_WP: NVGoggles_INDEP {
+        displayName = CSTRING(NVG_Gen3_green_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
     };
     class ACE_NVG_Gen1: NVGoggles_OPFOR {
         author = ECSTRING(common,ACETeam);
@@ -60,15 +76,30 @@ class CfgWeapons {
         displayName = CSTRING(NVG_Gen4_black);
         GVAR(generation) = 4;
     };
+    class ACE_NVG_Gen4_Black_WP: ACE_NVG_Gen4_Black {
+        displayName = CSTRING(NVG_Gen4_black_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
+    };
     class ACE_NVG_Gen4: NVGoggles {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(NVG_Gen4_brown);
         GVAR(generation) = 4;
     };
+    class ACE_NVG_Gen4_WP: ACE_NVG_Gen4 {
+        displayName = CSTRING(NVG_Gen4_brown_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
+    };
     class ACE_NVG_Gen4_Green: NVGoggles_INDEP {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(NVG_Gen4_green);
         GVAR(generation) = 4;
+    };
+    class ACE_NVG_Gen4_Green_WP: ACE_NVG_Gen4_Green {
+        displayName = CSTRING(NVG_Gen4_green_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
     };
     class ACE_NVG_Wide_Black: NVGoggles_OPFOR {
         author = ECSTRING(common,ACETeam);

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -7,7 +7,7 @@ class CfgWeapons {
         GVAR(bluRadius) = 0.15;
         NVG_GREEN_PRESET;
     };
-    class NVGoggles_WP: NVGoggles {
+    class ACE_NVGoggles_WP: NVGoggles {
         displayName = CSTRING(NVG_Gen3_brown_WP);
         descriptionShort = CSTRING(NVG_WP_desc);
         NVG_WHITE_PRESET;
@@ -27,7 +27,7 @@ class CfgWeapons {
         modelOptics = "";
         displayName = CSTRING(NVG_Gen3_black);
     };
-    class NVGoggles_OPFOR_WP: NVGoggles_OPFOR {
+    class ACE_NVGoggles_OPFOR_WP: NVGoggles_OPFOR {
         displayName = CSTRING(NVG_Gen3_black_WP);
         descriptionShort = CSTRING(NVG_WP_desc);
         NVG_WHITE_PRESET;
@@ -36,7 +36,7 @@ class CfgWeapons {
         modelOptics = "";
         displayName = CSTRING(NVG_Gen3_green);
     };
-    class NVGoggles_INDEP_WP: NVGoggles_INDEP {
+    class ACE_NVGoggles_INDEP_WP: NVGoggles_INDEP {
         displayName = CSTRING(NVG_Gen3_green_WP);
         descriptionShort = CSTRING(NVG_WP_desc);
         NVG_WHITE_PRESET;

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -106,15 +106,30 @@ class CfgWeapons {
         modelOptics = QPATHTOF(models\ACE_nvg_wide_optics);
         displayName = CSTRING(NVG_Wide_black);
     };
+    class ACE_NVG_Wide_Black_WP: ACE_NVG_Wide_Black {
+        displayName = CSTRING(NVG_Wide_black_wP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
+    };
     class ACE_NVG_Wide: NVGoggles {
         author = ECSTRING(common,ACETeam);
         modelOptics = QPATHTOF(models\ACE_nvg_wide_optics);
         displayName = CSTRING(NVG_Wide_brown);
     };
+    class ACE_NVG_Wide_WP: ACE_NVG_Wide {
+        displayName = CSTRING(NVG_Wide_brown_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
+    };
     class ACE_NVG_Wide_Green: NVGoggles_INDEP {
         author = ECSTRING(common,ACETeam);
         modelOptics = QPATHTOF(models\ACE_nvg_wide_optics);
         displayName = CSTRING(NVG_Wide_green);
+    };
+    class ACE_NVG_Wide_Green_WP: ACE_NVG_Wide_Green {
+        displayName = CSTRING(NVG_Wide_green_WP);
+        descriptionShort = CSTRING(NVG_WP_desc);
+        NVG_WHITE_PRESET;
     };
 
 

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -13,8 +13,11 @@ class CfgPatches {
             "ACE_NVG_Gen2",
             /*"ACE_NVG_Gen3",*/
             "ACE_NVG_Gen4_Black",
+            "ACE_NVG_Gen4_Black_WP",
             "ACE_NVG_Gen4",
+            "ACE_NVG_Gen4_WP",
             "ACE_NVG_Gen4_Green",
+            "ACE_NVG_Gen4_Green_WP",
             "ACE_NVG_Wide_Black",
             "ACE_NVG_Wide",
             "ACE_NVG_Wide_Green"

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -140,7 +140,7 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     // ColorCorrections - Changes brightness, contrast and "green" color of nvg
     // Params: [brightness(0..2), contrast(0..inf), offset(-x..+x), blendArray, colorizeArray, weightArray]
     GVAR(ppeffectColorCorrect) = ppEffectCreate ["ColorCorrections", 2003];
-    GVAR(ppeffectColorCorrect) ppEffectAdjust [_brightFinal, _contrastFinal, 0, [0.0, 0.0, 0.0, 0.0], [1.3, 1.2, 0.0, 0.9], [6, 1, 1, 0.0]];
+    GVAR(ppeffectColorCorrect) ppEffectAdjust [_brightFinal, _contrastFinal, GVAR(nvgOffset), GVAR(nvgBlend), GVAR(nvgColorize), GVAR(nvgWeight)];
     GVAR(ppeffectColorCorrect) ppEffectCommit 0;
     GVAR(ppeffectColorCorrect) ppEffectForceInNVG true;
     GVAR(ppeffectColorCorrect) ppEffectEnable true;

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -26,14 +26,8 @@ private _hideHex = true;
 private _nvgGen = 3;
 private _blurRadius = -1;
 
-// Privated NVD's PP Effects (ColorCorrection) Params / Contains original ACE3's (ST's) by default.
-private _offset = 0;
-private _blend = [0.0, 0.0, 0.0, 0.0];
-private _colorize = [1.3, 1.2, 0.0, 0.9];
-private _weight = [6, 1, 1, 0.0];
-// Adds Array of Params / Original ACE3's (ST's) by default.
-private _preset = [0, [0.0, 0.0, 0.0, 0.0], [1.3, 1.2, 0.0, 0.9], [6, 1, 1, 0.0]];
-
+// Adds Array of Params / Original ACE3's (ST's) by default. (NVG_GREEN_PRESET)
+private _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> "colorPreset");
 if (alive ACE_player) then {
     if (((vehicle ACE_player) == ACE_player) || {
         // Test if we are using player's nvg or if sourced from vehicle:

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -26,6 +26,14 @@ private _hideHex = true;
 private _nvgGen = 3;
 private _blurRadius = -1;
 
+// Privated NVD's PP Effects (ColorCorrection) Params / Contains original ACE3's (ST's) by default.
+private _offset = 0;
+private _blend = [0.0, 0.0, 0.0, 0.0];
+private _colorize = [1.3, 1.2, 0.0, 0.9];
+private _weight = [6, 1, 1, 0.0];
+// Adds Array of Params / Original ACE3's (ST's) by default.
+private _preset = [0, [0.0, 0.0, 0.0, 0.0], [1.3, 1.2, 0.0, 0.9], [6, 1, 1, 0.0]];
+
 if (alive ACE_player) then {
     if (((vehicle ACE_player) == ACE_player) || {
         // Test if we are using player's nvg or if sourced from vehicle:
@@ -61,6 +69,7 @@ if (alive ACE_player) then {
             TRACE_1("souce: binocular",binocular ACE_player); // Source is from player's binocular (Rangefinder/Vector21bNite)
             private _config = configFile >> "CfgWeapons" >> (binocular ACE_player);
             if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
+            if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
         };
 
         TRACE_1("source: hmd",GVAR(playerHMD)); // Source is player's HMD (or possibly a NVG scope, but no good way to detect that)
@@ -75,7 +84,7 @@ if (alive ACE_player) then {
             if (isNumber (_config >> QGVAR(bluRadius))) then {_blurRadius = getNumber (_config >> QGVAR(bluRadius));};
         };
         if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
-
+        if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
     } else {
         TRACE_1("source: vehicle - defaults",typeOf vehicle ACE_player);
     };
@@ -86,8 +95,17 @@ systemChat format ["NVG Refresh - Border: %1", _borderImage];
 systemChat format ["EyeCups: %1, HideHex %2, NVGen: %3, BluRadius: %4", _eyeCups, _hideHex, _nvgGen, _blurRadius];
 #endif
 
+// Selection cancelled, params added
+_preset params ["_offset", "_blend", "_colorize", "_weight"];
+
 GVAR(nvgBlurRadius) = _blurRadius;
 GVAR(nvgGeneration) = _nvgGen;
+
+// Additional Global variables for Params transfer & supporting
+GVAR(nvgOffset) = _offset;
+GVAR(nvgBlend) = _blend;
+GVAR(nvgColorize) = _colorize;
+GVAR(nvgWeight) = _weight;
 
 // Setup border and hex image based on NVG config:
 private _scale = (call EFUNC(common,getZoom)) * 1.12513;

--- a/addons/nightvision/script_component.hpp
+++ b/addons/nightvision/script_component.hpp
@@ -19,6 +19,9 @@
 
 // Effect Settings / Magic values to tweak:
 
+#define NVG_GREEN_PRESET colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}
+#define NVG_WHITE_PRESET colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}}
+
 // Decreases fog when in air vehicles
 #define ST_NVG_AIR_FOG_MULTIPLIER 0.5
 

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -216,6 +216,9 @@
             <Korean>야투경 (넓음, 갈색)</Korean>
             <Spanish>Gafas de visión nocturna (Panorámicas, Marrón)</Spanish>
         </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Wide_brown_WP">
+            <English>NV Goggles (Wide, Brown, WP)</English>
+        </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_black">
             <English>NV Goggles (Wide, Black)</English>
             <French>JVN (Large, noires)</French>
@@ -227,6 +230,9 @@
             <Korean>야투경 (넓음, 검정색)</Korean>
             <Spanish>Gafas de visión nocturna (Panorámicas, Negro)</Spanish>
         </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Wide_black_WP">
+            <English>NV Goggles (Wide, Black, WP)</English>
+        </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_green">
             <English>NV Goggles (Wide, Green)</English>
             <French>JVN (Large, vertes)</French>
@@ -237,6 +243,9 @@
             <Chinesesimp>夜视仪（宽，绿色）</Chinesesimp>
             <Korean>야투경 (넓음, 녹색)</Korean>
             <Spanish>Gafas de visión nocturna (Panorámicas, Verde)</Spanish>
+        </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Wide_green_WP">
+            <English>NV Goggles (Wide, Green, WP)</English>
         </Key>
         <Key ID="STR_ACE_NightVision_NVGBrightness">
             <English>Brightness: %1</English>

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -117,6 +117,12 @@
             <Chinese>夜視鏡 (三代, 棕色)</Chinese>
             <Turkish>GG Gözlüğü (3. Jen Kahverengi)</Turkish>
         </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Gen3_brown_WP">
+            <English>NV Goggles (Gen3, Brown, WP)</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_NVG_WP_desc">
+            <English>Night Vision Goggles, White Phosphor</English>
+        </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen3_green">
             <English>NV Goggles (Gen3, Green)</English>
             <Czech>Noktovizor (Gen3, zelený)</Czech>
@@ -133,6 +139,9 @@
             <Chinesesimp>夜视仪（三代，绿色）</Chinesesimp>
             <Chinese>夜視鏡 (三代, 綠色)</Chinese>
             <Turkish>GG Gözlüğü (3. Jen Yeşil)</Turkish>
+        </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Gen3_green_WP">
+            <English>NV Goggles (Gen3, Green, WP)</English>
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen3_black">
             <English>NV Goggles (Gen3, Black)</English>
@@ -151,6 +160,9 @@
             <Chinese>夜視鏡 (三代, 黑色)</Chinese>
             <Turkish>GG Gözlüğü (3. Jen Siyah)</Turkish>
         </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Gen3_black_WP">
+            <English>NV Goggles (Gen3, Black, WP)</English>
+        </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_brown">
             <English>NV Goggles (Gen4, Brown)</English>
             <French>JVN (Gen4, marron)</French>
@@ -161,6 +173,9 @@
             <Chinesesimp>夜视仪（四代，棕色）</Chinesesimp>
             <Korean>야투경 (4세대, 갈색)</Korean>
             <Spanish>Gafas de visión nocturna (Gen4, Marrón)</Spanish>
+        </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Gen4_brown_WP">
+            <English>NV Goggles (Gen4, Brown, WP)</English>
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_black">
             <English>NV Goggles (Gen4, Black)</English>
@@ -173,6 +188,9 @@
             <Korean>야투경 (4세대, 검정색)</Korean>
             <Spanish>Gafas de visión nocturna (Gen4, Negro)</Spanish>
         </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Gen4_black_WP">
+            <English>NV Goggles (Gen4, Black, WP)</English>
+        </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_green">
             <English>NV Goggles (Gen4, Green)</English>
             <French>JVN (Gen4, vertes)</French>
@@ -183,6 +201,9 @@
             <Chinesesimp>夜视仪（四代，绿色）</Chinesesimp>
             <Korean>야투경 (4세대, 녹색)</Korean>
             <Spanish>Gafas de visión nocturna (Gen4, Verde)</Spanish>
+        </Key>
+        <Key ID="STR_ACE_NightVision_NVG_Gen4_green_WP">
+            <English>NV Goggles (Gen4, Green, WP)</English>
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_brown">
             <English>NV Goggles (Wide, Brown)</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds White Phosphor NVGs in Gen3/Gen4/Wide.
- Direct continuation of #6190
- The original authors are credited in `authors.txt`
- Moved things to stringtable as requested in original PR.
- Used the alternative `colorPreset` provided in a comment on that PR in this one. (Comment mentions an issue with FFV, but not present on this.)
- both `colorPreset` are now defines.
- Issue mentioned with A3 Thermal Improvement I haven't reconfirmed, I don't use it.
- Close #6190 

Previews: (24 June, 2035 - 03:00)
![107410_20230812201232_1](https://github.com/acemod/ACE3/assets/29175040/c8c9c4b2-f2e0-406e-b068-4e7b424ff55a)
![107410_20230812201241_1](https://github.com/acemod/ACE3/assets/29175040/104eac85-ccd7-47d2-b049-1fb67ef33528)


### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
