### PR TITLE
CSW/Dragging - Handle null objects causing script errors

### DIFF
--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -16,6 +16,7 @@
  */
 
 params ["_staticWeapon"];
+if (isNull _staticWeapon) exitWith { WARNING_1("%1 became null",_staticWeapon) };
 private _typeOf = typeOf _staticWeapon;
 private _configOf = configOf _staticWeapon;
 private _configEnabled = (getNumber (_configOf >> "ace_csw" >> "enabled")) == 1;

--- a/addons/dragging/functions/fnc_initPerson.sqf
+++ b/addons/dragging/functions/fnc_initPerson.sqf
@@ -16,6 +16,7 @@
  */
 
 params ["_unit"];
+if (isNull _unit) exitWith { WARNING_1("%1 became null",_unit) };
 
 [_unit, true, [0, 1.1, 0.092], 180] call FUNC(setDraggable);
 [_unit, true, [0.4, -0.1, -1.25], 195] call FUNC(setCarryable); // Hard-coded selection: "LeftShoulder"


### PR DESCRIPTION
Fixes:
put down turret and put `deleteVehicle this` in it's init
```
  Error Reserved variable in expression
File /z/ace/addons/interact_menu/functions/fnc_addActionToClass.sqf..., line 62
[ACE] (interact_menu) ERROR: Failed to add action - action (ace_csw_magazine) to parent ["ACE_MainActions"] on object  [0]
```

Discord `W-Cephei` mentioned
> I think there is a bug happening with CSWs. If you load a mission saved with the previous version that had CSWs with the new version you will see this:

And I think it's related but not positive