### PR TITLE
Reload - Change "Check Ammo" anim to not block movement

### DIFF
--- a/addons/reload/functions/fnc_checkAmmo.sqf
+++ b/addons/reload/functions/fnc_checkAmmo.sqf
@@ -23,7 +23,7 @@ if (_unit == _target) then {
         _target = vehicle _target;
     };
 
-    [_unit, "Gear", 1] call EFUNC(common,doGesture);
+    [_unit, "reloadMagazine", 0] call EFUNC(common,doGesture);
 };
 
 [FUNC(displayAmmo), _target, 1] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
Fixes:
While walking forward, pressing check ammo will make character come to full stop to play the gear anim
"reloadMagazine" only effects arms
note, it's not the gun's full reload anim, it's just a generic one, so it shouldn't cause issues for belt fed weapons