### PR TITLE
Zeus - Fix `bis_fnc_activateaddons` error in moduleCurator

### DIFF
--- a/addons/zeus/functions/fnc_bi_moduleCurator.sqf
+++ b/addons/zeus/functions/fnc_bi_moduleCurator.sqf
@@ -73,7 +73,8 @@ if (_activated) then {
                     _class = _cfgPatches select _i;
                     if (isclass _class) then {_addons set [count _addons,configname _class];};
                 };
-                _addons call bis_fnc_activateaddons;
+                // Modified by ace_zeus - bis_fnc_activateaddons will error if time > 0 so only call if at start
+                if (time <= 0) then { _addons call bis_fnc_activateaddons; };
                 removeallcuratoraddons _logic;
                 _logic addcuratoraddons _addons;
             };
@@ -249,7 +250,8 @@ if (_activated) then {
                 } foreach _paramAddons;
             };
         } foreach (synchronizedobjects _logic);
-        _addons call bis_fnc_activateaddons;
+        // Modified by ace_zeus - bis_fnc_activateaddons will error if time > 0 so only call if at start
+        if (time <= 0) then { _addons call bis_fnc_activateaddons; };
     };
 
     //--- Player


### PR DESCRIPTION
Close #9445

bis_fnc_activateaddons:
```
if (time > 0) exitwith {"The function can be activated only during the mission init." call bis_fnc_error; []};
```
so there's no point in calling it after mission start
ace_zeus already handles the activating
https://github.com/acemod/ACE3/blob/a5a8b5387a610580f8bf182e94bd9b9387295749/addons/zeus/XEH_postInit.sqf#L52-L55