### PR TITLE
Cargo - Add checks for adding cargo via config

### DIFF
--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -41,6 +41,6 @@ if (_item isEqualType "") then {
 TRACE_1("loaded",_loaded);
 
 // Invoke listenable event
-["ace_cargoAdded", [_item, _vehicle, _amount]] call CBA_fnc_globalEvent;
+["ace_cargoAdded", [_item, _vehicle, _loaded]] call CBA_fnc_globalEvent;
 
 _loaded // return

--- a/addons/cargo/functions/fnc_addCargoItem.sqf
+++ b/addons/cargo/functions/fnc_addCargoItem.sqf
@@ -7,9 +7,10 @@
  * 0: Item to be loaded <STRING> or <OBJECT>
  * 1: Holder object (vehicle) <OBJECT>
  * 2: Amount <NUMBER> (default: 1)
+ * 3: Ignore interaction distance and stability checks <BOOL> (default: false)
  *
  * Return Value:
- * None
+ * Objects loaded <NUMBER>
  *
  * Example:
  * ["ACE_Wheel", cursorObject] call ace_cargo_fnc_addCargoItem
@@ -17,21 +18,29 @@
  * Public: No
  */
 
-params ["_item", "_vehicle", ["_amount", 1]];
-TRACE_3("params",_item,_vehicle,_amount);
+params ["_item", "_vehicle", ["_amount", 1], ["_ignoreInteraction", false]];
+TRACE_4("params",_item,_vehicle,_amount,_ignoreInteraction);
+
+private _loaded = 0;
 
 // Get config sensitive case name
 if (_item isEqualType "") then {
     _item = _item call EFUNC(common,getConfigName);
 
     for "_i" from 1 to _amount do {
-        [_item, _vehicle] call FUNC(loadItem);
+        if !([_item, _vehicle, _ignoreInteraction] call FUNC(loadItem)) exitWith {};
+
+        _loaded = _loaded + 1;
     };
 } else {
-    [_item, _vehicle] call FUNC(loadItem);
+    _loaded = parseNumber ([_item, _vehicle, _ignoreInteraction] call FUNC(loadItem));
 
     _item = typeOf _item;
 };
 
+TRACE_1("loaded",_loaded);
+
 // Invoke listenable event
 ["ace_cargoAdded", [_item, _vehicle, _amount]] call CBA_fnc_globalEvent;
+
+_loaded // return

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -63,7 +63,7 @@ if (isServer) then {
         // Ignore stability check (distance check is also ignored with this, but it's ignored by default if item is a string)
         _loaded = [_cargoClassname, _vehicle, _cargoCount, true] call FUNC(addCargoItem);
 
-        // Even though we know nothing else can fit, let loop continue until the end, so that it prints everything into the rpt
+        // Let loop continue until the end, so that it prints everything into the rpt (there might be smaller items that could still fit in cargo)
         if (_loaded != _cargoCount) then {
             WARNING_5("%1 (%2) could not fit %3 %4 inside its cargo, only %5 were loaded.",_vehicle,_type,_cargoCount,_cargoClassname,_loaded);
         };

--- a/addons/cargo/functions/fnc_initVehicle.sqf
+++ b/addons/cargo/functions/fnc_initVehicle.sqf
@@ -52,14 +52,21 @@ if (isServer) then {
 
     private _cargoClassname = "";
     private _cargoCount = 0;
+    private _loaded = 0;
 
     {
         _cargoClassname = getText (_x >> "type");
         _cargoCount = getNumber (_x >> "amount");
 
-        TRACE_3("adding ACE_Cargo",configName _x,_cargoClassname,_cargoCount);
+        TRACE_3("adding ace_cargo",configName _x,_cargoClassname,_cargoCount);
 
-        ["ace_addCargo", [_cargoClassname, _vehicle, _cargoCount]] call CBA_fnc_localEvent;
+        // Ignore stability check (distance check is also ignored with this, but it's ignored by default if item is a string)
+        _loaded = [_cargoClassname, _vehicle, _cargoCount, true] call FUNC(addCargoItem);
+
+        // Even though we know nothing else can fit, let loop continue until the end, so that it prints everything into the rpt
+        if (_loaded != _cargoCount) then {
+            WARNING_5("%1 (%2) could not fit %3 %4 inside its cargo, only %5 were loaded.",_vehicle,_type,_cargoCount,_cargoClassname,_loaded);
+        };
     } forEach ("true" configClasses (_config >> QUOTE(ADDON) >> "cargo"));
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Prints warnings if config defined cargo doesn't fit in a vehicle.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
