### PR TITLE
Scopes - Optimised `FUNC(getOptics)`

### DIFF
--- a/addons/scopes/functions/fnc_getOptics.sqf
+++ b/addons/scopes/functions/fnc_getOptics.sqf
@@ -19,14 +19,4 @@
 
 params ["_unit"];
 
-private _optics = ["", "", ""];
-
-if !(_unit isKindOf "CAManBase") exitWith {_optics};
-
-{
-    if (count _x >= 2) then {
-        _optics set [_forEachIndex, _x select 2];
-    };
-} forEach [primaryWeaponItems _unit, secondaryWeaponItems _unit, handgunItems _unit];
-
-_optics
+[primaryWeaponItems _unit, secondaryWeaponItems _unit, handgunItems _unit] apply {_x select 2} // return


### PR DESCRIPTION
**When merged this pull request will:**
- `objNull` and other types of objects don't throw errors when having the `xWeaponItems` commands called on them.
- Use apply to return result immediately.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
