### PR TITLE
Common - Synced Lists Functions

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -200,6 +200,8 @@ PREP(swayLoop);
 PREP(switchAttachmentMode);
 PREP(switchPersistentLaser);
 PREP(switchToGroupSide);
+PREP(syncedListGet);
+PREP(syncedListPush);
 PREP(throttledPublicVariable);
 PREP(toBin);
 PREP(toBitmask);

--- a/addons/common/functions/fnc_syncedListGet.sqf
+++ b/addons/common/functions/fnc_syncedListGet.sqf
@@ -1,0 +1,33 @@
+#include "..\script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Pushes a element to a synced list (broken into buckets to avoid re-pushing the same data on each update)
+ *
+ * Arguments:
+ * 0: Namespace <OBJECT><NAMESPACE>
+ * 1: Var name <STRING>
+ * 2: Max Bucket Size <NUMBER> (default: 10)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, "var"] call ace_common_fnc_syncedListGet
+ *
+ * Public: No
+ */
+
+params ["_namespace", "_var", ["_bucketMax", 10, [0]]];
+
+private _total = [];
+private _index = 0;
+while {
+    private _fullVar = format ["%1_%2", _var, _index];
+    private _bucket = _namespace getVariable [_fullVar, []];
+    _total append _bucket;
+    _bucket isNotEqualTo []
+} do {
+    _index = _index + 1;
+};
+
+_total

--- a/addons/common/functions/fnc_syncedListPush.sqf
+++ b/addons/common/functions/fnc_syncedListPush.sqf
@@ -1,0 +1,34 @@
+#include "..\script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Gets a synced list (broken into buckets to avoid re-pushing the same data on each update)
+ *
+ * Arguments:
+ * 0: Namespace <OBJECT><NAMESPACE>
+ * 1: Var name <STRING>
+ * 2: Element <ANY>
+ * 3: Max Bucket Size <NUMBER> (default: 10)
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player, "var", "x"] call ace_common_fnc_syncedListPush
+ *
+ * Public: No
+ */
+params ["_namespace", "_var", "_line", ["_bucketMax", 10, [0]]];
+
+private _fullVar = "";
+private _bucket = [];
+private _index = 0;
+while {
+    _fullVar = format ["%1_%2", _var, _index];
+    _bucket = _namespace getVariable [_fullVar, []];
+    (count _bucket) >= _bucketMax 
+} do {
+    _index = _index + 1;
+};
+
+_bucket pushBack _var;
+_namespace setVariable [_fullVar, _bucket, true];


### PR DESCRIPTION
Handles potentially extremely large lists that need to be network synced and only get added to
Breaks the list into multiple smaller bucket/chuncks
So we don't have to re-sync the entire list when pushing the 50th element, just the last bucket