### PR TITLE
Hearing - Find used magazine for determining combat deafness

### DIFF
--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -4,7 +4,7 @@ if (!hasInterface) exitWith {};
 
 #include "initKeybinds.inc.sqf"
 
-GVAR(cacheAmmoLoudness) = call CBA_fnc_createNamespace;
+GVAR(cacheAmmoLoudness) = createHashMap;
 
 GVAR(deafnessDV) = 0;
 GVAR(deafnessPrior) = 0;

--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -4,25 +4,25 @@
  * Handles deafness due to large-caliber weapons going off near the player.
  *
  * Arguments:
- * 0: Unit - Object the event handler is assigned to <OBJECT>
- * 1: Firer: Object - Object which fires a weapon near the unit <OBJECT>
- * 2: Distance - Distance in meters between the unit and firer <NUMBER>
- * 3: weapon - Fired weapon <STRING>
- * 4: muzzle - Muzzle that was used (not used) <STRING>
- * 5: mode - Current mode of the fired weapon (not used) <STRING>
- * 6: ammo - Ammo used <STRING>
+ * 0: Object the event handler is assigned to <OBJECT> (unused)
+ * 1: Object which fires a weapon near the unit <OBJECT>
+ * 2: Distance in meters between the unit and firer <NUMBER>
+ * 3: Weapon <STRING>
+ * 4: Muzzle <STRING>
+ * 5: Current mode of the fired weapon <STRING> (unused)
+ * 6: Ammo <STRING>
+ * 7: Unit that fired the weapon <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [clientFiredNearEvent] call ace_hearing_fnc_firedNear
- * [player, player, 10, "arifle_MX_ACO_pointer_F", "arifle_MX_ACO_pointer_F", "single", "B_65x39_Caseless"] call ace_hearing_fnc_firedNear
+ * [player, player, 10, "arifle_MX_ACO_pointer_F", "arifle_MX_ACO_pointer_F", "single", "B_65x39_Caseless", player] call ace_hearing_fnc_firedNear
  *
  * Public: No
  */
 
-params ["_object", "_firer", "_distance", "_weapon", "", "", "_ammo"];
+params ["", "_firer", "_distance", "_weapon", "_muzzle", "", "_ammo", "_gunner"];
 
 if (_weapon in ["Throw", "Put"]) exitWith {};
 if (_distance > 50) exitWith {};
@@ -32,62 +32,57 @@ private _vehAttenuation = [GVAR(playerVehAttenuation), 1] select (
 );
 private _distance = 1 max _distance;
 
-private _silencer = switch (_weapon) do {
-    case (primaryWeapon _firer) : {(primaryWeaponItems _firer) select 0};
-    case (secondaryWeapon _firer) : {(secondaryWeaponItems _firer) select 0};
-    case (handgunWeapon _firer) : {(handgunItems _firer) select 0};
-    default {""};
+private _magazine = if (_gunner == _firer) then {
+    // Units not in vehicles
+    private _weaponItems = weaponsItems [_firer, true];
+    private _index = _weaponItems findIf {(_x select 0) == _weapon};
+
+    if (_index == -1) exitWith {""};
+
+    _weaponItems = _weaponItems select _index;
+
+    // Check if the secondary muzzle was fired; If not, assume it's the primary muzzle
+    if (_weaponItems select 5 param [2, ""] == _muzzle) then {
+        _weaponItems select 5 param [0, ""]
+    } else {
+        _weaponItems select 4 param [0, ""]
+    };
+} else {
+    _firer currentMagazineTurret (_firer unitTurret _gunner)
+};
+
+if (_magazine == "") exitWith {
+    TRACE_5("No mag for weapon/ammo??",_weapon,_muzzle,_ammo_firer,_gunner);
 };
 
 private _audibleFireCoef = 1;
-if (_silencer != "") then {
-    _audibleFireCoef = getNumber (configFile >> "CfgWeapons" >> _silencer >> "ItemInfo" >> "AmmoCoef" >> "audibleFire");
+private _suppressor = _weaponItems select 1;
+
+if (_suppressor != "") then {
+    _audibleFireCoef = getNumber (configFile >> "CfgWeapons" >> _suppressor >> "ItemInfo" >> "AmmoCoef" >> "audibleFire");
 };
 
-private _loudness = GVAR(cacheAmmoLoudness) getVariable (format ["%1%2",_weapon,_ammo]);
-if (isNil "_loudness") then {
-    private _muzzles = getArray (configFile >> "CfgWeapons" >> _weapon >> "muzzles");
-    private _weaponMagazines = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines");
-    {
-        if (_x != "this") then {
-            private _muzzleMagazines = getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines");
-            _weaponMagazines append _muzzleMagazines;
-        };
-    } forEach _muzzles;
-    {
-        private _ammoType = getText(configFile >> "CfgMagazines" >> _x >> "ammo");
-        _weaponMagazines set [_forEachIndex, [_x, _ammoType]];
-    } forEach _weaponMagazines;
+private _loudness = GVAR(cacheAmmoLoudness) getOrDefaultCall [format ["%1$%2$%3", _weapon, _ammo, _magazine], {
+    private _cfgAmmo = configFile >> "CfgAmmo";
+    private _initSpeed = getNumber (configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
+    private _ammoConfig = _cfgAmmo >> _ammo;
+    private _caliber = getNumber (_ammoConfig >> "ACE_caliber");
 
-    private _magazine = "";
-    {
-        _x params ["_magazineType", "_ammoType"];
-        if (_ammoType == _ammo) exitWith {
-            _magazine = _magazineType;
-        };
-    } forEach _weaponMagazines;
-
-    if (_magazine == "") then {
-        _loudness = 0;
-        TRACE_2("No mag for Weapon/Ammo??",_weapon,_ammo);
-    } else {
-        private _initSpeed = getNumber(configFile >> "CfgMagazines" >> _magazine >> "initSpeed");
-        private _caliber = getNumber (configFile >> "CfgAmmo" >> _ammo >> "ACE_caliber");
-        _caliber = call {
-            // If explicilty defined, use ACE_caliber
-            if ((count configProperties [(configFile >> "CfgAmmo" >> _ammo), "configName _x == 'ACE_caliber'", false]) == 1) exitWith {_caliber};
-            if (_ammo isKindOf ["ShellBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
-            if (_ammo isKindOf ["RocketBase", (configFile >> "CfgAmmo")]) exitWith { 200 };
-            if (_ammo isKindOf ["MissileBase", (configFile >> "CfgAmmo")]) exitWith { 600 };
-            if (_ammo isKindOf ["SubmunitionBase", (configFile >> "CfgAmmo")]) exitWith { 80 };
-            [_caliber, 6.5] select (_caliber <= 0)
-        };
-
-        _loudness = (_caliber ^ 1.25 / 10) * (_initspeed / 1000) / 5;
-        TRACE_6("building cache",_weapon,_ammo,_magazine,_initSpeed,_caliber,_loudness);
+    _caliber = switch (true) do {
+        // If explicilty defined, use ACE_caliber
+        case (inheritsFrom (_ammoConfig >> "ACE_caliber") isEqualTo _ammoConfig): {_caliber};
+        case (_ammo isKindOf ["ShellBase", _cfgAmmo]): {80};
+        case (_ammo isKindOf ["RocketBase", _cfgAmmo]): {200};
+        case (_ammo isKindOf ["MissileBase", _cfgAmmo]): {600};
+        case (_ammo isKindOf ["SubmunitionBase", _cfgAmmo]): {80};
+        default {[_caliber, 6.5] select (_caliber <= 0)};
     };
-    GVAR(cacheAmmoLoudness) setVariable [(format ["%1%2",_weapon,_ammo]), _loudness];
-};
+
+    private _loudness = (_caliber ^ 1.25 / 10) * (_initspeed / 1000) / 5;
+    TRACE_6("building cache",_weapon,_ammo,_magazine,_initSpeed,_caliber,_loudness);
+
+    _loudness
+}, true];
 
 _loudness = _loudness * _audibleFireCoef;
 private _strength = _vehAttenuation * (_loudness - (_loudness / 50 * _distance)); // linear drop off


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Improve the caching by using the magazine name (`initSpeed` relies on the magazine) and by switching to a hashmap.

I've tested it, but I want someone who uses ACE hearing to also test it, as I don't usually enable ACE hearing.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
