### PR TITLE
Cup Weapon Compat - Fix NVG classnames

### DIFF
--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
@@ -107,12 +107,12 @@ class CfgWeapons {
         displayName = SUBCSTRING(CUP_NVG_GPNVG_tan_WP);
         NVG_WP_PRESET;
     };
-    class CUP_GPNVG_green_WP: CUP_NVG_GPNVG_green {
-        displayName = SUBCSTRING(CUP_GPNVG_green_WP);
+    class CUP_NVG_GPNVG_green_WP: CUP_NVG_GPNVG_green {
+        displayName = SUBCSTRING(CUP_NVG_GPNVG_green_WP);
         NVG_WP_PRESET;
     };
-    class CUP_GPNVG_winter_WP: CUP_NVG_GPNVG_winter {
-        displayName = SUBCSTRING(CUP_GPNVG_winter_WP);
+    class CUP_NVG_GPNVG_winter_WP: CUP_NVG_GPNVG_winter {
+        displayName = SUBCSTRING(CUP_NVG_GPNVG_winter_WP);
         NVG_WP_PRESET;
     };
 };

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {
             "CUP_NVG_PVS14_WP", "CUP_NVG_PVS15_black_WP", "CUP_NVG_PVS15_green_WP", "CUP_NVG_PVS15_tan_WP", "CUP_NVG_PVS15_winter_WP",
-            "CUP_NVG_GPNVG_black_WP", "CUP_NVG_GPNVG_tan_WP", "CUP_GPNVG_green_WP", "CUP_GPNVG_winter_WP"
+            "CUP_NVG_GPNVG_black_WP", "CUP_NVG_GPNVG_tan_WP", "CUP_NVG_GPNVG_green_WP", "CUP_NVG_GPNVG_winter_WP"
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {

--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/stringtable.xml
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/stringtable.xml
@@ -67,7 +67,7 @@
             <French>GPNVG (marron clair, WP)</French>
             <Russian>GPNVG (Желтовато-коричневый, БФ)</Russian>
         </Key>
-        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_GPNVG_green_WP">
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_GPNVG_green_WP">
             <English>GPNVG (Green, WP)</English>
             <Japanese>GPNVG (ブラック、白色蛍光)</Japanese>
             <Italian>GPNVG (Nero, FB)</Italian>
@@ -77,7 +77,7 @@
             <French>GPNVG (noires, WP)</French>
             <Russian>GPNVG (Зелёный, БФ)</Russian>
         </Key>
-        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_GPNVG_winter_WP">
+        <Key ID="STR_ACE_Compat_CUP_Weapons_nightvision_CUP_NVG_GPNVG_winter_WP">
             <English>GPNVG (Winter, WP)</English>
             <Japanese>GPNVG (冬季迷彩, WP)</Japanese>
             <Korean>GPNVG (설상, WP)</Korean>


### PR DESCRIPTION
fixes new classnames to be consistent (format `X_WP`)
this matches all the others such as `class CUP_NVG_GPNVG_tan_WP: CUP_NVG_GPNVG_tan`