### PR TITLE
Medical - Add `ace_medical_enabled` variable for future-proofing API

### DIFF
--- a/addons/medical_engine/XEH_preInit.sqf
+++ b/addons/medical_engine/XEH_preInit.sqf
@@ -85,6 +85,6 @@ addMissionEventHandler ["Loaded", {
 [] call FUNC(disableThirdParty);
 
 // Future-proofing
-QEGVAR(medical,enabled) = true; // TODO: remove when medical enable setting is implemented
+EGVAR(medical,enabled) = true; // TODO: remove when medical enable setting is implemented
 
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Add a variable for 3rd party to check against for medical's overall enabled status. Hard set here, switch to setting when we implement it.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
