### PR TITLE
Compat SOG - Add barrel swap for MGs and belt linking for drum magazines

### DIFF
--- a/addons/compat_sog/CfgMagazines/belts.hpp
+++ b/addons/compat_sog/CfgMagazines/belts.hpp
@@ -12,3 +12,8 @@ class vn_m16_mag_base;
 class vn_m63a_100_mag: vn_m16_mag_base {
     ACE_isBelt = 1;
 };
+class vn_mg42_50_mag: vn_lmgmag_base {
+    ACE_isBelt = 1;
+};
+class vn_mg42_50_t_mag: vn_mg42_50_mag {};
+class vn_rpd_125_mag: vn_rpd_100_mag {};

--- a/addons/compat_sog/CfgMagazines/belts.hpp
+++ b/addons/compat_sog/CfgMagazines/belts.hpp
@@ -15,5 +15,3 @@ class vn_m63a_100_mag: vn_m16_mag_base {
 class vn_mg42_50_mag: vn_lmgmag_base {
     ACE_isBelt = 1;
 };
-class vn_mg42_50_t_mag: vn_mg42_50_mag {};
-class vn_rpd_125_mag: vn_rpd_100_mag {};

--- a/addons/compat_sog/CfgWeapons/weapons.hpp
+++ b/addons/compat_sog/CfgWeapons/weapons.hpp
@@ -13,6 +13,18 @@ class vn_pk: vn_lmg {
 class vn_m60: vn_lmg {
     EGVAR(overheating,allowSwapBarrel) = 1;
 };
+class vn_mg42: vn_lmg {
+    EGVAR(overheating,allowSwapBarrel) = 1;
+};
+class vn_l4: vn_lmg {
+    EGVAR(overheating,allowSwapBarrel) = 1;
+};
+class vn_m1918: vn_lmg {
+    EGVAR(overheating,allowSwapBarrel) = 1;
+};
+class vn_rpd: vn_lmg {
+    EGVAR(overheating,allowSwapBarrel) = 1;
+};
 
 class vn_smg: vn_rifle {
     EGVAR(overheating,closedBolt) = 0;

--- a/addons/compat_sog/CfgWeapons/weapons.hpp
+++ b/addons/compat_sog/CfgWeapons/weapons.hpp
@@ -19,12 +19,6 @@ class vn_mg42: vn_lmg {
 class vn_l4: vn_lmg {
     EGVAR(overheating,allowSwapBarrel) = 1;
 };
-class vn_m1918: vn_lmg {
-    EGVAR(overheating,allowSwapBarrel) = 1;
-};
-class vn_rpd: vn_lmg {
-    EGVAR(overheating,allowSwapBarrel) = 1;
-};
 
 class vn_smg: vn_rifle {
     EGVAR(overheating,closedBolt) = 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Add barrel swapping to the following SOGPF weapons: MG42 and L4.
- Change the drum magazines for MG42 to be considered belts. This will allow belt linking with these magazines.

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
