### PR TITLE
Interaction - Add Interaction to take another players launcher

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -68,6 +68,14 @@ class CfgVehicles {
                     };
                 };
 
+                class ACE_TakeLauncher {
+                    displayName = CSTRING(takeLauncher);
+                    condition = QUOTE([ARR_3(_player,_target,(secondaryWeapon _target) param [ARR_2(0,'')])] call FUNC(canTakeLauncher));
+                    statement = QUOTE([ARR_3(_player,_target,(secondaryWeapon _target) param [ARR_2(0,'')])] call FUNC(takeLauncher));
+                    exceptions[] = {"isNotSwimming"};
+                    showDisabled = 0;
+                };
+
                 class ACE_PassThrowable {
                     displayName = CSTRING(PassThrowable);
                     condition = QUOTE([ARR_3(_player,_target,(currentThrowable _player) param [ARR_2(0,'')])] call FUNC(canPassThrowable));

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -39,6 +39,8 @@ PREP(pullOutBody);
 PREP(canRenameGroup);
 PREP(renameGroupUI);
 PREP(renameGroup);
+PREP(canTakeLauncher);
+PREP(takeLauncher);
 
 // Weapon Attachments
 PREP(getWeaponAttachmentsActions);

--- a/addons/interaction/functions/fnc_canTakeLauncher.sqf
+++ b/addons/interaction/functions/fnc_canTakeLauncher.sqf
@@ -1,0 +1,27 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Timi007, Cplhardcore
+ * Checks if target unit can accept given launcher.
+ * Does not check if the launcher exists in the inventory of the player.
+ *
+ * Arguments:
+ * 0: Unit that passes the launcher <OBJECT>
+ * 1: Unit to pass the launcher to <OBJECT>
+ * 2: launcher classname <STRING>
+ *
+ * Return Value:
+ * Unit can pass launcher <BOOL>
+ *
+ * Example:
+ * [_player, _target, "launch_NLAW_F"] call ace_interaction_fnc_canTakeLauncher
+ *
+ * Public: No
+ */
+
+params ["_player", "_target", "_launcher"];
+
+if (!GVAR(enableLauncherTaking)) exitWith {false};
+if (_launcher isEqualTo "") exitWith {false};
+if ((!isNull objectParent _target) && {(vehicle _player) isNotEqualTo (vehicle _target)}) exitWith {false};
+private _hasLauncher = secondaryWeapon _target;
+if (_hasLauncher != "") exitWith {false};

--- a/addons/interaction/functions/fnc_takeLauncher.sqf
+++ b/addons/interaction/functions/fnc_takeLauncher.sqf
@@ -1,0 +1,46 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Timi007. Cplhardcore
+ * Pass launcher to another unit.
+ *
+ * Arguments:
+ * 0: Unit that passes the launcher <OBJECT>
+ * 1: Unit to pass the launcher to <OBJECT>
+ * 2: launcher classname <STRING>
+ * 3: Play passing animation <BOOL> (default: true)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_player, _target, "launch_NLAW_F"] call ace_interaction_fnc_passLauncher
+ *
+ * Public: No
+ */
+
+params ["_player", "_target", "_launcher", ["_animate", true, [true]]];
+TRACE_4("Pass launcher params",_player,_target,_launcher,_animate);
+
+if (_launcher isEqualTo "") exitWith {ERROR("No launcher specified.")};
+private _hasLauncher = secondaryWeapon _player;
+if (_hasLauncher == "") exitWith {ERROR("Cannot add launcher to target due to lack of inventory space.")};
+
+private _CfgWeapons = configFile >> "CfgWeapons" >> _launcher;
+private _attachments = _target weaponAccessories _launcher;
+private _launcherAmmo = (currentMagazine _unit) select {
+    _x in getArray (configFile >> "CfgWeapons" >> _launcherClassname >> "magazines")
+};
+_target removeWeapon _launcher;
+{
+        _unit removeMagazine _x;
+    } forEach _launcherAmmo;
+
+_player addWeapon _launcher;
+{_player addSecondaryWeaponItem _x;} forEach _attachments;
+{_unit addMagazine _x;} forEach _launcherAmmo;
+
+if (_animate) then {[_player, "PutDown"] call EFUNC(common,doGesture)};
+
+private _playerName = [_player] call EFUNC(common,getName);
+private _displayName = getText (_cfgWeapons >> "displayName");
+[QEGVAR(common,displayTextStructured), [[LSTRING(PassLauncherHint), _playerName, _displayName], 1.5, _target], [_target]] call CBA_fnc_targetEvent;

--- a/addons/interaction/initSettings.inc.sqf
+++ b/addons/interaction/initSettings.inc.sqf
@@ -78,3 +78,10 @@
     [[0, 1, 2], [ELSTRING(common,Never), LSTRING(interactWithEnemyCrew_allowCSW), ELSTRING(common,Always)], 0],
     true
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(enableLauncherTaking), "CHECKBOX",
+    LSTRING(takeLauncherSetting),
+    format ["ACE %1", LLSTRING(DisplayName)],
+    true
+] call CBA_fnc_addSetting;

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -1425,5 +1425,14 @@
             <Japanese>インタラクションから使用中の武器に対してのアタッチメント取り外しを可能にします。</Japanese>
             <Chinesesimp>启用当前武器的附加/拆卸武器配件的动作。</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Interaction_takeLauncher">
+            <English>Take Launcher</English>
+        </Key>
+        <Key ID="STR_ACE_Interaction_takeLauncherSetting">
+            <English>Allow people to take Launchers</English>
+        </Key>
+        <Key ID="STR_ACE_Interaction_PassLauncherHint">
+            <English>You took %1's %2</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
-  Allow players to take launchers off others backs, without needing to go through the inventory

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
