### PR TITLE
Interaction - Add door events

### DIFF
--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -63,6 +63,9 @@ GVAR(doorTargetPhase) = _house animationPhase (_animations select 0);
 GVAR(isOpeningDoor) = true;
 GVAR(usedScrollWheel) = false;
 
+// Rise local started opening event
+[QGVAR(doorOpeningStarted)] call CBA_fnc_localEvent;
+
 [{
     (_this select 0) params ["_house", "_animations", "_position", "_time", "_frame"];
 
@@ -75,6 +78,9 @@ GVAR(usedScrollWheel) = false;
 
             {_house animate [_x, _phase]; false} count _animations;
         };
+
+        // Rise local stopped opening event
+        [QGVAR(doorOpeningStopped)] call CBA_fnc_localEvent;
     };
 
     // check if player moved too far away


### PR DESCRIPTION
**When merged this pull request will:**
- Adds events for door opening interaction
- https://discord.com/channels/976165959041679380/976224730422063214/1224467574926872597

Given that all the important vars are made global just before this event is risen and it's all local, I don't think it's necessary to use arguments.

 ### IMPORTANT
* If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
* [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
* Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.