### PR TITLE
Missile Guidance - Fix SACLOS on sub-turrets

### DIFF
--- a/addons/missileguidance/functions/fnc_SACLOS_onFired.sqf
+++ b/addons/missileguidance/functions/fnc_SACLOS_onFired.sqf
@@ -14,11 +14,17 @@
  *
  * Public: No
  */
+#define SCALOS_DIR_WEAPON 0
+#define SCALOS_DIR_ANIM 1
+#define SCALOS_DIR_PILOTCAM 2
+#define SCALOS_DIR_TURRETDIR 3
+
 params ["_firedEH", "", "", "", "_stateParams"];
 _firedEH params ["_shooter","_weapon","","","","","_projectile"];
 _stateParams params ["", "_seekerStateParams"];
 
 private _usePilotCamera = getNumber (configOf _shooter >> "pilotCamera" >> QGVAR(usePilotCameraForTargeting)) == 1;
+private _useTurretDir = getNumber (configOf _shooter >> QGVAR(useTurretDirectionForTargeting)) == 1;
 
 private _turretPath = [_shooter, _weapon] call CBA_fnc_turretPathWeapon;
 private _turretConfig = [_shooter, _turretPath] call CBA_fnc_getTurret;
@@ -26,9 +32,17 @@ private _memoryPointGunnerOptics = getText(_turretConfig >> "memoryPointGunnerOp
 private _animationSourceBody = getText(_turretConfig >> "animationSourceBody");
 private _animationSourceGun = getText(_turretConfig >> "animationSourceGun");
 
+private _dirMode = switch (true) do {
+    case (_shooter isKindOf "CAManBase" || {_shooter isKindOf "StaticWeapon"}): { SCALOS_DIR_WEAPON };
+    case (_usePilotCamera || { (_shooter isKindOf "Plane") && hasPilotCamera _shooter }): { SCALOS_DIR_PILOTCAM };
+    case (_useTurretDir || {(count _turretPath) > 1}): { SCALOS_DIR_TURRETDIR };
+    default { SCALOS_DIR_ANIM };
+};
+
 _seekerStateParams set [0, _memoryPointGunnerOptics];
 _seekerStateParams set [1, _animationSourceBody];
 _seekerStateParams set [2, _animationSourceGun];
-_seekerStateParams set [3, _usePilotCamera || { (_shooter isKindOf "Plane") && hasPilotCamera _shooter }];
+_seekerStateParams set [3, _dirMode];
+_seekerStateParams set [4, _turretPath];
 
 if ((_shooter isKindOf "Plane") && !hasPilotCamera _shooter) then { WARNING("SACLOS fired from planes without pilot camera unsupported!"); };


### PR DESCRIPTION
e.g. GM BMP-1P
the saclos is fired from a sub-turret from the main `[0,0]`
so we need to take into account the animation of both turrets

`CBA_fnc_turretDir` seems to be ok for this
IIRC it isn't as accurate as using the raw anim, but seems to do a reasonably good job