### PR TITLE
NightVision - Draw under HUD (requires 2.16)

### DIFF
--- a/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
+++ b/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
@@ -51,11 +51,7 @@ if (GVAR(fogScaling) > 0) then {
 // Note: Using BIS_fnc_rscLayer because of bug with string syntax - https://feedback.bistudio.com/T120768
 (QGVAR(display) call BIS_fnc_rscLayer) cutText ["", "PLAIN"]; // Cleanup Old Display
 if (_activated) then { // Create New Display
-    if (productVersion select 2 > 214) then { // TODO remove block after 2.16 release
-        (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false, false]; // draw under HUD
-    } else {
-        (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false];
-    };
+    (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false, false]; // draw under HUD
 };
 
 // Cleanup Old PP Effects

--- a/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
+++ b/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
@@ -51,7 +51,11 @@ if (GVAR(fogScaling) > 0) then {
 // Note: Using BIS_fnc_rscLayer because of bug with string syntax - https://feedback.bistudio.com/T120768
 (QGVAR(display) call BIS_fnc_rscLayer) cutText ["", "PLAIN"]; // Cleanup Old Display
 if (_activated) then { // Create New Display
-    (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false];
+    if (productVersion select 2 > 214) then { // TODO remove block after 2.16 release
+        (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false, false]; // draw under HUD
+    } else {
+        (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false];
+    };
 };
 
 // Cleanup Old PP Effects


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #6819
- Require Arma 3 v2.16 to have effect (backwards-compatible implementation)

Thanks to BI @Leopard20 for implementing [`cutRsc`](https://community.bistudio.com/wiki/cutRsc) `drawOverHUD` parameter!

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
