### PR TITLE
Zeus - Fix trench module on clients

### DIFF
--- a/addons/zeus/functions/fnc_moduleLayTrench.sqf
+++ b/addons/zeus/functions/fnc_moduleLayTrench.sqf
@@ -27,6 +27,9 @@ if !(["ace_trenches"] call EFUNC(common,isModLoaded)) exitWith {
     [LSTRING(RequiresAddon)] call FUNC(showMessage);
 };
 
+if (_logic getVariable [QGVAR(ran), false]) exitWith { WARNING("double run?") };
+_logic setVariable [QGVAR(ran), true];
+
 private _drawCode = {
     params ["_object", "_mousePos"];
     private _startPos = getPos _object;


### PR DESCRIPTION
```
TRACE: 92958 moduleLayTrench: _logic=L Alpha 1-2:1, _logic getVariable "test"=any z\ace\addons\zeus\functions\fnc_moduleLayTrench.sqf:23
TRACE: 92962 moduleLayTrench: _logic=L ACE Utility:1, _logic getVariable "test"=92958 z\ace\addons\zeus\functions\fnc_moduleLayTrench.sqf:23
```

I put one module down on a client and get `function` runs twice for the same module, separated by ~5 frames?
I have no idea why