### PR TITLE
Common - Improve file checking error messages

### DIFF
--- a/addons/common/functions/fnc_checkFiles.sqf
+++ b/addons/common/functions/fnc_checkFiles.sqf
@@ -1,6 +1,6 @@
 #include "..\script_component.hpp"
 /*
- * Author: commy2, johnb432, LinkIsGrim
+ * Author: commy2, johnb43, LinkIsGrim
  * Compares version numbers of PBOs and DLLs. Logs and displays error message on any version/addon errors in multiplayer.
  *
  * Arguments:
@@ -267,7 +267,6 @@ if (isMultiplayer) then {
                     private _errorMsg = format ["%1<br/><br/>%2<br/><br/>%3", _reasonMsg, _fixMsg, _infoMsg];
                     [_title, _errorMsg] call FUNC(errorMessage);
                 };
-
             };
         };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Let me call people stupid when they don't read.

Example formatting:
![image](https://github.com/user-attachments/assets/00bd9097-b6ec-4035-af9c-2a5361301a4f)


![image](https://github.com/user-attachments/assets/befdc01f-e154-4131-9c59-d8276d31f09a)



Cases for errors are:
```
Client has additional ace addons, and compats are in additional addons // CDLC/RHS/etc loaded on client but not on server
Client has additional ace addons, and compats are not in additional addons (e.g. server has no medical loaded) // ace from different places

Version mismatch between server and client // what it says on the tin

Client has outdated addons across multiple ACE sources // conflicting install
Client has outdated addons across a single ACE source // corrupted install or bad repack
```

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
