### PR TITLE
compat_cup - Fix T72 and M60 inheritance

### DIFF
--- a/addons/compat_cup_vehicles/CfgVehicles.hpp
+++ b/addons/compat_cup_vehicles/CfgVehicles.hpp
@@ -269,10 +269,6 @@ class CfgVehicles {
         ace_hunterkiller = 1;
     };
 
-    class CUP_M60A3_TTS_Base: Tank_F {
-        ace_hunterkiller = 1;
-    };
-
     class CUP_T55_Base: Tank_F {
         ace_hunterkiller = 1;
     };
@@ -311,9 +307,7 @@ class CfgVehicles {
         };
     };
 
-    class CUP_T72_ACR_Base: Tank_F {
-        ace_hunterkiller = 1;
-    };
+    class CUP_T72_ACR_Base: CUP_T72_Base {};
     class CUP_B_T72_CZ: CUP_T72_ACR_Base {
         EGVAR(vehicle_damage,eraHitpoints)[] = {
             "hitera_top_l1", "hitera_top_l2", "hitera_top_l3", "hitera_top_l4",


### PR DESCRIPTION
fix
```
Updating base class CUP_M60A3_Base->Tank_F, by z\ace\addons\compat_cup_vehicles\config.cpp/CfgVehicles/CUP_M60A3_TTS_Base/ (original CUP\TrackedVehicles\CUP_TrackedVehicles_M60\config.bin)
Updating base class CUP_T72_Base->Tank_F, by z\ace\addons\compat_cup_vehicles\config.cpp/CfgVehicles/CUP_T72_ACR_Base/ (original CUP\TrackedVehicles\CUP_TrackedVehicles_T72\config.bin)
```