### PR TITLE
Repair - Improve location of repair interaction points

### DIFF
--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -119,6 +119,10 @@ private _turretPaths = ((fullCrew [_vehicle, "gunner", true]) + (fullCrew [_vehi
 
         // Find the action position
         private _position = compile format ["_target selectionPosition ['%1', 'HitPoints'];", _selection];
+        if ("rotor" in _hitpoint) then {
+            _position = compile format ["_target selectionPosition ['%1', 'HitPoints', 'AveragePoint'];", _selection];
+        };
+        
         {
             _x params ["_hit", "_pos"];
             if (_hitpoint == _hit) exitWith {

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -31,7 +31,7 @@ if (_type in _initializedClasses) exitWith {};
 if (_type == "") exitWith {};
 
 // get selections to ignore
-private _selectionsToIgnore = _vehicle call FUNC(getSelectionsToIgnore);
+([_vehicle] call FUNC(getSelectionsToIgnore)) params["_selectionsToIgnore", "_dependsArray"];
 
 // get all hitpoints and selections
 (getAllHitPointsDamage _vehicle) params [["_hitPoints", []], ["_hitSelections", []]];  // Since 1.82 these are all lower case
@@ -155,6 +155,15 @@ private _turretPaths = ((fullCrew [_vehicle, "gunner", true]) + (fullCrew [_vehi
         _hitPointsAddedNames = _trackArray select 0;
         _hitPointsAddedStrings = _trackArray select 1;
         _hitPointsAddedAmount = _trackArray select 2;
+
+        // Add name of dependant hitpoints to the parent hitpoint
+        { 
+            if (_hitpoint == (_x select 0)) then {
+                private _dependsHitpoint = (_x select 1);
+                ([_dependsHitpoint, "%1", _dependsHitpoint, [_hitPointsAddedNames, _hitPointsAddedStrings, _hitPointsAddedAmount]] call FUNC(getHitPointString)) params ["_dependsText", ""];
+                _text = _text + " / " + _dependsText;
+            };
+        } forEach _dependsArray;
 
         if (_hitpoint in TRACK_HITPOINTS) then {
             _position = compile format ["private _return = _target selectionPosition ['%1', 'HitPoints']; _return set [1, 0]; _return", _selection];

--- a/addons/repair/functions/fnc_fullRepairProgress.sqf
+++ b/addons/repair/functions/fnc_fullRepairProgress.sqf
@@ -32,7 +32,7 @@ if (_totalTime - _elapsedTime > ([_engineer, _vehicle] call FUNC(getFullRepairTi
 private _allHitPointsDamage = getAllHitPointsDamage _vehicle;
 _allHitPointsDamage params ["_hitPoints", "", "_damageValues"];
 
-private _selectionsToIgnore = _vehicle call FUNC(getSelectionsToIgnore);
+([_vehicle] call FUNC(getSelectionsToIgnore)) params["_selectionsToIgnore", ""];
 
 private _firstDamagedIndex = {
     if (_x > 0 && {!(_forEachIndex in _selectionsToIgnore)}) exitWith {_forEachIndex};

--- a/addons/repair/functions/fnc_getFullRepairTime.sqf
+++ b/addons/repair/functions/fnc_getFullRepairTime.sqf
@@ -21,7 +21,7 @@ params ["_engineer", "_vehicle"];
 private _allHitPointsDamage = getAllHitPointsDamage _vehicle;
 _allHitPointsDamage params ["_hitPoints", "", "_damageValues"];
 
-private _selectionsToIgnore = _vehicle call FUNC(getSelectionsToIgnore);
+([_vehicle] call FUNC(getSelectionsToIgnore)) params["_selectionsToIgnore", ""];
 
 private _repairsNeeded = 0;
 private _doExtraRepair = false;

--- a/addons/repair/functions/fnc_getSelectionsToIgnore.sqf
+++ b/addons/repair/functions/fnc_getSelectionsToIgnore.sqf
@@ -31,6 +31,7 @@ private _turretPaths = ((fullCrew [_vehicle, "gunner", true]) + (fullCrew [_vehi
 ([_vehicle] call FUNC(getWheelHitPointsWithSelections)) params ["_wheelHitPoints", "_wheelHitSelections"];
 
 private _indexesToIgnore = [];
+private _dependsArray = [];
 private _processedSelections = [];
 
 {
@@ -128,8 +129,10 @@ private _processedSelections = [];
             ERROR_2("[%1] hitpoint [%2] is both a group-parent and a depends and will be unrepairable",_type,_hitpoint);
             ERROR_1("group: %1",_hitpointGroups # _groupIndex);
         };
+        private _dependsParentHitpoint = [_vehCfg >> "HitPoints" >> _hitpoint, "depends"] call BIS_fnc_returnConfigEntry;
 
         _indexesToIgnore pushBack _forEachIndex;
+        _dependsArray pushBack [_dependsParentHitpoint, _hitpoint];
         _processedSelections pushBack _selection;
         continue
     };
@@ -150,4 +153,4 @@ private _processedSelections = [];
 _initializedClasses set [_type, _indexesToIgnore];
 missionNamespace setVariable [QGVAR(hitPointsToIgnoreInitializedClasses), _initializedClasses];
 
-_indexesToIgnore
+[_indexesToIgnore, _dependsArray]

--- a/addons/repair/functions/fnc_getSelectionsToIgnore.sqf
+++ b/addons/repair/functions/fnc_getSelectionsToIgnore.sqf
@@ -64,8 +64,10 @@ private _processedSelections = [];
         continue
     };
 
-    if (_hitpoint select [0,7] isEqualTo "hitera_" || {_hitpoint select [0,8] isEqualTo "hitslat_"} || {_hitpoint select [0,4] isEqualTo "era_"}) then { // skip era/slat
-        TRACE_3("Skipping ERA/Slat HitPoint",_hitpoint,_forEachIndex,_selection);
+    if (_hitpoint select [0,7] isEqualTo "hitera_" || {_hitpoint select [0,4] isEqualTo "era_"}
+    || {_hitpoint select [0,8] isEqualTo "hitslat_"}  || {_hitpoint select [0,5] isEqualTo "slat_"}
+    || {_hitpoint select [0,9] isEqualTo "sideskirt"} || {_hitpoint select [0,6] isEqualTo "armor_"}) then { // skip era/slat/sideskirt/armor
+        TRACE_3("Skipping ERA/Slat/Sideskirt/Armor HitPoint",_hitpoint,_forEachIndex,_selection);
         /*#ifdef DEBUG_MODE_FULL
         systemChat format ["Skipping ERA/SLAT, hitpoint %1, index %2, selection %3", _hitpoint, _forEachIndex, _selection];
         #endif*/


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #9558 
- Add names of hitpoints with `depends` parameter to the name of the hitpoint they depend on
- Expand ignored hipoint list to include armor parts, sideskirts and missing slats
- 
### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
