### PR TITLE
GM Compat - Make PK Magazine Visible in ACE Arsenal

### DIFF
--- a/addons/compat_gm/CfgMagazines.hpp
+++ b/addons/compat_gm/CfgMagazines.hpp
@@ -15,14 +15,18 @@ class CfgMagazines {
     class gm_100rnd_762x54mmR_pk_grn;
     class gm_100Rnd_762x54mm_API_b32_pk_grn: gm_100rnd_762x54mmR_pk_grn {
         ACE_isBelt = 1;
+        type = 256;
     };
     class gm_100Rnd_762x54mm_B_T_t46_pk_grn: gm_100rnd_762x54mmR_pk_grn {
         ACE_isBelt = 1;
+        type = 256;
     };
     class gm_100Rnd_762x54mmR_API_7bz3_pk_grn: gm_100rnd_762x54mmR_pk_grn {
         ACE_isBelt = 1;
+        type = 256;
     };
     class gm_100Rnd_762x54mmR_B_T_7t2_pk_grn: gm_100rnd_762x54mmR_pk_grn {
         ACE_isBelt = 1;
+        type = 256;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Makes PK Magazines Visible in arsenal by setting type to 256.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
