### PR TITLE
EF Compat - Remove `ace_hearing` hard dependency

### DIFF
--- a/addons/compat_ef/CfgWeapons.hpp
+++ b/addons/compat_ef/CfgWeapons.hpp
@@ -7,25 +7,6 @@ class CfgWeapons {
         EGVAR(nightvision,border) = QPATHTOEF(nightvision,data\nvg_mask_binos_4096.paa);
     };
 
-    // -- ace_hearing --
-    class HelmetBase;
-    class EF_H_Protecta: HelmetBase {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class EF_H_MCH; // this does not have peltor
-    class EF_H_MCH_Basic: EF_H_MCH {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class EF_H_MCH_BasicNet_Des: EF_H_MCH {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class EF_H_MCH_Full: EF_H_MCH {
-        HEARING_PROTECTION_PELTOR;
-    };
-    class EF_H_MCH_FullCamo_Des: EF_H_MCH {
-        HEARING_PROTECTION_PELTOR;
-    };
-
     // -- ace_overpressure --
     class autocannon_30mm;
     class EF_autocannon_50mm_AAV9: autocannon_30mm {

--- a/addons/compat_ef/compat_ef_hearing/CfgWeapons.hpp
+++ b/addons/compat_ef/compat_ef_hearing/CfgWeapons.hpp
@@ -1,0 +1,19 @@
+class CfgWeapons {
+    class HelmetBase;
+    class EF_H_Protecta: HelmetBase {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class EF_H_MCH; // this does not have peltor
+    class EF_H_MCH_Basic: EF_H_MCH {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class EF_H_MCH_BasicNet_Des: EF_H_MCH {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class EF_H_MCH_Full: EF_H_MCH {
+        HEARING_PROTECTION_PELTOR;
+    };
+    class EF_H_MCH_FullCamo_Des: EF_H_MCH {
+        HEARING_PROTECTION_PELTOR;
+    };
+};

--- a/addons/compat_ef/compat_ef_hearing/config.cpp
+++ b/addons/compat_ef/compat_ef_hearing/config.cpp
@@ -1,16 +1,18 @@
 #include "script_component.hpp"
+#include "\z\ace\addons\hearing\script_macros_hearingProtection.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class SUBADDON {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_common", "EF_Weapons", "EF_Marines"};
+        requiredAddons[] = {"EF_Weapons", "EF_Marines", "ace_hearing"};
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+        addonRootClass = QUOTE(ADDON);
     };
 };
 

--- a/addons/compat_ef/compat_ef_hearing/script_component.hpp
+++ b/addons/compat_ef/compat_ef_hearing/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT hearing
+#define SUBCOMPONENT_BEAUTIFIED Hearing
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- The hard dependency is only an issue if you build with `--no-rap`, but I'd still like to rectify the issue fully.

Need the following 3 questions answered:
1. Is this wanted?

If so:

2. Do I rectify the other components that need it as well?
3. Should this be included in the release changelog?

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
