### PR TITLE
Medical & Vehicle Damage - Fix end key fix

### DIFF
--- a/addons/medical_engine/functions/fnc_handleDamage.sqf
+++ b/addons/medical_engine/functions/fnc_handleDamage.sqf
@@ -33,7 +33,7 @@ if (_structuralDamage) then {
 if !(isDamageAllowed _unit && {_unit getVariable [QEGVAR(medical,allowDamage), true]}) exitWith {_oldDamage};
 
 // Killing units via End key is an edge case (#10375)
-if (_structuralDamage && {_damage == 1 && _ammo == "" && isNull _shooter && isNull _instigator}) exitWith {_damage};
+if (_structuralDamage && {_damage >= 1 && _ammo == "" && isNull _shooter && isNull _instigator}) exitWith {_damage};
 
 private _newDamage = _damage - _oldDamage;
 

--- a/addons/vehicle_damage/functions/fnc_handleDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_handleDamage.sqf
@@ -28,7 +28,7 @@ TRACE_9("handleDamage",_vehicle,_selection,_newDamage,_source,_projectile,_hitIn
 if (!local _vehicle) exitWith {};
 
 // Killing units via End key is an edge case (#10375)
-if (_context == 0 && {_newDamage == 1 && _projectile == "" && isNull _source && isNull _instigator}) exitWith {_newDamage};
+if (_context == 0 && {_newDamage >= 1 && _projectile == "" && isNull _source && isNull _instigator}) exitWith {_newDamage};
 
 private _currentDamage = if (_selection != "") then {
     _vehicle getHitIndex _hitIndex


### PR DESCRIPTION
**When merged this pull request will:**
- If the object has `damage`, the end key will add `1` damage on top of that, making the comparison fail, as it currently expects `1` exactly.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
