### PR TITLE
CSW - Fix round count in GMG belt description

### DIFF
--- a/addons/csw/CfgMagazines.hpp
+++ b/addons/csw/CfgMagazines.hpp
@@ -58,6 +58,7 @@ class CfgMagazines {
     class GVAR(20Rnd_20mm_G_belt): 40Rnd_20mm_G_belt {
         author = ECSTRING(common,ACETeam);
         displayName = CSTRING(GMGBelt_displayName);
+        descriptionShort = CSTRING(GMGBelt_descriptionShort);
         model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
         picture = QPATHTOF(UI\ammoBox_50bmg_ca.paa);
         type = 256;

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -672,6 +672,23 @@
             <Russian>[CSW] Лента 20-мм гранат для ст. гранатомёта</Russian>
             <Korean>[CSW] 20mm 고속유탄발사기 탄띠</Korean>
         </Key>
+        <Key ID="STR_ACE_CSW_GMGBelt_descriptionShort">
+            <Original>Caliber: 20 mm&lt;br/&gt;Rounds: 20&lt;br /&gt;Used in: Grenade Launcher</Original>
+            <Chinese>口徑：20 mm&lt;br/&gt;個數：20&lt;br /&gt;用於：榴彈發射器</Chinese>
+            <French>Calibre : 20 mm&lt;br/&gt;Munitions : 20&lt;br /&gt;Application : lance-grenades</French>
+            <Spanish>Calibre: 20 mm&lt;br/&gt;Cargas: 20&lt;br /&gt;Se usa en: lanzagranadas</Spanish>
+            <Italian>Calibro: 20 mm&lt;br/&gt;Munizioni: 20&lt;br /&gt;Si usa in: lanciagranate</Italian>
+            <Polish>Kaliber: 20 mm&lt;br/&gt;Naboje: 20&lt;br /&gt;Używane w: granatniku</Polish>
+            <Russian>Калибр: 20 мм&lt;br/&gt;Кол-во: 20&lt;br /&gt;Применение: гранатомет</Russian>
+            <German>Kaliber: 20 mm&lt;br/&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Granatenwerfer</German>
+            <Czech>Ráže: 20 mm&lt;br/&gt;Munice: 20&lt;br /&gt;Použití: Granátomet</Czech>
+            <English>Caliber: 20 mm&lt;br/&gt;Rounds: 20&lt;br /&gt;Used in: Grenade Launcher</English>
+            <Portuguese>Calibre: 20 mm&lt;br/&gt;Balas: 20&lt;br /&gt;Uso em: Lança-granadas</Portuguese>
+            <Korean>구경: 20mm&lt;br /&gt;탄 수: 20&lt;br /&gt;사용 가능: 유탄발사기</Korean>
+            <Chinesesimp>口径：20 毫米&lt;br/&gt;容弹量：20&lt;br /&gt;用于：枪榴弹发射器</Chinesesimp>
+            <Japanese>口径：20 mm &lt;br/&gt;弾薬：20&lt;br /&gt;使用：グレネードランチャー</Japanese>
+            <Turkish>Kalibre: 20 mm&lt;br/&gt;Mermi: 20&lt;br /&gt;Kullanıldığı Yer: Bombaatar</Turkish>
+        </Key>
         <Key ID="STR_ACE_CSW_m3Tripod_displayName">
             <English>M3 Tripod</English>
             <Spanish>Trípode M3</Spanish>

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -673,7 +673,7 @@
             <Korean>[CSW] 20mm 고속유탄발사기 탄띠</Korean>
         </Key>
         <Key ID="STR_ACE_CSW_GMGBelt_descriptionShort">
-            <Original>Caliber: 20 mm&lt;br/&gt;Rounds: 20&lt;br /&gt;Used in: Grenade Launcher</Original>
+            <English>Caliber: 20 mm&lt;br/&gt;Rounds: 20&lt;br /&gt;Used in: Grenade Launcher</English>
             <Chinese>口徑：20 mm&lt;br/&gt;個數：20&lt;br /&gt;用於：榴彈發射器</Chinese>
             <French>Calibre : 20 mm&lt;br/&gt;Munitions : 20&lt;br /&gt;Application : lance-grenades</French>
             <Spanish>Calibre: 20 mm&lt;br/&gt;Cargas: 20&lt;br /&gt;Se usa en: lanzagranadas</Spanish>
@@ -682,7 +682,6 @@
             <Russian>Калибр: 20 мм&lt;br/&gt;Кол-во: 20&lt;br /&gt;Применение: гранатомет</Russian>
             <German>Kaliber: 20 mm&lt;br/&gt;Patronen: 20&lt;br /&gt;Eingesetzt von: Granatenwerfer</German>
             <Czech>Ráže: 20 mm&lt;br/&gt;Munice: 20&lt;br /&gt;Použití: Granátomet</Czech>
-            <English>Caliber: 20 mm&lt;br/&gt;Rounds: 20&lt;br /&gt;Used in: Grenade Launcher</English>
             <Portuguese>Calibre: 20 mm&lt;br/&gt;Balas: 20&lt;br /&gt;Uso em: Lança-granadas</Portuguese>
             <Korean>구경: 20mm&lt;br /&gt;탄 수: 20&lt;br /&gt;사용 가능: 유탄발사기</Korean>
             <Chinesesimp>口径：20 毫米&lt;br/&gt;容弹量：20&lt;br /&gt;用于：枪榴弹发射器</Chinesesimp>


### PR DESCRIPTION
**When merged this pull request will:**
- Title. It would only display `40`, instead of how many rounds were left and the maximum possible (e.g. `20/20`).
- Took the stringtable entry from the base game and just changed the number of rounds.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
