### PR TITLE
CSW - Remove 'Disabled' option from Ammo Handling

### DIFF
--- a/addons/csw/functions/fnc_aceRearmGetCarryMagazines.sqf
+++ b/addons/csw/functions/fnc_aceRearmGetCarryMagazines.sqf
@@ -20,7 +20,7 @@ params ["_vehicle", ["_targetTurret", true, [[], true]]];
 
 if (!(_vehicle isKindOf "StaticWeapon")) exitWith { [[],[]] }; // limit to statics for now
 // Assembly mode: [0=disabled, 1=enabled, 2=enabled&unload, 3=default]
-if ((GVAR(ammoHandling) == 0) && {!([false, true, true, GVAR(defaultAssemblyMode)] select (_vehicle getVariable [QGVAR(assemblyMode), 3]))}) exitWith { [[],[]] };
+if (!([false, true, true, GVAR(defaultAssemblyMode)] select (_vehicle getVariable [QGVAR(assemblyMode), 3]))) exitWith { [[],[]] };
 
 private _turretMagsCSW = [];
 private _allCarryMags = [];

--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -70,7 +70,7 @@ if (hasInterface && {!(_typeOf in GVAR(initializedStaticTypes))}) then {
     private _magazineLocation = getText (_configOf >> QUOTE(ADDON) >> "magazineLocation");
     private _condition = { //IGNORE_PRIVATE_WARNING ["_target", "_player"];
         // If magazine handling is enabled or weapon assembly/disassembly is enabled we enable ammo handling
-        if ((GVAR(ammoHandling) == 0) && {!([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3]))}) exitWith { false };
+        if (!([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3]))) exitWith { false };
         [_player, _target, ["isNotSwimming", "isNotSitting"]] call EFUNC(common,canInteractWith)
     };
     private _childenCode = {
@@ -88,7 +88,7 @@ if (hasInterface && {!(_typeOf in GVAR(initializedStaticTypes))}) then {
         _ammoActionPath = [_typeOf, 0, ["ACE_MainActions"], _ammoAction] call EFUNC(interact_menu,addActionToClass);
     };
 
-    if (["ACE_reload"] call EFUNC(common,isModLoaded)) then {
+    if (["ACE_reload"] call EFUNC(common,isModLoaded) && {!([false, true, true, GVAR(defaultAssemblyMode)] select (_target getVariable [QGVAR(assemblyMode), 3]))}) then {
         // move reload's check ammo action to the ammo handling point (remove and re-add)
         [_typeOf, 0, ["ACE_MainActions", QEGVAR(reload,CheckAmmo)]] call EFUNC(interact_menu,removeActionFromClass);
         private _checkAmmoAction = [QGVAR(checkAmmo), localize ELSTRING(reload,checkAmmo), "", EFUNC(reload,checkAmmo), EFUNC(reload,canCheckAmmo)] call EFUNC(interact_menu,createAction);

--- a/addons/csw/initSettings.sqf
+++ b/addons/csw/initSettings.sqf
@@ -34,7 +34,7 @@ private _categoryArray = [format ["ACE %1", localize LSTRING(DisplayName)]];
     QGVAR(ammoHandling), "LIST",
     [LSTRING(ammoHandling_displayName), LSTRING(ammoHandling_description)],
     _categoryArray,
-    [[0, 1, 2], [LELSTRING(common,Disabled), LELSTRING(common,playerOnly), LELSTRING(common,playersAndAI)], 2], //  [_values, _valueTitles, _defaultIndex]
+    [[1, 2], [LELSTRING(common,playerOnly), LELSTRING(common,playersAndAI)], 2], //  [_values, _valueTitles, _defaultIndex]
     true, // isGlobal
     {[QGVAR(ammoHandling), _this] call EFUNC(common,cbaSettings_settingChanged)},
     true // Needs mission restart

--- a/docs/wiki/feature/crew-served-weapons.md
+++ b/docs/wiki/feature/crew-served-weapons.md
@@ -61,15 +61,15 @@ Static weapons are assembled when a tripod is placed down, and the weapon mounte
 
 ### 3.1 defaultAssemblyMode
 
-- Enables/Disables the ability to assemble the CSW through the addon (Non-Vanilla assembly)
+- Controls whether static weapons with CSW support will be forced to use its systems (disassembly and ammo handling).
 - Default: Off
 
 ### 3.2 handleExtraMagazines
 
-- Enables/Disables the magazines in the CSW will appear next to the gun on weapon initialization when using defaultAssemblyMode and you have a pre-placed static weapon
+- Controls whether magazines in pre-placed or vanilla assembled CSWs will be unloaded next to the weapon, or just deleted. Has no effect for CSW assembled through the ACE gunbags.
 - Default: On
 
 ### 3.3 ammoHandling
 
-- Whether or not you want to handle ammo using the CSW way. Does nothing if using defaultAssemblyMode
+- Whether or not AI can reload a CSW.
 - Default: On


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Ammo Handling for players is now available solely based on the weapon's assembly mode:
- Static Weapons assembled through CSW gunbags will always have ammo handling enabled.
- Static Weapons assembled through vanilla gunbags or placed by mission makers/`createVehicle` will have ammo handling enabled based on the Advanced Assembly setting.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
