### PR TITLE
Captives - Add Reusable and Locking restraints

### DIFF
--- a/addons/captives/CfgWeapons.hpp
+++ b/addons/captives/CfgWeapons.hpp
@@ -14,4 +14,25 @@ class CfgWeapons {
             mass = 1;
         };
     };
+    class ACE_Handcuffs: ACE_CableTie {
+        GVAR(reusable) = 1;
+        displayName = "Handcuffs"; //TODO: Localise
+        descriptionShort = "A pair of reusable handcuffs used for restraining prisoners."; //TODO: Localise
+        //model = QPATHTOF(models\ace_handcuffs.p3d); //No model source of current.
+        //picture = QPATHTOF(UI\ace_handcuffs_ca.paa); //Icon pending.
+        class ItemInfo: ItemInfo {
+            mass = 6.025;
+        };
+    };
+    class ACE_HandcuffKey: ACE_ItemCore {
+        author = ECSTRING(common,ACETeam);
+        GVAR(key) = 1;
+        displayName = "Handcuff Key"; //TODO: Localise
+        descriptionShort = "A key for a handcuff."; //TODO: Localise
+        //model = QPATHTOF(models\ace_handcuffkey.p3d); //No model source of current.
+        //picture = QPATHTOF(UI\ace_handcuffkey_ca.paa); //Icon pending.
+        class ItemInfo: CBA_MiscItem_ItemInfo {
+            mass = 1;
+        };
+    };
 };

--- a/addons/captives/CfgWeapons.hpp
+++ b/addons/captives/CfgWeapons.hpp
@@ -16,6 +16,7 @@ class CfgWeapons {
     };
     class ACE_Handcuffs: ACE_CableTie {
         GVAR(reusable) = 1;
+        GVAR(locked) = 1;
         displayName = "Handcuffs"; //TODO: Localise
         descriptionShort = "A pair of reusable handcuffs used for restraining prisoners."; //TODO: Localise
         //model = QPATHTOF(models\ace_handcuffs.p3d); //No model source of current.

--- a/addons/captives/XEH_preInit.sqf
+++ b/addons/captives/XEH_preInit.sqf
@@ -9,6 +9,7 @@ PREP_RECOMPILE_END;
 GVAR(captivityEnabled) = false;
 
 GVAR(restraints) = call (uiNamespace getVariable QGVAR(restraints));
+GVAR(lockedRestraints) = call (uiNamespace getVariable QGVAR(lockedRestraints));
 
 #include "initSettings.sqf"
 

--- a/addons/captives/XEH_preInit.sqf
+++ b/addons/captives/XEH_preInit.sqf
@@ -10,6 +10,7 @@ GVAR(captivityEnabled) = false;
 
 GVAR(restraints) = call (uiNamespace getVariable QGVAR(restraints));
 GVAR(lockedRestraints) = call (uiNamespace getVariable QGVAR(lockedRestraints));
+GVAR(keys) = call (uiNamespace getVariable QGVAR(keys));
 
 #include "initSettings.sqf"
 

--- a/addons/captives/XEH_preStart.sqf
+++ b/addons/captives/XEH_preStart.sqf
@@ -4,3 +4,6 @@
 
 private _restraints = (QUOTE(getNumber (_x >> QQGVAR(restraint)) > 0) configClasses (configFile >> "CfgWeapons") apply {configName _x});
 uiNamespace setVariable [QGVAR(restraints), compileFinal str _restraints];
+
+private _lockedRestraints = (QUOTE(getNumber (_x >> QQGVAR(locked)) > 0) configClasses (configFile >> "CfgWeapons") apply {configName _x});
+uiNamespace setVariable [QGVAR(lockedRestraints), compileFinal str _lockedRestraints];

--- a/addons/captives/XEH_preStart.sqf
+++ b/addons/captives/XEH_preStart.sqf
@@ -7,3 +7,6 @@ uiNamespace setVariable [QGVAR(restraints), compileFinal str _restraints];
 
 private _lockedRestraints = (QUOTE(getNumber (_x >> QQGVAR(locked)) > 0) configClasses (configFile >> "CfgWeapons") apply {configName _x});
 uiNamespace setVariable [QGVAR(lockedRestraints), compileFinal str _lockedRestraints];
+
+private _keys = (QUOTE(getNumber (_x >> QQGVAR(key)) > 0) configClasses (configFile >> "CfgWeapons") apply {configName _x});
+uiNamespace setVariable [QGVAR(keys), compileFinal str _keys];

--- a/addons/captives/functions/fnc_canRemoveHandcuffs.sqf
+++ b/addons/captives/functions/fnc_canRemoveHandcuffs.sqf
@@ -18,7 +18,11 @@
 
 params ["_unit", "_target"];
 
+private _unitItems = _unit call EFUNC(common,uniqueItems);
+private _restraintLocked = _target getVariable [QGVAR(cuffs), "ACE_CableTie"] findAny GVAR(lockedRestraints) != -1;
+
 //Unit is handcuffed and not currently being escorted
 _target getVariable [QGVAR(isHandcuffed), false] &&
 {isNull (attachedTo _target)} &&
-{(vehicle _target) == _target}
+{(vehicle _target) == _target} &&
+{(_restraintLocked && (_unitItems findAny GVAR(keys))) || !_restraintLocked}

--- a/addons/captives/functions/fnc_canRemoveHandcuffs.sqf
+++ b/addons/captives/functions/fnc_canRemoveHandcuffs.sqf
@@ -25,4 +25,4 @@ private _restraintLocked = _target getVariable [QGVAR(cuffs), "ACE_CableTie"] fi
 _target getVariable [QGVAR(isHandcuffed), false] &&
 {isNull (attachedTo _target)} &&
 {(vehicle _target) == _target} &&
-{(_restraintLocked && (_unitItems findAny GVAR(keys))) || !_restraintLocked}
+{(_restraintLocked && (_unitItems findAny GVAR(keys) != -1)) || !_restraintLocked}

--- a/addons/captives/functions/fnc_doApplyHandcuffs.sqf
+++ b/addons/captives/functions/fnc_doApplyHandcuffs.sqf
@@ -21,8 +21,9 @@ params ["_unit", "_target"];
 
 playSound3D [QUOTE(PATHTO_R(sounds\cable_tie_zipping.ogg)), objNull, false, (getPosASL _target), 1, 1, 10];
 
-[QGVAR(setHandcuffed), [_target, true, _unit], [_target]] call CBA_fnc_targetEvent;
-
 private _cuffs = (_unit call EFUNC(common,uniqueItems)) arrayIntersect GVAR(restraints);
+private _selectedCuffs = _cuffs#0;
 
-_unit removeItem (_cuffs#0);
+[QGVAR(setHandcuffed), [_target, true, _unit, _selectedCuffs], [_target]] call CBA_fnc_targetEvent;
+
+_unit removeItem _selectedCuffs;

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -7,6 +7,7 @@
  * 0: Unit <OBJECT>
  * 1: True to take captive, false to release captive <BOOL>
  * 2: Caller <OBJECT>
+ * 3: Selected Cuffs <STRING>
  *
  * Return Value:
  * None
@@ -17,7 +18,7 @@
  * Public: No
  */
 
-params ["_unit", "_state", ["_caller", objNull]];
+params ["_unit", "_state", ["_caller", objNull], "_selectedCuffs"];
 TRACE_3("params",_unit,_state,_caller);
 
 if (!local _unit) exitWith {
@@ -41,6 +42,7 @@ if ((_unit getVariable [QGVAR(isHandcuffed), false]) isEqualTo _state) exitWith 
 
 if (_state) then {
     _unit setVariable [QGVAR(isHandcuffed), true, true];
+    _unit setVariable [QGVAR(cuffs), _selectedCuffs, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
     [_unit, "blockRadio", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
 
@@ -81,7 +83,9 @@ if (_state) then {
 
     }, [_unit], 0.01] call CBA_fnc_waitAndExecute;
 } else {
+    private _usedCuffs = _unit getVariable [QGVAR(cuffs), ""];
     _unit setVariable [QGVAR(isHandcuffed), false, true];
+    _unit setVariable [QGVAR(cuffs), "", true];
     [_unit, "setCaptive", QGVAR(Handcuffed), false] call EFUNC(common,statusEffect_set);
     [_unit, "blockRadio", QGVAR(Handcuffed), false] call EFUNC(common,statusEffect_set);
 
@@ -102,6 +106,12 @@ if (_state) then {
 
     if (_unit == ACE_player) then {
         ["captive", []] call EFUNC(common,showHud); //same as showHud true;
+    };
+    
+    //Give de-arrestee restraint back if reusable.
+    private _reusable = getNumber (configFile >> "CfgWeapons" >> _usedCuffs >> QGVAR(reusable));
+    if (!(isNull _caller) && _reusable > 0) then {
+        [_caller, _usedCuffs, true] call CBA_fnc_addItem;
     };
 };
 

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_unit", "_state", ["_caller", objNull], "_selectedCuffs"];
+params ["_unit", "_state", ["_caller", objNull], "_selectedRestraint"];
 TRACE_3("params",_unit,_state,_caller);
 
 if (!local _unit) exitWith {

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -42,7 +42,7 @@ if ((_unit getVariable [QGVAR(isHandcuffed), false]) isEqualTo _state) exitWith 
 
 if (_state) then {
     _unit setVariable [QGVAR(isHandcuffed), true, true];
-    _unit setVariable [QGVAR(cuffs), _selectedCuffs, true];
+    _unit setVariable [QGVAR(cuffs), _selectedRestraint, true];
     [_unit, "setCaptive", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
     [_unit, "blockRadio", QGVAR(Handcuffed), true] call EFUNC(common,statusEffect_set);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add handcuffs
- Add ability for restraints to be reusable
- Add ability for restraints to be locked restraints
- Add restraint keys

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
