### PR TITLE
Common - Add lockInventory status effect

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -28,6 +28,7 @@
 ["setHidden", true, ["ace_unconscious"]] call FUNC(statusEffect_addType);
 ["blockRadio", false, [QEGVAR(captives,Handcuffed), QEGVAR(captives,Surrendered), "ace_unconscious"]] call FUNC(statusEffect_addType);
 ["blockSpeaking", false, ["ace_unconscious"]] call FUNC(statusEffect_addType);
+["lockInventory", true, []] call FUNC(statusEffect_addType);
 
 [QGVAR(forceWalk), {
     params ["_object", "_set"];
@@ -118,6 +119,12 @@
 [QGVAR(setMass), {
     params ["_object", "_mass"];
     _object setMass _mass;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(lockInventory), {
+    params ["_object", "_set"];
+    TRACE_2("lockInventory EH",_object,_set);
+    _object lockInventory (_set > 0);
 }] call CBA_fnc_addEventHandler;
 
 //Add a fix for BIS's zeus remoteControl module not reseting variables on DC when RC a unit


### PR DESCRIPTION
**When merged this pull request will:**
Adds [`lockInventory`](https://community.bistudio.com/wiki/lockInventory) status effect, for cross-mod compatibility possibilities.
Tested both in singleplayer and multiplayer settings.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
