### PR TITLE
Interaction Menu - Show distance to target on vehicle actions

### DIFF
--- a/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
+++ b/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
@@ -23,10 +23,11 @@ params ["_vehicles", "_statement", "_target"];
 _vehicles apply {
     private _name = getText ((configOf _x) >> "displayName");
     private _ownerName = [_x, true] call EFUNC(common,getName);
+    private _distanceStr = (ACE_player distance _x) toFixed 1;
     if ("" != _ownerName) then {
-        _name = format ["%1 (%2, %3m)", _name, _ownerName, (ACE_player distance _x) toFixed 1];
+        _name = format ["%1 (%2, %3m)", _name, _ownerName, _distanceStr];
     } else {
-        _name = format ["%1 (%2m)", _name, (ACE_player distance _x) toFixed 1];
+        _name = format ["%1 (%2m)", _name, _distanceStr];
     };
     private _icon = [_x] call EFUNC(common,getVehicleIcon);
     private _action = [format ["%1", _x], _name, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);

--- a/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
+++ b/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
@@ -24,7 +24,7 @@ _vehicles apply {
     private _name = getText ((configOf _x) >> "displayName");
     private _ownerName = [_x, true] call EFUNC(common,getName);
     if ("" != _ownerName) then {
-        _name = format ["%1 (%2)", _name, _ownerName];
+        _name = format ["%1 (%2, %3m)", _name, _ownerName, (ACE_player distance _x) toFixed 1];
     } else {
         _name = format ["%1 (%2m)", _name, (ACE_player distance _x) toFixed 1];
     };

--- a/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
+++ b/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
@@ -25,6 +25,8 @@ _vehicles apply {
     private _ownerName = [_x, true] call EFUNC(common,getName);
     if ("" != _ownerName) then {
         _name = format ["%1 (%2)", _name, _ownerName];
+    } else {
+        _name = format ["%1 (%2m)", _name, (ACE_player distance _x) toFixed 1];
     };
     private _icon = [_x] call EFUNC(common,getVehicleIcon);
     private _action = [format ["%1", _x], _name, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);

--- a/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
+++ b/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
@@ -20,15 +20,18 @@
 
 params ["_vehicles", "_statement", "_target"];
 
+_vehicles = _vehicles apply {[_x distanceSqr _target, _x]};
+_vehicles sort true;
+
 _vehicles apply {
-    private _name = getText ((configOf _x) >> "displayName");
-    private _ownerName = [_x, true] call EFUNC(common,getName);
+    private _name = getText ((configOf (_x select 1)) >> "displayName");
+    private _ownerName = [_x select 1, true] call EFUNC(common,getName);
     if ("" != _ownerName) then {
         _name = format ["%1 (%2)", _name, _ownerName];
     } else {
-        _name = format ["%1 (%2m)", _name, (ACE_player distance _x) toFixed 1];
+        _name = format ["%1 (%2m)", _name, sqrt (_x select 0) toFixed 1];
     };
-    private _icon = [_x] call EFUNC(common,getVehicleIcon);
-    private _action = [format ["%1", _x], _name, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);
+    private _icon = [_x select 1] call EFUNC(common,getVehicleIcon);
+    private _action = [format ["%1", _x select 1], _name, _icon, _statement, {true}, {}, _x select 1] call EFUNC(interact_menu,createAction);
     [_action, [], _target]
 }

--- a/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
+++ b/addons/interact_menu/functions/fnc_createVehiclesActions.sqf
@@ -20,18 +20,15 @@
 
 params ["_vehicles", "_statement", "_target"];
 
-_vehicles = _vehicles apply {[_x distanceSqr _target, _x]};
-_vehicles sort true;
-
 _vehicles apply {
-    private _name = getText ((configOf (_x select 1)) >> "displayName");
-    private _ownerName = [_x select 1, true] call EFUNC(common,getName);
+    private _name = getText ((configOf _x) >> "displayName");
+    private _ownerName = [_x, true] call EFUNC(common,getName);
     if ("" != _ownerName) then {
         _name = format ["%1 (%2)", _name, _ownerName];
     } else {
-        _name = format ["%1 (%2m)", _name, sqrt (_x select 0) toFixed 1];
+        _name = format ["%1 (%2m)", _name, (ACE_player distance _x) toFixed 1];
     };
-    private _icon = [_x select 1] call EFUNC(common,getVehicleIcon);
-    private _action = [format ["%1", _x select 1], _name, _icon, _statement, {true}, {}, _x select 1] call EFUNC(interact_menu,createAction);
+    private _icon = [_x] call EFUNC(common,getVehicleIcon);
+    private _action = [format ["%1", _x], _name, _icon, _statement, {true}, {}, _x] call EFUNC(interact_menu,createAction);
     [_action, [], _target]
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Show distance to vehicle in action name for vehicle actions. See screenshot below.

![107410_20231111095245_1](https://github.com/acemod/ACE3/assets/69561145/0db82412-9919-4122-9186-4d53e67388b4)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
