### PR TITLE
Medical - Fix using wrong param for `fnc_fullHeal`

### DIFF
--- a/addons/medical/functions/fnc_fullHeal.sqf
+++ b/addons/medical/functions/fnc_fullHeal.sqf
@@ -27,4 +27,4 @@ if (!alive _patient) exitWith {
     ERROR_2("fullHeal [medic %1][patient %2] Patient is dead or null",_medic,_patient);
 };
 
-[_medic, _patient, "", "", objNull, "", _logMessage] call EFUNC(medical_treatment,fullHeal);
+[_medic, _patient, "", "", objNull, "", false, _logMessage] call EFUNC(medical_treatment,fullHeal);

--- a/addons/medical_treatment/functions/fnc_fullHeal.sqf
+++ b/addons/medical_treatment/functions/fnc_fullHeal.sqf
@@ -22,7 +22,7 @@
  * Public: No
  */
 
-params ["_medic", "_patient", "", "", "", "", ["_logMessage", true]];
+params ["_medic", "_patient", "", "", "", "", "", ["_logMessage", true]];
 TRACE_3("fullHeal",_medic,_patient,_logMessage);
 
 if (_logMessage) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix using `_createLitter` param from medical treatment as `_logMessage`
  - Miscounted the number of elements in `params`

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
