### PR TITLE
change interact_SWA to use common_SAM

### DIFF
--- a/addons/common/functions/fnc_switchAttachmentMode.sqf
+++ b/addons/common/functions/fnc_switchAttachmentMode.sqf
@@ -58,7 +58,7 @@ switch (_weapon) do {
     };
     default { 
         ERROR_1("bad weapon - %1",_this);
-        _exit = true
+        _exit = true;
     };
 };
 if (_exit) exitWith {};

--- a/addons/common/functions/fnc_switchAttachmentMode.sqf
+++ b/addons/common/functions/fnc_switchAttachmentMode.sqf
@@ -6,7 +6,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: Weapon (String or CBA-Weapon-Index (not ace's getWeaponIndex)) <STRING><NUMBER>
+ * 1: Weapon (String or CBA-Weapon-Index (not ace's getWeaponIndex)) <STRING|NUMBER>
  * 2: From <STRING>
  * 3: To <STRING>
  *
@@ -24,7 +24,7 @@ TRACE_4("switchAttachmentMode",_unit,_weapon,_currItem,_switchItem);
 
 if (_weapon isEqualTo "") exitWith {};
 
-private _exit = false;
+private _exit = _unit != ACE_player;
 switch (_weapon) do {
     case 0;
     case (primaryWeapon _unit): {
@@ -56,19 +56,18 @@ switch (_weapon) do {
             ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
         }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
     };
-    default { 
+    default {
         ERROR_1("bad weapon - %1",_this);
         _exit = true;
     };
 };
-if (_exit) exitWith {};
+if (_exit) exitWith {}; // Don't notify if the unit isn't the local player or if an invalid weapon was passed
 
 private _configSwitchItem = configfile >> "CfgWeapons" >> _switchItem;
 private _switchItemHintText = getText (_configSwitchItem >> "MRT_SwitchItemHintText");
 private _switchItemHintImage = getText (_configSwitchItem >> "picture");
-if (_unit == ACE_player) then {
-    playSound "click";
-    if (_switchItemHintText != "") then {
-        [[_switchItemHintImage, 2.0], [_switchItemHintText], true] call CBA_fnc_notify;
-    };
+
+playSound "click";
+if (_switchItemHintText != "") then {
+    [[_switchItemHintImage, 2.0], [_switchItemHintText], true] call CBA_fnc_notify;
 };

--- a/addons/common/functions/fnc_switchAttachmentMode.sqf
+++ b/addons/common/functions/fnc_switchAttachmentMode.sqf
@@ -24,6 +24,7 @@ TRACE_4("switchAttachmentMode",_unit,_weapon,_currItem,_switchItem);
 
 if (_weapon isEqualTo "") exitWith {};
 
+private _exit = false;
 switch (_weapon) do {
     case 0;
     case (primaryWeapon _unit): {
@@ -55,8 +56,12 @@ switch (_weapon) do {
             ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
         }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
     };
-    default { ERROR_1("bad weapon - %1",_this) };
+    default { 
+        ERROR_1("bad weapon - %1",_this);
+        _exit = true
+    };
 };
+if (_exit) exitWith {};
 
 private _configSwitchItem = configfile >> "CfgWeapons" >> _switchItem;
 private _switchItemHintText = getText (_configSwitchItem >> "MRT_SwitchItemHintText");

--- a/addons/common/functions/fnc_switchAttachmentMode.sqf
+++ b/addons/common/functions/fnc_switchAttachmentMode.sqf
@@ -2,26 +2,30 @@
 /*
  * Author: PabstMirror
  * Switch attachment from one mode to another - based on CBA_accessory_fnc_switchAttachment
+ * ToDo: Port this to CBA?
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: From <STRING>
- * 2: To <STRING>
+ * 1: Weapon (String or CBA-Weapon-Index (not ace's getWeaponIndex)) <STRING><NUMBER>
+ * 2: From <STRING>
+ * 3: To <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, "ACE_DBAL_A3_Green_VP", "ACE_DBAL_A3_Green"] call ace_common_fnc_switchAttachmentMode
+ * [player, 0, "ACE_DBAL_A3_Green_VP", "ACE_DBAL_A3_Green"] call ace_common_fnc_switchAttachmentMode
  *
  * Public: No
  */
- 
-params ["_unit", "_currItem", "_switchItem"];
-TRACE_3("switchAttachmentMode",_unit,_currItem,_switchItem);
 
-switch (currentWeapon _unit) do {
-    case (""): {};
+params ["_unit", "_weapon", "_currItem", "_switchItem"];
+TRACE_4("switchAttachmentMode",_unit,_weapon,_currItem,_switchItem);
+
+if (_weapon isEqualTo "") exitWith {};
+
+switch (_weapon) do {
+    case 0;
     case (primaryWeapon _unit): {
         private _currWeaponType = 0;
         _unit removePrimaryWeaponItem _currItem;
@@ -31,6 +35,7 @@ switch (currentWeapon _unit) do {
             ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
         }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
     };
+    case 1;
     case (handgunWeapon _unit): {
         private _currWeaponType = 1;
         _unit removeHandgunItem _currItem;
@@ -40,6 +45,7 @@ switch (currentWeapon _unit) do {
             ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
         }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
     };
+    case 2;
     case (secondaryWeapon _unit): {
         private _currWeaponType = 2;
         _unit removeSecondaryWeaponItem _currItem;
@@ -49,13 +55,15 @@ switch (currentWeapon _unit) do {
             ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
         }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
     };
+    default { ERROR_1("bad weapon - %1",_this) };
 };
+
 private _configSwitchItem = configfile >> "CfgWeapons" >> _switchItem;
 private _switchItemHintText = getText (_configSwitchItem >> "MRT_SwitchItemHintText");
 private _switchItemHintImage = getText (_configSwitchItem >> "picture");
-if (_switchItemHintText isNotEqualTo "") then {
-    [[_switchItemHintImage, 2.0], [_switchItemHintText], true] call CBA_fnc_notify;
-};
 if (_unit == ACE_player) then {
     playSound "click";
+    if (_switchItemHintText != "") then {
+        [[_switchItemHintImage, 2.0], [_switchItemHintText], true] call CBA_fnc_notify;
+    };
 };

--- a/addons/interaction/functions/fnc_getWeaponAttachmentsActions.sqf
+++ b/addons/interaction/functions/fnc_getWeaponAttachmentsActions.sqf
@@ -110,10 +110,14 @@ params ["_unit"];
                                 QGVAR(switch_) + _x,
                                 format ["%1: %2", localize "str_sensortype_switch", _modeName],
                                 getText (_config >> "picture"),
-                                LINKFUNC(switchWeaponAttachment),
+                                {
+                                    params ["", "_unit", "_actionParams"];
+                                    _actionParams params ["_weapon", "_newAttachment", "_oldAttachment"];
+                                    [_unit, _weapon, _oldAttachment, _newAttachment] call EFUNC(common,switchAttachmentMode);
+                                },
                                 {true},
                                 {},
-                                [_currentWeapon, _x, _attachment, true]
+                                [_currentWeapon, _x, _attachment]
                             ] call EFUNC(interact_menu,createAction),
                             [],
                             _unit

--- a/addons/interaction/functions/fnc_getWeaponAttachmentsActions.sqf
+++ b/addons/interaction/functions/fnc_getWeaponAttachmentsActions.sqf
@@ -44,7 +44,7 @@ params ["_unit"];
                 {},
                 {true},
                 {
-                    params ["_unit", "", "_args"];
+                    params ["", "_unit", "_args"];
                     _args params ["_attachment", "_name", "_picture", "_weaponItems", "_currentWeapon"];
 
                     private _cfgWeapons = configFile >> "CfgWeapons";

--- a/addons/interaction/functions/fnc_getWeaponAttachmentsActions.sqf
+++ b/addons/interaction/functions/fnc_getWeaponAttachmentsActions.sqf
@@ -113,7 +113,7 @@ params ["_unit"];
                                 LINKFUNC(switchWeaponAttachment),
                                 {true},
                                 {},
-                                [_currentWeapon, _x, ""]
+                                [_currentWeapon, _x, _attachment, true]
                             ] call EFUNC(interact_menu,createAction),
                             [],
                             _unit

--- a/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
+++ b/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
@@ -24,13 +24,7 @@ params ["", "_unit", "_actionParams"];
 _actionParams params ["_weapon", "_newAttachment", "_oldAttachment"];
 TRACE_3("Switching attachment",_weapon,_newAttachment,_oldAttachment);
 
-private _currWeaponType = switch (_weapon) do {
-    case (""): {-1};
-    case (primaryWeapon _unit): {0};
-    case (handgunWeapon _unit): {1};
-    case (secondaryWeapon _unit): {2};
-    default {-1};
-};
+private _currWeaponType = [_unit, _weapon] call EFUNC(common,getWeaponIndex);
 
 if (_currWeaponType == -1) exitWith {};
 
@@ -53,23 +47,23 @@ if (_removeOld && {!([_unit, _oldAttachment] call CBA_fnc_canAddItem)}) exitWith
 
 if (_removeOld) then {
     [{
-        params ["_unit", "_oldAttachment", "", "_currWeaponType"];
+        params ["_unit", "_oldAttachment", "_currWeaponType"];
 
         switch (_currWeaponType) do {
             case 0: {_unit removePrimaryWeaponItem _oldAttachment};
-            case 1: {_unit removeHandgunItem _oldAttachment};
-            case 2: {_unit removeSecondaryWeaponItem _oldAttachment};
+            case 1: {_unit removeSecondaryWeaponItem _oldAttachment};
+            case 2: {_unit removeHandgunItem _oldAttachment};
             default {};
         };
 
         _unit addItem _oldAttachment;
-    }, [_unit, _oldAttachment, _newAttachment, _currWeaponType], 0.3] call CBA_fnc_waitAndExecute;
+    }, [_unit, _oldAttachment, _currWeaponType], 0.3] call CBA_fnc_waitAndExecute;
 };
 
 if (!_addNew) exitWith {};
 
 [{
-    params ["_unit", "", "_newAttachment", "", "_weapon"];
+    params ["_unit", "_newAttachment", "_weapon"];
 
     // Delete weapon from array, to be able to pass _this to EH
     _unit addWeaponItem [_weapon, _newAttachment];
@@ -79,4 +73,4 @@ if (!_addNew) exitWith {};
     if (_unit == ACE_player) then {
         playSound "click";
     };
-}, [_unit, _oldAttachment, _newAttachment, _currWeaponType, _weapon], 1] call CBA_fnc_waitAndExecute;
+}, [_unit, _newAttachment, _weapon], 1] call CBA_fnc_waitAndExecute;

--- a/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
+++ b/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
@@ -10,7 +10,6 @@
  * - 0: Weapon <STRING>
  * - 1: New Attachment <STRING>
  * - 2: Old Attachment <STRING>
- * - 3: Use CBA Mode Switch <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -22,12 +21,8 @@
  */
 
 params ["", "_unit", "_actionParams"];
-_actionParams params ["_weapon", "_newAttachment", "_oldAttachment", ["_cbaModeSwitch", false]];
+_actionParams params ["_weapon", "_newAttachment", "_oldAttachment"];
 TRACE_3("Switching attachment",_weapon,_newAttachment,_oldAttachment);
-
-if (_cbaModeSwitch) exitWith {
-    [_unit, _weapon, _oldAttachment, _newAttachment] call EFUNC(common,switchAttachmentMode);
-};
 
 private _currWeaponType = switch (_weapon) do {
     case (""): {-1};


### PR DESCRIPTION
this is for PR #10145

I included `switchAttachementMode` changes from https://github.com/acemod/ACE3/pull/10119
I think we could move this func over to cba and have `CBA_accessory_fnc_switchAttachment` use it as well

simplifies `switchWeaponAttachment` to just do add or removal and moves changing mode to SAM

it had problems with the laser mode not switching because we just passed `[_currentWeapon, _x, ""]` 
so it never did the removal and delay
was also removing extra scopes from inventory
