### PR TITLE
Wiki - Improve example code on wiki for blacklisting items for all arsenals

### DIFF
--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -573,7 +573,19 @@ The code will only have effect on clients where it is executed. It can placed in
 TAG_my_arsenal_blacklist = ["arifle_AK12_F", "LMG_03_F"]; // modify this
 
 ["ace_arsenal_displayOpened", {
-    [ace_arsenal_currentBox, TAG_my_arsenal_blacklist] call ace_arsenal_fnc_removeVirtualItems
+    // Use execNextFrame to ensure it applies to current opened arsenal
+    [{ call ace_arsenal_fnc_removeVirtualItems }, [ace_arsenal_currentBox, TAG_my_arsenal_blacklist]] call CBA_fnc_execNextFrame;
+}] call CBA_fnc_addEventHandler;
+```
+
+Alternatively you can use the following code to blacklist items for all arsenals at the creation of the arsenal, instead of when a player opens it. 
+
+```sqf
+TAG_my_arsenal_blacklist = ["arifle_AK12_F", "LMG_03_F"]; // modify this
+
+["ace_arsenal_boxInitialized", {
+	params ["_box"];
+	[_box, TAG_my_arsenal_blacklist] call ace_arsenal_fnc_removeVirtualItems;
 }] call CBA_fnc_addEventHandler;
 ```
 


### PR DESCRIPTION
**When merged this pull request will:**
- Change the current wiki example code for blacklisting items for all arsenals to use execNextFrame so it works on currently opened arsenal
- Added alternative code that blacklists all items on arsenal init, instead of applying the blacklist every time a player opens the arsenal
