### PR TITLE
CSW - Improve "disableWeaponAssembly" status effect usage

### DIFF
--- a/addons/csw/functions/fnc_assemble_deployTripod.sqf
+++ b/addons/csw/functions/fnc_assemble_deployTripod.sqf
@@ -58,9 +58,8 @@
             _cswTripod setVariable [QGVAR(secondaryWeaponMagazines), _secondaryWeaponMagazines, true];
         };
 
-        if (!GVAR(defaultAssemblyMode)) then {
-            [_cswTripod, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-        };
+        // Disable vanilla assembly until FUNC(initVehicle) runs and sets the definite value
+        [_cswTripod, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
         private _posATL = _player getRelPos [2, 0];
         _posATL set [2, ((getPosATL _player) select 2) + 0.5];

--- a/addons/csw/functions/fnc_assemble_deployWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_deployWeapon.sqf
@@ -76,9 +76,9 @@
                 _csw setVariable [QGVAR(secondaryWeaponMagazines), _secondaryWeaponMagazines, true];
             };
 
-            if (!GVAR(defaultAssemblyMode)) then {
-                [_csw, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-            };
+            // Disable vanilla assembly until FUNC(initVehicle) runs and sets the definite value
+            [_csw, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+
             _csw setDir _tripodDir;
             _csw setPosATL _tripodPos;
             if ((_tripodPos select 2) < 0.5) then {

--- a/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
+++ b/addons/csw/functions/fnc_staticWeaponInit_unloadExtraMags.sqf
@@ -5,8 +5,7 @@
  *
  * Arguments:
  * 0: CSW <OBJECT>
- * 1: Using advanced assembly <BOOL>
- * 2: Empty weapon <BOOL>
+ * 1: Empty weapon <BOOL>
  *
  * Return Value:
  * None
@@ -17,9 +16,8 @@
  * Public: No
  */
 
-params ["_vehicle", "_assemblyMode", "_emptyWeapon"];
-TRACE_3("staticWeaponInit_unloadExtraMags",_vehicle,_assemblyMode,_emptyWeapon);
-if (!_assemblyMode) exitWith {};
+params ["_vehicle", "_emptyWeapon"];
+TRACE_2("staticWeaponInit_unloadExtraMags",_vehicle,_emptyWeapon);
 
 private _desiredAmmo = getNumber (configOf _vehicle >> QUOTE(ADDON) >> "desiredAmmo");
 private _storeExtraMagazines = GVAR(handleExtraMagazines);


### PR DESCRIPTION
**When merged this pull request will:**
- Turn off vanilla assembly for placed tripods and assembled CSWs, so that `FUNC(initVehicle)` can handle enabling/disabling vanilla assembly when the `QGVAR(assemblyMode)` is set on the vehicle.
- Only set the status effect where the gunner's turret is local. Until now, every machine set a status effect that has a global effect, which is useless.
- Removed the `execNextFrame` in `FUNC(initVehicle)`, because it runs 1 second after a vehicle has been created, so no need for the frame of delay.
- Optimised `FUNC(staticWeaponInit_unloadExtraMags)` slightly (from #9901).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
