### PR TITLE
Tagging - Fix stringtable

### DIFF
--- a/addons/tagging/stringtable.xml
+++ b/addons/tagging/stringtable.xml
@@ -215,7 +215,7 @@
             <Spanish>Cuadrado</Spanish>
             <German>Quadrat</German>
         </Key>
-        <Key ID="STR_ACE_Tagging_Custom_square_filled">
+        <Key ID="STR_ACE_Tagging_square_filled">
             <English>Filled Square</English>
             <Japanese>四角 (塗りつぶし)</Japanese>
             <Polish>Wypełniony Kwadrat</Polish>


### PR DESCRIPTION
fix
[ACE] (tagging) ERROR: Failed compiling ACE_Tags for tag: ACE_square_filled_Black - missing displayName

