### PR TITLE
SPE Compat - Add Spearhead 1944 fuel drums to refuel system

### DIFF
--- a/addons/compat_spe/CfgVehicles.hpp
+++ b/addons/compat_spe/CfgVehicles.hpp
@@ -4,4 +4,5 @@ class CfgVehicles {
     #include "CfgVehicles\spe_boxes.hpp"
     #include "CfgVehicles\tracked.hpp"
     #include "CfgVehicles\wheeled.hpp"
+    #include "CfgVehicles\land.hpp"
 };

--- a/addons/compat_spe/CfgVehicles/land.hpp
+++ b/addons/compat_spe/CfgVehicles/land.hpp
@@ -1,0 +1,13 @@
+// fuel objects
+
+class SPE_items_base;
+class Land_SPE_Fuel_Barrel_German: SPE_items_base {
+    transportFuel = 0;
+    EGVAR(refuel,hooks)[] = {{0, 0, 0.5}}; // reference is Land_FlexibleTank_01_F
+    EGVAR(refuel,fuelCargo) = 300; // reference is Land_FlexibleTank_01_F
+};
+class Land_SPE_Fuel_Barrel_US: SPE_items_base {
+    transportFuel = 0;
+    EGVAR(refuel,hooks)[] = {{0, 0, 0.5}}; // reference is Land_FlexibleTank_01_F
+    EGVAR(refuel,fuelCargo) = 300; // reference is Land_FlexibleTank_01_F
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Adds ACE Fuel compatibility for `Land_SPE_Fuel_Barrel_German` and `class Land_SPE_Fuel_Barrel_US`

### IMPORTANT

- [] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
