### PR TITLE
CUP Compat - Improve explosives compat

### DIFF
--- a/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgVehicles.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_explosives/CfgVehicles.hpp
@@ -1,32 +1,31 @@
 class CfgVehicles {
     class ACE_Explosives_Place;
     class ACE_PipeBomb_place_CUP: ACE_Explosives_Place {
-        displayName = "Satchel Charge";
+        displayName = "$STR_CUP_dn_PipeBomb";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_Satchel.p3d";
-        ace_explosives_offset[] = {0, 0, 0};
     };
     class ACE_Mine_place_CUP: ACE_Explosives_Place {
-        displayName = "AT-15 Anti-Tank Mine";
+        displayName = "$STR_CUP_dn_Mine";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_AT15.p3d";
-        ace_explosives_offset[] = {0, 0, 0};
     };
     class ACE_MineE_place_CUP: ACE_Explosives_Place {
-        displayName = "TM46 Anti-Tank Mine";
+        displayName = "$STR_CUP_dn_MineE";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_TM46.p3d";
-        ace_explosives_offset[] = {0, 0, 0};
     };
     class ACE_IED_V1_place_CUP: ACE_Explosives_Place {
-        displayName = "IED";
+        displayName = "$STR_A3_CfgVehicles_IEDUrbanSmall_F";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V1.p3d";
-        ace_explosives_offset[] = {0, 0, 0};
     };
     class ACE_IED_V2_place_CUP: ACE_IED_V1_place_CUP {
+        displayName = "$STR_A3_CfgVehicles_IEDUrbanBig_F";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V2.p3d";
     };
     class ACE_IED_V3_place_CUP: ACE_IED_V1_place_CUP {
+        displayName = "$STR_A3_CfgVehicles_IEDLandSmall_F";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V3.p3d";
     };
     class ACE_IED_V4_place_CUP: ACE_IED_V1_place_CUP {
+        displayName = "$STR_A3_CfgVehicles_IEDLandBig_F";
         model = "\CUP\Weapons\CUP_Weapons_Put\CUP_IED_V4.p3d";
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Use stringtable entries.
- Remove `ace_explosives_offset` attributes (invalid).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
