### PR TITLE
General - Change UAV unit config lookups to `unitIsUAV`

### DIFF
--- a/addons/common/functions/fnc_getVehicleUAVCrew.sqf
+++ b/addons/common/functions/fnc_getVehicleUAVCrew.sqf
@@ -17,4 +17,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-crew _vehicle select {unitIsUAV _x} // return
+(crew _vehicle) select {unitIsUAV _x} // return

--- a/addons/common/functions/fnc_getVehicleUAVCrew.sqf
+++ b/addons/common/functions/fnc_getVehicleUAVCrew.sqf
@@ -17,4 +17,4 @@
 
 params [["_vehicle", objNull, [objNull]]];
 
-crew _vehicle select {getText (configOf _x >> "simulation") == "UAVPilot"} // return
+crew _vehicle select {unitIsUAV _x} // return

--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -28,7 +28,7 @@ if ((_unit getHitPointDamage "HitLegs") >= 0.5) exitWith {false};
 
 // Static weapons need to be empty for carrying (ignore UAV AI)
 if (_target isKindOf "StaticWeapon") exitWith {
-    (crew _target) findIf {getText (configOf _x >> "simulation") != "UAVPilot"} == -1
+    (crew _target) findIf {!unitIsUAV _x} == -1
 };
 
 // Units need to be unconscious or limping; Units also need to not be in ragdoll, as that causes desync issues

--- a/addons/dragging/functions/fnc_canDrag.sqf
+++ b/addons/dragging/functions/fnc_canDrag.sqf
@@ -24,7 +24,7 @@ if !([_unit, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)) exi
 
 // Static weapons need to be empty for dragging (ignore UAV AI)
 if (_target isKindOf "StaticWeapon") exitWith {
-    (crew _target) findIf {getText (configOf _x >> "simulation") != "UAVPilot"} == -1
+    (crew _target) findIf {!unitIsUAV _x} == -1
 };
 
 // Units need to be unconscious or limping; Units also need to not be in ragdoll, as that causes desync issues

--- a/addons/gforces/XEH_postInit.sqf
+++ b/addons/gforces/XEH_postInit.sqf
@@ -13,7 +13,7 @@ GVAR(playerIsVirtual) = false;
     ["unit", { // Add unit changed EH to check if player is either virtual (logic) or a UAV AI
         params ["_unit"];
         GVAR(playerIsVirtual) = ((getNumber (configOf _unit >> "isPlayableLogic")) == 1) ||
-        {(getText (configOf _unit >> "simulation")) == "UAVPilot"};
+        {unitIsUAV _unit};
         TRACE_3("unit changed",_unit,typeOf _unit,GVAR(playerIsVirtual));
     }, true] call CBA_fnc_addPlayerEventHandler;
 

--- a/addons/gforces/XEH_postInit.sqf
+++ b/addons/gforces/XEH_postInit.sqf
@@ -12,8 +12,7 @@ GVAR(playerIsVirtual) = false;
 
     ["unit", { // Add unit changed EH to check if player is either virtual (logic) or a UAV AI
         params ["_unit"];
-        GVAR(playerIsVirtual) = ((getNumber (configOf _unit >> "isPlayableLogic")) == 1) ||
-        {unitIsUAV _unit};
+        GVAR(playerIsVirtual) = unitIsUAV _unit || {(getNumber (configOf _unit >> "isPlayableLogic")) == 1};
         TRACE_3("unit changed",_unit,typeOf _unit,GVAR(playerIsVirtual));
     }, true] call CBA_fnc_addPlayerEventHandler;
 

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -16,8 +16,8 @@
     while {(_allHitPoints param [0, ""]) select [0,1] == "#"} do { WARNING_1("Ignoring Reflector hitpoint %1", _allHitPoints deleteAt 0); };
 
     if (_allHitPoints param [0, ""] != "ACE_HDBracket") then {
+        if (unitIsUAV _unit) exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
         private _config = configOf _unit;
-        if (getText (_config >> "simulation") == "UAVPilot") exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
         if (getNumber (_config >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
         ERROR_1("Bad hitpoints for unit type ""%1""",typeOf _unit);
     } else {

--- a/addons/medical_engine/XEH_postInit.sqf
+++ b/addons/medical_engine/XEH_postInit.sqf
@@ -17,8 +17,7 @@
 
     if (_allHitPoints param [0, ""] != "ACE_HDBracket") then {
         if (unitIsUAV _unit) exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
-        private _config = configOf _unit;
-        if (getNumber (_config >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
+        if (getNumber ((configOf _unit) >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
         ERROR_1("Bad hitpoints for unit type ""%1""",typeOf _unit);
     } else {
         // Calling this function inside curly brackets allows the usage of

--- a/addons/medical_status/XEH_preInit.sqf
+++ b/addons/medical_status/XEH_preInit.sqf
@@ -12,9 +12,8 @@ PREP_RECOMPILE_END;
 ["CAManBase", "init", {
     params ["_unit"];
 
-    private _config = configOf _unit;
-    if (getText (_config >> "simulation") == "UAVPilot") exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
-    if (getNumber (_config >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
+    if (unitIsUAV _unit) exitWith {TRACE_1("ignore UAV AI",typeOf _unit);};
+    if (getNumber ((configOf _unit) >> "isPlayableLogic") == 1) exitWith {TRACE_1("ignore logic unit",typeOf _unit)};
 
     // Hopefully this EH gets added first as it can only effect other EH called after it
     private _ehIndex = _unit addEventHandler ["Killed", {_this call FUNC(handleKilled)}];


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

As of 2.14 `unitIsUAV` does the same thing as the config lookup

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
