### PR TITLE
Cargo - Add object variable to allow for custom interaction delay

### DIFF
--- a/addons/cargo/XEH_PREP.hpp
+++ b/addons/cargo/XEH_PREP.hpp
@@ -5,6 +5,7 @@ PREP(canUnloadItem);
 PREP(deployCancel);
 PREP(deployConfirm);
 PREP(getCargoSpaceLeft);
+PREP(getDelayItem);
 PREP(getNameItem);
 PREP(getSelectedItem);
 PREP(getSizeItem);

--- a/addons/cargo/functions/fnc_deployConfirm.sqf
+++ b/addons/cargo/functions/fnc_deployConfirm.sqf
@@ -24,7 +24,7 @@ if (!isNull GVAR(itemPreviewObject) && {[GVAR(selectedItem), GVAR(interactionVeh
     // Position is AGL for unloading event
     private _position = ASLToAGL getPosASL GVAR(itemPreviewObject);
     private _direction = getDir GVAR(itemPreviewObject);
-    private _duration = GVAR(loadTimeCoefficient) * (GVAR(selectedItem) call FUNC(getSizeItem));
+    private _duration = [GVAR(selectedItem)] call FUNC(getDelayItem);
 
     // If unload time is 0, don't show a progress bar
     if (_duration <= 0) exitWith {

--- a/addons/cargo/functions/fnc_getDelayItem.sqf
+++ b/addons/cargo/functions/fnc_getDelayItem.sqf
@@ -1,0 +1,24 @@
+#include "..\script_component.hpp"
+/*
+ * Author: tcvm
+ * Gets the delay duration an item should take to load/unload.
+ *
+ * Arguments:
+ * 0: Item <OBJECT>
+ *
+ * Return Value:
+ * Item load/unload duration <NUMBER>
+ *
+ * Example:
+ * cursorObject call ace_cargo_fnc_getDelayItem
+ *
+ * Public: Yes
+ */
+
+params ["_item"];
+
+if (_item getVariable [QGVAR(delay), -1] >= 0) exitWith {
+    _item getVariable QGVAR(delay)  // return
+};
+GVAR(loadTimeCoefficient) * (_item call FUNC(getSizeItem))  // return
+

--- a/addons/cargo/functions/fnc_startLoadIn.sqf
+++ b/addons/cargo/functions/fnc_startLoadIn.sqf
@@ -36,7 +36,7 @@ if (isNull _vehicle) exitWith {
 
 // Start progress bar
 if ([_item, _vehicle] call FUNC(canLoadItemIn)) then {
-    private _duration = GVAR(loadTimeCoefficient) * (_item call FUNC(getSizeItem));
+    private _duration = [_item] call FUNC(getDelayItem);
 
     // If load time is 0, don't show a progress bar
     if (_duration <= 0) exitWith {

--- a/addons/cargo/functions/fnc_startUnload.sqf
+++ b/addons/cargo/functions/fnc_startUnload.sqf
@@ -26,7 +26,7 @@ if (GVAR(interactionParadrop)) exitWith {
     // Close the cargo menu
     closeDialog 0;
 
-    private _duration = GVAR(paradropTimeCoefficent) * (_item call FUNC(getSizeItem));
+    private _duration = [_item] call FUNC(getDelayItem);
 
     // If drop time is 0, don't show a progress bar
     if (_duration <= 0) exitWith {
@@ -81,7 +81,7 @@ if ([_item, GVAR(interactionVehicle), _unit] call FUNC(canUnloadItem)) then {
     // Close the cargo menu
     closeDialog 0;
 
-    private _duration = GVAR(loadTimeCoefficient) * (_item call FUNC(getSizeItem));
+    private _duration = [_item] call FUNC(getDelayItem);
 
     // If unload time is 0, don't show a progress bar
     if (_duration <= 0) exitWith {


### PR DESCRIPTION
**When merged this pull request will:**
- Add variable on items which will set how long it takes to interact with the item
- Add function to get this delay

When developing a feature for an in-house mod, we ran into a scenario where we want `itemSize = 0`  but still allow some time for the interaction to occur. I figured adding a variable to each item would allow this functionality without much hassle.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
