### PR TITLE
Compat RF - Field Rations - Watersource Offsets

### DIFF
--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles {
     // applies the offset to all RF Offroads which can have the optional Tank in the back
     class Offroad_01_unarmed_base_F;
-    class Pickup_01_base_rf : Offroad_01_unarmed_base_F {
+    class Pickup_01_base_rf: Offroad_01_unarmed_base_F {
         EXGVAR(field_rations,offset)[] = {-0.04, -2.45, -0.9};
     };
     

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -18,7 +18,7 @@ class CfgVehicles {
     };
 
     class B_Truck_01_fuel_F;
-    class C_Truck_01_water_rf : B_Truck_01_fuel_F {
+    class C_Truck_01_water_rf: B_Truck_01_fuel_F {
         EXGVAR(field_rations,waterSupply) = 10000;
         EXGVAR(field_rations,offset)[] = {-0.41, -5.15, -0.3};
     };

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,5 +1,5 @@
 class CfgVehicles {
-    // applies the offset to all RF Offroads which can have the optional Tank in the back
+    // Applies the offset to all RF Offroads which can have the optional tank in the back
     class Offroad_01_unarmed_base_F;
     class Pickup_01_base_rf: Offroad_01_unarmed_base_F {
         EXGVAR(field_rations,offset)[] = {-0.04, -2.45, -0.9};

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,5 +1,4 @@
 class CfgVehicles {
-
     // applies the offset to all RF Offroads which can have the optional Tank in the back
     class Offroad_01_unarmed_base_F;
     class Pickup_01_base_rf : Offroad_01_unarmed_base_F

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,39 +1,30 @@
-test attachTo [cursorObject, ];
-
-
-acex_field_rations_offset = [-0.04,-2.45,-0.9]
-
-
 class CfgVehicles {
 
-  
-
-    class C_IDAP_Pickup_rf;
-    class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf
+    class Offroad_01_unarmed_base_F;
+    class Pickup_01_base_rf : Offroad_01_unarmed_base_F
     {
-        acex_field_rations_waterSupply = 1000;
         acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
     };
     
-    class Pickup_01_base_rf;
-    class B_UN_Pickup_rf: Pickup_01_base_rf
+    class C_IDAP_Pickup_rf;
+    class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf
     {
+        acex_field_rations_waterSupply = 500;
         acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
     };
-
-
+    
     class O_Truck_03_fuel_F;
     class C_Truck_03_water_rf: O_Truck_03_fuel_F
     {
         acex_field_rations_waterSupply = 10000;
-        acex_field_rations_offset[] = {-0.03, -3.72, -1.05}; // Todo
+        acex_field_rations_offset[] = {0, -5.15, -0.3}; // Rear
+        //acex_field_rations_offset[] = {1.25,-1.59,-0.58}; // Right Side Latch
     };
 
     class B_Truck_01_fuel_F;
     class C_Truck_01_water_rf : B_Truck_01_fuel_F 
     {
         acex_field_rations_waterSupply = 10000;
-        acex_field_rations_offset[] = {-0.03, -3.72, -1.05}; // Todo
+        acex_field_rations_offset[] = {0, -5.15, -0.3};
     };
-
 };

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -3,28 +3,28 @@ class CfgVehicles {
     class Offroad_01_unarmed_base_F;
     class Pickup_01_base_rf : Offroad_01_unarmed_base_F
     {
-        acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
+        EXGVAR(field_rations,offset)[] = {-0.04, -2.45, -0.9};
     };
     
     // Enable Water Source by Default
     class C_IDAP_Pickup_rf;
     class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf
     {
-        acex_field_rations_waterSupply = 500;
+        EXGVAR(field_rations,waterSupply) = 500;
     };
     
     class O_Truck_03_fuel_F;
     class C_Truck_03_water_rf: O_Truck_03_fuel_F
     {
-        acex_field_rations_waterSupply = 10000;
-        acex_field_rations_offset[] = {0, -5.05, -0.3}; // Rear
-        //acex_field_rations_offset[] = {1.25,-1.59,-0.58}; // Right Side Latch
+        EXGVAR(field_rations,waterSupply) = 10000;
+        EXGVAR(field_rations,offset)[] = {0, -5.05, -0.3}; // Rear
+        //EXGVAR(field_rations,offset)[] = {1.25,-1.59,-0.58}; // Right Side Latch
     };
 
     class B_Truck_01_fuel_F;
     class C_Truck_01_water_rf : B_Truck_01_fuel_F 
     {
-        acex_field_rations_waterSupply = 10000;
-        acex_field_rations_offset[] = {-0.41,-5.15,-0.3};
+        EXGVAR(field_rations,waterSupply) = 10000;
+        EXGVAR(field_rations,offset)[] = {-0.41,-5.15,-0.3};
     };
 };

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -19,8 +19,7 @@ class CfgVehicles {
     };
 
     class B_Truck_01_fuel_F;
-    class C_Truck_01_water_rf : B_Truck_01_fuel_F 
-    {
+    class C_Truck_01_water_rf : B_Truck_01_fuel_F {
         EXGVAR(field_rations,waterSupply) = 10000;
         EXGVAR(field_rations,offset)[] = {-0.41,-5.15,-0.3};
     };

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,23 +1,24 @@
 class CfgVehicles {
 
+    // applies the offset to all RF Offroads which can have the optional Tank in the back
     class Offroad_01_unarmed_base_F;
     class Pickup_01_base_rf : Offroad_01_unarmed_base_F
     {
         acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
     };
     
+    // Enable Water Source by Default
     class C_IDAP_Pickup_rf;
     class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf
     {
         acex_field_rations_waterSupply = 500;
-        acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
     };
     
     class O_Truck_03_fuel_F;
     class C_Truck_03_water_rf: O_Truck_03_fuel_F
     {
         acex_field_rations_waterSupply = 10000;
-        acex_field_rations_offset[] = {0, -5.15, -0.3}; // Rear
+        acex_field_rations_offset[] = {0, -5.05, -0.3}; // Rear
         //acex_field_rations_offset[] = {1.25,-1.59,-0.58}; // Right Side Latch
     };
 
@@ -25,6 +26,6 @@ class CfgVehicles {
     class C_Truck_01_water_rf : B_Truck_01_fuel_F 
     {
         acex_field_rations_waterSupply = 10000;
-        acex_field_rations_offset[] = {0, -5.15, -0.3};
+        acex_field_rations_offset[] = {-0.41,-5.15,-0.3};
     };
 };

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,0 +1,39 @@
+test attachTo [cursorObject, ];
+
+
+acex_field_rations_offset = [-0.04,-2.45,-0.9]
+
+
+class CfgVehicles {
+
+  
+
+    class C_IDAP_Pickup_rf;
+    class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf
+    {
+        acex_field_rations_waterSupply = 1000;
+        acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
+    };
+    
+    class Pickup_01_base_rf;
+    class B_UN_Pickup_rf: Pickup_01_base_rf
+    {
+        acex_field_rations_offset[] = {-0.04, -2.45, -0.9};
+    };
+
+
+    class O_Truck_03_fuel_F;
+    class C_Truck_03_water_rf: O_Truck_03_fuel_F
+    {
+        acex_field_rations_waterSupply = 10000;
+        acex_field_rations_offset[] = {-0.03, -3.72, -1.05}; // Todo
+    };
+
+    class B_Truck_01_fuel_F;
+    class C_Truck_01_water_rf : B_Truck_01_fuel_F 
+    {
+        acex_field_rations_waterSupply = 10000;
+        acex_field_rations_offset[] = {-0.03, -3.72, -1.05}; // Todo
+    };
+
+};

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -12,8 +12,7 @@ class CfgVehicles {
     };
     
     class O_Truck_03_fuel_F;
-    class C_Truck_03_water_rf: O_Truck_03_fuel_F
-    {
+    class C_Truck_03_water_rf: O_Truck_03_fuel_F {
         EXGVAR(field_rations,waterSupply) = 10000;
         EXGVAR(field_rations,offset)[] = {0, -5.05, -0.3}; // Rear
         //EXGVAR(field_rations,offset)[] = {1.25,-1.59,-0.58}; // Right Side Latch

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -7,8 +7,7 @@ class CfgVehicles {
     
     // Enable Water Source by Default
     class C_IDAP_Pickup_rf;
-    class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf
-    {
+    class C_IDAP_Pickup_water_rf: C_IDAP_Pickup_rf {
         EXGVAR(field_rations,waterSupply) = 500;
     };
     

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -20,6 +20,6 @@ class CfgVehicles {
     class B_Truck_01_fuel_F;
     class C_Truck_01_water_rf : B_Truck_01_fuel_F {
         EXGVAR(field_rations,waterSupply) = 10000;
-        EXGVAR(field_rations,offset)[] = {-0.41,-5.15,-0.3};
+        EXGVAR(field_rations,offset)[] = {-0.41, -5.15, -0.3};
     };
 };

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -1,8 +1,7 @@
 class CfgVehicles {
     // applies the offset to all RF Offroads which can have the optional Tank in the back
     class Offroad_01_unarmed_base_F;
-    class Pickup_01_base_rf : Offroad_01_unarmed_base_F
-    {
+    class Pickup_01_base_rf : Offroad_01_unarmed_base_F {
         EXGVAR(field_rations,offset)[] = {-0.04, -2.45, -0.9};
     };
     

--- a/addons/compat_rf/CfgVehicles.hpp
+++ b/addons/compat_rf/CfgVehicles.hpp
@@ -14,8 +14,7 @@ class CfgVehicles {
     class O_Truck_03_fuel_F;
     class C_Truck_03_water_rf: O_Truck_03_fuel_F {
         EXGVAR(field_rations,waterSupply) = 10000;
-        EXGVAR(field_rations,offset)[] = {0, -5.05, -0.3}; // Rear
-        //EXGVAR(field_rations,offset)[] = {1.25,-1.59,-0.58}; // Right Side Latch
+        EXGVAR(field_rations,offset)[] = {0, -5.05, -0.3};
     };
 
     class B_Truck_01_fuel_F;

--- a/addons/compat_rf/config.cpp
+++ b/addons/compat_rf/config.cpp
@@ -16,3 +16,4 @@ class CfgPatches {
 };
 
 #include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/compat_rf/config.cpp
+++ b/addons/compat_rf/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"RF_Data_Loadorder"};
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
-        authors[] = {"Mike"};
+        authors[] = {"Mike", "OverlordZorn[CVO]"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
     };


### PR DESCRIPTION
Adds config properties for reaction forces vehicles which can carry drinking water.

![107410_20240901200514_1](https://github.com/user-attachments/assets/007cedc7-874c-4351-97f5-0ca08ee61634)
![107410_20240901190709_1](https://github.com/user-attachments/assets/c84cf934-1e6e-4a3f-8e65-cdf0ce664735)
![107410_20240901200633_1](https://github.com/user-attachments/assets/68f75630-413a-4366-b24c-8854fbe1f690)
