### PR TITLE
Realistic Names - Add missing classes

### DIFF
--- a/addons/realisticnames/Attachments.hpp
+++ b/addons/realisticnames/Attachments.hpp
@@ -1,0 +1,174 @@
+//attachments
+
+class ItemCore;
+
+class acc_flashlight: ItemCore {
+    displayName = CSTRING(flashlight_Name);
+};
+
+class optic_MRD: ItemCore {
+    displayName = CSTRING(optic_mrd_Name);
+};
+class optic_MRD_black: optic_MRD {
+    displayName = CSTRING(optic_mrd_black_Name);
+};
+
+class optic_Hamr: ItemCore {
+    displayName = CSTRING(optic_hamr);
+};
+class optic_Hamr_khk_F: optic_Hamr {
+    displayName = CSTRING(optic_hamr_khk);
+};
+class ACE_optic_Hamr_2D: optic_Hamr {
+    displayName = CSTRING(optic_hamr_2d);
+};
+class ACE_optic_Hamr_PIP: ACE_optic_Hamr_2D {
+    displayName = CSTRING(optic_hamr_pip);
+};
+
+class optic_Arco: ItemCore {
+    displayName = CSTRING(optic_arco);
+};
+class optic_Arco_blk_F: optic_Arco {
+    displayName = CSTRING(optic_arco_blk);
+};
+class optic_Arco_ghex_F: optic_Arco {
+    displayName = CSTRING(optic_arco_ghex);
+};
+class ACE_optic_Arco_2D: optic_Arco {
+    displayName = CSTRING(optic_arco_2d);
+};
+class ACE_optic_Arco_PIP: ACE_optic_Arco_2D {
+    displayName = CSTRING(optic_arco_pip);
+};
+class optic_Arco_lush_F: optic_Arco {
+    displayName = CSTRING(optic_arco_lush);
+};
+class optic_Arco_arid_F: optic_Arco {
+    displayName = CSTRING(optic_arco_arid);
+};
+class optic_Arco_AK_blk_F: optic_Arco_blk_F {
+    displayName = CSTRING(optic_arco_ak_blk);
+};
+class optic_Arco_AK_lush_F: optic_Arco_lush_F {
+    displayName = CSTRING(optic_arco_ak_lush);
+};
+class optic_Arco_AK_arid_F: optic_Arco_arid_F {
+    displayName = CSTRING(optic_arco_ak_arid);
+};
+
+class optic_ERCO_blk_f: optic_Arco {
+    displayName = CSTRING(optic_erco_blk);
+};
+class optic_ERCO_khk_f: optic_ERCO_blk_f {
+    displayName = CSTRING(optic_erco_khk);
+};
+class optic_ERCO_snd_f: optic_ERCO_blk_f {
+    displayName = CSTRING(optic_erco_snd);
+};
+
+class optic_LRPS: ItemCore {
+    displayName = CSTRING(optic_lrps);
+};
+class optic_LRPS_ghex_F: optic_LRPS {
+    displayName = CSTRING(optic_lrps_ghex);
+};
+class optic_LRPS_tna_F: optic_LRPS {
+    displayName = CSTRING(optic_lrps_tna);
+};
+class ACE_optic_LRPS_2D: optic_LRPS {
+    displayName = CSTRING(optic_lrps_2d);
+};
+class ACE_optic_LRPS_PIP: ACE_optic_LRPS_2D {
+    displayName = CSTRING(optic_lrps_pip);
+};
+
+class optic_AMS_base;
+class optic_AMS: optic_AMS_base {
+    displayName = CSTRING(optic_ams);
+};
+class optic_AMS_khk: optic_AMS {
+    displayName = CSTRING(optic_ams_khk);
+};
+class optic_AMS_snd: optic_AMS {
+    displayName = CSTRING(optic_ams_snd);
+};
+
+class optic_KHS_base;
+class optic_KHS_blk: optic_KHS_base {
+    displayName = CSTRING(optic_khs_blk);
+};
+class optic_KHS_hex: optic_KHS_blk {
+    displayName = CSTRING(optic_khs_hex);
+};
+class optic_KHS_old: ItemCore {
+    displayName = CSTRING(optic_khs_old);
+};
+class optic_KHS_tan: optic_KHS_blk {
+    displayName = CSTRING(optic_khs_tan);
+};
+
+class optic_DMS: ItemCore {
+    displayName = CSTRING(optic_dms);
+};
+class optic_DMS_ghex_F: optic_DMS {
+    displayName = CSTRING(optic_dms_ghex);
+};
+class optic_DMS_weathered_F: optic_DMS {
+    displayName = CSTRING(optic_dms_weathered);
+};
+class optic_DMS_weathered_Kir_F: optic_DMS_weathered_F {
+    displayName = CSTRING(optic_dms_weathered_kir);
+};
+
+class optic_holosight: ItemCore {
+    displayName = CSTRING(optic_holosight);
+};
+class optic_Holosight_blk_F: optic_holosight {
+    displayName = CSTRING(optic_holosight_blk);
+};
+class optic_Holosight_khk_F: optic_holosight {
+    displayName = CSTRING(optic_holosight_khk);
+};
+class optic_Holosight_lush_F: optic_holosight {
+    displayName = CSTRING(optic_holosight_lush);
+};
+class optic_Holosight_arid_F: optic_holosight {
+    displayName = CSTRING(optic_holosight_arid);
+};
+class optic_Holosight_smg: ItemCore {
+    displayName = CSTRING(optic_holosight_smg);
+};
+class optic_Holosight_smg_blk_F: optic_Holosight_smg {
+    displayName = CSTRING(optic_holosight_smg_blk);
+};
+class optic_Holosight_smg_khk_F: optic_Holosight_smg {
+    displayName = CSTRING(optic_holosight_smg_khk);
+};
+
+class optic_MRCO: ItemCore {
+    displayName = CSTRING(optic_MRCO);
+};
+class ACE_optic_MRCO_2D: optic_MRCO {
+    displayName = CSTRING(optic_MRCO_2d);
+};
+class ACE_optic_MRCO_PIP: ACE_optic_MRCO_2D {
+    displayName = CSTRING(optic_MRCO_pip);
+};
+
+class optic_Yorris: ItemCore {
+    displayName = CSTRING(optic_Yorris);
+};
+
+class optic_ACO: ItemCore {
+    displayName = CSTRING(optic_ACO);
+};
+class optic_ACO_grn: ItemCore {
+    displayName = CSTRING(optic_ACO_grn);
+};
+class optic_ACO_smg: ItemCore {
+    displayName = CSTRING(optic_ACO_smg);
+};
+class optic_ACO_grn_smg: ItemCore {
+    displayName = CSTRING(optic_ACO_grn_smg);
+};

--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -249,6 +249,10 @@ class CfgVehicles {
     class O_Truck_02_medical_F: Truck_02_medical_base_F {
         displayName = CSTRING(Truck_02_medical_Name);
     };
+    class Truck_02_water_base_F;
+    class C_IDAP_Truck_02_water_F: Truck_02_water_base_F {
+        displayName = CSTRING(Truck_02_water_Name);
+    };
     class I_Truck_02_transport_F: Truck_02_transport_base_F {
         displayName = CSTRING(Truck_02_transport_Name);
     };
@@ -282,6 +286,12 @@ class CfgVehicles {
     };
     class C_Truck_02_box_F: Truck_02_box_base_F {
         displayName = CSTRING(Truck_02_box_Name);
+    };
+    class C_IDAP_Truck_02_transport_F: Truck_02_transport_base_F {
+        displayName = CSTRING(Truck_02_transport_Name);
+    };
+    class C_IDAP_Truck_02_F: Truck_02_base_F {
+        displayName = CSTRING(Truck_02_covered_Name);
     };
 
     class Truck_03_base_F;
@@ -382,6 +392,9 @@ class CfgVehicles {
 
     class Heli_Transport_02_base_F;
     class I_Heli_Transport_02_F: Heli_Transport_02_base_F {
+        displayName = CSTRING(Heli_Transport_02_Name);
+    };
+    class C_IDAP_Heli_Transport_02_F: Heli_Transport_02_base_F {
         displayName = CSTRING(Heli_Transport_02_Name);
     };
 

--- a/addons/realisticnames/CfgWeapons.hpp
+++ b/addons/realisticnames/CfgWeapons.hpp
@@ -2,6 +2,7 @@ class Mode_SemiAuto;
 class Mode_FullAuto;
 
 class CfgWeapons {
+    #include "Attachments.hpp"
     // assault rifles
 
     // MX
@@ -707,175 +708,19 @@ class CfgWeapons {
         };
     };
 
-    //attachments
-
-    class ItemCore;
-
-    class acc_flashlight: ItemCore {
-        displayName = "UTG Defender 126";
-    };
-
-    class optic_Hamr: ItemCore {
-        displayName = CSTRING(optic_hamr);
-    };
-    class optic_Hamr_khk_F: optic_Hamr {
-        displayName = CSTRING(optic_hamr_khk);
-    };
-    class ACE_optic_Hamr_2D: optic_Hamr {
-        displayName = CSTRING(optic_hamr_2d);
-    };
-    class ACE_optic_Hamr_PIP: ACE_optic_Hamr_2D {
-        displayName = CSTRING(optic_hamr_pip);
-    };
-
-    class optic_Arco: ItemCore {
-        displayName = CSTRING(optic_arco);
-    };
-    class optic_Arco_blk_F: optic_Arco {
-        displayName = CSTRING(optic_arco_blk);
-    };
-    class optic_Arco_ghex_F: optic_Arco {
-        displayName = CSTRING(optic_arco_ghex);
-    };
-    class ACE_optic_Arco_2D: optic_Arco {
-        displayName = CSTRING(optic_arco_2d);
-    };
-    class ACE_optic_Arco_PIP: ACE_optic_Arco_2D {
-        displayName = CSTRING(optic_arco_pip);
-    };
-    class optic_Arco_lush_F: optic_Arco {
-        displayName = CSTRING(optic_arco_lush);
-    };
-    class optic_Arco_arid_F: optic_Arco {
-        displayName = CSTRING(optic_arco_arid);
-    };
-    class optic_Arco_AK_blk_F: optic_Arco_blk_F {
-        displayName = CSTRING(optic_arco_ak_blk);
-    };
-    class optic_Arco_AK_lush_F: optic_Arco_lush_F {
-        displayName = CSTRING(optic_arco_ak_lush);
-    };
-    class optic_Arco_AK_arid_F: optic_Arco_arid_F {
-        displayName = CSTRING(optic_arco_ak_arid);
-    };
-
-    class optic_ERCO_blk_f: optic_Arco {
-        displayName = CSTRING(optic_erco_blk);
-    };
-    class optic_ERCO_khk_f: optic_ERCO_blk_f {
-        displayName = CSTRING(optic_erco_khk);
-    };
-    class optic_ERCO_snd_f: optic_ERCO_blk_f {
-        displayName = CSTRING(optic_erco_snd);
-    };
-
-    class optic_LRPS: ItemCore {
-        displayName = CSTRING(optic_lrps);
-    };
-    class optic_LRPS_ghex_F: optic_LRPS {
-        displayName = CSTRING(optic_lrps_ghex);
-    };
-    class optic_LRPS_tna_F: optic_LRPS {
-        displayName = CSTRING(optic_lrps_tna);
-    };
-    class ACE_optic_LRPS_2D: optic_LRPS {
-        displayName = CSTRING(optic_lrps_2d);
-    };
-    class ACE_optic_LRPS_PIP: ACE_optic_LRPS_2D {
-        displayName = CSTRING(optic_lrps_pip);
-    };
-
-    class optic_AMS_base;
-    class optic_AMS: optic_AMS_base {
-        displayName = CSTRING(optic_ams);
-    };
-    class optic_AMS_khk: optic_AMS {
-        displayName = CSTRING(optic_ams_khk);
-    };
-    class optic_AMS_snd: optic_AMS {
-        displayName = CSTRING(optic_ams_snd);
-    };
-
-    class optic_KHS_base;
-    class optic_KHS_blk: optic_KHS_base {
-        displayName = CSTRING(optic_khs_blk);
-    };
-    class optic_KHS_hex: optic_KHS_blk {
-        displayName = CSTRING(optic_khs_hex);
-    };
-    class optic_KHS_old: ItemCore {
-        displayName = CSTRING(optic_khs_old);
-    };
-    class optic_KHS_tan: optic_KHS_blk {
-        displayName = CSTRING(optic_khs_tan);
-    };
-
-    class optic_DMS: ItemCore {
-        displayName = CSTRING(optic_dms);
-    };
-    class optic_DMS_ghex_F: optic_DMS {
-        displayName = CSTRING(optic_dms_ghex);
-    };
-    class optic_DMS_weathered_F: optic_DMS {
-        displayName = CSTRING(optic_dms_weathered);
-    };
-    class optic_DMS_weathered_Kir_F: optic_DMS_weathered_F {
-        displayName = CSTRING(optic_dms_weathered_kir);
-    };
-
-    class optic_holosight: ItemCore {
-        displayName = CSTRING(optic_holosight);
-    };
-    class optic_Holosight_blk_F: optic_holosight {
-        displayName = CSTRING(optic_holosight_blk);
-    };
-    class optic_Holosight_khk_F: optic_holosight {
-        displayName = CSTRING(optic_holosight_khk);
-    };
-    class optic_Holosight_lush_F: optic_holosight {
-        displayName = CSTRING(optic_holosight_lush);
-    };
-    class optic_Holosight_arid_F: optic_holosight {
-        displayName = CSTRING(optic_holosight_arid);
-    };
-    class optic_Holosight_smg: ItemCore {
-        displayName = CSTRING(optic_holosight_smg);
-    };
-    class optic_Holosight_smg_blk_F: optic_Holosight_smg {
-        displayName = CSTRING(optic_holosight_smg_blk);
-    };
-    class optic_Holosight_smg_khk_F: optic_Holosight_smg {
-        displayName = CSTRING(optic_holosight_smg_khk);
-    };
-
-    class optic_MRCO: ItemCore {
-        displayName = CSTRING(optic_MRCO);
-    };
-    class ACE_optic_MRCO_2D: optic_MRCO {
-        displayName = CSTRING(optic_MRCO_2d);
-    };
-    class ACE_optic_MRCO_PIP: ACE_optic_MRCO_2D {
-        displayName = CSTRING(optic_MRCO_pip);
-    };
-
-    class optic_Yorris: ItemCore {
-        displayName = CSTRING(optic_Yorris);
-    };
-
-    class optic_ACO: ItemCore {
-        displayName = CSTRING(optic_ACO);
-    };
-    class optic_ACO_grn: ItemCore {
-        displayName = CSTRING(optic_ACO_grn);
-    };
-    class optic_ACO_smg: ItemCore {
-        displayName = CSTRING(optic_ACO_smg);
-    };
-    class optic_ACO_grn_smg: ItemCore {
-        displayName = CSTRING(optic_ACO_grn_smg);
-    };
-
     // APEX/Tanoa
+
+    // Type 115
+    class arifle_ARX_base_F;
+    class arifle_ARX_blk_F: arifle_ARX_base_F {
+        displayName = CSTRING(arifle_arx_blk_Name);
+    };
+    class arifle_ARX_ghex_F: arifle_ARX_base_F {
+        displayName = CSTRING(arifle_arx_ghex_Name);
+    };
+    class arifle_ARX_hex_F: arifle_ARX_base_F {
+        displayName = CSTRING(arifle_arx_hex_Name);
+    };
 
     // QBZ-95 and variants
     class arifle_CTAR_base_F;
@@ -1017,6 +862,16 @@ class CfgWeapons {
     };
 
     // Contact/Livonia
+
+    // CZ 581 Shotgun
+    class sgun_HunterShotgun_01_base_F;
+    class sgun_HunterShotgun_01_F: sgun_HunterShotgun_01_base_F {
+        displayName = CSTRING(sgun_huntershotgun_01_Name);
+    };
+    class sgun_HunterShotgun_01_sawedoff_base_F;
+    class sgun_HunterShotgun_01_sawedoff_F: sgun_HunterShotgun_01_base_F {
+        displayName = CSTRING(sgun_huntershotgun_sawedoff_01_Name);
+    };
 
     // FNX-45 (Green)
     class hgun_Pistol_heavy_01_green_F: hgun_Pistol_heavy_01_F {

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -698,6 +698,9 @@
             <Chinesesimp>"卡玛兹"（医疗）</Chinesesimp>
             <Turkish>KamAZ Medikal</Turkish>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_Truck_02_water_Name">
+            <English>KamAZ Water</English>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_Truck_02_MRL_Name">
             <English>KamAZ MRL</English>
             <German>KamAS MRL</German>
@@ -1654,6 +1657,12 @@
             <Korean>FNX-45 택티컬</Korean>
             <Chinese>FNX-45戰術型手槍</Chinese>
             <Chinesesimp>FNX-45 战术型</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_sgun_huntershotgun_01_Name">
+            <English>CZ 581</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_sgun_huntershotgun_sawedoff_01_Name">
+            <English>CZ 581 (Sawed-Off)</English>
         </Key>
         <Key ID="STR_ACE_RealisticNames_hgun_Pistol_heavy_01_green_Name">
             <English>FNX-45 Tactical (Green)</English>
@@ -3056,6 +3065,15 @@
             <Chinesesimp>"柏拉格" 战斗无人机</Chinesesimp>
             <Turkish>Burraq UCAV</Turkish>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_arx_blk_Name">
+            <English>Type 115 (Black)</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_arx_ghex_Name">
+            <English>Type 115 (Green Hex)</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_arifle_arx_hex_Name">
+            <English>Type 115 (Hex)</English>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_arifle_CTAR_blk">
             <English>QBZ-95-1 (Black)</English>
             <Czech>QBZ-95-1 (Černá)</Czech>
@@ -3839,6 +3857,15 @@
             <Turkish>Wiesel 2 RFCV (Radar)</Turkish>
             <Spanish>Wiesel 2 RFCV (Radar)</Spanish>
             <Korean>비젤 2 RFCV (레이더)</Korean>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_flashlight_Name">
+            <English>UTG Defender 126</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_mrd_Name">
+            <English>EOTech MRDS</English>
+        </Key>
+        <Key ID="STR_ACE_RealisticNames_optic_mrd_black_Name">
+            <English>EOTech MRDS (Black)</English>
         </Key>
         <Key ID="STR_ACE_RealisticNames_optic_hamr">
             <English>Leupold Mark 4 HAMR</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Renames the Laws of War Zamaks to KamAZ
- Renames the MRD optic
- Renames the Kozlice shotgun to CZ 581 (everything I can find points to this being the original design)
- Removed 6.5 from Type 115 names
- Stringtabled the UTG Defender
- Separated out the attachments into it's own file because whoever did this originally is a heretic.
