### PR TITLE
Add Separate Treatment Times for Exceeding Required Skill level

### DIFF
--- a/addons/fire/compat_medical_engine/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/fire/compat_medical_engine/ACE_Medical_Treatment_Actions.hpp
@@ -10,7 +10,6 @@ class EGVAR(medical_treatment,actions) {
         allowSelfTreatment = 1;
         medicRequired = 0;
         treatmentTime = 5;
-        treatmentTimeTrained = 5;
         items[] = {};
         condition = QFUNC(medical_canPatDown);
         callbackSuccess = QFUNC(medical_success);

--- a/addons/fire/compat_medical_engine/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/fire/compat_medical_engine/ACE_Medical_Treatment_Actions.hpp
@@ -10,6 +10,7 @@ class EGVAR(medical_treatment,actions) {
         allowSelfTreatment = 1;
         medicRequired = 0;
         treatmentTime = 5;
+        treatmentTimeTrained = 5;
         items[] = {};
         condition = QFUNC(medical_canPatDown);
         callbackSuccess = QFUNC(medical_success);

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -16,7 +16,7 @@ class GVAR(actions) {
         treatmentLocations = TREATMENT_LOCATIONS_ALL;
 
         treatmentTime = QFUNC(getBandageTime);
-        treatmentTimeSelfCoef = 1; // todo: this isn't used anywhere, remove?
+        treatmentTimeTrained = QFUNC(getBandageTime);
 
         callbackStart = "";
         callbackProgress = "";
@@ -80,6 +80,7 @@ class GVAR(actions) {
         allowedSelections[] = {"LeftArm", "RightArm", "LeftLeg", "RightLeg"};
         items[] = {"ACE_tourniquet"};
         treatmentTime = QGVAR(treatmentTimeTourniquet);
+        treatmentTimeTrained = QGVAR(treatmentTimeTrainedTourniquet);
         condition = QUOTE(!([ARR_2(_patient,_bodyPart)] call FUNC(hasTourniquetAppliedTo)));
         callbackSuccess = QFUNC(tourniquet);
         litter[] = {};
@@ -105,6 +106,7 @@ class GVAR(actions) {
         items[] = {"ACE_splint"};
         treatmentLocations = QGVAR(locationSplint);
         treatmentTime = QGVAR(treatmentTimeSplint);
+        treatmentTimeTrained = QGVAR(treatmentTimeTrainedSplint);
         callbackSuccess = QFUNC(splint);
         condition = QFUNC(canSplint);
         litter[] = {
@@ -124,6 +126,7 @@ class GVAR(actions) {
         treatmentLocations = QGVAR(locationMorphine);
         condition = "";
         treatmentTime = QGVAR(treatmentTimeAutoinjector);
+        treatmentTimeTrained = QGVAR(treatmentTimeTrainedAutoinjector);
         callbackSuccess = QFUNC(medication);
         animationMedic = "AinvPknlMstpSnonWnonDnon_medic1";
         sounds[] = {{QPATHTO_R(sounds\Inject.ogg),1,1,50}};
@@ -156,6 +159,7 @@ class GVAR(actions) {
         medicRequired = 0;
         items[] = {"ACE_painkillers"};
         treatmentTime = 4;
+        treatmentTimeTrained = 4;
         sounds[] = {{QPATHTO_R(sounds\Pills.ogg),1,1,50}};
         litter[] = {{"Land_PainKillers_F"}}; // just use BI's model as litter
     };
@@ -170,6 +174,7 @@ class GVAR(actions) {
         category = "advanced";
         medicRequired = QGVAR(medicIV);
         treatmentTime = QGVAR(treatmentTimeIV);
+        treatmentTimeTrained = QGVAR(treatmentTimeTrainedIV);
         items[] = {"ACE_bloodIV"};
         treatmentLocations = QGVAR(locationIV);
         condition = "";
@@ -224,6 +229,7 @@ class GVAR(actions) {
         allowedSelections[] = {"Head", "Body"};
         medicRequired = 0;
         treatmentTime = 2.5;
+        treatmentTimeTrained = 2.5;
         items[] = {};
         condition = QUOTE(GVAR(advancedDiagnose) == 0);
         callbackSuccess = QFUNC(diagnose);
@@ -266,6 +272,7 @@ class GVAR(actions) {
         allowSelfTreatment = 0;
         medicRequired = 0;
         treatmentTime = QGVAR(treatmentTimeBodyBag);
+        treatmentTimeTrained = QGVAR(treatmentTimeBodyBag);
         items[] = {"ACE_bodyBag"};
         condition = QFUNC(canPlaceInBodyBag);
         callbackSuccess = QFUNC(placeInBodyBag);
@@ -285,6 +292,7 @@ class GVAR(actions) {
         displayNameProgress = CSTRING(DiggingGrave);
         icon = QPATHTOEF(medical_gui,ui\grave.paa);
         treatmentTime = QGVAR(treatmentTimeGrave);
+        treatmentTimeTrained = QGVAR(treatmentTimeGrave);
         condition = QFUNC(canDigGrave);
         callbackSuccess = QFUNC(placeInGrave);
         items[] = {};
@@ -300,6 +308,7 @@ class GVAR(actions) {
         allowSelfTreatment = 0;
         medicRequired = 0;
         treatmentTime = QGVAR(treatmentTimeCPR);
+        treatmentTimeTrained = QGVAR(treatmentTimeCPR);
         items[] = {};
         condition = QFUNC(canCPR);
         callbackSuccess = QFUNC(cprSuccess);
@@ -323,6 +332,7 @@ class GVAR(actions) {
         allowSelfTreatment = QGVAR(allowSelfStitch);
         medicRequired = QGVAR(medicSurgicalKit);
         treatmentTime = QFUNC(getStitchTime);
+        treatmentTimeTrained = QFUNC(getStitchTime);
         condition = QFUNC(canStitch);
         callbackSuccess = "";
         callbackStart = QFUNC(surgicalKitStart);
@@ -342,6 +352,7 @@ class GVAR(actions) {
         allowSelfTreatment = QGVAR(allowSelfPAK);
         medicRequired = QGVAR(medicPAK);
         treatmentTime = QFUNC(getHealTime);
+        treatmentTimeTrained = QFUNC(getHealTime);
         callbackSuccess = QFUNC(fullHeal);
         consumeItem = QGVAR(consumePAK);
         animationMedic = "AinvPknlMstpSlayW[wpn]Dnon_medicOther";

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -158,7 +158,6 @@ class GVAR(actions) {
         medicRequired = 0;
         items[] = {"ACE_painkillers"};
         treatmentTime = 4;
-        treatmentTimeTrained = 4;
         sounds[] = {{QPATHTO_R(sounds\Pills.ogg),1,1,50}};
         litter[] = {{"Land_PainKillers_F"}}; // just use BI's model as litter
     };

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -288,7 +288,6 @@ class GVAR(actions) {
         displayNameProgress = CSTRING(DiggingGrave);
         icon = QPATHTOEF(medical_gui,ui\grave.paa);
         treatmentTime = QGVAR(treatmentTimeGrave);
-        treatmentTimeTrained = QGVAR(treatmentTimeGrave);
         condition = QFUNC(canDigGrave);
         callbackSuccess = QFUNC(placeInGrave);
         items[] = {};

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -227,7 +227,6 @@ class GVAR(actions) {
         allowedSelections[] = {"Head", "Body"};
         medicRequired = 0;
         treatmentTime = 2.5;
-        treatmentTimeTrained = 2.5;
         items[] = {};
         condition = QUOTE(GVAR(advancedDiagnose) == 0);
         callbackSuccess = QFUNC(diagnose);

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -16,7 +16,6 @@ class GVAR(actions) {
         treatmentLocations = TREATMENT_LOCATIONS_ALL;
 
         treatmentTime = QFUNC(getBandageTime);
-        treatmentTimeTrained = QFUNC(getBandageTime);
 
         callbackStart = "";
         callbackProgress = "";

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -269,7 +269,6 @@ class GVAR(actions) {
         allowSelfTreatment = 0;
         medicRequired = 0;
         treatmentTime = QGVAR(treatmentTimeBodyBag);
-        treatmentTimeTrained = QGVAR(treatmentTimeBodyBag);
         items[] = {"ACE_bodyBag"};
         condition = QFUNC(canPlaceInBodyBag);
         callbackSuccess = QFUNC(placeInBodyBag);

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -303,7 +303,6 @@ class GVAR(actions) {
         allowSelfTreatment = 0;
         medicRequired = 0;
         treatmentTime = QGVAR(treatmentTimeCPR);
-        treatmentTimeTrained = QGVAR(treatmentTimeCPR);
         items[] = {};
         condition = QFUNC(canCPR);
         callbackSuccess = QFUNC(cprSuccess);

--- a/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/medical_treatment/ACE_Medical_Treatment_Actions.hpp
@@ -326,7 +326,6 @@ class GVAR(actions) {
         allowSelfTreatment = QGVAR(allowSelfStitch);
         medicRequired = QGVAR(medicSurgicalKit);
         treatmentTime = QFUNC(getStitchTime);
-        treatmentTimeTrained = QFUNC(getStitchTime);
         condition = QFUNC(canStitch);
         callbackSuccess = "";
         callbackStart = QFUNC(surgicalKitStart);
@@ -346,7 +345,6 @@ class GVAR(actions) {
         allowSelfTreatment = QGVAR(allowSelfPAK);
         medicRequired = QGVAR(medicPAK);
         treatmentTime = QFUNC(getHealTime);
-        treatmentTimeTrained = QFUNC(getHealTime);
         callbackSuccess = QFUNC(fullHeal);
         consumeItem = QGVAR(consumePAK);
         animationMedic = "AinvPknlMstpSlayW[wpn]Dnon_medicOther";

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -43,7 +43,6 @@ private _treatmentTime = if (isText (_config >> _treatmentTimeConfig)) then {
     getNumber (_config >> _treatmentTimeConfig);
 };
 
-
 if (_treatmentTime == 0) exitWith {false};
 
 // Consume one of the treatment items if needed

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -30,7 +30,7 @@ if !(_this call FUNC(canTreat)) exitWith {false};
 private _config = configFile >> QGVAR(actions) >> _classname;
 
 // Get treatment time from config, exit if treatment time is zero
-private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select ([_medic] call FUNC(isMedic));
+private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select (([_medic] call FUNC(isMedic)) && {!isNull (_config >> "treatmentTimeTrained")});
 private _treatmentTime = if (isText (_config >> _treatmentTimeConfig)) then {
     GET_FUNCTION(_treatmentTime,_config >> _treatmentTimeConfig);
 

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -30,8 +30,9 @@ if !(_this call FUNC(canTreat)) exitWith {false};
 private _config = configFile >> QGVAR(actions) >> _classname;
 
 // Get treatment time from config, exit if treatment time is zero
-private _treatmentTime = if (isText (_config >> "treatmentTime")) then {
-    GET_FUNCTION(_treatmentTime,_config >> "treatmentTime");
+private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select ([_medic] call ace_medical_treatment_fnc_isMedic);
+private _treatmentTime = if (isText (_config >> _treatmentTimeConfig)) then {
+    GET_FUNCTION(_treatmentTime,_config >> _treatmentTimeConfig);
 
     if (_treatmentTime isEqualType {}) then {
         _treatmentTime = call _treatmentTime;
@@ -39,8 +40,9 @@ private _treatmentTime = if (isText (_config >> "treatmentTime")) then {
 
     _treatmentTime
 } else {
-    getNumber (_config >> "treatmentTime");
+    getNumber (_config >> _treatmentTimeConfig);
 };
+
 
 if (_treatmentTime == 0) exitWith {false};
 

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -30,7 +30,8 @@ if !(_this call FUNC(canTreat)) exitWith {false};
 private _config = configFile >> QGVAR(actions) >> _classname;
 
 // Get treatment time from config, exit if treatment time is zero
-private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select (([_medic] call FUNC(isMedic)) && {!isNull (_config >> "treatmentTimeTrained")});
+private _medicRequiredLevel = GET_NUMBER_ENTRY(_config >> "medicRequired");
+private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select (([_medic, (_medicRequiredLevel + 1)] call FUNC(isMedic)) && {!isNull (_config >> "treatmentTimeTrained")});
 private _treatmentTime = if (isText (_config >> _treatmentTimeConfig)) then {
     GET_FUNCTION(_treatmentTime,_config >> _treatmentTimeConfig);
 

--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -30,7 +30,7 @@ if !(_this call FUNC(canTreat)) exitWith {false};
 private _config = configFile >> QGVAR(actions) >> _classname;
 
 // Get treatment time from config, exit if treatment time is zero
-private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select ([_medic] call ace_medical_treatment_fnc_isMedic);
+private _treatmentTimeConfig = ["treatmentTime", "treatmentTimeTrained"] select ([_medic] call FUNC(isMedic));
 private _treatmentTime = if (isText (_config >> _treatmentTimeConfig)) then {
     GET_FUNCTION(_treatmentTime,_config >> _treatmentTimeConfig);
 

--- a/addons/medical_treatment/initSettings.inc.sqf
+++ b/addons/medical_treatment/initSettings.inc.sqf
@@ -110,6 +110,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(treatmentTimeTrainedAutoinjector),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTrainedAutoinjector_DisplayName), LSTRING(TreatmentTimeTrainedAutoinjector_Description)],
+    LSTRING(Category),
+    [0.1, 60, 5, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(treatmentTimeTourniquet),
     "SLIDER",
     [LSTRING(TreatmentTimeTourniquet_DisplayName), LSTRING(TreatmentTimeTourniquet_Description)],
@@ -119,9 +128,27 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(treatmentTimeTrainedTourniquet),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTrainedTourniquet_DisplayName), LSTRING(TreatmentTimeTrainedTourniquet_Description)],
+    LSTRING(Category),
+    [0.1, 60, 7, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(treatmentTimeSplint),
     "SLIDER",
     [LSTRING(TreatmentTimeSplint_DisplayName), LSTRING(TreatmentTimeSplint_Description)],
+    LSTRING(Category),
+    [0.1, 60, 7, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeTrainedSplint),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTrainedSplint_DisplayName), LSTRING(TreatmentTimeTrainedSplint_Description)],
     LSTRING(Category),
     [0.1, 60, 7, 1],
     true
@@ -339,6 +366,15 @@
     QGVAR(treatmentTimeIV),
     "SLIDER",
     [LSTRING(TreatmentTimeIV_DisplayName), LSTRING(TreatmentTimeIV_Description)],
+    LSTRING(Category),
+    [0.1, 60, 12, 1],
+    true
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(treatmentTimeTrainedIV),
+    "SLIDER",
+    [LSTRING(TreatmentTimeTrainedIV_DisplayName), LSTRING(TreatmentTimeTrainedIV_Description)],
     LSTRING(Category),
     [0.1, 60, 12, 1],
     true

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4500,7 +4500,7 @@
             <Chinesesimp>自动注射器治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_Description">
-            <English>Time, in seconds, required to administer medication using an autoinjector. For a Meidc or Doctor</English>
+            <English>Time, in seconds, required to administer medication using an autoinjector. For a Medic or Doctor</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_DisplayName">
             <English>Skilled Autoinjector Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4632,7 +4632,7 @@
             <Chinesesimp>静脉输液袋治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_Description">
-            <English>Time, in seconds, required to administer an IV bag. For a Meidc or Doctor</English>
+            <English>Time, in seconds, required to administer an IV bag. For a Medic or Doctor</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_DisplayName">
             <English>Skilled IV Bag Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4696,7 +4696,7 @@
             <Chinesesimp>止血带治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_Description">
-            <English>Time, in seconds, required to apply/remove a tourniquet.. For a Meidc or Doctor</English>
+            <English>Time, in seconds, required to apply/remove a tourniquet. For a Medic or Doctor</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_DisplayName">
             <English>Skilled Tourniquet Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4632,7 +4632,7 @@
             <Chinesesimp>静脉输液袋治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_Description">
-            <English>Time, in seconds, required to administer an IV bag. For a Medic or Doctor</English>
+            <English>Time, in seconds, required for a Medic or Doctor to administer an IV bag.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_DisplayName">
             <English>Skilled IV Bag Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4664,7 +4664,7 @@
             <Chinesesimp>夹板治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_Description">
-            <English>Time, in seconds, required to apply a splint. For a Medic or Doctor</English>
+            <English>Time, in seconds, required for a Medic or Doctor to apply a splint.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_DisplayName">
             <English>Skilled Splint Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4500,7 +4500,7 @@
             <Chinesesimp>自动注射器治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_Description">
-            <English>Time, in seconds, required to administer medication using an autoinjector. For a Medic or Doctor</English>
+            <English>Time, in seconds, required for a Medic or Doctor to administer medication using an autoinjector.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_DisplayName">
             <English>Skilled Autoinjector Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4696,7 +4696,7 @@
             <Chinesesimp>止血带治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_Description">
-            <English>Time, in seconds, required to apply/remove a tourniquet. For a Medic or Doctor</English>
+            <English>Time, in seconds, required for a Medic or Doctor to apply or remove a tourniquet.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_DisplayName">
             <English>Skilled Tourniquet Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4664,7 +4664,7 @@
             <Chinesesimp>夹板治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_Description">
-            <English>Time, in seconds, required to apply a splint. For a Meidc or Doctor</English>
+            <English>Time, in seconds, required to apply a splint. For a Medic or Doctor</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_DisplayName">
             <English>Skilled Splint Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4500,7 +4500,7 @@
             <Chinesesimp>自动注射器治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_Description">
-            <English>Time, in seconds, required for a Medic or Doctor to administer medication using an autoinjector.</English>
+            <English>Time, in seconds, required for a unit exceeding required training level to administer medication using an autoinjector.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_DisplayName">
             <English>Skilled Autoinjector Treatment Time</English>
@@ -4632,7 +4632,7 @@
             <Chinesesimp>静脉输液袋治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_Description">
-            <English>Time, in seconds, required for a Medic or Doctor to administer an IV bag.</English>
+            <English>Time, in seconds, required for a unit exceeding required training level to administer an IV bag.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_DisplayName">
             <English>Skilled IV Bag Treatment Time</English>
@@ -4664,7 +4664,7 @@
             <Chinesesimp>夹板治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_Description">
-            <English>Time, in seconds, required for a Medic or Doctor to apply a splint.</English>
+            <English>Time, in seconds, required for a unit exceeding required training level to apply a splint.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_DisplayName">
             <English>Skilled Splint Treatment Time</English>
@@ -4696,7 +4696,7 @@
             <Chinesesimp>止血带治疗时间</Chinesesimp>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_Description">
-            <English>Time, in seconds, required for a Medic or Doctor to apply or remove a tourniquet.</English>
+            <English>Time, in seconds, required for a unit exceeding required training level to apply or remove a tourniquet.</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_DisplayName">
             <English>Skilled Tourniquet Treatment Time</English>

--- a/addons/medical_treatment/stringtable.xml
+++ b/addons/medical_treatment/stringtable.xml
@@ -4499,6 +4499,12 @@
             <Japanese>自動注射器の所要時間</Japanese>
             <Chinesesimp>自动注射器治疗时间</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_Description">
+            <English>Time, in seconds, required to administer medication using an autoinjector. For a Meidc or Doctor</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedAutoinjector_DisplayName">
+            <English>Skilled Autoinjector Treatment Time</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeBodyBag_Description">
             <English>Time, in seconds, required to put a patient in a body bag.</English>
             <French>Définit le temps nécessaire à la mise en housse d'un corps (en secondes).</French>
@@ -4625,6 +4631,12 @@
             <Japanese>点滴の所要時間</Japanese>
             <Chinesesimp>静脉输液袋治疗时间</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_Description">
+            <English>Time, in seconds, required to administer an IV bag. For a Meidc or Doctor</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedIV_DisplayName">
+            <English>Skilled IV Bag Treatment Time</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeSplint_Description">
             <English>Time, in seconds, required to apply a splint.</English>
             <French>Définit le temps nécessaire à l'application d'une attelle (en secondes).</French>
@@ -4651,6 +4663,12 @@
             <Japanese>添え木の所要時間</Japanese>
             <Chinesesimp>夹板治疗时间</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_Description">
+            <English>Time, in seconds, required to apply a splint. For a Meidc or Doctor</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedSplint_DisplayName">
+            <English>Skilled Splint Treatment Time</English>
+        </Key>
         <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTourniquet_Description">
             <English>Time, in seconds, required to apply/remove a tourniquet.</English>
             <French>Définit le temps nécessaire à l'application ou au retrait d'un garrot (en secondes).</French>
@@ -4676,6 +4694,12 @@
             <Korean>지혈대 사용 시간</Korean>
             <Japanese>止血帯の所要時間</Japanese>
             <Chinesesimp>止血带治疗时间</Chinesesimp>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_Description">
+            <English>Time, in seconds, required to apply/remove a tourniquet.. For a Meidc or Doctor</English>
+        </Key>
+        <Key ID="STR_ACE_Medical_Treatment_TreatmentTimeTrainedTourniquet_DisplayName">
+            <English>Skilled Tourniquet Treatment Time</English>
         </Key>
         <Key ID="STR_ACE_Medical_Treatment_TriageCard_NoEntry">
             <English>No entries on this triage card.</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add "Skilled" Variants of the treatment time setting for 
   - Auto-Injector
    - Tourniquet
    - IV Bag
    - Splint
    
   "Skilled" is defined as exceeding the required skill level for treatment. 
   Eg If anyone can do it then skilled is Medic or Doctor
   If a Medic is required, then Skilled is a Doctor
 
![20250129184850_1](https://github.com/user-attachments/assets/033b985b-0b20-4fad-b90d-cd97511024ea)


### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
