### PR TITLE
interaction menu: center on 32:9

### DIFF
--- a/addons/interact_menu/XEH_preInit.sqf
+++ b/addons/interact_menu/XEH_preInit.sqf
@@ -71,6 +71,20 @@ GVAR(collectedActionPoints) = [];
 GVAR(foundActions) = [];
 GVAR(lastTimeSearchedActions) = -1000;
 
+// Selector positioning
+GVAR(SELECTOR_LIST_X) = 0.014;
+GVAR(SELECTOR_LIST_Y) = 0.014;
+GVAR(SELECTOR_LIST_W) = 0.05;
+GVAR(SELECTOR_LIST_H) = 0.035;
+GVAR(SELECTOR_RADIAL_X) = 0.0505;
+GVAR(SELECTOR_RADIAL_Y) = 0.0125;
+GVAR(SELECTOR_RADIAL_W) = 0.1;
+GVAR(SELECTOR_RADIAL_H) = 0.035;
+if (str (getResolution select 4) == "3.55556") then { // 32:9
+    GVAR(SELECTOR_LIST_X) = 0.012;
+    GVAR(SELECTOR_LIST_Y) = 0.0125;
+};
+
 // Init zeus menu
 [] call FUNC(compileMenuZeus);
 

--- a/addons/interact_menu/functions/fnc_renderSelector.sqf
+++ b/addons/interact_menu/functions/fnc_renderSelector.sqf
@@ -29,12 +29,12 @@ if(GVAR(iconCount) > (count GVAR(iconCtrls))-1) then {
 
 private _ctrl = GVAR(iconCtrls) select GVAR(iconCount);
 
-private _pos = if (GVAR(UseListMenu)) then {
+private _pos = if ([GVAR(useListMenu), GVAR(useListMenuSelf)] select GVAR(keyDownSelfAction)) then {
     [_ctrl, GVAR(iconCount), format ["<img image='%1' color='%2' size='1.6'/>", _icon, GVAR(selectorColorHex)]] call FUNC(ctrlSetParsedTextCached);
-    [(_sPos select 0)-(0.014*safeZoneW), (_sPos select 1)-(0.014*safeZoneW), 0.05*safeZoneW, 0.035*safeZoneW]
+    [(_sPos select 0)-(GVAR(SELECTOR_LIST_X)*safeZoneW), (_sPos select 1)-(GVAR(SELECTOR_LIST_Y)*safeZoneW), GVAR(SELECTOR_LIST_W)*safeZoneW, GVAR(SELECTOR_LIST_H)*safeZoneW]
 } else {
     [_ctrl, GVAR(iconCount), format ["<img image='%1' color='%2' size='1.6' align='center'/>", _icon, GVAR(selectorColorHex)]] call FUNC(ctrlSetParsedTextCached);
-    [(_sPos select 0)-(0.050*safeZoneW), (_sPos select 1)-(0.014*safeZoneW), 0.1*safeZoneW, 0.035*safeZoneW]
+    [(_sPos select 0)-(GVAR(SELECTOR_RADIAL_X)*safeZoneW), (_sPos select 1)-(GVAR(SELECTOR_RADIAL_Y)*safeZoneW), GVAR(SELECTOR_RADIAL_W)*safeZoneW, GVAR(SELECTOR_RADIAL_H)*safeZoneW]
 };
 
 GVAR(iconCount) = GVAR(iconCount) + 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Uses GVARs for selector positions
- Changes the radial values to look good on 32:9, change isn't noticeable on 16:9
- Checks for 32:9, uses different list values, couldn't get values that looked good on both
- Fixes a bug when using "Display as List" only on the external interaction menu

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
