### PR TITLE
Medical Engine - Disable uniform passthrough scaling, increase passthrough effect on vests

### DIFF
--- a/addons/medical_engine/functions/fnc_getItemArmor.sqf
+++ b/addons/medical_engine/functions/fnc_getItemArmor.sqf
@@ -55,9 +55,13 @@ if (isNil "_return") then {
     };
 
     // Scale armor using passthrough to fix explosive-resistant armor (#9063)
-    // Skip scaling for items that don't cover the hitpoint to prevent infinite armor
+    // Skip scaling for uniforms and items that don't cover the hitpoint to prevent infinite armor
     if (_armor > 0) then {
-        _armorScaled = (log (_armor / (_passThrough ^ _passThroughEffect))) * 10;
+        if (_itemType == TYPE_UNIFORM) then {
+            _armorScaled = _armor;
+        } else {
+            _armorScaled = (log (_armor / (_passThrough ^ _passThroughEffect))) * 10;
+        };
     };
     _return = [_armor, _armorScaled];
     GVAR(armorCache) set [_key, _return];

--- a/addons/medical_engine/functions/fnc_getItemArmor.sqf
+++ b/addons/medical_engine/functions/fnc_getItemArmor.sqf
@@ -33,7 +33,7 @@ if (isNil "_return") then {
 
     private _itemInfo = configFile >> "CfgWeapons" >> _item >> "ItemInfo";
     private _itemType = getNumber (_itemInfo >> "type");
-    private _passThroughEffect = [1, 0.7] select (_itemType == TYPE_VEST);
+    private _passThroughEffect = [1, 0.72] select (_itemType == TYPE_VEST);
 
     if (_itemType == TYPE_UNIFORM) then {
         private _unitCfg = configFile >> "CfgVehicles" >> getText (_itemInfo >> "uniformClass");

--- a/addons/medical_engine/functions/fnc_getItemArmor.sqf
+++ b/addons/medical_engine/functions/fnc_getItemArmor.sqf
@@ -33,7 +33,7 @@ if (isNil "_return") then {
 
     private _itemInfo = configFile >> "CfgWeapons" >> _item >> "ItemInfo";
     private _itemType = getNumber (_itemInfo >> "type");
-    private _passThroughEffect = [1, 0.72] select (_itemType == TYPE_VEST);
+    private _passThroughEffect = [1, 0.6] select (_itemType == TYPE_VEST);
 
     if (_itemType == TYPE_UNIFORM) then {
         private _unitCfg = configFile >> "CfgVehicles" >> getText (_itemInfo >> "uniformClass");

--- a/addons/medical_engine/functions/fnc_getItemArmor.sqf
+++ b/addons/medical_engine/functions/fnc_getItemArmor.sqf
@@ -32,8 +32,10 @@ if (isNil "_return") then {
     };
 
     private _itemInfo = configFile >> "CfgWeapons" >> _item >> "ItemInfo";
+    private _itemType = getNumber (_itemInfo >> "type");
+    private _passThroughEffect = [1, 0.7] select (_itemType == TYPE_VEST);
 
-    if (getNumber (_itemInfo >> "type") == TYPE_UNIFORM) then {
+    if (_itemType == TYPE_UNIFORM) then {
         private _unitCfg = configFile >> "CfgVehicles" >> getText (_itemInfo >> "uniformClass");
         if (_hitpoint == "#structural") then {
             // TODO: I'm not sure if this should be multiplied by the base armor value or not
@@ -54,8 +56,8 @@ if (isNil "_return") then {
 
     // Scale armor using passthrough to fix explosive-resistant armor (#9063)
     // Skip scaling for items that don't cover the hitpoint to prevent infinite armor
-    if (_armor isNotEqualTo 0) then {
-        _armorScaled = (log (_armor / _passThrough)) * 10;
+    if (_armor > 0) then {
+        _armorScaled = (log (_armor / (_passThrough ^ _passThroughEffect))) * 10;
     };
     _return = [_armor, _armorScaled];
     GVAR(armorCache) set [_key, _return];


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

I forgot to take uniform hitpoint armor being multiplied by unit overall armor into account when adding up everything. This should also make stacking armored uniforms with vests less broken.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
