### PR TITLE
missileguidance - fix MCLOS direction error

### DIFF
--- a/addons/missileguidance/XEH_postInit.sqf
+++ b/addons/missileguidance/XEH_postInit.sqf
@@ -24,16 +24,16 @@
 [DIK_NUMPAD2, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 2
 
 ["ACE3 Weapons", QGVAR(mclosLeft), LLSTRING(mclosLeft), {
-    [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
-}, {
     [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
+}, {
+    [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD6, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 6
 
 ["ACE3 Weapons", QGVAR(mclosRight), LLSTRING(mclosRight), {
-    [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
-}, {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
+}, {
+    [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD4, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 4
 

--- a/addons/missileguidance/XEH_postInit.sqf
+++ b/addons/missileguidance/XEH_postInit.sqf
@@ -9,28 +9,28 @@
 }, [DIK_TAB, [false, true, false]], false] call CBA_fnc_addKeybind;  //Ctrl+Tab Key
 
 // Each MCLOS argument is the vector which acceleration will be applied
-["ACE3 Weapons", QGVAR(mclos_joystickUp), LLSTRING(mclosUp), {
+["ACE3 Weapons", QGVAR(adjustUp), LLSTRING(mclosUp), {
     [[0, 0, 1], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[0, 0, -1], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD8, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 8
 
-["ACE3 Weapons", QGVAR(mclos_joystickDown), LLSTRING(mclosDown), {
+["ACE3 Weapons", QGVAR(adjustDown), LLSTRING(mclosDown), {
     [[0, 0, -1], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[0, 0, 1], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD2, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 2
 
-["ACE3 Weapons", QGVAR(mclos_joystickLeft), LLSTRING(mclosLeft), {
+["ACE3 Weapons", QGVAR(adjustLeft), LLSTRING(mclosLeft), {
     [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD4, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 4
 
-["ACE3 Weapons", QGVAR(mclos_joystickRight), LLSTRING(mclosRight), {
+["ACE3 Weapons", QGVAR(adjustRight), LLSTRING(mclosRight), {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)

--- a/addons/missileguidance/XEH_postInit.sqf
+++ b/addons/missileguidance/XEH_postInit.sqf
@@ -28,14 +28,14 @@
 }, {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
-[DIK_NUMPAD6, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 6
+[DIK_NUMPAD4, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 4
 
 ["ACE3 Weapons", QGVAR(mclosRight), LLSTRING(mclosRight), {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
-[DIK_NUMPAD4, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 4
+[DIK_NUMPAD6, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 6
 
 if (!hasInterface) exitWith {};
 

--- a/addons/missileguidance/XEH_postInit.sqf
+++ b/addons/missileguidance/XEH_postInit.sqf
@@ -9,28 +9,28 @@
 }, [DIK_TAB, [false, true, false]], false] call CBA_fnc_addKeybind;  //Ctrl+Tab Key
 
 // Each MCLOS argument is the vector which acceleration will be applied
-["ACE3 Weapons", QGVAR(mclosUp), LLSTRING(mclosUp), {
+["ACE3 Weapons", QGVAR(mclos_joystickUp), LLSTRING(mclosUp), {
     [[0, 0, 1], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[0, 0, -1], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD8, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 8
 
-["ACE3 Weapons", QGVAR(mclosDown), LLSTRING(mclosDown), {
+["ACE3 Weapons", QGVAR(mclos_joystickDown), LLSTRING(mclosDown), {
     [[0, 0, -1], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[0, 0, 1], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD2, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 2
 
-["ACE3 Weapons", QGVAR(mclosLeft), LLSTRING(mclosLeft), {
+["ACE3 Weapons", QGVAR(mclos_joystickLeft), LLSTRING(mclosLeft), {
     [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 },
 [DIK_NUMPAD4, [false, false, false]], false, 0] call CBA_fnc_addKeybind;  // Numpad 4
 
-["ACE3 Weapons", QGVAR(mclosRight), LLSTRING(mclosRight), {
+["ACE3 Weapons", QGVAR(mclos_joystickRight), LLSTRING(mclosRight), {
     [[1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)
 }, {
     [[-1, 0, 0], ACE_player] call FUNC(MCLOS_buttonPressed)


### PR DESCRIPTION
**When merged this pull request will:**
- Fix MCLOS direction error

The controls were named wrong. The comments changed show that left was always bound to right, and vice versa.

Strictly speaking, not tested in game. But this is realistically the only path which this got changed so it should work - hopefully.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
