### PR TITLE
Misc. compats - Exclude some MLRS vehicles from own backblast

### DIFF
--- a/addons/compat_cup_vehicles/CfgVehicles.hpp
+++ b/addons/compat_cup_vehicles/CfgVehicles.hpp
@@ -25,6 +25,15 @@ class CfgVehicles {
             };
         };
     };
+
+    class CUP_Hilux_Base;
+    class CUP_Hilux_MLRS_Base: CUP_Hilux_Base {
+        EGVAR(overpressure,noReflection) = 1;
+    };
+    class CUP_Hilux_UB32_Base: CUP_Hilux_Base {
+        EGVAR(overpressure,noReflection) = 1;
+    };
+
     class CUP_Ural_BaseTurret;
     class CUP_BM21_Base: CUP_Ural_BaseTurret {
         EGVAR(overpressure,noReflection) = 1;

--- a/addons/compat_cup_weapons/compat_cup_weapons_csw/config.cpp
+++ b/addons/compat_cup_weapons/compat_cup_weapons_csw/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
-            "CUP_Weapons_loadOrder",
+            "CUP_Weapons_LoadOrder",
             "ace_csw"
         };
         skipWhenMissingDependencies = 1;

--- a/addons/compat_rhs_usf3/CfgVehicles.hpp
+++ b/addons/compat_rhs_usf3/CfgVehicles.hpp
@@ -78,6 +78,11 @@ class CfgVehicles {
         EGVAR(refuel,hooks)[] = {{-0.44,-4.87,0}, {0.5,-4.87,0}};
         EGVAR(refuel,fuelCargo) = 10000;
     };
+
+    class rhsusf_himars_base: Truck_01_base_F {
+        EGVAR(overpressure,noReflection) = 1;
+    };
+
     class Tank_F;
     class APC_Tracked_02_base_F: Tank_F {};
     class rhsusf_m113tank_base: APC_Tracked_02_base_F {

--- a/addons/compat_sog/CfgVehicles/turrets.hpp
+++ b/addons/compat_sog/CfgVehicles/turrets.hpp
@@ -423,6 +423,7 @@ class vn_static_h12_base: Mortar_01_base_F {
     EGVAR(dragging,canCarry) = 0;
     EGVAR(dragging,canDrag) = 1;
     EGVAR(dragging,dragPosition)[] = {0.4, 2.1, 0};
+    EGVAR(overpressure,noReflection) = 1;
 
     class ACE_Actions: ACE_Actions {
         class ACE_MainActions: ACE_MainActions {


### PR DESCRIPTION
**When merged this pull request will:**
- Title. Specific vehicles are:
    - RHS HIMARS
    - CUP Hiluxes with MLRS or UB-32
    - SOG H12
- Change addon dependency casing to remove warning from RPT (drive-by change).
- Closes #10821.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
