### PR TITLE
Carrying - Allow dropped objects to inherit velocity

### DIFF
--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -46,6 +46,7 @@ if (_tryLoad && {!(_target isKindOf "CAManBase")} && {["ace_cargo"] call EFUNC(c
 } else {
     // Release object
     detach _target;
+    [QEGVAR(common,setVelocity),[_target,getVelocity _unit],_target] call CBA_fnc_targetEvent;
 };
 
 // Fix anim when aborting carrying persons


### PR DESCRIPTION
Set box velocity to unit velocity

**When merged this pull request will:**
- Allow dropped objects to inherit the velocity of the unit carrying them. For instance, running and dropping a box while running will make the box continue forward.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
