### PR TITLE
Wiki - Fix spelling in vehicle lock framework wiki page

### DIFF
--- a/docs/wiki/framework/vehiclelock-framework.md
+++ b/docs/wiki/framework/vehiclelock-framework.md
@@ -27,7 +27,7 @@ Sync the module with vehicles and players. Custom keys will be handed to players
 
 ## 3. Scripting
 
-### 3.1 Assing Vehicle Key
+### 3.1 Adding Vehicle Key
 
 `ace_vehiclelock_fnc_addKeyForVehicle`
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix a spelling mistake in vehicle lock docs