### PR TITLE
Dragging - Fix being able to load cargo if the system is disabled

### DIFF
--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -83,6 +83,7 @@ if (
             [_cursorObject, 0, true] call EFUNC(common,nearestVehiclesFreeSeat) isNotEqualTo []
         } else {
             ["ace_cargo"] call EFUNC(common,isModLoaded) &&
+            {EGVAR(cargo,enable)} &&
             {[_target, _cursorObject] call EFUNC(cargo,canLoadItemIn)}
         }
     }

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -114,6 +114,7 @@ if (_tryLoad && {!isNull _cursorObject} && {[_unit, _cursorObject, ["isNotCarryi
     } else {
         if (
             ["ace_cargo"] call EFUNC(common,isModLoaded) &&
+            {EGVAR(cargo,enable)} &&
             {[_target, _cursorObject] call EFUNC(cargo,canLoadItemIn)}
         ) then {
             [_unit, _target, _cursorObject] call EFUNC(cargo,startLoadIn);


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Not sure if it should be in `fnc_cargo_canLoadItemIn` or directly in dragging, this implementation has least chance to break anything
- Whole dragging/carrying integration feels a bit spaghetti

Without the fix, if cargo is disabled you can load stuff in and you won't be able to get it back.