### PR TITLE
Arsenal - Fix `FUNC(baseAttachment)` returning non-CBA item modes

### DIFF
--- a/addons/arsenal/functions/fnc_baseAttachment.sqf
+++ b/addons/arsenal/functions/fnc_baseAttachment.sqf
@@ -26,6 +26,14 @@ private _cfgWeapons = configfile >> "CfgWeapons";
 private _config = _cfgWeapons >> _item;
 _item = configName _config;
 
+// If the switch config entries are inherited, ignore
+if (
+    (inheritsFrom (_config >> "MRT_SwitchItemNextClass") isNotEqualTo (_config >> "MRT_SwitchItemNextClass")) ||
+    {inheritsFrom (_config >> "MRT_SwitchItemPrevClass") isNotEqualTo (_config >> "MRT_SwitchItemPrevClass")}
+) exitWith {
+    _item // return
+};
+
 while {
     _config = _cfgWeapons >> getText (_config >> "MRT_SwitchItemNextClass");
     isClass _config && {_switchableClasses pushBackUnique configName _config != -1}


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- This *assumes* that each attachment that has valid entries redefines them.
- Needs more testing. I tested with RHS, but I want more testing from others.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
