### PR TITLE
Overheating - Add Bolt Type stat to arsenal

### DIFF
--- a/addons/overheating/ACE_Arsenal_Stats.hpp
+++ b/addons/overheating/ACE_Arsenal_Stats.hpp
@@ -1,0 +1,12 @@
+class EGVAR(arsenal,stats) {
+    class statBase;
+    class ACE_boltType: statBase {
+        scope = 2;
+        priority = 2;
+        stats[] = {"boltType"};
+        displayName = CSTRING(statBoltType);
+        showText = 1;
+        textStatement = QUOTE(call FUNC(statTextStatement_boltType));
+        tabs[] = {{0,1}, {}};
+    };
+};

--- a/addons/overheating/ACE_Arsenal_Stats.hpp
+++ b/addons/overheating/ACE_Arsenal_Stats.hpp
@@ -1,9 +1,19 @@
+
 class EGVAR(arsenal,stats) {
     class statBase;
+    class ACE_allowSwapBarrel: statBase {
+        scope = 2;
+        priority = -1;
+        stats[] = {QGVAR(allowSwapBarrel)};
+        displayName = CSTRING(statBarrelType);
+        showText = 1;
+        textStatement = QUOTE(call FUNC(statTextStatement_allowSwapBarrel));
+        tabs[] = {{0,1}, {}};
+    };
     class ACE_boltType: statBase {
         scope = 2;
-        priority = 2;
-        stats[] = {"boltType"};
+        priority = -1.1;
+        stats[] = {QGVAR(closedBolt)};
         displayName = CSTRING(statBoltType);
         showText = 1;
         textStatement = QUOTE(call FUNC(statTextStatement_boltType));

--- a/addons/overheating/XEH_PREP.hpp
+++ b/addons/overheating/XEH_PREP.hpp
@@ -25,6 +25,7 @@ PREP(overheat);
 PREP(sendSpareBarrelsTemperaturesHint);
 PREP(setAmmoTemperature);
 PREP(setWeaponTemperature);
+PREP(statTextStatement_boltType);
 PREP(swapBarrel);
 PREP(swapBarrelAssistant);
 PREP(swapBarrelCallback);

--- a/addons/overheating/XEH_PREP.hpp
+++ b/addons/overheating/XEH_PREP.hpp
@@ -26,6 +26,7 @@ PREP(sendSpareBarrelsTemperaturesHint);
 PREP(setAmmoTemperature);
 PREP(setWeaponTemperature);
 PREP(statTextStatement_boltType);
+PREP(statTextStatement_allowSwapBarrel);
 PREP(swapBarrel);
 PREP(swapBarrelAssistant);
 PREP(swapBarrelCallback);

--- a/addons/overheating/config.cpp
+++ b/addons/overheating/config.cpp
@@ -26,6 +26,8 @@ class CfgPatches {
 
 #include "ACE_Settings.hpp"
 
+#include "ACE_Arsenal_Stats.hpp"
+
 class CfgMovesBasic {
     class ManActions {
         GVAR(GestureMountMuzzle) = QGVAR(GestureMountMuzzle);

--- a/addons/overheating/functions/fnc_statTextStatement_allowSwapBarrel.sqf
+++ b/addons/overheating/functions/fnc_statTextStatement_allowSwapBarrel.sqf
@@ -1,0 +1,21 @@
+#include "..\script_component.hpp"
+/*
+ * Author: drofseh
+ * Bolt Type statement.
+ *
+ * Arguments:
+ * 0: Not used
+ * 1: Item config path <CONFIG>
+ *
+ * Return Value:
+ * Stat Text <STRING>
+ *
+ * Public: No
+*/
+
+params ["", "_config"];
+TRACE_1("statTextStatement_allowSwapBarrel",_config);
+
+if ((getNumber (_config >> QGVAR(allowSwapBarrel))) == 1) exitWith {LLSTRING(statBarrelType_removeable)};
+
+LLSTRING(statBarrelType_nonRemoveable)

--- a/addons/overheating/functions/fnc_statTextStatement_boltType.sqf
+++ b/addons/overheating/functions/fnc_statTextStatement_boltType.sqf
@@ -1,0 +1,21 @@
+#include "..\script_component.hpp"
+/*
+ * Author: drofseh
+ * Bolt Type statement.
+ *
+ * Arguments:
+ * 0: Not used
+ * 1: Item config path <CONFIG>
+ *
+ * Return Value:
+ * Stat Text <STRING>
+ *
+ * Public: No
+*/
+
+params ["", "_config"];
+TRACE_1("statTextStatement_boltType",_config);
+
+if ((getNumber (_config >> QGVAR(closedBolt))) == 1) exitWith {LLSTRING(statBoltType_closedBolt)};
+
+LLSTRING(statBoltType_openBolt)

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -884,5 +884,14 @@
         <Key ID="STR_ACE_Overheating_statBoltType_closedBolt">
             <English>Closed Bolt</English>
         </Key>
+        <Key ID="STR_ACE_Overheating_statBarrelType">
+            <English>Barrel Type</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_statBarrelType_nonRemoveable">
+            <English>Non-Removeable</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_statBarrelType_removeable">
+            <English>Quick Change</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -875,5 +875,14 @@
             <Chinesesimp>备用枪管温度非常热</Chinesesimp>
             <Chinese>備用槍管溫度超級熱</Chinese>
         </Key>
+        <Key ID="STR_ACE_Overheating_statBoltType">
+            <English>Bolt Type</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_statBoltType_openBolt">
+            <English>Open Bolt</English>
+        </Key>
+        <Key ID="STR_ACE_Overheating_statBoltType_closedBolt">
+            <English>Closed Bolt</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds an arsenal stat to show if the weapon is open or closed bolt.
- Adds an arsenal stat to show if the weapon's barrel can be swapped.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
