### PR TITLE
Grenades - Fix players not being able to switch grenade throw modes when in FFV seats

### DIFF
--- a/addons/grenades/XEH_postInit.sqf
+++ b/addons/grenades/XEH_postInit.sqf
@@ -17,7 +17,7 @@ GVAR(flashbangPPEffectCC) ppEffectForceInNVG true;
 // Add keybinds
 ["ACE3 Weapons", QGVAR(switchGrenadeMode), localize LSTRING(SwitchGrenadeMode), {
     // Conditions: canInteract
-    if !([ACE_player, objNull, ["isNotEscorting"]] call EFUNC(common,canInteractWith)) exitWith {false};
+    if !([ACE_player, objNull, ["isNotEscorting", "isNotInside"]] call EFUNC(common,canInteractWith)) exitWith {false};
     // Conditions: specific
     if (!([ACE_player] call CBA_fnc_canUseWeapon)) exitWith {false};
     // Don't change mode or show hint if advanced throwing is active


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
