### PR TITLE
Explosives - Fix AI always knowing Sapper's location

### DIFF
--- a/addons/explosives/XEH_postInit.sqf
+++ b/addons/explosives/XEH_postInit.sqf
@@ -23,7 +23,7 @@
 
     if (isServer) then {
         if (missionNamespace getVariable [QGVAR(setShotParents), true]) then {
-            _explosive setShotParents [_unit, _unit];
+            _explosive setShotParents [objNull, _unit];
         };
     };
 }] call CBA_fnc_addEventHandler;
@@ -36,7 +36,7 @@ if (isServer) then {
         params ["_unit", "_explosive", "_delay"];
         TRACE_3("server detonate EH",_unit,_explosive,_delay);
         if (missionNamespace getVariable [QGVAR(setShotParents), true]) then {
-            _explosive setShotParents [_unit, _unit];
+            _explosive setShotParents [objNull, _unit];
         };
         [{
             params ["_explosive"];


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent AI from always knowing the exact location of the player who placed/detonated a mine or explosive.

At the moment, whenever AI is hit by the effects of a mine (both sensor- and remotely triggered), it immediately knows the exact location of the one who triggered and/or placed that explosive and will turn around to engage. This is especially annoying when conducting ambushes against AFVs.

It turns out that the code causing this is [`setShotParents`](https://community.bistudio.com/wiki/setShotParents), more specifically the second argument which defines the "vehicle which shot the projectile".
Setting that to `objNull` prevents AI from knowing the killer's exact position, causing it to enter a more realistic search pattern where they progressively turn to scan the terrain.

I'm not 100% sure whether unsetting killer will cause other issues. Don't think so though, since `medical_status` appears to have code in place to catch just those.
https://github.com/acemod/ACE3/blob/1efe823fc224f4784676ce0261b26dc0332fe516/addons/medical_status/functions/fnc_handleKilled.sqf#L37