### PR TITLE
Spectator - Fix "Side" RPT spam

### DIFF
--- a/addons/spectator/functions/fnc_cam_setCameraMode.sqf
+++ b/addons/spectator/functions/fnc_cam_setCameraMode.sqf
@@ -61,7 +61,12 @@ if (!isNull _focus || _newMode == MODE_FREE) then {
 
     if (_newMode == MODE_FREE) then {
         _camera cameraEffect ["Internal", "BACK"];
-        switchCamera GVAR(camAgentFree); // Fix draw3D while in free camera for case where player is perma-dead
+
+        // Waiting for correct client state avoids "Side" being spammed every frame in RPT
+        if (getClientStateNumber >= 10) then {
+            switchCamera GVAR(camAgentFree); // Fix draw3D while in free camera for case where player is perma-dead
+        };
+
         _camera setDir getDirVisual _camera;
 
         if (!isNull _focus) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Title. When you are in an ACE spectator slot and in the briefing screen at mission start, it would just spam `Side` in the rpt. (see https://github.com/acemod/ACE3/issues/10440#issuecomment-2442982687)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
