### PR TITLE
Common - Make `FUNC(getVehicleIcon)` check for strings without the .paa extension

### DIFF
--- a/addons/common/functions/fnc_getVehicleIcon.sqf
+++ b/addons/common/functions/fnc_getVehicleIcon.sqf
@@ -35,7 +35,11 @@ if (isNil "_cachedValue") then {
         if (_vehicleValue != "" && {((toLowerANSI _vehicleValue) find ".paa") > -1}) then {
             _cachedValue = _vehicleValue;
         } else {
-            _cachedValue = DEFAULT_TEXTURE;
+            if (fileExists (_vehicleValue + ".paa")) then {
+                _cachedValue = _vehicleValue + ".paa";
+            } else {
+                _cachedValue = DEFAULT_TEXTURE;
+            };
         };
     } else {
         _cachedValue = _vehicleIconValue;

--- a/addons/common/functions/fnc_getVehicleIcon.sqf
+++ b/addons/common/functions/fnc_getVehicleIcon.sqf
@@ -35,7 +35,7 @@ if (isNil "_cachedValue") then {
         if (_vehicleValue != "" && {((toLowerANSI _vehicleValue) find ".paa") > -1}) then {
             _cachedValue = _vehicleValue;
         } else {
-            if (fileExists (_vehicleValue + ".paa")) then {
+            if (_vehicleValue != "" && {fileExists (_vehicleValue + ".paa")}) then {
                 _cachedValue = _vehicleValue + ".paa";
             } else {
                 _cachedValue = DEFAULT_TEXTURE;

--- a/addons/common/functions/fnc_getVehicleIcon.sqf
+++ b/addons/common/functions/fnc_getVehicleIcon.sqf
@@ -35,7 +35,7 @@ if (isNil "_cachedValue") then {
         if (_vehicleValue != "" && {((toLowerANSI _vehicleValue) find ".paa") > -1}) then {
             _cachedValue = _vehicleValue;
         } else {
-            if (fileExists (_vehicleValue + ".paa")) then {
+            if (_vehicleValue select [0,1] == "\" && {fileExists (_vehicleValue + ".paa")}) then {
                 _cachedValue = _vehicleValue + ".paa";
             } else {
                 _cachedValue = DEFAULT_TEXTURE;

--- a/addons/common/functions/fnc_getVehicleIcon.sqf
+++ b/addons/common/functions/fnc_getVehicleIcon.sqf
@@ -35,7 +35,7 @@ if (isNil "_cachedValue") then {
         if (_vehicleValue != "" && {((toLowerANSI _vehicleValue) find ".paa") > -1}) then {
             _cachedValue = _vehicleValue;
         } else {
-            if (_vehicleValue select [0,1] == "\" && {fileExists (_vehicleValue + ".paa")}) then {
+            if (fileExists (_vehicleValue + ".paa")) then {
                 _cachedValue = _vehicleValue + ".paa";
             } else {
                 _cachedValue = DEFAULT_TEXTURE;


### PR DESCRIPTION
**When merged this pull request will:**
- Suggests a possible fix when the ".paa" extension is not included\*.
  - This specifically would fix GM's vehicle icons not being retrieved.

\* Apparently the ".paa" on a vehicle's icon config entry is optional.
### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
