### PR TITLE
Interaction - Use `animateSource` instead of `animate` for interaction anims

### DIFF
--- a/addons/interaction/functions/fnc_initAnimActions.sqf
+++ b/addons/interaction/functions/fnc_initAnimActions.sqf
@@ -125,7 +125,7 @@ private _statement = {
 
             if (!_success) exitWith {};
 
-            _target animate [_anim, _phase, true];
+            _target animateSource [_anim, _phase, true];
         },
         {},
         _text,


### PR DESCRIPTION
**When merged this pull request will:**
- According to the wiki, `animateSource` is better in MP (https://community.bistudio.com/wiki/animateSource). Testing in SP suggests all existing interactions work as before.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
