### PR TITLE
Arsenal - Make ACE_asItem and ACE_isUnique apply to items

### DIFF
--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -51,6 +51,7 @@ PREP(handleSearchInputChanged);
 PREP(handleSearchModeToggle);
 PREP(handleStats);
 PREP(initBox);
+PREP(isMiscItem);
 PREP(itemInfo);
 PREP(loadoutsChangeTab);
 PREP(message);

--- a/addons/arsenal/functions/fnc_addRightPanelButton.sqf
+++ b/addons/arsenal/functions/fnc_addRightPanelButton.sqf
@@ -63,11 +63,9 @@ private _configItemInfo = "";
 _items = _items select {
     _configItemInfo = _cfgWeapons >> _x >> "ItemInfo";
 
-    _x isKindOf ["CBA_MiscItem", _cfgWeapons] && {getNumber (_configItemInfo >> "type") in [TYPE_MUZZLE, TYPE_OPTICS, TYPE_FLASHLIGHT, TYPE_BIPOD]} ||
+    _x call FUNC(isMiscItem) && {getNumber (_configItemInfo >> "type") in [TYPE_MUZZLE, TYPE_OPTICS, TYPE_FLASHLIGHT, TYPE_BIPOD]} ||
     {getNumber (_configItemInfo >> "type") in [TYPE_FIRST_AID_KIT, TYPE_MEDIKIT, TYPE_TOOLKIT]} ||
-    {getText (_cfgWeapons >> _x >> "simulation") == "ItemMineDetector"} ||
-    {getNumber (_cfgMagazines >> _x >> "ACE_isUnique") == 1} ||
-    {getNumber (_cfgMagazines >> _x >> "ACE_asItem") == 1}
+    {getText (_cfgWeapons >> _x >> "simulation") == "ItemMineDetector"}
 };
 
 GVAR(customRightPanelButtons) set [_position, [_items apply {_x call EFUNC(common,getConfigName)}, _picture, _tooltip, _moveOnOverwrite]];

--- a/addons/arsenal/functions/fnc_isMiscItem.sqf
+++ b/addons/arsenal/functions/fnc_isMiscItem.sqf
@@ -1,0 +1,24 @@
+#include "..\script_component.hpp"
+/*
+ * Author: DartRuffian
+ * Determines if a class is a miscellaneous item or not.
+ *
+ * Arguments:
+ * 0: Item, or magazine <STRING>
+ *
+ * Return Value:
+ * True if class is a misc item, otherwise false <BOOL>
+ *
+ * Example:
+ * "ACE_CableTie" call ace_arsenal_fnc_isMiscItem;
+ *
+ * Public: No
+*/
+
+params ["_item"];
+
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _config = _item call CBA_fnc_getItemConfig;
+_item isKindOf ["CBA_MiscItem", _cfgWeapons] ||
+{getNumber (_config >> "ACE_asItem") == 1} ||
+{getNumber (_config >> "ACE_isUnique") == 1};

--- a/addons/arsenal/functions/fnc_scanConfig.sqf
+++ b/addons/arsenal/functions/fnc_scanConfig.sqf
@@ -50,7 +50,7 @@ private _isTool = false;
     _configItemInfo = _x >> "ItemInfo";
     _hasItemInfo = isClass (_configItemInfo);
     _itemInfoType = if (_hasItemInfo) then {getNumber (_configItemInfo >> "type")} else {0};
-    _isMiscItem = _className isKindOf ["CBA_MiscItem", _cfgWeapons];
+    _isMiscItem = _className call FUNC(isMiscItem);
     _isTool = getNumber (_x >> "ACE_isTool") isEqualTo 1;
 
     switch (true) do {
@@ -160,7 +160,7 @@ private _magazineMiscItems = createHashMap;
 
 {
     _magazineMiscItems set [configName _x, nil];
-} forEach ((toString {getNumber (_x >> "ACE_isUnique") == 1 || getNumber (_x >> "ACE_asItem") == 1}) configClasses _cfgMagazines);
+} forEach (QUOTE(_x call FUNC(isMiscItem)) configClasses _cfgMagazines);
 
 // Remove invalid/non-existent entries
 _grenadeList deleteAt "";

--- a/addons/arsenal/functions/fnc_updateUniqueItemsList.sqf
+++ b/addons/arsenal/functions/fnc_updateUniqueItemsList.sqf
@@ -211,7 +211,7 @@ private _attachments = GVAR(virtualItems) get IDX_VIRT_ATTACHMENTS;
             _configItemInfo = _config >> "ItemInfo";
             _hasItemInfo = isClass (_configItemInfo);
             _itemInfoType = if (_hasItemInfo) then {getNumber (_configItemInfo >> "type")} else {0};
-            _isMiscItem = _x isKindOf ["CBA_MiscItem", _cfgWeapons];
+            _isMiscItem = _x call FUNC(isMiscItem);
 
             _baseWeapon = if (!_isMiscItem) then {
                 _x call FUNC(baseWeapon)

--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -137,8 +137,8 @@ Examples:
 ACE Arsenal uses 2 existing config entries to sort and display items.
 
 - `baseWeapon`: Class name that is used to display an item in the arsenal, used for weapon/attachment variants that are not normally shown to the player (AI variants, PIP optics, and so on). This property can be applied to any weapon or weapon attachment in `CfgWeapons`. Items using CBA or RHS' Scripted Optics systems, or CBA Switchable Attachments do not need this property explictly set, and will automatically use their player-accessible class.
-- `ACE_isUnique`: Classes in `CfgMagazines` with this property set to `1` will be treated and shown by the Arsenal as Misc. Items. Used for items with attached data that needs to be kept track of, such as Notepads or Spare Barrels.
-- `ACE_asItem`: Classes in `CfgMagazines` with this property set to `1` will be treated and shown by the Arsenal as Items. Used for magazines that are not meant to be used in a weapon, such as Painkillers.
+- `ACE_isUnique`: Classes in `CfgWeapons` or `CfgMagazines` with this property set to `1` will be treated and shown by the Arsenal as Misc. Items. Used for items with attached data that needs to be kept track of, such as Notepads or Spare Barrels.
+- `ACE_asItem`: Classes in `CfgWeapons` or `CfgMagazines` with this property set to `1` will be treated and shown by the Arsenal as Items. Used for magazines that are not meant to be used in a weapon, such as Painkillers.
 
 ### 3.2 New config entries
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title. Use-case is for updating items from other mods to not act as mine-detectors and still show in the ACE Arsenal.
  - Updating their `simulation` / `type` alone makes them work correctly, but they don't show as misc items since they do not inherit from `CBA_MiscItem`.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
