### PR TITLE
Interaction - Use `assignTeam` instead of deprecated CBA event

### DIFF
--- a/addons/interaction/functions/fnc_joinTeam.sqf
+++ b/addons/interaction/functions/fnc_joinTeam.sqf
@@ -19,7 +19,7 @@
 
 params ["_unit", "_team", ["_displayHint", false, [false]]];
 
-["CBA_teamColorChanged", [_unit, _team]] call CBA_fnc_globalEvent;
+_unit assignTeam _team;
 
 // display message
 if (_unit == ACE_player) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title - `assignTeam` is global in Arma 3 and sync is fixed since Arma 3 v1.62 (ref. https://github.com/CBATeam/CBA_A3/pull/511)

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
