### PR TITLE
Medical - Fix getting no pulse on a dead patient receiving CPR

### DIFF
--- a/addons/medical_treatment/functions/fnc_checkPulseLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_checkPulseLocal.sqf
@@ -29,6 +29,7 @@ if (!([_patient, _bodyPart] call FUNC(hasTourniquetAppliedTo))) then {
         case (alive (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])): {
             random [25, 30, 35] // fake heart rate because patient is dead and off state machine
         };
+        default { 0 };
     };
 };
 

--- a/addons/medical_treatment/functions/fnc_checkPulseLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_checkPulseLocal.sqf
@@ -23,6 +23,9 @@ private _heartRate = 0;
 
 if (alive _patient && {!([_patient, _bodyPart] call FUNC(hasTourniquetAppliedTo))}) then {
     _heartRate = GET_HEART_RATE(_patient);
+    if (!alive _patient and !isNull (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])) then {
+        _heartRate = random [25, 30, 35]; // fake heart rate because they are dead and off state machine
+    }
 };
 
 private _heartRateOutput = LSTRING(Check_Pulse_Output_5);

--- a/addons/medical_treatment/functions/fnc_checkPulseLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_checkPulseLocal.sqf
@@ -21,11 +21,15 @@ params ["_medic", "_patient", "_bodyPart"];
 
 private _heartRate = 0;
 
-if (alive _patient && {!([_patient, _bodyPart] call FUNC(hasTourniquetAppliedTo))}) then {
-    _heartRate = GET_HEART_RATE(_patient);
-    if (!alive _patient and !isNull (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])) then {
-        _heartRate = random [25, 30, 35]; // fake heart rate because they are dead and off state machine
-    }
+if (!([_patient, _bodyPart] call FUNC(hasTourniquetAppliedTo))) then {
+    _heartRate = switch (true) do {
+        case (alive _patient): {
+            GET_HEART_RATE(_patient)
+        };
+        case (alive (_patient getVariable [QEGVAR(medical,CPR_provider), objNull])): {
+            random [25, 30, 35] // fake heart rate because patient is dead and off state machine
+        };
+    };
 };
 
 private _heartRateOutput = LSTRING(Check_Pulse_Output_5);


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Checking pulse while CPR is being performed can be used to diagnose death, as dead units will not have their pulse updated.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
