### PR TITLE
Medical Treatment - Fix `GET_FUNCTION` macro

### DIFF
--- a/addons/medical_treatment/script_component.hpp
+++ b/addons/medical_treatment/script_component.hpp
@@ -20,7 +20,7 @@
 // Returns a text config entry as compiled code or variable from missionNamespace
 #define GET_FUNCTION(var,cfg) \
     private var = getText (cfg); \
-    if (isNil var) then { \
+    if (missionNamespace isNil var) then { \
         var = compile var; \
     } else { \
         var = missionNamespace getVariable var; \


### PR DESCRIPTION
**When merged this pull request will:**
- Fix.
- When you use `getText` on an invalid config or on a config whose type is different than text , it will return `""` and not `nil`. This meant that prior to this PR it would always try to interpret the text as a function name.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
