### PR TITLE
Marking Laser - Change warning to info

### DIFF
--- a/addons/markinglaser/functions/fnc_onAircraftInit.sqf
+++ b/addons/markinglaser/functions/fnc_onAircraftInit.sqf
@@ -27,7 +27,7 @@ private _hasPilotCamera = getNumber (_config >> "PilotCamera" >> "controllable")
 
 if ((_turretData isEqualTo []) && {!_hasPilotCamera}) exitWith {
     _aircraft setVariable [QGVAR(enabled), false];
-    WARNING_1("Class %1 does not have a pilot camera nor a turret that could be equipped with an IR marking laser.",configName _config);
+    INFO_1("Class %1 does not have a pilot camera nor a turret that could be equipped with an IR marking laser.",configName _config);
 };
 
 _aircraft setVariable [QGVAR(enabled), true];


### PR DESCRIPTION
`[ACE] (markinglaser) WARNING: Class CUP_O_Mi8_SLA_1 does not have a pilot camera nor a turret that could be equipped with an IR marking laser.`

fairly common for transport helicopters