### PR TITLE
Yardage - Fix broken display in 2.16

### DIFF
--- a/addons/yardage450/functions/fnc_turnOn.sqf
+++ b/addons/yardage450/functions/fnc_turnOn.sqf
@@ -33,12 +33,15 @@ GVAR(active) = true;
 [{
     if (CBA_missionTime - GVAR(powerOnTime) > 30) exitWith {
         GVAR(active) = false;
-        74210 cutText ["", "PLAIN"];
+        QUOTE(ADDON) cutText ["", "PLAIN"];
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };
 
     if (currentWeapon ACE_player == "ACE_Yardage450" && cameraView == "GUNNER") then {
-        74210 cutRsc ["ACE_RscYardage450", "PLAIN", 1, false];
+        if (isNil {__dsp} || {isNull __dsp} || {ctrlIDD __dsp != -1}) then {
+            TRACE_1("making display",__dsp);
+            QUOTE(ADDON) cutRsc ["ACE_RscYardage450", "PLAIN", 1, false];
+        };
 
         __ctrlLaser ctrlShow GVAR(lasing);
         if (GVAR(targetAcquired)) then {
@@ -51,7 +54,7 @@ GVAR(active) = true;
         __ctrlMeters ctrlShow !GVAR(useYards);
         __ctrlYards ctrlShow GVAR(useYards);
     } else {
-        74210 cutText ["", "PLAIN"];
+        QUOTE(ADDON) cutText ["", "PLAIN"];
     };
 
 }, 0, []] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Fix #9891
Before the code would spam `74210 cutText ["", "PLAIN"];` each frame
which should be valid, but it does create a new display each time
for some reason the `onUnload` of the last display would run after the `onLoad` of the new display
(apparently fixed in profiling branch)

```
Normal 2.16.151618:
[ACE] (yardage450) TRACE: 2198 before cut: (uiNamespace getVariable "ACE_RscYardage450")=any z\ace\addons\yardage450\functions\fnc_turnOn.sqf:46
"""onLoad"""
[ACE] (yardage450) TRACE: 2198 after cut: (uiNamespace getVariable "ACE_RscYardage450")=Display #-1 z\ace\addons\yardage450\functions\fnc_turnOn.sqf:50

[ACE] (yardage450) TRACE: 2226 before cut: (uiNamespace getVariable "ACE_RscYardage450")=Display #-1 z\ace\addons\yardage450\functions\fnc_turnOn.sqf:46
"""onLoad"""
"""onUnload""" // notice the order, this does `ACE_RscYardage450 = displayNull;`
[ACE] (yardage450) TRACE: 2226 after cut: (uiNamespace getVariable "ACE_RscYardage450")=No display z\ace\addons\yardage450\functions\fnc_turnOn.sqf:50
```

```
Profiling 2.16.151648:
[ACE] (yardage450) TRACE: 1325 before cut: (uiNamespace getVariable "ACE_RscYardage450")=any z\ace\addons\yardage450\functions\fnc_turnOn.sqf:46
"""onLoad"""
[ACE] (yardage450) TRACE: 1325 after cut: (uiNamespace getVariable "ACE_RscYardage450")=Display #-1 z\ace\addons\yardage450\functions\fnc_turnOn.sqf:50

[ACE] (yardage450) TRACE: 1353 before cut: (uiNamespace getVariable "ACE_RscYardage450")=Display #-1 z\ace\addons\yardage450\functions\fnc_turnOn.sqf:46
"""onUnload"""
"""onLoad"""
[ACE] (yardage450) TRACE: 1353 after cut: (uiNamespace getVariable "ACE_RscYardage450")=Display #-1 z\ace\addons\yardage450\functions\fnc_turnOn.sqf:50
```
