### PR TITLE
Trenches - Make entrenching tool cache use hashMap

### DIFF
--- a/addons/trenches/XEH_preInit.sqf
+++ b/addons/trenches/XEH_preInit.sqf
@@ -8,6 +8,6 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.inc.sqf"
 
-GVAR(entrenchingTools) = call (uiNamespace getVariable QGVAR(entrenchingTools));
+GVAR(entrenchingTools) = keys (uiNamespace getVariable QGVAR(entrenchingTools));
 
 ADDON = true;

--- a/addons/trenches/XEH_preStart.sqf
+++ b/addons/trenches/XEH_preStart.sqf
@@ -6,4 +6,4 @@ private _entrenchingTools = (QUOTE(getNumber (_x >> QQGVAR(entrenchingTool)) > 0
 _entrenchingTools append    (QUOTE(getNumber (_x >> QQGVAR(entrenchingTool)) > 0) configClasses (configFile >> "CfgVehicles") apply {configName _x});
 TRACE_1("",_entrenchingTools);
 
-uiNamespace setVariable [QGVAR(entrenchingTools), compileFinal str _entrenchingTools];
+uiNamespace setVariable [QGVAR(entrenchingTools), compileFinal (_entrenchingTools createHashMapFromArray [])];


### PR DESCRIPTION
**When merged this pull request will:**
- Save entrenching tools to a hash map on preStart instead of saving code

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
