### PR TITLE
Repair - Add RHS BMP hit point localisation

### DIFF
--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -492,40 +492,6 @@
             <Chinesesimp>弹药</Chinesesimp>
             <Turkish>Cephane</Turkish>
         </Key>
-        <Key ID="STR_ACE_Repair_HitLAileron">
-            <English>Left Aileron</English>
-            <Czech>Levý křidélko</Czech>
-            <French>Aileron gauche</French>
-            <Spanish>Alerón izquierdo</Spanish>
-            <Italian>Alettoni sinistro</Italian>
-            <Polish>Lewe lotki</Polish>
-            <Portuguese>Aileron esquerdo</Portuguese>
-            <Russian>Левый элерон</Russian>
-            <German>Linkes Querruder</German>
-            <Korean>왼쪽 보조익</Korean>
-            <Japanese>左補助翼</Japanese>
-            <Chinese>左副翼</Chinese>
-            <Chinesesimp>左副翼</Chinesesimp>
-            <Turkish>Sol Kanatçık</Turkish>
-            <Hungarian>Bal csűrőlap</Hungarian>
-        </Key>
-        <Key ID="STR_ACE_Repair_HitRAileron">
-            <English>Right Aileron</English>
-            <Czech>Pravý křidélko</Czech>
-            <French>Aileron droit</French>
-            <Spanish>Alerón derecho</Spanish>
-            <Italian>Alettoni destro</Italian>
-            <Polish>Prawe lotki</Polish>
-            <Portuguese>Aileron direito</Portuguese>
-            <Russian>Правый элерон</Russian>
-            <German>Rechtes Querruder</German>
-            <Korean>오른쪽 보조익</Korean>
-            <Japanese>右補助翼</Japanese>
-            <Chinese>右副翼</Chinese>
-            <Chinesesimp>右副翼</Chinesesimp>
-            <Turkish>Sağ Kanatçık</Turkish>
-            <Hungarian>Jobb csűrőlap</Hungarian>
-        </Key>
         <Key ID="STR_ACE_Repair_HitAvionics">
             <English>Avionics</English>
             <Czech>Elektronika</Czech>
@@ -743,6 +709,23 @@
             <Turkish>Gövde</Turkish>
             <Hungarian>Test</Hungarian>
         </Key>
+        <Key ID="STR_ACE_Repair_HitLAileron">
+            <English>Left Aileron</English>
+            <Czech>Levý křidélko</Czech>
+            <French>Aileron gauche</French>
+            <Spanish>Alerón izquierdo</Spanish>
+            <Italian>Alettoni sinistro</Italian>
+            <Polish>Lewe lotki</Polish>
+            <Portuguese>Aileron esquerdo</Portuguese>
+            <Russian>Левый элерон</Russian>
+            <German>Linkes Querruder</German>
+            <Korean>왼쪽 보조익</Korean>
+            <Japanese>左補助翼</Japanese>
+            <Chinese>左副翼</Chinese>
+            <Chinesesimp>左副翼</Chinesesimp>
+            <Turkish>Sol Kanatçık</Turkish>
+            <Hungarian>Bal csűrőlap</Hungarian>
+        </Key>
         <Key ID="STR_ACE_Repair_HitLBWheel">
             <English>Left Rear Wheel</English>
             <Czech>Levé zadní Kolo</Czech>
@@ -877,6 +860,20 @@
         </Key>
         <Key ID="STR_ACE_Repair_HitPeriscope">
             <English>Periscope</English>
+            <Czech>Periskop</Czech>
+            <French>Périscope</French>
+            <Spanish>Periscopio</Spanish>
+            <Italian>Periscopio</Italian>
+            <Polish>Periskop</Polish>
+            <Portuguese>Periscópio</Portuguese>
+            <Russian>Перископ</Russian>
+            <German>Periskop</German>
+            <Korean>잠망경</Korean>
+            <Japanese>潜望鏡</Japanese>
+            <Chinese>潛望鏡</Chinese>
+            <Chinesesimp>潜望镜</Chinesesimp>
+            <Turkish>Periskop</Turkish>
+            <Hungarian>Periszkóp</Hungarian>
         </Key>
         <Key ID="STR_ACE_Repair_HitPitotTube">
             <English>Pitot Tube</English>
@@ -893,6 +890,23 @@
             <Chinese>空速管</Chinese>
             <Chinesesimp>空速管</Chinesesimp>
             <Turkish>Pilot Tüpü</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Repair_HitRAileron">
+            <English>Right Aileron</English>
+            <Czech>Pravý křidélko</Czech>
+            <French>Aileron droit</French>
+            <Spanish>Alerón derecho</Spanish>
+            <Italian>Alettoni destro</Italian>
+            <Polish>Prawe lotki</Polish>
+            <Portuguese>Aileron direito</Portuguese>
+            <Russian>Правый элерон</Russian>
+            <German>Rechtes Querruder</German>
+            <Korean>오른쪽 보조익</Korean>
+            <Japanese>右補助翼</Japanese>
+            <Chinese>右副翼</Chinese>
+            <Chinesesimp>右副翼</Chinesesimp>
+            <Turkish>Sağ Kanatçık</Turkish>
+            <Hungarian>Jobb csűrőlap</Hungarian>
         </Key>
         <Key ID="STR_ACE_Repair_HitRBWheel">
             <English>Right Rear Wheel</English>

--- a/addons/repair/stringtable.xml
+++ b/addons/repair/stringtable.xml
@@ -470,6 +470,12 @@
             <Chinese>完整修復條件</Chinese>
             <Chinesesimp>全面维修条件</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_Repair_HitAASight">
+            <English>AA Sight</English>
+        </Key>
+        <Key ID="STR_ACE_Repair_HitATGMSight">
+            <English>ATGM Sight</English>
+        </Key>
         <Key ID="STR_ACE_Repair_HitAmmo">
             <English>Ammo</English>
             <Czech>Munice</Czech>
@@ -816,6 +822,9 @@
             <Chinesesimp>轻型</Chinesesimp>
             <Turkish>Işık</Turkish>
         </Key>
+        <Key ID="STR_ACE_Repair_HitMainSight">
+            <English>Main Sight</English>
+        </Key>
         <Key ID="STR_ACE_Repair_HitMissiles">
             <English>Missiles</English>
             <Czech>Rakety</Czech>
@@ -831,6 +840,9 @@
             <Chinese>導彈</Chinese>
             <Chinesesimp>导弹</Chinesesimp>
             <Turkish>Füzeler</Turkish>
+        </Key>
+        <Key ID="STR_ACE_Repair_HitPeriscope">
+            <English>Periscope</English>
         </Key>
         <Key ID="STR_ACE_Repair_HitPitotTube">
             <English>Pitot Tube</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds some missing hit point localisation.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
