### PR TITLE
General/Medical - Lower inventory size for misc items

### DIFF
--- a/addons/artillerytables/CfgWeapons.hpp
+++ b/addons/artillerytables/CfgWeapons.hpp
@@ -10,7 +10,7 @@ class CfgWeapons {
         picture = QPATHTOF(UI\icon_rangeTable.paa);
         ACE_isTool = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 0.5;
+            mass = 0.1;
         };
     };
 };

--- a/addons/captives/CfgWeapons.hpp
+++ b/addons/captives/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
         picture = QPATHTOF(UI\ace_cabletie_ca.paa);
         scope = 2;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.3;
         };
     };
 };

--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -10,7 +10,7 @@ class CfgWeapons {
         picture = QPATHTOF(UI\ACE_earplugs_x_ca.paa);
         scope = 2;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.1;
         };
     };
 

--- a/addons/intelitems/CfgMagazines.hpp
+++ b/addons/intelitems/CfgMagazines.hpp
@@ -2,7 +2,7 @@ class CfgMagazines {
     class CA_Magazine;
     class GVAR(base): CA_Magazine {
         count = 1;
-        mass = 1;
+        mass = 0.1;
         ACE_isUnique = 1;
         GVAR(intel) = 1;
         GVAR(control) = "";

--- a/addons/maptools/CfgWeapons.hpp
+++ b/addons/maptools/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
         scope = 2;
         ACE_isTool = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.2;
         };
     };
 };

--- a/addons/medical_treatment/CfgWeapons.hpp
+++ b/addons/medical_treatment/CfgWeapons.hpp
@@ -31,7 +31,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Bandage_Basic_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.6;
         };
     };
     class ACE_packingBandage: ACE_ItemCore {
@@ -44,7 +44,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Packing_Bandage_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.6;
         };
     };
     class ACE_elasticBandage: ACE_ItemCore {
@@ -57,7 +57,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Bandage_Elastic_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.6;
         };
     };
     class ACE_tourniquet: ACE_ItemCore {
@@ -150,7 +150,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Plasma_IV_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 10;
+            mass = 7;
         };
     };
     class ACE_plasmaIV_500: ACE_plasmaIV {
@@ -158,7 +158,7 @@ class CfgWeapons {
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_plasma_500ml_ca.paa)};
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 5;
+            mass = 4;
         };
     };
     class ACE_plasmaIV_250: ACE_plasmaIV {
@@ -181,7 +181,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Blood_IV_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 10;
+            mass = 7;
         };
     };
     class ACE_bloodIV_500: ACE_bloodIV {
@@ -189,7 +189,7 @@ class CfgWeapons {
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_blood_500ml_ca.paa)};
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 5;
+            mass = 4;
         };
     };
     class ACE_bloodIV_250: ACE_bloodIV {
@@ -212,7 +212,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Saline_IV_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 10;
+            mass = 7;
         };
     };
     class ACE_salineIV_500: ACE_salineIV {
@@ -220,7 +220,7 @@ class CfgWeapons {
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_saline_500ml_ca.paa)};
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 5;
+            mass = 4;
         };
     };
     class ACE_salineIV_250: ACE_salineIV {
@@ -241,7 +241,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(QuikClot_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.5;
         };
     };
     class ACE_personalAidKit: ACE_ItemCore {

--- a/addons/medical_treatment/CfgWeapons.hpp
+++ b/addons/medical_treatment/CfgWeapons.hpp
@@ -150,7 +150,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Plasma_IV_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 7;
+            mass = 10;
         };
     };
     class ACE_plasmaIV_500: ACE_plasmaIV {
@@ -158,7 +158,7 @@ class CfgWeapons {
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_plasma_500ml_ca.paa)};
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 4;
+            mass = 5;
         };
     };
     class ACE_plasmaIV_250: ACE_plasmaIV {
@@ -181,7 +181,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Blood_IV_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 7;
+            mass = 10;
         };
     };
     class ACE_bloodIV_500: ACE_bloodIV {
@@ -189,7 +189,7 @@ class CfgWeapons {
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_blood_500ml_ca.paa)};
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 4;
+            mass = 5;
         };
     };
     class ACE_bloodIV_250: ACE_bloodIV {
@@ -212,7 +212,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(Saline_IV_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 7;
+            mass = 10;
         };
     };
     class ACE_salineIV_500: ACE_salineIV {
@@ -220,7 +220,7 @@ class CfgWeapons {
         model = QPATHTOF(data\IVBag_500ml.p3d);
         hiddenSelectionsTextures[] = {QPATHTOF(data\IVBag_saline_500ml_ca.paa)};
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 4;
+            mass = 5;
         };
     };
     class ACE_salineIV_250: ACE_salineIV {

--- a/addons/medical_treatment/CfgWeapons.hpp
+++ b/addons/medical_treatment/CfgWeapons.hpp
@@ -241,7 +241,7 @@ class CfgWeapons {
         descriptionUse = CSTRING(QuikClot_Desc_Use);
         ACE_isMedicalItem = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 0.5;
+            mass = 0.6;
         };
     };
     class ACE_personalAidKit: ACE_ItemCore {

--- a/addons/mk6mortar/CfgWeapons.hpp
+++ b/addons/mk6mortar/CfgWeapons.hpp
@@ -10,7 +10,7 @@ class CfgWeapons {
         picture = QPATHTOF(UI\icon_rangeTable.paa);
         ACE_isTool = 1;
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 0.5;
+            mass = 0.1;
         };
     };
 

--- a/addons/overheating/CfgMagazines.hpp
+++ b/addons/overheating/CfgMagazines.hpp
@@ -7,7 +7,7 @@ class CfgMagazines {
         descriptionshort = CSTRING(SpareBarrelDescription);
         picture = QUOTE(PATHTOF(UI\spare_barrel_ca.paa));
         count = 1;
-        mass = 60;
+        mass = 25;
         ACE_isUnique = 1;
     };
 };

--- a/addons/overheating/CfgWeapons.hpp
+++ b/addons/overheating/CfgWeapons.hpp
@@ -109,7 +109,7 @@ class CfgWeapons {
         descriptionshort = CSTRING(SpareBarrelDescription);
         picture = QUOTE(PATHTOF(UI\spare_barrel_ca.paa));
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 60;
+            mass = 25;
         };
     };
 };

--- a/addons/rangecard/CfgWeapons.hpp
+++ b/addons/rangecard/CfgWeapons.hpp
@@ -14,7 +14,7 @@ class CfgWeapons {
         ACE_isTool = 1;
 
         class ItemInfo: CBA_MiscItem_ItemInfo {
-            mass = 1;
+            mass = 0.1;
         };
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

In mass units:
- Cable Ties: 1 -> 0.3
- Range Cards/Artillery Tables: 1/0.5 -> 0.1
- Intel Items: 1 -> 0.1
- Ear Plugs: 1 -> 0.1
- Bandages: 1 -> 0.6
- Spare Barrel: 60 -> 25
~~- IVs: 2.5, 5, 10 -> 2.5, 4, 7 (reward carrying larger bags)~~ Reverted
