### PR TITLE
Medical Treatment - Don't warn for diagnose animation duration

### DIFF
--- a/addons/medical_treatment/functions/fnc_treatment.sqf
+++ b/addons/medical_treatment/functions/fnc_treatment.sqf
@@ -80,7 +80,7 @@ if (_medic isNotEqualTo player || {!_isInZeus}) then {
     // Determine the animation length
     private _animDuration = GVAR(animDurations) get toLowerANSI _medicAnim;
     if (isNil "_animDuration") then {
-        WARNING_2("animation [%1] for [%2] has no duration defined",_medicAnim,_classname);
+        if (_medicAnim != "") then { WARNING_2("animation [%1] for [%2] has no duration defined",_medicAnim,_classname); };
         _animDuration = 10;
     };
 


### PR DESCRIPTION
Fix
`WARNING: animation [] for [CheckResponse] has no duration defined`