### PR TITLE
Sitting - Various improvements

### DIFF
--- a/addons/sitting/XEH_clientInit.sqf
+++ b/addons/sitting/XEH_clientInit.sqf
@@ -9,13 +9,10 @@ if (!hasInterface) exitWith {};
     // If not enabled, then do not add CanInteractWith Condition or event handlers
     if (!XGVAR(enable)) exitWith {};
 
-    // Initialize classes as they spawn
-    ["ThingX", "init", LINKFUNC(addSitActions), nil, nil, true] call CBA_fnc_addClassEventHandler;
-
-    // Initialize statically defined benches (also appear as world objects, no class EH thrown)
+    // Initialize all seats
     {
-        [_x] call FUNC(addSitActions);
-    } forEach [BENCHES];
+        _x call FUNC(addSitActions);
+    } forEach (uiNamespace getVariable [QGVAR(seats), []]);
 
     // Add interaction menu exception
     ["isNotSitting", {isNil {(_this select 0) getVariable QGVAR(sittingStatus)}}] call EFUNC(common,addCanInteractWithCondition);

--- a/addons/sitting/XEH_preStart.sqf
+++ b/addons/sitting/XEH_preStart.sqf
@@ -1,3 +1,8 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.hpp"
+
+private _seats = QUOTE(getNumber (_x >> QQXGVAR(canSit)) == 1) configClasses (configFile >> "CfgVehicles");
+_seats = _seats apply {configName _x};
+
+uiNamespace setVariable [QGVAR(seats), _seats];

--- a/addons/sitting/functions/fnc_addSitActions.sqf
+++ b/addons/sitting/functions/fnc_addSitActions.sqf
@@ -15,6 +15,11 @@
  * Public: No
  */
 
+// Only run this after the settings are initialized
+if !(EGVAR(common,settingsInitFinished)) exitWith {
+    EGVAR(common,runAtSettingsInitialized) pushBack [FUNC(addSitActions), _this];
+};
+
 params ["_seat"];
 
 private _type = _seat;
@@ -69,3 +74,4 @@ if !((_sitPosition select 0) isEqualType []) then {
     [_type, 0, _menuType, _sitAction] call EFUNC(interact_menu,addActionToClass);
 } forEach _sitPosition;
 
+nil // return

--- a/addons/sitting/functions/fnc_canSit.sqf
+++ b/addons/sitting/functions/fnc_canSit.sqf
@@ -21,10 +21,9 @@ params ["_seat", "_player", ["_seatPos", 0]];
 
 // Sitting enabled, not occupied and standing up (or not on a big slope)
 XGVAR(enable) &&
-{[_player, _seat] call EFUNC(common,canInteractWith)} &&
 {isNil {_player getVariable QGVAR(sittingStatus)}} &&
 {
     private _seatsClaimed = _seat getVariable [QGVAR(seatsClaimed), []];
-    _seatsClaimed isEqualTo [] || {!(_seatsClaimed select _seatPos)}
+    _seatsClaimed isEqualTo [] || {isNull (_seatsClaimed select _seatPos)}
 } &&
 {round (vectorUp _seat select 0) == 0 && {round (vectorUp _seat select 1) == 0} && {round (vectorUp _seat select 2) == 1}}

--- a/addons/sitting/functions/fnc_sit.sqf
+++ b/addons/sitting/functions/fnc_sit.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 /*
  * Author: Jonpas, vabene1111
- * Sits down the player.
+ * Makes the player sit down.
  *
  * Arguments:
  * 0: Seat <OBJECT>
@@ -65,16 +65,9 @@ _player setVariable [QGVAR(sittingStatus), [_seat, _actionID, _seatPos]];
 private _seatsClaimed = _seat getVariable [QGVAR(seatsClaimed), []];
 // Initialize claimed seats if first time sitting on it
 if (_seatsClaimed isEqualTo []) then {
-    if (_multiSitting) then {
-        for "_i" from 0 to ((count _sitPositionAll) - 1) do {
-            _seatsClaimed pushBack (_i == _seatPos);
-        };
-    } else {
-        _seatsClaimed = [true];
-    };
-} else {
-    _seatsClaimed set [_seatPos, true];
+    _seatsClaimed resize [count _sitPositionAll, objNull];
 };
+_seatsClaimed set [_seatPos, _player];
 _seat setVariable [QGVAR(seatsClaimed), _seatsClaimed, true];
 
 // Also prevent dragging/carrying
@@ -82,27 +75,38 @@ if !([_seat] call EFUNC(common,owned)) then {
     [_player, _seat] call EFUNC(common,claim);
 };
 
-// Add automatical stand PFH in case of interruptions
+// Automatically stand up if interrupted
 private _seatPosOrig = getPosASL _seat;
 private _seatDistOrig = (getPosASL _player) distance _seat;
 [{
     params ["_args", "_pfhId"];
-    _args params ["_player", "_seat", "_seatPosOrig", "_seatDistOrig"];
+    _args params ["_player", "_seat", "_seatPos", "_seatPosOrig", "_seatDistOrig"];
 
     // Remove PFH if not sitting any more
     if (isNil {_player getVariable QGVAR(sittingStatus)}) exitWith {
         [_pfhId] call CBA_fnc_removePerFrameHandler;
         TRACE_1("Remove PFH",_player getVariable [ARR_2(QGVAR(sittingStatus),false)]);
+
+        if (!alive _seat) exitWith {};
+
+        // Allow sitting on this seat again
+        private _seatsClaimed = _seat getVariable [QGVAR(seatsClaimed), []];
+        _seatsClaimed set [_seatPos, objNull];
+        _seat setVariable [QGVAR(seatsClaimed), _seatsClaimed, true];
+
+        // Unclaim if no one else sitting on it, but pass ownership if someone remains
+        private _newOwner = _seatsClaimed param [_seatsClaimed findIf {!isNull _x}, objNull];
+        [_newOwner, _seat] call EFUNC(common,claim);
     };
 
-    //  Stand up if chair gets deleted or moved
-    if (isNull _seat ||
+    // Stand up if chair gets deleted or moved
+    if (!alive _seat ||
         {getPosASL _player distance _seatPosOrig > _seatDistOrig + 0.5} ||
         {((getPosASL _seat) vectorDistance _seatPosOrig) > 0.01}
     ) exitWith {
         _player call FUNC(stand);
         TRACE_2("Chair moved",getPosASL _seat,_seatPosOrig);
     };
-}, 0, [_player, _seat, _seatPosOrig, _seatDistOrig]] call CBA_fnc_addPerFrameHandler;
+}, 0, [_player, _seat, _seatPos, _seatPosOrig, _seatDistOrig]] call CBA_fnc_addPerFrameHandler;
 
 ["ace_satDown", [_player, _seat, _seatPos]] call CBA_fnc_localEvent;

--- a/addons/sitting/functions/fnc_sit.sqf
+++ b/addons/sitting/functions/fnc_sit.sqf
@@ -94,9 +94,15 @@ private _seatDistOrig = (getPosASL _player) distance _seat;
         _seatsClaimed set [_seatPos, objNull];
         _seat setVariable [QGVAR(seatsClaimed), _seatsClaimed, true];
 
-        // Unclaim if no one else sitting on it, but pass ownership if someone remains
-        private _newOwner = _seatsClaimed param [_seatsClaimed findIf {!isNull _x}, objNull];
-        [_newOwner, _seat] call EFUNC(common,claim);
+        // Unclaim...
+        [objNull, _seat] call EFUNC(common,claim);
+
+        // ...but have a remaining unit reclaim ownership immediately
+        private _index = _seatsClaimed findIf {!isNull _x};
+
+        if (_index == -1) exitWith {};
+
+        [_seatsClaimed select _index, _seat] call EFUNC(common,claim);
     };
 
     // Stand up if chair gets deleted or moved

--- a/addons/sitting/functions/fnc_stand.sqf
+++ b/addons/sitting/functions/fnc_stand.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 /*
  * Author: Jonpas
- * Stands up the player.
+ * Makes the player stand up.
  *
  * Arguments:
  * Player <OBJECT>
@@ -39,14 +39,13 @@ _player setVariable [QGVAR(sittingStatus), nil];
 
 ["ace_stoodUp", [_player, _seat, _seatPos]] call CBA_fnc_localEvent;
 
-if (isNull _seat) exitWith {};
+if (!alive _seat) exitWith {};
 
 // Allow sitting on this seat again
 private _seatsClaimed = _seat getVariable [QGVAR(seatsClaimed), []];
-_seatsClaimed set [_seatPos, false];
+_seatsClaimed set [_seatPos, objNull];
 _seat setVariable [QGVAR(seatsClaimed), _seatsClaimed, true];
 
-// Unclaim if no one else sitting on it
-if (_seatsClaimed find true == -1) then {
-    [objNull, _seat] call EFUNC(common,claim);
-};
+// Unclaim if no one else sitting on it, but pass ownership if someone remains
+private _newOwner = _seatsClaimed param [_seatsClaimed findIf {!isNull _x}, objNull];
+[_newOwner, _seat] call EFUNC(common,claim);

--- a/addons/sitting/functions/fnc_stand.sqf
+++ b/addons/sitting/functions/fnc_stand.sqf
@@ -46,6 +46,12 @@ private _seatsClaimed = _seat getVariable [QGVAR(seatsClaimed), []];
 _seatsClaimed set [_seatPos, objNull];
 _seat setVariable [QGVAR(seatsClaimed), _seatsClaimed, true];
 
-// Unclaim if no one else sitting on it, but pass ownership if someone remains
-private _newOwner = _seatsClaimed param [_seatsClaimed findIf {!isNull _x}, objNull];
-[_newOwner, _seat] call EFUNC(common,claim);
+// Unclaim...
+[objNull, _seat] call EFUNC(common,claim);
+
+// ...but have a remaining unit reclaim ownership immediately
+private _index = _seatsClaimed findIf {!isNull _x};
+
+if (_index == -1) exitWith {};
+
+[_seatsClaimed select _index, _seat] call EFUNC(common,claim);

--- a/docs/wiki/framework/sitting-framework.md
+++ b/docs/wiki/framework/sitting-framework.md
@@ -1,7 +1,7 @@
 ---
 layout: wiki
 title: Sitting Framework
-description: Explains how to set-up sitting objects (eg. chairs) with ACE sitting system.
+description: Explains how to set-up sitting objects (e.g. chairs) with ACE sitting system.
 group: framework
 order: 5
 parent: wiki
@@ -15,10 +15,7 @@ redirect_from: "/wiki/frameworkx/sitting-framework.md"
 
 ## 1. Requirements
 
-Object must inherit from `ThingX` or any of its sub-classes.
-
-Object must have Extended Event Handler (XEH) enabled (this is not the case for the majority of vanilla objects in `ThingX` class), configuration entry on how to do that is shown below.
-
+Object must have `acex_sitting_canSit = 1` defined.
 
 ## 2. Config Values
 
@@ -30,7 +27,6 @@ class CfgVehicles {
         acex_sitting_sitPosition[] = {0, -0.1, -0.45};  // Position relative to object (may behave weird with certain objects)
         acex_sitting_interactPosition[] = {0, -0.1, -0.45};
         ace_sitting_animations[] = {"ace_sitting_HubSittingChairA_idle1"}; // Overwrite random animation pool
-        XEH_ENABLED;  // Enable XEH (only necessary if XEH is not yet enabled for this class or the one this inherits from)
     };
 };
 ```


### PR DESCRIPTION
**When merged this pull request will:**
- No longer require seats to inherit from `Thing`. This allows mods (including other components in ACE) to define classes inheriting from e.g.  `Static` to be seats.
- Add a safeguard to `FUNC(addSitActions)`, so if it's called by mod and mission makers, it's executed after settings are initialised.
- Store the people sitting on the seats, so that multiple people can sit at once. Fixes #10486.
- Pass new ownership onto other people sitting, if existent, instead of keeping it until everyone has left the bench.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
