### PR TITLE
Kill Tracker - Add setting to show kills from vehicle to crew

### DIFF
--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -139,7 +139,7 @@ GVAR(killCount) = 0;
         TRACE_3("send kill event",_instigator,_unitName,_killInfo);
         [QGVAR(kill), [_unitName, _killInfo], _instigator] call CBA_fnc_targetEvent;
 
-        if (GVAR(showCrewKills) && {!(_killer isKindof "CAManBase")}) then {
+        if (GVAR(showCrewKills) && {!(_killer isKindOf "CAManBase")}) then {
             private _crew = [driver _killer, gunner _killer, commander _killer] - [_instigator];
             _crew = _crew select {[_x] call EFUNC(common,isPlayer)};
             _crew = _crew arrayIntersect _crew;

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -73,11 +73,11 @@ GVAR(killCount) = 0;
         };
     };
     private _unitIsPlayer = hasInterface && {_unit in [player, ace_player]}; // isPlayer check will fail at this point
-    private _killerIsPlayer = (!isNull _instigator) && {_unit != _instigator} && {[_instigator] call EFUNC(common,isPlayer)};
-    TRACE_2("",_unitIsPlayer,_killerIsPlayer);
+    private _instigatorIsPlayer = (!isNull _instigator) && {_unit != _instigator} && {[_instigator] call EFUNC(common,isPlayer)};
+    TRACE_2("",_unitIsPlayer,_instigatorIsPlayer);
 
     // Don't do anything if neither are players
-    if (!(_unitIsPlayer || _killerIsPlayer)) exitWith {};
+    if (!(_unitIsPlayer || _instigatorIsPlayer)) exitWith {};
 
     // Log firendly fire
     private _fnc_getSideFromConfig = {
@@ -110,23 +110,23 @@ GVAR(killCount) = 0;
 
     // If unit was player then send event to self
     if (_unitIsPlayer) then {
-        private _killerName = "Self?";
-        if ((!isNull _killer) && {_unit != _killer}) then {
-            if (_killerIsPlayer) then {
-                _killerName = [_killer, true, false] call EFUNC(common,getName);
+        private _instigatorName = "Self?";
+        if ((!isNull _instigator) && {_unit != _instigator}) then {
+            if (_instigatorIsPlayer) then {
+                _instigatorName = [_instigator, true, false] call EFUNC(common,getName);
             } else {
-                _killerName = _killer getVariable [QGVAR(aiName), ""]; // allow setting a custom AI name (e.g. VIP Target)
-                if (_killerName == "") then {
-                    _killerName = format ["*AI* - %1", getText ((configOf _killer) >> "displayName")];
+                _instigatorName = _instigator getVariable [QGVAR(aiName), ""]; // allow setting a custom AI name (e.g. VIP Target)
+                if (_instigatorName == "") then {
+                    _instigatorName = format ["*AI* - %1", getText ((configOf _instigator) >> "displayName")];
                 };
             };
         };
-        TRACE_3("send death event",_unit,_killerName,_killInfo);
-        [QGVAR(death), [_killerName, _killInfo]] call CBA_fnc_localEvent;
+        TRACE_3("send death event",_unit,_instigatorName,_killInfo);
+        [QGVAR(death), [_instigatorName, _killInfo]] call CBA_fnc_localEvent;
     };
 
-    // If killer was player then send event to killer
-    if (_killerIsPlayer) then {
+    // If shooter was player then send event to them (and optionally the whole crew)
+    if (_instigatorIsPlayer && {_unitIsPlayer || GVAR(trackAI)}) then {
         private _unitName = "";
         if (_unitIsPlayer) then {
             _unitName = [_unit, true, false] call EFUNC(common,getName); // should be same as profileName
@@ -136,9 +136,18 @@ GVAR(killCount) = 0;
                 _unitName = format ["*AI* - %1", getText ((configOf _unit) >> "displayName")];
             };
         };
-        if (_unitIsPlayer || GVAR(trackAI)) then {
-            TRACE_3("send kill event",_killer,_unitName,_killInfo);
-            [QGVAR(kill), [_unitName, _killInfo], _killer] call CBA_fnc_targetEvent;
+        TRACE_3("send kill event",_instigator,_unitName,_killInfo);
+        [QGVAR(kill), [_unitName, _killInfo], _instigator] call CBA_fnc_targetEvent;
+
+        if (GVAR(showCrewKills) && {!(_killer isKindof "CAManBase")}) then {
+            private _crew = [driver _killer, gunner _killer, commander _killer] - [_instigator];
+            _crew = _crew select {[_x] call EFUNC(common,isPlayer)};
+            _crew = _crew arrayIntersect _crew;
+            TRACE_1("showCrewKills",_crew);
+            _killInfo = format [" - [<t color='#99ff99'>%1</t>, %2", localize "str_a3_rscdisplaygarage_tab_crew", _killInfo select [4]];
+            {
+                [QGVAR(kill), [_unitName, _killInfo], _x] call CBA_fnc_targetEvent;
+            } forEach _crew;
         };
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/killtracker/initSettings.inc.sqf
+++ b/addons/killtracker/initSettings.inc.sqf
@@ -6,3 +6,12 @@
     true,
     1
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(showCrewKills),
+    "CHECKBOX",
+    [LSTRING(showCrewKills_DisplayName), LSTRING(showCrewKills_Description)],
+    LSTRING(Category),
+    false,
+    1
+] call CBA_fnc_addSetting;

--- a/addons/killtracker/stringtable.xml
+++ b/addons/killtracker/stringtable.xml
@@ -119,5 +119,11 @@
             <German>Legt fest, ob getötete KIs während des Endbildschirms der Mission in den Abschüssen angezeigt werden.</German>
             <Spanish>Define si las IAs matadas se mostrarán en el contador de muertes en el debiefring de la misión.</Spanish>
         </Key>
+        <Key ID="STR_ACE_KillTracker_showCrewKills_DisplayName">
+            <English>Show vehicle kills to other crew members</English>
+        </Key>
+        <Key ID="STR_ACE_KillTracker_showCrewKills_Description">
+            <English>Show kills from a vehicle to driver, gunner and commander</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf
+++ b/addons/medical_statemachine/functions/fnc_enteredStateDeath.sqf
@@ -25,6 +25,7 @@ if (isNull _unit || {!isNil {_unit getVariable QEGVAR(medical,causeOfDeath)}}) e
 TRACE_4("enteredStateDeath",_this,_thisOrigin,_thisTransition,CBA_missionTime);
 
 private _causeOfDeath = format ["%1:%2", _thisOrigin, _thisTransition];
+private _source = _unit getVariable [QEGVAR(medical,lastDamageSource), objNull];
 private _instigator = _unit getVariable [QEGVAR(medical,lastInstigator), objNull];
 
-[_unit, _causeOfDeath, _instigator] call EFUNC(medical_status,setDead);
+[_unit, _causeOfDeath, _source, _instigator] call EFUNC(medical_status,setDead);


### PR DESCRIPTION
Follow up to https://github.com/acemod/ACE3/pull/10045#issuecomment-2137912295

- Sends source and instigator to medical's setDead
- Adds a setting to killtracker to show kills from a vehicle to all crew members
before this, kills would usually go to the driver of a vehicle, not the trigger puller
so this setting attempts to mimic and expand that behavior