### PR TITLE
Arsenal - Left panel code improvements

### DIFF
--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -77,7 +77,7 @@ GVAR(insigniaCache) = +(uiNamespace getVariable QGVAR(insigniaCache));
 // BIS_fnc_setUnitInsignia will look in mission config, then campaign, then global config last, so overwrite accordingly
 private _insigniaCondition = toString {
     if (isNumber (_x >> "scope")) then {
-        getNumber (_x >> "scope") == 2;
+        getNumber (_x >> "scope") == 2
     } else {
         true
     };

--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -76,13 +76,6 @@ GVAR(voiceCache) merge [uiNamespace getVariable QGVAR(voiceCache), true];
 GVAR(insigniaCache) = createHashMap;
 GVAR(insigniaCache) merge [uiNamespace getVariable QGVAR(insigniaCache), true];
 
-{
-    private _varName = format [QGVAR(%1), _x];
-    SETMVAR(_varName,createHashMap);
-    GETMVAR(_varName,createHashMap) merge
-    (missionNamespace getVariable _varName) merge [uiNamespace getVariable _varName, true];
-} forEach ["voiceCache", "faceCache", "insigniaCache"];
-
 // Get mission/campaign insignias
 // BIS_fnc_setUnitInsignia will look in mission config, then campaign, then global config last, so overwrite accordingly
 private _insigniaCondition = toString {

--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -68,13 +68,10 @@ GVAR(idxMap) = createHashMapFromArray [
 ];
 
 // Make new hashmaps for face/voice/insignia so mission makers can disable them
-// Merge instead of copying so we don't inherit final status
-GVAR(faceCache) = createHashMap;
-GVAR(faceCache) merge [uiNamespace getVariable QGVAR(faceCache), true];
-GVAR(voiceCache) = createHashMap;
-GVAR(voiceCache) merge [uiNamespace getVariable QGVAR(voiceCache), true];
-GVAR(insigniaCache) = createHashMap;
-GVAR(insigniaCache) merge [uiNamespace getVariable QGVAR(insigniaCache), true];
+// Copies of hashmaps aren't final
+GVAR(faceCache) = +(uiNamespace getVariable QGVAR(faceCache));
+GVAR(voiceCache) = +(uiNamespace getVariable QGVAR(voiceCache));
+GVAR(insigniaCache) = +(uiNamespace getVariable QGVAR(insigniaCache));
 
 // Get mission/campaign insignias
 // BIS_fnc_setUnitInsignia will look in mission config, then campaign, then global config last, so overwrite accordingly

--- a/addons/arsenal/XEH_preInit.sqf
+++ b/addons/arsenal/XEH_preInit.sqf
@@ -48,4 +48,58 @@ call FUNC(compileStats);
 // Setup Tools tab
 [keys (uiNamespace getVariable [QGVAR(configItemsTools), createHashMap]), LLSTRING(toolsTab), TOOLS_TAB_ICON, -1, true] call FUNC(addRightPanelButton);
 
+// TODO: make IDCs able to match IDX with simple math?
+GVAR(idxMap) = createHashMapFromArray [
+    [IDC_buttonPrimaryWeapon, IDX_VIRT_PRIMARY_WEAPONS],
+    [IDC_buttonHandgun, IDX_VIRT_HANDGUN_WEAPONS],
+    [IDC_buttonSecondaryWeapon, IDX_VIRT_SECONDARY_WEAPONS],
+    [IDC_buttonHeadgear, IDX_VIRT_HEADGEAR],
+    [IDC_buttonUniform, IDX_VIRT_UNIFORM],
+    [IDC_buttonVest, IDX_VIRT_VEST],
+    [IDC_buttonBackpack, IDX_VIRT_BACKPACK],
+    [IDC_buttonGoggles, IDX_VIRT_GOGGLES],
+    [IDC_buttonNVG, IDX_VIRT_NVG],
+    [IDC_buttonBinoculars, IDX_VIRT_BINO],
+    [IDC_buttonMap, IDX_VIRT_MAP],
+    [IDC_buttonGPS, IDX_VIRT_COMMS],
+    [IDC_buttonRadio, IDX_VIRT_RADIO],
+    [IDC_buttonCompass, IDX_VIRT_COMPASS],
+    [IDC_buttonWatch, IDX_VIRT_WATCH]
+];
+
+// Make new hashmaps for face/voice/insignia so mission makers can disable them
+// Merge instead of copying so we don't inherit final status
+GVAR(faceCache) = createHashMap;
+GVAR(faceCache) merge [uiNamespace getVariable QGVAR(faceCache), true];
+GVAR(voiceCache) = createHashMap;
+GVAR(voiceCache) merge [uiNamespace getVariable QGVAR(voiceCache), true];
+GVAR(insigniaCache) = createHashMap;
+GVAR(insigniaCache) merge [uiNamespace getVariable QGVAR(insigniaCache), true];
+
+{
+    private _varName = format [QGVAR(%1), _x];
+    SETMVAR(_varName,createHashMap);
+    GETMVAR(_varName,createHashMap) merge
+    (missionNamespace getVariable _varName) merge [uiNamespace getVariable _varName, true];
+} forEach ["voiceCache", "faceCache", "insigniaCache"];
+
+// Get mission/campaign insignias
+// BIS_fnc_setUnitInsignia will look in mission config, then campaign, then global config last, so overwrite accordingly
+private _insigniaCondition = toString {
+    if (isNumber (_x >> "scope")) then {
+        getNumber (_x >> "scope") == 2;
+    } else {
+        true
+    };
+};
+
+// Ref fnc_addListBoxItem, 0/nil = configFile, 1 = campaignConfigFile, 2 = missionConfigFile
+{
+    GVAR(insigniaCache) set [_x, 1];
+} forEach (_insigniaCondition configClasses (campaignConfigFile >> "CfgUnitInsignia"));
+{
+    GVAR(insigniaCache) set [_x, 2];
+} forEach (_insigniaCondition configClasses (missionConfigFile >> "CfgUnitInsignia"));
+
+
 ADDON = true;

--- a/addons/arsenal/defines.hpp
+++ b/addons/arsenal/defines.hpp
@@ -270,6 +270,7 @@
 #define IDX_VIRT_UNIQUE_UNKNOWN_ITEMS 25
 
 // Indexes of current items array
+// Should match IDX_VIRT_X macros for any left panel tabs
 #define IDX_CURR_PRIMARY_WEAPON 0
 #define IDX_CURR_SECONDARY_WEAPON 1
 #define IDX_CURR_HANDGUN_WEAPON 2

--- a/addons/arsenal/functions/fnc_addListBoxItem.sqf
+++ b/addons/arsenal/functions/fnc_addListBoxItem.sqf
@@ -43,7 +43,7 @@ if (_skip) then {
 if (_skip) exitWith {};
 
 // Sanitise key, as it's public; If not in cache, find info and cache it for later use
-((uiNamespace getVariable QGVAR(addListBoxItemCache)) getOrDefaultCall [_configCategory + _className, {
+((uiNamespace getVariable QGVAR(addListBoxItemCache)) getOrDefaultCall [format ["%1%2%3", _configCategory, _className, _configRoot], {
     // Get classname (config case), display name, picture and DLC
     private _configPath = ([configFile, campaignConfigFile, missionConfigFile] select _configRoot) >> _configCategory >> _className;
     private _dlcName = _configPath call EFUNC(common,getAddon);

--- a/addons/arsenal/functions/fnc_addListBoxItem.sqf
+++ b/addons/arsenal/functions/fnc_addListBoxItem.sqf
@@ -43,7 +43,7 @@ if (_skip) then {
 if (_skip) exitWith {};
 
 // Sanitise key, as it's public; If not in cache, find info and cache it for later use
-((uiNamespace getVariable QGVAR(addListBoxItemCache)) getOrDefaultCall [format ["%1%2%3", _configCategory, _className, _configRoot], {
+((uiNamespace getVariable QGVAR(addListBoxItemCache)) getOrDefaultCall [_configCategory + _className + str _configRoot, {
     // Get classname (config case), display name, picture and DLC
     private _configPath = ([configFile, campaignConfigFile, missionConfigFile] select _configRoot) >> _configCategory >> _className;
     private _dlcName = _configPath call EFUNC(common,getAddon);

--- a/addons/arsenal/functions/fnc_addListBoxItem.sqf
+++ b/addons/arsenal/functions/fnc_addListBoxItem.sqf
@@ -9,6 +9,7 @@
  * 1: Classname <STRING>
  * 2: Panel control <CONTROL>
  * 3: Name of the picture entry in that Cfg class <STRING> (default: "picture")
+ * 4: Config root <NUMBER> (default: 0 -> configFile)
  *
  * Return Value:
  * None
@@ -19,7 +20,7 @@
  * Public: Yes
  */
 
-params ["_configCategory", "_className", "_ctrlPanel", ["_pictureEntryName", "picture", [""]]];
+params ["_configCategory", "_className", "_ctrlPanel", ["_pictureEntryName", "picture", [""]], ["_configRoot", 0, [0]]];
 
 private _skip = GVAR(favoritesOnly) && {!(_className in GVAR(currentItems))} && {!((toLower _className) in GVAR(favorites))};
 if (_skip) then {
@@ -44,7 +45,7 @@ if (_skip) exitWith {};
 // Sanitise key, as it's public; If not in cache, find info and cache it for later use
 ((uiNamespace getVariable QGVAR(addListBoxItemCache)) getOrDefaultCall [_configCategory + _className, {
     // Get classname (config case), display name, picture and DLC
-    private _configPath = configFile >> _configCategory >> _className;
+    private _configPath = ([configFile, campaignConfigFile, missionConfigFile] select _configRoot) >> _configCategory >> _className;
     private _dlcName = _configPath call EFUNC(common,getAddon);
 
     // If _pictureEntryName is empty, then this item has no picture (e.g. faces)

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -17,20 +17,27 @@
 
 params ["_display", "_control", ["_animate", true]];
 
+private _ctrlIDC = ctrlIDC _control;
+private _ctrlPanel = _display displayCtrl IDC_leftTabContent;
+private _idxVirt = GVAR(idxMap) getOrDefault [_ctrlIDC, -1, true];
+
 // Fade old control background
 if (!isNil QGVAR(currentLeftPanel)) then {
     private _previousCtrlBackground  = _display displayCtrl (GVAR(currentLeftPanel) - 1);
     _previousCtrlBackground ctrlSetFade 1;
     _previousCtrlBackground ctrlCommit ([0, FADE_DELAY] select _animate);
+
+    // When switching tabs, clear searchbox
+    if (GVAR(currentLeftPanel) != _ctrlIDC) then {
+        (_display displayCtrl IDC_leftSearchbar) ctrlSetText "";
+        (_display displayCtrl IDC_rightSearchbar) ctrlSetText "";
+    };
 };
 
 // Show new control background
-private _ctrlIDC = ctrlIDC _control;
 private _ctrlBackground = _display displayCtrl (_ctrlIDC - 1);
 _ctrlBackground ctrlSetFade 0;
 _ctrlBackground ctrlCommit ([0, FADE_DELAY] select _animate);
-
-private _ctrlPanel = _display displayCtrl IDC_leftTabContent;
 
 // Force a "refresh" animation of the panel
 if (_animate) then {
@@ -41,212 +48,80 @@ if (_animate) then {
 };
 
 _ctrlPanel lbSetCurSel -1;
+// Purge old data
+lbClear _ctrlPanel;
 
-// Handle icons and filling
-private _selectedItem = switch (true) do {
-    // Primary weapons, secondary weapons, handgun weapons
-    case (_ctrlIDC in [IDC_buttonPrimaryWeapon, IDC_buttonHandgun, IDC_buttonSecondaryWeapon]): {
-        // Purge old data
-        lbClear _ctrlPanel;
-
-        // Add "Empty" entry
-        private _addEmpty = _ctrlPanel lbAdd format [" <%1>", localize "str_empty"];
-        _ctrlPanel lbSetValue [_addEmpty, -1];
-
-        // Add selected tab's weapons
-        private _index = [IDC_buttonPrimaryWeapon, IDC_buttonSecondaryWeapon, IDC_buttonHandgun] find _ctrlIDC;
-
-        {
-            ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-        } forEach (keys ((GVAR(virtualItems) get IDX_VIRT_WEAPONS) get _index));
-
-        GVAR(currentItems) select _index
-    };
-    // Uniforms, vests, backpacks
-    case (_ctrlIDC in [IDC_buttonUniform, IDC_buttonVest, IDC_buttonBackpack]): {
-        // Purge old data
-        lbClear _ctrlPanel;
-
-        // Add "Empty" entry
-        private _addEmpty = _ctrlPanel lbAdd format [" <%1>", localize "str_empty"];
-        _ctrlPanel lbSetValue [_addEmpty, -1];
-
-        switch (_ctrlIDC) do {
-            // Add uniforms
-            case IDC_buttonUniform: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_UNIFORM));
-
-                GVAR(currentItems) select IDX_CURR_UNIFORM
-            };
-            // Add vests
-            case IDC_buttonVest: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_VEST));
-
-                GVAR(currentItems) select IDX_CURR_VEST
-            };
-            // Add backpacks
-            case IDC_buttonBackpack: {
-                {
-                    ["CfgVehicles", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_BACKPACK));
-
-                GVAR(currentItems) select IDX_CURR_BACKPACK
-            };
-        };
-    };
-    // Other
-    default {
-        // Don't reset right panel selection if left tab is binos
-        if (_ctrlIDC != IDC_buttonBinoculars) then {
-            GVAR(currentRightPanel) = nil;
-        };
-
-        lbClear _ctrlPanel;
-
-        // For every left tab except faces and voices, add "Empty" entry
-        if !(_ctrlIDC in [IDC_buttonFace, IDC_buttonVoice]) then {
-            private _addEmpty = _ctrlPanel lbAdd format [" <%1>", localize "str_empty"];
-            _ctrlPanel lbSetValue [_addEmpty, -1];
-        };
-
-        switch (_ctrlIDC) do {
-            // Headgear
-            case IDC_buttonHeadgear: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_HEADGEAR));
-
-                GVAR(currentItems) select IDX_CURR_HEADGEAR
-            };
-            // Facewear
-            case IDC_buttonGoggles: {
-                {
-                    ["CfgGlasses", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_GOGGLES));
-
-                GVAR(currentItems) select IDX_CURR_GOGGLES
-            };
-            // NVGs
-            case IDC_buttonNVG: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_NVG));
-
-                GVAR(currentItems) select IDX_CURR_NVG
-            };
-            // Binoculars
-            case IDC_buttonBinoculars: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_BINO));
-
-                GVAR(currentItems) select IDX_CURR_BINO
-            };
-            // Maps
-            case IDC_buttonMap: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_MAP));
-
-                GVAR(currentItems) select IDX_CURR_MAP
-            };
-            // Compasses
-            case IDC_buttonCompass: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_COMPASS));
-
-                GVAR(currentItems) select IDX_CURR_COMPASS
-            };
-            // Radios
-            case IDC_buttonRadio: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_RADIO));
-
-                GVAR(currentItems) select IDX_CURR_RADIO
-            };
-            // Watches
-            case IDC_buttonWatch: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_WATCH));
-
-                GVAR(currentItems) select IDX_CURR_WATCH
-            };
-            // GPS and UAV Terminals
-            case IDC_buttonGPS: {
-                {
-                    ["CfgWeapons", _x, _ctrlPanel] call FUNC(addListBoxItem);
-                } forEach (keys (GVAR(virtualItems) get IDX_VIRT_COMMS));
-
-                GVAR(currentItems) select IDX_CURR_COMMS
-            };
-            // Faces
-            case IDC_buttonFace: {
-                private _lbAdd = -1;
-
-                {
-                    _y params ["_displayName", "_modPicture"];
-
-                    _lbAdd = _ctrlPanel lbAdd _displayName;
-                    _ctrlPanel lbSetData [_lbAdd, _x];
-                    _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _x]];
-                    _ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture] select GVAR(enableModIcons)];
-                } forEach (uiNamespace getVariable QGVAR(faceCache));
-
-                GVAR(currentFace)
-            };
-            // Voices
-            case IDC_buttonVoice: {
-                {
-                    ["CfgVoice", _x, _ctrlPanel, "icon"] call FUNC(addListBoxItem);
-                } forEach (uiNamespace getVariable QGVAR(voiceCache));
-
-                GVAR(currentVoice)
-            };
-            // Insignia
-            case IDC_buttonInsignia: {
-                // Insignia from config
-                {
-                    ["CfgUnitInsignia", _x, _ctrlPanel, "texture"] call FUNC(addListBoxItem);
-                } forEach (uiNamespace getVariable QGVAR(insigniaCache));
-
-                private _displayName = "";
-                private _className = "";
-                private _lbAdd = -1;
-
-                // Insignia from mission file
-                {
-                    _className = configName _x;
-                    _displayName = getText (_x >> "displayName");
-                    _lbAdd = _ctrlPanel lbAdd _displayName;
-
-                    _ctrlPanel lbSetData [_lbAdd, _className];
-                    _ctrlPanel lbSetPicture [_lbAdd, getText (_x >> "texture")];
-                    _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _className]];
-                } forEach ("(if (isNumber (_x >> 'scope')) then {getNumber (_x >> 'scope')} else {2}) == 2" configClasses (missionConfigFile >> "CfgUnitInsignia"));
-
-                GVAR(currentInsignia)
-            };
-            // Unknown
-            default {""};
-        };
-    };
+// For every left tab except faces and voices, add "Empty" entry
+if !(_ctrlIDC in [IDC_buttonFace, IDC_buttonVoice]) then {
+    private _addEmpty = _ctrlPanel lbAdd format [" <%1>", localize "str_empty"];
+    _ctrlPanel lbSetValue [_addEmpty, -1];
 };
 
-// When switching tabs, clear searchbox
-if (GVAR(currentLeftPanel) != _ctrlIDC) then {
-    (_display displayCtrl IDC_leftSearchbar) ctrlSetText "";
-    (_display displayCtrl IDC_rightSearchbar) ctrlSetText "";
+// Don't reset the current right panel for weapons and binos
+if !(_idxVirt in [IDX_VIRT_PRIMARY_WEAPONS, IDX_VIRT_SECONDARY_WEAPONS, IDX_VIRT_HANDGUN_WEAPONS, IDX_VIRT_BINO]) then {
+    GVAR(currentRightPanel) = nil;
+};
+GVAR(currentLeftPanel) = _ctrlIDC;
+
+// Add items to the listbox
+private _selectedItem = if (_idxVirt != -1) then { // Items
+    private _configParent = switch (_idxVirt) do {
+        case IDX_VIRT_GOGGLES: {"CfgGlasses"};
+        case IDX_VIRT_BACKPACK: {"CfgVehicles"};
+        default {"CfgWeapons"};
+    };
+
+    private _items = if (_idxVirt < IDX_VIRT_HEADGEAR) then {
+        keys ((GVAR(virtualItems) get IDX_VIRT_WEAPONS) get _idxVirt);
+    } else {
+        keys (GVAR(virtualItems) get _idxVirt);
+    };
+
+    {
+        [_configParent, _x, _ctrlPanel] call FUNC(addListBoxItem);
+    } forEach _items;
+
+    GVAR(currentItems) select _idxVirt
+} else { // Special cases
+    switch (_ctrlIDC) do {
+        // Faces
+        case IDC_buttonFace: {
+            private _lbAdd = -1; // micro-optimization
+            {
+                _y params ["_displayName", "_modPicture"];
+                _lbAdd = _ctrlPanel lbAdd _displayName;
+                _ctrlPanel lbSetData [_lbAdd, _x];
+                _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _x]];
+                _ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture] select GVAR(enableModIcons)];;
+            } forEach GVAR(faceCache); // HashMap, not array
+
+            GVAR(currentFace)
+        };
+        // Voices
+        case IDC_buttonVoice: {
+            {
+                ["CfgVoice", _x, _ctrlPanel, "icon"] call FUNC(addListBoxItem);
+            } forEach (keys GVAR(voiceCache));
+
+            GVAR(currentVoice)
+        };
+        // Insignia
+        case IDC_buttonInsignia: {
+            {
+                ["CfgUnitInsignia", _x, _ctrlPanel, "texture", _insignias get _x] call FUNC(addListBoxItem);
+            } forEach (keys GVAR(insigniaCache));
+
+            GVAR(currentInsignia)
+        };
+        // Unknown
+        default {
+            WARNING("Unknown arsenal left panel");
+            ""
+        };
+    };
 };
 
 // Trigger event
-GVAR(currentLeftPanel) = _ctrlIDC;
 [QGVAR(leftPanelFilled), [_display, _ctrlIDC, GVAR(currentRightPanel)]] call CBA_fnc_localEvent;
 
 // Sort

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -57,8 +57,8 @@ if !(_ctrlIDC in [IDC_buttonFace, IDC_buttonVoice]) then {
     _ctrlPanel lbSetValue [_addEmpty, -1];
 };
 
-// Don't reset the current right panel for weapons and binos
-if !(_idxVirt in [IDX_VIRT_PRIMARY_WEAPONS, IDX_VIRT_SECONDARY_WEAPONS, IDX_VIRT_HANDGUN_WEAPONS, IDX_VIRT_BINO]) then {
+// Don't reset the current right panel for weapons, binos and containers
+if !(_idxVirt in [IDX_VIRT_PRIMARY_WEAPONS, IDX_VIRT_SECONDARY_WEAPONS, IDX_VIRT_HANDGUN_WEAPONS, IDX_VIRT_BINO, IDX_VIRT_UNIFORM, IDX_VIRT_VEST, IDX_VIRT_BACKPACK]) then {
     GVAR(currentRightPanel) = nil;
 };
 GVAR(currentLeftPanel) = _ctrlIDC;

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -110,8 +110,8 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
         // Insignia
         case IDC_buttonInsignia: {
             {
-                ["CfgUnitInsignia", _x, _ctrlPanel, "texture", _insignias get _x] call FUNC(addListBoxItem);
-            } forEach (keys GVAR(insigniaCache));
+                ["CfgUnitInsignia", _x, _ctrlPanel, "texture", _y] call FUNC(addListBoxItem);
+            } forEach GVAR(insigniaCache);
 
             GVAR(currentInsignia)
         };

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -87,6 +87,8 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
         // Faces
         case IDC_buttonFace: {
             private _lbAdd = -1; // micro-optimization
+            // Faces need to be added like this because their config path is
+            // configFile >> "CfgFaces" >> face category >> className
             {
                 _y params ["_displayName", "_modPicture"];
                 _lbAdd = _ctrlPanel lbAdd _displayName;

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -94,7 +94,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
                 _lbAdd = _ctrlPanel lbAdd _displayName;
                 _ctrlPanel lbSetData [_lbAdd, _x];
                 _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _x]];
-                _ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture] select GVAR(enableModIcons)];;
+                _ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture] select GVAR(enableModIcons)];
             } forEach GVAR(faceCache); // HashMap, not array
 
             GVAR(currentFace)

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -72,9 +72,9 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
     };
 
     private _items = if (_idxVirt < IDX_VIRT_HEADGEAR) then {
-        keys ((GVAR(virtualItems) get IDX_VIRT_WEAPONS) get _idxVirt);
+        keys ((GVAR(virtualItems) get IDX_VIRT_WEAPONS) get _idxVirt)
     } else {
-        keys (GVAR(virtualItems) get _idxVirt);
+        keys (GVAR(virtualItems) get _idxVirt)
     };
 
     {

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 #include "..\defines.hpp"
 /*
- * Author: Alganthe, johnb43
+ * Author: Alganthe, johnb43, LinkIsGrim
  * Fills left panel.
  *
  * Arguments:

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -117,7 +117,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
         };
         // Unknown
         default {
-            WARNING("Unknown arsenal left panel");
+            WARNING_1("Unknown arsenal left panel with IDC %1, update ace_arsenal_idxMap and relevant macros if adding a new tab",_ctrlIDC);
             ""
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Port code changes from #9785
- Add mission variable mapping left panel tab button IDCs to the virtualItems map IDs
- Add support for campaign unit insignias, prevent unacessible insignias from being shown in the arsenal (two insignias with the same classname from different configs).
- Add support for mission makers to disable specific faces/voices/insignias at the mission level via scripting (by modifying a copy of the configFile cache).
- Add some comments to hopefully help the next poor sod who touches this.

~~I'm not sure if this is faster (should be, but I haven't done any profiling), but it sure is smaller.~~
There's a minimal performance increase:
```
12:07:07 [ACE] (arsenal) INFO: fill left panel old performance: [17.1853,59] panel item count: 141
12:07:08 [ACE] (arsenal) INFO: fill left panel new performance: [17.1179,59] panel item count: 141
12:07:24 [ACE] (arsenal) INFO: fill left panel old performance: [13.7859,73] panel item count: 205
12:07:25 [ACE] (arsenal) INFO: fill left panel new performance: [13.5717,74] panel item count: 205
```
But it gets noticeable as left panel size increases:
```
12:10:39 [ACE] (arsenal) INFO: fill left panel old performance: [205.879,5] panel item count: 1266
12:10:40 [ACE] (arsenal) INFO: fill left panel new performance: [165.977,7] panel item count: 1266
12:11:27 [ACE] (arsenal) INFO: fill left panel old performance: [271.516,4] panel item count: 2214
12:11:28 [ACE] (arsenal) INFO: fill left panel new performance: [198.845,6] panel item count: 2214
12:11:29 [ACE] (arsenal) INFO: fill left panel old performance: [62.9986,16] panel item count: 524
12:11:30 [ACE] (arsenal) INFO: fill left panel new performance: [58.483,18] panel item count: 524
```

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
