### PR TITLE
Vehicle Damage - Fix applying medical damage to non-local and invulnerable units

### DIFF
--- a/addons/vehicle_damage/XEH_PREP.hpp
+++ b/addons/vehicle_damage/XEH_PREP.hpp
@@ -11,3 +11,4 @@ PREP(knockOut);
 PREP(addDamage);
 PREP(handleDamageEjectIfDestroyed);
 PREP(blowOffTurret);
+PREP(medicalDamage);

--- a/addons/vehicle_damage/XEH_postInit.sqf
+++ b/addons/vehicle_damage/XEH_postInit.sqf
@@ -3,6 +3,8 @@
 ["ace_settingsInitialized", {
     TRACE_1("settings init",GVAR(enabled));
     if (GVAR(enabled)) then {
+        [QGVAR(medicalDamage), LINKFUNC(medicalDamage)] call CBA_fnc_addEventHandler;
+
         [QGVAR(bailOut), {
             params ["_center", "_crewman", "_vehicle"];
             TRACE_3("bailOut",_center,_crewman,_vehicle);

--- a/addons/vehicle_damage/functions/fnc_detonate.sqf
+++ b/addons/vehicle_damage/functions/fnc_detonate.sqf
@@ -27,9 +27,6 @@ if (_vehicleAmmo isEqualTo []) then {
 
 if ((_vehicleAmmo select 1) > 0) then {
     {
-        // random amount of injuries
-        for "_i" from 0 to random 5 do {
-            [_x, random 1 , selectRandom ["Head", "Body", "LeftArm", "RightArm", "LeftLeg", "RightLeg"], selectRandom ["bullet", "shell", "explosive"], _injurer] call EFUNC(medical,addDamageToUnit);
-        };
-    } forEach crew _vehicle;
+        [QGVAR(medicalDamage), [_x, _injurer, _injurer], _x] call CBA_fnc_targetEvent;
+    } forEach (crew _vehicle);
 };

--- a/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * [cursorObject, player, player] call grenades_hatches_main_fnc_medicalDamage;
+ * [cursorObject, player, player] call ace_vehicle_damage_main_fnc_medicalDamage;
  *
  * Public: No
  */

--- a/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
@@ -35,5 +35,5 @@ if (["ace_medical"] call EFUNC(common,isModLoaded)) then {
 
 // If guaranteed death is wished
 if (_guaranteeDeath && {alive _unit}) then {
-    [_unit, "", _source, _instigator] call EFUNC(common,setDead);
+    [_unit, QGVAR(medicalDamage), _source, _instigator] call EFUNC(common,setDead);
 };

--- a/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
@@ -35,10 +35,5 @@ if (["ace_medical"] call EFUNC(common,isModLoaded)) then {
 
 // If guaranteed death is wished
 if (_guaranteeDeath && {alive _unit}) then {
-    // From 'ace_medical_status_fnc_setDead': Kill the unit without changing visual appearance
-    private _currentDamage = _unit getHitPointDamage "HitHead";
-
-    _unit setHitPointDamage ["HitHead", 1, true, _source, _instigator];
-
-    _unit setHitPointDamage ["HitHead", _currentDamage, true, _source, _instigator];
+    [_unit, "", _source, _instigator] call EFUNC(common,setDead);
 };

--- a/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
@@ -1,0 +1,44 @@
+#include "..\script_component.hpp"
+/*
+ * Author: johnb43
+ * Applies medical damage to a unit.
+ *
+ * Arguments:
+ * 0: Target <OBJECT>
+ * 1: Source <OBJECT>
+ * 2: Instigator <OBJECT>
+ * 3: Guarantee death? <BOOL> (default: false)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject, player, player] call grenades_hatches_main_fnc_medicalDamage;
+ *
+ * Public: No
+ */
+
+params ["_unit", "_source", "_instigator", ["_guaranteeDeath", false]];
+
+// Check if unit is invulnerable
+if !(isDamageAllowed _unit && {_unit getVariable [QEGVAR(medical,allowDamage), true]}) exitWith {};
+
+if (["ace_medical"] call EFUNC(common,isModLoaded)) then {
+    for "_i" from 0 to floor (4 + random 3) do {
+        [_unit, random [0, 0.66, 1], selectRandom ["Head", "Body", "LeftArm", "RightArm", "LeftLeg", "RightLeg"], selectRandom ["bullet", "shell", "explosive"], _instigator] call EFUNC(medical,addDamageToUnit);
+    };
+} else {
+    {
+        _unit setHitPointDamage [_x, (_unit getHitPointDamage _x) + random [0, 0.66, 1], true, _source, _instigator];
+    } forEach ["HitFace", "HitNeck", "HitHead", "HitPelvis", "HitAbdomen", "HitDiaphragm", "HitChest", "HitBody", "HitArms", "HitHands", "HitLegs"];
+};
+
+// If guaranteed death is wished
+if (_guaranteeDeath && {alive _unit}) then {
+    // From 'ace_medical_status_fnc_setDead': Kill the unit without changing visual appearance
+    private _currentDamage = _unit getHitPointDamage "HitHead";
+
+    _unit setHitPointDamage ["HitHead", 1, true, _source, _instigator];
+
+    _unit setHitPointDamage ["HitHead", _currentDamage, true, _source, _instigator];
+};

--- a/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_medicalDamage.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * [cursorObject, player, player] call ace_vehicle_damage_main_fnc_medicalDamage;
+ * [cursorObject, player, player] call ace_vehicle_damage_fnc_medicalDamage;
  *
  * Public: No
  */

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -37,12 +37,10 @@ if (_newDamage >= 15) exitWith {
     TRACE_2("immediate destruction - high damage",_newDamage,_currentPartDamage);
     [_vehicle] call FUNC(knockOut);
     [_vehicle, 1] call FUNC(handleDetonation);
-    // kill everyone inside for very insane damage
+    // Kill everyone inside for very insane damage
     {
-        _x setDamage 1;
-        _x setVariable [QEGVAR(medical,lastDamageSource), _injurer];
-        _x setVariable [QEGVAR(medical,lastInstigator), _injurer];
-    } forEach crew _vehicle;
+        [QGVAR(medicalDamage), [_x, _injurer, _injurer, true], _x] call CBA_fnc_targetEvent;
+    } forEach (crew _vehicle);
     _vehicle setDamage 1;
     _return = false;
     _return


### PR DESCRIPTION
**When merged this pull request will:**
- Requires #10045.
- Fixes medical damage application:
    - It would try damage non-local units, making it fail.
    - It would injure invulnerable units.
    - I've added a new function to address those issues. If medical is not loaded, it will apply vanilla damage to the crew.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
