### PR TITLE
Headless - Fix unable to transfer groups

### DIFF
--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -146,11 +146,13 @@ private _previousOwner = -1;
             // Don't transfer if it's already local to HC1
             if (_previousOwner == _idHC1) exitWith {};
 
-            [QGVAR(groupTransferPre), [_x, _HC1, _previousOwner, _idHC1], [_previousOwner, _idHC1]] call CBA_fnc_targetEvent; // API
+            [QGVAR(groupTransferPre), [_x, _HC1, _previousOwner, _idHC1], _previousOwner] call CBA_fnc_ownerEvent; // API
+            [QGVAR(groupTransferPre), [_x, _HC1, _previousOwner, _idHC1], _idHC1] call CBA_fnc_ownerEvent; // API
 
             private _transferred = _x setGroupOwner _idHC1;
 
-            [QGVAR(groupTransferPost), [_x, _HC1, _previousOwner, _idHC1, _transferred], [_previousOwner, _idHC1]] call CBA_fnc_targetEvent; // API
+            [QGVAR(groupTransferPost), [_x, _HC1, _previousOwner, _idHC1, _transferred], _previousOwner] call CBA_fnc_ownerEvent; // API
+            [QGVAR(groupTransferPost), [_x, _HC1, _previousOwner, _idHC1, _transferred], _idHC1] call CBA_fnc_ownerEvent; // API
 
             if (_transferred) then {
                 _numTransferredHC1 = _numTransferredHC1 + 1;
@@ -172,11 +174,13 @@ private _previousOwner = -1;
             // Don't transfer if it's already local to HC2
             if (_previousOwner == _idHC2) exitWith {};
 
-            [QGVAR(groupTransferPre), [_x, _HC2, _previousOwner, _idHC2], [_previousOwner, _idHC2]] call CBA_fnc_targetEvent; // API
+            [QGVAR(groupTransferPre), [_x, _HC2, _previousOwner, _idHC2], _previousOwner] call CBA_fnc_ownerEvent; // API
+            [QGVAR(groupTransferPre), [_x, _HC2, _previousOwner, _idHC2], _idHC2] call CBA_fnc_ownerEvent; // API
 
             private _transferred = _x setGroupOwner _idHC2;
 
-            [QGVAR(groupTransferPost), [_x, _HC2, _previousOwner, _idHC2, _transferred], [_previousOwner, _idHC2]] call CBA_fnc_targetEvent; // API
+            [QGVAR(groupTransferPost), [_x, _HC2, _previousOwner, _idHC2, _transferred], _previousOwner] call CBA_fnc_ownerEvent; // API
+            [QGVAR(groupTransferPost), [_x, _HC2, _previousOwner, _idHC2, _transferred], _idHC2] call CBA_fnc_ownerEvent; // API
 
             if (_transferred) then {
                 _numTransferredHC2 = _numTransferredHC2 + 1;
@@ -198,11 +202,13 @@ private _previousOwner = -1;
             // Don't transfer if it's already local to HC3
             if (_previousOwner == _idHC3) exitWith {};
 
-            [QGVAR(groupTransferPre), [_x, _HC3, _previousOwner, _idHC3], [_previousOwner, _idHC3]] call CBA_fnc_targetEvent; // API
+            [QGVAR(groupTransferPre), [_x, _HC3, _previousOwner, _idHC3], _previousOwner] call CBA_fnc_ownerEvent; // API
+            [QGVAR(groupTransferPre), [_x, _HC3, _previousOwner, _idHC3], _idHC3] call CBA_fnc_ownerEvent; // API
 
             private _transferred = _x setGroupOwner _idHC2;
 
-            [QGVAR(groupTransferPost), [_x, _HC3, _previousOwner, _idHC3, _transferred], [_previousOwner, _idHC3]] call CBA_fnc_targetEvent; // API
+            [QGVAR(groupTransferPost), [_x, _HC3, _previousOwner, _idHC3, _transferred], _previousOwner] call CBA_fnc_ownerEvent; // API
+            [QGVAR(groupTransferPost), [_x, _HC3, _previousOwner, _idHC3, _transferred], _idHC3] call CBA_fnc_ownerEvent; // API
 
             if (_transferred) then {
                 _numTransferredHC3 = _numTransferredHC3 + 1;

--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -74,13 +74,9 @@ private _numTransferredHC1 = 0;
 private _numTransferredHC2 = 0;
 private _numTransferredHC3 = 0;
 
-private _units = [];
-private _transfer = false;
-private _previousOwner = -1;
-
 // Transfer AI groups
 {
-    _units = units _x;
+    private _units = units _x;
 
     // No transfer if empty group or if group is blacklisted
     if (_units isEqualTo [] || {_x getVariable [QXGVAR(blacklist), false]}) then {
@@ -92,7 +88,8 @@ private _previousOwner = -1;
         continue;
     };
 
-    _transfer = true;
+    private _transfer = true;
+
     {
         // No transfer if already transferred
         if (!_force && {(owner _x) in [_idHC1, _idHC2, _idHC3]}) exitWith {
@@ -127,7 +124,7 @@ private _previousOwner = -1;
     };
 
     // Round robin between HCs if load balance enabled, else pass all to one HC
-    _previousOwner = groupOwner _x;
+    private _previousOwner = groupOwner _x;
 
     switch (_currentHC) do {
         case 1: {

--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -92,6 +92,7 @@ private _previousOwner = -1;
         continue;
     };
 
+    _transfer = true;
     {
         // No transfer if already transferred
         if (!_force && {(owner _x) in [_idHC1, _idHC2, _idHC3]}) exitWith {


### PR DESCRIPTION
**When merged this pull request will:**
- `_trasnfer` in headless transfer groups is never set to true, so no groups ever transfer

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
