### PR TITLE
Zeus - Fix Group Side module

### DIFF
--- a/addons/zeus/functions/fnc_moduleGroupSide.sqf
+++ b/addons/zeus/functions/fnc_moduleGroupSide.sqf
@@ -48,7 +48,10 @@ if (GETVAR(_unit,ACE_isUnconscious,false) && {GETMVAR(EGVAR(medical,moveUnitsFro
 
     // Preserve assignedTeam for each unit
     // Teams need to be gotten before removing units from group
-    _teams = _units apply {private _team = assignedTeam _x; ["MAIN", _team] select (_team != "")};
+    private _teams = _units apply {
+        private _team = assignedTeam _x;
+        [_team, "MAIN"] select (_team == "")
+    };
 
     {
         [_x] joinSilent _newGroup;

--- a/addons/zeus/functions/fnc_moduleGroupSide.sqf
+++ b/addons/zeus/functions/fnc_moduleGroupSide.sqf
@@ -44,11 +44,16 @@ if (GETVAR(_unit,ACE_isUnconscious,false) && {GETMVAR(EGVAR(medical,moveUnitsFro
 
     _unit setVariable [QEGVAR(common,previousGroupSwitchTo), _previousGroupsList, true];
 } else {
+    private _units = units _unit;
+
     // Preserve assignedTeam for each unit
+    // Teams need to be gotten before removing units from group
+    _teams = _units apply {private _team = assignedTeam _x; ["MAIN", _team] select (_team != "")};
+
     {
-        private _team = assignedTeam _x;
         [_x] joinSilent _newGroup;
-        _x assignTeam _team;
-    } forEach units _unit;
+        _x assignTeam (_teams select _forEachIndex);
+    } forEach _units;
+
     deleteGroup _oldGroup;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes following issue that was found:
```SQF
20:23:46 Error in expression <dTeam _x;
[_x] joinSilent _newGroup;
_x assignTeam _team;
} forEach units _unit;>
20:23:46   Error position: <assignTeam _team;
} forEach units _unit;>
20:23:46   Error Foreign error: Unknown enum value: ""
20:23:46 File /z/ace/addons/zeus/functions/fnc_moduleGroupSide.sqf..., line 343
```
- If `assignedTeam` returns `""`, the default team is `"MAIN"`.

I'm convinced that prior to `2.14` this was not an issue. I think there were some related changes, but I can't remember for sure.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
