### PR TITLE
SPE Compat - Fix flamethrower magazines not showing in arsenal / 50 Cal deafness

### DIFF
--- a/addons/compat_spe/CfgAmmo.hpp
+++ b/addons/compat_spe/CfgAmmo.hpp
@@ -3,4 +3,5 @@ class CfgAmmo {
     #include "CfgAmmo\explosives.hpp"
     #include "CfgAmmo\grenades.hpp"
     #include "CfgAmmo\melee.hpp"
+    #include "CfgAmmo\bullets.hpp"
 };

--- a/addons/compat_spe/CfgAmmo/bullets.hpp
+++ b/addons/compat_spe/CfgAmmo/bullets.hpp
@@ -1,4 +1,3 @@
-class BulletBase;
 class SubmunitionBase;
 class BulletCore;
 class SPE_Bullet_Vehicle_base;

--- a/addons/compat_spe/CfgAmmo/bullets.hpp
+++ b/addons/compat_spe/CfgAmmo/bullets.hpp
@@ -1,0 +1,19 @@
+class BulletBase;
+class SubmunitionBase;
+class BulletCore;
+class SPE_Bullet_Vehicle_base;
+
+class SPE_B_127x99_Mixed: SubmunitionBase {
+  ACE_caliber = 12.954;
+};
+
+class SPE_B_127x99_Ball: SPE_Bullet_Vehicle_base {
+  ACE_caliber = 12.954;
+};
+class SPE_B_127x99_AP: SPE_B_127x99_Ball {
+  ACE_caliber = 12.954;
+};
+class SPE_B_127x99_API: SPE_B_127x99_Ball {
+  ACE_caliber = 12.954;
+  ace_vehicle_damage_incendiary = 1;
+};

--- a/addons/compat_spe/CfgAmmo/bullets.hpp
+++ b/addons/compat_spe/CfgAmmo/bullets.hpp
@@ -1,5 +1,3 @@
-class SubmunitionBase;
-class BulletCore;
 class SPE_Bullet_Vehicle_base;
 
 class SPE_B_127x99_Mixed: SubmunitionBase {

--- a/addons/compat_spe/CfgAmmo/bullets.hpp
+++ b/addons/compat_spe/CfgAmmo/bullets.hpp
@@ -1,16 +1,12 @@
 class SPE_Bullet_Vehicle_base;
 
 class SPE_B_127x99_Mixed: SubmunitionBase {
-  ACE_caliber = 12.954;
+    ACE_caliber = 12.954;
 };
 
 class SPE_B_127x99_Ball: SPE_Bullet_Vehicle_base {
-  ACE_caliber = 12.954;
-};
-class SPE_B_127x99_AP: SPE_B_127x99_Ball {
-  ACE_caliber = 12.954;
+    ACE_caliber = 12.954;
 };
 class SPE_B_127x99_API: SPE_B_127x99_Ball {
-  ACE_caliber = 12.954;
-  ace_vehicle_damage_incendiary = 1;
+    EGVAR(vehicle_damage,incendiary) = 1;
 };

--- a/addons/compat_spe/CfgMagazines.hpp
+++ b/addons/compat_spe/CfgMagazines.hpp
@@ -1,3 +1,4 @@
 class CfgMagazines {
     #include "CfgMagazines\csw.hpp"
+    #include "CfgMagazines\flamethrower.hpp"
 };

--- a/addons/compat_spe/CfgMagazines/flamethrower.hpp
+++ b/addons/compat_spe/CfgMagazines/flamethrower.hpp
@@ -1,5 +1,3 @@
-class CA_Magazine;
-
 class SPE_Flamethrower_Mag: CA_Magazine {
   type = "256";
 };

--- a/addons/compat_spe/CfgMagazines/flamethrower.hpp
+++ b/addons/compat_spe/CfgMagazines/flamethrower.hpp
@@ -1,0 +1,5 @@
+class CA_Magazine;
+
+class SPE_Flamethrower_Mag: CA_Magazine {
+  type = "256";
+};

--- a/addons/compat_spe/CfgMagazines/flamethrower.hpp
+++ b/addons/compat_spe/CfgMagazines/flamethrower.hpp
@@ -1,3 +1,3 @@
 class SPE_Flamethrower_Mag: CA_Magazine {
-  type = "256";
+    type = 256;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes flamethrower magazines not appearing in ace arsenal
- Sets ACE_Caliber on SPE 50 cal ammo to put it more in line with vanilla ammo when it comes to causing deafness (Without it earplugs were ineffective)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [X]  [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [X]  Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
