### PR TITLE
Hearing - Add earplugs only if not present

### DIFF
--- a/addons/hearing/functions/fnc_addEarPlugs.sqf
+++ b/addons/hearing/functions/fnc_addEarPlugs.sqf
@@ -20,11 +20,14 @@ if !(EGVAR(common,settingsInitFinished)) exitWith {
     EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addEarPlugs), _this];
 };
 
+// Exit if hearing is disabled or if autoAdd is disabled
+if (!GVAR(enableCombatDeafness) || {GVAR(autoAddEarplugsToUnits) == 0}) exitWith {};
+
 params ["_unit"];
 TRACE_2("params",_unit,typeOf _unit);
 
-// Exit if hearing is disabled OR autoAdd is disabled OR soldier has earplugs already in (persistence scenarios)
-if (!GVAR(enableCombatDeafness) || {GVAR(autoAddEarplugsToUnits) == 0} || {[_unit] call FUNC(hasEarPlugsIn)}) exitWith {};
+// Exit if the unit already has earplugs (in ears (persistence scenarios) or inventory)
+if (_unit call FUNC(hasEarPlugsIn) || {[_unit, "ACE_EarPlugs"] call EFUNC(common,hasItem)}) exitWith {};
 
 // Add earplugs if enabled for everyone or if the soldier has a rocket launcher
 if (GVAR(autoAddEarplugsToUnits) == 2 || {(secondaryWeapon _unit) != ""}) exitWith {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- In theory, if a unit's loadout in config would have earplugs, it would add a second pair because it would never check the unit's inventory. However, I haven't actually encountered this because I don't play with hearing enabled, so I don't know how necessary it is.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
