### PR TITLE
Compat GM: Add Hearing Proctection to missing helmets

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -27,6 +27,12 @@ dlc = [
     "Reaction Forces"
 ]
 
+[gm]
+extends = "default"
+dlc = [
+    "Global Mobilization - Cold War Germany"
+]
+
 [rhs]
 extends = "default"
 workshop = [

--- a/addons/compat_gm/CfgWeapons.hpp
+++ b/addons/compat_gm/CfgWeapons.hpp
@@ -95,20 +95,16 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR;
     };
 
+    class gm_ge_headgear_beret_crew_base;
+    class gm_ge_headgear_beret_crew_blk: gm_ge_headgear_beret_crew_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+
     class gm_ge_headgear_beret_crew_bdx;
-    class gm_ge_headgear_beret_crew_blk;
     class gm_ge_headgear_beret_crew_grn;
     class gm_ge_headgear_beret_crew_red;
+
     class gm_ge_headgear_beret_crew_red_antiair: gm_ge_headgear_beret_crew_red {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class gm_ge_headgear_beret_crew_blk_antitank: gm_ge_headgear_beret_crew_blk {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class gm_ge_headgear_beret_crew_blk_armor: gm_ge_headgear_beret_crew_blk {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class gm_ge_headgear_beret_crew_blk_armorrecon: gm_ge_headgear_beret_crew_blk {
         HEARING_PROTECTION_PELTOR;
     };
     class gm_ge_headgear_beret_crew_red_artillery: gm_ge_headgear_beret_crew_red {
@@ -139,9 +135,6 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR;
     };
     class gm_ge_headgear_beret_crew_bdx_lrrp: gm_ge_headgear_beret_crew_bdx {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class gm_ge_headgear_beret_crew_blk_recon: gm_ge_headgear_beret_crew_blk {
         HEARING_PROTECTION_PELTOR;
     };
     class gm_ge_headgear_beret_crew_red_supply: gm_ge_headgear_beret_crew_red {
@@ -185,11 +178,6 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR;
     };
     class gm_xx_headgear_headwrap_crew_01_trp: gm_xx_headgear_headwrap_01_base {
-        HEARING_PROTECTION_PELTOR;
-    };
-
-    class gm_ge_headgear_beret_crew_base;
-    class gm_ge_headgear_beret_crew_blk: gm_ge_headgear_beret_crew_base {
         HEARING_PROTECTION_PELTOR;
     };
 };

--- a/addons/compat_gm/CfgWeapons.hpp
+++ b/addons/compat_gm/CfgWeapons.hpp
@@ -123,6 +123,9 @@ class CfgWeapons {
     class gm_ge_headgear_beret_crew_grn_mechinf: gm_ge_headgear_beret_crew_grn {
         HEARING_PROTECTION_PELTOR;
     };
+    class gm_ge_headgear_beret_crew_grn_infantry: gm_ge_headgear_beret_crew_grn {
+        HEARING_PROTECTION_PELTOR;
+    };
     class gm_ge_headgear_beret_crew_red_militarypolice: gm_ge_headgear_beret_crew_red {
         HEARING_PROTECTION_PELTOR;
     };
@@ -135,6 +138,9 @@ class CfgWeapons {
     class gm_ge_headgear_beret_crew_bdx_paratrooper: gm_ge_headgear_beret_crew_bdx {
         HEARING_PROTECTION_PELTOR;
     };
+    class gm_ge_headgear_beret_crew_bdx_lrrp: gm_ge_headgear_beret_crew_bdx {
+        HEARING_PROTECTION_PELTOR;
+    };
     class gm_ge_headgear_beret_crew_blk_recon: gm_ge_headgear_beret_crew_blk {
         HEARING_PROTECTION_PELTOR;
     };
@@ -142,6 +148,48 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR;
     };
     class gm_ge_headgear_beret_crew_red_signals: gm_ge_headgear_beret_crew_red {
+        HEARING_PROTECTION_PELTOR;
+    };
+
+    class gm_ge_bgs_headgear_beret_crew_grn: gm_ge_headgear_beret_crew_grn {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_ge_bgs_headgear_beret_crew_grn_sf: gm_ge_headgear_beret_crew_grn {
+        HEARING_PROTECTION_PELTOR;
+    };
+
+    class gm_ge_headgear_hat_beanie_crew_blk: gm_ge_headgear_hat_beanie_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+
+    class gm_xx_headgear_headwrap_01_base;
+    class gm_xx_headgear_headwrap_crew_01_oli: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_m84: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_m84: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_grn: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_smp: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_blk: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_flk: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class gm_xx_headgear_headwrap_crew_01_trp: gm_xx_headgear_headwrap_01_base {
+        HEARING_PROTECTION_PELTOR;
+    };
+
+    class gm_ge_headgear_beret_crew_base;
+    class gm_ge_headgear_beret_crew_blk: gm_ge_headgear_beret_crew_base {
         HEARING_PROTECTION_PELTOR;
     };
 };

--- a/addons/compat_gm/CfgWeapons.hpp
+++ b/addons/compat_gm/CfgWeapons.hpp
@@ -151,15 +151,13 @@ class CfgWeapons {
         HEARING_PROTECTION_PELTOR;
     };
 
+    class gm_ge_headgear_hat_beanie_base;
     class gm_ge_headgear_hat_beanie_crew_blk: gm_ge_headgear_hat_beanie_base {
         HEARING_PROTECTION_PELTOR;
     };
 
     class gm_xx_headgear_headwrap_01_base;
     class gm_xx_headgear_headwrap_crew_01_oli: gm_xx_headgear_headwrap_01_base {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class gm_xx_headgear_headwrap_crew_01_m84: gm_xx_headgear_headwrap_01_base {
         HEARING_PROTECTION_PELTOR;
     };
     class gm_xx_headgear_headwrap_crew_01_m84: gm_xx_headgear_headwrap_01_base {


### PR DESCRIPTION
**When merged this pull request will:**
- add `HEARING_PROTECTION_PELTOR` to some Helmets that were missing it
- since `gm_ge_headgear_beret_crew_blk` is also the base class for some other items removed the entry for them
- add GM to launch.toml

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
