### PR TITLE
Scopes - Add `optic_DMS_weathered_Kir_F` ACE3 values

### DIFF
--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -173,20 +173,12 @@ class CfgWeapons {
         };
     };
 
-    class optic_DMS_weathered_F: optic_DMS {
-        class ItemInfo: ItemInfo {
-            class OpticsModes: OpticsModes {
-                class Snip: Snip {};
-            };
-        };
-    };
+    class optic_DMS_weathered_F: optic_DMS {};
 
     class optic_DMS_weathered_Kir_F: optic_DMS_weathered_F {
         class ItemInfo: ItemInfo {
             class OpticsModes: OpticsModes {
                 class Snip: Snip {
-                    // discreteDistance[] = {50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550, 600};
-                    // discreteDistanceInitIndex = 6;
                     discreteDistance[] = {100};
                     discreteDistanceInitIndex = 0;
                 };


### PR DESCRIPTION
**When merged this pull request will:**
- Add ACE3 values to the `optic_DMS_weathered_Kir_F`, same that all other DMS scopes, to have a zeroed distance at 100m, not vanilla 200m which is not the best choice for a subsonic ammunition.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
