### PR TITLE
Hearing - Removed `remoteExec` & added microoptimisations

### DIFF
--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -23,6 +23,8 @@ GVAR(lastPlayerVehicle) = objNull;
     // Spawn volume updating process
     [LINKFUNC(updateVolume), 1, [false]] call CBA_fnc_addPerFrameHandler;
 
+    [QGVAR(updateVolume), LINKFUNC(updateVolume)] call CBA_fnc_addEventHandler;
+
     // Update veh attunation when player veh changes
     ["vehicle", {
         params ["_player", "_vehicle"];

--- a/addons/hearing/XEH_preInit.sqf
+++ b/addons/hearing/XEH_preInit.sqf
@@ -15,7 +15,7 @@ PREP_RECOMPILE_END;
     if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
         _unit setVariable ["ACE_hasEarPlugsIn", true, true];
 
-        [QGVAR(updateVolume), [true], _unit] call CBA_fnc_targetEvent;
+        [QGVAR(updateVolume), [[true]], _unit] call CBA_fnc_targetEvent;
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/hearing/XEH_preInit.sqf
+++ b/addons/hearing/XEH_preInit.sqf
@@ -8,8 +8,6 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.inc.sqf"
 
-[QGVAR(updateVolume), LINKFUNC(updateVolume)] call CBA_fnc_addEventHandler;
-
 ["CBA_loadoutSet", {
     params ["_unit", "_loadout", "_extendedInfo"];
     if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {

--- a/addons/hearing/XEH_preInit.sqf
+++ b/addons/hearing/XEH_preInit.sqf
@@ -8,11 +8,14 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.inc.sqf"
 
+[QGVAR(updateVolume), LINKFUNC(updateVolume)] call CBA_fnc_addEventHandler;
+
 ["CBA_loadoutSet", {
     params ["_unit", "_loadout", "_extendedInfo"];
     if (_extendedInfo getOrDefault ["ace_earplugs", false]) then {
         _unit setVariable ["ACE_hasEarPlugsIn", true, true];
-        [[true]] remoteExec [QFUNC(updateVolume), _unit];
+
+        [QGVAR(updateVolume), [true], _unit] call CBA_fnc_targetEvent;
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/hearing/functions/fnc_addEarPlugs.sqf
+++ b/addons/hearing/functions/fnc_addEarPlugs.sqf
@@ -15,13 +15,13 @@
  * Public: No
  */
 
-params ["_unit"];
-TRACE_2("params",_unit,typeOf _unit);
-
 // only run this after the settings are initialized
 if !(EGVAR(common,settingsInitFinished)) exitWith {
     EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addEarPlugs), _this];
 };
+
+params ["_unit"];
+TRACE_2("params",_unit,typeOf _unit);
 
 // Exit if hearing is disabled OR autoAdd is disabled OR soldier has earplugs already in (persistence scenarios)
 if (!GVAR(enableCombatDeafness) || {!GVAR(autoAddEarplugsToUnits)} || {[_unit] call FUNC(hasEarPlugsIn)}) exitWith {};
@@ -38,16 +38,20 @@ if ((primaryWeapon _unit) == "") exitWith {};
 (primaryWeaponMagazine _unit) params [["_magazine", ""]];
 if (_magazine == "") exitWith {};
 
-private _initSpeed = getNumber (configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
-private _ammo = getText (configFile >> "CfgMagazines" >> _magazine >> "ammo");
-private _count = getNumber (configFile >> "CfgMagazines" >> _magazine >> "count");
+private _cfgMagazine = configFile >> "CfgMagazines" >> _magazine;
 
-private _caliber = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_caliber");
+private _initSpeed = getNumber (_cfgMagazine >> "initSpeed");
+private _ammo = getText (_cfgMagazine >> "ammo");
+private _count = getNumber (_cfgMagazine >> "count");
+
+private _cfgAmmo = configFile >> "CfgAmmo";
+
+private _caliber = getNumber (_cfgAmmo >> _ammo >> "ACE_caliber");
 _caliber = call {
-    if (_ammo isKindOf ["ShellBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
-    if (_ammo isKindOf ["RocketBase", (configFile >> "CfgAmmo")]) exitWith { 200 };
-    if (_ammo isKindOf ["MissileBase", (configFile >> "CfgAmmo")]) exitWith { 600 };
-    if (_ammo isKindOf ["SubmunitionBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
+    if (_ammo isKindOf ["ShellBase", _cfgAmmo]) exitWith { 80 };
+    if (_ammo isKindOf ["RocketBase", _cfgAmmo]) exitWith { 200 };
+    if (_ammo isKindOf ["MissileBase", _cfgAmmo]) exitWith { 600 };
+    if (_ammo isKindOf ["SubmunitionBase", _cfgAmmo]) exitWith { 80 };
     [_caliber, 6.5] select (_caliber <= 0);
 };
 private _loudness = (_caliber ^ 1.25 / 10) * (_initspeed / 1000) / 5;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Moved `TRACE` down to where it's actually called, in case it's called before CBA settings are ready.

@BrettMayson you added `remoteExec`, is there any specific reason why? I couldn't find anything on the PR.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
