### PR TITLE
Dragging - Fix dragging breaking via keybind

### DIFF
--- a/addons/dragging/functions/fnc_carryObject.sqf
+++ b/addons/dragging/functions/fnc_carryObject.sqf
@@ -48,9 +48,6 @@ if (_target isKindOf "CAManBase") then {
 
 [QEGVAR(common,setDir), [_target, _direction], _target] call CBA_fnc_targetEvent;
 
-_unit setVariable [QGVAR(isCarrying), true, true];
-_unit setVariable [QGVAR(carriedObject), _target, true];
-
 // Add drop action
 _unit setVariable [QGVAR(releaseActionID), [
     _unit, "DefaultAction",

--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -49,9 +49,6 @@ if (_target isKindOf "CAManBase") then {
     [_target, "AinjPpneMrunSnonWnonDb_still", 0] call EFUNC(common,doAnimation);
 };
 
-_unit setVariable [QGVAR(isDragging), true, true];
-_unit setVariable [QGVAR(draggedObject), _target, true];
-
 // Add drop action
 GVAR(unit) = _unit;
 

--- a/addons/dragging/functions/fnc_startCarryLocal.sqf
+++ b/addons/dragging/functions/fnc_startCarryLocal.sqf
@@ -82,7 +82,7 @@ if (_target isKindOf "CAManBase") then {
 // Prevents dragging and carrying at the same time
 _unit setVariable [QGVAR(isCarrying), true, true];
 
-// Required for aborting animation
+// Required for aborting (animation & keybind)
 _unit setVariable [QGVAR(carriedObject), _target, true];
 
 [LINKFUNC(startCarryPFH), 0.2, [_unit, _target, _timer]] call CBA_fnc_addPerFrameHandler;

--- a/addons/dragging/functions/fnc_startCarryPFH.sqf
+++ b/addons/dragging/functions/fnc_startCarryPFH.sqf
@@ -53,10 +53,9 @@ if (_target isKindOf "CAManBase") then {
     // Timeout: Drop target. CBA_missionTime, because anim length is linked to ingame time
     if (CBA_missionTime > _timeOut) exitWith {
         TRACE_4("timeout",_unit,_target,_timeOut,CBA_missionTime);
-        _idPFH call CBA_fnc_removePerFrameHandler;
+        [_unit, _target] call FUNC(dropObject_carry);
 
-        private _carriedObject = _unit getVariable [QGVAR(carriedObject), objNull];
-        [_unit, _carriedObject] call FUNC(dropObject_carry);
+        _idPFH call CBA_fnc_removePerFrameHandler;
     };
 
     // Wait for the unit to stand up

--- a/addons/dragging/functions/fnc_startDragLocal.sqf
+++ b/addons/dragging/functions/fnc_startDragLocal.sqf
@@ -99,6 +99,9 @@ if (_target isKindOf "CAManBase") then {
 // Prevents dragging and carrying at the same time
 _unit setVariable [QGVAR(isDragging), true, true];
 
+// Required for aborting (keybind)
+_unit setVariable [QGVAR(draggedObject), _target, true];
+
 [LINKFUNC(startDragPFH), 0.2, [_unit, _target, CBA_missionTime + 5]] call CBA_fnc_addPerFrameHandler;
 
 // Disable collisions by setting the physx mass to almost zero

--- a/addons/dragging/functions/fnc_startDragPFH.sqf
+++ b/addons/dragging/functions/fnc_startDragPFH.sqf
@@ -43,11 +43,9 @@ if (!alive _target || {_unit distance _target > 10}) exitWith {
 // Timeout: Drop target. CBA_missionTime, because anim length is linked to ingame time
 if (CBA_missionTime > _timeOut) exitWith {
     TRACE_4("timeout",_unit,_target,_timeOut,CBA_missionTime);
-    _idPFH call CBA_fnc_removePerFrameHandler;
+    [_unit, _target] call FUNC(dropObject);
 
-    // Drop if in timeout
-    private _draggedObject = _unit getVariable [QGVAR(draggedObject), objNull];
-    [_unit, _draggedObject] call FUNC(dropObject);
+    _idPFH call CBA_fnc_removePerFrameHandler;
 };
 
 // Unit is ready to start dragging


### PR DESCRIPTION
**When merged this pull request will:**
- Previously, if you double tapped the dragging keybind, it would fail to release the claim on the dragged object. This PR fixes that.
- Stopped setting variables unnecessarily. I'm a little afraid of race condition bs that *could* happen.
- Use local `_target` variable, instead of getting `QGVAR(draggedObject)`. Imo the updated version is safer, because `QGVAR(draggedObject)` could be changed for some reason.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
