### PR TITLE
SPE Compat - Add interaction anims to SPE vehicles

### DIFF
--- a/addons/compat_spe/CfgVehicles/wheeled.hpp
+++ b/addons/compat_spe/CfgVehicles/wheeled.hpp
@@ -56,8 +56,12 @@ class SPE_OpelBlitz_Ammo: SPE_OpelBlitz_base {
     EGVAR(rearm,defaultSupply) = 1200;
 };
 
-// WHEELED - ALLIED FORCES
+class SPE_OpelBlitz_Fuel: SPE_OpelBlitz_base {
+    EGVAR(refuel,hooks)[] = {{-0.23, -2.58, -0.59}};
+    EGVAR(refuel,fuelCargo) = 2000;
+};
 
+// WHEELED - ALLIED FORCES
 class SPE_US_M3_Halftrack_Ambulance: SPE_Halftrack_base {
     EGVAR(medical,medicClass) = 1;
 };
@@ -68,4 +72,70 @@ class SPE_US_M3_Halftrack_Repair: SPE_Halftrack_base {
 
 class SPE_US_M3_Halftrack_Ammo: SPE_Halftrack_base {
     EGVAR(rearm,defaultSupply) = 1200;
+};
+
+class SPE_US_M3_Halftrack_Fuel: SPE_Halftrack_base {
+    EGVAR(refuel,hooks)[] = {{-0.23, -2.58, -0.59}};
+    EGVAR(refuel,fuelCargo) = 2000;
+};
+
+class SPE_Car_base;
+class SPE_G503_MB_base: SPE_Car_base {
+    class EGVAR(interaction,anims) {
+        class hide_musette_source {
+            positions[] = {{0.8, -0.97, -0.6}, {-0.8, -0.92, -0.6}};
+            items[] = {"B_SPE_US_M36", "B_SPE_US_M36"};
+            name = "$STR_a3_cfgvehicleclasses_backpacks0";
+            text = "$STR_a3_cfgvehicleclasses_backpacks0";
+        };
+    };
+};
+class SPE_US_G503_MB_M1919_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
+};
+class SPE_US_G503_MB_M1919_Armoured_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
+};
+class SPE_US_G503_MB_M1919_PATROL_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
+};
+class SPE_US_G503_MB_M2_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
+};
+class SPE_US_G503_MB_M2_Armoured_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
+};
+class SPE_US_G503_MB_M2_PATROL_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
+};
+class SPE_G503_MB_Ambulance_base: SPE_G503_MB_base {
+    class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+        class hide_musette_source: hide_musette_source {
+            positions[] = {{0.8, -0.5, -0.6}, {-0.8, -0.45, -0.6}};
+        };
+    };
 };

--- a/addons/compat_spe/compat_spe_refuel/CfgVehicles.hpp
+++ b/addons/compat_spe/compat_spe_refuel/CfgVehicles.hpp
@@ -1,12 +1,57 @@
 class CfgVehicles {
-    class SPE_Halftrack_base;
-    class SPE_US_M3_Halftrack_Fuel: SPE_Halftrack_base {
-        EGVAR(refuel,hooks)[] = {{-0.23,-2.58,-0.59}};
-        EGVAR(refuel,fuelCargo) = 2000;
+    // Vehicle animation interactions
+    class SPE_Car_base;
+    class SPE_G503_MB_base: SPE_Car_base {
+        class EGVAR(interaction,anims) {
+            class hide_jerry_can_source {
+                positions[] = {"_target selectionPosition ['hide_jerry_can', 'ViewGeometry', 'AveragePoint']"};
+                items[] = {"Land_CanisterFuel_F"};
+                name = ECSTRING(refuel,TakeFuelCanister);
+                text = ECSTRING(refuel,TakeFuelCanisterAction);
+            };
+        };
     };
-    class SPE_OpelBlitz_base;
-    class SPE_OpelBlitz_Fuel: SPE_OpelBlitz_base {
-        EGVAR(refuel,hooks)[] = {{-0.23,-2.58,-0.59}};
-        EGVAR(refuel,fuelCargo) = 2000;
+
+    class SPE_Truck_base;
+    class SPE_CCKW_353_Base: SPE_Truck_base {
+        class EGVAR(interaction,anims) {
+            class spare_fuel_hide_source {
+                positions[] = {{0.8, 1.8, -1}, {-0.8, 1.8, -1}, {0.8, 3.5, -1}, {-0.8, 3.5, -1}};
+                items[] = {"Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F"};
+                name = ECSTRING(refuel,TakeFuelCanister);
+                text = ECSTRING(refuel,TakeFuelCanisterAction);
+            };
+        };
+    };
+    class SPE_CCKW_353_Ammo: SPE_CCKW_353_Base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class spare_fuel_hide_source: spare_fuel_hide_source {
+                positions[] = {{0.8, 1.8, -0.85}, {-0.8, 1.8, -0.85}, {0.8, 3.5, -0.85}, {-0.8, 3.5, -0.85}};
+            };
+        };
+    };
+    class SPE_CCKW_353_Repair: SPE_CCKW_353_Base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class spare_fuel_hide_source: spare_fuel_hide_source {
+                positions[] = {{0.8, 1.9, -0.85}, {-0.8, 1.9, -0.85}, {0.8, 3.6, -0.85}, {-0.8, 3.6, -0.85}};
+            };
+        };
+    };
+    class SPE_CCKW_353_Fuel: SPE_CCKW_353_Base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class spare_fuel_hide_source: spare_fuel_hide_source {
+                positions[] = {{0.8, 1.25, -0.8}, {-0.8, 1.25, -0.8}, {0.8, 2.95, -0.8}, {-0.8, 2.95, -0.8}, {0.8, -1, -0.3}, {-0.8, -1, -0.3}};
+                items[] = { // 32x
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F",
+                    "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F", "Land_CanisterFuel_F"
+                };
+            };
+        };
     };
 };

--- a/addons/compat_spe/compat_spe_repair/CfgVehicles.hpp
+++ b/addons/compat_spe/compat_spe_repair/CfgVehicles.hpp
@@ -1,0 +1,106 @@
+class CfgVehicles {
+    // Vehicle animation interactions
+    class SPE_Car_base;
+    class SPE_G503_MB_base: SPE_Car_base {
+        class EGVAR(interaction,anims) {
+            class hide_spare_wheel_source {
+                positions[] = {"_target selectionPosition ['hide_spare_wheel', 'ViewGeometry', 'AveragePoint']"};
+                items[] = {"ACE_Wheel"};
+                name = ECSTRING(repair,RemoveWheel);
+                text = ECSTRING(repair,RemovingWheel);
+            };
+        };
+    };
+
+    class SPE_Truck_base;
+    class SPE_CCKW_353_Base: SPE_Truck_base {
+        class EGVAR(interaction,anims) {
+            class spare_wheel_hide_source {
+                positions[] = {{-0.9, 0.35, -0.95}};
+                items[] = {"ACE_Wheel"};
+                name = ECSTRING(repair,RemoveWheel);
+                text = ECSTRING(repair,RemovingWheel);
+            };
+        };
+    };
+    class SPE_CCKW_353_Ammo: SPE_CCKW_353_Base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class spare_wheel_hide_source: spare_wheel_hide_source {
+                positions[] = {{-0.9, 0.35, -0.8}};
+            };
+        };
+    };
+
+    class SPE_R200_base: SPE_Car_base {
+        class EGVAR(interaction,anims) {
+            class hide_spare_wheel_source {
+                positions[] = {"_target selectionPosition ['hide_sparetire', 'FireGeometry', 'AveragePoint']"};
+                items[] = {"ACE_Wheel"};
+                name = ECSTRING(repair,RemoveWheel);
+                text = ECSTRING(repair,RemovingWheel);
+            };
+        };
+    };
+
+    class SPE_Tank_base;
+    class SPE_M18_Hellcat_Base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class hull_armour_hide_source {
+                positions[] = {"_target selectionPosition ['spare_track_hull', 'FireGeometry', 'AveragePoint']"};
+                items[] = {"ACE_Track", "ACE_Track", "ACE_Track"};
+                name = ECSTRING(repair,RemoveTrack);
+                text = ECSTRING(repair,RemovingTrack);
+            };
+        };
+    };
+
+    class SPE_PzKpfwV_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class spare_tracks_hide_source {
+                selections[] = {"spare_tracks"};
+                positions[] = {"private _pos = _target selectionPosition 'spare_tracks'; _pos set [0, -(_pos select 0)]; _pos"}; // Mirror position to other side of vehicle
+                items[] = {"ACE_Track", "ACE_Track", "ACE_Track"};
+                name = ECSTRING(repair,RemoveTrack);
+                text = ECSTRING(repair,RemovingTrack);
+            };
+        };
+    };
+
+    class SPE_PzKpfwVI_H1_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class hull_armour_hide_source {
+                positions[] = {{-1.3, 1.7, -0.75}, {1.1, 1.7, -0.75}, {-0.05, 2.35, -1.5}};
+                items[] = {"ACE_Track", "ACE_Track", "ACE_Track", "ACE_Track", "ACE_Track"};
+                name = ECSTRING(repair,RemoveTrack);
+                text = ECSTRING(repair,RemovingTrack);
+            };
+            class turret_armour_hide_source {
+                // Rotate interactions with turret rotation
+                positions[] = {
+                    "[0, -0.6, 0] vectorAdd ([[1.2, 0, -0.2], [0, 0, 1], deg (_target animationPhase 'MainTurret')] call CBA_fnc_vectRotate3D)",
+                    "[0, -0.6, 0] vectorAdd ([[-1.3, -0.3, -0.2], [0, 0, 1], deg (_target animationPhase 'MainTurret')] call CBA_fnc_vectRotate3D)"
+                };
+                items[] = {"ACE_Track", "ACE_Track"};
+                name = ECSTRING(repair,RemoveTrack);
+                text = ECSTRING(repair,RemovingTrack);
+            };
+        };
+    };
+
+    class SPE_Jagdpanther_G1_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class hide_spare_tracks_left_source {
+                positions[] = {"private _pos = _target selectionPosition ['hide_spare_tracks_right', 'FireGeometry', 'AveragePoint']; _pos set [0, -(_pos select 0)]; _pos vectorAdd [0, 0.335, 0]"};
+                items[] = {"ACE_Track"};
+                name = ECSTRING(repair,RemoveTrack);
+                text = ECSTRING(repair,RemovingTrack);
+            };
+            class hide_spare_tracks_right_source {
+                positions[] = {"_target selectionPosition ['hide_spare_tracks_right', 'FireGeometry', 'AveragePoint']"};
+                items[] = {"ACE_Track", "ACE_Track"};
+                name = ECSTRING(repair,RemoveTrack);
+                text = ECSTRING(repair,RemovingTrack);
+            };
+        };
+    };
+};

--- a/addons/compat_spe/compat_spe_repair/config.cpp
+++ b/addons/compat_spe/compat_spe_repair/config.cpp
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "ww2_spe_assets_c_weapons_infantryweapons_c",
+            "ww2_spe_assets_c_vehicles_staticweapons_c",
+            "ww2_spe_assets_c_vehicles_weapons_c",
+            "ww2_spe_core_f_system_staticweapons_f",
+            "ww2_spe_core_c_core_c_eventhandlers",
+            "ace_repair"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"johnb43"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_spe/compat_spe_repair/script_component.hpp
+++ b/addons/compat_spe/compat_spe_repair/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT repair
+#define SUBCOMPONENT_BEAUTIFIED Repair
+#include "..\script_component.hpp"

--- a/addons/compat_spe/compat_spe_trenches/CfgVehicles.hpp
+++ b/addons/compat_spe/compat_spe_trenches/CfgVehicles.hpp
@@ -1,0 +1,119 @@
+class CfgVehicles {
+    // Vehicle animation interactions
+    class SPE_Car_base;
+    class SPE_G503_MB_base: SPE_Car_base {
+        class EGVAR(interaction,anims) {
+            class hide_tools_source {
+                positions[] = {{-0.7, 0, -0.9}};
+                items[] = {"ACE_EntrenchingTool"};
+                name = ECSTRING(trenches,EntrenchingToolName);
+                text = ECSTRING(trenches,EntrenchingToolName);
+            };
+        };
+    };
+    class SPE_US_G503_MB_M1919_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+    class SPE_US_G503_MB_M1919_Armoured_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+    class SPE_US_G503_MB_M1919_PATROL_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+    class SPE_US_G503_MB_M2_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+    class SPE_US_G503_MB_M2_Armoured_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+    class SPE_US_G503_MB_M2_PATROL_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+    class SPE_G503_MB_Ambulance_base: SPE_G503_MB_base {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class hide_tools_source: hide_tools_source {
+                positions[] = {{-0.7, 0.45, -0.9}};
+            };
+        };
+    };
+
+    class SPE_R200_base: SPE_Car_base {
+        class EGVAR(interaction,anims) {
+            class hide_shovel_source {
+                positions[] = {{0.5, 1.2, -1.05}};
+                items[] = {"ACE_EntrenchingTool"};
+                name = ECSTRING(trenches,EntrenchingToolName);
+                text = ECSTRING(trenches,EntrenchingToolName);
+            };
+        };
+    };
+
+    class SPE_Tank_base;
+    class SPE_PzKpfwV_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class tools_hide_source {
+                positions[] = {{-1.45, 0.7, -0.4}};
+                items[] = {"ACE_EntrenchingTool", "ACE_wirecutter"};
+                name = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+                text = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+            };
+        };
+    };
+
+    class SPE_PzKpfwVI_H1_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class tools_hide_source {
+                positions[] = {{0, 1, -0.6}, {1.1, 0.1, -0.6}};
+                items[] = {"ACE_EntrenchingTool", "ACE_wirecutter"};
+                name = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+                text = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+            };
+        };
+    };
+
+    class SPE_StuG_III_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class hide_tools_left_source {
+                positions[] = {{-1.4, -1.4, -0.7}, {-1, -2.2, -0.65}};
+                items[] = {"ACE_EntrenchingTool", "ACE_wirecutter"};
+                name = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+                text = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+            };
+        };
+    };
+
+    class SPE_Jagdpanther_G1_base: SPE_Tank_base {
+        class EGVAR(interaction,anims) {
+            class hide_tools_left_source {
+                positions[] = {{-1.4, 0.5, -0.7}};
+                items[] = {"ACE_EntrenchingTool", "ACE_wirecutter"};
+                name = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+                text = "$STR_a3_cfgeditorsubcategories_edsubcat_tools0";
+            };
+        };
+    };
+};

--- a/addons/compat_spe/compat_spe_trenches/config.cpp
+++ b/addons/compat_spe/compat_spe_trenches/config.cpp
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "ww2_spe_assets_c_weapons_infantryweapons_c",
+            "ww2_spe_assets_c_vehicles_staticweapons_c",
+            "ww2_spe_assets_c_vehicles_weapons_c",
+            "ww2_spe_core_f_system_staticweapons_f",
+            "ww2_spe_core_c_core_c_eventhandlers",
+            "ace_trenches"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"johnb43"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_spe/compat_spe_trenches/script_component.hpp
+++ b/addons/compat_spe/compat_spe_trenches/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT trenches
+#define SUBCOMPONENT_BEAUTIFIED Trenches
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Adds #6144 to SPE vehicles.
- The number of tracks received from vehicles such as the Panther, Jagdpanther and Tiger is lower than the visual amount of tracks. The reason is a bit balancing (Tiger would be spawning in 26 Tracks, Panther & Jagdpanther would be 6), which imo is excessive.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
