### PR TITLE
Arsenal - Reuse current inventory containers when importing invalid loadouts

### DIFF
--- a/addons/arsenal/functions/fnc_buttonLoadoutsLoad.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsLoad.sqf
@@ -34,6 +34,20 @@ private _extendedLoadout = switch (GVAR(currentLoadoutsTab)) do {
     };
 };
 
+// Keep current loadout containers if those being loaded are not present or unavailable
+private _uniform = _extendedLoadout select 0 select 3;
+if (_uniform select 0 == "") then {
+    _uniform set [0, uniform GVAR(center)];
+};
+private _vest = _extendedLoadout select 0 select 4;
+if (_vest select 0 == "") then {
+    _vest set [0, vest GVAR(center)];
+};
+private _backpack = _extendedLoadout select 0 select 5;
+if (_backpack select 0 == "") then {
+    _backpack set [0, backpack GVAR(center)];
+};
+
 // Apply loadout to unit
 [GVAR(center), _extendedLoadout, true] call CBA_fnc_setLoadout;
 

--- a/addons/arsenal/functions/fnc_verifyLoadout.sqf
+++ b/addons/arsenal/functions/fnc_verifyLoadout.sqf
@@ -70,12 +70,7 @@ private _fnc_filterLoadout = {
         } else {
             // Handle arrays
             if (_x isEqualType []) then {
-                _itemArray = _x call _fnc_filterLoadout;
-                // If "" is given as a container, an error is thrown, therefore, filter out all unavailable/null containers
-                if (count _itemArray == 2 && {(_itemArray select 0) isEqualTo ""} && {(_itemArray select 1) isEqualType []}) then {
-                    _itemArray = [];
-                };
-                _itemArray
+                _x call _fnc_filterLoadout
             } else {
                 // All other types and empty strings
                 _x


### PR DESCRIPTION
**When merged this pull request will:**
- When importing a stored loadout which has a uniform/vest/backpack that is missing or from an unloaded mod, retain the currently equipped container and fill it with available items from the stored loadout.

The use case for this change is missions in which the arsenal is restricted to clothing from a specific faction, but still contains all the usual medical and other specialized equipment for a given role.
Previously, even if one had saved a very similar loadout, but with a different camo, it was impossible to load it without losing all clothing items. Forcing one to redo the entire loadout from scratch.
With this change, it will be possible to import such a loadout, so that the numerous equipment items will be placed in already worn clothing of the specific faction, saving time.

> If "" is given as a container, an error is thrown, therefore, filter out all unavailable/null containers

I realize that this was part of optimization work in #9316. Since it hinders this implementation, I removed that check. I have not found it causing errors when importing loadouts.
