### PR TITLE
Mk6 Mortar - Improve and correct string table entries

### DIFF
--- a/addons/mk6mortar/stringtable.xml
+++ b/addons/mk6mortar/stringtable.xml
@@ -120,10 +120,10 @@
             <Turkish>Hava Direnci</Turkish>
         </Key>
         <Key ID="STR_ACE_Mk6Mortar_airResistanceEnabled_Description">
-            <English>For Player Shots, Model Air Resistance and Wind Effects</English>
+            <English>Simulates air resistance and wind effects for player shots.</English>
             <Polish>Modeluj opór powietrza oraz wpływ wiatru na tor lotu pocisku dla strzałów z moździerza Mk6 przez graczy</Polish>
             <Spanish>Para disparos del jugador, modelo de resistencia al aire y efectos de viento</Spanish>
-            <German>Für Spielerschüsse, Luftwiderstand und Windeffekte</German>
+            <German>Simuliert Luftwiderstand und Windeffekte für Spielerschüsse.</German>
             <Czech>Pro hráčovu střelbu, Model odporu vzduchu a povětrných podmínek</Czech>
             <Portuguese>Para disparos do jogador, modelo de resistência de ar e efeitos de vento</Portuguese>
             <French>Pour les tirs des joueurs, simule la résistance de l'air et les effets du vent.</French>
@@ -233,19 +233,19 @@
             <Czech>Používat ruční manipulaci s municí</Czech>
         </Key>
         <Key ID="STR_ACE_Mk6Mortar_useAmmoHandling_Description">
-            <English>Removes mortar magazines, requiring individual rounds to be loaded by the gunner or loader. Does not affect AI mortars.</English>
-            <German>Enfernt das Magzin des Mörsers. Es ist nun erforderlich, die einzelnen Patronen manuell zu laden. Dies beeinflusst nicht die KI-Truppen.</German>
-            <Spanish>Elimina los cargadores del mortero, requiriendo al artillero o cargador la carga manual de cada rondas. No afecta morteros controlados por IA.</Spanish>
-            <Polish>Usuwa magazynki moździerza, wymagając ładowania pojedynczych pocisków przez strzelca lub ładowniczego. Nie dotyczy moździerzy AI.</Polish>
-            <French>Enlève les chargeurs de mortier, ce qui oblige le tireur ou le servant à charger les obus manuellement. N'affecte pas les mortiers IA.</French>
-            <Italian>Rimuove i caricatori di colpi dal mortaio. Un operatore dovrà caricare proiettili singoli prima di poter fare fuoco. Non viene applicato su operatori IA.</Italian>
-            <Portuguese>Elimina os carregadores do morteiro, requerendo que o atirador ou carregador utilize de forma individual a munição. Não afeta os morteiros controlados pela IA.</Portuguese>
-            <Russian>Удаляет артиллерийские магазины, требует загрузку отдельных снарядов стрелком или заряжающим. Не влияет на артиллерию ИИ.</Russian>
-            <Japanese>迫撃砲から弾倉を除去します。一発ずつ射手か装填手によって装填される必要があります。AIの迫撃砲には影響を与えません。</Japanese>
-            <Korean>박격포 탄창을 제거합니다, 사수나 장전수가 개별적으로 탄환을 넣어줘야 합니다. 인공지능은 영향을 받지 않습니다.</Korean>
-            <Chinesesimp>开启此功能时。迫击炮的弹药需由炮手与装填手共同合作来进行装填。此功能并不影响由 AI 射击的迫击炮</Chinesesimp>
-            <Chinese>開啟此功能時。迫擊砲的彈藥需由砲手與裝填手共同合作來進行裝填。此功能並不影響由AI射擊的迫擊砲</Chinese>
-            <Czech>Odstraní z minometu zásobník a vynucuje nabíjení po každém výstřelu buď mířičem nebo nabíječem. Tato možnost neovlivňuje AI posádky.</Czech>
+            <English>Removes mortar magazines, requiring individual rounds to be loaded by the gunner or loader.</English>
+            <German>Enfernt das Magzin des Mörsers. Es ist nun erforderlich, die einzelnen Patronen manuell zu laden.</German>
+            <Spanish>Elimina los cargadores del mortero, requiriendo al artillero o cargador la carga manual de cada rondas.</Spanish>
+            <Polish>Usuwa magazynki moździerza, wymagając ładowania pojedynczych pocisków przez strzelca lub ładowniczego.</Polish>
+            <French>Enlève les chargeurs de mortier, ce qui oblige le tireur ou le servant à charger les obus manuellement.</French>
+            <Italian>Rimuove i caricatori di colpi dal mortaio. Un operatore dovrà caricare proiettili singoli prima di poter fare fuoco.</Italian>
+            <Portuguese>Elimina os carregadores do morteiro, requerendo que o atirador ou carregador utilize de forma individual a munição.</Portuguese>
+            <Russian>Удаляет артиллерийские магазины, требует загрузку отдельных снарядов стрелком или заряжающим.</Russian>
+            <Japanese>迫撃砲から弾倉を除去します。一発ずつ射手か装填手によって装填される必要があります。</Japanese>
+            <Korean>박격포 탄창을 제거합니다, 사수나 장전수가 개별적으로 탄환을 넣어줘야 합니다.</Korean>
+            <Chinesesimp>开启此功能时。迫击炮的弹药需由炮手与装填手共同合作来进行装填</Chinesesimp>
+            <Chinese>開啟此功能時。迫擊砲的彈藥需由砲手與裝填手共同合作來進行裝填</Chinese>
+            <Czech>Odstraní z minometu zásobník a vynucuje nabíjení po každém výstřelu buď mířičem nebo nabíječem.</Czech>
         </Key>
         <Key ID="STR_ACE_Mk6Mortar_unloadMortar">
             <English>Remove Round</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Improve English and German entries for `STR_ACE_Mk6Mortar_airResistanceEnabled_Description`.
- Removed `Does not affect AI mortars.` (and all translations of it) from `STR_ACE_Mk6Mortar_useAmmoHandling_Description`, because it affects all mortars.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
