### PR TITLE
Translations - Add German

### DIFF
--- a/addons/cargo/stringtable.xml
+++ b/addons/cargo/stringtable.xml
@@ -268,12 +268,14 @@
             <English>Check Cargo Size</English>
             <French>Vérifier la taille de la cargaison</French>
             <Russian>Проверить размер груза</Russian>
+            <German>Prüfe Frachtgröße</German>
             <Korean>화물 크기 확인</Korean>
             <Japanese>貨物の大きさを確認</Japanese>
         </Key>
         <Key ID="STR_ACE_Cargo_checkSizeInteraction">
             <English>Show Check Cargo Size Interaction</English>
             <Russian>Вкл. проверку размера груза</Russian>
+            <German>Zeige Interaktion zum Prüfen der Frachtgröße</German>
             <Japanese>貨物の大きさを確認のインタラクションを表示</Japanese>
             <Korean>화물 크기 확인 상호작용 표시</Korean>
             <French>Afficher l'interaction de confirmation de la taille de la cargaison</French>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1796,11 +1796,13 @@
         <Key ID="STR_ACE_Common_magneticDeclination">
             <English>Realistic Compass Declination</English>
             <French>Déclinaison réaliste de la boussole</French>
+            <German>Realistische Missweisung des Kompasses</German>
             <Japanese>現実的なコンパス偏角</Japanese>
         </Key>
         <Key ID="STR_ACE_Common_magneticDeclinationooltip">
             <English>Compass will point to magnetic north</English>
             <French>La boussole indique le nord magnétique</French>
+            <German>Der Kompass zeigt nach missweisend Nord</German>
             <Japanese>コンパスが磁北を指すようになります</Japanese>
         </Key>
         <Key ID="STR_ACE_Common_playerOnly">

--- a/addons/field_rations/stringtable.xml
+++ b/addons/field_rations/stringtable.xml
@@ -1284,12 +1284,14 @@
         </Key>
         <Key ID="STR_ACE_Field_Rations_ZeusUpdates_Description">
             <English>If enabled, hunger and thirst will continue to increase while the Zeus interface is open.</English>
+            <German>Wenn aktiviert, werden Hunger und Durst bei geöffnetem Zeus-Interface weiter zunehmen.</German>
             <Japanese>有効化すると、空腹と渇きはZeusインタフェイスを開いている間も継続して進行します。</Japanese>
             <Korean>활성화 시 제우스 인터페이스가 열려 있는 동안 허기와 갈증이 계속 증가합니다.</Korean>
             <French>Si cette option est activée, la faim et la soif continueront d'augmenter tant que l'interface Zeus sera ouverte.</French>
         </Key>
         <Key ID="STR_ACE_Field_Rations_ZeusUpdates_DisplayName">
             <English>Update Hunger and Thirst in Zeus</English>
+            <German>Zunehmender Hunger und Durst im Zeus</German>
             <Japanese>Zeus時に空腹と渇きを進行させる</Japanese>
             <Korean>제우스의 허기와 갈증 업데이트</Korean>
             <French>Mise à jour Faim et soif dans Zeus</French>

--- a/addons/frag/stringtable.xml
+++ b/addons/frag/stringtable.xml
@@ -122,7 +122,7 @@
             <Polish>Symulacja odprysków</Polish>
             <Portuguese>Simulação de estilhaços</Portuguese>
             <Russian>Симуляция обломков</Russian>
-            <German>Explosionssimulation</German>
+            <German>Simulation von Spreng- und Wurfstücken</German>
             <Korean>파편 시뮬레이션</Korean>
             <Japanese>スポーリング シミュレーション</Japanese>
             <Chinese>模擬剝落</Chinese>
@@ -138,7 +138,7 @@
             <Polish>Aktywuje symulację odprysków ACE</Polish>
             <Portuguese>Ativa a simulação de estilhaços do ACE</Portuguese>
             <Russian>Включить симуляцию обломков ACE</Russian>
-            <German>Aktiviere ACE-Explosionssimulation</German>
+            <German>Aktiviere die ACE Simulation von Spreng- und Wurfstücken</German>
             <Korean>ACE 파편 시뮬레이션을 적용합니다.</Korean>
             <Japanese>ACE スポーリング シミュレーションを有効化</Japanese>
             <Chinese>啟用ACE模擬剝落</Chinese>
@@ -185,7 +185,7 @@
             <Spanish>Intensidad del astillamiento</Spanish>
             <Italian>Intensità dello spalling</Italian>
             <Russian>Интенсивность обрушения</Russian>
-            <German>Intensität der Abplatzungen</German>
+            <German>Intensität der Wurfstücke</German>
             <Korean>파편 강도</Korean>
             <Japanese>スポーリング強度</Japanese>
         </Key>
@@ -195,7 +195,7 @@
             <Spanish>Modificador para aumentar o disminuir el número y la intensidad de los eventos de astillamiento. Aumentar este valor puede producir una degradación en el rendimiento.</Spanish>
             <Italian>Modificatore per il numero e intensità di spalling simulato, ovvero la frammentazione interna ad un veicolo colpito. Valori alti possono causare una degradazione della performance.</Italian>
             <Russian>Модификатор для увеличения или уменьшения количества и интенсивности событий обрушения. Увеличение этого значения может привести к ухудшению производительности.</Russian>
-            <German>Ein Modifikator, der die Anzahl und Intensität von Abplatzungen erhöht oder verringert. Eine Erhöhung dieses Wertes kann zu Leistungseinbußen führen.</German>
+            <German>Ein Modifikator, der die Anzahl und Intensität der Wurfstücke erhöht oder verringert. Eine Erhöhung dieses Wertes kann zu Leistungseinbußen führen.</German>
             <Korean>파편 이벤트 수와 강도를 늘리거나 줄입니다. 이 값을 늘리면 성능이 저하될 수 있습니다.</Korean>
             <Japanese>スポーリング現象が発生する数と強度を増減することが出来ます。この値を大きくすることはパフォーマンスの低下につながる可能性があります。</Japanese>
         </Key>

--- a/addons/frag/stringtable.xml
+++ b/addons/frag/stringtable.xml
@@ -37,7 +37,7 @@
             <Spanish>Trazado Debug de Fragmentación/Astillamiento</Spanish>
             <Italian>Traccia Frag/Spall per Debug</Italian>
             <Russian>Отладка трассировки фрагментации/осколков</Russian>
-            <German>Splitter-/Explosions-Debug-Verfolgung</German>
+            <German>Debug-Verfolgung von Splitter und Wurfstücke</German>
             <Korean>파열/파편 디버그 추적</Korean>
             <Japanese>フラグとスポールの追跡デバッグ</Japanese>
         </Key>
@@ -47,7 +47,7 @@
             <Spanish>Habilitar trazado visual de los proyectiles generados por la fragmentación y el astillamiento.</Spanish>
             <Italian>Abilita il tracciamento visivo di effetti di frammentazione e spalling.</Italian>
             <Russian>Включает визуальную трассировку фрагментации и осколочных снарядов.</Russian>
-            <German>Aktiviert die visuelle Verfolgung von Splittern.</German>
+            <German>Aktiviert die visuelle Verfolgung von Splittern und Wurfstücken.</German>
             <Korean>파열과 파편의 시각적 추적을 활성화합니다.</Korean>
             <Japanese>フラグメンテーションとスポーリングによって発生した破片飛翔体の動きを視覚的に追跡できる機能を有効化します。</Japanese>
         </Key>
@@ -151,6 +151,7 @@
             <Spanish>Dibujar Esferas de Eventos</Spanish>
             <Italian>Visualizza sfere eventi</Italian>
             <Russian>Изобразить сферы событий</Russian>
+            <German>Visualisiere Ereigniskugeln</German>
             <Korean>이벤트 구체 그리기</Korean>
             <Japanese>イベントを球体として描画</Japanese>
         </Key>
@@ -160,6 +161,7 @@
             <Spanish>Dibujar esferas codificadas por color en cualquier evento para proyectiles seguidos.</Spanish>
             <Italian>Visualizza sfere colorate su ogni evento di un frammento tracciato.</Italian>
             <Russian>Изобразить цветные сферы на любом событии для отслеживаемых раундов.</Russian>
+            <German>Zeige bei jedem Ereignis farbige Kugeln für verfolgte Wurfstücke.</German>
             <Korean>모든 이벤트에서 추적된 파편을 위한 색상으로 구분하는 구체를 그립니다.</Korean>
             <Japanese>追跡中の飛翔体に発生した全てのイベントを色付けた球体として描画します。</Japanese>
         </Key>

--- a/addons/frag/stringtable.xml
+++ b/addons/frag/stringtable.xml
@@ -7,6 +7,7 @@
             <Spanish>Debug</Spanish>
             <Italian>Debug</Italian>
             <Russian>Отладка</Russian>
+            <German>Debug</German>
             <Korean>디버그</Korean>
             <Japanese>デバッグ</Japanese>
         </Key>
@@ -16,6 +17,7 @@
             <Spanish>Dibujar hitboxes</Spanish>
             <Italian>Visualizza hitbox</Italian>
             <Russian>Изобразить хитбоксы</Russian>
+            <German>Zeige Hitboxen</German>
             <Korean>히트박스 그리기</Korean>
             <Japanese>ヒットボックスを描画</Japanese>
         </Key>
@@ -25,7 +27,7 @@
             <Spanish>Dibuja hitboxes en objetos que son seguidos.</Spanish>
             <Italian>Visualizza hitbox su potenziali bersagli della frammentazione.</Italian>
             <Russian>Изобразить хитбоксы на объектах, которые были нацелены.</Russian>
-            <German>Splitter-/Explosions-Debugging</German>
+            <German>Zeige Hitboxen von Zielobjekten</German>
             <Korean>타겟팅된 오브젝트에 히트박스를 그립니다.</Korean>
             <Japanese>被弾した物体のヒットボックスを描画します。</Japanese>
         </Key>
@@ -45,7 +47,7 @@
             <Spanish>Habilitar trazado visual de los proyectiles generados por la fragmentación y el astillamiento.</Spanish>
             <Italian>Abilita il tracciamento visivo di effetti di frammentazione e spalling.</Italian>
             <Russian>Включает визуальную трассировку фрагментации и осколочных снарядов.</Russian>
-            <German>Splitter-/Explosions-Debugging</German>
+            <German>Aktiviert die visuelle Verfolgung von Splittern.</German>
             <Korean>파열과 파편의 시각적 추적을 활성화합니다.</Korean>
             <Japanese>フラグメンテーションとスポーリングによって発生した破片飛翔体の動きを視覚的に追跡できる機能を有効化します。</Japanese>
         </Key>
@@ -183,6 +185,7 @@
             <Spanish>Intensidad del astillamiento</Spanish>
             <Italian>Intensità dello spalling</Italian>
             <Russian>Интенсивность обрушения</Russian>
+            <German>Intensität der Abplatzungen</German>
             <Korean>파편 강도</Korean>
             <Japanese>スポーリング強度</Japanese>
         </Key>
@@ -192,6 +195,7 @@
             <Spanish>Modificador para aumentar o disminuir el número y la intensidad de los eventos de astillamiento. Aumentar este valor puede producir una degradación en el rendimiento.</Spanish>
             <Italian>Modificatore per il numero e intensità di spalling simulato, ovvero la frammentazione interna ad un veicolo colpito. Valori alti possono causare una degradazione della performance.</Italian>
             <Russian>Модификатор для увеличения или уменьшения количества и интенсивности событий обрушения. Увеличение этого значения может привести к ухудшению производительности.</Russian>
+            <German>Ein Modifikator, der die Anzahl und Intensität von Abplatzungen erhöht oder verringert. Eine Erhöhung dieses Wertes kann zu Leistungseinbußen führen.</German>
             <Korean>파편 이벤트 수와 강도를 늘리거나 줄입니다. 이 값을 늘리면 성능이 저하될 수 있습니다.</Korean>
             <Japanese>スポーリング現象が発生する数と強度を増減することが出来ます。この値を大きくすることはパフォーマンスの低下につながる可能性があります。</Japanese>
         </Key>

--- a/addons/goggles/stringtable.xml
+++ b/addons/goggles/stringtable.xml
@@ -23,6 +23,7 @@
             <Korean>고글 오버레이 표시</Korean>
             <French>Afficher la superposition des lunettes</French>
             <Russian>Показать оверлей очков</Russian>
+            <German>Zeige Schutzbrillenoberfläche</German>
         </Key>
         <Key ID="STR_ACE_Goggles_SettingShowClearGlasses">
             <English>Show Wipe Goggles self interaction</English>

--- a/addons/hearing/stringtable.xml
+++ b/addons/hearing/stringtable.xml
@@ -172,7 +172,7 @@
             <Polish>Możliwość chwilowej utraty słuchu przy głośnych wystrzałach i jednoczesnym braku włożonych stoperów</Polish>
             <Portuguese>Ativar surdez em combate?</Portuguese>
             <Russian>Уменьшает возможность игрока слышать звуки при повреждении органов слуха</Russian>
-            <German>Verringert das Hörvermögen wenn der Spieler einen Hörschaden davonträg</German>
+            <German>Verringert das Hörvermögen, wenn der Spieler Hörschäden erleidet</German>
             <Korean>청력에 손상을 입으면 듣는 소리가 감소합니다.</Korean>
             <Japanese>プレイヤーが聴覚にダメージを受けると聴力が低下します</Japanese>
             <Chinese>當玩家聽力受損時降低聽力能力?</Chinese>
@@ -352,6 +352,7 @@
         <Key ID="STR_ACE_Hearing_explosionDeafnessCoefficient_Description">
             <English>Changes how much deafness explosions cause.\nSetting to 0 will disable explosion hearing damage.</English>
             <Russian>Изменяет степень глухоты, вызываемой взрывами.\nУстановка значения 0 отключает повреждение слуха при взрыве.</Russian>
+            <German>Ändert den Grad der Taubheit, den Explosionen verursachen.\nEin Wert von 0 deaktiviert von Explosionen verursachten Hörschäden.</German>
             <Korean>폭발로 인한 청력 상실 정도를 변경합니다.\n0으로 설정하면 폭발에도 청력을 온전히 유지할 수 있습니다.</Korean>
             <Japanese>爆発による聴力低下の程度を変更します。\n0に設定することで爆発による聴力低下を無効化できます。</Japanese>
             <French>Modifie le degré de surdité causé par les explosions.\nLa valeur 0 désactive les dégâts auditifs causés par les explosions.</French>
@@ -359,6 +360,7 @@
         <Key ID="STR_ACE_Hearing_explosionDeafnessCoefficient_DisplayName">
             <English>Explosion Deafness Coefficient</English>
             <Russian>Коэффициент оглушения при взрыве</Russian>
+            <German>Koeffizient für Taubheit bei Explosionen</German>
             <Korean>폭발 난청 계수</Korean>
             <Japanese>爆発による難聴発生係数</Japanese>
             <French>Coefficient de surdité à l'explosion</French>
@@ -406,6 +408,7 @@
         </Key>
         <Key ID="STR_ACE_Hearing_statEHP">
             <English>ELECTRONIC</English>
+            <German>ELEKTRONISCH</German>
             <Japanese>電子聴覚保護</Japanese>
         </Key>
         <Key ID="STR_ACE_Hearing_unconsciousnessVolume_Description">

--- a/addons/hitreactions/stringtable.xml
+++ b/addons/hitreactions/stringtable.xml
@@ -4,6 +4,7 @@
         <Key ID="STR_ACE_HitReactions_minDamageToTrigger_Description">
             <English>If a unit takes more damage than this setting's value whilst moving on foot, they will fall over.\nIf set to -1 the mechanic is turned off.</English>
             <Russian>Если при передвижении пешком юнит получит больше урона, чем указано в этой настройке,то он упадет.\nЕсли установлено значение -1, механика отключается.</Russian>
+            <German>Wenn eine Einheit zu Fuß mehr Schaden als diesen Wert erleidet, stürzt sie.\nBei einem Wert von -1, ist diese Mechanik ausgeschaltet.</German>
             <Korean>유닛이 도보로 이동하는 동안 이 설정 값보다 많은 대미지를 입으면 넘어집니다.\n-1로 설정하면 이 기능은 꺼집니다.</Korean>
             <Japanese>徒歩で移動中のユニットが設定値を超えるダメージを受けると転倒します。\n-1に設定することでこの機能を無効化できます。</Japanese>
             <French>Si une unité subit plus de dégâts que la valeur de ce paramètre alors qu'elle se déplace à pied, elle tombera à la renverse.\nSi le paramètre est réglé sur -1 le mécanisme est désactivé.</French>

--- a/addons/interaction/stringtable.xml
+++ b/addons/interaction/stringtable.xml
@@ -999,6 +999,7 @@
             <Spanish>Interacción con animaciones</Spanish>
             <Italian>Interazione con animazioni</Italian>
             <Russian>Взаимодействие с анимациями</Russian>
+            <German>Interaktion mit Animationen</German>
             <Korean>애니메이션 있는 상호작용</Korean>
             <Japanese>車両アニメーションベースのインタラクション</Japanese>
         </Key>
@@ -1337,6 +1338,7 @@
             <Spanish>Limita algunas interacciones en vehículos tripulador por facciones enemigas.</Spanish>
             <Italian>Limita alcune interazioni su veicoli con nemici a bordo.</Italian>
             <Russian>Ограничьте некоторые взаимодействия на транспортных средствах, управляемых вражеской стороной.</Russian>
+            <German>Beschränkt einige Interaktionen auf Fahrzeuge, die von feindlichen Fraktionen besetzt sind.</German>
             <Korean>적 진영이 탑승한 차량과의 일부 상호작용을 제한합니다.</Korean>
             <Japanese>敵性力の乗員が乗っている車両へのインタラクションを一部制限します。</Japanese>
         </Key>
@@ -1346,6 +1348,7 @@
             <Spanish>Interactuar Con Tripulación Enemiga</Spanish>
             <Italian>Interazioni con equipaggio nemico</Italian>
             <Russian>Взаимодействие с вражеским экипажем</Russian>
+            <German>Interaktion mit feindlicher Besatzung</German>
             <Korean>적 승무원과의 상호작용</Korean>
             <Japanese>敵乗員がいる状態でのインタラクト</Japanese>
         </Key>
@@ -1355,6 +1358,7 @@
             <Spanish>Permitir para Armas Estáticas</Spanish>
             <Italian>Permetti con armi statiche</Italian>
             <Russian>Разрешить использование статического оружия</Russian>
+            <German>Erlaube für statische Waffen</German>
             <Korean>고정화기 허용</Korean>
             <Japanese>固定火器での許可</Japanese>
         </Key>
@@ -1377,6 +1381,7 @@
             <Spanish>Permite abandonar y cambiar el color del equipo de cualquier unidad en la escuadra del jugador</Spanish>
             <Italian>Permetti di cambiare il colore o rimuovere una qualsiasi unità della propria squadra</Italian>
             <Russian>Позволяет сбрасывать и менять командные цвета любого подразделения в отряде игрока</Russian>
+            <German>Erlaubt das Ändern der Teamfarbe einer beliebigen Einheit in der Gruppe des Spielers</German>
             <Korean>플레이어 분대의 모든 유닛을 삭제하고 팀 색상 변경하는 것을 허용합니다.</Korean>
             <Japanese>プレイヤー分隊内の任意のユニットにチームからの脱退と色の変更を許可します</Japanese>
         </Key>
@@ -1386,6 +1391,7 @@
             <Spanish>Gestión Remota de Escuadra</Spanish>
             <Italian>Gestione squadra da remoto</Italian>
             <Russian>Дистанционное управление отрядом</Russian>
+            <German>Fernverwaltung von Gruppen</German>
             <Korean>분대 원격 관리</Korean>
             <Japanese>遠隔分隊管理</Japanese>
         </Key>

--- a/addons/maverick/stringtable.xml
+++ b/addons/maverick/stringtable.xml
@@ -8,6 +8,7 @@
                 <Spanish>AGM-65 Maverick D</Spanish>
                 <Italian>AGM-65 Maverick D</Italian>
                 <Russian>AGM-65 Maverick D</Russian>
+                <German>AGM-65 Maverick D</German>
                 <Korean>AGM-65 매버릭 D</Korean>
                 <Japanese>AGM-65 マーベリック D</Japanese>
             </Key>
@@ -17,6 +18,7 @@
                 <Spanish>AGM-65 Maverick D [ACE]</Spanish>
                 <Italian>AGM-65 Maverick D [ACE]</Italian>
                 <Russian>AGM-65 Maverick D [ACE]</Russian>
+                <German>AGM-65 Maverick D [ACE]</German>
                 <Korean>AGM-65 매버릭 D [ACE]</Korean>
                 <Japanese>AGM-65 マーベリック D [ACE]</Japanese>
             </Key>
@@ -26,6 +28,7 @@
                 <Spanish>3x AGM-65 Maverick D [ACE]</Spanish>
                 <Italian>3x AGM-65 Maverick D [ACE]</Italian>
                 <Russian>3x AGM-65 Maverick D [ACE]</Russian>
+                <German>3x AGM-65 Maverick D [ACE]</German>
                 <Korean>3x AGM-65 매버릭 D [ACE]</Korean>
                 <Japanese>3x AGM-65 マーベリック D [ACE]</Japanese>
             </Key>
@@ -35,6 +38,7 @@
                 <Spanish>AGM-65 Maverick G</Spanish>
                 <Italian>AGM-65 Maverick G</Italian>
                 <Russian>AGM-65 Maverick G</Russian>
+                <German>AGM-65 Maverick G</German>
                 <Korean>AGM-65 매버릭 G</Korean>
                 <Japanese>AGM-65 マーベリック G</Japanese>
             </Key>
@@ -44,6 +48,7 @@
                 <Spanish>AGM-65 Maverick G [ACE]</Spanish>
                 <Italian>AGM-65 Maverick G [ACE]</Italian>
                 <Russian>AGM-65 Maverick G [ACE]</Russian>
+                <German>AGM-65 Maverick G [ACE]</German>
                 <Korean>AGM-65 매버릭 G [ACE]</Korean>
                 <Japanese>AGM-65 マーベリック G [ACE]</Japanese>
             </Key>
@@ -53,6 +58,7 @@
                 <Spanish>2x AGM-65 Maverick G [ACE]</Spanish>
                 <Italian>2x AGM-65 Maverick G [ACE]</Italian>
                 <Russian>2x AGM-65 Maverick G [ACE]</Russian>
+                <German>2x AGM-65 Maverick G [ACE]</German>
                 <Korean>2x AGM-65 매버릭 G [ACE]</Korean>
                 <Japanese>2x AGM-65 マーベリック G [ACE]</Japanese>
             </Key>
@@ -62,6 +68,7 @@
                 <Spanish>3x AGM-65 Maverick G [ACE]</Spanish>
                 <Italian>3x AGM-65 Maverick G [ACE]</Italian>
                 <Russian>3x AGM-65 Maverick G [ACE]</Russian>
+                <German>3x AGM-65 Maverick G [ACE]</German>
                 <Korean>3x AGM-65 매버릭 G [ACE]</Korean>
                 <Japanese>3x AGM-65 マーベリック G [ACE]</Japanese>
             </Key>

--- a/addons/medical_damage/stringtable.xml
+++ b/addons/medical_damage/stringtable.xml
@@ -846,6 +846,7 @@
         <Key ID="STR_ACE_Medical_Damage_limbDamageThreshold_Description">
             <English>Sets the amount of damage limbs can receive before going critical, leading to death. Must be over 0 for any effect.\nRequires the "Use Limb Damage" setting to be enabled and "Fatal Damage Source" to be set to "Sum of Trauma" or "Either".\nStacks multiplicatively with the overall unit Damage Threshold. Doesn't interact with fractures/limping at all.</English>
             <Russian>Устанавливает величину урона, который могут получить конечности, прежде чем урон станет критическим, что приведет к смерти. Для любого эффекта должно быть больше 0.\nТребуется, чтобы настройка "Использовать урон конечностям" была включена, а "Причина смертельного урона" была установлена на "Совокупность травмы" или "Оба".\nУмножается с общим порогом повреждения. Никак не взаимодействует с переломами или хроманием.</Russian>
+            <German>Legt die Menge an Gliedmaßenschaden fest, bevor sie kritisch werden und zum Tod führen. Muss über 0 liegen, um einen Effekt zu bewirken.\nDie Einstellung "Verwende Gliedmaßenschaden" muss aktiviert und "Quelle für tödlichen Schaden" muss auf "Summe aller Traumata" oder "Beide" eingestellt sein.\nStapelt sich multiplikativ mit der Gesamtschadensschwelle der Einheit. Interagiert nicht mit Brüchen/Humpeln.</German>
             <Japanese>致命的状態となり死亡する前に手足が受けられるダメージの量を設定します。\n効果の発動には0より大きい数字に設定する必要があります。\n"手足のダメージを使用" 設定を有効化した上で "致命ダメージの原因" を "外傷の合計" または "どちらか" に設定する必要があります。\nユニット全体のダメージしきい値に対して乗算的に上乗せされます。 骨折や足の引きずり(跛行)とは無関係です。</Japanese>
             <Korean>치명적인 상태가 되어 죽음에 이르기 전까지 사지에 받는 피해량을 설정합니다. 효과가 생기려면 값이 0보다 커야 합니다.\n"사지 피해 사용" 설정을 활성화하고 "치명상의 원인"을 "외상 중첩" 또는 "둘 다"로 설정해야 합니다.\n전체 유닛 피해량 임계값과 곱해져서 누적됩니다. 골절/절뚝거림과는 전혀 상관 없습니다.</Korean>
             <French>Définit la quantité de dégâts que les membres peuvent recevoir avant de devenir critiques et d'entraîner la mort. Doit être supérieur à 0 pour avoir un effet.\nIl faut que le paramètre « Utiliser les dommages aux membres » soit activé et que « Cause de blessure mortelle » soit réglé sur « Somme des traumatismes » ou « Les deux ».\nS'empile de façon multiplicative avec le seuil de dégâts de l'unité globale. N'interagit pas du tout avec les fractures et le boitement.</French>
@@ -853,6 +854,7 @@
         <Key ID="STR_ACE_Medical_Damage_limbDamageThreshold_DisplayName">
             <English>Limb Damage Threshold</English>
             <Russian>Порог повреждения конечностей</Russian>
+            <German>Schwellenwert für Gliedmaßenschaden</German>
             <Japanese>手足のダメージしきい値</Japanese>
             <Korean>사지 피해량 임계값</Korean>
             <French>Seuil de dommages aux membres</French>
@@ -860,6 +862,7 @@
         <Key ID="STR_ACE_Medical_Damage_uselimbDamage_Description">
             <English>Controls whether limb damage is taken into account for sum of trauma calculations.</English>
             <Russian>Определяет, учитывается ли повреждение конечностей при расчете совокупности травм.</Russian>
+            <German>Steuert, ob Gliedmaßenschäden bei der Berechnung der Summe aller Traumata berücksichtigt werden.</German>
             <Japanese>"外傷の合計" の計算に手足のダメージを考慮するかどうかを制御します。</Japanese>
             <Korean>외상 중첩을 계산할 때 사지 피해량을 고려할지 여부를 제어합니다.</Korean>
             <French>Contrôle si les dommages aux membres sont pris en compte dans les calculs de la somme des traumatismes.</French>
@@ -867,6 +870,7 @@
         <Key ID="STR_ACE_Medical_Damage_uselimbDamage_DisplayName">
             <English>Use Limb Damage</English>
             <Russian>Использовать урон конечностям</Russian>
+            <German>Verwende Gliedmaßenschaden</German>
             <Japanese>手足のダメージを使用</Japanese>
             <Korean>사지 피해 사용</Korean>
             <French>Utiliser les dommages aux membres</French>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -3081,6 +3081,7 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationAdenosine_Description">
             <English>Controls where Adenosine can be used.</English>
             <Russian>Контролирует, где можно использовать Аденозин.</Russian>
+            <German>Legt fest, wo Adenosin benutzt werden kann.</German>
             <Japanese>アデノシンが使える場所を制御します。</Japanese>
             <Korean>아데노신을 사용할 수 있는 장소를 정합니다.</Korean>
             <French>Contrôle où l'Adénosine peut être utilisée.</French>
@@ -3088,6 +3089,7 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationAdenosine_DisplayName">
             <English>Locations Adenosine</English>
             <Russian>Места использования Аденозина</Russian>
+            <German>Orte für Adenosin</German>
             <Japanese>アデノシンの使用可能な場所</Japanese>
             <Korean>아데노신 사용 장소</Korean>
             <French>Lieux d'utilisation de l'adénosine</French>
@@ -3101,7 +3103,7 @@
             <Polish>Kontroluje, gdzie można stosować epinefrynę.</Polish>
             <Portuguese>Controla onde Epinefrina pode ser utilizada.</Portuguese>
             <Russian>Контролирует, где можно использовать Адреналин.</Russian>
-            <German>Legt fest, wo Epinephrin genutzt werden kann.</German>
+            <German>Legt fest, wo Epinephrin benutzt werden kann.</German>
             <Korean>에피네프린을 사용할 수 있는 장소를 정합니다.</Korean>
             <Japanese>アドレナリンが使える場所を制御します。</Japanese>
             <Chinese>控制何處能使用腎上腺素</Chinese>
@@ -3153,6 +3155,7 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationMorphine_Description">
             <English>Controls where Morphine can be used.</English>
             <Russian>Контролирует, где можно использовать Морфин.</Russian>
+            <German>Legt fest, wo Morphin benutzt werden kann.</German>
             <Japanese>モルヒネが使える場所を制御します。</Japanese>
             <Korean>모르핀을 사용할 수 있는 장소를 정합니다.</Korean>
             <French>Contrôle où la morphine peut être utilisée.</French>
@@ -3160,6 +3163,7 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationMorphine_DisplayName">
             <English>Locations Morphine</English>
             <Russian>Места использования Морфина</Russian>
+            <German>Orte für Morphin</German>
             <Japanese>モルヒネの使用可能な場所</Japanese>
             <Korean>모르핀 사용 장소</Korean>
             <French>Lieux d'utilisation de la morphine</French>
@@ -3173,7 +3177,7 @@
             <Polish>Kontroluje, gdzie można korzystać z apteczek osobistych.</Polish>
             <Portuguese>Controla onde o KPS pode ser utilizado.</Portuguese>
             <Russian>Контролирует, где можно использовать Аптечку.</Russian>
-            <German>Kontrolliert, wo ein Erste-Hilfe-Set benutzt werden kann.</German>
+            <German>Legt fest, wo ein Erste-Hilfe-Set benutzt werden kann.</German>
             <Korean>개인응급키트을 사용할 수 있는 장소를 정합니다.</Korean>
             <Japanese>PAKが使える場所を制御します。</Japanese>
             <Chinese>控制何處能使用個人急救包</Chinese>
@@ -3200,6 +3204,7 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationSplint_Description">
             <English>Controls where Splints can be used.</English>
             <Russian>Контролирует, где можно использовать шины.</Russian>
+            <German>Legt fest, wo eine Schiene benutzt werden kann.</German>
             <Japanese>添え木が使える場所を制御します。</Japanese>
             <Korean>부목을 사용할 수 있는 장소를 정합니다.</Korean>
             <French>Contrôle l'endroit où les attelles peuvent être utilisées.</French>
@@ -3207,6 +3212,7 @@
         <Key ID="STR_ACE_Medical_Treatment_LocationSplint_DisplayName">
             <English>Locations Splint</English>
             <Russian>Места наложения шины</Russian>
+            <German>Orte für Schiene</German>
             <Japanese>添え木の使用可能な場所</Japanese>
             <Korean>부목 사용 장소</Korean>
             <French>Emplacement des attelles</French>
@@ -3220,7 +3226,7 @@
             <Polish>Kontroluje, gdzie można użyć Zestawu Chirurgicznego.</Polish>
             <Portuguese>Controle onde o Kit Cirúrgico pode ser utilizado.</Portuguese>
             <Russian>Контролирует, где можно использовать Хирургический набор</Russian>
-            <German>Legt fest, wo ein Operations-Set genutzt werden kann.</German>
+            <German>Legt fest, wo ein Operations-Set benutzt werden kann.</German>
             <Korean>봉합 키트를 사용할 수 있는 장소를 정합니다.</Korean>
             <Japanese>手術キットが使える場所を制御します。</Japanese>
             <Chinese>控制何處能使用手術包</Chinese>
@@ -3293,6 +3299,7 @@
         <Key ID="STR_ACE_Medical_Treatment_MedicAdenosine_Description">
             <English>Training level required to use Adenosine.</English>
             <Russian>Уровень подготовки, необходимый для использования Аденозина</Russian>
+            <German>'Fähigkeiten-Level', das benötigt wird, um Adenosin zu benutzen.</German>
             <Japanese>アデノシンの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Korean>아데노신을 사용하는데 필요한 등급을 정합니다.</Korean>
             <French>Niveau de formation requis pour utiliser l'Adénosine.</French>
@@ -3300,6 +3307,7 @@
         <Key ID="STR_ACE_Medical_Treatment_MedicAdenosine_DisplayName">
             <English>Allow Adenosine</English>
             <Russian>Доступ к Аденозину</Russian>
+            <German>Erlaube Adenosin</German>
             <Japanese>アデノシンの許可</Japanese>
             <Korean>아데노신 사용 허가</Korean>
             <French>Autoriser l'adénosine</French>
@@ -3313,7 +3321,7 @@
             <Polish>Poziom wyszkolenia wymagany do korzystania z epinefryny.</Polish>
             <Portuguese>É necessária uma qualificação médica para usar epinefrina.</Portuguese>
             <Russian>Уровень подготовки, необходимый для использования Адреналина.</Russian>
-            <German>'Fähigkeiten-Level', das benötigt wird, um Epinephrin zu nutzen.</German>
+            <German>'Fähigkeiten-Level', das benötigt wird, um Epinephrin zu benutzen.</German>
             <Korean>에피네프린을 사용하는데 필요한 등급을 정합니다.</Korean>
             <Japanese>アドレナリンの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>要受過何種程度的醫療訓練才可以使用腎上腺素</Chinese>
@@ -3369,6 +3377,7 @@
         <Key ID="STR_ACE_Medical_Treatment_MedicMorphine_Description">
             <English>Training level required to use Morphine.</English>
             <Russian>Уровень подготовки, необходимый для использования Морфина.</Russian>
+            <German>'Fähigkeiten-Level', das benötigt wird, um Morphin zu benutzen.</German>
             <Japanese>モルヒネの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Korean>모르핀을 사용하는데 필요한 등급을 정합니다.</Korean>
             <French>Niveau de formation requis pour l'utilisation de la morphine.</French>
@@ -3376,6 +3385,7 @@
         <Key ID="STR_ACE_Medical_Treatment_MedicMorphine_DisplayName">
             <English>Allow Morphine</English>
             <Russian>Доступ к Морфину</Russian>
+            <German>Erlaube Morphin</German>
             <Japanese>モルヒネの許可</Japanese>
             <Korean>모르핀 사용 허가</Korean>
             <French>Autoriser la morphine</French>
@@ -3389,7 +3399,7 @@
             <Polish>Poziom wyszkolenia wymagany do korzystania z apteczek osobistych.</Polish>
             <Portuguese>É necessária uma qualificação médica para usar KPS</Portuguese>
             <Russian>Уровень подготовки, необходимый для использования Аптечки.</Russian>
-            <German>'Fähigkeiten-Level', das benötigt wird, um ein Erste-Hilfe-Set zu nutzen.</German>
+            <German>'Fähigkeiten-Level', das benötigt wird, um ein Erste-Hilfe-Set zu benutzen.</German>
             <Korean>개인응급키트을 사용하는 데 필요한 등급을 정합니다.</Korean>
             <Japanese>PAKの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>要受過何種程度的醫療訓練才可以使用個人急救包</Chinese>
@@ -3416,6 +3426,7 @@
         <Key ID="STR_ACE_Medical_Treatment_MedicSplint_Description">
             <English>Training level required to use Splint.</English>
             <Russian>Уровень подготовки, необходимый для использования шины.</Russian>
+            <German>'Fähigkeiten-Level', das benötigt wird, um eine Schiene zu benutzen.</German>
             <Japanese>添え木の使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Korean>부목을 사용하는데 필요한 등급을 정합니다.</Korean>
             <French>Niveau de formation requis pour l'utilisation de l'attelle.</French>
@@ -3423,6 +3434,7 @@
         <Key ID="STR_ACE_Medical_Treatment_MedicSplint_DisplayName">
             <English>Allow Splint</English>
             <Russian>Доступ к наложению шины</Russian>
+            <German>Erlaube Schiene</German>
             <Japanese>添え木の許可</Japanese>
             <Korean>부목 사용 허가</Korean>
             <French>Accès aux attelles</French>
@@ -3436,7 +3448,7 @@
             <Polish>Poziom wyszkolenia wymagany do korzystania z Zestawu Chirurgicznego.</Polish>
             <Portuguese>É necessária uma qualificação médica para usar Kit Cirúrgico</Portuguese>
             <Russian>Уровень медицинской подготовки, необходимый для использования Хирургического набора.</Russian>
-            <German>'Fähigkeiten-Level', das benötigt wird um ein Operations-Set zu nutzen.</German>
+            <German>'Fähigkeiten-Level', das benötigt wird um ein Operations-Set zu benutzen.</German>
             <Korean>봉합 키트를 사용하는데 필요한 등급을 정합니다.</Korean>
             <Japanese>手術キットの使用に必要な医療スキルのレベルを設定します。</Japanese>
             <Chinese>要受過多少程度的醫療訓練才能使用手術包。</Chinese>
@@ -3594,6 +3606,7 @@
         <Key ID="STR_ACE_Medical_Treatment_NumericalPulse_Description">
             <English>Makes Check Pulse action give a numerical value based on setting</English>
             <Russian>Заставляет действие контрольного импульса выдавать числовое значение, основанное на настройке</Russian>
+            <German>Die Aktion "Puls überprüfen" liefert einen numerischen Wert abhängig von der Einstellung</German>
             <Japanese>脈拍の確認アクションから得られる情報が数値化されるようになる医療レベルを設定します</Japanese>
             <Korean>설정에 따라 맥박 확인 행동을 통해 숫자로 표시된 값을 제공합니다.</Korean>
             <French>L'action de vérification du pouls fournit une valeur numérique, en fonction de vos paramètres.</French>
@@ -3601,6 +3614,7 @@
         <Key ID="STR_ACE_Medical_Treatment_NumericalPulse_DisplayName">
             <English>Numerical Pulse</English>
             <Russian>Числовое значение пульса</Russian>
+            <German>Numerischer Puls</German>
             <Japanese>脈拍の数値化</Japanese>
             <Korean>맥박 수치</Korean>
             <French>Pouls numérique</French>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -974,6 +974,7 @@
         <Key ID="STR_ACE_Medical_Treatment_AllowSharedEquipment_PriorityMedicIfMedic">
             <English>Medic's Equipment First [If medic role]</English>
             <Russian>Сначала медикаменты врача [Если медик]</Russian>
+            <German>Ausrüstung des Sanitäters zuerst [Wenn Sanitäter]</German>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_AllowSharedEquipment_PriorityPatient">
             <English>Patient's Equipment First</English>

--- a/addons/missile_aim120/stringtable.xml
+++ b/addons/missile_aim120/stringtable.xml
@@ -6,78 +6,91 @@
             <French>AIM-120A [ACE]</French>
             <Japanese>AIM-120A [ACE]</Japanese>
             <Russian>AIM-120A [ACE]</Russian>
+            <German>AIM-120A [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_a_1x">
             <English>1x AIM-120A [ACE]</English>
             <French>1x AIM-120A [ACE]</French>
             <Japanese>1x AIM-120A [ACE]</Japanese>
             <Russian>1x AIM-120A [ACE]</Russian>
+            <German>1x AIM-120A [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_aim120">
             <English>AIM-120 [ACE]</English>
             <French>AIM-120 [ACE]</French>
             <Japanese>AIM-120 [ACE]</Japanese>
             <Russian>AIM-120 [ACE]</Russian>
+            <German>AIM-120 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_c">
             <English>AIM-120C [ACE]</English>
             <French>AIM-120C [ACE]</French>
             <Japanese>AIM-120C [ACE]</Japanese>
             <Russian>AIM-120C [ACE]</Russian>
+            <German>AIM-120C [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_c_1x">
             <English>1x AIM-120C [ACE]</English>
             <French>1x AIM-120C [ACE]</French>
             <Japanese>1x AIM-120C [ACE]</Japanese>
             <Russian>1x AIM-120C [ACE]</Russian>
+            <German>1x AIM-120C [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_c_2x">
             <English>2x AIM-120C [ACE]</English>
             <French>2x AIM-120C [ACE]</French>
             <Japanese>2x AIM-120C [ACE]</Japanese>
             <Russian>2x AIM-120C [ACE]</Russian>
+            <German>2x AIM-120C [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_d">
             <English>AIM-120D [ACE]</English>
             <French>AIM-120D [ACE]</French>
             <Japanese>AIM-120D [ACE]</Japanese>
             <Russian>AIM-120D [ACE]</Russian>
+            <German>AIM-120D [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_d_1x">
             <English>1x AIM-120D [ACE]</English>
             <French>1x AIM-120D [ACE]</French>
             <Japanese>1x AIM-120D [ACE]</Japanese>
             <Russian>1x AIM-120D [ACE]</Russian>
+            <German>1x AIM-120D [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_d_2x">
             <English>2x AIM-120D [ACE]</English>
             <French>2x AIM-120D [ACE]</French>
             <Japanese>2x AIM-120D [ACE]</Japanese>
             <Russian>2x AIM-120D [ACE]</Russian>
+            <German>2x AIM-120D [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_direct">
             <English>Direct</English>
             <French>Direct</French>
             <Japanese>ダイレクト</Japanese>
             <Russian>Прямой</Russian>
+            <German>Direct</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_loft">
             <English>Loft</English>
             <French>Loft</French>
             <Japanese>ロフト</Japanese>
             <Russian>Сверху</Russian>
+            <German>Loft</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_r77">
             <English>R-77 [ACE]</English>
             <French>R-77 [ACE]</French>
             <Japanese>R-77 [ACE]</Japanese>
             <Russian>R-77 [ACE]</Russian>
+            <German>R-77 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM120_r77_1x">
             <English>1x R-77 [ACE]</English>
             <French>1x R-77 [ACE]</French>
             <Japanese>1x R-77 [ACE]</Japanese>
             <Russian>1x R-77 [ACE]</Russian>
+            <German>1x R-77 [ACE]</German>
         </Key>
     </Package>
 </Project>

--- a/addons/missile_aim9/stringtable.xml
+++ b/addons/missile_aim9/stringtable.xml
@@ -5,76 +5,91 @@
             <English>AIM-9M [ACE]</English>
             <Japanese>AIM-9M [ACE]</Japanese>
             <Russian>AIM-9M [ACE]</Russian>
+            <German>AIM-9M [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_x">
             <English>AIM-9X [ACE]</English>
             <Japanese>AIM-9X [ACE]</Japanese>
             <Russian>AIM-9X [ACE]</Russian>
+            <German>AIM-9X [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_aim132">
             <English>AIM-132 [ACE]</English>
             <Japanese>AIM-132 [ACE]</Japanese>
             <Russian>AIM-132 [ACE]</Russian>
+            <German>AIM-132 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_r73">
             <English>R-73 [ACE]</English>
             <Japanese>R-73 [ACE]</Japanese>
             <Russian>R-73 [ACE]</Russian>
+            <German>R-73 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_r74">
             <English>R-74 [ACE]</English>
             <Japanese>R-74 [ACE]</Japanese>
             <Russian>R-74 [ACE]</Russian>
+            <German>R-74 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_m_1x">
             <English>1x AIM-9M [ACE]</English>
             <Japanese>1x AIM-9M [ACE]</Japanese>
             <Russian>1x AIM-9M [ACE]</Russian>
+            <German>1x AIM-9M [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_m_2x">
             <English>2x AIM-9M [ACE]</English>
             <Japanese>2x AIM-9M [ACE]</Japanese>
             <Russian>2x AIM-9M [ACE]</Russian>
+            <German>2x AIM-9M [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_x_1x">
             <English>1x AIM-9X [ACE]</English>
             <Japanese>1x AIM-9X [ACE]</Japanese>
             <Russian>1x AIM-9X [ACE]</Russian>
+            <German>1x AIM-9X [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_x_2x">
             <English>2x AIM-9X [ACE]</English>
             <Japanese>2x AIM-9X [ACE]</Japanese>
             <Russian>2x AIM-9X [ACE]</Russian>
+            <German>2x AIM-9X [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_aim132_1x">
             <English>1x AIM-132 [ACE]</English>
             <Japanese>1x AIM-132 [ACE]</Japanese>
             <Russian>1x AIM-132 [ACE]</Russian>
+            <German>1x AIM-132 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_aim132_2x">
             <English>2x AIM-132 [ACE]</English>
             <Japanese>2x AIM-132 [ACE]</Japanese>
             <Russian>2x AIM-132 [ACE]</Russian>
+            <German>2x AIM-132 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_aim132_4x">
             <English>4x AIM-132 [ACE]</English>
             <Japanese>4x AIM-132 [ACE]</Japanese>
             <Russian>4x AIM-132 [ACE]</Russian>
+            <German>4x AIM-132 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_r73_1x">
             <English>1x R-73 [ACE]</English>
             <Japanese>1x R-73 [ACE]</Japanese>
             <Russian>1x R-73 [ACE]</Russian>
+            <German>1x R-73 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_r74_1x">
             <English>1x R-74 [ACE]</English>
             <Japanese>1x R-74 [ACE]</Japanese>
             <Russian>1x R-74 [ACE]</Russian>
+            <German>1x R-74 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_AIM9_r74_2x">
             <English>2x R-74 [ACE]</English>
             <Japanese>2x R-74 [ACE]</Japanese>
             <Russian>2x R-74 [ACE]</Russian>
+            <German>2x R-74 [ACE]</German>
         </Key>
     </Package>
 </Project>

--- a/addons/missile_gbu/stringtable.xml
+++ b/addons/missile_gbu/stringtable.xml
@@ -7,6 +7,7 @@
             <Spanish>GBU-12 [ACE]</Spanish>
             <Italian>GBU-12 [ACE]</Italian>
             <Russian>GBU-12 [ACE]</Russian>
+            <German>GBU-12 [ACE]</German>
             <Korean>GBU-12 [ACE]</Korean>
             <Japanese>GBU-12 [ACE]</Japanese>
         </Key>
@@ -16,6 +17,7 @@
             <Spanish>1x GBU-12 [ACE]</Spanish>
             <Italian>1x GBU-12 [ACE]</Italian>
             <Russian>1x GBU-12 [ACE]</Russian>
+            <German>1x GBU-12 [ACE]</German>
             <Korean>1x GBU-12 [ACE]</Korean>
             <Japanese>1x GBU-12 [ACE]</Japanese>
         </Key>
@@ -25,6 +27,7 @@
             <Spanish>2x GBU-12 [ACE]</Spanish>
             <Italian>2x GBU-12 [ACE]</Italian>
             <Russian>2x GBU-12 [ACE]</Russian>
+            <German>2x GBU-12 [ACE]</German>
             <Korean>2x GBU-12 [ACE]</Korean>
             <Japanese>2x GBU-12 [ACE]</Japanese>
         </Key>
@@ -34,6 +37,7 @@
             <Spanish>4x GBU-12 [ACE]</Spanish>
             <Italian>4x GBU-12 [ACE]</Italian>
             <Russian>4x GBU-12 [ACE]</Russian>
+            <German>4x GBU-12 [ACE]</German>
             <Korean>4x GBU-12 [ACE]</Korean>
             <Japanese>4x GBU-12 [ACE]</Japanese>
         </Key>
@@ -43,6 +47,7 @@
             <Spanish>FAB-250M-54 [ACE]</Spanish>
             <Italian>FAB-250M-54 [ACE]</Italian>
             <Russian>ФАБ-250M-54 [ACE]</Russian>
+            <German>FAB-250M-54 [ACE]</German>
             <Korean>FAB-250M-54 [ACE]</Korean>
             <Japanese>FAB-250M-54 [ACE]</Japanese>
         </Key>
@@ -52,6 +57,7 @@
             <Spanish>1x FAB-250M-54 [ACE]</Spanish>
             <Italian>1x FAB-250M-54 [ACE]</Italian>
             <Russian>1x ФАБ-250M-54 [ACE]</Russian>
+            <German>1x FAB-250M-54 [ACE]</German>
             <Korean>1x FAB-250M-54 [ACE]</Korean>
             <Japanese>1x FAB-250M-54 [ACE]</Japanese>
         </Key>
@@ -61,6 +67,7 @@
             <Spanish>2x FAB-250M-54 [ACE]</Spanish>
             <Italian>2x FAB-250M-54 [ACE]</Italian>
             <Russian>2x ФАБ-250M-54 [ACE]</Russian>
+            <German>2x FAB-250M-54 [ACE]</German>
             <Korean>2x FAB-250M-54 [ACE]</Korean>
             <Japanese>2x FAB-250M-54 [ACE]</Japanese>
         </Key>

--- a/addons/missile_manpad/stringtable.xml
+++ b/addons/missile_manpad/stringtable.xml
@@ -5,21 +5,25 @@
             <English>FIM-92 Stinger [ACE]</English>
             <Japanese>FIM-92 スティンガー [ACE]</Japanese>
             <Russian>FIM-92 Stinger [ACE]</Russian>
+            <German>FIM-92 Stinger [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_MANPAD_rim116">
             <English>RIM-116 [ACE]</English>
             <Japanese>RIM-116 [ACE]</Japanese>
             <Russian>RIM-116 [ACE]</Russian>
+            <German>RIM-116 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_MANPAD_rim116_21x">
             <English>21x RIM-116 [ACE]</English>
             <Japanese>21x RIM-116 [ACE]</Japanese>
             <Russian>21x RIM-116 [ACE]</Russian>
+            <German>21x RIM-116 [ACE]</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_MANPAD_stinger_4x">
             <English>4x FIM-92 Stinger [ACE]</English>
             <Japanese>4x FIM-92 スティンガー [ACE]</Japanese>
             <Russian>4x FIM-92 Stinger [ACE]</Russian>
+            <German>4x FIM-92 Stinger [ACE]</German>
         </Key>
     </Package>
 </Project>

--- a/addons/missile_sam/stringtable.xml
+++ b/addons/missile_sam/stringtable.xml
@@ -6,54 +6,63 @@
             <French>Mk-29 ESSM</French>
             <Japanese>Mk-29 ESSM</Japanese>
             <Russian>Mk-29 ESSM</Russian>
+            <German>Mk-29 ESSM</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_essm_missile">
             <English>RIM-162 ESSM</English>
             <French>RIM-162 ESSM</French>
             <Japanese>RIM-162 ESSM</Japanese>
             <Russian>RIM-162 ESSM</Russian>
+            <German>RIM-162 ESSM</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_essm_operator">
             <English>Mk-29 Operator</English>
             <French>Mk-29 Operator</French>
             <Japanese>Mk-29 操作員</Japanese>
             <Russian>Mk-29 Operator</Russian>
+            <German>Mk-29 Bediener</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_patriot">
             <English>MIM-104 Patriot</English>
             <French>MIM-104 Patriot</French>
             <Japanese>MIM-104 ペトリオット</Japanese>
             <Russian>MIM-104 Patriot</Russian>
+            <German>MIM-104 Patriot</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_patriot_missile">
             <English>Patriot Missile</English>
             <French>Patriot Missile</French>
             <Japanese>ペトリオット ミサイル</Japanese>
             <Russian>Patriot Missile</Russian>
+            <German>Patriot Rakete</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_patriot_operator">
             <English>MIM-104 Operator</English>
             <French>MIM-104 Operator</French>
             <Japanese>MIM-104 操作員</Japanese>
             <Russian>MIM-104 Operator</Russian>
+            <German>MIM-104 Bediener</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_s400">
             <English>S-400</English>
             <French>S-400</French>
             <Japanese>S-400</Japanese>
             <Russian>S-400</Russian>
+            <German>S-400</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_s400_missile">
             <English>S-400 Missile</English>
             <French>S-400 Missile</French>
             <Japanese>S-400 ミサイル</Japanese>
             <Russian>S-400 Missile</Russian>
+            <German>S-400 Rakete</German>
         </Key>
         <Key ID="STR_ACE_MISSILE_SAM_s400_operator">
             <English>S-400 Operator</English>
             <French>S-400 Operator</French>
             <Japanese>S-400 操作員</Japanese>
             <Russian>S-400 Operator</Russian>
+            <German>S-400 Bediener</German>
         </Key>
     </Package>
 </Project>

--- a/addons/missile_vikhr/stringtable.xml
+++ b/addons/missile_vikhr/stringtable.xml
@@ -7,6 +7,7 @@
             <Spanish>1x 9k121 Vikhr [ACE]</Spanish>
             <Italian>1x 9k121 Vikhr [ACE]</Italian>
             <Russian>1x 9k121 Вихрь [ACE]</Russian>
+            <German>1x 9k121 Vikhr [ACE]</German>
             <Korean>1x 9K121 베프리 [ACE]</Korean>
             <Japanese>1x 9k121 ヴィーフリ [ACE]</Japanese>
         </Key>
@@ -16,6 +17,7 @@
             <Spanish>2x 9k121 Vikhr [ACE]</Spanish>
             <Italian>2x 9k121 Vikhr [ACE]</Italian>
             <Russian>2x 9k121 Вихрь [ACE]</Russian>
+            <German>2x 9k121 Vikhr [ACE]</German>
             <Korean>2x 9K121 베프리 [ACE]</Korean>
             <Japanese>2x 9k121 ヴィーフリ [ACE]</Japanese>
         </Key>
@@ -25,6 +27,7 @@
             <Spanish>3x 9k121 Vikhr [ACE]</Spanish>
             <Italian>3x 9k121 Vikhr [ACE]</Italian>
             <Russian>3x 9k121 Вихрь [ACE]</Russian>
+            <German>3x 9k121 Vikhr [ACE]</German>
             <Korean>3x 9K121 베프리 [ACE]</Korean>
             <Japanese>3x 9k121 ヴィーフリ [ACE]</Japanese>
         </Key>
@@ -34,6 +37,7 @@
             <Spanish>4x 9k121 Vikhr [ACE]</Spanish>
             <Italian>4x 9k121 Vikhr [ACE]</Italian>
             <Russian>4x 9k121 Вихрь [ACE]</Russian>
+            <German>4x 9k121 Vikhr [ACE]</German>
             <Korean>4x 9K121 베프리 [ACE]</Korean>
             <Japanese>4x 9k121 ヴィーフリ [ACE]</Japanese>
         </Key>
@@ -43,6 +47,7 @@
             <Spanish>6x 9k121 Vikhr [ACE]</Spanish>
             <Italian>6x 9k121 Vikhr [ACE]</Italian>
             <Russian>6x 9k121 Вихрь [ACE]</Russian>
+            <German>6x 9k121 Vikhr [ACE]</German>
             <Korean>6x 9K121 베프리 [ACE]</Korean>
             <Japanese>6x 9k121 ヴィーフリ [ACE]</Japanese>
         </Key>
@@ -52,6 +57,7 @@
             <Spanish>8x 9k121 Vikhr [ACE]</Spanish>
             <Italian>8x 9k121 Vikhr [ACE]</Italian>
             <Russian>8x 9k121 Вихрь [ACE]</Russian>
+            <German>8x 9k121 Vikhr [ACE]</German>
             <Korean>8x 9K121 베프리 [ACE]</Korean>
             <Japanese>8x 9k121 ヴィーフリ [ACE]</Japanese>
         </Key>
@@ -61,6 +67,7 @@
             <Spanish>9k121 Vikhr [ACE]</Spanish>
             <Italian>9k121 Vikhr [ACE]</Italian>
             <Russian>9k121 Вихрь [ACE]</Russian>
+            <German>9k121 Vikhr [ACE]</German>
             <Korean>9K121 베프리 [ACE]</Korean>
             <Japanese>9k121 ヴィーフリ [ACE]</Japanese>
         </Key>

--- a/addons/missileguidance/stringtable.xml
+++ b/addons/missileguidance/stringtable.xml
@@ -109,6 +109,7 @@
             <Spanish>12x DAGR [ACE]</Spanish>
             <Italian>12x DAGR [ACE]</Italian>
             <Russian>12x DAGR [ACE]</Russian>
+            <German>12x DAGR [ACE]</German>
             <Korean>12x DAGR [ACE]</Korean>
             <Japanese>12x DAGR [ACE]</Japanese>
         </Key>
@@ -118,6 +119,7 @@
             <Spanish>24x DAGR [ACE]</Spanish>
             <Italian>24x DAGR [ACE]</Italian>
             <Russian>24x DAGR [ACE]</Russian>
+            <German>24x DAGR [ACE]</German>
             <Korean>24x DAGR [ACE]</Korean>
             <Japanese>24x DAGR [ACE]</Japanese>
         </Key>
@@ -127,6 +129,7 @@
             <Spanish>6x DAGR [ACE]</Spanish>
             <Italian>6x DAGR [ACE]</Italian>
             <Russian>6x DAGR [ACE]</Russian>
+            <German>6x DAGR [ACE]</German>
             <Korean>6x DAGR [ACE]</Korean>
             <Japanese>6x DAGR [ACE]</Japanese>
         </Key>

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -728,6 +728,7 @@
             <Spanish>Ocultar toda la IU</Spanish>
             <Italian>Nascondi tutta l'IU</Italian>
             <Russian>Скрыть весь интерфейс</Russian>
+            <German>Gesamte Benutzeroberfläche ausblenden</German>
             <Korean>모든 UI 숨기기</Korean>
             <Japanese>全てのUIを隠す</Japanese>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Add missing German translations
- Improve German translation of frag

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

### Discussion

- Existing translation of electronic hearing protection is literal. Wouldn't "Aktiver Gehörschutz" be better?
- I'm not quite sure what the context of "Draw Event Spheres" in frag is