### PR TITLE
Markers - Use lbData for channel selection

### DIFF
--- a/addons/markers/functions/fnc_onLBSelChangedChannel.sqf
+++ b/addons/markers/functions/fnc_onLBSelChangedChannel.sqf
@@ -1,6 +1,6 @@
 #include "..\script_component.hpp"
 /*
- * Author: commy2, LinkIsGrim
+ * Author: commy2, LinkIsGrim, Avokadomos
  * When the channel list box is changed.
  *
  * Arguments:

--- a/addons/markers/functions/fnc_onLBSelChangedChannel.sqf
+++ b/addons/markers/functions/fnc_onLBSelChangedChannel.sqf
@@ -21,4 +21,4 @@ TRACE_2("params",_ctrl,_index);
 
 private _enabledChannels = false call FUNC(getEnabledChannels);
 
-setCurrentChannel (_enabledChannels select _index);
+setCurrentChannel (_enabledChannels select parseNumber (_ctrl lbData _index));


### PR DESCRIPTION
**When merged this pull request will:**
Make channel changes in the marker placement window based on the `lbData` of the selection, instead of its index in the list. This way, the order of the items won't matter, and mods that manipulate the list (e.g. deletes items) won't break its functionality.