### PR TITLE
Docs - Update CSW proxy weapon information

### DIFF
--- a/docs/wiki/framework/crew-served-weapons-framework.md
+++ b/docs/wiki/framework/crew-served-weapons-framework.md
@@ -16,7 +16,7 @@ version:
 
 To convert a static weapon into a crew served weapon, you need to create the following:
 
-- A proxy weapon
+- A proxy weapon (optional)
 - A carryable weapon that can be mounted on a tripod
 - Carryable weapon magazines
 - The CSW config in the static weapon
@@ -26,6 +26,8 @@ For the following examples, we are going to assume you are modifying your existi
 ### 1.1 Proxy Weapon
 
 Because the magazine loading time is already handled by the ACE interaction, a proxy weapon with a very low loading time is used. It automatically replaces the default weapon of the turret when CSW is enabled.
+
+A proxy weapon isn't required for a CSW to work. If a CSW uses the default weapons, the reload times will just be longer.
 
 ```cpp
 class CfgWeapons {
@@ -136,7 +138,7 @@ class CfgVehicles {
     class prefix_hmg: StaticMGWeapon {
         class ACE_CSW {
             enabled = 1; // Enables ACE CSW for this weapon              
-            proxyWeapon = "prefix_hmg_weapon_proxy"; // The proxy weapon created above
+            proxyWeapon = "prefix_hmg_weapon_proxy"; // The proxy weapon created above. This can also be a function name that returns a proxy weapon
             magazineLocation = "_target selectionPosition 'magazine'"; // Ammo handling interaction point location
             disassembleWeapon = "prefix_hmg_carry";  // Carryable weapon created above
             disassembleTurret = "ace_csw_m3Tripod";  // Which static tripod will appear when weapon is disassembled

--- a/docs/wiki/framework/crew-served-weapons-framework.md
+++ b/docs/wiki/framework/crew-served-weapons-framework.md
@@ -138,7 +138,7 @@ class CfgVehicles {
     class prefix_hmg: StaticMGWeapon {
         class ACE_CSW {
             enabled = 1; // Enables ACE CSW for this weapon              
-            proxyWeapon = "prefix_hmg_weapon_proxy"; // The proxy weapon created above. This can also be a function name that returns a proxy weapon
+            proxyWeapon = "prefix_hmg_weapon_proxy"; // The proxy weapon created above. This can also be a function name that returns a proxy weapon - passed [_vehicle, _turret, _currentWeapon, _needed, _emptyWeapon]
             magazineLocation = "_target selectionPosition 'magazine'"; // Ammo handling interaction point location
             disassembleWeapon = "prefix_hmg_carry";  // Carryable weapon created above
             disassembleTurret = "ace_csw_m3Tripod";  // Which static tripod will appear when weapon is disassembled


### PR DESCRIPTION
**When merged this pull request will:**
- Explicitly say that a proxy weapon is optional.
- Document that proxy weapon entry can be a function name. In ACE, it's only used in the mortar framework, but that will be removed with #9238. Question is: Do we really want to add it as API or leave it undocumented?

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
