### PR TITLE
Artillery - Add Rangetable Keybind, Fix remembering last charge

### DIFF
--- a/addons/artillerytables/functions/fnc_rangeTableUpdate.sqf
+++ b/addons/artillerytables/functions/fnc_rangeTableUpdate.sqf
@@ -22,10 +22,10 @@ private _ctrlElevationHigh = _dialog displayCtrl IDC_BUTTON_ELEV_HIGH;
 private _ctrlElevationLow = _dialog displayCtrl IDC_BUTTON_ELEV_LOW;
 
 GVAR(lastElevationMode) = param [0, GVAR(lastElevationMode)]; // update if passed a new value
-GVAR(lastCharge) = lbCurSel _ctrlChargeList;
+GVAR(lastTablePage) = lbCurSel _ctrlChargeList;
 
 // get data for currently selected mag/mode combo:
-(GVAR(magModeData) select GVAR(lastCharge)) params [["_muzzleVelocity", -1], ["_airFriction", 0]];
+(GVAR(magModeData) select GVAR(lastTablePage)) params [["_muzzleVelocity", -1], ["_airFriction", 0]];
 private _elevMin = _dialog getVariable [QGVAR(elevMin), 0];
 private _elevMax = _dialog getVariable [QGVAR(elevMax), 0];
 _ctrlElevationHigh ctrlSetTextColor ([[0.25,0.25,0.25,1],[1,1,1,1]] select GVAR(lastElevationMode));

--- a/addons/mk6mortar/CfgMagazines.hpp
+++ b/addons/mk6mortar/CfgMagazines.hpp
@@ -1,10 +1,11 @@
-class cfgMagazines {
+class CfgMagazines {
     class 8Rnd_82mm_Mo_shells;
     class ACE_1Rnd_82mm_Mo_HE: 8Rnd_82mm_Mo_shells {
         count = 1;
         scope = 2;
         scopeCurator = 2;
         EGVAR(arsenal,hide) = -1;
+        type = 256;
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(magazine_HE_displayName);
         displayNameShort = "";
@@ -19,6 +20,7 @@ class cfgMagazines {
         scope = 2;
         scopeCurator = 2;
         EGVAR(arsenal,hide) = -1;
+        type = 256;
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(magazine_Smoke_displayName);
         displayNameShort = "";
@@ -33,6 +35,7 @@ class cfgMagazines {
         scope = 2;
         scopeCurator = 2;
         EGVAR(arsenal,hide) = -1;
+        type = 256;
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(magazine_Illum_displayName);
         displayNameShort = "";
@@ -47,6 +50,7 @@ class cfgMagazines {
         scope = 2;
         scopeCurator = 2;
         EGVAR(arsenal,hide) = -1;
+        type = 256;
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(magazine_HE_Guided_displayName);
         displayNameShort = "";
@@ -61,6 +65,7 @@ class cfgMagazines {
         scope = 2;
         scopeCurator = 2;
         EGVAR(arsenal,hide) = -1;
+        type = 256;
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(magazine_HE_LaserGuided_displayName);
         displayNameShort = "";

--- a/addons/mk6mortar/XEH_preInit.sqf
+++ b/addons/mk6mortar/XEH_preInit.sqf
@@ -7,5 +7,6 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 #include "initSettings.inc.sqf"
+#include "initKeybinds.inc.sqf"
 
 ADDON = true;

--- a/addons/mk6mortar/initKeybinds.inc.sqf
+++ b/addons/mk6mortar/initKeybinds.inc.sqf
@@ -1,0 +1,15 @@
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
+["ACE3 Equipment", QGVAR(rangetable_action), LLSTRING(rangetable_action), {
+    if (
+        !([ACE_player, "ACE_RangeTable_82mm"] call EFUNC(common,hasItem)) ||
+        !([ACE_player, objNull, ["notOnMap", "isNotInside", "isNotSitting"]] call EFUNC(common,canInteractWith))
+    ) exitWith {false};
+
+    // Close previously opened dialogs
+    closeDialog 0;
+
+    // Statement
+    [] call FUNC(rangeTableOpen);
+    true
+}] call CBA_fnc_addKeybind; // Unbound


### PR DESCRIPTION
**When merged this pull request will:**
- Make 82mm Mortar Ammo visible in the Arsenal and Zeus inventory Editor, allowing individual rounds to be added and removed from inventories without throwing errors (at least with ZEN);
- Add a keybind to open the 82mm Artillery Rangetable directly;
- Fix the last selected charge not being remembered when reopening an artillery rangetable (not just 82mm), it appears this feature was incompletely implemented in the past;

**Further improvements for the future:**
- [ ] Add keybind to open Artillery Rangetable on the closest vehicle, though that would require delving deeper into and probably duplicating some `rangeTableOpen` code;
- [ ] Also allow adding 82mm Rounds into inventories from 3DEN's object inventory selector, no clue which `CfgMagazines` attributes needs to be overridden for that though;