### PR TITLE
Interaction - Fix unlocalized string in ACE_TeamManagement

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -109,7 +109,7 @@ class CfgVehicles {
                         modifierFunction = QUOTE([ARR_3('YELLOW','PATHTOF(UI\team\team_white_ca.paa)',_this select 3)] call FUNC(modifyTeamManagementAction));
                     };
                     class ACE_AssignTeamMain {
-                        displayName = "$str_assign_main";
+                        displayName = "$STR_assign_main";
                         condition = QUOTE([ARR_2(_player,_target)] call DFUNC(canJoinTeam) && {assignedTeam _target != 'MAIN'});
                         statement = QUOTE([ARR_3(_target,'MAIN',true)] call DFUNC(joinTeam));
                         exceptions[] = {"isNotSwimming"};


### PR DESCRIPTION
**When merged this pull request will:**
- Fix unlocalized `"$str_assign_main"` in `ACE_TeamManagement` - The string is correct, but the "$STR" part is [case sensitive.](https://community.bistudio.com/wiki/Stringtable.xml#Config) 

![image](https://github.com/user-attachments/assets/4cb3783e-be3c-45db-b4ab-9965e48a0f9d)


### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
