### PR TITLE
Compat WS - Change realisticname wording for Stripe camos

### DIFF
--- a/addons/compat_ws/compat_ws_realisticnames/stringtable.xml
+++ b/addons/compat_ws/compat_ws_realisticnames/stringtable.xml
@@ -559,12 +559,12 @@
             <Japanese>オトカ アルマ (非武装)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_aco_camo_Name">
-            <English>C-More Railway (Red, Camo)</English>
-            <Japanese>C-More レイルウェイ (レッド、迷彩)</Japanese>
+            <English>C-More Railway (Red, Stripe)</English>
+            <Japanese>C-More レイルウェイ (レッド、縞模様)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_aco_grn_camo_Name">
-            <English>C-More Railway (Green, Camo)</English>
-            <Japanese>C-More レイルウェイ (グリーン、迷彩)</Japanese>
+            <English>C-More Railway (Green, Stripe)</English>
+            <Japanese>C-More レイルウェイ (グリーン、縞模様)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_arco_hex_Name">
             <English>ELCAN SpecterOS (Hex)</English>

--- a/addons/compat_ws/compat_ws_realisticnames/stringtable.xml
+++ b/addons/compat_ws/compat_ws_realisticnames/stringtable.xml
@@ -353,8 +353,8 @@
             <Chinesesimp>XMS GL</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_GL_Camo_Name">
-            <English>XMS GL (Camo)</English>
-            <Japanese>XMS GL (迷彩)</Japanese>
+            <English>XMS GL (Stripes)</English>
+            <Japanese>XMS GL (縞模様迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_GL_Gray_Name">
             <English>XMS GL (Gray)</English>
@@ -397,8 +397,8 @@
             <Chinesesimp>XMS</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_Camo_Name">
-            <English>XMS (Camo)</English>
-            <Japanese>XMS (迷彩)</Japanese>
+            <English>XMS (Stripes)</English>
+            <Japanese>XMS (縞模様迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_Gray_Name">
             <English>XMS (Gray)</English>
@@ -429,8 +429,8 @@
             <Chinesesimp>XMS SG</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_SG_Camo_Name">
-            <English>XMS SG (Camo)</English>
-            <Japanese>XMS SG (迷彩)</Japanese>
+            <English>XMS SG (Stripes)</English>
+            <Japanese>XMS SG (縞模様迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_SG_Gray_Name">
             <English>XMS SG (Gray)</English>
@@ -473,8 +473,8 @@
             <Chinesesimp>XMS SW</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_SW_Camo_Name">
-            <English>XMS SW (Camo)</English>
-            <Japanese>XMS SW (迷彩)</Japanese>
+            <English>XMS SW (Stripes)</English>
+            <Japanese>XMS SW (縞模様迷彩)</Japanese>
         </Key>
         <Key ID="STR_ACE_Compat_WS_RealisticNames_XMS_SW_Gray_Name">
             <English>XMS SW (Gray)</English>


### PR DESCRIPTION
**When merged this pull request will:**
- _Change realistic name's text_
- _Valiant name of "Camo" is a confusing name if using with RF, so Revert the names to "Stripes"_
- _C-More and XMS is will be change_

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
