### PR TITLE
Explosives - Remove unnecessary info from RPT

### DIFF
--- a/addons/explosives/functions/fnc_openTimerUI.sqf
+++ b/addons/explosives/functions/fnc_openTimerUI.sqf
@@ -64,14 +64,14 @@ _display displayAddEventHandler ["MouseZChanged", {
 [{
     params ["_display", "_pfhID"];
 
-    // Make sure explosive still exists and is near player
-    if ((!isNull _display) && {!alive ACE_player} || {!alive GVAR(explosive)} || {(ACE_player distance GVAR(explosive)) > 5}) exitWith {
-        INFO_2("%1's explosive %2 became invalid",ACE_player,GVAR(explosive));
-        closeDialog 0;
+    if (isNull _display || {!alive ACE_player}) exitWith {
         _pfhID call CBA_fnc_removePerFrameHandler;
     };
 
-    if (isNull _display) exitWith {
+    // Make sure explosive still exists and is near player
+    if (!alive GVAR(explosive) || {(ACE_player distance GVAR(explosive)) > 5}) exitWith {
+        INFO_2("%1's explosive %2 became invalid",ACE_player,GVAR(explosive));
+        closeDialog 0;
         _pfhID call CBA_fnc_removePerFrameHandler;
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
Currently, if you place an explosive and set it with a timer, confirming the timer length by pressing the 'ok' button, it will print `19:27:17 [ACE] (explosives) INFO: C Alpha 1-1:1 (johnb43)'s explosive <NULL-object> became invalid`. It makes sense, as the dummy object is deleted and replaced by a real explosive.

I imagine the original intent was to use a `TRACE_2`? Doesn't matter though, these changes will make it not throw the error if you complete it successfully.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
