### PR TITLE
missile_sdb - Fix IR guidance

### DIFF
--- a/addons/missile_sdb/CfgAmmo.hpp
+++ b/addons/missile_sdb/CfgAmmo.hpp
@@ -4,6 +4,8 @@ class CfgAmmo {
     class GVAR(sdb): ammo_Bomb_SDB {
         author = "Dani (TCVM)";
         maneuvrability = 0; // no maneuvrability so that default guidance doesnt work
+        irLock = 0; // technically deprecated but useful for quick reference
+        class Components {}; // no components required
         class ace_missileguidance: EGVAR(missileguidance,type_Jdam) {
             enabled = 1;
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Remove IR guidance capability from ammo

Technically this doesn't change anything as far as using goes, but any guides/tooltips created via script would show ability for it to lock via laser

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
