### PR TITLE
CUP Terrains Compat - Add sitting compatibility

### DIFF
--- a/addons/compat_cup_terrains/CfgVehicles.hpp
+++ b/addons/compat_cup_terrains/CfgVehicles.hpp
@@ -1,56 +1,112 @@
-class CBA_Extended_EventHandlers;
-#define XEH_INHERITED class EventHandlers {class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};}
-
 class CfgVehicles {
-    class House;
-    class House_Small_F;
-    class Strategic;
-    class House_EP1: House {};
+    class House_EP1;
+    class Land_stand_waterl_EP1: House_EP1 {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {{-0.4, -0.8, -0.9}, {0.4, -0.8, -0.9}};
+        EXGVAR(sitting,interactPosition)[] = {{-0.4, -0.75, 0.3}, {0.4, -0.75, 0.3}};
+    };
 
-    class Land_Benzina_schnell: House {
-        XEH_INHERITED;
-        EGVAR(refuel,hooks)[] = {{-1.5,-3.93,-1.25}, {2.35,-3.93,-1.25}};
-        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
-        class ACE_Actions {
-            class ACE_MainActions {
-                displayName = ECSTRING(interaction,MainAction);
-                position = "[0,-3.93,-1.25]";
-                distance = 5;
-                condition = "true";
-            };
-        };
+    class Thing_EP1;
+    class Land_Bench_EP1: Thing_EP1 {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 90;
+        EXGVAR(sitting,sitPosition)[] = {{0, 0.45, -0.7}, {0, -0.45, -0.7}};
+        EXGVAR(sitting,interactPosition)[] = {{0, 0.45, 0.3}, {0, -0.45, 0.3}};
     };
-    class Land_A_FuelStation_Feed: Strategic {
-        XEH_INHERITED;
-        EGVAR(refuel,hooks)[] = {{-0.34,0,0}, {0.34,0,0}};
-        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+
+    class CUP_basin_a;
+    class CUP_hospital_bench: CUP_basin_a {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {{0.35, 0, 0}, {-0.35, 0, 0}};
+        EXGVAR(sitting,interactPosition)[] = {{0.35, 0, 0.45}, {-0.35, 0, 0.45}};
     };
-    class Land_Ind_FuelStation_Feed_EP1: House_EP1 {
-        XEH_INHERITED;
-        EGVAR(refuel,hooks)[] = {{-0.34,0,0}, {0.34,0,0}};
-        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+    class CUP_ch_mod_h: CUP_basin_a {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.4};
     };
-    class Land_FuelStation_Feed_PMC: Strategic {
-        XEH_INHERITED;
-        EGVAR(refuel,hooks)[] = {{-0.34,0,0}, {0.34,0,0}};
-        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+    class CUP_kitchen_chair_a: CUP_basin_a {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
     };
-    class FuelStation: House_Small_F {
-        XEH_INHERITED;
-        EGVAR(refuel,hooks)[] = {{1.25, .2, -1.1}};
-        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
-        class ACE_Actions {
-            class ACE_MainActions {
-                displayName = ECSTRING(interaction,MainAction);
-                position = "[1.25, .2, -1]";
-                distance = 5;
-                condition = "true";
-            };
-        };
+    class CUP_lobby_chair: CUP_basin_a {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
     };
-    class WarfareBBaseStructure;
-    class Base_WarfareBVehicleServicePoint: WarfareBBaseStructure {
-        // "vehicle service point" (a conex /w barrels) - need hooks???
-        XEH_INHERITED;
+    class CUP_office_chair: CUP_basin_a {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, -0.4};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0};
+    };
+    class CUP_ch_office_B: CUP_basin_a {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
+    };
+
+    class Thing;
+    class FoldChair: Thing {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, -0.1, -0.45};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.3};
+
+        EGVAR(interaction,replaceTerrainObject) = 1;
+        EGVAR(dragging,canCarry) = 1;
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
+        EGVAR(dragging,carryDirection) = 180;
+    };
+    class WoodChair: FoldChair {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
+    };
+    class Park_bench1: WoodChair {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitPosition)[] = {{0.45, 0, -0.3}, {-0.45, 0, -0.3}};
+        EXGVAR(sitting,interactPosition)[] = {{0.45, 0, 0.2}, {-0.45, 0, 0.2}};
+    };
+
+    class Base_CUP_Furniture;
+    class CUP_armchair: Base_CUP_Furniture {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
+    };
+    class CUP_ch_mod_d: CUP_armchair {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
+    };
+    class CUP_ch_mod_e: CUP_armchair {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 180;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, 0};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.45};
+    };
+
+    class Small_Items_EP1;
+    class Land_Chair_EP1: Small_Items_EP1 {
+        EXGVAR(sitting,canSit) = 1;
+        EXGVAR(sitting,sitDirection) = 90;
+        EXGVAR(sitting,sitPosition)[] = {0, 0, -0.5};
+        EXGVAR(sitting,interactPosition)[] = {0, 0, 0.3};
+
+        EGVAR(interaction,replaceTerrainObject) = 1;
+        EGVAR(dragging,canCarry) = 1;
+        EGVAR(dragging,carryPosition)[] = {0, 0.75, 0.5};
+        EGVAR(dragging,carryDirection) = 270;
     };
 };

--- a/addons/compat_cup_terrains/compat_cup_refuel/CfgVehicles.hpp
+++ b/addons/compat_cup_terrains/compat_cup_refuel/CfgVehicles.hpp
@@ -1,0 +1,56 @@
+class CBA_Extended_EventHandlers;
+#define XEH_INHERITED class EventHandlers {class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};}
+
+class CfgVehicles {
+    class House;
+    class House_Small_F;
+    class Strategic;
+    class House_EP1: House {};
+
+    class Land_Benzina_schnell: House {
+        XEH_INHERITED;
+        EGVAR(refuel,hooks)[] = {{-1.5,-3.93,-1.25}, {2.35,-3.93,-1.25}};
+        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+        class ACE_Actions {
+            class ACE_MainActions {
+                displayName = ECSTRING(interaction,MainAction);
+                position = "[0,-3.93,-1.25]";
+                distance = 5;
+                condition = "true";
+            };
+        };
+    };
+    class Land_A_FuelStation_Feed: Strategic {
+        XEH_INHERITED;
+        EGVAR(refuel,hooks)[] = {{-0.34,0,0}, {0.34,0,0}};
+        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+    };
+    class Land_Ind_FuelStation_Feed_EP1: House_EP1 {
+        XEH_INHERITED;
+        EGVAR(refuel,hooks)[] = {{-0.34,0,0}, {0.34,0,0}};
+        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+    };
+    class Land_FuelStation_Feed_PMC: Strategic {
+        XEH_INHERITED;
+        EGVAR(refuel,hooks)[] = {{-0.34,0,0}, {0.34,0,0}};
+        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+    };
+    class FuelStation: House_Small_F {
+        XEH_INHERITED;
+        EGVAR(refuel,hooks)[] = {{1.25, .2, -1.1}};
+        EGVAR(refuel,fuelCargo) = REFUEL_INFINITE_FUEL;
+        class ACE_Actions {
+            class ACE_MainActions {
+                displayName = ECSTRING(interaction,MainAction);
+                position = "[1.25, .2, -1]";
+                distance = 5;
+                condition = "true";
+            };
+        };
+    };
+    class WarfareBBaseStructure;
+    class Base_WarfareBVehicleServicePoint: WarfareBBaseStructure {
+        // "vehicle service point" (a conex /w barrels) - need hooks???
+        XEH_INHERITED;
+    };
+};

--- a/addons/compat_cup_terrains/compat_cup_refuel/config.cpp
+++ b/addons/compat_cup_terrains/compat_cup_refuel/config.cpp
@@ -1,18 +1,19 @@
 #include "script_component.hpp"
+#include "\z\ace\addons\refuel\defines.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class SUBADDON {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
-            "CUP_CAStructures_E_Misc_Misc_Interier",
-            "CUP_CAStructures_E_Misc_Misc_Market",
-            "CUP_Editor_Buildings_Config",
-            "CUP_Editor_Structures_Config",
-            "CUP_Misc3_Config",
-            "ace_common"
+            "CABuildings",
+            "CAStructuresHouse_A_FuelStation",
+            "CAStructures_E_Ind_Ind_FuelStation",
+            "CAStructures_PMC_FuelStation",
+            "CUP_Buildings_Config",
+            "ace_refuel"
         };
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
@@ -23,4 +24,3 @@ class CfgPatches {
 };
 
 #include "CfgVehicles.hpp"
-#include "CfgEventHandlers.hpp"

--- a/addons/compat_cup_terrains/compat_cup_refuel/script_component.hpp
+++ b/addons/compat_cup_terrains/compat_cup_refuel/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT refuel
+#define SUBCOMPONENT_BEAUTIFIED refuel
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Requires #10644 to function.
- Moved the refuelling part of the compat to its separate subaddon.
- I haven't tested with CUP terrains, but Zeus placed objects work without issue. Do I need to add `EGVAR(interaction,replaceTerrainObject) = 1;` to have it work with baked-in terrain objects?

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
