### PR TITLE
Dragging - Fix for #9385

### DIFF
--- a/addons/dragging/XEH_postInit.sqf
+++ b/addons/dragging/XEH_postInit.sqf
@@ -1,14 +1,9 @@
 // by PabstMirror, commy2
 #include "script_component.hpp"
 
-// Release object on disconnection. Function is identical to killed
 if (isServer) then {
-    // 'HandleDisconnect' EH triggers too late
-    addMissionEventHandler ["PlayerDisconnected", {
-        private _unit = (getUserInfo (_this select 5)) select 10;
-
-        _unit call FUNC(handleKilled);
-    }];
+    // Release object on disconnection. Function is identical to killed
+    addMissionEventHandler ["HandleDisconnect", LINKFUNC(handleKilled)];
 
     // Handle surrending and handcuffing
     ["ace_captiveStatusChanged", {


### PR DESCRIPTION
**When merged this pull request will:**
- Title (see https://github.com/acemod/ACE3/issues/9385).
- An alternative fix could be:

```SQF
// Release object on disconnection. Function is identical to killed
addMissionEventHandler ["PlayerDisconnected", {
    private _unit = (getUserInfo (_this select 5)) param [10, objNull];
    
    if (isNull _unit) exitWith {}; // This line wouldn't even be necessary, as FUNC(handleKilled) can accept objNull

    _unit call FUNC(handleKilled);
}];
```

`PlayerDisconnected` fires earlier than `HandleDisconnect`, but the comment I added in https://github.com/acemod/ACE3/commit/9505d4c47ef56e9c214b89b8d0768d986526c96b#diff-baccfba963e58cce5d824d01073bc7cc39f05a4a36030b6b9923904f6b7126c9 was wrong; it isn't too late, I just forgot to take something into account whilst testing.

Maybe one has better abnormal disconnection (force quitting, crashing, etc.) detection than the other, but I don't know.

Any input is appreciated.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
