### PR TITLE
Scopes - No Zeroing from Secondary Sights and Show UI while Sighted

### DIFF
--- a/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
+++ b/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
@@ -32,19 +32,17 @@ _adjustment set [_weaponIndex, [_elevation, _windage, _zero]];
 playSound selectRandom ["ACE_Scopes_Click_1", "ACE_Scopes_Click_2", "ACE_Scopes_Click_3"];
 
 // slightly rotate the player if looking through optic
-if (cameraView == "GUNNER") then {
-    if (!GVAR(simplifiedZeroing)) then {
-        // Convert adjustmentDifference from mils to degrees
-        _adjustmentDifference = _adjustmentDifference apply {MRAD_TO_DEG(_x)};
-        _adjustmentDifference params ["_elevationDifference", "_windageDifference"];
-        private _pitchBankYaw = [_unit] call EFUNC(common,getPitchBankYaw);
-        _pitchBankYaw params ["_pitch", "_bank", "_yaw"];
-        _pitch = _pitch + _elevationDifference;
-        _yaw = _yaw + _windageDifference;
-        [_unit, _pitch, _bank, _yaw] call EFUNC(common,setPitchBankYaw);
-    };
-} else {
-    [] call FUNC(showZeroing);
+if (cameraView == "GUNNER" && !GVAR(simplifiedZeroing)) then {
+    // Convert adjustmentDifference from mils to degrees
+    _adjustmentDifference = _adjustmentDifference apply {MRAD_TO_DEG(_x)};
+    _adjustmentDifference params ["_elevationDifference", "_windageDifference"];
+    private _pitchBankYaw = [_unit] call EFUNC(common,getPitchBankYaw);
+    _pitchBankYaw params ["_pitch", "_bank", "_yaw"];
+    _pitch = _pitch + _elevationDifference;
+    _yaw = _yaw + _windageDifference;
+    [_unit, _pitch, _bank, _yaw] call EFUNC(common,setPitchBankYaw);
 };
+
+[] call FUNC(showZeroing);
 
 true

--- a/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
+++ b/addons/scopes/functions/fnc_getCurrentZeroRange.sqf
@@ -35,7 +35,10 @@ private _opticConfig = if (_optic != "") then {
 };
 
 private _zeroRange = currentZeroing _unit;
-if (GVAR(overwriteZeroRange) && {GVAR(canAdjustElevation) select _weaponIndex}) then {
+if (
+    (GVAR(canAdjustElevation) select _weaponIndex) && 
+    {GVAR(overwriteZeroRange) || {getNumber (_opticConfig >> "ItemInfo" >> "OpticsModes" >> (_unit getOpticsMode _weaponIndex) >> "opticsZoomMax") > 0.2}}
+) then {
     _zeroRange = GVAR(defaultZeroRange);
 };
 if (isNumber (_opticConfig >> "ACE_ScopeZeroRange")) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent getting Zero from unmagnified secondary sights.\
Previously, opening the range card while having a secondary iron/holo-sight selected would skew the card's reference zero (often to 200m), needlessly requiring care to select the correct sight before adjusting the magnified one.\
The change makes the calculation revert to the default zero (100m) if the current sight is of very low magnification.
- Show the Scope Adjustment UI even while sighted in.\
IRL one should be able track the exact turret setting with the off-eye, or at least without having to unsight completely (and I guess also feel it to a certain extent).