### PR TITLE
Weaponselect - Fix case sensitivity when cycling throwables

### DIFF
--- a/addons/weaponselect/functions/fnc_selectNextGrenade.sqf
+++ b/addons/weaponselect/functions/fnc_selectNextGrenade.sqf
@@ -31,7 +31,7 @@ _currentGrenade = _currentGrenade select 0;
 private _grenadeType = [GVAR(GrenadesAll), GVAR(GrenadesFrag), GVAR(GrenadesNonFrag)] select _type;
 
 // This is faster than checking magazines
-private _grenades = (throwables _unit) apply {_x select 0} select {_x in _grenadeType};
+private _grenades = (throwables _unit) apply {_x select 0} select {private _i = _x; _grenadeType findIf {_x == _i} != -1};
 
 // abort if no grenades are available
 if (_grenades isEqualTo []) exitWith {false};


### PR DESCRIPTION
**When merged this pull request will:**
- Fix case issues in modded grenades blocking ACE throwable cycling (via Shift+G), by implementing a case-insensitive check.
It was encountered with grenades from the [Unsung mod](https://steamcommunity.com/workshop/filedetails/?id=943001311), the cause was that:
  - Grenades are sorted into `ace_weaponselect_GrenadesAll/Frag/NonFrag` at `preInit` by sifting through `"CfgWeapons" >> "Throw"`.
  - `weaponselect/fnc_selectNextGrenade.sqf` however intersects the `GrenadesAll` array with [`throwables player`](https://community.bistudio.com/wiki/throwables), which is generated from `CfgMagazines` names.
  - In the case of Unsung, some smoke grenades have case differences between `CfgMagazines` and `CfgWeapons`, like `uns_m18Purple` vs `uns_m18purple`, causing them to be excluded from the grenade list and impossible to cycle to.