### PR TITLE
Docs - Remove outdated Arsenal keybind warning

### DIFF
--- a/docs/wiki/feature/arsenal.md
+++ b/docs/wiki/feature/arsenal.md
@@ -81,11 +81,6 @@ Those settings cannot be overwritten by mission makers and are exclusively playe
 
 ## 3. Shortcuts
 
-<div class="panel callout">
-    <h5>Note:</h5>
-    <p><kbd>Ctrl</kbd> + <kbd>V</kbd> does NOT work in multiplayer due to a BI safety, however <kbd>Ctrl</kbd> + <kbd>C</kbd> does since it's using the ACE3 clipboard extension.</p>
-</div>
-
 ### 3.1 Outside of search bars
 
 - <kbd>Ctrl</kbd> + <kbd>C</kbd>: Export current loadout to clipboard.


### PR DESCRIPTION
**When merged this pull request will:**
- Uses the extension for reading now

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
