### PR TITLE
Medical Treatment - Fix script error on diagnosing dead patient in basic

### DIFF
--- a/addons/medical_treatment/functions/fnc_diagnose.sqf
+++ b/addons/medical_treatment/functions/fnc_diagnose.sqf
@@ -44,6 +44,8 @@ if (alive _patient) then {
     } else {
         _messages pushBack LSTRING(noPain);
     };
+} else {
+    _messages pushBack "";
 };
 
 [_messages, 3] call EFUNC(common,displayTextStructured);


### PR DESCRIPTION
format string expect 4