### PR TITLE
Hearing - prevent audio from stacking when tabbed out

### DIFF
--- a/addons/hearing/functions/fnc_updateVolume.sqf
+++ b/addons/hearing/functions/fnc_updateVolume.sqf
@@ -38,6 +38,7 @@ if (!_updateVolumeOnly) then {
         GVAR(deafnessDV) > 10) then {
 
         if (CBA_missionTime - GVAR(time3) < 3) exitWith {};
+        if (!isGameFocused) exitWith {}; // prevent audio from stacking when tabbed out
 
         GVAR(time3) = CBA_missionTime;
 


### PR DESCRIPTION
ref #10039

We still want this or sound effects will stack up when tabbed out and then play all at once when tabbing back