### PR TITLE
Balistics, SmallArms - Fix 9mm magazines Displaynames and Descriptions

### DIFF
--- a/addons/ballistics/stringtable.xml
+++ b/addons/ballistics/stringtable.xml
@@ -1568,21 +1568,21 @@
             <Turkish>12 kalibre 15 mermi #00 İrisaçma</Turkish>
         </Key>
         <Key ID="STR_ACE_Ballistics_16Rnd_9x19_mag_Description">
-            <English>9x19 mm 30Rnd Mag</English>
-            <Czech>9x19 mm 30náb. Zásobník</Czech>
-            <French>Ch. 9x19 mm 30Cps</French>
-            <Spanish>Cargador de 16 balas de 9x19 mm</Spanish>
-            <Italian>9x19 mm 30cp Car</Italian>
-            <Polish>Magazynek 9x19 mm 16rd</Polish>
-            <Portuguese>Carregador de 16 cartuchos 9x19 mm</Portuguese>
-            <Russian>Магазин из 16-ти 9х19 мм</Russian>
-            <German>9x19 mm 30-Patronen-Magazin</German>
-            <Korean>9x19mm 30발 들이 탄창</Korean>
-            <Japanese>9x19 mm 30Rnd マガジン</Japanese>
-            <Chinese>9x19毫米 30發 彈匣</Chinese>
-            <Chinesesimp>9x19 mm 30发 弹匣</Chinesesimp>
-            <Turkish>9x19 mm 30Rnd Mag</Turkish>
-            <Hungarian>9x19 mm 16-lövedékes tár</Hungarian>
+            <English>Caliber: 9x19 mm&lt;br /&gt;Rounds: 16</English>
+            <Czech>Ráže: 9x19 mm&lt;br /&gt;Nábojů: 16</Czech>
+            <French>Calibre: 9x19 mm&lt;br /&gt;Cartouches: 16</French>
+            <Spanish>Calibre: 9x19 mm&lt;br /&gt;Balas: 16</Spanish>
+            <Italian>Calibro: 9x19 mm&lt;br /&gt;Munizioni: 16</Italian>
+            <Polish>Kaliber: 9x19 mm&lt;br /&gt;Pociski: 16</Polish>
+            <Portuguese>Calibre: 9x19 mm&lt;br/&gt;Cartuchos: 16</Portuguese>
+            <Russian>Калибр: 9x19 мм&lt;br /&gt;Патронов: 16</Russian>
+            <German>Kaliber:9x19 mm&lt;br /&gt;Patronen: 16</German>
+            <Korean>구경: 9x19mm&lt;br/&gt;장탄수: 16</Korean>
+            <Japanese>口径: 9x19 mm&lt;br /&gt;装填数: 16</Japanese>
+            <Chinese>口徑: 9x19毫米&lt;br /&gt;發數: 16</Chinese>
+            <Chinesesimp>口径：9x19 mm&lt;br /&gt;发数：16</Chinesesimp>
+            <Turkish>Kalibre: 9x19 mm&lt;br /&gt;Mermi: 16</Turkish>
+            <Hungarian>Kaliber: 9x19 mm&lt;br /&gt;Lövedékek: 16</Hungarian>
         </Key>
         <Key ID="STR_ACE_Ballistics_16Rnd_9x19_mag_Name">
             <English>9x19 mm 16Rnd Mag</English>

--- a/addons/smallarms/CfgMagazines.hpp
+++ b/addons/smallarms/CfgMagazines.hpp
@@ -92,6 +92,7 @@ class CfgMagazines {
 
     class 11Rnd_45ACP_Mag: CA_Magazine {
         displayname = CSTRING(15Rnd_45_Name);
+        displaynameshort = ".45";
         count = 15;
     };
 };

--- a/addons/smallarms/CfgMagazines.hpp
+++ b/addons/smallarms/CfgMagazines.hpp
@@ -40,27 +40,20 @@ class CfgMagazines {
         lastRoundsTracer = 0;
     };
 
-    class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {};
-
-    class ACE_17Rnd_9x21_Mag: 16Rnd_9x21_Mag {
-        author = ECSTRING(common,ACETeam);
+    class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {
         displayname = CSTRING(17Rnd_9x19_Name);
-        count = 17;
     };
 
-    class ACE_17Rnd_9x21_red_Mag: ACE_17Rnd_9x21_Mag {
+    class 16Rnd_9x21_red_Mag: 16Rnd_9x21_Mag {
         displayname = CSTRING(17Rnd_9x19_red_Name);
-        ammo = "B_9x21_Ball_Tracer_Red";
     };
 
-    class ACE_17Rnd_9x21_green_Mag: ACE_17Rnd_9x21_Mag {
+    class 16Rnd_9x21_green_Mag: 16Rnd_9x21_Mag {
         displayname = CSTRING(17Rnd_9x19_green_Name);
-        ammo = "B_9x21_Ball_Tracer_Green";
     };
 
-    class ACE_17Rnd_9x21_yellow_Mag: ACE_17Rnd_9x21_Mag {
+    class 16Rnd_9x21_yellow_Mag: 16Rnd_9x21_Mag {
         displayname = CSTRING(17Rnd_9x19_yellow_Name);
-        ammo = "B_9x21_Ball_Tracer_Yellow";
     };
 
     class 30Rnd_45ACP_Mag_SMG_01: 30Rnd_9x21_Mag {

--- a/addons/smallarms/CfgMagazines.hpp
+++ b/addons/smallarms/CfgMagazines.hpp
@@ -40,9 +40,27 @@ class CfgMagazines {
         lastRoundsTracer = 0;
     };
 
-    class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {
+    class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {};
+
+    class ACE_17Rnd_9x21_Mag: 16Rnd_9x21_Mag {
+        author = ECSTRING(common,ACETeam);
         displayname = CSTRING(17Rnd_9x19_Name);
         count = 17;
+    };
+
+    class ACE_17Rnd_9x21_red_Mag: ACE_17Rnd_9x21_Mag {
+        displayname = CSTRING(17Rnd_9x19_red_Name);
+        ammo = "B_9x21_Ball_Tracer_Red";
+    };
+
+    class ACE_17Rnd_9x21_green_Mag: ACE_17Rnd_9x21_Mag {
+        displayname = CSTRING(17Rnd_9x19_green_Name);
+        ammo = "B_9x21_Ball_Tracer_Green";
+    };
+
+    class ACE_17Rnd_9x21_yellow_Mag: ACE_17Rnd_9x21_Mag {
+        displayname = CSTRING(17Rnd_9x19_yellow_Name);
+        ammo = "B_9x21_Ball_Tracer_Yellow";
     };
 
     class 30Rnd_45ACP_Mag_SMG_01: 30Rnd_9x21_Mag {

--- a/addons/smallarms/CfgMagazines.hpp
+++ b/addons/smallarms/CfgMagazines.hpp
@@ -42,6 +42,7 @@ class CfgMagazines {
 
     class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {
         displayname = CSTRING(17Rnd_9x19_Name);
+        count = 17;
     };
 
     class 16Rnd_9x21_red_Mag: 16Rnd_9x21_Mag {

--- a/addons/smallarms/CfgWeapons.hpp
+++ b/addons/smallarms/CfgWeapons.hpp
@@ -148,17 +148,11 @@ class CfgWeapons {
 
     // Pistols //////////////////////////////////////////////
 
-    class hgun_P07_F: Pistol_Base_F {
-        magazines[] = {"16Rnd_9x21_Mag","16Rnd_9x21_red_Mag","16Rnd_9x21_green_Mag","16Rnd_9x21_yellow_Mag"};
-        magazineWell[] = {};
-    };
-    class hgun_Rook40_F: Pistol_Base_F {
-        magazines[] = {"ACE_17Rnd_9x21_Mag","ACE_17Rnd_9x21_red_Mag","ACE_17Rnd_9x21_green_Mag","ACE_17Rnd_9x21_yellow_Mag"};
-        magazineWell[] = {};
-    };
-    //class hgun_ACPC2_F: Pistol_Base_F {};
-    //class hgun_Pistol_heavy_01_F: Pistol_Base_F {};
-    //class hgun_Pistol_heavy_02_F: Pistol_Base_F {};
+    /*class hgun_P07_F: Pistol_Base_F {};
+    class hgun_Rook40_F: Pistol_Base_F {};
+    class hgun_ACPC2_F: Pistol_Base_F {};
+    class hgun_Pistol_heavy_01_F: Pistol_Base_F {};
+    class hgun_Pistol_heavy_02_F: Pistol_Base_F {};*/
 
     // LMGs //////////////////////////////////////////////
 

--- a/addons/smallarms/CfgWeapons.hpp
+++ b/addons/smallarms/CfgWeapons.hpp
@@ -148,11 +148,17 @@ class CfgWeapons {
 
     // Pistols //////////////////////////////////////////////
 
-    /*class hgun_P07_F: Pistol_Base_F {};
-    class hgun_Rook40_F: Pistol_Base_F {};
-    class hgun_ACPC2_F: Pistol_Base_F {};
-    class hgun_Pistol_heavy_01_F: Pistol_Base_F {};
-    class hgun_Pistol_heavy_02_F: Pistol_Base_F {};*/
+    class hgun_P07_F: Pistol_Base_F {
+        magazines[] = {"16Rnd_9x21_Mag","16Rnd_9x21_red_Mag","16Rnd_9x21_green_Mag","16Rnd_9x21_yellow_Mag"};
+        magazineWell[] = {};
+    };
+    class hgun_Rook40_F: Pistol_Base_F {
+        magazines[] = {"ACE_17Rnd_9x21_Mag","ACE_17Rnd_9x21_red_Mag","ACE_17Rnd_9x21_green_Mag","ACE_17Rnd_9x21_yellow_Mag"};
+        magazineWell[] = {};
+    };
+    //class hgun_ACPC2_F: Pistol_Base_F {};
+    //class hgun_Pistol_heavy_01_F: Pistol_Base_F {};
+    //class hgun_Pistol_heavy_02_F: Pistol_Base_F {};
 
     // LMGs //////////////////////////////////////////////
 

--- a/addons/smallarms/stringtable.xml
+++ b/addons/smallarms/stringtable.xml
@@ -80,22 +80,6 @@
             <Japanese>9mm 17Rnd 装填トレーサー（緑）マガジン</Japanese>
             <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Yeşil) Şarjör</Turkish>
         </Key>
-        <Key ID="STR_ACE_SmallArms_17Rnd_9x19_Description">
-            <English>Caliber: 9x21 mm&lt;br /&gt;Rounds: 17&lt;br /&gt;Used in: ROOK-40</English>
-            <Chinese>口徑：9x21 mm&lt;br /&gt;個數：17&lt;br /&gt;用於：ROOK-40</Chinese>
-            <French>Calibre : 9x21 mm&lt;br /&gt;Munitions : 17&lt;br /&gt;Application : ROOK-40</French>
-            <Spanish>Calibre: 9x21 mm&lt;br /&gt;Cargas: 17&lt;br /&gt;Se usa en: ROOK-40</Spanish>
-            <Italian>Calibro: 9x21 mm&lt;br /&gt;Munizioni: 17&lt;br /&gt;Si usa in: ROOK-40</Italian>
-            <Polish>Kaliber: 9x21 mm&lt;br /&gt;Magazynki: 17&lt;br /&gt;Używane w: ROOK-40</Polish>
-            <Russian>Калибр: 9x21 мм&lt;br /&gt;Кол-во: 17&lt;br /&gt;Применение: Rook-40</Russian>
-            <German>Kaliber: 9x21 mm&lt;br /&gt;Patronen: 17 &lt;br /&gt;Eingesetzt von: ROOK-40</German>
-            <Czech>Ráže: 9x21 mm&lt;br /&gt;Munice: 17&lt;br /&gt;Použití: ROOK-40</Czech>
-            <Portuguese>Calibre: 9x21 mm&lt;br /&gt;Balas: 17&lt;br /&gt;Usada em: ROOK-40</Portuguese>
-            <Korean>구경: 9x21mm&lt;br /&gt;탄 수: 17&lt;br /&gt;사용 가능: 루크-40</Korean>
-            <Chinesesimp>类型：9x21 毫米&lt;br /&gt;容弹量：17&lt;br /&gt;用于：ROOK-40</Chinesesimp>
-            <Japanese>口径：9x21 mm&lt;br /&gt;弾薬：17&lt;br /&gt;使用：ROOK-40</Japanese>
-            <Turkish>Kalibre: 9x21 mm&lt;br /&gt;Mermi: 17&lt;br /&gt;Kullanıldığı Yer: ROOK-40</Turkish>
-        </Key>
         <Key ID="STR_ACE_SmallArms_25Rnd_45_Name">
             <English>.45 ACP 25Rnd Mag</English>
             <Czech>.45 ACP, 25ks zásobník</Czech>

--- a/addons/smallarms/stringtable.xml
+++ b/addons/smallarms/stringtable.xml
@@ -33,7 +33,7 @@
             <Turkish>9 mm 17 Merm. Şarjör</Turkish>
         </Key>
         <Key ID="STR_ACE_SmallArms_17Rnd_9x19_yellow_Name">
-            <Original>9 mm 17Rnd Reload Tracer (Yellow) Mag</Original>
+            <English>9 mm 17Rnd Reload Tracer (Yellow) Mag</English>
             <Chinese>9 mm 17 發重新裝填曳光彈（黃）彈匣</Chinese>
             <French>Mag. 17 traçantes recharge jaunes 9 mm</French>
             <Spanish>Cargador de 17 balas con trazadoras prerrecarga  (amarillo) de 9 mm</Spanish>
@@ -50,7 +50,7 @@
             <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Sarı) Şarjör</Turkish>
         </Key>
         <Key ID="STR_ACE_SmallArms_17Rnd_9x19_red_Name">
-            <Original>9 mm 17Rnd Reload Tracer (Red) Mag</Original>
+            <English>9 mm 17Rnd Reload Tracer (Red) Mag</English>
             <Chinese>9 mm 17 發重新裝填曳光彈（紅）彈匣</Chinese>
             <French>Mag. 17 traçantes recharge rouges 9 mm</French>
             <Spanish>Cargador de 17 balas con trazadoras prerrecarga  (rojo) de 9 mm</Spanish>
@@ -67,7 +67,7 @@
             <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Kırmızı) Şarjör</Turkish>
         </Key>
         <Key ID="STR_ACE_SmallArms_17Rnd_9x19_green_Name">
-            <Original>9 mm 17Rnd Reload Tracer (Green) Mag</Original>
+            <English>9 mm 17Rnd Reload Tracer (Green) Mag</English>
             <Chinese>9 mm 17 發重新裝填曳光彈（綠）彈匣</Chinese>
             <French>Mag. 17 traçantes recharge vertes 9 mm</French>
             <Spanish>Cargador de 17 balas con trazadoras prerrecarga  (verde) de 9 mm</Spanish>
@@ -84,7 +84,7 @@
             <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Yeşil) Şarjör</Turkish>
         </Key>
         <Key ID="STR_ACE_SmallArms_17Rnd_9x19_Description">
-            <Original>Caliber: 9x21 mm&lt;br /&gt;Rounds: 17&lt;br /&gt;Used in: ROOK-40</Original>
+            <English>Caliber: 9x21 mm&lt;br /&gt;Rounds: 17&lt;br /&gt;Used in: ROOK-40</English>
             <Chinese>口徑：9x21 mm&lt;br /&gt;個數：17&lt;br /&gt;用於：ROOK-40</Chinese>
             <French>Calibre : 9x21 mm&lt;br /&gt;Munitions : 17&lt;br /&gt;Application : ROOK-40</French>
             <Spanish>Calibre: 9x21 mm&lt;br /&gt;Cargas: 17&lt;br /&gt;Se usa en: ROOK-40</Spanish>

--- a/addons/smallarms/stringtable.xml
+++ b/addons/smallarms/stringtable.xml
@@ -32,6 +32,74 @@
             <Chinesesimp>9 mm 17发 弹匣</Chinesesimp>
             <Turkish>9 mm 17 Merm. Şarjör</Turkish>
         </Key>
+        <Key ID="STR_ACE_SmallArms_17Rnd_9x19_yellow_Name">
+            <Original>9 mm 17Rnd Reload Tracer (Yellow) Mag</Original>
+            <Chinese>9 mm 17 發重新裝填曳光彈（黃）彈匣</Chinese>
+            <French>Mag. 17 traçantes recharge jaunes 9 mm</French>
+            <Spanish>Cargador de 17 balas con trazadoras prerrecarga  (amarillo) de 9 mm</Spanish>
+            <Italian>Caricatore 17 colpi 9 mm con traccianti intervallati (gialli)</Italian>
+            <Polish>17-nab. mag. przeł. 9 mm (żółty smugacz)</Polish>
+            <Russian>Магазин, 17 патр. с послед. трас. 9 мм (желтые)</Russian>
+            <German>17-Schuss-9mm-Magazin (Nachlade-Leuchtspur Gelb)</German>
+            <Czech>9 mm, 17ks zásobník nabíjecí stopovky (žluté)</Czech>
+            <English>9 mm 17Rnd Reload Tracer (Yellow) Mag</English>
+            <Portuguese>Carregador 17Mun. Traçante Recarga (Amarelo) 9 mm</Portuguese>
+            <Korean>9mm 17발 재장전 예광탄 (황색) 탄창</Korean>
+            <Chinesesimp>9 毫米 17 发装弹指示（黄色）弹匣</Chinesesimp>
+            <Japanese>9mm 17Rnd 装填トレーサー（黄）マガジン</Japanese>
+            <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Sarı) Şarjör</Turkish>
+        </Key>
+        <Key ID="STR_ACE_SmallArms_17Rnd_9x19_red_Name">
+            <Original>9 mm 17Rnd Reload Tracer (Red) Mag</Original>
+            <Chinese>9 mm 17 發重新裝填曳光彈（紅）彈匣</Chinese>
+            <French>Mag. 17 traçantes recharge rouges 9 mm</French>
+            <Spanish>Cargador de 17 balas con trazadoras prerrecarga  (rojo) de 9 mm</Spanish>
+            <Italian>Caricatore 17 colpi 9 mm con traccianti intervallati (rossi)</Italian>
+            <Polish>17-nab. mag. przeł. 9 mm (czerwony smugacz)</Polish>
+            <Russian>Магазин, 17 патр. с послед. трас. 9 мм (красные)</Russian>
+            <German>17-Schuss-9mm-Magazin (Nachlade-Leuchtspur Rot)</German>
+            <Czech>9 mm, 17ks zásobník nabíjecí stopovky (červené)</Czech>
+            <English>9 mm 17Rnd Reload Tracer (Red) Mag</English>
+            <Portuguese>Carregador 17Mun. Traçante Recarga (Vermelho) 9 mm</Portuguese>
+            <Korean>9mm 17발 재장전 예광탄 (적색) 탄창</Korean>
+            <Chinesesimp>9 毫米 17 发装弹指示（红色）弹匣</Chinesesimp>
+            <Japanese>9mm 17Rnd 装填トレーサー（赤）マガジン</Japanese>
+            <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Kırmızı) Şarjör</Turkish>
+        </Key>
+        <Key ID="STR_ACE_SmallArms_17Rnd_9x19_green_Name">
+            <Original>9 mm 17Rnd Reload Tracer (Green) Mag</Original>
+            <Chinese>9 mm 17 發重新裝填曳光彈（綠）彈匣</Chinese>
+            <French>Mag. 17 traçantes recharge vertes 9 mm</French>
+            <Spanish>Cargador de 17 balas con trazadoras prerrecarga  (verde) de 9 mm</Spanish>
+            <Italian>Caricatore 17 colpi 9 mm con traccianti intervallati (verdi)</Italian>
+            <Polish>17-nab. mag. przeł. 9 mm (zielony smugacz)</Polish>
+            <Russian>Магазин, 17 патр. с послед. трас. 9 мм (зеленые)</Russian>
+            <German>17-Schuss-9mm-Magazin (Nachlade-Leuchtspur Grün)</German>
+            <Czech>9 mm, 17ks zásobník nabíjecí stopovky (zelené)</Czech>
+            <English>9 mm 17Rnd Reload Tracer (Green) Mag</English>
+            <Portuguese>Carregador 17Mun. Traçante Recarga (Verde) 9 mm</Portuguese>
+            <Korean>9mm 17발 재장전 예광탄 (녹색) 탄창</Korean>
+            <Chinesesimp>9 毫米 17 发装弹指示（绿色）弹匣</Chinesesimp>
+            <Japanese>9mm 17Rnd 装填トレーサー（緑）マガジン</Japanese>
+            <Turkish>9 mm 17 Merm. Tekrar Doldurulabilir İzli (Yeşil) Şarjör</Turkish>
+        </Key>
+        <Key ID="STR_ACE_SmallArms_17Rnd_9x19_Description">
+            <Original>Caliber: 9x21 mm&lt;br /&gt;Rounds: 17&lt;br /&gt;Used in: ROOK-40</Original>
+            <Chinese>口徑：9x21 mm&lt;br /&gt;個數：17&lt;br /&gt;用於：ROOK-40</Chinese>
+            <French>Calibre : 9x21 mm&lt;br /&gt;Munitions : 17&lt;br /&gt;Application : ROOK-40</French>
+            <Spanish>Calibre: 9x21 mm&lt;br /&gt;Cargas: 17&lt;br /&gt;Se usa en: ROOK-40</Spanish>
+            <Italian>Calibro: 9x21 mm&lt;br /&gt;Munizioni: 17&lt;br /&gt;Si usa in: ROOK-40</Italian>
+            <Polish>Kaliber: 9x21 mm&lt;br /&gt;Magazynki: 17&lt;br /&gt;Używane w: ROOK-40</Polish>
+            <Russian>Калибр: 9x21 мм&lt;br /&gt;Кол-во: 17&lt;br /&gt;Применение: Rook-40</Russian>
+            <German>Kaliber: 9x21 mm&lt;br /&gt;Patronen: 17 &lt;br /&gt;Eingesetzt von: ROOK-40</German>
+            <Czech>Ráže: 9x21 mm&lt;br /&gt;Munice: 17&lt;br /&gt;Použití: ROOK-40</Czech>
+            <English>Caliber: 9x21 mm&lt;br /&gt;Rounds: 17&lt;br /&gt;Used in: ROOK-40</English>
+            <Portuguese>Calibre: 9x21 mm&lt;br /&gt;Balas: 17&lt;br /&gt;Usada em: ROOK-40</Portuguese>
+            <Korean>구경: 9x21mm&lt;br /&gt;탄 수: 17&lt;br /&gt;사용 가능: 루크-40</Korean>
+            <Chinesesimp>类型：9x21 毫米&lt;br /&gt;容弹量：17&lt;br /&gt;用于：ROOK-40</Chinesesimp>
+            <Japanese>口径：9x21 mm&lt;br /&gt;弾薬：17&lt;br /&gt;使用：ROOK-40</Japanese>
+            <Turkish>Kalibre: 9x21 mm&lt;br /&gt;Mermi: 17&lt;br /&gt;Kullanıldığı Yer: ROOK-40</Turkish>
+        </Key>
         <Key ID="STR_ACE_SmallArms_25Rnd_45_Name">
             <English>.45 ACP 25Rnd Mag</English>
             <Czech>.45 ACP, 25ks zásobník</Czech>

--- a/addons/smallarms/stringtable.xml
+++ b/addons/smallarms/stringtable.xml
@@ -42,7 +42,6 @@
             <Russian>Магазин, 17 патр. с послед. трас. 9 мм (желтые)</Russian>
             <German>17-Schuss-9mm-Magazin (Nachlade-Leuchtspur Gelb)</German>
             <Czech>9 mm, 17ks zásobník nabíjecí stopovky (žluté)</Czech>
-            <English>9 mm 17Rnd Reload Tracer (Yellow) Mag</English>
             <Portuguese>Carregador 17Mun. Traçante Recarga (Amarelo) 9 mm</Portuguese>
             <Korean>9mm 17발 재장전 예광탄 (황색) 탄창</Korean>
             <Chinesesimp>9 毫米 17 发装弹指示（黄色）弹匣</Chinesesimp>
@@ -59,7 +58,6 @@
             <Russian>Магазин, 17 патр. с послед. трас. 9 мм (красные)</Russian>
             <German>17-Schuss-9mm-Magazin (Nachlade-Leuchtspur Rot)</German>
             <Czech>9 mm, 17ks zásobník nabíjecí stopovky (červené)</Czech>
-            <English>9 mm 17Rnd Reload Tracer (Red) Mag</English>
             <Portuguese>Carregador 17Mun. Traçante Recarga (Vermelho) 9 mm</Portuguese>
             <Korean>9mm 17발 재장전 예광탄 (적색) 탄창</Korean>
             <Chinesesimp>9 毫米 17 发装弹指示（红色）弹匣</Chinesesimp>
@@ -76,7 +74,6 @@
             <Russian>Магазин, 17 патр. с послед. трас. 9 мм (зеленые)</Russian>
             <German>17-Schuss-9mm-Magazin (Nachlade-Leuchtspur Grün)</German>
             <Czech>9 mm, 17ks zásobník nabíjecí stopovky (zelené)</Czech>
-            <English>9 mm 17Rnd Reload Tracer (Green) Mag</English>
             <Portuguese>Carregador 17Mun. Traçante Recarga (Verde) 9 mm</Portuguese>
             <Korean>9mm 17발 재장전 예광탄 (녹색) 탄창</Korean>
             <Chinesesimp>9 毫米 17 发装弹指示（绿色）弹匣</Chinesesimp>
@@ -93,7 +90,6 @@
             <Russian>Калибр: 9x21 мм&lt;br /&gt;Кол-во: 17&lt;br /&gt;Применение: Rook-40</Russian>
             <German>Kaliber: 9x21 mm&lt;br /&gt;Patronen: 17 &lt;br /&gt;Eingesetzt von: ROOK-40</German>
             <Czech>Ráže: 9x21 mm&lt;br /&gt;Munice: 17&lt;br /&gt;Použití: ROOK-40</Czech>
-            <English>Caliber: 9x21 mm&lt;br /&gt;Rounds: 17&lt;br /&gt;Used in: ROOK-40</English>
             <Portuguese>Calibre: 9x21 mm&lt;br /&gt;Balas: 17&lt;br /&gt;Usada em: ROOK-40</Portuguese>
             <Korean>구경: 9x21mm&lt;br /&gt;탄 수: 17&lt;br /&gt;사용 가능: 루크-40</Korean>
             <Chinesesimp>类型：9x21 毫米&lt;br /&gt;容弹量：17&lt;br /&gt;用于：ROOK-40</Chinesesimp>


### PR DESCRIPTION
**When merged this pull request will:**
- _Fix ACE 16Rnd 9x19 magazine description was the display name for the non-existent 30Rnd 9x19 magazine._
- _Fix BIS 16rnd 9x21 tracer magazine display name shown as 16Rnd despite being 17Rnd by ACE._
- _Add missing FNX-45 magazine displaynameshort. That is displayed like other .45 magazines._

Note: The localization is based on what we copied from the game, so it should be fine.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
