### PR TITLE
Map Tools - Fix wrong Plotting Board strings targets

### DIFF
--- a/addons/maptools/CfgVehicles.hpp
+++ b/addons/maptools/CfgVehicles.hpp
@@ -140,7 +140,7 @@ class CfgVehicles {
                         showDisabled = 0;
 
                         class ACE_PlottingBoardAlignBoardMaptool {
-                            displayName = CSTRING(Name);
+                            displayName = CSTRING(ToMapToolLabel);
                             condition = QUOTE(GVAR(mapTool_Shown) > 0 && GVAR(plottingBoard_angle) != GVAR(mapTool_angle));
                             statement = QUOTE(GVAR(plottingBoard_angle) = GVAR(mapTool_angle));
                             EXCEPTIONS;
@@ -162,7 +162,7 @@ class CfgVehicles {
                         showDisabled = 0;
 
                         class ACE_PlottingBoardAlignAcrylicMaptool {
-                            displayName = CSTRING(Name);
+                            displayName = CSTRING(ToMapToolLabel);
                             condition = QUOTE(GVAR(mapTool_Shown) > 0 && GVAR(plottingBoard_acrylicAngle) != GVAR(mapTool_angle));
                             statement = QUOTE(GVAR(plottingBoard_acrylicAngle) = GVAR(mapTool_angle));
                             EXCEPTIONS;
@@ -184,7 +184,7 @@ class CfgVehicles {
                         showDisabled = 0;
 
                         class ACE_PlottingBoardAlignRulerMaptool {
-                            displayName = CSTRING(Name);
+                            displayName = CSTRING(ToMapToolLabel);
                             condition = QUOTE(GVAR(mapTool_Shown) > 0 && GVAR(plottingBoard_rulerAngle) != GVAR(mapTool_angle));
                             statement = QUOTE(GVAR(plottingBoard_rulerAngle) = GVAR(mapTool_angle));
                             EXCEPTIONS;

--- a/addons/maptools/CfgWeapons.hpp
+++ b/addons/maptools/CfgWeapons.hpp
@@ -18,7 +18,7 @@ class CfgWeapons {
     class ACE_PlottingBoard: ACE_ItemCore {
         displayName = CSTRING(PlottingBoard_Name);
         author = ECSTRING(common,ACETeam);
-        descriptionShort = CSTRING(Description);
+        descriptionShort = CSTRING(PlottingBoard_Description);
         model = QPATHTOF(data\ace_MapTools.p3d);
         picture = QPATHTOF(UI\plottingboard_item.paa);
         scope = 2;


### PR DESCRIPTION
**When merged this pull request will:**
- _Change Plotting Board descriptionShort CSTRING target `(Description)` (Map Tool description) to `(PlottingBoard_Description)` (True Plotting Board description)_
- _Change Plotting Board map interaction menu name CSTRING target `(name)` (item name "Map Tools") to `(ToMapToolLabel)` ("To Maptool" string)_

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
