### PR TITLE
Overheating - Increase cooling for open bolt guns and spare barrels

### DIFF
--- a/addons/overheating/functions/fnc_calculateCooling.sqf
+++ b/addons/overheating/functions/fnc_calculateCooling.sqf
@@ -7,6 +7,7 @@
  * 0: Initial temperature <NUMBER>
  * 1: Barrel mass <NUMBER>
  * 2: Time interval  <NUMBER>
+ * 3: Bolt type  <NUMBER>
  *
  * Return Value:
  * Final temperature <NUMBER>
@@ -17,7 +18,7 @@
  * Public: No
  */
 
-params ["_temperature", "_barrelMass", "_totalTime"];
+params ["_temperature", "_barrelMass", "_totalTime", "_boltType"];
 
 // The lowest temperature a weapon can reach is the ambient air temperature.
 private _ambientTemperature = ambientTemperature select 0;
@@ -42,6 +43,9 @@ if (ACE_player call EFUNC(common,isSwimming)) then {
     // this will give a convection rate between 25 (no wind or rain) and 125 (max rain and >=50 m/s wind)
     _convectionRate = _convectionRate * ((linearConversion [0,1,rain,1,5,true] + (5 min (vectorMagnitude wind / 10))) / 2);
 };
+
+//Increase convection cooling for open bolt type guns
+if (_boltType == 0) then {_convectionRate = _convectionRate * 1.1};
 
 TRACE_4("cooling",_temperature,_totalTime,_barrelMass,_barrelSurface);
 

--- a/addons/overheating/functions/fnc_calculateCooling.sqf
+++ b/addons/overheating/functions/fnc_calculateCooling.sqf
@@ -45,7 +45,7 @@ if (ACE_player call EFUNC(common,isSwimming)) then {
 };
 
 //Increase convection cooling for open bolt type guns
-if (_boltType == 0) then {_convectionRate = _convectionRate * 1.1};
+if (_boltType == 0) then {_convectionRate = _convectionRate * OPEN_BOLT_ADDITIONAL_CONVECTION};
 
 TRACE_4("cooling",_temperature,_totalTime,_barrelMass,_barrelSurface);
 

--- a/addons/overheating/functions/fnc_coolWeaponWithItem.sqf
+++ b/addons/overheating/functions/fnc_coolWeaponWithItem.sqf
@@ -61,8 +61,8 @@ private _fnc_onSuccess = {
     };
 
     // cool the weapon
-    private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
-    _temperature = [_temperature, _barrelMass, _liquidAmount * 10] call FUNC(calculateCooling);
+    private _weaponData = [_weapon] call FUNC(getWeaponData);
+    _temperature = [_temperature, _weaponData select 7, _liquidAmount * 10, _weaponData select 6] call FUNC(calculateCooling);
     [_target, _tempVarName, _temperature, TEMP_TOLERANCE] call EFUNC(common,setApproximateVariablePublic);
 };
 

--- a/addons/overheating/functions/fnc_coolWeaponWithWaterSource.sqf
+++ b/addons/overheating/functions/fnc_coolWeaponWithWaterSource.sqf
@@ -59,8 +59,8 @@ private _fnc_condition = {
         };
 
         //Cool the weapon down
-        private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
-        _temperature = [_temperature, _barrelMass, 20] call FUNC(calculateCooling);
+        private _weaponData = [_weapon] call FUNC(getWeaponData);
+        _temperature = [_temperature, _weaponData select 7, 20, _weaponData select 6] call FUNC(calculateCooling);
         [_player, _tempVarName, _temperature, TEMP_TOLERANCE] call EFUNC(common,setApproximateVariablePublic);
 
 /* // to be added when licence compatible audio can be found or recorded

--- a/addons/overheating/functions/fnc_updateSpareBarrelsTemperaturesThread.sqf
+++ b/addons/overheating/functions/fnc_updateSpareBarrelsTemperaturesThread.sqf
@@ -20,10 +20,10 @@ TRACE_1("updateSpareBarrelsTemperaturesThread1",GVAR(storedSpareBarrels));
     _y params ["_initialTemp","_initialTime", "_barrelMass"];
 
     // Calculate cooling
-    private _finalTemp = [_initialTemp, _barrelMass, CBA_missionTime - _initialTime] call FUNC(calculateCooling);
+    private _finalTemp = [_initialTemp, _barrelMass, CBA_missionTime - _initialTime, 0] call FUNC(calculateCooling); //the zero is to indicate an open bolt gun. Barrel is outside of a gun here, so always open.
     TRACE_4("updateSpareBarrelsTemperaturesThread2",_barrelMagazineID,_initialTemp,_finalTemp,_barrelMass);
-    if (_finalTemp < 5) then {
-        // The barrel is cool enough to keep calculating. Remove it from the hash
+    if (_finalTemp <= (ambientTemperature select 0)) then {
+        // The barrel is cool enough to finish calculating. Remove it from the hash
         GVAR(storedSpareBarrels) deleteAt _x;
     } else {
         // Store the new temp

--- a/addons/overheating/functions/fnc_updateTemperature.sqf
+++ b/addons/overheating/functions/fnc_updateTemperature.sqf
@@ -33,8 +33,9 @@ _trackedWeapons pushBackUnique _tempVarName;
 _unit setVariable [QGVAR(trackedWeapons), _trackedWeapons];
 
 // Calculate cooling
-private _barrelMass = ([_weapon] call FUNC(getWeaponData)) select 7;
-_temperature = [_temperature, _barrelMass, CBA_missionTime - _lastTime] call FUNC(calculateCooling);
+private _weaponData = [_weapon] call FUNC(getWeaponData);
+private _barrelMass = _weaponData select 7;
+_temperature = [_temperature, _barrelMass, CBA_missionTime - _lastTime, _weaponData select 6] call FUNC(calculateCooling);
 
 TRACE_1("cooledTo",_temperature);
 // Calculate heating

--- a/addons/overheating/script_component.hpp
+++ b/addons/overheating/script_component.hpp
@@ -19,6 +19,7 @@
 #define TEMP_TOLERANCE 50
 #define METAL_MASS_RATIO 0.55
 #define GUNPOWDER_IGNITION_TEMP 180
+#define OPEN_BOLT_ADDITIONAL_CONVECTION 1.1
 
 #ifdef DEBUG_MODE_FULL
     #define TRACE_PROJECTILE_INFO(BULLET) _vdir = vectorNormalized velocity BULLET; _dir = (_vdir select 0) atan2 (_vdir select 1); _up = asin (_vdir select 2); _mv = vectorMagnitude velocity BULLET; TRACE_3("adjusted projectile",_dir,_up,_mv);


### PR DESCRIPTION
**When merged this pull request will:**
- Open bolt guns have airflow down the bore that increases convective cooling a small amount.
- I've applied this to spare barrels as well as they are not in a gun and so cannot have a bolt closed on them.