### PR TITLE
Nightvision - Fix when in 3den multiplayer

### DIFF
--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -37,6 +37,7 @@ GVAR(isUsingMagnification) = false;
 
     ["unit", {
         // Call manually to update existing value
+        GVAR(playerHMD) = hmd ace_player;
         [] call FUNC(refreshGoggleType);
     }, true] call CBA_fnc_addPlayerEventHandler;
 


### PR DESCRIPTION
- Launch mp from 3den
- "SlotItemChanged" event never fires

(other use of this eh in map and hearing both seem to be ok)