### PR TITLE
Grenades - Fix Flashbang in epilepsy mode

### DIFF
--- a/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
+++ b/addons/grenades/functions/fnc_flashbangExplosionEH.sqf
@@ -145,11 +145,11 @@ if (hasInterface && {!isNull ACE_player} && {alive ACE_player}) then {
 
         //PARTIALRECOVERY - start decreasing effect over time
         [{
-            params ["_strength"];
+            params ["_strength", "_blend"];
 
-            GVAR(flashbangPPEffectCC) ppEffectAdjust [1,1,0,[1,1,1,0],[0,0,0,1],[0,0,0,0]];
+            GVAR(flashbangPPEffectCC) ppEffectAdjust [1, 1, 0, _blend, [0,0,0,1], [0,0,0,0]];
             GVAR(flashbangPPEffectCC) ppEffectCommit (10 * _strength);
-        }, [_strength], 7 * _strength] call CBA_fnc_waitAndExecute;
+        }, [_strength, _blend], 7 * _strength] call CBA_fnc_waitAndExecute;
 
         //FULLRECOVERY - end effect
         [{


### PR DESCRIPTION
**When merged this pull request will:**
- With epilepsy mode enabled, screen goes grey instead of pure white, but as the effect fades out you get a white flash as you're able to see again. It's just as bad as the initial (non-epilepsy mode) effect. Now uses whatever blend was selected instead of hard setting white.

I tested, screen goes grey, stays that way and comes back instantly. Not exactly the nicest way but the original is not epilepsy friendly.
