### PR TITLE
Fortify - Add onDeployStop event for cancelling before confirming

### DIFF
--- a/addons/fortify/functions/fnc_deployConfirm.sqf
+++ b/addons/fortify/functions/fnc_deployConfirm.sqf
@@ -50,9 +50,12 @@ private _perframeCheck = {
 [
     _totalTime,
     [_unit, _side, _typeOf, _posASL, _vectorDir, _vectorUp, _cost],
-    QGVAR(deployFinished),
-    QGVAR(deployCanceled),
+    QGVAR(deployFinished), {
+        params ["_unit", "", "_typeOf"];
+        private _cost = _this select 6;
+        [QGVAR(deployCanceled), _this] call CBA_fnc_localEvent;
+        [QGVAR(onDeployStop), [_unit, _typeOf, _cost]] call CBA_fnc_localEvent;
+    },
     LLSTRING(progressBarTitle),
     _perframeCheck
 ] call EFUNC(common,progressBar);
-

--- a/addons/fortify/functions/fnc_deployConfirm.sqf
+++ b/addons/fortify/functions/fnc_deployConfirm.sqf
@@ -50,11 +50,8 @@ private _perframeCheck = {
 [
     _totalTime,
     [_unit, _side, _typeOf, _posASL, _vectorDir, _vectorUp, _cost],
-    QGVAR(deployFinished), {
-        _this#0 params ["_unit", "", "_typeOf", "", "", "", "_cost"];
-        [QGVAR(deployCanceled), _this] call CBA_fnc_localEvent;
-        [QGVAR(onDeployStop), [_unit, _typeOf, _cost]] call CBA_fnc_localEvent;
-    },
+    QGVAR(deployFinished),
+    QGVAR(deployCanceled),
     LLSTRING(progressBarTitle),
     _perframeCheck
 ] call EFUNC(common,progressBar);

--- a/addons/fortify/functions/fnc_deployConfirm.sqf
+++ b/addons/fortify/functions/fnc_deployConfirm.sqf
@@ -51,8 +51,7 @@ private _perframeCheck = {
     _totalTime,
     [_unit, _side, _typeOf, _posASL, _vectorDir, _vectorUp, _cost],
     QGVAR(deployFinished), {
-        params ["_unit", "", "_typeOf"];
-        private _cost = _this select 6;
+        _this#0 params ["_unit", "", "_typeOf", "", "", "", "_cost"];
         [QGVAR(deployCanceled), _this] call CBA_fnc_localEvent;
         [QGVAR(onDeployStop), [_unit, _typeOf, _cost]] call CBA_fnc_localEvent;
     },

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -70,7 +70,6 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
             [_unit, _object] call FUNC(deployConfirm);
         } else {
             TRACE_1("deleting object",_object);
-            [QGVAR(onDeployStop), [_unit, typeOf _object, _cost]] call CBA_fnc_localEvent;
             deleteVehicle _object;
         };
     };

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -70,6 +70,7 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
             [_unit, _object] call FUNC(deployConfirm);
         } else {
             TRACE_1("deleting object",_object);
+            [QGVAR(onDeployStop), [_unit, typeOf _object, _cost]] call CBA_fnc_localEvent;
             deleteVehicle _object;
         };
     };

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -47,7 +47,7 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
 
 [{
     params ["_args", "_pfID"];
-    _args params ["_unit", "_object", "_cost", "_mouseClickID"];
+    _args params ["_unit", "_object", "_cost", "_mouseClickID", "_side"];
 
     if (_unit != ACE_player || {isNull _object} || {!([_unit, _object, []] call EFUNC(common,canInteractWith))} || {!([_unit, _cost] call FUNC(canFortify))}) then {
         GVAR(isPlacing) = PLACE_CANCEL;
@@ -70,6 +70,7 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
             [_unit, _object] call FUNC(deployConfirm);
         } else {
             TRACE_1("deleting object",_object);
+            [QGVAR(deployCanceled), [_unit, _side, typeOf _object, getPosASL _object, vectorDir _object, vectorUp _object]] call CBA_fnc_localEvent;
             deleteVehicle _object;
         };
     };
@@ -95,4 +96,4 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
     #ifdef DEBUG_MODE_FULL
     hintSilent format ["Rotation:\nX: %1\nY: %2\nZ: %3", GVAR(objectRotationX), GVAR(objectRotationY), GVAR(objectRotationZ)];
     #endif
-}, 0, [_player, _object, _cost, _mouseClickID]] call CBA_fnc_addPerFrameHandler;
+}, 0, [_player, _object, _cost, _mouseClickID, _side]] call CBA_fnc_addPerFrameHandler;

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -70,7 +70,7 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
             [_unit, _object] call FUNC(deployConfirm);
         } else {
             TRACE_1("deleting object",_object);
-            [QGVAR(deployCanceled), [_unit, _side, typeOf _object, getPosASL _object, vectorDir _object, vectorUp _object]] call CBA_fnc_localEvent;
+            [QGVAR(onDeployStop), [_unit, _object, _cost]] call CBA_fnc_localEvent;
             deleteVehicle _object;
         };
     };

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -47,7 +47,7 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
 
 [{
     params ["_args", "_pfID"];
-    _args params ["_unit", "_object", "_cost", "_mouseClickID", "_side"];
+    _args params ["_unit", "_object", "_cost", "_mouseClickID"];
 
     if (_unit != ACE_player || {isNull _object} || {!([_unit, _object, []] call EFUNC(common,canInteractWith))} || {!([_unit, _cost] call FUNC(canFortify))}) then {
         GVAR(isPlacing) = PLACE_CANCEL;
@@ -96,4 +96,4 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
     #ifdef DEBUG_MODE_FULL
     hintSilent format ["Rotation:\nX: %1\nY: %2\nZ: %3", GVAR(objectRotationX), GVAR(objectRotationY), GVAR(objectRotationZ)];
     #endif
-}, 0, [_player, _object, _cost, _mouseClickID, _side]] call CBA_fnc_addPerFrameHandler;
+}, 0, [_player, _object, _cost, _mouseClickID]] call CBA_fnc_addPerFrameHandler;

--- a/docs/wiki/framework/fortify-framework.md
+++ b/docs/wiki/framework/fortify-framework.md
@@ -119,5 +119,6 @@ Event Name | Passed Parameter(s) | Locality | Description
 `acex_fortify_objectPlaced` | [player, side, objectPlaced] | Global | Foritfy object placed
 `acex_fortify_objectDeleted` | [player, side, objectDeleted] | Global | Foritfy object deleted
 `acex_fortify_onDeployStart` | [player, object, cost] | Local | Player starts placing object
+`ace_fortify_onDeployStop` | [player, object, cost] | Local | Player stops placing object. Raised only if stopped before trying to place (= before progress bar appears). If it's during progress bar, only `ace_fortify_deployCanceled` is raised.
 `ace_fortify_deployFinished` | [player, side, configName, posASL, vectorDir, vectorUp] | Local | Player successfully finishes building object
 `ace_fortify_deployCanceled` | [player, side, configName, posASL, vectorDir, vectorUp] | Local | Player cancels building object

--- a/docs/wiki/framework/fortify-framework.md
+++ b/docs/wiki/framework/fortify-framework.md
@@ -119,6 +119,5 @@ Event Name | Passed Parameter(s) | Locality | Description
 `acex_fortify_objectPlaced` | [player, side, objectPlaced] | Global | Foritfy object placed
 `acex_fortify_objectDeleted` | [player, side, objectDeleted] | Global | Foritfy object deleted
 `acex_fortify_onDeployStart` | [player, object, cost] | Local | Player starts placing object
-`ace_fortify_onDeployStop` | [player, objectType, cost] | Local | Player stops placing object
 `ace_fortify_deployFinished` | [player, side, configName, posASL, vectorDir, vectorUp] | Local | Player successfully finishes building object
 `ace_fortify_deployCanceled` | [player, side, configName, posASL, vectorDir, vectorUp] | Local | Player cancels building object

--- a/docs/wiki/framework/fortify-framework.md
+++ b/docs/wiki/framework/fortify-framework.md
@@ -119,5 +119,6 @@ Event Name | Passed Parameter(s) | Locality | Description
 `acex_fortify_objectPlaced` | [player, side, objectPlaced] | Global | Foritfy object placed
 `acex_fortify_objectDeleted` | [player, side, objectDeleted] | Global | Foritfy object deleted
 `acex_fortify_onDeployStart` | [player, object, cost] | Local | Player starts placing object
+`ace_fortify_onDeployStop` | [player, objectType, cost] | Local | Player stops placing object
 `ace_fortify_deployFinished` | [player, side, configName, posASL, vectorDir, vectorUp] | Local | Player successfully finishes building object
 `ace_fortify_deployCanceled` | [player, side, configName, posASL, vectorDir, vectorUp] | Local | Player cancels building object


### PR DESCRIPTION
**When merged this pull request will:**
- _Add a_ `ace_fortify_onDeployStop` _local event for when deploying is cancelled before confirming_
  - I.e. is called when right clicking after the menu appears
  - Is also called when `ace_fortify_deployCanceled` is

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
