### PR TITLE
Translations - Improve/Add Japanese localization.

### DIFF
--- a/addons/compat_ws/compat_ws_realisticnames/stringtable.xml
+++ b/addons/compat_ws/compat_ws_realisticnames/stringtable.xml
@@ -55,14 +55,14 @@
             <Korean>GLX-160 (육각)</Korean>
             <German>GLX 160 (Hex)</German>
             <Italian>GLX-160 (Hex)</Italian>
-            <Japanese>GLX 160 (ヘックス)</Japanese>
+            <Japanese>GLX 160 (六角形迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_GLX_GreenHex_Name">
             <English>GLX 160 (Green Hex)</English>
             <Korean>GLX-160 (초록육각)</Korean>
             <German>GLX 160 (Grün Hex)</German>
             <Italian>GLX-160 (Hex Verde)</Italian>
-            <Japanese>GLX 160 (緑ヘックス)</Japanese>
+            <Japanese>GLX 160 (緑六角形迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_GLX_Camo_Name">
             <English>GLX 160 (Camo)</English>
@@ -110,14 +110,14 @@
             <Korean>벡터 SS-77 (육각)</Korean>
             <German>Vektor SS-77 (Hex)</German>
             <Italian>Vektor SS-77 (Hex)</Italian>
-            <Japanese>ヴェクター SS-77 (ヘックス)</Japanese>
+            <Japanese>ヴェクター SS-77 (六角形迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_S77_GreenHex_Name">
             <English>Vektor SS-77 (Green Hex)</English>
             <Korean>벡터 SS-77 (초록육각)</Korean>
             <German>Vektor SS-77 (Grün Hex)</German>
             <Italian>Vektor SS-77 (Hex Verde)</Italian>
-            <Japanese>ヴェクター SS-77 (緑ヘックス)</Japanese>
+            <Japanese>ヴェクター SS-77 (緑六角形迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_S77_Desert_Name">
             <English>Vektor SS-77 (Desert)</English>

--- a/addons/fcs/stringtable.xml
+++ b/addons/fcs/stringtable.xml
@@ -44,7 +44,7 @@
             <Portuguese>Ajustar distância do FCS (Acima)</Portuguese>
             <Italian>Aumenta la portata dell'FCS</Italian>
             <Russian>Диапазон СУО (выше)</Russian>
-            <Japanese>FCS による距離を調節 (上げ)</Japanese>
+            <Japanese>FCS 距離を調節 (上げ)</Japanese>
             <Korean>사통장치 거리 조정 (위로)</Korean>
             <Chinesesimp>调整火控系统距离（上调）</Chinesesimp>
             <Chinese>調整火控系統距離 (上)</Chinese>
@@ -60,7 +60,7 @@
             <Portuguese>Ajustar distância do FCS (Abaixo)</Portuguese>
             <Italian>Riduci la portata dell'FCS</Italian>
             <Russian>Диапазон СУО (ниже)</Russian>
-            <Japanese>FCS による距離を調節 (下げ)</Japanese>
+            <Japanese>FCS 距離を調節 (下げ)</Japanese>
             <Korean>사통장치 거리 조정 (아래로)</Korean>
             <Chinesesimp>调整火控系统距离（下调）</Chinesesimp>
             <Chinese>調整火控系統距離 (下)</Chinese>

--- a/addons/map/stringtable.xml
+++ b/addons/map/stringtable.xml
@@ -60,7 +60,7 @@
             <Czech>Nasvícení mapy pomocí baterky</Czech>
             <Italian>Effetto luminoso sul giocatore</Italian>
             <French>Lueur lampe carte</French>
-            <Japanese>地図をライトで照らす</Japanese>
+            <Japanese>地図用ライトの光放射</Japanese>
             <Korean>지도 조명 발광</Korean>
             <Chinesesimp>增加地图亮度</Chinesesimp>
             <Chinese>增加地圖亮度</Chinese>
@@ -75,7 +75,7 @@
             <Spanish>Añadir resplandor externo a los jugadores que utilizan la linterna en el mapa?</Spanish>
             <Czech>Přidat externí záři hráči který používá baterku v mapě?</Czech>
             <Italian>Aggiungi un effetto di luce sul giocatore che sta usando la torcia in mappa, questo è visibile ad altri giocatori.</Italian>
-            <Japanese>プレイヤーが地図をフラッシュライトで照らせられるように設定します。</Japanese>
+            <Japanese>マップ上で懐中電灯を使用しているプレイヤーから辺りへの光放射を追加しますか?</Japanese>
             <Korean>지도에 조명을 사용하는 플레이어에 외부 불빛을 추가합니까?</Korean>
             <Chinesesimp>当玩家打开手电筒时，增加地图亮度。</Chinesesimp>
             <Chinese>當玩家擁有手電筒時，增加地圖亮度?</Chinese>
@@ -91,7 +91,7 @@
             <Hungarian>Térkép-rázkódás</Hungarian>
             <Russian>Тряска карты</Russian>
             <Italian>Scuotimento della mappa</Italian>
-            <Japanese>地図を揺らす</Japanese>
+            <Japanese>地図の揺れ</Japanese>
             <Korean>지도 흔들림</Korean>
             <Chinesesimp>地图震动</Chinesesimp>
             <Chinese>地圖震動</Chinese>
@@ -108,7 +108,7 @@
             <Hungarian>Rázkódjon-e a térkép mozgáskor?</Hungarian>
             <Russian>Заставлять карту трястись при ходьбе?</Russian>
             <Italian>Far scuotere la mappa mentre cammini?</Italian>
-            <Japanese>歩いているときは地図を揺らすかかどうかを設定できます。</Japanese>
+            <Japanese>歩いているときに地図を揺らしますか?</Japanese>
             <Korean>걸을 때 지도를 보면 흔들리게 합니까?</Korean>
             <Chinesesimp>走路时打开地图会产生晃动。</Chinesesimp>
             <Chinese>走路時讓地圖有震動的感覺?</Chinese>
@@ -140,7 +140,7 @@
             <Hungarian>Korlátozva legyen-e a nagyítás mennyisége a térképnél?</Hungarian>
             <Russian>Ограничить максимальное приближение, доступное на карте?</Russian>
             <Italian>Limita i livelli di zoom disponibili sulla mappa?</Italian>
-            <Japanese>地図上で利用できる拡大倍率を制限できます。</Japanese>
+            <Japanese>地図上で利用できる拡大倍率を制限しますか?</Japanese>
             <Korean>지도 확대에 제한을 둡니까?</Korean>
             <Chinesesimp>限制地图上可允许缩放的倍率？</Chinesesimp>
             <Chinese>限制地圖上可允許縮放的倍率?</Chinese>
@@ -156,7 +156,7 @@
             <Hungarian>Kurzor-koordináták mutatása</Hungarian>
             <Russian>Показывать координаты курсора</Russian>
             <Italian>Mostra coordinate sul cursore</Italian>
-            <Japanese>カーソル先で座標を表示</Japanese>
+            <Japanese>カーソル先の座標を表示</Japanese>
             <Korean>커서에 좌표를 보이기</Korean>
             <Chinesesimp>显示光标的座标</Chinesesimp>
             <Chinese>顯示游標的座標</Chinese>
@@ -172,7 +172,7 @@
             <Hungarian>Mutatva legyen-e a kurzornál található rész rácskoordinátája?</Hungarian>
             <Russian>Показывать координаты около курсора мыши?</Russian>
             <Italian>Mostra il numero della coordinata-griglia sul cursore del mouse in mappa?</Italian>
-            <Japanese>カーソルで合わせた先を地図座標で表示するかどうかを設定できます。</Japanese>
+            <Japanese>カーソルで合わせた先の地図グリッド座標を表示しますか?</Japanese>
             <Korean>지도에서 커서 옆에 좌표가 뜨게 합니까?</Korean>
             <Chinesesimp>显示鼠标光标所在的网格座标？</Chinesesimp>
             <Chinese>顯示滑鼠游標所在的網格座標?</Chinese>
@@ -300,7 +300,7 @@
             <Hungarian>Jelölők elrejtése "csak AI" csoportoknál?</Hungarian>
             <Russian>Скрыть маркеры групп, которые состоят полностью из ботов?</Russian>
             <Italian>Nascondi marker per gruppi di sole IA?</Italian>
-            <Japanese>'AIのみ'グループのマーカー表示有無を設定できます。</Japanese>
+            <Japanese>'AIのみ'のグループのマーカー表示有無を設定できます。</Japanese>
             <Korean>인공지능만 있는 그룹의 마커를 숨깁니까?</Korean>
             <Chinesesimp>隐藏'AI 小队'的追踪？</Chinesesimp>
             <Chinese>隱藏'AI小隊'的蹤跡?</Chinese>
@@ -379,7 +379,7 @@
             <Czech>NVG</Czech>
             <Spanish>NVG</Spanish>
             <Italian>NVG</Italian>
-            <Japanese>夜間暗視装置</Japanese>
+            <Japanese>暗視装置</Japanese>
             <Korean>야간투시경</Korean>
             <Chinesesimp>夜视仪</Chinesesimp>
             <Chinese>夜視鏡</Chinese>
@@ -491,7 +491,7 @@
             <Italian>Imposta Canale all'Avvio</Italian>
             <Spanish>Setear canal al comenzar</Spanish>
             <French>Définir un canal par défaut</French>
-            <Japanese>開始時のチャンネルを決定</Japanese>
+            <Japanese>開始時のチャンネルを指定</Japanese>
             <Korean>시작시 채널</Korean>
             <Chinesesimp>设定游戏开始时的聊天频道</Chinesesimp>
             <Chinese>設定遊戲開始時的聊天頻道</Chinese>
@@ -506,7 +506,7 @@
             <Italian>Cambia il canale marker iniziale all'avvio della missione</Italian>
             <Spanish>Cambiar el canal de marcadores inicial al comenzar la misión</Spanish>
             <French>Change le canal de communication par défaut au début de la mission.</French>
-            <Japanese>ミッション開始時にあらかじめ設定されているマーカ チャンネルを変更します</Japanese>
+            <Japanese>ミッション開始時に使用されるマーカーチャンネルの指定を変更します</Japanese>
             <Korean>미션 시작시 마커채널을 변경합니다</Korean>
             <Chinesesimp>更改任务启动时的聊天频道</Chinesesimp>
             <Chinese>更改任務啟動時的聊天頻道</Chinese>

--- a/addons/map_gestures/stringtable.xml
+++ b/addons/map_gestures/stringtable.xml
@@ -75,7 +75,7 @@
             <German>Maximale Reichweite zwischen Spielern um Kartenzeichen anzuzeigen</German>
             <Spanish>Máxima distancia a la cual pueden verse el indicador de gestos</Spanish>
             <French>Définit le rayon au-delà duquel un joueur ne verra plus l'indicateur de pointage des autres joueurs.</French>
-            <Japanese>プレイヤーによるマップ ジェスチャーの表示範囲を設定します</Japanese>
+            <Japanese>マップ ジェスチャーのインジケーターを表示可能なプレーヤー間の最大距離</Japanese>
             <Korean>플레이어간에 지도 신호 표시거리를 설정합니다.</Korean>
             <Chinesesimp>设定地图指示显示的最大范围距离</Chinesesimp>
             <Chinese>設定地圖指示器顯示的最大範圍距離</Chinese>
@@ -122,7 +122,7 @@
             <German>Farbe der Namenstexte.</German>
             <Spanish>Color de los nombres</Spanish>
             <French>Couleur du texte du nom</French>
-            <Japanese>名前への色</Japanese>
+            <Japanese>名前の文字色</Japanese>
             <Korean>글 색상 명칭</Korean>
             <Chinesesimp>名称文字颜色</Chinesesimp>
             <Chinese>名稱文字顏色</Chinese>
@@ -137,7 +137,7 @@
             <German>Farbe der Namenstexte neben der Kartenzeichen-Markierung.</German>
             <Spanish>Color de los nombres dibujados al lado del marcados de gestos.</Spanish>
             <French>Définit la couleur du texte pour le nom à côté du marqueur de pointage sur carte.</French>
-            <Japanese>マップ ジェスチャーに表示される、名前の色を決定します。</Japanese>
+            <Japanese>マップ ジェスチャーに添えて表示される名前の文字色。</Japanese>
             <Korean>지도 색상에 표시되는 이름의 색상을 결정합니다.</Korean>
             <Chinesesimp>定义名称文字颜色。使其与地图指示颜色有所区别。</Chinesesimp>
             <Chinese>定義名稱文字顏色。使其與地圖指示器顏色有所區別</Chinese>
@@ -153,7 +153,7 @@
             <German>Gruppenführer-Standardfarbe</German>
             <Spanish>Color por defecto para el lider</Spanish>
             <French>Couleur de commandement par défaut</French>
-            <Japanese>リーダー用標準の色</Japanese>
+            <Japanese>部隊長用の標準色</Japanese>
             <Korean>리더 기본 색상</Korean>
             <Chinesesimp>队长预设颜色</Chinesesimp>
             <Chinese>隊長預設顏色</Chinese>
@@ -167,7 +167,7 @@
             <German>Ersatz-Farbwert für Gruppenführer wenn keine Gruppeneinstellung vorhanden ist. [Modul: leer lassen um Anwendung bei Clients nicht zu erzwingen]</German>
             <Spanish>Color por defecto para líderes cuando no está configurado [Módulo: dejar en blanco para no forzar]</Spanish>
             <French>Définit la couleur par défaut pour les chefs de groupe quand il n'y a pas de réglage de groupe. [Module : laisser vide pour ne pas forcer chez les clients.]</French>
-            <Japanese>グループ設定が存在しない場合に、グループ リーダーへ設定される色の値を設定します。[モジュール:空の場合はクライアントへ強制しません]</Japanese>
+            <Japanese>グループ設定がない場合に部隊長へ設定される色の値を設定します。[モジュール:空の場合はクライアントへ強制しません]</Japanese>
             <Korean>그룹 설정이 없는 경우 리더의 예비 색상 값입니다. [모듈: 클라이언트에서 강체하지 않기 위해 공백으로 비워둘 것]</Korean>
             <Chinesesimp>当没有设定小队颜色时，此功能会定义队长的指示颜色。[模块：此栏留空来保持预设颜色]</Chinesesimp>
             <Chinese>當沒有設定小隊顏色時，此功能會定義隊長的指示器顏色。[模塊: 此欄留空來保持預設顏色]</Chinese>
@@ -198,7 +198,7 @@
             <German>Ersatz-Farbwert wenn keine Gruppeneinstellung vorhanden ist. [Modul: leer lassen um Anwendung bei Clients nicht zu erzwingen]</German>
             <Spanish>Color por defecto cuando no está configurado [Módulo: dejar en blanco para no forzar]</Spanish>
             <French>Définit la couleur par défaut quand il n'y a pas de réglage pour le groupe. [Module : laisser vide pour ne pas forcer chez les clients.]</French>
-            <Japanese>グループ設定が存在しない場合に、グループ リーダーへ設定される色の値を設定します。[モジュール:空の場合はクライアントへ強制しません]</Japanese>
+            <Japanese>グループ設定がない場合に設定される色の値を設定します。[モジュール:空の場合はクライアントへ強制しません]</Japanese>
             <Korean>그룹 설정이 없을 경우의 예비 색상입니다. [모듈: 클라이언트에서 강체하지 않기 위해 공백으로 비워둘 것]</Korean>
             <Chinesesimp>当没有设定小队颜色时，此功能会定义玩家的指示颜色。[模块：此栏留空来保持预设颜色]</Chinesesimp>
             <Chinese>當沒有設定小隊顏色時，此功能會定義玩家的指示器顏色。[模塊: 此欄留空來保持預設顏色]</Chinese>
@@ -214,7 +214,7 @@
             <German>Gruppenführer-Farbe</German>
             <Spanish>Color para el líder</Spanish>
             <French>Couleur de commandement</French>
-            <Japanese>リーダー用の色</Japanese>
+            <Japanese>部隊長用の色</Japanese>
             <Korean>리더 색상</Korean>
             <Chinesesimp>队长颜色</Chinesesimp>
             <Chinese>隊長顏色</Chinese>
@@ -228,7 +228,7 @@
             <German>Farbwert für Gruppenführer, die mit diesem Modul synchronisiert werden.</German>
             <Spanish>Color para los líderes de los grupos sincronizados al módulo.</Spanish>
             <French>Couleur pour les chefs des groupes synchronisés avec ce module.</French>
-            <Japanese>モジュールで同期されたグループのリーダー用に色の値を決定します。</Japanese>
+            <Japanese>モジュールで同期されたグループの隊長に設定される色の値を決定します。</Japanese>
             <Korean>그룹이 이 모듈에 동기화 됐을 때의 리더 색상입니다.</Korean>
             <Chinesesimp>改变与此同步小队队长的指示颜色。</Chinesesimp>
             <Chinese>改變與此同步小隊隊長的指示器顏色</Chinese>
@@ -259,7 +259,7 @@
             <German>Farbwert für Gruppenmitglieder, die mit diesem Modul synchronisiert werden.</German>
             <Spanish>Color para los miembros de los grupos sincronizados al módulo.</Spanish>
             <French>Couleur pour les membres des groupes synchronisés avec ce module.</French>
-            <Japanese>モジュールで同期されたグループのメンバ用に色の値を決定します。</Japanese>
+            <Japanese>モジュールで同期されたグループの隊員に設定される色の値を決定します。</Japanese>
             <Korean>그룹이 이 모듈에 동기화 됐을 때의 멤버 색상입니다.</Korean>
             <Chinesesimp>改变与此同步小队队员的指示颜色</Chinesesimp>
             <Chinese>改變與此同步小隊隊員的指示器顏色</Chinese>
@@ -270,7 +270,7 @@
             <Russian>Показывать только союзные жесты</Russian>
             <Polish>Pokazuj jedynie sojusznicze gesty</Polish>
             <French>Afficher uniquement le pointage des alliés</French>
-            <Japanese>友軍ジェスチャーのみ表示</Japanese>
+            <Japanese>友軍のジェスチャーのみ表示</Japanese>
             <Spanish>Mostrar sólo gestos de aliados</Spanish>
             <German>Nur Gesten befreundeter Einheiten zeigen</German>
             <Italian>Mostra solo gesti di alleati</Italian>
@@ -283,7 +283,7 @@
             <Russian>Показывать жесты только от игроков союзной стороны.</Russian>
             <French>Affiche uniquement les pointages effectués par des unités qui sont du même camp, ou d'un camp allié.</French>
             <Italian>Mostra solo gesti effettuati da unità che sono della stessa fazione o una fazione alleata.</Italian>
-            <Japanese>友軍ユニットのみからジェスチャーを表示します。</Japanese>
+            <Japanese>同じ陣営または味方陣営のユニットからのジェスチャーのみを表示します。</Japanese>
             <Spanish>Muestra únicamente gestos de las unidades que son del mismo bando o de un bando aliado</Spanish>
             <Polish>Pokazuj tylko Gesty od jednostek z tej samej lub sojuszniczej strony</Polish>
             <German>Nur Gesten von Einheiten der selben oder einer verbündeten Seite zeigen.</German>
@@ -295,7 +295,7 @@
             <English>Max range Camera</English>
             <Russian>Макс. дальность действия камеры</Russian>
             <French>Portée de la caméra</French>
-            <Japanese>カメラ最大範囲</Japanese>
+            <Japanese>カメラの最大範囲</Japanese>
             <Spanish>Máximo alcance de cámara</Spanish>
             <Polish>Maksymalny zasięg kamery</Polish>
             <German>Maximale Kamerareichweite</German>
@@ -308,7 +308,7 @@
             <English>Max range between a Camera and players to show the map gesture indicator</English>
             <Russian>Устанавливает макс. дальность между игроком и камерой для отображения жестов на карте</Russian>
             <French>Définit le rayon au-delà duquel une caméra ne verra plus l'indicateur de pointage des autres joueurs.</French>
-            <Japanese>プレイヤーが行うマップ ジェスチャーをカメラから確認できる最大範囲を設定します。</Japanese>
+            <Japanese>観戦カメラから確認可能なマップ ジェスチャーのインジケーターを表示するカメラとプレーヤー間の最大距離</Japanese>
             <Spanish>Máxima distancia entre una cámara y los jugadores para mostrar el indicador de gestos en mapa</Spanish>
             <Italian>Distanza massima da cui videocamere (spettatore/zeus) può vedere i gesti di giocatori.</Italian>
             <Polish>Maksymalny zasięg pomiędzy kamerą a graczami do pokazania gestów na mapie</Polish>

--- a/addons/maptools/stringtable.xml
+++ b/addons/maptools/stringtable.xml
@@ -290,15 +290,15 @@
         </Key>
         <Key ID="STR_ACE_MapTools_ToPlottingBoardLabel">
             <English>To Plotting Board</English>
-            <Japanese>標定盤へ</Japanese>
+            <Japanese>標定盤に</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToPlottingBoardAcrylicLabel">
             <English>To Plotting Board Acrylic</English>
-            <Japanese>標定盤の アクリル板へ</Japanese>
+            <Japanese>標定盤の アクリル板に</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToPlottingBoardRulerLabel">
             <English>To Plotting Board Ruler</English>
-            <Japanese>標定盤の 定規へ</Japanese>
+            <Japanese>標定盤の 定規に</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_WipeBoard">
             <English>Wipe all markers off Plotting Board</English>
@@ -314,7 +314,7 @@
         </Key>
         <Key ID="STR_ACE_MapTools_TogglePlottingBoardRuler">
             <English>Toggle Plotting Board Ruler</English>
-            <Japanese>標定盤の 定規を 切り替え</Japanese>
+            <Japanese>標定盤の 定規を 表示切替</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_AlignTo">
             <English>Align</English>

--- a/addons/maptools/stringtable.xml
+++ b/addons/maptools/stringtable.xml
@@ -12,7 +12,7 @@
             <Portuguese>Ferramentas de Mapa</Portuguese>
             <Hungarian>Térképészeti eszközök</Hungarian>
             <Russian>Инструменты карты</Russian>
-            <Japanese>マップ ツール</Japanese>
+            <Japanese>マップツール</Japanese>
             <Korean>독도용 도구</Korean>
             <Chinesesimp>地图工具</Chinesesimp>
             <Chinese>地圖工具</Chinese>
@@ -29,7 +29,7 @@
             <Portuguese>As Ferramentas de Mapa permitem que você meça distâncias e ângulos no mapa.</Portuguese>
             <Hungarian>A térképészeti eszközökkel távolságokat és szögeket tudsz mérni a térképen.</Hungarian>
             <Russian>Картографические инструменты позволяют измерять расстояния и углы на карте.</Russian>
-            <Japanese>マップ ツールは地図上で距離や角度を測れます。</Japanese>
+            <Japanese>マップツールは地図上で距離や角度を測れます。</Japanese>
             <Korean>독도용 도구는 지도상에서 거리나 각도를 잴 수 있게 해줍니다.</Korean>
             <Chinesesimp>地图工具能够让你在地图上测量距离与角度</Chinesesimp>
             <Chinese>地圖工具能夠讓你在地圖上測量距離與角度</Chinese>
@@ -37,9 +37,11 @@
         </Key>
         <Key ID="STR_ACE_MapTools_PlottingBoard_Name">
             <English>Plotting Board</English>
+            <Japanese>標定盤</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_PlottingBoard_Description">
             <English>The Plotting Board is a map tool designed for use in the directing of short range indirect fires.</English>
+            <Japanese>標定盤(プロッティング・ボード)は、短距離の間接射撃の指示に使用するために設計されたマップツールです。</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_MapTools_Menu">
             <English>Map Tools</English>
@@ -52,7 +54,7 @@
             <Portuguese>Ferramentas de Mapa</Portuguese>
             <Hungarian>Térképészeti eszközök</Hungarian>
             <Russian>Инструменты карты</Russian>
-            <Japanese>マップ ツール</Japanese>
+            <Japanese>マップツール</Japanese>
             <Korean>독도용 도구</Korean>
             <Chinesesimp>地图工具</Chinesesimp>
             <Chinese>地圖工具</Chinese>
@@ -198,7 +200,7 @@
             <English>Rotate Map Tools Key</English>
             <French>Touche de rotation des outils de navigation</French>
             <Russian>Клавиша поворота инструментов карты</Russian>
-            <Japanese>マップ ツールの回転キー</Japanese>
+            <Japanese>マップツールの回転キー</Japanese>
             <Polish>Klawisz obrotu narzędzi nawigacyjnych</Polish>
             <German>Taste zum Drehen des Kartenwerkzeugs</German>
             <Korean>독도용 도구 돌리기 키</Korean>
@@ -214,7 +216,7 @@
             <English>Modifier key to allow rotating map tools</English>
             <French>Touche modificatrice permettant la rotation des outils de navigation.</French>
             <Russian>Клавиша-модификатор, позволяющая поворачивать инструменты карты</Russian>
-            <Japanese>マップ ツールを回転させるキーを編集できます。</Japanese>
+            <Japanese>マップツールを回転させるキーを編集できます。</Japanese>
             <Polish>Modyfikator pozwalający na obracanie narzędzi nawigacyjnych</Polish>
             <German>Steuerungstaste, um Drehung des Kartenwerkzeugs zu ermöglichen.</German>
             <Korean>독도용 도구를 돌리기 위한 키를 변경할 수 있습니다.</Korean>
@@ -228,7 +230,7 @@
         </Key>
         <Key ID="STR_ACE_MapTools_drawStraightLines_displayName">
             <English>Draw straight lines with maptools</English>
-            <Japanese>マップ ツールを使って直線を書く</Japanese>
+            <Japanese>マップツールを使って直線を書く</Japanese>
             <German>Zeichne gerade Linien mit dem Kartenwerkzeug</German>
             <Korean>독도용 도구로 직선 그리기</Korean>
             <Polish>Rysuj proste linie przy użyciu narzędzi nawigacyjnych</Polish>
@@ -260,45 +262,59 @@
         </Key>
         <Key ID="STR_ACE_MapTools_allowChannelDrawing_displayName">
             <English>Allow Plotting Board Drawing channels</English>
+            <Japanese>標定盤への書き込みを許可するチャンネル</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_allowChannelDrawing_description">
             <English>Channels in which plotting board drawing is enabled.</English>
+            <Japanese>どのチャンネルで標定盤の書き込みを有効化するか。</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_allowDirectCommsOnly">
             <English>Allow Direct Comms Only (Polylines Only)</English>
+            <Japanese>直接チャンネルのみ許可 (折れ線のみ)</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_allowDirectGroupComms">
             <English>Allow Direct/Group Comms (Polylines and Group Markers)</English>
+            <Japanese>直接/グループチャンネルを許可 (折れ線とグループマーカー)</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_PlottingBoardLabel">
             <English>Plotting Board</English>
+            <Japanese>標定盤</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_PlottingBoardAcrylicLabel">
             <English>Plotting Board Acrylic</English>
+            <Japanese>標定盤の アクリル板</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_PlottingBoardRulerLabel">
             <English>Plotting Board Ruler</English>
+            <Japanese>標定盤の 定規</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToPlottingBoardLabel">
             <English>To Plotting Board</English>
+            <Japanese>標定盤へ</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToPlottingBoardAcrylicLabel">
             <English>To Plotting Board Acrylic</English>
+            <Japanese>標定盤の アクリル板へ</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToPlottingBoardRulerLabel">
             <English>To Plotting Board Ruler</English>
+            <Japanese>標定盤の 定規へ</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_WipeBoard">
             <English>Wipe all markers off Plotting Board</English>
+            <Japanese>標定盤の 全マーカーを 拭き消す</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ShowPlottingBoard">
             <English>Show Plotting Board</English>
+            <Japanese>標定盤を 表示</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_HidePlottingBoard">
             <English>Hide Plotting Board</English>
+            <Japanese>標定盤を 隠す</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_TogglePlottingBoardRuler">
             <English>Toggle Plotting Board Ruler</English>
+            <Japanese>標定盤の 定規を 切り替え</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_AlignTo">
             <English>Align</English>
@@ -311,6 +327,7 @@
             <Polish>Wyrównaj</Polish>
             <Czech>Srovnat</Czech>
             <Russian>Выровнять</Russian>
+            <Japanese>向きを合わせる</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToNorthLabel">
             <English>To North</English>
@@ -323,6 +340,7 @@
             <Polish>Do północy</Polish>
             <Czech>Na sever</Czech>
             <Russian>На север</Russian>
+            <Japanese>北に</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToCompassLabel">
             <English>To Compass</English>
@@ -335,12 +353,15 @@
             <Polish>Do kompasu</Polish>
             <Czech>Ke kompasu</Czech>
             <Russian>По компасу</Russian>
+            <Japanese>方位磁石に</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToUpLabel">
             <English>Up</English>
+            <Japanese>上に</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_ToMapToolLabel">
             <English>To Maptool</English>
+            <Japanese>マップツールに</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/maptools/stringtable.xml
+++ b/addons/maptools/stringtable.xml
@@ -270,11 +270,11 @@
         </Key>
         <Key ID="STR_ACE_MapTools_allowDirectCommsOnly">
             <English>Allow Direct Comms Only (Polylines Only)</English>
-            <Japanese>直接チャンネルのみ許可 (折れ線のみ)</Japanese>
+            <Japanese>直接チャンネルのみ許可 (線のみ)</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_allowDirectGroupComms">
             <English>Allow Direct/Group Comms (Polylines and Group Markers)</English>
-            <Japanese>直接/グループチャンネルを許可 (折れ線とグループマーカー)</Japanese>
+            <Japanese>直接/グループチャンネルを許可 (線とグループマーカー)</Japanese>
         </Key>
         <Key ID="STR_ACE_MapTools_PlottingBoardLabel">
             <English>Plotting Board</English>

--- a/addons/marker_flags/stringtable.xml
+++ b/addons/marker_flags/stringtable.xml
@@ -6,7 +6,7 @@
             <German>Markierungsfahnen</German>
             <Italian>Bandiere segnaletiche</Italian>
             <Polish>Chorągiewki</Polish>
-            <Japanese>旗マーカー</Japanese>
+            <Japanese>マーカー旗</Japanese>
             <Korean>마킹용 깃발</Korean>
             <Chinesesimp>标记旗</Chinesesimp>
             <Russian>Флажки</Russian>
@@ -48,7 +48,7 @@
             <Korean>마킹용 깃발 꽂기</Korean>
             <Russian>Поставить флажок</Russian>
             <Spanish>Colocar Bandera de señalizado</Spanish>
-            <Japanese>マーカーフラッグを置く</Japanese>
+            <Japanese>マーカー旗 を置く</Japanese>
             <French>Placer le drapeau de marquage</French>
             <Portuguese>Colocar Bandeira de Marcação</Portuguese>
         </Key>
@@ -102,7 +102,7 @@
             <German>Markierungsfahne (Weiß)</German>
             <Italian>Bandiera segnaletica (Bianca)</Italian>
             <Polish>Chorągiewka (Biała)</Polish>
-            <Japanese>旗マーカー (白)</Japanese>
+            <Japanese>マーカー旗 (白)</Japanese>
             <Korean>마킹용 깃발(하양)</Korean>
             <Chinesesimp>标记旗（白）</Chinesesimp>
             <Russian>Флажок (белый)</Russian>
@@ -115,7 +115,7 @@
             <German>Markierungsfahne (Schwarz)</German>
             <Italian>Bandiera segnaletica (Nera)</Italian>
             <Polish>Chorągiewka (Czarna)</Polish>
-            <Japanese>旗マーカー (黒)</Japanese>
+            <Japanese>マーカー旗 (黒)</Japanese>
             <Korean>마킹용 깃발(검정)</Korean>
             <Chinesesimp>标记旗（黑）</Chinesesimp>
             <Russian>Флажок (чёрный)</Russian>
@@ -128,7 +128,7 @@
             <German>Markierungsfahne (Rot)</German>
             <Italian>Bandiera segnaletica (Rossa)</Italian>
             <Polish>Chorągiewka (Czerwona)</Polish>
-            <Japanese>旗マーカー (赤)</Japanese>
+            <Japanese>マーカー旗 (赤)</Japanese>
             <Korean>마킹용 깃발(빨강)</Korean>
             <Chinesesimp>标记旗（红）</Chinesesimp>
             <Russian>Флажок (красный)</Russian>
@@ -141,7 +141,7 @@
             <German>Markierungsfahne (Grün)</German>
             <Italian>Bandiera segnaletica (Verde)</Italian>
             <Polish>Chorągiewka (Zielona)</Polish>
-            <Japanese>旗マーカー (緑)</Japanese>
+            <Japanese>マーカー旗 (緑)</Japanese>
             <Korean>마킹용 깃발(초록)</Korean>
             <Chinesesimp>标记旗（绿）</Chinesesimp>
             <Russian>Флажок (зелёный)</Russian>
@@ -154,7 +154,7 @@
             <German>Markierungsfahne (Blau)</German>
             <Italian>Bandiera segnaletica (Blu)</Italian>
             <Polish>Chorągiewka (Niebieska)</Polish>
-            <Japanese>旗マーカー (青)</Japanese>
+            <Japanese>マーカー旗 (青)</Japanese>
             <Korean>마킹용 깃발(파랑)</Korean>
             <Chinesesimp>标记旗（蓝）</Chinesesimp>
             <Russian>Флажок (синий)</Russian>
@@ -167,7 +167,7 @@
             <German>Markierungsfahne (Gelb)</German>
             <Italian>Bandiera segnaletica (Gialla)</Italian>
             <Polish>Chorągiewka (Żółta)</Polish>
-            <Japanese>旗マーカー (黄)</Japanese>
+            <Japanese>マーカー旗 (黄)</Japanese>
             <Korean>마킹용 깃발(노랑)</Korean>
             <Chinesesimp>标记旗（黄）</Chinesesimp>
             <Russian>Флажок (жёлтый)</Russian>
@@ -180,7 +180,7 @@
             <German>Markierungsfahne (Orange)</German>
             <Italian>Bandiera segnaletica (Arancione)</Italian>
             <Polish>Chorągiewka (Pomarańczowa)</Polish>
-            <Japanese>旗マーカー (橙)</Japanese>
+            <Japanese>マーカー旗 (橙)</Japanese>
             <Korean>마킹용 깃발(주황)</Korean>
             <Chinesesimp>标记旗（橙）</Chinesesimp>
             <Russian>Флажок (оранжевый)</Russian>
@@ -193,7 +193,7 @@
             <German>Markierungsfahne (Lila)</German>
             <Italian>Bandiera segnaletica (Viola)</Italian>
             <Polish>Chorągiewka (Fioletowa)</Polish>
-            <Japanese>旗マーカー (紫)</Japanese>
+            <Japanese>マーカー旗 (紫)</Japanese>
             <Korean>마킹용 깃발(보라)</Korean>
             <Chinesesimp>标记旗（紫）</Chinesesimp>
             <Russian>Флажок (фиолетовый)</Russian>

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -63,7 +63,7 @@
         <Key ID="STR_ACE_Markers_MoveRestriction">
             <English>Allow moving markers for</English>
             <German>Erlaube Marker zu bewegen für</German>
-            <Japanese>マーカー移動を許可するユーザー</Japanese>
+            <Japanese>マーカー移動を許可する対象</Japanese>
             <Korean>마커 이동 허가</Korean>
             <Chinese>誰可以移動標誌</Chinese>
             <Chinesesimp>谁可以移动标识</Chinesesimp>
@@ -78,7 +78,7 @@
         <Key ID="STR_ACE_Markers_MoveRestriction_Description">
             <English>Restricts which players are able to move markers while holding the Alt key.</English>
             <German>Beschränkt welche Spieler Marker mit gedrückter Alt-Taste bewegen können.</German>
-            <Japanese>どのプレイヤーが Alt キーを押しながらマーカー移動をできるか制限できます。</Japanese>
+            <Japanese>Altキーを押している時に可能なマーカー移動機能を使用できるプレイヤーを制限します。</Japanese>
             <Korean>Alt 키를 누른 상태에서 마커를 움직일 수 있는 플레이어를 제한합니다.</Korean>
             <Chinese>設定誰可以透過按住Alt鍵來移動標誌</Chinese>
             <Chinesesimp>设定谁可以透过按住 Alt 键来移动标识。</Chinesesimp>
@@ -204,7 +204,7 @@
             <English>Whether to allow timestamps to be automatically applied to markers</English>
             <Russian>Автоматическое отображение времени, когда поставлена метка</Russian>
             <French>Active une interface permettant d'apposer un horodatage sur les marqueurs.</French>
-            <Japanese>マーカーへ自動的にタイムスタンプを付与するかどうかを設定できます。</Japanese>
+            <Japanese>タイムスタンプをマーカーに自動的に適用することを許可するかどうか</Japanese>
             <Spanish>Permitir que las marcas de tiempo sean automáticamente aplicadas a los marcadores</Spanish>
             <Polish>Zezwól na automatyczne stosowanie znaczników czasu do markerów</Polish>
             <German>Ob Zeitstempel automatisch auf Maker angewendet werden sollen.</German>
@@ -230,7 +230,7 @@
             <English>Watch Required</English>
             <Russian>Необходимы часы</Russian>
             <French>Une montre est requise.</French>
-            <Japanese>時計の要求</Japanese>
+            <Japanese>時計が必要</Japanese>
             <Spanish>Reloj requerido</Spanish>
             <Polish>Wymagany zegarek</Polish>
             <German>Uhr benötigt</German>
@@ -243,7 +243,7 @@
             <English>Time Zone</English>
             <Russian>Часовой пояс</Russian>
             <French>Fuseau horaire</French>
-            <Japanese>時間帯</Japanese>
+            <Japanese>時刻帯</Japanese>
             <Spanish>Zona horaria</Spanish>
             <Polish>Strefa czasowa</Polish>
             <German>Zeitzone</German>
@@ -254,7 +254,7 @@
             <English>Changes the time zone for the timestamp</English>
             <Russian>Измените часовой пояс для метки времени</Russian>
             <French>Modifiez le fuseau horaire pour l'horodatage</French>
-            <Japanese>タイムスタンプの時間帯を変更します</Japanese>
+            <Japanese>タイムスタンプの時刻帯を変更します</Japanese>
             <Spanish>Cambie la zona horaria para la marca de tiempo</Spanish>
             <Polish>Zmień strefę czasową dla znaczników czasu</Polish>
             <German>Ändern Sie die Zeitzone für den Zeitstempel</German>
@@ -309,7 +309,7 @@
             <English>Changes the time offset for the UTC timestamp</English>
             <Russian>Измените смещение времени для метки времени UTC</Russian>
             <French>Modifier le décalage horaire pour l'horodatage UTC</French>
-            <Japanese>UTCタイムスタンプの時差を変更する</Japanese>
+            <Japanese>UTCタイムスタンプの時オフセットを変更します</Japanese>
             <Spanish>Cambiar el desplazamiento horario para la marca de tiempo UTC</Spanish>
             <Polish>Zmień przesunięcie czasu dla sygnatury czasowej UTC</Polish>
             <German>Ändere die Zeitverschiebung für den UTC-Zeitstempel</German>
@@ -331,7 +331,7 @@
             <English>Change the minute offset for the UTC timestamp</English>
             <Russian>Изменить минутное смещение для времени UTC</Russian>
             <French>Modifier le décalage des minutes pour l'horodatage UTC</French>
-            <Japanese>UTCタイムスタンプの分差を変更する</Japanese>
+            <Japanese>UTCタイムスタンプの分オフセットを変更します</Japanese>
             <Spanish>Cambiar el desplazamiento de minutos para la marca de tiempo UTC</Spanish>
             <Polish>Zmień przesunięcie minut dla sygnatury czasowej UTC</Polish>
             <German>Ändere den Minutenversatz für den UTC-Zeitstempel</German>
@@ -368,7 +368,7 @@
             <English>"HH" - Hour</English>
             <Russian>"ЧЧ" - Час</Russian>
             <French>"HH" - Heures</French>
-            <Japanese>"HH" - 時間</Japanese>
+            <Japanese>"HH" - 時</Japanese>
             <Spanish>"HH" - Hora</Spanish>
             <Polish>"HH" - Godziny</Polish>
             <German>"HH" - Stunden</German>
@@ -408,12 +408,14 @@
             <French>"MM" - Millisecondes (de 0 à 59)</French>
             <German>"MS" - Milisekunden (von 0 bis 59)</German>
             <Portuguese>"MS" - Milissegundos (de 0 a 59)</Portuguese>
+            <Japanese>"MM" - ミリ秒 (0から59)</Japanese>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampFormatDescription5">
             <English>"mmm" - Milliseconds (from 0 to 999)</English>
             <French>"mmm" - Millisecondes (de 0 à 999)</French>
             <German>"mmm" - Milisekunden (von 0 bis 999)</German>
             <Portuguese>"mmm" - Milissegundos (de 0 a 999)</Portuguese>
+            <Japanese>"mmm" - ミリ秒 (0から599)</Japanese>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampHourFormat">
             <English>Timestamp Hour Format</English>
@@ -432,7 +434,7 @@
             <English>24-Hour Clock</English>
             <Russian>24 часовой формат</Russian>
             <French>Format 24 heures</French>
-            <Japanese>24 時間表記</Japanese>
+            <Japanese>24時間表記</Japanese>
             <Spanish>Reloj 24-Horas</Spanish>
             <Polish>Zegar 24-godzinny</Polish>
             <German>24-Stunden</German>
@@ -445,7 +447,7 @@
             <English>12-Hour Clock</English>
             <Russian>12 часовой формат</Russian>
             <French>Format 12 heures</French>
-            <Japanese>12 時間表記</Japanese>
+            <Japanese>12時間表記</Japanese>
             <Spanish>Reloj 12-Horas</Spanish>
             <Polish>Zegar 12-godzinny</Polish>
             <German>12-Stunden</German>
@@ -458,7 +460,7 @@
             <English>Changes timestamp to use either 24-hour or 12-hour clock format</English>
             <Russian>Изменяет формат времени на маркере на 24 часовой, либо 12 часовой</Russian>
             <French>Permet de choisir le système d'horodatage souhaité, au format 12 ou 24 heures.</French>
-            <Japanese>タイムスタンプの時刻を 24 時間か 12 時間表記のどちらかに変更できます。</Japanese>
+            <Japanese>タイムスタンプの時刻を24時間表記か12時間表記かのどちらかに変更します</Japanese>
             <Spanish>Cambia que la marca de tiempo sea en formato de reloj 24-horas o 12-horas</Spanish>
             <Polish>Zmienia znacznik czasu tak, aby używał formatu 24-godzinnego lub 12-godzinnego</Polish>
             <German>Ändert den Zeitstempel, um entweder das 24-Stunden- oder das 12-Stunden-Format zu verwenden</German>

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -78,7 +78,7 @@
         <Key ID="STR_ACE_Markers_MoveRestriction_Description">
             <English>Restricts which players are able to move markers while holding the Alt key.</English>
             <German>Beschränkt welche Spieler Marker mit gedrückter Alt-Taste bewegen können.</German>
-            <Japanese>Altキーを押している時に可能なマーカー移動機能を使用できるプレイヤーを制限します。</Japanese>
+            <Japanese>Altキーを押しながらマーカー移動をできるプレイヤーを制限します。</Japanese>
             <Korean>Alt 키를 누른 상태에서 마커를 움직일 수 있는 플레이어를 제한합니다.</Korean>
             <Chinese>設定誰可以透過按住Alt鍵來移動標誌</Chinese>
             <Chinesesimp>设定谁可以透过按住 Alt 键来移动标识。</Chinesesimp>
@@ -243,7 +243,7 @@
             <English>Time Zone</English>
             <Russian>Часовой пояс</Russian>
             <French>Fuseau horaire</French>
-            <Japanese>時刻帯</Japanese>
+            <Japanese>タイムゾーン</Japanese>
             <Spanish>Zona horaria</Spanish>
             <Polish>Strefa czasowa</Polish>
             <German>Zeitzone</German>
@@ -254,7 +254,7 @@
             <English>Changes the time zone for the timestamp</English>
             <Russian>Измените часовой пояс для метки времени</Russian>
             <French>Modifiez le fuseau horaire pour l'horodatage</French>
-            <Japanese>タイムスタンプの時刻帯を変更します</Japanese>
+            <Japanese>タイムスタンプのタイムゾーンを変更します</Japanese>
             <Spanish>Cambie la zona horaria para la marca de tiempo</Spanish>
             <Polish>Zmień strefę czasową dla znaczników czasu</Polish>
             <German>Ändern Sie die Zeitzone für den Zeitstempel</German>
@@ -265,7 +265,7 @@
             <English>In-game Time</English>
             <Russian>Время в игре</Russian>
             <French>Heure de jeu</French>
-            <Japanese>ゲーム内時刻</Japanese>
+            <Japanese>ゲーム内時間</Japanese>
             <Spanish>Hora del juego</Spanish>
             <Polish>Czas gry</Polish>
             <German>Ingame-Zeit</German>
@@ -276,7 +276,7 @@
             <English>System Time</English>
             <Russian>Системное время</Russian>
             <French>Heure système</French>
-            <Japanese>システム時刻</Japanese>
+            <Japanese>システム時間</Japanese>
             <Spanish>Hora del sistema</Spanish>
             <Polish>Czas systemowy</Polish>
             <German>Systemzeit</German>
@@ -287,7 +287,7 @@
             <English>UTC Time</English>
             <Russian>Время UTC</Russian>
             <French>Heure UTC</French>
-            <Japanese>UTC時刻</Japanese>
+            <Japanese>UTC時間</Japanese>
             <Spanish>Hora UTC</Spanish>
             <Polish>Czas UTC</Polish>
             <German>UTC-Zeit</German>

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -125,7 +125,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen3_brown_WP">
             <English>NV Goggles (Gen3, Brown, WP)</English>
-            <Japanese>暗視装置 (第3世代、ブラウン)</Japanese>
+            <Japanese>暗視装置 (第3世代、ブラウン、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen3, Marrone, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, Brązowe, WP)</Polish>
             <German>NS-Brille (3. Generation, Braun, WP)</German>
@@ -219,7 +219,7 @@
             <French>JVN (Gen4, noires)</French>
             <Russian>ПНВ (Gen4, Чёрный)</Russian>
             <Italian>Visore Notturno (Gen4, Nero)</Italian>
-            <Japanese>暗視装置 (第3世代、ブラック)</Japanese>
+            <Japanese>暗視装置 (第4世代、ブラック)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 4, Czarne)</Polish>
             <German>NS-Brille (4. Gen., schwarz)</German>
             <Chinesesimp>夜视仪（四代，黑色）</Chinesesimp>
@@ -228,7 +228,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_black_WP">
             <English>NV Goggles (Gen4, Black, WP)</English>
-            <Japanese>暗視装置 (第3世代、ブラック、白色蛍光)</Japanese>
+            <Japanese>暗視装置 (第4世代、ブラック、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen4, Nero, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen 4, Czarne, WP)</Polish>
             <German>NS-Brille (4. Generation, Schwarz, WP)</German>
@@ -240,7 +240,7 @@
             <French>JVN (Gen4, vertes)</French>
             <Russian>ПНВ (Gen4, Зелёный)</Russian>
             <Italian>Visore Notturno (Gen4, Verde)</Italian>
-            <Japanese>暗視装置 (第3世代、グリーン)</Japanese>
+            <Japanese>暗視装置 (第4世代、グリーン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 4, Zielone)</Polish>
             <German>NS-Brille (4. Gen., grün)</German>
             <Chinesesimp>夜视仪（四代，绿色）</Chinesesimp>

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -22,7 +22,7 @@
             <French>JVN (Gen1, marron)</French>
             <Russian>ПНВ (Gen1, Коричневый)</Russian>
             <Italian>Visore Notturno (Gen1, Marrone)</Italian>
-            <Japanese>暗視装置 (第1世代、ブラウン)</Japanese>
+            <Japanese>NVゴーグル (第1世代、ブラウン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 1, Brązowe)</Polish>
             <German>NS-Brille (1. Gen., braun)</German>
             <Chinesesimp>夜视仪（一代，棕色）</Chinesesimp>
@@ -34,7 +34,7 @@
             <French>JVN (Gen1, noires)</French>
             <Russian>ПНВ (Gen1, Чёрный)</Russian>
             <Italian>Visore Notturno (Gen1, Nero)</Italian>
-            <Japanese>暗視装置 (第1世代、ブラック)</Japanese>
+            <Japanese>NVゴーグル (第1世代、ブラック)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 1, Czarne)</Polish>
             <German>NS-Brille (1. Gen., schwarz)</German>
             <Chinesesimp>夜视仪（一代，黑色）</Chinesesimp>
@@ -46,7 +46,7 @@
             <French>JVN (Gen1, vertes)</French>
             <Russian>ПНВ (Gen1, Зелёный)</Russian>
             <Italian>Visore Notturno (Gen1, Verde)</Italian>
-            <Japanese>暗視装置 (第1世代、グリーン)</Japanese>
+            <Japanese>NVゴーグル (第1世代、グリーン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 1, Zielone)</Polish>
             <German>NS-Brille (1. Gen., grün)</German>
             <Chinesesimp>夜视仪（一代，绿色）</Chinesesimp>
@@ -58,7 +58,7 @@
             <French>JVN (Gen2, marron)</French>
             <Russian>ПНВ (Gen2, Коричневый)</Russian>
             <Italian>Visore Notturno (Gen2, Marrone)</Italian>
-            <Japanese>暗視装置 (第2世代、ブラウン)</Japanese>
+            <Japanese>NVゴーグル (第2世代、ブラウン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 2, Brązowe)</Polish>
             <German>NS-Brille (2. Gen., braun)</German>
             <Chinesesimp>夜视仪（二代，棕色）</Chinesesimp>
@@ -70,7 +70,7 @@
             <French>JVN (Gen2, noires)</French>
             <Russian>ПНВ (Gen2, Чёрный)</Russian>
             <Italian>Visore Notturno (Gen2, Nero)</Italian>
-            <Japanese>暗視装置 (第2世代、ブラック)</Japanese>
+            <Japanese>NVゴーグル (第2世代、ブラック)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 2, Czarne)</Polish>
             <German>NS-Brille (2. Gen., schwarz)</German>
             <Chinesesimp>夜视仪（二代，黑色）</Chinesesimp>
@@ -82,7 +82,7 @@
             <French>NV Goggles (Gen2, vertes)</French>
             <Russian>ПНВ (Gen2, Зелёный)</Russian>
             <Italian>Visore Notturno (Gen2, Verde)</Italian>
-            <Japanese>暗視装置 (第2世代、グリーン)</Japanese>
+            <Japanese>NVゴーグル (第2世代、グリーン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 2, Zielone)</Polish>
             <German>NS-Brille (2. Gen., grün)</German>
             <Chinesesimp>夜视仪（二代，绿色）</Chinesesimp>
@@ -100,7 +100,7 @@
             <Russian>ПНВ (Gen3)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen.)</Hungarian>
-            <Japanese>暗視装置 (第3世代)</Japanese>
+            <Japanese>NVゴーグル (第3世代)</Japanese>
             <Korean>야투경 (3세대)</Korean>
             <Chinesesimp>夜视仪（三代）</Chinesesimp>
             <Chinese>夜視鏡 (三代)</Chinese>
@@ -117,7 +117,7 @@
             <Russian>ПНВ (Gen3, Коричневый)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, Marrón)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., barna)</Hungarian>
-            <Japanese>暗視装置 (第3世代、ブラウン)</Japanese>
+            <Japanese>NVゴーグル (第3世代、ブラウン)</Japanese>
             <Korean>야투경 (3세대, 갈색)</Korean>
             <Chinesesimp>夜视仪（三代，棕色）</Chinesesimp>
             <Chinese>夜視鏡 (三代, 棕色)</Chinese>
@@ -125,7 +125,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen3_brown_WP">
             <English>NV Goggles (Gen3, Brown, WP)</English>
-            <Japanese>暗視装置 (第3世代、ブラウン、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (第3世代、ブラウン、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen3, Marrone, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, Brązowe, WP)</Polish>
             <German>NS-Brille (3. Generation, Braun, WP)</German>
@@ -134,7 +134,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_WP_desc">
             <English>Night Vision Goggles, White Phosphor</English>
-            <Japanese>暗視装置、白色蛍光</Japanese>
+            <Japanese>ナイトビジョン・ゴーグル、白色蛍光</Japanese>
             <Italian>Visore Notturno, Fosforo Bianco</Italian>
             <Polish>Gogle noktowizyjne, Biały Fosfor</Polish>
             <German>Nachtsichtbrille, weißer Phosphor</German>
@@ -152,7 +152,7 @@
             <Russian>ПНВ (Gen3, Зелёный)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, Verde)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., zöld)</Hungarian>
-            <Japanese>暗視装置 (第3世代、グリーン)</Japanese>
+            <Japanese>NVゴーグル (第3世代、グリーン)</Japanese>
             <Korean>야투경 (3세대, 녹색)</Korean>
             <Chinesesimp>夜视仪（三代，绿色）</Chinesesimp>
             <Chinese>夜視鏡 (三代, 綠色)</Chinese>
@@ -161,7 +161,7 @@
         <Key ID="STR_ACE_NightVision_NVG_Gen3_green_WP">
             <English>NV Goggles (Gen3, Green, WP)</English>
             <Italian>Visore Notturno (Gen3, Verde, FB)</Italian>
-            <Japanese>暗視装置 (第3世代、グリーン、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (第3世代、グリーン、白色蛍光)</Japanese>
             <Polish>Gogle noktowizyjne (Gen3, Zielone, WP)</Polish>
             <German>NS-Brille (3. Generation, Grün, WP)</German>
             <Korean>야투경 (3세대, 녹색, 백색광)</Korean>
@@ -178,7 +178,7 @@
             <Russian>ПНВ (Gen3, Чёрный)</Russian>
             <Spanish>Gafas de visión nocturna (Gen3, Negro)</Spanish>
             <Hungarian>Éjjellátó szemüveg (3. Gen., fekete)</Hungarian>
-            <Japanese>暗視装置 (第3世代、ブラック)</Japanese>
+            <Japanese>NVゴーグル (第3世代、ブラック)</Japanese>
             <Korean>야투경 (3세대, 검정색)</Korean>
             <Chinesesimp>夜视仪（三代，黑色）</Chinesesimp>
             <Chinese>夜視鏡 (三代, 黑色)</Chinese>
@@ -186,7 +186,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen3_black_WP">
             <English>NV Goggles (Gen3, Black, WP)</English>
-            <Japanese>暗視装置 (第3世代、ブラック、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (第3世代、ブラック、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen3, Nero, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen3, Czarne, WP)</Polish>
             <German>NS-Brille (3. Generation, Schwarz, WP)</German>
@@ -198,7 +198,7 @@
             <French>JVN (Gen4, marron)</French>
             <Russian>ПНВ (Gen4, Коричневый)</Russian>
             <Italian>Visore Notturno (Gen4, Marrone)</Italian>
-            <Japanese>暗視装置 (第4世代、ブラウン)</Japanese>
+            <Japanese>NVゴーグル (第4世代、ブラウン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 4, Brązowe)</Polish>
             <German>NS-Brille (4. Gen., braun)</German>
             <Chinesesimp>夜视仪（四代，棕色）</Chinesesimp>
@@ -207,7 +207,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_brown_WP">
             <English>NV Goggles (Gen4, Brown, WP)</English>
-            <Japanese>暗視装置 (第4世代、ブラウン、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (第4世代、ブラウン、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen4, Marrone, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen 4, Brązowe, WP)</Polish>
             <German>NS-Brille (4. Generation, Braun, WP)</German>
@@ -219,7 +219,7 @@
             <French>JVN (Gen4, noires)</French>
             <Russian>ПНВ (Gen4, Чёрный)</Russian>
             <Italian>Visore Notturno (Gen4, Nero)</Italian>
-            <Japanese>暗視装置 (第4世代、ブラック)</Japanese>
+            <Japanese>NVゴーグル (第4世代、ブラック)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 4, Czarne)</Polish>
             <German>NS-Brille (4. Gen., schwarz)</German>
             <Chinesesimp>夜视仪（四代，黑色）</Chinesesimp>
@@ -228,7 +228,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_black_WP">
             <English>NV Goggles (Gen4, Black, WP)</English>
-            <Japanese>暗視装置 (第4世代、ブラック、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (第4世代、ブラック、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen4, Nero, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen 4, Czarne, WP)</Polish>
             <German>NS-Brille (4. Generation, Schwarz, WP)</German>
@@ -240,7 +240,7 @@
             <French>JVN (Gen4, vertes)</French>
             <Russian>ПНВ (Gen4, Зелёный)</Russian>
             <Italian>Visore Notturno (Gen4, Verde)</Italian>
-            <Japanese>暗視装置 (第4世代、グリーン)</Japanese>
+            <Japanese>NVゴーグル (第4世代、グリーン)</Japanese>
             <Polish>Gogle noktowizyjne (Gen 4, Zielone)</Polish>
             <German>NS-Brille (4. Gen., grün)</German>
             <Chinesesimp>夜视仪（四代，绿色）</Chinesesimp>
@@ -249,7 +249,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Gen4_green_WP">
             <English>NV Goggles (Gen4, Green, WP)</English>
-            <Japanese>暗視装置 (第3世代、グリーン、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (第3世代、グリーン、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Gen4, Verde, FB)</Italian>
             <Polish>Gogle noktowizyjne (Gen 4, Zielone, WP)</Polish>
             <German>NS-Brille (4. Generation, Grün, WP)</German>
@@ -261,7 +261,7 @@
             <French>JVN (Large, marron)</French>
             <Russian>ПНВ (Широкий, Коричневый)</Russian>
             <Italian>Visore Notturno (Grandangolo, Marrone)</Italian>
-            <Japanese>暗視装置 (ワイド、ブラウン)</Japanese>
+            <Japanese>NVゴーグル (ワイド、ブラウン)</Japanese>
             <Polish>Gogle noktowizyjne (Szerokie, Brązowe)</Polish>
             <German>NS-Brille (Weit, braun)</German>
             <Chinesesimp>夜视仪（宽，棕色）</Chinesesimp>
@@ -270,7 +270,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_brown_WP">
             <English>NV Goggles (Wide, Brown, WP)</English>
-            <Japanese>暗視装置 (ワイド、ブラウン、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (ワイド、ブラウン、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Grandangolo, Marrone, FB)</Italian>
             <Polish>Gogle noktowizyjne (Szerokie, Brązowe, WP)</Polish>
             <German>NS-Brille (Weit, Braun, WP)</German>
@@ -282,7 +282,7 @@
             <French>JVN (Large, noires)</French>
             <Russian>ПНВ (Широкий, Чёрный)</Russian>
             <Italian>Visore Notturno (Grandangolo, Nero)</Italian>
-            <Japanese>暗視装置 (ワイド、ブラック)</Japanese>
+            <Japanese>NVゴーグル (ワイド、ブラック)</Japanese>
             <Polish>Gogle noktowizyjne (Szerokie, Czarne)</Polish>
             <German>NS-Brille (Weit, schwarz)</German>
             <Chinesesimp>夜视仪（宽，黑色）</Chinesesimp>
@@ -291,7 +291,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_black_WP">
             <English>NV Goggles (Wide, Black, WP)</English>
-            <Japanese>暗視装置 (ワイド、ブラック、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (ワイド、ブラック、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Grandangolo, Nero, FB)</Italian>
             <Polish>Gogle noktowizyjne (Szerokie, Czarne, WP)</Polish>
             <German>NS-Brille (Weit, Schwarz, WP)</German>
@@ -303,7 +303,7 @@
             <French>JVN (Large, vertes)</French>
             <Russian>ПНВ (Широкий, Зелёный)</Russian>
             <Italian>Visore Notturno (Grandangolo, Verde)</Italian>
-            <Japanese>暗視装置 (ワイド、グリーン)</Japanese>
+            <Japanese>NVゴーグル (ワイド、グリーン)</Japanese>
             <Polish>Gogle noktowizyjne (Szerokie, Zielone)</Polish>
             <German>NS-Brille (Weit, grün)</German>
             <Chinesesimp>夜视仪（宽，绿色）</Chinesesimp>
@@ -312,7 +312,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_NVG_Wide_green_WP">
             <English>NV Goggles (Wide, Green, WP)</English>
-            <Japanese>暗視装置 (ワイド、グリーン、白色蛍光)</Japanese>
+            <Japanese>NVゴーグル (ワイド、グリーン、白色蛍光)</Japanese>
             <Italian>Visore Notturno (Grandangolo, Verde, FB)</Italian>
             <Polish>Gogle noktowizyjne (Szerokie, Zielone, WP)</Polish>
             <German>NS-Brille (Weit, Grün, WP)</German>
@@ -450,7 +450,7 @@
         </Key>
         <Key ID="STR_ACE_NightVision_fogScaling_Description">
             <English>Fog is used to limit visibility.</English>
-            <Japanese>フォグは視程制限のために使われます。</Japanese>
+            <Japanese>霧で視程を制限します。</Japanese>
             <Italian>La nebbia viene utilizzata per limitare la visibilità.</Italian>
             <German>Nebel wird genutzt, um die Sichtbarkeit einzuschränken.</German>
             <Chinese>透過霧氣來縮減夜視鏡的可視距離</Chinese>
@@ -528,7 +528,7 @@
             <German>Intensität des Bildrauschens im Nachtsichtgerät</German>
             <Chinese>調整配戴夜視鏡時畫面雜訊的多寡。</Chinese>
             <Chinesesimp>调整配戴夜视仪时画面噪声的强度。</Chinesesimp>
-            <Japanese>暗視装置を使用時に起きる画像ノイズの強度です</Japanese>
+            <Japanese>暗視装置使用時の画像ノイズの強度</Japanese>
             <French>Intensité du bruit de l'image lorsque vous portez des JVN.</French>
             <Italian>Intensità del disturbo nell'immagine degli NVG</Italian>
             <Polish>Intensywność efektu szumu podczas noszenia gogli noktowizyjnych</Polish>
@@ -556,7 +556,7 @@
         <Key ID="STR_ACE_NightVision_shutterEffects_description">
             <English>Rolling shutter effect from muzzle flashes</English>
             <German>Rolling-Shutter-Effekt bei Müdungsfeuer</German>
-            <Japanese>発射炎が作るローリング シャッター効果</Japanese>
+            <Japanese>発射炎によるローリング シャッター効果</Japanese>
             <Chinesesimp>枪械开火时产生瞬间快门效果</Chinesesimp>
             <Chinese>槍開火時瞬間產生快門效果</Chinese>
             <French>Effet d'obturateur à rideau dû aux flashs du canon.</French>

--- a/addons/overheating/stringtable.xml
+++ b/addons/overheating/stringtable.xml
@@ -877,21 +877,27 @@
         </Key>
         <Key ID="STR_ACE_Overheating_statBoltType">
             <English>Bolt Type</English>
+            <Japanese>遊底(ボルト)形式</Japanese>
         </Key>
         <Key ID="STR_ACE_Overheating_statBoltType_openBolt">
             <English>Open Bolt</English>
+            <Japanese>オープンボルト</Japanese>
         </Key>
         <Key ID="STR_ACE_Overheating_statBoltType_closedBolt">
             <English>Closed Bolt</English>
+            <Japanese>クローズドボルト</Japanese>
         </Key>
         <Key ID="STR_ACE_Overheating_statBarrelType">
             <English>Barrel Type</English>
+            <Japanese>銃身形式</Japanese>
         </Key>
         <Key ID="STR_ACE_Overheating_statBarrelType_nonRemoveable">
             <English>Non-Removeable</English>
+            <Japanese>取り外し不可</Japanese>
         </Key>
         <Key ID="STR_ACE_Overheating_statBarrelType_removeable">
             <English>Quick Change</English>
+            <Japanese>即時交換可</Japanese>
         </Key>
     </Package>
 </Project>

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -2151,7 +2151,7 @@
             <Russian>F2000 (камуфляжный)</Russian>
             <Portuguese>F2000 (Camo)</Portuguese>
             <Italian>F2000 (Mimetica)</Italian>
-            <Japanese>F2000 (迷彩)</Japanese>
+            <Japanese>F2000 (AAF迷彩)</Japanese>
             <Korean>F2000 (위장)</Korean>
             <Chinese>F2000突擊步槍 (迷彩)</Chinese>
             <Chinesesimp>F2000（迷彩）</Chinesesimp>
@@ -2185,7 +2185,7 @@
             <Russian>F2000 Tactical (камуфляжный)</Russian>
             <Portuguese>F2000 Tactical (Camo)</Portuguese>
             <Italian>F2000 Tactical (Mimetica)</Italian>
-            <Japanese>F2000 タクティカル (迷彩)</Japanese>
+            <Japanese>F2000 タクティカル (AAF迷彩)</Japanese>
             <Korean>F2000 택티컬 (위장)</Korean>
             <Chinese>F2000戰術型突擊步槍 (迷彩)</Chinese>
             <Chinesesimp>F2000 战术型（迷彩）</Chinesesimp>
@@ -2219,7 +2219,7 @@
             <Russian>F2000 EGLM (камуфляжный)</Russian>
             <Portuguese>F2000 EGLM (Camo)</Portuguese>
             <Italian>F2000 EGLM (Mimetica)</Italian>
-            <Japanese>F2000 EGLM (迷彩)</Japanese>
+            <Japanese>F2000 EGLM (AAF迷彩)</Japanese>
             <Korean>F2000 EGLM (위장)</Korean>
             <Chinese>F2000突擊步槍 (榴彈—迷彩)</Chinese>
             <Chinesesimp>F2000 ELGM（迷彩）</Chinesesimp>
@@ -2440,7 +2440,7 @@
             <Russian>GM6 Lynx (камуфляжный)</Russian>
             <Portuguese>GM6 Lynx (Camo)</Portuguese>
             <Italian>GM6 Lynx (Mimetica)</Italian>
-            <Japanese>GM6 リンクス (迷彩)</Japanese>
+            <Japanese>GM6 リンクス (六角形迷彩)</Japanese>
             <Korean>GM6 링스 (위장)</Korean>
             <Chinese>GM6 "天貓"反器材狙擊步槍 (迷彩)</Chinese>
             <Chinesesimp>GM6 "猞猁"（迷彩）</Chinesesimp>
@@ -2542,7 +2542,7 @@
             <Italian>Noreen "Bad News" ULR (Mimetica)</Italian>
             <Hungarian>Noreen "Bad News"ULR (Terepmintás)</Hungarian>
             <Portuguese>Noreen "Bad News" ULR (Camuflagem)</Portuguese>
-            <Japanese>ノレーン "バッド ニュース" ULR (迷彩)</Japanese>
+            <Japanese>ノレーン "バッド ニュース" ULR (CTRG迷彩)</Japanese>
             <Korean>노린 "배드뉴스" ULR (위장)</Korean>
             <Chinese>諾琳"壞消息"極距狙擊步槍 (迷彩)</Chinese>
             <Chinesesimp>诺琳 "坏消息" 极距狙击步枪（迷彩）</Chinesesimp>
@@ -2644,7 +2644,7 @@
             <Italian>SIG 556 (Mimetica)</Italian>
             <Hungarian>SIG 556 (Terepmintás)</Hungarian>
             <Portuguese>SIG 556 (Camuflagem)</Portuguese>
-            <Japanese>SIG 556 (迷彩)</Japanese>
+            <Japanese>SIG 556 (MTP迷彩)</Japanese>
             <Korean>시그 556 (위장)</Korean>
             <Chinese>SIG 556精準步槍 (迷彩)</Chinese>
             <Chinesesimp>SIG 556（迷彩）</Chinesesimp>
@@ -2763,7 +2763,7 @@
             <Italian>Cyrus (Hex)</Italian>
             <Hungarian>Cyrus (Hex)</Hungarian>
             <Portuguese>Cyrus (Hex)</Portuguese>
-            <Japanese>サイラス (ヘックス)</Japanese>
+            <Japanese>サイラス (六角形迷彩)</Japanese>
             <Korean>사이러스 (육각)</Korean>
             <Chinese>"居鲁士"狙擊步槍 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>"居鲁士"（蜂巢迷彩）</Chinesesimp>
@@ -2831,7 +2831,7 @@
             <Italian>M14 (Oliva)</Italian>
             <Hungarian>M14 (Olíva)</Hungarian>
             <Portuguese>M14 (Oliva)</Portuguese>
-            <Japanese>M14 (オリーブド ラブ)</Japanese>
+            <Japanese>M14 (オリーブ)</Japanese>
             <Korean>M14 (올리브)</Korean>
             <Chinese>M14精準步槍 (橄欖色)</Chinese>
             <Chinesesimp>M14（橄榄色）</Chinesesimp>
@@ -2865,7 +2865,7 @@
             <Italian>HK121 (Hex)</Italian>
             <Hungarian>HK121 (Hex)</Hungarian>
             <Portuguese>HK121 (Hex)</Portuguese>
-            <Japanese>HK 121 (ヘックス)</Japanese>
+            <Japanese>HK 121 (六角形迷彩)</Japanese>
             <Korean>HK121 (육각)</Korean>
             <Chinese>HK121中型機槍 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>HK121（蜂巢迷彩）</Chinesesimp>
@@ -2916,7 +2916,7 @@
             <Italian>LWMMG (MTP)</Italian>
             <Hungarian>LWMMG (MTP)</Hungarian>
             <Portuguese>LWMMG (MTP)</Portuguese>
-            <Japanese>LWMMG (MTP)</Japanese>
+            <Japanese>LWMMG (MTP迷彩)</Japanese>
             <Korean>LWMMG (MTP)</Korean>
             <Chinese>輕量化中型機槍 (多地形迷彩)</Chinese>
             <Chinesesimp>LWMMG（多地形迷彩）</Chinesesimp>
@@ -3084,7 +3084,7 @@
             <Portuguese>QBZ-95-1 (Verde Hex)</Portuguese>
             <Hungarian>QBZ-95-1 (Zöld Hex)</Hungarian>
             <Italian>QBZ-95-1 (Hex Verde)</Italian>
-            <Japanese>QBZ-95-1 (緑ヘックス)</Japanese>
+            <Japanese>QBZ-95-1 (緑六角形迷彩)</Japanese>
             <Korean>QBZ-95-1 (초록육각)</Korean>
             <Chinese>QBZ-95-1式自動步槍 (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>95-1式自动步枪（绿色蜂巢迷彩）</Chinesesimp>
@@ -3101,7 +3101,7 @@
             <Portuguese>QBZ-95-1 (Hex)</Portuguese>
             <Hungarian>QBZ-95-1 (Hex)</Hungarian>
             <Italian>QBZ-95-1 (Hex)</Italian>
-            <Japanese>QBZ-95-1 (ヘックス)</Japanese>
+            <Japanese>QBZ-95-1 (六角形迷彩)</Japanese>
             <Korean>QBZ-95-1 (육각)</Korean>
             <Chinese>QBZ-95-1式自動步槍 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>95-1式自动步枪（蜂巢迷彩）</Chinesesimp>
@@ -3135,7 +3135,7 @@
             <Portuguese>QBZ-95-1 GL (Verde Hex)</Portuguese>
             <Hungarian>QBZ-95-1 GL (Zöld Hex)</Hungarian>
             <Italian>QBZ-95-1 GL (Hex Verde)</Italian>
-            <Japanese>QBZ-95-1 GL (緑ヘックス)</Japanese>
+            <Japanese>QBZ-95-1 GL (緑六角形迷彩)</Japanese>
             <Korean>QBZ-95-1 GL (초록육각)</Korean>
             <Chinese>QBZ-95-1式自動步槍 (榴彈—綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>95-1式自动步枪 10A式榴弹（绿色蜂巢迷彩）</Chinesesimp>
@@ -3152,7 +3152,7 @@
             <Portuguese>QBZ-95-1 GL (Hex)</Portuguese>
             <Hungarian>QBZ-95-1 GL (Hex)</Hungarian>
             <Italian>QBZ-95-1 GL (Hex)</Italian>
-            <Japanese>QBZ-95-1 GL (ヘックス)</Japanese>
+            <Japanese>QBZ-95-1 GL (六角形迷彩)</Japanese>
             <Korean>QBZ-95-1 GL (육각)</Korean>
             <Chinese>QBZ-95-1式自動步槍 (榴彈—數位蜂巢迷彩)</Chinese>
             <Chinesesimp>95-1式自动步枪 10A式榴弹（蜂巢迷彩）</Chinesesimp>
@@ -3186,7 +3186,7 @@
             <Portuguese>QBZ-95-1 LSW (Verde Hex)</Portuguese>
             <Hungarian>QBZ-95-1 LSW (Zöld Hex)</Hungarian>
             <Italian>QBZ-95-1 LSW (Hex Verde)</Italian>
-            <Japanese>QBZ-95-1 LSW (緑ヘックス)</Japanese>
+            <Japanese>QBZ-95-1 LSW (緑六角形迷彩)</Japanese>
             <Korean>QBZ-95-1 LSW (초록육각)</Korean>
             <Chinese>QBZ-95-1式輕機槍 (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>95-1式班用机枪（绿色蜂巢迷彩）</Chinesesimp>
@@ -3203,7 +3203,7 @@
             <Portuguese>QBZ-95-1 LSW (Hex)</Portuguese>
             <Hungarian>QBZ-95-1 LSW (Hex)</Hungarian>
             <Italian>QBZ-95-1 LSW (Hex)</Italian>
-            <Japanese>QBZ-95-1 LSW (ヘックス)</Japanese>
+            <Japanese>QBZ-95-1 LSW (六角形迷彩)</Japanese>
             <Korean>QBZ-95-1 LSW (육각)</Korean>
             <Chinese>QBZ-95-1式輕機槍 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>95-1式班用机枪（蜂巢迷彩）</Chinesesimp>
@@ -3237,7 +3237,7 @@
             <Portuguese>QBU-88 (Verde Hex)</Portuguese>
             <Hungarian>QBU-88 (Zöld Hex)</Hungarian>
             <Italian>QBU-88 (Hex Verde)</Italian>
-            <Japanese>QBU-88 (緑ヘックス)</Japanese>
+            <Japanese>QBU-88 (緑六角形迷彩)</Japanese>
             <Korean>QBU-88 (초록육각)</Korean>
             <Chinese>QBU-88式狙擊步槍 (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>88式狙击步枪（绿色蜂巢迷彩）</Chinesesimp>
@@ -3254,7 +3254,7 @@
             <Portuguese>QBU-88 (Hex)</Portuguese>
             <Hungarian>QBU-88 (Hex)</Hungarian>
             <Italian>QBU-88 (Hex)</Italian>
-            <Japanese>QBU-88 (ヘックス)</Japanese>
+            <Japanese>QBU-88 (六角形迷彩)</Japanese>
             <Korean>QBU-88 (육각)</Korean>
             <Chinese>QBU-88式狙擊步槍 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>88式狙击步枪（蜂巢迷彩）</Chinesesimp>
@@ -3271,7 +3271,7 @@
             <Portuguese>GM6 Lynx (Verde Hex)</Portuguese>
             <Hungarian>GM6 Lynx (Zöld Hex)</Hungarian>
             <Italian>GM6 Lynx (Hex Verde)</Italian>
-            <Japanese>GM6 リンクス (緑ヘックス)</Japanese>
+            <Japanese>GM6 リンクス (緑六角形迷彩)</Japanese>
             <Korean>GM6 링스 (초록육각)</Korean>
             <Chinese>GM6 "天貓"反器材狙擊步槍 (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>GM6 "猞猁"（绿色蜂巢迷彩）</Chinesesimp>
@@ -3305,7 +3305,7 @@
             <Russian>M200 Intervention (тропик)</Russian>
             <Portuguese>M200 Intervention (Trópico)</Portuguese>
             <Italian>M200 Intervention (Tropico)</Italian>
-            <Japanese>M200 インターベンション (熱帯迷彩)</Japanese>
+            <Japanese>M200 インターベンション (熱帯ジャングル迷彩)</Japanese>
             <Korean>M200 인터벤션 (열대)</Korean>
             <Chinese>M200干預型狙擊步槍 (熱帶迷彩)</Chinese>
             <Chinesesimp>M200 "干预"（热带迷彩）</Chinesesimp>
@@ -3543,7 +3543,7 @@
             <Portuguese>RPG-32 (Verde Hex)</Portuguese>
             <Hungarian>RPG-32 (Zöld Hex)</Hungarian>
             <Italian>RPG-32 (Hex Verde)</Italian>
-            <Japanese>RPG-32 (緑ヘックス)</Japanese>
+            <Japanese>RPG-32 (緑六角形迷彩)</Japanese>
             <Korean>RPG-32 (초록육각)</Korean>
             <Chinese>RPG-32火箭發射器 (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>RPG-32（绿色蜂巢迷彩）</Chinesesimp>
@@ -3940,7 +3940,7 @@
             <English>ELCAN SpecterOS (Green Hex)</English>
             <Chinese>ELCAN SpecterOS (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>ELCAN SpecterOS（绿色蜂巢迷彩）</Chinesesimp>
-            <Japanese>ELCAN SpecterOS (緑ヘックス)</Japanese>
+            <Japanese>ELCAN SpecterOS (緑六角形迷彩)</Japanese>
             <Italian>ELCAN SpecterOS (Hex Verde)</Italian>
             <Polish>ELCAN SpecterOS (Zielony Hex)</Polish>
             <Russian>ELCAN SpecterOS (зелёный гекс)</Russian>
@@ -3989,7 +3989,7 @@
             <Polish>ELCAN SpecterOS (Leśny)</Polish>
             <French>ELCAN SpecterOS (Forêt)</French>
             <Italian>ELCAN SpecterOS (Verdeggiante)</Italian>
-            <Japanese>ELCAN SpecterOS (緑地)</Japanese>
+            <Japanese>ELCAN SpecterOS (緑地迷彩)</Japanese>
             <German>ELCAN SpecterOS (Grün)</German>
             <Chinesesimp>ELCAN SpecterOS（繁茂）</Chinesesimp>
             <Korean>엘칸 스펙터OS (초목)</Korean>
@@ -4001,7 +4001,7 @@
             <Polish>ELCAN SpecterOS (Jałowy)</Polish>
             <French>ELCAN SpecterOS (Désert)</French>
             <Italian>ELCAN SpecterOS (Arido)</Italian>
-            <Japanese>ELCAN SpecterOS (乾燥地帯)</Japanese>
+            <Japanese>ELCAN SpecterOS (乾燥地帯迷彩)</Japanese>
             <German>ELCAN SpecterOS (Trocken)</German>
             <Chinesesimp>ELCAN SpecterOS（干旱）</Chinesesimp>
             <Korean>엘칸 스펙터OS (건조)</Korean>
@@ -4025,7 +4025,7 @@
             <Polish>ELCAN SpecterOS 7.62 (Leśny)</Polish>
             <French>ELCAN SpecterOS 7.62 (Forêt)</French>
             <Italian>ELCAN SpecterOS 7.62 (Verdeggiante)</Italian>
-            <Japanese>ELCAN SpecterOS 7.62 (緑地)</Japanese>
+            <Japanese>ELCAN SpecterOS 7.62 (緑地迷彩)</Japanese>
             <German>ELCAN SpecterOS 7.62 (Grün)</German>
             <Chinesesimp>ELCAN SpecterOS 7.62（繁茂）</Chinesesimp>
             <Korean>엘칸 스펙터OS 7.62 (초목)</Korean>
@@ -4037,7 +4037,7 @@
             <Polish>ELCAN SpecterOS 7.62 (Jałowy)</Polish>
             <French>ELCAN SpecterOS 7.62 (Désert)</French>
             <Italian>ELCAN SpecterOS 7.62 (Arido)</Italian>
-            <Japanese>ELCAN SpecterOS 7.62 (乾燥地帯)</Japanese>
+            <Japanese>ELCAN SpecterOS 7.62 (乾燥地帯迷彩)</Japanese>
             <German>ELCAN SpecterOS 7.62 (Trocken)</German>
             <Chinesesimp>ELCAN SpecterOS 7.62（干旱）</Chinesesimp>
             <Korean>엘칸 스펙터OS 7.62 (건조)</Korean>
@@ -4112,7 +4112,7 @@
             <English>Nightforce NXS (Green Hex)</English>
             <Chinese>Nightforce NXS (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>Nightforce NXS（绿色蜂巢迷彩）</Chinesesimp>
-            <Japanese>Nightforce NXS (緑ヘックス)</Japanese>
+            <Japanese>Nightforce NXS (緑六角形迷彩)</Japanese>
             <Italian>Nightforce NXS (Hex Verde)</Italian>
             <Polish>Nightforce NXS (Zielony Hex)</Polish>
             <Russian>Nightforce NXS (зелёный гекс)</Russian>
@@ -4129,7 +4129,7 @@
             <German>Nightforce NXS (Dschungel)</German>
             <Chinese>Nightforce NXS (叢林色)</Chinese>
             <Chinesesimp>Nightforce NXS（丛林色）</Chinesesimp>
-            <Japanese>Nightforce NXS (ジャングル)</Japanese>
+            <Japanese>Nightforce NXS (熱帯ジャングル迷彩)</Japanese>
             <Italian>Nightforce NXS (Giungla)</Italian>
             <Polish>Nightforce NXS (Dżungla)</Polish>
             <Russian>Nightforce NXS (джунгли)</Russian>
@@ -4240,7 +4240,7 @@
             <English>KAHLES Helia (Hex)</English>
             <Chinese>KAHLES Helia (Hex)</Chinese>
             <Chinesesimp>KAHLES Helia（蜂巢迷彩）</Chinesesimp>
-            <Japanese>KAHLES ヘリア (ヘックス)</Japanese>
+            <Japanese>KAHLES ヘリア (六角形迷彩)</Japanese>
             <Polish>KAHLES Helia (Hex)</Polish>
             <Italian>KAHLES Helia (Hex)</Italian>
             <Russian>KAHLES Helia (гекс)</Russian>
@@ -4304,7 +4304,7 @@
             <English>Burris XTR II (Green Hex)</English>
             <Chinese>Burris XTR II (綠色數位蜂巢迷彩)</Chinese>
             <Chinesesimp>Burris XTR II（绿色蜂巢迷彩）</Chinesesimp>
-            <Japanese>Burris XTR II (緑ヘックス)</Japanese>
+            <Japanese>Burris XTR II (緑六角形迷彩)</Japanese>
             <Italian>Burris XTR II (Hex Verde)</Italian>
             <Polish>Burris XTR II (Zielony Hex)</Polish>
             <Russian>Burris XTR II (зелёный гекс)</Russian>
@@ -4393,7 +4393,7 @@
             <Polish>EOTech XPS3 (Leśny)</Polish>
             <French>EOTech XPS3 (Forêt)</French>
             <Italian>EOTech XPS3 (Verdeggiante)</Italian>
-            <Japanese>EOTech XPS3 (緑地)</Japanese>
+            <Japanese>EOTech XPS3 (緑地迷彩)</Japanese>
             <German>EOTech XPS3 (Grün)</German>
             <Chinesesimp>EOTech XPS3（繁茂）</Chinesesimp>
             <Korean>이오텍 XPS3 (초목)</Korean>
@@ -4405,7 +4405,7 @@
             <Polish>EOTech XPS3 (Jałowy)</Polish>
             <French>EOTech XPS3 (Désert)</French>
             <Italian>EOTech XPS3 (Arido)</Italian>
-            <Japanese>EOTech XPS3 (乾燥地帯)</Japanese>
+            <Japanese>EOTech XPS3 (乾燥地帯迷彩)</Japanese>
             <German>EOTech XPS3 (Trocken)</German>
             <Chinesesimp>EOTech XPS3（干旱）</Chinesesimp>
             <Korean>이오텍 XPS3 (건조)</Korean>
@@ -4633,7 +4633,7 @@
             <Italian>P90 TR (Mimetica)</Italian>
             <Hungarian>P90 TR (Terepmintás)</Hungarian>
             <Portuguese>P90 TR (Camuflagem)</Portuguese>
-            <Japanese>P90 TR (迷彩)</Japanese>
+            <Japanese>P90 TR (AAF迷彩)</Japanese>
             <Chinese>P90 TR (迷彩)</Chinese>
             <Chinesesimp>P90 TR（迷彩）</Chinesesimp>
             <Korean>P90 TR (위장)</Korean>
@@ -4650,7 +4650,7 @@
             <Italian>P90 TR (Hex)</Italian>
             <Hungarian>P90 TR (Hex)</Hungarian>
             <Portuguese>P90 TR (Hex)</Portuguese>
-            <Japanese>P90 TR (ヘックス)</Japanese>
+            <Japanese>P90 TR (六角形迷彩)</Japanese>
             <Chinese>P90 TR (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>P90 TR（蜂巢迷彩）</Chinesesimp>
             <Korean>P90 TR (육각)</Korean>
@@ -4701,7 +4701,7 @@
             <Italian>P90 (Mimetica)</Italian>
             <Hungarian>P90 (Terepmintás)</Hungarian>
             <Portuguese>P90 (Camuflagem)</Portuguese>
-            <Japanese>P90 (迷彩)</Japanese>
+            <Japanese>P90 (AAF迷彩)</Japanese>
             <Chinese>P90 (迷彩)</Chinese>
             <Chinesesimp>P90（迷彩）</Chinesesimp>
             <Korean>P90 (위장)</Korean>
@@ -4718,7 +4718,7 @@
             <Italian>P90 (Hex)</Italian>
             <Hungarian>P90 (Hex)</Hungarian>
             <Portuguese>P90 (Hex)</Portuguese>
-            <Japanese>P90 (ヘックス)</Japanese>
+            <Japanese>P90 (六角形迷彩)</Japanese>
             <Chinese>P90 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>P90（蜂巢迷彩）</Chinesesimp>
             <Korean>P90 (육각)</Korean>
@@ -4769,7 +4769,7 @@
             <Italian>PS90 TR (Mimetica)</Italian>
             <Hungarian>PS90 TR (Terepmintás)</Hungarian>
             <Portuguese>PS90 TR (Camuflagem)</Portuguese>
-            <Japanese>PS90 TR (迷彩)</Japanese>
+            <Japanese>PS90 TR (AAF迷彩)</Japanese>
             <Chinese>PS90 TR (迷彩)</Chinese>
             <Chinesesimp>PS90 TR（迷彩）</Chinesesimp>
             <Korean>PS90 TR (위장)</Korean>
@@ -4786,7 +4786,7 @@
             <Italian>PS90 TR (Hex)</Italian>
             <Hungarian>PS90 TR (Hex)</Hungarian>
             <Portuguese>PS90 TR (Hex)</Portuguese>
-            <Japanese>PS90 TR (ヘックス)</Japanese>
+            <Japanese>PS90 TR (六角形迷彩)</Japanese>
             <Chinese>PS90 TR (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>PS90 TR（蜂巢迷彩）</Chinesesimp>
             <Korean>PS90 TR (육각)</Korean>
@@ -4837,7 +4837,7 @@
             <Italian>PS90 (Mimetica)</Italian>
             <Hungarian>PS90 (Terepmintás)</Hungarian>
             <Portuguese>PS90 (Camuflagem)</Portuguese>
-            <Japanese>PS90 (迷彩)</Japanese>
+            <Japanese>PS90 (AAF迷彩)</Japanese>
             <Chinese>PS90 (迷彩)</Chinese>
             <Chinesesimp>PS90（迷彩）</Chinesesimp>
             <Korean>PS90 (위장)</Korean>
@@ -4854,7 +4854,7 @@
             <Italian>PS90 (Hex)</Italian>
             <Hungarian>PS90 (Hex)</Hungarian>
             <Portuguese>PS90 (Hex)</Portuguese>
-            <Japanese>PS90 (ヘックス)</Japanese>
+            <Japanese>PS90 (六角形迷彩)</Japanese>
             <Chinese>PS90 (數位蜂巢迷彩)</Chinese>
             <Chinesesimp>PS90（蜂巢迷彩）</Chinesesimp>
             <Korean>PS90 (육각)</Korean>
@@ -4958,7 +4958,7 @@
             <Portuguese>AK-15 (Exuberante)</Portuguese>
             <Korean>AK-15 (초목)</Korean>
             <Chinesesimp>AK-15（繁茂）</Chinesesimp>
-            <Japanese>AK-15 (緑地)</Japanese>
+            <Japanese>AK-15 (緑地迷彩)</Japanese>
             <Turkish>AK-15 (Gür)</Turkish>
             <Hungarian>AK-15 (esőerdő)</Hungarian>
         </Key>
@@ -4975,7 +4975,7 @@
             <Portuguese>AK-15 (Árido)</Portuguese>
             <Korean>AK-15 (건조)</Korean>
             <Chinesesimp>AK-15（干旱）</Chinesesimp>
-            <Japanese>AK-15 (乾燥地帯)</Japanese>
+            <Japanese>AK-15 (乾燥地帯迷彩)</Japanese>
             <Turkish>AK-15 (Kurak)</Turkish>
             <Hungarian>AK-15 (sivatag)</Hungarian>
         </Key>
@@ -5009,7 +5009,7 @@
             <Portuguese>AK-15 GL (Exuberante)</Portuguese>
             <Korean>AK-15 GL (초목)</Korean>
             <Chinesesimp>AK-15 GP-34（繁茂）</Chinesesimp>
-            <Japanese>AK-15 GL (緑地)</Japanese>
+            <Japanese>AK-15 GL (緑地迷彩)</Japanese>
             <Turkish>AK-15 GL (Gür)</Turkish>
             <Hungarian>AK-15 GL (esőerdő)</Hungarian>
         </Key>
@@ -5026,7 +5026,7 @@
             <Portuguese>AK-15 GL (Árido)</Portuguese>
             <Korean>AK-15 GL (건조)</Korean>
             <Chinesesimp>AK-15 GP-34（干旱）</Chinesesimp>
-            <Japanese>AK-15 GL (乾燥地帯)</Japanese>
+            <Japanese>AK-15 GL (乾燥地帯迷彩)</Japanese>
             <Turkish>AK-15AK-15 GL (Kurak)</Turkish>
             <Hungarian>AK-15 GL (sivatag)</Hungarian>
         </Key>
@@ -5060,7 +5060,7 @@
             <Portuguese>AK-15K (Exuberante)</Portuguese>
             <Korean>AK-15K (초목)</Korean>
             <Chinesesimp>AK-15K（繁茂）</Chinesesimp>
-            <Japanese>AK-15K (緑地)</Japanese>
+            <Japanese>AK-15K (緑地迷彩)</Japanese>
             <Turkish>AK-15K (Gür)</Turkish>
             <Hungarian>AK-15K (esőerdő)</Hungarian>
         </Key>
@@ -5077,7 +5077,7 @@
             <Portuguese>AK-15K (Árido)</Portuguese>
             <Korean>AK-15K (건조)</Korean>
             <Chinesesimp>AK-15K（干旱）</Chinesesimp>
-            <Japanese>AK-15K (乾燥地帯)</Japanese>
+            <Japanese>AK-15K (乾燥地帯迷彩)</Japanese>
             <Turkish>AK-15K (Kurak)</Turkish>
             <Hungarian>AK-15K (sivatag)</Hungarian>
         </Key>
@@ -5111,7 +5111,7 @@
             <Portuguese>RPK (Exuberante)</Portuguese>
             <Korean>RPK (초목)</Korean>
             <Chinesesimp>RPK（繁茂）</Chinesesimp>
-            <Japanese>RPK (緑地)</Japanese>
+            <Japanese>RPK (緑地迷彩)</Japanese>
             <Turkish>RPK (Gür)</Turkish>
             <Hungarian>RPK (esőerdő)</Hungarian>
         </Key>
@@ -5128,7 +5128,7 @@
             <Portuguese>RPK (Árido)</Portuguese>
             <Korean>RPK (건조)</Korean>
             <Chinesesimp>RPK（干旱）</Chinesesimp>
-            <Japanese>RPK (乾燥地帯)</Japanese>
+            <Japanese>RPK (乾燥地帯迷彩)</Japanese>
             <Turkish>RPK (Kurak)</Turkish>
             <Hungarian>RPK (sivatag)</Hungarian>
         </Key>
@@ -5213,7 +5213,7 @@
             <Portuguese>MSBS Grot (Camo)</Portuguese>
             <Korean>MSBS 그롯 (위장)</Korean>
             <Chinesesimp>MSBS Grot（迷彩）</Chinesesimp>
-            <Japanese>MSBS グロート (迷彩)</Japanese>
+            <Japanese>MSBS グロート (LDF迷彩)</Japanese>
             <Turkish>MSBS Grot (Kamuflaj)</Turkish>
             <Hungarian>MSBS Grot (Terepmintás)</Hungarian>
         </Key>
@@ -5281,7 +5281,7 @@
             <Portuguese>MSBS Grot GL (Camo)</Portuguese>
             <Korean>MSBS 그롯 GL (위장)</Korean>
             <Chinesesimp>MSBS Grot GPBO-40（迷彩）</Chinesesimp>
-            <Japanese>MSBS グロート GL (迷彩)</Japanese>
+            <Japanese>MSBS グロート GL (LDF迷彩)</Japanese>
             <Turkish>MSBS Grot GL (Kamuflaj)</Turkish>
             <Hungarian>MSBS Grot GL (Terepmintás)</Hungarian>
         </Key>
@@ -5349,7 +5349,7 @@
             <Portuguese>MSBS Grot MR (Camo)</Portuguese>
             <Korean>MSBS 그롯 MR (위장)</Korean>
             <Chinesesimp>MSBS Grot MR（迷彩）</Chinesesimp>
-            <Japanese>MSBS グロート MR (迷彩)</Japanese>
+            <Japanese>MSBS グロート MR (LDF迷彩)</Japanese>
             <Turkish>MSBS Grot MR (Kamuflaj)</Turkish>
             <Hungarian>MSBS Grot MR (Terepmintás)</Hungarian>
         </Key>
@@ -5417,7 +5417,7 @@
             <Portuguese>MSBS Grot SG (Camo)</Portuguese>
             <Korean>MSBS 그롯 SG (위장)</Korean>
             <Chinesesimp>MSBS Grot SG（迷彩）</Chinesesimp>
-            <Japanese>MSBS グロート SG (迷彩)</Japanese>
+            <Japanese>MSBS グロート SG (LDF迷彩)</Japanese>
             <Turkish>MSBS Grot SG (Kamuflaj)</Turkish>
             <Hungarian>MSBS Grot SG (Terepmintás)</Hungarian>
         </Key>

--- a/addons/tagging/stringtable.xml
+++ b/addons/tagging/stringtable.xml
@@ -274,7 +274,7 @@
             <Czech>Černý sprej</Czech>
             <Portuguese>Spray de tinta preta</Portuguese>
             <Russian>Черный спрей</Russian>
-            <Japanese>ペイントスプレー缶 (黒色)</Japanese>
+            <Japanese>スプレーペイント缶 (黒色)</Japanese>
             <Korean>검정 스프레이</Korean>
             <Chinesesimp>黑色喷漆</Chinesesimp>
             <Chinese>黑色噴漆</Chinese>
@@ -290,7 +290,7 @@
             <Czech>Červený sprej</Czech>
             <Portuguese>Spray de tinta vermelha</Portuguese>
             <Russian>Красный спрей</Russian>
-            <Japanese>ペイントスプレー缶 (赤色)</Japanese>
+            <Japanese>スプレーペイント缶 (赤色)</Japanese>
             <Korean>빨강 스프레이</Korean>
             <Chinesesimp>红色喷漆</Chinesesimp>
             <Chinese>紅色噴漆</Chinese>
@@ -306,7 +306,7 @@
             <Czech>Zelený sprej</Czech>
             <Portuguese>Spray de tinta verde</Portuguese>
             <Russian>Зелёный спрей</Russian>
-            <Japanese>ペイントスプレー缶 (緑色)</Japanese>
+            <Japanese>スプレーペイント缶 (緑色)</Japanese>
             <Korean>초록 스프레이</Korean>
             <Chinesesimp>绿色喷漆</Chinesesimp>
             <Chinese>綠色噴漆</Chinese>
@@ -322,7 +322,7 @@
             <Czech>Modrý sprej</Czech>
             <Portuguese>Spray de tinta azul</Portuguese>
             <Russian>Синий спрей</Russian>
-            <Japanese>ペイントスプレー缶 (青色)</Japanese>
+            <Japanese>スプレーペイント缶 (青色)</Japanese>
             <Korean>파랑 스프레이</Korean>
             <Chinesesimp>蓝色喷漆</Chinesesimp>
             <Chinese>藍色噴漆</Chinese>
@@ -338,7 +338,7 @@
             <Czech>Žlutý sprej</Czech>
             <Portuguese>Spray de tinta amarela</Portuguese>
             <Russian>Желтый спрей</Russian>
-            <Japanese>ペイントスプレー缶 (黄色)</Japanese>
+            <Japanese>スプレーペイント缶 (黄色)</Japanese>
             <Korean>노랑 스프레이</Korean>
             <Chinesesimp>黄色喷漆</Chinesesimp>
             <Chinese>黃色噴漆</Chinese>
@@ -354,7 +354,7 @@
             <Czech>Bílý sprej</Czech>
             <Portuguese>Spray de tinta branca</Portuguese>
             <Russian>Белый спрей</Russian>
-            <Japanese>ペイントスプレー缶 (白色)</Japanese>
+            <Japanese>スプレーペイント缶 (白色)</Japanese>
             <Korean>하양 스프레이</Korean>
             <Chinesesimp>白色喷漆</Chinesesimp>
             <Chinese>白色噴漆</Chinese>
@@ -370,7 +370,7 @@
             <Czech>Plechovka se sprejem k vytváření značek.</Czech>
             <Portuguese>Uma lata de tinta spray para marcar paredes.</Portuguese>
             <Russian>Балончик спрея для рисования маркеров на стенах.</Russian>
-            <Japanese>壁にタグを描くためのペイントスプレー缶。</Japanese>
+            <Japanese>壁にタグを描くためのスプレーペイント缶。</Japanese>
             <Korean>벽에 낙서할 수 있는 스프레이캔 입니다.</Korean>
             <Chinesesimp>喷漆可喷涂在墙壁上</Chinesesimp>
             <Chinese>噴漆可噴塗在牆壁上</Chinese>

--- a/addons/zeus/stringtable.xml
+++ b/addons/zeus/stringtable.xml
@@ -207,7 +207,7 @@
             <Hungarian>Feltárja az aknákat a szövetségeseknek, és jelölőket helyez el a térképen.</Hungarian>
             <Russian>Показывает мины союзникам и отмечает их маркерами на карте.</Russian>
             <Italian>Rivela mine ad alleati e piazza marcatori in mappa.</Italian>
-            <Japanese>友軍に地雷と地図へ設置マーカーを表示します。</Japanese>
+            <Japanese>地雷の位置を味方に公開し、マップマーカーを配置します。</Japanese>
             <Korean>아군에게 지도 상의 모든 지뢰를 표시합니다.</Korean>
             <Chinesesimp>地图将标记队友放置的地雷</Chinesesimp>
             <Chinese>地圖將標記隊友放置的地雷</Chinese>


### PR DESCRIPTION
**When merged this pull request will:**
- _change/add Japanese strings to maptools for plotting board and some tweaks_
- _change/add Japanese strings to markers for milliseconds and some tweaks_
- _add Japanese strings to overheating for stat bolt type and barrel type description_
- _change Japanese strings in realisticnames (vanilla and for ws) for the display names, add camouflage details and hex wording katakana to kanji_
- _change Japanese strings in nightvision for the display names, some generation(4th) and wp version has wrong display name, and make matching to vanilla games name_
- _change Japanese strings in map for the Add-on options menu, some explanations are incorrect_
- _change Japanese strings in map_gestures for the Add-on options menu, some explanations are incorrect_
- _change Japanese strings in marker_flags for the display name of the marker flags because it is an unnatural expression_
- _change Japanese strings in zeus for "STR_ACE_Zeus_revealMines_Description" because it's unnatural wording_
- _change Japanese strings in fcs for "STR_ACE_FCS_AdjustRangeDown" and up, because it's unnatural wording_
- _change Japanese strings in tagging for the display name of the paint spray to spray paint_
- _All changes only affect Japanese, other languages remain unchanged._

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
