### PR TITLE
Common - Fix `FUNC(addActionEventHandler)`

### DIFF
--- a/addons/cargo/functions/fnc_startDeploy.sqf
+++ b/addons/cargo/functions/fnc_startDeploy.sqf
@@ -80,7 +80,7 @@ GVAR(deployPFH) = [{
 _unit setVariable [QGVAR(deploy), [
     _unit, "DefaultAction",
     {GVAR(deployPFH) != -1},
-    {[_this select 0] call FUNC(deployConfirm)}
+    {[_this select 1] call FUNC(deployConfirm)}
 ] call EFUNC(common,addActionEventHandler)];
 
 _unit setVariable [QGVAR(isDeploying), true, true];

--- a/addons/common/functions/fnc_addActionEventHandler.sqf
+++ b/addons/common/functions/fnc_addActionEventHandler.sqf
@@ -54,7 +54,7 @@ if (_actionID == -1) then {
             false,
             true,
             '%1',
-            ""if (_this != ACE_player || {vehicle _this != _target}) exitWith {false}; _actions = (_this getVariable '%2') select 1 select 2; _count = count _actions; _index = 0; _return = false; while {_index < _count && {!_return}} do {_return = [_target, _this] call ((_actions select _index) select 0); _index = _index + 1}; _return""
+            ""if (_this != ACE_player) exitWith {false}; _actions = (_this getVariable '%2') select 1 select 2; _count = count _actions; _index = 0; _return = false; while {_index < _count && {!_return}} do {_return = [_target, _this] call ((_actions select _index) select 0); _index = _index + 1}; _return""
         ]",
         _action,
         _name

--- a/addons/dragging/functions/fnc_carryObject.sqf
+++ b/addons/dragging/functions/fnc_carryObject.sqf
@@ -51,8 +51,8 @@ if (_target isKindOf "CAManBase") then {
 // Add drop action
 _unit setVariable [QGVAR(releaseActionID), [
     _unit, "DefaultAction",
-    {!isNull ((_this select 0) getVariable [QGVAR(carriedObject), objNull])},
-    {[_this select 0, (_this select 0) getVariable [QGVAR(carriedObject), objNull], true] call FUNC(dropObject_carry)}
+    {!isNull ((_this select 1) getVariable [QGVAR(carriedObject), objNull])},
+    {[_this select 1, (_this select 1) getVariable [QGVAR(carriedObject), objNull], true] call FUNC(dropObject_carry)}
 ] call EFUNC(common,addActionEventHandler)];
 
 // Add anim changed EH

--- a/addons/dragging/functions/fnc_resumeCarry.sqf
+++ b/addons/dragging/functions/fnc_resumeCarry.sqf
@@ -26,8 +26,8 @@ if (!isNil {_unit getVariable QGVAR(releaseActionID)}) exitWith {};
 // Remove drop action
 _unit setVariable [QGVAR(releaseActionID), [
     _unit, "DefaultAction",
-    {!isNull ((_this select 0) getVariable [QGVAR(carriedObject), objNull])},
-    {[_this select 0, (_this select 0) getVariable [QGVAR(carriedObject), objNull], true] call FUNC(dropObject_carry)}
+    {!isNull ((_this select 1) getVariable [QGVAR(carriedObject), objNull])},
+    {[_this select 1, (_this select 1) getVariable [QGVAR(carriedObject), objNull], true] call FUNC(dropObject_carry)}
 ] call EFUNC(common,addActionEventHandler)];
 
 // Show mouse hint (done in FUNC(carryObjectPFH))

--- a/addons/sandbag/functions/fnc_deploy.sqf
+++ b/addons/sandbag/functions/fnc_deploy.sqf
@@ -49,7 +49,7 @@ GVAR(deployPFH) = [{
 _unit setVariable [QGVAR(Deploy), [
     _unit, "DefaultAction",
     {GVAR(deployPFH) != -1},
-    {[_this select 0] call FUNC(deployConfirm)}
+    {[_this select 1] call FUNC(deployConfirm)}
 ] call EFUNC(common,addActionEventHandler)];
 
 _unit setVariable [QGVAR(isDeploying), true, true];

--- a/addons/tacticalladder/functions/fnc_positionTL.sqf
+++ b/addons/tacticalladder/functions/fnc_positionTL.sqf
@@ -49,5 +49,5 @@ GVAR(currentAngle) = 0;
 _unit setVariable [QGVAR(Deploy), [
     _unit, "DefaultAction",
     {!isNull GVAR(ladder)},
-    {[_this select 0, GVAR(ladder)] call FUNC(confirmTLdeploy)}
+    {[_this select 1, GVAR(ladder)] call FUNC(confirmTLdeploy)}
 ] call EFUNC(common,addActionEventHandler)];

--- a/addons/trenches/functions/fnc_placeTrench.sqf
+++ b/addons/trenches/functions/fnc_placeTrench.sqf
@@ -95,7 +95,7 @@ GVAR(digPFH) = [{
 _unit setVariable [QGVAR(Dig), [
     _unit, "DefaultAction",
     {GVAR(digPFH) != -1},
-    {[_this select 0] call FUNC(placeConfirm)}
+    {[_this select 1] call FUNC(placeConfirm)}
 ] call EFUNC(common,addActionEventHandler)];
 
 _unit setVariable [QGVAR(isPlacing), true, true];

--- a/addons/tripod/functions/fnc_adjust.sqf
+++ b/addons/tripod/functions/fnc_adjust.sqf
@@ -45,5 +45,5 @@ GVAR(adjustPFH) = [{
 _unit setVariable [QGVAR(Adjust), [
     _unit, "DefaultAction",
     {GVAR(adjustPFH) != -1},
-    {(_this select 0) setVariable [QGVAR(adjusting), false, true]}
+    {(_this select 1) setVariable [QGVAR(adjusting), false, true]}
 ] call EFUNC(common,addActionEventHandler)];


### PR DESCRIPTION
It wouldn't intercept mouse button inputs when in FFV seats

**When merged this pull request will:**
- Title: It would intercept mouse button clicks when in FFV seats. I'm guessing it's been broken for years, as I found a ticket from 2018 talking about the cause of the issue: https://feedback.bistudio.com/T131585.
- As a result, both jamming and weapon safety was broken when in FFV seats.
- Use the `_caller` instead of the `_target` for the statement (see https://community.bistudio.com/wiki/addAction).

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
