### PR TITLE
Explosives - Use detonator icon for consolidated detonate actions

### DIFF
--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -19,7 +19,8 @@
 params ["_unit", "_detonator"];
 TRACE_2("params",_unit,_detonator);
 
-private _range = getNumber (configFile >> "CfgWeapons" >> _detonator >> QGVAR(Range));
+private _detonatorConfig = configFile >> "CfgWeapons" >> _detonator;
+private _range = getNumber (_detonatorConfig >> QGVAR(Range));
 
 private _result = [_unit] call FUNC(getPlacedExplosives);
 private _children = [];
@@ -80,7 +81,7 @@ if (_detonator != "ACE_DeadManSwitch") then {
             [
                 "Explosive_All",
                 LLSTRING(DetonateAll),
-                getText (configFile >> "CfgWeapons" >> _detonator >> "picture"),
+                getText (_detonatorConfig >> "picture"),
                 {(_this select 2) call FUNC(detonateExplosiveAll);},
                 {true},
                 {},
@@ -106,7 +107,7 @@ if (_detonator != "ACE_DeadManSwitch") then {
             [
                 "Explosive_All_Deadman",
                 LLSTRING(DetonateAll),
-                getText (configFile >> "CfgWeapons" >> _detonator >> "picture"),
+                getText (_detonatorConfig >> "picture"),
                 {[_player] call FUNC(onIncapacitated)},
                 {true}
             ] call EFUNC(interact_menu,createAction),

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -33,11 +33,24 @@ private _explosivesList = [];
 
             _explosivesList pushBack _x;
 
+            // Prevent consolidated detonate actions from having the same icon as consolidated place actions of the same explosive type
+            private _icon = if (
+                EGVAR(interact_menu,consolidateSingleChild) && 
+                {_detonator == GVAR(activeTrigger)} && 
+                {count (_result select {(_x select 4) == getText (_detonatorConfig >> QGVAR(triggerType))}) < 2}
+            ) then {
+                systemChat "true";
+                getText (_detonatorConfig >> "picture")
+            } else {
+                systemChat "false";
+                getText (_item >> "picture")
+            };
+
             _children pushBack [
                 [
                     format ["Explosive_%1", _forEachIndex],
                     _x select 2,
-                    getText(_item >> "picture"),
+                    _icon,
                     {(_this select 2) call FUNC(detonateExplosive);},
                     {true},
                     {},

--- a/addons/explosives/functions/fnc_addDetonateActions.sqf
+++ b/addons/explosives/functions/fnc_addDetonateActions.sqf
@@ -32,20 +32,19 @@ private _explosivesList = [];
 
             _explosivesList pushBack _x;
 
-            _children pushBack
+            _children pushBack [
                 [
-                    [
-                        format ["Explosive_%1", _forEachIndex],
-                        _x select 2,
-                        getText(_item >> "picture"),
-                        {(_this select 2) call FUNC(detonateExplosive);},
-                        {true},
-                        {},
-                        [_unit,_range,_x,_detonator]
-                    ] call EFUNC(interact_menu,createAction),
-                    [],
-                    _unit
-                ];
+                    format ["Explosive_%1", _forEachIndex],
+                    _x select 2,
+                    getText(_item >> "picture"),
+                    {(_this select 2) call FUNC(detonateExplosive);},
+                    {true},
+                    {},
+                    [_unit,_range,_x,_detonator]
+                ] call EFUNC(interact_menu,createAction),
+                [],
+                _unit
+            ];
         };
     };
 } forEach _result;


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent consolidated detonate actions from using the same icon as consolidated place actions of the same explosive type, since it bears the potential for confusing them and mistakenly triggering the explosive.
![ui-change](https://github.com/user-attachments/assets/e21439c6-7e44-4631-861f-2d1c70aa1b49)
