### PR TITLE
Nightvision - Register effects during preInit

### DIFF
--- a/addons/nightvision/XEH_preInit.sqf
+++ b/addons/nightvision/XEH_preInit.sqf
@@ -8,4 +8,7 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.inc.sqf"
 
+// #9781 - register effects layer ASAP
+QGVAR(display) cutText ["", "PLAIN"];
+
 ADDON = true;

--- a/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
+++ b/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
@@ -48,10 +48,9 @@ if (GVAR(fogScaling) > 0) then {
     };
 };
 
-// Note: Using BIS_fnc_rscLayer because of bug with string syntax - https://feedback.bistudio.com/T120768
-(QGVAR(display) call BIS_fnc_rscLayer) cutText ["", "PLAIN"]; // Cleanup Old Display
+QGVAR(display) cutText ["", "PLAIN"]; // Cleanup Old Display
 if (_activated) then { // Create New Display
-    (QGVAR(display) call BIS_fnc_rscLayer) cutRsc [QGVAR(title), "PLAIN", 0, false, false]; // draw under HUD
+    QGVAR(display) cutRsc [QGVAR(title), "PLAIN", 0, false, false]; // draw under HUD
 };
 
 // Cleanup Old PP Effects


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Close #9781
- Drop `BIS_fnc_rscLayer` in nightvision component as it's no longer needed.

This might be overkill but if the linked issue is not intended behavior, we can't really make it happen on purpose, so it's best to be consistent instead IMO.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
