### PR TITLE
SPE Compat - Fix Spearhead 1944 fuel drums for refuel system

### DIFF
--- a/addons/compat_spe/CfgVehicles/land.hpp
+++ b/addons/compat_spe/CfgVehicles/land.hpp
@@ -1,12 +1,12 @@
 // fuel objects
 
-class SPE_items_base;
-class Land_SPE_Fuel_Barrel_German: SPE_items_base {
+class SPE_Fuel_Barrel_base;
+class SPE_Fuel_Barrel_German_01: SPE_Fuel_Barrel_base {
     transportFuel = 0;
     EGVAR(refuel,hooks)[] = {{0, 0, 0.5}}; // reference is Land_FlexibleTank_01_F
     EGVAR(refuel,fuelCargo) = 300; // reference is Land_FlexibleTank_01_F
 };
-class Land_SPE_Fuel_Barrel_US: SPE_items_base {
+class SPE_Fuel_Barrel_US_01: SPE_Fuel_Barrel_base {
     transportFuel = 0;
     EGVAR(refuel,hooks)[] = {{0, 0, 0.5}}; // reference is Land_FlexibleTank_01_F
     EGVAR(refuel,fuelCargo) = 300; // reference is Land_FlexibleTank_01_F


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes incorrect classnames in #9505 
- I added incorrect classnames as SPE has barrels in `Things` as well as `Supplies`. The ones used on the map are the `Things` versions with `Land_...` at the start of the classname, which should not be the ones compatible.

### IMPORTANT

- [] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
