### PR TITLE
Missile Guidance - Allow attackProfiles to return [0,0,0]

### DIFF
--- a/addons/missileguidance/functions/fnc_doAttackProfile.sqf
+++ b/addons/missileguidance/functions/fnc_doAttackProfile.sqf
@@ -25,7 +25,7 @@ private _attackProfileFunction = getText (configFile >> QGVAR(AttackProfiles) >>
 private _attackProfilePos = _this call (missionNamespace getVariable _attackProfileFunction);
 
 if ((isNil "_attackProfilePos") || {_attackProfilePos isEqualTo [0,0,0]}) exitWith {
-    ERROR_2("attack profile [%1] returned bad pos %2",_attackProfileName,_attackProfilePos);
+    // ERROR_2("attack profile [%1] returned bad pos %2",_attackProfileName,_attackProfilePos);
     [0,0,0]
 };
 

--- a/addons/missileguidance/functions/fnc_guidancePFH.sqf
+++ b/addons/missileguidance/functions/fnc_guidancePFH.sqf
@@ -50,7 +50,7 @@ _targetData set [1, _projectilePos vectorFromTo _profileAdjustedTargetPos];
 
 // If we have no seeker target, then do not change anything
 // If there is no deflection on the missile, this cannot change and therefore is redundant. Avoid calculations for missiles without any deflection
-if ((_pitchRate != 0 || {_yawRate != 0})) then {
+if ((_pitchRate != 0 || {_yawRate != 0}) && {_profileAdjustedTargetPos isNotEqualTo [0,0,0]}) then {
     private _navigationFunction = getText (configFile >> QGVAR(NavigationTypes) >> _navigationType >> "functionName");
     if (_navigationStateData isNotEqualTo []) then {
         (_navigationStateData select _currentState) params ["_transitionCondition"];


### PR DESCRIPTION
Shoot ace dagr without any laser source and it spams
`[ACE] (missileguidance) ERROR: attack profile [LIN] returned bad pos [0,0,0]`

this restores to how it worked before rewrite (see line 51)

another possibility is to change `_pitchRate` to 0 if an attack profile wants to fly straight, but this felt like the simplest way and should have the best backward compatibility 