### PR TITLE
Name Tags - Add variable to treat AI as players

### DIFF
--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -78,20 +78,23 @@ if (_enabledTagsCursor) then {
 if (_enabledTagsNearby) then {
     // Find valid targets and cache them
     private _targets = [[], {
+        private _fnc_basicChecks = {
+            params ["_unit"];
+            private _treatAsPlayer = _unit getVariable [QGVAR(treatAsPlayer), false];
+            _unit != ACE_player && {_treatAsPlayer || (side group _unit) == (side group ACE_player)} &&
+            {GVAR(showNamesForAI) || _treatAsPlayer || {_unit call EFUNC(common,isPlayer)}}
+        };
+
         private _nearMen = nearestObjects [_camPosAGL, ["CAManBase"], _maxDistance + 7];
         _nearMen = _nearMen select {
-            _x != ACE_player &&
-            {(side group _x) == (side group ACE_player)} &&
-            {GVAR(showNamesForAI) || {[_x] call EFUNC(common,isPlayer)}} &&
+            _x call _fnc_basicChecks &&
             {lineIntersectsSurfaces [_camPosASL, eyePos _x, ACE_player, _x] isEqualTo []} &&
             {!isObjectHidden _x}
         };
         private _crewMen = [];
         if (!isNull objectParent ACE_player) then {
             _crewMen = (crew vehicle ACE_player) select {
-                _x != ACE_player &&
-                {(side group _x) == (side group ACE_player)} &&
-                {GVAR(showNamesForAI) || {[_x] call EFUNC(common,isPlayer)}} &&
+                _x call _fnc_basicChecks &&
                 {lineIntersectsSurfaces [_camPosASL, eyePos _x, ACE_player, _x, true, 1, "GEOM", "NONE"] isEqualTo []} &&
                 {!isObjectHidden _x}
             };

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -80,9 +80,9 @@ if (_enabledTagsNearby) then {
     private _targets = [[], {
         private _fnc_basicChecks = {
             params ["_unit"];
-            private _treatAsPlayer = _unit getVariable [QGVAR(treatAsPlayer), false];
-            _unit != ACE_player && {_treatAsPlayer || (side group _unit) == (side group ACE_player)} &&
-            {GVAR(showNamesForAI) || _treatAsPlayer || {_unit call EFUNC(common,isPlayer)}}
+            private _forceShowTags = _unit getVariable [QGVAR(forceShowTags), false];
+            _unit != ACE_player && {_forceShowTags || (side group _unit) == (side group ACE_player)} &&
+            {GVAR(showNamesForAI) || _forceShowTags || {_unit call EFUNC(common,isPlayer)}}
         };
 
         private _nearMen = nearestObjects [_camPosAGL, ["CAManBase"], _maxDistance + 7];

--- a/addons/nametags/functions/fnc_onDraw3d.sqf
+++ b/addons/nametags/functions/fnc_onDraw3d.sqf
@@ -54,7 +54,7 @@ if (_enabledTagsCursor) then {
 
     if (_target != ACE_player &&
         {(side group _target) == (side group ACE_player)} &&
-        {GVAR(showNamesForAI) || {[_target] call EFUNC(common,isPlayer)}} &&
+        {(_target getVariable [QGVAR(forceShowTags), GVAR(showNamesForAI)]) || {_target call EFUNC(common,isPlayer)}} &&
         {lineIntersectsSurfaces [_camPosASL, eyePos _target, ACE_player, _target] isEqualTo []} &&
         {!isObjectHidden _target}) then {
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `GVAR(treatAsPlayer)` variable to treat AI units as a player, including enemy AI.
  - Use case is for having AI be disguised to players. Experienced players would immediately know they're an enemy due to the name tag not showing
- Moved common conditions to inline function

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
