### PR TITLE
Realistic Names - Add Stubwing AH-99

### DIFF
--- a/addons/realisticnames/CfgVehicles.hpp
+++ b/addons/realisticnames/CfgVehicles.hpp
@@ -357,6 +357,9 @@ class CfgVehicles {
     class B_Heli_Attack_01_dynamicLoadout_F: Heli_Attack_01_dynamicLoadout_base_F {
         displayName = CSTRING(Heli_Attack_01_Name);
     };
+    class B_Heli_Attack_01_pylons_dynamicLoadout_F: B_Heli_Attack_01_dynamicLoadout_F {
+        displayName = CSTRING(Heli_Attack_01_pylons_Name);
+    };
 
     class Heli_Light_01_unarmed_base_F;
     class B_Heli_Light_01_F: Heli_Light_01_unarmed_base_F {

--- a/addons/realisticnames/stringtable.xml
+++ b/addons/realisticnames/stringtable.xml
@@ -585,6 +585,23 @@
             <Turkish>RAH-66 Comanche</Turkish>
             <Hungarian>RAH-66 Comanche</Hungarian>
         </Key>
+        <Key ID="STR_ACE_RealisticNames_Heli_Attack_01_pylons_Name">
+            <English>RAH-66 Comanche (Stub Wings)</English>
+            <Czech>RAH-66 Comanche (křídla nízké štíhlosti)</Czech>
+            <French>RAH-66 Comanche (ailettes)</French>
+            <Spanish>RAH-66 Comanche (semialas)</Spanish>
+            <Italian>RAH-66 Comanche (semiali)</Italian>
+            <Polish>RAH-66 Comanche(skrzydełka)</Polish>
+            <Portuguese>RAH-66 Comanche (Asas auxiliares)</Portuguese>
+            <Russian>RAH-66 Comanche (короткие крылья)</Russian>
+            <German>RAH-66 Comanche (Stummelflügel)</German>
+            <Korean>RAH-66 코만치 (스터브 윙)</Korean>
+            <Japanese>RAH-66 コマンチ (スタブウイング)</Japanese>
+            <Chinese>RAH-66 "卡曼契"攻擊直升機（短翼）</Chinese>
+            <Chinesesimp>RAH-66 "科曼奇"（短翼）</Chinesesimp>
+            <Turkish>RAH-66 Comanche (Yarım Kanatlar)</Turkish>
+            <Hungarian>RAH-66 Comanche (csonk szárny)</Hungarian>
+        </Key>
         <Key ID="STR_ACE_RealisticNames_Heli_Light_01_Name">
             <English>MH-6 Little Bird</English>
             <Czech>MH-6 Little Bird</Czech>


### PR DESCRIPTION
**When merged this pull request will:**
- _Title_

Please merge after 2.20 update

Note: 
Localization of "stub wing" words are copy from `str_a3_cfgvehicles_b_heli_attack_01_pylons_dynamicloadout_f0`
except Hungarian


### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
