### PR TITLE
Repair - Fix script error if vehicle is null

### DIFF
--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -28,6 +28,7 @@ TRACE_2("addRepairActions", _vehicle,_type);
 // do nothing if the class is already initialized
 private _initializedClasses = GETMVAR(GVAR(initializedClasses),[]);
 if (_type in _initializedClasses) exitWith {};
+if (_type == "") exitWith {};
 
 // get selections to ignore
 private _selectionsToIgnore = _vehicle call FUNC(getSelectionsToIgnore);


### PR DESCRIPTION
Should fix #9478

I think because of recent lines
```
if !(EGVAR(common,settingsInitFinished)) exitWith {
    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addRepairActions), _this];
};
```
there might be an edge case when jipping for the object to become null, which would explain the
`Reserved variable in expression`
because type was "" 