### PR TITLE
Cookoff - Fix zeus end keybind not killing ammo containers

### DIFF
--- a/addons/cookoff/functions/fnc_handleDamageBox.sqf
+++ b/addons/cookoff/functions/fnc_handleDamageBox.sqf
@@ -18,12 +18,23 @@
 // If cookoff for boxes is disabled, exit
 if (!GVAR(enableAmmobox) || {GVAR(ammoCookoffDuration) == 0}) exitWith {};
 
-params ["_box", "", "_damage", "_source", "_ammo", "", "_instigator", "_hitPoint"];
+params ["_box", "_selection", "_damage", "_source", "_ammo", "_hitIndex", "_instigator", "_hitPoint", "", "_context"];
 
 if (!local _box) exitWith {};
 
 // If it's already dead, ignore
 if (!alive _box) exitWith {};
+
+private _currentDamage = if (_selection != "") then {
+    _box getHitIndex _hitIndex
+} else {
+    damage _box
+};
+
+// Killing units via End key is an edge case (#10375)
+// This didn't matter pre-Arma 3 2.18 but now this goes through the event handler
+// TODO: Structural fire damage >= 1 in a single damage event could still be caught here and we don't want that, but we haven't found a better way to catch this, fire damage should be small most of the time anyway
+if (_context == 0 && {(abs (_damage - _currentDamage - 1)) < 0.001 && _ammo == "" && isNull _source && isNull _instigator}) exitWith {_damage};
 
 if !(_box getVariable [QGVAR(enableAmmoCookoff), true]) exitWith {};
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #10432.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
