### PR TITLE
Hearing - Earplugs not added on dedicated server

### DIFF
--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -36,11 +36,11 @@ if (isServer) then {
     };
 }] call CBA_fnc_addEventHandler;
 
+GVAR(cacheAmmoLoudness) = createHashMap;
+
 if (!hasInterface) exitWith {};
 
 #include "initKeybinds.inc.sqf"
-
-GVAR(cacheAmmoLoudness) = createHashMap;
 
 GVAR(deafnessDV) = 0;
 GVAR(deafnessPrior) = 0;


### PR DESCRIPTION
If "Only units with heavy weapons" selected auto add earplugs not working on dedicated server because cache variable does not exist on server without interface.

Cache should exist on client and server.
On client getAmmoLoudness called from firedNear.
On server from addEarPlugs
