### PR TITLE
Artillery Tables - Don't block zeroing for turrets without `elevationMode`

### DIFF
--- a/addons/artillerytables/functions/fnc_turretChanged.sqf
+++ b/addons/artillerytables/functions/fnc_turretChanged.sqf
@@ -57,13 +57,13 @@ if ((alive _player) && {_showGunLaying > 0} && {_player == gunner _vehicle}) the
     _fireModes = _fireModes apply {[getNumber (_x >> "artilleryCharge"), configName _x]};
     _fireModes sort true;
     _fireModes = _fireModes apply {_x select 1};
+    private _elevationMode = getNumber (_turretCfg >> "elevationMode");
 
-    GVAR(pfID) = [LINKFUNC(turretPFEH), 0, [_vehicle, _turret, _fireModes, _useAltElevation, _turretAnimBody, _invalidGunnerMem]] call CBA_fnc_addPerFrameHandler;
+    GVAR(pfID) = [LINKFUNC(turretPFEH), 0, [_vehicle, _turret, _fireModes, _useAltElevation, _turretAnimBody, _invalidGunnerMem, _elevationMode]] call CBA_fnc_addPerFrameHandler;
     TRACE_4("added pfEH",GVAR(pfID),_useAltElevation,_turretAnimBody,_invalidGunnerMem);
 
     #ifdef DEBUG_MODE_FULL
     private _ballisticsComputer = getNumber (configFile >> "CfgWeapons" >> _weapon >> "ballisticsComputer");
-    private _elevationMode = getNumber (_turretCfg >> "elevationMode");
     private _discreteDistance = getArray (_turretCfg >> "discreteDistance");
     TRACE_4("",_weapon,_ballisticsComputer,_elevationMode,_discreteDistance);
     #endif

--- a/addons/artillerytables/functions/fnc_turretPFEH.sqf
+++ b/addons/artillerytables/functions/fnc_turretPFEH.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-(_this select 0) params ["_vehicle", "_turret", "_fireModes", "_useAltElevation", "_turretAnimBody", "_invalidGunnerMem"];
+(_this select 0) params ["_vehicle", "_turret", "_fireModes", "_useAltElevation", "_turretAnimBody", "_invalidGunnerMem", "_elevationMode"];
 
 if (shownArtilleryComputer && {GVAR(disableArtilleryComputer)}) then {
     // Still Don't like this solution, but it works
@@ -30,6 +30,15 @@ if (isNull (uiNamespace getVariable [QGVAR(display), displayNull])) then {
 };
 
 private _ctrlGroup = (uiNamespace getVariable [QGVAR(display), displayNull]) displayCtrl 1000;
+
+if (_elevationMode == 0) then {
+    // For turrets not using an elevation mode (i.e. mouse controls elevation instead of pageUp/Down)
+    // Show the info 1 step below, so it doesn't block vanilla ranging (discreteDistance)
+    // vanilla zeroing will have a negative effect, so it's best to range as low as possible
+    private _y = 3.5 * ((((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25) + (profileNamespace getVariable ['IGUI_GRID_WEAPON_Y', (safeZoneY + 0.5 * ((((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25))]);
+    _ctrlGroup ctrlSetPositionY _y;
+    _ctrlGroup ctrlCommit 0;
+};
 
 // Need to be in gunner mode, so we can check where the optics are aiming at
 // However, if there are no optics, ignore the above

--- a/addons/artillerytables/functions/fnc_turretPFEH.sqf
+++ b/addons/artillerytables/functions/fnc_turretPFEH.sqf
@@ -35,7 +35,8 @@ if (_elevationMode == 0) then {
     // For turrets not using an elevation mode (i.e. mouse controls elevation instead of pageUp/Down)
     // Show the info 1 step below, so it doesn't block vanilla ranging (discreteDistance)
     // vanilla zeroing will have a negative effect, so it's best to range as low as possible
-    private _y = 3.5 * ((((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25) + (profileNamespace getVariable ['IGUI_GRID_WEAPON_Y', (safeZoneY + 0.5 * ((((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25))]);
+    private _safeZoneGrid = (((safeZoneW / safeZoneH) min 1.2) / 1.2) / 25;
+    private _y = 3.5 * _safeZoneGrid + (profileNamespace getVariable ['IGUI_GRID_WEAPON_Y', safeZoneY + 0.5 * _safeZoneGrid]);
     _ctrlGroup ctrlSetPositionY _y;
     _ctrlGroup ctrlCommit 0;
 };


### PR DESCRIPTION
ref https://discord.com/channels/105462288051380224/122121444703338496/1350954562466480249

>I´d like to have a weapon display both the ACE elevation and azimuth numbers and PgUp / PgDwn zeroing numbers at the same time. 
Issue is, they seem to be getting displayed in the same place by default, so I can only see one of them 🤔


For turrets not using an elevation mode (i.e. mouse controls elevation instead of pageUp/Down)
Show the info 1 step below, so it doesn't block vanilla ranging (discreteDistance)
vanilla zeroing will have a negative effect, so it's best to range as low as possible


Could possibly handle the vanilla zeroing, but it would be a lot of work for something pretty uncommon
just range 100 and it's very close