### PR TITLE
Night Vision - Use default effects when controlling UAVs

### DIFF
--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -31,6 +31,7 @@ GVAR(isUsingMagnification) = false;
     ["cameraView", LINKFUNC(onCameraViewChanged), true] call CBA_fnc_addPlayerEventHandler;
     ["vehicle", LINKFUNC(refreshGoggleType), false] call CBA_fnc_addPlayerEventHandler;
     ["turret", LINKFUNC(refreshGoggleType), true] call CBA_fnc_addPlayerEventHandler;
+    ["ACE_controlledUAV", LINKFUNC(refreshGoggleType)] call CBA_fnc_addEventHandler;
 
     // handle only brightness if effects are disabled
     GVAR(ppEffectNVGBrightness) = ppEffectCreate ["ColorCorrections", 1236];

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -28,7 +28,7 @@ private _blurRadius = -1;
 
 // Adds Array of Params / Original ACE3's (ST's) by default. (NVG_GREEN_PRESET)
 private _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> "colorPreset");
-if (alive ACE_player) then {
+if ((alive ACE_player) && {isNull (ACE_controlledUAV select 0)}) then {
     if (((vehicle ACE_player) == ACE_player) || {
         // Test if we are using player's nvg or if sourced from vehicle:
 


### PR DESCRIPTION
fixes drones having player's nvg effects, really only noticeable in pilot view as it's zoomed out so much:
![20230821113452_1](https://github.com/acemod/ACE3/assets/9376747/be8a52ff-89c1-4116-b296-15ddf0fea8fb)
