### PR TITLE
Common - Remove ACEX addons from PBO version check

### DIFF
--- a/addons/common/functions/fnc_checkVersionNumber.sqf
+++ b/addons/common/functions/fnc_checkVersionNumber.sqf
@@ -29,6 +29,7 @@ private _files = CBA_common_addons select {
 
     (_addon select [0, 3] != "a3_") &&
     {_addon select [0, 4] != "ace_"} &&
+    {_addon select [0, 5] != "acex_"} &&
     {_addon select [0, 12] != "CuratorOnly_"} &&
     {_whitelist findIf {_addon regexMatch _x} == -1}
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Ignore ACEX addons in PBO version check

All ACEX CfgPatches classes have equivalent ACE CfgPatches classes and only exist for BWC. Therefore, the normal ACE version check should already cover all ACEX addons. We don't need to check them a second time.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
