### PR TITLE
RHS Compat - Disable overpressure for OTR-21

### DIFF
--- a/addons/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/addons/compat_rhs_afrf3/CfgVehicles.hpp
@@ -409,6 +409,7 @@ class CfgVehicles {
     };
 
     class OTR21_Base: Truck_F {
+        EGVAR(overpressure,noReflection) = 1;
         EGVAR(refuel,fuelCapacity) = 500;
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Follow-up to #10896.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
