### PR TITLE
Scopes - Add `optic_DMS_weathered_Kir_F` ACE3 windage values only

### DIFF
--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -182,13 +182,17 @@ class CfgWeapons {
     };
 
     class optic_DMS_weathered_Kir_F: optic_DMS_weathered_F {
+        ACE_ScopeAdjust_Vertical[] = {0, 0};
+        ACE_ScopeAdjust_Horizontal[] = {-6, 6};
+        ACE_ScopeAdjust_VerticalIncrement = 0;
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1;
         class ItemInfo: ItemInfo {
             class OpticsModes: OpticsModes {
                 class Snip: Snip {
-                    // discreteDistance[] = {50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550, 600};
-                    // discreteDistanceInitIndex = 6;
-                    discreteDistance[] = {100};
-                    discreteDistanceInitIndex = 0;
+                    discreteDistance[] = {50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550, 600};
+                    discreteDistanceInitIndex = 6;
+                    // discreteDistance[] = {100};
+                    // discreteDistanceInitIndex = 0;
                 };
             };
         };

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -173,29 +173,13 @@ class CfgWeapons {
         };
     };
 
-    class optic_DMS_weathered_F: optic_DMS {
-        class ItemInfo: ItemInfo {
-            class OpticsModes: OpticsModes {
-                class Snip: Snip {};
-            };
-        };
-    };
+    class optic_DMS_weathered_F: optic_DMS {};
 
     class optic_DMS_weathered_Kir_F: optic_DMS_weathered_F {
         ACE_ScopeAdjust_Vertical[] = {0, 0};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};
         ACE_ScopeAdjust_VerticalIncrement = 0;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-        class ItemInfo: ItemInfo {
-            class OpticsModes: OpticsModes {
-                class Snip: Snip {
-                    discreteDistance[] = {50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550, 600};
-                    discreteDistanceInitIndex = 6;
-                    // discreteDistance[] = {100};
-                    // discreteDistanceInitIndex = 0;
-                };
-            };
-        };
     };
 
     class optic_AMS_base: ItemCore {

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -173,6 +173,27 @@ class CfgWeapons {
         };
     };
 
+    class optic_DMS_weathered_F: optic_DMS {
+        class ItemInfo: ItemInfo {
+            class OpticsModes: OpticsModes {
+                class Snip: Snip {};
+            };
+        };
+    };
+
+    class optic_DMS_weathered_Kir_F: optic_DMS_weathered_F {
+        class ItemInfo: ItemInfo {
+            class OpticsModes: OpticsModes {
+                class Snip: Snip {
+                    // discreteDistance[] = {50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 425, 450, 475, 500, 550, 600};
+                    // discreteDistanceInitIndex = 6;
+                    discreteDistance[] = {100};
+                    discreteDistanceInitIndex = 0;
+                };
+            };
+        };
+    };
+
     class optic_AMS_base: ItemCore {
         ACE_ScopeHeightAboveRail = 3.8933;
         ACE_ScopeAdjust_Vertical[] = {0, 16};


### PR DESCRIPTION
**When merged this pull request will:**
- Add ACE3 values to the `optic_DMS_weathered_Kir_F`, **windage only**, to keep the specific `optic_DMS_weathered_Kir_F` vanilla `discreteDistance` (as a Russian BDC turret).

Screenshot basic test in-game AB enabled: 300m, compensation gyroscopic -0.7mRad: [discreteDistance 300](https://github.com/user-attachments/assets/80e469c3-6d01-41bd-88d1-68b6d8c67a5b)


### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
