### PR TITLE
Field Rations - Improve Vehicle Watersource Actions

### DIFF
--- a/addons/field_rations/CfgVehicles.hpp
+++ b/addons/field_rations/CfgVehicles.hpp
@@ -97,7 +97,6 @@ class CfgVehicles {
     class Truck_02_water_base_F;
     class C_IDAP_Truck_02_water_F: Truck_02_water_base_F {
         XGVAR(waterSupply) = 10000;
-        XGVAR(offset)[] = {-0.03, -3.72, -1.05};
     };
 
     class Item_Base_F;

--- a/addons/field_rations/CfgVehicles.hpp
+++ b/addons/field_rations/CfgVehicles.hpp
@@ -97,6 +97,7 @@ class CfgVehicles {
     class Truck_02_water_base_F;
     class C_IDAP_Truck_02_water_F: Truck_02_water_base_F {
         XGVAR(waterSupply) = 10000;
+        XGVAR(offset)[] = {-0.03, -3.72, -1.05};
     };
 
     class Item_Base_F;

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -15,7 +15,7 @@ if !(hasInterface) exitWith {};
     };
 
     // Compile water source actions
-    private _mainAction = [
+    GVAR(mainAction) = [
         QGVAR(waterSource),
         LLSTRING(WaterSource),
         QPATHTOF(ui\icon_water_tap.paa),
@@ -38,7 +38,7 @@ if !(hasInterface) exitWith {};
         [false, false, false, false, true]
     ] call EFUNC(interact_menu,createAction);
 
-    private _subActions = [
+    GVAR(subActions) = [
         [
             QGVAR(checkWater),
             LLSTRING(CheckWater),
@@ -68,10 +68,10 @@ if !(hasInterface) exitWith {};
     ];
 
     // Add water source actions to helper
-    [QGVAR(helper), 0, [], _mainAction] call EFUNC(interact_menu,addActionToClass);
+    [QGVAR(helper), 0, [], GVAR(mainAction)] call EFUNC(interact_menu,addActionToClass);
     {
         [QGVAR(helper), 0, [QGVAR(waterSource)], _x] call EFUNC(interact_menu,addActionToClass);
-    } forEach _subActions;
+    } forEach GVAR(subActions);
 
     // Add inventory context menu option to consume items
     private _eatOrDrinkCondition = [

--- a/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
+++ b/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
@@ -18,10 +18,9 @@
 
 params ["_interactionType"];
 
-// Ignore when self-interaction, mounted vehicle interaction, or water source actions are disabled
+// Ignore during self-interaction or when water source actions are disabled
 if (
     _interactionType != 0
-    || {!isNull objectParent ACE_player}
     || {XGVAR(waterSourceActions) == 0}
 ) exitWith {};
 
@@ -49,13 +48,30 @@ TRACE_1("Starting interact PFH",_interactionType);
 
                     if (_waterRemaining != REFILL_WATER_DISABLED) then {
                         private _offset = [_x] call FUNC(getActionOffset);
-                        private _helper = QGVAR(helper) createVehicleLocal [0, 0, 0];
-                        _helper setVariable [QGVAR(waterSource), _x];
-                        _helper attachTo [_x, _offset];
+                        if (_offset isEqualTo [0,0,0]) then {
+                            if !(_x getVariable [QGVAR(waterSourceActionsAdded), false]) then {
+                                private _vehicle = _x;
+                                _vehicle setVariable [QGVAR(waterSource), _vehicle];
+                                _sourcesHelped pushBack _vehicle;
+                                // Add water source actions to the vehicle itself
+                                private _mainAction = [_vehicle, 0, ["ACE_MainActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
+                                private _selfAction = [_vehicle, 1, ["ACE_SelfActions"], GVAR(mainAction)] call EFUNC(interact_menu,addActionToObject);
+                                {
+                                    [_vehicle, 0, _mainAction, _x] call EFUNC(interact_menu,addActionToObject);
+                                    [_vehicle, 1, _selfAction, _x] call EFUNC(interact_menu,addActionToObject);
+                                } forEach GVAR(subActions);
+                                _vehicle setVariable [QGVAR(waterSourceActionsAdded), true];
+                                TRACE_3("Added interaction to vehicle",_x,typeOf _x,_waterRemaining);
+                            };
+                        } else {
+                            private _helper = QGVAR(helper) createVehicleLocal [0, 0, 0];
+                            _helper setVariable [QGVAR(waterSource), _x];
+                            _helper attachTo [_x, _offset];
 
-                        _addedHelpers pushBack _helper;
-                        _sourcesHelped pushBack _x;
-                        TRACE_3("Added interaction helper",_x,typeOf _x,_waterRemaining);
+                            _addedHelpers pushBack _helper;
+                            _sourcesHelped pushBack _x;
+                            TRACE_3("Added interaction helper",_x,typeOf _x,_waterRemaining);
+                        };
                     };
                 };
             } forEach nearestObjects [ACE_player, [], 15];

--- a/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
+++ b/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
@@ -48,7 +48,7 @@ TRACE_1("Starting interact PFH",_interactionType);
 
                     if (_waterRemaining != REFILL_WATER_DISABLED) then {
                         private _offset = [_x] call FUNC(getActionOffset);
-                        if (_offset isEqualTo [0,0,0]) then {
+                        if (_offset isEqualTo [0, 0, 0]) then {
                             if !(_x getVariable [QGVAR(waterSourceActionsAdded), false]) then {
                                 private _vehicle = _x;
                                 _vehicle setVariable [QGVAR(waterSource), _vehicle];

--- a/addons/field_rations/functions/fnc_checkWater.sqf
+++ b/addons/field_rations/functions/fnc_checkWater.sqf
@@ -34,5 +34,7 @@ params ["_player", "_source"];
         };
     },
     {},
-    LLSTRING(CheckingWater)
+    LLSTRING(CheckingWater),
+    {true},
+    ["isNotInside"]
 ] call EFUNC(common,progressBar);

--- a/addons/field_rations/functions/fnc_drinkFromSource.sqf
+++ b/addons/field_rations/functions/fnc_drinkFromSource.sqf
@@ -76,5 +76,6 @@ private _progressText = if (isNull _sourceConfig) then {
     _fnc_onSuccess,
     _fnc_onFailure,
     _progressText,
-    _fnc_condition
+    _fnc_condition,
+    ["isNotInside"]
 ] call EFUNC(common,progressBar);

--- a/addons/field_rations/functions/fnc_refillItem.sqf
+++ b/addons/field_rations/functions/fnc_refillItem.sqf
@@ -78,5 +78,6 @@ private _fnc_condition = {
     _fnc_onSuccess,
     _fnc_onFailure,
     LLSTRING(Refilling),
-    _fnc_condition
+    _fnc_condition,
+    ["isNotInside"]
 ] call EFUNC(common,progressBar);


### PR DESCRIPTION
**When merged this pull request will:**
Changes moved here from #10675.
- Add water actions directly to the vehicle instead of the helper object if the vehicle has no custom `"waterActionPosition"`.
This was causing the helper object to be attached to the center of the vehicle, making the interaction almost impossible to access from the outside.
- Allow accessing the water source of vehicles with no custom `"waterActionPosition"` from the inside.