### PR TITLE
Compat WS - Add interaction anims to WS vehicles

### DIFF
--- a/addons/compat_ws/CfgVehicles.hpp
+++ b/addons/compat_ws/CfgVehicles.hpp
@@ -1,0 +1,45 @@
+class CfgVehicles {
+    // Vehicle animation interactions
+    class Offroad_01_base_lxWS;
+    class Offroad_01_armor_base_lxWS: Offroad_01_base_lxWS {
+        class EGVAR(interaction,anims) {
+            class HideBackpacks {
+                positions[] = {{-1.15, -1.15, -0.7}, {1.1, -1.15, -0.7}, {1.1, -2.5, -0.7}};
+                items[] = {"B_TacticalPack_blk", "B_TacticalPack_blk", "B_Carryall_khk", "B_Carryall_khk"};
+                name = "$STR_a3_cfgvehicleclasses_backpacks0";
+                text = "$STR_a3_cfgvehicleclasses_backpacks0";
+            };
+        };
+    };
+
+    class I_G_Offroad_01_AT_F;
+    class Offroad_01_AT_lxWS: I_G_Offroad_01_AT_F {
+        class EGVAR(interaction,anims) {
+            class HideBackpacks {
+                positions[] = {{-1.15, -1.25, -0.2}, {1.1, -1.25, -0.2}, {1.1, -2.6, -0.2}};
+                items[] = {"B_TacticalPack_blk", "B_TacticalPack_blk", "B_Carryall_khk", "B_Carryall_khk"};
+                name = "$STR_a3_cfgvehicleclasses_backpacks0";
+                text = "$STR_a3_cfgvehicleclasses_backpacks0";
+            };
+        };
+    };
+    class Offroad_01_armor_AT_lxWS: Offroad_01_AT_lxWS {
+        class EGVAR(interaction,anims): EGVAR(interaction,anims) {
+            class HideBackpacks: HideBackpacks {
+                positions[] = {{-1.15, -1.25, -0.7}, {1.1, -1.25, -0.7}, {1.1, -2.6, -0.7}};
+            };
+        };
+    };
+
+    class I_G_Offroad_01_armed_F;
+    class Offroad_01_armed_lxWS: I_G_Offroad_01_armed_F {
+        class EGVAR(interaction,anims) {
+            class HideBackpacks {
+                positions[] = {{-1.15, -1.03, -0.8}, {1.1, -1.03, -0.8}, {1.1, -2.38, -0.8}};
+                items[] = {"B_TacticalPack_blk", "B_TacticalPack_blk", "B_Carryall_khk", "B_Carryall_khk"};
+                name = "$STR_a3_cfgvehicleclasses_backpacks0";
+                text = "$STR_a3_cfgvehicleclasses_backpacks0";
+            };
+        };
+    };
+};

--- a/addons/compat_ws/compat_ws_repair/CfgVehicles.hpp
+++ b/addons/compat_ws/compat_ws_repair/CfgVehicles.hpp
@@ -1,0 +1,34 @@
+class CfgVehicles {
+    // Vehicle animation interactions
+    class Truck_02_base_F;
+    class Truck_02_aa_base_lxWS: Truck_02_base_F {
+        class EGVAR(interaction,anims) {
+            class hideSpareWheel {
+                positions[] = {{1, 1.93, -0.85}};
+                items[] = {"ACE_Wheel"};
+                name = ECSTRING(repair,RemoveWheel);
+                text = ECSTRING(repair,RemovingWheel);
+            };
+        };
+    };
+    class Truck_02_cargo_base_lxWS: Truck_02_base_F {
+        class EGVAR(interaction,anims) {
+            class hideSpareWheel {
+                positions[] = {{1, 1.93, -0.35}};
+                items[] = {"ACE_Wheel"};
+                name = ECSTRING(repair,RemoveWheel);
+                text = ECSTRING(repair,RemovingWheel);
+            };
+        };
+    };
+    class Truck_02_box_base_lxWS: Truck_02_base_F {
+        class EGVAR(interaction,anims) {
+            class hideSpareWheel {
+                positions[] = {{1, 1.7, -0.35}};
+                items[] = {"ACE_Wheel"};
+                name = ECSTRING(repair,RemoveWheel);
+                text = ECSTRING(repair,RemovingWheel);
+            };
+        };
+    };
+};

--- a/addons/compat_ws/compat_ws_repair/config.cpp
+++ b/addons/compat_ws/compat_ws_repair/config.cpp
@@ -1,19 +1,20 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class SUBADDON {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"data_f_lxWS_Loadorder", "ace_common"};
+        requiredAddons[] = {"data_f_lxWS_Loadorder", "ace_repair"};
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
-        authors[] = {"Mike"};
+        authors[] = {"johnb43"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
     };
 };
 
 #include "CfgVehicles.hpp"
-#include "CfgWeapons.hpp"

--- a/addons/compat_ws/compat_ws_repair/script_component.hpp
+++ b/addons/compat_ws/compat_ws_repair/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT repair
+#define SUBCOMPONENT_BEAUTIFIED Repair
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Adds #6144 to WS vehicles.
- Improves backpack interaction anims position on the offroad variants, but at the cost of losing inheritance for the anims. I'll gladly take someone's solution for not breaking inheritance for anims, I'm too stupid for this type of inheritance structure.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
