### PR TITLE
GM/CUP Compat - Fix overpressure settings for various artillery

### DIFF
--- a/addons/compat_cup_vehicles/CfgVehicles.hpp
+++ b/addons/compat_cup_vehicles/CfgVehicles.hpp
@@ -25,6 +25,10 @@ class CfgVehicles {
             };
         };
     };
+    class CUP_Ural_BaseTurret;
+    class CUP_BM21_Base: CUP_Ural_BaseTurret {
+        EGVAR(overpressure,noReflection) = 1;
+    };
 
     class CUP_MTVR_Base;
     class CUP_MTVR_Reammo_Base: CUP_MTVR_Base {
@@ -179,6 +183,9 @@ class CfgVehicles {
     };
 
     class Tank_F;
+    class CUP_M270_HE_Base: Tank_F {
+        EGVAR(overpressure,noReflection) = 1;
+    };
     class CUP_AAV_Base: Tank_F {
         class EGVAR(interaction,anims) {
             class Hide_Bags_Deployment {

--- a/addons/compat_cup_weapons/CfgWeapons.hpp
+++ b/addons/compat_cup_weapons/CfgWeapons.hpp
@@ -33,4 +33,28 @@ class CfgWeapons {
         ace_nlaw_enabled = 1;
         canLock = 1;
     };
+
+    // Vehicle weapons are still from @CUP Weapons
+    class rockets_230mm_GAT;
+    class CUP_Vmlauncher_GRAD_veh: rockets_230mm_GAT {
+        EGVAR(overpressure,offset) = 2.8;
+    };
+    class CUP_Vmlauncher_MLRS_veh: rockets_230mm_GAT {
+        EGVAR(overpressure,offset) = 1.9;
+    };
+    class mortar_155mm_AMOS;
+    class CUP_Vcannon_D30_veh: mortar_155mm_AMOS {
+        EGVAR(overpressure,offset) = 2;
+    };
+    class CUP_Vcannon_M119_veh: CUP_Vcannon_D30_veh {
+        EGVAR(overpressure,offset) = 3;
+    };
+    class cannon_120mm;
+    class CUP_Vcannon_D30AT_veh: cannon_120mm {
+        EGVAR(overpressure,offset) = 2;
+    };
+    class weapon_ShipCannon_120mm;
+    class CUP_Vmortar_M121: weapon_ShipCannon_120mm {
+        EGVAR(overpressure,offset) = 0.6;
+    };
 };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -216,6 +216,7 @@ class CfgVehicles {
         };
     };
     class gm_ural375d_mlrs_base: gm_ural375d_base {
+        EGVAR(overpressure,noReflection) = 1;
         class EGVAR(interaction,anims): EGVAR(interaction,anims) {
             class AmmoBox_01_unhide: AmmoBox_01_unhide {
                 positions[] = {{-0.55, 2, 0.5}};

--- a/addons/compat_gm/CfgWeapons.hpp
+++ b/addons/compat_gm/CfgWeapons.hpp
@@ -54,4 +54,9 @@ class CfgWeapons {
     class gm_p2a1_base: gm_pistol_base {
         EGVAR(overheating,jamTypesAllowed)[] = {"Fire", "Dud"};
     };
+
+    class gm_RocketLauncher_base;
+    class gm_mlrs_122mm_launcher_base: gm_RocketLauncher_base {
+        EGVAR(overpressure,offset) = 3;
+    };
 };


### PR DESCRIPTION
Add `noReflection` config for BM-21
Fix some offsets on some artillery

- Was at breech not muzzle ![p](https://github.com/user-attachments/assets/2f976ce5-374b-47c3-8b8e-fadab859f326)

