### PR TITLE
Medical Engine - Remove ACE_HDBracket hitpoint

### DIFF
--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -6,28 +6,15 @@
     [_new] call FUNC(updateDamageEffects); // Run on new controlled unit to update QGVAR(aimFracture)
 }, true] call CBA_fnc_addPlayerEventHandler;
 
-
 ["CAManBase", "init", {
     params ["_unit"];
 
-    // Check if last hit point is our dummy.
-    private _allHitPoints = getAllHitPointsDamage _unit param [0, []];
-    reverse _allHitPoints;
-    while {(_allHitPoints param [0, ""]) select [0,1] == "#"} do { WARNING_1("Ignoring Reflector hitpoint %1", _allHitPoints deleteAt 0); };
-
-    if (_allHitPoints param [0, ""] != "ACE_HDBracket") then {
-        private _config = configOf _unit;
-        if (getText (_config >> "simulation") == "UAVPilot") exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
-        if (getNumber (_config >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
-        ERROR_1("Bad hitpoints for unit type ""%1""",typeOf _unit);
-    } else {
-        // Calling this function inside curly brackets allows the usage of
-        // "exitWith", which would be broken with "HandleDamage" otherwise.
-        _unit setVariable [
-            QEGVAR(medical,HandleDamageEHID),
-            _unit addEventHandler ["HandleDamage", {_this call FUNC(handleDamage)}]
-        ];
-    };
+    // Calling this function inside curly brackets allows the usage of
+    // "exitWith", which would be broken with "HandleDamage" otherwise.
+    _unit setVariable [
+        QEGVAR(medical,HandleDamageEHID),
+        _unit addEventHandler ["HandleDamage", {_this call FUNC(handleDamage)}]
+    ];
 }, nil, [IGNORE_BASE_UAVPILOTS], true] call CBA_fnc_addClassEventHandler;
 
 #ifdef DEBUG_MODE_FULL

--- a/addons/medical_engine/script_macros_config.hpp
+++ b/addons/medical_engine/script_macros_config.hpp
@@ -47,15 +47,4 @@
     };\
     class HitRightLeg: HitLeftLeg {\
         name = "leg_r";\
-    };\
-    class ACE_HDBracket {\
-        armor = 1;\
-        material = -1;\
-        name = "head";\
-        passThrough = 0;\
-        radius = 1;\
-        explosionShielding = 1;\
-        visual = "";\
-        minimalHit = 0;\
-        depends = "HitHead";\
     }


### PR DESCRIPTION
**When merged this pull request will:**
- Arma 2.16 adds "context" param to HD which lets us know if we're at the last iteration of the event: https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#HandleDamage
- Some stuff had to be moved around in the function but it'll work the same.
- While this means that medical will still work even with broken inheritance now, arm/leg hitpoints could still be missing due to the same issue.

I'm looking into whether it's possible to simplify more of the function via other events or the `directHit` param.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
