### PR TITLE
Cargo - Fix/Improve FUNC(paradropItem)

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -2,9 +2,9 @@
 
 ["ace_addCargo", {_this call FUNC(addCargoItem)}] call CBA_fnc_addEventHandler;
 [QGVAR(paradropItem), {
-    params ["_item", "_vehicle"];
+    params ["_item", "_vehicle", ["_showHint", true]];
 
-    private _unloaded = [_item, _vehicle] call FUNC(paradropItem);
+    private _unloaded = [_item, _vehicle, _showHint] call FUNC(paradropItem);
 
     if (_unloaded && {GVAR(openAfterUnload) in [2, 3]}) then {
         GVAR(interactionVehicle) = _vehicle;

--- a/addons/cargo/functions/fnc_paradropItem.sqf
+++ b/addons/cargo/functions/fnc_paradropItem.sqf
@@ -49,7 +49,7 @@ if (_item isEqualType objNull) then {
     _object setPosASL (AGLtoASL _posBehindVehicleAGL);
 };
 
-_object setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5));
+[QEGVAR(common,setVelocity), [_object, ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir _vehicle)) vectorMultiply -5))], _object] call CBA_fnc_targetEvent;
 
 // open parachute and ir light effect
 [{
@@ -59,13 +59,20 @@ _object setVelocity ((velocity _vehicle) vectorAdd ((vectorNormalized (vectorDir
 
     private _parachute = createVehicle ["B_Parachute_02_F", [0,0,0], [], 0, "CAN_COLLIDE"];
 
+    // Prevent collision damage
+    [QEGVAR(common,fixCollision), _parachute] call CBA_fnc_localEvent;
+    [QEGVAR(common,fixCollision), _object, _object] call CBA_fnc_targetEvent;
+
     // cannot use setPos on parachutes without them closing down
     _parachute attachTo [_object, [0,0,0]];
     detach _parachute;
 
     private _velocity = velocity _object;
 
-    _object attachTo [_parachute, [0,0,1]];
+    // Attach to the middle of the object
+    (2 boundingBoxReal _object) params ["_bb1", "_bb2"];
+
+    _object attachTo [_parachute, [0, 0, ((_bb2 select 2) - (_bb1 select 2)) / 2]];
     _parachute setVelocity _velocity;
 
     if ((GVAR(disableParadropEffectsClasstypes) findIf {_object isKindOf _x}) == -1) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Implements `setVelocity` changes from #8204. This means that now `setVelocity` is run where `_object` is local.
  Should fix #8199, but I haven't checked.
- Takes the gist from #7128: This PR makes both `_object` and the parachute temporarily invulnerable (2 seconds).
- Parachute is now attached at half the height of the object. Previously it was constant (1 m).
- Adds a missing parameter to the `QGVAR(paradropItem)` event. This fixes an issue with the Zeus module where (at least in theory) it would show the hint, but actually the hint was unwanted.
https://github.com/acemod/ACE3/blob/f7b520b56b770dc232f70c751767e2fc1e08703d/addons/zeus/functions/fnc_moduleCargoParadropWaypoint.sqf#L65

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
