### PR TITLE
HEMTT - Use extends for launch presets

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -34,32 +34,26 @@ workshop = [
 ]
 
 [hemtt.launch.spe]
-workshop = [
-    "450814997", # CBA_A3
-]
+extends = "default"
 dlc = [
     "spe"
 ]
 
 [hemtt.launch.vn]
-workshop = [
-    "450814997", # CBA_A3's Workshop ID
-]
+extends = "default"
 dlc = [
     "S.O.G. Prairie Fire",
 ]
 
 [hemtt.launch.ws]
-workshop = [
-    "450814997", # CBA_A3's Workshop ID
-]
+extends = "default"
 dlc = [
     "Western Sahara",
 ]
 
 [hemtt.launch.rhs]
+extends = "default"
 workshop = [
-    "450814997", # CBA_A3's Workshop ID
     "843425103", # RHS AFRF Workshop ID
     "843577117", # RHS USAF Workshop ID
     "843593391", # RHS GREF Workshop ID


### PR DESCRIPTION
**When merged this pull request will:**
- Use `extends` for non-default launch presets

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
