### PR TITLE
Explosives - Add Cellphone/Detonator Keybinds

### DIFF
--- a/addons/explosives/XEH_PREP.hpp
+++ b/addons/explosives/XEH_PREP.hpp
@@ -10,6 +10,7 @@ PREP(cancelPlacement);
 PREP(canDefuse);
 PREP(canDetonate);
 PREP(connectExplosive);
+PREP(cycleActiveTrigger);
 PREP(defuseExplosive);
 PREP(detonateExplosive);
 PREP(detonateExplosiveAll);

--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -8,6 +8,7 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initKeybinds.inc.sqf"
 #include "initSettings.inc.sqf"
 
 GVAR(detonationHandlers) = [];

--- a/addons/explosives/XEH_preInit.sqf
+++ b/addons/explosives/XEH_preInit.sqf
@@ -11,6 +11,8 @@ PREP_RECOMPILE_END;
 #include "initKeybinds.inc.sqf"
 #include "initSettings.inc.sqf"
 
+GVAR(activeTrigger) = "";
+
 GVAR(detonationHandlers) = [];
 GVAR(excludedMines) = [];
 

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -52,7 +52,7 @@ private _explosivesList = [];
 
 if (_detonator != "ACE_DeadManSwitch") then {
     // Add action to detonate all explosives tied to the detonator
-    if (count _explosivesList > 0) then {
+    if (count _explosivesList > 1) then {
         _children pushBack [
             [
                 "Explosive_All",

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -52,19 +52,19 @@ private _explosivesList = [];
 
 // If the detonator is not active, is a clacker and has assigned explosives, generate an interaction to make it the active detonator for use with the "trigger all" keybind
 if (
-    _detonator isNotEqualTo GVAR(activeTrigger) &&
-    {_detonator isNotEqualTo "Cellphone"} && 
+    _detonator != GVAR(activeTrigger) &&
+    {_detonator != "Cellphone"} && 
     {
-        count(_explosivesList) > 0 ||
-        (_detonator isEqualTo "ACE_DeadManSwitch" && {_unit getVariable [QGVAR(deadmanInvExplosive), ""] != ""})
+        _explosivesList isNotEqualTo [] ||
+        {_detonator == "ACE_DeadManSwitch" && {_unit getVariable [QGVAR(deadmanInvExplosive), ""] != ""}}
     }
 ) then {
     _children pushBack [
         [
-            GVAR(SetActiveTrigger),
-            localize LSTRING(SetActiveTrigger),
+            QGVAR(setActiveTrigger),
+            LLSTRING(SetActiveTrigger),
             "",
-            {GVAR(activeTrigger) = (_this select 2) select 0;},
+            {GVAR(activeTrigger) = (_this select 2) select 0},
             {true},
             {},
             [_detonator]
@@ -80,12 +80,12 @@ if (_detonator != "ACE_DeadManSwitch") then {
         _children pushBack [
             [
                 "Explosive_All",
-                localize LSTRING(DetonateAll),
-                getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
-                {(_this select 2) call FUNC(detonateExplosiveAll);},
+                LLSTRING(DetonateAll),
+                getText (configFile >> "CfgWeapons" >> _detonator >> "picture"),
+                {(_this select 2) call FUNC(detonateExplosiveAll)},
                 {true},
                 {},
-                [_unit,_range,_explosivesList, _detonator]
+                [_unit, _range, _explosivesList, _detonator]
             ] call EFUNC(interact_menu,createAction),
             [],
             _unit
@@ -96,8 +96,8 @@ if (_detonator != "ACE_DeadManSwitch") then {
     _children pushBack [
         [
             "Explosive_All_Deadman",
-            localize LSTRING(DetonateAll),
-            getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
+            LLSTRING(DetonateAll),
+            getText (configFile >> "CfgWeapons" >> _detonator >> "picture"),
             {[_player] call FUNC(onIncapacitated)},
             {true}
         ] call EFUNC(interact_menu,createAction),

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -50,6 +50,30 @@ private _explosivesList = [];
     };
 } forEach _result;
 
+// If the detonator is not active, is a clacker and has assigned explosives, generate an interaction to make it the active detonator for use with the "trigger all" keybind
+if (
+    _detonator isNotEqualTo GVAR(activeTrigger) &&
+    {_detonator isNotEqualTo "Cellphone"} && 
+    {
+        count(_explosivesList) > 0 ||
+        (_detonator isEqualTo "ACE_DeadManSwitch" && {_unit getVariable [QGVAR(deadmanInvExplosive), ""] != ""})
+    }
+) then {
+    _children pushBack [
+        [
+            GVAR(SetActiveTrigger),
+            localize LSTRING(SetActiveTrigger),
+            "",
+            {GVAR(activeTrigger) = (_this select 2) select 0;},
+            {true},
+            {},
+            [_detonator]
+        ] call EFUNC(interact_menu,createAction),
+        [],
+        _unit
+    ];
+};
+
 if (_detonator != "ACE_DeadManSwitch") then {
     // Add action to detonate all explosives tied to the detonator
     if (count _explosivesList > 1) then {

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -49,18 +49,19 @@ private _explosivesList = [];
         };
     };
 } forEach _result;
+
 if (_detonator != "ACE_DeadManSwitch") then {
     // Add action to detonate all explosives tied to the detonator
     if (count _explosivesList > 0) then {
         _children pushBack [
-        [
-            "Explosive_All",
-            localize LSTRING(DetonateAll),
-            getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
-            {(_this select 2) call FUNC(detonateExplosiveAll);},
-            {true},
-            {},
-            [_unit,_range,_explosivesList, _detonator]
+            [
+                "Explosive_All",
+                localize LSTRING(DetonateAll),
+                getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
+                {(_this select 2) call FUNC(detonateExplosiveAll);},
+                {true},
+                {},
+                [_unit,_range,_explosivesList, _detonator]
             ] call EFUNC(interact_menu,createAction),
             [],
             _unit
@@ -69,15 +70,15 @@ if (_detonator != "ACE_DeadManSwitch") then {
 } else {
     //Add action to detonate all explosives (including the inventory explosive):
     _children pushBack [
-    [
-    "Explosive_All_Deadman",
-    localize LSTRING(DetonateAll),
-    getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
-    {[_player] call FUNC(onIncapacitated)},
-    {true}
-    ] call EFUNC(interact_menu,createAction),
-    [],
-    _unit
+        [
+            "Explosive_All_Deadman",
+            localize LSTRING(DetonateAll),
+            getText(ConfigFile >> "CfgWeapons" >> _detonator >> "picture"),
+            {[_player] call FUNC(onIncapacitated)},
+            {true}
+        ] call EFUNC(interact_menu,createAction),
+        [],
+        _unit
     ];
 
     //Adds actions for the explosives you can connect to the deadman switch.
@@ -89,7 +90,7 @@ if (_detonator != "ACE_DeadManSwitch") then {
 
     _connectedInventoryExplosive = _unit getVariable [QGVAR(deadmanInvExplosive), ""];
     if (_connectedInventoryExplosive != "") then {
-        //Add the disconect action
+        //Add the disconnect action
         private _magConfig = configFile >> "CfgMagazines" >> _connectedInventoryExplosive;
         private _name = if ((getText (_magConfig >> "displayNameShort")) != "") then {
             getText (_magConfig >> "displayNameShort")
@@ -99,17 +100,20 @@ if (_detonator != "ACE_DeadManSwitch") then {
         private _picture = getText (_magConfig >> "picture");
 
         _children pushBack [
-        ([
-        "Deadman_disconnect",
-        format ["%1 %2", localize "str_disp_disconnect", _name],
-        _picture,
-        {
-            params ["_player"];
-            TRACE_1("clear",_player);
-            _player setVariable [QGVAR(deadmanInvExplosive), "", true];
-        },
-        {true}
-        ] call EFUNC(interact_menu,createAction)), [], _unit];
+            ([
+                "Deadman_disconnect",
+                format ["%1 %2", localize "str_disp_disconnect", _name],
+                _picture,
+                {
+                    params ["_player"];
+                    TRACE_1("clear",_player);
+                    _player setVariable [QGVAR(deadmanInvExplosive), "", true];
+                },
+                {true}
+            ] call EFUNC(interact_menu,createAction)),
+            [],
+            _unit
+        ];
 
     } else {
         //Add all magazines that would work with the deadman switch

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -64,7 +64,7 @@ if (
             QGVAR(setActiveTrigger),
             LLSTRING(SetActiveTrigger),
             "",
-            {GVAR(activeTrigger) = (_this select 2) select 0},
+            {GVAR(activeTrigger) = (_this select 2) select 0;},
             {true},
             {},
             [_detonator]
@@ -82,7 +82,7 @@ if (_detonator != "ACE_DeadManSwitch") then {
                 "Explosive_All",
                 LLSTRING(DetonateAll),
                 getText (configFile >> "CfgWeapons" >> _detonator >> "picture"),
-                {(_this select 2) call FUNC(detonateExplosiveAll)},
+                {(_this select 2) call FUNC(detonateExplosiveAll);},
                 {true},
                 {},
                 [_unit, _range, _explosivesList, _detonator]

--- a/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
+++ b/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
@@ -21,7 +21,7 @@ TRACE_1("params",_unit);
 private _detonators = _unit call FUNC(getDetonators);
 
 // Remove ACE_Cellphone from list, as it should never be the active trigger due to having its own keybind
-_detonators deleteAt (_detonators find "ACE_Cellphone");
+_detonators deleteAt (_detonators findIf {_x == "ACE_Cellphone"});
 
 // Reset Active Trigger if none available
 if (_detonators isEqualTo []) exitWith {
@@ -29,11 +29,12 @@ if (_detonators isEqualTo []) exitWith {
 };
 
 private _activeTrigger = GVAR(activeTrigger);
-private _index = _detonators find _activeTrigger;
+private _index = _detonators findIf {_x == _activeTrigger};
+private _count = count _detonators;
 
-if (_activeTrigger != "" && {_index != -1} && {count(_detonators) > 1}) then {
+if (_activeTrigger != "" && {_index != -1} && {_count > 1}) then {
     // If active trigger is set and among current detonators, switch to the next one
-    if (_index < count(_detonators) - 1) then {
+    if (_index < _count - 1) then {
         _index = _index + 1;
     } else {
         _index = 0;
@@ -45,8 +46,9 @@ if (_activeTrigger != "" && {_index != -1} && {count(_detonators) > 1}) then {
 };
 
 GVAR(activeTrigger) = _activeTrigger;
-private _triggerName = getText (configFile >> "CfgWeapons" >> (_activeTrigger) >> "displayName");
-private _triggerIcon = getText (configFile >> "CfgWeapons" >> (_activeTrigger) >> "picture");
+private _triggerConfig = configFile >> "CfgWeapons" >> _activeTrigger;
+private _triggerName = getText (_triggerConfig >> "displayName");
+private _triggerIcon = getText (_triggerConfig >> "picture");
 
 [
     [format ["%1:", LLSTRING(ActiveTrigger)]],

--- a/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
+++ b/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
@@ -1,0 +1,56 @@
+#include "..\script_component.hpp"
+/*
+ * Author: mrschick
+ * Cycles the "Active Trigger" of a unit and shows a CBA Hint that displays the new Active Trigger.
+ *
+ * Arguments:
+ * 0: Target Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [ACE_player] call ACE_Explosives_fnc_cycleActiveTrigger;
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+TRACE_1("params",_unit);
+
+private _detonators = _unit call FUNC(getDetonators);
+
+// Remove ACE_Cellphone from list, as it should never be the active trigger due to having its own keybind
+_detonators deleteAt (_detonators find "ACE_Cellphone");
+
+// Reset Active Trigger if none available
+if (_detonators isEqualTo []) exitWith {
+    GVAR(activeTrigger) = "";
+};
+
+private _activeTrigger = GVAR(activeTrigger);
+private _index = _detonators find _activeTrigger;
+
+if (_activeTrigger != "" && {_index != -1} && {count(_detonators) > 1}) then {
+    // If active trigger is set and among current detonators, switch to the next one
+    if (_index < count(_detonators) - 1) then {
+        _index = _index + 1;
+    } else {
+        _index = 0;
+    };
+    _activeTrigger = _detonators select _index;
+} else {
+    // Assign first detonator in list as the active one
+    _activeTrigger = _detonators select 0;
+};
+
+GVAR(activeTrigger) = _activeTrigger;
+private _triggerName = getText (configFile >> "CfgWeapons" >> (_activeTrigger) >> "displayName");
+private _triggerIcon = getText (configFile >> "CfgWeapons" >> (_activeTrigger) >> "picture");
+
+[
+    [format ["%1:", LLSTRING(ActiveTrigger)]],
+    [_triggerName],
+    [_triggerIcon, 1.8],
+    true
+] call CBA_fnc_notify;

--- a/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
+++ b/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
@@ -50,9 +50,4 @@ private _triggerConfig = configFile >> "CfgWeapons" >> _activeTrigger;
 private _triggerName = getText (_triggerConfig >> "displayName");
 private _triggerIcon = getText (_triggerConfig >> "picture");
 
-[
-    [format ["%1:", LLSTRING(ActiveTrigger)]],
-    [_triggerName],
-    [_triggerIcon, 1.8],
-    true
-] call CBA_fnc_notify;
+[format ["%1: %2", LLSTRING(ActiveTrigger), _triggerName], _triggerIcon] call EFUNC(common,displayTextPicture);

--- a/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
+++ b/addons/explosives/functions/fnc_cycleActiveTrigger.sqf
@@ -4,13 +4,13 @@
  * Cycles the "Active Trigger" of a unit and shows a CBA Hint that displays the new Active Trigger.
  *
  * Arguments:
- * 0: Target Unit <OBJECT>
+ * 0: Unit <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * [ACE_player] call ACE_Explosives_fnc_cycleActiveTrigger;
+ * [ACE_player] call ace_explosives_fnc_cycleActiveTrigger;
  *
  * Public: No
  */

--- a/addons/explosives/functions/fnc_selectTrigger.sqf
+++ b/addons/explosives/functions/fnc_selectTrigger.sqf
@@ -24,7 +24,10 @@ private _config = ConfigFile >> "ACE_Triggers" >> _trigger;
 
 // Make selected trigger the active one (for keybind) if it's the first to be connected
 private _activeTrigger = GVAR(activeTrigger);
-if (_activeTrigger isEqualTo "" && {_trigger in ["Command", "MK16_Transmitter", "DeadManSwitch"]}) then {
+if (
+    _activeTrigger == "" &&
+    {(["Command", "MK16_Transmitter", "DeadManSwitch"] findIf {_x == _trigger}) != -1}
+) then {
     GVAR(activeTrigger) = getArray (_config >> "requires") select 0;
 };
 

--- a/addons/explosives/functions/fnc_selectTrigger.sqf
+++ b/addons/explosives/functions/fnc_selectTrigger.sqf
@@ -22,6 +22,12 @@ TRACE_3("params",_explosive,_magazine,_trigger);
 
 private _config = ConfigFile >> "ACE_Triggers" >> _trigger;
 
+// Make selected trigger the active one (for keybind) if it's the first to be connected
+private _activeTrigger = GVAR(activeTrigger);
+if (_activeTrigger isEqualTo "" && {_trigger in ["Command", "MK16_Transmitter", "DeadManSwitch"]}) then {
+    GVAR(activeTrigger) = getArray (_config >> "requires") select 0;
+};
+
 // If the onSetup function returns true, it is handled elsewhere
 if (isText(_config >> "onSetup") && {[_explosive,_magazine] call compile getText (_config >> "onSetup")}) exitWith {
     TRACE_2("onSetup returned true",_explosive,_trigger);

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -1,19 +1,15 @@
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
-["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName),
-{
+["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName), {
     if (
         !("ACE_Cellphone" in ([ACE_player] call EFUNC(common,uniqueItems))) ||
         !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))
     ) exitWith {};
     closeDialog 0;
     createDialog "Rsc_ACE_PhoneInterface";
-},
-{false},
-[DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)
+}, {false}, [DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)
 
-["ACE Explosives", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive),
-{
+["ACE Explosives", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive), {
     // Prevent use of keybind while surrendering or captive
     if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
 
@@ -38,14 +34,9 @@
     } forEach ([ACE_player] call FUNC(getPlacedExplosives));
 
     [ACE_player, _range, _explosivesList, _detonator] call FUNC(detonateExplosiveAll);
-},
-{false},
-[DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)
+}, {false}, [DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)
 
-["ACE Explosives", QGVAR(cycleActiveClacker), LLSTRING(CycleActiveTrigger),
-{
+["ACE Explosives", QGVAR(cycleActiveClacker), LLSTRING(CycleActiveTrigger), {
     if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
     [ACE_player] call FUNC(cycleActiveTrigger);
-},
-{false},
-[], false, 0] call CBA_fnc_addKeybind;
+}, {false}, [DIK_C, [false, true, false]], false, 0] call CBA_fnc_addKeybind; // (CTRL+C)

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -2,7 +2,7 @@
 
 ["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName), {
     if (
-        !("ACE_Cellphone" in ([ACE_player] call EFUNC(common,uniqueItems))) ||
+        !([ACE_player, "ACE_Cellphone"] call EFUNC(common,hasItem)) ||
         !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))
     ) exitWith {};
     closeDialog 0;

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -41,3 +41,11 @@
 },
 {false},
 [DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)
+
+["ACE Explosives", QGVAR(cycleActiveClacker), LLSTRING(CycleActiveTrigger),
+{
+    if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
+    [ACE_player] call FUNC(cycleActiveTrigger);
+},
+{false},
+[], false, 0] call CBA_fnc_addKeybind;

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -1,15 +1,18 @@
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
-["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName), {
+["ACE3 Equipment", QGVAR(openCellphone), LLSTRING(cellphone_displayName), {
     if (
         !([ACE_player, "ACE_Cellphone"] call EFUNC(common,hasItem)) ||
         !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))
     ) exitWith {};
+
     closeDialog 0;
     createDialog "Rsc_ACE_PhoneInterface";
-}, {false}, [DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)
 
-["ACE Explosives", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive), {
+    true
+}] call CBA_fnc_addKeybind; // Unbound
+
+["ACE3 Equipment", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive), {
     // Prevent use of keybind while surrendering or captive
     if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
 
@@ -34,9 +37,14 @@
     } forEach ([ACE_player] call FUNC(getPlacedExplosives));
 
     [ACE_player, _range, _explosivesList, _detonator] call FUNC(detonateExplosiveAll);
-}, {false}, [DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)
 
-["ACE Explosives", QGVAR(cycleActiveClacker), LLSTRING(CycleActiveTrigger), {
+    true
+}] call CBA_fnc_addKeybind; // Unbound
+
+["ACE3 Equipment", QGVAR(cycleActiveClacker), LLSTRING(CycleActiveTrigger), {
     if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
+
     [ACE_player] call FUNC(cycleActiveTrigger);
-}, {false}, [], false, 0] call CBA_fnc_addKeybind; // (Unbound)
+
+    true
+}] call CBA_fnc_addKeybind; // Unbound

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -11,7 +11,7 @@
     createDialog 'Rsc_ACE_PhoneInterface';
 },
 {false},
-[DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)
+[DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)
 
 ["ACE Explosives", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive),
 {
@@ -41,4 +41,4 @@
     [ACE_player, _range, _explosivesList, _detonator] call FUNC(detonateExplosiveAll);
 },
 {false},
-[DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)
+[DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -18,19 +18,19 @@
     if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
 
     private _detonator = GVAR(activeTrigger);
-    if (_detonator isEqualTo "" || !(_detonator in ([ACE_player] call FUNC(getDetonators)))) exitWith {};
+    if (_detonator == "" || !(_detonator in ([ACE_player] call FUNC(getDetonators)))) exitWith {};
 
     // When using a Dead Man's Switch, skip all other logic and just call fnc_onIncapacitated, since it already handles everything that is required to detonate all connected explosives
-    if (_detonator isEqualTo "ACE_DeadManSwitch") exitWith {
+    if (_detonator == "ACE_DeadManSwitch") exitWith {
         [ACE_player] call FUNC(onIncapacitated);
     };
 
-    private _range = getNumber (ConfigFile >> "CfgWeapons" >> _detonator >> QGVAR(Range));
+    private _range = getNumber (configFile >> "CfgWeapons" >> _detonator >> QGVAR(Range));
 
     private _explosivesList = [];
     {
-        if (!isNull(_x select 0)) then {
-            private _required = getArray (ConfigFile >> "ACE_Triggers" >> (_x select 4) >> "requires");
+        if (!isNull (_x select 0)) then {
+            private _required = getArray (configFile >> "ACE_Triggers" >> _x select 4 >> "requires");
             if (_detonator in _required) then {
                 _explosivesList pushBack _x;
             };

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -1,0 +1,14 @@
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
+["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName),
+{
+    if (
+        !('ACE_Cellphone' in (items ACE_player)) ||
+        {ACE_player getVariable [QEGVAR(captives,isSurrendering), false]} ||
+        {ACE_player getVariable [QEGVAR(captives,isHandcuffed), false]}
+    ) exitWith {};
+    closeDialog 0;
+    createDialog 'Rsc_ACE_PhoneInterface';
+},
+{false},
+[DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -12,3 +12,33 @@
 },
 {false},
 [DIK_C, [false, true, true]], false, 0] call CBA_fnc_addKeybind; // (CTRL+ALT+C)
+
+["ACE Explosives", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive),
+{
+    // Prevent use of keybind while surrendering or captive
+    if (ACE_player getVariable [QEGVAR(captives,isSurrendering), false] || {ACE_player getVariable [QEGVAR(captives,isHandcuffed), false]}) exitWith {};
+
+    private _detonator = GVAR(activeTrigger);
+    if (_detonator isEqualTo "" || !(_detonator in ([ACE_player] call FUNC(getDetonators)))) exitWith {};
+
+    // When using a Dead Man's Switch, skip all other logic and just call fnc_onIncapacitated, since it already handles everything that is required to detonate all connected explosives
+    if (_detonator isEqualTo "ACE_DeadManSwitch") exitWith {
+        [ACE_player] call FUNC(onIncapacitated);
+    };
+
+    private _range = getNumber (ConfigFile >> "CfgWeapons" >> _detonator >> QGVAR(Range));
+
+    private _explosivesList = [];
+    {
+        if (!isNull(_x select 0)) then {
+            private _required = getArray (ConfigFile >> "ACE_Triggers" >> (_x select 4) >> "requires");
+            if (_detonator in _required) then {
+                _explosivesList pushBack _x;
+            };
+        };
+    } forEach ([ACE_player] call FUNC(getPlacedExplosives));
+
+    [ACE_player, _range, _explosivesList, _detonator] call FUNC(detonateExplosiveAll);
+},
+{false},
+[DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -39,4 +39,4 @@
 ["ACE Explosives", QGVAR(cycleActiveClacker), LLSTRING(CycleActiveTrigger), {
     if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
     [ACE_player] call FUNC(cycleActiveTrigger);
-}, {false}, [DIK_C, [false, true, false]], false, 0] call CBA_fnc_addKeybind; // (CTRL+C)
+}, {false}, [], false, 0] call CBA_fnc_addKeybind; // (Unbound)

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -3,9 +3,8 @@
 ["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName),
 {
     if (
-        !('ACE_Cellphone' in (items ACE_player)) ||
-        {ACE_player getVariable [QEGVAR(captives,isSurrendering), false]} ||
-        {ACE_player getVariable [QEGVAR(captives,isHandcuffed), false]}
+        !('ACE_Cellphone' in ([ACE_player] call EFUNC(common,uniqueItems))) ||
+        !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))
     ) exitWith {};
     closeDialog 0;
     createDialog 'Rsc_ACE_PhoneInterface';
@@ -16,7 +15,7 @@
 ["ACE Explosives", QGVAR(detonateActiveClacker), LLSTRING(DetonateAllOnActive),
 {
     // Prevent use of keybind while surrendering or captive
-    if (ACE_player getVariable [QEGVAR(captives,isSurrendering), false] || {ACE_player getVariable [QEGVAR(captives,isHandcuffed), false]}) exitWith {};
+    if !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith)) exitWith {};
 
     private _detonator = GVAR(activeTrigger);
     if (_detonator isEqualTo "" || !(_detonator in ([ACE_player] call FUNC(getDetonators)))) exitWith {};

--- a/addons/explosives/initKeybinds.inc.sqf
+++ b/addons/explosives/initKeybinds.inc.sqf
@@ -3,11 +3,11 @@
 ["ACE Explosives", QGVAR(openCellphone), LLSTRING(cellphone_displayName),
 {
     if (
-        !('ACE_Cellphone' in ([ACE_player] call EFUNC(common,uniqueItems))) ||
+        !("ACE_Cellphone" in ([ACE_player] call EFUNC(common,uniqueItems))) ||
         !([ACE_player, objNull, ["isNotSwimming", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))
     ) exitWith {};
     closeDialog 0;
-    createDialog 'Rsc_ACE_PhoneInterface';
+    createDialog "Rsc_ACE_PhoneInterface";
 },
 {false},
 [DIK_C, [false, false, true]], false, 0] call CBA_fnc_addKeybind; // (ALT+C)

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -78,6 +78,16 @@
             <German>Als Standardzünder Wählen</German>
             <Italian>Imposta Detonatore Attivo</Italian>
         </Key>
+        <Key ID="STR_ACE_Explosives_CycleActiveTrigger">
+            <English>Cycle Active Clacker</English>
+            <German>Standardzünder Wechseln</German>
+            <Italian>Cambia Detonatore Attivo</Italian>
+        </Key>
+        <Key ID="STR_ACE_Explosives_ActiveTrigger">
+            <English>Active Clacker</English>
+            <German>Standardzünder</German>
+            <Italian>Detonatore Attivo</Italian>
+        </Key>
         <Key ID="STR_ACE_Explosives_DetonateCode">
             <English>Explosive code: %1</English>
             <German>Sprengstoffcode: %1</German>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -70,9 +70,13 @@
         </Key>
         <Key ID="STR_ACE_Explosives_DetonateAllOnActive">
             <English>Detonate All on Active Clacker</English>
+            <German>Alle auf Standardzünder zünden</German>
+            <Italian>Detona Tutti sul Detonatore Attivo</Italian>
         </Key>
         <Key ID="STR_ACE_Explosives_SetActiveTrigger">
             <English>Set Active Clacker</English>
+            <German>Als Standardzünder Wählen</German>
+            <Italian>Imposta Detonatore Attivo</Italian>
         </Key>
         <Key ID="STR_ACE_Explosives_DetonateCode">
             <English>Explosive code: %1</English>

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -75,12 +75,12 @@
         </Key>
         <Key ID="STR_ACE_Explosives_SetActiveTrigger">
             <English>Set Active Clacker</English>
-            <German>Als Standardzünder Wählen</German>
+            <German>Als Standardzünder wählen</German>
             <Italian>Imposta Detonatore Attivo</Italian>
         </Key>
         <Key ID="STR_ACE_Explosives_CycleActiveTrigger">
             <English>Cycle Active Clacker</English>
-            <German>Standardzünder Wechseln</German>
+            <German>Standardzünder wechseln</German>
             <Italian>Cambia Detonatore Attivo</Italian>
         </Key>
         <Key ID="STR_ACE_Explosives_ActiveTrigger">

--- a/addons/explosives/stringtable.xml
+++ b/addons/explosives/stringtable.xml
@@ -68,6 +68,12 @@
             <Chinese>引爆全部</Chinese>
             <Turkish>Hepsini Patlat</Turkish>
         </Key>
+        <Key ID="STR_ACE_Explosives_DetonateAllOnActive">
+            <English>Detonate All on Active Clacker</English>
+        </Key>
+        <Key ID="STR_ACE_Explosives_SetActiveTrigger">
+            <English>Set Active Clacker</English>
+        </Key>
         <Key ID="STR_ACE_Explosives_DetonateCode">
             <English>Explosive code: %1</English>
             <German>Sprengstoffcode: %1</German>

--- a/docs/wiki/feature/explosives.md
+++ b/docs/wiki/feature/explosives.md
@@ -35,7 +35,7 @@ Enables attaching explosives to vehicles.
 - Interact with the explosive <kbd>⊞&nbsp;Win</kbd> (ACE3 default key bind `Interact Key`).
 - Choose the arming method.
 - For clackers use Self Interaction `Explosives` &rarr; `Detonate` and choose the corresponding Firing Device.
-- Alternatively, use <kbd>Alt</kbd>+<kbd>C</kbd> (ACE3 default key bind `Detonate All on Active Clacker`) to detonate all explosives tied to the `Active Detonator`, which can be changed via the `Set Active Detonator` interaction on the desired Clacker / Dead Man Switch.
+- Alternatively, use <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd> (ACE3 default key bind `Detonate All on Active Clacker`) to detonate all explosives tied to the `Active Detonator`, which can be changed via the `Set Active Detonator` interaction on the desired Clacker / Dead Man Switch.
 
 ### 2.3 Defusing explosives
 - A `Defusal Kit` is required.

--- a/docs/wiki/feature/explosives.md
+++ b/docs/wiki/feature/explosives.md
@@ -35,6 +35,7 @@ Enables attaching explosives to vehicles.
 - Interact with the explosive <kbd>⊞&nbsp;Win</kbd> (ACE3 default key bind `Interact Key`).
 - Choose the arming method.
 - For clackers use Self Interaction `Explosives` &rarr; `Detonate` and choose the corresponding Firing Device.
+- Alternatively, use <kbd>Alt</kbd>+<kbd>C</kbd> (ACE3 default key bind `Detonate All on Active Clacker`) to detonate all explosives tied to the `Active Detonator`, which can be changed via the `Set Active Detonator` interaction on the desired Clacker / Dead Man Switch.
 
 ### 2.3 Defusing explosives
 - A `Defusal Kit` is required.


### PR DESCRIPTION
**When merged this pull request will:**
- Add `Cellphone` Keybind (unbound by default) to open the Cellphone interface;

- Add `Detonate All on Active Detonator` Keybind (unbound by default) to detonate all explosives tied to the current `Active Detonator`;
When connecting the first explosive to a detonator, that detonator will be selected as the active one, afterwards it's possible to switch the `Active Detonator` as desired via a `Set Active Detonator` interaction on any non-active detonator;

- Add `Cycle Active Detonator` Keybind (unbound by default) to cycle between the currently carried triggers, thereby selecting which is the `Active Detonator`, is visualized by ~~[`CBA Notification`](https://cbateam.github.io/CBA_A3/docs/files/ui/fnc_notify-sqf.html#CBA_fnc_notify)~~ [`common/fnc_displayTextPicture`](https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_displayTextPicture.sqf);

- Only show `Detonate All` interaction on a detonator if connected to more than 1 explosive, to allow the `ace_interact_menu_consolidateSingleChild` setting to consolidate that interaction;