### PR TITLE
Repair - Improve wheel repair interaction position

### DIFF
--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -57,7 +57,7 @@ private _turretPaths = ((fullCrew [_vehicle, "gunner", true]) + (fullCrew [_vehi
         // Wheels should always be unique
         if (_selection in _processedSelections) exitWith {TRACE_3("Duplicate Wheel",_hitpoint,_forEachIndex,_selection);};
 
-        private _position = compile format ["_target selectionPosition ['%1', 'HitPoints'];", _selection];
+        private _position = compile format ["_target selectionPosition ['%1', 'HitPoints', 'AveragePoint'];", _selection];
 
         TRACE_3("Adding Wheel Actions",_hitpoint,_forEachIndex,_selection);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Addresses https://github.com/acemod/ACE3/issues/8609.

I tested a bit with both Vanilla and RHS vehicles; the results are promising. The position for all interactions I tested was in the center of the wheel hub.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
