### PR TITLE
Arsenal - Add Incomplete Loadout Tooltips

### DIFF
--- a/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
+++ b/addons/arsenal/functions/fnc_fillLoadoutsList.sqf
@@ -104,6 +104,11 @@ if (GVAR(currentLoadoutsTab) != IDC_buttonSharedLoadouts) then {
         } else {
             if (_unavailableItemsList isNotEqualTo []) then {
                 _contentPanelCtrl lnbSetColor [[_newRow, 1], [1, 1, 1, 0.25]]; // Gray
+                if GVAR(unavailableItemsTooltip) then {
+                    private _unavailableItemsUnique = [];
+                    {_unavailableItemsUnique pushBackUnique _x} forEach _unavailableItemsList;
+                    _contentPanelCtrl lnbSetTooltip [[_newRow, 1],(format ["Missing Items: %1",_unavailableItemsUnique])]; 
+                };
             };
         };
 

--- a/addons/arsenal/initSettings.inc.sqf
+++ b/addons/arsenal/initSettings.inc.sqf
@@ -17,6 +17,14 @@ private _category = LLSTRING(settingCategory);
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(unavailableItemsTooltip),
+    "CHECKBOX",
+    LLSTRING(unavailableItemsTooltip),
+    _category,
+    false
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(fontHeight),
     "SLIDER",
     [LSTRING(fontHeightSetting), LSTRING(fontHeightTooltip)],

--- a/addons/arsenal/stringtable.xml
+++ b/addons/arsenal/stringtable.xml
@@ -952,6 +952,9 @@
             <Chinesesimp>反转摄影机控制</Chinesesimp>
             <Turkish>Kamera kontrollerini ters çevir</Turkish>
         </Key>
+        <Key ID="STR_ACE_Arsenal_unavailableItemsTooltip">
+            <English>Unavailable Items Tooltip</English>
+        </Key>
         <Key ID="STR_ACE_Arsenal_loadoutDeleted">
             <English>The following loadout was deleted:</English>
             <Czech>Tato sada vybavení byla smazána:</Czech>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds CBA option for incomplete loadout tooltips
- Will give a tooltip for each unique item that is missing from the arsenal (Not working on null items is intended)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
