### PR TITLE
Ballistics - Fix `ACE_408_Ball` inheritance

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -546,7 +546,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[]={867};
         ACE_barrelLengths[]={736.6};
     };
-    class ACE_408_Ball: BulletBase {
+    class ACE_408_Ball: B_408_Ball {
         timeToLive=10;
         airFriction=-0.00065414;
         typicalSpeed=1067;


### PR DESCRIPTION
**When merged this pull request will:**
- Update `ACE_408_Ball` inheritance `BulletBase` to `B_408_Ball` to fit with terminal ballistic values:
  - class `ACE_408_Ball: BulletBase` -> `hit = 8;` and `caliber = 1;`
  - class `ACE_408_Ball: B_408_Ball` -> `hit = 24;` and `caliber = 2.4;` (`B_408_Ball` default values)

That will fix probably the low damage effect of this bullet in-game.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
