### PR TITLE
CSW - Handle turret locality safer

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -215,6 +215,7 @@ if (isServer) then {
 [QGVAR(switchMove), {(_this select 0) switchMove (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(setVectorDirAndUp), {(_this select 0) setVectorDirAndUp (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(addWeaponItem), {(_this select 0) addWeaponItem [(_this select 1), (_this select 2)]}] call CBA_fnc_addEventHandler;
+[QGVAR(addMagazineTurret), {(_this select 0) addMagazineTurret (_this select 1)}] call CBA_fnc_addEventHandler;
 [QGVAR(removeMagazinesTurret), {(_this select 0) removeMagazinesTurret [_this select 1, _this select 2]}] call CBA_fnc_addEventHandler;
 [QGVAR(triggerAmmo), {triggerAmmo _this}] call CBA_fnc_addEventHandler;
 

--- a/addons/csw/functions/fnc_initVehicle.sqf
+++ b/addons/csw/functions/fnc_initVehicle.sqf
@@ -33,18 +33,11 @@ if (_configEnabled && {GVAR(ammoHandling) == 2}) then {
     _vehicle addEventHandler ["GetIn", LINKFUNC(ai_handleGetIn)]; // handle AI getting inside weapon with no ammo
 };
 
-if (_configEnabled) then {
+TRACE_2("",local _vehicle,_vehicle turretLocal [0]);
+if (_configEnabled && {_vehicle turretLocal [0]}) then { // if turret is local to us, then handle mags/weapon
     [{
         params ["_vehicle"];
-        TRACE_2("",local _vehicle,_vehicle turretLocal [0]);
-
         if (!alive _vehicle) exitWith { TRACE_1("dead/deleted",_vehicle); };
-
-        // If turret is local, handle mags/weapon
-        if !(_vehicle turretLocal [0]) exitWith {
-            TRACE_1("turret not local",_vehicle);
-        };
-
         // Assembly mode: [0=disabled, 1=enabled, 2=enabled&unload, 3=default]
         private _assemblyModeIndex = _vehicle getVariable [QGVAR(assemblyMode), 3];
         private _emptyWeapon = _assemblyModeIndex isEqualTo 2;

--- a/addons/csw/functions/fnc_initVehicle.sqf
+++ b/addons/csw/functions/fnc_initVehicle.sqf
@@ -33,11 +33,18 @@ if (_configEnabled && {GVAR(ammoHandling) == 2}) then {
     _vehicle addEventHandler ["GetIn", LINKFUNC(ai_handleGetIn)]; // handle AI getting inside weapon with no ammo
 };
 
-TRACE_2("",local _vehicle,_vehicle turretLocal [0]);
-if (_configEnabled && {_vehicle turretLocal [0]}) then { // if turret is local to us, then handle mags/weapon
+if (_configEnabled) then {
     [{
         params ["_vehicle"];
+        TRACE_2("",local _vehicle,_vehicle turretLocal [0]);
+
         if (!alive _vehicle) exitWith { TRACE_1("dead/deleted",_vehicle); };
+
+        // If turret is local, handle mags/weapon
+        if !(_vehicle turretLocal [0]) exitWith {
+            TRACE_1("turret not local",_vehicle);
+        };
+
         // Assembly mode: [0=disabled, 1=enabled, 2=enabled&unload, 3=default]
         private _assemblyModeIndex = _vehicle getVariable [QGVAR(assemblyMode), 3];
         private _emptyWeapon = _assemblyModeIndex isEqualTo 2;

--- a/addons/csw/functions/fnc_proxyWeapon.sqf
+++ b/addons/csw/functions/fnc_proxyWeapon.sqf
@@ -23,7 +23,7 @@ TRACE_4("proxyWeapon",_vehicle,_turret,_needed,_emptyWeapon);
 
 // addWeaponTurret/removeWeaponTurret need to be executed where turret is local
 if !(_vehicle turretLocal _turret) exitWith {
-    TRACE_1("turret not local",_vehicle);
+    WARNING_1("[%1]'s turret [%2] isn't local, skipping proxy weapon change",_vehicle,_turret);
 };
 
 if (_vehicle getVariable [format [QGVAR(proxyHandled_%1), _turret], false]) exitWith { TRACE_1("already handled",typeOf _vehicle); };

--- a/addons/csw/functions/fnc_proxyWeapon.sqf
+++ b/addons/csw/functions/fnc_proxyWeapon.sqf
@@ -23,7 +23,7 @@ TRACE_4("proxyWeapon",_vehicle,_turret,_needed,_emptyWeapon);
 
 // addWeaponTurret/removeWeaponTurret need to be executed where turret is local
 if !(_vehicle turretLocal _turret) exitWith {
-    WARNING_1("[%1]'s turret [%2] isn't local, skipping proxy weapon change",_vehicle,_turret);
+    WARNING_2("[%1]'s turret [%2] isn't local, skipping proxy weapon change",_vehicle,_turret);
 };
 
 if (_vehicle getVariable [format [QGVAR(proxyHandled_%1), _turret], false]) exitWith { TRACE_1("already handled",typeOf _vehicle); };

--- a/addons/csw/functions/fnc_proxyWeapon.sqf
+++ b/addons/csw/functions/fnc_proxyWeapon.sqf
@@ -21,6 +21,11 @@
 params ["_vehicle", "_turret", "_needed", "_emptyWeapon"];
 TRACE_4("proxyWeapon",_vehicle,_turret,_needed,_emptyWeapon);
 
+// addWeaponTurret/removeWeaponTurret need to be executed where turret is local
+if !(_vehicle turretLocal _turret) exitWith {
+    TRACE_1("turret not local",_vehicle);
+};
+
 if (_vehicle getVariable [format [QGVAR(proxyHandled_%1), _turret], false]) exitWith { TRACE_1("already handled",typeOf _vehicle); };
 
 private _proxyWeapon = getText (configOf _vehicle >> QUOTE(ADDON) >> "proxyWeapon");

--- a/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
@@ -62,10 +62,12 @@ private _containerMagazineCount = [];
 
 TRACE_1("Remove all loaded magazines",_magsToRemove);
 {
-    _vehicle removeMagazinesTurret _x;
+    [QEGVAR(common,removeMagazinesTurret), [_vehicle, _x select 0, _x select 1], _vehicle, _x select 1] call CBA_fnc_turretEvent;
+
     if ((_loadedMagazineInfo select [0,2]) isEqualTo _x) then {
         TRACE_1("Re-add the starting mag",_loadedMagazineInfo);
-        _vehicle addMagazineTurret _loadedMagazineInfo;
+
+        [QEGVAR(common,addMagazineTurret), [_vehicle, _loadedMagazineInfo], _vehicle, _x select 1] call CBA_fnc_turretEvent;
     };
 } forEach _magsToRemove;
 
@@ -83,7 +85,7 @@ if (_secondaryWeaponMagazines isNotEqualTo []) then {
 
         // If the magazine can be added to the static weapon, do it now
         if (_vehicleMag in _compatibleMagazinesTurret) then {
-            _vehicle addMagazineTurret [_vehicleMag, _turret, _x select 1];
+            [QEGVAR(common,addMagazineTurret), [_vehicle, [_vehicleMag, _turret, _x select 1]], _vehicle, _turret] call CBA_fnc_turretEvent;
         } else {
             // Find a suitable container to place items in if necessary
             if (isNull _container) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- ~~`FUNC(initVehicle)`: Nothing guarantees that the CSW will still be local in the next frame, so better to see if CSW is local in the next frame.~~ Addressed in  #10273, by removing the delay by a frame.
- `FUNC(proxyWeapon)`: Both calls to it (with the change above) check if the turret is local and quit if it isn't, so it should be fine. My worry is if it's called from a 3rd party, but idk how likely that is, so I'm unsure how needed this change is.
- `FUNC(staticWeaponInit_unloadExtraMags)`: Removes magazines from all turrets, a frame after the vehicle has been initialised, which technically leaves some time for a unit to be moved into a turret, which could force a locality switch if said unit is remote.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
