### PR TITLE
Advanced Ballistics - Fix `_mapSize` sometimes 0 by using engine command

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_initializeTerrainExtension.sqf
+++ b/addons/advanced_ballistics/functions/fnc_initializeTerrainExtension.sqf
@@ -19,7 +19,7 @@ if (!hasInterface) exitWith {};
 if (!GVAR(enabled)) exitWith {};
 
 private _initStartTime = diag_tickTime;
-private _mapSize = getNumber (configFile >> "CfgWorlds" >> worldName >> "MapSize");
+private _mapSize = worldSize;
 
 if (("ace_advanced_ballistics" callExtension format["init:%1:%2", worldName, _mapSize]) == "Terrain already initialized") exitWith {
     INFO_1("Terrain already initialized [world: %1]", worldName);


### PR DESCRIPTION
On certain maps, such as Virtual Reality, `getNumber (configFile >> "CfgWorlds" >> worldName >> "MapSize")` results in 0