### PR TITLE
Interaction - Add crew status check for some vehicle interactions

### DIFF
--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -81,7 +81,8 @@ GVAR(vehicleAction) = [
         {locked _target < 2} &&
         {([_player, _target] call EFUNC(interaction,getInteractionDistance)) < MAX_LOAD_DISTANCE} &&
         {alive _target} &&
-        {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)}
+        {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)} &&
+        {[_player, _target] call EFUNC(interaction,canInteractWithVehicleCrew)}
     }
 ] call EFUNC(interact_menu,createAction);
 
@@ -99,6 +100,7 @@ GVAR(objectActions) = [
             {(_target getVariable [QGVAR(canLoad), getNumber (configOf _target >> QGVAR(canLoad))]) in [true, 1]} &&
             {alive _target} &&
             {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)} &&
+            {[_player, _target] call EFUNC(interaction,canInteractWithVehicleCrew)} &&
             {(_target getVariable [QGVAR(noRename), getNumber (configOf _target >> QGVAR(noRename))]) in [false, 0]}
         }
     ] call EFUNC(interact_menu,createAction),
@@ -114,6 +116,7 @@ GVAR(objectActions) = [
             {locked _target < 2} &&
             {alive _target} &&
             {[_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)} &&
+            {[_player, _target] call EFUNC(interaction,canInteractWithVehicleCrew)} &&
             {((nearestObjects [_target, GVAR(cargoHolderTypes), (MAX_LOAD_DISTANCE + 10)]) findIf {
                 private _hasCargoConfig = 1 == getNumber (configOf _x >> QGVAR(hasCargo));
                 private _hasCargoPublic = _x getVariable [QGVAR(hasCargo), false];

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -14,6 +14,7 @@ PREP(hideMouseHint);
 
 // interaction with units
 PREP(canInteractWithCivilian);
+PREP(canInteractWithVehicleCrew);
 PREP(getDown);
 PREP(sendAway);
 PREP(canJoinGroup);

--- a/addons/interaction/functions/fnc_addPassengersActions.sqf
+++ b/addons/interaction/functions/fnc_addPassengersActions.sqf
@@ -6,65 +6,68 @@
  * Arguments:
  * 0: Vehicle <OBJECT>
  * 1: Player <OBJECT>
- * 3: Parameters <ARRAY>
+ * 2: Parameters <ARRAY>
  *
  * Return Value:
  * Children actions <ARRAY>
  *
  * Example:
- * [target, player, [params]] call ace_interaction_fnc_addPassengersActions
+ * [cursorObject, player, [params]] call ace_interaction_fnc_addPassengersActions
  *
  * Public: No
  */
 
 params ["_vehicle", "_player"];
 
+// If player is not in vehicle and the crew is hostile, do not show any actions
+if !(_player in _vehicle || {[_player, _vehicle] call FUNC(canInteractWithVehicleCrew)}) exitWith {
+    [] // return
+};
+
 private _actions = [];
+private _icon = "";
 
 {
-    private _unit = _x;
+    _x params ["_unit", "_role"];
 
-    if (_unit != _player && {getText (configOf _unit >> "simulation") != "UAVPilot"}) then {
-        private _icon = [
-            "",
-            "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_driver_ca.paa",
-            "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_gunner_ca.paa",
-            "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_commander_ca.paa"
-        ] select (([driver _vehicle, gunner _vehicle, commander _vehicle] find _unit) + 1);
+    _icon = [
+        "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_driver_ca.paa",
+        "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_gunner_ca.paa",
+        "A3\ui_f\data\IGUI\RscIngameUI\RscUnitInfo\role_commander_ca.paa",
+        ""
+    ] select (["driver", "gunner", "commander"] find _role);
 
-        if (_unit getVariable [QEGVAR(captives,isHandcuffed), false]) then {
-            _icon = QPATHTOEF(captives,UI\handcuff_ca.paa);
-        };
-
-        _actions pushBack [
-            [
-                format ["%1", _unit],
-                [_unit, true] call EFUNC(common,getName),
-                [_icon, "#FFFFFF"],
-                {
-                    //statement (Run on hover) - reset the cache so we will insert actions immedietly when hovering over new unit
-                    TRACE_2("Cleaning Cache",_target,vehicle _target);
-                    [vehicle _target, QEGVAR(interact_menu,ATCache_ACE_SelfActions)] call EFUNC(common,eraseCache);
-                },
-                {true},
-                {
-                    if (EGVAR(interact_menu,selectedTarget) isEqualTo _target) then {
-                        _this call FUNC(addPassengerActions)
-                    } else {
-                        [] //not selected, don't waste time on actions
-                    };
-                },
-                [_unit],
-                {[0, 0, 0]},
-                2,
-                [false,false,false,true,false], //add run on hover (4th bit true)
-                {if (["ace_medical_gui"] call EFUNC(common,isModLoaded)) then {call EFUNC(medical_gui,modifyActionTriageLevel)}}
-                ] call EFUNC(interact_menu,createAction),
-                [],
-                _unit
-            ];
+    if (_unit getVariable [QEGVAR(captives,isHandcuffed), false]) then {
+        _icon = QPATHTOEF(captives,UI\handcuff_ca.paa);
     };
-    false
-} count crew _vehicle;
+
+    _actions pushBack [
+        [
+            format ["%1", _unit],
+            [_unit, true] call EFUNC(common,getName),
+            [_icon, "#FFFFFF"],
+            {
+                // statement (Run on hover) - reset the cache so we will insert actions immediately when hovering over new unit
+                TRACE_2("Cleaning Cache",_target,objectParent _target);
+                [objectParent _target, QEGVAR(interact_menu,ATCache_ACE_SelfActions)] call EFUNC(common,eraseCache);
+            },
+            {true},
+            {
+                if (EGVAR(interact_menu,selectedTarget) isEqualTo _target) then {
+                    _this call FUNC(addPassengerActions)
+                } else {
+                    [] // not selected, don't waste time on actions
+                };
+            },
+            [_unit],
+            {[0, 0, 0]},
+            2,
+            [false, false, false, true, false], // add run on hover (4th bit true)
+            {if (["ace_medical_gui"] call EFUNC(common,isModLoaded)) then {call EFUNC(medical_gui,modifyActionTriageLevel)}}
+        ] call EFUNC(interact_menu,createAction),
+        [],
+        _unit
+    ];
+} forEach ((fullCrew _vehicle) select {_x select 0 != _player && {!unitIsUAV (_x select 0)}});
 
 _actions

--- a/addons/interaction/functions/fnc_canInteractWithVehicleCrew.sqf
+++ b/addons/interaction/functions/fnc_canInteractWithVehicleCrew.sqf
@@ -1,0 +1,26 @@
+#include "..\script_component.hpp"
+/*
+ * Author: johnb43
+ * Checks if a unit can interact with the vehicle crew inside.
+ *
+ * Arguments:
+ * 0: Player <OBJECT>
+ * 1: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * Unit can interact with vehicle crew <BOOL>
+ *
+ * Example:
+ * [cursorObject, player] call ace_interaction_fnc_canInteractWithVehicleCrew
+ *
+ * Public: No
+ */
+
+params ["_player", "_vehicle"];
+
+private _sidePlayer = side _player;
+
+((crew _vehicle) select {_x != _player && {!unitIsUAV _x}}) findIf { // ignore player and UAV units
+    // Units must all be unconscious, captive or friendly (side group is used in case unit is captive/unconscious) for actions to show up
+    !captive _x && {lifeState _x in ["HEALTHY", "INJURED"]} && {[_sidePlayer, side group _x] call BIS_fnc_sideIsEnemy}
+} == -1

--- a/addons/interaction/functions/fnc_canInteractWithVehicleCrew.sqf
+++ b/addons/interaction/functions/fnc_canInteractWithVehicleCrew.sqf
@@ -18,7 +18,7 @@
 
 params ["_player", "_vehicle"];
 
-private _sidePlayer = side _player;
+private _sidePlayer = side group _player;
 
 ((crew _vehicle) select {_x != _player && {!unitIsUAV _x}}) findIf { // ignore player and UAV units
     // Units must all be unconscious, captive or friendly (side group is used in case unit is captive/unconscious) for actions to show up

--- a/addons/interaction/functions/fnc_canInteractWithVehicleCrew.sqf
+++ b/addons/interaction/functions/fnc_canInteractWithVehicleCrew.sqf
@@ -18,9 +18,14 @@
 
 params ["_player", "_vehicle"];
 
+private _crew = crew _vehicle;
+
+// If vehicle is empty, quit
+if (_crew isEqualTo []) exitWith {true};
+
 private _sidePlayer = side group _player;
 
-((crew _vehicle) select {_x != _player && {!unitIsUAV _x}}) findIf { // ignore player and UAV units
+(_crew select {_x != _player && {!unitIsUAV _x}}) findIf { // ignore player and UAV units
     // Units must all be unconscious, captive or friendly (side group is used in case unit is captive/unconscious) for actions to show up
     !captive _x && {lifeState _x in ["HEALTHY", "INJURED"]} && {[_sidePlayer, side group _x] call BIS_fnc_sideIsEnemy}
 } == -1

--- a/addons/quickmount/config.cpp
+++ b/addons/quickmount/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common"};
+        requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Kingsley"};
         url = ECSTRING(main,URL);

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -32,8 +32,7 @@ GVAR(enabled)
 && {isNull getConnectedUAVUnit _unit}
 && {simulationEnabled _vehicle}
 && {
-    -1 == crew _vehicle findIf {alive _x}
-    || {0.6 <= side group _unit getFriend side group _vehicle}
+    [_unit, _vehicle] call EFUNC(interaction,canInteractWithVehicleCrew)
 }
 && {
     0.3 < vectorUp _vehicle select 2 // moveIn* and GetIn* don't work for flipped vehicles


### PR DESCRIPTION
**When merged this pull request will:**
- If one or more passengers in a vehicle are conscious, not captive and hostile to the interacting unit, interactions such as ACE passenger and cargo actions will not appear.
- Updated `FUNC(addPassengerActions)`. Using `objectParent` instead of `vehicle`.
- Addresses https://github.com/acemod/ACE3/pull/9618#issuecomment-1796694348.

I opted not to go with adding a condition for interacting via `EFUNC(common,addCanInteractWithCondition)`, as I don't want to impose this for all vehicle interactions.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
