### PR TITLE
Markers - Improve Timestamps check for GPS/UAV Terminals

### DIFF
--- a/addons/markers/functions/fnc_canTimestamp.sqf
+++ b/addons/markers/functions/fnc_canTimestamp.sqf
@@ -20,7 +20,7 @@ params [["_unit", ACE_player]];
 private _assignedItems = assignedItems _unit;
 
 private _index = _assignedItems findIf {
-    ([_x] call EFUNC(common,getItemType)) isEqualTo ["item", "watch"]
+    ([_x] call EFUNC(common,getItemType) select 1) in ["watch", "gps", "uav_terminal"]
 };
 
 _index != -1

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -227,7 +227,7 @@
             <Portuguese>Marcação de Tempo</Portuguese>
         </Key>
         <Key ID="STR_ACE_Markers_TimestampTooltipNoWatch">
-            <English>Watch Required</English>
+            <English>Watch, GPS or UAV Terminal Required</English>
             <Russian>Необходимы часы</Russian>
             <French>Une montre est requise.</French>
             <Japanese>時計が必要</Japanese>

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -233,7 +233,7 @@
             <Japanese>時計が必要</Japanese>
             <Spanish>Reloj requerido</Spanish>
             <Polish>Wymagany zegarek</Polish>
-            <German>Uhr benötigt</German>
+            <German>Uhr, GPS oder UAV Terminal benötigt</German>
             <Italian>Necessario orologio</Italian>
             <Chinesesimp>需要手表</Chinesesimp>
             <Korean>시계 필요함</Korean>


### PR DESCRIPTION
Updates the checks in the fnc_canTimestamp.sqf to also check for GPS and UAV's.

@BOT-Garry and @DartRuffian rubbed their braincells together for this one.