### PR TITLE
CSW - Take individual components into account for disassembly

### DIFF
--- a/addons/csw/functions/fnc_assemble_deployWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_deployWeapon.sqf
@@ -44,7 +44,7 @@
 
     private _onFinish = {
         params ["_args"];
-        _args params ["_tripod", "_player", "_assembledClassname", "", "_carryWeaponInfo"];
+        _args params ["_tripod", "_player", "_assembledClassname", "_tripodClassname", "_carryWeaponClassname", "_carryWeaponInfo"];
         TRACE_3("deployWeapon finish",_tripod,_player,_assembledClassname);
 
         private _secondaryWeaponMagazines = _tripod getVariable [QGVAR(secondaryWeaponMagazines), []];
@@ -56,10 +56,11 @@
         _tripodPos set [2, (_tripodPos select 2) + 0.1];
         // Delay a frame so tripod has a chance to be deleted
         [{
-            params ["_assembledClassname", "_tripodDir", "_tripodPos", "_player", "_carryWeaponInfo", "_secondaryWeaponMagazines"];
+            params ["_assembledClassname", "_componentClasses", "_tripodDir", "_tripodPos", "_player", "_carryWeaponInfo", "_secondaryWeaponMagazines"];
             private _csw = createVehicle [_assembledClassname, [0, 0, 0], [], 0, "NONE"];
             // Assembly mode: [0=disabled, 1=enabled, 2=enabled&unload, 3=default]
             _csw setVariable [QGVAR(assemblyMode), 2, true]; // Explicitly set advanced assembly mode + unload, and broadcast
+            _csw setVariable [QGVAR(componentClasses), _componentClasses, true];
 
             {
                 // Magazines
@@ -86,12 +87,12 @@
             };
             [QGVAR(deployWeaponSucceeded), [_csw]] call CBA_fnc_localEvent;
             TRACE_2("csw placed",_csw,_assembledClassname);
-        }, [_assembledClassname, _tripodDir, _tripodPos, _player, _carryWeaponInfo, _secondaryWeaponMagazines]] call CBA_fnc_execNextFrame;
+        }, [_assembledClassname, [_tripodClassname, _carryWeaponClassname], _tripodDir, _tripodPos, _player, _carryWeaponInfo, _secondaryWeaponMagazines]] call CBA_fnc_execNextFrame;
     };
 
     private _onFailure = {
         params ["_args"];
-        _args params ["", "_player", "", "_carryWeaponClassname", "_carryWeaponInfo"];
+        _args params ["", "_player", "", "", "_carryWeaponClassname", "_carryWeaponInfo"];
         TRACE_2("deployWeapon failure",_player,_carryWeaponClassname);
 
         // Add weapon back
@@ -110,5 +111,5 @@
         alive _tripod
     };
 
-    [TIME_PROGRESSBAR(_deployTime), [_tripod, _player, _assembledClassname, _carryWeaponClassname, _carryWeaponInfo], _onFinish, _onFailure, LLSTRING(AssembleCSW_progressBar), _condition] call EFUNC(common,progressBar);
+    [TIME_PROGRESSBAR(_deployTime), [_tripod, _player, _assembledClassname, _tripodClassname, _carryWeaponClassname, _carryWeaponInfo], _onFinish, _onFailure, LLSTRING(AssembleCSW_progressBar), _condition] call EFUNC(common,progressBar);
 }, _this] call CBA_fnc_execNextFrame;

--- a/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_pickupWeapon.sqf
@@ -21,13 +21,17 @@
     TRACE_2("assemble_pickupWeapon",_vehicle,_player);
 
     private _weaponConfig = configOf _vehicle >> QUOTE(ADDON);
-    private _carryWeaponClassname = getText (_weaponConfig >> "disassembleWeapon");
+    private _componentClasses = _vehicle getVariable QGVAR(componentClasses);
+
+    (if (!isNil "_componentClasses") then {
+        _componentClasses
+    } else {
+        [getText (_weaponConfig >> "disassembleTurret"), getText (_weaponConfig >> "disassembleWeapon")]
+    }) params ["_turretClassname", "_carryWeaponClassname"];
 
     if (!isClass (configFile >> "CfgWeapons" >> _carryWeaponClassname)) exitWith {
         ERROR_1("bad weapon classname [%1]",_carryWeaponClassname);
     };
-
-    private _turretClassname = getText (_weaponConfig >> "disassembleTurret");
 
     // Turret classname can equal nothing if the deploy bag is the "whole" weapon. e.g Kornet, Metis, other ATGMs
     if ((_turretClassname != "") && {!isClass (configFile >> "CfgVehicles" >> _turretClassname)}) exitWith {


### PR DESCRIPTION
**When merged this pull request will:**
E.g. if you use a Vanilla M3 tripod and a Spearhead M2 to build a CSW, currently when you disassemble it it returns a SPE M3 tripod and SPE M2 weapon.
This PR changes it so that it takes the originally used components into account.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
