### PR TITLE
Cargo & Dragging - Disable UAV AI when being dragged, carried or cargo

### DIFF
--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -62,6 +62,17 @@ if (_item isEqualType objNull) then {
 
     // Some objects below water will take damage over time, eventually becoming "water logged" and unfixable (because of negative z attach)
     [_item, "blockDamage", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+
+    // Prevent UAVs from firing
+    private _UAVCrew = _item call EFUNC(common,getVehicleUAVCrew);
+
+    if (_UAVCrew isNotEqualTo []) then {
+        {
+            [_x, true] call EFUNC(common,disableAiUAV);
+        } forEach _UAVCrew;
+
+        _item setVariable [QGVAR(isUAV), _UAVCrew, true];
+    };
 };
 
 // Invoke listenable event

--- a/addons/cargo/functions/fnc_unloadItem.sqf
+++ b/addons/cargo/functions/fnc_unloadItem.sqf
@@ -96,6 +96,18 @@ if (_object isEqualType objNull) then {
 
         [QEGVAR(zeus,addObjects), [[_object], _objectCurators]] call CBA_fnc_serverEvent;
     };
+
+    // Reenable UAV crew
+    private _UAVCrew = _object getVariable [QGVAR(isUAV), []];
+
+    if (_UAVCrew isNotEqualTo []) then {
+        // Reenable AI
+        {
+            [_x, false] call EFUNC(common,disableAiUAV);
+        } forEach _UAVCrew;
+
+        _object setVariable [QGVAR(isUAV), nil, true];
+    };
 } else {
     _object = createVehicle [_item, _emptyPosAGL, [], 0, "NONE"];
 

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -43,6 +43,7 @@ PREP(deviceKeyFindValidIndex);
 PREP(deviceKeyRegisterNew);
 PREP(deprecateComponent);
 PREP(disableAI);
+PREP(disableAiUAV);
 PREP(disableUserInput);
 PREP(displayIcon);
 PREP(displayText);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -133,6 +133,30 @@
     _object lockInventory (_set > 0);
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(disableAiUAV), {
+    params ["_unit", "_disable"];
+
+    if (_disable) then {
+        private _features = ["AUTOTARGET", "TARGET", "WEAPONAIM"/*, "FIREWEAPON"*/, "RADIOPROTOCOL"]; // TODO: Uncomment in 2.18
+
+        // Save current status
+        _unit setVariable [QGVAR(featuresAiUAV), _features apply {[_x, _unit checkAIFeature _x]}];
+
+        {
+            _unit enableAIFeature [_x, false];
+        } forEach _features;
+    } else {
+        // Restore previous status
+        private _features = _unit getVariable [QGVAR(featuresAiUAV), []];
+
+        {
+            _unit enableAIFeature [_x select 0, _x select 1];
+        } forEach _features;
+
+        _unit setVariable [QGVAR(featuresAiUAV), nil];
+    };
+}] call CBA_fnc_addEventHandler;
+
 //Add a fix for BIS's zeus remoteControl module not reseting variables on DC when RC a unit
 //This variable is used for isPlayer checks
 if (isServer) then {

--- a/addons/common/functions/fnc_disableAiUAV.sqf
+++ b/addons/common/functions/fnc_disableAiUAV.sqf
@@ -1,0 +1,40 @@
+#include "..\script_component.hpp"
+/*
+ * Author: johnb43
+ * Disables/Enables UAV AI crew members, can be run on any machine and is applied globally.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Disable AI <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject, true] call ace_common_fnc_disableAiUAV
+ *
+ * Public: No
+ */
+
+params [["_unit", objNull, [objNull]], ["_disable", true, [false]]];
+
+if (!alive _unit || {_unit call FUNC(isPlayer)} || {!unitIsUAV _unit}) exitWith {};
+
+if (_disable) then {
+    // Disable shooting and targetting on every machine
+    private _jipID = [QGVAR(disableAiUAV), [_unit, _disable]] call CBA_fnc_globalEventJIP;
+    [_jipID, _unit] call CBA_fnc_removeGlobalEventJIP;
+
+    _unit setVariable [QGVAR(disableAiUavJipID), _jipID, true];
+} else {
+    // Restore shooting and targetting to each client's individual state prior to disabling
+    private _jipID = _unit getVariable QGVAR(disableAiUavJipID);
+
+    if (!isNil "_jipID") then {
+        _jipID call CBA_fnc_removeGlobalEventJIP;
+
+        _unit setVariable [QGVAR(disableAiUavJipID), nil, true];
+    };
+
+    [QGVAR(disableAiUAV), [_unit, _disable]] call CBA_fnc_globalEvent;
+};

--- a/addons/common/functions/fnc_disableAiUAV.sqf
+++ b/addons/common/functions/fnc_disableAiUAV.sqf
@@ -18,11 +18,16 @@
 
 params [["_unit", objNull, [objNull]], ["_disable", true, [false]]];
 
-if (!alive _unit || {_unit call FUNC(isPlayer)} || {!unitIsUAV _unit}) exitWith {};
+// Allow disabling of Zeus remote controlled units
+if (!alive _unit || {isPlayer _unit} || {!unitIsUAV _unit}) exitWith {};
 
 if (_disable) then {
-    // Disable shooting and targetting on every machine
-    private _jipID = [QGVAR(disableAiUAV), [_unit, _disable]] call CBA_fnc_globalEventJIP;
+    // Ignore if already disabled
+    if (!isNil "_jipID") exitWith {};
+
+    // Disable shooting and targeting on every machine
+    // Give predefined JIP ID, in case of simultaneous executions on different machines
+    private _jipID = [QGVAR(disableAiUAV), [_unit, _disable], QGVAR(disableAiUAV_) + hashValue _unit] call CBA_fnc_globalEventJIP;
     [_jipID, _unit] call CBA_fnc_removeGlobalEventJIP;
 
     _unit setVariable [QGVAR(disableAiUavJipID), _jipID, true];
@@ -30,11 +35,11 @@ if (_disable) then {
     // Restore shooting and targeting to each client's individual state prior to disabling
     private _jipID = _unit getVariable QGVAR(disableAiUavJipID);
 
-    if (!isNil "_jipID") then {
-        _jipID call CBA_fnc_removeGlobalEventJIP;
+    if (isNil "_jipID") exitWith {};
 
-        _unit setVariable [QGVAR(disableAiUavJipID), nil, true];
-    };
+    _jipID call CBA_fnc_removeGlobalEventJIP;
+
+    _unit setVariable [QGVAR(disableAiUavJipID), nil, true];
 
     [QGVAR(disableAiUAV), [_unit, _disable]] call CBA_fnc_globalEvent;
 };

--- a/addons/common/functions/fnc_disableAiUAV.sqf
+++ b/addons/common/functions/fnc_disableAiUAV.sqf
@@ -27,7 +27,7 @@ if (_disable) then {
 
     _unit setVariable [QGVAR(disableAiUavJipID), _jipID, true];
 } else {
-    // Restore shooting and targetting to each client's individual state prior to disabling
+    // Restore shooting and targeting to each client's individual state prior to disabling
     private _jipID = _unit getVariable QGVAR(disableAiUavJipID);
 
     if (!isNil "_jipID") then {

--- a/addons/dragging/functions/fnc_carryObject.sqf
+++ b/addons/dragging/functions/fnc_carryObject.sqf
@@ -60,10 +60,10 @@ private _UAVCrew = _target call EFUNC(common,getVehicleUAVCrew);
 
 if (_UAVCrew isNotEqualTo []) then {
     {
-        _target deleteVehicleCrew _x;
+        [_x, true] call EFUNC(common,disableAiUAV);
     } forEach _UAVCrew;
 
-    _target setVariable [QGVAR(isUAV), true, true];
+    _target setVariable [QGVAR(isUAV), _UAVCrew, true];
 };
 
 // Check everything

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -73,8 +73,8 @@ if (_unit getHitPointDamage "HitLegs" >= 0.5) exitWith {
     _idPFH call CBA_fnc_removePerFrameHandler;
 };
 
-// Drop static if crew is in it (ignore UAVs)
-if (_target isKindOf "StaticWeapon" && {isNil {_target getVariable QGVAR(isUAV)}} && {(crew _target) isNotEqualTo []}) exitWith {
+// Drop static if either non-UAV crew or new UAV crew is in it (ignore saved UAV crew)
+if (_target isKindOf "StaticWeapon" && {((crew _target) - (_target getVariable [QGVAR(isUAV), []])) isNotEqualTo []}) exitWith {
     TRACE_2("static weapon crewed",_unit,_target);
 
     [_unit, _target] call FUNC(dropObject_carry);

--- a/addons/dragging/functions/fnc_carryObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_carryObjectPFH.sqf
@@ -73,8 +73,8 @@ if (_unit getHitPointDamage "HitLegs" >= 0.5) exitWith {
     _idPFH call CBA_fnc_removePerFrameHandler;
 };
 
-// Drop static if crew is in it (UAV crew deletion may take a few frames)
-if (_target isKindOf "StaticWeapon" && {!(_target getVariable [QGVAR(isUAV), false])} && {(crew _target) isNotEqualTo []}) exitWith {
+// Drop static if crew is in it (ignore UAVs)
+if (_target isKindOf "StaticWeapon" && {isNil {_target getVariable QGVAR(isUAV)}} && {(crew _target) isNotEqualTo []}) exitWith {
     TRACE_2("static weapon crewed",_unit,_target);
 
     [_unit, _target] call FUNC(dropObject_carry);

--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -73,10 +73,10 @@ private _UAVCrew = _target call EFUNC(common,getVehicleUAVCrew);
 
 if (_UAVCrew isNotEqualTo []) then {
     {
-        _target deleteVehicleCrew _x;
+        [_x, true] call EFUNC(common,disableAiUAV);
     } forEach _UAVCrew;
 
-    _target setVariable [QGVAR(isUAV), true, true];
+    _target setVariable [QGVAR(isUAV), _UAVCrew, true];
 };
 
 // Check everything

--- a/addons/dragging/functions/fnc_dragObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_dragObjectPFH.sqf
@@ -51,8 +51,8 @@ if (_unit distance _target > 10 && {(CBA_missionTime - _startTime) >= 1}) exitWi
     _idPFH call CBA_fnc_removePerFrameHandler;
 };
 
-// Drop static if crew is in it (UAV crew deletion may take a few frames)
-if (_target isKindOf "StaticWeapon" && {!(_target getVariable [QGVAR(isUAV), false])} && {(crew _target) isNotEqualTo []}) exitWith {
+// Drop static if crew is in it (ignore UAVs)
+if (_target isKindOf "StaticWeapon" && {isNil {_target getVariable QGVAR(isUAV)}} && {(crew _target) isNotEqualTo []}) exitWith {
     TRACE_2("static weapon crewed",_unit,_target);
 
     [_unit, _target] call FUNC(dropObject);

--- a/addons/dragging/functions/fnc_dragObjectPFH.sqf
+++ b/addons/dragging/functions/fnc_dragObjectPFH.sqf
@@ -51,8 +51,8 @@ if (_unit distance _target > 10 && {(CBA_missionTime - _startTime) >= 1}) exitWi
     _idPFH call CBA_fnc_removePerFrameHandler;
 };
 
-// Drop static if crew is in it (ignore UAVs)
-if (_target isKindOf "StaticWeapon" && {isNil {_target getVariable QGVAR(isUAV)}} && {(crew _target) isNotEqualTo []}) exitWith {
+// Drop static if either non-UAV crew or new UAV crew is in it (ignore saved UAV crew)
+if (_target isKindOf "StaticWeapon" && {((crew _target) - (_target getVariable [QGVAR(isUAV), []])) isNotEqualTo []}) exitWith {
     TRACE_2("static weapon crewed",_unit,_target);
 
     [_unit, _target] call FUNC(dropObject);

--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -80,16 +80,16 @@ if (_unit getVariable ["ACE_isUnconscious", false]) then {
     [_unit, "unconscious", 2] call EFUNC(common,doAnimation);
 };
 
-// Recreate UAV crew (add a frame delay or this may cause the vehicle to be moved to [0,0,0])
-if (_target getVariable [QGVAR(isUAV), false]) then {
-    _target setVariable [QGVAR(isUAV), nil, true];
+// Reenable UAV crew
+private _UAVCrew = _target getVariable [QGVAR(isUAV), []];
 
-    [{
-        params ["_target"];
-        if (!alive _target) exitWith {};
-        TRACE_2("restoring uav crew",_target,getPosASL _target);
-        createVehicleCrew _target;
-    }, [_target]] call CBA_fnc_execNextFrame;
+if (_UAVCrew isNotEqualTo []) then {
+    // Reenable AI
+    {
+        [_x, false] call EFUNC(common,disableAiUAV);
+    } forEach _UAVCrew;
+
+    _target setVariable [QGVAR(isUAV), nil, true];
 };
 
 // Fixes not being able to move when in combat pace

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -86,16 +86,16 @@ if !(_target isKindOf "CAManBase") then {
     [QEGVAR(common,fixFloating), _target, _target] call CBA_fnc_targetEvent;
 };
 
-// Recreate UAV crew (add a frame delay or this may cause the vehicle to be moved to [0,0,0])
-if (_target getVariable [QGVAR(isUAV), false]) then {
-    _target setVariable [QGVAR(isUAV), nil, true];
+// Reenable UAV crew
+private _UAVCrew = _target getVariable [QGVAR(isUAV), []];
 
-    [{
-        params ["_target"];
-        if (!alive _target) exitWith {};
-        TRACE_2("restoring uav crew",_target,getPosASL _target);
-        createVehicleCrew _target;
-    }, [_target]] call CBA_fnc_execNextFrame;
+if (_UAVCrew isNotEqualTo []) then {
+    // Reenable AI
+    {
+        [_x, false] call EFUNC(common,disableAiUAV);
+    } forEach _UAVCrew;
+
+    _target setVariable [QGVAR(isUAV), nil, true];
 };
 
 // Reset mass


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a new function to common which handles turning off UAV AI, instead of deleting the UAV crew as was done previously.
  Cargo doesn't handle UAV crew at all currently, meaning if airbourne vehicles are >100m above the ground and enemies are in sight, the turret shoots when possible.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
