### PR TITLE
Common - Add word `weapon` to sway setting

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1829,12 +1829,12 @@
             <Turkish>Alt</Turkish>
         </Key>
         <Key ID="STR_ACE_Common_subcategory_sway">
-            <English>Sway</English>
+            <English>Weapon Sway</English>
             <Japanese>手ぶれ</Japanese>
             <Korean>무기 흔들림</Korean>
         </Key>
         <Key ID="STR_ACE_Common_EnableSway">
-            <English>Enable ACE Sway</English>
+            <English>Enable ACE Weapon Sway</English>
             <Japanese>ACE 手ぶれを有効化</Japanese>
             <Korean>ACE 무기 흔들림 추가</Korean>
         </Key>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1834,9 +1834,9 @@
             <Korean>무기 흔들림</Korean>
         </Key>
         <Key ID="STR_ACE_Common_EnableSway">
-            <English>Enable ACE Weapon Sway</English>
-            <Japanese>ACE 手ぶれを有効化</Japanese>
-            <Korean>ACE 무기 흔들림 추가</Korean>
+            <English>Enable Weapon Sway</English>
+            <Japanese>手ぶれを有効化</Japanese>
+            <Korean>무기 흔들림 추가</Korean>
         </Key>
         <Key ID="STR_ACE_Common_EnableSway_Description">
             <English>Enables weapon sway influenced by sway factors, such as stance, fatigue and medical condition.\nDisabling this setting will defer sway to vanilla or other mods.</English>


### PR DESCRIPTION
imho we could also drop the `ACE` because it's already under ace common?