### PR TITLE
Medical Treatment - Enhanced Setting: Add option to allow Self-Stitch/PAK/IV only for Doctors

### DIFF
--- a/addons/medical_treatment/functions/fnc_canTreat.sqf
+++ b/addons/medical_treatment/functions/fnc_canTreat.sqf
@@ -47,7 +47,13 @@ private _config = configFile >> QGVAR(actions) >> _classname;
     (_medic isEqualTo player && {!isNull findDisplay 312}) || {
         // Conditions that apply when not in Zeus
         (
-            _medic != _patient || {GET_NUMBER_ENTRY(_config >> "allowSelfTreatment") == 1}
+            _medic != _patient || {
+                switch (GET_NUMBER_ENTRY(_config >> "allowSelfTreatment")) do {
+                    case 0: { false };
+                    case 1: { true };
+                    case 2: { [_medic, 2] call FUNC(isMedic) };
+                };
+            }
         ) && {
             [_medic, GET_NUMBER_ENTRY(_config >> "medicRequired")] call FUNC(isMedic)
         } && {

--- a/addons/medical_treatment/initSettings.inc.sqf
+++ b/addons/medical_treatment/initSettings.inc.sqf
@@ -277,7 +277,7 @@
     "LIST",
     [LSTRING(AllowSelfPAK_DisplayName), LSTRING(AllowSelfPAK_Description)],
     LSTRING(Category),
-    [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 0],
+    [[0, 1, 2], [ELSTRING(common,No), ELSTRING(common,Yes), LSTRING(Doctors)], 0],
     true
 ] call CBA_fnc_addSetting;
 
@@ -358,7 +358,7 @@
     "LIST",
     [LSTRING(AllowSelfIV_DisplayName), LSTRING(AllowSelfIV_Description)],
     LSTRING(Category),
-    [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 1],
+    [[0, 1, 2], [ELSTRING(common,No), ELSTRING(common,Yes), LSTRING(Doctors)], 1],
     true
 ] call CBA_fnc_addSetting;
 

--- a/addons/medical_treatment/initSettings.inc.sqf
+++ b/addons/medical_treatment/initSettings.inc.sqf
@@ -322,7 +322,7 @@
     "LIST",
     [LSTRING(AllowSelfStitch_DisplayName), LSTRING(AllowSelfStitch_Description)],
     LSTRING(Category),
-    [[0, 1], [ELSTRING(common,No), ELSTRING(common,Yes)], 0],
+    [[0, 1, 2], [ELSTRING(common,No), ELSTRING(common,Yes), LSTRING(Doctors)], 0],
     true
 ] call CBA_fnc_addSetting;
 


### PR DESCRIPTION
**When merged this pull request will:**

### fn_canTreat.sqf
- Enhanced handling of the allowSelfTreatment property:
  - New Case: `2`
    - Requires Medic to be a Doctor to perform Self Treatment

### initSettings.inc.sqf
- Added selectable Option, limiting selfstitching to only doctors.
  - Updated `QGVAR(allowSelfStitch)` Setting
  - Updated `QGVAR(allowSelfPAK)` Setting
  - Updated `QGVAR(allowSelfIV)` Setting


## Notes
- [x] I dont know if there's a better way to handle the check in `fn_canTreat.sqf`. Open to suggestions.
- [x] For the moment, i only used existing Stringtable entries. The setting: `Allow Self-Stitching` currently says `No, Yes, Doctors`.
  - Can upgrade to `No, Yes, Doctors Only` if needed but would require new stringtable entry.