### PR TITLE
Arsenal - Use `canAdd` to check if item can be added to container

### DIFF
--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -80,29 +80,13 @@ private _fnc_fillRightContainer = {
             _itemInfo = isClass (_cfgWeapons >> configName _configPath);
         };
 
-        // Get mass
-        private _mass = if (!_hasItemInfo) then {
-            getNumber (_configPath >> "mass")
-        } else {
-            private _mass = getNumber (_configPath >> "itemInfo" >> "mass");
-
-            if (_mass == 0) then {
-                _mass = getNumber (_configPath >> "WeaponSlotsInfo" >> "mass");
-            };
-
-            _mass
-        };
-
-        _rightPanelCache set [_className, _mass]; // Needed because this provides more accurate weight for FUNC(updateRightPanel)
-
-        [getText (_configPath >> "displayName"), getText (_configPath >> "picture"), _mass]
-    }, true]) params ["_displayName", "_picture", "_mass"];
+        [getText (_configPath >> "displayName"), getText (_configPath >> "picture")]
+    }, true]) params ["_displayName", "_picture"];
 
     private _lbAdd = _ctrlPanel lnbAddRow ["", _displayName, "0"];
     _ctrlPanel lnbSetText [[_lbAdd, 1], _displayName];
     _ctrlPanel lnbSetData [[_lbAdd, 0], _className];
     _ctrlPanel lnbSetPicture [[_lbAdd, 0], _picture];
-    _ctrlPanel lnbSetValue [[_lbAdd, 0], _mass];
     _ctrlPanel lnbSetValue [[_lbAdd, 2], [0, 1] select _isUnique];
     _ctrlPanel lnbSetTooltip [[_lbAdd, 0], format ["%1\n%2", _displayName, _className]];
     if ((toLower _className) in GVAR(favorites)) then {

--- a/addons/arsenal/functions/fnc_fillRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillRightPanel.sqf
@@ -47,7 +47,7 @@ private _rightPanelCache = uiNamespace getVariable QGVAR(rightPanelCache);
 private _currentCargo = itemsWithMagazines GVAR(center);
 
 private _fnc_fillRightContainer = {
-    params ["_configCategory", "_className", "_hasItemInfo", ["_isUnique", false, [false]], ["_unknownOrigin", false, [false]]];
+    params ["_configCategory", "_className", ["_isUnique", false, [false]], ["_unknownOrigin", false, [false]]];
 
     if (GVAR(favoritesOnly) && {!(_className in _currentCargo)} && {!((toLower _className) in GVAR(favorites))}) exitWith {};
 
@@ -64,7 +64,6 @@ private _fnc_fillRightContainer = {
         // "Misc. items" magazines (e.g. spare barrels, intel, photos)
         if (_className in (uiNamespace getVariable QGVAR(magazineMiscItems))) then {
             _configPath = _cfgMagazines >> _className;
-            _hasItemInfo = false;
         };
 
         // If an item with unknown origin is in the arsenal list, try to find it
@@ -75,9 +74,6 @@ private _fnc_fillRightContainer = {
             if (isNull _configPath) then {
                 _configPath = _className call CBA_fnc_getObjectConfig;
             };
-
-            // Check if item is has item info
-            _itemInfo = isClass (_cfgWeapons >> configName _configPath);
         };
 
         [getText (_configPath >> "displayName"), getText (_configPath >> "picture")]
@@ -214,11 +210,11 @@ switch (_ctrlIDC) do {
             } forEach _compatibleItems;
         } else {
             {
-                ["CfgWeapons", _x, true] call _fnc_fillRightContainer;
+                ["CfgWeapons", _x] call _fnc_fillRightContainer;
             } forEach (keys ((GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS) get _index));
 
             {
-                ["CfgWeapons", _x, true, true] call _fnc_fillRightContainer;
+                ["CfgWeapons", _x, true] call _fnc_fillRightContainer;
             } forEach (keys ((GVAR(virtualItems) get IDX_VIRT_UNIQUE_ATTACHMENTS) get _index));
         };
     };
@@ -237,44 +233,44 @@ switch (_ctrlIDC) do {
     case IDC_buttonMag: {
         {
             if (_x in (GVAR(virtualItems) get IDX_VIRT_ITEMS_ALL)) then {
-                ["CfgMagazines", _x, false] call _fnc_fillRightContainer;
+                ["CfgMagazines", _x] call _fnc_fillRightContainer;
 
                 continue;
             };
 
             if (_x in (GVAR(virtualItems) get IDX_VIRT_UNIQUE_VIRT_ITEMS_ALL)) then {
-                ["CfgMagazines", _x, false, true] call _fnc_fillRightContainer;
+                ["CfgMagazines", _x, true] call _fnc_fillRightContainer;
             };
         } forEach (keys _compatibleMagsAll);
     };
     // All magazines
     case IDC_buttonMagALL: {
         {
-            ["CfgMagazines", _x, false] call _fnc_fillRightContainer;
+            ["CfgMagazines", _x] call _fnc_fillRightContainer;
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_ITEMS_ALL));
 
         {
-            ["CfgMagazines", _x, false, true] call _fnc_fillRightContainer;
+            ["CfgMagazines", _x, true] call _fnc_fillRightContainer;
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_VIRT_ITEMS_ALL));
     };
     // Grenades
     case IDC_buttonThrow: {
         {
-            ["CfgMagazines", _x, false] call _fnc_fillRightContainer;
+            ["CfgMagazines", _x] call _fnc_fillRightContainer;
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_GRENADES));
 
         {
-            ["CfgMagazines", _x, false, true] call _fnc_fillRightContainer;
+            ["CfgMagazines", _x, true] call _fnc_fillRightContainer;
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_GRENADES));
     };
     // Explosives
     case IDC_buttonPut: {
         {
-            ["CfgMagazines", _x, false] call _fnc_fillRightContainer;
+            ["CfgMagazines", _x] call _fnc_fillRightContainer;
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_EXPLOSIVES));
 
         {
-            ["CfgMagazines", _x, false, true] call _fnc_fillRightContainer;
+            ["CfgMagazines", _x, true] call _fnc_fillRightContainer;
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_EXPLOSIVES));
     };
     // Misc. items
@@ -293,31 +289,31 @@ switch (_ctrlIDC) do {
         // "Regular" misc. items
         {
             if !(_x in _items) then {
-                ["CfgWeapons", _x, true] call _fnc_fillRightContainer;
+                ["CfgWeapons", _x] call _fnc_fillRightContainer;
             };
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_MISC_ITEMS));
         // Unique items
         {
             if !(_x in _items) then {
-                ["CfgWeapons", _x, true, true] call _fnc_fillRightContainer;
+                ["CfgWeapons", _x, true] call _fnc_fillRightContainer;
             };
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_MISC_ITEMS));
         // Unique backpacks
         {
             if !(_x in _items) then {
-                ["CfgVehicles", _x, false, true] call _fnc_fillRightContainer;
+                ["CfgVehicles", _x, true] call _fnc_fillRightContainer;
             };
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_BACKPACKS));
         // Unique goggles
         {
             if !(_x in _items) then {
-                ["CfgGlasses", _x, false, true] call _fnc_fillRightContainer;
+                ["CfgGlasses", _x, true] call _fnc_fillRightContainer;
             };
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_GOGGLES));
         // Unknown items
         {
             if !(_x in _items) then {
-                ["CfgWeapons", _x, true, !(_x in GVAR(virtualItemsFlat)), true] call _fnc_fillRightContainer;
+                ["CfgWeapons", _x, !(_x in GVAR(virtualItemsFlat)), true] call _fnc_fillRightContainer;
             };
         } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIQUE_UNKNOWN_ITEMS)); // if an item is here but in virtual items, it's just in the wrong place
     };
@@ -331,23 +327,23 @@ switch (_ctrlIDC) do {
                 switch (true) do {
                     // "Regular" misc. items
                     case (_x in (GVAR(virtualItems) get IDX_VIRT_MISC_ITEMS)): {
-                        ["CfgWeapons", _x, true] call _fnc_fillRightContainer;
+                        ["CfgWeapons", _x] call _fnc_fillRightContainer;
                     };
                     // Unique items
                     case (_x in (GVAR(virtualItems) get IDX_VIRT_UNIQUE_MISC_ITEMS)): {
-                        ["CfgWeapons", _x, true, true] call _fnc_fillRightContainer;
+                        ["CfgWeapons", _x, true] call _fnc_fillRightContainer;
                     };
                     // Unique backpacks
                     case (_x in (GVAR(virtualItems) get IDX_VIRT_UNIQUE_BACKPACKS)): {
-                        ["CfgVehicles", _x, false, true] call _fnc_fillRightContainer;
+                        ["CfgVehicles", _x, true] call _fnc_fillRightContainer;
                     };
                     // Unique goggles
                     case (_x in (GVAR(virtualItems) get IDX_VIRT_UNIQUE_GOGGLES)): {
-                        ["CfgGlasses", _x, false, true] call _fnc_fillRightContainer;
+                        ["CfgGlasses", _x, true] call _fnc_fillRightContainer;
                     };
                     // Unknown items
                     case (_x in (GVAR(virtualItems) get IDX_VIRT_UNIQUE_UNKNOWN_ITEMS)): {
-                        ["CfgWeapons", _x, true, !(_x in GVAR(virtualItemsFlat)), true] call _fnc_fillRightContainer;
+                        ["CfgWeapons", _x, !(_x in GVAR(virtualItemsFlat)), true] call _fnc_fillRightContainer;
                     };
                 };
             } forEach _items;

--- a/addons/arsenal/functions/fnc_updateRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_updateRightPanel.sqf
@@ -18,7 +18,6 @@
 params ["_control", "_container", "_hasItems"];
 
 private _loadRemaining = maxLoad _container - loadAbs _container;
-private _rightPanelCache = uiNamespace getVariable [QGVAR(rightPanelCache), createHashMap];
 
 private _item = "";
 private _color = [];

--- a/addons/arsenal/functions/fnc_updateRightPanel.sqf
+++ b/addons/arsenal/functions/fnc_updateRightPanel.sqf
@@ -20,17 +20,17 @@ params ["_control", "_container", "_hasItems"];
 private _loadRemaining = maxLoad _container - loadAbs _container;
 private _rightPanelCache = uiNamespace getVariable [QGVAR(rightPanelCache), createHashMap];
 
-private _mass = -1;
+private _item = "";
 private _color = [];
 private _alpha = 1;
 
 // Grey out items that are too big to fit in remaining space of the container
 for "_row" from 0 to (lnbSize _control select 0) - 1 do {
-    _mass = _rightPanelCache getOrDefault [_control lnbData [_row, 0], 0];
+    _item = _control lnbData [_row, 0];
     _color = _control lnbColor [_row, 1];
 
     // Lower alpha on color for items that can't fit
-    _alpha = [0.25, 1] select (_mass <= _loadRemaining);
+    _alpha = [0.25, 1] select (_container canAdd _item);
     _color set [3, _alpha];
     _control lnbSetColor [[_row, 1], _color];
     _control lnbSetColor [[_row, 2], [1, 1, 1, _alpha]];
@@ -55,6 +55,6 @@ private _curSel = lnbCurSelRow _control;
 // Disable '+' button if item is unique or too big to fit in remaining space
 if (_curSel != -1) then {
     private _plusButtonCtrl = _display displayCtrl IDC_arrowPlus;
-    _plusButtonCtrl ctrlEnable !((_control lnbValue [_curSel, 2]) == 1 || {(_rightPanelCache getOrDefault [_control lnbData [_curSel, 0], 0]) > _loadRemaining});
+    _plusButtonCtrl ctrlEnable ((_control lnbValue [_curSel, 2]) != 1 && {_container canAdd (_control lnbData [_curSel, 0])});
     _plusButtonCtrl ctrlCommit FADE_DELAY;
 };

--- a/addons/arsenal/script_component.hpp
+++ b/addons/arsenal/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_ARSENAL

--- a/addons/arsenal/script_component.hpp
+++ b/addons/arsenal/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_ARSENAL


### PR DESCRIPTION
**When merged this pull request will:**
- Title. Makes items also respect config `allowedSlots[]` property now.
- Drop mass property from right panel cache and ListNBox. I'm 99% 3rd parties don't use this anyway.
- Drop itemInfo param and lookups from right panel cache. Not needed due to dropping mass.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
