### PR TITLE
Interaction - Improve `FUNC(switchWeaponAttachment)`

### DIFF
--- a/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
+++ b/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
@@ -4,8 +4,8 @@
  * Switches weapon attachment.
  *
  * Arguments:
- * 0: Target <OBJECT>
- * 1: Player (not used) <OBJECT>
+ * 0: Target (not used) <OBJECT>
+ * 1: Player <OBJECT>
  * 2: Action params <ARRAY>
  *
  * Return Value:
@@ -17,11 +17,19 @@
  * Public: No
  */
 
-params ["_unit", "", "_actionParams"];
+params ["", "_unit", "_actionParams"];
 _actionParams params ["_weapon", "_newAttachment", "_oldAttachment"];
 TRACE_3("Switching attachment",_weapon,_newAttachment,_oldAttachment);
 
-[_unit, "Gear"] call EFUNC(common,doGesture);
+private _currWeaponType = switch (_weapon) do {
+    case (""): {-1};
+    case (primaryWeapon _unit): {0};
+    case (handgunWeapon _unit): {1};
+    case (secondaryWeapon _unit): {2};
+    default {-1};
+};
+
+if (_currWeaponType == -1) exitWith {};
 
 private _addNew = _newAttachment isNotEqualTo "";
 private _removeOld = _oldAttachment isNotEqualTo "";
@@ -38,22 +46,42 @@ if (_removeOld && {!([_unit, _oldAttachment] call CBA_fnc_canAddItem)}) exitWith
     };
 };
 
+[_unit, "Gear"] call EFUNC(common,doGesture);
+
 if (_removeOld) then {
     [{
-        params ["_unit", "_weapon", "_oldAttachment"];
-        switch (_weapon) do {
-            case (primaryWeapon _unit): {_unit removePrimaryWeaponItem _oldAttachment;};
-            case (handgunWeapon _unit): {_unit removeHandgunItem _oldAttachment;};
-            default {_unit removeSecondaryWeaponItem _oldAttachment;};
+        params ["_unit", "_oldAttachment", "", "_currWeaponType"];
+
+        switch (_currWeaponType) do {
+            case 0: {_unit removePrimaryWeaponItem _oldAttachment};
+            case 1: {_unit removeHandgunItem _oldAttachment};
+            case 2: {_unit removeSecondaryWeaponItem _oldAttachment};
+            default {};
         };
+
         _unit addItem _oldAttachment;
-    }, [_unit, _weapon, _oldAttachment], 0.3] call CBA_fnc_waitAndExecute;
+
+        // If adding a new item, let that code handle raising EH
+        // Delete addNew from array, to be able to pass _this to EH
+        if (_this deleteAt 4) exitWith {};
+
+        ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
+    }, [_unit, _oldAttachment, _newAttachment, _currWeaponType, _addNew], 0.3] call CBA_fnc_waitAndExecute;
 };
 
 if (!_addNew) exitWith {};
 
 [{
-    params ["_unit", "_weapon", "_newAttachment"];
-    _unit addWeaponItem [_weapon, _newAttachment];
+    params ["_unit", "", "_newAttachment"];
+
+    // Delete weapon from array, to be able to pass _this to EH
+    _unit addWeaponItem [_this deleteAt 4, _newAttachment];
+
     [[getText (configFile >> "CfgWeapons" >> _newAttachment >> "picture"), 4], true] call CBA_fnc_notify;
-}, [_unit, _weapon, _newAttachment], 1] call CBA_fnc_waitAndExecute;
+
+    if (_unit == ACE_player) then {
+        playSound "click";
+    };
+
+    ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
+}, [_unit, _oldAttachment, _newAttachment, _currWeaponType, _weapon], 1] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Only play animation if the attachment can be switched.
- Only play sound if unit is `ACE_player` (should always be the case, but added as precaution).
- Raise CBA attachment switched EH.

If we want to remove the delays between switching items, we can probably use #10135.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
