### PR TITLE
Compat RF - Fix UBC

### DIFF
--- a/addons/compat_rf/compat_rf_realisticnames/CfgVehicles.hpp
+++ b/addons/compat_rf/compat_rf_realisticnames/CfgVehicles.hpp
@@ -97,7 +97,7 @@ class CfgVehicles {
     class Pickup_comms_base_rf: Pickup_service_base_rf {
         displayName = SUBCSTRING(pickup_01_comms_Name);
     };
-    class Pickup_repair_ig_base_rf: Pickup_repair_base_rf {
+    class Pickup_repair_ig_base_rf: Pickup_service_base_old_rf {
         displayName = SUBCSTRING(pickup_01_repair_Name);
     };
     class Pickup_covered_base_rf: Pickup_service_base_rf {


### PR DESCRIPTION
```
Updating base class Pickup_service_base_old_rf->Pickup_repair_base_rf, by z\ace\addons\compat_rf\compat_rf_realisticnames\config.cpp/CfgVehicles/Pickup_repair_ig_base_rf/ (original lxRF\vehicles_rf\pickup_01\config.bin)

