### PR TITLE
Compat RHS - ACE Hellfire Improvements

### DIFF
--- a/addons/compat_rhs_usf3/CfgAmmo.hpp
+++ b/addons/compat_rhs_usf3/CfgAmmo.hpp
@@ -389,4 +389,10 @@ class CfgAmmo {
     class rhs_ammo_smaw_SR: RocketBase {
         ACE_caliber = 9;
     };
+
+    class M_Scalpel_AT;
+    class ACE_Hellfire_AGM114K: M_Scalpel_AT {
+        model = "\rhsusf\addons\rhsusf_airweapons\proxyammo\rhsusf_m_AGM114K_fly";
+        proxyShape = "\rhsusf\addons\rhsusf_airweapons\proxyammo\rhsusf_m_AGM114K";
+    };
 };

--- a/addons/compat_rhs_usf3/CfgMagazineWells.hpp
+++ b/addons/compat_rhs_usf3/CfgMagazineWells.hpp
@@ -1,11 +1,11 @@
 class CfgMagazineWells {
     class ace_hellfire_K {
-        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_k)};
+        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_k), QGVAR(pylon_mag_4rnd_hellfire_k)};
     };
     class ace_hellfire_N {
-        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_n)};
+        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_n), QGVAR(pylon_mag_4rnd_hellfire_n)};
     };
     class ace_hellfire_L {
-        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_l)};
+        ADDON[] = {QGVAR(pylon_mag_2rnd_hellfire_l), QGVAR(pylon_mag_4rnd_hellfire_l)};
     };
 };

--- a/addons/compat_rhs_usf3/CfgMagazines.hpp
+++ b/addons/compat_rhs_usf3/CfgMagazines.hpp
@@ -55,4 +55,21 @@ class cfgMagazines {
         pylonWeapon = "ace_hellfire_launcher_L";
         ammo = "ACE_Hellfire_AGM114L";
     };
+
+    class rhs_mag_AGM114K_4;
+    class GVAR(pylon_mag_4rnd_hellfire_k): rhs_mag_AGM114K_4 {
+        displayName = "4x AGM-114K [ACE]";
+        pylonWeapon = "ace_hellfire_launcher";
+        ammo = "ACE_Hellfire_AGM114K";
+    };
+    class GVAR(pylon_mag_4rnd_hellfire_n): rhs_mag_AGM114K_4 {
+        displayName = "4x AGM-114N [ACE]";
+        pylonWeapon = "ace_hellfire_launcher_N";
+        ammo = "ACE_Hellfire_AGM114N";
+    };
+    class GVAR(pylon_mag_4rnd_hellfire_l): rhs_mag_AGM114K_4 {
+        displayName = "4x AGM-114L [ACE]";
+        pylonWeapon = "ace_hellfire_launcher_L";
+        ammo = "ACE_Hellfire_AGM114L";
+    };
 };

--- a/addons/compat_rhs_usf3/config.cpp
+++ b/addons/compat_rhs_usf3/config.cpp
@@ -7,7 +7,10 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhsusf_main_loadorder"};
+        requiredAddons[] = {
+            "rhsusf_main_loadorder",
+            "ace_hellfire"
+        };
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "Fyuran"};

--- a/addons/hellfire/CfgMagazines.hpp
+++ b/addons/hellfire/CfgMagazines.hpp
@@ -32,7 +32,7 @@ class CfgMagazines {
         count = 3;
         mass = 250;
         pylonWeapon = QGVAR(launcher);
-        hardpoints[] = {"B_MISSILE_PYLON", "UNI_SCALPEL", "CUP_NATO_HELO_LARGE", "RHS_HP_LONGBOW_RACK"};
+        hardpoints[] = {"B_MISSILE_PYLON", "UNI_SCALPEL", "CUP_NATO_HELO_LARGE"};
         model = "\A3\Weapons_F\DynamicLoadout\PylonPod_3x_Missile_LG_scalpel_F.p3d";
         mirrorMissilesIndexes[] = {2, 1, 3};
     };
@@ -41,7 +41,7 @@ class CfgMagazines {
         count = 4;
         mass = 340;
         pylonWeapon = QGVAR(launcher);
-        hardpoints[] = {"UNI_SCALPEL", "CUP_NATO_HELO_LARGE", "RHS_HP_HELLFIRE_RACK", "RHS_HP_LONGBOW_RACK"};
+        hardpoints[] = {"UNI_SCALPEL", "CUP_NATO_HELO_LARGE"};
         model = "\A3\Weapons_F\DynamicLoadout\PylonPod_4x_Missile_LG_scalpel_F.p3d";
         mirrorMissilesIndexes[] = {2, 1, 4, 3};
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Make ACE Hellfires use the RHS Hellfire's 3D Model (both on the pylon and in flight) when RHSUSAF is loaded, so they won't look out of place anymore when used on RHS Helicopters. IMO they look much better even on vanilla helicopters;
![New-ACE-Hellfires-with-RHS-Compat](https://github.com/acemod/ACE3/assets/58027418/a5883015-d2f7-48d4-970b-4cc21a5aa40f)
- In addition to the existing 2 Round rack of the Compat, add a 4 Round ACE Hellfire rack compatible only with RHS Helicopters, as the standard ACE 4 Round Hellfire rack would be misaligned (shifted ~1/2 its length forward) on the Apache and Blackhawk;
![New-4-Round-ACE-Hellfire-Rack-for-RHS-Compat](https://github.com/acemod/ACE3/assets/58027418/af67f17a-5480-4ac5-9ef1-e5406e35f7e5)
- Remove the hardpoint config that allowed putting the standard 4 Round ACE Hellfire rack on RHS Apaches/Blackhawks, as it would just be an uglier duplicate of the Compat's new Quad Rack;