### PR TITLE
Medical Treatment - Change isAwake check for grave digging to only apply to CAManBase

### DIFF
--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -258,7 +258,7 @@ class GVAR(actions) {
         displayNameProgress = CSTRING(DiggingGrave);
         icon = QPATHTOEF(medical_gui,ui\cross_grave.paa);
         treatmentTime = QGVAR(treatmentTimeGrave);
-        condition = QFUNC(canDigGrave);
+        condition = QUOTE(!([_this#1] call EFUNC(common,isAwake)) && {_this call FUNC(canDigGrave)});
         callbackSuccess = QFUNC(placeInGrave);
         items[] = {};
         consumeItem = 0;

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -258,7 +258,7 @@ class GVAR(actions) {
         displayNameProgress = CSTRING(DiggingGrave);
         icon = QPATHTOEF(medical_gui,ui\cross_grave.paa);
         treatmentTime = QGVAR(treatmentTimeGrave);
-        condition = QUOTE(!([_this#1] call EFUNC(common,isAwake)) && {_this call FUNC(canDigGrave)});
+        condition = QFUNC(canDigGrave);
         callbackSuccess = QFUNC(placeInGrave);
         items[] = {};
         consumeItem = 0;

--- a/addons/medical_treatment/functions/fnc_canDigGrave.sqf
+++ b/addons/medical_treatment/functions/fnc_canDigGrave.sqf
@@ -20,4 +20,7 @@ params ["_medic", "_patient"];
 
 if !(["ace_trenches"] call EFUNC(common,isModLoaded)) exitWith {false};
 
-(GVAR(allowGraveDigging) > 0) && {_patient call EFUNC(common,canDig)} && {_medic call EFUNC(trenches,hasEntrenchingTool)}
+(GVAR(allowGraveDigging) > 0) 
+&& {!((_patient isKindOf "CaManBase") && {_patient call EFUNC(common,isAwake)})} 
+&& {_patient call EFUNC(common,canDig)} 
+&& {_medic call EFUNC(trenches,hasEntrenchingTool)}

--- a/addons/medical_treatment/functions/fnc_canDigGrave.sqf
+++ b/addons/medical_treatment/functions/fnc_canDigGrave.sqf
@@ -20,4 +20,4 @@ params ["_medic", "_patient"];
 
 if !(["ace_trenches"] call EFUNC(common,isModLoaded)) exitWith {false};
 
-(GVAR(allowGraveDigging) > 0) && {!(_patient call EFUNC(common,isAwake))} && {_patient call EFUNC(common,canDig)} && {_medic call EFUNC(trenches,hasEntrenchingTool)}
+(GVAR(allowGraveDigging) > 0) && {_patient call EFUNC(common,canDig)} && {_medic call EFUNC(trenches,hasEntrenchingTool)}


### PR DESCRIPTION
**When merged this pull request will:**
- Change isAwake check for grave digging to only apply to CaManBase and not to burying bodybags from #9442 
- Change required as bodybags are always awake apparently

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
