### PR TITLE
RHS Compat - Readd basic 5.56 suppressor to 5.56 muzzle slot

### DIFF
--- a/addons/compat_rhs_usf3/CfgJointRails.hpp
+++ b/addons/compat_rhs_usf3/CfgJointRails.hpp
@@ -1,0 +1,11 @@
+// RHS specifically disables only the base vanilla 5.56 suppressor, the camo variants are untouched
+
+class asdg_MuzzleSlot;
+class asdg_MuzzleSlot_556: asdg_MuzzleSlot {
+    class compatibleItems;
+};
+class rhs_western_rifle_muzzle_slot: asdg_MuzzleSlot_556 {
+    class compatibleItems: compatibleItems {
+        muzzle_snds_M = 1;
+    };
+};

--- a/addons/compat_rhs_usf3/config.cpp
+++ b/addons/compat_rhs_usf3/config.cpp
@@ -22,3 +22,4 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgGlasses.hpp"
+#include "CfgJointRails.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

I have many theories as to why specifically this attachment was disabled. They all make no sense: the variants are available and it's a compatible suppressor on every other weapon.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
