### PR TITLE
Medical - Improve - Overdose and Medications Improvements

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -1,6 +1,8 @@
 [default]
 workshop = [
     "450814997", # CBA_A3
+    "2369477168", # Advanced Developer Tools's Workshop ID
+    "1779063631", # ZEN
 ]
 
 [spe]

--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -1,8 +1,6 @@
 [default]
 workshop = [
     "450814997", # CBA_A3
-    "2369477168", # Advanced Developer Tools's Workshop ID
-    "1779063631", # ZEN
 ]
 
 [spe]

--- a/addons/medical_status/XEH_PREP.hpp
+++ b/addons/medical_status/XEH_PREP.hpp
@@ -6,6 +6,7 @@ PREP(getBloodPressure);
 PREP(getBloodVolumeChange);
 PREP(getCardiacOutput);
 PREP(getMedicationCount);
+PREP(getAllMedicationCount);
 PREP(handleKilled);
 PREP(handleKilledMission);
 PREP(hasStableVitals);

--- a/addons/medical_status/functions/fnc_addMedicationAdjustment.sqf
+++ b/addons/medical_status/functions/fnc_addMedicationAdjustment.sqf
@@ -1,27 +1,27 @@
 #include "..\script_component.hpp"
 /*
- * Author: BaerMitUmlaut, PabstMirror
+ * Author: BaerMitUmlaut, PabstMirror modified by Cplhardcore
  * Adds a medication and it's effects
  *
  * Arguments:
  * 0: The Unit <OBJECT>
  * 1: Medication <STRING>
- * 2: Time in system for the adjustment to reach its peak <NUMBER>
- * 3: Duration the adjustment will have an effect <NUMBER>
- * 4: Heart Rate Adjust <NUMBER>
- * 5: Pain Suppress Adjust <NUMBER>
- * 6: Flow Adjust <NUMBER>
+ * 3: Time in system for the adjustment to reach its peak <NUMBER>
+ * 4: Duration the adjustment will have an effect <NUMBER>
+ * 5: Heart Rate Adjust <NUMBER>
+ * 6: Pain Suppress Adjust <NUMBER>
+ * 7: Flow Adjust <NUMBER>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, "Morphine", 120, 60, -10, 0.8, -10] call ace_medical_status_fnc_addMedicationAdjustment
+ * [player, "Morphine", 1, 120, 60, -10, 0.8, -10] call ace_medical_status_fnc_addMedicationAdjustment
  *
  * Public: No
  */
-params ["_unit", "_medication", "_timeToMaxEffect", "_maxTimeInSystem", "_hrAdjust", "_painAdjust", "_flowAdjust"];
-TRACE_7("addMedicationAdjustment",_unit,_medication,_timeToMaxEffect,_maxTimeInSystem,_hrAdjust,_painAdjust,_flowAdjust);
+params ["_unit", "_medication", "_dose", "_timeToMaxEffect", "_maxTimeInSystem", "_hrAdjust", "_painAdjust", "_flowAdjust"];
+TRACE_8("addMedicationAdjustment",_unit,_medication,_dose,_timeToMaxEffect,_maxTimeInSystem,_hrAdjust,_painAdjust,_flowAdjust);
 
 if (_maxTimeInSystem <= 0) exitWith { WARNING_1("bad value for _maxTimeInSystem - %1",_this); };
 _timeToMaxEffect = _timeToMaxEffect max 1;
@@ -29,6 +29,6 @@ _timeToMaxEffect = _timeToMaxEffect max 1;
 
 private _adjustments = _unit getVariable [VAR_MEDICATIONS, []];
 
-_adjustments pushBack [_medication, CBA_missionTime, _timeToMaxEffect, _maxTimeInSystem, _hrAdjust, _painAdjust, _flowAdjust];
+_adjustments pushBack [_medication, CBA_missionTime, _dose, _timeToMaxEffect, _maxTimeInSystem, _hrAdjust, _painAdjust, _flowAdjust];
 
 _unit setVariable [VAR_MEDICATIONS, _adjustments, true];

--- a/addons/medical_status/functions/fnc_addMedicationAdjustment.sqf
+++ b/addons/medical_status/functions/fnc_addMedicationAdjustment.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: The Unit <OBJECT>
  * 1: Medication <STRING>
+ * 2: Dose of medication <NUMBER>
  * 3: Time in system for the adjustment to reach its peak <NUMBER>
  * 4: Duration the adjustment will have an effect <NUMBER>
  * 5: Heart Rate Adjust <NUMBER>

--- a/addons/medical_status/functions/fnc_getAllMedicationCount.sqf
+++ b/addons/medical_status/functions/fnc_getAllMedicationCount.sqf
@@ -1,0 +1,43 @@
+#include "..\script_component.hpp"
+/*
+ * Author: PabstMirror, modified by Cplhardcore
+ * Gets effective count of all medications in a unit's system
+ * (each medication dose is scaled from 0..1 based on time till max effect and max time in system)
+ *
+ * Arguments:
+ * 0: The patient <OBJECT>
+ * 1: Get raw count (true) or effect ratio (false) <BOOL>(default: true)
+ *
+ * Return Value:
+ * Dose Count <NUMBER>
+ * Medication effectiveness (float) <NUMBER>
+ *
+ * Example:
+ * [player] call ace_medical_status_fnc_getAllMedicationCount
+ *
+ * Public: No
+ */
+
+params ["_target", ["_getCount", true]];
+
+private _results = [];  // Array to store medication info
+{
+    _x params ["_xMed", "_timeAdded", "_dose", "_timeTillMaxEffect", "_maxTimeInSystem"];
+    
+    private _timeInSystem = CBA_missionTime - _timeAdded;
+    private _medDose = _dose;
+    private _medication = _xMed;
+    private _effectiveness = 0; 
+
+    if (_getCount) then {
+        _effectiveness = linearConversion [_timeTillMaxEffect, _maxTimeInSystem, _timeInSystem, 1, 0, true];
+    } else {
+        _effectiveness = (((_timeInSystem / _timeTillMaxEffect) ^ 2) min 1) * (_maxTimeInSystem - _timeInSystem) / _maxTimeInSystem;
+    };
+    _results pushBack [_medication, _medDose, _effectiveness];
+
+} forEach (_target getVariable [VAR_MEDICATIONS, []]);
+
+TRACE_4("getMedicationCount",_target,_medication,_getCount,_results);
+
+_results

--- a/addons/medical_status/functions/fnc_getAllMedicationCount.sqf
+++ b/addons/medical_status/functions/fnc_getAllMedicationCount.sqf
@@ -20,24 +20,38 @@
 
 params ["_target", ["_getCount", true]];
 
-private _results = [];  // Array to store medication info
+private _medStack = []; // Array to store stacked medication info
+
 {
     _x params ["_xMed", "_timeAdded", "_dose", "_timeTillMaxEffect", "_maxTimeInSystem"];
     
     private _timeInSystem = CBA_missionTime - _timeAdded;
-    private _medDose = _dose;
-    private _medication = _xMed;
-    private _effectiveness = 0; 
-
+    private _effectiveness = 0;
+    
     if (_getCount) then {
         _effectiveness = linearConversion [_timeTillMaxEffect, _maxTimeInSystem, _timeInSystem, 1, 0, true];
     } else {
         _effectiveness = (((_timeInSystem / _timeTillMaxEffect) ^ 2) min 1) * (_maxTimeInSystem - _timeInSystem) / _maxTimeInSystem;
     };
-    _results pushBack [_medication, _medDose, _effectiveness];
+    
+    private _found = false;
+    {
+        _x params ["_existingMed", "_totalDose", "_totalEffectiveness"];
+        
+        if (_existingMed isEqualTo _xMed) then {
+            _found = true;
+            _medStack set [_forEachIndex, [_existingMed, _totalDose + _dose, _totalEffectiveness + _effectiveness]]; // Stack dose and add effectiveness
+            true
+        } else {
+            false
+        };
+    } forEach _medStack;
+    if (!_found) then {
+        _medStack pushBack [_xMed, _dose, _effectiveness];
+    };
 
 } forEach (_target getVariable [VAR_MEDICATIONS, []]);
 
-TRACE_4("getMedicationCount",_target,_medication,_getCount,_results);
+TRACE_3("getMedicationStack", _target, _medStack, _getCount);
 
-_results
+_medStack

--- a/addons/medical_status/functions/fnc_getMedicationCount.sqf
+++ b/addons/medical_status/functions/fnc_getMedicationCount.sqf
@@ -1,6 +1,6 @@
 #include "..\script_component.hpp"
 /*
- * Author: PabstMirror
+ * Author: PabstMirror modified by Cplhardcore
  * Gets effective count of medications in a unit's system
  * (each medication dose is scaled from 0..1 based on time till max effect and max time in system)
  *
@@ -10,7 +10,8 @@
  * 2: Get raw count (true) or effect ratio (false) <BOOL>(default: true)
  *
  * Return Value:
- * Medication count (float) <NUMBER>
+ * Dose Count <NUMBER>
+ * Medication effectiveness (float) <NUMBER>
  *
  * Example:
  * [player, "Epinephrine"] call ace_medical_status_fnc_getMedicationCount
@@ -21,10 +22,12 @@
 params ["_target", "_medication", ["_getCount", true]];
 
 private _return = 0;
+private _medDose = 0;
 {
-    _x params ["_xMed", "_timeAdded", "_timeTillMaxEffect", "_maxTimeInSystem"];
+    _x params ["_xMed", "_timeAdded", "_dose", "_timeTillMaxEffect", "_maxTimeInSystem"];
     if (_xMed == _medication) then {
         private _timeInSystem = CBA_missionTime - _timeAdded;
+        _medDose = _medDose + _dose;
         if (_getCount) then {
             // just return effective count, a medication will always start at 1 and only drop after reaching timeTilMaxEffect
             _return = _return + linearConversion [_timeTillMaxEffect, _maxTimeInSystem, _timeInSystem, 1, 0, true];
@@ -35,5 +38,6 @@ private _return = 0;
     };
 } forEach (_target getVariable [VAR_MEDICATIONS, []]);
 
-TRACE_4("getMedicationCount",_target,_medication,_getCount,_return);
-_return
+TRACE_5("getMedicationCount",_target,_medication,_getCount,_return,_medDose);
+
+[_medDose, _return]

--- a/addons/medical_treatment/ACE_Medical_Treatment.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment.hpp
@@ -571,7 +571,7 @@ class ADDON {
         // Example with maxDose = 4 and maxDoseDeviation = 2: Dose 4: Safe | Dose 5 and 6: Possible overdose | Dose 7: Guaranteed overdose
         maxDoseDeviation = 2;
         // Function to execute upon overdose. Arguments passed to call back are 0: unit <OBJECT>, 1: medicationClassName <STRING>
-        onOverDose = "";
+        onOverDoseCustom = "";
         // The viscosity of a fluid is a measure of its resistance to gradual deformation by shear stress or tensile stress. For liquids, it corresponds to the informal concept of "thickness". This value will increase/decrease the viscoty of the blood with the percentage given. Where 100 = max. Using the minus will decrease viscosity
         viscosityChange = 0;
 
@@ -584,6 +584,7 @@ class ADDON {
             timeInSystem = 1800;
             timeTillMaxEffect = 30;
             maxDose = 4;
+            dose = 1;
             incompatibleMedication[] = {};
             viscosityChange = -10;
         };
@@ -595,6 +596,7 @@ class ADDON {
             timeInSystem = 120;
             timeTillMaxEffect = 10;
             maxDose = 9;
+            dose = 1;
             incompatibleMedication[] = {};
         };
         class Adenosine {
@@ -605,6 +607,7 @@ class ADDON {
             timeInSystem = 120;
             timeTillMaxEffect = 15;
             maxDose = 5;
+            dose = 1;
             incompatibleMedication[] = {};
         };
         class PainKillers {
@@ -615,6 +618,7 @@ class ADDON {
             timeInSystem = 420;
             timeTillMaxEffect = 60;
             maxDose = 5;
+            dose = 1;
             incompatibleMedication[] = {};
             viscosityChange = 5;
         };

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -114,10 +114,12 @@ class GVAR(actions) {
     class Morphine: FieldDressing {
         displayName = CSTRING(Inject_Morphine);
         displayNameProgress = CSTRING(Injecting_Morphine);
+        medicRequired = QGVAR(medicMorphine);
         icon = QPATHTOEF(medical_gui,ui\auto_injector.paa);
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         category = "medication";
         items[] = {"ACE_morphine"};
+        treatmentLocations = QGVAR(locationMorphine);
         condition = "";
         treatmentTime = QGVAR(treatmentTimeAutoinjector);
         callbackSuccess = QFUNC(medication);
@@ -128,8 +130,10 @@ class GVAR(actions) {
     class Adenosine: Morphine {
         displayName = CSTRING(Inject_Adenosine);
         displayNameProgress = CSTRING(Injecting_Adenosine);
+        medicRequired = QGVAR(medicAdenosine);
         condition = QGVAR(advancedMedication);
         items[] = {"ACE_adenosine"};
+        treatmentLocations = QGVAR(locationAdenosine);
         litter[] = {{"ACE_MedicalLitter_adenosine"}};
     };
     class Epinephrine: Morphine {

--- a/addons/medical_treatment/XEH_PREP.hpp
+++ b/addons/medical_treatment/XEH_PREP.hpp
@@ -67,3 +67,4 @@ PREP(treatmentFailure);
 PREP(treatmentSuccess);
 PREP(unloadUnit);
 PREP(useItem);
+PREP(onOverdose);

--- a/addons/medical_treatment/functions/fnc_medicationLocal.sqf
+++ b/addons/medical_treatment/functions/fnc_medicationLocal.sqf
@@ -1,6 +1,6 @@
 #include "..\script_component.hpp"
 /*
- * Author: Glowbal, mharis001
+ * Author: Glowbal, mharis001, modified by Cplhardcore
  * Local callback for administering medication to a patient.
  *
  * Arguments:
@@ -65,8 +65,7 @@ private _medicationConfig = _defaultConfig >> _classname;
 private _painReduce             = GET_NUMBER(_medicationConfig >> "painReduce",getNumber (_defaultConfig >> "painReduce"));
 private _timeInSystem           = GET_NUMBER(_medicationConfig >> "timeInSystem",getNumber (_defaultConfig >> "timeInSystem"));
 private _timeTillMaxEffect      = GET_NUMBER(_medicationConfig >> "timeTillMaxEffect",getNumber (_defaultConfig >> "timeTillMaxEffect"));
-private _maxDose                = GET_NUMBER(_medicationConfig >> "maxDose",getNumber (_defaultConfig >> "maxDose"));
-private _maxDoseDeviation       = GET_NUMBER(_medicationConfig >> "maxDoseDeviation",getNumber (_defaultConfig >> "maxDoseDeviation"));
+private _dose                = GET_NUMBER(_medicationConfig >> "dose",getNumber (_defaultConfig >> "dose"));
 private _viscosityChange        = GET_NUMBER(_medicationConfig >> "viscosityChange",getNumber (_defaultConfig >> "viscosityChange"));
 private _hrIncreaseLow          = GET_ARRAY(_medicationConfig >> "hrIncreaseLow",getArray (_defaultConfig >> "hrIncreaseLow"));
 private _hrIncreaseNormal       = GET_ARRAY(_medicationConfig >> "hrIncreaseNormal",getArray (_defaultConfig >> "hrIncreaseNormal"));
@@ -80,7 +79,7 @@ private _heartRateChange = _minIncrease + random (_maxIncrease - _minIncrease);
 
 // Adjust the medication effects and add the medication to the list
 TRACE_3("adjustments",_heartRateChange,_painReduce,_viscosityChange);
-[_patient, _className, _timeTillMaxEffect, _timeInSystem, _heartRateChange, _painReduce, _viscosityChange] call EFUNC(medical_status,addMedicationAdjustment);
+[_patient, _className, _dose, _timeTillMaxEffect, _timeInSystem, _heartRateChange, _painReduce, _viscosityChange] call EFUNC(medical_status,addMedicationAdjustment);
 
 // Check for medication compatiblity
-[_patient, _className, _maxDose, _maxDoseDeviation, _incompatibleMedication] call FUNC(onMedicationUsage);
+[_patient, _className, _incompatibleMedication] call FUNC(onMedicationUsage);

--- a/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
@@ -1,32 +1,32 @@
 #include "..\script_component.hpp"
 /*
- * Author: Glowbal
+ * Author: Glowbal, modified by Cplhardcore
  * Handles the medication given to a patient.
  *
  * Arguments:
  * 0: The patient <OBJECT>
  * 1: Medication Treatment classname <STRING>
- * 2: Max dose (0 to ignore) <NUMBER>
- * 3: Max dose deviation <NUMBER>
- * 3: Incompatable medication <ARRAY<STRING>>
+ * 2: Incompatable medication <ARRAY<STRING>>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, "morphine", 4, 2, [["x", 1]]] call ace_medical_treatment_fnc_onMedicationUsage
+ * [player, "morphine", [["x", 1]]] call ace_medical_treatment_fnc_onMedicationUsage
  *
  * Public: No
  */
 
-params ["_target", "_className", "_maxDose", "_maxDoseDeviation", "_incompatibleMedication"];
-TRACE_5("onMedicationUsage",_target,_className,_maxDose,_maxDoseDeviation,_incompatibleMedication);
-
-private _overdosedMedications = [];
+params ["_target", "_className", "_incompatibleMedication"];
+TRACE_3("onMedicationUsage",_target,_className,_incompatibleMedication);
 
 // Check for overdose from current medication
+private _defaultConfig = configFile >> QUOTE(ADDON) >> "Medication";
+private _medicationConfig = _defaultConfig >> _classname;
+private _maxDose                = GET_NUMBER(_medicationConfig >> "maxDose",getNumber (_defaultConfig >> "maxDose"));
+private _maxDoseDeviation       = GET_NUMBER(_medicationConfig >> "maxDoseDeviation",getNumber (_defaultConfig >> "maxDoseDeviation"));
 if (_maxDose > 0) then {
-    private _currentDose = [_target, _className] call EFUNC(medical_status,getMedicationCount);
+    private _currentDose = [_target, _className] call EFUNC(medical_status,getMedicationCount) select 1;
     // Because both {floor random 0} and {floor random 1} return 0
     if (_maxDoseDeviation > 0) then {
         _maxDoseDeviation = _maxDoseDeviation + 1;
@@ -34,7 +34,7 @@ if (_maxDose > 0) then {
 
     if (_currentDose > _maxDose + (floor random _maxDoseDeviation)) then {
         TRACE_1("exceeded max dose",_currentDose);
-        _overdosedMedications pushBackUnique _className;
+        [_target, _classname] call FUNC(onOverdose);
     };
 };
 
@@ -43,26 +43,6 @@ if (_maxDose > 0) then {
     _x params ["_xMed", "_xLimit"];
     private _inSystem = [_target, _xMed] call EFUNC(medical_status,getMedicationCount);
     if (_inSystem> _xLimit) then {
-        _overdosedMedications pushBackUnique _xMed;
+        [_target, _classname] call FUNC(onOverdose);
     };
 } forEach _incompatibleMedication;
-
-if (_overdosedMedications isNotEqualTo []) then {
-    private _medicationConfig = (configFile >> "ace_medical_treatment" >> "Medication");
-    private _onOverDose = getText (_medicationConfig >> "onOverDose");
-    if (isClass (_medicationConfig >> _className)) then {
-        _medicationConfig = (_medicationConfig >> _className);
-        if (isText (_medicationConfig  >> "onOverDose")) then { _onOverDose = getText (_medicationConfig >> "onOverDose"); };
-    };
-    TRACE_2("overdose",_overdosedMedications,_onOverDose);
-    if (_onOverDose == "") exitWith {
-        TRACE_1("CriticalVitals Event",_target); // make unconscious
-        [QEGVAR(medical,CriticalVitals), _target] call CBA_fnc_localEvent;
-    };
-    if (isNil _onOverDose) then {
-        _onOverDose = compile _onOverDose;
-    } else {
-        _onOverDose = missionNamespace getVariable _onOverDose;
-    };
-    [_target, _className, _overdosedMedications] call _onOverDose;
-};

--- a/addons/medical_treatment/functions/fnc_onOverdose.sqf
+++ b/addons/medical_treatment/functions/fnc_onOverdose.sqf
@@ -1,0 +1,36 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Cplhardcore
+ * Handles the overdose effects of a medication.
+ *
+ * Arguments:
+ * 0: The patient <OBJECT>
+ * 1: Medication Treatment classname <STRING>
+ * 2: Incompatable medication <ARRAY<STRING>>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, "morphine"] call ace_medical_treatment_fnc_onOverDose
+ * Public: No
+ */
+
+ params ["_unit", "_classname"];
+
+private _medicationConfig = (configFile >> "ace_medical_treatment" >> "_classname");
+private _onOverDoseCustom = getText (_medicationConfig >> "onOverDoseCustom");
+if (isClass (_medicationConfig >> _className)) then {
+     _medicationConfig = (_medicationConfig >> _className);
+    if (isText (_medicationConfig  >> "onOverDoseCustom")) then { _onOverDoseCustom = getText (_medicationConfig >> "onOverDoseCustom"); };
+};
+TRACE_2("overdose",_classname,_onOverDoseCustom);
+if (_onOverDoseCustom == "") exitWith {
+    TRACE_1("CriticalVitals Event",_target); // make unconscious
+    [QEGVAR(medical,CriticalVitals), _target] call CBA_fnc_localEvent;
+};
+if (isNil _onOverDoseCustom) then {
+    _onOverDose = compile _onOverDoseCustom;
+} else {
+    _onOverDoseCustom = missionNamespace getVariable _onOverDoseCustom;
+};

--- a/addons/medical_treatment/initSettings.inc.sqf
+++ b/addons/medical_treatment/initSettings.inc.sqf
@@ -191,24 +191,6 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(MorphineDoseLimit),
-    "SLIDER",
-    [LSTRING(DoseLimitMorphine_DisplayName), LSTRING(DoseLimitMorphine_DESC)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [1, 9, 3, 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(MorphineDoseLimitDeviation),
-    "SLIDER",
-    [LSTRING(DoseLimitDeviationMorphine_DisplayName), LSTRING(DoseLimitDeviationMorphine_DESC)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0, 3, 1, 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
     QGVAR(medicAdenosine),
     "LIST",
     [LSTRING(MedicAdenosine_DisplayName), LSTRING(MedicAdenosine_Description)],
@@ -223,24 +205,6 @@
     [LSTRING(LocationAdenosine_DisplayName), LSTRING(LocationAdenosine_Description)],
     [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
     [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(AdenosineDoseLimit),
-    "SLIDER",
-    [LSTRING(DoseLimitAdenosine_DisplayName), LSTRING(DoseLimitAdenosine_DESC)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [1, 9, 3, 0],
-    true
-] call CBA_fnc_addSetting;
-
-[
-    QGVAR(AdenosineDoseLimitDeviation),
-    "SLIDER",
-    [LSTRING(DoseLimitDeviationAdenosine_DisplayName), LSTRING(DoseLimitDeviationAdenosine_DESC)],
-    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
-    [0, 3, 1, 0],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_treatment/initSettings.inc.sqf
+++ b/addons/medical_treatment/initSettings.inc.sqf
@@ -155,6 +155,96 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(EpinephrineDoseLimit),
+    "SLIDER",
+    [LSTRING(DoseLimitEpinephrine_DisplayName), LSTRING(DoseLimitEpinephrine_DESC)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [1, 9, 3, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(EpinephrineDoseLimitDeviation),
+    "SLIDER",
+    [LSTRING(DoseLimitDeviationEpinephrine_DisplayName), LSTRING(DoseLimitDeviationEpinephrine_DESC)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0, 3, 1, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(medicMorphine),
+    "LIST",
+    [LSTRING(MedicMorphine_DisplayName), LSTRING(MedicMorphine_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(locationMorphine),
+    "LIST",
+    [LSTRING(LocationMorphine_DisplayName), LSTRING(LocationMorphine_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(MorphineDoseLimit),
+    "SLIDER",
+    [LSTRING(DoseLimitMorphine_DisplayName), LSTRING(DoseLimitMorphine_DESC)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [1, 9, 3, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(MorphineDoseLimitDeviation),
+    "SLIDER",
+    [LSTRING(DoseLimitDeviationMorphine_DisplayName), LSTRING(DoseLimitDeviationMorphine_DESC)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0, 3, 1, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(medicAdenosine),
+    "LIST",
+    [LSTRING(MedicAdenosine_DisplayName), LSTRING(MedicAdenosine_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2], [LSTRING(Anyone), LSTRING(Medics), LSTRING(Doctors)], 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(locationAdenosine),
+    "LIST",
+    [LSTRING(LocationAdenosine_DisplayName), LSTRING(LocationAdenosine_Description)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [[0, 1, 2, 3, 4], [ELSTRING(common,Anywhere), ELSTRING(common,Vehicle), LSTRING(MedicalFacilities), LSTRING(VehiclesAndFacilities), ELSTRING(common,Disabled)], 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AdenosineDoseLimit),
+    "SLIDER",
+    [LSTRING(DoseLimitAdenosine_DisplayName), LSTRING(DoseLimitAdenosine_DESC)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [1, 9, 3, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(AdenosineDoseLimitDeviation),
+    "SLIDER",
+    [LSTRING(DoseLimitDeviationAdenosine_DisplayName), LSTRING(DoseLimitDeviationAdenosine_DESC)],
+    [ELSTRING(medical,Category), LSTRING(SubCategory_Treatment)],
+    [0, 3, 1, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(medicPAK),
     "LIST",
     [LSTRING(MedicPAK_DisplayName), LSTRING(MedicPAK_Description)],

--- a/addons/medical_treatment/script_component.hpp
+++ b/addons/medical_treatment/script_component.hpp
@@ -2,7 +2,7 @@
 #define COMPONENT_BEAUTIFIED Medical Treatment
 #include "\z\ace\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
+#define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -546,6 +546,66 @@
             <Spanish>Controla donde puede sr usada la Epinefrina.</Spanish>
             <Korean>에피네프린을 사용할 수 있는 장소를 정합니다.</Korean>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitEpinephrine_DisplayName">
+            <English>Maximum Dose of Epinephrine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitEpinephrine_DESC">
+            <English>The maximum Dose of Epinephrine you can give to a player</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationEpinephrine_DisplayName">
+            <English>Maximum Dose Deviation of Epinephrine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationEpinephrine_DESC">
+            <English>The number of additional doses you may be able to give of Epinephrine, while risking overdose</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_MedicMorphine_DisplayName">
+            <English>Allow Morphine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_MedicMorphine_Description">
+            <English>Training level required to use Morphine.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationMorphine_DisplayName">
+            <English>Locations Morphine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationMorphine_Description">
+            <English>Controls where Morphine can be used.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitMorphine_DisplayName">
+            <English>Maximum Dose of Morphine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitMorphine_DESC">
+            <English>The maximum Dose of Morphine you can give to a player</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationMorphine_DisplayName">
+            <English>Maximum Dose Deviation of Morphine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationMorphine_DESC">
+            <English>The number of additional doses you may be able to give of Morphine, while risking overdose</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_MedicAdenosine_DisplayName">
+            <English>Allow Adenosine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_MedicAdenosine_Description">
+            <English>Training level required to use Adenosine.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationAdenosine_DisplayName">
+            <English>Locations Adenosine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_LocationAdenosine_Description">
+            <English>Controls where Adenosine can be used.</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitAdenosine_DisplayName">
+            <English>Maximum Dose of Adenosine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitAdenosine_DESC">
+            <English>The maximum Dose of Adenosine you can give to a player</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationAdenosine_DisplayName">
+            <English>Maximum Dose Deviation of Adenosine</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationAdenosine_DESC">
+            <English>The number of additional doses you may be able to give of Adenosine, while risking overdose</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicPAK_DisplayName">
             <English>Allow PAK</English>
             <Russian>Доступ к Аптечке</Russian>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -546,18 +546,6 @@
             <Spanish>Controla donde puede sr usada la Epinefrina.</Spanish>
             <Korean>에피네프린을 사용할 수 있는 장소를 정합니다.</Korean>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitEpinephrine_DisplayName">
-            <English>Maximum Dose of Epinephrine</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitEpinephrine_DESC">
-            <English>The maximum Dose of Epinephrine you can give to a player</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationEpinephrine_DisplayName">
-            <English>Maximum Dose Deviation of Epinephrine</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationEpinephrine_DESC">
-            <English>The number of additional doses you may be able to give of Epinephrine, while risking overdose</English>
-        </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicMorphine_DisplayName">
             <English>Allow Morphine</English>
         </Key>
@@ -570,18 +558,6 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationMorphine_Description">
             <English>Controls where Morphine can be used.</English>
         </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitMorphine_DisplayName">
-            <English>Maximum Dose of Morphine</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitMorphine_DESC">
-            <English>The maximum Dose of Morphine you can give to a player</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationMorphine_DisplayName">
-            <English>Maximum Dose Deviation of Morphine</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationMorphine_DESC">
-            <English>The number of additional doses you may be able to give of Morphine, while risking overdose</English>
-        </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicAdenosine_DisplayName">
             <English>Allow Adenosine</English>
         </Key>
@@ -593,18 +569,6 @@
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_LocationAdenosine_Description">
             <English>Controls where Adenosine can be used.</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitAdenosine_DisplayName">
-            <English>Maximum Dose of Adenosine</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitAdenosine_DESC">
-            <English>The maximum Dose of Adenosine you can give to a player</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationAdenosine_DisplayName">
-            <English>Maximum Dose Deviation of Adenosine</English>
-        </Key>
-        <Key ID="STR_ACE_Medical_Treatment_DoseLimitDeviationAdenosine_DESC">
-            <English>The number of additional doses you may be able to give of Adenosine, while risking overdose</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_MedicPAK_DisplayName">
             <English>Allow PAK</English>

--- a/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
+++ b/addons/medical_vitals/functions/fnc_handleUnitVitals.sqf
@@ -81,7 +81,7 @@ private _adjustments = _unit getVariable [VAR_MEDICATIONS,[]];
 if (_adjustments isNotEqualTo []) then {
     private _deleted = false;
     {
-        _x params ["_medication", "_timeAdded", "_timeTillMaxEffect", "_maxTimeInSystem", "_hrAdjust", "_painAdjust", "_flowAdjust"];
+        _x params ["_medication", "_dose", "_timeAdded", "_timeTillMaxEffect", "_maxTimeInSystem", "_hrAdjust", "_painAdjust", "_flowAdjust"];
         private _timeInSystem = CBA_missionTime - _timeAdded;
         if (_timeInSystem >= _maxTimeInSystem) then {
             _deleted = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Rework overdose slightly, for better handling with external mods with multiple dose levels for one kind of medication
- splits overdose into its own function
- adds the getAllMedicationCount function, which gets all medications in a unit and outputs them in an array of arrays containing the medication's name, the dose, and the effectiveness

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
