### PR TITLE
Disarming - Code cleanup

### DIFF
--- a/addons/disarming/CfgEventHandlers.hpp
+++ b/addons/disarming/CfgEventHandlers.hpp
@@ -1,4 +1,3 @@
-
 class Extended_PreStart_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));

--- a/addons/disarming/XEH_PREP.hpp
+++ b/addons/disarming/XEH_PREP.hpp
@@ -1,4 +1,3 @@
-
 PREP(canBeDisarmed);
 PREP(canPlayerDisarmUnit);
 PREP(disarmDropItems);

--- a/addons/disarming/functions/fnc_canBeDisarmed.sqf
+++ b/addons/disarming/functions/fnc_canBeDisarmed.sqf
@@ -1,34 +1,32 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
- * Checks the conditions for being able to disarm a unit
+ * Checks the conditions for being able to disarm a unit.
  *
  * Arguments:
  * 0: Target <OBJECT>
  *
  * Return Value:
- * Can Be Disarmed <BOOL>
+ * Can be disarmed <BOOL>
  *
  * Example:
- * [cursorTarget] call ace_disarming_fnc_canBeDisarmed
+ * cursorObject call ace_disarming_fnc_canBeDisarmed
  *
  * Public: No
  */
 
 params ["_target"];
 
-//Check animationState for putDown anim
-//This ensures the unit doesn't have to actualy do any animation to drop something
-//This should always be true for the 3 possible status effects that allow disarming
-private _animationStateCfgMoves = getText (configFile >> "CfgMovesMaleSdr" >> "States" >> (animationState _target) >> "actions");
+// Check animationState for putDown anim
+// This ensures the unit doesn't have to actualy do any animation to drop something
+// This should always be true for the 3 possible status effects that allow disarming
+private _animationStateCfgMoves = getText (configFile >> "CfgMovesMaleSdr" >> "States" >> animationState _target >> "actions");
 if (_animationStateCfgMoves == "") exitWith { false };
 private _putDownAnim = getText (configFile >> "CfgMovesBasic" >> "Actions" >> _animationStateCfgMoves >> "PutDown");
 if (_putDownAnim != "") exitWith { false };
 
-
 (alive _target) &&
 {(abs (speed _target)) < 1} &&
-{(_target getVariable ["ACE_isUnconscious", false]) ||
+{lifeState _target == "INCAPACITATED" ||
     {_target getVariable [QEGVAR(captives,isHandcuffed), false]} ||
     {_target getVariable [QEGVAR(captives,isSurrendering), false]}}

--- a/addons/disarming/functions/fnc_canPlayerDisarmUnit.sqf
+++ b/addons/disarming/functions/fnc_canPlayerDisarmUnit.sqf
@@ -1,15 +1,14 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
- * Checks the conditions for being able to disarm a unit
+ * Checks the conditions for being able to disarm a unit.
  *
  * Arguments:
- * 0: Player <OBJECT>
+ * 0: Caller <OBJECT>
  * 1: Target <OBJECT>
  *
  * Return Value:
- * Can Be Disarm Target <BOOL>
+ * Can target be disarmed? <BOOL>
  *
  * Example:
  * [player, cursorTarget] call ace_disarming_fnc_canPlayerDisarmUnit
@@ -17,7 +16,8 @@
  * Public: No
  */
 
-params ["_player", "_target"];
+params ["_caller", "_target"];
 
-([_target] call FUNC(canBeDisarmed)) &&
-{([_player, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith))}
+(objectParent _caller) isEqualTo (objectParent _target) &&
+{_target call FUNC(canBeDisarmed)} &&
+{[_caller, _target, ["isNotSwimming"]] call EFUNC(common,canInteractWith)}

--- a/addons/disarming/functions/fnc_disarmDropItems.sqf
+++ b/addons/disarming/functions/fnc_disarmDropItems.sqf
@@ -1,11 +1,10 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
- * Makes a unit drop items
+ * Makes a unit drop items.
  *
  * Arguments:
- * 0: Caller (player) <OBJECT>
+ * 0: Caller <OBJECT>
  * 1: Target <OBJECT>
  * 2: Classnames <ARRAY>
  * 3: Do Not Drop Ammo <BOOL> (default: false)
@@ -21,30 +20,24 @@
 
 #define TIME_MAX_WAIT 5
 
-params ["_caller", "_target", "_listOfItemsToRemove", ["_doNotDropAmmo", false, [false]]]; //By default units drop all weapon mags when dropping a weapon
+params ["_caller", "_target", "_listOfItemsToRemove", ["_doNotDropAmmo", false]]; // By default units drop all weapon mags when dropping a weapon
 
-private _fncSumArray = {
-    private _return = 0;
-    {_return = _return + _x;} count (_this select 0);
-    _return
-};
-
-//Sanity Checks
-if !([_target] call FUNC(canBeDisarmed)) exitWith {
+// Sanity Checks
+if !(_target call FUNC(canBeDisarmed)) exitWith {
     [_caller, _target, "Debug: Cannot disarm target"] call FUNC(eventTargetFinish);
 };
-if (_doNotDropAmmo && {({_x in _listOfItemsToRemove} count (magazines _target)) > 0}) exitWith {
+if (_doNotDropAmmo && {(magazines _target) findIf {_x in _listOfItemsToRemove} != -1}) exitWith {
     [_caller, _target, "Debug: Trying to drop magazine with _doNotDropAmmo flag"] call FUNC(eventTargetFinish);
 };
 
 private _holder = objNull;
 
-// if _target is in a vehicle, use vehicle inventory as container
+// If _target is in a vehicle, use vehicle inventory as container
 if (!isNull objectParent _target) then {
     _holder = objectParent _target;
 };
 
-//If not dropping ammo, don't use an existing container
+// If not dropping ammo, don't use an existing container
 if (!_doNotDropAmmo) then {
     {
         if ((_x getVariable [QGVAR(disarmUnit), objNull]) == _target) exitWith {
@@ -53,34 +46,33 @@ if (!_doNotDropAmmo) then {
     } forEach ((getPos _target) nearObjects [DISARM_CONTAINER, 3]);
 };
 
-//Create a new weapon holder
+// Create a new weapon holder
 if (isNull _holder) then {
-    private _dropPos = _target modelToWorld [0.4, 0.75, 0]; //offset someone unconscious isn't lying over it
-    _dropPos set [2, ((getPosASL _target) select 2)];
+    private _dropPos = _target modelToWorld [0.4, 0.75, 0]; // Offset someone unconscious isn't lying over it
+    _dropPos set [2, (getPosASL _target) select 2];
     _holder = createVehicle [DISARM_CONTAINER, _dropPos, [], 0, "CAN_COLLIDE"];
     _holder setPosASL _dropPos;
     _holder setVariable [QGVAR(disarmUnit), _target, true];
 };
 
-//Verify holder created
+// Verify holder created
 if (isNull _holder) exitWith {
     [_caller, _target, "Debug: Null Holder"] call FUNC(eventTargetFinish);
 };
-//Make sure only one drop operation at a time (using PFEH system as a queue)
+// Make sure only one drop operation at a time (using PFH system as a queue)
 if (_holder getVariable [QGVAR(holderInUse), false]) exitWith {
-    [{
-        call FUNC(disarmDropItems);
-    }, _this] call CBA_fnc_execNextFrame;
+    [FUNC(disarmDropItems), _this] call CBA_fnc_execNextFrame;
 };
 _holder setVariable [QGVAR(holderInUse), true];
 
-//Remove Magazines
+// Remove Magazines
+private _cfgMagazines = configFile >> "CfgMagazines";
 private _targetMagazinesStart = magazinesAmmo _target;
 private _holderMagazinesStart = magazinesAmmoCargo _holder;
 
 {
     _x params ["_xClassname", "_xAmmo"];
-    if ((_xClassname in _listOfItemsToRemove) && {(getNumber (configFile >> "CfgMagazines" >> _xClassname >> "ACE_isUnique")) == 0}) then {
+    if ((_xClassname in _listOfItemsToRemove) && {(getNumber (_cfgMagazines >> _xClassname >> "ACE_isUnique")) == 0}) then {
         _holder addMagazineAmmoCargo [_xClassname, 1, _xAmmo];
         _target removeMagazine _xClassname;
     };
@@ -89,26 +81,25 @@ private _holderMagazinesStart = magazinesAmmoCargo _holder;
 private _targetMagazinesEnd = magazinesAmmo _target;
 private _holderMagazinesEnd = magazinesAmmoCargo _holder;
 
-//Verify Mags dropped from unit:
-if (({((_x select 0) in _listOfItemsToRemove) && {(getNumber (configFile >> "CfgMagazines" >> (_x select 0) >> "ACE_isUnique")) == 0}} count _targetMagazinesEnd) != 0) exitWith {
+// Verify Mags dropped from unit
+if (_targetMagazinesEnd findIf {((_x select 0) in _listOfItemsToRemove) && {(getNumber (_cfgMagazines >> _x select 0 >> "ACE_isUnique")) == 0}} != -1) exitWith {
     _holder setVariable [QGVAR(holderInUse), false];
     [_caller, _target, "Debug: Didn't Remove Magazines"] call FUNC(eventTargetFinish);
 };
-//Verify holder has mags unit had
+// Verify holder has mags unit had
 if !([_targetMagazinesStart, _targetMagazinesEnd, _holderMagazinesStart, _holderMagazinesEnd] call FUNC(verifyMagazinesMoved)) then {
     _holder setVariable [QGVAR(holderInUse), false];
     [_caller, _target, "Debug: Crate Magazines not in holder"] call FUNC(eventTargetFinish);
 };
 
-//Remove Items, Assigned Items and NVG
+// Remove Items, Assigned Items and NVG
 private _holderItemsStart = getItemCargo _holder;
 private _targetItemsStart = (assignedItems _target) + (items _target) - (weapons _target);
 if ((headgear _target) != "") then {_targetItemsStart pushBack (headgear _target);};
 if ((goggles _target) != "") then {_targetItemsStart pushBack (goggles _target);};
 
+private _addToCrate = createHashMap;
 
-private _addToCrateClassnames = [];
-private _addToCrateCount = [];
 {
     if (_x in _listOfItemsToRemove) then {
         if (_x in (items _target)) then {
@@ -116,85 +107,95 @@ private _addToCrateCount = [];
         } else {
             _target unlinkItem _x;
         };
-        private _index = _addToCrateClassnames find _x;
-        if (_index != -1) then {
-            _addToCrateCount set [_index, ((_addToCrateCount select _index) + 1)];
-        } else {
-            _addToCrateClassnames pushBack _x;
-            _addToCrateCount pushBack 1;
-        };
+
+        _addToCrate set [_x, (_addToCrate getOrDefault [_x, 0]) + 1];
     };
 } forEach _targetItemsStart;
 
-//Add the items to the holder (combined to reduce addItemCargoGlobal calls)
+private _addToCrateTotal = 0;
+
+// Add the items to the holder (combined to reduce addItemCargoGlobal calls)
 {
-    _holder addItemCargoGlobal [(_addToCrateClassnames select _forEachIndex), (_addToCrateCount select _forEachIndex)];
-} forEach _addToCrateClassnames;
+    _holder addItemCargoGlobal [_x, _y];
+    _addToCrateTotal = _addToCrateTotal + _y;
+} forEach _addToCrate;
 
 private _holderItemsEnd = getItemCargo _holder;
 private _targetItemsEnd = (assignedItems _target) + (items _target) - (weapons _target);
 if ((headgear _target) != "") then {_targetItemsEnd pushBack (headgear _target);};
 if ((goggles _target) != "") then {_targetItemsEnd pushBack (goggles _target);};
 
-//Verify Items Added
-if (((count _targetItemsStart) - (count _targetItemsEnd)) != ([_addToCrateCount] call _fncSumArray)) exitWith {
+// Verify Items Added
+if (((count _targetItemsStart) - (count _targetItemsEnd)) != _addToCrateTotal) exitWith {
     _holder setVariable [QGVAR(holderInUse), false];
     [_caller, _target, "Debug: Items Not Removed From Player"] call FUNC(eventTargetFinish);
 };
-if ((([_holderItemsEnd select 1] call _fncSumArray) - ([_holderItemsStart select 1] call _fncSumArray)) != ([_addToCrateCount] call _fncSumArray)) exitWith {
+
+private _fncSumArray = {
+    private _return = 0;
+
+    {
+        _return = _return + _x;
+    } forEach _this;
+
+    _return
+};
+
+if ((((_holderItemsEnd select 1) call _fncSumArray) - ((_holderItemsStart select 1) call _fncSumArray)) != _addToCrateTotal) exitWith {
     _holder setVariable [QGVAR(holderInUse), false];
     [_caller, _target, "Debug: Items Not Added to Holder"] call FUNC(eventTargetFinish);
 };
 
-//Script drop uniforms/vest if empty
+// Script drop uniforms/vest if empty
 if (((uniform _target) != "") && {(uniform _target) in _listOfItemsToRemove} && {(uniformItems _target) isEqualTo []}) then {
-    _holder addItemCargoGlobal [(uniform _target), 1];
+    _holder addItemCargoGlobal [uniform _target, 1];
     removeUniform _target;
 };
 if (((vest _target) != "") && {(vest _target) in _listOfItemsToRemove} && {(vestItems _target) isEqualTo []}) then {
-    _holder addItemCargoGlobal [(vest _target), 1];
+    _holder addItemCargoGlobal [vest _target, 1];
     removeVest _target;
 };
 
-
-//If holder is still empty, it will be 'garbage collected' while we wait for the drop 'action' to take place
-//So add a dummy item and just remove at the end
-private _holderIsEmpty = ([_holder] call FUNC(getAllGearContainer)) isEqualTo [[],[]];
+// If holder is still empty, it will be 'garbage collected' while we wait for the drop 'action' to take place
+// So add a dummy item and just remove at the end
+private _holderIsEmpty = (_holder call FUNC(getAllGearContainer)) isEqualTo [[], []];
 if (_holderIsEmpty) then {
     TRACE_1("Debug: adding dummy item to holder",_holder);
     _holder addItemCargoGlobal [DUMMY_ITEM, 1];
 };
 
-//Start the PFEH to do the actions (which could take >1 frame)
+// Start the PFH to do the actions (which could take >1 frame)
 [{
-    params ["_args", "_pfID"];
+    params ["_args", "_pfhID"];
     _args params ["_caller", "_target", "_listOfItemsToRemove", "_holder", "_holderIsEmpty", "_maxWaitTime", "_doNotDropAmmo", "_startingMagazines"];
 
-    private _needToRemoveWeapon = ({_x in _listOfItemsToRemove} count (weapons _target)) > 0;
-    private _needToRemoveMagazines = ({_x in _listOfItemsToRemove} count (magazines _target)) > 0;
+    private _needToRemoveWeapon = (weapons _target) findIf {_x in _listOfItemsToRemove} != -1;
+    private _needToRemoveMagazines = (magazines _target) findIf {_x in _listOfItemsToRemove} != -1;
     private _needToRemoveBackpack = ((backpack _target) != "") && {(backpack _target) in _listOfItemsToRemove};
     private _needToRemoveVest = ((vest _target) != "") && {(vest _target) in _listOfItemsToRemove};
     private _needToRemoveUniform = ((uniform _target) != "") && {(uniform _target) in _listOfItemsToRemove};
 
-    if ((CBA_missionTime < _maxWaitTime) && {[_target] call FUNC(canBeDisarmed)} && {_needToRemoveWeapon || _needToRemoveMagazines || _needToRemoveBackpack}) then {
-        //action drop weapons (keeps loaded magazine and attachements)
+    if ((CBA_missionTime < _maxWaitTime) && {_target call FUNC(canBeDisarmed)} && {_needToRemoveWeapon || _needToRemoveMagazines || _needToRemoveBackpack}) then {
+        // Action drop weapons (keeps loaded magazine and attachements)
         {
             if (_x in _listOfItemsToRemove) then {
                 _target action ["DropWeapon", _holder, _x];
             };
         } forEach (weapons _target);
 
-        //Drop magazine (keeps unique ID)
+        // Drop magazine (keeps unique ID)
         {
             if (_x in _listOfItemsToRemove) then {
                 _target action ["DropMagazine", _holder, _x];
             };
         } forEach (magazines _target);
 
-        //Drop backpack (Keeps variables for ACRE/TFR)
-        if (_needToRemoveBackpack) then {_target action ["DropBag", _holder, (backpack _target)];};
+        // Drop backpack (Keeps variables for ACRE/TFR)
+        if (_needToRemoveBackpack) then {
+            _target action ["DropBag", _holder, backpack _target];
+        };
     } else {
-        [_pfID] call CBA_fnc_removePerFrameHandler;
+        _pfhID call CBA_fnc_removePerFrameHandler;
 
         if (_doNotDropAmmo) then {
             private _error = false;
@@ -213,8 +214,8 @@ if (_holderIsEmpty) then {
                 _magazinesInHolder deleteAt _index;
             } forEach _magsToPickup;
 
-            //No Error (all the ammo in the container is ammo we should have);
-            if ((!_error) && {_magazinesInHolder isEqualTo []}) then {
+            // No Error (all the ammo in the container is ammo we should have);
+            if (!_error && {_magazinesInHolder isEqualTo []}) then {
                 {
                     _target addMagazine _x;
                 } forEach (magazinesAmmoCargo _holder);
@@ -222,8 +223,8 @@ if (_holderIsEmpty) then {
             };
         };
 
-        //If we added a dummy item, remove it now
-        if (_holderIsEmpty && {(getItemCargo _holder) isNotEqualTo [[DUMMY_ITEM],[1]]}) exitWith {
+        // If we added a dummy item, remove it now
+        if (_holderIsEmpty && {(getItemCargo _holder) isNotEqualTo [[DUMMY_ITEM], [1]]}) exitWith {
             _holder setVariable [QGVAR(holderInUse), false];
             [_caller, _target, "Debug: Holder should only have dummy item"] call FUNC(eventTargetFinish);
         };
@@ -231,13 +232,13 @@ if (_holderIsEmpty) then {
             TRACE_1("Debug: removing dummy item from holder",_holder);
             clearItemCargoGlobal _holder;
         };
-        //Verify we didn't timeout waiting on drop action
+        // Verify we didn't timeout waiting on drop action
         if (CBA_missionTime >= _maxWaitTime)  exitWith {
             _holder setVariable [QGVAR(holderInUse), false];
             [_caller, _target, "Debug: Drop Actions Timeout"] call FUNC(eventTargetFinish);
         };
-        //If target lost disarm status:
-        if !([_target] call FUNC(canBeDisarmed)) exitWith {
+        // If target lost disarm status:
+        if !(_target call FUNC(canBeDisarmed)) exitWith {
             _holder setVariable [QGVAR(holderInUse), false];
             [_caller, _target, "Debug: Target cannot be disarmed"] call FUNC(eventTargetFinish);
         };
@@ -246,7 +247,7 @@ if (_holderIsEmpty) then {
             [_caller, _target, "Debug: Vest Not Empty"] call FUNC(eventTargetFinish);
         };
         if (_needToRemoveVest) then {
-            _holder addItemCargoGlobal [(vest _target), 1];
+            _holder addItemCargoGlobal [vest _target, 1];
             removeVest _target;
         };
         if (_needToRemoveUniform && {(uniformItems _target) isNotEqualTo []}) exitWith {
@@ -254,12 +255,11 @@ if (_holderIsEmpty) then {
             [_caller, _target, "Debug: Uniform Not Empty"] call FUNC(eventTargetFinish);
         };
         if (_needToRemoveUniform) then {
-            _holder addItemCargoGlobal [(uniform _target), 1];
+            _holder addItemCargoGlobal [uniform _target, 1];
             removeUniform _target;
         };
 
         _holder setVariable [QGVAR(holderInUse), false];
         [_caller, _target, ""] call FUNC(eventTargetFinish);
     };
-
-}, 0.0, [_caller,_target, _listOfItemsToRemove, _holder, _holderIsEmpty, (CBA_missionTime + TIME_MAX_WAIT), _doNotDropAmmo, _targetMagazinesEnd]] call CBA_fnc_addPerFrameHandler;
+}, 0, [_caller,_target, _listOfItemsToRemove, _holder, _holderIsEmpty, CBA_missionTime + TIME_MAX_WAIT, _doNotDropAmmo, _targetMagazinesEnd]] call CBA_fnc_addPerFrameHandler;

--- a/addons/disarming/functions/fnc_disarmDropItems.sqf
+++ b/addons/disarming/functions/fnc_disarmDropItems.sqf
@@ -26,7 +26,7 @@ params ["_caller", "_target", "_listOfItemsToRemove", ["_doNotDropAmmo", false]]
 if !(_target call FUNC(canBeDisarmed)) exitWith {
     [_caller, _target, "Debug: Cannot disarm target"] call FUNC(eventTargetFinish);
 };
-if (_doNotDropAmmo && {(magazines _target) findIf {_x in _listOfItemsToRemove} != -1}) exitWith {
+if (_doNotDropAmmo && {_listOfItemsToRemove findAny (magazines _target) != -1}) exitWith {
     [_caller, _target, "Debug: Trying to drop magazine with _doNotDropAmmo flag"] call FUNC(eventTargetFinish);
 };
 
@@ -169,8 +169,8 @@ if (_holderIsEmpty) then {
     params ["_args", "_pfhID"];
     _args params ["_caller", "_target", "_listOfItemsToRemove", "_holder", "_holderIsEmpty", "_maxWaitTime", "_doNotDropAmmo", "_startingMagazines"];
 
-    private _needToRemoveWeapon = (weapons _target) findIf {_x in _listOfItemsToRemove} != -1;
-    private _needToRemoveMagazines = (magazines _target) findIf {_x in _listOfItemsToRemove} != -1;
+    private _needToRemoveWeapon = _listOfItemsToRemove findAny (weapons _target) != -1;
+    private _needToRemoveMagazines = _listOfItemsToRemove findAny (magazines _target) != -1;
     private _needToRemoveBackpack = ((backpack _target) != "") && {(backpack _target) in _listOfItemsToRemove};
     private _needToRemoveVest = ((vest _target) != "") && {(vest _target) in _listOfItemsToRemove};
     private _needToRemoveUniform = ((uniform _target) != "") && {(uniform _target) in _listOfItemsToRemove};

--- a/addons/disarming/functions/fnc_eventCallerFinish.sqf
+++ b/addons/disarming/functions/fnc_eventCallerFinish.sqf
@@ -12,7 +12,7 @@
  * None
  *
  * Example:
- * [player, cursorTarget, "Someting fucked up"] call ace_disarming_fnc_eventCallerFinish
+ * [player, cursorTarget, "Something fucked up"] call ace_disarming_fnc_eventCallerFinish
  *
  * Public: No
  */

--- a/addons/disarming/functions/fnc_eventCallerFinish.sqf
+++ b/addons/disarming/functions/fnc_eventCallerFinish.sqf
@@ -1,19 +1,18 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
- * Recieves a possible error code from FUNC(eventTargetFinish)
+ * Receives a possible error code from FUNC(eventTargetFinish).
  *
  * Arguments:
- * 0: caller (player) <OBJECT>
- * 1: target <OBJECT>
- * 2: error message <STRING>
+ * 0: Caller <OBJECT>
+ * 1: Target <OBJECT>
+ * 2: Error message <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player1, player2, "Someting fucked up"] call ace_disarming_fnc_eventCallerFinish
+ * [player, cursorTarget, "Someting fucked up"] call ace_disarming_fnc_eventCallerFinish
  *
  * Public: No
  */

--- a/addons/disarming/functions/fnc_eventTargetFinish.sqf
+++ b/addons/disarming/functions/fnc_eventTargetFinish.sqf
@@ -1,20 +1,19 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
  * After FUNC(disarmDropItems) has completed, passing a possible error code.
  * Passes that error back to orginal caller.
  *
  * Arguments:
- * 0: caller <OBJECT>
- * 1: target <OBJECT>
- * 2: errorMsg <STRING>
+ * 0: Caller <OBJECT>
+ * 1: Target <OBJECT>
+ * 2: Error message <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player1, player2, "Someting fucked up"] call ace_disarming_fnc_eventTargetFinish
+ * [player, cursorTarget, "Something fucked up"] call ace_disarming_fnc_eventTargetFinish
  *
  * Public: No
  */
@@ -23,5 +22,5 @@ params ["_caller", "_target", "_errorMsg"];
 
 if (_errorMsg != "") then {
     INFO_2("%1 - eventTargetFinish: %2",CBA_missionTime,_this);
-    [QGVAR(debugCallback), [_caller, _target, _errorMsg], [_caller]] call CBA_fnc_targetEvent;
+    [QGVAR(debugCallback), [_caller, _target, _errorMsg], _caller] call CBA_fnc_targetEvent;
 };

--- a/addons/disarming/functions/fnc_eventTargetStart.sqf
+++ b/addons/disarming/functions/fnc_eventTargetStart.sqf
@@ -1,40 +1,35 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
  * Disarm Event Handler, Starting func, called on the target.
  * If target has to remove uniform/vest, this will add all uniform/vest items to the drop list.
  *
  * Arguments:
- * 0: caller (player) <OBJECT>
- * 1: target <OBJECT>
- * 2: type of disarm <STRING>
+ * 0: Caller <OBJECT>
+ * 1: Target <OBJECT>
+ * 2: Item to remove (even if it's 1 item, array is kept for BWC) <ARRAY of STRING>
+ * 3: Amount of item to remove (not used) <NUMBER>
  *
  * Return Value:
  * None
  *
  * Example:
- * [bob, kevin, "disarm"] call ace_disarming_fnc_eventTargetStart
+ * [player, cursorTarget, [vest cursorTarget], 1] call ace_disarming_fnc_eventTargetStart
  *
  * Public: No
  */
 
-params ["_caller", "_target", "_listOfObjectsToRemove"];
-
-private _itemsToAdd = [];
-{
-    if (_x == (uniform _target)) then {
-        _itemsToAdd = _itemsToAdd + (uniformItems _target);
-    };
-    if (_x == (vest _target)) then {
-        _itemsToAdd = _itemsToAdd + (vestItems _target);
-    };
-} forEach _listOfObjectsToRemove;
+params ["_caller", "_target", "_itemToRemove"];
 
 {
-    if !(_x in _listOfObjectsToRemove) then {
-        _listOfObjectsToRemove pushBack _x;
+    switch (true) do {
+        case (_x == (uniform _target)): {
+            _itemToRemove append (uniformItems _target);
+        };
+        case (_x == (vest _target)): {
+            _itemToRemove append (vestItems _target);
+        };
     };
-} forEach _itemsToAdd;
+} forEach _itemToRemove;
 
-[_caller, _target, _listOfObjectsToRemove] call FUNC(disarmDropItems);
+[_caller, _target, _itemToRemove arrayIntersect _itemToRemove] call FUNC(disarmDropItems);

--- a/addons/disarming/functions/fnc_getAllGearContainer.sqf
+++ b/addons/disarming/functions/fnc_getAllGearContainer.sqf
@@ -1,17 +1,16 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
- * Helper function to get all gear of a container
+ * Helper function to get all gear of a container.
  *
  * Arguments:
  * 0: Container <OBJECT>
  *
  * Return Value:
- * Array of 2 arrays, classnames and count<ARRAY>
+ * Array of 2 arrays, classnames and count <ARRAY>
  *
  * Example:
- * [["ace_bandage"],[2]] = [box] call ace_disarming_fnc_getAllGearContainer
+ * cursorObject call ace_disarming_fnc_getAllGearContainer
  *
  * Public: No
  */
@@ -20,10 +19,11 @@ params ["_target"];
 
 private _items = [];
 private _counts = [];
+
 {
     _x params ["_item", "_count"];
     _items append _item;
     _counts append _count;
-} forEach [(getWeaponCargo _target), (getItemCargo _target), (getMagazineCargo _target), (getBackpackCargo _target)];
+} forEach [getWeaponCargo _target, getItemCargo _target, getMagazineCargo _target, getBackpackCargo _target];
 
-[_items,_counts] // Return
+[_items, _counts] // return

--- a/addons/disarming/functions/fnc_getAllGearUnit.sqf
+++ b/addons/disarming/functions/fnc_getAllGearUnit.sqf
@@ -1,53 +1,67 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
  * Helper function to get all gear of a unit.
  *
  * Arguments:
  * 0: Target <OBJECT>
  *
  * Return Value:
- * Array of 2 arrays, classnames and count<ARRAY>
+ * Array of 2 arrays, classnames and count <ARRAY>
  *
  * Example:
- * [["ace_bandage"],[2]] = [bob] call ace_disarming_fnc_getAllGearUnit
+ * cursorTarget call ace_disarming_fnc_getAllGearUnit
  *
  * Public: No
  */
 
 params ["_target"];
 
-private _allItems = (((items _target) + (assignedItems _target)) - (weapons _target)) + (weapons _target) + (magazines _target);
+private _weapons = weapons _target;
+private _allItems = (((items _target) + (assignedItems _target)) - _weapons) + _weapons + (magazines _target);
+private _backpack = backpack _target;
 
-if ((backpack _target) != "") then {
-    _allItems pushBack (backpack _target);
+if (_backpack != "") then {
+    _allItems pushBack _backpack;
 };
-if ((vest _target) != "") then {
-    _allItems pushBack (vest _target);
+
+private _vest = vest _target;
+
+if (_vest != "") then {
+    _allItems pushBack _vest;
 };
-if ((uniform _target) != "") then {
-    _allItems pushBack (uniform _target);
+
+private _uniform = uniform _target;
+
+if (_uniform != "") then {
+    _allItems pushBack _uniform;
 };
-if ((headgear _target) != "") then {
-    _allItems pushBack (headgear _target);
+
+private _headgear = headgear _target;
+
+if (_headgear != "") then {
+    _allItems pushBack _headgear;
 };
-//What kind of asshole takes a man's glasses?
-if ((goggles _target) != "") then {
-    _allItems pushBack (goggles _target);
+
+// What kind of asshole takes a man's glasses?
+private _goggles = goggles _target;
+
+if (_goggles != "") then {
+    _allItems pushBack _goggles;
 };
 
 private _uniqueClassnames = [];
 private _classnamesCount = [];
-//Filter unique and count
-{
-    private _index = _uniqueClassnames find _x;
-    if (_index != -1) then {
-        _classnamesCount set [_index, ((_classnamesCount select _index) + 1)];
-    } else {
-        _uniqueClassnames pushBack _x;
-        _classnamesCount pushBack 1;
-    };
-} forEach _allItems;
+private _countA = count _allItems;
 
-[_uniqueClassnames, _classnamesCount]
+// From CBA_fnc_getArrayElements
+while {_countA > 0} do {
+     private _var = _allItems select 0;
+     _allItems = _allItems - [_var];
+     private _countB = count _allItems;
+     _uniqueClassnames pushBack _var;
+     _classnamesCount pushBack (_countA - _countB);
+     _countA = _countB;
+};
+
+[_uniqueClassnames, _classnamesCount] // return

--- a/addons/disarming/functions/fnc_openDisarmDialog.sqf
+++ b/addons/disarming/functions/fnc_openDisarmDialog.sqf
@@ -1,18 +1,17 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
- * Opens the disarm dialog (allowing a person to remove items)
+ * Opens the disarm dialog, allowing a person to remove items.
  *
  * Arguments:
- * 0: Caller (player) <OBJECT>
+ * 0: Caller <OBJECT>
  * 1: Target <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, bob] call ace_disarming_fnc_openDisarmDialog
+ * [player, cursorTarget] call ace_disarming_fnc_openDisarmDialog
  *
  * Public: No
  */
@@ -21,7 +20,7 @@ params ["_caller", "_target"];
 
 #define DEFAULTPATH "\A3\Ui_f\data\GUI\Cfg\Ranks\%1_gs.paa"
 
-//Sanity Checks
+// Sanity Checks
 if (_caller != ACE_player) exitWith {ERROR("Player isn't caller?");};
 if !([_caller, _target] call FUNC(canPlayerDisarmUnit)) exitWith {ERROR("Can't Disarm Unit");};
 if (dialog) then {ERROR("Dialog open when trying to open disarm dialog"); closeDialog 0;};
@@ -35,15 +34,15 @@ if (isNull _display) exitWith {ERROR("Display is Null");};
 
 GVAR(disarmTarget) = _target;
 
-//Setup Drop Event (on right pannel)
+// Setup Drop Event (on right panel)
 (_display displayCtrl 632) ctrlAddEventHandler ["LBDrop", {
     if (isNull GVAR(disarmTarget)) exitWith {};
-    params ["_ctrl", "_xPos", "_yPos", "_idc", "_itemInfo"];
-    (_itemInfo select 0) params ["_displayText", "_value", "_data"];
 
-    if (isNull GVAR(disarmTarget)) exitWith {ERROR("disarmTarget is null");};
+    params ["", "", "", "_idc", "_itemInfo"];
+    (_itemInfo select 0) params ["", "", "_data"];
 
     private _textRight = "";
+
     for "_i" from 0 to (lbSize _idc) - 1 do {
         if (lbData [_idc, _i] isEqualTo _data) exitWith {
             _textRight = lbTextRight [_idc, _i];
@@ -51,57 +50,55 @@ GVAR(disarmTarget) = _target;
     };
 
     TRACE_2("Debug: Droping %1 from %2",_data,GVAR(disarmTarget));
-    [QGVAR(dropItems), [ACE_player, GVAR(disarmTarget), [_data], parseNumber _textRight], [GVAR(disarmTarget)]] call CBA_fnc_targetEvent;
-
-    false //not sure what this does
+    [QGVAR(dropItems), [ACE_player, GVAR(disarmTarget), [_data], parseNumber _textRight], GVAR(disarmTarget)] call CBA_fnc_targetEvent;
 }];
 
-//Setup PFEH
+// Setup PFH
 [{
     disableSerialization;
     params ["_args", "_idPFH"];
     _args params ["_player", "_target", "_display"];
 
-    if ((!([_player, _target] call FUNC(canPlayerDisarmUnit))) ||
-            {isNull _display} ||
-            {_player != ACE_player}) then {
-
-        [_idPFH] call CBA_fnc_removePerFrameHandler;
+    if (!([_player, _target] call FUNC(canPlayerDisarmUnit)) || {isNull _display} || {_player != ACE_player}) exitWith {
+        _idPFH call CBA_fnc_removePerFrameHandler;
         GVAR(disarmTarget) = objNull;
-        if (!isNull _display) then { closeDialog 0; }; //close dialog if still open
-    } else {
 
-        private _groundContainer = _display displayCtrl 632;
-        private _targetContainer = _display displayCtrl 633;
-        private _playerName = _display displayCtrl 111;
-        private _rankPicture = _display displayCtrl 1203;
-
-        //Show rank and name (just like BIS's inventory)
-        private _icon = format [DEFAULTPATH, toLowerANSI (rank _target)];
-        if (_icon isEqualTo DEFAULTPATH) then {_icon = ""};
-        _rankPicture ctrlSetText _icon;
-        _playerName ctrlSetText ([GVAR(disarmTarget), false, true] call EFUNC(common,getName));
-
-        //Clear both inventory lists:
-        lbClear _groundContainer;
-        lbClear _targetContainer;
-
-        //Show the items in the ground disarmTarget's inventory
-        private _targetUniqueItems = [GVAR(disarmTarget)] call FUNC(getAllGearUnit);
-        [_targetContainer, _targetUniqueItems] call FUNC(showItemsInListbox);
-
-        //Try to find a holder that the target is using to drop items into:
-        private _holder = objNull;
-        {
-            if ((_x getVariable [QGVAR(disarmUnit), objNull]) == _target) exitWith {
-                _holder = _x;
-            };
-        } forEach ((getPos _target) nearObjects [DISARM_CONTAINER, 3]);
-
-        //If a holder exists, show it's inventory
-        if (!isNull _holder) then {
-            private _holderUniqueItems = [_holder] call FUNC(getAllGearContainer);
-            [_groundContainer, _holderUniqueItems] call FUNC(showItemsInListbox);
+        // Close dialog if still open
+        if (!isNull _display) then {
+            closeDialog 0;
         };
+    };
+
+    private _groundContainer = _display displayCtrl 632;
+    private _targetContainer = _display displayCtrl 633;
+    private _playerName = _display displayCtrl 111;
+    private _rankPicture = _display displayCtrl 1203;
+
+    // Show rank and name (just like BIS's inventory)
+    private _icon = format [DEFAULTPATH, toLowerANSI (rank _target)];
+    if (_icon isEqualTo DEFAULTPATH) then {_icon = ""};
+    _rankPicture ctrlSetText _icon;
+    _playerName ctrlSetText ([GVAR(disarmTarget), false, true] call EFUNC(common,getName));
+
+    // Clear both inventory lists
+    lbClear _groundContainer;
+    lbClear _targetContainer;
+
+    // Show the items in the ground disarmTarget's inventory
+    private _targetUniqueItems = GVAR(disarmTarget) call FUNC(getAllGearUnit);
+    [_targetContainer, _targetUniqueItems] call FUNC(showItemsInListbox);
+
+    // Try to find a holder that the target is using to drop items into
+    private _holder = objNull;
+    {
+        if ((_x getVariable [QGVAR(disarmUnit), objNull]) == _target) exitWith {
+            _holder = _x;
+        };
+    } forEach ((getPos _target) nearObjects [DISARM_CONTAINER, 3]);
+
+    // If a holder exists, show its inventory
+    if (!isNull _holder) then {
+        private _holderUniqueItems = _holder call FUNC(getAllGearContainer);
+        [_groundContainer, _holderUniqueItems] call FUNC(showItemsInListbox);
     };
 }, 0, [_caller, _target, _display]] call CBA_fnc_addPerFrameHandler;

--- a/addons/disarming/functions/fnc_showItemsInListbox.sqf
+++ b/addons/disarming/functions/fnc_showItemsInListbox.sqf
@@ -1,18 +1,17 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
  * Shows a list of inventory items in a listBox control.
  *
  * Arguments:
  * 0: RscListBox <CONTROL>
- * 1: ItemArray [["itemClassnames"],[counts]] <ARRAY>
+ * 1: Items array [["itemClassnames"], [counts]] <ARRAY>
  *
  * Return Value:
  * None
  *
  * Example:
- * [theListBox, [["ace_bandage"],[2]]] call ace_disarming_fnc_showItemsInListbox
+ * [theListBox, [["ace_bandage"], [2]]] call ace_disarming_fnc_showItemsInListbox
  *
  * Public: No
  */
@@ -21,32 +20,38 @@ disableSerialization;
 
 params ["_listBoxCtrl", "_itemsCountArray"];
 
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+private _cfgVehicles = configFile >> "CfgVehicles";
+private _cfgGlasses = configFile >> "CfgGlasses";
+
 {
     private _classname = _x;
     private _count = (_itemsCountArray select 1) select _forEachIndex;
 
-    if ((_classname != DUMMY_ITEM) && {_classname != "ACE_FakePrimaryWeapon"}) then { //Don't show the dummy potato or fake weapon
+    if ((_classname != DUMMY_ITEM) && {_classname != "ACE_FakePrimaryWeapon"}) then { // Don't show the dummy potato or fake weapon
         private _configPath = configNull;
         private _displayName = "";
         private _picture = "";
+
         switch (true) do {
-            case (isClass (configFile >> "CfgWeapons" >> _classname)): {
-                _configPath = (configFile >> "CfgWeapons");
+            case (isClass (_cfgWeapons >> _classname)): {
+                _configPath = _cfgWeapons;
                 _displayName = getText (_configPath >> _classname >> "displayName");
                 _picture = getText (_configPath >> _classname >> "picture");
             };
-            case (isClass (configFile >> "CfgMagazines" >> _classname)): {
-                _configPath = (configFile >> "CfgMagazines");
+            case (isClass (_cfgMagazines >> _classname)): {
+                _configPath = _cfgMagazines;
                 _displayName = getText (_configPath >> _classname >> "displayName");
                 _picture = getText (_configPath >> _classname >> "picture");
             };
-            case (isClass (configFile >> "CfgVehicles" >> _classname)): {
-                _configPath = (configFile >> "CfgVehicles");
+            case (isClass (_cfgVehicles >> _classname)): {
+                _configPath = _cfgVehicles;
                 _displayName = getText (_configPath >> _classname >> "displayName");
                 _picture = getText (_configPath >> _classname >> "picture");
             };
-            case (isClass (configFile >> "CfgGlasses" >> _classname)): {
-                _configPath = (configFile >> "CfgGlasses");
+            case (isClass (_cfgGlasses >> _classname)): {
+                _configPath = _cfgGlasses;
                 _displayName = getText (_configPath >> _classname >> "displayName");
                 _picture = getText (_configPath >> _classname >> "picture");
             };
@@ -55,9 +60,9 @@ params ["_listBoxCtrl", "_itemsCountArray"];
             };
         };
 
-        _listBoxCtrl lbAdd _displayName;
-        _listBoxCtrl lbSetData [((lbSize _listBoxCtrl) - 1), _classname];
-        _listBoxCtrl lbSetPicture [((lbSize _listBoxCtrl) - 1), _picture];
-        _listBoxCtrl lbSetTextRight [((lbSize _listBoxCtrl) - 1), str _count];
+        private _index = _listBoxCtrl lbAdd _displayName;
+        _listBoxCtrl lbSetData [_index, _classname];
+        _listBoxCtrl lbSetPicture [_index, _picture];
+        _listBoxCtrl lbSetTextRight [_index, str _count];
     };
 } forEach (_itemsCountArray select 0);

--- a/addons/disarming/functions/fnc_verifyMagazinesMoved.sqf
+++ b/addons/disarming/functions/fnc_verifyMagazinesMoved.sqf
@@ -1,10 +1,9 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror
- *
  * Verifies magazines moved with exact ammo counts preserved.
  * Arrays will be in format from magazinesAmmo/magazinesAmmoCargo
- * e.g.: [["30Rnd_65x39_caseless_mag",15], ["30Rnd_65x39_caseless_mag",30]]
+ * e.g.: [["30Rnd_65x39_caseless_mag", 15], ["30Rnd_65x39_caseless_mag", 30]]
  *
  * Arguments:
  * 0: Start on container A <ARRAY>
@@ -23,18 +22,18 @@
 
 params ["_startA", "_endA", "_startB", "_endB"];
 
-//Quick Lazy Count Check
+// Quick Lazy Count Check
 if (((count _startA) + (count _startB)) != ((count _endA) + (count _endB))) exitWith {
-    false
+    false // return
 };
 
-private _beginingArray = (_startA + _startB);
+private _beginningArray = _startA + _startB;
 
 private _problem = false;
 {
-    private _index = _beginingArray find _x;
+    private _index = _beginningArray find _x;
     if (_index == -1) exitWith {_problem = true;};
-    _beginingArray deleteAt _index;
+    _beginningArray deleteAt _index;
 } forEach (_endA + _endB);
 
-(!_problem) && {_beginingArray isEqualTo []}
+!_problem && {_beginningArray isEqualTo []} // return

--- a/addons/disarming/gui_disarm.hpp
+++ b/addons/disarming/gui_disarm.hpp
@@ -1,12 +1,11 @@
-//The disarming dialog
-//Meant to mimic the real BIS inventory (so people understand how to use it)
-
+// The disarming dialog
+// Meant to mimic the real BIS inventory (so people understand how to use it)
 class RscText;
 class RscPicture;
 class RscActiveText;
 class RscListBox;
 
-//Use the definese from
+// Use the definitions from
 #define X_BIS(num) (num * (((safeZoneW / safeZoneH) min 1.2) / 40) + (safeZoneX + (safeZoneW - ((safeZoneW / safeZoneH) min 1.2))/2))
 #define Y_BIS(num) (num * ((((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25) + (safeZoneY + (safeZoneH - (((safeZoneW / safeZoneH) min 1.2) / 1.2))/2))
 #define W_BIS(num) (num * (((safeZoneW / safeZoneH) min 1.2) / 40))
@@ -17,10 +16,10 @@ class RscListBox;
 #define W_MAKEITBIGGA(num) (num * (safeZoneH / 40))
 #define H_MAKEITBIGGA(num) (num * (safeZoneH / 30))
 
-#define X_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QUOTE(QEGVAR(inventory,inventoryDisplaySize)),0)]),X_BIS(num),X_MAKEITBIGGA(num))])
-#define Y_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QUOTE(QEGVAR(inventory,inventoryDisplaySize)),0)]),Y_BIS(num),Y_MAKEITBIGGA(num))])
-#define W_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QUOTE(QEGVAR(inventory,inventoryDisplaySize)),0)]),W_BIS(num),W_MAKEITBIGGA(num))])
-#define H_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QUOTE(QEGVAR(inventory,inventoryDisplaySize)),0)]),H_BIS(num),H_MAKEITBIGGA(num))])
+#define X_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QQEGVAR(inventory,inventoryDisplaySize),0)]),X_BIS(num),X_MAKEITBIGGA(num))])
+#define Y_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QQEGVAR(inventory,inventoryDisplaySize),0)]),Y_BIS(num),Y_MAKEITBIGGA(num))])
+#define W_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QQEGVAR(inventory,inventoryDisplaySize),0)]),W_BIS(num),W_MAKEITBIGGA(num))])
+#define H_PART(num) QUOTE(linearConversion [ARR_5(0,2,(missionNamespace getVariable [ARR_2(QQEGVAR(inventory,inventoryDisplaySize),0)]),H_BIS(num),H_MAKEITBIGGA(num))])
 
 class GVAR(remoteInventory) {
     idd = -1;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Header fixes.
- Optimisations.
- Changes:
  - Use `lifeState` instead of `getVariable "ACE_isUnconscious"` for unconsciousness.
  - Players can only disarm units that are either in the same vehicle as them or if player and target are both on foot.
    Not too sure about this change, but imo it's weird to be able to disarm a person in a vehicle, when you are not in it.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
