### PR TITLE
Common - Fix adding unusable throwables

### DIFF
--- a/addons/common/functions/fnc_addToInventory.sqf
+++ b/addons/common/functions/fnc_addToInventory.sqf
@@ -60,15 +60,17 @@ switch (_container) do {
 };
 
 if (_type select 0 == "magazine") then {
-    if (_ammoCount == -1) then {
-        _ammoCount = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
-    };
+    private _configAmmoCount = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
 
     // https://feedback.bistudio.com/T74244
     // When adding throwables with the addXXXCargo(Global) commands, they don't show up in the throwables list
     // If a throwable has more than 1 ammo count, adding it with addItem(XXX) commands also renders the throwable unusable
-    if (_ammoCount == 1 && {_classname call BIS_fnc_isThrowable}) then { // TODO: replace with https://community.bistudio.com/wiki/isThrowable in 2.18
+    if (_configAmmoCount == 1 && {_ammoCount in [-1, 1]} && {_classname call BIS_fnc_isThrowable}) then { // TODO: replace with https://community.bistudio.com/wiki/isThrowable in 2.18
         _type set [0, "item"];
+    };
+
+    if (_ammoCount == -1) then {
+        _ammoCount = _configAmmoCount;
     };
 };
 

--- a/addons/common/functions/fnc_addToInventory.sqf
+++ b/addons/common/functions/fnc_addToInventory.sqf
@@ -59,6 +59,18 @@ switch (_container) do {
     };
 };
 
+if (_type select 0 == "magazine") then {
+    if (_ammoCount == -1) then {
+        _ammoCount = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
+    };
+
+    // https://feedback.bistudio.com/T74244
+    // When adding throwables with the addXXXCargo(Global) commands, they don't show up in the throwables list
+    if (_ammoCount == 1 && {_classname call BIS_fnc_isThrowable}) then {
+        _type set [0, "item"];
+    };
+};
+
 switch (_type select 0) do {
     case "weapon": {
         if (_canAdd || {_canFitWeaponSlot}) then {
@@ -106,10 +118,6 @@ switch (_type select 0) do {
     };
 
     case "magazine": {
-        if (_ammoCount == -1) then {
-            _ammoCount = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
-        };
-
         if (_canAdd) then {
             _addedToUnit = true;
 

--- a/addons/common/functions/fnc_addToInventory.sqf
+++ b/addons/common/functions/fnc_addToInventory.sqf
@@ -67,7 +67,7 @@ if (_type select 0 == "magazine") then {
     // https://feedback.bistudio.com/T74244
     // When adding throwables with the addXXXCargo(Global) commands, they don't show up in the throwables list
     // If a throwable has more than 1 ammo count, adding it with addItem(XXX) commands also renders the throwable unusable
-    if (_ammoCount == 1 && {_classname call BIS_fnc_isThrowable}) then {
+    if (_ammoCount == 1 && {_classname call BIS_fnc_isThrowable}) then { // TODO: replace with https://community.bistudio.com/wiki/isThrowable in 2.18
         _type set [0, "item"];
     };
 };

--- a/addons/common/functions/fnc_addToInventory.sqf
+++ b/addons/common/functions/fnc_addToInventory.sqf
@@ -66,6 +66,7 @@ if (_type select 0 == "magazine") then {
 
     // https://feedback.bistudio.com/T74244
     // When adding throwables with the addXXXCargo(Global) commands, they don't show up in the throwables list
+    // If a throwable has more than 1 ammo count, adding it with addItem(XXX) commands also renders the throwable unusable
     if (_ammoCount == 1 && {_classname call BIS_fnc_isThrowable}) then {
         _type set [0, "item"];
     };


### PR DESCRIPTION
**When merged this pull request will:**
- `FUNC(addToInventory)` has been changed so that when you convert explosives using the CBA context menu, you don't have to drop them in order for you to use them. This change can be reverted once the bug in question (https://feedback.bistudio.com/T74244) has been addressed.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
