### PR TITLE
Fastroping - Enable FRIES functionality on Plane child classes with necessary config entries

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -1,3 +1,68 @@
+#define MACRO_FRIES_SELFACTIONS \
+    class ACE_SelfActions { \
+        class ACE_prepareFRIES { \
+            displayName = CSTRING(Interaction_prepareFRIES); \
+            condition = QUOTE([_target] call FUNC(canPrepareFRIES)); \
+            statement = QUOTE([_target] call FUNC(prepareFRIES)); \
+        }; \
+        class ACE_stowFRIES { \
+            displayName = CSTRING(Interaction_stowFRIES); \
+            condition = QUOTE([_target] call FUNC(canStowFRIES)); \
+            statement = QUOTE([_target] call FUNC(stowFRIES)); \
+        }; \
+        class ACE_deployRopes3 { \
+            displayName = CSTRING(Interaction_deployRopes3); \
+            condition = QUOTE([ARR_3(_target,_player,'ACE_rope3')] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope3')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_deployRopes6 { \
+            displayName = CSTRING(Interaction_deployRopes6); \
+            condition = QUOTE([ARR_3(_target,_player,'ACE_rope6')] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope6')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_deployRopes12 { \
+            displayName = CSTRING(Interaction_deployRopes12); \
+            condition = QUOTE([ARR_3(_target,_player,'ACE_rope12')] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope12')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_deployRopes15 { \
+            displayName = CSTRING(Interaction_deployRopes15); \
+            condition = QUOTE([ARR_3(_target,_player,'ACE_rope15')] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope15')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_deployRopes18 { \
+            displayName = CSTRING(Interaction_deployRopes18); \
+            condition = QUOTE([ARR_3(_target,_player,'ACE_rope18')] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope18')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_deployRopes27 { \
+            displayName = CSTRING(Interaction_deployRopes27); \
+            condition = QUOTE([ARR_3(_target,_player,'ACE_rope27')] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope27')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_deployRopes36 { \
+            displayName = CSTRING(Interaction_deployRopes36); \
+            condition = QUOTE([ARR_4(_target,_player,'ACE_rope36',true)] call FUNC(canDeployRopes)); \
+            statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope36')])] call CBA_fnc_serverEvent); \
+        }; \
+        class ACE_cutRopes { \
+            displayName = CSTRING(Interaction_cutRopes); \
+            condition = QUOTE([_target] call FUNC(canCutRopes)); \
+            statement = QUOTE(true); \
+            class confirmCutRopes { \
+                displayName = ECSTRING(common,confirm); \
+                condition = QUOTE([_target] call FUNC(canCutRopes)); \
+                statement = QUOTE([_target] call FUNC(cutRopes)); \
+            }; \
+        }; \
+        class ACE_fastRope { \
+            displayName = CSTRING(Interaction_fastRope); \
+            condition = QUOTE([ARR_2(_player,_target)] call FUNC(canFastRope)); \
+            statement = QUOTE([ARR_2(_player,_target)] call FUNC(fastRope)); \
+        }; \
+    }; 
+
+
 class CfgVehicles {
     class Logic;
     class Module_F: Logic {
@@ -24,134 +89,10 @@ class CfgVehicles {
 
     class Air;
     class Helicopter: Air {
-        class ACE_SelfActions {
-            class ACE_prepareFRIES {
-                displayName = CSTRING(Interaction_prepareFRIES);
-                condition = QUOTE([_target] call FUNC(canPrepareFRIES));
-                statement = QUOTE([_target] call FUNC(prepareFRIES));
-            };
-            class ACE_stowFRIES {
-                displayName = CSTRING(Interaction_stowFRIES);
-                condition = QUOTE([_target] call FUNC(canStowFRIES));
-                statement = QUOTE([_target] call FUNC(stowFRIES));
-            };
-            class ACE_deployRopes3 {
-                displayName = CSTRING(Interaction_deployRopes3);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope3')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope3')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes6 {
-                displayName = CSTRING(Interaction_deployRopes6);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope6')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope6')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes12 {
-                displayName = CSTRING(Interaction_deployRopes12);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope12')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope12')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes15 {
-                displayName = CSTRING(Interaction_deployRopes15);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope15')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope15')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes18 {
-                displayName = CSTRING(Interaction_deployRopes18);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope18')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope18')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes27 {
-                displayName = CSTRING(Interaction_deployRopes27);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope27')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope27')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes36 {
-                displayName = CSTRING(Interaction_deployRopes36);
-                condition = QUOTE([ARR_4(_target,_player,'ACE_rope36',true)] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope36')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_cutRopes {
-                displayName = CSTRING(Interaction_cutRopes);
-                condition = QUOTE([_target] call FUNC(canCutRopes));
-                // should not be empty to work with EGVAR(interact_menu,consolidateSingleChild) setting
-                statement = QUOTE(true);
-                class confirmCutRopes {
-                    displayName = ECSTRING(common,confirm);
-                    condition = QUOTE([_target] call FUNC(canCutRopes));
-                    statement = QUOTE([_target] call FUNC(cutRopes));
-                };
-            };
-            class ACE_fastRope {
-                displayName = CSTRING(Interaction_fastRope);
-                condition = QUOTE([ARR_2(_player,_target)] call FUNC(canFastRope));
-                statement = QUOTE([ARR_2(_player,_target)] call FUNC(fastRope));
-            };
-        };
+        MACRO_FRIES_SELFACTIONS
     };
 	class Plane: Air {
-        class ACE_SelfActions {
-            class ACE_prepareFRIES {
-                displayName = CSTRING(Interaction_prepareFRIES);
-                condition = QUOTE([_target] call FUNC(canPrepareFRIES));
-                statement = QUOTE([_target] call FUNC(prepareFRIES));
-            };
-            class ACE_stowFRIES {
-                displayName = CSTRING(Interaction_stowFRIES);
-                condition = QUOTE([_target] call FUNC(canStowFRIES));
-                statement = QUOTE([_target] call FUNC(stowFRIES));
-            };
-            class ACE_deployRopes3 {
-                displayName = CSTRING(Interaction_deployRopes3);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope3')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope3')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes6 {
-                displayName = CSTRING(Interaction_deployRopes6);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope6')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope6')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes12 {
-                displayName = CSTRING(Interaction_deployRopes12);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope12')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope12')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes15 {
-                displayName = CSTRING(Interaction_deployRopes15);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope15')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope15')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes18 {
-                displayName = CSTRING(Interaction_deployRopes18);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope18')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope18')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes27 {
-                displayName = CSTRING(Interaction_deployRopes27);
-                condition = QUOTE([ARR_3(_target,_player,'ACE_rope27')] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope27')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_deployRopes36 {
-                displayName = CSTRING(Interaction_deployRopes36);
-                condition = QUOTE([ARR_4(_target,_player,'ACE_rope36',true)] call FUNC(canDeployRopes));
-                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope36')])] call CBA_fnc_serverEvent);
-            };
-            class ACE_cutRopes {
-                displayName = CSTRING(Interaction_cutRopes);
-                condition = QUOTE([_target] call FUNC(canCutRopes));
-                // should not be empty to work with EGVAR(interact_menu,consolidateSingleChild) setting
-                statement = QUOTE(true);
-                class confirmCutRopes {
-                    displayName = ECSTRING(common,confirm);
-                    condition = QUOTE([_target] call FUNC(canCutRopes));
-                    statement = QUOTE([_target] call FUNC(cutRopes));
-                };
-            };
-            class ACE_fastRope {
-                displayName = CSTRING(Interaction_fastRope);
-                condition = QUOTE([ARR_2(_player,_target)] call FUNC(canFastRope));
-                statement = QUOTE([ARR_2(_player,_target)] call FUNC(fastRope));
-            };
-        };
+        MACRO_FRIES_SELFACTIONS
     };
 
     class Helicopter_Base_F;

--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -88,6 +88,71 @@ class CfgVehicles {
             };
         };
     };
+	class Plane: Air {
+        class ACE_SelfActions {
+            class ACE_prepareFRIES {
+                displayName = CSTRING(Interaction_prepareFRIES);
+                condition = QUOTE([_target] call FUNC(canPrepareFRIES));
+                statement = QUOTE([_target] call FUNC(prepareFRIES));
+            };
+            class ACE_stowFRIES {
+                displayName = CSTRING(Interaction_stowFRIES);
+                condition = QUOTE([_target] call FUNC(canStowFRIES));
+                statement = QUOTE([_target] call FUNC(stowFRIES));
+            };
+            class ACE_deployRopes3 {
+                displayName = CSTRING(Interaction_deployRopes3);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope3')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope3')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_deployRopes6 {
+                displayName = CSTRING(Interaction_deployRopes6);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope6')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope6')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_deployRopes12 {
+                displayName = CSTRING(Interaction_deployRopes12);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope12')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope12')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_deployRopes15 {
+                displayName = CSTRING(Interaction_deployRopes15);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope15')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope15')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_deployRopes18 {
+                displayName = CSTRING(Interaction_deployRopes18);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope18')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope18')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_deployRopes27 {
+                displayName = CSTRING(Interaction_deployRopes27);
+                condition = QUOTE([ARR_3(_target,_player,'ACE_rope27')] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope27')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_deployRopes36 {
+                displayName = CSTRING(Interaction_deployRopes36);
+                condition = QUOTE([ARR_4(_target,_player,'ACE_rope36',true)] call FUNC(canDeployRopes));
+                statement = QUOTE([ARR_2(QQGVAR(deployRopes),[ARR_3(_target,_player,'ACE_rope36')])] call CBA_fnc_serverEvent);
+            };
+            class ACE_cutRopes {
+                displayName = CSTRING(Interaction_cutRopes);
+                condition = QUOTE([_target] call FUNC(canCutRopes));
+                // should not be empty to work with EGVAR(interact_menu,consolidateSingleChild) setting
+                statement = QUOTE(true);
+                class confirmCutRopes {
+                    displayName = ECSTRING(common,confirm);
+                    condition = QUOTE([_target] call FUNC(canCutRopes));
+                    statement = QUOTE([_target] call FUNC(cutRopes));
+                };
+            };
+            class ACE_fastRope {
+                displayName = CSTRING(Interaction_fastRope);
+                condition = QUOTE([ARR_2(_player,_target)] call FUNC(canFastRope));
+                statement = QUOTE([ARR_2(_player,_target)] call FUNC(fastRope));
+            };
+        };
+    };
 
     class Helicopter_Base_F;
     class ACE_friesBase: Helicopter_Base_F {

--- a/addons/fastroping/XEH_postInit.sqf
+++ b/addons/fastroping/XEH_postInit.sqf
@@ -31,7 +31,7 @@
 
 
 if (isServer) then {
-    ["Helicopter", "init", {
+    ["Air", "init", {
         if (!GVAR(autoAddFRIES)) exitWith {};
         params ["_vehicle"];
         if (isNumber (configOf _vehicle >> QGVAR(enabled)) && {isNil {_vehicle getVariable [QGVAR(FRIES), nil]}}) then {
@@ -51,7 +51,7 @@ if (isServer) then {
 
 #ifdef DRAW_FASTROPE_INFO
 addMissionEventHandler ["Draw3D", {
-    if !(cursorObject isKindOf "Helicopter") exitWith {};
+    if !(cursorObject isKindOf "Air") exitWith {};
     private _config = configOf cursorObject;
     private _enabled = getNumber (_config >> QGVAR(enabled));
     drawIcon3D ["", [.5,.5,1,1], (ASLToAGL getPosASL cursorObject), 0.5, 0.5, 0, format ["%1 = %2", typeOf cursorObject, _enabled], 0.5, 0.025, "TahomaB"];

--- a/addons/fastroping/XEH_preInit.sqf
+++ b/addons/fastroping/XEH_preInit.sqf
@@ -9,9 +9,9 @@ PREP_RECOMPILE_END;
 #include "initSettings.inc.sqf"
 
 if (isServer) then {
-    ["Helicopter", "Deleted", LINKFUNC(unequipFRIES)] call CBA_fnc_addClassEventHandler;
+    ["Air", "Deleted", LINKFUNC(unequipFRIES)] call CBA_fnc_addClassEventHandler;
 };
 
-["Helicopter", "Killed", LINKFUNC(unequipFRIES)] call CBA_fnc_addClassEventHandler;
+["Air", "Killed", LINKFUNC(unequipFRIES)] call CBA_fnc_addClassEventHandler;
 
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Extend FRIES functionality to any classes that inherit from `Plane` in addition to `Helicopter`. The primary reason for this change was to allow VTOL aircraft to implement FRIES. 