### PR TITLE
CSW - Force `QGVAR(handleExtraMagazinesType)` to be respected

### DIFF
--- a/addons/csw/functions/fnc_reload_handleReturnAmmo.sqf
+++ b/addons/csw/functions/fnc_reload_handleReturnAmmo.sqf
@@ -41,7 +41,7 @@ if ((_fullMagazines == 0) && {_bulletsRemaining == 0}) exitWith {};
 private _container = _unloadTo getVariable [QGVAR(container), objNull];
 if ((_container distance _unloadTo) > 10) then { _container = objNull; };
 if (isNull _container) then {
-    _container = (nearestObjects [_unloadTo, [QGVAR(ammo_holder), "GroundWeaponHolder"], 10]) param [0, objNull];
+    _container = (nearestObjects [_unloadTo, [["GroundWeaponHolder"], [QGVAR(ammo_holder)]] select GVAR(handleExtraMagazinesType), 10]) param [0, objNull];
 };
 
 


### PR DESCRIPTION
**When merged this pull request will:**
- When returning ammo, it could find weapon holders when ammo storage was set to ammo box and vice versa. This changes makes it so it respects the setting strictly.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
