### PR TITLE
Hearing - Add Peltor-style Earpro to Headgear with a 2-Ear Headset

### DIFF
--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -100,4 +100,28 @@ class CfgWeapons {
     class H_HelmetHBK_headset_base_F: H_HelmetHBK_base_F {
         HEARING_PROTECTION_PELTOR;
     };
+
+    // Military headgear with a both-ear headset (similar to the modern INVISIO X7) should have active earpro.
+    class H_Watchcap_blk: HelmetBase {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class H_Bandanna_khk;
+    class H_Bandanna_khk_hs: H_Bandanna_khk {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class H_Booniehat_khk;
+    class H_Booniehat_khk_hs: H_Booniehat_khk {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class H_Cap_oli;
+    class H_Cap_oli_hs: H_Cap_oli {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class H_MilCap_ocamo: HelmetBase {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class H_Shemag_olive;
+    class H_Shemag_olive_hs: H_Shemag_olive {
+        HEARING_PROTECTION_PELTOR;
+    };
 };

--- a/addons/hearing/CfgWeapons.hpp
+++ b/addons/hearing/CfgWeapons.hpp
@@ -34,7 +34,7 @@ class CfgWeapons {
 
     class HelmetBase;
     class H_Cap_headphones: HelmetBase {
-        HEARING_PROTECTION_EARMUFF;
+        HEARING_PROTECTION_PELTOR;
     };
 
     class H_Construction_earprot_base_F: HelmetBase {


### PR DESCRIPTION
**When merged this pull request will:**
- Add Peltor levels of hearing protection to vanilla headgear with a "headset"
- Make the "Rangemaster Cap" an active earpro instead of passive muffling, since its model looks very much like a Peltor earmuff with microphones.

European militaries are starting to trend away from bulky Peltor earmuffs and towards more compact "earplug"-style active hearing protection like the [INVISIO X7](https://invisio.com/products/headsets/invisio-x7/) (which matches the capabilities of Peltors).

Some vanilla headgear like caps, beanies and booniehats have an added "headset" inside both ears + microphone. In the 2030s that kind of configuration would certainly provide active hearing protection.