### PR TITLE
Map Tools - Show GPS on Map when equipped with UAV Terminal

### DIFF
--- a/addons/maptools/functions/fnc_canUseMapGPS.sqf
+++ b/addons/maptools/functions/fnc_canUseMapGPS.sqf
@@ -15,6 +15,14 @@
  * Public: No
  */
 
-visibleMap &&
-{alive ACE_player} &&
-{"ItemGPS" in (assignedItems ACE_player)}
+if (!visibleMap || {!alive ACE_player}) exitWith {false};
+
+private _playerTerminal = ACE_player getSlotItemName 612;
+[
+    "ItemGPS",
+    "B_UavTerminal",
+    "O_UavTerminal",
+    "I_UavTerminal",
+    "C_UavTerminal",
+    "I_E_UavTerminal"
+] findIf { _x == _playerTerminal } != -1;

--- a/docs/wiki/feature/maptools.md
+++ b/docs/wiki/feature/maptools.md
@@ -25,7 +25,7 @@ This adds map tools that can be used to measure distances between two points or 
 This adds a plotting board that can be used to aid in the rapid usage and adjustment of short-ranged indirect fires, as well as quick measurements of directions and distances between points, and general land-navigation.
 
 ### 1.4 GPS on map
-If you are equipped with a vanilla GPS it will be shown on the map. (You don't need the `Map Tools` item in your inventory for this.)
+If you are equipped with a vanilla GPS or UAV Terminal, a GPS display will be shown on the map. (You don't need the `Map Tools` item in your inventory for this.)
 
 ## 2. Usage
 


### PR DESCRIPTION
**When merged this pull request will:**
- Show the GPS grid display on map when carrying a UAV Terminal, and not just the vanilla GPS item;
- Rephrase maptools documentation accordingly;