### PR TITLE
GM Compat - Change Default Magazine for 9P133 to SACLOS Variant

### DIFF
--- a/addons/compat_gm/compat_gm_missileguidance/CfgAmmo.hpp
+++ b/addons/compat_gm/compat_gm_missileguidance/CfgAmmo.hpp
@@ -87,6 +87,21 @@ class CfgAmmo {
             showTrail = 1;
         };
     };
+    class GVAR(missile_maljutka_heat_9m14p): gm_missile_maljutka_heat_9m14m {
+        class ace_missileguidance: ace_missileguidance {
+            enabled = 1;
+
+            pitchRate = 45;
+            yawRate = 45;
+            lineGainP = 12;
+            lineGainD = 4;
+            defaultSeekerType = "SACLOS";
+            seekerTypes[] = { "SACLOS" };
+
+            defaultSeekerLockMode = "LOAL";
+            seekerLockModes[] = { "LOAL", "LOBL" };
+        };
+    };
     // Milan - problem with SCALOS aiming
     /* class gm_missile_milan_base: gm_missile_saclos_base {
         maneuvrability = 0;

--- a/addons/compat_gm/compat_gm_missileguidance/CfgMagazineWells.hpp
+++ b/addons/compat_gm/compat_gm_missileguidance/CfgMagazineWells.hpp
@@ -1,0 +1,5 @@
+class CfgMagazineWells {
+    class gm_magazineWell_maljutka_9k14 {
+        GVAR(magazines)[] = {QGVAR(6Rnd_maljutka_heat_9m14p)};
+    };
+};

--- a/addons/compat_gm/compat_gm_missileguidance/CfgMagazines.hpp
+++ b/addons/compat_gm/compat_gm_missileguidance/CfgMagazines.hpp
@@ -1,0 +1,6 @@
+class CfgMagazines {
+    class gm_6Rnd_maljutka_heat_9m14m;
+    class GVAR(6Rnd_maljutka_heat_9m14p): gm_6Rnd_maljutka_heat_9m14m {
+        ammo = QGVAR(missile_maljutka_heat_9m14p);
+    };
+};

--- a/addons/compat_gm/compat_gm_missileguidance/CfgVehicles.hpp
+++ b/addons/compat_gm/compat_gm_missileguidance/CfgVehicles.hpp
@@ -1,0 +1,32 @@
+class CfgVehicles {
+    // Updated 9P133 to SACLOS variant
+    class gm_wheeled_base;
+    class gm_wheeled_APC_base: gm_wheeled_base {
+        class Turrets;
+    };
+    class gm_brdm2_base: gm_wheeled_APC_base {
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+    class gm_brdm2_9p133_base: gm_brdm2_base {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                magazines[] = {QGVAR(6Rnd_maljutka_heat_9m14p),QGVAR(6Rnd_maljutka_heat_9m14p),QGVAR(6Rnd_maljutka_heat_9m14p)};
+                class Components;
+                class GunClouds;
+                class GunFire;
+                class Hitpoints;
+                class MGunClouds;
+                class OpticsIn;
+                class Reflectors;
+                class TurnIn;
+                class TurnOut;
+                class Turrets;
+                class TurretSpec;
+                class ViewGunner;
+                class ViewOptics;
+            };
+        };
+    };
+};

--- a/addons/compat_gm/compat_gm_missileguidance/config.cpp
+++ b/addons/compat_gm/compat_gm_missileguidance/config.cpp
@@ -21,6 +21,9 @@ class CfgPatches {
         addonRootClass = QUOTE(ADDON);
     };
 };
- 
+
 #include "\z\ace\addons\missileguidance\script_missileBases.hpp"
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgMagazineWells.hpp"
+#include "CfgVehicles.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Both East German and Polish 9P133's used the 9M14P, a SACLOS variant of the Malyutka. This PR changes the default missile guidance configuration to support that.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
