### PR TITLE
Night Vision - Add prefix to `colorPreset`

### DIFF
--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -27,7 +27,13 @@ private _nvgGen = 3;
 private _blurRadius = -1;
 
 // Adds Array of Params / Original ACE3's (ST's) by default. (NVG_GREEN_PRESET)
-private _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> "colorPreset");
+private _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> QGVAR(colorPreset));
+
+// BWC for ACE prefix on colorPreset.
+if (_preset isEqualTo []) then {
+    _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> "colorPreset");
+};
+
 if ((alive ACE_player) && {isNull (ACE_controlledUAV select 0)}) then {
     if (((vehicle ACE_player) == ACE_player) || {
         // Test if we are using player's nvg or if sourced from vehicle:
@@ -47,7 +53,7 @@ if ((alive ACE_player) && {isNull (ACE_controlledUAV select 0)}) then {
             TRACE_1("souce: binocular",binocular ACE_player); // Source is from player's binocular (Rangefinder/Vector21bNite)
             private _config = configFile >> "CfgWeapons" >> (binocular ACE_player);
             if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
-            if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
+            if (isArray (_config >> QGVAR(colorPreset))) then {_preset = getArray (_config >> QGVAR(colorPreset));};
         };
 
         TRACE_1("source: hmd",GVAR(playerHMD)); // Source is player's HMD (or possibly a NVG scope, but no good way to detect that)
@@ -62,7 +68,7 @@ if ((alive ACE_player) && {isNull (ACE_controlledUAV select 0)}) then {
             if (isNumber (_config >> QGVAR(bluRadius))) then {_blurRadius = getNumber (_config >> QGVAR(bluRadius));};
         };
         if (isNumber (_config >> QGVAR(generation))) then {_nvgGen = getNumber (_config >> QGVAR(generation));};
-        if (isArray (_config >> "colorPreset")) then {_preset = getArray (_config >> "colorPreset");};
+        if (isArray (_config >> QGVAR(colorPreset))) then {_preset = getArray (_config >> QGVAR(colorPreset));};
     } else {
         TRACE_1("source: vehicle - defaults",typeOf vehicle ACE_player);
     };

--- a/addons/nightvision/functions/fnc_refreshGoggleType.sqf
+++ b/addons/nightvision/functions/fnc_refreshGoggleType.sqf
@@ -29,11 +29,6 @@ private _blurRadius = -1;
 // Adds Array of Params / Original ACE3's (ST's) by default. (NVG_GREEN_PRESET)
 private _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> QGVAR(colorPreset));
 
-// BWC for ACE prefix on colorPreset.
-if (_preset isEqualTo []) then {
-    _preset = getArray (configFile >> "CfgWeapons" >> "NVGoggles" >> "colorPreset");
-};
-
 if ((alive ACE_player) && {isNull (ACE_controlledUAV select 0)}) then {
     if (((vehicle ACE_player) == ACE_player) || {
         // Test if we are using player's nvg or if sourced from vehicle:

--- a/addons/nightvision/script_component.hpp
+++ b/addons/nightvision/script_component.hpp
@@ -19,8 +19,8 @@
 
 // Effect Settings / Magic values to tweak:
 
-#define NVG_GREEN_PRESET colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}
-#define NVG_WHITE_PRESET colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}}
+#define NVG_GREEN_PRESET GVAR(colorPreset)[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}
+#define NVG_WHITE_PRESET GVAR(colorPreset)[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}}
 
 // Decreases fog when in air vehicles
 #define ST_NVG_AIR_FOG_MULTIPLIER 0.5

--- a/docs/wiki/framework/nightvision-framework.md
+++ b/docs/wiki/framework/nightvision-framework.md
@@ -27,10 +27,19 @@ class CfgWeapons {
       author = ECSTRING(common,ACETeam);
       descriptionShort = "Biocular nightvision goggles";
       displayName = "NV Goggles (Bio)";
-      GVAR(border) = QPATHTOF(data\nvg_mask_binos_4096.paa); // Edge mask for different tube configurations. Three types: mono, bino and quad.
-      GVAR(bluRadius) = 0.13; // Edge blur radius.
-      GVAR(eyeCups) = 1; // Does have eyecups.
-      GVAR(generation) = 4; // Generation 4. Affects image quality.
+      ace_nightvision_border = QPATHTOF(data\nvg_mask_binos_4096.paa); // Edge mask for different tube configurations. Three types: mono, bino and quad.
+      ace_nightvision_bluRadius = 0.13; // Edge blur radius.
+      ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}; // Green preset
+      ace_nightvision_eyeCups = 1; // Does have eyecups.
+      ace_nightvision_generation = 4; // Generation 4. Affects image quality.
   };
 };
+```
+
+## 2. Color Presets
+
+Additional color presets
+
+```cpp
+ace_nightvision_colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}}; // White Phosphor Preset
 ```


### PR DESCRIPTION
**When merged this pull request will:**
- Prefixes `colorPreset`
- ~~Adds BWC for `"colorPreset"`~~
- Update framework wiki page because the standard doesn't seem to be `GVAR(x)`

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
