### PR TITLE
Cargo - Improve cargo space values

### DIFF
--- a/addons/cargo/CfgVehicles.hpp
+++ b/addons/cargo/CfgVehicles.hpp
@@ -75,94 +75,103 @@ class CfgVehicles {
         GVAR(hasCargo) = 1;
     };
 
-    // hemets
+    // HEMTTs - Default at 10, some variants are altered based on model size and/or expected level of free space inside.
     class Truck_01_base_F: Truck_F {
-        GVAR(space) = 8;
+        GVAR(space) = 30;
     };
     class B_Truck_01_transport_F: Truck_01_base_F {
-        GVAR(space) = 20;
+        GVAR(space) = 30;
     };
     class B_Truck_01_covered_F: B_Truck_01_transport_F {
-        GVAR(space) = 20;
+        GVAR(space) = 30;
     };
     class B_Truck_01_mover_F: B_Truck_01_transport_F {
         GVAR(space) = 4;
     };
     class B_Truck_01_box_F: B_Truck_01_mover_F {
-        GVAR(space) = 40;
+        GVAR(space) = 50;
     };
     class B_Truck_01_Repair_F: B_Truck_01_mover_F {
-        GVAR(space) = 20;
+        GVAR(space) = 4;
     };
     class B_Truck_01_ammo_F: B_Truck_01_mover_F {
-        GVAR(space) = 8;
+        GVAR(space) = 10;
     };
     class B_Truck_01_fuel_F: B_Truck_01_mover_F {
         GVAR(space) = 4;
     };
     class B_Truck_01_medical_F: B_Truck_01_transport_F {
-        GVAR(space) = 8;
+        GVAR(space) = 30;
     };
 
-    // kamaz'
-    class Truck_02_base_F: Truck_F { //covers "covered" variants
-        GVAR(space) = 20;
+    // Kamaz'
+    class Truck_02_base_F: Truck_F { // Covers "transport" variants.
+        GVAR(space) = 25;
     };
     class Truck_02_transport_base_F: Truck_02_base_F {
-        GVAR(space) = 20;
+        GVAR(space) = 25;
     };
-    class Truck_02_box_base_F: Truck_02_base_F { // repair variant, not actually cargo box like hemet
-        GVAR(space) = 12;
+    class Truck_02_box_base_F: Truck_02_base_F { // Repair variant, smaller than HEMTT.
+        GVAR(space) = 4;
     };
     class Truck_02_medical_base_F: Truck_02_box_base_F {
-        GVAR(space) = 8;
+        GVAR(space) = 25;
     };
     class Truck_02_Ammo_base_F: Truck_02_base_F {
-        GVAR(space) = 12;
+        GVAR(space) = 4;
     };
     class Truck_02_fuel_base_F: Truck_02_base_F {
         GVAR(space) = 4;
     };
 
-    // typhoon
+    // Typhoon - Roughly the same size if not slightly larger than HEMTT.
     class Truck_03_base_F: Truck_F {
         GVAR(space) = 8;
     };
     class O_Truck_03_transport_F: Truck_03_base_F {
-        GVAR(space) = 20;
+        GVAR(space) = 30;
     };
     class O_Truck_03_covered_F: Truck_03_base_F {
-        GVAR(space) = 20;
+        GVAR(space) = 30;
     };
     class O_Truck_03_repair_F: Truck_03_base_F {
-        GVAR(space) = 12;
+        GVAR(space) = 4;
     };
     class O_Truck_03_ammo_F: Truck_03_base_F {
-        GVAR(space) = 8;
+        GVAR(space) = 4;
     };
     class O_Truck_03_fuel_F: Truck_03_base_F {
         GVAR(space) = 4;
     };
     class O_Truck_03_medical_F: Truck_03_base_F {
-        GVAR(space) = 8;
+        GVAR(space) = 30;
     };
     class O_Truck_03_device_F: Truck_03_base_F {
         GVAR(space) = 4;
     };
 
-    // civ trucks
+    // Civilian Trucks
     class Van_01_base_F: Truck_F {
         GVAR(space) = 8;
     };
     class Van_01_transport_base_F: Van_01_base_F {
         GVAR(space) = 8;
     };
-    class Van_01_box_base_F: Van_01_base_F { // repair variant, not actually cargo box like hemet
-        GVAR(space) = 12;
+    class Van_01_box_base_F: Van_01_base_F {
+        GVAR(space) = 15;
     };
     class Van_01_fuel_base_F: Van_01_base_F {
-        GVAR(space) = 4;
+        GVAR(space) = 2;
     };
+
+    // Laws of War Vans
+    class Van_02_base_F: Truck_F { // Transport
+        GVAR(space) = 10;
+    };
+    class Van_02_vehicle_base_F: Van_02_base_F { // Cargo
+        GVAR(space) = 20;
+    };
+
 
     // misc. vehicles
     class Quadbike_01_base_F: Car_F {
@@ -194,12 +203,12 @@ class CfgVehicles {
     };
 
     class Heli_Light_02_base_F: Helicopter_Base_H {
-        GVAR(space) = 4;
+        GVAR(space) = 8;
     };
 
     class Helicopter_Base_F;
     class Heli_light_03_base_F: Helicopter_Base_F {
-        GVAR(space) = 4;
+        GVAR(space) = 6;
     };
 
     class Heli_Transport_01_base_F: Helicopter_Base_H {
@@ -227,19 +236,19 @@ class CfgVehicles {
     };
 
     class O_Heli_Transport_04_repair_F: Heli_Transport_04_base_F {
-        GVAR(space) = 12;
+        GVAR(space) = 2;
         GVAR(hasCargo) = 1;
     };
 
     class O_Heli_Transport_04_ammo_F: Heli_Transport_04_base_F {
-        GVAR(space) = 8;
+        GVAR(space) = 2;
         GVAR(hasCargo) = 1;
     };
 
     class O_Heli_Transport_04_fuel_F: Heli_Transport_04_base_F {};
 
     class O_Heli_Transport_04_medevac_F: Heli_Transport_04_base_F {
-        GVAR(space) = 8;
+        GVAR(space) = 10;
         GVAR(hasCargo) = 1;
     };
 
@@ -252,7 +261,7 @@ class CfgVehicles {
         GVAR(space) = 4;
     };
 
-    // planes (off by default as most are attack jets)
+    // Planes, does not apply to attack jets.
     class Plane: Air {
         GVAR(space) = 0;
         GVAR(hasCargo) = 0;
@@ -265,15 +274,15 @@ class CfgVehicles {
     };
     class VTOL_Base_F;
     class VTOL_01_base_F: VTOL_Base_F {
-        GVAR(space) = 20;
+        GVAR(space) = 30;
         GVAR(hasCargo) = 1;
     };
     class VTOL_02_base_F: VTOL_Base_F {
-        GVAR(space) = 10;
+        GVAR(space) = 15;
         GVAR(hasCargo) = 1;
     };
 
-    // autonomous
+    // Drones
     class UAV_01_base_F: Helicopter_Base_F {
         GVAR(space) = 0;
         GVAR(hasCargo) = 0;
@@ -287,7 +296,7 @@ class CfgVehicles {
         GVAR(hasCargo) = 0;
     };
 
-    // boats
+    // Boats
     class Ship;
     class Ship_F: Ship {
         GVAR(space) = 4;
@@ -295,7 +304,7 @@ class CfgVehicles {
     };
 
     class Boat_Civil_01_base_F: Ship_F {
-        GVAR(space) = 4;
+        GVAR(space) = 2;
         GVAR(hasCargo) = 1;
     };
 
@@ -306,11 +315,11 @@ class CfgVehicles {
     };
 
     class Boat_Armed_01_base_F: Boat_F {
-        GVAR(space) = 8;
+        GVAR(space) = 4;
         GVAR(hasCargo) = 1;
     };
 
-    // submarines
+    // Submarines
     class SDV_01_base_F: Boat_F {
         GVAR(space) = 0;
         GVAR(hasCargo) = 0;
@@ -340,10 +349,10 @@ class CfgVehicles {
         GVAR(size) = 2; // 1 = small, 2 = large
         GVAR(canLoad) = 1;
     };
-    class Land_RepairDepot_01_base_F: ReammoBox_F { // TanksDLC - Repair Depo Thing (probably too big to safely unload)
+    class Land_RepairDepot_01_base_F: ReammoBox_F { // Tanks DLC - Repair Depot, too big to safely unload.
         GVAR(canLoad) = 0;
     };
-    //"Supply Box" - Small Pallets
+    // "Supply Box" - Small Pallets
     class B_supplyCrate_F: ReammoBox_F {
         GVAR(size) = 6;
     };
@@ -359,7 +368,7 @@ class CfgVehicles {
         GVAR(size) = 6;
     };
 
-     //Huron 20ft containers
+    // Huron 20ft containers
     class Slingload_01_Base_F: Slingload_base_F {
         GVAR(canLoad) = 1;
         GVAR(size) = 50; // Use same size value from 20ft containers for consistancy
@@ -369,15 +378,15 @@ class CfgVehicles {
         GVAR(hasCargo) = 1;
     };
     class B_Slingload_01_Ammo_F: Slingload_01_Base_F { // Huron Ammo
-        GVAR(space) = 8;
+        GVAR(space) = 0;
         GVAR(hasCargo) = 1;
     };
     class B_Slingload_01_Medevac_F: Slingload_01_Base_F { // Huron Medevac
-        GVAR(space) = 8;
+        GVAR(space) = 10;
         GVAR(hasCargo) = 1;
     };
     class B_Slingload_01_Repair_F: Slingload_01_Base_F { // Huron Repair
-        GVAR(space) = 12;
+        GVAR(space) = 0;
         GVAR(hasCargo) = 1;
     };
 
@@ -387,15 +396,15 @@ class CfgVehicles {
         GVAR(size) = -1;
     };
     class Land_Pod_Heli_Transport_04_ammo_F: Pod_Heli_Transport_04_base_F {
-        GVAR(space) = 8;
+        GVAR(space) = 0;
         GVAR(hasCargo) = 1;
     };
-    class Land_Pod_Heli_Transport_04_box_F: Pod_Heli_Transport_04_base_F {
-        GVAR(space) = 20;
+    class Land_Pod_Heli_Transport_04_box_F: Pod_Heli_Transport_04_base_F { // Smaller than Huron Cargo
+        GVAR(space) = 15;
         GVAR(hasCargo) = 1;
     };
     class Land_Pod_Heli_Transport_04_repair_F: Pod_Heli_Transport_04_base_F {
-        GVAR(space) = 12;
+        GVAR(space) = 0;
         GVAR(hasCargo) = 1;
     };
     class Pod_Heli_Transport_04_crewed_base_F: StaticWeapon {
@@ -411,7 +420,7 @@ class CfgVehicles {
         GVAR(hasCargo) = 1;
     };
 
-    //Plastic and metal case
+    // Plastic and metal case
     class PlasticCase_01_base_F: Items_base_F {
         GVAR(size) = 1; // 1 = small, 2 = large
         GVAR(canLoad) = 1;
@@ -441,7 +450,7 @@ class CfgVehicles {
         GVAR(noRename) = 1;
     };
 
-    // objects
+    // Objects
     class RoadCone_F: ThingX {
         GVAR(size) = 1;
         GVAR(canLoad) = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Alter cargo space for vehicles depending on the size/realistic space you would expect within the vehicle.
- Added Laws of War Transport/Cargo Van
- Things like Repair trucks would have low amounts of space since apparently they carry everything they need to repair any vehicle.
- I didn't touch object space size as I feel it's perfectly fine as is, just vehicles.
- Fixed the comments as they were bothering me.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
