### PR TITLE
Fastrope/IntelItems - Fix destType

### DIFF
--- a/addons/fastroping/CfgVehicles.hpp
+++ b/addons/fastroping/CfgVehicles.hpp
@@ -97,7 +97,7 @@ class CfgVehicles {
 
     class Helicopter_Base_F;
     class ACE_friesBase: Helicopter_Base_F {
-        destrType = "";
+        destrType = "DestructNo";
         class Turrets {};
         class ACE_Actions {};
         class ACE_SelfActions {};

--- a/addons/intelitems/CfgVehicles.hpp
+++ b/addons/intelitems/CfgVehicles.hpp
@@ -19,7 +19,7 @@ class CfgVehicles {
         icon = "iconObject_2x3";
         mapSize = 0.3;
         simulation = "House"; // Needed because the objects don't have good collision physx
-        destrType = "DesturctNo";
+        destrType = "DestructNo";
         curatorInfoTypeEmpty = QGVAR(RscSetData);
         editorSubcategory = QUOTE(XADDON);
         GVAR(magazine) = "";


### PR DESCRIPTION
```
Warning: Cannot evaluate ''
âž¥ Context: bin\config.bin/CfgVehicles/ACE_friesBase.ACE_friesBase
->Last modified by: ace_fastroping
Warning: Cannot evaluate 'DesturctNo'
âž¥ Context: bin\config.bin/CfgVehicles/ace_intelitems_base.ace_intelitems_base
->Last modified by: ace_intelitems
```

not entirely sure, but this seems to be the intention
warning seems new (might only be on profiling build)