### PR TITLE
Arsenal - Fix closing arsenal when ignoring content

### DIFF
--- a/addons/arsenal/functions/fnc_onArsenalClose.sqf
+++ b/addons/arsenal/functions/fnc_onArsenalClose.sqf
@@ -136,4 +136,6 @@ GVAR(favorites) = nil;
 GVAR(center) = nil;
 GVAR(centerNotPlayer) = nil;
 
+GVAR(ignoredVirtualItems) = nil;
+
 [QUOTE(ADDON), []] call EFUNC(common,showHud);

--- a/addons/arsenal/functions/fnc_openBox.sqf
+++ b/addons/arsenal/functions/fnc_openBox.sqf
@@ -52,6 +52,8 @@ if (_mode) then {
     // Add all the items from the game that the arsenal has detected
     GVAR(virtualItems) = +(uiNamespace getVariable QGVAR(configItems));
     GVAR(virtualItemsFlat) = +(uiNamespace getVariable QGVAR(configItemsFlat));
+
+    GVAR(ignoredVirtualItems) = true;
 } else {
     // Add only specified items to the arsenal
     private _virtualItems = _object getVariable QGVAR(virtualItems);

--- a/addons/arsenal/functions/fnc_refresh.sqf
+++ b/addons/arsenal/functions/fnc_refresh.sqf
@@ -42,7 +42,8 @@ if (is3DEN) then {
     _animate = true; // CBA frame functions are disabled during preInit
 };
 
-if (isNil "_virtualItems") exitWith {
+// Do not close an arsenal if it was opened with ignoring the existing content (see FUNC(openBox))
+if (isNil "_virtualItems" && {isNil QGVAR(ignoredVirtualItems)}) exitWith {
     [LLSTRING(noVirtualItems), false, 5, 1] call EFUNC(common,displayText);
     // Delay a frame in case this is running on display open
     [{(findDisplay IDD_ace_arsenal) closeDisplay 0}] call CBA_fnc_execNextFrame;

--- a/addons/arsenal/functions/fnc_removeBox.sqf
+++ b/addons/arsenal/functions/fnc_removeBox.sqf
@@ -41,8 +41,8 @@ if (_global && {isMultiplayer} && {!isNil "_id"}) then {
     [QGVAR(boxRemoved), _object] call CBA_fnc_localEvent;
 };
 
-// If the arsenal is already open, close arsenal display
-if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object}) then {
+// If the arsenal is already open and not ignoring content (see FUNC(openBox)), close arsenal display
+if (!isNil QGVAR(currentBox) && {GVAR(currentBox) isEqualTo _object} && {isNil QGVAR(ignoredVirtualItems)}) then {
     [LLSTRING(noVirtualItems), false, 5, 1] call EFUNC(common,displayText);
     // Delay a frame in case this is running on display open
     [{(findDisplay IDD_ace_arsenal) closeDisplay 0}] call CBA_fnc_execNextFrame;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Fixes https://discord.com/channels/976165959041679380/1167933574654205993/1169139121281839155. In case message is delete, `[player, player, true] call ace_arsenal_fnc_openBox` stopped working after 3.16.0.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
