### PR TITLE
Compat CFP - Add `logistics` compatibility

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -49,3 +49,9 @@ workshop = [
     "541888371", # CUP Vehicles
     "497661914", # CUP Units
 ]
+
+[cfp]
+extends = "cup"
+workshop = [
+    "1369691841", # Community Factions Project
+]

--- a/addons/compat_cfp/$PBOPREFIX$
+++ b/addons/compat_cfp/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_cfp

--- a/addons/compat_cfp/CfgVehicles.hpp
+++ b/addons/compat_cfp/CfgVehicles.hpp
@@ -1,0 +1,6 @@
+class CfgVehicles {
+    class Bag_Base;
+    class CFP_Cutters: Bag_Base {
+        EGVAR(logistics_wirecutter,hasWirecutter) = 1;
+    };
+};

--- a/addons/compat_cfp/CfgWeapons.hpp
+++ b/addons/compat_cfp/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons {
+    class V_PlateCarrier1_rgr;
+    class CFP_HV2_Ciras_Olive: V_PlateCarrier1_rgr {
+        EGVAR(logistics_wirecutter,hasWirecutter) = 1;
+    };
+};

--- a/addons/compat_cfp/config.cpp
+++ b/addons/compat_cfp/config.cpp
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_common", "cfp_main"};
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"Andx"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/compat_cfp/script_component.hpp
+++ b/addons/compat_cfp/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT compat_cfp
+#define COMPONENT_BEAUTIFIED Community Factions Project Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a new component for Community Factions Project
- Adds wirecutter function to a vest and a backpack
- Adds cfp to launch.toml as an extension of cup

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
