### PR TITLE
Repair - Change isNearRepairVehicle to include more types of objects

### DIFF
--- a/addons/repair/functions/fnc_isNearRepairVehicle.sqf
+++ b/addons/repair/functions/fnc_isNearRepairVehicle.sqf
@@ -21,7 +21,7 @@ params ["_unit"];
 TRACE_1("params",_unit);
 
 private _fnc_check = {
-    private _nearObjects = nearestObjects [_unit, ["Air", "LandVehicle", "ThingX"], 20];
+    private _nearObjects = nearestObjects [_unit, ["Air", "LandVehicle", "Ship", "ThingX"], 20];
     CHECK_OBJECTS(_nearObjects)
 };
 

--- a/addons/repair/functions/fnc_isNearRepairVehicle.sqf
+++ b/addons/repair/functions/fnc_isNearRepairVehicle.sqf
@@ -21,7 +21,7 @@ params ["_unit"];
 TRACE_1("params",_unit);
 
 private _fnc_check = {
-    private _nearObjects = nearestObjects [_unit, ["Air", "LandVehicle", "Slingload_base_F"], 20];
+    private _nearObjects = nearestObjects [_unit, ["Air", "LandVehicle", "ThingX"], 20];
     CHECK_OBJECTS(_nearObjects)
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Expand what types of objects can be considered repair vehicles to things like ammo boxes and portable cranes.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
