### PR TITLE
Cookoff - Fix endless loop on dead vehicles

### DIFF
--- a/addons/cookoff/XEH_postInit.sqf
+++ b/addons/cookoff/XEH_postInit.sqf
@@ -1,5 +1,7 @@
 #include "script_component.hpp"
 
+GVAR(flareHash) = createHashMap;
+
 [QGVAR(cookOffBoxLocal), LINKFUNC(cookOffBoxLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(cookOffLocal), LINKFUNC(cookOffLocal)] call CBA_fnc_addEventHandler;
 [QGVAR(engineFireLocal), LINKFUNC(engineFireLocal)] call CBA_fnc_addEventHandler;

--- a/addons/cookoff/functions/fnc_detonateAmmunitionServer.sqf
+++ b/addons/cookoff/functions/fnc_detonateAmmunitionServer.sqf
@@ -43,7 +43,7 @@ _object setVariable [QGVAR(isAmmoDetonating), true, true];
 _object setVariable [QGVAR(virtualMagazines), nil];
 
 // Save the vehicle's ammo, so it won't be removed during cook-off
-if (!GVAR(removeAmmoDuringCookoff)) then {
+if (!alive _object || !GVAR(removeAmmoDuringCookoff)) then {
     _object setVariable [QGVAR(cookoffMagazines), [_object, true] call FUNC(getVehicleAmmo)];
 };
 

--- a/addons/cookoff/functions/fnc_detonateAmmunitionServerLoop.sqf
+++ b/addons/cookoff/functions/fnc_detonateAmmunitionServerLoop.sqf
@@ -99,6 +99,10 @@ if (_removeAmmoDuringCookoff) then {
         };
         // Inventory magazines
         case (_magazineInfo isEqualTo false): {
+            if (!alive _object) exitWith {
+                TRACE_1("clearing cargo mags from dead object",alive _object);
+                clearMagazineCargoGlobal _object;
+            };
             // Remove selected magazine
             _object addMagazineAmmoCargo [_magazineClassname, -1, _ammoCount];
 

--- a/addons/cookoff/functions/fnc_isMagazineFlare.sqf
+++ b/addons/cookoff/functions/fnc_isMagazineFlare.sqf
@@ -15,12 +15,10 @@
  * Public: No
  */
 
-GVAR(flareHash) getOrDefaultCall [_this, {
-
 params ["_magazine"];
 
-private _configAmmo = configFile >> "CfgAmmo" >> getText (configFile >> "CfgMagazines" >> _magazine >> "ammo");
+GVAR(flareHash) getOrDefaultCall [_magazine, {
+    private _configAmmo = configFile >> "CfgAmmo" >> getText (configFile >> "CfgMagazines" >> _magazine >> "ammo");
 
-getNumber (_configAmmo >> "intensity") != 0 || {getNumber (_configAmmo >> QEGVAR(grenades,flare)) == 1}
-
+    getNumber (_configAmmo >> "intensity") != 0 || {getNumber (_configAmmo >> QEGVAR(grenades,flare)) == 1}
 }, true]

--- a/addons/cookoff/functions/fnc_isMagazineFlare.sqf
+++ b/addons/cookoff/functions/fnc_isMagazineFlare.sqf
@@ -15,8 +15,12 @@
  * Public: No
  */
 
+GVAR(flareHash) getOrDefaultCall [_this, {
+
 params ["_magazine"];
 
 private _configAmmo = configFile >> "CfgAmmo" >> getText (configFile >> "CfgMagazines" >> _magazine >> "ammo");
 
 getNumber (_configAmmo >> "intensity") != 0 || {getNumber (_configAmmo >> QEGVAR(grenades,flare)) == 1}
+
+}, true]


### PR DESCRIPTION
Shoot `m-atv (hmg)` with rocket

` _object addMagazineAmmoCargo [_magazineClassname, -1, _ammoCount];`
has no effect on vehicles that are not alive
so mags are never removed
and cookoff effect never ends