### PR TITLE
Arsenal - don't lowercase displayName

### DIFF
--- a/addons/arsenal/functions/fnc_attributeAddItems.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddItems.sqf
@@ -64,10 +64,10 @@ if (_category == IDX_CAT_ALL) exitWith {
             default {_cfgWeapons >> _x};
         };
 
-        _displayName = toLower getText (_config >> "displayName");
+        _displayName = getText (_config >> "displayName");
 
         // Add item if not filtered
-        if (_displayName regexMatch _filter || {_x regexMatch _filter}) then {
+        if (toLower _displayName regexMatch _filter || {_x regexMatch _filter}) then {
             _index = _listbox lnbAddRow ["", _displayName, _modeSymbol];
             _listbox lnbSetData [[_index, 1], _x];
             _listbox lnbSetPicture [[_index, 0], getText (_config >> "picture")];
@@ -116,10 +116,10 @@ private _config = _cfgClass;
         _config = [_cfgClass, _cfgMagazines] select (_x in _magazineMiscItems);
     };
 
-    _displayName = toLower getText (_config >> _x >> "displayName");
+    _displayName = getText (_config >> _x >> "displayName");
 
     // Add item if not filtered
-    if (_displayName regexMatch _filter || {_x regexMatch _filter}) then {
+    if (toLower _displayName regexMatch _filter || {_x regexMatch _filter}) then {
         // Change symbol and alpha if item already selected
         if (_x in _attributeItems) then {
             _symbol = _modeSymbol;


### PR DESCRIPTION
**When merged this pull request will:**
- Change ACE Arsenal attribute not to use lowercase displayName
- For #9565 

![image](https://github.com/acemod/ACE3/assets/3946739/62f48198-8bb7-49b4-9417-c56db62e0185)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
