### PR TITLE
Compat CUP Weapons - Fix mono NVGs having bino vision

### DIFF
--- a/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_nightvision/CfgWeapons.hpp
@@ -34,7 +34,7 @@ class CfgWeapons {
 
     // Binocular
     class CUP_NVG_PVS14: NVGoggles {
-        NVG_BINO_PRESET;
+        NVG_MONO_PRESET(3);
         NVG_GREEN_PRESET;
     };
     class CUP_NVG_PVS15_black: NVGoggles {


### PR DESCRIPTION
**When merged this pull request will:**
- PVS14 had bino vision instead of mono.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
