### PR TITLE
Fortify/Trenches - Fix blowing-up uniqueItems cache

### DIFF
--- a/addons/fortify/functions/fnc_canFortify.sqf
+++ b/addons/fortify/functions/fnc_canFortify.sqf
@@ -20,7 +20,7 @@ params ["_player", ["_cost", 0]];
 
 (missionNamespace getVariable [QGVAR(fortifyAllowed), true]) &&
 {
-    private _items = _player call EFUNC(common,uniqueItems);
+    private _items = +(_player call EFUNC(common,uniqueItems));
     _items append weapons _player;
     _items pushBack backpack _player;
     GVAR(fortifyTools) findAny _items != -1

--- a/addons/trenches/functions/fnc_hasEntrenchingTool.sqf
+++ b/addons/trenches/functions/fnc_hasEntrenchingTool.sqf
@@ -19,7 +19,7 @@ params [
     ["_unit", objNull, [objNull]]
 ];
 
-private _uniqueItems = _unit call EFUNC(common,uniqueItems);
+private _uniqueItems = +(_unit call EFUNC(common,uniqueItems));
 _uniqueItems append weapons _unit;
 _uniqueItems pushBack backpack _unit;
 


### PR DESCRIPTION
Fix #10799

could also have `ace_common_fnc_uniqueItems` return a copy, but most times that isn't needed