### PR TITLE
Advanced Throwing - Fix multiple round grenades

### DIFF
--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -65,7 +65,7 @@ private _power = linearConversion [0, 180, _phi - 30, 1, 0.3, true];
 ACE_player setVariable [QGVAR(throwSpeed), _throwSpeed * _power];
 
 #ifdef DEBUG_MODE_FULL
-hintSilent format ["Heading: %1\nPower: %2\nSpeed: %3\nThrowMag: %4\nMuzzle: %5", _phi, _power, _throwSpeed * _power, _throwableMag, ACE_player getVariable [QGVAR(activeMuzzle), ""]];
+hintSilent format ["Heading: %1\nPower: %2\nSpeed: %3\nThrowMag: %4\nMuzzle & ammo: %5", _phi, _power, _throwSpeed * _power, _throwableMag, ACE_player getVariable [QGVAR(activeMuzzle), ["", -1]]];
 #endif
 
 private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag >> "ammo");
@@ -73,25 +73,25 @@ private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag 
 if (!([ACE_player] call FUNC(canThrow)) && {!_primed}) exitWith {
     if (!isNull _activeThrowable) then {
         deleteVehicle _activeThrowable;
-        // Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
-        ACE_player setAmmo [ACE_player getVariable [QGVAR(activeMuzzle), ""], 1];
+        // Restore muzzle ammo (setAmmo has no impact if no applicable throwable in inventory)
+        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", -1]]);
     };
 };
 
 if (isNull _activeThrowable || {(_throwableType != typeOf _activeThrowable) && {!_primed}}) then {
     if (!isNull _activeThrowable) then {
         deleteVehicle _activeThrowable;
-        // Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
-        ACE_player setAmmo [ACE_player getVariable [QGVAR(activeMuzzle), ""], 1];
+        // Restore muzzle ammo (setAmmo has no impact if no applicable throwable in inventory)
+        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", -1]]);
     };
     _activeThrowable = _throwableType createVehicleLocal [0, 0, 0];
     _activeThrowable enableSimulation false;
     ACE_player setVariable [QGVAR(activeThrowable), _activeThrowable];
 
-    // Set muzzle ammo to 0 to block vanilla throwing (can only be 0 or 1)
+    // Set muzzle ammo to 0 to block vanilla throwing
     private _muzzle = _throwableMag call FUNC(getMuzzle);
+    ACE_player setVariable [QGVAR(activeMuzzle), [_muzzle, ACE_player ammo _muzzle]];
     ACE_player setAmmo [_muzzle, 0];
-    ACE_player setVariable [QGVAR(activeMuzzle), _muzzle];
 };
 
 // Exit in case of explosion in hand

--- a/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
+++ b/addons/advanced_throwing/functions/fnc_exitThrowMode.sqf
@@ -38,13 +38,13 @@ if !(_unit getVariable [QGVAR(primed), false]) then {
     [QEGVAR(common,setShotParents), [_activeThrowable, _unit, _instigator]] call CBA_fnc_serverEvent;
 };
 
-// Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
-_unit setAmmo [_unit getVariable [QGVAR(activeMuzzle), ""], 1];
+// Restore muzzle ammo (setAmmo has no impact if no applicable throwable in inventory)
+_unit setAmmo (_unit getVariable [QGVAR(activeMuzzle), ["", -1]]);
 
 _unit setVariable [QGVAR(inHand), false];
 _unit setVariable [QGVAR(primed), false];
 _unit setVariable [QGVAR(activeThrowable), objNull];
-_unit setVariable [QGVAR(activeMuzzle), ""];
+_unit setVariable [QGVAR(activeMuzzle), ["", -1]];
 _unit setVariable [QGVAR(throwType), THROW_TYPE_DEFAULT];
 _unit setVariable [QGVAR(throwSpeed), THROW_SPEED_DEFAULT];
 _unit setVariable [QGVAR(dropMode), false];

--- a/addons/advanced_throwing/functions/fnc_prepare.sqf
+++ b/addons/advanced_throwing/functions/fnc_prepare.sqf
@@ -23,9 +23,9 @@ if (_unit getVariable [QGVAR(inHand), false]) exitWith {
     TRACE_1("inHand",_unit);
     if !(_unit getVariable [QGVAR(primed), false]) then {
         TRACE_1("not primed",_unit);
-        // Restore muzzle ammo (setAmmo 1 has no impact if no appliccable throwable in inventory)
+        // Restore muzzle ammo (setAmmo has no impact if no applicable throwable in inventory)
         // selectNextGrenade relies on muzzles array (setAmmo 0 removes the muzzle from the array and current can't be found, cycles between 0 and 1 muzzles)
-        ACE_player setAmmo [ACE_player getVariable [QGVAR(activeMuzzle), ""], 1];
+        ACE_player setAmmo (ACE_player getVariable [QGVAR(activeMuzzle), ["", -1]]);
         [_unit] call EFUNC(weaponselect,selectNextGrenade);
     };
 };

--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -23,13 +23,27 @@ _unit setVariable [QGVAR(primed), true];
 
 // Remove item before cooking to prevent weaponselect showing more throwables than there actually are in inventory
 private _throwableMag = (currentThrowable _unit) select 0;
-_unit removeItem _throwableMag;
+private _config = configFile >> "CfgMagazines" >> _throwableMag;
 
-private _throwableType = getText (configFile >> "CfgMagazines" >> _throwableMag >> "ammo");
-private _muzzle = _unit getVariable [QGVAR(activeMuzzle), ""];
+(_unit getVariable [QGVAR(activeMuzzle), ["", -1]]) params ["_muzzle", "_ammoCount"];
 
-// Set muzzle ammo to 0 to block vanilla throwing (can only be 0 or 1), removeItem above resets it
+// If there is 1 "round" left in the grenade, remove it from the player's inventory
+if (_ammoCount == 1) then {
+    // Grenade has ammo set to 0, so remove that one specifically
+    [_unit, _throwableMag, 0] call EFUNC(common,removeSpecificMagazine);
+
+    // Get ammo count of new magazine
+    _unit setVariable [QGVAR(activeMuzzle), [_muzzle, _unit ammo _muzzle]];
+} else {
+    if (_ammoCount > 1 && {getNumber (_config >> "count") > 1}) then {
+        _unit setVariable [QGVAR(activeMuzzle), [_muzzle, _ammoCount - 1]];
+    };
+};
+
+// Set muzzle ammo to 0 to block vanilla throwing, removing magazine above resets it
 _unit setAmmo [_muzzle, 0];
+
+private _throwableType = getText (_config >> "ammo");
 
 // Handle weird scripted grenades (RHS) which could cause unexpected behaviour
 private _nonInheritedCfg = configProperties [configFile >> "CfgAmmo" >> _throwableType, 'configName _x == QGVAR(replaceWith)', false];
@@ -59,8 +73,8 @@ deleteVehicle _activeThrowableOld;
 
 if (_showHint) then {
     // Show primed hint
-    private _displayNameShort = getText (configFile >> "CfgMagazines" >> _throwableMag >> "displayNameShort");
-    private _picture = getText (configFile >> "CfgMagazines" >> _throwableMag >> "picture");
+    private _displayNameShort = getText (_config >> "displayNameShort");
+    private _picture = getText (_config >> "picture");
 
     [[_displayNameShort, localize LSTRING(Primed)] joinString " ", _picture] call EFUNC(common,displayTextPicture);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Grenades with multiple rounds (e.g. SOG's `vn_v40_grenade_mag`) would not behave nicely with advanced throwing, which was hard coded to only handle grenades with 1 round.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
