### PR TITLE
Advanced Ballistics - Take object size and trees into account for terrain roughness

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_initializeTerrainExtension.sqf
+++ b/addons/advanced_ballistics/functions/fnc_initializeTerrainExtension.sqf
@@ -43,7 +43,7 @@ GVAR(currentGrid) = 0;
 INFO_2("Starting Terrain Extension [cells: %1] [world: %2]",_gridCells,worldName);
 
 [{
-    params ["_args","_idPFH"];
+    params ["_args", "_idPFH"];
     _args params ["_mapGrids", "_gridCells", "_initStartTime"];
 
     if (GVAR(currentGrid) >= _gridCells) exitWith {
@@ -57,12 +57,21 @@ INFO_2("Starting Terrain Extension [cells: %1] [world: %2]",_gridCells,worldName
     for "_i" from 1 to 50 do {
         private _x = floor(GVAR(currentGrid) / _mapGrids) * 50;
         private _y = (GVAR(currentGrid) - floor(GVAR(currentGrid) / _mapGrids) * _mapGrids) * 50;
+
         private _gridCenter = [_x + 25, _y + 25];
-        private _gridHeight = round(getTerrainHeightASL _gridCenter);
-        private _gridNumObjects = count (_gridCenter nearObjects ["Building", 50]);
-        "ace" callExtension ["ballistics:map:set", [GVAR(currentGrid), _gridHeight, _gridNumObjects, surfaceIsWater _gridCenter]];
+        private _gridHeight = round getTerrainHeightASL _gridCenter;
+        private _gridBuildingCount = {
+            private _bb = boundingBoxReal [_x, "ViewGeometry"];
+            private _height = _bb#1#2 - _bb#0#2;
+            private _volume = (_bb#1#0 - _bb#0#0) * (_bb#1#1 - _bb#0#1) * _height;
+
+            (_height > 0.3) && {_volume > 10}
+        } count (_windSource nearObjects ["Building", 50]);
+        private _gridTreeCount = count nearestTerrainObjects [_windSource, ["TREE"], 50, false];
+        private _roughnessIndex = _gridBuildingCount + round (_gridTreeCount / 9);
+
+        "ace" callExtension ["ballistics:map:set", [GVAR(currentGrid), _gridHeight, _roughnessIndex, surfaceIsWater _gridCenter]];
         GVAR(currentGrid) = GVAR(currentGrid) + 1;
         if (GVAR(currentGrid) >= _gridCells) exitWith {};
     };
-
 }, 0, [_mapGrids, _gridCells, _initStartTime]] call CBA_fnc_addPerFrameHandler

--- a/addons/weather/functions/fnc_calculateRoughnessLength.sqf
+++ b/addons/weather/functions/fnc_calculateRoughnessLength.sqf
@@ -18,19 +18,20 @@
 // Source: http://es.ucsc.edu/~jnoble/wind/extrap/index.html
 #define ROUGHNESS_LENGTHS [0.0002, 0.0005, 0.0024, 0.03, 0.055, 0.1, 0.2, 0.4, 0.8, 1.6]
 
-private _windSource = _this vectorDiff ((vectorNormalized wind) vectorMultiply 25);
+private _windSource = ASLtoAGL (_this vectorDiff ((vectorNormalized wind) vectorMultiply 25));
 private _nearBuildingCount = {
-    // Filter lights - fixes high roughness on airports (#6602)
-    str _x find "light" == -1
-} count (ASLToAGL _windSource nearObjects ["Building", 50]);
+    private _bb = boundingBoxReal [_x, "ViewGeometry"];
+    private _height = _bb#1#2 - _bb#0#2;
+    private _volume = (_bb#1#0 - _bb#0#0) * (_bb#1#1 - _bb#0#1) * _height;
+
+    (_height > 0.3) && {_volume > 10}
+} count (_windSource nearObjects ["Building", 50]);
+private _nearTreeCount = count nearestTerrainObjects [_windSource, ["TREE"], 50, false];
 private _isWater = surfaceIsWater _windSource;
 
 if (_nearBuildingCount == 0 && _isWater) exitWith {
     0.0005
 };
 
-if (_nearBuildingCount >= 10) exitWith {
-    1.6
-};
-
-ROUGHNESS_LENGTHS select (2 + (_nearBuildingCount min 6))
+private _roughnessIndex = _nearBuildingCount + round (_nearTreeCount / 9);
+ROUGHNESS_LENGTHS select (2 + _roughnessIndex min 9)


### PR DESCRIPTION
**When merged this pull request will:**
Refactor terrain roughness to:
- Ignore small buildings (height < 30 cm or volume < 10 m³) 
- Take trees into account

Did not touch the extension, should work as before.

Results were compared with this table, not perfect but definitely better than before:
![grafik](https://github.com/user-attachments/assets/cc34f6d3-7c32-4b5b-add6-d60c9657007a)
[Source](https://www.researchgate.net/publication/228474930_Roughness_length_classification_of_Corine_Land_Cover_classes)