### PR TITLE
Inventory - Fix filtering for items without file extension in picture property

### DIFF
--- a/addons/inventory/XEH_preStart.sqf
+++ b/addons/inventory/XEH_preStart.sqf
@@ -17,6 +17,7 @@ uiNamespace setVariable [QGVAR(ItemKeyCache), _allItems apply {
         _picture = _picture select [1];
     };
     if (count _picture > 0 && !(_picture regexMatch ".*?\.paa")) then { // handle missing file extension
+        if (!fileExists (_picture + ".paa")) exitWith {};
         _picture = _picture + ".paa";
     };
 

--- a/addons/inventory/XEH_preStart.sqf
+++ b/addons/inventory/XEH_preStart.sqf
@@ -16,6 +16,9 @@ uiNamespace setVariable [QGVAR(ItemKeyCache), _allItems apply {
     if (_picture select [0,1] == "\") then {
         _picture = _picture select [1];
     };
+    if (count _picture > 0 && !(_picture regexMatch ".*?\.paa")) then { // handle missing file extension
+        _picture = _picture + ".paa";
+    };
 
     [format ["%1:%2", _displayName, _picture], _x];
 }];

--- a/addons/inventory/functions/fnc_forceItemListUpdate.sqf
+++ b/addons/inventory/functions/fnc_forceItemListUpdate.sqf
@@ -23,7 +23,6 @@ private _itemList = _display call FUNC(currentItemListBox);
 private _filterFunction = missionNamespace getVariable ((_display displayCtrl IDC_FILTERLISTS) lbData _index);
 
 if (_filterFunction isEqualType {}) then {
-    private _i = 0;
     for "_i" from (lbSize _itemList) - 1 to 0 step -1 do {
         private _config = GVAR(ItemKeyNamespace) getVariable format ["%1:%2", _itemList lbText _i, _itemList lbPicture _i];
 

--- a/addons/inventory/functions/fnc_forceItemListUpdate.sqf
+++ b/addons/inventory/functions/fnc_forceItemListUpdate.sqf
@@ -24,17 +24,11 @@ private _filterFunction = missionNamespace getVariable ((_display displayCtrl ID
 
 if (_filterFunction isEqualType {}) then {
     private _i = 0;
-
-    while {_i < lbSize _itemList} do {
+    for "_i" from (lbSize _itemList) - 1 to 0 step -1 do {
         private _config = GVAR(ItemKeyNamespace) getVariable format ["%1:%2", _itemList lbText _i, _itemList lbPicture _i];
 
         if (!isNil "_config" && {!(_config call _filterFunction)}) then {
             _itemList lbDelete _i;
-
-            // in case the filter function returns nil. Otherwise could lock up the game.
-            _i = _i - 1;
         };
-
-        _i = _i + 1;
     };
 };

--- a/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
+++ b/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
@@ -49,9 +49,7 @@ _filter ctrlAddEventHandler ["LBSelChanged", {_this call FUNC(onLBSelChanged)}];
 
         _index = _filter lbAdd _name;
         _filter lbSetData [_index, _fncName];
-
-        false
-    } count GVAR(customFilters);
+    } forEach GVAR(customFilters);
 
     // readd "All" filter to last position and select it
     _index = _filter lbAdd _nameAll;

--- a/addons/logistics_rope/CfgWeapons.hpp
+++ b/addons/logistics_rope/CfgWeapons.hpp
@@ -3,7 +3,7 @@ class CfgWeapons {
     class ACE_ItemCore;
     class ACE_ropeBase: ACE_ItemCore {
         scope = 1;
-        picture = QPATHTOF(data\m_rope_ca);
+        picture = QPATHTOF(data\m_rope_ca.paa);
         // model = "\A3\Structures_F_Heli\Items\Tools\Rope_01_F.p3d"; // model is Locked to Helicopter DLC
         descriptionShort = CSTRING(descriptionShort);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Add missing .paa file extension to logistics ropes.
- Replace a while loop.
- Replace a count loop with forEach.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
