### PR TITLE
Medical GUI - Display qualitative bleed rate in injury list

### DIFF
--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -76,6 +76,12 @@
 #define DAMAGE_BLUE_THRESHOLD 0.8
 #define DAMAGE_TOTAL_COLORS 10
 
+// Qualitative bleed rate thresholds in liters per second
+#define BLEED_RATE_SLOW 0.00625 // Slow - Fatal blood loss in 8-infinity minutes
+#define BLEED_RATE_MODERATE 0.0167 // Moderate - Fatal blood loss in 3-8 minutes
+#define BLEED_RATE_SEVERE 0.05 // Severe - Fatal blood loss in 1-3 minutes
+// Massive - Fatal blood loss in <1 minute
+
 // Pain above which a unit can go unconscious upon receiving damage
 #define PAIN_UNCONSCIOUS EGVAR(medical,painUnconsciousThreshold)
 

--- a/addons/medical_engine/script_macros_medical.hpp
+++ b/addons/medical_engine/script_macros_medical.hpp
@@ -76,11 +76,12 @@
 #define DAMAGE_BLUE_THRESHOLD 0.8
 #define DAMAGE_TOTAL_COLORS 10
 
-// Qualitative bleed rate thresholds in liters per second
-#define BLEED_RATE_SLOW 0.00625 // Slow - Fatal blood loss in 8-infinity minutes
-#define BLEED_RATE_MODERATE 0.0167 // Moderate - Fatal blood loss in 3-8 minutes
-#define BLEED_RATE_SEVERE 0.05 // Severe - Fatal blood loss in 1-3 minutes
-// Massive - Fatal blood loss in <1 minute
+// Qualitative bleed rate thresholds as a fraction of knock out blood loss
+// Note that half of knock out blood loss is considered unstable, and knock out blood loss is considered critical
+#define BLEED_RATE_SLOW 0.1 // Slow - One fifth of unstable blood loss
+#define BLEED_RATE_MODERATE 0.5 // Moderate - Vitals considered stable
+#define BLEED_RATE_SEVERE 1.0 // Severe - Vitals considered unstable
+// Massive - Vitals considered critical
 
 // Pain above which a unit can go unconscious upon receiving damage
 #define PAIN_UNCONSCIOUS EGVAR(medical,painUnconsciousThreshold)

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -73,18 +73,22 @@ if (GVAR(showDamageEntry)) then {
 // Indicate if unit is bleeding at all
 if (IS_BLEEDING(_target)) then {
     // Give a qualitative description of the rate of bleeding
-    private _bleed_rate = GET_BLOOD_LOSS(_target);
+    private _cardiacOutput = [_target] call EFUNC(medical_status,getCardiacOutput);
+    private _bleedRate = GET_BLOOD_LOSS(_target);
+    private _bleedRateKO = BLOOD_LOSS_KNOCK_OUT_THRESHOLD * (_cardiacOutput max 0.05);
+    // Use nonzero minimum cardiac output to prevent all bleeding showing as massive during cardiac arrest
+
     switch (true) do {
-        case (_bleed_rate <= BLEED_RATE_SLOW): {
+        case (_bleedRate < _bleedRateKO * BLEED_RATE_SLOW): {
             _entries pushBack [localize LSTRING(Bleed_Rate1), [1, 1, 0, 1]];
         };
-        case (_bleed_rate <= BLEED_RATE_MODERATE): {
+        case (_bleedRate < _bleedRateKO * BLEED_RATE_MODERATE): {
             _entries pushBack [localize LSTRING(Bleed_Rate2), [1, 0.67, 0, 1]];
         };
-        case (_bleed_rate <= BLEED_RATE_SEVERE): {
+        case (_bleedRate < _bleedRateKO * BLEED_RATE_SEVERE): {
             _entries pushBack [localize LSTRING(Bleed_Rate3), [1, 0.33, 0, 1]];
         };
-        case (_bleed_rate > BLEED_RATE_SEVERE): {
+        case (_bleedRate >= _bleedRateKO * BLEED_RATE_SEVERE): {
             _entries pushBack [localize LSTRING(Bleed_Rate4), [1, 0, 0, 1]];
         };
     };

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -72,7 +72,23 @@ if (GVAR(showDamageEntry)) then {
 
 // Indicate if unit is bleeding at all
 if (IS_BLEEDING(_target)) then {
-    _entries pushBack [localize LSTRING(Status_Bleeding), [1, 0, 0, 1]];
+    // Give a qualitative description of the rate of bleeding
+    private _bleed_rate = GET_BLOOD_LOSS(_target);
+    systemChat str _bleed_rate;
+    switch (true) do {
+        case (_bleed_rate <= BLEED_RATE_SLOW): {
+            _entries pushBack [localize LSTRING(Bleed_Rate1), [1, 1, 0, 1]];
+        };
+        case (_bleed_rate <= BLEED_RATE_MODERATE): {
+            _entries pushBack [localize LSTRING(Bleed_Rate2), [1, 0.67, 0, 1]];
+        };
+        case (_bleed_rate <= BLEED_RATE_SEVERE): {
+            _entries pushBack [localize LSTRING(Bleed_Rate3), [1, 0.33, 0, 1]];
+        };
+        case (_bleed_rate > BLEED_RATE_SEVERE): {
+            _entries pushBack [localize LSTRING(Bleed_Rate4), [1, 0, 0, 1]];
+        };
+    };
 };
 
 if (GVAR(showBloodlossEntry)) then {

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -74,7 +74,6 @@ if (GVAR(showDamageEntry)) then {
 if (IS_BLEEDING(_target)) then {
     // Give a qualitative description of the rate of bleeding
     private _bleed_rate = GET_BLOOD_LOSS(_target);
-    systemChat str _bleed_rate;
     switch (true) do {
         case (_bleed_rate <= BLEED_RATE_SLOW): {
             _entries pushBack [localize LSTRING(Bleed_Rate1), [1, 1, 0, 1]];

--- a/addons/medical_gui/functions/fnc_updateInjuryList.sqf
+++ b/addons/medical_gui/functions/fnc_updateInjuryList.sqf
@@ -40,7 +40,7 @@ if (IS_BLEEDING(_target)) then {
         case (_bleedRate < _bleedRateKO * BLEED_RATE_SEVERE): {
             _entries pushBack [localize LSTRING(Bleed_Rate3), [1, 0.33, 0, 1]];
         };
-        case (_bleedRate >= _bleedRateKO * BLEED_RATE_SEVERE): {
+        default {
             _entries pushBack [localize LSTRING(Bleed_Rate4), [1, 0, 0, 1]];
         };
     };

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -957,6 +957,18 @@
             <Chinese>出血中</Chinese>
             <Turkish>Kanama var</Turkish>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_Bleed_Rate1">
+            <English>Slow bleeding</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_Bleed_Rate2">
+            <English>Moderate bleeding</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_Bleed_Rate3">
+            <English>Severe bleeding</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_Bleed_Rate4">
+            <English>Massive bleeding</English>
+        </Key>
         <Key ID="STR_ACE_Medical_GUI_STATUS_PAIN">
             <English>in Pain</English>
             <German>hat Schmerzen</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Specify the severity of bleeding in the injury list with an adjective and color

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
