### PR TITLE
Compat CUP Vehicles - Lower Vodnik Cook-off Chance

### DIFF
--- a/addons/compat_cup_vehicles/CfgVehicles.hpp
+++ b/addons/compat_cup_vehicles/CfgVehicles.hpp
@@ -323,4 +323,39 @@ class CfgVehicles {
             "hitera_r16", "hitera_r17", "hitera_r18", "hitera_r19", "hitera_r20"
         };
     };
+    class CUP_GAZ_Vodnik_Base: Wheeled_APC_F {
+        EGVAR(vehicle_damage,engineFireProb) = 0.1;
+    };
+    class CUP_GAZ_Vodnik_AGS_Base: CUP_GAZ_Vodnik_Base {
+        EGVAR(vehicle_damage,hullDetonationProb) = 0;
+        EGVAR(vehicle_damage,hullFireProb) = 0;
+        EGVAR(vehicle_damage,turretDetonationProb) = 0;
+        EGVAR(vehicle_damage,turretFireProb) = 0;
+        EGVAR(vehicle_damage,canHaveFireRing) = 0;
+        EGVAR(vehicle_damage,canHaveFireJet) = 0;
+    };
+    class CUP_GAZ_Vodnik_Unarmed_base: CUP_GAZ_Vodnik_Base {
+        EGVAR(vehicle_damage,hullDetonationProb) = 0;
+        EGVAR(vehicle_damage,hullFireProb) = 0;
+        EGVAR(vehicle_damage,turretDetonationProb) = 0;
+        EGVAR(vehicle_damage,turretFireProb) = 0;
+        EGVAR(vehicle_damage,canHaveFireRing) = 0;
+        EGVAR(vehicle_damage,canHaveFireJet) = 0;
+    };
+    class CUP_GAZ_Vodnik_MedEvac_Base: CUP_GAZ_Vodnik_Base {
+        EGVAR(vehicle_damage,hullDetonationProb) = 0;
+        EGVAR(vehicle_damage,hullFireProb) = 0;
+        EGVAR(vehicle_damage,turretDetonationProb) = 0;
+        EGVAR(vehicle_damage,turretFireProb) = 0;
+        EGVAR(vehicle_damage,canHaveFireRing) = 0;
+        EGVAR(vehicle_damage,canHaveFireJet) = 0;
+    };
+    class CUP_O_GAZ_Vodnik_PK_RU: CUP_GAZ_Vodnik_Base {
+        EGVAR(vehicle_damage,hullDetonationProb) = 0;
+        EGVAR(vehicle_damage,hullFireProb) = 0;
+        EGVAR(vehicle_damage,turretDetonationProb) = 0;
+        EGVAR(vehicle_damage,turretFireProb) = 0;
+        EGVAR(vehicle_damage,canHaveFireRing) = 0;
+        EGVAR(vehicle_damage,canHaveFireJet) = 0;
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Lower the chance for engine fire from a Vodnik
- Remove fire jets from unarmed, medical, and "turned out" pkt / AGS vodniks

Reasoning: If you spray a Vodnik with an M2 as it stands, it starts cooking off within the first 5 rounds. This doesn't make sense (to me) for the non-turreted Vodnik variants.
### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
