### PR TITLE
Compat WS - Add barrel swap to WS machine guns

### DIFF
--- a/addons/compat_ws/CfgWeapons.hpp
+++ b/addons/compat_ws/CfgWeapons.hpp
@@ -20,11 +20,13 @@ class CfgWeapons {
         ACE_barrelLength = 550;
         ACE_barrelTwist = 304.8;
         ACE_twistDirection = 1;
+        EGVAR(overheating,allowSwapBarrel) = 1;
     };
     class LMG_S77_Compact_base_lxWS: LMG_S77_base_lxWS {
         ACE_barrelLength = 500;
         ACE_barrelTwist = 304.8;
         ACE_twistDirection = 1;
+        EGVAR(overheating,allowSwapBarrel) = 1;
     };
 
     // SLR


### PR DESCRIPTION
**When merged this pull request will:**
- Add barrel swapping to the SA-77 and SA-77 Compact.
- IRL version of the gun, Vektor SS-77, is quick change capable and that appears to be reflected in the WS model.