### PR TITLE
Improve Ace Casings  to include 40mm casings

### DIFF
--- a/addons/casings/config.cpp
+++ b/addons/casings/config.cpp
@@ -13,5 +13,13 @@ class CfgPatches {
         VERSION_CONFIG;
     };
 };
+class CfgAmmo {
+    class GrenadeBase; // Reference the base class
 
+    class G_40mm_HE: GrenadeBase {
+        // Override the specific parameters here
+        cartridge = "FxCartridge_40mm";
+        // Other parameters can also be modified if needed
+    };
+};
 #include "CfgEventHandlers.hpp"

--- a/addons/casings/functions/fnc_createCasing.sqf
+++ b/addons/casings/functions/fnc_createCasing.sqf
@@ -40,6 +40,7 @@ if (isNil "_modelPath") then {
         case "FxCartridge_12Gauge_Slug_lxWS":   { "lxWS\weapons_1_f_lxws\Ammo\cartridge_slug_lxws.p3d" };
         case "FxCartridge_12Gauge_Smoke_lxWS":  { "lxWS\weapons_1_f_lxws\Ammo\cartridge_smoke_lxws.p3d" };
         case "FxCartridge_12Gauge_Pellet_lxWS": { "lxWS\weapons_1_f_lxws\Ammo\cartridge_pellet_lxws.p3d" };
+		case "FxCartridge_40mm":                { "A3\Weapons_F\MagazineProxies\mag_40x36_HE_1rnd.p3d" };
         case "":                                { "" };
         default { "A3\Weapons_f\ammo\cartridge.p3d" };
     };


### PR DESCRIPTION
adds parameter FxCartridge_40mm to the 40mm classes. (grenadecore)

**When merged this pull request will:**
- _Describe what this pull request will do_

This pull request will enable underbarrel grenade launchers (40mm) to be included in creating casings on the ground. 
This is done by two changes.

1.Adding to config.cpp a cfgammo edit that changes the 40mm grenades classes to include a cartridge parameter called "FxCartridge_40mm"

2.editing fnc_createcasing.sqf to include a search for this casing and applying the relevant 3d model for this casing

 _Each change in a separate line_

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
