### PR TITLE
Repair - Fix unit being vanilla engineer when ACE Repair is enabled

### DIFF
--- a/addons/repair/XEH_postInit.sqf
+++ b/addons/repair/XEH_postInit.sqf
@@ -39,12 +39,28 @@
 
     ["CAManBase", "InitPost", {
         params ["_unit"];
-        if !(local _unit && {_unit getUnitTrait "engineer"}) exitWith {};
+        // getUnitTrait can return nil so check config instead
+        if (getNumber (configOf _unit >> "engineer") < 1) exitWith {};
+
+        // unit can be local here for both server and client so use CBA_fnc_execNextFrame for safe
+        [{
+            params ["_unit"];
+            if !(local _unit) exitWith {};
+            private _isEngineer = _unit getUnitTrait "engineer";
+            if (isNil "_isEngineer" || {_isEngineer isNotEqualTo true}) exitWith {};
+            _unit setUnitTrait ["engineer", false];
+            TRACE_3("setUnitTrait2",_unit,typeOf _unit,_unit getUnitTrait "engineer");
+        }, _unit] call CBA_fnc_execNextFrame;
+
+        if !(local _unit) exitWith {};
+        private _isEngineer = _unit getUnitTrait "engineer";
+        if (isNil "_isEngineer" || {_isEngineer isNotEqualTo true}) exitWith {};
         _unit setUnitTrait ["engineer", false];
+        TRACE_3("setUnitTrait1",_unit,typeOf _unit,_unit getUnitTrait "engineer");
+
         if (_unit getVariable ["ACE_IsEngineer", -1] isEqualTo -1) then {
             _unit setVariable ["ACE_IsEngineer", true, true];
         };
-        TRACE_3("setUnitTrait",_unit,typeOf _unit,_unit getUnitTrait "engineer");
     }, true, [], true] call CBA_fnc_addClassEventHandler;
 
 


### PR DESCRIPTION
**When merged this pull request will:**
- title.

I met this bug only once in multiplayer when made Repair `enable` setting. Since then I played hundred of times as engineer with `DEBUG_MODE_FULL` but bug disappeared. And when I tested 3.18.0 RC1 I met it again.

1. `getUnitTrait "engineer"` can return `nil` (e.g. for `ace_dragging_clone`) so I added nil check.
2. On unit `InitPost` event unit is (can be?) local for both server and client. In the next frame unit became local only for client in my tests.
I used this code:
```
        INFO_4("setUnitTrait1 u=%1 t=%2 l=%3 e=%4",_unit,typeOf _unit,local _unit,_unit getUnitTrait "engineer");
        _unit setUnitTrait ["engineer", false];
        [{
            params ["_unit"];
            INFO_4("setUnitTrait3 u=%1 t=%2 l=%3 e=%4",_unit,typeOf _unit,local _unit,_unit getUnitTrait "engineer");
        }, _unit] call CBA_fnc_execNextFrame;
```
client:
```
19:10:42 [ACE] (repair) INFO: setUnitTrait1 u=B Alpha 1-1:1 (D) t=B_engineer_F l=true e=true
19:10:42 [ACE] (repair) INFO: setUnitTrait3 u=B Alpha 1-1:1 (D) t=B_engineer_F l=true e=false
```
server:
```
19:12:34 [ACE] (repair) INFO: setUnitTrait1 u=B Alpha 1-1:1 (D) t=B_engineer_F l=true e=true
19:12:34 [ACE] (repair) INFO: setUnitTrait3 u=B Alpha 1-1:1 (D) REMOTE t=B_engineer_F l=false e=false
```

The fix looks bad I know. Any suggestions are welcomed.