### PR TITLE
compat_cup_units - Add Hearing Protection to `CUP_H_RUS_K6_3` Helmets

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -41,3 +41,11 @@ workshop = [
     "843593391", # RHS GREF Workshop ID
     "843632231", # RHS SAF  Workshop ID
 ]
+
+[cup]
+extends = "default"
+workshop = [
+    "497660133", # CUP Weapons
+    "541888371", # CUP Vehicles
+    "497661914", # CUP Units
+]

--- a/addons/compat_cup_units/CfgWeapons.hpp
+++ b/addons/compat_cup_units/CfgWeapons.hpp
@@ -67,6 +67,7 @@ class CfgWeapons {
     HEARING(CUP_H_PMC_Cap_EP_Grey);
     HEARING(CUP_H_PMC_Cap_EP_Tan);
     HEARING(CUP_H_PMC_EP_Headset);
+    HEARING(CUP_H_RUS_K6_3);
     HEARING(CUP_H_USArmy_HelmetMICH_earpro);
     HEARING(CUP_H_USArmy_HelmetMICH_earpro_DCU);
     HEARING(CUP_H_USArmy_HelmetMICH_earpro_ess);


### PR DESCRIPTION
**When merged this pull request will:**
- title
- also: add CUP mods to `launch.toml`

Context:

> Only the goggles versions of the K6-3 Combat Helmet have ACE Hearing Protection values defined

on the CUP Discord. The Goggles Variant inherits differently and get their values from `CUP_H_RUS_Altyn` which has its values in CUP directly.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
