### PR TITLE
Wiki - Fix search being broken by the attach-framework page

### DIFF
--- a/docs/wiki/framework/attach-framework.md
+++ b/docs/wiki/framework/attach-framework.md
@@ -15,7 +15,7 @@ version:
 ## 1. Config Values
 ### 1.1 Make item attachable
 
-An item can be added to the ACE Attach framework by adding the ``ACE_attachable`` property to a class in ``CfgWeapons`` or ``CfgMagazines``. The value must be the classname of a valid class in ``CfgVehicles``:
+An item can be added to the ACE Attach framework by adding the `ACE_attachable` property to a class in `CfgWeapons` or `CfgMagazines`. The value must be the classname of a valid class in `CfgVehicles`:
 ```cpp
 class CfgWeapons {
     class attach_item: CBA_MiscItem {
@@ -29,14 +29,14 @@ class CfgVehicles {
         scope = 1; // Should be 1 (private) or 2 (public), scope 0 will cause errors on object creation
         displayName = "New ACE attachable item";
         model = "\path\to\my\model.p3d";
-		vehicleClass = "";
+        vehicleClass = "";
     };
 };
 ```
 
 ### 1.2 Define attach orientation for non-symmetric items
-In the case the item needs to have a particular orientation when attached, add the config value: ``ace_attach_orientation`` which is an array describing the ``roll`` and ``yaw`` orientation of the object.
-The default value is: ``[0,0]``.
+In the case the item needs to have a particular orientation when attached, add the config value: `ace_attach_orientation` which is an array describing the `roll` and `yaw` orientation of the object.
+The default value is: `[0,0]`.
 
 Example:
 ```cpp


### PR DESCRIPTION
**When merged this pull request will:**
- Change tab chars on attach-framework wiki page to space, so the wiki search feature works again
- Replace inline code-text `` with single ` to follow the standard from the other pages

Currently trying to search on the live wiki:
![billede](https://github.com/acemod/ACE3/assets/7889925/16e6dca1-a598-493d-a8ec-471bbc2498dd)

Searching on local hosted wiki with this PR:
![billede](https://github.com/acemod/ACE3/assets/7889925/96123747-9c99-4a2f-9be3-16a3e82fdc8a)



### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
