### PR TITLE
extension - allow static_mut_refs

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![deny(missing_debug_implementations)]
+#![allow(static_mut_refs)]
 
 //! ACE3 Extension for quick maths and OS APIs
 


### PR DESCRIPTION
suppress the warnings (I think this becoming a `deny` in 1.85)