### PR TITLE
Arsenal - Fix `modParams` printing messages in RPT

### DIFF
--- a/addons/arsenal/functions/fnc_sortStatement_mod.sqf
+++ b/addons/arsenal/functions/fnc_sortStatement_mod.sqf
@@ -14,4 +14,9 @@
 
 params ["_config"];
 
-(modParams [_config call EFUNC(common,getAddon), ["name"]]) param [0, ""]
+private _addon = _config call EFUNC(common,getAddon);
+
+// Calling modParams with "" prints 'ModParams - Undefined or empty mod directory' in RPT
+if (_addon == "") exitWith {""};
+
+(modParams [_addon, ["name"]]) param [0, ""]


### PR DESCRIPTION
**When merged this pull request will:**
- Title. It was printing `ModParams - Undefined or empty mod directory` for base game weapons, because their addon is `""`.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
