### PR TITLE
Hit reactions - Improve fall down description

### DIFF
--- a/addons/hitreactions/functions/fnc_fallDown.sqf
+++ b/addons/hitreactions/functions/fnc_fallDown.sqf
@@ -20,7 +20,7 @@
 params ["_unit", "_firer", "_damage"];
 
 // exit if system is disabled
-if (GVAR(minDamageToTrigger) == -1) exitWith {};
+if (GVAR(minDamageToTrigger) < 0) exitWith {};
 
 // exit if damage is disabled on unit
 if !(isDamageAllowed _unit && {_unit getVariable [QEGVAR(medical,allowDamage), true]}) exitWith {};

--- a/addons/hitreactions/initSettings.inc.sqf
+++ b/addons/hitreactions/initSettings.inc.sqf
@@ -3,7 +3,7 @@ private _category = [LELSTRING(common,categoryUncategorized), QUOTE(COMPONENT_BE
 [
     QGVAR(minDamageToTrigger),
     "SLIDER",
-    LSTRING(minDamageToTrigger_displayName),
+    [LSTRING(minDamageToTrigger_displayName), LSTRING(minDamageToTrigger_Description)],
     _category,
     [-1, 1, 0.1, 1],
     1

--- a/addons/hitreactions/stringtable.xml
+++ b/addons/hitreactions/stringtable.xml
@@ -17,6 +17,9 @@
             <Turkish>Düşmeyi tetikleyen min hasar</Turkish>
             <Spanish>Daño mínimo para provocar la caída</Spanish>
         </Key>
+        <Key ID="STR_ACE_HitReactions_minDamageToTrigger_Description">
+            <English>If a unit takes more damage than this setting's value whilst moving on foot, they will fall over.\nIf set to a negative value, this mechanic is turned off.</English>
+        </Key>
         <Key ID="STR_ACE_HitReactions_weaponDropChanceArmHitPlayer_displayName">
             <English>Player Weapon Drop Chance (Arm Hit)</English>
             <Japanese>プレイヤーが武器を落とす確率 (腕部への被弾)</Japanese>


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Changes so that all negative values are considered to turn off this mechanic (instead of just `-1`).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
