### PR TITLE
Reload - Code cleanup and various improvements

### DIFF
--- a/addons/common/initSettings.sqf
+++ b/addons/common/initSettings.sqf
@@ -68,7 +68,7 @@ private _categoryColors = [_category, format ["| %1 |", LLSTRING(subcategory_col
     QGVAR(persistentLaserEnabled),
     "CHECKBOX",
     [LSTRING(SettingPersistentLaserName), LSTRING(SettingPersistentLaserDesc)],
-    localize LSTRING(ACEKeybindCategoryWeapons),
+    LSTRING(ACEKeybindCategoryWeapons),
     false,
     false,
     LINKFUNC(switchPersistentLaser)

--- a/addons/laserpointer/initSettings.sqf
+++ b/addons/laserpointer/initSettings.sqf
@@ -1,7 +1,7 @@
 [
     QGVAR(enabled), "CHECKBOX",
     LSTRING(DisplayName),
-    localize ELSTRING(common,ACEKeybindCategoryWeapons),
+    ELSTRING(common,ACEKeybindCategoryWeapons),
     true,
     1
 ] call CBA_fnc_addSetting;

--- a/addons/reload/CfgEventHandlers.hpp
+++ b/addons/reload/CfgEventHandlers.hpp
@@ -1,4 +1,3 @@
-
 class Extended_PreStart_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));

--- a/addons/reload/CfgVehicles.hpp
+++ b/addons/reload/CfgVehicles.hpp
@@ -14,16 +14,16 @@ class CfgVehicles {
 
         class ACE_Actions {
             class ACE_Weapon {
-                class GVAR(LinkBelt) {
-                    displayName = CSTRING(LinkBelt);
-                    distance = 2.0;
+                class GVAR(linkBelt) {
+                    displayName = CSTRING(linkBelt);
+                    distance = 2;
                     condition = QUOTE(([ARR_2(_player, _target)] call FUNC(getAmmoToLinkBelt)) > 0);
                     statement = QUOTE([ARR_2(_player, _target)] call FUNC(startLinkingBelt));
                     exceptions[] = {"isNotInside"};
                 };
-                class GVAR(CheckAmmo) {
+                class GVAR(checkAmmo) {
                     displayName = CSTRING(checkAmmo);
-                    distance = 2.0;
+                    distance = 2;
                     condition = QUOTE(call FUNC(canCheckAmmo));
                     statement = QUOTE(call FUNC(checkAmmo));
                     exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};
@@ -36,9 +36,9 @@ class CfgVehicles {
     class StaticWeapon: LandVehicle {
         class ACE_Actions {
             class ACE_MainActions {
-                class GVAR(CheckAmmo) {
+                class GVAR(checkAmmo) {
                     displayName = CSTRING(checkAmmo);
-                    distance = 2.0;
+                    distance = 2;
                     condition = QUOTE(call FUNC(canCheckAmmo));
                     statement = QUOTE(call FUNC(checkAmmo));
                     exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};

--- a/addons/reload/XEH_PREP.hpp
+++ b/addons/reload/XEH_PREP.hpp
@@ -1,4 +1,3 @@
-
 PREP(canCheckAmmo);
 PREP(canCheckAmmoSelf);
 PREP(getAmmoToLinkBelt);

--- a/addons/reload/functions/fnc_canCheckAmmo.sqf
+++ b/addons/reload/functions/fnc_canCheckAmmo.sqf
@@ -1,13 +1,13 @@
 #include "script_component.hpp"
 /*
- * Author: CAA-Picard
- * Check if the player can check the ammo of the target.
+ * Author: CAA-Picard, johnb43
+ * Check if a unit can check the ammo of the target.
  *
  * Arguments:
- * 0: Target <OBJECT>
+ * 0: Unit equipped with the weapon <OBJECT>
  *
  * Return Value:
- * Can link belt<BOOL>
+ * Can check ammo <BOOL>
  *
  * Example:
  * [cursorObject] call ace_reload_fnc_canCheckAmmo
@@ -17,26 +17,18 @@
 
 params ["_target"];
 
-// Return true for static weapons if they have been fired once, @todo 1.40 this work-around doesn't work anymore
+// Static weapons
 if (_target isKindOf "StaticWeapon") exitWith {
-    if (currentMagazine _target != "") exitWith {true};
-
-    // no check ammo action on destroyed static weapons
+    // No check ammo action on destroyed static weapons
     if (!alive _target) exitWith {false};
 
-    private _found = false;
+    if (currentMagazine _target != "") exitWith {true};
 
-    {
-        if (_x select 2) exitWith {
-            _found = true;
-        };
-        false
-    } count magazinesAmmoFull _target;
-
-    _found
+    // Check for loaded magazines
+    (magazinesAmmoFull _target) findIf {_x select 2} != -1
 };
 
-// Return false for all other vehicles
+// All other vehicles
 if !(_target isKindOf "CAManBase") exitWith {false};
 
 // For men

--- a/addons/reload/functions/fnc_canCheckAmmoSelf.sqf
+++ b/addons/reload/functions/fnc_canCheckAmmoSelf.sqf
@@ -7,10 +7,10 @@
  * 0: Player <OBJECT>
  *
  * Return Value:
- * Can check ammo <BOOL>
+ * Can check ammo for self <BOOL>
  *
  * Example:
- * [cursorObject] call ace_reload_fnc_canCheckAmmoSelf
+ * [player] call ace_reload_fnc_canCheckAmmoSelf
  *
  * Public: No
  */

--- a/addons/reload/functions/fnc_checkAmmo.sqf
+++ b/addons/reload/functions/fnc_checkAmmo.sqf
@@ -1,11 +1,11 @@
 #include "script_component.hpp"
 /*
- * Author: commy2 and esteldunedain
- * Count the ammo of the currently loaded magazine or count rifle grenades. Play animation and display message.
+ * Author: commy2, esteldunedain
+ * Play animation and display message.
  *
  * Arguments:
- * 0: Target. <OBJECT>
- * 1: Player <OBJECT>
+ * 0: Unit equipped with the weapon <OBJECT>
+ * 1: Unit to execute the reload <OBJECT>
  *
  * Return Value:
  * None
@@ -16,13 +16,14 @@
  * Public: No
  */
 
-params ["_target", "_player"];
+params ["_target", "_unit"];
 
-if (_player == _target) then {
+if (_unit == _target) then {
     if ((vehicle _target) isKindOf "StaticWeapon") then {
         _target = vehicle _target;
     };
-    [_player, "Gear", 1] call EFUNC(common,doGesture);
+
+    [_unit, "Gear", 1] call EFUNC(common,doGesture);
 };
 
-[FUNC(displayAmmo), [_target], 1] call CBA_fnc_waitAndExecute;
+[FUNC(displayAmmo), _target, 1] call CBA_fnc_waitAndExecute;

--- a/addons/reload/functions/fnc_displayAmmo.sqf
+++ b/addons/reload/functions/fnc_displayAmmo.sqf
@@ -1,16 +1,16 @@
 #include "script_component.hpp"
 /*
- * Author: commy2 and esteldunedain
+ * Author: commy2, esteldunedain
  * Display the ammo of the currently loaded magazine of the target or count rifle grenades.
  *
  * Arguments:
- * 0: Target <OBJECT>
+ * 0: Unit equipped with the weapon <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * player call ace_reload_fnc_displayAmmo
+ * [player] call ace_reload_fnc_displayAmmo
  *
  * Public: No
  */
@@ -21,59 +21,58 @@ params ["_target"];
 
 private _isStaticWeapon = _target isKindOf "StaticWeapon";
 
-if (_isStaticWeapon) then {
-    [currentWeapon _target, currentMuzzle _target, "", currentMagazine _target]
-} else {
-    weaponState _target
-} params ["_weapon", "_muzzle", "", "_magazine"];
+// currentWeapon, currentMagazine and weaponState return "" for static weapons before they have been entered once
+(if (_isStaticWeapon) then {
+    private _weapon = currentWeapon _target;
 
-// currentWeapon returns "" for static weapons before they are shot once
-if (_isStaticWeapon) then {
     if (_weapon == "") then {
-        if (count (weapons _target) == 1) then {
-            _weapon = (weapons _target) select 0;
-            _muzzle = _weapon;
+        private _weapons = weapons _target;
+
+        if (count _weapons == 1) then {
+            _weapon = _weapons select 0;
         };
     };
 
+    private _magazine = currentMagazine _target;
+
     if (_magazine == "") then {
         // Try to get magazine using magazinesAmmoFull
-        private _magazines = magazinesAmmoFull _target;
-
         {
             if (_x select 2) exitWith {
                 _magazine = _x select 0;
             };
-        } forEach _magazines;
+        } forEach magazinesAmmoFull _target;
     };
 
-    // For static weapons the muzzle seemingly never returns anything for static weapons with/without people inside
-    if (_muzzle == "") then {
-        _muzzle = _weapon;
-    };
-};
+    // currentMuzzle always returns ""
+    [_weapon, _weapon, "", _magazine]
+} else {
+    weaponState _target
+}) params ["_weapon", "_muzzle", "", "_magazine"];
 
 TRACE_3("",_weapon,_muzzle,_magazine);
 
-if ("" in [_weapon, _magazine]) exitWith {};
+if ("" == _weapon) exitWith {};
 
 private _ammo = _target ammo _muzzle;
-private _magazineConfig = configFile >> "CfgMagazines" >> _magazine;
-private _maxRounds = getNumber (_magazineConfig >> "count") max 1;
+private _magazineCfg = configFile >> "CfgMagazines" >> _magazine;
+private _maxRounds = getNumber (_magazineCfg >> "count") max 1;
 private _count = -1; // Show a count instead of ammo bars (ignore if -1)
 
-if (_muzzle != _weapon) then {
-    // grenade launcher (or some kind of seconday muzzle)
-    if (_ammo > 0) then {
-        if (_maxRounds == 1) then { // singleShot so show count of identical mags available instead of ammo bars
-            _count = 1 + ({_x == _magazine} count magazines _target);
-        };
-    } else {
-        if (_maxRounds <= 3) then { // empty GL/3GL - don't have a real magazine so just show count of any compatible mag
-            _magazine = "";
-            private _compatibleMagazines =  [configFile >> "CfgWeapons" >> _weapon >> _muzzle] call CBA_fnc_compatibleMagazines;
-            _count = {_x in _compatibleMagazines} count (magazines _target); // safe because everything is config case
-         };
+// If secondary muzzle is selected or no magazine in current muzzle
+if (_muzzle != _weapon || {_magazine == ""}) then {
+    // Check if no or empty magazine; If true, just show count of compatible magazines
+    if (_ammo == 0) exitWith {
+        _magazine = ""; // Make sure, as it could also be secondary muzzle being selected
+
+        private _compatibleMagazines = compatibleMagazines [_weapon, _muzzle];
+
+        _count = {_x in _compatibleMagazines} count (magazines _target);
+    };
+
+    // singleShot, so show count of identical mags available instead of ammo bars
+    if (_ammo > 0 && {_maxRounds == 1}) exitWith {
+        _count = 1 + ({_x == _magazine} count (magazines _target));
     };
 };
 
@@ -83,21 +82,29 @@ private _ammoBarsStructuredText = if (_count >= 0) then {
     if (_maxRounds >= COUNT_BARS) then {
         _count = round (COUNT_BARS * _ammo / _maxRounds);
 
-        if (_ammo > 0) then {_count = _count max 1};
-        if (_ammo < _maxRounds) then {_count = _count min (COUNT_BARS - 1)};
+        if (_ammo > 0) then {
+            _count = _count max 1;
+        };
+
+        if (_ammo < _maxRounds) then {
+            _count = _count min (COUNT_BARS - 1);
+        };
     } else {
         _count = _ammo;
     };
 
-    private _color = [((2 * (1 - _ammo / _maxRounds)) min 1), ((2 * _ammo / _maxRounds) min 1), 0];
+    private _color = [(2 * (1 - _ammo / _maxRounds)) min 1, (2 * _ammo / _maxRounds) min 1, 0];
 
     private _string = "";
+
     for "_a" from 1 to _count do {
         _string = _string + "|";
     };
+
     private _text = [_string, _color] call EFUNC(common,stringToColoredText);
 
     _string = "";
+
     for "_a" from (_count + 1) to (_maxRounds min COUNT_BARS) do {
         _string = _string + "|";
     };
@@ -105,16 +112,21 @@ private _ammoBarsStructuredText = if (_count >= 0) then {
     composeText [_text, [_string, "#808080"] call EFUNC(common,stringToColoredText)];
 };
 
-
 if (_isStaticWeapon) then {
-    //Vehicle mags (usualy) don't have pictures, so just show the text above ammo count
-    private _loadedName = getText (_magazineConfig >> "displaynameshort");
+    // Vehicle mags usually don't have pictures, so just show the text above ammo count
+    private _loadedName = getText (_magazineCfg >> "displayNameShort");
+
+    if (_loadedName == "") then {
+        _loadedName = getText (_magazineCfg >> "displayName");
+    };
+
     _loadedName = parseText format ["<t align='center' >%1</t>", _loadedName];
+
     private _text = composeText [_loadedName, linebreak, _ammoBarsStructuredText];
     [_text] call EFUNC(common,displayTextStructured);
 } else {
     if (_magazine != "") then {
-        private _picture = getText (_magazineConfig >> "picture");
+        private _picture = getText (_magazineCfg >> "picture");
         [_ammoBarsStructuredText, _picture] call EFUNC(common,displayTextPicture);
     } else {
         [_ammoBarsStructuredText, 1] call EFUNC(common,displayTextStructured);

--- a/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
+++ b/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
@@ -4,7 +4,7 @@
  * Check if the target has an MG equipped with belt system that a unit can link.
  *
  * Arguments:
- * 0: Unit to execute the reload <OBJECT>
+ * 0: Unit wanting to execute the reload <OBJECT>
  * 1: Unit equipped with the weapon <OBJECT>
  *
  * Return Value:

--- a/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
+++ b/addons/reload/functions/fnc_getAmmoToLinkBelt.sqf
@@ -1,11 +1,11 @@
 #include "script_component.hpp"
 /*
  * Author: esteldunedain, phyma
- * Check if the target has an MG equiped with belt system that the player can link
+ * Check if the target has an MG equipped with belt system that a unit can link.
  *
  * Arguments:
- * 0: Player <OBJECT>
- * 1: Target <OBJECT>
+ * 0: Unit to execute the reload <OBJECT>
+ * 1: Unit equipped with the weapon <OBJECT>
  *
  * Return Value:
  * Maximum ammo of magazine (-1 on error) <NUMBER>
@@ -16,12 +16,12 @@
  * Public: No
  */
 
-params ["_player", "_target"];
+params ["_unit", "_target"];
 
-if (vehicle _target != _target) exitWith {-1};
+if !(isNull objectParent _target) exitWith {-1};
 
-private _magazineType = currentMagazine _target;
-private _magazineCfg = configFile >> "CfgMagazines" >> _magazineType;
+private _magazine = currentMagazine _target;
+private _magazineCfg = configFile >> "CfgMagazines" >> _magazine;
 
 if (getNumber (_magazineCfg >> "ACE_isBelt") == 0) exitWith {-1};
 
@@ -29,14 +29,13 @@ if (getNumber (_magazineCfg >> "ACE_isBelt") == 0) exitWith {-1};
 private _ammoCount = _target ammo currentWeapon _target;
 
 // Exit if the belt is full or empty
-if (_ammoCount == 0 || getNumber (_magazineCfg >> "count") - _ammoCount == 0) exitWith {-1};
+if (_ammoCount == 0 || {getNumber (_magazineCfg >> "count") - _ammoCount == 0}) exitWith {-1};
 
-// Check if the player has any of the same magazines
-// Calculate max ammo
+// Check if the unit has any of the same magazines and calculate max ammo
 private _maxAmmo = 0;
 
 {
     _maxAmmo = _maxAmmo max (_x select 1);
-} forEach (magazinesAmmo _player select {_x select 0 == _magazineType});
+} forEach (magazinesAmmo _unit select {(_x select 0) == _magazine});
 
 _maxAmmo

--- a/addons/reload/functions/fnc_onTake.sqf
+++ b/addons/reload/functions/fnc_onTake.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 /*
- * Author: ?
+ * Author: jokoho48
+ * Called from "Take" EH.
  *
  * Arguments:
  * 0: Unit <OBJECT>
@@ -11,17 +12,18 @@
  * None
  *
  * Example:
- * [bob, backpackContainer bob, "ACE_Banana"] call ace_reload_fnc_onTake
+ * [player, backpackContainer player, "ACE_Banana"] call ace_reload_fnc_onTake
  *
  * Public: No
  */
 
 params ["_unit", "_container", "_item"];
+
 if (
-    _unit == ACE_player
-    && {GVAR(DisplayText)}
-    && {_item == currentMagazine _unit}
-    && {_container in [uniformContainer _unit, vestContainer _unit, backpackContainer _unit]}
+    _unit == ACE_player &&
+    {GVAR(displayText)} &&
+    {_item == currentMagazine _unit} &&
+    {_container in [uniformContainer _unit, vestContainer _unit, backpackContainer _unit]}
 ) then {
     _unit call FUNC(displayAmmo);
 };

--- a/addons/reload/functions/fnc_startLinkingBelt.sqf
+++ b/addons/reload/functions/fnc_startLinkingBelt.sqf
@@ -1,58 +1,57 @@
 #include "script_component.hpp"
 /*
- * Author: esteldunedain
- * Start linking the belt
+ * Author: esteldunedain, johnb43
+ * Start linking the belt.
  *
  * Arguments:
- * 0: Player <OBJECT>
- * 1: Target <OBJECT>
+ * 0: Unit executing the reload <OBJECT>
+ * 1: Unit equipped with the weapon <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * [bob, kevin] call ace_reload_fnc_startLinkingBelt
+ * [player, cursorTarget] call ace_reload_fnc_startLinkingBelt
  *
  * Public: No
  */
 
-params ["_player", "_target"];
+params ["_unit", "_target"];
 
-if (vehicle _target != _target) exitWith {false};
+if !(isNull objectParent _target) exitWith {false};
 
-private _magazineType = currentMagazine _target;
+private _magazine = currentMagazine _target;
+private _ammo = [_unit, _target] call FUNC(getAmmoToLinkBelt);
 
-
-private _maxAmmo = [_player, _target] call FUNC(getAmmoToLinkBelt);
-
-//if _maxAmmo is below 0 we quit
-if (_maxAmmo <= 0) exitWith {};
+// If _ammo is below 0 we quit
+if (_ammo <= 0) exitWith {};
 
 // Condition to call each frame
 private _condition = {
-    (_this select 0) params ["_player", "_target"];
-    ([_player, _target, []] call EFUNC(common,canInteractWith)) && ((_player distance _target) < 3) && ((speed _target) < 1)
+    (_this select 0) params ["_unit", "_target"];
+
+    ([_unit, _target, []] call EFUNC(common,canInteractWith)) && {(_unit distance _target) < 3} && {(speed _target) < 1}
 };
 
 private _onFinish = {
-    (_this select 0) params ["_player", "_target", "_magazine"];
+    (_this select 0) params ["_unit", "_target", "_magazineInfo"];
+
+    // Remove the magazine with given remaining ammo; If not possible, quit
+    if !([_unit, _magazineInfo select 0, _magazineInfo select 1] call EFUNC(common,removeSpecificMagazine)) exitWith {
+        [LSTRING(BeltNotLinked)] call EFUNC(common,displayTextStructured);
+    };
 
     // Raise event on remote unit
-    [QGVAR(ammoLinked), [_target, _player, _magazine], [_target]] call CBA_fnc_targetEvent;
+    [QGVAR(ammoLinked), [_target, _unit, _magazineInfo], _target] call CBA_fnc_targetEvent;
 };
 
 private _onFailure = {
-    (_this select 0) params ["_player", "_target", "_magazine"];
-    [_player, "AmovPknlMstpSrasWrflDnon", 1] call EFUNC(common,doAnimation);
+    (_this select 0) params ["_unit"];
 
-    // Add back the magazine with the former ammo count
-    _player addMagazine _magazine;
+    [_unit, "AmovPknlMstpSrasWrflDnon", 1] call EFUNC(common,doAnimation);
 };
 
-[_player, "PutDown"] call EFUNC(common,doGesture);
-
-// Remove the magazine with maximum remaining ammo
-[_player, _magazineType, _maxAmmo] call EFUNC(common,removeSpecificMagazine);
+[_unit, "PutDown"] call EFUNC(common,doGesture);
 
 // Call progress bar
-[4, [_player, _target, [_magazineType, _maxAmmo]], _onFinish, _onFailure, (localize LSTRING(LinkingBelt)), _condition, ["isNotInside"]] call EFUNC(common,progressBar);
+[4, [_unit, _target, [_magazine, _ammo]], _onFinish, _onFailure, LLSTRING(LinkingBelt), _condition, ["isNotInside"]] call EFUNC(common,progressBar);

--- a/addons/reload/functions/fnc_startLinkingBelt.sqf
+++ b/addons/reload/functions/fnc_startLinkingBelt.sqf
@@ -49,6 +49,8 @@ private _onFailure = {
     (_this select 0) params ["_unit"];
 
     [_unit, "AmovPknlMstpSrasWrflDnon", 1] call EFUNC(common,doAnimation);
+
+    [LSTRING(BeltNotLinked)] call EFUNC(common,displayTextStructured);
 };
 
 [_unit, "PutDown"] call EFUNC(common,doGesture);

--- a/addons/reload/initKeybinds.sqf
+++ b/addons/reload/initKeybinds.sqf
@@ -1,0 +1,16 @@
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
+// Add Keybinds
+["ACE3 Weapons", QGVAR(checkAmmo), LSTRING(checkAmmo), {
+    // Conditions: canInteract
+    if !([ACE_player, vehicle ACE_player, ["isNotInside", "isNotSwimming", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    // Ignore if controlling UAV (blocks radar keybind)
+    if (!isNull (ACE_controlledUAV param [0, objNull])) exitWith {false};
+    // Conditions: specific
+    if !(ACE_player call FUNC(canCheckAmmoSelf)) exitWith {false};
+
+    // Statement
+    [ACE_player, ACE_player] call FUNC(checkAmmo);
+
+    true
+}, {false}, [DIK_R, [false, true, false]], false] call CBA_fnc_addKeybind; // Ctrl + R

--- a/addons/reload/initSettings.sqf
+++ b/addons/reload/initSettings.sqf
@@ -1,18 +1,15 @@
-
 [
     QGVAR(displayText),
     "CHECKBOX",
     [LSTRING(SettingDisplayTextName), LSTRING(SettingDisplayTextDesc)],
-    localize ELSTRING(common,ACEKeybindCategoryWeapons),
-    true,
-    0
+    ELSTRING(common,ACEKeybindCategoryWeapons),
+    true // default value
 ] call CBA_fnc_addSetting;
 
 [
     QGVAR(showCheckAmmoSelf),
     "CHECKBOX",
     [LSTRING(SettingShowCheckAmmoSelf), LSTRING(SettingShowCheckAmmoSelfDesc)],
-    localize ELSTRING(common,ACEKeybindCategoryWeapons),
-    false, // default value
-    0 // isGlobal
+    ELSTRING(common,ACEKeybindCategoryWeapons),
+    false // default value
 ] call CBA_fnc_addSetting;

--- a/addons/reload/stringtable.xml
+++ b/addons/reload/stringtable.xml
@@ -129,5 +129,15 @@
             <Chinesesimp>正在连接弹链...</Chinesesimp>
             <Chinese>連接彈鏈中...</Chinese>
         </Key>
+        <Key ID="STR_ACE_Reload_BeltLinked">
+            <English>Belt was linked</English>
+            <French>Bande a été attachée</French>
+            <German>Gurt wurde angehängt</German>
+        </Key>
+        <Key ID="STR_ACE_Reload_BeltNotLinked">
+            <English>Belt could not be linked</English>
+            <French>Bande n'a pas pu être attachée</French>
+            <German>Gurt konnte nicht angehängt werden</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/weaponselect/initSettings.sqf
+++ b/addons/weaponselect/initSettings.sqf
@@ -1,7 +1,7 @@
 [
     QGVAR(displayText), "CHECKBOX",
     [LSTRING(SettingDisplayTextName), LSTRING(SettingDisplayTextDesc)],
-    localize ELSTRING(common,ACEKeybindCategoryWeapons),
+    ELSTRING(common,ACEKeybindCategoryWeapons),
     true, // default value
     false, // isGlobal
     {[QGVAR(displayText), _this] call EFUNC(common,cbaSettings_settingChanged)}


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Improvements/Changes:
  - Previously, when linking a belt, a magazine was removed upon the action start from the unit's (who was trying to link) inventory and readded in case of failure. This PR changes it: It now only removes the magazine at the end of the progressbar upon successful completion. It will check if it was able to remove the magazine; if not, the interaction is cancelled.
  - Upon completion or failure of a belt linking, a notification shows up. #9202 (or a follow-up PR) could be made to disable these notifications.
  - Previously, there was some very specific behaviour concerning UGLs and checking of their ammo. This has been expanded to where if any secondary muzzle has no ammo left, it will show the number of compatible magazines on the unit.
  - CBA events are now added to connected machines that don't have interfaces. I imagine this could cause issues if the unit you are trying to link a belt to is local to a dedicated server or headless client. I don't remember coming across problems stemming from this, but it's a safety measure that doesn't impact performance greatly.
  - If `displayNameShort` for static weapon magazines can't be found, `displayName` is used instead. I don't recall encountering an issue caused from the lack of a `displayNameShort` entry, but it's a small safeguard that doesn't cost much.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [ ] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
