### PR TITLE
Reload Launchers - Code cleanup

### DIFF
--- a/addons/reloadlaunchers/CfgEventHandlers.hpp
+++ b/addons/reloadlaunchers/CfgEventHandlers.hpp
@@ -1,4 +1,3 @@
-
 class Extended_PreStart_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));

--- a/addons/reloadlaunchers/CfgVehicles.hpp
+++ b/addons/reloadlaunchers/CfgVehicles.hpp
@@ -1,4 +1,3 @@
-
 class CfgVehicles {
     class Man;
     class CAManBase: Man {

--- a/addons/reloadlaunchers/CfgWeapons.hpp
+++ b/addons/reloadlaunchers/CfgWeapons.hpp
@@ -1,4 +1,3 @@
-
 class CfgWeapons {
     class Launcher_Base_F;
     class launch_Titan_base: Launcher_Base_F {

--- a/addons/reloadlaunchers/XEH_PREP.hpp
+++ b/addons/reloadlaunchers/XEH_PREP.hpp
@@ -1,4 +1,3 @@
-
 PREP(addMissileReloadActions);
 PREP(canLoad);
 PREP(getLoadableMissiles);

--- a/addons/reloadlaunchers/XEH_postInit.sqf
+++ b/addons/reloadlaunchers/XEH_postInit.sqf
@@ -1,4 +1,4 @@
 // by commy2
 #include "script_component.hpp"
 
-[QGVAR(reloadLauncher), {_this call DFUNC(reloadLauncher)}] call CBA_fnc_addEventHandler;
+[QGVAR(reloadLauncher), LINKFUNC(reloadLauncher)] call CBA_fnc_addEventHandler;

--- a/addons/reloadlaunchers/config.cpp
+++ b/addons/reloadlaunchers/config.cpp
@@ -15,6 +15,5 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
-
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/reloadlaunchers/functions/fnc_addMissileReloadActions.sqf
+++ b/addons/reloadlaunchers/functions/fnc_addMissileReloadActions.sqf
@@ -1,17 +1,17 @@
 #include "script_component.hpp"
 /*
  * Author: commy2
- * Create one action per reloadable missile
+ * Create one action per reloadable missile.
  *
  * Arguments:
- * 1: Target <OBJECT>
- * 0: Player <OBJECT>
+ * 0: Unit equipped with the launcher <OBJECT>
+ * 1: Unit to execute the reload <OBJECT>
  *
  * Return Value:
  * Children actions <ARRAY>
  *
  * Example:
- * [bob, kevin] call ace_reloadlaunchers_fnc_addMissileReloadActions
+ * [cursorTarget, player] call ace_reloadlaunchers_fnc_addMissileReloadActions
  *
  * Public: No
  *
@@ -20,8 +20,9 @@
 params ["_target", "_unit"];
 TRACE_2("params",_target,_unit);
 
-//Fast exit for common case:
+// Fast exit for common cases
 private _weapon = secondaryWeapon _target;
+
 if ((_weapon == "") || {(getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(enabled))) == 0}) exitWith {
     TRACE_1("weapon not supported",_weapon);
     []
@@ -32,16 +33,18 @@ private _actions = [];
 private _loadableMissiles = [_unit, _weapon] call FUNC(getLoadableMissiles);
 TRACE_2("",_weapon,_loadableMissiles);
 
+private _cfgMagazines = configFile >> "CfgMagazines";
+
 {
     private _name = format [QGVAR(Missile_%1), _x];
-    private _displayName = format [localize LSTRING(LoadMagazine), getText (configFile >> "CfgMagazines" >> _x >> "displayName")];
+    private _displayName = format [LLSTRING(LoadMagazine), getText (_cfgMagazines >> _x >> "displayName")];
 
     private _statement = {
-        (_this select 2) call DFUNC(load);
+        (_this select 2) call FUNC(load);
     };
 
     private _condition = {
-        (_this select 2) call DFUNC(canLoad)
+        (_this select 2) call FUNC(canLoad)
     };
 
     private _action = [_name, _displayName, "", _statement, _condition, {}, [_unit, _target, _weapon, _x], "", 4] call EFUNC(interact_menu,createAction);

--- a/addons/reloadlaunchers/functions/fnc_canLoad.sqf
+++ b/addons/reloadlaunchers/functions/fnc_canLoad.sqf
@@ -4,16 +4,16 @@
  * Check of the unit can reload the launcher of target unit.
  *
  * Arguments:
- * 0: Unit to do the reloading <OBJECT>
- * 1: Unit eqipped with launcher <OBJECT>
- * 2: weapon name <STRING>
- * 3: missile name <STRING>
+ * 0: Unit to execute the reload <OBJECT>
+ * 1: Unit equipped with the launcher <OBJECT>
+ * 2: Launcher name <STRING>
+ * 3: Missile name <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [bob, kevin, "weapon", "missile"] call ace_reloadlaunchers_fnc_canLoad
+ * [player, cursorTarget, "launch_RPG32_F", "RPG32_F"] call ace_reloadlaunchers_fnc_canLoad
  *
  * Public: No
  */
@@ -21,21 +21,21 @@
 params ["_unit", "_target", "_weapon", "_magazine"];
 TRACE_4("params",_unit,_target,_weapon,_magazine);
 
-if (!alive _target) exitWith {false};
-if (vehicle _target != _target) exitWith {false};
+// Target must be awake
+if !(_target call EFUNC(common,isAwake)) exitWith {false};
+
+// Target must not be in a vehicle
+if !(isNull objectParent _target) exitWith {false};
 if !([_unit, _target, ["isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
-// target is awake
-if (_target getVariable ["ACE_isUnconscious", false]) exitWith {false};
-
-// has secondary weapon equipped
-if !(_weapon in weapons _target) exitWith {false};
-
-// check if the target really needs to be reloaded
-if (count secondaryWeaponMagazine _target > 0) exitWith {false};
-
-// check if the launcher is compatible
+// Check if the launcher is compatible
 if (getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(enabled)) == 0) exitWith {false};
 
-// check if the magazine compatible with targets launcher
+// Check if target has its secondary weapon equipped
+if !(_weapon in weapons _target) exitWith {false};
+
+// Check if the target's launcher's primary muzzle really needs to be reloaded
+if (((getUnitLoadout _target) select 1 param [4, []] param [1, 0]) != 0) exitWith {false};
+
+// Check if the magazine is compatible with target's launcher
 _magazine in ([_unit, _weapon] call FUNC(getLoadableMissiles))

--- a/addons/reloadlaunchers/functions/fnc_canLoad.sqf
+++ b/addons/reloadlaunchers/functions/fnc_canLoad.sqf
@@ -35,7 +35,7 @@ if (getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(enabled)) == 0) ex
 if !(_weapon in weapons _target) exitWith {false};
 
 // Check if the target's launcher's primary muzzle really needs to be reloaded
-if (((getUnitLoadout _target) select 1 param [4, []] param [1, 0]) != 0) exitWith {false};
+if (_target ammo _weapon != 0) exitWith {false};
 
 // Check if the magazine is compatible with target's launcher
 _magazine in ([_unit, _weapon] call FUNC(getLoadableMissiles))

--- a/addons/reloadlaunchers/functions/fnc_getLoadableMissiles.sqf
+++ b/addons/reloadlaunchers/functions/fnc_getLoadableMissiles.sqf
@@ -1,17 +1,17 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, johnb43
  * Return all magazine types from reloaders inventory that are compatible with given weapon.
  *
  * Arguments:
- * 0: Unit to to the reload <OBJECT>
- * 1: A launcher <OBJECT>
+ * 0: Unit to execute the reload <OBJECT>
+ * 1: Launcher name <STRING>
  *
  * Return Value:
  * Reloable magazines <ARRAY>
  *
  * Example:
- * [bob, launcher] call ace_reloadlaunchers_fnc_getLoadableMissiles
+ * [player, "launch_RPG32_F"] call ace_reloadlaunchers_fnc_getLoadableMissiles
  *
  * Public: No
  */
@@ -19,11 +19,5 @@
 params ["_unit", "_weapon"];
 TRACE_2("params",_unit,_weapon);
 
-// get available magazines of reloader, Note: "magazines" does not include currently loaded magazines
-private _magazines = magazines _unit;
-
-// case sensitvity
-_magazines = _magazines apply {toLower _x};
-
-// get reloaders magazine types compatible with targets launcher. No duplicates.
-getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") select {toLower _x in _magazines} // return
+// Look for primary muzzle magazines only
+(compatibleMagazines [_weapon, "this"]) arrayIntersect (magazines _unit)

--- a/addons/reloadlaunchers/functions/fnc_load.sqf
+++ b/addons/reloadlaunchers/functions/fnc_load.sqf
@@ -1,19 +1,19 @@
 #include "script_component.hpp"
 /*
  * Author: commy2
- * Reload a launcher
+ * Start reloading a launcher, reload started by the unit who has the missile.
  *
  * Arguments:
- * 0: Unit with magazine <OBJECT>
- * 1: Unit with launcher <OBJECT>
- * 2: weapon name <STRING>
- * 3: missile name <STRING>
+ * 0: Unit executing the reload <OBJECT>
+ * 1: Unit equipped with the launcher <OBJECT>
+ * 2: Launcher name <STRING>
+ * 3: Missile name <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [bob, kevin, "weapon", "missile"] call ace_reloadlaunchers_fnc_load
+ * [player, cursorTarget, "launch_RPG32_F", "RPG32_F"] call ace_reloadlaunchers_fnc_load
  *
  * Public: No
  */
@@ -21,30 +21,37 @@
 params ["_unit", "_target", "_weapon", "_magazine"];
 TRACE_4("params",_unit,_target,_weapon,_magazine);
 
-private _reloadTime = if (isNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(buddyReloadTime))) then {
-    getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(buddyReloadTime))
+private _config = configFile >> "CfgWeapons" >> _weapon >> QGVAR(buddyReloadTime);
+
+private _reloadTime = if (isNumber _config) then {
+    getNumber _config
 } else {
     2.5
 };
 
-// do animation
+// Play animation
 [_unit] call EFUNC(common,goKneeling);
 
-// show progress bar
-
+// Show progress bar
 private _onSuccess =  {
-    (_this select 0 select 0) removeMagazine (_this select 0 select 3);
-    [QGVAR(reloadLauncher), _this select 0, _this select 0 select 1] call CBA_fnc_targetEvent;
+    (_this select 0) params ["_unit", "_target", "_weapon", "_magazine"];
 
-    [localize LSTRING(LauncherLoaded)] call DEFUNC(common,displayTextStructured);
+    _unit removeMagazine _magazine;
+
+    // Reload target's launcher
+    [QGVAR(reloadLauncher), [_unit, _target, _weapon, _magazine], _target] call CBA_fnc_targetEvent;
+
+    [LLSTRING(LauncherLoaded)] call EFUNC(common,displayTextStructured);
 };
 
 private _onFailure = {
-    [localize ELSTRING(common,ActionAborted)] call DEFUNC(common,displayTextStructured);
+    [LELSTRING(common,ActionAborted)] call EFUNC(common,displayTextStructured);
 };
 
 private _condition = {
-    (_this select 0) call DFUNC(canLoad) && {(_this select 0 select 0) distance (_this select 0 select 1) < 4}
+    (_this select 0) params ["_unit", "_target"];
+
+    (_this select 0) call FUNC(canLoad) && {_unit distance _target < 4}
 };
 
-[_reloadTime, [_unit, _target, _weapon, _magazine], _onSuccess, _onFailure, localize LSTRING(LoadingLauncher), _condition, ["isNotInside", "isNotSwimming"]] call EFUNC(common,progressBar);
+[_reloadTime, [_unit, _target, _weapon, _magazine], _onSuccess, _onFailure, LLSTRING(LoadingLauncher), _condition, ["isNotInside", "isNotSwimming"]] call EFUNC(common,progressBar);

--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -1,24 +1,24 @@
 #include "script_component.hpp"
 /*
  * Author: commy2
- * Reload a launcher
+ * Reload a launcher for the unit who has the launcher.
  *
  * Arguments:
- * 0: Unit to do the reloading <OBJECT>
- * 1: Target to rload <OBJECT>
- * 2: weapon name <STRING>
- * 3: missile name <STRING>
+ * 0: Unit executing the reload <OBJECT>
+ * 1: Unit equipped with the launcher <OBJECT>
+ * 2: Launcher name <STRING>
+ * 3: Missile name <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [bob, kevin, "weapon", "missile"] call ace_reloadlaunchers_fnc_reloadLauncher
+ * [player, cursorTarget, "launch_RPG32_F", "RPG32_F"] call ace_reloadlaunchers_fnc_reloadLauncher
  *
  * Public: No
  */
 
-params ["_unit","_target","_weapon","_magazine"];
+params ["_unit", "_target", "_weapon", "_magazine"];
 TRACE_4("params",_unit,_target,_weapon,_magazine);
 
 _target selectWeapon _weapon;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Some changes :
    - If a launcher has two muzzles, e.g. RHS SMAW, and if the secondary muzzle were loaded but not the first, you could not use the reload action. Same happened if the launcher had a magazine in the primary muzzle with 0 ammo in it. This PR makes it so that it only checks the primary muzzle and checks if the ammo is 0.
    - The compatible magazines check did not check for magazines in magwells. This PR adds support for magwells.
    
The changes were included in this PR because I deemed them to be relatively small.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [ ] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
