### PR TITLE
Reload Launcher - Improve various aspects

### DIFF
--- a/addons/reloadlaunchers/CfgWeapons.hpp
+++ b/addons/reloadlaunchers/CfgWeapons.hpp
@@ -7,6 +7,9 @@ class CfgWeapons {
     class launch_RPG32_F: Launcher_Base_F {
         GVAR(enabled) = 1;
     };
+    class launch_RPG7_F: Launcher_Base_F {
+        GVAR(enabled) = 1;
+    };
     class launch_MRAWS_base_F: Launcher_Base_F {
         GVAR(enabled) = 1;
     };

--- a/addons/reloadlaunchers/functions/fnc_canLoad.sqf
+++ b/addons/reloadlaunchers/functions/fnc_canLoad.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, johnb43
  * Check of the unit can reload the launcher of target unit.
  *
  * Arguments:
@@ -24,6 +24,9 @@ TRACE_4("params",_unit,_target,_weapon,_magazine);
 if (!alive _target) exitWith {false};
 if (vehicle _target != _target) exitWith {false};
 if !([_unit, _target, ["isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
+
+// Target must not be captive
+if (_target getVariable [QEGVAR(captives,isHandcuffed), false] || {_target getVariable [QEGVAR(captives,isSurrendering), false]}) exitWith {false};
 
 // target is awake
 if (_target getVariable ["ACE_isUnconscious", false]) exitWith {false};

--- a/addons/reloadlaunchers/functions/fnc_load.sqf
+++ b/addons/reloadlaunchers/functions/fnc_load.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, johnb43
  * Reload a launcher
  *
  * Arguments:
@@ -41,7 +41,7 @@ private _onSuccess =  {
     // Get count of rounds in magazines, then select maximum
     private _ammo = selectMax (_magazinesAmmoFull apply {_x select 1});
 
-    // Try to remove magazine; If failure, quit
+    // Try to remove magazine; If not possible, quit
     if !([_unit, _magazine, _ammo] call EFUNC(common,removeSpecificMagazine)) exitWith {
         [LELSTRING(common,ActionAborted)] call EFUNC(common,displayTextStructured);
     };

--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -2,12 +2,14 @@
 /*
  * Author: commy2
  * Reload a launcher
+ * If the ammo argument is nil, a full magazine will be given.
  *
  * Arguments:
  * 0: Unit to do the reloading <OBJECT>
  * 1: Target to rload <OBJECT>
  * 2: weapon name <STRING>
  * 3: missile name <STRING>
+ * 4: Ammo count <NUMBER>
  *
  * Return Value:
  * None
@@ -18,12 +20,26 @@
  * Public: No
  */
 
-params ["_unit","_target","_weapon","_magazine"];
-TRACE_4("params",_unit,_target,_weapon,_magazine);
+params ["_unit", "_target", "_weapon", "_magazine", "_ammo"];
+TRACE_5("params",_unit,_target,_weapon,_magazine,_ammo);
 
-_target selectWeapon _weapon;
+private _checkSelectedWeapon = isPlayer _target || {!isNull (_target getVariable ["bis_fnc_moduleRemoteControl_owner", objNull])};
 
-if (currentWeapon _target != _weapon) exitWith {};
-if (currentMagazine _target != "") exitWith {};
+// AI don't select launchers with selectWeapon/switchWeapon
+if (_checkSelectedWeapon) then {
+    _target selectWeapon _weapon;
+};
 
-_target addWeaponItem [_weapon, _magazine, true];
+// Check if the launcher has been selected (but only for players and remote controlled AI) and hadn't been reloaded
+if ((_checkSelectedWeapon && {currentWeapon _target != _weapon}) || {currentMagazine _target != ""}) exitWith {
+    // If failed, readd magazine back to reloading unit
+    [_unit, _magazine, _ammo, true] call CBA_fnc_addMagazine;
+
+    [QEGVAR(common,displayTextStructured), [LELSTRING(common,ActionAborted)], _unit] call CBA_fnc_targetEvent;
+};
+
+// Add magazine to launcher immediately
+_target addWeaponItem [_weapon, [_magazine, _ammo], true];
+
+// Notify reloading unit about success
+[QEGVAR(common,displayTextStructured), [LLSTRING(LauncherLoaded)], _unit] call CBA_fnc_targetEvent;

--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, johnb43
  * Reload a launcher
  * If the ammo argument is nil, a full magazine will be given.
  *
@@ -35,6 +35,7 @@ if ((_checkSelectedWeapon && {currentWeapon _target != _weapon}) || {currentMaga
     // If failed, readd magazine back to reloading unit
     [_unit, _magazine, _ammo, true] call CBA_fnc_addMagazine;
 
+    // Notify reloading unit about failure
     [QEGVAR(common,displayTextStructured), [LELSTRING(common,ActionAborted)], _unit] call CBA_fnc_targetEvent;
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Added reload launcher support to the RPG 7 from APEX.
- Removed reloading of captive units' launchers.
- Added proper support for launchers with magazines that contain more than 1 rocket/missile. The magazine with the highest amount of ammo is selected for reloading.
- In some cases the reload process fails, e.g. AI don't switch to a launcher, despite the use of `selectWeapon` or `action ["switchWeapon"]` commands, or perhaps the launcher had been reloaded by someone else whilst you were interacting.
If one of the cases described happened, the missile is deleted, but never given back.
This PR fixes that:
  - If the unit to be reloaded is AI (excluding remote-controlled AI), it will no longer check if the unit has its secondary weapon selected. It will just reload the unit.
  - If the reloading failed, the magazine will be returned to the unit initiating the reload. If that unit has a full inventory, the magazine will be dropped on the ground.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
