### PR TITLE
Medical - Increase pain from bullet-inflicted bruises

### DIFF
--- a/addons/medical_damage/ACE_Medical_Injuries.hpp
+++ b/addons/medical_damage/ACE_Medical_Injuries.hpp
@@ -97,8 +97,8 @@ class ACE_Medical_Injuries {
                 weighting[] = {{0.35, 0}, {0.35, 1}};
                 // bruises caused by bullets hitting the plate are big
                 sizeMultiplier = 3.2;
-                // tone down the pain a tiny bit to compensate
-                painMultiplier = 0.8;
+                // increase the pain to allow for bruises to actually knock out on repeated hits
+                painMultiplier = 2.2;
             };
             class VelocityWound {
                 // velocity wounds are only in the 0.35-1.5 range


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

With an average vest (armor 20, passthrough 0.3) and 5.56 (hit 9) this allows bruises to actually knock someone out from pain at default settings.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
