### PR TITLE
SPE Compat - Make 50Rnd M1919 & M2 100Rnd belts linkable

### DIFF
--- a/addons/compat_spe/CfgMagazines/csw.hpp
+++ b/addons/compat_spe/CfgMagazines/csw.hpp
@@ -2,43 +2,29 @@ class CA_Magazine;
 
 // M1919A4/A6
 class SPE_50Rnd_762x63: CA_Magazine {
-    ACE_isBelt = 0;
-};
-
-class SPE_100Rnd_762x63: SPE_50Rnd_762x63 {
     ACE_isBelt = 1;
 };
 
-class SPE_100Rnd_762x63_M1: SPE_100Rnd_762x63 {
+// M2
+class VehicleMagazine;
+class SPE_100Rnd_127x99_M2: VehicleMagazine {
     ACE_isBelt = 1;
 };
 
-class SPE_100Rnd_762x63_M2_AP: SPE_100Rnd_762x63 {
-    ACE_isBelt = 1;
-};
-
-//MG34/42
-
+// MG34/42
 class SPE_50Rnd_792x57: CA_Magazine {
     ACE_isBelt = 0;
 };
-
-class SPE_50Rnd_792x57_sS: SPE_50Rnd_792x57 {
-    ACE_isBelt = 0;
-};
-
-class SPE_50Rnd_792x57_SMK: SPE_50Rnd_792x57_sS {
-    ACE_isBelt = 0;
-};
-
 class SPE_100Rnd_792x57: SPE_50Rnd_792x57 {
     ACE_isBelt = 1;
 };
 
+class SPE_50Rnd_792x57_sS;
 class SPE_100Rnd_792x57_sS: SPE_50Rnd_792x57_sS {
     ACE_isBelt = 1;
 };
 
+class SPE_50Rnd_792x57_SMK;
 class SPE_100Rnd_792x57_SMK: SPE_50Rnd_792x57_SMK {
     ACE_isBelt = 1;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- 50 round .30-06 belts for the M1919 are linkable belts as far as I can tell, so I made them linkable.
- Don't set `ACE_isBelt = 0;` on all 7.92x57 Gurttrommeln, imo there's no reason to.
- Make the .50 BMG belt linkable.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
