### PR TITLE
Arsenal - Fix `FUNC(removeVirtualItems)` for JIP players

### DIFF
--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -18,6 +18,15 @@ GVAR(lastSortDirectionRight) = DESCENDING;
 [QGVAR(removeDefaultLoadout), LINKFUNC(removeDefaultLoadout)] call CBA_fnc_addEventHandler;
 [QGVAR(renameDefaultLoadout), LINKFUNC(renameDefaultLoadout)] call CBA_fnc_addEventHandler;
 
+[QGVAR(refresh), {
+    params ["_object"];
+
+    // If the arsenal is already open, refresh arsenal display
+    if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {
+        [true, true] call FUNC(refresh);
+    };
+}] call CBA_fnc_addEventHandler;
+
 [QGVAR(broadcastFace), {
     params ["_unit", "_face"];
     _unit setFace _face;

--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -14,6 +14,8 @@ GVAR(lastSortDirectionRight) = DESCENDING;
 
 [QGVAR(initBox), LINKFUNC(initBox)] call CBA_fnc_addEventHandler;
 [QGVAR(removeBox), LINKFUNC(removeBox)] call CBA_fnc_addEventHandler;
+[QGVAR(addVirtualItems), LINKFUNC(addVirtualItems)] call CBA_fnc_addEventHandler;
+[QGVAR(removeVirtualItems), LINKFUNC(removeVirtualItems)] call CBA_fnc_addEventHandler;
 [QGVAR(addDefaultLoadout), LINKFUNC(addDefaultLoadout)] call CBA_fnc_addEventHandler;
 [QGVAR(removeDefaultLoadout), LINKFUNC(removeDefaultLoadout)] call CBA_fnc_addEventHandler;
 [QGVAR(renameDefaultLoadout), LINKFUNC(renameDefaultLoadout)] call CBA_fnc_addEventHandler;

--- a/addons/arsenal/XEH_postInit.sqf
+++ b/addons/arsenal/XEH_postInit.sqf
@@ -14,8 +14,6 @@ GVAR(lastSortDirectionRight) = DESCENDING;
 
 [QGVAR(initBox), LINKFUNC(initBox)] call CBA_fnc_addEventHandler;
 [QGVAR(removeBox), LINKFUNC(removeBox)] call CBA_fnc_addEventHandler;
-[QGVAR(addVirtualItems), LINKFUNC(addVirtualItems)] call CBA_fnc_addEventHandler;
-[QGVAR(removeVirtualItems), LINKFUNC(removeVirtualItems)] call CBA_fnc_addEventHandler;
 [QGVAR(addDefaultLoadout), LINKFUNC(addDefaultLoadout)] call CBA_fnc_addEventHandler;
 [QGVAR(removeDefaultLoadout), LINKFUNC(removeDefaultLoadout)] call CBA_fnc_addEventHandler;
 [QGVAR(renameDefaultLoadout), LINKFUNC(renameDefaultLoadout)] call CBA_fnc_addEventHandler;

--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -19,11 +19,6 @@
  * Public: Yes
 */
 
-// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
-if !(EGVAR(common,settingsInitFinished)) exitWith {
-    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addVirtualItems), _this];
-};
-
 params [["_object", objNull, [objNull]], ["_items", [], [true, []]], ["_global", false, [false]]];
 
 if (isNull _object || {_items isEqualTo []}) exitWith {};
@@ -130,6 +125,8 @@ if (_items isEqualType true) then {
 _object setVariable [QGVAR(virtualItems), _cargo, _global];
 
 // If the arsenal is already open, refresh arsenal display
-if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {
-    [true, true] call FUNC(refresh);
+if (_global) then {
+    [QGVAR(refresh), _object] call CBA_fnc_globalEvent;
+} else {
+    [QGVAR(refresh), _object] call CBA_fnc_localEvent;
 };

--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -28,19 +28,6 @@ params [["_object", objNull, [objNull]], ["_items", [], [true, []]], ["_global",
 
 if (isNull _object || {_items isEqualTo []}) exitWith {};
 
-if (_global) exitWith {
-    private _id = [QGVAR(addVirtualItems), [_object, _items]] call CBA_fnc_globalEventJIP;
-
-    [_id, _object] call CBA_fnc_removeGlobalEventJIP;
-
-    // FUNC(addVirtualItems) might be called multiple times on the same object
-    private _jipIDs = _object getVariable [QGVAR(addVirtualItemsJipIDs), []];
-
-    _jipIDs pushBack _id;
-
-    _object setVariable [QGVAR(addVirtualItemsJipIDs), _jipIDs];
-};
-
 private _cargo = _object getVariable QGVAR(virtualItems);
 
 if (isNil "_cargo") then {
@@ -140,7 +127,6 @@ if (_items isEqualType true) then {
     } forEach _items;
 };
 
-_object setVariable [QGVAR(virtualItems), _cargo];
 
 // If the arsenal is already open, refresh arsenal display
 if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {

--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -127,6 +127,7 @@ if (_items isEqualType true) then {
     } forEach _items;
 };
 
+_object setVariable [QGVAR(virtualItems), _cargo, _global];
 
 // If the arsenal is already open, refresh arsenal display
 if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {

--- a/addons/arsenal/functions/fnc_addVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_addVirtualItems.sqf
@@ -19,9 +19,27 @@
  * Public: Yes
 */
 
+// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
+if !(EGVAR(common,settingsInitFinished)) exitWith {
+    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addVirtualItems), _this];
+};
+
 params [["_object", objNull, [objNull]], ["_items", [], [true, []]], ["_global", false, [false]]];
 
 if (isNull _object || {_items isEqualTo []}) exitWith {};
+
+if (_global) exitWith {
+    private _id = [QGVAR(addVirtualItems), [_object, _items]] call CBA_fnc_globalEventJIP;
+
+    [_id, _object] call CBA_fnc_removeGlobalEventJIP;
+
+    // FUNC(addVirtualItems) might be called multiple times on the same object
+    private _jipIDs = _object getVariable [QGVAR(addVirtualItemsJipIDs), []];
+
+    _jipIDs pushBack _id;
+
+    _object setVariable [QGVAR(addVirtualItemsJipIDs), _jipIDs];
+};
 
 private _cargo = _object getVariable QGVAR(virtualItems);
 
@@ -122,7 +140,7 @@ if (_items isEqualType true) then {
     } forEach _items;
 };
 
-_object setVariable [QGVAR(virtualItems), _cargo, _global];
+_object setVariable [QGVAR(virtualItems), _cargo];
 
 // If the arsenal is already open, refresh arsenal display
 if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {

--- a/addons/arsenal/functions/fnc_attributeInit.sqf
+++ b/addons/arsenal/functions/fnc_attributeInit.sqf
@@ -23,15 +23,7 @@ TRACE_2("Initializing object with attribute",_object,_value);
 if (_mode > 0) then {
     // Blacklist: add full arsenal and take items away
     [_object, true, true] call FUNC(initBox);
-
-    // Need to delay removal by 2 frames
-    [{
-        [{
-            params ["_object", "_items"];
-
-            [_object, _items, true] call FUNC(removeVirtualItems);
-        }, _this] call CBA_fnc_execNextFrame;
-    }, [_object, _items]] call CBA_fnc_execNextFrame;
+    [_object, _items, true] call FUNC(removeVirtualItems);
 } else {
      // Exit on whitelist mode with no items
     if (_items isEqualTo []) exitWith {};

--- a/addons/arsenal/functions/fnc_attributeInit.sqf
+++ b/addons/arsenal/functions/fnc_attributeInit.sqf
@@ -23,7 +23,13 @@ TRACE_2("Initializing object with attribute",_object,_value);
 if (_mode > 0) then {
     // Blacklist: add full arsenal and take items away
     [_object, true, true] call FUNC(initBox);
-    [_object, _items, true] call FUNC(removeVirtualItems);
+
+    // Wait until all items have been added, so that the blacklisted items can be removed
+    [{
+        !isNil {(_this select 0) getVariable QGVAR(virtualItems)}
+    }, {
+        [_this select 0, _this select 1, true] call FUNC(removeVirtualItems);
+    }, [_object, _items], 20] call CBA_fnc_waitUntilAndExecute; // 20s timeout in case of failure
 } else {
      // Exit on whitelist mode with no items
     if (_items isEqualTo []) exitWith {};

--- a/addons/arsenal/functions/fnc_initBox.sqf
+++ b/addons/arsenal/functions/fnc_initBox.sqf
@@ -51,7 +51,10 @@ if (_global && {isMultiplayer} && {isNil {_object getVariable QGVAR(initBoxJIP)}
     ] call EFUNC(interact_menu,createAction);
     [_object, 0, ["ACE_MainActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
-    [_object, _items, false] call FUNC(addVirtualItems);
+    // If items were set globally, do not add items locally
+    if (isNil {_object getVariable QGVAR(virtualItems)}) then {
+        [_object, _items, false] call FUNC(addVirtualItems);
+    };
 
     [QGVAR(boxInitialized), [_object, _items]] call CBA_fnc_localEvent;
 };

--- a/addons/arsenal/functions/fnc_openBox.sqf
+++ b/addons/arsenal/functions/fnc_openBox.sqf
@@ -18,11 +18,6 @@
  * Public: Yes
 */
 
-// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
-if !(EGVAR(common,settingsInitFinished)) exitWith {
-    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(openBox), _this];
-};
-
 params [["_object", objNull, [objNull]], ["_center", objNull, [objNull]], ["_mode", false, [false]]];
 
 if (

--- a/addons/arsenal/functions/fnc_openBox.sqf
+++ b/addons/arsenal/functions/fnc_openBox.sqf
@@ -18,6 +18,11 @@
  * Public: Yes
 */
 
+// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
+if !(EGVAR(common,settingsInitFinished)) exitWith {
+    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(openBox), _this];
+};
+
 params [["_object", objNull, [objNull]], ["_center", objNull, [objNull]], ["_mode", false, [false]]];
 
 if (
@@ -28,13 +33,15 @@ if (
 ) exitWith {};
 
 // If object has no arsenal and chosen option is to not ignore virtual items of object, exit
-if (isNil {_object getVariable QGVAR(virtualItems)} && {!_mode}) exitWith {
+private _virtualItems = _object getVariable QGVAR(virtualItems);
+
+if (isNil "_virtualItems" && {!_mode}) exitWith {
     [LLSTRING(noVirtualItems), false, 5, 1] call EFUNC(common,displayText);
 };
 
 // Don't execute in scheduled environment
 if (canSuspend) exitWith {
-    [{_this call FUNC(openBox)}, _this] call CBA_fnc_directCall;
+    [FUNC(openBox), _this] call CBA_fnc_directCall;
 };
 
 private _displayToUse = findDisplay IDD_RSCDISPLAYCURATOR;
@@ -46,6 +53,7 @@ if (isNull _displayToUse || {!isNil QGVAR(camera)}) exitWith {
     [LLSTRING(CantOpenDisplay), false, 5, 1] call EFUNC(common,displayText);
 };
 
+GVAR(center) = _center;
 GVAR(currentBox) = _object;
 
 if (_mode) then {
@@ -54,28 +62,11 @@ if (_mode) then {
     GVAR(virtualItemsFlat) = +(uiNamespace getVariable QGVAR(configItemsFlat));
 } else {
     // Add only specified items to the arsenal
-    private _virtualItems = _object getVariable QGVAR(virtualItems);
-
-    GVAR(virtualItems) = if (isNil "_virtualItems") then {
-        _virtualItems = [
-            [IDX_VIRT_WEAPONS, createHashMapFromArray [[IDX_VIRT_PRIMARY_WEAPONS, createHashMap], [IDX_VIRT_SECONDARY_WEAPONS, createHashMap], [IDX_VIRT_HANDGUN_WEAPONS, createHashMap]]],
-            [IDX_VIRT_ATTACHMENTS, createHashMapFromArray [[IDX_VIRT_OPTICS_ATTACHMENTS, createHashMap], [IDX_VIRT_FLASHLIGHT_ATTACHMENTS, createHashMap], [IDX_VIRT_MUZZLE_ATTACHMENTS, createHashMap], [IDX_VIRT_BIPOD_ATTACHMENTS, createHashMap]]]
-        ];
-
-        _virtualItems = createHashMapFromArray _virtualItems;
-
-        for "_index" from IDX_VIRT_ITEMS_ALL to IDX_VIRT_MISC_ITEMS do {
-            _virtualItems set [_index, createHashMap];
-        };
-    } else {
-        +_virtualItems
-    };
+    GVAR(virtualItems) = +_virtualItems;
 
     // Flatten out hashmaps for easy checking later
     call FUNC(updateVirtualItemsFlat);
 };
-
-GVAR(center) = _center;
 
 if (is3DEN) then {
     _displayToUse createDisplay QGVAR(display);

--- a/addons/arsenal/functions/fnc_removeBox.sqf
+++ b/addons/arsenal/functions/fnc_removeBox.sqf
@@ -17,6 +17,11 @@
  * Public: Yes
 */
 
+// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
+if !(EGVAR(common,settingsInitFinished)) exitWith {
+    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(removeBox), _this];
+};
+
 params [["_object", objNull, [objNull]], ["_global", true, [true]]];
 
 if (isNull _object) exitWith {};
@@ -25,10 +30,19 @@ private _id = _object getVariable QGVAR(initBoxJIP);
 
 if (_global && {isMultiplayer} && {!isNil "_id"}) then {
     // Remove event from JIP queue
-    [_id] call CBA_fnc_removeGlobalEventJIP;
+    _id call CBA_fnc_removeGlobalEventJIP;
 
     // Reset JIP ID
     _object setVariable [QGVAR(initBoxJIP), nil, true];
+
+    // Remove all JIP events for adding and remove items to the object's arsenal
+    {
+        _x call CBA_fnc_removeGlobalEventJIP;
+    } forEach (_object getVariable [QGVAR(addVirtualItemsJipIDs), []]);
+
+    {
+        _x call CBA_fnc_removeGlobalEventJIP;
+    } forEach (_object getVariable [QGVAR(removeVirtualItemsJipIDs), []]);
 
     // Remove box for everyone
     [QGVAR(removeBox), [_object, false]] call CBA_fnc_globalEvent;

--- a/addons/arsenal/functions/fnc_removeBox.sqf
+++ b/addons/arsenal/functions/fnc_removeBox.sqf
@@ -17,11 +17,6 @@
  * Public: Yes
 */
 
-// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
-if !(EGVAR(common,settingsInitFinished)) exitWith {
-    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(removeBox), _this];
-};
-
 params [["_object", objNull, [objNull]], ["_global", true, [true]]];
 
 if (isNull _object) exitWith {};

--- a/addons/arsenal/functions/fnc_removeBox.sqf
+++ b/addons/arsenal/functions/fnc_removeBox.sqf
@@ -35,15 +35,6 @@ if (_global && {isMultiplayer} && {!isNil "_id"}) then {
     // Reset JIP ID
     _object setVariable [QGVAR(initBoxJIP), nil, true];
 
-    // Remove all JIP events for adding and remove items to the object's arsenal
-    {
-        _x call CBA_fnc_removeGlobalEventJIP;
-    } forEach (_object getVariable [QGVAR(addVirtualItemsJipIDs), []]);
-
-    {
-        _x call CBA_fnc_removeGlobalEventJIP;
-    } forEach (_object getVariable [QGVAR(removeVirtualItemsJipIDs), []]);
-
     // Remove box for everyone
     [QGVAR(removeBox), [_object, false]] call CBA_fnc_globalEvent;
 

--- a/addons/arsenal/functions/fnc_removeVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_removeVirtualItems.sqf
@@ -19,11 +19,6 @@
  * Public: Yes
 */
 
-// Only run this after FUNC(initBox) has run (easier to check if the settings are initialized)
-if !(EGVAR(common,settingsInitFinished)) exitWith {
-    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(removeVirtualItems), _this];
-};
-
 params [["_object", objNull, [objNull]], ["_items", [], [true, [""]]], ["_global", false, [false]]];
 
 if (isNull _object || {_items isEqualTo []}) exitWith {};
@@ -107,8 +102,10 @@ if (_items isEqualType true) then {
         _object setVariable [QGVAR(virtualItems), _cargo, _global];
 
         // If the arsenal is already open, refresh arsenal display
-        if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {
-            [true, true] call FUNC(refresh);
+        if (_global) then {
+            [QGVAR(refresh), _object] call CBA_fnc_globalEvent;
+        } else {
+            [QGVAR(refresh), _object] call CBA_fnc_localEvent;
         };
     };
 };

--- a/addons/arsenal/functions/fnc_removeVirtualItems.sqf
+++ b/addons/arsenal/functions/fnc_removeVirtualItems.sqf
@@ -39,19 +39,6 @@ if (_items isEqualType true) then {
         [_object, _global] call FUNC(removeBox);
     };
 
-    if (_global) exitWith {
-        private _id = [QGVAR(removeVirtualItems), [_object, _items]] call CBA_fnc_globalEventJIP;
-
-        [_id, _object] call CBA_fnc_removeGlobalEventJIP;
-
-        // FUNC(removeVirtualItems) might be called multiple times on the same object
-        private _jipIDs = _object getVariable [QGVAR(removeVirtualItemsJipIDs), []];
-
-        _jipIDs pushBack _id;
-
-        _object setVariable [QGVAR(removeVirtualItemsJipIDs), _jipIDs];
-    };
-
     // Make sure all items are in string form, then convert to config case (non-existent items return "")
     _items = (_items select {_x isEqualType ""}) apply {_x call EFUNC(common,getConfigName)};
 
@@ -117,7 +104,7 @@ if (_items isEqualType true) then {
     if (_cargo isEqualTo _empty) then {
         [_object, _global] call FUNC(removeBox);
     } else {
-        _object setVariable [QGVAR(virtualItems), _cargo];
+        _object setVariable [QGVAR(virtualItems), _cargo, _global];
 
         // If the arsenal is already open, refresh arsenal display
         if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Fix for https://discord.com/channels/976165959041679380/1174212946793074768.
- The arsenal now refreshes globally if `FUNC(addVirtualItems)` or `FUNC(removeVirtualItems)` was applied globally.

The side effect is that all changes are stored in the JIP queue until the arsenal or its object is deleted. I'm not sure how to handle this any better.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
