### PR TITLE
Tools - Modify HEMTT ASC exclude to match

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -24,7 +24,7 @@ exclude = [
     "/initsettings.sqf",
     "/initkeybinds.sqf",
     "/xeh_prep.sqf",
-    "dev",
+    "/dev/",
     "medical_ai/statemachine.sqf",
     "common/functions/fnc_dummy.sqf",
 ]


### PR DESCRIPTION
It was matching `fnc_deviceAddWaypoint`