### PR TITLE
Hearing - Tone down strength of explosion hearing damage

### DIFF
--- a/addons/hearing/functions/fnc_explosion.sqf
+++ b/addons/hearing/functions/fnc_explosion.sqf
@@ -49,8 +49,7 @@ if (_distance > _maxDistance) exitWith {
 };
 
 // Tone down _maxDistance to bring strength back to similar levels as a large burst of a loud weapon
-private _strength = _vehAttenuation * _explosive * _volume * (sqrt _maxDistance) / _distance^2;
-
+private _strength = _vehAttenuation * _explosive * _volume * (_maxDistance / 2) / _distance^2;
 TRACE_6("strength",_vehAttenuation,_explosive,_volume,_maxDistance,_distance,_strength);
 
 // Call immediately, as it will get picked up later by the update thread anyway

--- a/addons/hearing/functions/fnc_explosion.sqf
+++ b/addons/hearing/functions/fnc_explosion.sqf
@@ -48,7 +48,8 @@ if (_distance > _maxDistance) exitWith {
     TRACE_2("too far away",_distance,_maxDistance);
 };
 
-private _strength = _vehAttenuation * _explosive * _volume * _maxDistance / _distance^2;
+// Tone down _maxDistance to bring strength back to similar levels as a large burst of a loud weapon
+private _strength = _vehAttenuation * _explosive * _volume * (sqrt _maxDistance) / _distance^2;
 
 TRACE_2("strength",_volume,_strength);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

This makes a grenade @ 10m equivalent to a ~50 round burst from a .50 BMG static. Manageable with earpro, but still quite loud when closer. Grenades exploding at a player's feet will still blow out their eardrums, but hey, realism.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
