### PR TITLE
Arsenal - Show DLC REquirement

### DIFF
--- a/addons/arsenal/functions/fnc_addListBoxItem.sqf
+++ b/addons/arsenal/functions/fnc_addListBoxItem.sqf
@@ -48,14 +48,21 @@ if (_skip) exitWith {};
     private _configPath = ([configFile, campaignConfigFile, missionConfigFile] select _configRoot) >> _configCategory >> _className;
     private _dlcName = _configPath call EFUNC(common,getAddon);
 
+    // Get DLC requirements
+    ([_configPath] call EFUNC(common,getDLC)) params ["_dlcClass", "_dlcSteamID"];
+    private _dlcPicture = "";
+    if (_dlcClass != "") then {
+        _dlcPicture = getText (configFile >> "CfgMods" >> _dlcClass >> "logo");
+    };
+
     // If _pictureEntryName is empty, then this item has no picture (e.g. faces)
-    [configName _configPath, getText (_configPath >> "displayName"), if (_pictureEntryName == "") then {""} else {getText (_configPath >> _pictureEntryName)}, if (_dlcName != "") then {(modParams [_dlcName, ["logo"]]) param [0, ""]} else {""}]
-}, true]) params ["_className", "_displayName", "_itemPicture", "_modPicture"];
+    [configName _configPath, getText (_configPath >> "displayName"), if (_pictureEntryName == "") then {""} else {getText (_configPath >> _pictureEntryName)}, if (_dlcName != "") then {(modParams [_dlcName, ["logo"]]) param [0, ""]} else {""}, _dlcPicture]
+}, true]) params ["_className", "_displayName", "_itemPicture", "_modPicture", "_dlcPicture"];
 
 private _lbAdd = _ctrlPanel lbAdd _displayName;
 _ctrlPanel lbSetData [_lbAdd, _className];
 _ctrlPanel lbSetPicture [_lbAdd, _itemPicture];
-_ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture] select GVAR(enableModIcons)];
+_ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture, _dlcPicture] select GVAR(enableModIcons)];
 _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _className]];
 
 if ((toLowerANSI _className) in GVAR(favorites)) then {

--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -94,7 +94,7 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
                 _lbAdd = _ctrlPanel lbAdd _displayName;
                 _ctrlPanel lbSetData [_lbAdd, _x];
                 _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _x]];
-                _ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture] select GVAR(enableModIcons)];
+                _ctrlPanel lbSetPictureRight [_lbAdd, ["", _modPicture, ""] select GVAR(enableModIcons)];
             } forEach GVAR(faceCache); // HashMap, not array
 
             GVAR(currentFace)

--- a/addons/arsenal/initSettings.inc.sqf
+++ b/addons/arsenal/initSettings.inc.sqf
@@ -10,10 +10,10 @@ private _category = LLSTRING(settingCategory);
 
 [
     QGVAR(enableModIcons),
-    "CHECKBOX",
+    "LIST",
     [LSTRING(modIconsSetting), LSTRING(modIconsTooltip)],
     _category,
-    true
+    [[0,1,2], [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(DLCRequirement)], 1]
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACE">
     <Package name="Arsenal">
+        <Key ID="STR_ACE_Arsenal_DLCRequirement">
+            <English>DLC Required</English>
+            <Spanish>Requiere DLC</Spanish>
+            <French>DLC requis</French>
+            <German>DLC erforderlich</German>
+            <Polish>Wymagane DLC</Polish>
+            <Japanese>DLCが必要です</Japanese>
+            <Italian>DLC richiesto</Italian>
+            <Korean>DLC 필요</Korean>
+            <Chinese>需要DLC</Chinese>
+            <Chinesesimp>需要DLC</Chinesesimp>
+            <Russian>Требуется DLC</Russian>
+            <Portuguese>DLC necessário</Portuguese>
+            <Czech>Vyžadováno DLC</Czech>
+            <Turkish>DLC gereklidir</Turkish>
+        </Key>
         <Key ID="STR_ACE_Arsenal_buttonHideText">
             <English>Hide</English>
             <Spanish>Ocultar</Spanish>

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -73,6 +73,7 @@ PREP(getDefaultAnim);
 PREP(getDefinedVariable);
 PREP(getDefinedVariableDefault);
 PREP(getDefinedVariableInfo);
+PREP(getDLC);
 PREP(getFiremodeIndex);
 PREP(getFirstObjectIntersection);
 PREP(getFirstTerrainIntersection);

--- a/docs/src/package-lock.json
+++ b/docs/src/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "ace3",
       "version": "0.1.0",
+      "dependencies": {
+        "ace3": "file:"
+      },
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",
         "node-sass": "^9.0.0",
@@ -253,6 +256,10 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/ace3": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/acorn": {
       "version": "8.10.0",

--- a/docs/src/package.json
+++ b/docs/src/package.json
@@ -11,5 +11,8 @@
     "rollup-plugin-scss": "^4.0.0",
     "rollup-plugin-svg-icons": "^2.1.2",
     "rollup-plugin-svg-sprite-loader": "^0.0.4"
+  },
+  "dependencies": {
+    "ace3": "file:"
   }
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Adds an option to show the required DLC ownership instead of which DLC introduced the item
- I'm not sure if there are any more exceptions, RF changes the MRD model of the vanilla object, which I am imagine means it isn't DLC restricted, but I can not confirm as I own all the DLCs

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
