### PR TITLE
Medical GUI - Add keybind to show player's patient information display

### DIFF
--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -71,6 +71,17 @@ GVAR(selfInteractionActions) = [];
     false
 }, [DIK_H, [false, false, false]], false, 0] call CBA_fnc_addKeybind;
 
+["ACE3 Common", QGVAR(peekMedicalInfoKey), localize LSTRING(PeekMedicalInfo),
+{
+    // Conditions: canInteract
+    if !([ACE_player, objNull, []] call EFUNC(common,canInteractWith)) exitWith {false};
+
+    // Statement
+    [ACE_player, 0] call FUNC(displayPatientInformation);
+}, {
+    QGVAR(RscPatientInfo) cutFadeOut 0.3;
+}, [DIK_H, [false, true, false]], false, 0] call CBA_fnc_addKeybind;
+
 
 // Close patient information display when interaction menu is closed
 ["ace_interactMenuClosed", {

--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -80,7 +80,7 @@ GVAR(selfInteractionActions) = [];
     [ACE_player, 0] call FUNC(displayPatientInformation);
     false
 }, {
-    [{QGVAR(RscPatientInfo) cutFadeOut 0.3; false}, [], round GVAR(peekMedicalInfoReleaseDelay)] call CBA_fnc_waitAndExecute;
+    [{QGVAR(RscPatientInfo) cutFadeOut 0.3; false}, [], GVAR(peekMedicalInfoReleaseDelay)] call CBA_fnc_waitAndExecute;
 }, [DIK_H, [false, true, false]], false, 0] call CBA_fnc_addKeybind;
 
 

--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -78,8 +78,10 @@ GVAR(selfInteractionActions) = [];
 
     // Statement
     [ACE_player, 0] call FUNC(displayPatientInformation);
+    false
 }, {
     QGVAR(RscPatientInfo) cutFadeOut 0.3;
+    false
 }, [DIK_H, [false, true, false]], false, 0] call CBA_fnc_addKeybind;
 
 

--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -12,6 +12,8 @@ GVAR(pendingReopen) = false;
 
 GVAR(menuPFH) = -1;
 
+GVAR(peekLastOpenedOn) = -1;
+
 GVAR(selfInteractionActions) = [];
 [] call FUNC(addTreatmentActions);
 [] call FUNC(collectActions);
@@ -80,7 +82,14 @@ GVAR(selfInteractionActions) = [];
     [ACE_player, 0] call FUNC(displayPatientInformation);
     false
 }, {
-    [{QGVAR(RscPatientInfo) cutFadeOut 0.3; false}, [], GVAR(peekMedicalInfoReleaseDelay)] call CBA_fnc_waitAndExecute;
+    GVAR(peekLastOpenedOn) = CBA_missionTime;
+    [{
+        CBA_missionTime - GVAR(peekLastOpenedOn) > GVAR(peekMedicalInfoReleaseDelay)
+    }, {
+        QGVAR(RscPatientInfo) cutFadeOut 0.3;
+        false
+    }] call CBA_fnc_waitUntilAndExecute;
+    false
 }, [DIK_H, [false, true, false]], false, 0] call CBA_fnc_addKeybind;
 
 

--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -80,8 +80,7 @@ GVAR(selfInteractionActions) = [];
     [ACE_player, 0] call FUNC(displayPatientInformation);
     false
 }, {
-    QGVAR(RscPatientInfo) cutFadeOut 0.3;
-    false
+    [{QGVAR(RscPatientInfo) cutFadeOut 0.3; false}, [], round GVAR(peekMedicalInfoReleaseDelay)] call CBA_fnc_waitAndExecute;
 }, [DIK_H, [false, true, false]], false, 0] call CBA_fnc_addKeybind;
 
 

--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -82,13 +82,12 @@ GVAR(selfInteractionActions) = [];
     [ACE_player, 0] call FUNC(displayPatientInformation);
     false
 }, {
+    if (CBA_missionTime - GVAR(peekLastOpenedOn) > GVAR(peekMedicalInfoReleaseDelay)) then {
+        [{
+            CBA_missionTime - GVAR(peekLastOpenedOn) > GVAR(peekMedicalInfoReleaseDelay)
+        }, {QGVAR(RscPatientInfo) cutFadeOut 0.3}] call CBA_fnc_waitUntilAndExecute;
+    };
     GVAR(peekLastOpenedOn) = CBA_missionTime;
-    [{
-        CBA_missionTime - GVAR(peekLastOpenedOn) > GVAR(peekMedicalInfoReleaseDelay)
-    }, {
-        QGVAR(RscPatientInfo) cutFadeOut 0.3;
-        false
-    }] call CBA_fnc_waitUntilAndExecute;
     false
 }, [DIK_H, [false, true, false]], false, 0] call CBA_fnc_addKeybind;
 

--- a/addons/medical_gui/initSettings.sqf
+++ b/addons/medical_gui/initSettings.sqf
@@ -129,9 +129,9 @@ private _categoryColors = [ELSTRING(medical,Category), format ["| %1 |", LELSTRI
 
 [
     QGVAR(peekMedicalInfoReleaseDelay),
-    "SLIDER",
+    "TIME",
     [LSTRING(PeekMedicalInfoReleaseDelay_DisplayName), LSTRING(PeekMedicalInfoReleaseDelay_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory)],
-    [0, 5, 1, -1],
+    [0, 5, 1],
     false
 ] call CBA_fnc_addSetting;

--- a/addons/medical_gui/initSettings.sqf
+++ b/addons/medical_gui/initSettings.sqf
@@ -132,6 +132,6 @@ private _categoryColors = [ELSTRING(medical,Category), format ["| %1 |", LELSTRI
     "SLIDER",
     [LSTRING(PeekMedicalInfoReleaseDelay_DisplayName), LSTRING(PeekMedicalInfoReleaseDelay_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory)],
-    [0, 5, 1, 0],
+    [0, 5, 1, -1],
     false
 ] call CBA_fnc_addSetting;

--- a/addons/medical_gui/initSettings.sqf
+++ b/addons/medical_gui/initSettings.sqf
@@ -126,3 +126,12 @@ private _categoryColors = [ELSTRING(medical,Category), format ["| %1 |", LELSTRI
     true,
     true // isGlobal
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(peekMedicalInfoReleaseDelay),
+    "SLIDER",
+    [LSTRING(PeekMedicalInfoReleaseDelay_DisplayName), LSTRING(PeekMedicalInfoReleaseDelay_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory)],
+    [0, 5, 1, 0],
+    false
+] call CBA_fnc_addSetting;

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -282,6 +282,9 @@
             <Chinese>開起醫療選單</Chinese>
             <Turkish>Medikal Menüyü Aç</Turkish>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_PeekMedicalInfo">
+            <English>Peek Medical Info</English>
+        </Key>
         <Key ID="STR_ACE_Medical_GUI_LoadPatient">
             <English>Load Patient</English>
             <Spanish>Cargar al paciente en</Spanish>

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -286,10 +286,10 @@
             <English>Peek Medical Info</English>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_PeekMedicalInfoReleaseDelay_DisplayName">
-            <English>Medical Info Peek Fadeout Delay</English>
+            <English>Medical Peek Duration</English>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_PeekMedicalInfoReleaseDelay_Description">
-            <English>Number of seconds the medical info peek remains open after releasing the key.</English>
+            <English>How long the medical info peek remains open after releasing the key.</English>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_LoadPatient">
             <English>Load Patient</English>

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -285,6 +285,12 @@
         <Key ID="STR_ACE_Medical_GUI_PeekMedicalInfo">
             <English>Peek Medical Info</English>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_PeekMedicalInfoReleaseDelay_DisplayName">
+            <English>Medical Info Peek Fadeout Delay</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_PeekMedicalInfoReleaseDelay_Description">
+            <English>Number of seconds the medical info peek remains open after releasing the key.</English>
+        </Key>
         <Key ID="STR_ACE_Medical_GUI_LoadPatient">
             <English>Load Patient</English>
             <Spanish>Cargar al paciente en</Spanish>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a keybind to temporarily show your patient information display

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
