### PR TITLE
GM Compat - Fix mine base classes

### DIFF
--- a/addons/compat_gm/compat_gm_explosives/CfgMagazines.hpp
+++ b/addons/compat_gm/compat_gm_explosives/CfgMagazines.hpp
@@ -36,8 +36,9 @@ class CfgMagazines {
         };
     };
 
+    class gm_mine_base;
     class gm_mine_at_base;
-    class gm_mine_at_tm46: gm_mine_at_base {
+    class gm_mine_at_tm46: gm_mine_base {
         EGVAR(explosives,placeable) = 1;
         EGVAR(explosives,setupObject) = QEGVAR(explosives,Place_gm_mine_tm46);
         useAction = 0;
@@ -48,7 +49,7 @@ class CfgMagazines {
             };
         };
     };
-    class gm_mine_at_dm21: gm_mine_at_base {
+    class gm_mine_at_dm21: gm_mine_base {
         EGVAR(explosives,placeable) = 1;
         EGVAR(explosives,setupObject) = QEGVAR(explosives,Place_gm_explosive_dm21);
         useAction = 0;
@@ -71,7 +72,7 @@ class CfgMagazines {
         };
     };
 
-    class gm_mine_ap_dm31: gm_mine_at_base {
+    class gm_mine_ap_dm31: gm_mine_base {
         EGVAR(explosives,placeable) = 1;
         EGVAR(explosives,setupObject) = QEGVAR(explosives,Place_gm_explosive_dm31);
         useAction = 0;


### PR DESCRIPTION
Fix `gm_mine_at_dm21` popup and UBC

```
Updating base class gm_mine_base->gm_mine_at_base, by z\ace\addons\compat_gm\compat_gm_explosives\config.cpp/CfgMagazines/gm_mine_at_tm46/ (original gm\gm_weapons\gm_put\config.bin)
Updating base class gm_mine_base->gm_mine_at_base, by z\ace\addons\compat_gm\compat_gm_explosives\config.cpp/CfgMagazines/gm_mine_at_dm21/ (original gm\gm_weapons\gm_put\config.bin)
Updating base class gm_mine_base->gm_mine_at_base, by z\ace\addons\compat_gm\compat_gm_explosives\config.cpp/CfgMagazines/gm_mine_ap_dm31/ (original gm\gm_weapons\gm_put\config.bin)


```