### PR TITLE
Common - Add ability to check for skill levels for isMedic and isEngineer

### DIFF
--- a/addons/common/functions/fnc_isEngineer.sqf
+++ b/addons/common/functions/fnc_isEngineer.sqf
@@ -1,10 +1,12 @@
 #include "..\script_component.hpp"
 /*
- * Author: marc_book, edited by commy2
+ * Author: marc_book, commy2, DartRuffian
  * Checks if a unit is an engineer.
  *
  * Arguments:
- * 0: unit to be checked <OBJECT>
+ * 0: Unit to be checked <OBJECT>
+ * 1: Engineer level <NUMBER><OPTIONAL>
+ *    - Only relevant if ace_repair is loaded
  *
  * Return Value:
  * is the unit an engineer <BOOL>
@@ -15,10 +17,10 @@
  * Public: Yes
  */
 
-params ["_unit"];
+params ["_unit", ["_engineerN", 1]];
 
 private _isEngineer = _unit getVariable ["ACE_isEngineer", _unit getUnitTrait "engineer"];
-//Handle ace_repair modules setting this to a number
-if (_isEngineer isEqualType 0) then {_isEngineer = _isEngineer > 0};
+// Handle ace_repair modules setting this to a number
+if (_isEngineer isEqualType 0) then {_isEngineer = _isEngineer >= _engineerN};
 
 _isEngineer

--- a/addons/common/functions/fnc_isMedic.sqf
+++ b/addons/common/functions/fnc_isMedic.sqf
@@ -1,10 +1,12 @@
 #include "..\script_component.hpp"
 /*
- * Author: kymckay
+ * Author: kymckay, DartRuffian
  * Check if a unit is a medic
  *
  * Arguments:
  * 0: The Unit <OBJECT>
+ * 1: Medic level <NUMBER><OPTIONAL>
+ *    - Only relevant if ace_medical is loaded
  *
  * Return Value:
  * Unit is medic <BOOL>
@@ -15,8 +17,8 @@
  * Public: Yes
  */
 
-params ["_unit"];
+params ["_unit", ["_medicN", 1]];
 
 private _isMedic = _unit getVariable [QEGVAR(medical,medicClass), getNumber (configOf _unit >> "attendant")];
 
-_isMedic > 0
+_isMedic >= _medicN


### PR DESCRIPTION
**When merged this pull request will:**
- Add an optional parameter to `isMedic` and `isEngineer` to allow checking for specific skill levels. These are only relevant if their respective components are loaded, obviously.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
