### PR TITLE
RHS Compats - Add `common` to loadorder

### DIFF
--- a/addons/compat_rhs_afrf3/config.cpp
+++ b/addons/compat_rhs_afrf3/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhs_main_loadorder"};
+        requiredAddons[] = {"ace_common", "rhs_main_loadorder"};
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "commy2", "Skengman2"};
         url = ECSTRING(main,URL);

--- a/addons/compat_rhs_gref3/config.cpp
+++ b/addons/compat_rhs_gref3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhsgref_main_loadorder"};
+        requiredAddons[] = {"ace_common", "rhsgref_main_loadorder"};
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
         authors[] = {"PabstMirror", "Ruthberg", "Anton"};

--- a/addons/compat_rhs_saf3/config.cpp
+++ b/addons/compat_rhs_saf3/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhssaf_main_loadorder"};
+        requiredAddons[] = {"ace_common", "rhssaf_main_loadorder"};
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
         authors[] = {};

--- a/addons/compat_rhs_usf3/config.cpp
+++ b/addons/compat_rhs_usf3/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"rhsusf_main_loadorder"};
+        requiredAddons[] = {"ace_common", "rhsusf_main_loadorder"};
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
         authors[] = {"Ruthberg", "GitHawk", "BaerMitUmlaut", "Fyuran"};


### PR DESCRIPTION
**When merged this pull request will:**
- Required for #6144.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
