### PR TITLE
Javelin - Fix enabling on retextured Titans

### DIFF
--- a/addons/javelin/CfgWeapons.hpp
+++ b/addons/javelin/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
     };
     class missiles_titan_static: missiles_titan {};
     class GVAR(Titan_Static): missiles_titan_static {
-        GVAR(enabled) = 1;
+        GVAR(baseEnabled) = 1;
         weaponInfoType = "ACE_RscOptics_javelin";
         modelOptics = QPATHTOF(data\reticle_titan.p3d);
 
@@ -30,51 +30,9 @@ class CfgWeapons {
             EGVAR(missileGuidance,attackProfile) = "JAV_TOP";
         };
     };
-    class launch_Titan_short_base: launch_Titan_base {};
-    class launch_B_Titan_short_F: launch_Titan_short_base {
-        GVAR(enabled) = 1;
+    class launch_Titan_short_base: launch_Titan_base {
+        GVAR(baseEnabled) = 1;
         weaponInfoType = "ACE_RscOptics_javelin";
         modelOptics = QPATHTOF(data\reticle_titan.p3d);
-
-        canLock = 0;
-
-        lockingTargetSound[] = {"",0,1};
-        lockedTargetSound[] = {"",0,1};
-    };
-    class launch_B_Titan_short_tna_F: launch_B_Titan_short_F {
-        GVAR(enabled) = 1;
-    };
-    class launch_I_Titan_short_F: launch_Titan_short_base {
-        GVAR(enabled) = 1;
-        weaponInfoType = "ACE_RscOptics_javelin";
-        modelOptics = QPATHTOF(data\reticle_titan.p3d);
-
-        canLock = 0;
-
-        lockingTargetSound[] = {"",0,1};
-        lockedTargetSound[] = {"",0,1};
-    };
-    class launch_O_Titan_short_F: launch_Titan_short_base {
-        GVAR(enabled) = 1;
-        weaponInfoType = "ACE_RscOptics_javelin";
-        modelOptics = QPATHTOF(data\reticle_titan.p3d);
-
-        canLock = 0;
-
-        lockingTargetSound[] = {"",0,1};
-        lockedTargetSound[] = {"",0,1};
-    };
-    class launch_O_Titan_short_ghex_F: launch_O_Titan_short_F {
-        GVAR(enabled) = 1;
-    };
-    class launch_Titan_short_F: launch_Titan_short_base {
-        GVAR(enabled) = 1;
-        weaponInfoType = "ACE_RscOptics_javelin";
-        modelOptics = QPATHTOF(data\reticle_titan.p3d);
-
-        canLock = 0;
-
-        lockingTargetSound[] = {"",0,1};
-        lockedTargetSound[] = {"",0,1};
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes #8884 
- Any retextured Titan's with the vanilla model will now use the javelin system
- Any weapons that inherit from the Titan but change the model will not use the system unless enabled
- No changes required for other launchers with `ace_javelin_enabled`

Tested with Aegis Titan retextures, which now use the javelin system
Tested with RHS Javelin compat, works fine
Tested with RHS Javelin without compat, uses vanilla locking fine

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
