### PR TITLE
Compat RHS - Fix USAF flashlights materializing PEQ-15s

### DIFF
--- a/addons/compat_rhs_usf3/compat_rhs_usf3_arsenal/CfgWeapons.hpp
+++ b/addons/compat_rhs_usf3/compat_rhs_usf3_arsenal/CfgWeapons.hpp
@@ -18,6 +18,8 @@ class CfgWeapons {
         baseWeapon = "rhsusf_acc_anpeq15_wmx";
     };
     class rhsusf_acc_M952V: rhsusf_acc_anpeq15_light {
+        rhs_acc_combo = ""; // prevent materializing a PEQ-15 if RHS's attachment switch is called
+        rhs_anpeq15_base = ""; // same deal
         baseWeapon = "rhsusf_acc_M952V";
     };
     class rhsusf_acc_wmx: rhsusf_acc_M952V {
@@ -28,6 +30,12 @@ class CfgWeapons {
     };
     class rhsusf_acc_anpeq15A: acc_pointer_IR {
         baseWeapon = "rhsusf_acc_anpeq15A";
+    };
+    class rhsusf_acc_anpeq15_top: rhsusf_acc_anpeq15A {
+        baseWeapon = "rhsusf_acc_anpeq15_top";
+    };
+    class rhsusf_acc_anpeq15_bk_top: rhsusf_acc_anpeq15_top {
+        baseWeapon = "rhsusf_acc_anpeq15_bk_top";
     };
     class rhsusf_acc_anpeq15side: acc_pointer_IR {
         baseWeapon = "rhsusf_acc_anpeq15side";


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Fix `baseWeapon` property on top-mounted lasers.

Want a fun repro? Load pure RHS, equip a M952V, switch to one of the combo attachments, reequip the M952V, press Ctrl-C, congratulations, you have a free laser.

Addresses https://discord.com/channels/976165959041679380/1182576398418849862/1182576398418849862

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
