### PR TITLE
Tools - Allow full code coverage on hemtt nobin build

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -36,13 +36,15 @@ jobs:
       uses: arma-actions/sqflint@master
       continue-on-error: true # No failure due to many false-positives
 
-  build:
+  hemtt-nobin:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
+    - name: Convert to full coverage
+      uses: python3 tools/convertToFullCoverage.py
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder
@@ -50,5 +52,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ace3-${{ github.sha }}-nobin
+        name: ace3-${{ github.sha }}-nobin-fullcoverage
         path: .hemttout/@*

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
     - name: Convert to full coverage
-      uses: python3 tools/convertToFullCoverage.py
+      run: python3 tools/convertToFullCoverage.py
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -36,7 +36,7 @@ jobs:
       uses: arma-actions/sqflint@master
       continue-on-error: true # No failure due to many false-positives
 
-  hemtt-nobin:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code

--- a/tools/convertToFullCoverage.py
+++ b/tools/convertToFullCoverage.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# PabstMirror
+# Converts all addons so they are fully buildable/lintable by hemtt
+# Clears "has_include" and "[rapify] enabled = false"
+
+
+import re
+import os.path
+
+addon_base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+token_from = r"#if __has_include\(.*\)"
+token_to = r"#ifdef IGNORE_ME"
+
+for root, _dirs, files in os.walk(os.path.join(addon_base_path, "addons")):
+    for file in files:
+        if file == "config.cpp":
+            path_config = os.path.join(root, file)
+            with open(path_config, "r", encoding="utf-8") as f:
+                content = f.read()
+            if (bool(re.search(token_from,content))):
+                print(f"- Replacing {token_from} in {path_config}")
+                content = re.sub(token_from, token_to, content)
+                with open(path_config, "w", encoding="utf-8") as f:
+                    f.write(content)
+                path_toml = os.path.join(root, "addon.toml")
+                os.remove(path_toml)
+
+print(f"--- Removed all has_includes from project ---")


### PR DESCRIPTION
just for hemtt no bin build
Converts all addons so they are fully buildable/lintable by hemtt
Clears "has_include" and "[rapify] enabled = false"
allows hemtt to lint all of ace_medical*

the new "binned" hemtt build action is untouched