### PR TITLE
Interaction - Make magazine passing animation optional

### DIFF
--- a/addons/interaction/functions/fnc_passMagazine.sqf
+++ b/addons/interaction/functions/fnc_passMagazine.sqf
@@ -1,4 +1,4 @@
-#include "script_component.hpp"
+#include "..\script_component.hpp"
 /*
  * Author: BaerMitUmlaut
  * Pass spare magazine for the specified weapon.

--- a/addons/interaction/functions/fnc_passMagazine.sqf
+++ b/addons/interaction/functions/fnc_passMagazine.sqf
@@ -37,7 +37,6 @@ private _magToPassIndex = 0;
 } foreach _filteredMags;
 
 //remove the magazine from _player and add it to _target
-//_player plays animation if _animate is true
 _magToPass params ["_magToPassClassName", "_magToPassAmmoCount"];
 [_player, _magToPassClassName, _magToPassAmmoCount] call CBA_fnc_removeMagazine;
 

--- a/addons/interaction/functions/fnc_passMagazine.sqf
+++ b/addons/interaction/functions/fnc_passMagazine.sqf
@@ -38,7 +38,8 @@ private _magToPassIndex = 0;
 
 //remove the magazine from _player and add it to _target
 _magToPass params ["_magToPassClassName", "_magToPassAmmoCount"];
-[_player, _magToPassClassName, _magToPassAmmoCount] call CBA_fnc_removeMagazine;
+// Exit if failed to remove specific magazine
+if !([_player, _magToPassClassName, _magToPassAmmoCount] call EFUNC(common,removeSpecificMagazine)) exitWith {};
 
 if (_animate) then {[_player, "PutDown"] call EFUNC(common,doGesture)};
 

--- a/addons/interaction/functions/fnc_passMagazine.sqf
+++ b/addons/interaction/functions/fnc_passMagazine.sqf
@@ -1,4 +1,4 @@
-#include "..\script_component.hpp"
+#include "script_component.hpp"
 /*
  * Author: BaerMitUmlaut
  * Pass spare magazine for the specified weapon.
@@ -7,6 +7,7 @@
  * 0: Unit that passes the magazine <OBJECT>
  * 1: Unit to pass the magazine to <OBJECT>
  * 2: Weapon classname <STRING>
+ * 3: Play passing animation <BOOL> (default: true)
  *
  * Return Value:
  * None
@@ -16,7 +17,7 @@
  *
  * Public: No
  */
-params ["_player", "_target", "_weapon"];
+params ["_player", "_target", "_weapon", ["_animate", true, [true]]];
 
 private _compatibleMags = [_weapon] call CBA_fnc_compatibleMagazines;
 private _filteredMags = magazinesAmmoFull _player select {
@@ -35,18 +36,12 @@ private _magToPassIndex = 0;
     };
 } foreach _filteredMags;
 
-//remove all magazines and add them again, except the one to be passed
-//needed because of missing commands, see http://feedback.arma3.com/view.php?id=12782
+//remove the magazine from _player and add it to _target
+//_player plays animation if _animate is true
 _magToPass params ["_magToPassClassName", "_magToPassAmmoCount"];
-_player removeMagazines _magToPassClassName;
-{
-    _x params ["_className", "_ammoCount"];
-    if ((_className == _magToPassClassName) && (_forEachIndex != _magToPassIndex)) then {
-        _player addMagazine [_className, _ammoCount];
-    };
-} foreach _filteredMags;
+[_player, _magToPassClassName, _magToPassAmmoCount] call CBA_fnc_removeMagazine;
 
-[_player, "PutDown"] call EFUNC(common,doGesture);
+if (_animate) then {[_player, "PutDown"] call EFUNC(common,doGesture)};
 
 _target addMagazine [_magToPassClassName, _magToPassAmmoCount];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add optional _animate parameter
- Change to removing the magazine from _player using CBA_fnc_removeMagazine

_animate is optional and the Default is true so should not break anything. Function can then be used for tossing magazines and the like.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
