### PR TITLE
Overheating - fix/improve ace_overheating_fnc_jamWeapon

### DIFF
--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -103,10 +103,10 @@ if (_unit getVariable [QGVAR(JammingActionID), -1] == -1) then {
         if (!(missionNamespace getVariable [QGVAR(knowAboutJam), false]) && {_one ammo currentWeapon _one > 0} && {GVAR(DisplayTextOnJam)}) then {
             private _jamType = _one getVariable [format [QGVAR(%1_jamType), currentWeapon _one], "None"];
             private _jamMessage = localize LSTRING(FailureToFire);
-            switch true do {
-                case (_jamType isEqualTo "eject"): {_jamMessage = localize LSTRING(FailureToEject)};
-                case (_jamType isEqualTo "extract"): {_jamMessage = localize LSTRING(FailureToExtract)};
-                case (_jamType isEqualTo "feed"): {_jamMessage = localize LSTRING(FailureToFeed)};
+            switch _jamType do {
+                case ("eject"): {_jamMessage = localize LSTRING(FailureToEject)};
+                case ("extract"): {_jamMessage = localize LSTRING(FailureToExtract)};
+                case ("feed"): {_jamMessage = localize LSTRING(FailureToFeed)};
             };
             [
                 [localize LSTRING(WeaponJammed)],

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -17,8 +17,10 @@
  * Public: No
  */
 
-params ["_unit", ["_weapon", primaryWeapon ace_player, ""], ["_jamType", "", ""]];
+params ["_unit", "_weapon", ["_jamType", "", ""]];
 TRACE_3("params",_unit,_weapon,_jamType);
+
+_weapon = param [1, primaryWeapon _unit, [""]];
 
 // don't jam a weapon with no rounds left
 private _ammo = _unit ammo _weapon;

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -39,7 +39,7 @@ if (_jamTypesAllowed isEqualTo []) then {
     _jamTypesAllowed = ["eject", 1, "extract", 1, "feed", 1, "fire", 1, "dud", (5 / (_temp / 5))];
 } else {
     for "_i" from count _jamTypesAllowed -2 to 0 step -2 do {
-        private _jamCurretType = toLower (_jamTypesAllowed select _i);
+        private _jamCurretType = toLowerANSI (_jamTypesAllowed select _i);
         if !(_jamCurretType in ["eject", "extract", "feed", "fire", "dud"]) exitWith { // check config values and switch to default values if unusual value found
             ERROR_2("Weapon '%1' has unexpected value %2 in QQGVAR(jamTypesAllowed). Expected values are 'Eject', 'Extract', 'Feed', 'Fire', 'Dud'.",_weapon,_jamCurretType);
             _jamTypesAllowed = ["eject", 1, "extract", 1, "feed", 1, "fire", 1, "dud", (5 / (_temp / 5))];
@@ -53,7 +53,7 @@ if (_jamTypesAllowed isEqualTo []) then {
 };
 
 // if _jamType was given as a param when the function called check validity and select randomly if not valid.
-_jamType = toLower _jamType;
+_jamType = toLowerANSI _jamType;
 if !(_jamType in _jamTypesAllowed) then {
     if (_jamType != "") then {
         ERROR_2("Weapon '%1' has attempted to jam with unexpected value %2. Expected values are 'Eject', 'Extract', 'Feed', 'Fire', 'Dud'.",_weapon,_jamType);

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -5,19 +5,20 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: Weapon <STRING>
+ * 1: Weapon <STRING>, (default: primaryWeapon ace_player)
+ * 2: Jam Type <STRING> (default: ""), must be an allowed jam type for the weapon, if default or invalid selects randomly from allowed types
  *
  * Return Value:
  * None
  *
  * Example:
- * [player, currentWeapon player] call ace_overheating_fnc_jamWeapon
+ * [player, primaryWeapon player, "Feed"] call ace_overheating_fnc_jamWeapon
  *
  * Public: No
  */
 
-params ["_unit", "_weapon"];
-TRACE_2("params",_unit,_weapon);
+params ["_unit", ["_weapon", primaryWeapon ace_player, ""], ["_jamType", "", ""]];
+TRACE_3("params",_unit,_weapon,_jamType);
 
 // don't jam a weapon with no rounds left
 private _ammo = _unit ammo _weapon;
@@ -35,15 +36,15 @@ private _temp = 1 max (_unit getVariable [format [QGVAR(%1_temp), _weapon], 0]);
 private _jamTypesAllowed = getArray (configFile >> 'CfgWeapons' >> currentWeapon _unit >> QGVAR(jamTypesAllowed));
 
 if (_jamTypesAllowed isEqualTo []) then {
-    _jamTypesAllowed = ["Eject", 1, "Extract", 1, "Feed", 1, "Fire", 1, "Dud", (5 / (_temp / 5))];
+    _jamTypesAllowed = ["eject", 1, "extract", 1, "feed", 1, "fire", 1, "dud", (5 / (_temp / 5))];
 } else {
-    for "_i" from count _jamTypesAllowed to 1 step -1 do {
-        private _jamCurretType = _jamTypesAllowed select _i;
-        if !(_jamCurretType in ["Eject", "Extract", "Feed", "Fire", "Dud"]) exitWith { // check config values and switch to default values if unusual value found
+    for "_i" from count _jamTypesAllowed -2 to 0 step -2 do {
+        private _jamCurretType = toLower (_jamTypesAllowed select _i);
+        if !(_jamCurretType in ["eject", "extract", "feed", "fire", "dud"]) exitWith { // check config values and switch to default values if unusual value found
             ERROR_2("Weapon '%1' has unexpected value %2 in QQGVAR(jamTypesAllowed). Expected values are 'Eject', 'Extract', 'Feed', 'Fire', 'Dud'.",_weapon,_jamCurretType);
-            _jamTypesAllowed = ["Eject", 1, "Extract", 1, "Feed", 1, "Fire", 1, "Dud", (5 / (_temp / 5))];
+            _jamTypesAllowed = ["eject", 1, "extract", 1, "feed", 1, "fire", 1, "dud", (5 / (_temp / 5))];
         };
-        if (_jamCurretType == "Dud") then {
+        if (_jamCurretType == "dud") then {
             _jamTypesAllowed insert [_i, [5 / (_temp / 5)]];
         } else {
             _jamTypesAllowed insert [_i, [1]];
@@ -51,9 +52,16 @@ if (_jamTypesAllowed isEqualTo []) then {
     };
 };
 
-private _jamType = selectRandomWeighted _jamTypesAllowed;
-_unit setVariable [format [QGVAR(%1_jamType), _weapon], _jamType];
+// if _jamType was given as a param when the function called check validity and select randomly if not valid.
+_jamType = toLower _jamType;
+if !(_jamType in _jamTypesAllowed) then {
+    if (_jamType != "") then {
+        ERROR_2("Weapon '%1' has attempted to jam with unexpected value %2. Expected values are 'Eject', 'Extract', 'Feed', 'Fire', 'Dud'.",_weapon,_jamType);
+    };
+    _jamType = selectRandomWeighted _jamTypesAllowed;
+};
 
+_unit setVariable [format [QGVAR(%1_jamType), _weapon], _jamType];
 
 // Stop current burst
 _unit setAmmo [_weapon, 0];
@@ -96,9 +104,9 @@ if (_unit getVariable [QGVAR(JammingActionID), -1] == -1) then {
             private _jamType = _one getVariable [format [QGVAR(%1_jamType), currentWeapon _one], "None"];
             private _jamMessage = localize LSTRING(FailureToFire);
             switch true do {
-                case (_jamType isEqualTo "Eject"): {_jamMessage = localize LSTRING(FailureToEject)};
-                case (_jamType isEqualTo "Extract"): {_jamMessage = localize LSTRING(FailureToExtract)};
-                case (_jamType isEqualTo "Feed"): {_jamMessage = localize LSTRING(FailureToFeed)};
+                case (_jamType isEqualTo "eject"): {_jamMessage = localize LSTRING(FailureToEject)};
+                case (_jamType isEqualTo "extract"): {_jamMessage = localize LSTRING(FailureToExtract)};
+                case (_jamType isEqualTo "feed"): {_jamMessage = localize LSTRING(FailureToFeed)};
             };
             [
                 [localize LSTRING(WeaponJammed)],

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: Weapon <STRING>, (default: primaryWeapon ace_player)
+ * 1: Weapon <STRING> (default: primaryWeapon _unit)
  * 2: Jam Type <STRING> (default: ""), must be an allowed jam type for the weapon, if default or invalid selects randomly from allowed types
  *
  * Return Value:
@@ -17,10 +17,10 @@
  * Public: No
  */
 
-params ["_unit", "_weapon", ["_jamType", "", ""]];
+params ["_unit", "", ["_jamType", "", ""]];
 TRACE_3("params",_unit,_weapon,_jamType);
 
-_weapon = param [1, primaryWeapon _unit, [""]];
+private _weapon = param [1, primaryWeapon _unit, [""]];
 
 // don't jam a weapon with no rounds left
 private _ammo = _unit ammo _weapon;

--- a/addons/overheating/functions/fnc_jamWeapon.sqf
+++ b/addons/overheating/functions/fnc_jamWeapon.sqf
@@ -35,7 +35,7 @@ _unit setVariable [QGVAR(jammedWeapons), _jammedWeapons];
 // Cookoffs only happen on Fire and Dud, dud rounds are lost on jam clear.
 // Reduce chance of duds as temp increases (functionally increasing the chance of the others but with fewer commands)
 private _temp = 1 max (_unit getVariable [format [QGVAR(%1_temp), _weapon], 0]);
-private _jamTypesAllowed = getArray (configFile >> 'CfgWeapons' >> currentWeapon _unit >> QGVAR(jamTypesAllowed));
+private _jamTypesAllowed = getArray (configFile >> 'CfgWeapons' >> _weapon >> QGVAR(jamTypesAllowed));
 
 if (_jamTypesAllowed isEqualTo []) then {
     _jamTypesAllowed = ["eject", 1, "extract", 1, "feed", 1, "fire", 1, "dud", (5 / (_temp / 5))];


### PR DESCRIPTION
**When merged this pull request will:**
- fix `for "_i" from count _jamTypesAllowed` steps, should only have returned the strings like "Feed" but was returning numbers as well and therefore always failing the `if !(_jamCurretType in ["eject", etc]` check and falling back to default .
- new param for the type of jam
- add defaults for weapon and jam type
- make jam types case insensitive