### PR TITLE
Tools - make.py print tail of packing log on error

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -40,6 +40,7 @@ if sys.version_info[0] == 2:
 
 import os
 import os.path
+import pathlib
 import shutil
 import platform
 import glob
@@ -1538,6 +1539,16 @@ See the make.cfg file for additional build options.
         if len(failedBuilds) > 0:
             for failedBuild in failedBuilds:
                 print("- {} build failed!".format(failedBuild))
+                failedBuild_path = pathlib.Path(
+                    "P:/temp").joinpath(f"{failedBuild}.packing.log")
+                if (failedBuild_path.exists()):
+                    print(f"  Log {failedBuild_path} tail:")
+                    with open(failedBuild_path) as failedBuild_file:
+                        lines = failedBuild_file.readlines()
+                        for index, line in enumerate(lines[-3:]):
+                            print(f"    {len(lines) + index -2}: {line}", end='')
+                else:
+                    print(f"  Log {failedBuild_path} does not exist")
         if len(missingFiles) > 0:
             for missingFile in missingFiles:
                 print("- {} not found!".format(missingFile))


### PR DESCRIPTION
dumps useful info at end if build fails
useful for automated check builds

example
```
- compat_spe build failed!
  Log P:\temp\compat_spe.packing.log tail:
    3474: duplicated 'ace_csw_baseTripod'
    3475:
    3476: \z\ace\addons\compat_spe\config.cpp Rapify:Rap: In File \z\ace\addons\compat_spe\CfgVehicles\turrets.hpp: circa Line 19 Rap: duplicated token or class
```