### PR TITLE
Hearing - Require mission restart for combat deafness settings change

### DIFF
--- a/addons/hearing/initSettings.inc.sqf
+++ b/addons/hearing/initSettings.inc.sqf
@@ -5,7 +5,9 @@ private _category = format ["ACE %1", localize LSTRING(Module_DisplayName)];
     [LSTRING(EnableCombatDeafness_DisplayName), LSTRING(EnableCombatDeafness_Description)],
     _category,
     true,
-    1
+    1,
+    {[QGVAR(enableCombatDeafness), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- It always required a mission restart to change the setting, but now the user is informed about it.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
