### PR TITLE
Common - Add better support for status effects in other components

### DIFF
--- a/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
+++ b/addons/advanced_fatigue/functions/fnc_handleEffects.sqf
@@ -64,10 +64,10 @@ if (GVAR(isSwimming)) exitWith {
     };
 
     if (isSprintAllowed _unit && _fatigue > 0.7) then { // small checks like these are faster without lazy eval
-        [_unit, "blockSprint", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
     } else {
         if (!isSprintAllowed _unit && _fatigue < 0.7) then {
-            [_unit, "blockSprint", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+            [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
         };
     };
 };
@@ -79,19 +79,19 @@ if (getAnimSpeedCoef _unit != 1 && {GVAR(setAnimExclusions) isEqualTo []}) then 
 };
 
 if (!isForcedWalk _unit && _fatigue >= 1) then { // small checks like these are faster without lazy eval
-    [_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-    [_unit, "blockSprint", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 } else {
     if (isForcedWalk _unit && _fatigue < 0.7) then {
-        [_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-        [_unit, "blockSprint", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
     } else {
         // Forward angle is the slope of the terrain, side angle simulates the unevenness/roughness of the terrain
         if (isSprintAllowed _unit && {_fatigue > 0.7 || abs _fwdAngle > 20 || abs _sideAngle > 20}) then {
-            [_unit, "blockSprint", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+            [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
         } else {
             if (!isSprintAllowed _unit && _fatigue < 0.6 && abs _fwdAngle < 20 && abs _sideAngle < 20) then {
-                [_unit, "blockSprint", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+                [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
             };
         };
     };

--- a/addons/attach/functions/fnc_attach.sqf
+++ b/addons/attach/functions/fnc_attach.sqf
@@ -50,8 +50,8 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
 } else {
     GVAR(placeAction) = PLACE_WAITING;
 
-    [_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-    [_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
     [{[localize LSTRING(PlaceAction), ""] call EFUNC(interaction,showMouseHint)}, []] call CBA_fnc_execNextFrame;
     _unit setVariable [QGVAR(placeActionEH), [_unit, "DefaultAction", {true}, {GVAR(placeAction) = PLACE_APPROVE;}] call EFUNC(common,AddActionEventHandler)];
@@ -88,8 +88,8 @@ if (_unit == _attachToVehicle) then {  //Self Attachment
                 {!([_attachToVehicle, _unit, _itemClassname] call FUNC(canAttach))}) then {
 
             [_idPFH] call CBA_fnc_removePerFrameHandler;
-            [_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-            [_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+            [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+            [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
             [] call EFUNC(interaction,hideMouseHint);
             [_unit, "DefaultAction", (_unit getVariable [QGVAR(placeActionEH), -1])] call EFUNC(common,removeActionEventHandler);
             _unit removeAction _actionID;

--- a/addons/captives/functions/fnc_handleRespawn.sqf
+++ b/addons/captives/functions/fnc_handleRespawn.sqf
@@ -40,12 +40,12 @@ if (_respawn > 3) then {
     if (_unit getVariable [QGVAR(isHandcuffed), false]) then {
         [_unit, false] call FUNC(setHandcuffed);
     };
-    [_unit, "setCaptive", QGVAR(handcuffed), false] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,setCaptive), QGVAR(handcuffed), false] call EFUNC(common,statusEffect_set);
 
     if (_unit getVariable [QGVAR(isSurrendering), false]) then {
         [_unit, false] call FUNC(setSurrendered);
     };
-    [_unit, "setCaptive", QGVAR(surrendered), false] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,setCaptive), QGVAR(surrendered), false] call EFUNC(common,statusEffect_set);
 
     if (_unit getVariable [QGVAR(isEscorting), false]) then {
         _unit setVariable [QGVAR(isEscorting), false, true];

--- a/addons/captives/functions/fnc_setHandcuffed.sqf
+++ b/addons/captives/functions/fnc_setHandcuffed.sqf
@@ -41,21 +41,21 @@ if ((_unit getVariable [QGVAR(isHandcuffed), false]) isEqualTo _state) exitWith 
 
 if (_state) then {
     _unit setVariable [QGVAR(isHandcuffed), true, true];
-    [_unit, "setCaptive", QGVAR(handcuffed), true] call EFUNC(common,statusEffect_set);
-    [_unit, "blockRadio", QGVAR(handcuffed), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,setCaptive), QGVAR(handcuffed), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockRadio), QGVAR(handcuffed), true] call EFUNC(common,statusEffect_set);
 
-    if (_unit getVariable [QGVAR(isSurrendering), false]) then {  //If surrendering, stop
+    if (_unit getVariable [QGVAR(isSurrendering), false]) then { // If surrendering, stop
         [_unit, false] call FUNC(setSurrendered);
     };
 
-    //Set unit cargoIndex (will be -1 if dismounted)
+    // Set unit cargoIndex (will be -1 if dismounted)
     _unit setVariable [QGVAR(CargoIndex), ((vehicle _unit) getCargoIndex _unit), true];
 
     if (_unit == ACE_player) then {
         ["captive", [false, false, false, false, false, false, false, false, false, true]] call EFUNC(common,showHud);
     };
 
-    // fix anim on mission start (should work on dedicated servers)
+    // Fix anim on mission start (should work on dedicated servers)
     [{
         params ["_unit"];
         if !(_unit getVariable [QGVAR(isHandcuffed), false]) exitWith {};
@@ -68,8 +68,8 @@ if (_state) then {
             [_unit, "ACE_HandcuffedFFV", 1] call EFUNC(common,doAnimation);
         };
 
-        //Adds an animation changed eh
-        //If we get a change in animation then redo the animation (handles people vaulting to break the animation chain)
+        // Adds an animation changed eh
+        // If we get a change in animation then redo the animation (handles people vaulting to break the animation chain)
         private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];
         if (_animChangedEHID != -1) then {
             TRACE_1("removing animChanged EH",_animChangedEHID);
@@ -82,17 +82,17 @@ if (_state) then {
     }, [_unit], 0.01] call CBA_fnc_waitAndExecute;
 } else {
     _unit setVariable [QGVAR(isHandcuffed), false, true];
-    [_unit, "setCaptive", QGVAR(handcuffed), false] call EFUNC(common,statusEffect_set);
-    [_unit, "blockRadio", QGVAR(handcuffed), false] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,setCaptive), QGVAR(handcuffed), false] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockRadio), QGVAR(handcuffed), false] call EFUNC(common,statusEffect_set);
 
-    //remove AnimChanged EH
+    // Remove AnimChanged EH
     private _animChangedEHID = _unit getVariable [QGVAR(handcuffAnimEHID), -1];
     TRACE_1("removing animChanged EH",_animChangedEHID);
     _unit removeEventHandler ["AnimChanged", _animChangedEHID];
     _unit setVariable [QGVAR(handcuffAnimEHID), -1];
 
     if ((isNull objectParent _unit) && {_unit call EFUNC(common,isAwake)}) then {
-        //Break out of hands up animation loop
+        // Break out of hands up animation loop
         [_unit, "ACE_AmovPercMstpScapWnonDnon_AmovPercMstpSnonWnonDnon", 2] call EFUNC(common,doAnimation);
     };
 

--- a/addons/captives/functions/fnc_setSurrendered.sqf
+++ b/addons/captives/functions/fnc_setSurrendered.sqf
@@ -44,8 +44,8 @@ if (_state) then {
 
     _unit setVariable [QGVAR(isSurrendering), true, true];
 
-    [_unit, "setCaptive", QGVAR(surrendered), true] call EFUNC(common,statusEffect_set);
-    [_unit, "blockRadio", QGVAR(surrendered), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,setCaptive), QGVAR(surrendered), true] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockRadio), QGVAR(surrendered), true] call EFUNC(common,statusEffect_set);
 
     if (_unit == ACE_player) then {
         ["captive", [false, false, false, false, false, false, false, false, false, true]] call EFUNC(common,showHud);
@@ -71,16 +71,16 @@ if (_state) then {
     }, [_unit], 0.01] call CBA_fnc_waitAndExecute;
 } else {
     _unit setVariable [QGVAR(isSurrendering), false, true];
-    [_unit, "setCaptive", QGVAR(surrendered), false] call EFUNC(common,statusEffect_set);
-    [_unit, "blockRadio", QGVAR(surrendered), false] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,setCaptive), QGVAR(surrendered), false] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockRadio), QGVAR(surrendered), false] call EFUNC(common,statusEffect_set);
 
-    //remove AnimChanged EH
+    // Remove AnimChanged EH
     private _animChangedEHID = _unit getVariable [QGVAR(surrenderAnimEHID), -1];
     _unit removeEventHandler ["AnimChanged", _animChangedEHID];
     _unit setVariable [QGVAR(surrenderAnimEHID), -1];
 
     if (_unit == ACE_player) then {
-        //only re-enable HUD if not handcuffed
+        // Only re-enable HUD if not handcuffed
         if !(_unit getVariable [QGVAR(isHandcuffed), false]) then {
             ["captive", []] call EFUNC(common,showHud); //same as showHud true;
         };

--- a/addons/cargo/XEH_postInit.sqf
+++ b/addons/cargo/XEH_postInit.sqf
@@ -54,7 +54,7 @@
     _item setPosASL (AGLToASL _emptyPosAGL);
 
     // Let objects remain invulernable for a short while after placement
-    [EFUNC(common,statusEffect_set), [_item, "blockDamage", QUOTE(ADDON), false], 2] call CBA_fnc_waitAndExecute;
+    [EFUNC(common,statusEffect_set), [_item, QEGVAR(common,blockDamage), QUOTE(ADDON), false], 2] call CBA_fnc_waitAndExecute;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(paradropItem), {

--- a/addons/cargo/functions/fnc_deployCancel.sqf
+++ b/addons/cargo/functions/fnc_deployCancel.sqf
@@ -24,8 +24,8 @@ GVAR(deployPFH) = -1;
 params ["_unit"];
 
 // Enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 // Delete placement dummy
 deleteVehicle GVAR(itemPreviewObject);

--- a/addons/cargo/functions/fnc_loadItem.sqf
+++ b/addons/cargo/functions/fnc_loadItem.sqf
@@ -61,7 +61,7 @@ if (_item isEqualType objNull) then {
     };
 
     // Some objects below water will take damage over time, eventually becoming "water logged" and unfixable (because of negative z attach)
-    [_item, "blockDamage", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    [_item, QEGVAR(common,blockDamage), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
     // Prevent UAVs from firing
     private _UAVCrew = _item call EFUNC(common,getVehicleUAVCrew);

--- a/addons/cargo/functions/fnc_startDeploy.sqf
+++ b/addons/cargo/functions/fnc_startDeploy.sqf
@@ -40,8 +40,8 @@ if (_classname isEqualType objNull) then {
 };
 
 // Prevent the placing unit from running
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 // Create a local preview object
 private _itemPreviewObject = createVehicleLocal [_classname, [0, 0, 0], [], 0, "CAN_COLLIDE"];

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -191,14 +191,14 @@ if (isServer) then {
     _this setVariable [QGVAR(lockStatus), locked _this];
     _this lock 2;
     if ([] isNotEqualTo getArray (configOf _this >> "assembleInfo" >> "dissasembleTo")) then {
-        [_this, "disableWeaponAssembly", QGVAR(lockVehicle), true] call FUNC(statusEffect_set);
+        [_this, QGVAR(disableWeaponAssembly), QGVAR(lockVehicle), true] call FUNC(statusEffect_set);
     };
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(unlockVehicle), {
     _this lock (_this getVariable [QGVAR(lockStatus), locked _this]);
     if ([] isNotEqualTo getArray (configOf _this >> "assembleInfo" >> "dissasembleTo")) then {
-        [_this, "disableWeaponAssembly", QGVAR(lockVehicle), false] call FUNC(statusEffect_set);
+        [_this, QGVAR(disableWeaponAssembly), QGVAR(lockVehicle), false] call FUNC(statusEffect_set);
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -19,17 +19,17 @@
 
 //Status Effect EHs:
 [QGVAR(setStatusEffect), LINKFUNC(statusEffect_set)] call CBA_fnc_addEventHandler;
-["forceWalk", false, ["ace_advanced_fatigue", "ace_attach", "ace_dragging", "ace_explosives", QEGVAR(medical,fracture), "ace_rearm", "ace_refuel", "ace_sandbag", "ace_switchunits", "ace_tacticalladder", "ace_trenches"]] call FUNC(statusEffect_addType);
-["blockSprint", false, ["ace_advanced_fatigue", "ace_dragging", QEGVAR(medical,fracture)]] call FUNC(statusEffect_addType);
-["setCaptive", true, [QEGVAR(captives,handcuffed), QEGVAR(captives,surrendered)]] call FUNC(statusEffect_addType);
-["blockDamage", false, ["fixCollision", "ace_cargo"]] call FUNC(statusEffect_addType);
-["blockEngine", false, ["ace_refuel"]] call FUNC(statusEffect_addType);
-["blockThrow", false, ["ace_attach", "ace_concertina_wire", "ace_dragging", "ace_explosives", "ace_rearm", "ace_refuel", "ace_sandbag", "ace_tacticalladder", "ace_trenches", "ace_tripod"]] call FUNC(statusEffect_addType);
-["setHidden", true, ["ace_unconscious"]] call FUNC(statusEffect_addType);
-["blockRadio", false, [QEGVAR(captives,handcuffed), QEGVAR(captives,surrendered), "ace_unconscious"]] call FUNC(statusEffect_addType);
-["blockSpeaking", false, ["ace_unconscious"]] call FUNC(statusEffect_addType);
-["disableWeaponAssembly", false, ["ace_common", QGVAR(lockVehicle), "ace_csw"]] call FUNC(statusEffect_addType);
-["lockInventory", true, [], true] call FUNC(statusEffect_addType);
+[QGVAR(forceWalk), false, ["ace_advanced_fatigue", "ace_attach", "ace_dragging", "ace_explosives", QEGVAR(medical,fracture), "ace_rearm", "ace_refuel", "ace_sandbag", "ace_switchunits", "ace_tacticalladder", "ace_trenches"]] call FUNC(statusEffect_addType);
+[QGVAR(blockSprint), false, ["ace_advanced_fatigue", "ace_dragging", QEGVAR(medical,fracture)]] call FUNC(statusEffect_addType);
+[QGVAR(setCaptive), true, [QEGVAR(captives,handcuffed), QEGVAR(captives,surrendered)]] call FUNC(statusEffect_addType);
+[QGVAR(blockDamage), false, ["fixCollision", "ace_cargo"]] call FUNC(statusEffect_addType);
+[QGVAR(blockEngine), false, ["ace_refuel"]] call FUNC(statusEffect_addType);
+[QGVAR(blockThrow), false, ["ace_attach", "ace_concertina_wire", "ace_dragging", "ace_explosives", "ace_rearm", "ace_refuel", "ace_sandbag", "ace_tacticalladder", "ace_trenches", "ace_tripod"]] call FUNC(statusEffect_addType);
+[QGVAR(setHidden), true, ["ace_unconscious"]] call FUNC(statusEffect_addType);
+[QGVAR(blockRadio), false, [QEGVAR(captives,handcuffed), QEGVAR(captives,surrendered), "ace_unconscious"]] call FUNC(statusEffect_addType);
+[QGVAR(blockSpeaking), false, ["ace_unconscious"]] call FUNC(statusEffect_addType);
+[QGVAR(disableWeaponAssembly), false, ["ace_common", QGVAR(lockVehicle), "ace_csw"]] call FUNC(statusEffect_addType);
+[QGVAR(lockInventory), true, [], true] call FUNC(statusEffect_addType);
 
 [QGVAR(forceWalk), {
     params ["_object", "_set"];

--- a/addons/common/functions/fnc_fixCollision.sqf
+++ b/addons/common/functions/fnc_fixCollision.sqf
@@ -18,8 +18,8 @@
 // allowDamage requires local object
 if (!local _this) exitWith {};
 
-// prevent collision damage
-[_this, "blockDamage", "fixCollision", true] call FUNC(statusEffect_set);
+// Prevent collision damage
+[_this, QGVAR(blockDamage), "fixCollision", true] call FUNC(statusEffect_set);
 
-// re-allow damage after 2 seconds
-[{[_this, "blockDamage", "fixCollision", false] call FUNC(statusEffect_set);}, _this, 2] call CBA_fnc_waitAndExecute;
+// Re-allow damage after 2 seconds
+[{[_this, QGVAR(blockDamage), "fixCollision", false] call FUNC(statusEffect_set);}, _this, 2] call CBA_fnc_waitAndExecute;

--- a/addons/common/functions/fnc_statusEffect_addType.sqf
+++ b/addons/common/functions/fnc_statusEffect_addType.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * ["setCaptive", true, []] call ace_common_fnc_statusEffect_addType
+ * ["ace_common_setCaptive", true, []] call ace_common_fnc_statusEffect_addType
  *
  * Public: No
  */

--- a/addons/common/functions/fnc_statusEffect_get.sqf
+++ b/addons/common/functions/fnc_statusEffect_get.sqf
@@ -27,7 +27,7 @@ if (isNull _object) exitWith {
 };
 
 // BWC: Status effect names used to not be prefixed
-if (_effectName in STATUS_EFFECTS_BWC) then {
+if (toLowerANSI _effectName in STATUS_EFFECTS_BWC) then {
     TRACE_1("Deprecated effect name used",_effectName);
     _effectName = format [QGVAR(%1), _effectName];
 };

--- a/addons/common/functions/fnc_statusEffect_get.sqf
+++ b/addons/common/functions/fnc_statusEffect_get.sqf
@@ -13,7 +13,7 @@
  *  1: reasons why it is set true (list of strings, count of 0 = false, 1+ = true) <ARRAY>
  *
  * Example:
- * [player, "forceWalk"] call ace_common_fnc_statusEffect_get
+ * [player, "ace_common_forceWalk"] call ace_common_fnc_statusEffect_get
  *
  * Public: Yes
  */
@@ -26,28 +26,34 @@ if (isNull _object) exitWith {
     [false, []]
 };
 
-[_object, false] call FUNC(statusEffect_resetVariables); //Check for mismatch
+// BWC: Status effect names used to not be prefixed
+if (_effectName in STATUS_EFFECTS_BWC) then {
+    TRACE_1("Deprecated effect name used",_effectName);
+    _effectName = format [QGVAR(%1), _effectName];
+};
 
-//List of reasons
+[_object, false] call FUNC(statusEffect_resetVariables); // Check for mismatch
+
+// List of reasons
 private _statusReasons = missionNamespace getVariable [(format [QGVAR(statusEffects_%1), _effectName]), []];
 if (_statusReasons isEqualTo []) exitWith {
     TRACE_1("no reasons - bad effect?",_statusReasons);
     [false, []]
 };
 
-//Get Effect Number
+// Get Effect Number
 private _effectVarName = format [QGVAR(effect_%1), _effectName];
 private _effectNumber = _object getVariable [_effectVarName, -1];
 TRACE_2("current",_effectVarName,_effectNumber);
 
-if (_effectNumber == -1) exitWith { //Nil array - no effect
+if (_effectNumber == -1) exitWith { // Nil array - no effect
     [false, []]
 };
-if (_effectNumber == 0) exitWith { //empty array - false effect
+if (_effectNumber == 0) exitWith { // Empty array - false effect
     [true, []]
 };
 
-//if no change: skip sending publicVar and events
+// If no change: skip sending publicVar and events
 private _effectBoolArray = [_effectNumber, count _statusReasons] call FUNC(binarizeNumber);
 TRACE_1("bitArray",_effectBoolArray);
 
@@ -58,5 +64,5 @@ private _activeEffects = [];
     };
 } forEach _effectBoolArray;
 
-//non-empty array - true effect
+// Mon-empty array - true effect
 [true, _activeEffects]

--- a/addons/common/functions/fnc_statusEffect_sendEffects.sqf
+++ b/addons/common/functions/fnc_statusEffect_sendEffects.sqf
@@ -29,21 +29,20 @@ if (isNull _object) exitWith {};
         //We only do anything if the effect has been defined at some point in the game for this unit
         TRACE_2("checking if event is nil",_x,_effectNumber);
         if (_effectNumber != -1) then {
-            private _eventName = format [QGVAR(%1), _x];
             switch (true) do {
                 case (GVAR(statusEffect_sendJIP) select _forEachIndex): {
                     TRACE_2("Sending Global JIP Event",_object,_effectNumber);
-                    private _jipID = format [QGVAR(effect_%1_%2), _eventName, hashValue _object];
-                    [_eventName, [_object, _effectNumber], _jipID] call CBA_fnc_globalEventJIP;
+                    private _jipID = format [QGVAR(effect_%1_%2), _effectName, hashValue _object];
+                    [_effectName, [_object, _effectNumber], _jipID] call CBA_fnc_globalEventJIP;
                     [_jipID, _object] call CBA_fnc_removeGlobalEventJIP;
                 };
                 case (GVAR(statusEffect_isGlobal) select _forEachIndex): {
                     TRACE_2("Sending Global Event",_object,_effectNumber);
-                    [_eventName, [_object, _effectNumber]] call CBA_fnc_globalEvent;
+                    [_effectName, [_object, _effectNumber]] call CBA_fnc_globalEvent;
                 };
                 default {
                     TRACE_2("Sending Target Event",_object,_effectNumber);
-                    [_eventName, [_object, _effectNumber], _object] call CBA_fnc_targetEvent;
+                    [_effectName, [_object, _effectNumber], _object] call CBA_fnc_targetEvent;
                 };
             };
         };

--- a/addons/common/functions/fnc_statusEffect_set.sqf
+++ b/addons/common/functions/fnc_statusEffect_set.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * [player, "setCaptive", "reason1", true] call ace_common_fnc_statusEffect_set
+ * [player, "ace_common_setCaptive", "reason1", true] call ace_common_fnc_statusEffect_set
  *
  * Public: Yes
  */
@@ -21,7 +21,7 @@
 params [["_object", objNull, [objNull]], ["_effectName", "", [""]], ["_ID", "", [""]], ["_set", true, [false]]];
 TRACE_4("params",_object,_effectName,_ID,_set);
 
-//Only run this after the settings are initialized
+// Only run this after the settings are initialized
 if !(GVAR(settingsInitFinished)) exitWith {
     TRACE_1("pushing to runAtSettingsInitialized",_this);
     GVAR(runAtSettingsInitialized) pushBack [FUNC(statusEffect_set), _this];
@@ -29,9 +29,15 @@ if !(GVAR(settingsInitFinished)) exitWith {
 
 if (isNull _object) exitWith {TRACE_1("null",_object);};
 
-[_object, true] call FUNC(statusEffect_resetVariables); //Check for mismatch, and set object ref
+// BWC: Status effect names used to not be prefixed
+if (_effectName in STATUS_EFFECTS_BWC) then {
+    TRACE_1("Deprecated effect name used",_effectName);
+    _effectName = format [QGVAR(%1), _effectName];
+};
 
-//check ID case and set globally if not already set:
+[_object, true] call FUNC(statusEffect_resetVariables); // Check for mismatch, and set object ref
+
+// Check ID case and set globally if not already set:
 _ID = toLowerANSI _ID;
 private _statusReasons = missionNamespace getVariable [(format [QGVAR(statusEffects_%1), _effectName]), []];
 private _statusIndex = _statusReasons find _ID;
@@ -46,13 +52,13 @@ private _effectNumber = _object getVariable [_effectVarName, -1];
 TRACE_2("current",_effectVarName,_effectNumber);
 
 if ((_effectNumber == -1) && {!_set}) exitWith {
-    //Optimization for modules that always set an ID to false even if never set true
+    // Optimization for modules that always set an ID to false even if never set true
     TRACE_2("Set False on nil array, exiting",_set,_effectNumber);
 };
 
 if (_effectNumber == -1) then {_effectNumber = 0}; //reset (-1/nil) to 0
 
-//if no change: skip sending publicVar and events
+// If no change: skip sending publicVar and events
 private _effectBoolArray = [_effectNumber, count _statusReasons] call FUNC(binarizeNumber);
 TRACE_2("bitArray",_statusIndex,_effectBoolArray);
 if (_set isEqualTo (_effectBoolArray select _statusIndex)) exitWith {
@@ -61,7 +67,7 @@ if (_set isEqualTo (_effectBoolArray select _statusIndex)) exitWith {
 
 TRACE_2("Setting to new value",_set,_effectBoolArray select _statusIndex);
 _effectBoolArray set [_statusIndex, _set];
-private _newEffectNumber = _effectBoolArray call FUNC(toBitmask); //Convert array back to number
+private _newEffectNumber = _effectBoolArray call FUNC(toBitmask); // Convert array back to number
 
 TRACE_2("Saving globally",_effectVarName,_newEffectNumber);
 _object setVariable [_effectVarName, _newEffectNumber, true];
@@ -69,5 +75,5 @@ _object setVariable [_effectVarName, _newEffectNumber, true];
 if (_effectNumber == 0 || {_newEffectNumber == 0}) then {
     [_object, _effectName] call FUNC(statusEffect_sendEffects);
 } else {
-    LOG("not sending more than once");
+    LOG("Not sending more than once");
 };

--- a/addons/common/functions/fnc_statusEffect_set.sqf
+++ b/addons/common/functions/fnc_statusEffect_set.sqf
@@ -30,7 +30,7 @@ if !(GVAR(settingsInitFinished)) exitWith {
 if (isNull _object) exitWith {TRACE_1("null",_object);};
 
 // BWC: Status effect names used to not be prefixed
-if (_effectName in STATUS_EFFECTS_BWC) then {
+if (toLowerANSI _effectName in STATUS_EFFECTS_BWC) then {
     TRACE_1("Deprecated effect name used",_effectName);
     _effectName = format [QGVAR(%1), _effectName];
 };

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -32,4 +32,4 @@
 #define DIG_SURFACE_WHITELIST ["grass", "grasstall_exp", "forest_exp", "snow"]
 
 // BWC: Status effect names used to not be prefixed
-#define STATUS_EFFECTS_BWC ["forceWalk", "blockSprint", "setCaptive", "blockDamage", "blockEngine", "blockThrow", "setHidden", "blockRadio", "blockSpeaking", "disableWeaponAssembly", "lockInventory"]
+#define STATUS_EFFECTS_BWC ["forcewalk", "blocksprint", "setcaptive", "blockdamage", "blockengine", "blockthrow", "sethidden", "blockradio", "blockspeaking", "disableweaponAssembly", "lockinventory"]

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -30,3 +30,6 @@
 ]
 
 #define DIG_SURFACE_WHITELIST ["grass", "grasstall_exp", "forest_exp", "snow"]
+
+// BWC: Status effect names used to not be prefixed
+#define STATUS_EFFECTS_BWC ["forceWalk", "blockSprint", "setCaptive", "blockDamage", "blockEngine", "blockThrow", "setHidden", "blockRadio", "blockSpeaking", "disableWeaponAssembly", "lockInventory"]

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Common
 #include "\z\ace\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_COMMON

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -2,8 +2,8 @@
 #define COMPONENT_BEAUTIFIED Common
 #include "\z\ace\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_COMMON

--- a/addons/concertina_wire/functions/fnc_deploy.sqf
+++ b/addons/concertina_wire/functions/fnc_deploy.sqf
@@ -65,7 +65,7 @@ GVAR(deployPFH) = [{
         }, 0, [_wireNoGeo, _wire, _anim, _dir, _wireNoGeoPos]] call CBA_fnc_addPerFrameHandler;
 
         [_unit, "DefaultAction", _unit getVariable [QGVAR(Deploy), -1]] call EFUNC(Common,removeActionEventHandler);
-        [_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
         call EFUNC(interaction,hideMouseHint);
 
         [_idPFH] call CBA_fnc_removePerFrameHandler;
@@ -79,7 +79,7 @@ GVAR(deployPFH) = [{
 
 [LLSTRING(RollWire), "", ""] call EFUNC(interaction,showMouseHint);
 
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 GVAR(placer) setVariable [QGVAR(Deploy),
     [GVAR(placer), "DefaultAction",

--- a/addons/csw/functions/fnc_assemble_deployTripod.sqf
+++ b/addons/csw/functions/fnc_assemble_deployTripod.sqf
@@ -59,7 +59,7 @@
         };
 
         // Disable vanilla assembly until FUNC(initVehicle) runs and sets the definite value
-        [_cswTripod, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+        [_cswTripod, QEGVAR(common,disableWeaponAssembly), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
         private _posATL = _player getRelPos [2, 0];
         _posATL set [2, ((getPosATL _player) select 2) + 0.5];
@@ -70,7 +70,7 @@
 
         [_player, "PutDown"] call EFUNC(common,doGesture);
 
-        // drag after deploying
+        // Drag after deploying
         if ((missionNamespace getVariable [QGVAR(dragAfterDeploy), false]) && {["ace_dragging"] call EFUNC(common,isModLoaded)}) then {
             if ([_player, _cswTripod] call EFUNC(dragging,canCarry)) then {
                 TRACE_1("starting carry",_cswTripod);

--- a/addons/csw/functions/fnc_assemble_deployWeapon.sqf
+++ b/addons/csw/functions/fnc_assemble_deployWeapon.sqf
@@ -83,7 +83,7 @@
             };
 
             // Disable vanilla assembly until FUNC(initVehicle) runs and sets the definite value
-            [_csw, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+            [_csw, QEGVAR(common,disableWeaponAssembly), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
             _csw setDir _tripodDir;
             _csw setPosATL _tripodPos;

--- a/addons/csw/functions/fnc_initVehicle.sqf
+++ b/addons/csw/functions/fnc_initVehicle.sqf
@@ -59,7 +59,7 @@ if (_vehicle turretLocal [0]) then {
         TRACE_2("assemblyConfig present",_vehicle,_assemblyMode);
         // Disable vanilla assembly if assemblyMode enabled
         // Need to wait to allow setting object vars during assembly, but since this function runs 1 second after vehicle init, it can run immediately
-        [_vehicle, "disableWeaponAssembly", QUOTE(ADDON), _assemblyMode] call EFUNC(common,statusEffect_set);
+        [_vehicle, QEGVAR(common,disableWeaponAssembly), QUOTE(ADDON), _assemblyMode] call EFUNC(common,statusEffect_set);
     };
 };
 

--- a/addons/dragging/XEH_postInit.sqf
+++ b/addons/dragging/XEH_postInit.sqf
@@ -156,8 +156,8 @@ if (isNil QGVAR(maxWeightCarryRun)) then {
     private _canRun = [_weight] call FUNC(canRun_carry);
 
     // Force walking based on weight
-    [_owner, "forceWalk", QUOTE(ADDON), !_canRun] call EFUNC(common,statusEffect_set);
-    [_owner, "blockSprint", QUOTE(ADDON), _canRun] call EFUNC(common,statusEffect_set);
+    [_owner, QEGVAR(common,forceWalk), QUOTE(ADDON), !_canRun] call EFUNC(common,statusEffect_set);
+    [_owner, QEGVAR(common,blockSprint), QUOTE(ADDON), _canRun] call EFUNC(common,statusEffect_set);
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(draggingContainerClosed), {

--- a/addons/dragging/functions/fnc_dragObject.sqf
+++ b/addons/dragging/functions/fnc_dragObject.sqf
@@ -86,7 +86,7 @@ if (_UAVCrew isNotEqualTo []) then {
 [LINKFUNC(dragObjectPFH), 0.5, [_unit, _target, CBA_missionTime]] call CBA_fnc_addPerFrameHandler;
 
 // Fixes not being able to move when in combat pace
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 // API
 [QGVAR(startedDrag), [_unit, _target]] call CBA_fnc_localEvent;

--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -60,7 +60,7 @@ if (_target isKindOf "CAManBase") then {
 
 _unit removeWeapon "ACE_FakePrimaryWeapon";
 
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 // Prevent object from flipping inside buildings
 if (_inBuilding && {!_isClone}) then {
@@ -99,7 +99,7 @@ if (_UAVCrew isNotEqualTo []) then {
 };
 
 // Fixes not being able to move when in combat pace
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 // Reset mass
 private _mass = _target getVariable [QGVAR(originalMass), 0];

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -73,9 +73,9 @@ if (!isNil "_previousWeaponState") then {
     _unit setVariable [QGVAR(previousWeapon), nil, true];
 };
 
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockSprint", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 // Prevent object from flipping inside buildings
 if (_inBuilding && {!_isClone}) then {

--- a/addons/dragging/functions/fnc_startCarryLocal.sqf
+++ b/addons/dragging/functions/fnc_startCarryLocal.sqf
@@ -78,11 +78,11 @@ if (_target isKindOf "CAManBase") then {
     private _canRun = _weight call FUNC(canRun_carry);
 
     // Only force walking if we're overweight
-    [_unit, "forceWalk", QUOTE(ADDON), !_canRun] call EFUNC(common,statusEffect_set);
-    [_unit, "blockSprint", QUOTE(ADDON), _canRun] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), !_canRun] call EFUNC(common,statusEffect_set);
+    [_unit, QEGVAR(common,blockSprint), QUOTE(ADDON), _canRun] call EFUNC(common,statusEffect_set);
 };
 
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 // Prevents dragging and carrying at the same time
 _unit setVariable [QGVAR(isCarrying), true, true];

--- a/addons/dragging/functions/fnc_startDragLocal.sqf
+++ b/addons/dragging/functions/fnc_startDragLocal.sqf
@@ -73,7 +73,7 @@ if (!GVAR(dragAndFire)) then {
 // Save the weapon so we can monitor if it changes
 _unit setVariable [QGVAR(currentWeapon), currentWeapon _unit];
 
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 // Can't play action that depends on weapon if it was added the same frame
 if !(_unit call EFUNC(common,isSwimming)) then {

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -29,8 +29,8 @@ if (!isClass (configFile >> "CfgVehicles" >> _setupObjectClass)) exitWith {ERROR
 private _p3dModel = getText (configFile >> "CfgVehicles" >> _setupObjectClass >> "model");
 if (_p3dModel == "") exitWith {ERROR("No Model");}; //"" - will crash game!
 
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 //Show mouse buttons:
 [localize LSTRING(PlaceAction), localize LSTRING(CancelAction), localize LSTRING(ScrollAction)] call EFUNC(interaction,showMouseHint);
@@ -149,8 +149,8 @@ GVAR(TweakedAngle) = 0;
         [_pfID] call CBA_fnc_removePerFrameHandler;
         GVAR(pfeh_running) = false;
 
-        [_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-        [_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
         [] call EFUNC(interaction,hideMouseHint);
         [_unit, "DefaultAction", (_unit getVariable [QGVAR(placeActionEH), -1])] call EFUNC(common,removeActionEventHandler);
         [_unit, "zoomtemp", (_unit getVariable [QGVAR(cancelActionEH), -1])] call EFUNC(common,removeActionEventHandler);

--- a/addons/interaction/functions/fnc_initAnimActions.sqf
+++ b/addons/interaction/functions/fnc_initAnimActions.sqf
@@ -73,8 +73,8 @@ private _statement = {
 
                         if (!isNull _object) then {
                             // Prevent items from taking damage when unloaded
-                            [_object, "blockDamage", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-                            [EFUNC(common,statusEffect_set), [_object, "blockDamage", QUOTE(ADDON), false], 2] call CBA_fnc_waitAndExecute;
+                            [_object, QEGVAR(common,blockDamage), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+                            [EFUNC(common,statusEffect_set), [_object, QEGVAR(common,blockDamage), QUOTE(ADDON), false], 2] call CBA_fnc_waitAndExecute;
 
                             _success = true;
                         } else {

--- a/addons/medical_engine/functions/fnc_updateDamageEffects.sqf
+++ b/addons/medical_engine/functions/fnc_updateDamageEffects.sqf
@@ -36,9 +36,9 @@ if (EGVAR(medical,fractures) > 0) then {
         // Block sprint / force walking based on fracture setting and leg splint status
         private _hasLegSplint = (_fractures select 4) == -1 || {(_fractures select 5) == -1};
         if (EGVAR(medical,fractures) == 2) then {
-            [_unit, "blockSprint", QEGVAR(medical,fracture), _hasLegSplint] call EFUNC(common,statusEffect_set);
+            [_unit, QEGVAR(common,blockSprint), QEGVAR(medical,fracture), _hasLegSplint] call EFUNC(common,statusEffect_set);
         } else {
-            [_unit, "forceWalk", QEGVAR(medical,fracture), _hasLegSplint] call EFUNC(common,statusEffect_set);
+            [_unit, QEGVAR(common,forceWalk), QEGVAR(medical,fracture), _hasLegSplint] call EFUNC(common,statusEffect_set);
         };
 
         if ((_fractures select 2) == -1) then { _aimFracture = _aimFracture + 2; };

--- a/addons/medical_status/functions/fnc_setStatusEffects.sqf
+++ b/addons/medical_status/functions/fnc_setStatusEffects.sqf
@@ -19,12 +19,12 @@ params ["_unit", "_set", ["_skipSetHidden", false]];
 TRACE_3("setStatusEffect",_unit,_set,_skipSetHidden);
 
 // Block radio on unconsciousness for compatibility with captive module
-[_unit, "blockRadio", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockRadio), "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
 
 // Block speaking on unconsciousness
-[_unit, "blockSpeaking", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockSpeaking), "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
 
 if (_skipSetHidden) exitWith {};
 
 // Stop AI firing at unconscious units in most situations (global effect)
-[_unit, "setHidden", "ace_unconscious", _set] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,setHidden), "ace_unconscious", _set] call EFUNC(common,statusEffect_set);

--- a/addons/rearm/functions/fnc_dropAmmo.sqf
+++ b/addons/rearm/functions/fnc_dropAmmo.sqf
@@ -38,8 +38,8 @@ if (_actionID != -1) then {
     _unit removeAction _actionID;
     _unit setVariable [QGVAR(ReleaseActionID), nil];
 };
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 if (_unholster) then {
     REARM_UNHOLSTER_WEAPON

--- a/addons/rearm/functions/fnc_grabAmmo.sqf
+++ b/addons/rearm/functions/fnc_grabAmmo.sqf
@@ -19,8 +19,8 @@
 params ["_dummy", "_unit"];
 
 REARM_HOLSTER_WEAPON;
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 [
     TIME_PROGRESSBAR(5),

--- a/addons/rearm/functions/fnc_takeSuccess.sqf
+++ b/addons/rearm/functions/fnc_takeSuccess.sqf
@@ -36,8 +36,8 @@ if (_vehicle == _unit) exitWith {
     [_unit, _magazineClass, _rounds] call EFUNC(csw,reload_handleReturnAmmo);
 };
 
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 private _dummy = [_unit, _magazineClass] call FUNC(createDummy);
 [_dummy, _unit] call FUNC(pickUpAmmo);
 

--- a/addons/refuel/functions/fnc_handleDisconnect.sqf
+++ b/addons/refuel/functions/fnc_handleDisconnect.sqf
@@ -24,4 +24,4 @@ private _nozzle = _unit getVariable [QGVAR(nozzle), objNull];
 if (isNull _nozzle) exitWith {};
 
 [_unit, _nozzle] call FUNC(dropNozzle);
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);

--- a/addons/refuel/functions/fnc_returnNozzle.sqf
+++ b/addons/refuel/functions/fnc_returnNozzle.sqf
@@ -48,7 +48,7 @@ if (isNull _nozzle || {_source != _nozzle getVariable QGVAR(source)}) exitWith {
         _source setVariable [QEGVAR(dragging,canCarry), _source getVariable [QGVAR(canCarryLast), false], true];
         _source setVariable [QEGVAR(dragging,canDrag),  _source getVariable [QGVAR(canDragLast),  false], true];
 
-        [_source, "blockEngine", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_source, QEGVAR(common,blockEngine), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
     },
     "",
     localize LSTRING(ReturnAction),

--- a/addons/refuel/functions/fnc_startNozzleInHandsPFH.sqf
+++ b/addons/refuel/functions/fnc_startNozzleInHandsPFH.sqf
@@ -23,8 +23,8 @@
 #define END_PFH \
     _unit setVariable [QGVAR(hint), nil]; \
     call EFUNC(interaction,hideMouseHint); \
-    [_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set); \
-    [_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set); \
+    [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set); \
+    [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set); \
     [_idPFH] call CBA_fnc_removePerFrameHandler;
 
 params ["_unit", "_nozzle"];

--- a/addons/refuel/functions/fnc_takeNozzle.sqf
+++ b/addons/refuel/functions/fnc_takeNozzle.sqf
@@ -70,7 +70,7 @@ params [
             if (count _attachPos == 1) then {
                 _attachPos = _attachPos select 0;
             } else {
-                // select closest hook
+                // Select closest hook
                 private _hookDistances = _attachPos apply {_unit distance (_source modelToWorld _x)};
                 _attachPos = _attachPos select (_hookDistances find selectMin _hookDistances);
             };
@@ -80,7 +80,7 @@ params [
             _nozzle setVariable [QGVAR(attachPos), _attachPos, true];
             _nozzle setVariable [QGVAR(source), _source, true];
 
-            [_source, "blockEngine", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+            [_source, QEGVAR(common,blockEngine), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
             _source setVariable [QGVAR(isConnected), true, true];
             _source setVariable [QGVAR(ownedNozzle), _nozzle, true];
 
@@ -95,13 +95,13 @@ params [
         _unit setVariable [QGVAR(nozzle), _nozzle, true];
         _unit setVariable [QGVAR(isRefueling), true];
 
-        // holster weapon
+        // Holster weapon
         _unit setVariable [QGVAR(selectedWeaponOnRefuel), currentWeapon _unit];
         _unit call EFUNC(common,fixLoweredRifleAnimation);
         _unit action ["SwitchWeapon", _unit, _unit, 299];
 
-        [_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-        [_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
         [_unit, _nozzle] call FUNC(startNozzleInHandsPFH);
     },

--- a/addons/sandbag/functions/fnc_deploy.sqf
+++ b/addons/sandbag/functions/fnc_deploy.sqf
@@ -17,16 +17,16 @@
 
 params ["_unit"];
 
-// prevent the placing unit from running
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+// Prevent the placing unit from running
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 // create the sandbag
 private _sandBag = createVehicle ["ACE_SandbagObject_NoGeo", [0, 0, 0], [], 0, "NONE"];
 
 GVAR(sandBag) = _sandBag;
 
-// prevent collisions with sandbag
+// Prevent collisions with sandbag
 [QEGVAR(common,enableSimulationGlobal), [_sandBag, false]] call CBA_fnc_serverEvent;
 
 GVAR(deployDirection) = 0;
@@ -43,7 +43,7 @@ GVAR(deployPFH) = [{
     _sandBag setDir (GVAR(deployDirection) + getDir _unit);
 }, 0, [_unit, _sandBag]] call CBA_fnc_addPerFrameHandler;
 
-// add mouse button action and hint
+// Add mouse button action and hint
 [localize LSTRING(ConfirmDeployment), localize LSTRING(CancelDeployment), localize LSTRING(ScrollAction)] call EFUNC(interaction,showMouseHint);
 
 _unit setVariable [QGVAR(Deploy), [

--- a/addons/sandbag/functions/fnc_deployCancel.sqf
+++ b/addons/sandbag/functions/fnc_deployCancel.sqf
@@ -20,18 +20,18 @@ params ["_unit", "_key"];
 
 if (_key != 1 || {GVAR(deployPFH) == -1}) exitWith {};
 
-// enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+// Enable running again
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
-// delete placement dummy
+// Delete placement dummy
 deleteVehicle GVAR(sandBag);
 
-// remove deployment pfh
+// Remove deployment pfh
 [GVAR(deployPFH)] call CBA_fnc_removePerFrameHandler;
 GVAR(deployPFH) = -1;
 
-// remove mouse button actions
+// Remove mouse button actions
 call EFUNC(interaction,hideMouseHint);
 
 [_unit, "DefaultAction", _unit getVariable [QGVAR(Deploy), -1]] call EFUNC(common,removeActionEventHandler);

--- a/addons/sandbag/functions/fnc_deployConfirm.sqf
+++ b/addons/sandbag/functions/fnc_deployConfirm.sqf
@@ -17,14 +17,14 @@
 
 params ["_unit"];
 
-// enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+// Enable running again
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
-// remove sandbag from inventory
+// Remove sandbag from inventory
 _unit removeItem "ACE_Sandbag_empty";
 
-// delete placement dummy and create real sandbag
+// Delete placement dummy and create real sandbag
 [{
     if (isNull GVAR(sandBag)) exitWith {};
 
@@ -42,16 +42,16 @@ _unit removeItem "ACE_Sandbag_empty";
     GVAR(sandBag) = objNull;
 }, [_unit], 1] call CBA_fnc_waitAndExecute;
 
-// remove deployment pfh
+// Remove deployment pfh
 [GVAR(deployPFH)] call CBA_fnc_removePerFrameHandler;
 GVAR(deployPFH) = -1;
 
-// remove mouse button actions
+// Remove mouse button actions
 call EFUNC(interaction,hideMouseHint);
 
 [_unit, "DefaultAction", _unit getVariable [QGVAR(Deploy), -1]] call EFUNC(common,removeActionEventHandler);
 
-// play animation
+// Play animation
 [_unit, "PutDown"] call EFUNC(common,doGesture);
 
 _unit setVariable [QGVAR(isDeploying), false, true];

--- a/addons/switchunits/functions/fnc_initPlayer.sqf
+++ b/addons/switchunits/functions/fnc_initPlayer.sqf
@@ -36,7 +36,7 @@ if (isNull objectParent _playerUnit) then {
     removeAllContainers _playerUnit;
     _playerUnit linkItem  "ItemMap";
 
-    [_playerUnit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+    [_playerUnit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
     [] call FUNC(addMapFunction);
 };

--- a/addons/tacticalladder/functions/fnc_cancelTLdeploy.sqf
+++ b/addons/tacticalladder/functions/fnc_cancelTLdeploy.sqf
@@ -22,9 +22,9 @@ params ["_unit", "_key"];
 
 if (_key != 1 || {isNull GVAR(ladder)}) exitWith {};
 
-// enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+// Enable running again
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 detach GVAR(ladder);
 
@@ -32,9 +32,9 @@ GVAR(ladder) animate ["rotate", 0];
 
 {
     GVAR(ladder) animate [_x, 0];
-} forEach __ANIMS; //Don't "optimize" this to a count. See #6607
+} forEach __ANIMS; // Don't "optimize" this to a count. See #6607
 
-// remove mouse buttons and hint
+// Remove mouse buttons and hint
 call EFUNC(interaction,hideMouseHint);
 
 [_unit, "DefaultAction", _unit getVariable [QGVAR(Deploy), -1]] call EFUNC(Common,removeActionEventHandler);

--- a/addons/tacticalladder/functions/fnc_confirmTLdeploy.sqf
+++ b/addons/tacticalladder/functions/fnc_confirmTLdeploy.sqf
@@ -18,9 +18,9 @@
 
 params ["_unit", "_ladder"];
 
-// enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+// Enable running again
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
 private _pos1 = getPosASL _ladder;
 private _pos2 = _ladder modelToWorldWorld (_ladder selectionPosition "check2");
@@ -29,7 +29,7 @@ if (lineIntersects [_pos1, _pos2, _ladder]) exitWith {false};
 
 detach _ladder;
 
-// remove mouse buttons and hint
+// Remove mouse buttons and hint
 call EFUNC(interaction,hideMouseHint);
 
 [_unit, "DefaultAction", _unit getVariable [QGVAR(Deploy), -1]] call EFUNC(common,removeActionEventHandler);

--- a/addons/tacticalladder/functions/fnc_positionTL.sqf
+++ b/addons/tacticalladder/functions/fnc_positionTL.sqf
@@ -20,9 +20,9 @@
 
 params ["_unit", "_ladder"];
 
-// prevent the placing unit from running
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+// Prevent the placing unit from running
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 {
     _ladder animate [_x, 0];
@@ -42,8 +42,8 @@ GVAR(cancelTime) = CBA_missionTime + 1; // Workaround to prevent accidental canc
 GVAR(currentStep) = 3;
 GVAR(currentAngle) = 0;
 
-// add mouse buttons and hints
-//private _adjustText = format ["%1, +%2", localize LSTRING(Adjust), localize LSTRING(AdjustTilt)]; // Tilting disabled due to sinking, interaction point offset and unsuitable animation
+// Add mouse buttons and hints
+// private _adjustText = format ["%1, +%2", localize LSTRING(Adjust), localize LSTRING(AdjustTilt)]; // Tilting disabled due to sinking, interaction point offset and unsuitable animation
 [localize LSTRING(Deploy), localize LSTRING(Drop), /*_adjustText*/ localize LSTRING(Adjust)] call EFUNC(interaction,showMouseHint);
 
 _unit setVariable [QGVAR(Deploy), [

--- a/addons/trenches/functions/fnc_placeCancel.sqf
+++ b/addons/trenches/functions/fnc_placeCancel.sqf
@@ -20,18 +20,18 @@ params ["_unit", "_key"];
 
 if (_key != 1 || {GVAR(digPFH) == -1}) exitWith {};
 
-// enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+// Enable running again
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
-// delete placement dummy
+// Delete placement dummy
 deleteVehicle GVAR(trench);
 
-// remove digment pfh
+// Remove digment pfh
 [GVAR(digPFH)] call CBA_fnc_removePerFrameHandler;
 GVAR(digPFH) = -1;
 
-// remove mouse button actions
+// Remove mouse button actions
 call EFUNC(interaction,hideMouseHint);
 
 [_unit, "DefaultAction", _unit getVariable [QGVAR(Dig), -1]] call EFUNC(common,removeActionEventHandler);

--- a/addons/trenches/functions/fnc_placeConfirm.sqf
+++ b/addons/trenches/functions/fnc_placeConfirm.sqf
@@ -17,15 +17,15 @@
 
 params ["_unit"];
 
-// enable running again
-[_unit, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+// Enable running again
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
-// remove dig pfh
+// Remove dig pfh
 [GVAR(digPFH)] call CBA_fnc_removePerFrameHandler;
 GVAR(digPFH) = -1;
 
-// remove mouse button actions
+// Remove mouse button actions
 call EFUNC(interaction,hideMouseHint);
 
 [_unit, "DefaultAction", _unit getVariable [QGVAR(Dig), -1]] call EFUNC(common,removeActionEventHandler);

--- a/addons/trenches/functions/fnc_placeTrench.sqf
+++ b/addons/trenches/functions/fnc_placeTrench.sqf
@@ -27,8 +27,8 @@ GVAR(trenchPlacementData) = getArray (configFile >> "CfgVehicles" >> _trenchClas
 TRACE_1("",GVAR(trenchPlacementData));
 
 // prevent the placing unit from running
-[_unit, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,forceWalk), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
 // create the trench
 private _trench = createVehicle [_noGeoModel, [0, 0, 0], [], 0, "NONE"];

--- a/addons/tripod/functions/fnc_adjust.sqf
+++ b/addons/tripod/functions/fnc_adjust.sqf
@@ -25,7 +25,7 @@ GVAR(adjustPFH) = [{
 
     if (!(_unit getVariable [QGVAR(adjusting), false]) || {isNull _tripod} || {_unit distance _tripod > 5}) exitWith {
         call EFUNC(interaction,hideMouseHint);
-        [_unit, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+        [_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
 
         [_unit, "DefaultAction", _unit getVariable [QGVAR(Adjust), -1]] call EFUNC(common,removeActionEventHandler);
 
@@ -38,7 +38,7 @@ GVAR(adjustPFH) = [{
     } forEach ["slide_down_tripod", "retract_leg_1", "retract_leg_2", "retract_leg_3"];
 }, 0, [_unit, _tripod]] call CBA_fnc_addPerFrameHandler;
 
-[_unit, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_unit, QEGVAR(common,blockThrow), QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 // add mouse button action and hint
 [LLSTRING(Done), "", LLSTRING(ScrollAction)] call EFUNC(interaction,showMouseHint);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add prefixes to status effects, i.e. `"blockDamage"` -> `QGVAR(blockDamage)`
  - BWC for all current status effects
  - Currently status effects added in another component always have `ace_common_` appended to it, see [#10462](https://github.com/acemod/ACE3/pull/10462/files#diff-f398fe1fd48c91ed2eff9cbe29fa19e0c70d11167a043863ae3edf309d87dfdaR139)
- Fix small capitalization mistakes in comments

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
