### PR TITLE
Attach - Add config property to set object orientation

### DIFF
--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -115,9 +115,8 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
                 private _dir = (positionCameraToWorld [0,0,1]) vectorFromTo (positionCameraToWorld [0,0,0]);
                 private _angle = asin (_dir select 2);
 
-                // default for current ACE attach behaviour is 90deg rotation in yaw, so setting defaults to that to not break backwards compatibility
+                // Tranform yaw/roll angle to vector, defaults are pre-#9623 behavior
                 _itemModelOrientation params [["_roll", 0], ["_yaw", 90]];
-                // do rotation for how the model should be oriented in roll and yaw, and then in pitch for the view angle
                 private _dirAndUp = [[[0,1,0], [0,0,1]], _yaw, 0, _roll] call BIS_fnc_transformVectorDirAndUp;
                 private _dirAndUp = [_dirAndUp, 0, _angle, 0] call BIS_fnc_transformVectorDirAndUp;
                 ((uiNamespace getVariable [QGVAR(virtualAmmoDisplay), displayNull]) displayCtrl 800851) ctrlSetModelDirAndUp _dirAndUp;

--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -26,13 +26,20 @@ if ((_itemClassname == "") || {(!_silentScripted) && {!(_this call FUNC(canAttac
 
 private _itemVehClass = getText (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_Attachable");
 private _onAttachText = getText (configFile >> "CfgWeapons" >> _itemClassname >> "displayName");
+private _itemModelOrientation = getArray (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_attachable_orientation");
 
 if (_itemVehClass == "") then {
     _itemVehClass = getText (configFile >> "CfgMagazines" >> _itemClassname >> "ACE_Attachable");
     _onAttachText = getText (configFile >> "CfgMagazines" >> _itemClassname >> "displayName");
+    _itemModelOrientation = getArray (configFile >> "CfgWeapons" >> _itemClassname >> "ACE_attachable_orientation");
 };
 
 if (_itemVehClass == "") exitWith {ERROR("no ACE_Attachable for Item");};
+
+// If orientation is not set in config, use default [1,0,0]
+if (count _itemModelOrientation < 3) then {
+    _itemModelOrientation = [1,0,0];
+};
 
 private _onAttachText = format [localize LSTRING(Item_Attached), _onAttachText];
 
@@ -68,7 +75,7 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
 
     [{
         params ["_args","_idPFH"];
-        _args params ["_unit","_attachToVehicle","_itemClassname","_itemVehClass","_onAttachText","_actionID"];
+        _args params ["_unit","_attachToVehicle","_itemClassname","_itemVehClass","_onAttachText","_actionID", "_itemModelOrientation"];
 
         private _virtualPosASL = (eyePos _unit) vectorAdd (positionCameraToWorld [0,0,0.6]) vectorDiff (positionCameraToWorld [0,0,0]);
         if (cameraView == "EXTERNAL") then {
@@ -95,7 +102,7 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
             (QGVAR(virtualAmmo) call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
 
             if (GVAR(placeAction) == PLACE_APPROVE) then {
-                [_unit, _attachToVehicle, _itemClassname, _itemVehClass, _onAttachText, _virtualPos] call FUNC(placeApprove);
+                [_unit, _attachToVehicle, _itemClassname, _itemVehClass, _onAttachText, _virtualPos, _itemModelOrientation] call FUNC(placeApprove);
             };
         } else {
             //Show the virtual object:
@@ -113,8 +120,8 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
                 private _dir = (positionCameraToWorld [0,0,1]) vectorFromTo (positionCameraToWorld [0,0,0]);
                 private _angle = asin (_dir select 2);
                 private _up = [0, cos _angle, sin _angle];
-                ((uiNamespace getVariable [QGVAR(virtualAmmoDisplay), displayNull]) displayCtrl 800851) ctrlSetModelDirAndUp [[1,0,0], _up];
+                ((uiNamespace getVariable [QGVAR(virtualAmmoDisplay), displayNull]) displayCtrl 800851) ctrlSetModelDirAndUp [_itemModelOrientation, _up];
             };
         };
-    }, 0, [_unit, _attachToVehicle, _itemClassname, _itemVehClass, _onAttachText, _actionID]] call CBA_fnc_addPerFrameHandler;
+    }, 0, [_unit, _attachToVehicle, _itemClassname, _itemVehClass, _onAttachText, _actionID, _itemModelOrientation]] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -94,11 +94,11 @@ _endPosTestOffset set [2, (_startingOffset select 2)];
 private _attachedObject = _itemVehClass createVehicle (getPos _unit);
 _attachedObject attachTo [_attachToVehicle, _endPosTestOffset];
 
-// get wanted orientation if any is set
+// Get wanted orientation if any is set
 _itemModelOrientation params [["_roll", 0], ["_yaw", 90]];
 private _dirAndUp = [[[0,1,0],[0,0,1]], -_yaw, 0, _roll] call BIS_fnc_transformVectorDirAndUp;
 
-// transform dir and up vector from player model to world, then to model-space of _attachToVehicle
+// Transform dir and up vector from player model to world, then to model-space of _attachToVehicle
 private _dir = _unit vectorModelToWorldVisual _dirAndUp#0;
 _dir = _attachToVehicle vectorWorldToModelVisual _dir; 
 

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -15,6 +15,7 @@
  * 3: Light Vehicle Classname <STRING>
  * 4: On Attach Text <STRING>
  * 5: Starting Pos of dummy item <ARRAY>
+ * 5: Orientation of model <ARRAY>
  *
  * Return Value:
  * None
@@ -25,7 +26,7 @@
  * Public: No
  */
 
-params ["_unit", "_attachToVehicle", "_itemClassname", "_itemVehClass", "_onAttachText", "_startingPosition"];
+params ["_unit", "_attachToVehicle", "_itemClassname", "_itemVehClass", "_onAttachText", "_startingPosition", "_itemModelOrientation"];
 TRACE_6("params",_unit,_attachToVehicle,_itemClassname,_itemVehClass,_onAttachText,_startingPosition);
 
 private _startingOffset = _attachToVehicle worldToModel _startingPosition;
@@ -92,6 +93,13 @@ private _endPosTestOffset = _startingOffset vectorAdd (_closeInUnitVector vector
 _endPosTestOffset set [2, (_startingOffset select 2)];
 private _attachedObject = _itemVehClass createVehicle (getPos _unit);
 _attachedObject attachTo [_attachToVehicle, _endPosTestOffset];
+
+// Convert dir from player perspective to world, then to attached object space
+_itemModelOrientation = _unit vectorModelToWorldVisual _itemModelOrientation;
+_itemModelOrientation = _attachToVehicle vectorWorldToModelVisual _itemModelOrientation;
+_attachedObject setVectorDirAndUp [_itemModelOrientation, vectorUp _attachedObject];
+// call pos set, to sync direction across MP
+_attachedObject setPosWorld getPosWorld _attachedObject;
 
 //Remove Item from inventory
 _unit removeItem _itemClassname;

--- a/addons/attach/functions/fnc_placeApprove.sqf
+++ b/addons/attach/functions/fnc_placeApprove.sqf
@@ -94,12 +94,18 @@ _endPosTestOffset set [2, (_startingOffset select 2)];
 private _attachedObject = _itemVehClass createVehicle (getPos _unit);
 _attachedObject attachTo [_attachToVehicle, _endPosTestOffset];
 
-// Convert dir from player perspective to world, then to attached object space
-_itemModelOrientation = _unit vectorModelToWorldVisual _itemModelOrientation;
-_itemModelOrientation = _attachToVehicle vectorWorldToModelVisual _itemModelOrientation;
-_attachedObject setVectorDirAndUp [_itemModelOrientation, vectorUp _attachedObject];
-// call pos set, to sync direction across MP
-_attachedObject setPosWorld getPosWorld _attachedObject;
+// get wanted orientation if any is set
+_itemModelOrientation params [["_roll", 0], ["_yaw", 90]];
+private _dirAndUp = [[[0,1,0],[0,0,1]], -_yaw, 0, _roll] call BIS_fnc_transformVectorDirAndUp;
+
+// transform dir and up vector from player model to world, then to model-space of _attachToVehicle
+private _dir = _unit vectorModelToWorldVisual _dirAndUp#0;
+_dir = _attachToVehicle vectorWorldToModelVisual _dir; 
+
+private _up = _unit vectorModelToWorldVisual _dirAndUp#1;
+_up = _attachToVehicle vectorWorldToModelVisual _up;
+
+_attachedObject setVectorDirAndUp [_dir, _up];
 
 //Remove Item from inventory
 _unit removeItem _itemClassname;

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -85,7 +85,7 @@ You can then register the listener in ``CfgEventHandlers``:
 ```cpp
 class Extended_InitPost_Eventhandlers {
 	class new_attachable_item_classname {
-	 	init = QUOTE( _this call FUNC(initEvent));
+	 	init = QUOTE(_this call FUNC(initEvent));
 	};
 };
 ```

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -39,15 +39,15 @@ class CfgVehicles {
 ```
 
 ### 1.2 Define attach orientation for non-symmetric items
-In the case the item needs to have a particular orientation when attached, add the config value: ``ACE_attachable_orientation`` which is an array describing the ``vectorDir`` orientation of the object.  
-The default value is: ``[1,0,0]``. 
+In the case the item needs to have a particular orientation when attached, add the config value: ``ace_attach_orientation`` which is an array describing the ``roll`` and ``yaw`` orientation of the object.  
+The default value is: ``[0,0]``. 
 
 Example: 
 ```cpp
 class CfgWeapons {
     class attach_item: CBA_MiscItem {
         ACE_attachable = "new_attachable_item_classname";
-        ACE_attachable_orientation[] = {-1,0,0};
+        ace_attach_orientation[] = {0,180}; // 180deg yaw
     };
 };
 ```
@@ -91,4 +91,5 @@ class Extended_InitPost_Eventhandlers {
 ```
 
 Make sure that the classname you are listening to is the one defined in ``CfgVehicles`` as this is the physical item that gets created when attached.   
+
 **NOTE:** If attaching the object to yourself, as a player, then the init event will be rerun everytime you leave a vehicle, as ACE Attach system will remove and re-add player attached items whenever they enter and leave vehicles.   

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -15,28 +15,23 @@ version:
 ## 1. Config Values
 ### 1.1 Make item attachable
 
-An item can be added to ACEs "Attach to Vehicle" and "Attach to Self" system by adding the following config value to the ``CfgWeapons`` or ``CfgMagazines`` configs:
+An item can be added to the ACE Attach framework by adding the ``ACE_attachable``` property to a class in ``CfgWeapons`` or ``CfgMagazines``. The value must be the classname of a valid class in ``CfgVehicles``:
 ```cpp
 class CfgWeapons {
     class attach_item: CBA_MiscItem {
         ACE_attachable = "new_attachable_item_classname";
     };
 };
-```
 
-The classname in ``ACE_attachable`` has to match a config value in ``CfgVehicle`` which to be able to spawn the physical item in the world. Example:
-```cpp
 class CfgVehicles {
     class ThingX;
-	// The object that gets created and attached in ACE
     class new_attachable_item_classname: ThingX {
-        scope = HIDDEN;
+        scope = 1; // Should be 1 (private) or 2 (public), scope 0 will cause errors on object creation
         displayName = "New ACE attachable item";
-        model = QPATHTOF(data\model_file.p3d);
+        model = "\path\to\my\model.p3d";
 		vehicleClass = "";
     };
 };
-```
 
 ### 1.2 Define attach orientation for non-symmetric items
 In the case the item needs to have a particular orientation when attached, add the config value: ``ace_attach_orientation`` which is an array describing the ``roll`` and ``yaw`` orientation of the object.  
@@ -53,13 +48,11 @@ class CfgWeapons {
 ```
 
 ## 2. Event Handlers
-### 2.1 Attach Events   
-Attach system have certain events for attaching and detatching you can listen to:  
-
+### 2.1 Listenable Events   
 | Event Key | Parameters | Locality | Type | Description |
 |----------|---------|---------|---------|---------|---------|
-|`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | After an item was attached to a unit/vehicle. _temporary flag means a item is being re-attached after the player exits a vehicle
-|`ace_attach_detaching` | [_attachedObject, _itemName, _temporary] | Local | Listen | Just before an item gets detached/removed from a unit/vehicle. _temporary flag means its detached because the player unit entered a vehicle.
+|`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | Called after an item is attached to an object. `_temporary` flag means the item is being re-attached (after a unit is exiting a vehicle, for example)
+|`ace_attach_detaching` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | Called just before an item is detached/removed from an object. `_temporary` flag means the item will be reattached later, see above.
 
 
 ### 2.2 Init event for newly attached objects

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -55,35 +55,5 @@ class CfgWeapons {
 |`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Called after an item is attached to an object. `_temporary` flag means the item is being re-attached (after a unit is exiting a vehicle, for example)
 |`ace_attach_detaching` | [_attachedObject, _itemClassname, _temporary] | Local | Called just before an item is detached/removed from an object. `_temporary` flag means the item will be reattached later, see above.
 
-
-### 2.2 Init event for newly attached objects
-If you wish to listen to the ``postInit`` event of the physical object that gets attached after its created and attached, use ``CBA_Extended_EventHandlers`` in the ``CfgVehicles`` config of your new item:
-```cpp
-class CBA_Extended_EventHandlers_base;
-class CfgVehicles {
-    class ThingX;
-	// The object that gets created and attached in ACE
-    class new_attachable_item_classname: ThingX {
-        scope = HIDDEN;
-        displayName = "New ACE attachable item";
-        model = QPATHTOF(data\model_file.p3d);
-		vehicleClass = "";
-        
-        class EventHandlers {
-            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers_base {};
-        };
-    };
-};
-```
-You can then register the listener in ``CfgEventHandlers``:
-```cpp
-class Extended_InitPost_Eventhandlers {
-	class new_attachable_item_classname {
-	 	init = QUOTE(_this call FUNC(initEvent));
-	};
-};
-```
-
-Make sure that the classname you are listening to is the one defined in ``CfgVehicles`` as this is the physical item that gets created when attached.   
-
-**NOTE:** If attaching the object to yourself, as a player, then the init event will be rerun everytime you leave a vehicle, as ACE Attach system will remove and re-add player attached items whenever they enter and leave vehicles.   
+### 2.2 Other events for attached objects
+Use [CBA Extended Event Handlers](https://github.com/CBATeam/CBA_A3/wiki/Extended-Event-Handlers-(new)). Note that objects attached to units will be deleted/created upon entering/exiting vehicles and should be handled accordingly.

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -15,7 +15,7 @@ version:
 ## 1. Config Values
 ### 1.1 Make item attachable
 
-An item can be added to the ACE Attach framework by adding the ``ACE_attachable``` property to a class in ``CfgWeapons`` or ``CfgMagazines``. The value must be the classname of a valid class in ``CfgVehicles``:
+An item can be added to the ACE Attach framework by adding the ``ACE_attachable`` property to a class in ``CfgWeapons`` or ``CfgMagazines``. The value must be the classname of a valid class in ``CfgVehicles``:
 ```cpp
 class CfgWeapons {
     class attach_item: CBA_MiscItem {
@@ -32,6 +32,7 @@ class CfgVehicles {
 		vehicleClass = "";
     };
 };
+```
 
 ### 1.2 Define attach orientation for non-symmetric items
 In the case the item needs to have a particular orientation when attached, add the config value: ``ace_attach_orientation`` which is an array describing the ``roll`` and ``yaw`` orientation of the object.  
@@ -49,10 +50,10 @@ class CfgWeapons {
 
 ## 2. Event Handlers
 ### 2.1 Listenable Events   
-| Event Key | Parameters | Locality | Type | Description |
+| Event Key | Parameters | Locality | Description |
 |----------|---------|---------|---------|---------|---------|
-|`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | Called after an item is attached to an object. `_temporary` flag means the item is being re-attached (after a unit is exiting a vehicle, for example)
-|`ace_attach_detaching` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | Called just before an item is detached/removed from an object. `_temporary` flag means the item will be reattached later, see above.
+|`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Called after an item is attached to an object. `_temporary` flag means the item is being re-attached (after a unit is exiting a vehicle, for example)
+|`ace_attach_detaching` | [_attachedObject, _itemClassname, _temporary] | Local | Called just before an item is detached/removed from an object. `_temporary` flag means the item will be reattached later, see above.
 
 
 ### 2.2 Init event for newly attached objects

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -1,7 +1,7 @@
 ---
 layout: wiki
 title: Attach Framework
-description: Explains how to add items to ACE's Attach system.
+description: Explains how to add items to the ACE Attach Framework.
 group: framework
 order: 0
 parent: wiki

--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -1,0 +1,94 @@
+---
+layout: wiki
+title: Attach Framework
+description: Explains how to add items to ACE's Attach system.
+group: framework
+order: 0
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 17
+  patch: 0
+---
+
+## 1. Config Values
+### 1.1 Make item attachable
+
+An item can be added to ACEs "Attach to Vehicle" and "Attach to Self" system by adding the following config value to the ``CfgWeapons`` or ``CfgMagazines`` configs:
+```cpp
+class CfgWeapons {
+    class attach_item: CBA_MiscItem {
+        ACE_attachable = "new_attachable_item_classname";
+    };
+};
+```
+
+The classname in ``ACE_attachable`` has to match a config value in ``CfgVehicle`` which to be able to spawn the physical item in the world. Example:
+```cpp
+class CfgVehicles {
+    class ThingX;
+	// The object that gets created and attached in ACE
+    class new_attachable_item_classname: ThingX {
+        scope = HIDDEN;
+        displayName = "New ACE attachable item";
+        model = QPATHTOF(data\model_file.p3d);
+		vehicleClass = "";
+    };
+};
+```
+
+### 1.2 Define attach orientation for non-symmetric items
+In the case the item needs to have a particular orientation when attached, add the config value: ``ACE_attachable_orientation`` which is an array describing the ``vectorDir`` orientation of the object.  
+The default value is: ``[1,0,0]``. 
+
+Example: 
+```cpp
+class CfgWeapons {
+    class attach_item: CBA_MiscItem {
+        ACE_attachable = "new_attachable_item_classname";
+        ACE_attachable_orientation[] = {-1,0,0};
+    };
+};
+```
+
+## 2. Event Handlers
+### 2.1 Attach Events   
+Attach system have certain events for attaching and detatching you can listen to:  
+
+| Event Key | Parameters | Locality | Type | Description |
+|----------|---------|---------|---------|---------|---------|
+|`ace_attach_attached` | [_attachedObject, _itemClassname, _temporary] | Local | Listen | After an item was attached to a unit/vehicle. _temporary flag means a item is being re-attached after the player exits a vehicle
+|`ace_attach_detaching` | [_attachedObject, _itemName, _temporary] | Local | Listen | Just before an item gets detached/removed from a unit/vehicle. _temporary flag means its detached because the player unit entered a vehicle.
+
+
+### 2.2 Init event for newly attached objects
+If you wish to listen to the ``postInit`` event of the physical object that gets attached after its created and attached, use ``CBA_Extended_EventHandlers`` in the ``CfgVehicles`` config of your new item:
+```cpp
+class CBA_Extended_EventHandlers_base;
+class CfgVehicles {
+    class ThingX;
+	// The object that gets created and attached in ACE
+    class new_attachable_item_classname: ThingX {
+        scope = HIDDEN;
+        displayName = "New ACE attachable item";
+        model = QPATHTOF(data\model_file.p3d);
+		vehicleClass = "";
+        
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers_base {};
+        };
+    };
+};
+```
+You can then register the listener in ``CfgEventHandlers``:
+```cpp
+class Extended_InitPost_Eventhandlers {
+	class new_attachable_item_classname {
+	 	init = QUOTE( _this call FUNC(initEvent));
+	};
+};
+```
+
+Make sure that the classname you are listening to is the one defined in ``CfgVehicles`` as this is the physical item that gets created when attached.   
+**NOTE:** If attaching the object to yourself, as a player, then the init event will be rerun everytime you leave a vehicle, as ACE Attach system will remove and re-add player attached items whenever they enter and leave vehicles.   


### PR DESCRIPTION
**When merged this pull request will:**
Add an optional parameter to config for item attach system that describes the item's orientation. This allows to make custom items that are not symmetric and define when attached to vehicles what side should be "outwards". 

This came about while I was looking into what I could do to make my custom item be oriented the right way when used with ACE attach system. If this doesn't fit or it's a bad way to solve the problem feel free to close the PR. I could probably solve this by applying the same orientation change in my own mod by listening to the ``ace_attach_attached`` event, but thought it might make more sense to have the option in ACE. 

Parameter added for config is:
```
ACE_attachable_orientation[] = {0,-1,0};
```
So config in the example video becomes: 
```hpp
class crowsew_ctrack: CBA_MiscItem {
	displayName = "C-TRACK (3km)";
	descriptionShort = "Tracking device that can be put on objects to make them trackable with spectrum device";
	model = QPATHTOF(data\c_track\c_track.p3d);
	picture = QPATHTOF(data\c_track\ctrack_picture_ca.paa);
	icon = QPATHTOF(data\c_track\ctrack_icon_ca.paa);
	ACE_attachable = "crowsew_ctrack_effect_3km";
	ACE_attachable_orientation[] = {0,-1,0};
};
```

Example:
Video of current attach system for a non-symmetric custom item:

https://github.com/acemod/ACE3/assets/7889925/3e6adcf5-8fd7-4c35-9d00-7ccec0d56669  

Video of new behaviour with the config attribute:

https://github.com/acemod/ACE3/assets/7889925/e89aace0-3bd8-4238-9ddf-30e93b355a97  

