### PR TITLE
Arsenal - Add support for structured text in arsenal stats

### DIFF
--- a/addons/arsenal/functions/fnc_handleStats.sqf
+++ b/addons/arsenal/functions/fnc_handleStats.sqf
@@ -124,7 +124,7 @@ private _fnc_handleStats = {
         _statsTextCtrl = _display displayCtrl (_statsTitleIDC + 3);
 
         _statsCount = _statsCount + 1;
-        _statsTitleCtrl ctrlSetText _title;
+        _statsTitleCtrl ctrlSetStructuredText parseText _title;
         _statsTitleCtrl ctrlSetFade 0;
 
         // Handle bars
@@ -145,7 +145,7 @@ private _fnc_handleStats = {
                 _textStatementResult = str _textStatementResult;
             };
 
-            _statsTextCtrl ctrlSetText _textStatementResult;
+            _statsTextCtrl ctrlSetStructuredText parseText _textStatementResult;
             _statsTextCtrl ctrlSetTextColor ([[1, 1, 1, 1], [0, 0, 0, 1]] select (_showBar));
             _statsTextCtrl ctrlSetFade 0;
         } else {

--- a/addons/arsenal/ui/RscAttributes.hpp
+++ b/addons/arsenal/ui/RscAttributes.hpp
@@ -298,7 +298,7 @@ class GVAR(display) {
                     h = QUOTE(5 * GRID_H);
                     colorBackground[] = {0.1,0.1,0.1,0.8};
                 };
-                class statsTitle1: RscText {
+                class statsTitle1: RscStructuredText {
                     idc = IDC_statsTitle1;
                     fade = 1;
                     x = QUOTE(0 * GRID_W);
@@ -307,7 +307,7 @@ class GVAR(display) {
                     h = QUOTE(5 * GRID_H);
                     colorBackground[] = {0,0,0,0};
                     colorText[] = {0.7,0.7,0.7,1};
-                    sizeEx = QUOTE(5 * GRID_H);
+                    size = QUOTE(5 * GRID_H);
                     text = "";
                 };
                 class statsBackground1: ctrlStaticBackground {
@@ -331,7 +331,7 @@ class GVAR(display) {
                     w = QUOTE(45 * GRID_W);
                     h = QUOTE(4 * GRID_H);
                 };
-                class statsText1: RscText {
+                class statsText1: RscStructuredText {
                     idc = IDC_statsText1;
                     shadow = 0;
                     fade = 1;
@@ -341,7 +341,7 @@ class GVAR(display) {
                     y = QUOTE(10 * GRID_H);
                     w = QUOTE(45 * GRID_W);
                     h = QUOTE(4 * GRID_H);
-                    sizeEx = QUOTE(5 * GRID_H);
+                    size = QUOTE(5 * GRID_H);
                     text = "";
                 };
                 class statsTitle2: statsTitle1 {

--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -207,13 +207,13 @@ class ace_arsenal_stats {
 
     class TAG_myStat: statBase {
         scope = 2; // Only scope 2 show up in arsenal, scope 1 is used for base classes.
-        displayName = "Test entry title"; // Title of the stat.
+        displayName = "Test entry title"; // Title of the stat. Supports structured text.
         priority = 0; // A higher value means the stat will be displayed higher on the page.
         stats[] = {"mySuperStat"}; // Array of strings to pass to the statements, typically
         showBar = 1; // 0 disabled; 1 enabled;
         showText = 1; // 0 disabled; 1 enabled;
         barStatement = "1"; // Statement evaluated to set the bar progress, needs to return a NUMBER.
-        textStatement = "test entry"; // statement evaluated to set the text entry, can return anything.
+        textStatement = "test entry"; // statement evaluated to set the text entry, can return anything. Supports structured text.
         condition = "true"; // Condition for the stats to be displayed, default is true if not defined, needs to return a BOOL.
         tabs[] = { {0,1,2}, { } }; // Arrays of tabs, left array is left tabs, right array is right tabs.
     };


### PR DESCRIPTION
**When merged this pull request will:**
- _Add support for structured text in an arsenal stat's `textStatement`_
- _Add support for structured text in an arsenal stat's `displayName` (title)_

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
