### PR TITLE
CI - Fix HEMTT CI artifacts not uploaded

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -43,3 +43,4 @@ jobs:
       with:
         name: ace3-${{ github.sha }}-nobin
         path: .hemttout/@*
+        include-hidden-files: true # Because .hemttout is a hidden directory

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@main
+      uses: arma-actions/hemtt@v1
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@v1
+      uses: arma-actions/hemtt@main
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.arrays.os.target }}
         path: target/debug/ace.dll

--- a/.github/workflows/hemtt.yml
+++ b/.github/workflows/hemtt.yml
@@ -44,3 +44,4 @@ jobs:
       with:
         name: ace3-${{ github.sha }}
         path: .hemttout/@*
+        include-hidden-files: true # Because .hemttout is a hidden directory

--- a/.github/workflows/hemtt.yml
+++ b/.github/workflows/hemtt.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@main
+      uses: arma-actions/hemtt@v1
     - name: Checkout pull request
       uses: actions/checkout@v4
       if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/hemtt.yml
+++ b/.github/workflows/hemtt.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@v1
+      uses: arma-actions/hemtt@main
     - name: Checkout pull request
       uses: actions/checkout@v4
       if: ${{ github.event_name == 'pull_request_target' }}


### PR DESCRIPTION
**When merged this pull request will:**
- ~~Fix HEMTT CI annotations not shown since HEMTT v1.11. This was fixed by arma-actions/hemtt#2.~~ Edit: Tag was updated.
- Fix HEMTT artifacts not uploaded. `actions/upload-artifact` v4.4 changed the behavior of hidden files. They're now excluded by default [[Source]](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes).
- Bump up [`actions/upload-artifact` in `extensions.yml`](https://github.com/Timi007/ACE3/blob/e23a26da1c0ca940b5e4c03aa9661cf3868b91c0/.github/workflows/extensions.yml#L60) to v4 since [v2 is already deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
