### PR TITLE
Tools - Add a VS Code task to just build a given addon

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -109,14 +109,13 @@
         },
         {
             "label": "Build: HEMTT --just",
-            "command": "hemtt.exe",
+            "command": "python",
             "options": {
                 "cwd": "${workspaceFolder}"
             },
             "args": [
-                "build",
-                "--just",
-                "${input:addon}"
+                "tools/build_current_addon.py",
+                "${relativeFile}"
             ],
             "group": {
                 "kind": "build"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -93,7 +93,7 @@
             }
         },
         {
-            "label": "Build: Hemtt",
+            "label": "Build: HEMTT",
             "command": "hemtt.exe",
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -105,6 +105,21 @@
             "group": {
                 "kind": "build",
                 "isDefault": true
+            }
+        },
+        {
+            "label": "Build: HEMTT --just",
+            "command": "hemtt.exe",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "args": [
+                "build",
+                "--just",
+                "${input:addon}"
+            ],
+            "group": {
+                "kind": "build"
             }
         },
         {
@@ -134,6 +149,14 @@
             "group": {
                 "kind": "build"
             }
+        }
+    ],
+    "inputs": [
+        {
+            "id": "addon",
+            "description": "Addon Name:",
+            "default": "common",
+            "type": "promptString"
         }
     ]
 }

--- a/tools/build_current_addon.py
+++ b/tools/build_current_addon.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+Author: DartRuffian
+Builds the current addon, intended to be executed from a VS Code task
+"""
+
+import sys
+import os
+
+def main() -> None:
+    filepath = sys.argv[1]
+    if not (filepath.startswith("addons")):
+        sys.exit(os.system(f"echo Failed to build: {filepath} is not an addon path"))
+
+    addon = filepath.split("\\")[1]
+    os.system(f"echo Building addon: {addon}")
+    os.system(f"hemtt build --just {addon}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**When merged this pull request will:**
- Add a task to just build the given addon
  - E.g. Doing `Ctrl+Shift+P` -> `Run: Task` -> `Build: HEMETT -just` and writing `common` will run `hemtt build --just common`

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
