### PR TITLE
Arsenal - Add `ace_arsenal_loadoutVerified` event

### DIFF
--- a/addons/arsenal/functions/fnc_verifyLoadout.sqf
+++ b/addons/arsenal/functions/fnc_verifyLoadout.sqf
@@ -19,7 +19,7 @@ private _extendedInfo = createHashMap;
 
 // Check if the provided loadout is a CBA extended loadout
 if (count _loadout == 2) then {
-    _extendedInfo = _loadout select 1;
+    _extendedInfo = +(_loadout select 1); // Copy the hashmap to prevent events from modifiyng the profileNamespace extendedInfo
     _loadout = _loadout select 0;
 };
 
@@ -69,5 +69,8 @@ private _fnc_filterLoadout = {
 // Convert loadout to config case and replace null/unavailable items
 // Loadout might come from a different modpack, which might have different config naming
 _loadout = _loadout call _fnc_filterLoadout;
+
+// Raise event for 3rd party: mostly for handling extended info
+[QGVAR(loadoutVerified), [_loadout, _extendedInfo]] call CBA_fnc_localEvent;
 
 [[_loadout, _extendedInfo], _nullItemsList arrayIntersect _nullItemsList, _unavailableItemsList arrayIntersect _unavailableItemsList]

--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -26,17 +26,30 @@ PREP_RECOMPILE_END;
     }, _this] call CBA_fnc_execNextFrame;
 }] call CBA_fnc_addClassEventHandler;
 
+[QEGVAR(arsenal,loadoutVerified), {
+    params ["_loadout", "_extendedInfo"];
+    private _gunbagInfo = _extendedInfo getOrDefault [QGVAR(gunbagWeapon), []];
+    if (_gunbagInfo isEqualTo []) exitWith {};
+
+    private _weapon = (_gunbagInfo select 0) call EFUNC(arsenal,baseWeapon);
+    if !(_weapon in EGVAR(arsenal,virtualItemsFlat)) exitWith {
+        INFO_1("removing [%1] from loadout",_gunbagInfo);
+        _extendedInfo deleteAt QGVAR(gunbagWeapon);
+    };
+    {
+        private _class = _x param [0, ""];
+        private _defaultValue = ["", []] select {_x isEqualType []};
+        if (_class != "" && {!(_class in EGVAR(arsenal,virtualItemsFlat))}) then {
+            INFO_1("removing [%1] from loadout",_x);
+            _gunbagInfo set [_forEachIndex, _defaultValue];
+        };
+    } forEach _gunbagInfo;
+}] call CBA_fnc_addEventHandler;
+
 ["CBA_loadoutSet", {
     params ["_unit", "_loadout", "_extendedInfo"];
     private _gunbagWeapon = _extendedInfo getOrDefault [QGVAR(gunbagWeapon), []];
     if (_gunbagWeapon isNotEqualTo []) then {
-        if (!isNil QEGVAR(arsenal,virtualItemsFlatAll)) then {
-            private _weapon = (_gunbagWeapon select 0) call EFUNC(arsenal,baseWeapon);
-            if !(_weapon in EGVAR(arsenal,virtualItemsFlatAll)) then {
-                INFO_1("removing [%1] from loadout",_gunbagWeapon);
-                _gunbagWeapon = [];
-            };
-        };
         (backpackContainer _unit) setVariable [QGVAR(gunbagWeapon), _gunbagWeapon, true];
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -43,7 +43,7 @@ PREP_RECOMPILE_END;
             INFO_1("removing [%1] from loadout",_x);
             _gunbagInfo set [_forEachIndex, _defaultValue];
         };
-    } forEach _gunbagInfo;
+    } forEach (_gunbagInfo select [1]); // weapon was verified above
 }] call CBA_fnc_addEventHandler;
 
 ["CBA_loadoutSet", {

--- a/addons/gunbag/XEH_preInit.sqf
+++ b/addons/gunbag/XEH_preInit.sqf
@@ -41,7 +41,7 @@ PREP_RECOMPILE_END;
         private _defaultValue = ["", []] select {_x isEqualType []};
         if (_class != "" && {!(_class in EGVAR(arsenal,virtualItemsFlat))}) then {
             INFO_1("removing [%1] from loadout",_x);
-            _gunbagInfo set [_forEachIndex, _defaultValue];
+            _gunbagInfo set [_forEachIndex + 1, _defaultValue];
         };
     } forEach (_gunbagInfo select [1]); // weapon was verified above
 }] call CBA_fnc_addEventHandler;

--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -511,6 +511,7 @@ All are local.
 | ace_arsenal_loadoutsDisplayClosed | None | 3.12.3 |
 | ace_arsenal_loadoutsTabChanged | loadouts screen display (DISPLAY), tab control (CONTROL) | 3.12.3 |
 | ace_arsenal_loadoutsListFilled | loadouts screen display (DISPLAY), tab control (CONTROL) | 3.12.3 |
+| ace_arsenal_loadoutVerified | loadout data (ARRAY), loadout CBA extended data (HASHMAP) | 3.17.0 |
 | ace_arsenal_weaponItemChanged | weapon classname (STRING), item classname (STRING), item index (NUMBER, 0-5: muzzle, side, optic, bipod, magazine, underbarrel) | 3.16.0 |
 
 ## 9. Custom sub item categories


### PR DESCRIPTION
**When merged this pull request will:**
- Raise an event during loadout verification with loadout data and extended info.

See gunbag changes in diff for intent and use.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
