### PR TITLE
Cargo - Remove cargo objects from zeus editable objects

### DIFF
--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -38,6 +38,17 @@ if (_item isEqualType objNull) then {
     _item attachTo [_vehicle,[0,0,-100]];
     [QEGVAR(common,hideObjectGlobal), [_item, true]] call CBA_fnc_serverEvent;
 
+    if (["ace_zeus"] call EFUNC(common,isModLoaded)) then {
+        private _objectCurators = objectCurators _item;
+
+        // Save which curators had this object as editable
+        _item setVariable [QGVAR(objectCurators), _objectCurators, true];
+
+        if (_objectCurators isEqualTo []) exitWith {};
+
+        [QEGVAR(zeus,removeObjects), [[_item], _objectCurators]] call CBA_fnc_serverEvent;
+    };
+
     // Some objects below water will take damage over time and eventualy become "water logged" and unfixable (because of negative z attach)
     [_item, "blockDamage", "ACE_cargo", true] call EFUNC(common,statusEffect_set);
 };

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -53,6 +53,15 @@ if (_object isEqualType objNull) then {
     // hideObjectGlobal must be executed before setPos to ensure light objects are rendered correctly
     // do both on server to ensure they are executed in the correct order
     [QGVAR(serverUnload), [_object, _emptyPosAGL]] call CBA_fnc_serverEvent;
+
+    if (["ace_zeus"] call EFUNC(common,isModLoaded)) then {
+        // Get which curators had this object as editable
+        private _objectCurators = _object getVariable [QGVAR(objectCurators), []];
+
+        if (_objectCurators isEqualTo []) exitWith {};
+
+        [QEGVAR(zeus,addObjects), [[_object], _objectCurators]] call CBA_fnc_serverEvent;
+    };
 } else {
     _object = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
     _object setPosASL (AGLtoASL _emptyPosAGL);

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -19,20 +19,32 @@ if (isServer) then {
     [QGVAR(addObjects), {
         params ["_objects", ["_curator", objNull]];
 
-        if (!isNull _curator) exitWith {_curator addCuratorEditableObjects [_objects, true]};
+        // If valid object
+        if (_curator isEqualType objNull && {!isNull _curator}) exitWith {_curator addCuratorEditableObjects [_objects, true]};
+
+        // If invalid object (= objNull) or other
+        if !(_curator isEqualType []) then {
+            _curator = allCurators;
+        };
 
         {
             _x addCuratorEditableObjects [_objects, true];
-        } forEach allCurators;
+        } forEach _curator;
     }] call CBA_fnc_addEventHandler;
     [QGVAR(removeObjects), {
         params ["_objects", ["_curator", objNull]];
 
-        if (!isNull _curator) exitWith {_curator removeCuratorEditableObjects [_objects, true]};
+        // If valid object
+        if (_curator isEqualType objNull && {!isNull _curator}) exitWith {_curator removeCuratorEditableObjects [_objects, true]};
+
+        // If invalid object (= objNull) or other
+        if !(_curator isEqualType []) then {
+            _curator = allCurators;
+        };
 
         {
             _x removeCuratorEditableObjects [_objects, true];
-        } forEach allCurators;
+        } forEach _curator;
     }] call CBA_fnc_addEventHandler;
 
     [QGVAR(createZeus), {


### PR DESCRIPTION
**When merged this pull request will:**
- Title. I found it mildly annoying to see ACE cargo objects attached to the vehicle they belong to in the zeus interface.
  This only applies if the `ace_zeus` component is loaded
- `QGVAR(addObjects)` and `QGVAR(removeObjects)` event in the `ace_zeus` component can now accept an array of curators instead of just a single curator or all.
- I have tested this in SP only. I imagine it should work fine in MP, but I don't know the locality of `objectCurators`, as the wiki doesn't mention it.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
