### PR TITLE
Medical Engine - Change Unconscious animations collisionshape to be empty to allow units to walk over bodies

### DIFF
--- a/addons/medical_engine/CfgMoves.hpp
+++ b/addons/medical_engine/CfgMoves.hpp
@@ -13,7 +13,8 @@ class CfgMovesMaleSdr: CfgMovesBasic {
             aiming = "aimingNo";
             aimingBody = "aimingUpNo";
             head = "headNo";
-
+            collisionShape = "A3\anims_f\Data\Geom\Sdr\geom_empty.p3d"; //Allows for units to walk through/step over the body
+            collisionShapeSafe = "A3\anims_f\Data\Geom\Sdr\geom_empty.p3d";
             file = QPATHTO_T(data\ace_unconscious_1.rtm);
         };
 
@@ -79,10 +80,16 @@ class CfgMovesMaleSdr: CfgMovesBasic {
 
         /* added for the "ace_unc" part */
         class KIA_passenger_boat_holdleft;
-        class UNCON_ANIM(9): KIA_passenger_boat_holdleft {};
+        class UNCON_ANIM(9): KIA_passenger_boat_holdleft {
+          collisionShape = "A3\anims_f\Data\Geom\Sdr\geom_empty.p3d";
+          collisionShapeSafe = "A3\anims_f\Data\Geom\Sdr\geom_empty.p3d";
+        };
 
         class KIA_driver_boat01;
-        class UNCON_ANIM(10): KIA_driver_boat01 {};
+        class UNCON_ANIM(10): KIA_driver_boat01 {
+          collisionShape = "A3\anims_f\Data\Geom\Sdr\geom_empty.p3d";
+          collisionShapeSafe = "A3\anims_f\Data\Geom\Sdr\geom_empty.p3d";
+        };
 
         class Unconscious;
         class UNCON_ANIM(faceDown): Unconscious {};


### PR DESCRIPTION
**When merged this pull request will:**
-  Change the geometry shape of the unconscious animations to be empty, allowing units to move through the 'body' as if walking over them or the likes

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
