### PR TITLE
Dragging - Fix dead body weapon carrying

### DIFF
--- a/addons/dragging/functions/fnc_canCarry.sqf
+++ b/addons/dragging/functions/fnc_canCarry.sqf
@@ -21,7 +21,11 @@ params ["_unit", "_target"];
 private _alive = alive _target;
 private _isPerson = _target isKindOf "CAManBase";
 
-if !((_alive || _isPerson) && {_target getVariable [QGVAR(canCarry), false]} && {isNull objectParent _target}) exitWith {false};
+if !(
+    (_alive || _isPerson)
+    && {_target getVariable [QGVAR(canCarry), false]}
+    && {!_isPerson || {isNull objectParent _target}}
+) exitWith {false};
 
 if !([_unit, _target, []] call EFUNC(common,canInteractWith)) exitWith {false};
 


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Looks like `isNull objectParent _target` part here is for unit vehicle check. Since recent Arma changes `objectParent` for `WeaponHolderSimulated` (dead body weapons) returns dead body unit. And then you can't carry these weapons anymore.

This PR forces `objectParent` check only for units. 