### PR TITLE
Medical - Fix bandage effectiveness type

### DIFF
--- a/addons/medical_treatment/functions/fnc_bandage.sqf
+++ b/addons/medical_treatment/functions/fnc_bandage.sqf
@@ -21,7 +21,7 @@
  * Public: No
  */
 
-_this set [6, _this param [6, 1]]; // set default Bandage effectiveness coefficient
+_this set [6, 1]; // set bandage effectiveness coefficient - overwrites bool of createLitter
 [QGVAR(bandaged), _this] call CBA_fnc_localEvent; // Raise event with reference so mods can modify this
 
 params ["_medic", "_patient", "_bodyPart", "_classname", "", "", "_bandageEffectiveness"];


### PR DESCRIPTION
**When merged this pull request will:**
- On bandage success callback, overwrite the value of createLitter set by treatment to 1 for bandage effectiveness.
- I could not see where an actual value for bandage effectiveness was being passed through, so could also remove this value and its usages entirely
- See [discord thread](https://discord.com/channels/976165959041679380/1228532885812809738) for more context and explanation

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
