### PR TITLE
arsenal - Fix the arsenal overfill prevention function fnc_preventOverfilling.sqf

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -205,3 +205,5 @@ Zakant <Zakant@gmx.de>
 zGuba
 Zman6258
 Zorn <lordzorn1337@gmail.com>
+Redwan S. / Nomas <nomasx2000@gmail.com>
+Sky / Esmeray6

--- a/addons/arsenal/functions/fnc_preventOverfilling.sqf
+++ b/addons/arsenal/functions/fnc_preventOverfilling.sqf
@@ -29,9 +29,9 @@ if (isNull _container || _container isEqualTo _unit) then {
 	{
 		private _cargoType = _x;
 		private _cargoList = switch (_cargoType) do {
-			case "Weapon": { weaponCargo _currentContainer };
-			case "Magazine": { magazineCargo _currentContainer };
-			case "Item": { itemCargo _currentContainer };
+			case "Weapon":		{ weaponCargo _currentContainer };
+			case "Magazine":	{ magazineCargo _currentContainer };
+			case "Item":		{ itemCargo _currentContainer };
 		};
 
 		{
@@ -40,9 +40,9 @@ if (isNull _container || _container isEqualTo _unit) then {
 			};
 			
 			switch (_cargoType) do {
-				case "Weapon":   { _currentContainer addWeaponCargoGlobal [_x, -1]; };
-				case "Magazine": { _currentContainer addMagazineCargoGlobal [_x, -1]; };
-				case "Item":     { _currentContainer addItemCargoGlobal [_x, -1]; };
+				case "Weapon":		{ _currentContainer addWeaponCargoGlobal [_x, -1]; };
+				case "Magazine":	{ _currentContainer addMagazineCargoGlobal [_x, -1]; };
+				case "Item":		{ _currentContainer addItemCargoGlobal [_x, -1]; };
 			};
 		} forEachReversed _cargoList;
 

--- a/addons/arsenal/functions/fnc_preventOverfilling.sqf
+++ b/addons/arsenal/functions/fnc_preventOverfilling.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 #include "..\defines.hpp"
 /*
- * Author: Alganthe, johnb43, mrschick
+ * Author: Alganthe, johnb43, mrschick, Redwan S. / Nomas, Sky / Esmeray6
  * Checks the current loadout of the given unit for inventory containers (uniform/vest/backpack) filled beyond their max load, removing excess items if present.
  *
  * Arguments:

--- a/addons/arsenal/functions/fnc_preventOverfilling.sqf
+++ b/addons/arsenal/functions/fnc_preventOverfilling.sqf
@@ -23,18 +23,29 @@ if (isNull _container || _container isEqualTo _unit) then {
 };
 
 {
-    private _currentContainer = _x;
+	private _currentContainer = _x;
 	private _cargoTypes = ["Weapon", "Magazine", "Item"];
 
 	{
 		private _cargoType = _x;
+		private _cargoList = switch (_cargoType) do {
+			case "Weapon": { weaponCargo _currentContainer };
+			case "Magazine": { magazineCargo _currentContainer };
+			case "Item": { itemCargo _currentContainer };
+		};
+
 		{
 			if (load _currentContainer <= 1) then {
 				break;
 			};
+			
+			switch (_cargoType) do {
+				case "Weapon":   { _currentContainer addWeaponCargoGlobal [_x, -1]; };
+				case "Magazine": { _currentContainer addMagazineCargoGlobal [_x, -1]; };
+				case "Item":     { _currentContainer addItemCargoGlobal [_x, -1]; };
+			};
+		} forEachReversed _cargoList;
 
-			(call compile format ["_currentContainer add%1CargoGlobal [_x, -1];", _cargoType]);
-		} forEachReversed (call compile format ["%1Cargo _currentContainer", toLower(_cargoType)]);
 	} forEach _cargoTypes;
 
 } forEach (_container select {load _x > 1});

--- a/addons/arsenal/functions/fnc_preventOverfilling.sqf
+++ b/addons/arsenal/functions/fnc_preventOverfilling.sqf
@@ -24,11 +24,17 @@ if (isNull _container || _container isEqualTo _unit) then {
 
 {
     private _currentContainer = _x;
-    {
-        _currentContainer addItemCargoGlobal [_x, -1];
+	private _cargoTypes = ["Weapon", "Magazine", "Item"];
 
-        if (load _currentContainer <= 1) then {
-            break;
-        };
-    } forEachReversed (itemCargo _currentContainer);
+	{
+		private _cargoType = _x;
+		{
+			if (load _currentContainer <= 1) then {
+				break;
+			};
+
+			(call compile format ["_currentContainer add%1CargoGlobal [_x, -1];", _cargoType]);
+		} forEachReversed (call compile format ["%1Cargo _currentContainer", toLower(_cargoType)]);
+	} forEach _cargoTypes;
+
 } forEach (_container select {load _x > 1});


### PR DESCRIPTION
**When merged this pull request will:**
- _Describe what this pull request will do_
- _Each change in a separate line_
- This merge will fix issue #10945 and allow overfill prevention to work properly. Specifically instead of only removing items cargo when the overfill prevention function is called, weapons and magazines now also can be removed.
  - Replaced the original item cargo check [here](https://github.com/acemod/ACE3/blob/bcbdb6071ec4d78ec54d529de8edcb9b44ebb560/addons/arsenal/functions/fnc_preventOverfilling.sqf#L26C1-L33C53) with one that checks for all cargo types of weapon, magazine, and items to ensure overfill prevention works properly.
  - A switch was added to go through all item types properly.
- This merge adds the authors of the code and bug find / fix to the `AUTHORS.txt`.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
