### PR TITLE
Artillery Tables - Fix artillery UI not refreshing when being teleported from one vehicle to another

### DIFF
--- a/addons/artillerytables/XEH_postInit.sqf
+++ b/addons/artillerytables/XEH_postInit.sqf
@@ -4,9 +4,12 @@
     TRACE_2("CBA_settingsInitialized",GVAR(advancedCorrections),GVAR(disableArtilleryComputer));
 
     if (hasInterface) then {
-        // Add hud overlay for actuall azimuth and elevation:
+        // Add hud overlay for actual azimuth and elevation:
         GVAR(pfID) = -1;
         ["turret", LINKFUNC(turretChanged), true] call CBA_fnc_addPlayerEventHandler;
+
+        // Handles being teleported from one vehicle to another
+        ["vehicle", {[_this select 0, (_this select 1) unitTurret (_this select 0)] call FUNC(turretChanged)}] call CBA_fnc_addPlayerEventHandler;
 
         // Add ability to dynamically open rangetables:
         ["ace_interactMenuOpened", LINKFUNC(interactMenuOpened)] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Specifically, teleported from vehicle to another in the same turret (same turret path).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
