### PR TITLE
Headless - Improve group transfer and add API

### DIFF
--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -17,6 +17,9 @@
 
 params ["_force"];
 
+// Filter out any invalid entries
+GVAR(headlessClients) = GVAR(headlessClients) select {!isNull _x};
+
 GVAR(headlessClients) params [
     ["_HC1", objNull, [objNull]],
     ["_HC2", objNull, [objNull]],
@@ -36,12 +39,13 @@ private _idHC2 = -1;
 private _idHC3 = -1;
 private _currentHC = 0;
 
-if (!local _HC1) then {
+// objNull is never local
+if (!local _HC1 && !isNull _HC1) then {
     _idHC1 = owner _HC1;
     _currentHC = 1;
 };
 
-if (!local _HC2) then {
+if (!local _HC2 && !isNull _HC2) then {
     _idHC2 = owner _HC2;
 
     if (_currentHC == 0) then {
@@ -49,11 +53,19 @@ if (!local _HC2) then {
     };
 };
 
-if (!local _HC3) then {
+if (!local _HC3 && !isNull _HC3) then {
     _idHC3 = owner _HC3;
 
     if (_currentHC == 0) then {
         _currentHC = 3;
+    };
+};
+
+if (_currentHC == 0) exitWith {
+    TRACE_1("No Valid HC to transfer to",_currentHC);
+
+    if (XGVAR(log)) then {
+        INFO("No Valid HC to transfer to");
     };
 };
 
@@ -62,77 +74,135 @@ private _numTransferredHC1 = 0;
 private _numTransferredHC2 = 0;
 private _numTransferredHC3 = 0;
 
+private _units = [];
+private _transfer = false;
+private _previousOwner = -1;
+
 // Transfer AI groups
 {
-    // No transfer if empty group
-    private _transfer = ((units _x) isNotEqualTo []) && {!(_x getVariable [QXGVAR(blacklist), false])};
-    if (_transfer) then {
-        // No transfer if waypoints with synchronized triggers exist for the group
-        private _allWaypointsWithTriggers = (waypoints _x) select {(synchronizedTriggers _x) isNotEqualTo []};
-        if (_allWaypointsWithTriggers isNotEqualTo []) exitWith {
+    _units = units _x;
+
+    // No transfer if empty group or if group is blacklisted
+    if (_units isEqualTo [] || {_x getVariable [QXGVAR(blacklist), false]}) then {
+        continue;
+    };
+
+    // No transfer if waypoints with synchronized triggers exist for the group
+    if (((waypoints _x) select {(synchronizedTriggers _x) isNotEqualTo []}) isNotEqualTo []) then {
+        continue;
+    };
+
+    {
+        // No transfer if already transferred
+        if (!_force && {(owner _x) in [_idHC1, _idHC2, _idHC3]}) exitWith {
             _transfer = false;
         };
 
-        {
-            // No transfer if already transferred
-            if (!_force && {(owner _x) in [_idHC1, _idHC2, _idHC3]}) exitWith {
-                _transfer = false;
-            };
+        // No transfer if player in this group
+        if (isPlayer _x) exitWith {
+            _transfer = false;
+        };
 
-            // No transfer if player in this group
-            if (isPlayer _x) exitWith {
-                _transfer = false;
-            };
+        // No transfer if any unit in group is blacklisted
+        if (_x getVariable [QXGVAR(blacklist), false]) exitWith {
+            _transfer = false;
+        };
 
-            // No transfer if any unit in group is blacklisted
-            if (_x getVariable [QXGVAR(blacklist), false]) exitWith {
-                _transfer = false;
-            };
+        // No transfer if vehicle unit is in or crew in that vehicle is blacklisted
+        if (vehicle _x != _x && {(vehicle _x) getVariable [QXGVAR(blacklist), false]}) exitWith {
+            _transfer = false;
+        };
 
-            // No transfer if vehicle unit is in or crew in that vehicle is blacklisted
-            if (vehicle _x != _x && {(vehicle _x) getVariable [QXGVAR(blacklist), false]}) exitWith {
-                _transfer = false;
-            };
+        // Save gear if unit about to be transferred with current loadout (naked unit work-around)
+        if (XGVAR(transferLoadout) == 1) then {
+            _x setVariable [QGVAR(loadout), _x call CBA_fnc_getLoadout, true];
+        };
+    } forEach _units;
 
-            // Save gear if unit about to be transferred with current loadout (naked unit work-around)
-            if (XGVAR(transferLoadout) == 1) then {
-                _x setVariable [QGVAR(loadout), [_x] call CBA_fnc_getLoadout, true];
-            };
-        } forEach (units _x);
+    if (!_transfer) then {
+        continue;
     };
 
     // Round robin between HCs if load balance enabled, else pass all to one HC
-    if (_transfer) then {
-        switch (_currentHC) do {
-            case 1: {
-                private _transferred = _x setGroupOwner _idHC1;
-                if (_loadBalance) then {
-                    _currentHC = [3, 2] select (!local _HC2);
-                };
-                if (_transferred) then {
-                    _numTransferredHC1 = _numTransferredHC1 + 1;
-                };
-            };
-            case 2: {
-                private _transferred = _x setGroupOwner _idHC2;
-                if (_loadBalance) then {
-                    _currentHC = [1, 3] select (!local _HC3);
-                };
-                if (_transferred) then {
-                    _numTransferredHC2 = _numTransferredHC2 + 1;
+    _previousOwner = groupOwner _x;
+
+    switch (_currentHC) do {
+        case 1: {
+            if (_loadBalance) then {
+                // Find the next valid HC
+                // If none are valid, _currentHC will remain the same
+                if (_idHC2 != -1) then {
+                    _currentHC = 2;
+                } else {
+                    if (_idHC3 != -1) then {
+                        _currentHC = 3;
+                    };
                 };
             };
-            case 3: {
-                private _transferred = _x setGroupOwner _idHC3;
-                if (_loadBalance) then {
-                    _currentHC = [2, 1] select (!local _HC1);
-                };
-                if (_transferred) then {
-                    _numTransferredHC3 = _numTransferredHC3 + 1;
+
+            // Don't transfer if it's already local to HC1
+            if (_previousOwner == _idHC1) exitWith {};
+
+            [QGVAR(groupTransferPre), [_x, _HC1, _previousOwner, _idHC1]] call CBA_fnc_globalEvent; // API
+
+            private _transferred = _x setGroupOwner _idHC1;
+
+            [QGVAR(groupTransferPost), [_x, _HC1, _previousOwner, _idHC1, _transferred]] call CBA_fnc_globalEvent; // API
+
+            if (_transferred) then {
+                _numTransferredHC1 = _numTransferredHC1 + 1;
+            };
+        };
+        case 2: {
+            if (_loadBalance) then {
+                // Find the next valid HC
+                // If none are valid, _currentHC will remain the same
+                if (_idHC3 != -1) then {
+                    _currentHC = 3;
+                } else {
+                    if (_idHC1 != -1) then {
+                        _currentHC = 1;
+                    };
                 };
             };
-            default {
-                TRACE_1("No Valid HC to transfer to",_currentHC);
+
+            // Don't transfer if it's already local to HC2
+            if (_previousOwner == _idHC2) exitWith {};
+
+            [QGVAR(groupTransferPre), [_x, _HC2, _previousOwner, _idHC2]] call CBA_fnc_globalEvent; // API
+
+            private _transferred = _x setGroupOwner _idHC2;
+
+            [QGVAR(groupTransferPost), [_x, _HC2, _previousOwner, _idHC2, _transferred]] call CBA_fnc_globalEvent; // API
+
+            if (_transferred) then {
+                _numTransferredHC2 = _numTransferredHC2 + 1;
+            };
+        };
+        case 3: {
+            if (_loadBalance) then {
+                // Find the next valid HC
+                // If none are valid, _currentHC will remain the same
+                if (_idHC1 != -1) then {
+                    _currentHC = 1;
+                } else {
+                    if (_idHC2 != -1) then {
+                        _currentHC = 2;
+                    };
+                };
+            };
+
+            // Don't transfer if it's already local to HC3
+            if (_previousOwner == _idHC3) exitWith {};
+
+            [QGVAR(groupTransferPre), [_x, _HC3, _previousOwner, _idHC3]] call CBA_fnc_globalEvent; // API
+
+            private _transferred = _x setGroupOwner _idHC2;
+
+            [QGVAR(groupTransferPost), [_x, _HC3, _previousOwner, _idHC3, _transferred]] call CBA_fnc_globalEvent; // API
+
+            if (_transferred) then {
+                _numTransferredHC3 = _numTransferredHC3 + 1;
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Checks for valid HCs before trying to transfer groups.
- Adds API for group transferral: 1 global event before a group is transferred, 1 global event after.
  The API is very much WIP and I'd appreciate any input @LinkIsGrim.
  Because of it being WIP, I haven't made any documentation for it yet.
  
### IMPORTANT

- [ ] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
