### PR TITLE
Laser - Fix getting laser position from aircraft `pilotCamera`

### DIFF
--- a/addons/laser/functions/fnc_addLaserTarget.sqf
+++ b/addons/laser/functions/fnc_addLaserTarget.sqf
@@ -43,6 +43,10 @@ if (_vehicle isKindOf "CAManBase") then {
             };
         } forEach (_vehicle weaponsTurret _turretPath);
     } forEach (allTurrets [_vehicle, true]);
+    if ((_vehicleSourceSelection == "") && hasPilotCamera _vehicle) then {
+        // must not be a turret, assume it is from the aircraft's PilotCamera
+        _vehicleSourceSelection = getText (configOf _vehicle >> "memoryPointDriverOptics");
+    };
 };
 
 private _methodArgs = [_vehicleSourceSelection];


### PR DESCRIPTION
This primarily effects marking laser module
before the laser origin would be model's center
now properly from the targeting pod
![Untitled](https://github.com/user-attachments/assets/a6225451-8d27-4bb3-8ee7-76b239e1bb36)
