### PR TITLE
Options Menu - Fix main-menu news setting not working

### DIFF
--- a/addons/optionsmenu/initSettings.inc.sqf
+++ b/addons/optionsmenu/initSettings.inc.sqf
@@ -5,5 +5,9 @@ private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(aceNews)]
     LSTRING(showNewsOnMainMenu_name),
     _category,
     true,
-    0
+    0,
+    {
+        if (!hasInterface) exitWith {};
+        profileNamespace setVariable [QGVAR(showNewsOnMainMenu), _this];
+    }
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/blob/master/addons/optionsmenu/init_loadMainMenuBox.sqf#L22-L23
was expecting value set in profileNamespace like how ace_settings used to work