### PR TITLE
Parachute - Add Seconds Indicator to Altimeter Watch

### DIFF
--- a/addons/parachute/RscTitles.hpp
+++ b/addons/parachute/RscTitles.hpp
@@ -42,7 +42,7 @@ class RscTitles {
                 text = "00:00:00";
                 x = "0.202094 * safezoneW + safezoneX";
                 y = "0.819 * safezoneH + safezoneY";
-                w = "0.0350375 * safezoneW";
+                w = "0.0380375 * safezoneW";
                 h = "0.022 * safezoneH";
                 colorText[] = {0,0,0,1};
             };

--- a/addons/parachute/RscTitles.hpp
+++ b/addons/parachute/RscTitles.hpp
@@ -39,10 +39,10 @@ class RscTitles {
             };
             class TimeText: RscText {
                 idc = 1001;
-                text = "00:00";
-                x = "0.206094 * safezoneW + safezoneX";
+                text = "00:00:00";
+                x = "0.202094 * safezoneW + safezoneX";
                 y = "0.819 * safezoneH + safezoneY";
-                w = "0.0309375 * safezoneW";
+                w = "0.0350375 * safezoneW";
                 h = "0.022 * safezoneH";
                 colorText[] = {0,0,0,1};
             };

--- a/addons/parachute/functions/fnc_showAltimeter.sqf
+++ b/addons/parachute/functions/fnc_showAltimeter.sqf
@@ -40,8 +40,10 @@ private _TimeText = _display displayCtrl 1001;
         _pfhID call CBA_fnc_removePerFrameHandler;
     };
 
-    private _hour = floor daytime;
-    private _minute = floor ((daytime - _hour) * 60);
+    private _daytime = dayTime;
+    private _hour = floor _daytime;
+    private _minute = floor ((_daytime - _hour) * 60);
+    private _seconds = floor ((((_daytime - _hour) * 60) - _minute) * 60);
     private _curTime = CBA_missionTime;
     private _timeDiff = _curTime - _prevTime;
 
@@ -52,7 +54,7 @@ private _TimeText = _display displayCtrl 1001;
         0
     };
 
-    _TimeText ctrlSetText (format ["%1:%2", [_hour, 2] call CBA_fnc_formatNumber, [_minute, 2] call CBA_fnc_formatNumber]);
+    _TimeText ctrlSetText (format ["%1:%2:%3", [_hour, 2] call CBA_fnc_formatNumber, [_minute, 2] call CBA_fnc_formatNumber, [_seconds, 2] call CBA_fnc_formatNumber]);
     _HeightText ctrlSetText str floor _height;
     _DecendRate ctrlSetText str (_descentRate max 0);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `seconds` to the digital clock on the Altimeter Watch, changing its format to `HH:MM:SS`. Making it more useful for timing explosives or tracking artillery TOF accurately;