### PR TITLE
Medical AI - Give blood in Cardiac Arrest before doing CPR

### DIFF
--- a/addons/medical_ai/functions/fnc_playTreatmentAnim.sqf
+++ b/addons/medical_ai/functions/fnc_playTreatmentAnim.sqf
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * [cursorObject, true, true] call ace_medical_ai_fnc_playTreatmentAnim
+ * [cursorObject, "Splint", true] call ace_medical_ai_fnc_playTreatmentAnim
  *
  * Public: No
  */

--- a/addons/medical_ai/functions/fnc_requestMedic.sqf
+++ b/addons/medical_ai/functions/fnc_requestMedic.sqf
@@ -17,8 +17,11 @@
 
 private _assignedMedic = _this getVariable QGVAR(assignedMedic);
 private _healQueue = _assignedMedic getVariable [QGVAR(healQueue), []];
-_healQueue pushBack _this;
-_assignedMedic setVariable [QGVAR(healQueue), _healQueue];
+
+// Only update if it was actually changed
+if (_healQueue pushBackUnique _this != -1) then {
+    _assignedMedic setVariable [QGVAR(healQueue), _healQueue];
+};
 
 #ifdef DEBUG_MODE_FULL
     systemChat format ["%1 requested %2 for medical treatment", _this, _assignedMedic];

--- a/addons/medical_ai/stateMachine.inc.sqf
+++ b/addons/medical_ai/stateMachine.inc.sqf
@@ -17,13 +17,8 @@ GVAR(stateMachine) = [{call EFUNC(common,getLocalUnits)}, true] call CBA_statema
     #endif
 }, {}, {}, "Safe"] call CBA_statemachine_fnc_addState;
 
-[GVAR(stateMachine), LINKFUNC(healSelf), {}, {
-    _this setVariable [QGVAR(treatmentOverAt), nil];
-}, "HealSelf"] call CBA_statemachine_fnc_addState;
-
-[GVAR(stateMachine), LINKFUNC(healUnit), {}, {
-    _this setVariable [QGVAR(treatmentOverAt), nil];
-}, "HealUnit"] call CBA_statemachine_fnc_addState;
+[GVAR(stateMachine), LINKFUNC(healSelf), {}, {}, "HealSelf"] call CBA_statemachine_fnc_addState;
+[GVAR(stateMachine), LINKFUNC(healUnit), {}, {}, "HealUnit"] call CBA_statemachine_fnc_addState;
 
 // Add Transistions [statemachine, originalState, targetState, condition, onTransition, name]
 [GVAR(stateMachine), "Initial", "Injured", LINKFUNC(isInjured), {}, "Injured"] call CBA_statemachine_fnc_addTransition;


### PR DESCRIPTION
**When merged this pull request will:**
- Bring injured unit in a state where CPR is effective (for cardiac arrest induced by blood loss).
- If medic is waiting on blood, allow him to apply splints during that time.
- Prevent AI medics from sending patients into cardiac arrest by using drugs (look at HR and go from there).
- Added triage card and activity logs for AI.
- Prevent adding the same unit twice to the heal queue of a medic.
- Some code cleanup.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
