### PR TITLE
Medical - Fix incompatibleMedication array Error

### DIFF
--- a/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
@@ -41,12 +41,11 @@ if (_maxDose > 0) then {
 };
 
 // Check incompatible medication (format [med,limit])
-if (_incompatibleMedication isNotEqualTo []) then {
-	{
-		_x params ["_xMed", "_xLimit"];
-		private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
-		if (_inSystem > _xLimit) then {
-			[_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
-		};
-	} forEach _incompatibleMedication;
-};
+if (typeName _array != "ARRAY" || _incompatibleMedication isEqualTo []) exitWith {};
+{
+	_x params ["_xMed", "_xLimit"];
+	private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
+	if (_inSystem > _xLimit) then {
+		[_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
+	};
+} forEach _incompatibleMedication;

--- a/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
@@ -43,9 +43,9 @@ if (_maxDose > 0) then {
 // Check incompatible medication (format [med,limit])
 if (typeName _array != "ARRAY" || _incompatibleMedication isEqualTo []) exitWith {};
 {
-	_x params ["_xMed", "_xLimit"];
-	private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
-	if (_inSystem > _xLimit) then {
-		[_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
-	};
+    _x params ["_xMed", "_xLimit"];
+    private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
+    if (_inSystem > _xLimit) then {
+        [_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
+    };
 } forEach _incompatibleMedication;

--- a/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
@@ -41,11 +41,12 @@ if (_maxDose > 0) then {
 };
 
 // Check incompatible medication (format [med,limit])
-if (typeName _array != "ARRAY" || _incompatibleMedication isEqualTo []) exitWith {};
-{
-    _x params ["_xMed", "_xLimit"];
-    private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
-    if (_inSystem > _xLimit) then {
-        [_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
-    };
-} forEach _incompatibleMedication;
+if (_incompatibleMedication isEqualType []) then {
+    {
+        _x params ["_xMed", "_xLimit"];
+        private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
+        if (_inSystem > _xLimit) then {
+            [_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
+        };
+    } forEach _incompatibleMedication;
+};

--- a/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
@@ -41,7 +41,7 @@ if (_maxDose > 0) then {
 };
 
 // Check incompatible medication (format [med,limit])
-if !(isNil _incompatibleMedication) then {
+if (_incompatibleMedication isNotEqualTo []) then {
 	{
 		_x params ["_xMed", "_xLimit"];
 		private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;

--- a/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
+++ b/addons/medical_treatment/functions/fnc_onMedicationUsage.sqf
@@ -41,10 +41,12 @@ if (_maxDose > 0) then {
 };
 
 // Check incompatible medication (format [med,limit])
-{
-    _x params ["_xMed", "_xLimit"];
-    private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
-    if (_inSystem > _xLimit) then {
-        [_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
-    };
-} forEach _incompatibleMedication;
+if !(isNil _incompatibleMedication) then {
+	{
+		_x params ["_xMed", "_xLimit"];
+		private _inSystem = ([_target, _xMed] call EFUNC(medical_status,getMedicationCount)) select 0;
+		if (_inSystem > _xLimit) then {
+			[_target, _classname, _inSystem, _xLimit, _xMed] call FUNC(overDose);
+		};
+	} forEach _incompatibleMedication;
+};


### PR DESCRIPTION
**When merged this pull request will:**
- _Fix error if `incompatibleMedication` is empty_
- _Avoid with `isEqualType []`_

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
