### PR TITLE
Common - Add Entries to canDigSurfaces for GM Terrains

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -73,7 +73,7 @@ GVAR(canDigSurfaces) = createHashMapFromArray [
     ["wavymetal_exp",false],["int_metal",false],["asphalt_exp",false],["pavement_exp",false],["gridmetal_exp",false],
     ["rooftiles_exp",false],["rock",false],["int_mat_exp",false],["wood_int",false],["concrete_int",false],["tarmac",false],["wood",false],
     ["roof_tin",false],["lino_exp",false],["concrete",false],["int_softwood_exp",false], ["concrete_exp",false],["stones_exp",false],
-    ["forest_exp",true],["snow",true],["grasstall_exp",true],["grass",true]
+    ["forest_exp",true],["snow",true],["grasstall_exp",true],["grass",true],["forest",true],["drygrass",true]
 ];
 
 isHC = !hasInterface && !isDedicated; // deprecated because no tag


### PR DESCRIPTION
**When merged this pull request will:**
- Adds two common surfaces in GM terrains (official and a few community terrains) to the `ace_common_canDigSurfaces` array.


### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
