### PR TITLE
CUP Weapons Compat - Add WP NVGs

### DIFF
--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
@@ -1,64 +1,118 @@
-#define NVG_MACRO_GREEN_GEN3 \
+#define NVG_BINO_PRESET \
     ace_nightvision_bluRadius = 0.13; \
-    ace_nightvision_border = QPATHTOEF(nightvision,data\nvg_mask_4096.paa); \
-    ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}; \
-    ace_nightvision_generation = 3; \
+    EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_binos_4096.paa); \
+    EGVAR(nightvision,generation) = 3; \
     modelOptics = ""
 
-#define NVG_MACRO_GREEN_GPNVG \
-    ace_nightvision_bluRadius = 0.13; \
-    ace_nightvision_border = "z\ace\addons\nightvision\data\nvg_mask_quad_4096.paa"; \
-    ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}}; \
-    ace_nightvision_generation = 4; \
+#define NVG_MONO_PRESET(GEN) \
+    EGVAR(nightvision,eyeCups) = 1; \
+    EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_4096.paa); \
+    EGVAR(nightvision,bluRadius) = 0.13; \
+    EGVAR(nightvision,generation) = GEN; \
     modelOptics = ""
+
+#define NVG_GPNVG_PRESET \
+    EGVAR(nightvision,bluRadius) = 0.13; \
+    EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_quad_4096.paa); \
+    EGVAR(nightvision,generation) = 4; \
+    modelOptics = ""
+
+#define NVG_GREEN_PRESET EGVAR(nightvision,colorPreset)[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0}}
+#define NVG_WP_PRESET EGVAR(nightvision,colorPreset)[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0}}
 
 class CfgWeapons {
     class NVGoggles;
+    // Monocular
     class CUP_NVG_PVS7: NVGoggles {
-        modelOptics = "";
-        ace_nightvision_border = QPATHTOEF(nightvision,data\nvg_mask_4096.paa);
-        ace_nightvision_bluRadius = 0;
-        ace_nightvision_eyeCups = 1;
-        ace_nightvision_generation = 3;
-        ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
+        NVG_MONO_PRESET(3);
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_HMNVS: NVGoggles {
-        NVG_MACRO_GREEN_GEN3;
+        NVG_MONO_PRESET(3);
+        NVG_GREEN_PRESET;
     };
+
+    // Binocular
     class CUP_NVG_PVS14: NVGoggles {
-        NVG_MACRO_GREEN_GEN3;
+        NVG_BINO_PRESET;
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_PVS15_black: NVGoggles {
-        NVG_MACRO_GREEN_GEN3;
-    };
-    class CUP_NVG_PVS15_tan: NVGoggles {
-        NVG_MACRO_GREEN_GEN3;
+        NVG_BINO_PRESET;
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_PVS15_green: NVGoggles {
-        NVG_MACRO_GREEN_GEN3;
+        NVG_BINO_PRESET;
+        NVG_GREEN_PRESET;
+    };
+    class CUP_NVG_PVS15_tan: NVGoggles {
+        NVG_BINO_PRESET;
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_PVS15_winter: NVGoggles {
-        NVG_MACRO_GREEN_GEN3;
+        NVG_BINO_PRESET;
+        NVG_GREEN_PRESET;
+    };
+
+    // White Phosphor NVGs
+    class CUP_NVG_PVS14_WP: CUP_NVG_PVS14 {
+        displayName = "AN/PVS-14 (WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_NVG_PVS15_black_WP: CUP_NVG_PVS15_black {
+        displayName = "AN/PVS-15 (Black, WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_NVG_PVS15_green_WP: CUP_NVG_PVS15_green {
+        displayName = "AN/PVS-15 (Green, WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_NVG_PVS15_tan_WP: CUP_NVG_PVS15_tan {
+        displayName = "AN/PVS-15 (Tan, WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_NVG_PVS15_winter_WP: CUP_NVG_PVS15_winter {
+        displayName = "AN/PVS-15 (Winter, WP)";
+        NVG_WP_PRESET;
     };
 
     // Gen4s
     class CUP_NVG_1PN138: NVGoggles {
-        ace_nightvision_bluRadius = 0.13;
-        ace_nightvision_border = QPATHTOEF(nightvision,data\nvg_mask_4096.paa);
-        ace_nightvision_colorPreset[] = {0, {0.0, 0.0, 0.0, 0.0}, {1.3, 1.2, 0.0, 0.9}, {6, 1, 1, 0.0}};
-        ace_nightvision_generation = 4;
-        modelOptics = "";
+        NVG_MONO_PRESET(4);
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_GPNVG_black: NVGoggles {
-        NVG_MACRO_GREEN_GPNVG;
+        NVG_GPNVG_PRESET;
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_GPNVG_tan: NVGoggles {
-        NVG_MACRO_GREEN_GPNVG;
+        NVG_GPNVG_PRESET;
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_GPNVG_green: NVGoggles {
-        NVG_MACRO_GREEN_GPNVG;
+        NVG_GPNVG_PRESET;
+        NVG_GREEN_PRESET;
     };
     class CUP_NVG_GPNVG_winter: NVGoggles {
-        NVG_MACRO_GREEN_GPNVG;
+        NVG_GPNVG_PRESET;
+        NVG_GREEN_PRESET;
+    };
+
+    // White Phosphor NVGs
+    class CUP_NVG_GPNVG_black_WP: CUP_NVG_GPNVG_black {
+        displayName = "GPNVG (Black, WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_NVG_GPNVG_tan_WP: CUP_NVG_GPNVG_tan {
+        displayName = "GPNVG (Tan, WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_GPNVG_green_WP: CUP_NVG_GPNVG_green {
+        displayName = "GPNVG (Green, WP)";
+        NVG_WP_PRESET;
+    };
+    class CUP_GPNVG_winter_WP: CUP_NVG_GPNVG_winter {
+        displayName = "GPNVG (Winter, WP)";
+        NVG_WP_PRESET;
     };
 };

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
@@ -56,23 +56,23 @@ class CfgWeapons {
 
     // White Phosphor NVGs
     class CUP_NVG_PVS14_WP: CUP_NVG_PVS14 {
-        displayName = "AN/PVS-14 (WP)";
+        displayName = SUBCSTRING(CUP_NVG_PVS14_WP);
         NVG_WP_PRESET;
     };
     class CUP_NVG_PVS15_black_WP: CUP_NVG_PVS15_black {
-        displayName = "AN/PVS-15 (Black, WP)";
+        displayName = SUBCSTRING(CUP_NVG_PVS15_black_WP);
         NVG_WP_PRESET;
     };
     class CUP_NVG_PVS15_green_WP: CUP_NVG_PVS15_green {
-        displayName = "AN/PVS-15 (Green, WP)";
+        displayName = SUBCSTRING(CUP_NVG_PVS15_green_WP);
         NVG_WP_PRESET;
     };
     class CUP_NVG_PVS15_tan_WP: CUP_NVG_PVS15_tan {
-        displayName = "AN/PVS-15 (Tan, WP)";
+        displayName = SUBCSTRING(CUP_NVG_PVS15_tan_WP);
         NVG_WP_PRESET;
     };
     class CUP_NVG_PVS15_winter_WP: CUP_NVG_PVS15_winter {
-        displayName = "AN/PVS-15 (Winter, WP)";
+        displayName = SUBCSTRING(CUP_NVG_PVS15_winter_WP);
         NVG_WP_PRESET;
     };
 
@@ -100,19 +100,19 @@ class CfgWeapons {
 
     // White Phosphor NVGs
     class CUP_NVG_GPNVG_black_WP: CUP_NVG_GPNVG_black {
-        displayName = "GPNVG (Black, WP)";
+        displayName = SUBCSTRING(CUP_NVG_GPNVG_black_WP);
         NVG_WP_PRESET;
     };
     class CUP_NVG_GPNVG_tan_WP: CUP_NVG_GPNVG_tan {
-        displayName = "GPNVG (Tan, WP)";
+        displayName = SUBCSTRING(CUP_NVG_GPNVG_tan_WP);
         NVG_WP_PRESET;
     };
     class CUP_GPNVG_green_WP: CUP_NVG_GPNVG_green {
-        displayName = "GPNVG (Green, WP)";
+        displayName = SUBCSTRING(CUP_GPNVG_green_WP);
         NVG_WP_PRESET;
     };
     class CUP_GPNVG_winter_WP: CUP_NVG_GPNVG_winter {
-        displayName = "GPNVG (Winter, WP)";
+        displayName = SUBCSTRING(CUP_GPNVG_winter_WP);
         NVG_WP_PRESET;
     };
 };

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/config.cpp
@@ -4,7 +4,10 @@ class CfgPatches {
     class SUBADDON {
         name = COMPONENT_NAME;
         units[] = {};
-        weapons[] = {};
+        weapons[] = {
+            "CUP_NVG_PVS14_WP", "CUP_NVG_PVS15_black_WP", "CUP_NVG_PVS15_green_WP", "CUP_NVG_PVS15_tan_WP", "CUP_NVG_PVS15_winter_WP",
+            "CUP_NVG_GPNVG_black_WP", "CUP_NVG_GPNVG_tan_WP", "CUP_GPNVG_green_WP", "CUP_GPNVG_winter_WP"
+        };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "CUP_Weapons_LoadOrder",

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/stringtable.xml
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/stringtable.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACE">
+    <Package name="Compat_CUP_Weapons_nightvision">
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_PVS14_WP">
+            <English>AN/PVS-14 (WP)</English>
+            <Japanese>AN/PVS-14 (白色蛍光)</Japanese>
+            <Italian>AN/PVS-14 (FB)</Italian>
+            <Polish>AN/PVS-14 (WP)</Polish>
+            <German>AN/PVS-14 (WP)</German>
+            <Korean>AN/PVS-14 (백색광)</Korean>
+            <French>AN/PVS-14 (WP)</French>
+            <Russian>AN/PVS-14 (БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_PVS15_black_WP">
+            <English>AN/PVS-15 (Black, WP)</English>
+            <Japanese>AN/PVS-15 (グリーン, 白色蛍光)</Japanese>
+            <Italian>AN/PVS-15 (Verde, FB)</Italian>
+            <Polish>AN/PVS-15 (Zielone, WP)</Polish>
+            <German>AN/PVS-15 (grün, WP)</German>
+            <Korean>AN/PVS-15 (녹색, 백색광)</Korean>
+            <French>AN/PVS-15 (vertes, WP)</French>
+            <Russian>AN/PVS-15 (Зелёный, БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_PVS15_green_WP">
+            <English>AN/PVS-15 (Green, WP)</English>
+            <Japanese>AN/PVS-15 (ブラック、白色蛍光)</Japanese>
+            <Italian>AN/PVS-15 (Nero, FB)</Italian>
+            <Polish>AN/PVS-15 (Czarne, WP)</Polish>
+            <German>AN/PVS-15 (Schwarz, WP)</German>
+            <Korean>AN/PVS-15 (검정, 백색광)</Korean>
+            <French>AN/PVS-15 (noires, WP)</French>
+            <Russian>AN/PVS-15 (Чёрный, БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_PVS15_tan_WP">
+            <English>AN/PVS-15 (Tan, WP)</English>
+            <Japanese>AN/PVS-15 (タン, 白色蛍光)</Japanese>
+            <Italian>AN/PVS-15 (Marroncina, FB)</Italian>
+            <Polish>AN/PVS-15 (jasnobrązowa, WP)</Polish>
+            <German>AN/PVS-15 (hellbraun, WP)</German>
+            <Korean>AN/PVS-15 (황갈색, 백색광)</Korean>
+            <French>AN/PVS-15 (marron clair, WP)</French>
+            <Russian>AN/PVS-15 (желтовато-коричневый, БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_PVS15_winter_WP">
+            <English>AN/PVS-15 (Winter, WP)</English>
+            <Japanese>AN/PVS-15 (冬季迷彩, WP)</Japanese>
+            <Korean>AN/PVS-15 (설상, WP)</Korean>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_GPNVG_black_WP">
+            <English>GPNVG (Black, WP)</English>
+            <Japanese>GPNVG (グリーン, 白色蛍光)</Japanese>
+            <Italian>GPNVG (Verde, FB)</Italian>
+            <Polish>GPNVG (Zielone, WP)</Polish>
+            <German>GPNVG (grün, WP)</German>
+            <Korean>GPNVG (녹색, 백색광)</Korean>
+            <French>GPNVG (vertes, WP)</French>
+            <Russian>GPNVG (Зелёный, БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_GPNVG_tan_WP">
+            <English>GPNVG (Tan, WP)</English>
+            <Japanese>GPNVG (タン, 白色蛍光)</Japanese>
+            <Italian>GPNVG (Marroncina, FB)</Italian>
+            <Polish>GPNVG (jasnobrązowa, WP)</Polish>
+            <German>GPNVG (hellbraun, WP)</German>
+            <Korean>GPNVG (황갈색, 백색광)</Korean>
+            <French>GPNVG (marron clair, WP)</French>
+            <Russian>GPNVG (желтовато-коричневый, БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_GPNVG_green_WP">
+            <English>GPNVG (Green, WP)</English>
+            <Japanese>GPNVG (ブラック、白色蛍光)</Japanese>
+            <Italian>GPNVG (Nero, FB)</Italian>
+            <Polish>GPNVG (Czarne, WP)</Polish>
+            <German>GPNVG (Schwarz, WP)</German>
+            <Korean>GPNVG (검정, 백색광)</Korean>
+            <French>GPNVG (noires, WP)</French>
+            <Russian>GPNVG (Чёрный, БФ)</Russian>
+        </Key>
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_GPNVG_winter_WP">
+            <English>GPNVG (Winter, WP)</English>
+            <Japanese>GPNVG (冬季迷彩, WP)</Japanese>
+            <Korean>GPNVG (설상, WP)</Korean>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes binocular NVGs having Monocular vision.
- Adds WP variants of GPNVGs, PVS-14/15s as Pabst suggested.
