### PR TITLE
Add CUP Weapons Compatibility

### DIFF
--- a/addons/compat_cup_weapons/$PBOPREFIX$
+++ b/addons/compat_cup_weapons/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_cup_weapons

--- a/addons/compat_cup_weapons/CfgMagazines.hpp
+++ b/addons/compat_cup_weapons/CfgMagazines.hpp
@@ -1,0 +1,37 @@
+class CfgMagazines {
+	class CA_LauncherMagazine;
+	class CUP_NLAW_M: CA_LauncherMagazine {
+		ammo = "ACE_NLAW";
+	};
+
+	// legacy classes from ACE disposable launchers
+	class CUP_M136_M;
+	class ACE_PreloadedMissileDummy_CUP: CUP_M136_M {
+		scope = 1;
+		scopeArsenal = 0;
+	};
+	class CUP_RPG18_M;
+	class ACE_PreloadedMissileDummy_RPG18_CUP: CUP_RPG18_M {
+		scope = 1;
+		scopeArsenal = 0;
+	};
+	class CUP_M72A6_M;
+	class ACE_PreloadedMissileDummy_M72A6_CUP: CUP_M72A6_M {
+		scope = 1;
+		scopeArsenal = 0;
+	};
+	class ACE_PreloadedMissileDummy_NLAW_CUP: CUP_NLAW_M {
+		scope = 1;
+		scopeArsenal = 0;
+	};
+	class CUP_Stinger_M;
+	class ACE_PreloadedMissileDummy_Stinger_CUP: CUP_Stinger_M {
+		scope = 1;
+		scopeArsenal = 0;
+	};
+	class CUP_Strela_2_M;
+	class ACE_PreloadedMissileDummy_Strela_2_CUP: CUP_Strela_2_M {
+		scope = 1;
+		scopeArsenal = 0;
+	};
+};

--- a/addons/compat_cup_weapons/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/CfgWeapons.hpp
@@ -1,0 +1,36 @@
+class CfgWeapons {
+    class Launcher_Base_F;
+	class CUP_launch_M47: Launcher_Base_F {
+		ace_overpressure_angle = 45;
+		ace_overpressure_range = 8;
+		ace_overpressure_damage = 0.5;
+	};
+
+	class CUP_launch_MAAWS: Launcher_Base_F {
+		ace_overpressure_angle = 60;
+		ace_overpressure_range = 15;
+		ace_overpressure_damage = 0.7;
+	};
+	class CUP_launch_MAAWS_Scope: CUP_launch_MAAWS {};
+
+	class CUP_launch_RPG7V: Launcher_Base_F {
+		ace_overpressure_angle = 45;
+		ace_overpressure_range = 6;
+		ace_overpressure_damage = 0.5;
+	};
+
+	class CUP_launch_Mk153Mod0: Launcher_Base_F {
+		ace_overpressure_angle = 30;
+		ace_overpressure_range = 15;
+		ace_overpressure_damage = 0.7;
+	};
+	class CUP_launch_Mk153Mod0_SMAWOptics: CUP_launch_Mk153Mod0 {};
+
+	class CUP_launch_NLAW_Loaded: Launcher_Base_F {
+		ace_overpressure_angle = 30;
+		ace_overpressure_range = 2;
+		ace_overpressure_damage = 0.5;
+		ace_nlaw_enabled = 1;
+		canLock = 1;
+	};
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgMagazineGroups.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgMagazineGroups.hpp
@@ -1,0 +1,56 @@
+class ace_csw_groups {
+    class CUP_compats_29Rnd_30mm_AGS30_M {
+		CUP_29Rnd_30mm_AGS30_M = 1;
+	};
+    class CUP_compats_48Rnd_40mm_MK19_M {
+		CUP_48Rnd_40mm_MK19_M = 1;
+	};
+    class CUP_AT13_M  {
+		CUP_6Rnd_AT13_M = 1;
+	};
+    class CUP_compats_TOW_M {
+		CUP_6Rnd_TOW_HMMWV_M = 1;
+	};
+    class CUP_compats_TOW2_M {
+		CUP_6Rnd_TOW2_M = 1;
+	};
+    class CUP_compats_PG9_M {
+		CUP_16Rnd_PG9_AT_M = 1;
+	};
+    class CUP_compats_OG9_M {
+		CUP_16Rnd_OG9_HE_M = 1;
+	};
+    class CUP_compats_105mm_he {
+        CUP_30Rnd_105mmHE_M119_M = 1;
+    };
+    class CUP_compats_105mm_smoke {
+        CUP_30Rnd_105mmSMOKE_M119_M = 1;
+    };
+    class CUP_compats_105mm_wp {
+        CUP_30Rnd_105mmWP_M119_M = 1;
+    };
+    class CUP_compats_105mm_laser {
+		CUP_30Rnd_105mmLASER_M119_M = 1;
+	};
+    class CUP_compats_105mm_illum {
+		CUP_30Rnd_105mmILLUM_M119_M = 1;
+	};
+    class CUP_compats_122mm_he {
+		CUP_30Rnd_122mmHE_D30_M = 1;
+	};
+    class CUP_compats_122mm_smoke {
+		CUP_30Rnd_122mmSMOKE_D30_M = 1;
+	};
+    class CUP_compats_122mm_wp {
+		CUP_30Rnd_122mmHE_D30_M = 1;
+	};
+    class CUP_compats_122mm_laser {
+		CUP_30Rnd_122mmLASER_D30_M = 1;
+	};
+    class CUP_compats_122mm_illum {
+		CUP_30Rnd_122mmILLUM_D30_M = 1;
+	};
+    class CUP_compats_122mm_at {
+		CUP_30Rnd_122mmAT_D30_M = 1;
+	};
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgMagazines.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgMagazines.hpp
@@ -1,0 +1,111 @@
+class CfgMagazines {
+	class VehicleMagazine;
+	class CUP_29Rnd_30mm_AGS30_M: VehicleMagazine {
+        ace_isbelt = 1;
+    };
+
+	class CUP_compats_29Rnd_30mm_AGS30_M: CUP_29Rnd_30mm_AGS30_M {
+        scope = 2;
+        type = 256;
+        count = 29;
+        mass = 40;
+        displayName = SUBCSTRING(mag_AGS30_displayName);
+		model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+		picture ="\z\ace\addons\csw\UI\ammoBox_50bmg_ca.paa";
+    };
+
+	class 200Rnd_40mm_G_belt;
+	class CUP_48Rnd_40mm_MK19_M: 200Rnd_40mm_G_belt {
+        ace_isbelt = 1;
+    };
+
+	class CUP_compats_48Rnd_40mm_MK19_M: CUP_29Rnd_30mm_AGS30_M {
+        scope = 2;
+        type = 256;
+        count = 48;
+        mass = 40;
+		displayname = SUBCSTRING(mag_MK19_displayName);
+		model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+		picture ="\z\ace\addons\csw\UI\ammoBox_50bmg_ca.paa";
+    };
+
+    class CUP_6Rnd_TOW_HMMWV_M;
+    class CUP_compats_TOW_M: CUP_6Rnd_TOW_HMMWV_M {
+        scope = 2;
+        type = 256;
+        count = 1;
+        mass = 200;
+        displayname = "[CSW] TOW Tube"; // the fuck?
+		model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+        picture = "\A3\Weapons_F_beta\Launchers\titan\Data\UI\gear_titan_missile_at_ca.paa";
+    };
+
+    class CUP_6Rnd_TOW2_M;
+    class CUP_compats_TOW2_M: CUP_6Rnd_TOW2_M {
+        scope = 2;
+        type = 256;
+        count = 1;
+        mass = 200;
+		displayname = "[CSW] TOW2 Tube";
+        model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+        picture = "\A3\Weapons_F_beta\Launchers\titan\Data\UI\gear_titan_missile_at_ca.paa";
+    };
+
+    class CUP_16Rnd_PG9_AT_M;
+    class CUP_compats_PG9_M: CUP_16Rnd_PG9_AT_M {
+        displayName = SUBCSTRING(mag_PG9_displayName);
+        model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+        scope = 2;
+        type = 256;
+        count = 1;
+        mass = 80;
+        picture = "\A3\Weapons_F_Exp\Launchers\RPG7\Data\UI\icon_rocket_RPG7_ca.paa";
+    };
+
+    class CUP_16Rnd_OG9_HE_M;
+    class CUP_compats_OG9_M: CUP_16Rnd_OG9_HE_M {
+        displayName = SUBCSTRING(mag_OG9_displayName);
+        model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+        scope = 2;
+        type = 256;
+        count = 1;
+        mass = 80;
+        picture = "\A3\Weapons_F_Exp\Launchers\RPG7\Data\UI\icon_rocket_RPG7_ca.paa";
+    };
+
+    class ACE_1Rnd_82mm_Mo_HE;
+    class CUP_compats_105mm_he: ACE_1Rnd_82mm_Mo_HE {
+        displayName = SUBCSTRING(mag_M1HE_displayName);
+        mass = 120;
+    };
+    class CUP_compats_105mm_smoke: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_M84Smoke_displayName);
+    };
+    class CUP_compats_105mm_wp: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_M60A2_displayName);
+    };
+    class CUP_compats_105mm_laser: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_M67AT_displayName);
+    };
+    class CUP_compats_105mm_illum: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_M314Illum_displayName);
+    };
+	class CUP_compats_122mm_he: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_3OF56_displayName);
+    };
+	class CUP_compats_122mm_laser: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_3OF69M_displayName);
+    };
+	class CUP_compats_122mm_wp: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_122mmWP_displayName);
+    };
+	class CUP_compats_122mm_smoke: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_122mmSmoke_displayName);
+    };
+	class CUP_compats_122mm_illum: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_122mmIllum_displayName);
+    };
+	class CUP_compats_122mm_at: CUP_compats_105mm_he {
+        displayName = SUBCSTRING(mag_122mmAT_displayName);
+    };
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgVehicles.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgVehicles.hpp
@@ -1,0 +1,201 @@
+class CfgVehicles {
+	class LandVehicle;
+	class StaticWeapon: LandVehicle {
+        class ACE_Actions {
+            class ACE_MainActions;
+        };
+    };
+
+	class StaticMortar;
+    class CUP_2b14_82mm_Base: StaticMortar {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                position = "";
+                selection = ""; // no good selections for this mortar
+            };
+        };
+        class ace_csw {
+            enabled = 1;
+            magazineLocation = "_target selectionPosition 'otochlaven'";
+            proxyWeapon = "CUP_proxy_mortar_82mm";
+            disassembleWeapon = "CUP_2b14_carry";
+            disassembleTurret = "ace_csw_mortarBaseplate";
+            desiredAmmo = 1;
+            ammoLoadTime = 3;
+            ammoUnloadTime = 3;
+        };
+    };
+
+    class CUP_M252_base: CUP_2b14_82mm_Base {
+        class ace_csw: ace_csw {
+            disassembleWeapon = "CUP_m252_carry";
+            disassembleTurret = "ace_csw_mortarBaseplate";
+        };
+    };
+
+    class CUP_L16A2_base: CUP_M252_base {
+        class ace_csw: ace_csw {
+            disassembleWeapon = "CUP_l16a2_carry";
+            disassembleTurret = "ace_csw_mortarBaseplate";
+        };
+    };
+
+	class StaticMGWeapon;
+    class CUP_M2StaticMG_base: StaticMGWeapon {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_m2";
+            magazineLocation = "_target selectionPosition 'magazine'";
+            disassembleWeapon = "CUP_m2_carry";
+            disassembleTurret = "ace_csw_m3Tripod";
+            desiredAmmo = 100;
+            ammoLoadTime = 10;
+            ammoUnloadTime = 8;
+        };
+    };
+
+    class CUP_M2StaticMG_MiniTripod_base: CUP_M2StaticMG_base {
+        class ace_csw: ace_csw {
+            enabled = 1;
+            disassembleTurret = "ace_csw_m3TripodLow";
+        };
+    };
+
+    class CUP_DSHKM_base: StaticMGWeapon {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_DSHKM";
+            magazineLocation = "_target selectionPosition 'magazine'";
+            disassembleWeapon = "CUP_DSHKM_carry";
+            disassembleTurret = "ace_csw_kordTripod";
+            desiredAmmo = 100;
+            ammoLoadTime = 10;
+            ammoUnloadTime = 8;
+        };
+    };
+
+    class CUP_DSHKM_MiniTripod_base: CUP_DSHKM_base {
+        class ace_csw: ace_csw {
+            enabled = 1;
+            disassembleTurret = "ace_csw_kordTripodLow";
+        };
+    };
+
+    class CUP_KORD_Base: StaticMGWeapon {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_KORD";
+            magazineLocation = "_target selectionPosition 'magazine'";
+            disassembleWeapon = "CUP_KORD_carry";
+            disassembleTurret = "ace_csw_kordTripod";
+            desiredAmmo = 100;
+            ammoLoadTime = 10;
+            ammoUnloadTime = 8;
+        };
+    };
+
+    class CUP_KORD_MiniTripod_Base: CUP_KORD_Base {
+        class ace_csw: ace_csw {
+            enabled = 1;
+            disassembleTurret = "ace_csw_kordTripodLow";
+        };
+    };
+
+	class StaticGrenadeLauncher;
+    class CUP_AGS_base: StaticGrenadeLauncher {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_AGS30";
+            magazineLocation = "_target selectionPosition 'otochlaven'";
+            disassembleWeapon = "CUP_AGS30_carry";
+            disassembleTurret = "ace_csw_sag30Tripod";
+            desiredAmmo = 29;
+            ammoLoadTime = 10;
+            ammoUnloadTime = 8;
+        };
+    };
+
+	class CUP_MK19_TriPod_base: StaticGrenadeLauncher {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_MK19";
+            magazineLocation = "_target selectionPosition 'magazine'";
+            disassembleWeapon = "CUP_MK19_carry";
+            disassembleTurret = "ace_csw_m3TripodLow";
+            desiredAmmo = 48;
+            ammoLoadTime = 10;
+            ammoUnloadTime = 8;
+        };
+    };
+
+	class AT_01_base_F;
+	class CUP_Metis_Base: AT_01_base_F {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_AT13";
+            magazineLocation = "_target selectionPosition 'gun'";
+            disassembleWeapon = "CUP_launch_Metis";
+            disassembleTurret = "";
+            desiredAmmo = 1;
+            ammoLoadTime = 7;
+            ammoUnloadTime = 5;
+        };
+    };
+
+	class StaticATWeapon;
+    class CUP_TOW_TriPod_base: StaticATWeapon {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_TOW";
+            magazineLocation = "_target selectionPosition 'otochlaven'";
+            disassembleWeapon = "CUP_TOW_carry";
+            disassembleTurret = "ace_csw_m220Tripod";
+            desiredAmmo = 1;
+            ammoLoadTime = 8;
+            ammoUnloadTime = 5;
+        };
+    };
+
+    class CUP_TOW2_TriPod_base: CUP_TOW_TriPod_base {
+        class ace_csw: ace_csw {
+            disassembleWeapon = "CUP_TOW2_carry";
+        };
+    };
+
+    class CUP_SPG9_base: StaticATWeapon {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_SPG9";
+            magazineLocation = "_target selectionPosition 'otochlaven'";
+            disassembleWeapon = "CUP_SPG9_carry";
+            disassembleTurret = "ace_csw_spg9Tripod";
+            desiredAmmo = 1;
+            ammoLoadTime = 5;
+            ammoUnloadTime = 3;
+        };
+    };
+
+	class StaticCannon;
+    class CUP_D30_base: StaticCannon {
+        class ace_csw {
+            enabled = 1;
+            proxyWeapon = "CUP_proxy_D30";
+            magazineLocation = "_target selectionPosition 'otochlaven'";
+			desiredAmmo = 1;
+            ammoLoadTime = 5;
+            ammoUnloadTime = 5;
+        };
+    };
+
+    class CUP_D30_AT_base: CUP_D30_base {
+        class ace_csw: ace_csw {
+            proxyWeapon = "CUP_proxy_D30AT";
+        };
+    };
+
+    class CUP_M119_base: CUP_D30_base {
+        class ace_csw: ace_csw {
+            proxyWeapon = "CUP_proxy_M119";
+        };
+    };
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/CfgWeapons.hpp
@@ -1,0 +1,290 @@
+class CfgWeapons {
+    class Launcher;
+	class Launcher_Base_F: Launcher {
+		class WeaponSlotsInfo;
+	};
+
+	class CUP_2b14_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,2b14_tube);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\Podnos\data\ui\podnos_2b14_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 20;
+            pickupTime = 25;
+            class assembleTo {
+                ace_csw_mortarBaseplate = "CUP_O_2b14_82mm_RU";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 670;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+	class CUP_m252_carry: CUP_2b14_carry {
+        displayName = ECSTRING(csw,m252_tube);
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\M252\data\ui\icomap_mortar_m251_ca.paa";
+        class ace_csw: ace_csw {
+            class assembleTo {
+                ace_csw_mortarBaseplate = "CUP_B_M252_US";
+            };
+        };
+    };
+
+	class CUP_l16a2_carry: CUP_2b14_carry {
+        displayName = ECSTRING(csw,m252_tube);
+		scope = 1;
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\M252\data\ui\icomap_mortar_m251_ca.paa";
+        class ace_csw: ace_csw {
+            class assembleTo {
+                ace_csw_mortarBaseplate = "CUP_B_L16A2_BAF_MPT";
+            };
+        };
+    };
+
+    class CUP_m2_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,m2_gun);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\M2\data\ui\icomap_M2_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_m3Tripod = "CUP_B_M2StaticMG_US";
+                ace_csw_m3TripodLow = "CUP_B_M2StaticMG_MiniTripod_US";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 840;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class CUP_DSHKM_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,dshk_gun);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\DShKM\data\ui\icomap_DShKM_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_kordTripod = "CUP_O_DSHKM_ChDKZ";
+                ace_csw_kordTripodLow = "CUP_O_DSHkM_MiniTriPod_ChDKZ";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 740;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class CUP_KORD_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,kord_gun);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\KORD\data\ui\icomap_kord_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_kordTripod = "CUP_O_KORD_high_RU";
+                ace_csw_kordTripodLow = "CUP_O_KORD_RU";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 550;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class CUP_AGS30_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,ags30_gun);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\AGS\data\ui\ags_static_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_sag30Tripod = "CUP_O_AGS_RU";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 400;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class CUP_MK19_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,mk19_gun);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+		picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\Mk19\data\ui\icomap_mk19_stat_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_m3TripodLow = "CUP_B_MK19_TriPod_US";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 770;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class CUP_launch_Metis: Launcher_Base_F {
+		ace_overpressure_angle = 45;
+		ace_overpressure_range = 15;
+		ace_overpressure_damage = 0.7;
+        class ace_csw {
+            type = "mount";
+            deployTime = 4;
+            pickupTime = 4;
+            deploy = "CUP_O_Metis_RU";
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 300;
+		};
+    };
+
+    class CUP_TOW_carry: Launcher_Base_F {
+        displayName = ECSTRING(csw,tow_tube);
+        scope = 2;
+        model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\TOW\data\ui\icomap_tow_static_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_m220Tripod = "CUP_B_TOW_TriPod_US";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 500;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class CUP_TOW2_carry: CUP_TOW_carry {
+        class ace_csw: ace_csw {
+            class assembleTo {
+                ace_csw_m220Tripod = "CUP_B_TOW2_TriPod_US";
+            };
+        };
+    };
+
+    class CUP_SPG9_carry: Launcher_Base_F {
+		displayName = ECSTRING(csw,spg9_tube);
+        scope = 2;
+		model = QPATHTOEF(apl,ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\CUP\Weapons\CUP_Weapons_StaticWeapons\SPG9\data\ui\icon_spg9_ca.paa";
+        class ace_csw {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_spg9Tripod = "CUP_B_SPG9_CDF";
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 1000;
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+        };
+    };
+
+    class mortar_82mm;
+    class CUP_proxy_mortar_82mm: mortar_82mm {
+        magazineReloadTime = 0.5;
+    };
+
+    class CUP_Vhmg_M2_static;
+    class CUP_proxy_m2: CUP_Vhmg_M2_static {
+        magazineReloadTime = 0.5;
+	};
+
+    class CUP_Vhmg_DSHKM_veh;
+    class CUP_proxy_DSHKM: CUP_Vhmg_DSHKM_veh {
+        magazineReloadTime = 0.5;
+	};
+
+    class CUP_Vhmg_KORD_veh;
+    class CUP_proxy_KORD: CUP_Vhmg_KORD_veh {
+        magazineReloadTime = 0.5;
+	};
+
+	class CUP_Vhmg_AGS30_veh;
+    class CUP_proxy_AGS30: CUP_Vhmg_AGS30_veh {
+        magazineReloadTime = 0.5;
+	};
+
+	class CUP_Vgmg_MK19_veh;
+    class CUP_proxy_MK19: CUP_Vgmg_MK19_veh {
+        magazineReloadTime = 0.5;
+	};
+
+   	class CUP_Vmlauncher_AT13_single_veh;
+    class CUP_proxy_AT13: CUP_Vmlauncher_AT13_single_veh {
+        magazineReloadTime = 0.5;
+	};
+
+   	class CUP_Vmlauncher_TOW_single_veh;
+    class CUP_proxy_TOW: CUP_Vmlauncher_TOW_single_veh {
+        magazineReloadTime = 0.5;
+	};
+
+	class CUP_Vacannon_SPG9_veh;
+    class CUP_proxy_SPG9: CUP_Vacannon_SPG9_veh {
+        magazineReloadTime = 0.5;
+	};
+
+  	class CUP_Vcannon_M119_veh;
+    class CUP_proxy_M119: CUP_Vcannon_M119_veh {
+        magazineReloadTime = 0.5;
+	};
+
+	class CUP_Vcannon_D30_veh;
+    class CUP_proxy_D30: CUP_Vcannon_D30_veh {
+        magazineReloadTime = 0.5;
+	};
+
+	class CUP_Vcannon_D30AT_veh;
+    class CUP_proxy_D30AT: CUP_Vcannon_D30AT_veh {
+        magazineReloadTime = 0.5;
+	};
+};
+

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/config.cpp
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "CUP_Weapons_loadOrder",
+            "ace_csw"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgMagazines.hpp"
+#include "CfgMagazineGroups.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/script_component.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/script_component.hpp
@@ -1,0 +1,5 @@
+#define SUBCOMPONENT csw
+#define SUBCOMPONENT_BEAUTIFIED Crew-Served Weapons
+#include "..\script_component.hpp"
+
+#include "\z\ace\addons\csw\script_config_macros_csw.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/stringtable.xml
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/stringtable.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACE">
+    <Package name="Compat_CUP_Weapons_CSW">
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_AGS30_displayName">
+            <English>[CSW] AGS30 Belt</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_MK19_displayName">
+            <English>[CSW] MK19 Belt</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_PG9_displayName">
+            <English>[CSW] PG-9 Round</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_OG9_displayName">
+            <English>[CSW] OG-9 Round</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_M1HE_displayName">
+            <English>[CSW] M1 HE</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_M84Smoke_displayName">
+            <English>[CSW] M84 Smoke</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_M60A2_displayName">
+            <English>[CSW] M60A2 WP</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_M67AT_displayName">
+            <English>[CSW] M67 AT Laser Guided</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_M314Illum_displayName">
+            <English>[CSW] M314 Illumination</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_3OF56_displayName">
+            <English>[CSW] 3OF56 HE</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_3OF69M_displayName">
+            <English>[CSW] 3OF69M Laser Guided</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_122mmWP_displayName">
+            <English>[CSW] 122mm WP</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_122mmSmoke_displayName">
+            <English>[CSW] D-462 Smoke</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_122mmIllum_displayName">
+            <English>[CSW] S-463 Illumination</English>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_CSW_mag_122mmAT_displayName">
+            <English>[CSW] BK-6M HEAT</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgAmmo.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgAmmo.hpp
@@ -1,0 +1,21 @@
+class CfgAmmo {
+    class PipeBombBase;
+    class CUP_TimeBomb_Ammo: PipeBombBase {
+        hit = 3000;
+        indirectHit = 3000;
+        indirectHitRange = 5;
+        ace_explosives_explodeOnDefuse = 0.02;
+    };
+    class CUP_PipeBomb_Ammo: PipeBombBase {
+        hit = 3000;
+        indirectHit = 3000;
+        indirectHitRange = 5;
+        ace_explosives_explodeOnDefuse = 0.02;
+    };
+
+    class CUP_Mine_Ammo;
+    class CUP_IED_V1_Ammo: CUP_Mine_Ammo {
+        ace_explosives_explodeOnDefuse = 0.06;
+        triggerWhenDestroyed = 1;
+    };
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgMagazines.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgMagazines.hpp
@@ -1,0 +1,103 @@
+class CfgMagazines {
+	class CA_Magazine;
+	class CUP_TimeBomb_M: CA_Magazine {
+		scope = 1;
+		ace_explosives_placeable = 1;
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_PipeBomb_place_CUP";
+		class ACE_Triggers {
+			SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch", "Cellphone"};
+			class Timer {
+				FuseTime = 0.5;
+			};
+			class Command {
+				FuseTime = 0.5;
+			};
+		};
+	};
+	class CUP_Mine_M: CUP_TimeBomb_M {
+		ace_explosives_placeable = 1;
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_Mine_place_CUP";
+		class ACE_Triggers {
+			SupportedTriggers[] = {"PressurePlate"};
+			class PressurePlate {
+				digDistance = 0.08;
+			};
+		};
+	};
+	class CUP_MineE_M: CUP_TimeBomb_M {
+		ace_explosives_placeable = 1;
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_MineE_place_CUP";
+		class ACE_Triggers {
+			SupportedTriggers[] = {"PressurePlate"};
+			class PressurePlate {
+				digDistance = 0.06;
+			};
+		};
+	};
+
+	class CUP_IED_V1_M: CUP_Mine_M {
+		ace_explosives_placeable = 1;
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_IED_V1_place_CUP";
+		class ACE_Triggers {
+			SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch", "Cellphone", "PressurePlate"};
+		};
+	};
+	class CUP_IED_V2_M: CUP_IED_V1_M {
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_IED_V2_place_CUP";
+	};
+	class CUP_IED_V3_M: CUP_IED_V1_M {
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_IED_V3_place_CUP";
+		class ACE_Triggers {
+			SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch", "Cellphone", "PressurePlate"};
+			class Timer {
+				digDistance = 0.06;
+			};
+			class Command {
+				digDistance = 0.06;
+			};
+			class MK16_Transmitter {
+				digDistance = 0.06;
+			};
+			class DeadmanSwitch {
+				digDistance = 0.06;
+			};
+			class Cellphone {
+				digDistance = 0.06;
+			};
+			class PressurePlate {
+				digDistance = 0.06;
+			};
+		};
+	};
+	class CUP_IED_V4_M: CUP_IED_V1_M {
+		useAction = 0;
+		ace_explosives_setupObject = "ACE_IED_V4_place_CUP";
+		class ACE_Triggers {
+			SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch", "Cellphone", "PressurePlate"};
+			class Timer {
+				digDistance = 0.08;
+			};
+			class Command {
+				digDistance = 0.08;
+			};
+			class MK16_Transmitter {
+				digDistance = 0.08;
+			};
+			class DeadmanSwitch {
+				digDistance = 0.08;
+			};
+			class Cellphone {
+				digDistance = 0.08;
+			};
+			class PressurePlate {
+				digDistance = 0.08;
+			};
+		};
+	};
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgVehicles.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgVehicles.hpp
@@ -1,0 +1,32 @@
+class CfgVehicles {
+	class ACE_Explosives_Place;
+	class ACE_PipeBomb_place_CUP: ACE_Explosives_Place {
+		displayName = "Satchel Charge";
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_Satchel.p3d";
+		ace_explosives_offset[] = {0, 0, 0};
+	};
+	class ACE_Mine_place_CUP: ACE_Explosives_Place {
+		displayName = "AT-15 Anti-Tank Mine";
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_AT15.p3d";
+		ace_explosives_offset[] = {0, 0, 0};
+	};
+	class ACE_MineE_place_CUP: ACE_Explosives_Place {
+		displayName = "TM46 Anti-Tank Mine";
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_TM46.p3d";
+		ace_explosives_offset[] = {0, 0, 0};
+	};
+	class ACE_IED_V1_place_CUP: ACE_Explosives_Place {
+		displayName = "IED";
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V1.p3d";
+		ace_explosives_offset[] = {0, 0, 0};
+	};
+	class ACE_IED_V2_place_CUP: ACE_IED_V1_place_CUP {
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V2.p3d";
+	};
+	class ACE_IED_V3_place_CUP: ACE_IED_V1_place_CUP {
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V3.p3d";
+	};
+	class ACE_IED_V4_place_CUP: ACE_IED_V1_place_CUP {
+		model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V4.p3d";
+	};
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_explosives/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_explosives/config.cpp
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "CUP_Weapons_LoadOrder",
+            "ace_explosives"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_explosives/script_component.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_explosives/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT explosives
+#define SUBCOMPONENT_BEAUTIFIED Explosives
+#include "..\script_component.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_javelin/CfgAmmo.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_javelin/CfgAmmo.hpp
@@ -1,0 +1,26 @@
+class CfgAmmo {
+    class MissileBase;
+    class CUP_M_Javelin_AT: MissileBase {
+        irLock = 1;
+        laserLock = 0;
+        airLock = 0;
+
+        class ace_missileguidance {
+            enabled = 1;
+            minDeflection = 0.00005;
+            maxDeflection = 0.025;
+            incDeflection = 0.00005;
+            canVanillaLock = 0;
+            defaultSeekerType = "Optic";
+            seekerTypes[] = {"Optic"};
+            defaultSeekerLockMode = "LOBL";
+            seekerLockModes[] = {"LOBL"};
+            seekerAngle = 180;
+            seekerAccuracy = 1;
+            seekerMinRange = 0;
+            seekerMaxRange = 2500;
+            defaultAttackProfile = "JAV_TOP";
+            attackProfiles[] = {"JAV_TOP", "JAV_DIR"};
+        };
+    };
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_javelin/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_javelin/CfgWeapons.hpp
@@ -1,0 +1,14 @@
+class CfgWeapons {
+    class Launcher_Base_F;
+	class CUP_launch_Javelin: Launcher_Base_F {
+		ace_javelin_enabled = 1;
+		weaponInfoType = "ACE_RscOptics_javelin";
+		modelOptics = QPATHTOEF(javelin,data\reticle_titan.p3d);
+		canLock = 0;
+		lockingTargetSound[] = {"", 0, 1};
+		lockedTargetSound[] = {"", 0, 1};
+		ace_overpressure_angle = 30;
+		ace_overpressure_range = 2;
+		ace_overpressure_damage = 0.5;
+	};
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_javelin/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_javelin/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "CUP_Weapons_LoadOrder",
+            "ace_javelin"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgAmmo.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_javelin/script_component.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_javelin/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT javelin
+#define SUBCOMPONENT_BEAUTIFIED Javelin
+#include "..\script_component.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
@@ -1,0 +1,64 @@
+#define NVG_MACRO_GREEN_GEN3 \
+	ace_nightvision_bluRadius = 0.13; \
+	ace_nightvision_border = QPATHTOEF(nightvision,data\nvg_mask_4096.paa); \
+	ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}; \
+	ace_nightvision_generation = 3; \
+	modelOptics = ""
+
+#define NVG_MACRO_GREEN_GPNVG \
+	ace_nightvision_bluRadius = 0.13; \
+	ace_nightvision_border = "z\ace\addons\nightvision\data\nvg_mask_quad_4096.paa"; \
+	ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}; \
+	ace_nightvision_generation = 4; \
+	modelOptics = ""
+
+class CfgWeapons {
+	class NVGoggles;
+	class CUP_NVG_PVS7: NVGoggles {
+		modelOptics = "";
+		ace_nightvision_border = QPATHTOEF(nightvision,data\nvg_mask_4096.paa);
+		ace_nightvision_bluRadius = 0;
+		ace_nightvision_eyeCups = 0;
+		ace_nightvision_generation = 3;
+		ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
+	};
+	class CUP_NVG_HMNVS: NVGoggles {
+		NVG_MACRO_GREEN_GEN3;
+	};
+	class CUP_NVG_PVS14: NVGoggles {
+		NVG_MACRO_GREEN_GEN3;
+	};
+	class CUP_NVG_PVS15_black: NVGoggles {
+		NVG_MACRO_GREEN_GEN3;
+	};
+	class CUP_NVG_PVS15_tan: NVGoggles {
+		NVG_MACRO_GREEN_GEN3;
+	};
+	class CUP_NVG_PVS15_green: NVGoggles {
+		NVG_MACRO_GREEN_GEN3;
+	};
+	class CUP_NVG_PVS15_winter: NVGoggles {
+		NVG_MACRO_GREEN_GEN3;
+	};
+
+	// Gen4s
+	class CUP_NVG_1PN138: NVGoggles {
+		ace_nightvision_bluRadius = 0.13;
+		ace_nightvision_border = QPATHTOEF(nightvision,data\nvg_mask_4096.paa);
+		ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
+		ace_nightvision_generation = 4;
+		modelOptics = "";
+	};
+	class CUP_NVG_GPNVG_black: NVGoggles {
+		NVG_MACRO_GREEN_GPNVG;
+	};
+	class CUP_NVG_GPNVG_tan: NVGoggles {
+        NVG_MACRO_GREEN_GPNVG;
+	};
+	class CUP_NVG_GPNVG_green: NVGoggles {
+        NVG_MACRO_GREEN_GPNVG;
+	};
+	class CUP_NVG_GPNVG_winter: NVGoggles {
+        NVG_MACRO_GREEN_GPNVG;
+	};
+};

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/config.cpp
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "CUP_Weapons_LoadOrder",
+            "ace_nightvision"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/script_component.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT nightvision
+#define SUBCOMPONENT_BEAUTIFIED Night Vision
+#include "..\script_component.hpp"

--- a/addons/compat_cup_weapons/config.cpp
+++ b/addons/compat_cup_weapons/config.cpp
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"CUP_Weapons_LoadOrder"};
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Community Upgrade Project", "Mike"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/compat_cup_weapons/script_component.hpp
+++ b/addons/compat_cup_weapons/script_component.hpp
@@ -1,0 +1,9 @@
+#define COMPONENT compat_cup_weapons
+#define COMPONENT_BEAUTIFIED CUP Weapons Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
+
+// Backwards compatibility
+#undef GVAR
+#define GVAR(var) TRIPLES(PREFIX,COMPONENT,var)


### PR DESCRIPTION
**When merged this pull request will:**
- Merges CUP Weapons Compat from CUP to ACE.

ToDo:
- [ ] Test all of it
- [ ] Figure out what to do with the Laserpointer stuff in original compat
- [ ] Figure out what to do with the displayName in CSW subconfig/magazines/L38 & L49 

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
