### PR TITLE
Arsenal - Fix displaying virtual items & weapon attachments in cargo

### DIFF
--- a/addons/arsenal/functions/fnc_buttonCargo.sqf
+++ b/addons/arsenal/functions/fnc_buttonCargo.sqf
@@ -47,8 +47,8 @@ private _container = switch (GVAR(currentLeftPanel)) do {
             };
         };
 
-        /// Get all items from container (excluding container itself)
-        _containerItems = [GVAR(center), 0, 3, 0, 0, false] call EFUNC(common,uniqueUnitItems);
+        // Get all items from container
+        _containerItems = uniformItems GVAR(center);
 
         // Update currentItems
         GVAR(currentItems) set [IDX_CURR_UNIFORM_ITEMS, ((getUnitLoadout GVAR(center)) select IDX_LOADOUT_UNIFORM) param [1, []]];
@@ -75,8 +75,8 @@ private _container = switch (GVAR(currentLeftPanel)) do {
             };
         };
 
-        // Get all items from container (excluding container itself)
-        _containerItems = [GVAR(center), 0, 0, 3, 0, false] call EFUNC(common,uniqueUnitItems);
+        // Get all items from container
+        _containerItems = vestItems GVAR(center);
 
         // Update currentItems
         GVAR(currentItems) set [IDX_CURR_VEST_ITEMS, ((getUnitLoadout GVAR(center)) select IDX_LOADOUT_VEST) param [1, []]];
@@ -103,8 +103,8 @@ private _container = switch (GVAR(currentLeftPanel)) do {
             };
         };
 
-        // Get all items from container (excluding container itself)
-        _containerItems = [GVAR(center), 0, 0, 0, 3, false] call EFUNC(common,uniqueUnitItems);
+        // Get all items from container
+        _containerItems = backpackItems GVAR(center);
 
         // Update currentItems
         GVAR(currentItems) set [IDX_CURR_BACKPACK_ITEMS, ((getUnitLoadout GVAR(center)) select IDX_LOADOUT_BACKPACK) param [1, []]];
@@ -117,7 +117,7 @@ private _container = switch (GVAR(currentLeftPanel)) do {
 };
 
 // Find out how many items of that type there are and update the number displayed
-_ctrlList lnbSetText [[_lnbCurSel, 2], str (_containerItems getOrDefault [_item, 0])];
+_ctrlList lnbSetText [[_lnbCurSel, 2], str ({_item == _x} count _containerItems)];
 
 [QGVAR(cargoChanged), [_display, _item, _addOrRemove, GVAR(shiftState)]] call CBA_fnc_localEvent;
 

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -389,8 +389,8 @@ if (_isContainer) then {
             // Update load bar
             (_display displayCtrl IDC_loadIndicatorBar) progressSetPosition (loadUniform GVAR(center));
 
-            // Get all items from container (excluding container itself)
-            _containerItems = [GVAR(center), 0, 3, 0, 0, false] call EFUNC(common,uniqueUnitItems);
+            // Get all items from container
+            _containerItems = uniformItems GVAR(center);
 
             uniformContainer GVAR(center)
         };
@@ -399,8 +399,8 @@ if (_isContainer) then {
             // Update load bar
             (_display displayCtrl IDC_loadIndicatorBar) progressSetPosition (loadVest GVAR(center));
 
-            // Get all items from container (excluding container itself)
-            _containerItems = [GVAR(center), 0, 0, 3, 0, false] call EFUNC(common,uniqueUnitItems);
+            // Get all items from container
+            _containerItems = vestItems GVAR(center);
 
             vestContainer GVAR(center)
         };
@@ -409,8 +409,8 @@ if (_isContainer) then {
             // Update load bar
             (_display displayCtrl IDC_loadIndicatorBar) progressSetPosition (loadBackpack GVAR(center));
 
-            // Get all items from container (excluding container itself)
-            _containerItems = [GVAR(center), 0, 0, 0, 3, false] call EFUNC(common,uniqueUnitItems);
+            // Get all items from container
+            _containerItems = backpackItems GVAR(center);
 
             backpackContainer GVAR(center)
         };
@@ -418,7 +418,7 @@ if (_isContainer) then {
 
     // Find out how many items of a type there are and update the number displayed
     for "_lbIndex" from 0 to (lnbSize _ctrlPanel select 0) - 1 do {
-        _ctrlPanel lnbSetText [[_lbIndex, 2], str (_containerItems getOrDefault [_ctrlPanel lnbData [_lbIndex, 0], 0])];
+        _ctrlPanel lnbSetText [[_lbIndex, 2], str ({_ctrlPanel lnbData [_lbIndex, 0] == _x} count _containerItems)];
     };
 
     // Refresh availibility of items based on space remaining in container

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -418,7 +418,8 @@ if (_isContainer) then {
 
     // Find out how many items of a type there are and update the number displayed
     for "_lbIndex" from 0 to (lnbSize _ctrlPanel select 0) - 1 do {
-        _ctrlPanel lnbSetText [[_lbIndex, 2], str ({_ctrlPanel lnbData [_lbIndex, 0] == _x} count _containerItems)];
+        private _xItem = _ctrlPanel lnbData [_lbIndex, 0];
+        _ctrlPanel lnbSetText [[_lbIndex, 2], str ({_xItem == _x} count _containerItems)];
     };
 
     // Refresh availibility of items based on space remaining in container

--- a/addons/arsenal/functions/fnc_updateUniqueItemsList.sqf
+++ b/addons/arsenal/functions/fnc_updateUniqueItemsList.sqf
@@ -125,7 +125,8 @@ private _fnc_uniqueEquipment = {
     };
 } forEach (getUnitLoadout GVAR(center)); // Only need items, not extended loadout
 
-
+// Get all items from unit
+_items = itemsWithMagazines GVAR(center);
 private _isMagazine = false;
 private _isWeapon = false;
 private _isGrenade = false;
@@ -184,7 +185,12 @@ private _itemInfoType = 0;
                 // Unknown
                 default {
                     // Don't add items that are part of the arsenal
-                    if !(_x in GVAR(virtualItemsFlatAll)) then {
+                    if (
+                        !(_x in (GVAR(virtualItems) get IDX_VIRT_MISC_ITEMS)) &&
+                        {!(_x in (GVAR(virtualItems) get IDX_VIRT_GRENADES))} &&
+                        {!(_x in (GVAR(virtualItems) get IDX_VIRT_EXPLOSIVES))} &&
+                        {!(_x in (GVAR(virtualItems) get IDX_VIRT_ITEMS_ALL))}
+                    ) then {
                         (GVAR(virtualItems) get IDX_VIRT_UNIQUE_UNKNOWN_ITEMS) set [_x, nil];
                     };
                 };
@@ -255,7 +261,13 @@ private _itemInfoType = 0;
                 // Unknown
                 default {
                     // Don't add items that are part of the arsenal
-                    if !(_x in GVAR(virtualItemsFlatAll)) then {
+                    if (
+                        !(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_OPTICS_ATTACHMENTS)) &&
+                        {!(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_FLASHLIGHT_ATTACHMENTS))} &&
+                        {!(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_MUZZLE_ATTACHMENTS))} &&
+                        {!(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_BIPOD_ATTACHMENTS))} &&
+                        {!(_x in (GVAR(virtualItems) get IDX_VIRT_MISC_ITEMS))}
+                    ) then {
                         (GVAR(virtualItems) get IDX_VIRT_UNIQUE_UNKNOWN_ITEMS) set [_x, nil];
                     };
                 };
@@ -277,4 +289,4 @@ private _itemInfoType = 0;
             };
         };
     };
-} forEach (keys ([GVAR(center), 0, 3, 3, 3, false] call EFUNC(common,uniqueUnitItems))); // Get all items from unit
+} forEach (_items arrayIntersect _items);

--- a/addons/arsenal/functions/fnc_updateUniqueItemsList.sqf
+++ b/addons/arsenal/functions/fnc_updateUniqueItemsList.sqf
@@ -261,11 +261,12 @@ private _itemInfoType = 0;
                 // Unknown
                 default {
                     // Don't add items that are part of the arsenal
+                    private _attachments = GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS;
                     if (
-                        !(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_OPTICS_ATTACHMENTS)) &&
-                        {!(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_FLASHLIGHT_ATTACHMENTS))} &&
-                        {!(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_MUZZLE_ATTACHMENTS))} &&
-                        {!(_x in ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get IDX_VIRT_BIPOD_ATTACHMENTS))} &&
+                        !(_x in (_attachments get IDX_VIRT_OPTICS_ATTACHMENTS)) &&
+                        {!(_x in (_attachments get IDX_VIRT_FLASHLIGHT_ATTACHMENTS))} &&
+                        {!(_x in (_attachments get IDX_VIRT_MUZZLE_ATTACHMENTS))} &&
+                        {!(_x in (_attachments get IDX_VIRT_BIPOD_ATTACHMENTS))} &&
                         {!(_x in (GVAR(virtualItems) get IDX_VIRT_MISC_ITEMS))}
                     ) then {
                         (GVAR(virtualItems) get IDX_VIRT_UNIQUE_UNKNOWN_ITEMS) set [_x, nil];


### PR DESCRIPTION
**When merged this pull request will:**
- Unique items would not show up in containers when they were available in the arsenal. E.g. If you put NVGs in your backpack, they wouldn't show up in the backpack's items when using an arsenal that has those NVGs available in the NVG tab.
- If a unit had weapons in a container, it would show all of its accessories as unique items. Now you no longer see a weapon's accessories.

This essentially reverts some of the changes I made in #9040, but it's for the better.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
