### PR TITLE
Map - Update map lighting effect every frame

### DIFF
--- a/addons/map/functions/fnc_updateMapEffects.sqf
+++ b/addons/map/functions/fnc_updateMapEffects.sqf
@@ -21,7 +21,7 @@ private _mapCentre = _mapCtrl ctrlMapScreenToWorld [0.5, 0.5];
 
 if (GVAR(mapIllumination)) then {
     //get nearby lighting
-    private _light = [[ACE_player], FUNC(determineMapLight), missionNamespace, QGVAR(mapLight), 0.1] call EFUNC(common,cachedCall);
+    private _light = [ACE_player] call FUNC(determineMapLight);
 
     _light params ["_applyLighting", "_lightLevel"];
 


### PR DESCRIPTION
After #8343 the cost has become something we can afford everyframe (~0.05ms)
this makes the effects less strobe-like when passing street lights rapidly as there is a smooth ramping of lighting up and down