### PR TITLE
Medical Treatment - Enforce bandage effectiveness variable type

### DIFF
--- a/addons/medical_treatment/functions/fnc_bandageLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_bandageLocal.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_patient", "_bodyPart", "_bandage", ["_bandageEffectiveness", 1]];
+params ["_patient", "_bodyPart", "_bandage", ["_bandageEffectiveness", 1, [0]]];
 TRACE_4("bandageLocal",_patient,_bodyPart,_bandage,_bandageEffectiveness);
 _bodyPart = toLowerANSI _bodyPart;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- This would still throw an error, but at least the unit could be bandaged.

Experienced the following in a test mission:

```
16:37:04 Error in expression <ndage, _bodyPart, _bandageEffectiveness * ace_medical_treatment_bandageEffective>
16:37:04   Error position: <* ace_medical_treatment_bandageEffective>
16:37:04   Error *: Type Bool, expected Number,Not a Number
16:37:04 File /z/ace/addons/medical_treatment/functions/fnc_bandageLocal.sqf..., line 421
16:37:06 Ref to nonnetwork object 564990: <no shape>
16:37:19 Ref to nonnetwork object 565123: <no shape>
16:37:19 Error in expression <ndage, _bodyPart, _bandageEffectiveness * ace_medical_treatment_bandageEffective>
16:37:19   Error position: <* ace_medical_treatment_bandageEffective>
16:37:19   Error *: Type Bool, expected Number,Not a Number
16:37:19 File /z/ace/addons/medical_treatment/functions/fnc_bandageLocal.sqf..., line 421
```

I was in a heavily modded environment, so I don't think there is a way of finding out which mod is causing it. Not running KAT. I don't remember the context, so can't really give any info on that.
Only happened those two times, bandaging worked after that.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
