### PR TITLE
Aegis Compat - Overwrite some Aegis changes

### DIFF
--- a/addons/compat_aegis/$PBOPREFIX$
+++ b/addons/compat_aegis/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_aegis

--- a/addons/compat_aegis/CfgVehicles.hpp
+++ b/addons/compat_aegis/CfgVehicles.hpp
@@ -12,8 +12,43 @@ class CfgVehicles {
                 // Overwrite the changes Aegis makes for the .338 coax MG on the Slammer/Merkava
                 // The idea is:
                 // 1) keep it as realistic as possible
-                // 2) the TUSK variant keeps the 7.62mm variant, so the base variant should too
-                // 3) easier to overwrite something with skipWhenMissingDependencies than to not overwrite something if another mod is loaded
+                // 2) easier to overwrite something with skipWhenMissingDependencies than to not overwrite something if another mod is loaded
+                weapons[] = {"cannon_120mm", "ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "cannon_120mm","LMG_coax"
+                magazines[] = {
+                    "24Rnd_120mm_APFSDS_shells_Tracer_Red",
+                    "12Rnd_120mm_HE_shells_Tracer_Red",
+                    "12Rnd_120mm_HEAT_MP_T_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "4Rnd_120mm_LG_cannon_missiles" // Aegis adds laser-guided munitions
+                };
+            };
+        };
+    };
+
+    class B_MBT_01_base_F: MBT_01_base_F {};
+    class B_MBT_01_cannon_F: B_MBT_01_base_F {};
+    class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
                 weapons[] = {"cannon_120mm", "ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "cannon_120mm","LMG_coax"
                 magazines[] = {
                     "24Rnd_120mm_APFSDS_shells_Tracer_Red",

--- a/addons/compat_aegis/CfgVehicles.hpp
+++ b/addons/compat_aegis/CfgVehicles.hpp
@@ -1,0 +1,47 @@
+class CfgVehicles {
+    class Tank;
+    class Tank_F: Tank {
+        class Turrets {
+            class MainTurret;
+        };
+    };
+
+    class MBT_01_base_F: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                // Overwrite the changes Aegis makes for the .338 coax MG on the Slammer/Merkava
+                // The idea is:
+                // 1) keep it as realistic as possible
+                // 2) the TUSK variant keeps the 7.62mm variant, so the base variant should too
+                // 3) easier to overwrite something with skipWhenMissingDependencies than to not overwrite something if another mod is loaded
+                weapons[] = {"cannon_120mm", "ACE_LMG_coax_MAG58_mem3"}; // Base 1.82: "cannon_120mm","LMG_coax"
+                magazines[] = {
+                    "24Rnd_120mm_APFSDS_shells_Tracer_Red",
+                    "12Rnd_120mm_HE_shells_Tracer_Red",
+                    "12Rnd_120mm_HEAT_MP_T_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "200Rnd_762x51_Belt_Red",
+                    "4Rnd_120mm_LG_cannon_missiles" // Aegis adds laser-guided munitions
+                };
+            };
+        };
+    };
+};

--- a/addons/compat_aegis/config.cpp
+++ b/addons/compat_aegis/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_vehicles", "A3_Aegis_Armor_F_Aegis_MBT_01"};
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"johnb43"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_aegis/script_component.hpp
+++ b/addons/compat_aegis/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT compat_aegis
+#define COMPONENT_BEAUTIFIED Aegis Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- "Compat" is too strong of a term, the purpose of this is to only overwrite some changes Aegis makes, in order to fix the stuff that is currently broken when loading both Aegis and ACE.

I've added the "ignore-changelog" tag because I don't want people thinking this is an official ACE-Aegis compat, as atm it's only doing fixes. Personally I'm not planning on adding any compatibility, but I decided to add it for future use.
In order to drop the word "compat", the only alternative would be to add this into the vehicles addon directly.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
