### PR TITLE
Aircraft - Drone "Follow Unit" Waypoint Action

### DIFF
--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -40,7 +40,7 @@ private _action = [QGVAR(droneSetWaypointMove), localize "$STR_AC_MOVE",
 // follow unit/vehicle at turret location
 private _condition = {
     params ["_vehicle"];
-    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {cursorTarget isKindOf "CAManBase" || (cursorTarget isKindOf "LandVehicle")}
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull cursorTarget} && {cursorTarget isKindOf "CAManBase" || (cursorTarget isKindOf "LandVehicle")}
 };
 private _statement = {
     params ["_vehicle"];

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -22,7 +22,7 @@ if (!alive _vehicle) exitWith {};
 if (_vehicle getVariable [QGVAR(droneActionsAdded), false]) exitWith {};
 _vehicle setVariable [QGVAR(droneActionsAdded), true];
 
-// move to location
+// Move to location
 private _condition = {
     params ["_vehicle"];
     (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]}
@@ -37,13 +37,13 @@ private _action = [QGVAR(droneSetWaypointMove), localize "$STR_AC_MOVE",
     "\a3\3DEN\Data\CfgWaypoints\Move_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
 [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
-// follow unit/vehicle at turret location
-private _condition = {
+// Follow unit/vehicle at turret location
+_condition = {
     params ["_vehicle"];
     private _target = cursorTarget;
     (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull _target} && {["CAManBase", "LandVehicle", "Ship"] findIf {_target isKindOf _x} != -1}
 };
-private _statement = {
+_statement = {
     params ["_vehicle"];
     private _group = group driver _vehicle;
     private _pos = ([_vehicle, [0]] call FUNC(droneGetTurretTargetPos)) select 0;
@@ -51,8 +51,8 @@ private _statement = {
     private _followDistance = _vehicle getVariable [QGVAR(wpFollowDistance), 0];
     [[LLSTRING(DroneFollowHint), _followDistance], 3] call EFUNC(common,displayTextStructured);
 };
-private _action = [QGVAR(droneSetWaypointFollow), localize "$STR_AC_FOLLOW", "\a3\3DEN\Data\CfgWaypoints\Follow_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
-private _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
+_action = [QGVAR(droneSetWaypointFollow), localize "$STR_AC_FOLLOW", "\a3\3DEN\Data\CfgWaypoints\Follow_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
+[_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
 // Set drone follow distance
 _condition = {
@@ -68,7 +68,7 @@ _statement = {
     [[LLSTRING(DroneFollowHint), _value], 3] call EFUNC(common,displayTextStructured);
 };
 _action = [QGVAR(droneSetFollowDistance), LLSTRING(DroneFollowDistance), "", {}, _condition] call EFUNC(interact_menu,createAction);
-_base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
+private _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 private _followDistances = if (_vehicle isKindOf "Car_F") then {
     [0, 25, 50, 100, 200]
 } else {
@@ -76,7 +76,7 @@ private _followDistances = if (_vehicle isKindOf "Car_F") then {
 };
 {
     _action = [
-        str _x,
+        QGVAR(droneSetFollowDistance_) + str _x,
         str _x,
         "",
         _statement,
@@ -88,7 +88,7 @@ private _followDistances = if (_vehicle isKindOf "Car_F") then {
 } forEach _followDistances;
 
 if (_vehicle isKindOf "Air") then {
-    // loiter at location
+    // Loiter at location
     _condition = {
         params ["_vehicle"];
         (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]}
@@ -104,7 +104,7 @@ if (_vehicle isKindOf "Air") then {
     [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
 
-    // set height
+    // Set height
     _condition = {
         params ["_vehicle"];
         (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]}
@@ -123,7 +123,7 @@ if (_vehicle isKindOf "Air") then {
     } forEach [20, 50, 200, 500, 2000];
 
 
-    // set loiter radius
+    // Set loiter radius
     _condition = {
         params ["_vehicle"];
         private _group = group driver _vehicle;
@@ -146,7 +146,7 @@ if (_vehicle isKindOf "Air") then {
     } forEach [500, 750, 1000, 1250, 1500];
 
 
-    // set loiter direction
+    // Set loiter direction
     _condition = {
         params ["_vehicle", "", "_args"];
         private _group = group driver _vehicle;

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -70,7 +70,7 @@ _statement = {
 _action = [QGVAR(droneSetFollowDistance), LLSTRING(DroneFollowDistance), "", {}, _condition] call EFUNC(interact_menu,createAction);
 _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 private _followDistances = [];
-if (_vehicle isKindOf "UGV_01_base_F") then {
+if (_vehicle isKindOf "Car_F") then {
     _followDistances = [0, 25, 50, 100, 200];
 } else {
     _followDistances = [0, 100, 200, 300, 400, 500];

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -54,12 +54,17 @@ private _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_
 // Set drone follow distance
 _condition = {
     params ["_vehicle"];
-    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]}
+    private _group = group driver _vehicle;
+    private _index = (currentWaypoint _group) min count waypoints _group;
+    private _waypoint = [_group, _index];
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {(waypointType _waypoint) == "HOLD"}
 };
 _statement = {
     params ["_vehicle", "", "_value"];
     _vehicle setVariable [QGVAR(wpFollowDistance), _value];
 };
+_action = [QGVAR(droneSetFollowDistance), "Follow Distance", "", {}, _condition] call EFUNC(interact_menu,createAction);
+_base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 private _followDistances = [];
 if (_vehicle isKindOf "UGV_01_base_F") then {
     _followDistances = [0, 25, 50, 100, 200];

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -63,7 +63,7 @@ _statement = {
     params ["_vehicle", "", "_value"];
     _vehicle setVariable [QGVAR(wpFollowDistance), _value];
 };
-_action = [QGVAR(droneSetFollowDistance), "Follow Distance", "", {}, _condition] call EFUNC(interact_menu,createAction);
+_action = [QGVAR(droneSetFollowDistance), LLSTRING(DroneFollowDistance), "", {}, _condition] call EFUNC(interact_menu,createAction);
 _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 private _followDistances = [];
 if (_vehicle isKindOf "UGV_01_base_F") then {

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -41,7 +41,7 @@ private _action = [QGVAR(droneSetWaypointMove), localize "$STR_AC_MOVE",
 private _condition = {
     params ["_vehicle"];
     private _target = cursorTarget;
-    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull _target} && {_target isKindOf "CAManBase" || (_target isKindOf "LandVehicle")}
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull _target} && {["CAManBase", "LandVehicle"] findIf {_target isKindOf _x} != -1}
 };
 private _statement = {
     params ["_vehicle"];

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -40,7 +40,8 @@ private _action = [QGVAR(droneSetWaypointMove), localize "$STR_AC_MOVE",
 // follow unit/vehicle at turret location
 private _condition = {
     params ["_vehicle"];
-    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull cursorTarget} && {cursorTarget isKindOf "CAManBase" || (cursorTarget isKindOf "LandVehicle")}
+    private _target = cursorTarget;
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull _target} && {_target isKindOf "CAManBase" || (_target isKindOf "LandVehicle")}
 };
 private _statement = {
     params ["_vehicle"];

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -69,11 +69,10 @@ _statement = {
 };
 _action = [QGVAR(droneSetFollowDistance), LLSTRING(DroneFollowDistance), "", {}, _condition] call EFUNC(interact_menu,createAction);
 _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
-private _followDistances = [];
-if (_vehicle isKindOf "Car_F") then {
-    _followDistances = [0, 25, 50, 100, 200];
+private _followDistances = if (_vehicle isKindOf "Car_F") then {
+    [0, 25, 50, 100, 200]
 } else {
-    _followDistances = [0, 100, 200, 300, 400, 500];
+    [0, 100, 200, 300, 400, 500]
 };
 {
     _action = [

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -41,7 +41,7 @@ private _action = [QGVAR(droneSetWaypointMove), localize "$STR_AC_MOVE",
 private _condition = {
     params ["_vehicle"];
     private _target = cursorTarget;
-    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull _target} && {["CAManBase", "LandVehicle"] findIf {_target isKindOf _x} != -1}
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {!isNull _target} && {["CAManBase", "LandVehicle", "Ship"] findIf {_target isKindOf _x} != -1}
 };
 private _statement = {
     params ["_vehicle"];

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -37,6 +37,20 @@ private _action = [QGVAR(droneSetWaypointMove), localize "$STR_AC_MOVE",
     "\a3\3DEN\Data\CfgWaypoints\Move_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
 [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
+// follow unit/vehicle at turret location
+private _condition = {
+    params ["_vehicle"];
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]} && {cursorTarget isKindOf "CAManBase" || (cursorTarget isKindOf "LandVehicle")}
+};
+private _statement = {
+    params ["_vehicle"];
+    private _group = group driver _vehicle;
+    private _pos = ([_vehicle, [0]] call FUNC(droneGetTurretTargetPos)) select 0;
+    [QGVAR(droneSetWaypoint), [_vehicle, _group, _pos, "FOLLOW", cursorTarget], _group] call CBA_fnc_targetEvent;
+};
+private _action = [QGVAR(droneSetWaypointFollow), localize "$STR_AC_FOLLOW", "\a3\3DEN\Data\CfgWaypoints\Follow_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
+[_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
+
 
 if (_vehicle isKindOf "Air") then {
     // loiter at location

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -49,8 +49,35 @@ private _statement = {
     [QGVAR(droneSetWaypoint), [_vehicle, _group, _pos, "FOLLOW", cursorTarget], _group] call CBA_fnc_targetEvent;
 };
 private _action = [QGVAR(droneSetWaypointFollow), localize "$STR_AC_FOLLOW", "\a3\3DEN\Data\CfgWaypoints\Follow_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
-[_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
+private _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
 
+// Set drone follow distance
+_condition = {
+    params ["_vehicle"];
+    (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]}
+};
+_statement = {
+    params ["_vehicle", "", "_value"];
+    _vehicle setVariable [QGVAR(wpFollowDistance), _value];
+};
+private _followDistances = [];
+if (_vehicle isKindOf "UGV_01_base_F") then {
+    _followDistances = [0, 25, 50, 100, 200];
+} else {
+    _followDistances = [0, 100, 200, 300, 400, 500];
+};
+{
+    _action = [
+        str _x,
+        str _x,
+        "",
+        _statement,
+        {true},
+        {},
+        _x
+    ] call EFUNC(interact_menu,createAction);
+    [_vehicle, 1, _base, _action] call EFUNC(interact_menu,addActionToObject);
+} forEach _followDistances;
 
 if (_vehicle isKindOf "Air") then {
     // loiter at location
@@ -58,7 +85,7 @@ if (_vehicle isKindOf "Air") then {
         params ["_vehicle"];
         (missionNamespace getVariable [QGVAR(droneWaypoints), true]) && {waypointsEnabledUAV _vehicle} && {(ACE_controlledUAV select 2) isEqualTo [0]}
     };
-    _statement = {        
+    _statement = {
         params ["_vehicle"];
         private _group = group driver _vehicle;
         private _pos = ([_vehicle, [0]] call FUNC(droneGetTurretTargetPos)) select 0;

--- a/addons/aircraft/functions/fnc_droneAddActions.sqf
+++ b/addons/aircraft/functions/fnc_droneAddActions.sqf
@@ -47,6 +47,8 @@ private _statement = {
     private _group = group driver _vehicle;
     private _pos = ([_vehicle, [0]] call FUNC(droneGetTurretTargetPos)) select 0;
     [QGVAR(droneSetWaypoint), [_vehicle, _group, _pos, "FOLLOW", cursorTarget], _group] call CBA_fnc_targetEvent;
+    private _followDistance = _vehicle getVariable [QGVAR(wpFollowDistance), 0];
+    [[LLSTRING(DroneFollowHint), _followDistance], 3] call EFUNC(common,displayTextStructured);
 };
 private _action = [QGVAR(droneSetWaypointFollow), localize "$STR_AC_FOLLOW", "\a3\3DEN\Data\CfgWaypoints\Follow_ca.paa", _statement, _condition] call EFUNC(interact_menu,createAction);
 private _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);
@@ -62,6 +64,7 @@ _condition = {
 _statement = {
     params ["_vehicle", "", "_value"];
     _vehicle setVariable [QGVAR(wpFollowDistance), _value];
+    [[LLSTRING(DroneFollowHint), _value], 3] call EFUNC(common,displayTextStructured);
 };
 _action = [QGVAR(droneSetFollowDistance), LLSTRING(DroneFollowDistance), "", {}, _condition] call EFUNC(interact_menu,createAction);
 _base = [_vehicle, 1, ["ACE_SelfActions"], _action] call EFUNC(interact_menu,addActionToObject);

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -50,6 +50,7 @@ if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target i
             _waypoint select 1 != currentWaypoint _group || 
             {!alive _vehicle} || {isNull _target}
         ) exitWith {
+            deleteWaypoint _waypoint;
             [_handle] call CBA_fnc_removePerFrameHandler;
         };
 

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -48,7 +48,7 @@ if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target i
 
         if ( // Abort PFH if a new waypoint is created via UAV Terminal or ACE Interaction
             _waypoint select 1 != currentWaypoint _group || 
-            {!alive _vehicle}
+            {!alive _vehicle} || {isNull _target}
         ) exitWith {
             [_handle] call CBA_fnc_removePerFrameHandler;
         };

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -38,7 +38,7 @@ _pos set [
 _waypoint = _group addWaypoint [_pos, 0];
 if (_type == "FOLLOW" && {_target isKindOf "CAManBase" || (_target isKindOf "LandVehicle")}) then {
     _waypoint setWaypointType "HOLD";
-    _waypoint waypointAttachVehicle _target;
+    //_waypoint waypointAttachVehicle _target;
     [{
         params ["_args", "_handle"];
         _args params ["_vehicle", "_group", "_waypoint", "_target"];
@@ -50,7 +50,14 @@ if (_type == "FOLLOW" && {_target isKindOf "CAManBase" || (_target isKindOf "Lan
             [_handle] call CBA_fnc_removePerFrameHandler;
         };
 
-        _waypoint setWaypointPosition [(getPosASL _target), -1];
+        private _followDistance = _vehicle getVariable [QGVAR(wpFollowDistance), 0];
+        if ((_vehicle distance2D _target) < _followDistance) then {
+            _waypoint setWaypointPosition [(getPosASL _vehicle), -1];
+            systemChat "waypoint updated, waiting.";
+        } else {
+            _waypoint setWaypointPosition [(getPosASL _target), -1];
+            systemChat "waypoint updated, following.";
+        };
     }, 3, [_vehicle, _group, _waypoint, _target]] call CBA_fnc_addPerFrameHandler;
 };
 

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -8,6 +8,7 @@
  * 1: Group <GROUP>
  * 2: Pos 2D <ARRAY>
  * 3: Type <STRING>
+ * 4: Target to follow <OBJECT> (default: objNull)
  *
  * Return Value:
  * None
@@ -47,7 +48,7 @@ if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target i
         _args params ["_vehicle", "_group", "_waypoint", "_target"];
 
         if ( // Abort PFH if a new waypoint is created via UAV Terminal or ACE Interaction
-            _waypoint select 1 != currentWaypoint _group || 
+            _waypoint select 1 != currentWaypoint _group ||
             {!alive _vehicle} || {isNull _target}
         ) exitWith {
             deleteWaypoint _waypoint;

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -36,7 +36,7 @@ _pos set [
 
 // [_group] call CBA_fnc_clearWaypoints;
 _waypoint = _group addWaypoint [_pos, 0];
-if (_type == "FOLLOW" && {["CAManBase", "LandVehicle"] findIf {_target isKindOf _x} != -1}) then {
+if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target isKindOf _x} != -1}) then {
     _waypoint setWaypointType "HOLD";
     //_waypoint waypointAttachVehicle _target;
     [{

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_vehicle", "_group", "_pos", "_type"];
+params ["_vehicle", "_group", "_pos", "_type", "_target"];
 TRACE_4("droneSetWaypoint",_vehicle,_group,_pos,_type);
 
 private _index = (currentWaypoint _group) min count waypoints _group;
@@ -37,6 +37,9 @@ _pos set [
 // [_group] call CBA_fnc_clearWaypoints;
 _waypoint = _group addWaypoint [_pos, 0];
 _waypoint setWaypointType _type;
+if (_type == "FOLLOW" && {_target isKindOf "CAManBase" || (_target isKindOf "LandVehicle")}) then {
+    _waypoint waypointAttachVehicle _target;
+};
 
 TRACE_3("",_currentHeight,_currentLoiterRadius,_currentLoiterType);
 if (_currentHeight > 1) then { _vehicle flyInHeight _currentHeight; };

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -55,9 +55,9 @@ if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target i
 
         private _followDistance = _vehicle getVariable [QGVAR(wpFollowDistance), 0];
         if ((_vehicle distance2D _target) < _followDistance) then {
-            _waypoint setWaypointPosition [(getPosASL _vehicle), -1];
+            _waypoint setWaypointPosition [getPosASL _vehicle, -1];
         } else {
-            _waypoint setWaypointPosition [(getPosASL _target), -1];
+            _waypoint setWaypointPosition [getPosASL _target, -1];
         };
     }, 3, [_vehicle, _group, _waypoint, _target]] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_vehicle", "_group", "_pos", "_type", "_target"];
+params ["_vehicle", "_group", "_pos", "_type", ["_target", objNull]];
 TRACE_4("droneSetWaypoint",_vehicle,_group,_pos,_type);
 
 private _index = (currentWaypoint _group) min count waypoints _group;
@@ -37,25 +37,21 @@ _pos set [
 // [_group] call CBA_fnc_clearWaypoints;
 _waypoint = _group addWaypoint [_pos, 0];
 if (_type == "FOLLOW" && {_target isKindOf "CAManBase" || (_target isKindOf "LandVehicle")}) then {
-    if (_vehicle isKindOf "UGV_01_base_F") then { // Vanilla follow waypoint is broken for UGVs, requiring a workaround.
-        _waypoint setWaypointType "HOLD";
-        [{
-            params ["_args", "_handle"];
-            _args params ["_vehicle", "_group", "_waypoint", "_target"];
+    _waypoint setWaypointType "HOLD";
+    _waypoint waypointAttachVehicle _target;
+    [{
+        params ["_args", "_handle"];
+        _args params ["_vehicle", "_group", "_waypoint", "_target"];
 
-            if ( // Abort PFH if a new waypoint is created via UAV Terminal or ACE Interaction
-                _waypoint select 1 != currentWaypoint _group || 
-                {!alive _vehicle}
-            ) exitWith {
-                [_handle] call CBA_fnc_removePerFrameHandler;
-            };
+        if ( // Abort PFH if a new waypoint is created via UAV Terminal or ACE Interaction
+            _waypoint select 1 != currentWaypoint _group || 
+            {!alive _vehicle}
+        ) exitWith {
+            [_handle] call CBA_fnc_removePerFrameHandler;
+        };
 
-            _waypoint setWaypointPosition [(getPosASL _target), -1];
-        }, 3, [_vehicle, _group, _waypoint, _target]] call CBA_fnc_addPerFrameHandler;
-    } else {
-        _waypoint setWaypointType _type;
-        _waypoint waypointAttachVehicle _target;
-    };
+        _waypoint setWaypointPosition [(getPosASL _target), -1];
+    }, 3, [_vehicle, _group, _waypoint, _target]] call CBA_fnc_addPerFrameHandler;
 };
 
 TRACE_3("",_currentHeight,_currentLoiterRadius,_currentLoiterType);

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -34,11 +34,9 @@ _pos set [
     [0, _currentHeight] select (_currentHeight >= 50)
 ];
 
-// [_group] call CBA_fnc_clearWaypoints;
 _waypoint = _group addWaypoint [_pos, 0];
 if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target isKindOf _x} != -1}) then {
     _waypoint setWaypointType "HOLD";
-    //_waypoint waypointAttachVehicle _target;
     [{
         params ["_args", "_handle"];
         _args params ["_vehicle", "_group", "_waypoint", "_target"];
@@ -53,10 +51,8 @@ if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target i
         private _followDistance = _vehicle getVariable [QGVAR(wpFollowDistance), 0];
         if ((_vehicle distance2D _target) < _followDistance) then {
             _waypoint setWaypointPosition [(getPosASL _vehicle), -1];
-            systemChat "waypoint updated, waiting.";
         } else {
             _waypoint setWaypointPosition [(getPosASL _target), -1];
-            systemChat "waypoint updated, following.";
         };
     }, 3, [_vehicle, _group, _waypoint, _target]] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -35,6 +35,11 @@ _pos set [
 ];
 
 _waypoint = _group addWaypoint [_pos, 0];
+// The Vanilla "FOLLOW"-type waypoint is not used directly, due to 2 main issues (as of v2.16):
+// - It does not work at all for UGVs, which is a known issue https://feedback.bistudio.com/T126283;
+// - No clear scripting way was found to mimic the UAV Terminal's "Follow Distance" functionality;
+// Instead, the solution for both UAV and UGV following consists of a CBA PFH that moves a "HOLD"-type Waypoint every 3 seconds.
+// Either on the target itself, or on the Drone's current position if the target is within the desired follow distance.
 if (_type == "FOLLOW" && {["CAManBase", "LandVehicle", "Ship"] findIf {_target isKindOf _x} != -1}) then {
     _waypoint setWaypointType "HOLD";
     [{

--- a/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
+++ b/addons/aircraft/functions/fnc_droneSetWaypoint.sqf
@@ -36,7 +36,7 @@ _pos set [
 
 // [_group] call CBA_fnc_clearWaypoints;
 _waypoint = _group addWaypoint [_pos, 0];
-if (_type == "FOLLOW" && {_target isKindOf "CAManBase" || (_target isKindOf "LandVehicle")}) then {
+if (_type == "FOLLOW" && {["CAManBase", "LandVehicle"] findIf {_target isKindOf _x} != -1}) then {
     _waypoint setWaypointType "HOLD";
     //_waypoint waypointAttachVehicle _target;
     [{

--- a/addons/aircraft/stringtable.xml
+++ b/addons/aircraft/stringtable.xml
@@ -177,5 +177,10 @@
             <Russian>30мм СБ 5:1</Russian>
             <Korean>30mm CM 5:1</Korean>
         </Key>
+        <Key ID="STR_ACE_Aircraft_DroneFollowDistance">
+            <English>Follow Distance</English>
+            <Italian>Distanza di seguimento</Italian>
+            <German>Folge-Entfernung</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/aircraft/stringtable.xml
+++ b/addons/aircraft/stringtable.xml
@@ -182,5 +182,10 @@
             <Italian>Distanza di seguimento</Italian>
             <German>Folge-Entfernung</German>
         </Key>
+        <Key ID="STR_ACE_Aircraft_DroneFollowHint">
+            <English>Following unit within %1m</English>
+            <Italian>Seguendo unità entro %1m</Italian>
+            <German>Folgt Einheit bis zu %1m</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/logistics_uavbattery/functions/fnc_canRefuelUAV.sqf
+++ b/addons/logistics_uavbattery/functions/fnc_canRefuelUAV.sqf
@@ -18,4 +18,4 @@
 
 params ["_caller", "_target"];
 
-("ACE_UAVBattery" in (_caller call EFUNC(common,uniqueItems))) && {(fuel _target) < 1} && {(speed _target) < 1} && {!(isEngineOn _target)} && {(_target distance _caller) <= 4}
+(alive _target) && {"ACE_UAVBattery" in (_caller call EFUNC(common,uniqueItems))} && {(fuel _target) < 1} && {(speed _target) < 1} && {!(isEngineOn _target)} && {(_target distance _caller) <= 4}


### PR DESCRIPTION
**When merged this pull request will:**
- Add a "Follow Unit" Waypoint Action to Drones, to emulate the vanilla "Follow Unit" behaviour from the UAV Terminal, which is unfortunately only available on other drones unless "friendly map content" is enabled;
  - [x] Follow action is available when pointing at a man/vehicle (currently via `cursorTarget`) and creates a persistent "follow" type waypoint;
    - [x] Works from UAVs;
    - [x] Works from UGVs;
  - [x] Follow action permits selecting a min distance to follow to, just like the vanilla interface (unclear how that logic works);
- Fix the "recharge" action being shown on destroyed drones;