### PR TITLE
Nametags - Visibility improvements

### DIFF
--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -40,7 +40,7 @@ if !((_camPosAGL select 0) isEqualType 0) exitWith {}; // handle RHS / bugged ve
 private _camPosASL = AGLToASL _camPosAGL;
 
 // Show nametag for the unit behind the cursor or its commander
-if (_enabledTagsCursor) then {
+if (_enabledTagsCursor || {GVAR(showCursorTagForVehicles)}) then {
     private _target = cursorTarget;
     if !(_target isKindOf "CAManBase") then {
         // When cursorTarget is on a vehicle show the nametag for the commander.

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -83,7 +83,7 @@ if (_enabledTagsNearby) then {
             _x != ACE_player &&
             {(side group _x) == (side group ACE_player)} &&
             {GVAR(showNamesForAI) || {[_x] call EFUNC(common,isPlayer)}} &&
-            {lineIntersectsSurfaces [_camPosASL, eyePos _x, ACE_player, _x] isEqualTo []} &&
+            {lineIntersectsSurfaces [_camPosASL, eyePos _x, ACE_player, _x, true, 1, "GEOM", "NONE"] isEqualTo []} &&
             {!isObjectHidden _x}
         };
         private _crewMen = [];

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -55,7 +55,7 @@ if (_enabledTagsCursor) then {
     if (_target != ACE_player &&
         {(side group _target) == (side group ACE_player)} &&
         {GVAR(showNamesForAI) || {[_target] call EFUNC(common,isPlayer)}} &&
-        {lineIntersectsSurfaces [_camPosASL, eyePos _target, ACE_player, _target] isEqualTo []} &&
+        {lineIntersectsSurfaces [_camPosASL, eyePos _target, ACE_player, _target, true, 1, "GEOM", "NONE"] isEqualTo []} &&
         {!isObjectHidden _target}) then {
 
         private _distance = ACE_player distance _target;


### PR DESCRIPTION
**When merged this pull request will:**
- [x] **More reliable NT drawing on dismounted units while inside an open vehicle:**
It appears that the current LOD checks are too restrictive when mounted on vehicles like quads, preventing drawing of the tags of dismounted units. Needs some more testing.
- [x] **Make the setting `GVAR(showCursorTagForVehicles)` always show VC nametags**:
It appears that the setting didn't have any effect previously. Only setting nametags to "cursor only" would enable the functionality of displaying VC nametags from outside.
- [x] **More reliable NT drawing on a vehicle's commander from the outside:**
Would previously be blocked on some vehicles, again due to a too restrictive LOD check.
Needs more testing, maybe it could become a List-type setting with options: Always/On cursor/On Keybind Toggle/Never.
- [ ] **Show nametags of all units within an open vehicle to the outside:**
Could be setting-dependent, maybe a List with options: Always/On cursor/On Keybind Toggle/Never.