### PR TITLE
Refuel - Add ownership concept to nozzles & jerry cans

### DIFF
--- a/addons/refuel/functions/fnc_canTakeNozzle.sqf
+++ b/addons/refuel/functions/fnc_canTakeNozzle.sqf
@@ -24,7 +24,7 @@ if (isNull _unit ||
     {!alive _object} ||
     {!isNull (_unit getVariable [QGVAR(nozzle), objNull])} || // Not already carrying a nozzle
     {(_object getVariable [QGVAR(jerryCan), false]) && {!isNull (_object getVariable [QGVAR(nozzle), objNull])}} || // Prevent jerry cans from being picked up if they have a nozzle connected
-    {typeOf _object == QGVAR(fuelNozzle) && {!isNull (attachedTo _object)}} || // Not carried by someone else
+    {!([_unit, _object, [INTERACT_EXCEPTIONS]] call EFUNC(common,canInteractWith))} || // Not carried by someone else
     {([_unit, _object] call EFUNC(interaction,getInteractionDistance)) > REFUEL_ACTION_DISTANCE}) exitWith {false};
 
 !(_object getVariable [QGVAR(isConnected), false]) && {!(_unit getVariable [QGVAR(isRefueling), false])}

--- a/addons/refuel/functions/fnc_connectNozzleAction.sqf
+++ b/addons/refuel/functions/fnc_connectNozzleAction.sqf
@@ -116,6 +116,9 @@ private _attachPosModel = _sink worldToModel (ASLtoAGL _bestPosASL);
         // Reset fuel counter
         _source setVariable [QGVAR(fuelCounter), 0, true];
 
+        // Let other players access nozzle
+        [objNull, _nozzle] call EFUNC(common,claim);
+
         [_unit, _sink, _nozzle, _endPosTestOffset] call FUNC(refuel);
 
         private _canReceive = getNumber ((configOf _sink) >> QGVAR(canReceive)) == 1;

--- a/addons/refuel/functions/fnc_dropNozzle.sqf
+++ b/addons/refuel/functions/fnc_dropNozzle.sqf
@@ -24,6 +24,9 @@ TRACE_3("dropNozzle",_unit,_nozzle,_disconnectOnly);
 detach _nozzle;
 _nozzle setVariable [QGVAR(isRefueling), false, true];
 
+// Remove claim on nozzle
+[objNull, _nozzle] call EFUNC(common,claim);
+
 if (_disconnectOnly) exitWith {};
 _nozzle setVelocity [0, 0, 0];
 

--- a/addons/refuel/functions/fnc_startNozzleInHandsPFH.sqf
+++ b/addons/refuel/functions/fnc_startNozzleInHandsPFH.sqf
@@ -35,11 +35,9 @@ TRACE_2("start",_unit,_nozzle);
     _args params ["_unit", "_nozzle"];
 
     if !(
-        alive _unit
+        _unit call EFUNC(common,isAwake)
         && {"" isEqualTo currentWeapon _unit || {_unit call EFUNC(common,isSwimming)}}
         && {[_unit, objNull, [INTERACT_EXCEPTIONS, "notOnMap"]] call EFUNC(common,canInteractWith)}
-        && {"unconscious" isNotEqualTo toLower animationState _unit}
-        && {!(_unit getVariable ["ACE_isUnconscious", false])}
     ) exitWith {
         TRACE_3("stop dead/weapon/interact/uncon",_unit,alive _unit,currentWeapon _unit);
         DROP_NOZZLE

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -32,16 +32,22 @@ params [
 
         private _source = _object;
         private _nozzle = _object;
-        if (typeOf _object isEqualTo QGVAR(fuelNozzle) || {_object getVariable [QGVAR(jerryCan), false]}) then { // func is called on muzzle either connected or on ground
+        if (typeOf _object isEqualTo QGVAR(fuelNozzle) || {_object getVariable [QGVAR(jerryCan), false]}) then { // func is called on nozzle either connected or on ground
             _source = _nozzle getVariable QGVAR(source);
             if (_nozzle getVariable [QGVAR(jerryCan), false]) then {
                 _nozzle attachTo [_unit, [0,1,0], "pelvis"];
             } else {
                 _nozzle attachTo [_unit, [-0.02,0.05,-0.12], "righthandmiddle1"];
             };
+
+            // Don't allow other players to take nozzle
+            [_unit, _nozzle] call EFUNC(common,claim);
         } else { // func is called on fuel truck
             _nozzle = QGVAR(fuelNozzle) createVehicle [0,0,0];
             _nozzle attachTo [_unit, [-0.02,0.05,-0.12], "righthandmiddle1"];
+
+            // Don't allow other players to take nozzle
+            [_unit, _nozzle] call EFUNC(common,claim);
 
             private _ropeTarget = _source;
             if !(_source isKindOf "AllVehicles") then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes #9753.
- Minor optimisation.
- You can still check the amount of fuel left in a jerry can when someone is carrying it. I left it in because I felt it was ok to leave in.
- Race condition for claiming the object can most likely occur, but I'm not willing to rewrite the component with `ace_common_fnc_claimSafeServer` now.
- I'm not sure which interaction expections should be checked for, but in my testing it worked. I was testing the virtual world with vehicles, did not test anything related to swimming, being on ladder, inside vehicles etc - I only tested the basic and most used use cases.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
