### PR TITLE
CSW - Delay init for CSW with simulation disabled

### DIFF
--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -16,7 +16,8 @@
  */
 
 params ["_staticWeapon"];
-if (isNull _staticWeapon) exitWith { WARNING_1("%1 became null",_staticWeapon) };
+if (isNull _staticWeapon) exitWith { WARNING_1("%1 became null",_staticWeapon); };
+if (!alive _staticWeapon) exitWith { WARNING_1("%1 not alive",_staticWeapon); };
 if (!simulationEnabled _staticWeapon) exitWith {
     [{simulationEnabled _this}, FUNC(staticWeaponInit), _staticWeapon] call CBA_fnc_waitUntilAndExecute;
 };

--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -17,6 +17,9 @@
 
 params ["_staticWeapon"];
 if (isNull _staticWeapon) exitWith { WARNING_1("%1 became null",_staticWeapon) };
+if (!simulationEnabled _staticWeapon) exitWith {
+    [{simulationEnabled _this}, FUNC(staticWeaponInit), _staticWeapon] call CBA_fnc_waitUntilAndExecute;
+};
 private _typeOf = typeOf _staticWeapon;
 private _configOf = configOf _staticWeapon;
 private _configEnabled = (getNumber (_configOf >> "ace_csw" >> "enabled")) == 1;

--- a/addons/csw/functions/fnc_staticWeaponInit.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit.sqf
@@ -16,7 +16,6 @@
  */
 
 params ["_staticWeapon"];
-if (isNull _staticWeapon) exitWith { WARNING_1("%1 became null",_staticWeapon); };
 if (!alive _staticWeapon) exitWith { WARNING_1("%1 not alive",_staticWeapon); };
 if (!simulationEnabled _staticWeapon) exitWith {
     [{simulationEnabled _this}, FUNC(staticWeaponInit), _staticWeapon] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Title. This is relevant for ZEN's placement preview feature, which breaks magazine unloading if advanced assembly is enabled.

`simulationEnabled objNull` is `true` so this handles the csw being deleted

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
