### PR TITLE
Compat WS - Fix UBC

### DIFF
--- a/addons/compat_ws/compat_ws_realisticnames/CfgWeapons.hpp
+++ b/addons/compat_ws/compat_ws_realisticnames/CfgWeapons.hpp
@@ -175,7 +175,7 @@ class CfgWeapons {
     class arifle_XMS_Shot_Sand_lxWS: arifle_XMS_Shot_lxWS {
         displayName = SUBCSTRING(XMS_SG_Sand_Name);
     };
-    class arifle_XMS_M_lxWS: arifle_XMS_Base_lxWS {
+    class arifle_XMS_M_lxWS: arifle_XMS_lxWS {
         displayName = SUBCSTRING(XMS_SW_Name);
     };
     class arifle_XMS_M_Camo_lxWS: arifle_XMS_M_lxWS {


### PR DESCRIPTION
**When merged this pull request will:** Title
- Fixes incorrect inheritance of ``arifle_XMS_M_lxWS`` in ``compat_ws_realisticnames``

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
