### PR TITLE
Arsenal - Fill left panel over multiple frames

### DIFF
--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -48,6 +48,7 @@ PREP(handleSearchbar);
 PREP(handleSearchInputChanged);
 PREP(handleSearchModeToggle);
 PREP(handleStats);
+PREP(idcToIDX);
 PREP(initBox);
 PREP(itemInfo);
 PREP(loadoutsChangeTab);

--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -48,4 +48,11 @@ call FUNC(compileStats);
 // Setup Tools tab
 [keys (uiNamespace getVariable [QGVAR(configItemsTools), createHashMap]), LLSTRING(toolsTab), TOOLS_TAB_ICON, -1, true] call FUNC(addRightPanelButton);
 
+GVAR(insigniaCache) = createHashMap;
+GVAR(insigniaCache) merge [uiNamespace getVariable QGVAR(insigniaCache), true]; // Don't copy directly because the uiNamespace cache is final
+{
+    GVAR(insigniaCache) set [configName _x, true];
+} forEach ("(if (isNumber (_x >> 'scope')) then {getNumber (_x >> 'scope')} else {2}) == 2" configClasses (missionConfigFile >> "CfgUnitInsignia"));
+GVAR(insigniaCache) = compileFinal GVAR(insigniaCache);
+
 ADDON = true;

--- a/addons/arsenal/functions/fnc_addListBoxItem.sqf
+++ b/addons/arsenal/functions/fnc_addListBoxItem.sqf
@@ -9,6 +9,7 @@
  * 1: Classname <STRING>
  * 2: Panel control <CONTROL>
  * 3: Name of the picture entry in that Cfg class <STRING> (default: "picture")
+ * 4: Use missionConfigFile for config path <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -19,7 +20,7 @@
  * Public: Yes
  */
 
-params ["_configCategory", "_className", "_ctrlPanel", ["_pictureEntryName", "picture", [""]]];
+params ["_configCategory", "_className", "_ctrlPanel", ["_pictureEntryName", "picture", [""]], ["_useMissionConfig", false, [false]]];
 
 private _skip = GVAR(favoritesOnly) && {!(_className in GVAR(currentItems))} && {!((toLower _className) in GVAR(favorites))};
 if (_skip) then {
@@ -44,7 +45,7 @@ if (_skip) exitWith {};
 // Sanitise key, as it's public; If not in cache, find info and cache it for later use
 ((uiNamespace getVariable QGVAR(addListBoxItemCache)) getOrDefaultCall [_configCategory + _className, {
     // Get classname (config case), display name, picture and DLC
-    private _configPath = configFile >> _configCategory >> _className;
+    private _configPath = ([configFile, missionConfigFile] select _useMissionConfig) >> _configCategory >> _className;
     private _dlcName = _configPath call EFUNC(common,getAddon);
 
     // If _pictureEntryName is empty, then this item has no picture (e.g. faces)

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -25,7 +25,7 @@ params ["_display", "_control", ["_animate", true], ["_framesToFill", -1], ["_cu
 private _ctrlIDC = ctrlIDC _control;
 if (
     !isNil QGVAR(currentLeftPanel) &&
-    {(_currentFrame == 0) == (GVAR(currentLeftPanel) == _ctrlIDC)} // either this is a new tab before filling finished, or a switch to the same tab
+    {(_currentFrame != 0) && (GVAR(currentLeftPanel) != _ctrlIDC)} // abort if we switched to a different tab before finishing
 ) exitWith {
     TRACE_1("abort",_currentFrame);
 };
@@ -35,6 +35,7 @@ private _idxVirt = _control getVariable QGVAR(idx);
 
 if (_currentFrame == 0) then {
     TRACE_3("filling left panel",_animate,_ctrlIDC,_framesToFill);
+    _control ctrlEnable false;
     // Fade old control background
     if (!isNil QGVAR(currentLeftPanel)) then {
         private _previousCtrlBackground  = _display displayCtrl (GVAR(currentLeftPanel) - 1);
@@ -90,6 +91,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
     if (_currentFrame == 0) then {
         _framesToFill = floor ((count _items) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
         _this set [3, _framesToFill];
+        [{_this ctrlEnable true}, _control, _framesToFill] call CBA_fnc_execAfterNFrames; // prevent the user from switching to the same tab while it's being filled
         TRACE_3("items to add",count _items,_currentItem,_idxVirt);
 
         // Current item gets preferential treatment so we can fill the right panel ASAP
@@ -125,6 +127,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
             if (_currentFrame == 0) then {
                 _framesToFill = floor ((count _faces) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
                 _this set [3, _framesToFill];
+                [{_this ctrlEnable true}, _control, _framesToFill] call CBA_fnc_execAfterNFrames;
                 TRACE_1("items to add",count _faces);
 
                 GVAR(currentFace) call _fnc_addFace;
@@ -144,6 +147,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
             if (_currentFrame == 0) then {
                 _framesToFill = floor ((count _voices) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
                 _this set [3, _framesToFill];
+                [{_this ctrlEnable true}, _control, _framesToFill] call CBA_fnc_execAfterNFrames;
                 TRACE_1("items to add",count _voices);
 
                 ["CfgVoice", GVAR(currentVoice), _ctrlPanel, "icon"] call FUNC(addListBoxItem);
@@ -163,6 +167,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
             if (_currentFrame == 0) then {
                 _framesToFill = floor ((count _insignias) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
                 _this set [3, _framesToFill];
+                [{_this ctrlEnable true}, _control, _framesToFill] call CBA_fnc_execAfterNFrames;
                 TRACE_1("items to add",count _insignias);
 
                 if (GVAR(currentInsignia) != "") then {
@@ -183,6 +188,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
         // Unknown
         default {
             _framesToFill = 0;
+            _control ctrlEnable true;
             _this set [3, _framesToFill];
             WARNING("Unknown arsenal left panel");
             ""

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -18,7 +18,7 @@
  * Public: No
 */
 
-#define ITEMS_PER_FRAME 100
+#define ITEMS_PER_FRAME 200
 
 params ["_display", "_control", ["_animate", true], ["_framesToFill", -1], ["_currentFrame", 0]];
 
@@ -62,7 +62,7 @@ if (_currentFrame == 0) then {
 private _idxVirt = _control getVariable QGVAR(idx);
 private _selectedItem = if (
     _idxVirt == IDX_VIRT_BINO ||
-    {_idxVirt != IDX_VIRT_HEADGEAR && (_idxVirt < IDX_VIRT_UNIFORM)}
+    {_idxVirt != IDX_VIRT_HEADGEAR && (_idxVirt < IDX_VIRT_GOGGLES)}
 ) then { // this is everything with a right panel
     private _configParent = ["CfgWeapons", "CfgVehicles"] select (_idxVirt == IDX_VIRT_BACKPACK);
     private _isWeapon = _idxVirt < IDX_VIRT_UNIFORM;
@@ -74,6 +74,7 @@ private _selectedItem = if (
     if (_currentFrame == 0) then {
         _framesToFill = floor ((count _items) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
         _this set [3, _framesToFill];
+        TRACE_1("items to add",count _items);
     };
 
     {
@@ -87,8 +88,10 @@ private _selectedItem = if (
         private _configParent = ["CfgWeapons", "CfgGlasses"] select (_idxVirt == IDX_VIRT_GOGGLES);
         private _items = keys (GVAR(virtualItems) get _idxVirt);
         if (_currentFrame == 0) then {
+            GVAR(currentRightPanel) = nil;
             _framesToFill = floor ((count _items) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
             _this set [3, _framesToFill];
+            TRACE_1("items to add",count _items);
         };
         {
             [_configParent, _x, _ctrlPanel] call FUNC(addListBoxItem);
@@ -108,6 +111,7 @@ if (_idxVirt == -1) then {
             if (_currentFrame == 0) then {
                 _framesToFill = floor ((count _faces) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
                 _this set [3, _framesToFill];
+                TRACE_1("items to add",count _items);
             };
 
             {
@@ -127,6 +131,7 @@ if (_idxVirt == -1) then {
             if (_currentFrame == 0) then {
                 _framesToFill = floor ((count _voices) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
                 _this set [3, _framesToFill];
+                TRACE_1("items to add",count _items);
             };
 
             {
@@ -142,6 +147,7 @@ if (_idxVirt == -1) then {
             if (_currentFrame == 0) then {
                 _framesToFill = floor ((count _insignias) / ITEMS_PER_FRAME); // floor because we already do something on frame 0
                 _this set [3, _framesToFill];
+                TRACE_1("items to add",count _items);
             };
 
             {
@@ -171,6 +177,7 @@ if (_idxVirt == -1) then {
         default {
             _framesToFill = 0;
             _this set [3, _framesToFill];
+            TRACE_1("items to add",count _items);
             ""
         };
     };

--- a/addons/arsenal/functions/fnc_idcToIDX.sqf
+++ b/addons/arsenal/functions/fnc_idcToIDX.sqf
@@ -14,7 +14,7 @@
 */
 params ["_ctrlIDC"];
 
-switch (_ctrlIDC) do {
+private _ret = switch (_ctrlIDC) do {
     case (IDC_buttonPrimaryWeapon): {IDX_VIRT_PRIMARY_WEAPONS};
     case (IDC_buttonHandgun): {IDX_VIRT_HANDGUN_WEAPONS};
     case (IDC_buttonSecondaryWeapon): {IDX_VIRT_SECONDARY_WEAPONS};
@@ -32,3 +32,7 @@ switch (_ctrlIDC) do {
     case (IDC_buttonWatch): {IDX_VIRT_WATCH};
     default {-1};
 };
+
+TRACE_2("idcToIDX",_ctrlIDC,_ret);
+
+_ret

--- a/addons/arsenal/functions/fnc_idcToIDX.sqf
+++ b/addons/arsenal/functions/fnc_idcToIDX.sqf
@@ -1,0 +1,34 @@
+#include "..\script_component.hpp"
+#include "..\defines.hpp"
+/*
+ * Author: LinkIsGrim
+ * Converts left panel ctrlIDC to virtualItems map key
+ *
+ * Arguments:
+ * 0: ctrlIDC <NUMBER>
+ *
+ * Return Value:
+ * virtualItems map key, or -1 if invalid <NUMBER>
+ *
+ * Public: No
+*/
+params ["_ctrlIDC"];
+
+switch (_ctrlIDC) do {
+    case (IDC_buttonPrimaryWeapon): {IDX_VIRT_PRIMARY_WEAPONS};
+    case (IDC_buttonHandgun): {IDX_VIRT_HANDGUN_WEAPONS};
+    case (IDC_buttonSecondaryWeapon): {IDX_VIRT_SECONDARY_WEAPONS};
+    case (IDC_buttonHeadgear): {IDX_VIRT_HEADGEAR};
+    case (IDC_buttonUniform): {IDX_VIRT_UNIFORM};
+    case (IDC_buttonVest): {IDX_VIRT_VEST};
+    case (IDC_buttonBackpack): {IDX_VIRT_BACKPACK};
+    case (IDC_buttonGoggles): {IDX_VIRT_GOGGLES};
+    case (IDC_buttonNVG): {IDX_VIRT_NVG};
+    case (IDC_buttonBinoculars): {IDX_VIRT_BINO};
+    case (IDC_buttonMap): {IDX_VIRT_MAP};
+    case (IDC_buttonGPS): {IDX_VIRT_COMMS};
+    case (IDC_buttonRadio): {IDX_VIRT_RADIO};
+    case (IDC_buttonCompass): {IDX_VIRT_COMPASS};
+    case (IDC_buttonWatch): {IDX_VIRT_WATCH};
+    default {-1};
+};

--- a/addons/arsenal/ui/RscAttributes.hpp
+++ b/addons/arsenal/ui/RscAttributes.hpp
@@ -690,6 +690,7 @@ class GVAR(display) {
                     idc = IDC_buttonPrimaryWeapon;
                     text = "\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\PrimaryWeapon_ca.paa";
                     tooltip = "$STR_A3_RscDisplayArsenal_tab_PrimaryWeapon";
+                    onLoad = QUOTE((_this select 0) setVariable [ARR_2(QQGVAR(idx),(ctrlIDC (_this select 0)) call FUNC(idcToIDX))]);
                     onButtonClick = QUOTE([ARR_2(ctrlParent (_this select 0),_this select 0)] call FUNC(fillLeftPanel));
                     colorBackground[] = {0,0,0,0.5};
                     x = QUOTE(0 * GRID_W);


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Cache missionConfigFile insignias.

Specifics:
- Up to 250 items are processed per frame.
- If less than 250 items are available, filling is done in a single frame.
- The arsenal center's current item (if equipped) for that tab is added and selected first so actions, stats, and the right panel can be handled immediately for responsiveness.
- The button for the current tab is disabled until all items are added.
- If the player switches tabs before all items are added, filling for the previous tab is aborted.
- The `leftPanelFilled` event is only raised once all virtual items for that tab are processed. Anything using API *shouldn't* be affected.
- Sorting is only done after all items are processed.

Known issues:
- Opening and closing the loadouts display before processing is done will overload the tab.
- Since the current item is added first, the scroll bar will jump around noticeably if the item is sorted lower on the panel:

https://github.com/acemod/ACE3/assets/69561145/4ba66e88-679d-4cd7-b46c-e5b6f7553ead

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
