### PR TITLE
Medical Damage - Throw no errors for the last damage handler

### DIFF
--- a/addons/medical_damage/ACE_Medical_Injuries.hpp
+++ b/addons/medical_damage/ACE_Medical_Injuries.hpp
@@ -73,7 +73,7 @@ class ACE_Medical_Injuries {
         // each entry should be a SQF expression that returns a function
         // this can also be overridden for each damage type
         class woundHandlers {
-            ADDON = QFUNC(woundsHandlerBase);
+            GVAR(woundsHandlerBase) = QFUNC(woundsHandlerBase);
         };
 
         class bullet {
@@ -171,14 +171,14 @@ class ACE_Medical_Injuries {
             // vehicle explosions are usually caused by explosive damage and should behave similarly
             thresholds[] = {{6, 3}, {4.5, 2}, {2, 2}, {0.8, 1}, {0.2, 1}, {0, 0}};
             class woundHandlers: woundHandlers {
-                GVAR(vehiclehit) = QFUNC(woundsHandlerVehiclehit);
+                GVAR(woundsHandlerVehiclehit) = QFUNC(woundsHandlerVehiclehit);
             };
         };
         class vehiclecrash {
             thresholds[] = {{1.5, 3}, {1.5, 2}, {1, 2}, {1, 1}, {0.05, 1}}; // prevent subdividing wounds past FRACTURE_DAMAGE_THRESHOLD to ensure limp/fractue is triggered
             selectionSpecific = 0;
             class woundHandlers: woundHandlers {
-                GVAR(vehiclecrash) = QFUNC(woundsHandlerVehiclecrash);
+                GVAR(woundsHandlerVehiclecrash) = QFUNC(woundsHandlerVehiclecrash);
             };
             class Abrasion {
                 weighting[] = {{0.30, 0}, {0.30, 1}};
@@ -291,7 +291,7 @@ class ACE_Medical_Injuries {
             // custom handling for environmental fire sources
             // passes damage to "burn" so doesn't need its own wound stats
             class woundHandlers {
-                ADDON = QFUNC(woundsHandlerBurning);
+                GVAR(woundsHandlerBurning) = QFUNC(woundsHandlerBurning);
             };
         };
         class burn {

--- a/addons/medical_damage/functions/fnc_woundReceived.sqf
+++ b/addons/medical_damage/functions/fnc_woundReceived.sqf
@@ -28,20 +28,26 @@ if !(_typeOfDamage in GVAR(damageTypeDetails)) exitWith {};
 
 private _damageData = [_unit, _allDamages, _typeOfDamage, _ammo];
 private _originalCount = count _damageData;
+private _lastHandlerName = _woundHandlers select -1 select 0; // will usually be ace_medical_damage_woundsHandlerBase
 
 {
     _x params ["_handlerName", "_handlerCode"];
     _damageData = _damageData call _handlerCode;
     TRACE_2("Wound handler returned",_damageData,_handlerName);
 
+    // Done
+    if (_handlerName == _lastHandlerName) then {
+        break;
+    };
+
     if ((count _damageData) == (_originalCount - 1)) then {
         ERROR_1("Wound handler '%1' missing latest param in return, readding. This will be deprecated in the future, check Medical Framework wiki.",_handlerName);
         _damageData pushBack _ammo;
     };
 
-    // If invalid return, log an error and exit
+    // If invalid return and not the last handler, log an error and exit
     if (isNil "_damageData" || {!(_damageData isEqualType [])} || {(count _damageData) < _originalCount}) then {
-        ERROR_2("Return for handler '%1' invalid - '%2', skipping wound handling",_damageData,_handlerName);
+        ERROR_2("Return for handler '%1' invalid - '%2', skipping wound handling",_handlerName,_damageData);
         break;
     };
 } forEach _woundHandlers;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.

Alternatively, can check for `QUOTE(ADDON) in _handlerName`. We can ignore our own API within this component.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
