### PR TITLE
Documentation - Add Moderators to Team page

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -11,7 +11,6 @@ bux578 <github@jonathandavid.de>
 commy2
 Dahlgren
 Drofseh <drofseh.arma@gmail.com>
-tcvm <baileydanyluk@gmail.com>
 esteldunedain <nicolas.d.badano@gmail.com>
 Felix Wiegand <koffeinflummi@gmail.com>
 Garth "L-H" de Wet <garthofhearts@gmail.com>
@@ -28,6 +27,7 @@ MikeMF
 NouberNou
 PabstMirror <pabstmirror@gmail.com>
 Ruthberg <ulteq@web.de>
+tcvm <baileydanyluk@gmail.com>
 tpM
 veteran29
 ViperMaul

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -23,6 +23,7 @@ Jonpas <jonpas33@gmail.com>
 Kieran
 kymckay
 mharis001 <mhariszakar@gmail.com>
+MikeMF
 NouberNou
 PabstMirror <pabstmirror@gmail.com>
 Ruthberg <ulteq@web.de>
@@ -135,7 +136,6 @@ MarcBook
 meat <p.humberdroz@gmail.com>
 Michail Nikolaev
 MikeMatrix <m.braun92@gmail.com>
-MikeMF
 mjc4wilton <mjc4wilton@gmail.com>
 Mysteryjuju
 nic547 <nic547@outlook.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -10,6 +10,7 @@ Brett Mayson
 bux578 <github@jonathandavid.de>
 commy2
 Dahlgren
+Drofseh <drofseh.arma@gmail.com>
 tcvm <baileydanyluk@gmail.com>
 esteldunedain <nicolas.d.badano@gmail.com>
 Felix Wiegand <koffeinflummi@gmail.com>
@@ -80,7 +81,6 @@ diwako
 dixon13 <dixonbegay@gmail.com>
 Drift_91
 Drill <drill87@gmail.com>
-Drofseh <drofseh@gmail.com>
 Dslyecxi <dslyecxi@gmail.com>
 Dudakov aka [OMCB]Kaban <dudakov.s@gmail.com>
 Eclipser <jms@modeemi.fi>

--- a/docs/team.md
+++ b/docs/team.md
@@ -13,18 +13,18 @@ This lists all the maintainers responsible for project management and the overal
 
 - [bux](https://github.com/bux){:target="_blank"}
   - Scripting, Testing
-- [Jonpas](https://github.com/Jonpas){:target="_blank"}
-  - Scripting, Tools, Documentation
 - [Felix Wiegand](https://github.com/koffeinflummi){:target="_blank"}
   - Scripting, Model Import
+- [Glowbal](https://github.com/thojkooi){:target="_blank"}
+  - Build automation, project management, architecture
+- [Jonpas](https://github.com/Jonpas){:target="_blank"}
+  - Scripting, Tools, Documentation
 - [NouberNou](https://github.com/Noubernou){:target="_blank"}
   - Coding, Modeling, Performance, SME
 - [PabstMirror](https://github.com/PabstMirror){:target="_blank"}
   - Scripting, Config
 - [ViperMaul](https://github.com/vipermaul){:target="_blank"}
   - Project management
-- [Glowbal](https://github.com/thojkooi){:target="_blank"}
-  - Build automation, project management, architecture
 
 ## Core Maintainers
 
@@ -47,23 +47,23 @@ This lists all the maintainers responsible for project management and the overal
 
 ## Maintainers
 
+- [654wak654](https://github.com/654wak654){:target="_blank"}
 - [Alganthe](https://github.com/alganthe){:target="_blank"}
-- [TheMagnetar](https://github.com/TheMagnetar){:target="_blank"}
-  - Scripting
+- [BrettMayson](https://github.com/BrettMayson){:target="_blank"}
+- [Dahlgren](https://github.com/Dahlgren){:target="_blank"}
 - [Garth "L-H" de Wet](https://github.com/CorruptedHeart){:target="_blank"}
   - Scripting, Config
+- [Giallustio](https://github.com/Giallustio){:target="_blank"}
+- [Grim](https://github.com/LinkIsGrim){:target="_blank"}
 - gundy
 - Janus
-- tpM
 - [Kieran](https://github.com/kieran-s){:target="_blank"}
-- [Giallustio](https://github.com/Giallustio){:target="_blank"}
-- [654wak654](https://github.com/654wak654){:target="_blank"}
 - [mharis001](https://github.com/mharis001){:target="_blank"}
 - [tcvm](https://github.com/TheCandianVendingMachine){:target="_blank"}
+- [TheMagnetar](https://github.com/TheMagnetar){:target="_blank"}
+  - Scripting
+- tpM
 - [veteran29](https://github.com/veteran29){:target="_blank"}
-- [Dahlgren](https://github.com/Dahlgren){:target="_blank"}
-- [BrettMayson](https://github.com/BrettMayson){:target="_blank"}
-- [Grim](https://github.com/LinkIsGrim){:target="_blank"}
 
 ## Moderators
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -7,7 +7,7 @@ order: 3
 
 This page lists all current maintainers for the ACE3 projects with their areas of expertise and roles.
 
-## Project maintainers
+## Project Managers
 
 This lists all the maintainers responsible for project management and the overall direction of the ACE3 project.
 
@@ -26,7 +26,7 @@ This lists all the maintainers responsible for project management and the overal
 - [Glowbal](https://github.com/thojkooi){:target="_blank"}
   - Build automation, project management, architecture
 
-## Core maintainers
+## Core Maintainers
 
 - [BaerMitUmlaut](https://github.com/BaerMitUmlaut){:target="_blank"}
   - Scripting, Config
@@ -64,6 +64,11 @@ This lists all the maintainers responsible for project management and the overal
 - [Dahlgren](https://github.com/Dahlgren){:target="_blank"}
 - [BrettMayson](https://github.com/BrettMayson){:target="_blank"}
 - [Grim](https://github.com/LinkIsGrim){:target="_blank"}
+
+## Moderators
+
+-
+-
 
 ## Contributors
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -67,8 +67,8 @@ This lists all the maintainers responsible for project management and the overal
 
 ## Moderators
 
+- [drofseh](https://github.com/Drofseh){:target="_blank"}
 - [MikeMF](https://github.com/Mike-MF){:target="_blank"}
--
 
 ## Contributors
 

--- a/docs/team.md
+++ b/docs/team.md
@@ -67,7 +67,7 @@ This lists all the maintainers responsible for project management and the overal
 
 ## Moderators
 
--
+- [MikeMF](https://github.com/Mike-MF){:target="_blank"}
 -
 
 ## Contributors


### PR DESCRIPTION
**When merged this pull request will:**
- Add Moderators to Team page
  - [x] @Mike-MF 
  - [x] @Drofseh 
- Rename "Project maintainers" header to "Project Managers" to standardize naming across platforms.