### PR TITLE
Hearing - Use class EH instead of extended EH

### DIFF
--- a/addons/hearing/CfgEventHandlers.hpp
+++ b/addons/hearing/CfgEventHandlers.hpp
@@ -13,15 +13,7 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientinit = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
-    };
-};
-
-class Extended_Init_EventHandlers {
-    class CAManBase {
-        class GVAR(AddEarPlugs) {
-            serverInit = QUOTE(_this call FUNC(addEarPlugs));
-        };
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
     };
 };
 

--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -1,5 +1,15 @@
 #include "script_component.hpp"
 
+if (isServer) then {
+    ["CBA_settingsInitialized", {
+        TRACE_1("settingInit - server",GVAR(EnableCombatDeafness));
+        // Only install event handler if combat deafness is enabled
+        if (!GVAR(EnableCombatDeafness)) exitWith {};
+
+        ["CAManBase", "Init", LINKFUNC(addEarPlugs), true, [], true] call CBA_fnc_addClassEventHandler;
+    }] call CBA_fnc_addEventHandler;
+};
+
 if (!hasInterface) exitWith {};
 
 #include "initKeybinds.inc.sqf"


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Means that `FUNC(addEarPlugs)` isn't called every time a unit is placed if hearing is off.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
