### PR TITLE
medical_treatement  - Improve `ace_placedInBodyBag` and `ace_placedInGrave` events by adding medic as parameter

### DIFF
--- a/addons/medical_treatment/functions/fnc_placeInBodyBagOrGrave.sqf
+++ b/addons/medical_treatment/functions/fnc_placeInBodyBagOrGrave.sqf
@@ -69,7 +69,7 @@ if (_restingPlaceClass != "") then {
 
 // Server will handle hiding and deleting the body
 // Keep event name as body bag only to avoid breaking things for others
-["ace_placedInBodyBag", [_patient, _restingPlace, _isGrave]] call CBA_fnc_globalEvent;
+["ace_placedInBodyBag", [_patient, _restingPlace, _isGrave, _medic]] call CBA_fnc_globalEvent;
 if (_isGrave) then {
-    ["ace_placedInGrave", [_patient, _restingPlace]] call CBA_fnc_globalEvent;
+    ["ace_placedInGrave", [_patient, _restingPlace, _medic]] call CBA_fnc_globalEvent;
 };


### PR DESCRIPTION
I don't see easy way to know which medic trigger the `ace_placedInBodyBag` and `ace_placedInGrave` events

**When merged this pull request will:**
- `ace_placedInBodyBag` and `ace_placedInGrave` events now report the medic performing the action