### PR TITLE
CI - Run HEMTT on Windows for binarization

### DIFF
--- a/.github/workflows/hemtt.yml
+++ b/.github/workflows/hemtt.yml
@@ -18,6 +18,21 @@ jobs:
       uses: actions/checkout@v4
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
+    - name: Checkout pull request
+      uses: actions/checkout@v4
+      if: ${{ github.event_name == 'pull_request_target' }}
+      with:
+        path: pullrequest
+        ref: 'refs/pull/${{ github.event.number }}/merge'
+    - name: Replace addons with pull request addons
+      if: ${{ github.event_name == 'pull_request_target' }}
+      run: |
+        rm -r addons\
+        rm -r optionals\
+        rm -r include\
+        xcopy /e /h /q pullrequest\addons addons\
+        xcopy /e /h /q pullrequest\optionals optionals\
+        xcopy /e /h /q pullrequest\include include\
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder

--- a/.github/workflows/hemtt.yml
+++ b/.github/workflows/hemtt.yml
@@ -1,0 +1,29 @@
+name: HEMTT
+
+on:
+  push:
+    branches:
+    - master
+  pull_request_target:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+    - name: Install Arma 3 Tools
+      uses: arma-actions/arma3-tools@master
+      with:
+        toolsUrl: ${{ secrets.ARMA3_TOOLS_URL }}
+    - name: Checkout the source code
+      uses: actions/checkout@v4
+    - name: Setup HEMTT
+      uses: arma-actions/hemtt@v1
+    - name: Run HEMTT build
+      run: hemtt build
+    - name: Rename build folder
+      run: mv .hemttout/build .hemttout/@ace
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ace3-${{ github.sha }}
+        path: .hemttout/@*


### PR DESCRIPTION
**When merged this pull request will:**
- Run a HEMTT Windows build on pull requests and after merge to main
- Make the Arma 3 Tools made available via `arma-actions/arma3-tools` for access to `binarize_x64.exe`, requires `pull_request_target` instead of `pull_request`
- Using `pull_request_target` means it will use files from base branch by default. To get around this it will copy `addons`, `optionals` and `include` from the PR files into build directory.

Example Windows build: https://github.com/Dahlgren/ACE3/actions/runs/6658953635/job/18096958599, I accidentally flipped the names during test build so `-nobin` is the binarized one from Windows

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
