### PR TITLE
Medical GUI - Add R and L labels on body image

### DIFF
--- a/addons/medical_gui/gui.hpp
+++ b/addons/medical_gui/gui.hpp
@@ -406,6 +406,23 @@ class ACE_Medical_Menu {
         };
         class TriageToggle: GVAR(TriageToggle) {};
         class TriageSelect: GVAR(TriageSelect) {};
+        class BodyLabelLeft: RscText {
+            idc = -1;
+            style = ST_RIGHT;
+            text = CSTRING(BodyLabelLeft);
+            font = "RobotoCondensedBold";
+            x = QUOTE(POS_X(16.5));
+            y = QUOTE(POS_Y(10.5));
+            w = QUOTE(POS_W(6.0));
+            h = QUOTE(POS_H(2.0));
+            sizeEx = QUOTE(POS_H(1.4));
+            colorText[] = {1, 1, 1, 0.33};
+            shadow = 0;
+        };
+        class BodyLabelRight: BodyLabelLeft {
+            style = ST_LEFT;
+            text = CSTRING(BodyLabelRight);
+        };
     };
 };
 

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -1325,5 +1325,11 @@
             <German>Chronisches Trauma</German>
             <Korean>심각한 외상</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_BodyLabelLeft">
+            <English>L</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_GUI_BodyLabelRight">
+            <English>R</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Label the right and left sides of the body image in the medical menu

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
