### PR TITLE
Weather - More permissive wind info indicator + auto-enabling when throwing grenades

### DIFF
--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -7,6 +7,9 @@ GVAR(ammoEventHandlers) = createHashMap;
 // Exit on HC
 if (!hasInterface) exitWith {};
 
+// Temporary Wind Info indication
+GVAR(tempWindInfo) = false;
+
 // Ammo/Magazines look-up hash for correctness of initSpeed
 GVAR(ammoMagLookup) = call CBA_fnc_createNamespace;
 {

--- a/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
@@ -53,6 +53,12 @@ _unit setVariable [QGVAR(dropDistance), DROP_DISTANCE_DEFAULT];
 // Remove controls hint (check if ever enabled is inside the function)
 call EFUNC(interaction,hideMouseHint);
 
+// Hide wind info after throw, if it was temporarily enabled for the throw
+if (GVAR(tempWindInfo)) then {
+    EGVAR(weather,WindInfo) = false;
+    GVAR(tempWindInfo) = false;
+};
+
 // Remove throw action
 [_unit, "DefaultAction", _unit getVariable [QGVAR(throwAction), -1]] call EFUNC(common,removeActionEventHandler);
 

--- a/addons/advanced_throwing/functions/fnc_prepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_prepare.sqf
@@ -19,7 +19,7 @@ params ["_unit"];
 TRACE_1("params",_unit);
 
 // Temporarily enable wind info, to aid in throwing smoke grenades effectively
-if (!EGVAR(weather,WindInfo)) then {
+if (GVAR(enableTempWindInfo) && {!EGVAR(weather,WindInfo)}) then {
     [] call EFUNC(weather,displayWindInfo);
     GVAR(tempWindInfo) = true;
 };

--- a/addons/advanced_throwing/functions/fnc_prepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_prepare.sqf
@@ -19,7 +19,10 @@ params ["_unit"];
 TRACE_1("params",_unit);
 
 // Temporarily enable wind info, to aid in throwing smoke grenades effectively
-if (GVAR(enableTempWindInfo) && {!EGVAR(weather,WindInfo)}) then {
+if (
+    GVAR(enableTempWindInfo) && 
+    {!(missionNamespace getVariable [QEGVAR(weather,WindInfo), false])}
+) then {
     [] call EFUNC(weather,displayWindInfo);
     GVAR(tempWindInfo) = true;
 };

--- a/addons/advanced_throwing/functions/fnc_prepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_prepare.sqf
@@ -18,6 +18,12 @@
 params ["_unit"];
 TRACE_1("params",_unit);
 
+// Temporarily enable wind info, to aid in throwing smoke grenades effectively
+if (!EGVAR(weather,WindInfo)) then {
+    [] call EFUNC(weather,displayWindInfo);
+    GVAR(tempWindInfo) = true;
+};
+
 // Select next throwable if one already in hand
 if (_unit getVariable [QGVAR(inHand), false]) exitWith {
     TRACE_1("inHand",_unit);

--- a/addons/advanced_throwing/initSettings.inc.sqf
+++ b/addons/advanced_throwing/initSettings.inc.sqf
@@ -40,3 +40,11 @@ private _category = format ["ACE %1", localize LSTRING(Category)];
     true,
     1
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(enableTempWindInfo), "CHECKBOX",
+    [LSTRING(EnableTempWindInfo_DisplayName), LSTRING(EnableTempWindInfo_Description)],
+    _category,
+    true,
+    0
+] call CBA_fnc_addSetting;

--- a/addons/advanced_throwing/stringtable.xml
+++ b/addons/advanced_throwing/stringtable.xml
@@ -185,6 +185,16 @@
             <Portuguese>Permite que arremessáveis fixados em objetos sejam pegos.</Portuguese>
             <Czech>Zapíná schopnost zvednutí předmětů z objektů ke kterým jsou připnuté.</Czech>
         </Key>
+        <Key ID="STR_ACE_Advanced_Throwing_EnableTempWindInfo_DisplayName">
+            <English>Show Temporary Wind Info</English>
+            <German>Zeige temporäre Windinformationen</German>
+            <Italian>Mostra informazioni sul vento temporaneamente</Italian>
+        </Key>
+        <Key ID="STR_ACE_Advanced_Throwing_EnableTempWindInfo_Description">
+            <English>Temporarily display Wind Info while throwing, to aid in placing smoke grenades effectively.</English>
+            <German>Zeige während des werfens Windinformationen an, um Rauchgranaten effektiver zu platzieren.</German>
+            <Italian>Mostra le informazioni sul vento durante il lancio di granate, facilitando il piazzamento ottimale di fumogeni.</Italian>
+        </Key>
         <Key ID="STR_ACE_Advanced_Throwing_Prepare">
             <English>Prepare/Change Throwable</English>
             <Spanish>Preparar/Cambiar objetos lanzables</Spanish>

--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
 GVAR(WindInfo) = false;
+
 ["ACE3 Common", QGVAR(WindInfoKey), localize LSTRING(WindInfoKeyToggle),
 {
     // Conditions: canInteract

--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -6,6 +6,7 @@ GVAR(WindInfo) = false;
 {
     // Conditions: canInteract
     if !([ACE_player, ACE_player, ["isNotDragging", "isNotCarrying", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !(isNull objectParent ACE_player || {objectParent ACE_player isKindOf "StaticWeapon"}) exitWith {false};
 
     // Statement
     [] call FUNC(displayWindInfo);
@@ -17,6 +18,7 @@ GVAR(WindInfo) = false;
 {
     // Conditions: canInteract
     if !([ACE_player, ACE_player, ["isNotDragging", "isNotCarrying", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !(isNull objectParent ACE_player || {objectParent ACE_player isKindOf "StaticWeapon"}) exitWith {false};
 
     // Statement
     [] call FUNC(displayWindInfo);

--- a/addons/weather/XEH_postInit.sqf
+++ b/addons/weather/XEH_postInit.sqf
@@ -4,7 +4,7 @@ GVAR(WindInfo) = false;
 ["ACE3 Common", QGVAR(WindInfoKey), localize LSTRING(WindInfoKeyToggle),
 {
     // Conditions: canInteract
-    if !([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, ACE_player, ["isNotDragging", "isNotCarrying", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
     // Statement
     [] call FUNC(displayWindInfo);
@@ -15,7 +15,7 @@ GVAR(WindInfo) = false;
 ["ACE3 Common", QGVAR(WindInfoKey_hold), localize LSTRING(WindInfoKeyHold),
 {
     // Conditions: canInteract
-    if !([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, ACE_player, ["isNotDragging", "isNotCarrying", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
     // Statement
     [] call FUNC(displayWindInfo);

--- a/addons/weather/functions/fnc_displayWindInfo.sqf
+++ b/addons/weather/functions/fnc_displayWindInfo.sqf
@@ -35,9 +35,12 @@ TRACE_1("Starting Wind Info PFEH",GVAR(WindInfo));
     disableSerialization;
     params ["", "_pfID"];
 
+    // Allow wind indicator inside static weapons
+    private _playerInStaticWeapon = objectParent ACE_Player isKindOf "StaticWeapon";
+
     if (
         (!GVAR(WindInfo)) || 
-        {!([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting"]] call EFUNC(common,canInteractWith)) && !(objectParent ACE_Player isKindOf "StaticWeapon")}
+        {!([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting"]] call EFUNC(common,canInteractWith)) && !(_playerInStaticWeapon)}
     ) exitWith {
         TRACE_1("Ending Wind Info PFEH",GVAR(WindInfo));
         GVAR(WindInfo) = false;
@@ -48,12 +51,18 @@ TRACE_1("Starting Wind Info PFEH",GVAR(WindInfo));
     //Keeps the display open:
     (["RscWindIntuitive"] call BIS_fnc_rscLayer) cutRsc ["RscWindIntuitive", "PLAIN", 1, false];
 
+    private _playerEyePos = eyePos ACE_Player;
+    if (_playerInStaticWeapon) then {
+        // Raise eyePos by 1 meter if player is in a static weapon, to prevent wind from being blocked by the open vehicle
+        _playerEyePos = _playerEyePos vectorAdd [0, 0, 1];
+    };
+
     private _windSpeed = if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {
         // With wind gradient
-        [eyePos ACE_player, true, true, true] call FUNC(calculateWindSpeed);
+        [_playerEyePos, true, true, true] call FUNC(calculateWindSpeed);
     } else {
         // Without wind gradient
-        [eyePos ACE_player, false, true, true] call FUNC(calculateWindSpeed);
+        [_playerEyePos, false, true, true] call FUNC(calculateWindSpeed);
     };
 
 

--- a/addons/weather/functions/fnc_displayWindInfo.sqf
+++ b/addons/weather/functions/fnc_displayWindInfo.sqf
@@ -35,7 +35,10 @@ TRACE_1("Starting Wind Info PFEH",GVAR(WindInfo));
     disableSerialization;
     params ["", "_pfID"];
 
-    if ((!GVAR(WindInfo)) || {!([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith))}) exitWith {
+    if (
+        (!GVAR(WindInfo)) || 
+        {!(objectParent ACE_Player isKindOf "StaticWeapon") && !([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting"]] call EFUNC(common,canInteractWith))}
+    ) exitWith {
         TRACE_1("Ending Wind Info PFEH",GVAR(WindInfo));
         GVAR(WindInfo) = false;
         (["RscWindIntuitive"] call BIS_fnc_rscLayer) cutText ["", "PLAIN"];

--- a/addons/weather/functions/fnc_displayWindInfo.sqf
+++ b/addons/weather/functions/fnc_displayWindInfo.sqf
@@ -37,7 +37,7 @@ TRACE_1("Starting Wind Info PFEH",GVAR(WindInfo));
 
     if (
         (!GVAR(WindInfo)) || 
-        {!(objectParent ACE_Player isKindOf "StaticWeapon") && !([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting"]] call EFUNC(common,canInteractWith))}
+        {!([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting"]] call EFUNC(common,canInteractWith)) && !(objectParent ACE_Player isKindOf "StaticWeapon")}
     ) exitWith {
         TRACE_1("Ending Wind Info PFEH",GVAR(WindInfo));
         GVAR(WindInfo) = false;

--- a/addons/weather/functions/fnc_displayWindInfo.sqf
+++ b/addons/weather/functions/fnc_displayWindInfo.sqf
@@ -35,7 +35,7 @@ TRACE_1("Starting Wind Info PFEH",GVAR(WindInfo));
     disableSerialization;
     params ["", "_pfID"];
 
-    if ((!GVAR(WindInfo)) || {!([ACE_player, ACE_player, []] call EFUNC(common,canInteractWith))}) exitWith {
+    if ((!GVAR(WindInfo)) || {!([ACE_player, ACE_player, ["notOnMap", "isNotDragging", "isNotCarrying", "isNotSitting", "isNotInside"]] call EFUNC(common,canInteractWith))}) exitWith {
         TRACE_1("Ending Wind Info PFEH",GVAR(WindInfo));
         GVAR(WindInfo) = false;
         (["RscWindIntuitive"] call BIS_fnc_rscLayer) cutText ["", "PLAIN"];


### PR DESCRIPTION
**When merged this pull request will:**
- Make Wind Info indication more permissible, by preventing it from being disabled when looking at the map, carrying, dragging or entering a vehicle (useful for mortar/turret windage correction);
- Temporarily enable Wind Info while in the Advanced Throwing interface, to aid in placing smoke grenades effectively;