### PR TITLE
Repair - Allow setting spare wheels/tracks count in config

### DIFF
--- a/addons/repair/XEH_postInit.sqf
+++ b/addons/repair/XEH_postInit.sqf
@@ -64,7 +64,8 @@
 
             private _spareTracks = _vehicle getVariable QGVAR(editorLoadedTracks);
             if (isNil "_spareTracks") then {
-                _spareTracks = parseNumber (_vehicle isKindOf "Tank"); // must match eden attribute default
+                private _defaultCount = parseNumber (_vehicle isKindOf "Tank"); // must match eden attribute default
+                _spareTracks = [configOf _vehicle >> QGVAR(spareTracks), "NUMBER", _defaultCount] call CBA_fnc_getConfigEntry;
             };
             if (_spareTracks > 0) then {
                 [_vehicle, _spareTracks, "ACE_Track"] call FUNC(addSpareParts);
@@ -72,7 +73,8 @@
 
             private _spareWheels = _vehicle getVariable QGVAR(editorLoadedWheels);
             if (isNil "_spareWheels") then {
-                _spareWheels = parseNumber (_vehicle isKindOf "Car"); // must match eden attribute default
+                private _defaultCount = parseNumber (_vehicle isKindOf "Car"); // must match eden attribute default
+                _spareWheels = [configOf _vehicle >> QGVAR(spareWheels), "NUMBER", _defaultCount] call CBA_fnc_getConfigEntry;
             };
             if (_spareWheels > 0) then {
                 [_vehicle, _spareWheels, "ACE_Wheel"] call FUNC(addSpareParts);

--- a/docs/wiki/framework/repair-framework.md
+++ b/docs/wiki/framework/repair-framework.md
@@ -14,15 +14,34 @@ version:
 
 ## 1. Config Values
 
-### 1.2 Setting Vehicle As Repair Location
+### 1.1 Setting Vehicle As Repair Location
 
 A vehicle will be set as a repair truck based on the config `ace_repair_canRepair`.
 Setting `fullRepairLocation` needs to be enabled and is by *disabled* default.
 
 ```cpp
-class CfgVehicles: Car_F{
-    class MyRepairTruck {
+class CfgVehicles {
+    class Car_F;
+    class MyTruck: Car_F {
         ace_repair_canRepair = 1; // Make repair vehicle
+    };
+};
+```
+
+### 1.2 Setting Vehicle Spare Wheels and Tracks
+
+A vehicle can have a default count of spare wheels/tracks based on the config `ace_repair_spareWheels` and `ace_repair_spareTracks`.
+Values set in 3den for a vehicle will be used first. Vehicles with no value set in 3den or config will default to 1 spare wheel/track.
+
+```cpp
+class CfgVehicles {
+    class Car_F;
+    class MyTruck: Car_F {
+        ace_repair_spareWheels = 4;
+    };
+    class Tank_F;
+    class MyTank: Tank_F {
+        ace_repair_spareTracks = 4;
     };
 };
 ```


### PR DESCRIPTION
**When merged this pull request will:**
- Allow setting spare wheels and tracks counts for a vehicle in its config

### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [ ] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [ ] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
