### PR TITLE
Fastroping - End descent with weapon holstered

### DIFF
--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -58,6 +58,7 @@ if (isNull attachedTo _unit) exitWith {
             params ["_unit", "_weapon"];
             // Abort if the unit already selected a different weapon
             if (currentWeapon _unit != "") exitWith {};
+            if (!([_unit] call EFUNC(common,isAwake))) exitWith {};
             _unit selectWeapon _weapon;
         }, [_unit, _currentWeapon], 2] call CBA_fnc_waitAndExecute;
     };

--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -50,6 +50,9 @@ if (isNull attachedTo _unit) exitWith {
         playSound QGVAR(Thud);
     };
 
+    // Holster weapon
+    [_unit] call EFUNC(weaponselect,putWeaponAway);
+
     [_pfhHandle] call CBA_fnc_removePerFrameHandler;
 };
 

--- a/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
+++ b/addons/fastroping/functions/fnc_fastRopeLocalPFH.sqf
@@ -50,8 +50,17 @@ if (isNull attachedTo _unit) exitWith {
         playSound QGVAR(Thud);
     };
 
-    // Holster weapon
-    [_unit] call EFUNC(weaponselect,putWeaponAway);
+    // Holster weapon if one is being held, then unholster it again
+    private _currentWeapon = currentWeapon _unit;
+    if (_currentWeapon != "") then {
+        [_unit] call EFUNC(weaponselect,putWeaponAway);
+        [{
+            params ["_unit", "_weapon"];
+            // Abort if the unit already selected a different weapon
+            if (currentWeapon _unit != "") exitWith {};
+            _unit selectWeapon _weapon;
+        }, [_unit, _currentWeapon], 2] call CBA_fnc_waitAndExecute;
+    };
 
     [_pfhHandle] call CBA_fnc_removePerFrameHandler;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Holster your weapon after reaching the ground.
IMO reaching the ground and being instantly ready to fire is a bit immersion breaking.
I don't think there is a way to have the weapon holstered **before** running the fastroping animation? Holstering before L39 doesn't work.