### PR TITLE
Captives - Allow disarming and blindfolding of captives in vehicles

### DIFF
--- a/addons/captives/functions/fnc_canBlindfoldCaptive.sqf
+++ b/addons/captives/functions/fnc_canBlindfoldCaptive.sqf
@@ -22,7 +22,5 @@ params ["_unit", "_target"];
 (_target getVariable [QGVAR(isHandcuffed), false]) &&
 {isNull (attachedTo _target)} &&
 {alive _target} &&
-{isNull objectParent _unit} &&
-{isNull objectParent _target} &&
 {(GVAR(blindfolds) findAny (_unit call EFUNC(common,uniqueItems))) != -1} &&
 {!((goggles _target) in GVAR(blindfolds))}

--- a/addons/captives/functions/fnc_canRemoveBlindfoldCaptive.sqf
+++ b/addons/captives/functions/fnc_canRemoveBlindfoldCaptive.sqf
@@ -22,6 +22,4 @@ params ["_unit", "_target"];
 (_target getVariable [QGVAR(isHandcuffed), false]) &&
 {isNull (attachedTo _target)} &&
 {alive _target} &&
-{isNull objectParent _unit} &&
-{isNull objectParent _target} &&
 {(goggles _target) in GVAR(blindfolds)}

--- a/addons/captives/functions/fnc_doBlindfoldCaptive.sqf
+++ b/addons/captives/functions/fnc_doBlindfoldCaptive.sqf
@@ -69,6 +69,12 @@ if (_state) then { // Blindfold target
 // Handle for things that need to be dropped to the ground
 if (_dropGoggles) then {
     private _weaponHolder = nearestObject [_target, "WeaponHolder"];
+
+    // if _target is in a vehicle, use vehicle inventory as container
+    if ((vehicle _target) != _target) then {
+        _weaponHolder = vehicle _target;
+    };
+
     if (isNull _weaponHolder || {_target distance _weaponHolder > 2}) then {
         _weaponHolder = createVehicle ["GroundWeaponHolder", [0, 0, 0], [], 0, "NONE"];
         _weaponHolder setPosASL getPosASL _target;

--- a/addons/captives/functions/fnc_doBlindfoldCaptive.sqf
+++ b/addons/captives/functions/fnc_doBlindfoldCaptive.sqf
@@ -69,13 +69,13 @@ if (_state) then { // Blindfold target
 // Handle for things that need to be dropped to the ground or in a vehicle inventory
 if (_dropGoggles) then {
     private _weaponHolder = nearestObject [_target, "WeaponHolder"];
-
     // if _target is in a vehicle, use vehicle inventory as container
-    if ((vehicle _target) != _target) then {
-        _weaponHolder = vehicle _target;
+    private _inVehicle = !isNull objectParent _target;
+    if (_inVehicle) then {
+        _weaponHolder = objectParent _target;
     };
 
-    if (isNull _weaponHolder && {_target distance _weaponHolder > 2}) then {
+    if (!_inVehicle && {isNull _weaponHolder || {_target distance _weaponHolder > 2}}) then {
         _weaponHolder = createVehicle ["GroundWeaponHolder", [0, 0, 0], [], 0, "NONE"];
         _weaponHolder setPosASL getPosASL _target;
     };

--- a/addons/captives/functions/fnc_doBlindfoldCaptive.sqf
+++ b/addons/captives/functions/fnc_doBlindfoldCaptive.sqf
@@ -66,7 +66,7 @@ if (_state) then { // Blindfold target
     removeGoggles _target;
 };
 
-// Handle for things that need to be dropped to the ground
+// Handle for things that need to be dropped to the ground or in a vehicle inventory
 if (_dropGoggles) then {
     private _weaponHolder = nearestObject [_target, "WeaponHolder"];
 
@@ -75,7 +75,7 @@ if (_dropGoggles) then {
         _weaponHolder = vehicle _target;
     };
 
-    if (isNull _weaponHolder || {_target distance _weaponHolder > 2}) then {
+    if (isNull _weaponHolder && {_target distance _weaponHolder > 2}) then {
         _weaponHolder = createVehicle ["GroundWeaponHolder", [0, 0, 0], [], 0, "NONE"];
         _weaponHolder setPosASL getPosASL _target;
     };

--- a/addons/disarming/functions/fnc_canBeDisarmed.sqf
+++ b/addons/disarming/functions/fnc_canBeDisarmed.sqf
@@ -29,7 +29,6 @@ if (_putDownAnim != "") exitWith { false };
 
 (alive _target) &&
 {(abs (speed _target)) < 1} &&
-{(vehicle _target) == _target} &&
 {(_target getVariable ["ACE_isUnconscious", false]) ||
     {_target getVariable [QEGVAR(captives,isHandcuffed), false]} ||
     {_target getVariable [QEGVAR(captives,isSurrendering), false]}}

--- a/addons/disarming/functions/fnc_disarmDropItems.sqf
+++ b/addons/disarming/functions/fnc_disarmDropItems.sqf
@@ -40,8 +40,8 @@ if (_doNotDropAmmo && {({_x in _listOfItemsToRemove} count (magazines _target)) 
 private _holder = objNull;
 
 // if _target is in a vehicle, use vehicle inventory as container
-if ((vehicle _target) != _target) then {
-    _holder = vehicle _target;
+if (!isNull objectParent _target) then {
+    _holder = objectParent _target;
 };
 
 //If not dropping ammo, don't use an existing container

--- a/addons/disarming/functions/fnc_disarmDropItems.sqf
+++ b/addons/disarming/functions/fnc_disarmDropItems.sqf
@@ -39,6 +39,11 @@ if (_doNotDropAmmo && {({_x in _listOfItemsToRemove} count (magazines _target)) 
 
 private _holder = objNull;
 
+// if _target is in a vehicle, use vehicle inventory as container
+if ((vehicle _target) != _target) then {
+    _holder = vehicle _target;
+};
+
 //If not dropping ammo, don't use an existing container
 if (!_doNotDropAmmo) then {
     {


### PR DESCRIPTION
**When merged this pull request will:**
- Allow disarming of captives in vehicles, the items will then be dropped in the vehicle's inventory;
- Allow blindfolding or removing the blindfold from captives in vehicles;

This is somewhat of a continuation of #9361.
To allow manipulating captives in vehicles I removed some `isNull objectParent _captive` exit conditions that check if the captives are not in any vehicle. Not sure what they were needed for and if they shouldn't be removed, but everything seems to work fine from my testing.