### PR TITLE
Explosives - Use full magazine name in interaction menu

### DIFF
--- a/addons/explosives/CfgMagazines.hpp
+++ b/addons/explosives/CfgMagazines.hpp
@@ -171,7 +171,6 @@ class CfgMagazines {
 
     // Orange DLC:
     class APERSMineDispenser_Mag: SatchelCharge_Remote_Mag {
-        displayNameShort = ""; // Original text: "Mine Dispenser descr. short" which is useless
         GVAR(SetupObject) = "ACE_Explosives_Place_APERSMineDispenser";
         class ACE_Triggers {
             SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter"};
@@ -185,7 +184,6 @@ class CfgMagazines {
         };
     };
     class TrainingMine_Mag: APERSMine_Range_Mag {
-        displayNameShort = ""; // Original text: "Dummy Mine descr. short" which is useless
         GVAR(SetupObject) = "ACE_Explosives_Place_TrainingMine";
         class ACE_Triggers {
             SupportedTriggers[] = {"PressurePlate"};

--- a/addons/explosives/CfgMagazines.hpp
+++ b/addons/explosives/CfgMagazines.hpp
@@ -171,6 +171,7 @@ class CfgMagazines {
 
     // Orange DLC:
     class APERSMineDispenser_Mag: SatchelCharge_Remote_Mag {
+        displayNameShort = ""; // Original text: "Mine Dispenser descr. short" which is useless
         GVAR(SetupObject) = "ACE_Explosives_Place_APERSMineDispenser";
         class ACE_Triggers {
             SupportedTriggers[] = {"Timer", "Command", "MK16_Transmitter"};
@@ -184,6 +185,7 @@ class CfgMagazines {
         };
     };
     class TrainingMine_Mag: APERSMine_Range_Mag {
+        displayNameShort = ""; // Original text: "Dummy Mine descr. short" which is useless
         GVAR(SetupObject) = "ACE_Explosives_Place_TrainingMine";
         class ACE_Triggers {
             SupportedTriggers[] = {"PressurePlate"};

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -119,11 +119,7 @@ if (_detonator != "ACE_DeadManSwitch") then {
     if (_connectedInventoryExplosive != "") then {
         //Add the disconnect action
         private _magConfig = configFile >> "CfgMagazines" >> _connectedInventoryExplosive;
-        private _name = if ((getText (_magConfig >> "displayNameShort")) != "") then {
-            getText (_magConfig >> "displayNameShort")
-        } else {
-            getText(_magConfig >> "displayName")
-        };
+        private _name = getText (_magConfig >> "displayName");
         private _picture = getText (_magConfig >> "picture");
 
         _children pushBack [
@@ -152,11 +148,7 @@ if (_detonator != "ACE_DeadManSwitch") then {
                 private _magConfig = configFile >> "CfgMagazines" >> _mag;
                 private _supportedTriggers = getArray (_magConfig >> "ACE_Triggers" >> "SupportedTriggers");
                 if (({_x == "DeadmanSwitch"} count _supportedTriggers) == 1) then { //case insensitive search
-                    private _name = if ((getText (_magConfig >> "displayNameShort")) != "") then {
-                        getText (_magConfig >> "displayNameShort")
-                    } else {
-                        getText(_magConfig >> "displayName")
-                    };
+                    private _name = getText (_magConfig >> "displayName");
                     private _picture = getText (_magConfig >> "picture");
 
                     _children pushBack [

--- a/addons/explosives/functions/fnc_addExplosiveActions.sqf
+++ b/addons/explosives/functions/fnc_addExplosiveActions.sqf
@@ -27,11 +27,8 @@
     {
         private _config = _cfgMagazines >> _x;
         if (getNumber (_config >> QGVAR(Placeable)) == 1) then {
-            private _name = getText (_config >> "displayNameShort");
+            private _name = getText (_config >> "displayName");
             private _picture = getText (_config >> "picture");
-            if (_name isEqualTo "") then {
-                _name = getText (_config >> "displayName");
-            };
 
             private _action = [_x, format ["%1 (%2)", _name, _totalCount - count (_magazines - [_x])], _picture, {[{_this call FUNC(setupExplosive)}, _this] call CBA_fnc_execNextFrame}, {true}, {}, _x] call EFUNC(interact_menu,createAction);
             _actions pushBack [_action, [], _player];


### PR DESCRIPTION
**When merged this pull request will:**
- Title. Currently, the explosives interactions for the APERS mine dispenser and the training mine include "descr. short", which is ugly imo and can be avoided.
- There are two solutions to the problem described above: The first is that we make explosives use `displayName` directly (so what this PR does). Having loaded RHS & CUP, no CUP explosives set `displayNameShort` and only the WW2 mines in RHS set it. Given explosives have no submenus, imo it's acceptable and moreover necessary to use `displayName` directly, as some of the RHS `displayNameShort` are identical for 2 mines.
The other solution is to set `displayNameShort` (which was previously used as a 1st priority) to `""`  for the APERS mine dispenser and the training mine (see first commits).

It looks like it was changed here: https://github.com/acemod/ACE3/commit/7d5555a2e01245ffebca6aaea74c02257a161b89#diff-db84d721501439b53633c8db074b40274285a7c09c9d087650807500882cfffd
The problem is, I don't understand why (`displayNameShort` isn't listed as API, if anything, `displayName` is).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
