### PR TITLE
Vehicle Damage - Fix zeus end keybind not killing units

### DIFF
--- a/addons/vehicle_damage/functions/fnc_handleDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_handleDamage.sqf
@@ -22,10 +22,13 @@
  * Public: No
  */
 
-params ["_vehicle", "_selection", "_newDamage", "_source", "_projectile", "_hitIndex", "_instigator", "_hitPoint"];
-TRACE_8("handleDamage",_vehicle,_selection,_newDamage,_source,_projectile,_hitIndex,_instigator,_hitPoint);
+params ["_vehicle", "_selection", "_newDamage", "_source", "_projectile", "_hitIndex", "_instigator", "_hitPoint", "", "_context"];
+TRACE_9("handleDamage",_vehicle,_selection,_newDamage,_source,_projectile,_hitIndex,_instigator,_hitPoint,_context);
 
 if (!local _vehicle) exitWith {};
+
+// Killing units via End key is an edge case (#10375)
+if (_context == 0 && {_newDamage == 1 && _projectile == "" && isNull _source && isNull _instigator}) exitWith {_newDamage};
 
 private _currentDamage = if (_selection != "") then {
     _vehicle getHitIndex _hitIndex


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes #10395.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
