### PR TITLE
Improve - Stringtables containing Ampersands

### DIFF
--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -1591,7 +1591,7 @@
             <Chinesesimp>主镜内置</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Arsenal_statVisionMode_intPrimTi">
-            <English>Thermal &amp; Primary integrated</English>
+            <English>Thermal & Primary integrated</English>
             <French>Thermique et primaire intégrés</French>
             <Spanish>Térmica y Primaria integrada</Spanish>
             <Italian>Termico e Primario integrato</Italian>

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -283,20 +283,20 @@
             <Turkish>Sürükle / Taşı</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_EXAMINE_TREATMENT">
-            <English>EXAMINE &amp; TREATMENT</English>
-            <Czech>VYŠETŘENÍ &amp; LÉČBA</Czech>
-            <French>EXAMENS &amp; TRAITEMENTS</French>
-            <Spanish>EXAMINAR &amp; TRATAMIENTO</Spanish>
-            <Italian>ESAMINA &amp; TRATTA</Italian>
-            <Polish>BADANIE &amp; LECZENIE</Polish>
-            <Portuguese>EXAMINAR &amp; TRATAMENTO</Portuguese>
+            <English>EXAMINE & TREATMENT</English>
+            <Czech>VYŠETŘENÍ & LÉČBA</Czech>
+            <French>EXAMENS & TRAITEMENTS</French>
+            <Spanish>EXAMINAR & TRATAMIENTO</Spanish>
+            <Italian>ESAMINA & TRATTA</Italian>
+            <Polish>BADANIE & LECZENIE</Polish>
+            <Portuguese>EXAMINAR & TRATAMENTO</Portuguese>
             <Russian>ОСМОТР И ЛЕЧЕНИЕ</Russian>
-            <German>Untersuchung &amp; Behandlung</German>
+            <German>Untersuchung & Behandlung</German>
             <Korean>검사 / 치료</Korean>
             <Japanese>診断と治療</Japanese>
-            <Chinese>檢查 &amp; 治療</Chinese>
-            <Chinesesimp>检查 &amp; 治疗</Chinesesimp>
-            <Turkish>MUAYENE &amp; TEDAVİ</Turkish>
+            <Chinese>檢查 & 治療</Chinese>
+            <Chinesesimp>检查 & 治疗</Chinesesimp>
+            <Turkish>MUAYENE & TEDAVİ</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_GUI_EnableActions_Description">
             <English>Enables medical actions for the Interaction Menu and selects their style.</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -569,18 +569,18 @@
             <Turkish>Gelişmiş Bandajlar</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedBandages_EnabledCanReopen">
-            <English>Enabled &amp; Can Reopen</English>
-            <Czech>Zapnuto &amp; Úrazy se mohou znovu otevřít</Czech>
-            <French>Activé &amp; peuvent se rouvrir</French>
+            <English>Enabled & Can Reopen</English>
+            <Czech>Zapnuto & Úrazy se mohou znovu otevřít</Czech>
+            <French>Activé & peuvent se rouvrir</French>
             <Spanish>Habilitada y pueden reabrirse</Spanish>
             <Italian>Attivi e possono riaprirsi</Italian>
-            <Polish>Aktywne &amp; możliwe ponowne otwarcie</Polish>
+            <Polish>Aktywne & możliwe ponowne otwarcie</Polish>
             <Portuguese>Habilitado e pode reabrir</Portuguese>
             <Russian>Включено и может открыться заново</Russian>
             <German>Aktiviert und können sich wieder öffnen</German>
             <Korean>활성화 및 붕대 풀림 구현</Korean>
-            <Japanese>有効 &amp; 再開放</Japanese>
-            <Chinesesimp>已启用 &amp; 可以伤口开裂</Chinesesimp>
+            <Japanese>有効 & 再開放</Japanese>
+            <Chinesesimp>已启用 & 可以伤口开裂</Chinesesimp>
             <Turkish>Etkinleştirildi ve Yeniden Açılabilir</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_Description">
@@ -600,27 +600,27 @@
             <Turkish>Genel Teşhis eylemi yerine Nabzı Kontrol Et, Kan Basıncını Kontrol Et ve Yanıtı Kontrol Et tedavi eylemlerini etkinleştirir. \ Devre dışı bırakıldığında, CPR eylemi yalnızca CPR gerçekleştirilmesi uygun olduğunda gösterilecektir.</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_DiagnoseCardiacArrest">
-            <English>Enabled &amp; Can Diagnose Death/Cardiac Arrest</English>
-            <French>Activé &amp; Diagnostic du décès/de l'arrêt cardiaque</French>
+            <English>Enabled & Can Diagnose Death/Cardiac Arrest</English>
+            <French>Activé & Diagnostic du décès/de l'arrêt cardiaque</French>
             <Spanish>Habilitado y poder diagnosticar Muerte/Parada cardíaca</Spanish>
             <Italian>Abilitato e può diagnosticare Morte/Arresto Cardiaco</Italian>
             <Polish>Włączone i pozwala zdiagnozować Śmierć/Zatrzymanie Akcji Serca</Polish>
             <Portuguese>Habilitado e permite diagnosticar morte/parada cardíaca</Portuguese>
             <Russian>Включено и может диагностировать смерть/остановку сердца</Russian>
-            <German>Aktiviert &amp; kann Tod/Herzstillstand diagnostizieren</German>
+            <German>Aktiviert & kann Tod/Herzstillstand diagnostizieren</German>
             <Korean>활성화 및 사망/심정지 진찰 가능</Korean>
-            <Japanese>有効 &amp; 死亡/心停止状態を診断可能</Japanese>
-            <Chinesesimp>已启用 &amp; 可以诊断死亡/心搏骤停</Chinesesimp>
+            <Japanese>有効 & 死亡/心停止状態を診断可能</Japanese>
+            <Chinesesimp>已启用 & 可以诊断死亡/心搏骤停</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_DiagnoseCardiacArrestDirect">
-            <English>Enabled &amp; Can Diagnose Death/Cardiac Arrest [Directly]</English>
-            <French>Activé &amp; peut diagnostiquer la mort/l'arrêt cardiaque [Direct].</French>
+            <English>Enabled & Can Diagnose Death/Cardiac Arrest [Directly]</English>
+            <French>Activé & peut diagnostiquer la mort/l'arrêt cardiaque [Direct].</French>
             <Spanish>Habilitado y poder diagnosticar Muerte/Parada cardíaca [Directamente]</Spanish>
             <Italian>Abilitato e può diagnosticare Morte/Arresto Cardiaco [Esplicito]</Italian>
             <Russian>Включено и может диагностировать смерть/остановку сердца [Напрямую]</Russian>
-            <German>Aktiviert &amp; kann Tod/Herzstillstand diagnostizieren [Direkt]</German>
+            <German>Aktiviert & kann Tod/Herzstillstand diagnostizieren [Direkt]</German>
             <Korean>활성화 및 사망/심정지 진찰 가능 [직접]</Korean>
-            <Japanese>有効 &amp; 死亡/心停止状態を診断可能 [直接的に]</Japanese>
+            <Japanese>有効 & 死亡/心停止状態を診断可能 [直接的に]</Japanese>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AdvancedDiagnose_DisplayName">
             <English>Advanced Diagnose</English>
@@ -4767,9 +4767,9 @@
             <Hungarian>Sebészeti készlet használata</Hungarian>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_VehiclesAndFacilities">
-            <English>Vehicles &amp; Facilities</English>
+            <English>Vehicles & Facilities</English>
             <Czech>Zdravotnická zařízení a vozidla</Czech>
-            <French>Véhicules &amp; installations sanitaires</French>
+            <French>Véhicules & installations sanitaires</French>
             <Spanish>Vehículos e instalaciones médicas</Spanish>
             <Italian>Veicoli e strutture</Italian>
             <Polish>Pojazdy i Obiekty</Polish>
@@ -4777,9 +4777,9 @@
             <Russian>Техника и госпитали</Russian>
             <German>Fahrzeuge und Einrichtungen</German>
             <Korean>의료 차량 및 시설</Korean>
-            <Japanese>車両 &amp; 施設</Japanese>
+            <Japanese>車両 & 施設</Japanese>
             <Chinese>車輛與設施</Chinese>
-            <Chinesesimp>载具&amp;设施</Chinesesimp>
+            <Chinesesimp>载具&设施</Chinesesimp>
             <Turkish>Araçlar ve Tesisler</Turkish>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_VeryLightlyWounded">

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -660,7 +660,7 @@
             <Hungarian>Ka-60 Kasatka (fegyvertelen)</Hungarian>
         </Key>
         <Key ID="STR_ACE_RealisticNames_Heli_Light_02_v2_Name">
-            <English>Ka-60 Kasatka (Black &amp; White)</English>
+            <English>Ka-60 Kasatka (Black & White)</English>
             <Czech>Ka-60 Kasatka (černobílá)</Czech>
             <French>Ka-60 Kasatka (noir et blanc)</French>
             <Spanish>Ka-60 Kasatka (blanco y negro)</Spanish>
@@ -670,10 +670,10 @@
             <Russian>Ka-60 Касатка (чёрно-белый)</Russian>
             <German>Ka-60 Kasatka (Schwarz-weiß)</German>
             <Korean>Ka-60 카사트카 (검정 및 하양)</Korean>
-            <Japanese>Ka-60 カサートカ (ブラック &amp; ホワイト)</Japanese>
-            <Chinese>Ka-60 "逆戟鯨"直升機 (黑&amp;白)</Chinese>
+            <Japanese>Ka-60 カサートカ (ブラック & ホワイト)</Japanese>
+            <Chinese>Ka-60 "逆戟鯨"直升機 (黑&白)</Chinese>
             <Chinesesimp>Ka-60 "虎鲸"（黑白）</Chinesesimp>
-            <Turkish>Ka-60 Kasatka (Siyah &amp; Beyaz)</Turkish>
+            <Turkish>Ka-60 Kasatka (Siyah & Beyaz)</Turkish>
         </Key>
         <Key ID="STR_ACE_RealisticNames_Heli_Transport_02_Name">
             <English>AW101 Merlin</English>

--- a/docs/wiki/feature/vector.md
+++ b/docs/wiki/feature/vector.md
@@ -86,7 +86,7 @@ The Vector is controlled with 2 keys: the azimuth key and the range key; <kbd>Ta
 - Sight the circle on the object and tap <kbd>R</kbd> while further holding <kbd>Tab&nbsp;↹</kbd>. The first measurement is confirmed ("1-P" = first point).
 - Sight the Fall of shot and release <kbd>Tab&nbsp;↹</kbd>. The left digits display the left (`L`)/right (`r`) correction value in meter and the right digits display the longer (`A` = add)/shorter (`d` = drop) correction value in meter. If <kbd>R</kbd> is tapped the height correction values will be displayed (`UP` and `dn`).
 
-#### 2.10 Setting the measurement units (degrees/mils &amp; meters/feet)
+#### 2.10 Setting the measurement units (degrees/mils & meters/feet)
 
 - Tap <kbd>Tab&nbsp;↹</kbd> five times fast. "Unit SEtt" appears briefly.
 - Press <kbd>R</kbd> until the desired units are displayed.


### PR DESCRIPTION
**When merged this pull request will:**
-During a prior PR, unknown which, all Ampersands were changed to `&`amp;`
- This PR reverts that to how it is in the current ACE release
### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
