### PR TITLE
Common - Make fnc_isAwake also check isAwake command

### DIFF
--- a/addons/common/functions/fnc_isAwake.sqf
+++ b/addons/common/functions/fnc_isAwake.sqf
@@ -18,3 +18,4 @@
 params ["_unit"];
 
 lifeState _unit in ["HEALTHY", "INJURED"]
+&& {isAwake _unit}


### PR DESCRIPTION
**When merged this pull request will:**
- title.

[isAwake](https://community.bistudio.com/wiki/isAwake) command checks if alive unit is ragdolling. This state is like temporary unconscious. I know at least one method to cause it: push unit with moving vehicle quite intensely but don't kill him. The unit stops reacting to control, starts almost unconscious animation and comes round after some seconds.
Since recent Arma changes this state is not considered with `lifeState` command as it was before. So we need additional `isAwake` check.