### PR TITLE
Explosives - Remove `delayTime` for explosives, as it no longer serves any purpose

### DIFF
--- a/addons/compat_gm/compat_gm_explosives/CfgMagazines.hpp
+++ b/addons/compat_gm/compat_gm_explosives/CfgMagazines.hpp
@@ -2,7 +2,6 @@ class CfgMagazines {
     // Explosives
     class gm_explosive_petn_charge_base;
     class gm_explosive_petn_charge: gm_explosive_petn_charge_base {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) =QEGVAR(explosives,Place_gm_explosive_petn);
         useAction = 0;
@@ -21,7 +20,6 @@ class CfgMagazines {
 
     class gm_explosive_plnp_charge_base;
     class gm_explosive_plnp_charge: gm_explosive_plnp_charge_base {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) =QEGVAR(explosives,Place_gm_explosive_plnp);
         useAction = 0;

--- a/addons/compat_rhs_afrf3/compat_rhs_afrf3_explosives/CfgMagazines.hpp
+++ b/addons/compat_rhs_afrf3/compat_rhs_afrf3_explosives/CfgMagazines.hpp
@@ -42,7 +42,6 @@ class CfgMagazines {
     };
 
     class rhs_ec75_mag: ATMine_Range_Mag {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,SetupObject) = QEGVAR(explosives,Place_rhs_ec75);
         useAction = 0;
         class ACE_Triggers {
@@ -133,7 +132,6 @@ class CfgMagazines {
     };
 
     class rhs_mine_ozm72_c_mag: rhs_mine_ozm72_a_mag {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,SetupObject) = QEGVAR(explosives,Place_rhs_mine_ozm72_c);
         useAction = 0;
         class ACE_Triggers {

--- a/addons/compat_rhs_saf3/compat_rhs_saf3_explosives/CfgMagazines.hpp
+++ b/addons/compat_rhs_saf3/compat_rhs_saf3_explosives/CfgMagazines.hpp
@@ -51,7 +51,6 @@ class CfgMagazines {
     class CA_Magazine;
     class rhssaf_tm100_mag: CA_Magazine {
         useAction = 0;
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) = QEGVAR(explosives,Place_rhssaf_tm100);
         class ACE_Triggers {

--- a/addons/compat_rhs_usf3/compat_rhs_usf3_explosives/CfgMagazines.hpp
+++ b/addons/compat_rhs_usf3/compat_rhs_usf3_explosives/CfgMagazines.hpp
@@ -1,7 +1,6 @@
 class CfgMagazines {
     class CA_Magazine;
     class rhsusf_m112_mag: CA_Magazine {
-        EGVAR(explosives,delayTime) = 1;
         EGVAR(explosives,placeable) = 1;
         EGVAR(explosives,setupObject) = QEGVAR(explosives,Place_rhsusf_explosive_m112);
         useAction = 0;

--- a/addons/compat_spe/compat_spe_explosives/CfgMagazines.hpp
+++ b/addons/compat_spe/compat_spe_explosives/CfgMagazines.hpp
@@ -1,7 +1,6 @@
 class CfgMagazines {
     class SPE_Mine_Magazine;
     class SPE_US_TNT_4pound_mag: SPE_Mine_Magazine {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(4LBTNT);
         useAction = 0;
@@ -19,7 +18,6 @@ class CfgMagazines {
     };
 
     class SPE_US_TNT_half_pound_mag: SPE_Mine_Magazine {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(halfLBTNT);
         useAction = 0;
@@ -37,7 +35,6 @@ class CfgMagazines {
     };
 
     class SPE_US_Bangalore_mag: SPE_Mine_Magazine {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(bangalore);
         useAction = 0;
@@ -55,7 +52,6 @@ class CfgMagazines {
     };
 
     class SPE_Ladung_Small_MINE_mag: SPE_Mine_Magazine {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(smallLadung);
         useAction = 0;
@@ -73,7 +69,6 @@ class CfgMagazines {
     };
 
     class SPE_Ladung_Big_MINE_mag: SPE_Mine_Magazine {
-        EGVAR(explosives,DelayTime) = 1;
         EGVAR(explosives,Placeable) = 1;
         EGVAR(explosives,SetupObject) = QEXPLOSIVES_PLACE(bigLadung);
         useAction = 0;

--- a/addons/explosives/CfgMagazines.hpp
+++ b/addons/explosives/CfgMagazines.hpp
@@ -4,7 +4,6 @@ class CfgMagazines {
         GVAR(Placeable) = 1;
         useAction = 0;
         GVAR(SetupObject) = "ACE_Explosives_Place_ATMine"; // CfgVehicle class for setup object.
-        GVAR(DelayTime) = 2.5;
         class ACE_Triggers {
             SupportedTriggers[] = {"PressurePlate"};
             class PressurePlate {
@@ -50,7 +49,6 @@ class CfgMagazines {
         GVAR(Placeable) = 1;
         useAction = 0;
         GVAR(SetupObject) = "ACE_Explosives_Place_Claymore";
-        GVAR(DelayTime) = 1.5;
         class ACE_Triggers {
             SupportedTriggers[] = {"Command", "MK16_Transmitter"};
             class Command {
@@ -64,7 +62,6 @@ class CfgMagazines {
         GVAR(Placeable) = 1;
         useAction = 0;
         GVAR(SetupObject) = "ACE_Explosives_Place_SatchelCharge";
-        GVAR(DelayTime) = 1;
         class ACE_Triggers {
             SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch"};
             class Timer {

--- a/docs/wiki/development/ace3-config-entries.md
+++ b/docs/wiki/development/ace3-config-entries.md
@@ -140,7 +140,6 @@ ace_isbelt
 ace_attachable
 ace_placeable
 ace_setupobject
-ace_delaytime
 ace_triggers
 ace_magazines_forcemagazinemuzzlevelocity
 ```

--- a/docs/wiki/framework/explosives-framework.md
+++ b/docs/wiki/framework/explosives-framework.md
@@ -28,7 +28,6 @@ class CfgMagazines {
         ACE_Explosives_Placeable = 1;  // Can be placed
         useAction = 0;  // Disable the vanilla interaction
         ACE_Explosives_SetupObject = "banana_satchel_place";  // The object placed before the explosive is armed
-        ACE_Explosives_DelayTime = 1.5;  // Seconds between trigger activation and explosion
         class ACE_Triggers {  // Trigger configurations
             SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter", "DeadmanSwitch"};  // Triggers that can be used
             class Timer {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- As far as I can tell, it `ACE_delayTime` was used as a delay when setting up explosives back in 3.0.0. Somewhere along the way it was removed from usage, but still prevailed in mod for some reason.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
