### PR TITLE
Refuel - Fix infinite recursion for `getCapacity` on a non-CfgVehicle

### DIFF
--- a/addons/refuel/functions/fnc_getCapacity.sqf
+++ b/addons/refuel/functions/fnc_getCapacity.sqf
@@ -30,7 +30,7 @@ if (isNil "_capacity") then {
     // Set capacity even if this isn't a fuel source to save on config lookup time in the event this function is used in a loop
     _source setVariable [QGVAR(capacity), _capacity, true];
     // handle weird edge case when trying to run on "camera"/CfgNonAIVehicles which won't support setVariable and will inf-loop
-    if (isNil {_source getVariable QGVAR(capacity)}) exitWith {};
+    if (isNil {_source getVariable QGVAR(capacity)}) exitWith { WARNING_1("trying to getCapacity from non-CfgVehicle %1", _this); };
     [_source, _capacity] call FUNC(setFuel);
 };
 

--- a/addons/refuel/functions/fnc_getCapacity.sqf
+++ b/addons/refuel/functions/fnc_getCapacity.sqf
@@ -29,6 +29,8 @@ if (isNil "_capacity") then {
     
     // Set capacity even if this isn't a fuel source to save on config lookup time in the event this function is used in a loop
     _source setVariable [QGVAR(capacity), _capacity, true];
+    // handle weird edge case when trying to run on "camera"/CfgNonAIVehicles which won't support setVariable and will inf-loop
+    if (isNil {_source getVariable QGVAR(capacity)}) exitWith {};
     [_source, _capacity] call FUNC(setFuel);
 };
 


### PR DESCRIPTION
Fix #9620
handle weird edge case when trying to run on "camera"/CfgNonAIVehicles which won't support setVariable and will inf-loop

getCapacity calls setFuel
setFuel calls getCapacity
normally works fine but some objects don't support setVariable and cause infinity loop
e.g. `"camera" camCreate (getpos player)`

I took out the warning because it was just getting spammed by the mod but I could leave it in
```
[ACE] (refuel) WARNING: trying to getCapacity from non-CfgVehicle [164071: honeybee.p3d]
[ACE] (refuel) WARNING: trying to getCapacity from non-CfgVehicle [164077: cl_leaf3.p3d]
[ACE] (refuel) WARNING: trying to getCapacity from non-CfgVehicle [82674: t_ficusb1s_f.p3d]
```

