### PR TITLE
Docs - Force functions to be alphabetically sorted on wiki

### DIFF
--- a/docs/tools/document_functions.py
+++ b/docs/tools/document_functions.py
@@ -339,6 +339,8 @@ def document_functions(addons_dir, components):
 
     return errors
 
+def getFunctionPath(func):
+    return func.path.casefold()
 
 def crawl_dir(addons_dir, directory, debug=False, lint_private=False):
     components = {}
@@ -360,7 +362,11 @@ def crawl_dir(addons_dir, directory, debug=False, lint_private=False):
                     if function.is_public() and not debug:
                         # Add functions to component key (initalise key if necessary)
                         component = os.path.basename(os.path.dirname(root))
-                        components.setdefault(component, []).append(function)
+
+                        # Sort functions alphabetically
+                        functions = components.setdefault(component, [])
+                        functions.append(function)
+                        functions.sort(key=getFunctionPath)
 
                         function.feedback("Publicly documented")
                 else:


### PR DESCRIPTION
**When merged this pull request will:**
- Title. At the moment, all functions are not alphabetically sorted (e.g. https://ace3.acemod.org/wiki/functions/explosives).
- When hosting the website locally, no changes are needed to have it alphabetically sorted, but I don't have the same SW versions.
- It's not efficient, but it does the job.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
