### PR TITLE
Inventory - Fix item lockup when dragging into same inventory

### DIFF
--- a/addons/inventory/XEH_preStart.sqf
+++ b/addons/inventory/XEH_preStart.sqf
@@ -17,6 +17,7 @@ uiNamespace setVariable [QGVAR(ItemKeyCache), _allItems apply {
         _picture = _picture select [1];
     };
     if (count _picture > 0 && !(_picture regexMatch ".*?\.paa")) then { // handle missing file extension
+        if (!fileExists (_picture + ".paa")) exitWith {};
         _picture = _picture + ".paa";
     };
 

--- a/addons/inventory/XEH_preStart.sqf
+++ b/addons/inventory/XEH_preStart.sqf
@@ -16,6 +16,9 @@ uiNamespace setVariable [QGVAR(ItemKeyCache), _allItems apply {
     if (_picture select [0,1] == "\") then {
         _picture = _picture select [1];
     };
+    if (count _picture > 0 && !(_picture regexMatch ".*?\.paa")) then { // handle missing file extension
+        _picture = _picture + ".paa";
+    };
 
     [format ["%1:%2", _displayName, _picture], _x];
 }];

--- a/addons/inventory/functions/fnc_forceItemListUpdate.sqf
+++ b/addons/inventory/functions/fnc_forceItemListUpdate.sqf
@@ -23,7 +23,6 @@ private _itemList = _display call FUNC(currentItemListBox);
 private _filterFunction = missionNamespace getVariable ((_display displayCtrl IDC_FILTERLISTS) lbData _index);
 
 if (_filterFunction isEqualType {}) then {
-    private _i = 0;
     for "_i" from (lbSize _itemList) - 1 to 0 step -1 do {
         private _config = GVAR(ItemKeyNamespace) getVariable format ["%1:%2", _itemList lbText _i, _itemList lbPicture _i];
 

--- a/addons/inventory/functions/fnc_forceItemListUpdate.sqf
+++ b/addons/inventory/functions/fnc_forceItemListUpdate.sqf
@@ -24,17 +24,11 @@ private _filterFunction = missionNamespace getVariable ((_display displayCtrl ID
 
 if (_filterFunction isEqualType {}) then {
     private _i = 0;
-
-    while {_i < lbSize _itemList} do {
+    for "_i" from (lbSize _itemList) - 1 to 0 step -1 do {
         private _config = GVAR(ItemKeyNamespace) getVariable format ["%1:%2", _itemList lbText _i, _itemList lbPicture _i];
 
         if (!isNil "_config" && {!(_config call _filterFunction)}) then {
             _itemList lbDelete _i;
-
-            // in case the filter function returns nil. Otherwise could lock up the game.
-            _i = _i - 1;
         };
-
-        _i = _i + 1;
     };
 };

--- a/addons/inventory/functions/fnc_forceItemListUpdate.sqf
+++ b/addons/inventory/functions/fnc_forceItemListUpdate.sqf
@@ -18,9 +18,8 @@
 disableSerialization;
 params ["_display"];
 
-private _index = GVAR(selectedFilterIndex);
 private _itemList = _display call FUNC(currentItemListBox);
-private _filterFunction = missionNamespace getVariable ((_display displayCtrl IDC_FILTERLISTS) lbData _index);
+private _filterFunction = missionNamespace getVariable ((_display displayCtrl IDC_FILTERLISTS) lbData GVAR(selectedFilterIndex));
 
 if (_filterFunction isEqualType {}) then {
     for "_i" from (lbSize _itemList) - 1 to 0 step -1 do {

--- a/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
+++ b/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
@@ -70,9 +70,5 @@ _dummyControl ctrlAddEventHandler ["Draw", {
 
     private _itemList = _display call FUNC(currentItemListBox);
 
-    // monitoring is done by setting a lb value. These are unused here and are reset every time the list box updates.
-    if (_itemList lbValue 0 != DUMMY_VALUE) then {
-        _display call FUNC(forceItemListUpdate);
-        _itemList lbSetValue [0, DUMMY_VALUE];
-    };
+    _display call FUNC(forceItemListUpdate);
 }];

--- a/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
+++ b/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
@@ -49,9 +49,7 @@ _filter ctrlAddEventHandler ["LBSelChanged", {_this call FUNC(onLBSelChanged)}];
 
         _index = _filter lbAdd _name;
         _filter lbSetData [_index, _fncName];
-
-        false
-    } count GVAR(customFilters);
+    } forEach GVAR(customFilters);
 
     // readd "All" filter to last position and select it
     _index = _filter lbAdd _nameAll;

--- a/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
+++ b/addons/inventory/functions/fnc_inventoryDisplayLoad.sqf
@@ -25,7 +25,7 @@ private _filter = _display displayCtrl IDC_FILTERLISTS;
 // the first three indecies are hard coded: 0 - weapons , 1 - magazines, 2 - items
 // all of them show backpacks, because BI
 // all other indecies show everything, so all we have to do is delete stuff we dont like
-_filter ctrlAddEventHandler ["LBSelChanged", {_this call FUNC(onLBSelChanged)}];
+_filter ctrlAddEventHandler ["LBSelChanged", LINKFUNC(onLBSelChanged)];
 
 // have to add these a frame later, because this event happens before the engine adds the default filters
 [{

--- a/addons/logistics_rope/CfgWeapons.hpp
+++ b/addons/logistics_rope/CfgWeapons.hpp
@@ -3,7 +3,7 @@ class CfgWeapons {
     class ACE_ItemCore;
     class ACE_ropeBase: ACE_ItemCore {
         scope = 1;
-        picture = QPATHTOF(data\m_rope_ca);
+        picture = QPATHTOF(data\m_rope_ca.paa);
         // model = "\A3\Structures_F_Heli\Items\Tools\Rope_01_F.p3d"; // model is Locked to Helicopter DLC
         descriptionShort = CSTRING(descriptionShort);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Close #9163.

Needs #9696.
This does make the filtering run every frame instead of only when needed, but the performance loss is negligible unless dealing with inventories with hundreds of unique items displayed at once (in which case, you have other concerns anyway).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
