### PR TITLE
Improve GitHub labels and Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,11 +11,10 @@ sort-direction: ascending
 categories:
   - title: '**ADDED:**'
     labels:
-      - 'kind/feature request'
-      - 'kind/added feature'
+      - 'kind/feature'
   - title: '**FIXED:**'
     labels:
-      - 'kind/bug fix'
+      - 'kind/bug-fix'
   - title: '**IMPROVED:**'
     labels:
       - 'kind/enhancement'
@@ -23,17 +22,16 @@ categories:
   - title: '**CHANGED:**'
     labels:
       - 'kind/cleanup'
-      - 'area/compatibility'
       - 'kind/change'
   - title: '**SETTINGS:**'
     labels:
       - 'kind/setting'
   - title: '**TRANSLATIONS:**'
     labels:
-      - 'area/translations'
+      - 'kind/translation'
 
 exclude-labels:
-  - 'ignore changelog'
+  - 'ignore-changelog'
   - 'dependencies'
 
 change-template: '- $TITLE (#$NUMBER)'


### PR DESCRIPTION
**When merged this pull request will:**
- Adapt Release Drafter for below changes to labels used in this project

I adapted some of our labels in accordance with the use in the past years and what @BaerMitUmlaut applied to ACE-Anvil.

- `kind/Focus Feature` -> `area/focus-feature`
- `kind/feature request` -> `kind/feature`
- `area/translations` -> `kind/translation`
- `kind/bug fix` -> `kind/bug-fix` 
- `ignore changelog` -> `ignore-changelog`
- ~`kind/refactor`~ _(and some other ones that were not widely used)_

Release Drafter now includes only `kind/` labels. Notable example being `area/compatibility` which should always be used in combination with `kind/feature`, `kind/bug-fix` or `kind/change`. We should see less duplicates in the changelog now and those that remain are more likely to actually be included in multiple categories.