### PR TITLE
Dragging - Fix being able to load people into vehicles from any distance

### DIFF
--- a/addons/cargo/functions/fnc_canLoadItemIn.sqf
+++ b/addons/cargo/functions/fnc_canLoadItemIn.sqf
@@ -28,7 +28,7 @@ if (_item isEqualType objNull && {{alive _x && {getText (configOf _x >> "simulat
 
 private _itemSize = [_item] call FUNC(getSizeItem);
 private _validItem = false;
-if (_item  isEqualType "") then {
+if (_item isEqualType "") then {
     _validItem =
         isClass (configFile >> "CfgVehicles" >> _item) &&
         {getNumber (configFile >> "CfgVehicles" >> _item >> QGVAR(canLoad)) == 1};

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -75,12 +75,10 @@ private _hintLMB = LLSTRING(Drop);
 getCursorObjectParams params ["_cursorObject", "", "_distance"];
 
 if (
-    !isNull _cursorObject &&
-    {_distance < MAX_LOAD_DISTANCE} &&
-    {[_unit, _cursorObject, ["isNotCarrying"]] call EFUNC(common,canInteractWith)} &&
+    !isNull _cursorObject && {[_unit, _cursorObject, ["isNotCarrying"]] call EFUNC(common,canInteractWith)} &&
     {
         if (_target isKindOf "CAManBase") then {
-            [_cursorObject, 0, true] call EFUNC(common,nearestVehiclesFreeSeat) isNotEqualTo []
+            (_distance <= MAX_LOAD_DISTANCE_MAN) && {[_cursorObject, 0, true] call EFUNC(common,nearestVehiclesFreeSeat) isNotEqualTo []}
         } else {
             ["ace_cargo"] call EFUNC(common,isModLoaded) &&
             {[_target, _cursorObject] call EFUNC(cargo,canLoadItemIn)}

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -79,7 +79,7 @@ if !(_target isKindOf "CAManBase") then {
 
 // Recreate UAV crew (add a frame delay or this may cause the vehicle to be moved to [0,0,0])
 if (_target getVariable [QGVAR(isUAV), false]) then {
-    [{  
+    [{
         params ["_target"];
         if (!alive _target) exitWith {};
         TRACE_2("restoring uav crew",_target,getPosASL _target);
@@ -97,11 +97,13 @@ if (_mass != 0) then {
 // Reset temp direction
 _target setVariable [QGVAR(carryDirection_temp), nil];
 
-private _cursorObject = cursorObject;
+getCursorObjectParams params ["_cursorObject", "", "_distance"];
 
 // Try loading into vehicle
 if (_tryLoad && {!isNull _cursorObject} && {[_unit, _cursorObject, ["isNotCarrying"]] call EFUNC(common,canInteractWith)}) then {
     if (_target isKindOf "CAManBase") then {
+        if (_distance > MAX_LOAD_DISTANCE_MAN) exitWith {};
+
         private _vehicles = [_cursorObject, 0, true] call EFUNC(common,nearestVehiclesFreeSeat);
 
         if ([_cursorObject] isEqualTo _vehicles) then {

--- a/addons/dragging/script_component.hpp
+++ b/addons/dragging/script_component.hpp
@@ -16,7 +16,7 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
-#define MAX_LOAD_DISTANCE 5
+#define MAX_LOAD_DISTANCE_MAN 5
 
 #define DRAG_ANIMATIONS ["amovpercmstpslowwrfldnon_acinpknlmwlkslowwrfldb_2", "amovpercmstpsraswpstdnon_acinpknlmwlksnonwpstdb_2", "amovpercmstpsnonwnondnon_acinpknlmwlksnonwnondb_2", "acinpknlmstpsraswrfldnon", "acinpknlmstpsnonwpstdnon", "acinpknlmstpsnonwnondnon", "acinpknlmwlksraswrfldb", "acinpknlmwlksnonwnondb", "ace_dragging_rifle_limpb", "ace_dragging", "ace_dragging_limpb", "ace_dragging_static", "ace_dragging_drop"]
 #define CARRY_ANIMATIONS ["acinpercmstpsnonwnondnon", "acinpknlmstpsnonwnondnon_acinpercmrunsnonwnondnon"]


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Remove distance checks for `cargo` loads as it's redundant due to `fnc_cargo_canLoadItemIn`
- Rename the distance define to indicate it's used only for "Man" loading, cargo has it's own one which had the same name

