### PR TITLE
Advanced Fatigue - Change default terrain gradient factor setting

### DIFF
--- a/addons/advanced_fatigue/initSettings.inc.sqf
+++ b/addons/advanced_fatigue/initSettings.inc.sqf
@@ -76,6 +76,6 @@
     "SLIDER",
     [LSTRING(TerrainGradientFactor), LSTRING(TerrainGradientFactor_Description)],
     LSTRING(DisplayName),
-    [0, 5, 1, 2],
+    [0, 5, 0.1, 2],
     1
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
**When merged this pull request will:**
- Address #10347. Imo `0.1` is a bit too lenient on rocks, but any higher is too brutal for stairs.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
