### PR TITLE
Wiki - Fix dependencies list on wiki

### DIFF
--- a/addons/atragmx/config.cpp
+++ b/addons/atragmx/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {"ACE_Item_ATragMX"};
         weapons[] = {"ACE_ATragMX"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ACE_Advanced_Ballistics", "ACE_common", "ACE_weather"};
+        requiredAddons[] = {"ace_advanced_ballistics", "ace_common", "ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
         url = ECSTRING(main,URL);

--- a/addons/kestrel4500/config.cpp
+++ b/addons/kestrel4500/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {"ACE_Item_Kestrel4500"};
         weapons[] = {"ACE_Kestrel4500"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ACE_common", "ACE_weather"};
+        requiredAddons[] = {"ace_common", "ace_weather"};
         author = ECSTRING(common,ACETeam);
         authors[] = {ECSTRING(common,ACETeam), "Ruthberg"};
         url = ECSTRING(main,URL);

--- a/addons/rangecard/config.cpp
+++ b/addons/rangecard/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {"ACE_Item_RangeCard"};
         weapons[] = {"ACE_RangeCard"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ACE_Advanced_Ballistics","ace_scopes"};
+        requiredAddons[] = {"ace_advanced_ballistics", "ace_scopes"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg"};
         url = ECSTRING(main,URL);

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'tzinfo-data'
+gem 'webrick'

--- a/docs/wiki/development/dependencies.md
+++ b/docs/wiki/development/dependencies.md
@@ -21,16 +21,18 @@ Because `ace_zeus` is being removed you must also remove any components that req
 
 ## 2. Dependencies
 
-{% assign pages_by_title = site.pages | sort: "title" %}
+{% assign pages_by_title = site.pages | sort_natural: "title" %}
 {% for page in pages_by_title %}
     {%- if page.group == 'feature' and page.component -%}
-        ### {{ page.title }}
+        {%- unless page.version.removed -%}
+            ### {{ page.title }}
+            
+            {% capture component %}{{ page.component }}{% endcapture %}
+            {% include dependencies_list.md component=component %}
 
-        {% capture component %}{{ page.component }}{% endcapture %}
-        {% include dependencies_list.md component=component %}
-
-        {%- if page.core_component -%}
-            _Note: This module is required by nearly all other modules. Do NOT remove it!_
-        {% endif %}
+            {%- if page.core_component -%}
+                _Note: This module is required by nearly all other modules. Do NOT remove it!_
+            {% endif %}
+        {% endunless %}
     {% endif %}
 {% endfor %}

--- a/docs/wiki/feature/artillerytables.md
+++ b/docs/wiki/feature/artillerytables.md
@@ -1,0 +1,30 @@
+---
+layout: wiki
+title: Artillery Tables
+component: artillerytables
+description: Adds universal rangetables for artillery.
+group: feature
+category: equipment
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 13
+  patch: 0
+---
+
+## 1. Overview
+
+### 1.1 Features
+- Adds a rangetable to accurately take out your target without the artillery computer.
+- Shows accurate elevation and azimuth.
+- Optionally adds wind deflection and air friction for shells.
+- Optionally disables artillery computers.
+
+## 2. Usage
+
+### 2.1 Opening a rangetable
+- Enter a piece of artillery.
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select `Equipment`.
+- Select the rangetable of the piece of artillery you are in.

--- a/docs/wiki/feature/cargo.md
+++ b/docs/wiki/feature/cargo.md
@@ -1,0 +1,41 @@
+---
+layout: wiki
+title: Cargo
+component: cargo
+description: Adds the ability to transport cargo using vehicles.
+group: feature
+category: interaction
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 3
+  patch: 0
+---
+
+## 1. Overview
+Adds the ability to load and unload cargo from vehicles. Unloading can happen via two methods: Regular unloading and deploying, where you can preplace the item before it's unloaded.
+
+## 2. Usage
+
+### 2.1 Loading an object
+- Interact with the object to be loaded <kbd>⊞ win</kbd>.
+- Select the `Load` option.
+- Select which vehicle you want to load the object in.
+- Wait for the progress bar to finish. To cancel loading, press <kbd>Escape</kbd>.
+
+### 2.2 Checking a vehicle's cargo
+- Interact with the vehicle whose cargo is to b e checked <kbd>⊞ win</kbd>.
+- Select the `Cargo` option.
+
+### 2.3 Unloading an object from a vehicle
+- Open the vehicle's cargo menu (see "Checking a vehicle's cargo")
+- Press `Unload`.
+- Wait for the progress bar to finish. To cancel unloading, press <kbd>Escape</kbd>.
+
+### 2.4 Deploying an object from a vehicle
+- Open the vehicle's cargo menu (see "Checking a vehicle's cargo")
+- Press `Deploy`.
+- Use the mouse to fine tune the placement of the object.
+- When ready to place, press left click to start deploying the object.
+- Wait for the progress bar to finish. To cancel deploying, press <kbd>Escape</kbd>.

--- a/docs/wiki/feature/casings.md
+++ b/docs/wiki/feature/casings.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: Casings
+component: casings
+description: Adds infantry bullet casings on the ground when weapons are fired.
+group: feature
+category: realism
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 15
+  patch: 0
+---
+
+## 1. Overview
+Spits out casings from infantry weapons when fired.

--- a/docs/wiki/feature/cookoff.md
+++ b/docs/wiki/feature/cookoff.md
@@ -1,0 +1,22 @@
+---
+layout: wiki
+title: Cook-off
+component: cookoff
+description: Adds cook-off effects to vehicles and ammunition boxes that have had their ammunition detonated or that have been destroyed.
+group: feature
+category: realism
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 7
+  patch: 0
+---
+
+## 1. Overview
+
+### 1.1 Features
+- Adds engine fires when a vehicle's engine is damaged heavily.
+- Optionally adds fire if a vehicle suffers ammunition detonations (requires `Vehicle Damage` to be enabled).
+- Optionally adds ammunition detonation if a vehicle is destroyed.
+- Optionally adds ammunition detonation if an ammunition box is destroyed or hit with explosive, incendiary or tracer ammunition.

--- a/docs/wiki/feature/dogtags.md
+++ b/docs/wiki/feature/dogtags.md
@@ -1,0 +1,40 @@
+---
+layout: wiki
+title: Dog Tags
+component: dogtags
+description: Adds dog tags to units.
+group: feature
+category: realism
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 7
+  patch: 0
+---
+
+## 1. Overview
+Provides dog tags to units, which include name, social security number and blood type as information.
+
+## 2. Usage
+
+### 2.1 Checking a unit's dog tags
+- Interact with the unconscious or dead unit whose dog tags are to be checked <kbd>⊞ win</kbd>.
+- Select the `Dog Tag` option.
+- Select the `Check` option.
+
+### 2.2 Taking a unit's dog tags
+- Interact with the unconscious or dead unit whose dog tags are to be checked <kbd>⊞ win</kbd>.
+- Select the `Dog Tag` option.
+- Select the `Take` option.
+- If the one of the two dog tags has already been taken, it will inform you and not give you the 2nd dog tag
+
+### 2.3 Checking what dog tags you have via self-interaction
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select the `Equipment` option.
+- Select the `Check Dog Tag` option.
+
+### 2.4 Checking what dog tags you have via context menu
+- Open your inventory and find the dog tag you want to inspect.
+- Double click the item.
+- Click `Check Dog Tag`.

--- a/docs/wiki/feature/field-rations.md
+++ b/docs/wiki/feature/field-rations.md
@@ -1,0 +1,30 @@
+---
+layout: wiki
+title: Field Rations
+component: field_rations
+description: Adds a thirst and hunger system, along with food to replenish those.
+group: feature
+category: realism
+parent: wiki
+mod: acex
+version:
+  major: 3
+  minor: 4
+  patch: 0
+---
+
+## 1. Overview
+Simulates hunger and thirst which need to be replenished. This system is affected by other modules, such as weather and medical, and can in turn affect fatigue.
+
+## 2. Usage
+
+### 2.1 Satiate hunger/Quench thirst via self-interaction
+- Pick up a drink.
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select the `Survival` option.
+- Choose an item to consume.
+
+### 2.2 Satiate hunger/Quench thirst via context menu
+- Open your inventory and find the item you want to consume.
+- Double click the item.
+- Click `Eat/Drink`.

--- a/docs/wiki/feature/fieldmanual.md
+++ b/docs/wiki/feature/fieldmanual.md
@@ -1,0 +1,23 @@
+---
+layout: wiki
+title: Field Manual
+component: fieldmanual
+description: Adds ACE3 content to the field manual.
+group: feature
+category: general
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 16
+  patch: 0
+---
+
+## 1. Overview
+Provides information on items and mechanics that ACE3 adds.
+
+## 2. Usage
+
+### 2.1 Opening the field manual
+- Press <kbd>Escape</kbd>.
+- Press `Field Manual`.

--- a/docs/wiki/feature/gestures.md
+++ b/docs/wiki/feature/gestures.md
@@ -1,0 +1,32 @@
+---
+layout: wiki
+title: Gestures
+component: gestures
+description: Adds gestures that can be used for communication.
+group: feature
+category: interaction
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 4
+  patch: 0
+---
+
+## 1. Overview
+Adds the ability to use 14 gestures for communication.
+
+## 2. Usage
+
+### 2.1 Using gestures via self-interaction
+
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select the `Gestures` option.
+
+### 2.2 Rebinding keybinds for gestures
+
+- Press <kbd>Escape</kbd>.
+- Select `Options`.
+- Select `Controls`.
+- Select `Configure Addons`.
+- Select `ACE Gestures`.

--- a/docs/wiki/feature/gunbag.md
+++ b/docs/wiki/feature/gunbag.md
@@ -1,0 +1,32 @@
+---
+layout: wiki
+title: Gun Bag
+component: gunbag
+description: Adds a gun bag that can be used to store a weapon.
+group: feature
+category: equipment
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 6
+  patch: 0
+---
+
+## 1. Overview
+Adds easy handling and storage of an additional weapon in a backpack.
+
+## 2. Usage
+
+### 2.1 Interacting with your gun bag via self-interaction
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select the `Equipment` option.
+- Select the `Gunbag` option.
+
+### 2.2 Interacting with your gun bag via the ACE arsenal
+- Open an ACE arsenal.
+- Get yourself a gun bag if you don't have one already.
+- Select the primary weapon or backpack tab to interact with weapon.
+
+### 2.3 Interacting with another unit's gun bag
+- Interact with the unit <kbd>⊞ win</kbd>.

--- a/docs/wiki/feature/index.md
+++ b/docs/wiki/feature/index.md
@@ -19,7 +19,7 @@ redirect_from: "/wiki/featurex"
         <h2>General</h2>
         <nav>
             <ul>
-                {% assign feature_list = site.pages | sort: "title" %}
+                {% assign feature_list = site.pages | sort_natural: "title" %}
                 {% assign group = 'feature' %}
                 {% assign category = 'general' %}
                 {% include feature_list %}
@@ -30,7 +30,7 @@ redirect_from: "/wiki/featurex"
         <h2>Interaction</h2>
         <nav>
             <ul>
-                {% assign feature_list = site.pages | sort: "title" %}
+                {% assign feature_list = site.pages | sort_natural: "title" %}
                 {% assign group = 'feature' %}
                 {% assign category = 'interaction' %}
                 {% include feature_list %}
@@ -41,7 +41,7 @@ redirect_from: "/wiki/featurex"
         <h2>Realism</h2>
         <nav>
             <ul>
-                {% assign feature_list = site.pages | sort: "title" %}
+                {% assign feature_list = site.pages | sort_natural: "title" %}
                 {% assign group = 'feature' %}
                 {% assign category = 'realism' %}
                 {% include feature_list %}
@@ -52,7 +52,7 @@ redirect_from: "/wiki/featurex"
         <h2>Equipment</h2>
         <nav>
             <ul>
-                {% assign feature_list = site.pages | sort: "title" %}
+                {% assign feature_list = site.pages | sort_natural: "title" %}
                 {% assign group = 'feature' %}
                 {% assign category = 'equipment' %}
                 {% include feature_list %}

--- a/docs/wiki/feature/killtracker.md
+++ b/docs/wiki/feature/killtracker.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: Kill Tracker
+component: killtracker
+description: Tracks deaths/kills and displays them at the mission end.
+group: feature
+category: general
+parent: wiki
+mod: acex
+version:
+  major: 3
+  minor: 1
+  patch: 0
+---
+
+## 1. Overview
+Provides a method of tracking kills/deaths and displays them in the mission end screen.

--- a/docs/wiki/feature/logistics-rope.md
+++ b/docs/wiki/feature/logistics-rope.md
@@ -1,0 +1,22 @@
+---
+layout: wiki
+title: Logistics - Rope
+component: logistics_rope
+description: Adds ropes.
+group: feature
+category: equipment
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 14
+  patch: 0
+---
+
+<div class="panel callout">
+    <h5>Note:</h5>
+    <p>Ropes were moved from fastroping to logistics_rope in 3.14.0, but were introduced in 3.12.6!</p>
+</div>
+
+## 1. Overview
+Adds several rope items of different lengths that are required for fastroping and towing. 

--- a/docs/wiki/feature/maverick.md
+++ b/docs/wiki/feature/maverick.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: Maverick
+component: maverick
+description: Adds pylon magazines with laser guided AGM-65 Maverick L and KH25ML.
+group: feature
+category: equipment
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 11
+  patch: 0
+---
+
+## 1. Overview
+Adds pylon magazines with laser guided AGM-65 Maverick L and KH25ML. 

--- a/docs/wiki/feature/metis.md
+++ b/docs/wiki/feature/metis.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: Metis
+component: metis
+description: Converts the vanilla "Vorona" Missile Guidance into ACE SACLOS Guidance.
+group: feature
+category: equipment
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 13
+  patch: 0
+---
+
+## 1. Overview
+Converts the vanilla "Vorona" Missile Guidance into ACE SACLOS Guidance.

--- a/docs/wiki/feature/minedetector.md
+++ b/docs/wiki/feature/minedetector.md
@@ -1,0 +1,25 @@
+---
+layout: wiki
+title: Mine Detector
+component: minedetector
+description: Adds 2 mine detectors, as well as a framework to implement your own.
+group: feature
+category: equipment
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 6
+  patch: 0
+---
+
+## 1. Overview
+Provides a system for implementing mine detectors and adds 2 of its own (`VMH3`, `VMM3`).
+
+## 2. Usage
+
+### 2.1 Interacting with the mine detector
+- Select your mine detector.
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select the `Equipment` option.
+- Select the `Metal detector` option.

--- a/docs/wiki/feature/mk6mortar.md
+++ b/docs/wiki/feature/mk6mortar.md
@@ -18,7 +18,6 @@ version:
 ### 1.1 Mk6 Mortar overhaul
 ACE3 adds wind deflection for shells as well as a rangetable to accurately take out your target without the artillery computer. If ammunition handling is enabled, rounds must be loaded manually.
 
-
 ## 2. Usage
 
 ### 2.1 Switching charge
@@ -31,7 +30,6 @@ ACE3 adds wind deflection for shells as well as a rangetable to accurately take 
 
 ### 2.2 Getting your shells to land where you want.
 For this you need a `82mm Rangetable`, `Map Tools` and a `Vector 21` are also recommended.
-
 
 - Get the distance and elevation difference between you and the target (you can use map tools).
 - Select the charge you want to use (0 = close / 1 = medium  / 2 = far).

--- a/docs/wiki/feature/quickmount.md
+++ b/docs/wiki/feature/quickmount.md
@@ -1,0 +1,27 @@
+---
+layout: wiki
+title: Quick-mount
+component: quickmount
+description: Adds a keybind to quickly mount vehicles.
+group: feature
+category: interaction
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 10
+  patch: 0
+---
+
+## 1. Overview
+Provides a method for quickly getting into vehicles, as well as vehicle seat interactions.
+
+## 2. Usage
+
+### 2.1 Quick-mount
+- Assign keybind (unbound by default).
+- Press keybind when looking at vehicle.
+
+### 2.1 Loading an object
+- Interact with the object to be mount up in <kbd>⊞ win</kbd>.
+- Select the `Get In` option.

--- a/docs/wiki/feature/realisticweights.md
+++ b/docs/wiki/feature/realisticweights.md
@@ -1,0 +1,19 @@
+---
+layout: wiki
+title: Realistic Weights
+component: realisticweights
+description: More realistic weapon weights.
+group: feature
+category: realism
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 7
+  patch: 0
+---
+
+## 1. Overview
+
+### 1.1 Real weights
+Changes the weights of weapons to their respective real-world counterparts whenever possible.

--- a/docs/wiki/feature/testmissions.md
+++ b/docs/wiki/feature/testmissions.md
@@ -16,4 +16,4 @@ version:
 
 ## 1. Overview
 
-Adds an ACE3 Test Missions
+Adds ACE3 Test Missions.

--- a/docs/wiki/feature/towing.md
+++ b/docs/wiki/feature/towing.md
@@ -1,0 +1,33 @@
+---
+layout: wiki
+title: Towing
+component: towing
+description: Adds the ability to tow vehicles.
+group: feature
+category: interaction
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 14
+  patch: 0
+---
+
+## 1. Overview
+Adds the ability to tow vehicles.
+
+## 2. Usage
+
+It is recommended to not have anyone in the towed vehicle!
+
+### 2.1 Adding a tow rope between two vehicles
+- Pick up a rope.
+- Interact with the vehicle that is going to tow <kbd>⊞ win</kbd>.
+- Select `Towing`.
+- Select whichever rope you want.
+- Place the first attachment point on the towing vehicle wherever you want.
+- Place the second attachment point on the towed vehicle wherever you want.
+
+### 2.2 Removing a tow rope between two vehicles
+- Interact with either vehicle <kbd>⊞ win</kbd>.
+- Select `Towing`.

--- a/docs/wiki/feature/trenches.md
+++ b/docs/wiki/feature/trenches.md
@@ -1,0 +1,42 @@
+---
+layout: wiki
+title: Trenches
+component: trenches
+description: Provides players with the capability of digging trenches.
+group: feature
+category: interaction
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 5
+  patch: 0
+---
+
+## 1. Overview
+Provides players with the capability of digging trenches.
+
+## 2. Usage
+
+You can see if any tool/backpack is defined as an entrenching tool by opening the ACE arsenal and looking at the stats box.
+
+### 2.1 Digging a trench
+- Pick up an entrenching tool.
+- Use Self Interact <kbd>Ctrl</kbd>+<kbd>⊞&nbsp;Win</kbd> (ACE3 default).
+- Select the `Equipment` option.
+- Select which trench type you want to build.
+- Use the mouse to place the trench how you want.
+- When ready to place, press left click to start digging.
+- Wait for the progress bar to finish. To stop digging, press <kbd>Escape</kbd>.
+
+### 2.2 Removing a trench
+- Pick up an entrenching tool.
+- Interact with the trench to remove <kbd>⊞ win</kbd>.
+- Select the `Remove Trench` option.
+- Wait for the progress bar to finish. To stop removing, press <kbd>Escape</kbd>.
+
+### 2.3 Continue digging a trench
+- Pick up an entrenching tool.
+- Interact with the trench to continue to dig <kbd>⊞ win</kbd>.
+- Select the `Continue Digging Trench` option.
+- Wait for the progress bar to finish. To stop digging, press <kbd>Escape</kbd>.

--- a/docs/wiki/feature/viewports.md
+++ b/docs/wiki/feature/viewports.md
@@ -1,6 +1,7 @@
 ---
 layout: wiki
 title: Viewports
+component: viewports
 description: Allows crew to look through periscopes.
 group: feature
 category: interaction

--- a/docs/wiki/feature/viewrestrictions.md
+++ b/docs/wiki/feature/viewrestrictions.md
@@ -1,0 +1,17 @@
+---
+layout: wiki
+title: View Restrictions
+component: viewrestriction
+description: Adds the ability to enforce certain view modes.
+group: feature
+category: realism
+parent: wiki
+mod: acex
+version:
+  major: 3
+  minor: 0
+  patch: 0
+---
+
+## 1. Overview
+Restricts view modes according to the settings chosen.

--- a/docs/wiki/feature/xm157.md
+++ b/docs/wiki/feature/xm157.md
@@ -1,0 +1,27 @@
+---
+layout: wiki
+title: XM157
+component: xm157
+description: Adds a framework for the XM157 scope.
+group: feature
+category: general
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 15
+  patch: 1
+---
+
+## 1. Overview
+Adds a framework for the XM157 scope.
+
+## 2. Usage
+
+### 2.1 Ranging
+- Press <kbd>Tab</kbd> for rangefinding.
+- Use <kbd>PageUP</kbd> and <kbd>PageDOWN</kbd> to manually increase/decrease respectively.
+
+### 2.2 Menu navigation
+- Use <kbd>Delete</kbd> and <kbd>End</kbd> to cycle through menus.
+- Use <kbd>PageUP</kbd> and <kbd>PageDOWN</kbd> to increase/decrease values respectively.

--- a/docs/wiki/framework/index.md
+++ b/docs/wiki/framework/index.md
@@ -28,7 +28,7 @@ redirect_from:
     <div class="large-12 columns">
         <nav>
             <ul class="columns">
-                {% assign pages_list = site.pages | sort: "title" %}
+                {% assign pages_list = site.pages | sort_natural: "title" %}
                 {% assign group = 'framework' %}
                 {% include pages_list %}
             </ul>

--- a/docs/wiki/functions/index.md
+++ b/docs/wiki/functions/index.md
@@ -23,7 +23,7 @@ parent: wiki
     <div class="large-12 columns">
         <nav>
             <ul class="columns">
-                {% assign pages_list = site.pages | sort: "title" %}
+                {% assign pages_list = site.pages | sort_natural: "title" %}
                 {% assign group = 'functions' %}
                 {% include pages_list %}
             </ul>

--- a/optionals/nomedical/config.cpp
+++ b/optionals/nomedical/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {};
+        requiredAddons[] = {"ace_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Dystopian"};
         url = ECSTRING(main,URL);

--- a/optionals/norealisticnames/config.cpp
+++ b/optionals/norealisticnames/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {};
+        requiredAddons[] = {"ace_main"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Dystopian"};
         url = ECSTRING(main,URL);

--- a/tools/extract_dependencies.py
+++ b/tools/extract_dependencies.py
@@ -89,6 +89,9 @@ def main():
                             data += get_dependencies(line)
                             continue
 
+            # Sort addons alphabetically
+            data.sort(key=str.casefold)
+
             data = "`, `".join(data)
             data = "`{}`".format(data)
 


### PR DESCRIPTION
**When merged this pull request will:**
- Address https://github.com/acemod/ACE3/issues/9676#issuecomment-1850158563.
- Complete the dependencies list on the wiki (https://ace3.acemod.org/wiki/development/dependencies).
- List all dependencies in alphabetical order.
- Only list categories that haven't been removed (previously, `testmission` was displayed).
- Sort all lists case-insensitively.

Question:
How do I go about fixing https://ace3.acemod.org/wiki/development/dependencies#medical-menu? I don't understand to what it's referring to (`ace_medical_gui` includes both interactions and the medical menu).

Future TODOs:
- Make title clickable so that they update the url to their position. I couldn't wrap my head around where that needs to be added.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
