### PR TITLE
Goggles - Replace class EH with `CBA_fnc_addBISPlayerEventHandler`

### DIFF
--- a/addons/goggles/XEH_postInit.sqf
+++ b/addons/goggles/XEH_postInit.sqf
@@ -90,8 +90,8 @@ if (!hasInterface) exitWith {};
         // Register fire event handler
         ["ace_firedPlayer", LINKFUNC(handleFired)] call CBA_fnc_addEventHandler;
 
-        //Add Explosion XEH
-        ["CAManBase", "explosion", LINKFUNC(handleExplosion)] call CBA_fnc_addClassEventHandler;
+        // Add Explosion EH
+        [QGVAR(explosion), "Explosion", LINKFUNC(handleExplosion)] call CBA_fnc_addBISPlayerEventHandler;
 
         GVAR(PostProcessEyes) = ppEffectCreate ["ColorCorrections", 1992];
         GVAR(PostProcessEyes) ppEffectAdjust [1, 1, 0, [0, 0, 0, 0], [0, 0, 0, 1], [1, 1, 1, 0]];


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Previously virtual units weren't excluded from having the EH assigned. `CBA_fnc_addBISPlayerEventHandler` excludes virtual units by default. Thoughts?

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
