### PR TITLE
Fire - Fix medical macros in compiled sqfc

### DIFF
--- a/addons/fire/addon.toml
+++ b/addons/fire/addon.toml
@@ -1,3 +1,0 @@
-[tools]
-pboProject_noBinConfig = true
-sqfvm_skipConfigChecks = true

--- a/addons/fire/functions/fnc_burnSimulation.sqf
+++ b/addons/fire/functions/fnc_burnSimulation.sqf
@@ -151,7 +151,7 @@ params ["_unit", "_instigator"];
         // Keep pain around unconsciousness limit to allow for more fun interactions
         private _painPercieved = (0 max ((_unit getVariable [QEGVAR(medical,pain), 0]) - (_unit getVariable [QEGVAR(medical,painSuppress), 0])) min 1);
         private _painUnconscious = missionNamespace getVariable [QEGVAR(medical,painUnconsciousThreshold), 0];
-        private _damageToAdd = [0.15, _intensity / BURN_MAX_INTENSITY] select (!alive _unit || {_painPercieved < _painUnconscious});
+        private _damageToAdd = [0.15, _intensity / BURN_MAX_INTENSITY] select (!alive _unit || {_painPercieved < _painUnconscious + random 0.2});
 
         if (GETEGVAR(medical,enabled,false)) then {
             if (!isNull _instigator) then {

--- a/addons/fire/functions/fnc_burnSimulation.sqf
+++ b/addons/fire/functions/fnc_burnSimulation.sqf
@@ -149,7 +149,9 @@ params ["_unit", "_instigator"];
         };
 
         // Keep pain around unconsciousness limit to allow for more fun interactions
-        private _damageToAdd = [0.15, _intensity / BURN_MAX_INTENSITY] select (!alive _unit || {GET_PAIN_PERCEIVED(_unit) < (PAIN_UNCONSCIOUS + random 0.2)});
+        private _painPercieved = (0 max ((_unit getVariable [QEGVAR(medical,pain), 0]) - (_unit getVariable [QEGVAR(medical,painSuppress), 0])) min 1);
+        private _painUnconscious = missionNamespace getVariable [QEGVAR(medical,painUnconsciousThreshold), 0];
+        private _damageToAdd = [0.15, _intensity / BURN_MAX_INTENSITY] select (!alive _unit || {_painPercieved < _painUnconscious});
 
         if (GETEGVAR(medical,enabled,false)) then {
             if (!isNull _instigator) then {

--- a/addons/fire/script_component.hpp
+++ b/addons/fire/script_component.hpp
@@ -17,14 +17,6 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
-#pragma hemtt flag pe23_ignore_has_include
-#if __has_include("\z\ace\addons\medical_engine\script_macros_medical.hpp")
-#include "\z\ace\addons\medical_engine\script_macros_medical.hpp"
-#else
-#define GET_PAIN_PERCEIVED(var) 0
-#define PAIN_UNCONSCIOUS 1
-#endif
-
 #define FIRE_MANAGER_PFH_DELAY 0.25
 #define FLARE_SIZE_MODIFIER 5
 #define PRONE_ROLLING_ANIMS [\


### PR DESCRIPTION
`#if has_include` for sqf is evaluated at build time
e.g. the compiled .sqfc was 
`private _damageToAdd = [0.15, _intensity / 10] select (!alive _unit || {0 < (1 + random 0.2)});`