### PR TITLE
Arsenal - Use regex for searchbar

### DIFF
--- a/addons/arsenal/functions/fnc_attributeAddItems.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddItems.sqf
@@ -19,13 +19,20 @@
 params ["_controlsGroup"];
 
 private _category = lbCurSel (_controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_CATEGORY);
-private _filter = toLower ctrlText (_controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_SEARCHBAR);
+private _filter = ctrlText (_controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_SEARCHBAR);
 private _configItems = uiNamespace getVariable QGVAR(configItems);
 private _magazineMiscItems = uiNamespace getVariable QGVAR(magazineMiscItems);
 private _attributeValue = uiNamespace getVariable [QGVAR(attributeValue), [[], 0]];
 _attributeValue params ["_attributeItems", "_attributeMode"];
 
 TRACE_3("Populating list",_category,_filter,_attributeValue);
+if (_filter != "") then {
+    _filter = _filter call EFUNC(common,escapeRegex);
+    _filter = ".*?" + (_filter splitString " " joinString ".*?" + ".*?/io");
+} else {
+    _filter = ".*?/io";
+};
+
 
 private _modeSymbol = [SYMBOL_ITEM_VIRTUAL, SYMBOL_ITEM_REMOVE] select _attributeMode;
 
@@ -59,7 +66,7 @@ if (_category == IDX_CAT_ALL) exitWith {
         _displayName = getText (_config >> "displayName");
 
         // Add item if not filtered
-        if (_filter in (toLower _displayName) || {_filter in (toLower _x)}) then {
+        if (_displayName regexMatch _filter || {_x regexMatch _filter}) then {
             _index = _listbox lnbAddRow ["", _displayName, _modeSymbol];
             _listbox lnbSetData [[_index, 1], _x];
             _listbox lnbSetPicture [[_index, 0], getText (_config >> "picture")];
@@ -111,7 +118,7 @@ private _config = _cfgClass;
     _displayName = getText (_config >> _x >> "displayName");
 
     // Add item if not filtered
-    if (_filter in (toLower _displayName) || {_filter in (toLower _x)}) then {
+    if (_displayName regexMatch _filter || {_x regexMatch _filter}) then {
         // Change symbol and alpha if item already selected
         if (_x in _attributeItems) then {
             _symbol = _modeSymbol;

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -18,7 +18,6 @@ params ["_display", "_control"];
 
 private _searchString = ctrlText _control;
 if (_searchString != "") then {
-    // Sanitize to prevent script errors
     _searchString = ".*?\Q" + (_searchString splitString " " joinString "\E.*?\Q") + "\E.*?/io";
 };
 

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -18,7 +18,7 @@ params ["_display", "_control"];
 
 private _searchString = ctrlText _control;
 if (_searchString != "") then {
-    _searchString = ".*?" + ((_searchString splitString " ") joinString ".*?) + ".*?";
+    _searchString = ".*?" + ((_searchString splitString " ") joinString ".*?") + ".*?";
 };
 
 // Right panel search bar

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -18,7 +18,7 @@ params ["_display", "_control"];
 
 private _searchString = ctrlText _control;
 if (_searchString != "") then {
-    _searchString = ".*?\b" + (_searchString splitString " " joinString ".*?\b.*") + ".*?/io";
+    _searchString = ".*?" + (_searchString splitString " " joinString ".*?") + ".*?/io";
 };
 
 // Right panel search bar

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -49,8 +49,8 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // Go through all items in panel and see if they need to be deleted or not
         for "_lbIndex" from (lbSize _rightPanelCtrl) - 1 to 0 step -1 do {
-            _currentDisplayName = (_rightPanelCtrl lbText _lbIndex);
-            _currentClassname = (_rightPanelCtrl lbData _lbIndex);
+            _currentDisplayName = _rightPanelCtrl lbText _lbIndex;
+            _currentClassname = _rightPanelCtrl lbData _lbIndex;
 
             // Remove item in panel if it doesn't match search, skip otherwise
             if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchString) && {!(_currentClassname regexMatch _searchString)}}) then {
@@ -89,8 +89,8 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // Go through all items in panel and see if they need to be deleted or not
         for "_lbIndex" from (lnbSize _rightPanelCtrl select 0) - 1 to 0 step -1 do {
-            _currentDisplayName = (_rightPanelCtrl lnbText [_lbIndex, 1]);
-            _currentClassname = (_rightPanelCtrl lnbData [_lbIndex, 0]);
+            _currentDisplayName = _rightPanelCtrl lnbText [_lbIndex, 1];
+            _currentClassname = _rightPanelCtrl lnbData [_lbIndex, 0];
 
             // Remove item in panel if it doesn't match search, skip otherwise
             if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchString) && {!(_currentClassname regexMatch _searchString)}}) then {
@@ -145,8 +145,8 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     // Go through all items in panel and see if they need to be deleted or not
     for "_lbIndex" from (lbSize _leftPanelCtrl) - 1 to 0 step -1 do {
-        _currentDisplayName = (_leftPanelCtrl lbText _lbIndex);
-        _currentClassname = (_leftPanelCtrl lbData _lbIndex);
+        _currentDisplayName = _leftPanelCtrl lbText _lbIndex;
+        _currentClassname = _leftPanelCtrl lbData _lbIndex;
 
         // Remove item in panel if it doesn't match search, skip otherwise
         if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchString) && {!(_currentClassname regexMatch _searchString)}}) then {

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -16,12 +16,15 @@
 
 params ["_display", "_control"];
 
-private _searchString = format [".*?%1.*?", ctrlText _control];
+private _searchString = ctrlText _control;
+if (_searchString != "") then {
+    _searchString = ".*?" + ((_searchString splitString " ") joinString ".*?) + ".*?";
+};
 
 // Right panel search bar
 if ((ctrlIDC _control) == IDC_rightSearchbar) then {
     // Don't refill if there is no need
-    if (GVAR(lastSearchTextRight) != "" && {(_searchString find GVAR(lastSearchTextRight)) != 0}) then {
+    if (GVAR(lastSearchTextRight) != "" && {GVAR(lastSearchTextRight) isNotEqualTo _searchString}) then {
         [_display, _display displayCtrl GVAR(currentRightPanel)] call FUNC(fillRightPanel);
     };
 
@@ -120,7 +123,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 } else {
     // Left panel search bar
     // Don't refill if there is no need
-    if (GVAR(lastSearchTextLeft) != "" && {(_searchString find GVAR(lastSearchTextLeft)) != 0}) then {
+    if (GVAR(lastSearchTextLeft) != "" && {GVAR(lastSearchTextLeft) isNotEqualTo _searchString}) then {
         [_display, _display displayCtrl GVAR(currentLeftPanel)] call FUNC(fillLeftPanel);
     };
 

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -18,7 +18,8 @@ params ["_display", "_control"];
 
 private _searchString = ctrlText _control;
 if (_searchString != "") then {
-    _searchString = ".*?" + (_searchString splitString " " joinString ".*?") + ".*?/io";
+    // Sanitize to prevent script errors
+    _searchString = ".*?\Q" + (_searchString splitString " " joinString "\E.*?\Q") + "\E.*?/io";
 };
 
 // Right panel search bar

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -16,7 +16,7 @@
 
 params ["_display", "_control"];
 
-private _searchString = ctrlText _control;
+private _searchString = format [".*?%1.*?", ctrlText _control];
 
 // Right panel search bar
 if ((ctrlIDC _control) == IDC_rightSearchbar) then {
@@ -32,8 +32,6 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     private _rightPanelState = GVAR(currentLeftPanel) in [IDC_buttonPrimaryWeapon, IDC_buttonHandgun, IDC_buttonSecondaryWeapon, IDC_buttonBinoculars];
     private _rightPanelCtrl = [_display displayCtrl IDC_rightTabContentListnBox, _display displayCtrl IDC_rightTabContent] select _rightPanelState;
-
-    _searchString = toLower _searchString;
 
     // If right panel selection is weapons or binoculars
     if (_rightPanelState) then {
@@ -51,11 +49,11 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // Go through all items in panel and see if they need to be deleted or not
         for "_lbIndex" from (lbSize _rightPanelCtrl) - 1 to 0 step -1 do {
-            _currentDisplayName = toLower (_rightPanelCtrl lbText _lbIndex);
-            _currentClassname = toLower (_rightPanelCtrl lbData _lbIndex);
+            _currentDisplayName = (_rightPanelCtrl lbText _lbIndex);
+            _currentClassname = (_rightPanelCtrl lbData _lbIndex);
 
             // Remove item in panel if it doesn't match search, skip otherwise
-            if ((_currentDisplayName == "") || {!(_searchString in _currentDisplayName) && {!(_searchString in _currentClassname)}}) then {
+            if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchString) && {!(_currentClassname regexMatch _searchString)}}) then {
                 _rightPanelCtrl lbDelete _lbIndex;
             };
         };
@@ -91,11 +89,11 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // Go through all items in panel and see if they need to be deleted or not
         for "_lbIndex" from (lnbSize _rightPanelCtrl select 0) - 1 to 0 step -1 do {
-            _currentDisplayName = toLower (_rightPanelCtrl lnbText [_lbIndex, 1]);
-            _currentClassname = toLower (_rightPanelCtrl lnbData [_lbIndex, 0]);
+            _currentDisplayName = (_rightPanelCtrl lnbText [_lbIndex, 1]);
+            _currentClassname = (_rightPanelCtrl lnbData [_lbIndex, 0]);
 
             // Remove item in panel if it doesn't match search, skip otherwise
-            if ((_currentDisplayName == "") || {!(_searchString in _currentDisplayName) && {!(_searchString in _currentClassname)}}) then {
+            if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchString) && {!(_currentClassname regexMatch _searchString)}}) then {
                 _rightPanelCtrl lnbDeleteRow _lbIndex;
             };
         };
@@ -133,8 +131,6 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     private _leftPanelCtrl = _display displayCtrl IDC_leftTabContent;
 
-    _searchString = toLower _searchString;
-
     // Get the currently selected item in panel
     private _selectedItemIndex = lbCurSel _leftPanelCtrl;
     private _selectedItem = "";
@@ -149,11 +145,11 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     // Go through all items in panel and see if they need to be deleted or not
     for "_lbIndex" from (lbSize _leftPanelCtrl) - 1 to 0 step -1 do {
-        _currentDisplayName = toLower (_leftPanelCtrl lbText _lbIndex);
-        _currentClassname = toLower (_leftPanelCtrl lbData _lbIndex);
+        _currentDisplayName = (_leftPanelCtrl lbText _lbIndex);
+        _currentClassname = (_leftPanelCtrl lbData _lbIndex);
 
         // Remove item in panel if it doesn't match search, skip otherwise
-        if ((_currentDisplayName == "") || {!(_searchString in _currentDisplayName) && {!(_searchString in _currentClassname)}}) then {
+        if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchString) && {!(_currentClassname regexMatch _searchString)}}) then {
             _leftPanelCtrl lbDelete _lbIndex;
         };
     };

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -18,7 +18,7 @@ params ["_display", "_control"];
 
 private _searchString = ctrlText _control;
 if (_searchString != "") then {
-    _searchString = ".*?" + ((_searchString splitString " ") joinString ".*?") + ".*?";
+    _searchString = ".*?\b" + (_searchString splitString " " joinString ".*?\b.*") + ".*?/io";
 };
 
 // Right panel search bar

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -18,7 +18,8 @@ params ["_display", "_control"];
 
 private _searchString = ctrlText _control;
 if (_searchString != "") then {
-    _searchString = ".*?\Q" + (_searchString splitString " " joinString "\E.*?\Q") + "\E.*?/io";
+    _searchString = _searchString call EFUNC(common,escapeRegex);
+    _searchString = ".*?" + (_searchString splitString " " joinString ".*?") + ".*?/io";
 };
 
 // Right panel search bar


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Allow searching for multiple, not necessarily adjacent, words in sequential order (AK GL will show AK-15 GL, Opscore AOR1 will show Opscore 2 AOR1, etc.)

Removes need to `toLower` everything.

~~I was working on changing searching so words would be considered individually (so searching for "AK GL" would show AKs with GLs) but I'm not happy with that yet.~~

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
