### PR TITLE
WS Compat - Use ACE MG for realistic name

### DIFF
--- a/addons/compat_ws/compat_ws_vehicles/CfgVehicles.hpp
+++ b/addons/compat_ws/compat_ws_vehicles/CfgVehicles.hpp
@@ -1,0 +1,27 @@
+class CfgVehicles {
+    class Car_F;
+    class Wheeled_APC_F: Car_F {
+        class Turrets {
+            class MainTurret;
+        };
+    };
+    class APC_Wheeled_01_base_F: Wheeled_APC_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {};
+        };
+    };
+    class APC_Wheeled_01_atgm_base_lxWS: APC_Wheeled_01_base_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"autocannon_40mm_CTWS", "ACE_LMG_coax_MAG58_mem3", "missiles_titan"}; // For realistic MG name
+            };
+        };
+    };
+    class APC_Wheeled_01_command_base_lxWS: APC_Wheeled_01_base_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"HMG_127_lxWS", "ACE_LMG_coax_MAG58_mem3"}; // For realistic MG name
+            };
+        };
+    };
+};

--- a/addons/compat_ws/compat_ws_vehicles/config.cpp
+++ b/addons/compat_ws/compat_ws_vehicles/config.cpp
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "data_f_lxWS_Loadorder",
+            "ace_vehicles"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"johnb43"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_ws/compat_ws_vehicles/script_component.hpp
+++ b/addons/compat_ws/compat_ws_vehicles/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT vehicles
+#define SUBCOMPONENT_BEAUTIFIED Vehicles
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- If realistic names is loaded, the Badger's coaxial MG is named "PKT". This PR addresses that.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
