### PR TITLE
Field Rations - Support negative thirst and hunger values

### DIFF
--- a/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
+++ b/addons/field_rations/functions/fnc_addWaterSourceInteractions.sqf
@@ -81,4 +81,4 @@ TRACE_1("Starting interact PFH",_interactionType);
         };
     };
     END_COUNTER(interactEH);
-}, 0.5, [getPosASL ACE_player vectorAdd [-100, 0, 0], [], []]] call CBA_fnc_addPerFrameHandler;
+}, 0.5, [[0, 0, -100], [], []]] call CBA_fnc_addPerFrameHandler;

--- a/addons/field_rations/functions/fnc_canRefillItem.sqf
+++ b/addons/field_rations/functions/fnc_canRefillItem.sqf
@@ -26,8 +26,8 @@ _itemData params ["_item", "_itemConfig", "_isMagazine"];
 alive _source
 && {XGVAR(waterSourceActions) != 0}
 && {
-    (_isMagazine && {_item in magazines _player})
-    || {_item in (_player call EFUNC(common,uniqueItems))}
+    (_isMagazine && {_item in ([_player, 2] call EFUNC(common,uniqueItems))})
+    || {!_isMagazine && {_item in (_player call EFUNC(common,uniqueItems))}}
 }
 && {
     private _water = _source call FUNC(getRemainingWater);

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -37,7 +37,7 @@ private _displayName = getText (_config >> "displayName");
 private _consumeText = getText (_config >> QXGVAR(consumeText));
 
 if (_consumeText == "") then {
-    _consumeText = if (_hungerSatiated > 0) then {
+    _consumeText = if (_hungerSatiated != 0) then {
         LLSTRING(EatingX);
     } else {
         LLSTRING(DrinkingX);
@@ -88,14 +88,14 @@ private _fnc_onSuccess = {
     };
 
     // Handle thirst and hunger values
-    if (_thirstQuenched > 0) then {
+    if (_thirstQuenched != 0) then {
         private _thirst = _player getVariable [QXGVAR(thirst), 0];
-        _player setVariable [QXGVAR(thirst), (_thirst - _thirstQuenched) max 0];
+        _player setVariable [QXGVAR(thirst), (_thirst - _thirstQuenched) min 100 max 0];
     };
 
-    if (_hungerSatiated > 0) then {
+    if (_hungerSatiated != 0) then {
         private _hunger = _player getVariable [QXGVAR(hunger), 0];
-        _player setVariable [QXGVAR(hunger), (_hunger - _hungerSatiated) max 0];
+        _player setVariable [QXGVAR(hunger), (_hunger - _hungerSatiated) min 100 max 0];
     };
 
     ["acex_rationConsumed", [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated, _isMagazine]] call CBA_fnc_localEvent;
@@ -130,7 +130,7 @@ private _fnc_condition = {
     };
 
     if (_isMagazine) exitWith {
-        _consumeItem in magazines _player // return
+        _consumeItem in ([_player, 2] call EFUNC(common,uniqueItems)) // return
     };
     _consumeItem in (_player call EFUNC(common,uniqueItems)) // return
 };

--- a/addons/field_rations/functions/fnc_getConsumableChildren.sqf
+++ b/addons/field_rations/functions/fnc_getConsumableChildren.sqf
@@ -29,7 +29,7 @@ private _fnc_getActions = {
         private _isMagazine = _config == _cfgMagazines;
         {
             private _itemConfig = _config >> _x;
-            if (getNumber (_itemConfig >> QXGVAR(thirstQuenched)) > 0 || {getNumber (_itemConfig >> QXGVAR(hungerSatiated)) > 0}) then {
+            if (getNumber (_itemConfig >> QXGVAR(thirstQuenched)) != 0 || {getNumber (_itemConfig >> QXGVAR(hungerSatiated)) != 0}) then {
                 private _displayName = getText (_itemConfig >> "displayName");
                 private _picture = getText (_itemConfig >> "picture");
 
@@ -40,7 +40,7 @@ private _fnc_getActions = {
         } forEach _items;
     } forEach [
         [_cfgWeapons, _player call EFUNC(common,uniqueItems)],
-        [_cfgMagazines, [magazines _player] call EFUNC(common,uniqueElements)]
+        [_cfgMagazines, [_player, 2] call EFUNC(common,uniqueItems)]
     ];
 
     _actions

--- a/addons/field_rations/functions/fnc_getRefillChildren.sqf
+++ b/addons/field_rations/functions/fnc_getRefillChildren.sqf
@@ -40,7 +40,7 @@ private _cfgMagazines = configFile >> "CfgMagazines";
     } forEach _items;
 } forEach [
     [_cfgWeapons, _player call EFUNC(common,uniqueItems)],
-    [_cfgMagazines, [magazines _player] call EFUNC(common,uniqueElements)]
+    [_cfgMagazines, [_player, 2] call EFUNC(common,uniqueItems)]
 ];
 
 _actions

--- a/addons/field_rations/functions/fnc_handleEffects.sqf
+++ b/addons/field_rations/functions/fnc_handleEffects.sqf
@@ -29,17 +29,17 @@ if !(_player call EFUNC(common,isAwake)) exitWith {};
 
 // Make unit moan from high hunger/thirst
 if (
-    GETEGVAR(medical,enabled,false) && 
-    {(_thirst > CONSEQ_THRESHOLD_LIGHT) || {_hunger > CONSEQ_THRESHOLD_LIGHT}} && 
+    GETEGVAR(medical,enabled,false) &&
+    {(_thirst > CONSEQ_THRESHOLD_LIGHT) || {_hunger > CONSEQ_THRESHOLD_LIGHT}} &&
     {random 1 < linearConversion [CONSEQ_THRESHOLD_LIGHT, 100, (_thirst max _hunger), 0.05, 0.2, true]}
 ) then {
-    [ACE_Player, "moan", round (linearConversion [CONSEQ_THRESHOLD_LIGHT, 90, (_thirst max _hunger), 0, 2, true])] call EFUNC(medical_feedback,playInjuredSound);
+    [_player, "moan", round (linearConversion [CONSEQ_THRESHOLD_LIGHT, 90, (_thirst max _hunger), 0, 2, true])] call EFUNC(medical_feedback,playInjuredSound);
 };
 
 // Trigger high thirst/hunger consequence (chance based on how high thirst/hunger are)
 if (
-    GETEGVAR(medical,enabled,false) && 
-    {(_thirst > CONSEQ_THRESHOLD_SEVERE || {_hunger > CONSEQ_THRESHOLD_SEVERE}) && 
+    GETEGVAR(medical,enabled,false) &&
+    {(_thirst > CONSEQ_THRESHOLD_SEVERE || {_hunger > CONSEQ_THRESHOLD_SEVERE}) &&
     {random 1 < linearConversion [CONSEQ_THRESHOLD_SEVERE, 100, _thirst max _hunger, 0.05, 0.1, true]}}
 ) exitWith {
     if (XGVAR(nearDepletedConsequence) == 1) then { // Set unit unconscious with a 45s cooldown
@@ -48,8 +48,8 @@ if (
             [_player, true, 5, true] call EFUNC(medical,setUnconscious);
         };
     } else { // Add pain
-        if (ACE_Player getVariable [QEGVAR(medical,pain), 0] < 0.1) then {
-            [ACE_Player, 0.1] call EFUNC(medical,adjustPainLevel);
+        if (_player getVariable [QEGVAR(medical,pain), 0] < 0.1) then {
+            [_player, 0.1] call EFUNC(medical,adjustPainLevel);
         };
     };
 };

--- a/addons/field_rations/functions/fnc_scanFieldRations.sqf
+++ b/addons/field_rations/functions/fnc_scanFieldRations.sqf
@@ -20,7 +20,7 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 private _cfgMagazines = configFile >> "CfgMagazines";
 
 private _fnc_isFieldRationItem = toString {
-    (getNumber (_x >> "ACE_isFieldRationItem") isEqualTo 1) || {(getNumber (_x >> QXGVAR(thirstQuenched))) > 0} || {(getNumber (_x >> QXGVAR(hungerSatiated))) > 0} || {(getText (_x >> QXGVAR(refillItem))) isNotEqualTo ""}
+    (getNumber (_x >> "ACE_isFieldRationItem") isEqualTo 1) || {(getNumber (_x >> QXGVAR(thirstQuenched))) != 0} || {(getNumber (_x >> QXGVAR(hungerSatiated))) != 0} || {(getText (_x >> QXGVAR(refillItem))) isNotEqualTo ""}
 };
 
 {

--- a/docs/wiki/framework/field-rations-framework.md
+++ b/docs/wiki/framework/field-rations-framework.md
@@ -31,7 +31,7 @@ redirect_from: "/wiki/frameworkx/field-rations-framework.html"
 | `ACE_isFieldRationItem` | Number | Force adds the item to the ACE Field Rations category in ACE Arsenal (OPTIONAL) |
 
 
-_* Value range is 0 to 100 and can be modified by the corresponding coefficient setting._
+_* Value range is -100 to 100 and can be modified by the corresponding coefficient setting._
 
 _** Array is in format: STAND, CROUCH, PRONE. If player is in vehicle, the first element is used._
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Minor optimisation: Use `EFUNC(common,uniqueItems)` to get magazines
- Use `_player` instead of `ACE_player`.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
