### PR TITLE
Explosives - Fix "Active Detonator" not being reset after no charges remaining

### DIFF
--- a/addons/explosives/functions/fnc_selectTrigger.sqf
+++ b/addons/explosives/functions/fnc_selectTrigger.sqf
@@ -22,11 +22,10 @@ TRACE_3("params",_explosive,_magazine,_trigger);
 
 private _config = configFile >> "ACE_Triggers" >> _trigger;
 
-// Make selected trigger the active one (for keybind) if it's the first to be connected
+// Make selected trigger the active one (for keybind) if it's the first to be connected, or the current active trigger has no connected explosives
 private _activeTrigger = GVAR(activeTrigger);
 if (
-    _activeTrigger == "" &&
-    {(["Command", "MK16_Transmitter", "DeadManSwitch"] findIf {_x == _trigger}) != -1}
+    (_activeTrigger == "" || {([ACE_Player, getArray (configFile >> "ACE_Triggers" >> _activeTrigger >> "requires") select 0] call FUNC(getPlacedExplosives)) isEqualTo []}) && {(["Command", "MK16_Transmitter", "DeadManSwitch"] findIf {_x == _trigger}) != -1}
 ) then {
     GVAR(activeTrigger) = getArray (_config >> "requires") select 0;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes the "Active Detonator" not being reset to a different detonator used to arm a new explosive, when the current active one had no connected charges remaining.