### PR TITLE
Common - getDLC should return a number

### DIFF
--- a/addons/common/functions/fnc_getDLC.sqf
+++ b/addons/common/functions/fnc_getDLC.sqf
@@ -65,4 +65,8 @@ private _name = switch (_id) do {
     default { "" };
 };
 
+if !(_id isEqualType 0) then {
+    _id = parseNumber _id;
+};
+
 [_name, _id]


### PR DESCRIPTION
**When merged this pull request will:**
- `getAssetDLCInfo` returns a string while most DLC related commands take numbers
- The function header also says number

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
