### PR TITLE
Rangecard - fix CTD on weapons with invalid configs

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_diagnoseWeapons.sqf
+++ b/addons/advanced_ballistics/functions/fnc_diagnoseWeapons.sqf
@@ -66,6 +66,10 @@ for "_i" from 0 to (count _cfgWeapons)-1 do {
                 _WeaponCacheEntry params ["_barrelTwist", "_twistDirection", "_barrelLength"];
 
                 private _barrelVelocityShift = [_barrelLength, _muzzleVelocityTable, _barrelLengthTable, _vanillaInitialSpeed] call FUNC(calculateBarrelLengthVelocityShift);
+                if (_barrelLength > 0) then {
+                    private _shiftedMV = [_barrelLength, _muzzleVelocityTable, _barrelLengthTable, 0] call FUNC(calculateBarrelLengthVelocityShift);
+                    if (_shiftedMV == 0) then { ERROR_2("%1:%2 has length set but invalid mags",_weapon,_magazine)};
+                };
                 private _abInitialSpeed = _vanillaInitialSpeed + _barrelVelocityShift;
                 // --------------------------------------------------
 

--- a/addons/rangecard/functions/fnc_updateRangeCard.sqf
+++ b/addons/rangecard/functions/fnc_updateRangeCard.sqf
@@ -119,7 +119,8 @@ private _useAmmoTemperatureInfluence = (
 
 if (_barrelLength > 0 && _useBarrelLengthInfluence) then {
     _muzzleVelocity = [_barrelLength, _ammoConfig select 10, _ammoConfig select 11, 0] call EFUNC(advanced_ballistics,calculateBarrelLengthVelocityShift);
-} else {
+};
+if (_muzzleVelocity == 0) then {
     private _initSpeed     = getNumber (configFile >> "CfgMagazines" >> _magazineClass >> "initSpeed");
     private _initSpeedCoef = getNumber (configFile >> "CfgWeapons" >> _weaponClass >> "initSpeed");
     if (_initSpeedCoef < 0) then {

--- a/addons/xm157/functions/fnc_ballistics_getData.sqf
+++ b/addons/xm157/functions/fnc_ballistics_getData.sqf
@@ -54,7 +54,7 @@ if ((_weaponInfo isEqualTo []) && {_magazineClass != ""}) then {
         if (_initSpeedCoef > 0) then {
             _initSpeed = _initSpeedCoef;
         };
-        _initSpeed
+        _muzzleVelocity = _initSpeed
     };
 
     // Scope Base Angle

--- a/addons/xm157/functions/fnc_ballistics_getData.sqf
+++ b/addons/xm157/functions/fnc_ballistics_getData.sqf
@@ -41,9 +41,11 @@ if ((_weaponInfo isEqualTo []) && {_magazineClass != ""}) then {
     );
 
     // Get Muzzle Velocity
-    private _muzzleVelocity = if (_barrelLength > 0 && _useAB) then {
-        [_barrelLength, _muzzleVelocityTable, _barrelLengthTable, 0] call EFUNC(advanced_ballistics,calculateBarrelLengthVelocityShift)
-    } else {
+    private _muzzleVelocity = 0;
+    if (_barrelLength > 0 && _useAB) then {
+        _muzzleVelocity = [_barrelLength, _muzzleVelocityTable, _barrelLengthTable, 0] call EFUNC(advanced_ballistics,calculateBarrelLengthVelocityShift)
+    };
+    if (_muzzleVelocity == 0) then {
         private _initSpeed = getNumber (configFile >> "CfgMagazines" >> _magazineClass >> "initSpeed");
         private _initSpeedCoef = getNumber (configFile >> "CfgWeapons" >> _weaponClass >> "initSpeed");
         if (_initSpeedCoef < 0) then {

--- a/extension/src/ballistics/zero.rs
+++ b/extension/src/ballistics/zero.rs
@@ -39,6 +39,7 @@ pub fn calculate(
     bore_height: f64,
     ballistic_model: BallisticModel,
 ) -> f64 {
+    if *muzzle_velocity<= 0.0 { return 0.0 }
     let mut zero_angle = 0.0f64;
     let delta_time = 1.0 / 100.0f64.max(zero_range);
 

--- a/extension/src/ballistics/zero.rs
+++ b/extension/src/ballistics/zero.rs
@@ -39,7 +39,9 @@ pub fn calculate(
     bore_height: f64,
     ballistic_model: BallisticModel,
 ) -> f64 {
-    if *muzzle_velocity<= 0.0 { return 0.0 }
+    if *muzzle_velocity <= 0.0 {
+        return 0.0;
+    }
     let mut zero_angle = 0.0f64;
     let delta_time = 1.0 / 100.0f64.max(zero_range);
 


### PR DESCRIPTION
`"ace" callExtension ["ballistics:zero_advanced",[200,0,6.69248,15,1013.25,0,0.5,1,"ICAO"]]`
will crash game, key number probably is 2nd (muzzle velocity of 0)

can reproduce with western sahri AA12

todo:

- [x] handle in extension as well
 ```
panicked at extension\src\ballistics\drag.rs:167:45:
attempt to subtract with overflow
```

- [x] look into AA12 configs and why `calculateBarrelLengthVelocityShift` is returning 0