### PR TITLE
Compat SOG - Add field rations to 'Survival' tab in arsenal

### DIFF
--- a/addons/compat_sog/CfgMagazines/food.hpp
+++ b/addons/compat_sog/CfgMagazines/food.hpp
@@ -16,6 +16,7 @@ class vn_prop_base;
 // US Canteen 0.75l
 class vn_prop_drink_01: vn_prop_base {
     // assuming 250ml = 5% of thirst
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = 15;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -42,6 +43,7 @@ class vn_prop_drink_04: vn_prop_drink_01 {
 
 // Bottle 0.5l
 class vn_prop_drink_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = 10;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -51,6 +53,7 @@ class vn_prop_drink_05: vn_prop_base {
 
 // Bottle 2.0l
 class vn_prop_drink_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = 40;
 
     EXGVAR(field_rations,consumeTime) = 15;
@@ -60,6 +63,7 @@ class vn_prop_drink_06: vn_prop_base {
 
 // Tilts Hot Sauce
 class vn_prop_drink_07_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = -10;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -69,6 +73,7 @@ class vn_prop_drink_07_01: vn_prop_base {
 
 // Hoangs Muoc Mam
 class vn_prop_drink_07_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = -10;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -78,6 +83,7 @@ class vn_prop_drink_07_02: vn_prop_base {
 
 // Napalm Sauce
 class vn_prop_drink_07_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = -10;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -87,6 +93,7 @@ class vn_prop_drink_07_03: vn_prop_base {
 
 // Savage Bia (Beer)
 class vn_prop_drink_08_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = 10;
     EXGVAR(field_rations,hungerSatiated) = 2; // beer is food too ;)
 
@@ -97,6 +104,7 @@ class vn_prop_drink_08_01: vn_prop_base {
 
 // Whiskey
 class vn_prop_drink_09_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = 5;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -106,6 +114,7 @@ class vn_prop_drink_09_01: vn_prop_base {
 
 // Water pack 2.0l
 class vn_prop_drink_10: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,thirstQuenched) = 40;
 
     EXGVAR(field_rations,consumeTime) = 15;
@@ -115,6 +124,7 @@ class vn_prop_drink_10: vn_prop_base {
 
 // Ration 0.75Kg
 class vn_prop_food_meal_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 15;
 
     EXGVAR(field_rations,consumeTime) = 10;
@@ -122,6 +132,7 @@ class vn_prop_food_meal_01: vn_prop_base {
 
 // Fox Hole Dinner for Two. Chicken and Noodles + Turkey Loaf + Cheese Spread + Hot sauce
 class vn_prop_food_meal_01_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -130,6 +141,7 @@ class vn_prop_food_meal_01_01: vn_prop_base {
 
 // Soup Du Jour. Ham and Lima Beans + Crackers + Hot sauce
 class vn_prop_food_meal_01_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -138,6 +150,7 @@ class vn_prop_food_meal_01_02: vn_prop_base {
 
 // Breast of Chicken Under Bullets. Boned Chicken + Cheese Spread + White Bread + Hot sauce
 class vn_prop_food_meal_01_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -146,6 +159,7 @@ class vn_prop_food_meal_01_03: vn_prop_base {
 
 // Battlefield Fufu. Boned Chicken + Peanut Butter + Milk + Hot sauce
 class vn_prop_food_meal_01_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -154,6 +168,7 @@ class vn_prop_food_meal_01_04: vn_prop_base {
 
 // Ham with Spiced Apricots. Fried Ham + Apricots + Jam + Hot sauce
 class vn_prop_food_meal_01_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -162,6 +177,7 @@ class vn_prop_food_meal_01_05: vn_prop_base {
 
 // Pork Mandarin. Pork-steak + Hot sauce
 class vn_prop_food_meal_01_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -170,6 +186,7 @@ class vn_prop_food_meal_01_06: vn_prop_base {
 
 // Tin Can Casserole. Frank and Beans + Beefsteak + Crackers + Cheese Spread + Hot sauce
 class vn_prop_food_meal_01_07: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -178,6 +195,7 @@ class vn_prop_food_meal_01_07: vn_prop_base {
 
 // Creamed Turkey on Toast. Turkey loaf + White Bread + Hot sauce
 class vn_prop_food_meal_01_08: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -186,6 +204,7 @@ class vn_prop_food_meal_01_08: vn_prop_base {
 
 // Fish with Front line Stuffing. Crackers + Ham and Egg Chopped + Hot sauce
 class vn_prop_food_meal_01_09: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -194,6 +213,7 @@ class vn_prop_food_meal_01_09: vn_prop_base {
 
 // Combat Zone Burgoo. Spiced Beef + Ham and Lima Beans + Crackers + Hot sauce
 class vn_prop_food_meal_01_10: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -202,6 +222,7 @@ class vn_prop_food_meal_01_10: vn_prop_base {
 
 // Patrol Chicken Soup. Fresh Chicken + Crackers + Hot sauce
 class vn_prop_food_meal_01_11: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -210,6 +231,7 @@ class vn_prop_food_meal_01_11: vn_prop_base {
 
 // Guard Relief Eggs Benedict. White Bread + Ham and Eggs Chopped + Cheese Spread + Hot sauce
 class vn_prop_food_meal_01_12: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -218,6 +240,7 @@ class vn_prop_food_meal_01_12: vn_prop_base {
 
 // Beefsteak En Croute. White Bread + Beefsteak + Hot sauce
 class vn_prop_food_meal_01_13: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -226,6 +249,7 @@ class vn_prop_food_meal_01_13: vn_prop_base {
 
 // Curried Meat Balls Over Rice. Meat Balls and Beans + Hot sauce
 class vn_prop_food_meal_01_14: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -234,6 +258,7 @@ class vn_prop_food_meal_01_14: vn_prop_base {
 
 // Cease Fire Casserole. Beefsteak + Spiced Beef + Hot sauce
 class vn_prop_food_meal_01_15: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -242,6 +267,7 @@ class vn_prop_food_meal_01_15: vn_prop_base {
 
 // Rice Paddy Shrimp. Fresh Shrimp + Cheese Spread + Hot sauce
 class vn_prop_food_meal_01_16: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -250,6 +276,7 @@ class vn_prop_food_meal_01_16: vn_prop_base {
 
 // Battlefield Birthday Cake. Pound Cake + Chocolate Candy + Hot sauce
 class vn_prop_food_meal_01_17: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -258,6 +285,7 @@ class vn_prop_food_meal_01_17: vn_prop_base {
 
 // Pecan Cake Roll with Peanut Butter Sauce. Pecan Cake Roll + Peanut Butter + Hot sauce
 class vn_prop_food_meal_01_18: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,thirstQuenched) = -1; // hot!
 
@@ -266,306 +294,357 @@ class vn_prop_food_meal_01_18: vn_prop_base {
 
 // Con ho. Rice + Tiger + Vegetables + Fish Sauce
 class vn_prop_food_meal_02_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Con voi. Rice + Elephant + Vegetables + Fish Sauce
 class vn_prop_food_meal_02_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Con ran. Rice + Snake + Vegetables + Fish Sauce
 class vn_prop_food_meal_02_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Cha ca la vong. Rice + Fish + Vegetables + Fish Sauce
 class vn_prop_food_meal_02_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Con tom. Rice + Shrimp + Vegetables + Fish sauce
 class vn_prop_food_meal_02_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Pho ga. Rice + Chicken + Vegetables + Fish sauce
 class vn_prop_food_meal_02_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // PIR Rations. Contains 1Kg of high energy food: PIR ration (Beef)
 class vn_prop_food_pir_01_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // PIR Rations. Contains 1Kg of high energy food: PIR ration (Fish and Squid)
 class vn_prop_food_pir_01_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // PIR Rations. Contains 1Kg of high energy food: PIR ration (Shrimp and Mushroom)
 class vn_prop_food_pir_01_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // PIR Rations. Contains 1Kg of high energy food: PIR ration (Mutton)
 class vn_prop_food_pir_01_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // PIR Rations. Contains 1Kg of high energy food: PIR ration (Sausage)
 class vn_prop_food_pir_01_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 10Kg of food: Ration box (LRP Ration Box)
 class vn_prop_food_box_01_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 100;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 10Kg of food: Ration box (PIR Ration Box)
 class vn_prop_food_box_01_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 100;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 10Kg of food: Ration box (MCI Ration Box)
 class vn_prop_food_box_01_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 100;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Ham and Eggs Chopped)
 class vn_prop_food_box_02_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Ham Fried)
 class vn_prop_food_box_02_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Beans w/ Frankfurter Chunks)
 class vn_prop_food_box_02_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Spaghetti w/ Ground Meat)
 class vn_prop_food_box_02_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Turkey Loaf)
 class vn_prop_food_box_02_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Pork Steak)
 class vn_prop_food_box_02_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Beef w/ Spiced Sauce)
 class vn_prop_food_box_02_07: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Boxed Rations. Contains 2Kg of food: Ration box (Chicken Boned)
 class vn_prop_food_box_02_08: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 50;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Beefsteak)
 class vn_prop_food_can_01_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Spiced Sauce)
 class vn_prop_food_can_01_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Turkey Loaf)
 class vn_prop_food_can_01_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Ham, Fried)
 class vn_prop_food_can_01_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Ham and Eggs Chopped)
 class vn_prop_food_can_01_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Tuna)
 class vn_prop_food_can_01_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Chicken and Noodles)
 class vn_prop_food_can_01_07: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Chicken Boned)
 class vn_prop_food_can_01_08: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Pork Slices with Juices)
 class vn_prop_food_can_01_09: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (B-1A Unit Crackers and Candy)
 class vn_prop_food_can_01_10: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (B-2 Unit Crackers and Cheese Spread)
 class vn_prop_food_can_01_11: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Pound Cake)
 class vn_prop_food_can_01_12: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Pecan Cake Roll)
 class vn_prop_food_can_01_13: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Chocolate Nut Roll)
 class vn_prop_food_can_01_14: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (Fruitcake)
 class vn_prop_food_can_01_15: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.5Kg of food: Ration can (White Bread)
 class vn_prop_food_can_01_16: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 25;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Beans w/ Meat Balls in Tomato Sauce)
 class vn_prop_food_can_02_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Ham and Lima Beans)
 class vn_prop_food_can_02_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Beans w/ Frankfurter Chunks in Tomato Sauce)
 class vn_prop_food_can_02_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Spaghetti w/ Ground Meat)
 class vn_prop_food_can_02_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (B-3 Unit Cookies, Jam and Cocoa Beverage Powder)
 class vn_prop_food_can_02_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Apricots)
 class vn_prop_food_can_02_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Peaches)
 class vn_prop_food_can_02_07: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.75Kg of food: Ration can (Pears)
 class vn_prop_food_can_02_08: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.3Kg of food: Ration can (Peanut Butter)
 class vn_prop_food_can_03_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 15;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.3Kg of food: Ration can (Jam, Seedless Blackberry)
 class vn_prop_food_can_03_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 15;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.3Kg of food: Ration can (Pineapple Jam)
 class vn_prop_food_can_03_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 15;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Canned Rations. Contains 0.3Kg of food: Ration can (Cheese Spread)
 class vn_prop_food_can_03_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 15;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Orange
 class vn_prop_food_fresh_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 10;
     EXGVAR(field_rations,thirstQuenched) = 10;
     EXGVAR(field_rations,consumeTime) = 10;
@@ -573,6 +652,7 @@ class vn_prop_food_fresh_01: vn_prop_base {
 
 // Pumpik 3Kg
 class vn_prop_food_fresh_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,thirstQuenched) = 5;
     EXGVAR(field_rations,consumeTime) = 10;
@@ -580,96 +660,126 @@ class vn_prop_food_fresh_02: vn_prop_base {
 
 // Chicken 3Kg
 class vn_prop_food_fresh_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 35;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Shrimp 3Kg
 class vn_prop_food_fresh_04: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Fish 3Kg
 class vn_prop_food_fresh_05: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Pork 3Kg
 class vn_prop_food_fresh_06: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 35;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Snake 3Kg
 class vn_prop_food_fresh_07: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Tiger 3Kg
 class vn_prop_food_fresh_08: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Elephant 3Kg
 class vn_prop_food_fresh_09: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // Rau Ma 3Kg
 class vn_prop_food_fresh_10: vn_prop_food_fresh_03 {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 30;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Beef Hash)
 class vn_prop_food_lrrp_01_01: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Chili Con Carne)
 class vn_prop_food_lrrp_01_02: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Spaghetti w/ Meat Sauce)
 class vn_prop_food_lrrp_01_03: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Beef and Rice)
 class vn_prop_food_lrrp_01_04: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Chicken Stew)
 class vn_prop_food_lrrp_01_05: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Pork w/ Escalloped Potatoes)
 class vn_prop_food_lrrp_01_06: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Beef Stew)
 class vn_prop_food_lrrp_01_07: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
     EXGVAR(field_rations,consumeTime) = 10;
 };
 
 // LRRP Rations. Contains 1Kg of high energy food: LRRP ration (Chicken and Rice)
 class vn_prop_food_lrrp_01_08: vn_prop_base {
+    ACE_asItem = 1;
     EXGVAR(field_rations,hungerSatiated) = 90;
+    EXGVAR(field_rations,consumeTime) = 10;
+};
+
+// Rice 1Kg
+class vn_prop_food_sack_01: vn_prop_base {
+    ACE_asItem = 1;
+    EXGVAR(field_rations,hungerSatiated) = 5;
+    EXGVAR(field_rations,consumeTime) = 10;
+};
+
+// Rice 4Kg
+class vn_prop_food_sack_02: vn_prop_base {
+    ACE_asItem = 1;
+    EXGVAR(field_rations,hungerSatiated) = 20;
     EXGVAR(field_rations,consumeTime) = 10;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Add 2x rice sacks as food sources.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
