### PR TITLE
Translation - Korean minor fix

### DIFF
--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -267,7 +267,7 @@
             <Polish>Gogle noktowizyjne (Szerokie, Czarne)</Polish>
             <German>NS-Brille (Weit, schwarz)</German>
             <Chinesesimp>夜视仪（宽，黑色）</Chinesesimp>
-            <Korean>야투경 (넓음, 검정색)</Korean>
+            <Korean>야투경 (넓음, 검정)</Korean>
             <Spanish>Gafas de visión nocturna (Panorámicas, Negro)</Spanish>
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_black_WP">


### PR DESCRIPTION
- Improved one NVG's Korean name fixed for for grammar. (I obviously fixed this before, but I don't know why it's been rolled back.)