### PR TITLE
Compat Aegis: Add Aegis Titan variants Javelin compat

### DIFF
--- a/addons/compat_aegis/compat_aegis_javelin/CfgWeapons.hpp
+++ b/addons/compat_aegis/compat_aegis_javelin/CfgWeapons.hpp
@@ -1,0 +1,24 @@
+class CfgWeapons {
+    class launch_Titan_short_base;
+    class launch_Titan_short_blk_F: launch_Titan_short_base {
+        EGVAR(javelin,enabled) = 1;
+        weaponInfoType = "ACE_RscOptics_javelin";
+        modelOptics = QPATHTOEF(javelin,data\reticle_titan.p3d);
+
+        canLock = 0;
+
+        lockingTargetSound[] = {"",0,1};
+        lockedTargetSound[] = {"",0,1};
+    };
+
+    class launch_O_Titan_short_camo_F: launch_Titan_short_base {
+        EGVAR(javelin,enabled) = 1;
+        weaponInfoType = "ACE_RscOptics_javelin";
+        modelOptics = QPATHTOEF(javelin,data\reticle_titan.p3d);
+
+        canLock = 0;
+
+        lockingTargetSound[] = {"",0,1};
+        lockedTargetSound[] = {"",0,1};
+    };
+};

--- a/addons/compat_aegis/compat_aegis_javelin/config.cpp
+++ b/addons/compat_aegis/compat_aegis_javelin/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "ace_javelin",
+            "A3_Aegis_Weapons_F_Aegis"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"ThomasAngel"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/compat_aegis/compat_aegis_javelin/script_component.hpp
+++ b/addons/compat_aegis/compat_aegis_javelin/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT javelin
+#define SUBCOMPONENT_BEAUTIFIED Javelin
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Adds Javelin subcompat to compat Aegis
- Adds Javelin compat to the two Titan MPRL shoulder variants added by Aegis

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
