### PR TITLE
Advanced Throwing - Add GVAR so mod authors can disable grenade preview during preparation.

### DIFF
--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -10,9 +10,6 @@ if (!hasInterface) exitWith {};
 // Temporary Wind Info indication
 GVAR(tempWindInfo) = false;
 
-//Enable/Disable grenade preview when preparing
-GVAR(showThrowable) = true;
-
 // Add keybinds
 ["ACE3 Weapons", QGVAR(prepare), LLSTRING(Prepare), {
     // Condition

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -10,7 +10,7 @@ if (!hasInterface) exitWith {};
 // Temporary Wind Info indication
 GVAR(tempWindInfo) = false;
 
-//ENable/Disable grenade preview when preparing
+//Enable/Disable grenade preview when preparing
 GVAR(showThrowable) = true;
 
 // Add keybinds

--- a/addons/advanced_throwing/XEH_postInit.sqf
+++ b/addons/advanced_throwing/XEH_postInit.sqf
@@ -10,6 +10,9 @@ if (!hasInterface) exitWith {};
 // Temporary Wind Info indication
 GVAR(tempWindInfo) = false;
 
+//ENable/Disable grenade preview when preparing
+GVAR(showThrowable) = true;
+
 // Add keybinds
 ["ACE3 Weapons", QGVAR(prepare), LLSTRING(Prepare), {
     // Condition

--- a/addons/advanced_throwing/XEH_preInit.sqf
+++ b/addons/advanced_throwing/XEH_preInit.sqf
@@ -8,4 +8,7 @@ PREP_RECOMPILE_END;
 
 #include "initSettings.inc.sqf"
 
+//Enable/Disable grenade preview when preparing (insert typeNames or just true to disable all)
+GVAR(hiddenThrowables) = [];
+
 ADDON = true;

--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -86,6 +86,7 @@ if (isNull _activeThrowable || {!_primed && {_throwableType != typeOf _activeThr
     _activeThrowable = _throwableType createVehicleLocal [0, 0, 0];
     _activeThrowable enableSimulation false;
     ACE_player setVariable [QGVAR(activeThrowable), _activeThrowable];
+
     if ((GVAR(hiddenThrowables) findIf {(_x isEqualTo true) || {_x == _throwableType}}) != -1) then {
         //if show disabled, hide active but retain vehicle for path calculation.
         hideObject _activeThrowable;

--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -86,7 +86,10 @@ if (isNull _activeThrowable || {!_primed && {_throwableType != typeOf _activeThr
     _activeThrowable = _throwableType createVehicleLocal [0, 0, 0];
     _activeThrowable enableSimulation false;
     ACE_player setVariable [QGVAR(activeThrowable), _activeThrowable];
-
+    if(!GVAR(showThrowable)) then {
+        //if show disabled, hide active but retain vehicle for path calculation.
+        hideObject _activeThrowable;
+    };
     // Set muzzle ammo to 0 to block vanilla throwing
     ACE_player setVariable [QGVAR(activeMuzzle), [_muzzle, ACE_player ammo _muzzle]];
     ACE_player setAmmo [_muzzle, 0];

--- a/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
+++ b/addons/advanced_throwing/functions/fnc_drawThrowable.sqf
@@ -86,7 +86,7 @@ if (isNull _activeThrowable || {!_primed && {_throwableType != typeOf _activeThr
     _activeThrowable = _throwableType createVehicleLocal [0, 0, 0];
     _activeThrowable enableSimulation false;
     ACE_player setVariable [QGVAR(activeThrowable), _activeThrowable];
-    if(!GVAR(showThrowable)) then {
+    if ((GVAR(hiddenThrowables) findIf {(_x isEqualTo true) || {_x == _throwableType}}) != -1) then {
         //if show disabled, hide active but retain vehicle for path calculation.
         hideObject _activeThrowable;
     };

--- a/docs/wiki/framework/advanced-throwing-framework.md
+++ b/docs/wiki/framework/advanced-throwing-framework.md
@@ -26,5 +26,4 @@ Hide the (non-primed) preview grenade object by
 ```sqf
 ace_advanced_throwing_hiddenThrowables pushBack "grenadeHand"; // disable specific grenade types (CfgAmmo classname)
 ace_advanced_throwing_hiddenThrowables pushBack true; // disable all
-
 ```

--- a/docs/wiki/framework/advanced-throwing-framework.md
+++ b/docs/wiki/framework/advanced-throwing-framework.md
@@ -18,3 +18,13 @@ Pick-up interaction can be disabled for ammo (e.g. chemlights) attached to an ob
 ```sqf
 OBJECT setVariable ["ace_advanced_throwing_disablePickUp", true, true];
 ```
+
+## 2. Disable showing grenade preview
+
+Hide the (non-primed) preview grenade object by
+
+```sqf
+ace_advanced_throwing_hiddenThrowables pushBack "grenadeHand"; // disable specific grenade types (CfgAmmo classname)
+ace_advanced_throwing_hiddenThrowables pushBack true; // disable all
+
+```


### PR DESCRIPTION
**When merged this pull request will:**
Create a simple GVAR in advanced throwable to enable mod authors to hide the grenade preview with alternative animations are sought. 
CBA Setting not created to mitigate settings bloat. 
Discussed on Discord in ace3-dev