### PR TITLE
Fix - Incorrect parent class in cookoff sounds

### DIFF
--- a/addons/cookoff/CfgSounds.hpp
+++ b/addons/cookoff/CfgSounds.hpp
@@ -45,7 +45,7 @@ class CfgSounds {
     class GVAR(shotsubmunitions_close_3): GVAR(shotbullet_close_3) {
         sound[] = {QPATHTOF(sounds\shotbullet\close_3.wss), VOLUME, PITCH, 1600};
     };
-    class GVAR(shotsubmunitions_mid_1): GVAR(shotbullet_far_1) {
+    class GVAR(shotsubmunitions_mid_1): GVAR(shotbullet_mid_1) {
         sound[] = {QPATHTOF(sounds\shotbullet\mid_1.wss), VOLUME, PITCH, 1600};
     };
     class GVAR(shotsubmunitions_mid_2): GVAR(shotbullet_mid_2) {


### PR DESCRIPTION
**When merged this pull request will:**
- Assumed typo, found this when testing alternate sounds and getting a UBC

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
