### PR TITLE
Arsenal - Search fixes

### DIFF
--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -114,15 +114,9 @@ private _fnc_fillRightContainer = {
 private _ctrlPanel = _display displayCtrl IDC_rightTabContent;
 private _listnBox = _display displayCtrl IDC_rightTabContentListnBox;
 
-// Reset right panel content
-lbClear _ctrlPanel;
-lbClear _listnBox;
-
-_ctrlPanel lbSetCurSel -1;
-_listnBox lbSetCurSel -1;
-
 // Retrieve compatible items
-private _itemToCheck = "";
+private _isContainer = false;
+private _selectedItem = "";
 private _compatibleItems = [];
 private _compatibleMagsMuzzle = [];
 private _compatibleMagsAll = createHashMap;
@@ -154,12 +148,12 @@ switch (GVAR(currentLeftPanel)) do {
 
         // Check if weapon attachement or magazine
         if (_index != -1) then {
-            _itemToCheck = (GVAR(currentItems) select _currentWeaponItemsIndex) select _index;
+            _selectedItem = (GVAR(currentItems) select _currentWeaponItemsIndex) select _index;
 
             // If weapon attachment, get base weapon; Get compatible items
             if (_index <= 3) then {
                 _compatibleItems = compatibleItems _weapon;
-                _itemToCheck = _itemToCheck call FUNC(baseWeapon);
+                _selectedItem = _selectedItem call FUNC(baseWeapon);
             } else {
                 // Get compatible magazines for primary & secondary muzzle (secondary muzzle is not guaranteed to exist)
                 // Assumption: One weapon can have two muzzles maximum
@@ -171,7 +165,15 @@ switch (GVAR(currentLeftPanel)) do {
     case IDC_buttonUniform;
     case IDC_buttonVest;
     case IDC_buttonBackpack: {
-        _ctrlPanel = _listnBox;
+        _isContainer = true;
+
+        // Get the currently selected item in panel
+        private _selectedItemIndex = lnbCurSelRow _listnBox;
+
+        // If something is selected, save it
+        if (_selectedItemIndex != -1) then {
+            _selectedItem = _listnBox lnbData [_selectedItemIndex, 0];
+        };
 
         // This is for the "compatible magazines" tab when a container is open
         if (_ctrlIDC == IDC_buttonMag) then {
@@ -181,6 +183,17 @@ switch (GVAR(currentLeftPanel)) do {
             } forEach [GVAR(currentItems) select IDX_CURR_PRIMARY_WEAPON, GVAR(currentItems) select IDX_CURR_HANDGUN_WEAPON, GVAR(currentItems) select IDX_CURR_SECONDARY_WEAPON, GVAR(currentItems) select IDX_CURR_BINO];
         };
     };
+};
+
+// Reset right panel content
+lbClear _ctrlPanel;
+lnbClear _listnBox;
+
+_ctrlPanel lbSetCurSel -1;
+_listnBox lnbSetCurSelRow -1;
+
+if (_isContainer) then {
+    _ctrlPanel = _listnBox;
 };
 
 // Force a "refresh" animation of the panel
@@ -368,7 +381,7 @@ GVAR(currentRightPanel) = _ctrlIDC;
 [QGVAR(rightPanelFilled), [_display, GVAR(currentLeftPanel), _ctrlIDC]] call CBA_fnc_localEvent;
 
 // Add current items, change progress bar of container load and get relevant container
-if (GVAR(currentLeftPanel) in [IDC_buttonUniform, IDC_buttonVest, IDC_buttonBackpack]) then {
+if (_isContainer) then {
     private _containerItems = [];
     private _container = switch (GVAR(currentLeftPanel)) do {
         // Uniform
@@ -415,17 +428,34 @@ if (GVAR(currentLeftPanel) in [IDC_buttonUniform, IDC_buttonVest, IDC_buttonBack
 // Sorting
 [_display, _control, _display displayCtrl IDC_sortRightTab, _display displayCtrl IDC_sortRightTabDirection] call FUNC(fillSort);
 
-// Try to select previously selected item again, otherwise select first item ("Empty")
-if (_itemToCheck != "") then {
-    private _index = 0;
+if (_selectedItem != "") then {
+    if (_isContainer) then {
+        // Try to select previously selected item again, otherwise select nothing
+        private _index = -1;
 
-    for "_lbIndex" from 0 to (lbSize _ctrlPanel) - 1 do {
-        if ((_ctrlPanel lbData _lbIndex) == _itemToCheck) exitWith {
-            _index = _lbIndex;
+        for "_lbIndex" from 0 to (lnbSize _ctrlPanel select 0) - 1 do {
+            if ((_ctrlPanel lnbData [_lbIndex, 0]) == _selectedItem) exitWith {
+                _index = _lbIndex;
+            };
         };
-    };
 
-    _ctrlPanel lbSetCurSel _index;
+        _ctrlPanel lnbSetCurSelRow _index;
+    } else {
+        // Try to select previously selected item again, otherwise select first item ("Empty")
+        private _index = 0;
+
+        for "_lbIndex" from 0 to (lbSize _ctrlPanel) - 1 do {
+            if ((_ctrlPanel lbData _lbIndex) == _selectedItem) exitWith {
+                _index = _lbIndex;
+            };
+        };
+
+        _ctrlPanel lbSetCurSel _index;
+    };
 } else {
-    _ctrlPanel lbSetCurSel 0;
+    if (_isContainer) then {
+        _ctrlPanel lnbSetCurSelRow -1; // select nothing
+    } else {
+        _ctrlPanel lbSetCurSel 0; // select "Empty"
+    };
 };

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -49,7 +49,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // If something is selected, save it
         if (_selectedItemIndex != -1) then {
-            _selectedItem = _rightPanelCtrl lbText _selectedItemIndex;
+            _selectedItem = _rightPanelCtrl lbData _selectedItemIndex;
         };
 
         private _currentDisplayName = "";
@@ -72,7 +72,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
             // Try to find previously selected item in panel
             for "_lbIndex" from 0 to (lbSize _rightPanelCtrl) - 1 do {
-                if ((_rightPanelCtrl lbText _lbIndex) == _selectedItem) exitWith {
+                if ((_rightPanelCtrl lbData _lbIndex) == _selectedItem) exitWith {
                     _index = _lbIndex;
                 };
             };
@@ -89,7 +89,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
         // If something is selected, save it
         if (_selectedItemIndex != -1) then {
-            _selectedItem = _rightPanelCtrl lnbText [_selectedItemIndex, 1];
+            _selectedItem = _rightPanelCtrl lnbData [_selectedItemIndex, 0];
         };
 
         private _currentDisplayName = "";
@@ -112,7 +112,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
             // Try to find previously selected item in panel
             for "_lbIndex" from 0 to (lnbSize _rightPanelCtrl select 0) - 1 do {
-                if ((_rightPanelCtrl lnbText [_lbIndex, 1]) == _selectedItem) exitWith {
+                if ((_rightPanelCtrl lnbData [_lbIndex, 0]) == _selectedItem) exitWith {
                     _index = _lbIndex;
                 };
             };
@@ -145,7 +145,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
 
     // If something is selected, save it
     if (_selectedItemIndex != -1) then {
-        _selectedItem = _leftPanelCtrl lbText _selectedItemIndex;
+        _selectedItem = _leftPanelCtrl lbData _selectedItemIndex;
     };
 
     private _currentDisplayName = "";
@@ -167,7 +167,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
         private _index = -1;
 
         for "_lbIndex" from 0 to (lbSize _leftPanelCtrl) - 1 do {
-            if ((_leftPanelCtrl lbText _lbIndex) == _selectedItem) exitWith {
+            if ((_leftPanelCtrl lbData _lbIndex) == _selectedItem) exitWith {
                 _index = _lbIndex;
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- If two or more items had the same display name and you selected e.g. the second one, it would select the top most one when searching. E.g. having the `M1 Garand` selected from the CDLC SPE, but when updating the search bar, it would select the `M1 Garand` from the Iron Front mod.
The fix for this is to find the class name instead of the display name. 
- When searching in the listnbox panels (i.e. container content), it would deselect the currently selected item when removing characters from the search. E.g. seaching for `rope` and having the item `Rope 15.2 meters` selected, then updating the search to `rop` would deselect the item `Rope 15.2 meters`.
Now it only deselects the item if it isn't part of the search results.
- If an item wasn't found or just generally by default, it would select the first item in the container content.
Now it doesn't select anything by default.

The last change is a matter of opinion, can easily be reverted to selecting the first item.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
