### PR TITLE
KillTracker - Add option to filter out AI unit kills

### DIFF
--- a/addons/killtracker/CfgEventHandlers.hpp
+++ b/addons/killtracker/CfgEventHandlers.hpp
@@ -3,3 +3,9 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};

--- a/addons/killtracker/CfgEventHandlers.hpp
+++ b/addons/killtracker/CfgEventHandlers.hpp
@@ -1,11 +1,11 @@
-class Extended_PostInit_EventHandlers {
-    class ADDON {
-        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
-    };
-};
-
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -136,7 +136,9 @@ GVAR(killCount) = 0;
                 _unitName = format ["*AI* - %1", getText ((configOf _unit) >> "displayName")];
             };
         };
-        TRACE_3("send kill event",_killer,_unitName,_killInfo);
-        [QGVAR(kill), [_unitName, _killInfo], _killer] call CBA_fnc_targetEvent;
+        if (_unitIsPlayer || GVAR(trackAI)) then {
+            TRACE_3("send kill event",_killer,_unitName,_killInfo);
+            [QGVAR(kill), [_unitName, _killInfo], _killer] call CBA_fnc_targetEvent;
+        };
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/killtracker/XEH_preInit.sqf
+++ b/addons/killtracker/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "initSettings.inc.sqf"
+
+ADDON = true;

--- a/addons/killtracker/XEH_preInit.sqf
+++ b/addons/killtracker/XEH_preInit.sqf
@@ -2,6 +2,10 @@
 
 ADDON = false;
 
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
 #include "initSettings.inc.sqf"
 
 ADDON = true;

--- a/addons/killtracker/XEH_preInit.sqf
+++ b/addons/killtracker/XEH_preInit.sqf
@@ -2,10 +2,6 @@
 
 ADDON = false;
 
-PREP_RECOMPILE_START;
-#include "XEH_PREP.hpp"
-PREP_RECOMPILE_END;
-
 #include "initSettings.inc.sqf"
 
 ADDON = true;

--- a/addons/killtracker/initSettings.inc.sqf
+++ b/addons/killtracker/initSettings.inc.sqf
@@ -1,0 +1,10 @@
+[
+    QGVAR(trackAI),
+    "CHECKBOX",
+    [LSTRING(TrackAI_DisplayName), LSTRING(TrackAI_Description)],
+    LSTRING(Category),
+    true,
+    false,
+    {},
+    true
+] call CBA_fnc_addSetting;

--- a/addons/killtracker/initSettings.inc.sqf
+++ b/addons/killtracker/initSettings.inc.sqf
@@ -4,7 +4,7 @@
     [LSTRING(TrackAI_DisplayName), LSTRING(TrackAI_Description)],
     LSTRING(Category),
     true,
-    true,
+    1,
     {},
-    true
+    false
 ] call CBA_fnc_addSetting;

--- a/addons/killtracker/initSettings.inc.sqf
+++ b/addons/killtracker/initSettings.inc.sqf
@@ -4,7 +4,7 @@
     [LSTRING(TrackAI_DisplayName), LSTRING(TrackAI_Description)],
     LSTRING(Category),
     true,
-    false,
+    true,
     {},
     true
 ] call CBA_fnc_addSetting;

--- a/addons/killtracker/initSettings.inc.sqf
+++ b/addons/killtracker/initSettings.inc.sqf
@@ -4,7 +4,5 @@
     [LSTRING(TrackAI_DisplayName), LSTRING(TrackAI_Description)],
     LSTRING(Category),
     true,
-    1,
-    {},
-    false
+    1
 ] call CBA_fnc_addSetting;

--- a/addons/killtracker/stringtable.xml
+++ b/addons/killtracker/stringtable.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="KillTracker">
+        <Key ID="STR_ACE_KillTracker_Category">
+            <English>ACE Kill Tracker</English>
+            <Czech>ACE Kill Tracker</Czech>
+        </Key>
         <Key ID="STR_ACE_KillTracker_Title">
             <English>ACE Killed Events</English>
             <Japanese>ACE キルトラッカー</Japanese>
@@ -85,6 +89,14 @@
             <Chinesesimp>友军误击</Chinesesimp>
             <Japanese>同士討ち</Japanese>
             <Turkish>Dost Atışı</Turkish>
+        </Key>
+        <Key ID="STR_ACE_KillTracker_TrackAI_DisplayName">
+            <English>Track kills of AIs</English>
+            <Czech>Sledovat zabití AI</Czech>
+        </Key>
+        <Key ID="STR_ACE_KillTracker_TrackAI_Description">
+            <English>Defines if killed AIs will be shown in the KillTracker during mission debriefing</English>
+            <Czech>Udává zdali se zabité AI budou ukazovat v KillTrackeru v průběhu debriefingu po misi</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/killtracker/stringtable.xml
+++ b/addons/killtracker/stringtable.xml
@@ -91,12 +91,12 @@
             <Turkish>Dost Atışı</Turkish>
         </Key>
         <Key ID="STR_ACE_KillTracker_TrackAI_DisplayName">
-            <English>Track kills of AIs</English>
-            <Czech>Sledovat zabití AI</Czech>
+            <English>Track AI units killed by player</English>
+            <Czech>Sledovat AI zabité hráči</Czech>
         </Key>
         <Key ID="STR_ACE_KillTracker_TrackAI_Description">
-            <English>Defines if killed AIs will be shown in the KillTracker during mission debriefing</English>
-            <Czech>Udává zdali se zabité AI budou ukazovat v KillTrackeru v průběhu debriefingu po misi</Czech>
+            <English>Defines if killed AIs will be shown in the kill tracker during mission debriefing</English>
+            <Czech>Udává zdali se zabité AI budou ukazovat v kill trackeru v průběhu debriefingu po misi</Czech>
         </Key>
     </Package>
 </Project>

--- a/addons/killtracker/stringtable.xml
+++ b/addons/killtracker/stringtable.xml
@@ -95,7 +95,7 @@
             <Czech>Sledovat AI zabité hráči</Czech>
         </Key>
         <Key ID="STR_ACE_KillTracker_TrackAI_Description">
-            <English>Defines if killed AIs will be shown in the kill tracker during mission debriefing</English>
+            <English>Defines if killed AIs will be shown in the kill tracker during mission debriefing.</English>
             <Czech>Udává zdali se zabité AI budou ukazovat v kill trackeru v průběhu debriefingu po misi</Czech>
         </Key>
     </Package>

--- a/addons/killtracker/stringtable.xml
+++ b/addons/killtracker/stringtable.xml
@@ -96,7 +96,7 @@
         </Key>
         <Key ID="STR_ACE_KillTracker_TrackAI_Description">
             <English>Defines if killed AIs will be shown in the kill tracker during mission debriefing.</English>
-            <Czech>Udává zdali se zabité AI budou ukazovat v kill trackeru v průběhu debriefingu po misi</Czech>
+            <Czech>Udává zdali se zabité AI budou ukazovat v kill trackeru v průběhu debriefingu po misi.</Czech>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add an option to disable tracking of kills of AI units when using ACE Kill Tracker. Configurable through Addon Settings
- CfgEventHandlers.cpp
  - Added PreInit to Extended Event Handlers
- XEH_postInit.sqf
  - Added check if AI tracking is enabled and track AI kills only if so
- XEH_preInit.sqf
  - Added call to init Addon Settings
- initSettings.inc.sqf
  - Added the actual add settings call
- stringtable.xml
  - Added necessary translations
