### PR TITLE
UI - Add actions to check weapon zeroing when UI elements are disabled

### DIFF
--- a/addons/ui/CfgVehicles.hpp
+++ b/addons/ui/CfgVehicles.hpp
@@ -230,7 +230,7 @@ class CfgVehicles {
     };
 
 // neither syntax of currentZeroing works with FFV seats, always returns 0 or [0, -1] depending on the syntax used
-// also currentZeroing for laser rangefinder is borked, just shows the last manually selected range, despire the biki saying it works with the alt syntax
+// also currentZeroing for laser rangefinder is borked, just shows the last manually selected range, biki says it will work with the alt syntax in v2.20
 #define CHECKZERO_ACTIONS \
 class ACE_SelfActions { \
     class GVAR(checkWeaponZeroing) { \

--- a/addons/ui/CfgVehicles.hpp
+++ b/addons/ui/CfgVehicles.hpp
@@ -228,4 +228,58 @@ class CfgVehicles {
             description = CSTRING(ModuleDescription);
         };
     };
+
+// neither syntax of currentZeroing works with FFV seats, always returns 0 or [0, -1] depending on the syntax used
+// also currentZeroing for laser rangefinder is borked, just shows the last manually selected range, despire the biki saying it works with the alt syntax
+#define CHECKZERO_ACTIONS \
+class ACE_SelfActions { \
+    class GVAR(checkWeaponZeroing) { \
+        displayName = CSTRING(checkWeaponZeroing); \
+        icon = ""; \
+        condition = QUOTE(!GVAR(gunnerZeroing) && {currentMuzzle _player != ''}); \
+        statement = QUOTE([_player] call FUNC(checkWeaponZeroing)); \
+    }; \
+}
+
+    class LandVehicle;
+    class Car: LandVehicle {
+        CHECKZERO_ACTIONS;
+    };
+    class Motorcycle: LandVehicle {
+        CHECKZERO_ACTIONS;
+    };
+    class StaticWeapon: LandVehicle {
+        CHECKZERO_ACTIONS;
+    };
+    class Tank: LandVehicle {
+        CHECKZERO_ACTIONS;
+    };
+    class Air;
+    class Helicopter: Air {
+        CHECKZERO_ACTIONS;
+    };
+    class Plane: Air {
+        CHECKZERO_ACTIONS;
+    };
+    class Ship;
+    class Ship_F: Ship {
+        CHECKZERO_ACTIONS;
+    };
+
+    class Man;
+    class CAManBase: Man {
+        class ACE_SelfActions {
+            class ACE_Equipment {
+                class GVAR(checkWeaponZeroing) {
+                    displayName = CSTRING(checkWeaponZeroing);
+                    condition = QUOTE(!GVAR(zeroing) && {isNull objectParent player} && {currentMuzzle _player != ''});
+                    // don't show action if in vehicle because the return is always either [0, -1] or it returns the zero of the vehicle weapon depending on the syntax used
+                    exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};
+                    statement = QUOTE([_player] call FUNC(checkWeaponZeroing));
+                    showDisabled = 0;
+                    icon = "";
+                };
+            };
+        };
+    };
 };

--- a/addons/ui/XEH_PREP.hpp
+++ b/addons/ui/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(checkWeaponZeroing);
 PREP(compileConfigUI);
 PREP(handleSpeedIndicator);
 PREP(moduleInit);

--- a/addons/ui/functions/fnc_checkWeaponZeroing.sqf
+++ b/addons/ui/functions/fnc_checkWeaponZeroing.sqf
@@ -29,7 +29,7 @@ if (isNull _vehicle) then {
 
 [
     [LLSTRING(weaponZeroSetTo)],
-    [format ["%1 %2", str _currentZero, LLSTRING(meters)]],
+    [format ["%1 %2", _currentZero toFixed 0, LLSTRING(meters)]],
     true
 ] call CBA_fnc_notify;
 

--- a/addons/ui/functions/fnc_checkWeaponZeroing.sqf
+++ b/addons/ui/functions/fnc_checkWeaponZeroing.sqf
@@ -1,0 +1,27 @@
+#include "..\script_component.hpp"
+/*
+ * Author: drofseh
+ * Display the zeroing of the player's current muzzle.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * Current Zero <NUMBER>
+ *
+ * Example:
+ * [ace_player] call ace_ui_fnc_checkWeaponZeroing
+ *
+ * Public: No
+ */
+
+params ["_unit"];
+
+[
+    [LLSTRING(weaponZeroSetTo)],
+    [format ["%1 %2", str currentZeroing _unit, LLSTRING(meters)]],
+    true
+] call CBA_fnc_notify;
+
+_currentZero
+

--- a/addons/ui/functions/fnc_checkWeaponZeroing.sqf
+++ b/addons/ui/functions/fnc_checkWeaponZeroing.sqf
@@ -23,8 +23,8 @@ private _currentZero = -1;
 if (isNull _vehicle) then {
     _currentZero = currentZeroing _unit;
 } else {
-    // In Arma3 v2.20 this will return the zero set by vehicle laser rangefinders
-    _currentZero = (_vehicle currentZeroing [_vehicle currentWeaponTurret (_vehicle unitTurret _unit), currentMuzzle _unit]) select 0;
+    // This will return the zero set by vehicle laser rangefinders
+    _currentZero = (_unit currentZeroing [_vehicle currentWeaponTurret (_vehicle unitTurret _unit), currentMuzzle _unit]) param [0, 0];
 };
 
 [

--- a/addons/ui/functions/fnc_checkWeaponZeroing.sqf
+++ b/addons/ui/functions/fnc_checkWeaponZeroing.sqf
@@ -17,11 +17,20 @@
 
 params ["_unit"];
 
+private _vehicle = objectParent _unit;
+private _currentZero = -1;
+
+if (isNull _vehicle) then {
+    _currentZero = currentZeroing _unit;
+} else {
+    // In Arma3 v2.20 this will return the zero set by vehicle laser rangefinders
+    _currentZero = (_vehicle currentZeroing [_vehicle currentWeaponTurret (_vehicle unitTurret _unit), currentMuzzle _unit]) select 0;
+};
+
 [
     [LLSTRING(weaponZeroSetTo)],
-    [format ["%1 %2", str currentZeroing _unit, LLSTRING(meters)]],
+    [format ["%1 %2", str _currentZero, LLSTRING(meters)]],
     true
 ] call CBA_fnc_notify;
 
 _currentZero
-

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -733,5 +733,14 @@
             <Japanese>全てのUIを隠す</Japanese>
             <Chinesesimp>隐藏所有UI</Chinesesimp>
         </Key>
+        <Key ID="STR_ACE_UI_checkWeaponZeroing">
+            <English>Check Weapon Zeroing</English>
+        </Key>
+        <Key ID="STR_ACE_UI_weaponZeroSetTo">
+            <English>Zero is set to:</English>
+        </Key>
+        <Key ID="STR_ACE_UI_meters">
+            <English>Meters</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add ACE interactions to check the zero of vehicle and unit weapons when their respective UI elements are disabled.
- Has a soft dependency on interaction (obviously) but I don't think this should be a problem as the action are added via config.
- The currentZeroing command is a little quirky, but I think it's still worth having despite these issues.
It can't be used for a unit's primary/handgun weapon if the unit is in a vehicle. Return is for the vehicle weapon or [0,-1] depending on the syntax used.
It doesn't work at all for FFV seats, even when firing the primary/handgun weapon. Return is 0 or [0,-1] depending on the syntax used.
~~It doesn't currently work when the vehicle weapon zero is set using laser rangefinder. This should be fixed in Arma3 v2.20, but the current return is always the last manually set range.~~ Fixed with v2.20 release. 
