### PR TITLE
Scopes - Setting to show Adjustment UI while sighted in

### DIFF
--- a/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
+++ b/addons/scopes/functions/fnc_applyScopeAdjustment.sqf
@@ -43,6 +43,10 @@ if (cameraView == "GUNNER") then {
         _yaw = _yaw + _windageDifference;
         [_unit, _pitch, _bank, _yaw] call EFUNC(common,setPitchBankYaw);
     };
+
+    if (GVAR(inScopeAdjustment)) then {
+        [] call FUNC(showZeroing);
+    };
 } else {
     [] call FUNC(showZeroing);
 };

--- a/addons/scopes/initSettings.inc.sqf
+++ b/addons/scopes/initSettings.inc.sqf
@@ -91,3 +91,11 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     false,
     1
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(inScopeAdjustment), "CHECKBOX",
+    LSTRING(inScopeAdjustment_displayName),
+    _category,
+    false,
+    0
+] call CBA_fnc_addSetting;

--- a/addons/scopes/stringtable.xml
+++ b/addons/scopes/stringtable.xml
@@ -347,6 +347,11 @@
             <Czech>Replikuje systém naměřování puškohledů ze základní hry.</Czech>
             <Spanish>Replica en los visores el sistema de homogeneizado de vanilla</Spanish>
         </Key>
+        <Key ID="STR_ACE_Scopes_inScopeAdjustment_displayName">
+            <English>Show adjustment UI in scope</English>
+            <German>Zeige Absehenverstellungs-UI im Zielfernrohr</German>
+            <Italian>Mostra UI delle manopole nel mirino</Italian>
+        </Key>
         <Key ID="STR_ACE_Scopes_AdjustUpMinor">
             <English>Minor adjustment up</English>
             <German>Kleine Korrektur hoch</German>


### PR DESCRIPTION
**When merged this pull request will:**
- CBA Setting to show the Scope Adjustment UI even while sighted in (split from #10220).\
IRL one should be able track the exact turret setting with the off-eye, or at least without having to unsight completely (and I guess also feel it to a certain extent).