### PR TITLE
Interact menu - Fix condition in consolidated menu

### DIFF
--- a/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
+++ b/addons/interact_menu/functions/fnc_collectActiveActionTree.sqf
@@ -109,14 +109,14 @@ if ((_activeChildren isEqualTo []) && {_statementCode isEqualTo {}}) exitWith {
 
 if (GVAR(consolidateSingleChild) && {count _activeChildren == 1} && {_statementCode isEqualTo {}}) then {
     _activeChildren select 0 params ["_childActionData", "_childChildren", "_childObject"];
-    _childActionData params ["", "_displayNameChild", "_iconChild", "_statementChild", "", "", "_customParamsChild", "", "", "_paramsChild"];
+    _childActionData params ["", "_displayNameChild", "_iconChild", "_statementChild", "_conditionChild", "_insertChildrenChild", "_customParamsChild", "", "", "_paramsChild"];
     _origActionData = [
         _actionName,
         format ["%1 > %2", _displayName, _displayNameChild],
         _iconChild,
         _statementChild,
-        _conditionCode,
-        _insertChildrenCode,
+        _conditionChild,
+        _insertChildrenChild,
         _customParamsChild,
         _position,
         _distance,


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Currently consolidated menu runs original condition code before statement but with child custom params. This can lead to error when child params are different to parent params.

Thanks @mrschick for another pointing to problem in #9876.

`_insertChildrenChild` changes are made just for consistency. In fact it can be replaced with `{}` because it looks like it's never used after `fnc_collectActiveActionTree`.

I don't know why this wasn't implemented in #8060 :-(