### PR TITLE
Main - Update `ENABLE_PERFORMANCE_COUNTERS` macro

### DIFF
--- a/addons/main/script_debug.hpp
+++ b/addons/main/script_debug.hpp
@@ -43,7 +43,7 @@ PERFORMANCE COUNTERS SECTION
 // To Use: [] call ace_common_fnc_dumpPerformanceCounters;
 
 #ifdef ENABLE_PERFORMANCE_COUNTERS
-    #define CBA_fnc_addPerFrameHandler { _ret = [(_this select 0), (_this select 1), (_this select 2), #function] call CBA_fnc_addPerFrameHandler; if(isNil "ACE_PFH_COUNTER" ) then { ACE_PFH_COUNTER=[]; }; ACE_PFH_COUNTER pushBack [[_ret, __FILE__, __LINE__], [(_this select 0), (_this select 1), (_this select 2)]];  _ret }
+    #define CBA_fnc_addPerFrameHandler { private _ret = [(_this select 0), (_this select 1), (_this select 2)] call CBA_fnc_addPerFrameHandler; if(isNil "ACE_PFH_COUNTER" ) then { ACE_PFH_COUNTER=[]; }; ACE_PFH_COUNTER pushBack [[_ret, __FILE__, __LINE__], [(_this select 0), (_this select 1), (_this select 2)]];  _ret }
 
     #define CREATE_COUNTER(x) if(isNil "ACE_COUNTERS" ) then { ACE_COUNTERS=[]; }; GVAR(DOUBLES(x,counter))=[]; GVAR(DOUBLES(x,counter)) set[0, QUOTE(GVAR(DOUBLES(x,counter)))];  GVAR(DOUBLES(x,counter)) set[1, diag_tickTime]; ACE_COUNTERS pushBack GVAR(DOUBLES(x,counter));
     #define BEGIN_COUNTER(x) if(isNil QUOTE(GVAR(DOUBLES(x,counter)))) then { CREATE_COUNTER(x) }; GVAR(DOUBLES(x,counter)) set[2, diag_tickTime];


### PR DESCRIPTION
When `ENABLE_PERFORMANCE_COUNTERS` defined the extra `#function` causes
```
error[SPE2]: unparseable syntax
   ┌─ addons/attach/functions/fnc_placeApprove.sqf:64:84
   │
64 │                 }, 0, [_startingPosShifted, _endPosShifted, CBA_missionTime]] call CBA_fnc_addPerFrameHandler;
   │                                                                                    ^ unparseable syntax
```

