### PR TITLE
HEMTT - Update for 1.13

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -1,0 +1,31 @@
+[default]
+workshop = [
+    "450814997", # CBA_A3
+]
+
+[spe]
+extends = "default"
+dlc = [
+    "spe"
+]
+
+[vn]
+extends = "default"
+dlc = [
+    "S.O.G. Prairie Fire",
+]
+
+[ws]
+extends = "default"
+dlc = [
+    "Western Sahara",
+]
+
+[rhs]
+extends = "default"
+workshop = [
+    "843425103", # RHS AFRF Workshop ID
+    "843577117", # RHS USAF Workshop ID
+    "843593391", # RHS GREF Workshop ID
+    "843632231", # RHS SAF  Workshop ID
+]

--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -6,7 +6,7 @@ workshop = [
 [spe]
 extends = "default"
 dlc = [
-    "spe"
+    "Spearhead 1944"
 ]
 
 [vn]

--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -1,0 +1,5 @@
+[sqf.banned_commands]
+ignore = [
+    "addPublicVariableEventHandler", # Alt syntax is broken, we are using main syntax
+    "createSoundSource", # Greatly attenuated when in first person and in a vehicle
+]

--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -1,5 +1,5 @@
 [sqf.banned_commands]
-ignore = [
+options.ignore = [
     "addPublicVariableEventHandler", # Alt syntax is broken, we are using main syntax
     "createSoundSource", # Greatly attenuated when in first person and in a vehicle
 ]

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -27,35 +27,3 @@ exclude = [
     "common/functions/fnc_dummy.sqf",
     "zeus/functions/fnc_zeusAttributes.sqf",
 ]
-
-[hemtt.launch.default]
-workshop = [
-    "450814997", # CBA_A3
-]
-
-[hemtt.launch.spe]
-extends = "default"
-dlc = [
-    "spe"
-]
-
-[hemtt.launch.vn]
-extends = "default"
-dlc = [
-    "S.O.G. Prairie Fire",
-]
-
-[hemtt.launch.ws]
-extends = "default"
-dlc = [
-    "Western Sahara",
-]
-
-[hemtt.launch.rhs]
-extends = "default"
-workshop = [
-    "843425103", # RHS AFRF Workshop ID
-    "843577117", # RHS USAF Workshop ID
-    "843593391", # RHS GREF Workshop ID
-    "843632231", # RHS SAF  Workshop ID
-]


### PR DESCRIPTION
**When merged this pull request will:**
- Safe for CI to merge before the release of HEMTT 1.13.0, but will temporarily break `hemtt launch` on master until HEMTT 1.13.0
- Moves launch configs to `launch.toml`
- Creates `lints.toml` and ignores broken commands ACE is using

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
