### PR TITLE
Safemode - Add new unlock only keybind

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -196,3 +196,4 @@ xrufix
 Zakant <Zakant@gmx.de>
 zGuba
 Zman6258
+Puotek

--- a/addons/safemode/XEH_postInit.sqf
+++ b/addons/safemode/XEH_postInit.sqf
@@ -20,27 +20,17 @@ if (!hasInterface) exitWith {};
 }, {false}, [DIK_GRAVE, [false, true, false]], false] call CBA_fnc_addKeybind;
 
 ["ACE3 Weapons", QGVAR(safeModeUnlock), LLSTRING(TakeOffSafety), {
-    [{
-        if !([ace_player, objNull, ["isNotEscorting", "isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {};
+    // Conditions: canInteract
+    if !([ACE_player, objNull, ["isNotEscorting", "isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
-        (weaponState ace_player) params ["_currentWeapon", "_currentMuzzle"];
+    (weaponState ACE_player) params ["_currentWeapon", "_currentMuzzle"];
 
-        if !(ace_player call CBA_fnc_canUseWeapon && {_currentWeapon != ""} && {_currentWeapon != binocular ace_player}) exitWith {};
+    // Conditions: specific
+    if !(ACE_player call CBA_fnc_canUseWeapon && {_currentWeapon != ""} && {_currentWeapon != binocular ACE_player}) exitWith {false};
 
-        private _safedWeapons = ace_player getVariable QGVAR(safedWeapons);
-
-        if (isNil "_safedWeapons") then {
-            _safedWeapons = createHashMap;
-            ace_player setVariable [QGVAR(safedWeapons), _safedWeapons];
-        };
-
-        private _safedWeaponMuzzles = _safedWeapons getOrDefault [_currentWeapon, createHashMap, true];
-
-        if (_currentMuzzle in _safedWeaponMuzzles) exitWith {
-            [ace_player, _currentWeapon, _currentMuzzle, true] call ace_safemode_fnc_unlockSafety;
-        };
-    }] call CBA_fnc_execNextFrame;
-}, ""] call CBA_fnc_addKeybind;
+    // Statement: Toggle weapon safety
+    [ACE_player, _currentWeapon, _currentMuzzle, true, true] call FUNC(lockSafety);
+}, {}] call CBA_fnc_addKeybind;
 
 ["unit", {
     (weaponState ACE_player) params ["_currentWeapon", "_currentMuzzle"];

--- a/addons/safemode/XEH_postInit.sqf
+++ b/addons/safemode/XEH_postInit.sqf
@@ -28,7 +28,7 @@ if (!hasInterface) exitWith {};
     // Conditions: specific
     if !(ACE_player call CBA_fnc_canUseWeapon && {_currentWeapon != ""} && {_currentWeapon != binocular ACE_player}) exitWith {false};
 
-    // Statement: Toggle weapon safety
+    // Statement: Unlock weapon safety
     [ACE_player, _currentWeapon, _currentMuzzle, true, true] call FUNC(lockSafety);
 }, {}] call CBA_fnc_addKeybind;
 

--- a/addons/safemode/XEH_postInit.sqf
+++ b/addons/safemode/XEH_postInit.sqf
@@ -4,7 +4,7 @@
 
 if (!hasInterface) exitWith {};
 
-["ACE3 Weapons", QGVAR(safeMode), LLSTRING(SafeMode), {
+["ACE3 Weapons", QGVAR(safeMode), LLSTRING(SafeModeToggle), {
     // Conditions: canInteract
     if !([ACE_player, objNull, ["isNotEscorting", "isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {false};
 
@@ -19,7 +19,7 @@ if (!hasInterface) exitWith {};
     true
 }, {false}, [DIK_GRAVE, [false, true, false]], false] call CBA_fnc_addKeybind;
 
-["ACE3 Weapons", QGVAR(safeModeUnlock), LLSTRING(SafeModeUnlock), {
+["ACE3 Weapons", QGVAR(safeModeUnlock), LLSTRING(TakeOffSafety), {
     [{
         if !([ace_player, objNull, ["isNotEscorting", "isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {};
 

--- a/addons/safemode/XEH_postInit.sqf
+++ b/addons/safemode/XEH_postInit.sqf
@@ -19,6 +19,29 @@ if (!hasInterface) exitWith {};
     true
 }, {false}, [DIK_GRAVE, [false, true, false]], false] call CBA_fnc_addKeybind;
 
+["ACE3 Weapons", QGVAR(safeModeUnlock), LLSTRING(SafeModeUnlock), {
+    [{
+        if !([ace_player, objNull, ["isNotEscorting", "isNotInside", "isNotSwimming"]] call EFUNC(common,canInteractWith)) exitWith {};
+
+        (weaponState ace_player) params ["_currentWeapon", "_currentMuzzle"];
+
+        if !(ace_player call CBA_fnc_canUseWeapon && {_currentWeapon != ""} && {_currentWeapon != binocular ace_player}) exitWith {};
+
+        private _safedWeapons = ace_player getVariable QGVAR(safedWeapons);
+
+        if (isNil "_safedWeapons") then {
+            _safedWeapons = createHashMap;
+            ace_player setVariable [QGVAR(safedWeapons), _safedWeapons];
+        };
+
+        private _safedWeaponMuzzles = _safedWeapons getOrDefault [_currentWeapon, createHashMap, true];
+
+        if (_currentMuzzle in _safedWeaponMuzzles) exitWith {
+            [ace_player, _currentWeapon, _currentMuzzle, true] call ace_safemode_fnc_unlockSafety;
+        };
+    }] call CBA_fnc_execNextFrame;
+}, ""] call CBA_fnc_addKeybind;
+
 ["unit", {
     (weaponState ACE_player) params ["_currentWeapon", "_currentMuzzle"];
 

--- a/addons/safemode/functions/fnc_lockSafety.sqf
+++ b/addons/safemode/functions/fnc_lockSafety.sqf
@@ -8,6 +8,7 @@
  * 1: Weapon <STRING>
  * 2: Muzzle <STRING>
  * 3: Show hint <BOOL> (default: true)
+ * 3: Only unlock <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -18,7 +19,7 @@
  * Public: No
  */
 
-params ["_unit", "_weapon", "_muzzle", ["_hint", true]];
+params ["_unit", "_weapon", "_muzzle", ["_hint", true], ["_onlyUnlock", false]];
 
 private _safedWeapons = _unit getVariable QGVAR(safedWeapons);
 
@@ -35,6 +36,7 @@ private _safedWeaponMuzzles = _safedWeapons getOrDefault [_weapon, createHashMap
 if (_muzzle in _safedWeaponMuzzles) exitWith {
     [_unit, _weapon, _muzzle, _hint] call FUNC(unlockSafety);
 };
+if (_onlyUnlock) exitWith {};
 
 private _weaponSelected = currentWeapon _unit == _weapon;
 private _firemode = (_unit weaponState _muzzle) select 2;

--- a/addons/safemode/stringtable.xml
+++ b/addons/safemode/stringtable.xml
@@ -18,6 +18,10 @@
             <Turkish>Emniyete alındı</Turkish>
             <Hungarian>Biztonsági kapcsoló helyretolása</Hungarian>
         </Key>
+        <Key ID="STR_ACE_SafeMode_SafeModeUnlock">
+            <English>Safe Mode Unlock</English>
+            <Polish>Wyłącz Bezpiecznik</Polish>
+        </Key>
         <Key ID="STR_ACE_SafeMode_SafeMode">
             <English>Safe Mode</English>
             <Czech>Pojistka</Czech>

--- a/addons/safemode/stringtable.xml
+++ b/addons/safemode/stringtable.xml
@@ -18,10 +18,6 @@
             <Turkish>Emniyete alındı</Turkish>
             <Hungarian>Biztonsági kapcsoló helyretolása</Hungarian>
         </Key>
-        <Key ID="STR_ACE_SafeMode_SafeModeUnlock">
-            <English>Safe Mode Unlock</English>
-            <Polish>Wyłącz Bezpiecznik</Polish>
-        </Key>
         <Key ID="STR_ACE_SafeMode_SafeMode">
             <English>Safe Mode</English>
             <Czech>Pojistka</Czech>
@@ -29,6 +25,23 @@
             <Spanish>Poner seguro</Spanish>
             <Italian>Modalità Sicura</Italian>
             <Polish>Bezpiecznik</Polish>
+            <Portuguese>Modo de segurança</Portuguese>
+            <Russian>Предохранитель</Russian>
+            <German>Waffe sichern</German>
+            <Korean>안전 모드</Korean>
+            <Japanese>安全装置</Japanese>
+            <Chinese>保險模式</Chinese>
+            <Chinesesimp>保险</Chinesesimp>
+            <Turkish>Emniyet Modu</Turkish>
+            <Hungarian>Biztonságos mód</Hungarian>
+        </Key>
+        <Key ID="STR_ACE_SafeMode_SafeModeToggle">
+            <English>Safe Mode (Toggle)</English>
+            <Czech>Pojistka</Czech>
+            <French>Sécurité</French>
+            <Spanish>Poner seguro</Spanish>
+            <Italian>Modalità Sicura</Italian>
+            <Polish>Bezpiecznik (Przełącz)</Polish>
             <Portuguese>Modo de segurança</Portuguese>
             <Russian>Предохранитель</Russian>
             <German>Waffe sichern</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a new Keybind to `ACE Weapons` that allows to bind unlock safemode only to a key

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
