### PR TITLE
Medical Treatment - Add missing sutures to advanced crate

### DIFF
--- a/addons/medical_treatment/CfgVehicles.hpp
+++ b/addons/medical_treatment/CfgVehicles.hpp
@@ -354,6 +354,7 @@ class CfgVehicles {
             MACRO_ADDITEM(ACE_personalAidKit,3);
             MACRO_ADDITEM(ACE_surgicalKit,2);
             MACRO_ADDITEM(ACE_bodyBag,5);
+            MACRO_ADDITEM(ACE_suture,60);
         };
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- close #9549 
I am not sure if sutures should be added to basic crate (i guess in "basic" bandages dont reopen so no need for stitching).
60 sutures should be more than anough.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
