### PR TITLE
Medical Treatment - Allow diagnosing cardiac arrest with clear language

### DIFF
--- a/addons/medical_treatment/functions/fnc_checkResponse.sqf
+++ b/addons/medical_treatment/functions/fnc_checkResponse.sqf
@@ -22,6 +22,11 @@ params ["_medic", "_patient"];
 private _output = if (_patient call EFUNC(common,isAwake)) then {
      LSTRING(Check_Response_Responsive)
 } else {
+    if (GVAR(advancedDiagnose) == 3) exitWith {
+        if (IN_CRDC_ARRST(_patient)) exitWith { LSTRING(Check_Response_CardiacArrestDirect) };
+        if (!alive _patient) exitWith { LSTRING(Check_Response_DeadDirect) };
+        LSTRING(Check_Response_UnresponsiveDirect)
+    };
     if ((GVAR(advancedDiagnose) == 2) && {IN_CRDC_ARRST(_patient)}) exitWith { LSTRING(Check_Response_CardiacArrest) };
     if ((GVAR(advancedDiagnose) == 2) && {!alive _patient}) exitWith { LSTRING(Check_Response_Dead) };
     LSTRING(Check_Response_Unresponsive)

--- a/addons/medical_treatment/initSettings.inc.sqf
+++ b/addons/medical_treatment/initSettings.inc.sqf
@@ -3,7 +3,7 @@
     "LIST",
     [LSTRING(AdvancedDiagnose_DisplayName), LSTRING(AdvancedDiagnose_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [[0, 1, 2], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(AdvancedDiagnose_DiagnoseCardiacArrest)], 1],
+    [[0, 1, 2, 3], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(AdvancedDiagnose_DiagnoseCardiacArrest), LSTRING(AdvancedDiagnose_DiagnoseCardiacArrestDirect)], 1],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -77,6 +77,9 @@
             <Spanish>Habilitado y poder diagnosticar Muerte/Parada cardíaca</Spanish>
             <Italian>Abilitato e può diagnosticare Morte/Arresto Cardiaco</Italian>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_DiagnoseCardiacArrestDirect">
+            <English>Enabled &amp; Can Diagnose Death/Cardiac Arrest [Directly]</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedMedication_DisplayName">
             <English>Advanced Medication</English>
             <German>Erweiterte Medikation</German>
@@ -4149,6 +4152,9 @@
             <Chinese>%1 沒有反應</Chinese>
             <Turkish>%1 tepki vermiyor</Turkish>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Check_Response_UnresponsiveDirect">
+            <English>%1 is unconscious</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Response_CardiacArrest">
             <English>%1 is not responsive, taking shallow gasps and convulsing</English>
             <French>%1 est inconscient, respire par intermittence et convulse.</French>
@@ -4161,6 +4167,9 @@
             <Russian>%1 не реагирует на раздражители, поверхностно дышит, в конвульсиях</Russian>
             <Spanish>%1 no responde, dando pequeñas bocanadas y convulsionando</Spanish>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Check_Response_CardiacArrestDirect">
+            <English>%1 is in cardiac arrest</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Response_Dead">
             <English>%1 is not responsive, motionless and cold</English>
             <French>%1 est inconscient, inanimé et froid.</French>
@@ -4172,6 +4181,9 @@
             <Korean>%1 은 반응이 없고, 움직임이 없으며 차갑습니다</Korean>
             <Russian>%1 не реагирует на раздражители, не шевелится и холодный</Russian>
             <Spanish>%1 no responde, sin movimiento y frío</Spanish>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_Check_Response_DeadDirect">
+            <English>%1 is dead</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_Check_Response_You_Checked">
             <English>You checked %1</English>


### PR DESCRIPTION
Adds a new option to the diagnose setting
shows state of patient with clear un-ambiguous language