### PR TITLE
Interaction - Add action to drop distant units from group

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -316,6 +316,12 @@ class CfgVehicles {
                     statement = QUOTE(_player call FUNC(renameGroupUI));
                     showDisabled =1;
                 };
+                class ACE_groupDropDistantUnits {
+                    displayName = CSTRING(groupDropDistantUnits);
+                    condition = QUOTE(call FUNC(canGroupDropDistantUnits));
+                    exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting", "isNotOnLadder", "isNotRefueling"};
+                    statement = QUOTE(call FUNC(groupDropDistantUnits));
+                };
             };
 
             class ACE_Equipment {

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -36,6 +36,8 @@ PREP(pullOutBody);
 PREP(canRenameGroup);
 PREP(renameGroupUI);
 PREP(renameGroup);
+PREP(canGroupDropDistantUnits);
+PREP(groupDropDistantUnits);
 
 // Weapon Attachments
 PREP(getWeaponAttachmentsActions);

--- a/addons/interaction/functions/fnc_canGroupDropDistantUnits.sqf
+++ b/addons/interaction/functions/fnc_canGroupDropDistantUnits.sqf
@@ -1,0 +1,20 @@
+#include "..\script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Checks if the unit can drop distance units from their group
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * Unit can drop distant units <BOOL>
+ *
+ * Example:
+ * [player] call ace_interaction_fnc_canGroupDropDistantUnits
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+
+(_unit == leader _unit) && {missionNamespace getVariable [QGVAR(allowDropDistantUnits), true]}

--- a/addons/interaction/functions/fnc_groupDropDistantUnits.sqf
+++ b/addons/interaction/functions/fnc_groupDropDistantUnits.sqf
@@ -1,0 +1,25 @@
+#include "..\script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Drops distance units from their group
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] call ace_interaction_fnc_groupDropDistantUnits
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+
+{
+    if ((_x distance _unit) > 100) then {
+        TRACE_1("drop",_x);
+        [_x] joinSilent grpNull;
+    };
+} forEach (units group _unit);

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -582,6 +582,9 @@
             <Chinese>小隊管理</Chinese>
             <Turkish>Takım Yönetimi</Turkish>
         </Key>
+        <Key ID="STR_ACE_Interaction_groupDropDistantUnits">
+            <English>Drop Distant Members</English>
+        </Key>
         <Key ID="STR_ACE_Interaction_TeamRED">
             <English>Red</English>
             <German>Rot</German>


### PR DESCRIPTION
Adds team management action to leader to drop any unit far away
can add setting if needed (it's already under the team management settings)