### PR TITLE
missileguidance - cleanup 2 `params`

### DIFF
--- a/addons/missileguidance/functions/fnc_navigationType_line.sqf
+++ b/addons/missileguidance/functions/fnc_navigationType_line.sqf
@@ -15,7 +15,8 @@
  * Public: No
  */
 params ["_args", "_timestep", "_seekerTargetPos", "_profileAdjustedTargetPos", "_targetData", "_navigationParams"];
-_args params ["", "", "_flightParams"];
+_args params ["_firedEH", "", "_flightParams"];
+_firedEH params ["","","","","","","_projectile"];
 _targetData params ["", "_targetDir", "_distance"];
 _flightParams params ["_pitchRate", "_yawRate"];
 

--- a/addons/missileguidance/functions/fnc_proNav_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_proNav_onFired.sqf
@@ -14,12 +14,8 @@
  *
  * Public: No
  */
-params ["_firedEH", "", "", "", "_stateParams"];
-_firedEH params ["_shooter","","","","_ammo","","_projectile"];
-_launchParams params ["_shooter","_targetLaunchParams","_seekerType","_attackProfile","_lockMode","_laserInfo","_navigationType"];
-_targetLaunchParams params ["_target", "_targetPos", "_launchPos"];
-_stateParams params ["_lastRunTime", "_seekerStateParams", "_attackProfileStateParams", "_lastKnownPosState"];      
-_seekerParams params ["_seekerAngle", "_seekerAccuracy", "_seekerMaxRange", "_seekerMinRange"];
+params ["_firedEH"];
+_firedEH params ["","","","","","","_projectile"];
 
 private _ammoConfig = configOf _projectile;
 private _navigationGain = getNumber (_ammoConfig >> QUOTE(ADDON) >> "navigationGain");


### PR DESCRIPTION
_projectile undefined but was from upper scope
_seekerParams undefined but didn't matter

I've been thinking of just just unwrapping arrays once in guidancePFH 
and inheriting in all the sub funcs, but we can do that in another pr