### PR TITLE
General - Add replacement items for editor inventory management

### DIFF
--- a/addons/intelitems/CfgWeapons.hpp
+++ b/addons/intelitems/CfgWeapons.hpp
@@ -1,0 +1,17 @@
+class CfgWeapons {
+    class ACE_ItemCore;
+    class CBA_MiscItem_ItemInfo;
+
+    // Since base game doesn't support misc. items, this is needed to filling inventories in the editor
+    class GVAR(notepad_Item): ACE_ItemCore {
+        displayName = CSTRING(Notepad_DisplayName);
+        author = ECSTRING(common,ACETeam);
+        scope = 2;
+        scopeArsenal = 0;
+        descriptionShort = CSTRING(Notepad_Description);
+        picture = QPATHTOF(ui\notepad_ca.paa);
+        class ItemInfo: CBA_MiscItem_ItemInfo {
+            mass = 0.1;
+        };
+    };
+};

--- a/addons/intelitems/XEH_postInit.sqf
+++ b/addons/intelitems/XEH_postInit.sqf
@@ -1,5 +1,8 @@
 #include "script_component.hpp"
 
+// Notepad item to magazine
+[QGVAR(notepad_Item), QXGVAR(notepad)] call EFUNC(common,registerItemReplacement);
+
 // Only handle loadout change when on map or have open controls
 ["loadout", {
     if (!visibleMap && {GVAR(controlsGroups) isEqualTo []}) exitWith {};

--- a/addons/intelitems/config.cpp
+++ b/addons/intelitems/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
             QXGVAR(document),
             QXGVAR(photo)
         };
-        weapons[] = {};
+        weapons[] = {QGVAR(notepad_Item)};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interact_menu", "ace_zeus"};
         author = ECSTRING(common,ACETeam);
@@ -23,5 +23,6 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgEditorSubcategories.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"
 #include "gui.hpp"

--- a/addons/medical_treatment/CfgWeapons.hpp
+++ b/addons/medical_treatment/CfgWeapons.hpp
@@ -310,4 +310,17 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = {QPATHTOF(data\bodybagItem_white_co.paa)};
         GVAR(bodyBagObject) = "ACE_bodyBagObject_white";
     };
+
+    // Since base game doesn't support misc. items, this is needed to filling inventories in the editor
+    class ACE_painkillers_Item: ACE_ItemCore {
+        displayName = CSTRING(painkillers_Display);
+        author = ECSTRING(common,ACETeam);
+        scope = 2;
+        scopeArsenal = 0;
+        descriptionShort = CSTRING(painkillers_Desc_Short);
+        picture = QPATHTOF(ui\painkillers_ca.paa);
+        class ItemInfo: CBA_MiscItem_ItemInfo {
+            mass = 1;
+        };
+    };
 };

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -1,5 +1,8 @@
 #include "script_component.hpp"
 
+// Pain killers item to magazine
+["ACE_painkillers_Item", "ACE_painkillers"] call EFUNC(common,registerItemReplacement);
+
 [QEGVAR(medical_status,initialized), {
     params ["_unit"];
 

--- a/addons/medical_treatment/config.cpp
+++ b/addons/medical_treatment/config.cpp
@@ -12,7 +12,7 @@ class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
         units[] = {"ACE_fieldDressingItem","ACE_packingBandageItem","ACE_elasticBandageItem","ACE_tourniquetItem","ACE_splintItem","ACE_painkillersItem","ACE_morphineItem","ACE_adenosineItem","ACE_epinephrineItem","ACE_plasmaIVItem","ACE_bloodIVItem","ACE_salineIVItem","ACE_quikClotItem","ACE_personalAidKitItem","ACE_surgicalKitItem","ACE_sutureItem","ACE_bodyBagItem","ACE_medicalSupplyCrate","ACE_medicalSupplyCrate_advanced"};
-        weapons[] = {"ACE_fieldDressing","ACE_packingBandage","ACE_elasticBandage","ACE_tourniquet","ACE_splint","ACE_painkillers","ACE_morphine","ACE_adenosine","ACE_epinephrine","ACE_plasmaIV","ACE_plasmaIV_500","ACE_plasmaIV_250","ACE_bloodIV","ACE_bloodIV_500","ACE_bloodIV_250","ACE_salineIV","ACE_salineIV_500","ACE_salineIV_250","ACE_quikclot","ACE_personalAidKit","ACE_surgicalKit","ACE_suture","ACE_bodyBag","ACE_bodyBag_blue","ACE_bodyBag_white"};
+        weapons[] = {"ACE_fieldDressing","ACE_packingBandage","ACE_elasticBandage","ACE_tourniquet","ACE_splint","ACE_painkillers","ACE_morphine","ACE_adenosine","ACE_epinephrine","ACE_plasmaIV","ACE_plasmaIV_500","ACE_plasmaIV_250","ACE_bloodIV","ACE_bloodIV_500","ACE_bloodIV_250","ACE_salineIV","ACE_salineIV_500","ACE_salineIV_250","ACE_quikclot","ACE_personalAidKit","ACE_surgicalKit","ACE_suture","ACE_bodyBag","ACE_bodyBag_blue","ACE_bodyBag_white","ACE_painkillers_Item"};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_medical_status", "ace_medical_damage", "ace_apl"};
         author = ECSTRING(common,ACETeam);

--- a/addons/overheating/CfgWeapons.hpp
+++ b/addons/overheating/CfgWeapons.hpp
@@ -97,17 +97,19 @@ class CfgWeapons {
         GVAR(closedBolt) = 1;
         GVAR(jamTypesAllowed)[] = {"Fire", "Dud"};
     };
+
     class ACE_ItemCore;
     class CBA_MiscItem_ItemInfo;
 
-    // Deprecated, 3.16.0 Arsenal supports showing magazines as misc items
+    // Deprecated, 3.16.0 Arsenal supports showing magazines as misc. items
+    // However, since base game doesn't support misc. items, it's still needed to filling inventories in the editor
     class ACE_SpareBarrel_Item: ACE_ItemCore {
         displayName = CSTRING(SpareBarrelName);
         author = ECSTRING(common,ACETeam);
-        scope = 1;
+        scope = 2;
         scopeArsenal = 0;
-        descriptionshort = CSTRING(SpareBarrelDescription);
-        picture = QUOTE(PATHTOF(UI\spare_barrel_ca.paa));
+        descriptionShort = CSTRING(SpareBarrelDescription);
+        picture = QPATHTOF(UI\spare_barrel_ca.paa);
         class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 25;
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes painkillers, notepad and spare barrel not being available in the "equipment storage" attribute in the editor.
- It's either this (or some variant of item replacement) or we rewrite the attribute's function to accommodate.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
