### PR TITLE
Feature/field ration improv

### DIFF
--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -17,7 +17,7 @@ if !(hasInterface) exitWith {};
     };
 
     // Compile water source actions
-    private _mainAction = [
+    GVAR(mainAction) = [
         QGVAR(waterSource),
         LLSTRING(WaterSource),
         QPATHTOF(ui\icon_water_tap.paa),
@@ -40,7 +40,7 @@ if !(hasInterface) exitWith {};
         [false, false, false, false, true]
     ] call EFUNC(interact_menu,createAction);
 
-    private _subActions = [
+    GVAR(subActions) = [
         [
             QGVAR(checkWater),
             LLSTRING(CheckWater),
@@ -70,10 +70,10 @@ if !(hasInterface) exitWith {};
     ];
 
     // Add water source actions to helper
-    [QGVAR(helper), 0, [], _mainAction] call EFUNC(interact_menu,addActionToClass);
+    [QGVAR(helper), 0, [], GVAR(mainAction)] call EFUNC(interact_menu,addActionToClass);
     {
         [QGVAR(helper), 0, [QGVAR(waterSource)], _x] call EFUNC(interact_menu,addActionToClass);
-    } forEach _subActions;
+    } forEach GVAR(subActions);
 
     // Add inventory context menu option to consume items
     ["ACE_ItemCore", ["CONTAINER"], LSTRING(EatDrink), [], QPATHTOF(ui\icon_survival.paa),

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -6,6 +6,8 @@ if !(hasInterface) exitWith {};
     // Exit if not enabled
     if (!XGVAR(enabled)) exitWith {};
 
+    XGVAR(lastUnconEvent) = 0;
+
     // Add Advanced Fatigue duty factor
     if (XGVAR(affectAdvancedFatigue) && {missionNamespace getVariable [QEGVAR(advanced_fatigue,enabled), false]}) then {
         [QUOTE(ADDON), {

--- a/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
+++ b/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
@@ -49,13 +49,28 @@ TRACE_1("Starting interact PFH",_interactionType);
 
                     if (_waterRemaining != REFILL_WATER_DISABLED) then {
                         private _offset = [_x] call FUNC(getActionOffset);
-                        private _helper = QGVAR(helper) createVehicleLocal [0, 0, 0];
-                        _helper setVariable [QGVAR(waterSource), _x];
-                        _helper attachTo [_x, _offset];
+                        if (_offset isEqualTo [0,0,0]) then {
+                            if !(_x getVariable [QGVAR(waterSourceActionsAdded), false]) then {
+                                private _vehicle = _x;
+                                _vehicle setVariable [QGVAR(waterSource), _vehicle];
+                                _sourcesHelped pushBack _vehicle;
+                                // Add water source actions to the vehicle itself
+                                private _mainAction = [_vehicle, 0, ["ACE_MainActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
+                                {
+                                    [_vehicle, 0, _mainAction, _x] call EFUNC(interact_menu,addActionToObject);
+                                } forEach GVAR(subActions);
+                                _vehicle setVariable [QGVAR(waterSourceActionsAdded), true];
+                                TRACE_3("Added interaction to vehicle",_x,typeOf _x,_waterRemaining);
+                            };
+                        } else {
+                            private _helper = QGVAR(helper) createVehicleLocal [0, 0, 0];
+                            _helper setVariable [QGVAR(waterSource), _x];
+                            _helper attachTo [_x, _offset];
 
-                        _addedHelpers pushBack _helper;
-                        _sourcesHelped pushBack _x;
-                        TRACE_3("Added interaction helper",_x,typeOf _x,_waterRemaining);
+                            _addedHelpers pushBack _helper;
+                            _sourcesHelped pushBack _x;
+                            TRACE_3("Added interaction helper",_x,typeOf _x,_waterRemaining);
+                        };
                     };
                 };
             } forEach nearestObjects [ACE_player, [], 15];

--- a/addons/field_rations/functions/fnc_handleEffects.sqf
+++ b/addons/field_rations/functions/fnc_handleEffects.sqf
@@ -27,12 +27,14 @@ if ((_thirst > 99.9 || {_hunger > 99.9}) && {random 1 < 0.5}) exitWith {
 // Exit if unit is not awake, below are animation based consequences
 if !(_player call EFUNC(common,isAwake)) exitWith {};
 
-// Set unit unconscious (chance based on how high thirst/hunger are)
+// Set unit unconscious with 45s cooldown (chance based on how high thirst/hunger are)
 if (
     GETEGVAR(medical,enabled,false) && 
+    {(CBA_missionTime - XGVAR(lastUnconEvent)) > 45} && 
     {(_thirst > 85 || {_hunger > 85}) && {random 1 < linearConversion [85, 100, _thirst max _hunger, 0.05, 0.1, true]}}
 ) exitWith {
     [_player, true, 5, true] call EFUNC(medical,setUnconscious);
+    XGVAR(lastUnconEvent) = CBA_missionTime;
 };
 
 // Make unit fall if moving fast


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Add a 45s cooldown to thirst/hunger related loss of consciousness, to not require several tries before being able to complete the drinking/eating interaction.
- [x] Add water actions directly to vehicle instead of helper object if the vehicle has no custom "waterActionPosition":\
This was causing the helper object to be attached to the center of the vehicle, making the interaction almost impossible to access.
- [ ] Add audio cues for high thirst/hunger, possibly hearable by nearby players.
- [ ] Add the option for less punitive dehydration/starvation consequences, i.e: medical pain effects like loss of focus / chromatic aberration instead of going unconscious and/or dying.
- [ ] Make consumable items "magazines", so that they can have dynamic consumption and many more fill/integrity levels.
- [ ] Maybe make advanced fatigue influence hunger/thirst increase, as opposed to the current linear multiplier tied to movement speed and hunger/thirst influencing fatigue.
- [ ] Maybe add force-feeding interactions, ideally tied to CBA Setting.
- [ ] Multiply saline rehydrating effect by inverse water consumption, to maintain effectiveness at reduced "time without water" settings.
- [ ] Update Documentation.
