### PR TITLE
Medical - Fix showing 0 pulse on a dead patient that's receiving CPR

### DIFF
--- a/addons/medical_treatment/functions/fnc_cprFailure.sqf
+++ b/addons/medical_treatment/functions/fnc_cprFailure.sqf
@@ -20,3 +20,8 @@ params ["_medic", "_patient"];
 TRACE_2("cprFailure",_medic,_patient);
 
 _patient setVariable [QEGVAR(medical,CPR_provider), objNull, true];
+
+if (alive _patient) exitWith {};
+
+// See comment in fnc_cprStart
+_patient setVariable [VAR_HEART_RATE, 0, true];

--- a/addons/medical_treatment/functions/fnc_cprStart.sqf
+++ b/addons/medical_treatment/functions/fnc_cprStart.sqf
@@ -20,3 +20,9 @@ params ["_medic", "_patient"];
 TRACE_2("cprStart",_medic,_patient);
 
 _patient setVariable [QEGVAR(medical,CPR_provider), _medic, true];
+
+if (alive _patient) exitWith {};
+
+// Dead units are taken out of the statemachine, which means checking pulse while CPR is done on a dead unit will result in a HR of 0
+// This is a workaround for that, as adding the unit back into the statemachine or never taking out would be too performance-intensive
+_patient setVariable [VAR_HEART_RATE, random [25, 30, 35], true]; // value should match medical_vitals_fnc_updateHeartRate CPR value

--- a/addons/medical_treatment/functions/fnc_cprSuccess.sqf
+++ b/addons/medical_treatment/functions/fnc_cprSuccess.sqf
@@ -26,4 +26,8 @@ if (alive _patient && {IN_CRDC_ARRST(_patient)}) then {
     [QGVAR(cprLocal), [_medic, _patient], _patient] call CBA_fnc_targetEvent;
 } else {
     TRACE_1("not alive or in cardiac arrest",_patient);
+    if (!alive _patient) then {
+        // See comment in fnc_cprStart
+        _patient setVariable [VAR_HEART_RATE, 0, true];
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Checking pulse while CPR is being performed can be used to diagnose death, as dead units will not have their pulse updated.
Alternative solution: add dependency on `medical_vitals` to `medical_treatment` and call `FUNC(updateHeartRate)` directly with additional check for unit alive state along with cardiac arrest: https://github.com/acemod/ACE3/blob/master/addons/medical_vitals/functions/fnc_updateHeartRate.sqf#L25

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
