### PR TITLE
Medical GUI - Reformat injury list to clarify global vs. limb-specific information

### DIFF
--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -186,7 +186,7 @@ private _fnc_processWounds = {
 
 // Handle no wound entries
 if (_woundEntries isEqualTo []) then {
-    _entries pushBack [localize ELSTRING(medical_treatment,NoInjuriesBodypart), [1, 1, 1, 1]];
+    _entries pushBack [localize ELSTRING(medical_treatment,NoInjuriesBodypart), _nonissueColor];
 } else {
     _entries append _woundEntries;
 };

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -22,6 +22,13 @@ params ["_ctrl", "_target", "_selectionN"];
 private _entries = [];
 private _nonissueColor = [1, 1, 1, 0.33];
 
+// Indicate if unit is bleeding at all
+if (IS_BLEEDING(_target)) then {
+    _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
+} else {
+    _entries pushBack [localize LSTRING(Status_Nobleeding), _nonissueColor];
+};
+
 if (GVAR(showBloodlossEntry)) then {
     // Give a qualitative description of the blood volume lost
     switch (GET_HEMORRHAGE(_target)) do {
@@ -42,14 +49,6 @@ if (GVAR(showBloodlossEntry)) then {
         };
     };
 };
-
-// Indicate if unit is bleeding at all
-if (IS_BLEEDING(_target)) then {
-    _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
-} else {
-    _entries pushBack [localize LSTRING(Status_Nobleeding), _nonissueColor];
-};
-
 // Show receiving IV volume remaining
 private _totalIvVolume = 0;
 {

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -26,7 +26,7 @@ if (GVAR(showBloodlossEntry)) then {
     // Give a qualitative description of the blood volume lost
     switch (GET_HEMORRHAGE(_target)) do {
         case 0: {
-            _entries pushBack ["No blood loss", _nonissueColor];
+            _entries pushBack [localize LSTRING(Lost_Blood0), _nonissueColor];
         };
         case 1: {
             _entries pushBack [localize LSTRING(Lost_Blood1), [1, 1, 0, 1]];
@@ -47,7 +47,7 @@ if (GVAR(showBloodlossEntry)) then {
 if (IS_BLEEDING(_target)) then {
     _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
 } else {
-    _entries pushBack ["Not bleeding", _nonissueColor];
+    _entries pushBack [localize LSTRING(Status_Nobleeding), _nonissueColor];
 };
 
 // Show receiving IV volume remaining
@@ -60,7 +60,7 @@ private _totalIvVolume = 0;
 if (_totalIvVolume >= 1) then {
     _entries pushBack [format [localize ELSTRING(medical_treatment,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
 } else {
-    _entries pushBack ["No IV", _nonissueColor];
+    _entries pushBack [localize ELSTRING(medical_treatment,Status_NoIv), _nonissueColor];
 };
 
 // Indicate the amount of pain the unit is in
@@ -80,7 +80,7 @@ if (_target call EFUNC(common,isAwake)) then {
         };
         _entries pushBack [localize _painText, [1, 1, 1, 1]];
     } else {
-        _entries pushBack ["Not in pain", _nonissueColor];
+        _entries pushBack [localize ELSTRING(medical_treatment,Status_NoPain), _nonissueColor];
     };
 };
 

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -21,6 +21,61 @@ params ["_ctrl", "_target", "_selectionN"];
 
 private _entries = [];
 
+if (GVAR(showBloodlossEntry)) then {
+    // Give a qualitative description of the blood volume lost
+    switch (GET_HEMORRHAGE(_target)) do {
+        case 1: {
+            _entries pushBack [localize LSTRING(Lost_Blood1), [1, 1, 0, 1]];
+        };
+        case 2: {
+            _entries pushBack [localize LSTRING(Lost_Blood2), [1, 0.67, 0, 1]];
+        };
+        case 3: {
+            _entries pushBack [localize LSTRING(Lost_Blood3), [1, 0.33, 0, 1]];
+        };
+        case 4: {
+            _entries pushBack [localize LSTRING(Lost_Blood4), [1, 0, 0, 1]];
+        };
+    };
+};
+
+// Indicate if unit is bleeding at all
+if (IS_BLEEDING(_target)) then {
+    _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
+};
+
+// Show receiving IV volume remaining
+private _totalIvVolume = 0;
+{
+    _x params ["_volumeRemaining"];
+    _totalIvVolume = _totalIvVolume + _volumeRemaining;
+} forEach (_target getVariable [QEGVAR(medical,ivBags), []]);
+
+if (_totalIvVolume >= 1) then {
+    _entries pushBack [format [localize ELSTRING(medical_treatment,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
+};
+
+// Indicate the amount of pain the unit is in
+if (_target call EFUNC(common,isAwake)) then {
+    private _pain = GET_PAIN_PERCEIVED(_target);
+    if (_pain > 0) then {
+        private _painText = switch (true) do {
+            case (_pain > PAIN_UNCONSCIOUS): {
+                ELSTRING(medical_treatment,Status_SeverePain);
+            };
+            case (_pain > (PAIN_UNCONSCIOUS / 5)): {
+                ELSTRING(medical_treatment,Status_Pain);
+            };
+            default {
+                ELSTRING(medical_treatment,Status_MildPain);
+            };
+        };
+        _entries pushBack [localize _painText, [1, 1, 1, 1]];
+    };
+};
+
+_entries pushBack ["", [1, 1, 1, 1]];
+
 // Add selected body part name
 private _bodyPartName = [
     LSTRING(Head),
@@ -70,29 +125,6 @@ if (GVAR(showDamageEntry)) then {
     };
 };
 
-// Indicate if unit is bleeding at all
-if (IS_BLEEDING(_target)) then {
-    _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
-};
-
-if (GVAR(showBloodlossEntry)) then {
-    // Give a qualitative description of the blood volume lost
-    switch (GET_HEMORRHAGE(_target)) do {
-        case 1: {
-            _entries pushBack [localize LSTRING(Lost_Blood1), [1, 1, 0, 1]];
-        };
-        case 2: {
-            _entries pushBack [localize LSTRING(Lost_Blood2), [1, 0.67, 0, 1]];
-        };
-        case 3: {
-            _entries pushBack [localize LSTRING(Lost_Blood3), [1, 0.33, 0, 1]];
-        };
-        case 4: {
-            _entries pushBack [localize LSTRING(Lost_Blood4), [1, 0, 0, 1]];
-        };
-    };
-};
-
 // Indicate if a tourniquet is applied
 if (HAS_TOURNIQUET_APPLIED_ON(_target,_selectionN)) then {
     _entries pushBack [localize LSTRING(Status_Tourniquet_Applied), [0.77, 0.51, 0.08, 1]];
@@ -108,36 +140,6 @@ switch (GET_FRACTURES(_target) select _selectionN) do {
             _entries pushBack [localize LSTRING(Status_SplintApplied), [0.2, 0.2, 1, 1]];
         };
     };
-};
-
-// Indicate the amount of pain the unit is in
-if (_target call EFUNC(common,isAwake)) then {
-    private _pain = GET_PAIN_PERCEIVED(_target);
-    if (_pain > 0) then {
-        private _painText = switch (true) do {
-            case (_pain > PAIN_UNCONSCIOUS): {
-                ELSTRING(medical_treatment,Status_SeverePain);
-            };
-            case (_pain > (PAIN_UNCONSCIOUS / 5)): {
-                ELSTRING(medical_treatment,Status_Pain);
-            };
-            default {
-                ELSTRING(medical_treatment,Status_MildPain);
-            };
-        };
-        _entries pushBack [localize _painText, [1, 1, 1, 1]];
-    };
-};
-
-// Show receiving IV volume remaining
-private _totalIvVolume = 0;
-{
-    _x params ["_volumeRemaining"];
-    _totalIvVolume = _totalIvVolume + _volumeRemaining;
-} forEach (_target getVariable [QEGVAR(medical,ivBags), []]);
-
-if (_totalIvVolume >= 1) then {
-    _entries pushBack [format [localize ELSTRING(medical_treatment,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
 };
 
 // Add entries for open, bandaged, and stitched wounds

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -20,10 +20,14 @@
 params ["_ctrl", "_target", "_selectionN"];
 
 private _entries = [];
+private _nonissueColor = [1, 1, 1, 0.33];
 
 if (GVAR(showBloodlossEntry)) then {
     // Give a qualitative description of the blood volume lost
     switch (GET_HEMORRHAGE(_target)) do {
+        case 0: {
+            _entries pushBack ["No blood loss", _nonissueColor];
+        };
         case 1: {
             _entries pushBack [localize LSTRING(Lost_Blood1), [1, 1, 0, 1]];
         };
@@ -42,6 +46,8 @@ if (GVAR(showBloodlossEntry)) then {
 // Indicate if unit is bleeding at all
 if (IS_BLEEDING(_target)) then {
     _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
+} else {
+    _entries pushBack ["Not bleeding", _nonissueColor];
 };
 
 // Show receiving IV volume remaining
@@ -53,6 +59,8 @@ private _totalIvVolume = 0;
 
 if (_totalIvVolume >= 1) then {
     _entries pushBack [format [localize ELSTRING(medical_treatment,receivingIvVolume), floor _totalIvVolume], [1, 1, 1, 1]];
+} else {
+    _entries pushBack ["No IV", _nonissueColor];
 };
 
 // Indicate the amount of pain the unit is in
@@ -71,6 +79,8 @@ if (_target call EFUNC(common,isAwake)) then {
             };
         };
         _entries pushBack [localize _painText, [1, 1, 1, 1]];
+    } else {
+        _entries pushBack ["Not in pain", _nonissueColor];
     };
 };
 

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -957,6 +957,9 @@
             <Chinese>出血中</Chinese>
             <Turkish>Kanama var</Turkish>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_STATUS_NOBLEEDING">
+            <English>No bleeding</English>
+        </Key>
         <Key ID="STR_ACE_Medical_GUI_STATUS_PAIN">
             <English>in Pain</English>
             <German>hat Schmerzen</German>
@@ -1020,6 +1023,9 @@
             <Turkish>Atel Uygulandı</Turkish>
             <German>Schiene angelegt</German>
             <Korean>부목 적용함</Korean>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_Lost_Blood0">
+            <English>No blood loss</English>
         </Key>
         <!--Strings above match Blood2 but seem to differ in some languages, determine which is best to use-->
         <Key ID="STR_ACE_Medical_GUI_Lost_Blood1">

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -3417,6 +3417,9 @@
             <Chinese>呼吸極弱</Chinese>
             <Turkish>Neredeyse nefes almıyor</Turkish>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Status_NoPain">
+            <English>No pain</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_Status_MildPain">
             <English>In mild pain</English>
             <German>Hat leichte Schmerzen</German>
@@ -3495,6 +3498,9 @@
             <Korean>IV로 [%1ml] 수혈중</Korean>
             <Chinesesimp>正在接受静脉注射 [%1毫升]</Chinesesimp>
             <Chinese>接收靜脈注射液中 [%1毫升]</Chinese>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Status_NoIv">
+            <English>No IV</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Bloodpressure">
             <English>Blood Pressure</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Change the layout of the injury list to separate global and limb-specific information
- Add new non-issue text to positively indicate lack of conditions
- Deemphasize non-issues with darkened text color

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
