### PR TITLE
Laserpointer - Block switching to unsupported visible lasers

### DIFF
--- a/addons/common/functions/fnc_lightIntensityFromObject.sqf
+++ b/addons/common/functions/fnc_lightIntensityFromObject.sqf
@@ -30,8 +30,6 @@ if (_lightSource isKindOf "CAManBase") then {
 
     private _flashlight = (_lightSource weaponAccessories _weapon) select 1;
 
-    if (getNumber (configFile >> "CfgWeapons" >> _flashlight >> "ACE_laserpointer") > 0) exitWith {}; // Red = 1, Green = 2
-
     private _properties = [[_flashlight], FUNC(getLightPropertiesWeapon), uiNamespace, format [QEGVAR(cache,%1_%2), QUOTE(DFUNC(getLightPropertiesWeapon)), _flashlight], 1E11] call FUNC(cachedCall);
     //_properties = [_flashlight] call FUNC(getLightPropertiesWeapon);
 

--- a/addons/laserpointer/CfgEventHandlers.hpp
+++ b/addons/laserpointer/CfgEventHandlers.hpp
@@ -1,3 +1,8 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));

--- a/addons/laserpointer/XEH_preInit.sqf
+++ b/addons/laserpointer/XEH_preInit.sqf
@@ -1,3 +1,8 @@
 #include "script_component.hpp"
 
+{
+    TRACE_1("blocking switching to unsupported laser mode",_x);
+    [_x, { false }] call CBA_fnc_addAttachmentCondition;
+} forEach (keys (uiNamespace getVariable QGVAR(oldLasers)));
+
 ADDON = true;

--- a/addons/laserpointer/XEH_preStart.sqf
+++ b/addons/laserpointer/XEH_preStart.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+private _lasers = ((toString {(getNumber (_x >> "ACE_laserpointer")) > 0}) configClasses (configFile >> "CfgWeapons")) apply {configName _x};
+if (_lasers isNotEqualTo []) then { WARNING_1("%1 attachements still using unsupported ACE_laserpointer config",count _lasers) };
+uiNamespace setVariable [QGVAR(oldLasers), compileFinal (_lasers createHashMapFromArray [])];

--- a/docs/wiki/development/ace3-config-entries.md
+++ b/docs/wiki/development/ace3-config-entries.md
@@ -76,7 +76,6 @@ ace_detonator
 ace_barrelTwist
 ace_twistDirection
 ace_barrelLength
-ace_laserpointer
 ace_nextmodeclass
 ace_modedescription
 ace_hearing_protection


### PR DESCRIPTION
```
[ACE] (laserpointer) TRACE: 9148 blocking switching to unsupported laser mode: _x=CUP_acc_LLM01_hex_V z\ace\addons\laserpointer\XEH_preInit.sqf:4
[ACE] (laserpointer) TRACE: 9148 blocking switching to unsupported laser mode: _x=CUP_acc_LCU_PM_Laser_V z\ace\addons\laserpointer\XEH_preInit.sqf:4
[ACE] (laserpointer) TRACE: 9148 blocking switching to unsupported laser mode: _x=CUP_acc_ANPEQ_15_Top_Flashlight_Black_V z\ace\addons\laserpointer\XEH_preInit.sqf:4
...
```