### PR TITLE
Compat RHS AFRF - Remove 9M113 from Missile Guidance Compat

### DIFF
--- a/addons/compat_rhs_afrf3/compat_rhs_afrf3_missileguidance/CfgAmmo.hpp
+++ b/addons/compat_rhs_afrf3/compat_rhs_afrf3_missileguidance/CfgAmmo.hpp
@@ -308,18 +308,6 @@ class CfgAmmo {
             seekerMaxRange = 2500;
         };
     };
-    class rhs_ammo_9m113: rhs_ammo_atgmBase_base {
-        maneuvrability = 0;
-        ACE_MISSILE(Konkurs);
-        class EventHandlers: EventHandlers {
-            class RHS_Guidance {};
-        };
-    };
-    class rhs_ammo_9m113m: rhs_ammo_9m113 {
-        class ace_missileguidance: ace_missileguidance {
-            enabled = 1;
-        };
-    };
     class rhs_ammo_9m117: rhs_ammo_atgmCore_base {
         maneuvrability = 0;
         ACE_MISSILE(Bastion);


### PR DESCRIPTION
**When merged this pull request will:**
- Remove changes made to the 9M113, disabling ACE missile guidance
- Address part of https://github.com/acemod/ACE3/issues/10872

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
