### PR TITLE
Medical Damage - Fix wound handler returns

### DIFF
--- a/addons/medical_damage/functions/fnc_woundsHandlerVehiclecrash.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerVehiclecrash.sqf
@@ -25,4 +25,5 @@ private _newDamages = _allDamages apply {
 };
 
 TRACE_1("Vehicle crash handled, passing damage",_newDamages);
-[_unit, _newDamages, _typeOfDamage] //return
+_this set [1, _newDamages];
+_this

--- a/addons/medical_damage/functions/fnc_woundsHandlerVehiclehit.sqf
+++ b/addons/medical_damage/functions/fnc_woundsHandlerVehiclehit.sqf
@@ -43,4 +43,5 @@ private _newDamages = [];
 } forEach (keys _damageMap); // micro-optimization again, two 'get's is still faster than iterating over a hashmap
 
 TRACE_1("Vehicle explosion handled, passing damage",_newDamages);
-[_unit, _newDamages, _typeOfDamage] //return
+_this set [1, _newDamages];
+_this


### PR DESCRIPTION
```
[ACE] (medical_damage) ERROR: Wound handler 'ace_medical_damage_woundsHandlerVehiclehit' missing latest param in return readding. This will be deprecated in the future check Medical Framework wiki.

