### PR TITLE
Repair - Use object with lowest damage for changing wheels/tracks

### DIFF
--- a/addons/repair/functions/fnc_getClaimObjects.sqf
+++ b/addons/repair/functions/fnc_getClaimObjects.sqf
@@ -7,6 +7,7 @@
  * 0: Unit that does the repairing <OBJECT>
  * 1: Max range to seach from unit (meters) <NUMBER>
  * 2: Array of arrays of classnames <ARRAY>
+ * 3: Sort objects by damage <BOOL> (default: false)
  *
  * Return Value:
  * Array of objects, or [] if not all available <ARRAY>
@@ -17,8 +18,8 @@
  * Public: Yes
  */
 
-params ["_unit", "_maxRange", "_objectsToClaim"];
-TRACE_3("params",_unit,_maxRange,_objectsToClaim);
+params ["_unit", "_maxRange", "_objectsToClaim", ["_sortByDamage", false]];
+TRACE_4("params",_unit,_maxRange,_objectsToClaim,_sortByDamage);
 
 private _return = [];
 
@@ -27,6 +28,11 @@ private _return = [];
     private _ableToAquire = []; //will be array of objects
     {
         private _nearObjects =  _unit nearEntities [_x, _maxRange];
+        if (_sortByDamage && {count _nearObjects > 1}) then {
+            _nearObjects = _nearObjects apply {[damage _x, _x]};
+            _nearObjects sort true;
+            _nearObjects = _nearObjects apply {_x select 1};
+        };
         {
             if (!(_x in _ableToAquire) && {(_x getVariable [QEGVAR(common,owner), objNull]) in [objNull, _unit]}) exitWith { // skip claimed objects
                 _ableToAquire pushBack _x

--- a/addons/repair/functions/fnc_repair.sqf
+++ b/addons/repair/functions/fnc_repair.sqf
@@ -95,7 +95,7 @@ if (!("All" in _repairLocations)) then {
 private _requiredObjects = getArray (_config >> "claimObjects");
 private _claimObjectsAvailable = [];
 if (_requiredObjects isNotEqualTo []) then {
-    _claimObjectsAvailable = [_caller, 5, _requiredObjects] call FUNC(getClaimObjects);
+    _claimObjectsAvailable = [_caller, 5, _requiredObjects, true] call FUNC(getClaimObjects);
     if (_claimObjectsAvailable isEqualTo []) then {
         TRACE_2("Missing Required Objects",_requiredObjects,_claimObjectsAvailable);
         _return = false


### PR DESCRIPTION
**When merged this pull request will:**
- Add param to `FUNC(getClaimObjects)` to sort objects by damage. Default false, `FUNC(canRepair)` only checks for object existence, actual repair sorts.

Better yet would be to choose which items are used for the repair IMO but that's another pile of scrap.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
