### PR TITLE
Docs - Misc fixes

### DIFF
--- a/docs/wiki/framework/disposables-framework.md
+++ b/docs/wiki/framework/disposables-framework.md
@@ -12,8 +12,10 @@ version:
   patch: 0
 ---
 
-Support for the ACE3 disposable framework will be dropped in 3.13.0!
-Switch to the [CBA Disposable Framework](https://github.com/CBATeam/CBA_A3/wiki/Disposable-Launchers)
+<div class="panel callout">
+    <h5>Note:</h5>
+    <p>Deprecated and replaced with <a href="https://github.com/CBATeam/CBA_A3/wiki/Disposable-Launchers">CBA Disposable Framework</a> in 3.13.0!</p>
+</div>
 
 Old weapon configs that are no longer supported:
 ```cpp

--- a/docs/wiki/framework/dragging-framework.md
+++ b/docs/wiki/framework/dragging-framework.md
@@ -35,11 +35,6 @@ class CfgVehicles {
 
 ## 2. Functions
 
-<div class="panel callout">
-    <h5>Note:</h5>
-    <p>The following functions are NOT public and are likely to change in the future!</p>
-</div>
-
 You will **not** be able to carry / drag objects that are too heavy, the mass is also affected by what is inside the object. To bypass this empty the object. You can change the weight limits by setting `ACE_maxWeightDrag` (default 800) and `ACE_maxWeightCarry` (default 600).
 
 ### 2.1 Enabling / disabling dragging

--- a/docs/wiki/framework/grenades-framework.md
+++ b/docs/wiki/framework/grenades-framework.md
@@ -74,7 +74,7 @@ The average amount of time in seconds, after `explosionTime` has passed, between
 
 The amount of randomness in the fuse time.
 
-### 2.1.5 ace_grenades_flashbangExplodeSound
+#### 2.1.5 ace_grenades_flashbangExplodeSound
 
 The sounds that can be used when the flashbang detonates. It randomly selects an entry from this array (equal chances, there are no weights involved).
 If not defined, `[format ["A3\Sounds_F\arsenal\explosives\grenades\Explosion_HE_grenade_0%1.wss", floor (random 4) + 1], 5, 1.2, 400]` is used as a default instead (4 sounds total).
@@ -108,7 +108,7 @@ class CfgAmmo {
 
 If set to zero or left undefined, the grenade is not treated as a flare. If it is set to 1, the grenade will be treated as a flare with the associated effects.
 
-#### 2.3.1 ace_grenades_color
+#### 2.3.2 ace_grenades_color
 
 Sets the color of the emitted light. The first 3 values of the array of the color, the last is the light intensity.
 

--- a/docs/wiki/framework/javelin-framework.md
+++ b/docs/wiki/framework/javelin-framework.md
@@ -18,7 +18,7 @@ version:
 class CfgWeapons {
     class MyLauncher {
         ace_javelin_enabled = 1;  // Enable Javelin-style locking (0-disabled, 1-enabled)
-        weaponInfoType = "ACE_RscOptics_javelin";  // Inteface
+        weaponInfoType = "ACE_RscOptics_javelin";  // Interface
         modelOptics = "\z\ace\addons\javelin\data\reticle_titan.p3d";  // Optics model
         canLock = 0;  // Disable vanilla locking (0-disabled, 1-enabled)
         lockingTargetSound[] = {"", 0, 1};  // Locking sound


### PR DESCRIPTION
**When merged this pull request will:**
- Better warning for deprecation of disposable framework (copied from the settings one).
- Remove non-public warning of dragging functions, because headers say they are public.
- 2 Grenade titles weren't correct.
- Fixed minor typo in Javelin.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
