### PR TITLE
Common - Fix `ace_common_fnc_uniqueItems`

### DIFF
--- a/addons/common/functions/fnc_uniqueItems.sqf
+++ b/addons/common/functions/fnc_uniqueItems.sqf
@@ -28,10 +28,12 @@ private _fnc_getItems = {
     _inventoryItems append ((getItemCargo vestContainer _target) select 0);
     _inventoryItems append ((getItemCargo backpackContainer _target) select 0);
 
-    _items set [0, _inventoryItems];
-    _items set [1, magazines _target];
+    private _magazines = magazines _target;
 
-    _items arrayIntersect _items
+    _items set [0, _inventoryItems arrayIntersect _inventoryItems];
+    _items set [1, _magazines arrayIntersect _magazines];
+
+    _items
 };
 
 // Cache items list if unit is ACE_player


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- For items, it would return duplicates if the unit had multiple containers.
- For magazines, it would return duplicates if the unit had more than 1 magazine of a type.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
