### PR TITLE
Explosives - Optimise mine interaction code

### DIFF
--- a/addons/explosives/functions/fnc_interactEH.sqf
+++ b/addons/explosives/functions/fnc_interactEH.sqf
@@ -45,10 +45,9 @@ if (
 
         // Rescan if player has moved more than 5 meters from last position
         if (_playerPos distanceSqr _setPosition > 25) then {
-            private _cfgAmmo = configFile >> "CfgAmmo";
             {
-                if (_x distanceSqr _player < 225 && {!(_x in _minesHelped)} && {!(_x in GVAR(excludedMines))} && {getModelInfo _x select 0 isNotEqualTo "empty.p3d"}) then {
-                    private _config = _cfgAmmo >> typeOf _x;
+                if (!(_x in _minesHelped) && {!(_x in GVAR(excludedMines))} && {getModelInfo _x select 0 isNotEqualTo "empty.p3d"}) then {
+                    private _config = configOf _x;
                     private _size = getNumber (_config >> QGVAR(size));
                     private _defuseClass = ["ACE_DefuseObject", "ACE_DefuseObject_Large"] select (_size == 1);
                     private _defusePos = getArray (_config >> QGVAR(defuseObjectPosition));
@@ -64,10 +63,10 @@ if (
                     _addedHelpers pushBack _helper;
                     _minesHelped pushBack _x;
                 };
-            } forEach allMines;
+            } forEach (nearestMines [_player, [], 15, false, false]);
 
             _args set [0, _playerPos];
         };
     };
     END_COUNTER(interactEH);
-}, 0.5, [getPosASL ACE_player vectorAdd [-100, 0, 0], [], []]] call CBA_fnc_addPerFrameHandler;
+}, 0.5, [[0, 0, -100], [], []]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Depending on how dense the mines are, just switching from `allMines` to `nearestMines` is >10x speedup. Switching from `typeOf` to `configOf` is 2x.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
