### PR TITLE
Kestrel4500 - Measure wind relative to player's head direction

### DIFF
--- a/addons/kestrel4500/functions/fnc_measureWindSpeed.sqf
+++ b/addons/kestrel4500/functions/fnc_measureWindSpeed.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-private _playerDir = getDir ACE_player;
+private _playerDir = (ACE_player call CBA_fnc_headDir) select 0;
 private _windSpeed = vectorMagnitude wind;
 private _windDir = (wind select 0) atan2 (wind select 1);
 if (missionNamespace getVariable [QEGVAR(advanced_ballistics,enabled), false]) then {


### PR DESCRIPTION
**When merged this pull request will:**
- For wind measurements, simulate the instrument being held in the player's head direction instead of his body's:\
Makes it more intuitive to measure top wind speed for ballistic calculations, where previously the entire player had to face towards/away from wind to get a proper measurement. Now references the same direction as the wind indicator.\
https://github.com/bagigi-arma/ACE3/blob/8e2398d7cc073445b0d8232bfb02fc70339a8daa/addons/weather/functions/fnc_displayWindInfo.sqf#L69
