### PR TITLE
Repair - Patch to detect GM Wheel position and selection

### DIFF
--- a/addons/common/functions/fnc_getWheelHitPointsWithSelections.sqf
+++ b/addons/common/functions/fnc_getWheelHitPointsWithSelections.sqf
@@ -19,7 +19,6 @@
 params ["_vehicle"];
 TRACE_1("params",_vehicle);
 
-// TODO: Fix for GM vehicles
 GVAR(wheelSelections) getOrDefaultCall [typeOf _vehicle, {
     // Get the vehicles wheel config
     private _wheels = configOf _vehicle >> "Wheels";
@@ -33,6 +32,7 @@ GVAR(wheelSelections) getOrDefaultCall [typeOf _vehicle, {
 
         private _wheelHitPoints = [];
         private _wheelHitPointSelections = [];
+        private _isGM = 1 == getNumber (configOf _vehicle >> "isgmContent");
 
         {
             private _wheelName = configName _x;
@@ -54,6 +54,20 @@ GVAR(wheelSelections) getOrDefaultCall [typeOf _vehicle, {
                 };
             } forEach _hitPointSelections;
 
+            if (_isGM) then {
+                _wheelHitPointSelection = _wheelBone + "_axis";
+                { // modified Commy's method, they tag "hitpoint_" onto their hitpoints when they have htem
+                    if ((_wheelBoneNameResized != "") && {_x find _wheelBoneNameResized == 9}) exitWith {  // same as above. Requirement for physx.
+                        _wheelHitPoint = _hitPoints select _forEachIndex;
+                        TRACE_3("wheel found [GM :)]",_wheelName,_wheelHitPoint,_wheelHitPointSelection);
+                    };
+                } forEach _hitPointSelections;
+                if (_wheelHitPoint == "" && _vehicle isKindOf "Car") then { // takes longer but a guarentee you find it
+                    private _class = format ["""%1"" in getText (_x >> ""visual"")",_wheelName] configClasses (configOf _vehicle >> "Hitpoints");
+                    _wheelHitPoint = toLowerANSI configName (_class#0);
+                        TRACE_3("wheel found [GM :()]",_wheelName,_wheelHitPoint,_wheelHitPointSelection);
+                };
+            };
 
             if (_vehicle isKindOf "Car") then {
                 // Backup method, search for the closest hitpoint to the wheel's center selection pos.

--- a/addons/common/functions/fnc_getWheelHitPointsWithSelections.sqf
+++ b/addons/common/functions/fnc_getWheelHitPointsWithSelections.sqf
@@ -56,16 +56,16 @@ GVAR(wheelSelections) getOrDefaultCall [typeOf _vehicle, {
 
             if (_isGM) then {
                 _wheelHitPointSelection = _wheelBone + "_axis";
-                { // modified Commy's method, they tag "hitpoint_" onto their hitpoints when they have htem
+                { // modified Commy's method, they tag "hitpoint_" onto their hitpoints when they have them
                     if ((_wheelBoneNameResized != "") && {_x find _wheelBoneNameResized == 9}) exitWith {  // same as above. Requirement for physx.
                         _wheelHitPoint = _hitPoints select _forEachIndex;
-                        TRACE_3("wheel found [GM :)]",_wheelName,_wheelHitPoint,_wheelHitPointSelection);
+                        TRACE_3("wheel found [GM]",_wheelName,_wheelHitPoint,_wheelHitPointSelection);
                     };
                 } forEach _hitPointSelections;
-                if (_wheelHitPoint == "" && _vehicle isKindOf "Car") then { // takes longer but a guarentee you find it
+                if (_wheelHitPoint == "" && _vehicle isKindOf "Car") then { // takes longer but a guarantee to find the hitpoint name
                     private _class = format ["""%1"" in getText (_x >> ""visual"")",_wheelName] configClasses (configOf _vehicle >> "Hitpoints");
                     _wheelHitPoint = toLowerANSI configName (_class#0);
-                        TRACE_3("wheel found [GM :()]",_wheelName,_wheelHitPoint,_wheelHitPointSelection);
+                        TRACE_3("wheel found [GM Config)]",_wheelName,_wheelHitPoint,_wheelHitPointSelection);
                 };
             };
 

--- a/addons/repair/functions/fnc_addRepairActions.sqf
+++ b/addons/repair/functions/fnc_addRepairActions.sqf
@@ -38,6 +38,11 @@ private _selectionsToIgnore = _vehicle call FUNC(getSelectionsToIgnore);
 
 // get hitpoints of wheels with their selections
 ([_vehicle] call EFUNC(common,getWheelHitPointsWithSelections)) params ["_wheelHitPoints", "_wheelHitSelections"];
+private _isGM = 1 == getNumber (configOf _vehicle >> "isgmContent");
+if (_isGM) then { // the hitpoint selection does not properly overlap
+    _hitPoints append _wheelHitPoints;
+    _hitSelections append _wheelHitSelections;
+};
 
 private _hitPointsAddedNames = [];
 private _hitPointsAddedStrings = [];
@@ -61,7 +66,11 @@ private _turretPaths = ((fullCrew [_vehicle, "gunner", true]) + (fullCrew [_vehi
     };
 
     if (_selection in _wheelHitSelections) then {
-        private _position = compile format ["_target selectionPosition ['%1', 'HitPoints', 'AveragePoint'];", _selection];
+        private _position = if (_isGM) then {
+            compile format ["_target selectionPosition ['%1', 'Memory', 'AveragePoint'];", _selection];
+        } else {
+            compile format ["_target selectionPosition ['%1', 'HitPoints', 'AveragePoint'];", _selection];
+        };
 
         TRACE_3("Adding Wheel Actions",_hitpoint,_forEachIndex,_selection);
 

--- a/addons/repair/functions/fnc_getSelectionsToIgnore.sqf
+++ b/addons/repair/functions/fnc_getSelectionsToIgnore.sqf
@@ -25,6 +25,7 @@ if (_type in _initializedClasses) exitWith {_initializedClasses get _type};
 private _vehCfg = configOf _vehicle;
 private _hitpointGroups = getArray (_vehCfg >> QGVAR(hitpointGroups));
 private _turretPaths = ((fullCrew [_vehicle, "gunner", true]) + (fullCrew [_vehicle, "commander", true])) apply {_x # 3};
+private _isGM = 1 == getNumber (configOf _vehicle >> "isgmContent");
 
 (getAllHitPointsDamage _vehicle) params [["_hitPoints", []], ["_hitSelections", []]];
 // get hitpoints of wheels with their selections
@@ -40,6 +41,16 @@ private _processedSelections = [];
 
     if (_hitpoint isEqualTo "") then { // skip empty hitpoint
         _indexesToIgnore pushBack _forEachIndex;
+        continue
+    };
+
+    if (_isGM && {"wheel" in _selection}) then {
+        TRACE_3("Skipping GM wheels",_hitpoint,_forEachIndex,_selection);
+        /*#ifdef DEBUG_MODE_FULL
+        systemChat format ["Skipping duplicate wheel, hitpoint %1, index %2, selection %3", _hitpoint, _forEachIndex, _selection];
+        #endif*/
+        _indexesToIgnore pushBack _forEachIndex;
+        _processedSelections pushBack _selection;
         continue
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a method to `ace_common_fnc_getWheelHitPointsWithSelections` to find GM wheels and a selection that  does not disappear when wheel damage is one / the wheel proxy goes away.
- Adds a handle to skip normal GM wheel hitpoint selections and to add repair action to GM vehicles

Open to any feedback on how to make this less jank. I don't think anyone else uses proxies for wheels besides GM devs, so I only check for their work (they set a config flag on top of the DLC config entry).

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
