### PR TITLE
Arsenal - Add param to skip refresh animation

### DIFF
--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -7,6 +7,7 @@
  * Arguments:
  * 0: Arsenal display <DISPLAY>
  * 1: Tab control <CONTROL>
+ * 2: Animate panel refresh <BOOL>
  *
  * Return Value:
  * None
@@ -14,28 +15,30 @@
  * Public: No
 */
 
-params ["_display", "_control"];
+params ["_display", "_control", ["_animate", true]];
 
 // Fade old control background
 if (!isNil QGVAR(currentLeftPanel)) then {
     private _previousCtrlBackground  = _display displayCtrl (GVAR(currentLeftPanel) - 1);
     _previousCtrlBackground ctrlSetFade 1;
-    _previousCtrlBackground ctrlCommit FADE_DELAY;
+    _previousCtrlBackground ctrlCommit ([0, FADE_DELAY] select _animate);
 };
 
 // Show new control background
 private _ctrlIDC = ctrlIDC _control;
 private _ctrlBackground = _display displayCtrl (_ctrlIDC - 1);
 _ctrlBackground ctrlSetFade 0;
-_ctrlBackground ctrlCommit FADE_DELAY;
+_ctrlBackground ctrlCommit ([0, FADE_DELAY] select _animate);
 
 private _ctrlPanel = _display displayCtrl IDC_leftTabContent;
 
 // Force a "refresh" animation of the panel
-_ctrlPanel ctrlSetFade 1;
-_ctrlPanel ctrlCommit 0;
-_ctrlPanel ctrlSetFade 0;
-_ctrlPanel ctrlCommit FADE_DELAY;
+if (_animate) then {
+    _ctrlPanel ctrlSetFade 1;
+    _ctrlPanel ctrlCommit 0;
+    _ctrlPanel ctrlSetFade 0;
+    _ctrlPanel ctrlCommit FADE_DELAY;
+};
 
 _ctrlPanel lbSetCurSel -1;
 
@@ -244,7 +247,7 @@ if (GVAR(currentLeftPanel) != _ctrlIDC) then {
 
 // Trigger event
 GVAR(currentLeftPanel) = _ctrlIDC;
-[QGVAR(leftPanelFilled), [_display, _ctrlIDC, GVAR(currentRightPanel)]] call CBA_fnc_localEvent;
+[QGVAR(leftPanelFilled), [_display, _ctrlIDC, GVAR(currentRightPanel), _animate]] call CBA_fnc_localEvent;
 
 // Sort
 [_display, _control, _display displayCtrl IDC_sortLeftTab, _display displayCtrl IDC_sortLeftTabDirection] call FUNC(fillSort);

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -7,6 +7,7 @@
  * Arguments:
  * 0: Arsenal display <DISPLAY>
  * 1: Tab control <CONTROL>
+ * 2: Animate panel refresh <BOOL>
  *
  * Return Value:
  * None
@@ -14,13 +15,13 @@
  * Public: No
 */
 
-params ["_display", "_control"];
+params ["_display", "_control", ["_animate", false]];
 
 // Fade old control background
 if (!isNil QGVAR(currentRightPanel)) then {
     private _previousCtrlBackground  = _display displayCtrl (GVAR(currentRightPanel) - 1);
     _previousCtrlBackground ctrlSetFade 1;
-    _previousCtrlBackground ctrlCommit FADE_DELAY;
+    _previousCtrlBackground ctrlCommit ([0, FADE_DELAY] select _animate);
 };
 
 // Show new control background
@@ -28,7 +29,7 @@ private _ctrlIDC = ctrlIDC _control;
 private _ctrlBackground = _display displayCtrl (_ctrlIDC - 1);
 _ctrlBackground ctrlShow true;
 _ctrlBackground ctrlSetFade 0;
-_ctrlBackground ctrlCommit FADE_DELAY;
+_ctrlBackground ctrlCommit ([0, FADE_DELAY] select _animate);
 
 private _searchbarCtrl = _display displayCtrl IDC_rightSearchbar;
 
@@ -183,10 +184,12 @@ switch (GVAR(currentLeftPanel)) do {
 };
 
 // Force a "refresh" animation of the panel
-_ctrlPanel ctrlSetFade 1;
-_ctrlPanel ctrlCommit 0;
-_ctrlPanel ctrlSetFade 0;
-_ctrlPanel ctrlCommit FADE_DELAY;
+if (_animate) then {
+    _ctrlPanel ctrlSetFade 1;
+    _ctrlPanel ctrlCommit 0;
+    _ctrlPanel ctrlSetFade 0;
+    _ctrlPanel ctrlCommit FADE_DELAY;
+};
 
 // Check if the left panel is a weapon. If so, right panel will be compatible items with weapon only
 private _leftPanelState = GVAR(currentLeftPanel) in [IDC_buttonPrimaryWeapon, IDC_buttonHandgun, IDC_buttonSecondaryWeapon, IDC_buttonBinoculars];

--- a/addons/arsenal/functions/fnc_refresh.sqf
+++ b/addons/arsenal/functions/fnc_refresh.sqf
@@ -30,4 +30,4 @@ if (!isNull findDisplay IDD_loadouts_display) exitWith {};
 
 private _display = findDisplay IDD_ace_arsenal;
 
-[_display, _display displayCtrl GVAR(currentLeftPanel)] call FUNC(fillLeftPanel);
+[_display, _display displayCtrl GVAR(currentLeftPanel), false] call FUNC(fillLeftPanel);


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

IMO `FUNC(refresh)` should skip by default. Best done after #9542 to avoid conflicts

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
