### PR TITLE
Medical GUI - Change minimal value of damage threshold

### DIFF
--- a/addons/medical_damage/initSettings.sqf
+++ b/addons/medical_damage/initSettings.sqf
@@ -12,7 +12,7 @@
     "SLIDER",
     [LSTRING(PlayerDamageThreshold_DisplayName), LSTRING(PlayerDamageThreshold_Description)],
     ELSTRING(medical,Category),
-    [0, 25, 1, 2],
+    [0.01, 25, 1, 2],
     true
 ] call CBA_fnc_addSetting;
 
@@ -21,7 +21,7 @@
     "SLIDER",
     [LSTRING(AIDamageThreshold_DisplayName), LSTRING(AIDamageThreshold_Description)],
     ELSTRING(medical,Category),
-    [0, 25, 1, 2],
+    [0.01, 25, 1, 2],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_damage/initSettings.sqf
+++ b/addons/medical_damage/initSettings.sqf
@@ -12,7 +12,7 @@
     "SLIDER",
     [LSTRING(PlayerDamageThreshold_DisplayName), LSTRING(PlayerDamageThreshold_Description)],
     ELSTRING(medical,Category),
-    [0.01, 25, 1, 2],
+    [0, 25, 1, 2],
     true
 ] call CBA_fnc_addSetting;
 
@@ -21,7 +21,7 @@
     "SLIDER",
     [LSTRING(AIDamageThreshold_DisplayName), LSTRING(AIDamageThreshold_Description)],
     ELSTRING(medical,Category),
-    [0.01, 25, 1, 2],
+    [0, 25, 1, 2],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_gui/functions/fnc_updateBodyImage.sqf
+++ b/addons/medical_gui/functions/fnc_updateBodyImage.sqf
@@ -91,7 +91,7 @@ private _bodyPartBloodLoss = [0, 0, 0, 0, 0, 0];
                 _damageThreshold = _damageThreshold * 1.5
             };
         };
-        _damage = (_damage / _damageThreshold) min 1;
+        _damage = (_damage / 0.01 max  _damageThreshold) min 1;
         [_damage] call FUNC(damageToRGBA);
     };
 

--- a/addons/medical_gui/functions/fnc_updateBodyImage.sqf
+++ b/addons/medical_gui/functions/fnc_updateBodyImage.sqf
@@ -91,7 +91,7 @@ private _bodyPartBloodLoss = [0, 0, 0, 0, 0, 0];
                 _damageThreshold = _damageThreshold * 1.5
             };
         };
-        _damage = (_damage / 0.01 max  _damageThreshold) min 1;
+        _damage = (_damage / 0.01 max _damageThreshold) min 1;
         [_damage] call FUNC(damageToRGBA);
     };
 

--- a/addons/medical_gui/functions/fnc_updateBodyImage.sqf
+++ b/addons/medical_gui/functions/fnc_updateBodyImage.sqf
@@ -91,7 +91,7 @@ private _bodyPartBloodLoss = [0, 0, 0, 0, 0, 0];
                 _damageThreshold = _damageThreshold * 1.5
             };
         };
-        _damage = (_damage / 0.01 max _damageThreshold) min 1;
+        _damage = (_damage / (0.01 max _damageThreshold)) min 1;
         [_damage] call FUNC(damageToRGBA);
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- With changes from this #8444 in Line 94 we get zero divisor if damage threshold is set at 0. 
I think that easiest fix for this is just changing minimal value from settings.
![zeroDivisor](https://github.com/acemod/ACE3/assets/71414303/ffc28ed1-947b-4467-82e4-0ed144be3155)


### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
