### PR TITLE
Vehicles - Remove unneeded magazines

### DIFF
--- a/addons/vehicles/CfgWeapons.hpp
+++ b/addons/vehicles/CfgWeapons.hpp
@@ -13,8 +13,7 @@ class CfgWeapons {
     class ACE_LMG_coax_DenelMG4: LMG_coax {};
 
     class LMG_Minigun: LMG_RCWS {
-        // Add the following: "2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt"
-        magazines[] = {"PylonWeapon_2000Rnd_65x39_belt", "1000Rnd_65x39_Belt","1000Rnd_65x39_Belt_Green","1000Rnd_65x39_Belt_Tracer_Green","1000Rnd_65x39_Belt_Tracer_Red","1000Rnd_65x39_Belt_Tracer_Yellow","1000Rnd_65x39_Belt_Yellow","2000Rnd_65x39_Belt","2000Rnd_65x39_Belt_Green","2000Rnd_65x39_Belt_Tracer_Green","2000Rnd_65x39_Belt_Tracer_Green_Splash","2000Rnd_65x39_Belt_Tracer_Red","2000Rnd_65x39_Belt_Tracer_Yellow","2000Rnd_65x39_Belt_Tracer_Yellow_Splash","2000Rnd_65x39_Belt_Yellow","2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","200Rnd_65x39_Belt","200Rnd_65x39_Belt_Tracer_Green","200Rnd_65x39_Belt_Tracer_Red","200Rnd_65x39_Belt_Tracer_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt","500Rnd_65x39_Belt","500Rnd_65x39_Belt_Tracer_Red_Splash","500Rnd_65x39_Belt_Tracer_Green_Splash","500Rnd_65x39_Belt_Tracer_Yellow_Splash"};
+        magazines[] += {"2000Rnd_762x51_Belt_T_Green","2000Rnd_762x51_Belt_T_Red","2000Rnd_762x51_Belt_T_Yellow","5000Rnd_762x51_Belt","5000Rnd_762x51_Yellow_Belt"};
     };
 
     class HMG_127: LMG_RCWS {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- This resolves the Minigun incompatibility issue with Aegis.
- I don't understand why the 7.62mm magazines were added in the first place. They were ported over in https://github.com/acemod/ACE3/commit/9219909ec7cba37155187feda10bd06a258b0008#diff-e9a51ed9e439407632d86afb53fb5bf6fd4a54b7b25c47562fd47955b52cac9cR12, which doesn't make a lot of sense to me, as it's a 6.5mm weapon. We could either leave it as is, add all valid 7.62mm belts or remove the existing 7.62mm belts. Thoughts?
EDIT: Leaving as is for now.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
