### PR TITLE
Map Tools - Fix Straight Line Drawing being broken by Higher Draw Priority

### DIFF
--- a/addons/maptools/XEH_postInitClient.sqf
+++ b/addons/maptools/XEH_postInitClient.sqf
@@ -7,6 +7,7 @@ if (!hasInterface) exitWith {};
 // Init variables
 GVAR(mapGpsShow) = true;
 GVAR(mapGpsNextUpdate) = -1;
+GVAR(lastDrawnLine) = "";
 
 GVAR(mapTool_Shown) = 0;
 GVAR(mapTool_pos) = [0, 0];
@@ -47,6 +48,12 @@ GVAR(plottingBoard_markers) = createHashMap;
 
 addMissionEventHandler ["MarkerCreated", {
     [_this, false] call FUNC(handlePlottingBoardMarkers);
+
+    // Cache last user-drawn polyline marker
+    private _marker = _this select 0;
+    if ((markerPolyline _marker) isNotEqualTo []) then {
+        GVAR(lastDrawnLine) = _marker;
+    };
 }];
 
 addMissionEventHandler ["MarkerDeleted", {

--- a/addons/maptools/functions/fnc_handleMouseButton.sqf
+++ b/addons/maptools/functions/fnc_handleMouseButton.sqf
@@ -38,7 +38,7 @@ if ((_button == 0) && {GVAR(freedrawing) || _ctrlKey}) exitWith {
 
             if (_allMarkers isEqualTo []) exitWith {};
 
-            private _markerName = _allMarkers select -1;
+            private _markerName = GVAR(lastDrawnLine);
             private _markerPos = getMarkerPos _markerName;
             private _distanceCheck = _markerPos distance2D GVAR(drawPosStart);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes an issue where lines drawn along a map tool would not be straightened if the mission had an editor-placed marker with a draw priority higher than 0.
As mentioned [here](https://community.bistudio.com/wiki/setMarkerDrawPriority), since 2.18 `allMapMarkers` is ordered according to priority first, instead of creation. That causes those markers with higher priority to always be at the end of the array.
The current code however still assumes that `allMapMarkers select -1` is always the line that was just drawn, causing it to compare the cached `GVAR(drawPosStart)` with the wrong marker and always aborting line straightening due to the distance check.