### PR TITLE
Common - Use lifeState check in `FUNC(isAwake)`

### DIFF
--- a/addons/common/functions/fnc_isAwake.sqf
+++ b/addons/common/functions/fnc_isAwake.sqf
@@ -17,4 +17,4 @@
 
 params ["_unit"];
 
-alive _unit && {!(_unit getVariable ["ACE_isUnconscious", false])}
+lifeState _unit in ["HEALTHY", "INJURED"]


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

This is more reliable for non-ACE medical systems.