### PR TITLE
Explosives - Allow negative dig offsets to always apply

### DIFF
--- a/addons/explosives/functions/fnc_placeExplosive.sqf
+++ b/addons/explosives/functions/fnc_placeExplosive.sqf
@@ -57,13 +57,18 @@ if (isNumber (_magazineTrigger >> "digDistance")) then {
 
     //Get Surface Type:
     private _canDigDown = true;
-    private _surfaceType = surfaceType _pos;
-    if ((_surfaceType select [0,1]) == "#") then {_surfaceType = _surfaceType select [1, 99];};
-    if ((_surfaceType != "") || {isClass (configFile >> "CfgSurfaces" >> _surfaceType >> "soundEnviron")}) then {
-        private _soundEnviron = getText (configFile >> "CfgSurfaces" >> _surfaceType >> "soundEnviron");
-        TRACE_2("Dig Down Surface",_surfaceType,_soundEnviron);
-        _canDigDown = !(_soundEnviron in ["road", "tarmac", "concrete", "concrete_int", "int_concrete", "concrete_ext"]);
+
+    // If dig distance is negative (=> placed closer towards the sky), ignore digging requirements
+    if (_digDistance < 0) then {
+        private _surfaceType = surfaceType _pos;
+        if ((_surfaceType select [0,1]) == "#") then {_surfaceType = _surfaceType select [1, 99];};
+        if ((_surfaceType != "") || {isClass (configFile >> "CfgSurfaces" >> _surfaceType >> "soundEnviron")}) then {
+            private _soundEnviron = getText (configFile >> "CfgSurfaces" >> _surfaceType >> "soundEnviron");
+            TRACE_2("Dig Down Surface",_surfaceType,_soundEnviron);
+            _canDigDown = !(_soundEnviron in ["road", "tarmac", "concrete", "concrete_int", "int_concrete", "concrete_ext"]);
+        };
     };
+
     //Don't dig down if pos ATL is high (in a building or A2 road)
     if (_canDigDown && {(_pos select 2) < 0.1}) then {
         TRACE_2("Can Dig Down",_digDistance,_pos);


### PR DESCRIPTION
**When merged this pull request will:**
- Allows negative offset to be applied to non-diggable surfaces (e.g. in the VR world)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
