### PR TITLE
Arsenal - Use forceUnicode for search functions

### DIFF
--- a/addons/arsenal/functions/fnc_attributeAddItems.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddItems.sqf
@@ -141,3 +141,6 @@ private _config = _cfgClass;
 
 // Sort alphabetically
 _listbox lnbSort [1, false];
+
+// Reset unicode flag
+forceUnicode -1;

--- a/addons/arsenal/functions/fnc_attributeAddItems.sqf
+++ b/addons/arsenal/functions/fnc_attributeAddItems.sqf
@@ -18,9 +18,10 @@
 
 params ["_controlsGroup"];
 
+forceUnicode 0; // handle non-ANSI characters
+
 private _category = lbCurSel (_controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_CATEGORY);
-// Have to use toLower here and displayName to handle non-ANSI characters
-private _filter = toLower ctrlText (_controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_SEARCHBAR);
+private _filter = ctrlText (_controlsGroup controlsGroupCtrl IDC_ATTRIBUTE_SEARCHBAR);
 private _configItems = uiNamespace getVariable QGVAR(configItems);
 private _magazineMiscItems = uiNamespace getVariable QGVAR(magazineMiscItems);
 private _attributeValue = uiNamespace getVariable [QGVAR(attributeValue), [[], 0]];
@@ -67,7 +68,7 @@ if (_category == IDX_CAT_ALL) exitWith {
         _displayName = getText (_config >> "displayName");
 
         // Add item if not filtered
-        if (toLower _displayName regexMatch _filter || {_x regexMatch _filter}) then {
+        if (_displayName regexMatch _filter || {_x regexMatch _filter}) then {
             _index = _listbox lnbAddRow ["", _displayName, _modeSymbol];
             _listbox lnbSetData [[_index, 1], _x];
             _listbox lnbSetPicture [[_index, 0], getText (_config >> "picture")];
@@ -119,7 +120,7 @@ private _config = _cfgClass;
     _displayName = getText (_config >> _x >> "displayName");
 
     // Add item if not filtered
-    if (toLower _displayName regexMatch _filter || {_x regexMatch _filter}) then {
+    if (_displayName regexMatch _filter || {_x regexMatch _filter}) then {
         // Change symbol and alpha if item already selected
         if (_x in _attributeItems) then {
             _symbol = _modeSymbol;

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -17,8 +17,9 @@
 
 params ["_display", "_control", ["_animate", true]];
 
-// Have to use toLower here and displayName to handle non-ANSI characters
-private _searchString = toLower ctrlText _control;
+forceUnicode 0; // handle non-ANSI characters
+
+private _searchString = ctrlText _control;
 private _searchPattern = "";
 if (_searchString != "") then {
     _searchPattern = _searchString call EFUNC(common,escapeRegex);
@@ -56,7 +57,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // Go through all items in panel and see if they need to be deleted or not
         for "_lbIndex" from (lbSize _rightPanelCtrl) - 1 to 0 step -1 do {
-            _currentDisplayName = toLower (_rightPanelCtrl lbText _lbIndex);
+            _currentDisplayName = _rightPanelCtrl lbText _lbIndex;
             _currentClassname = _rightPanelCtrl lbData _lbIndex;
 
             // Remove item in panel if it doesn't match search, skip otherwise
@@ -152,7 +153,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     // Go through all items in panel and see if they need to be deleted or not
     for "_lbIndex" from (lbSize _leftPanelCtrl) - 1 to 0 step -1 do {
-        _currentDisplayName = toLower (_leftPanelCtrl lbText _lbIndex);
+        _currentDisplayName = _leftPanelCtrl lbText _lbIndex;
         _currentClassname = _leftPanelCtrl lbData _lbIndex;
 
         // Remove item in panel if it doesn't match search, skip otherwise

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -179,3 +179,6 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     [_display, nil, nil, configNull] call FUNC(itemInfo);
 };
+
+// Reset unicode flag
+forceUnicode -1;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

```
"Песочный" regexMatch "Песочный"; // true
"Песочный" regexMatch (toLower "Песочный"); // false
forceUnicode 1;
"Песочный" regexMatch (toLower "Песочный"); // true
```

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
