### PR TITLE
Medical Treatment - Improve display name for arsenal tab

### DIFF
--- a/addons/medical_treatment/XEH_preInit.sqf
+++ b/addons/medical_treatment/XEH_preInit.sqf
@@ -48,7 +48,7 @@ GVAR(facilityClasses) = [];
 
 // Custom Arsenal tab
 if (["ace_arsenal"] call EFUNC(common,isModLoaded)) then {
-    [MEDICAL_TREATMENT_ITEMS, LELSTRING(medical,Category), ARSENAL_CATEGORY_ICON, -1, true] call EFUNC(arsenal,addRightPanelButton);
+    [MEDICAL_TREATMENT_ITEMS, LLSTRING(medicalTab), ARSENAL_CATEGORY_ICON, -1, true] call EFUNC(arsenal,addRightPanelButton);
 };
 
 ADDON = true;

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4792,9 +4792,10 @@
             <Hungarian>Orvosi felszerelés</Hungarian>
             <Russian>Медицинские предметы</Russian>
             <Czech>Zdravotnický materiál</Czech>
-            <Turkish>Tıbbi ürünler</Turkish>
+            <Turkish>Tıbbi Ürünler</Turkish>
             <German>Medizinisches Material</German>
             <Japanese>医療品</Japanese>
+            <Spanish>Objetos médicos</Spanish>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4793,6 +4793,7 @@
             <Russian>Медицинские предметы</Russian>
             <Czech>Zdravotnický materiál</Czech>
             <Turkish>Tıbbi ürünler</Turkish>
+            <German>Medizinisches Material</German>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4794,6 +4794,7 @@
             <Czech>Zdravotnický materiál</Czech>
             <Turkish>Tıbbi ürünler</Turkish>
             <German>Medizinisches Material</German>
+            <Japanese>医療品</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4784,5 +4784,15 @@
             <German>Bestimmt, wie wirksam Bandagen beim Verschließen von Wunden sind.</German>
             <Korean>붕대가 상처를 치료하는 데 얼마나 효과적으로 지속되는지 결정합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_medicalTab">
+            <English>Medical Items</English>
+            <Polish>Przedmioty Medyczne</Polish>
+            <French>Matériel médical</French>
+            <Korean>의료 물품</Korean>
+            <Hungarian>Orvosi felszerelés</Hungarian>
+            <Russian>Медицинские предметы</Russian>
+            <Czech>Zdravotnický materiál</Czech>
+            <Turkish>Tıbbi ürünler</Turkish>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- As medical tab would gather all medical items from not only ACE, i suggest changing display name from ACE Medical to general "Medical Items"
- I got translations from native speakers that help with KAM translations

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
