### PR TITLE
Explosives - Remove replacement explosives

### DIFF
--- a/addons/compat_sog/CfgAmmo/explosives.hpp
+++ b/addons/compat_sog/CfgAmmo/explosives.hpp
@@ -2,16 +2,10 @@ class DirectionalBombBase;
 class vn_mine_m18_ammo: DirectionalBombBase {
     EGVAR(explosives,defuseObjectPosition)[] = {0, 0, 0.15};
     EGVAR(explosives,size) = 1;
-    EGVAR(explosives,explosive) = "vn_mine_m18_ammo_scripted";
 };
 
 class vn_mine_m18_x3_ammo: vn_mine_m18_ammo {
     EGVAR(explosives,defuseObjectPosition)[] = {0, 0, 0.1};
-    EGVAR(explosives,explosive) = "vn_mine_m18_x3_ammo_scripted";
-};
-
-class vn_mine_m18_wp_ammo: vn_mine_m18_ammo {
-    EGVAR(explosives,explosive) = "vn_mine_m18_wp_ammo_scripted";
 };
 
 class vn_mine_m16_base;
@@ -99,13 +93,7 @@ class vn_mine_punji_05_ammo: vn_mine_punji_04_ammo {
 };
 
 class APERSMine_Range_Ammo;
-class vn_mine_bike_ammo: APERSMine_Range_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_bike_ammo_scripted";
-};
-
 class vn_mine_cartridge_ammo: APERSMine_Range_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_cartridge_ammo_scripted";
-
     // bump range and damage slightly, default values do not work well with ACE Medical
     indirectHit = QUOTE(getNumber (configFile >> 'CfgAmmo' >> 'vn_mine_cartridge_ammo' >> 'GVAR(indirectHit)'));
     GVAR(indirectHit) = QUOTE([ARR_2(2,1)] select isNull (configFile >> 'CfgPatches' >> 'ace_medical'));
@@ -116,50 +104,8 @@ class vn_mine_cartridge_ammo: APERSMine_Range_Ammo {
 
 class vn_mine_lighter_ammo: APERSMine_Range_Ammo {
     ACE_damageType = QGVAR(explosive_incendiary);
-
-    EGVAR(explosives,explosive) = "vn_mine_lighter_ammo_scripted";
 };
 
 class vn_mine_jerrycan_ammo: APERSMine_Range_Ammo {
     ACE_damageType = QGVAR(explosive_incendiary);
-
-    EGVAR(explosives,explosive) = "vn_mine_jerrycan_ammo_scripted";
-};
-
-class vn_mine_pot_ammo: APERSMine_Range_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_pot_ammo_scripted";
-};
-
-class vn_mine_mortar_range_ammo: APERSMine_Range_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_mortar_range_ammo_scripted";
-};
-
-class vn_mine_limpet_01_ammo: DemoCharge_Remote_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_limpet_01_ammo_scripted";
-};
-
-class vn_mine_limpet_02_ammo: vn_mine_limpet_01_ammo {
-    EGVAR(explosives,explosive) = "vn_mine_limpet_02_ammo_scripted";
-};
-
-class vn_mine_chicom_no8_ammo: APERSMine_Range_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_chicom_no8_ammo_scripted";
-};
-
-class vn_mine_dh10_ammo: DirectionalBombBase {
-    EGVAR(explosives,explosive) = "vn_mine_dh10_ammo_scripted";
-};
-
-class PipeBombBase;
-class vn_mine_gboard_range_ammo: PipeBombBase {
-    EGVAR(explosives,explosive) = "vn_mine_gboard_range_ammo_scripted";
-};
-
-class SatchelCharge_Remote_Ammo;
-class vn_mine_satchelcharge_02_ammo: SatchelCharge_Remote_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_satchelcharge_02_ammo_scripted";
-};
-
-class vn_mine_bangalore_ammo: SatchelCharge_Remote_Ammo {
-    EGVAR(explosives,explosive) = "vn_mine_bangalore_ammo_scripted";
 };

--- a/addons/explosives/functions/fnc_detonateExplosive.sqf
+++ b/addons/explosives/functions/fnc_detonateExplosive.sqf
@@ -31,24 +31,8 @@ private _result = true;
 
 if !([_unit, _range, _item select 0, _item select 1, _triggerClassname] call FUNC(checkDetonateHandlers)) exitWith {false};
 
-if (getNumber (ConfigFile >> "CfgAmmo" >> typeOf (_item select 0) >> "TriggerWhenDestroyed") == 0) then {
-    private _previousExp = _item select 0;
-    private _exp = getText (ConfigFile >> "CfgAmmo" >> typeOf (_previousExp) >> QGVAR(Explosive));
-    if (_exp != "") then {
-        _exp = createVehicle [_exp, [0,0,15001], [], 0, "NONE"];
-        _exp setDir (getDir _previousExp);
-        _item set [0, _exp];
-        private _pos = getPosASL _previousExp;
-        deleteVehicle _previousExp;
-        _exp setPosASL _pos;
-    };
-};
-
 if (isNull (_item select 0)) then {
     WARNING_1("Explosive is null [%1]",_this);
-};
-if ((getNumber (configFile >> "CfgAmmo" >> (typeOf (_item select 0)) >> "triggerWhenDestroyed")) != 1) then {
-    WARNING_1("Explosive is not triggerWhenDestroyed [%1]",typeOf (_item select 0));
 };
 
 [QGVAR(detonate), [_unit, _item select 0, _item select 1]] call CBA_fnc_serverEvent;


### PR DESCRIPTION
**When merged this pull request will:**
- Follow up to #10182.
- Never mentioned in the documentation, so not considered API imo.
- This means that SOG explosives placed via ACE no longer blow up when destroyed.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
