### PR TITLE
Marking Laser - Fix parachute rpt spam

### DIFF
--- a/addons/markinglaser/CfgEventHandlers.hpp
+++ b/addons/markinglaser/CfgEventHandlers.hpp
@@ -20,6 +20,7 @@ class Extended_InitPost_EventHandlers {
     class Air {
         class ADDON {
             init = QUOTE(call FUNC(onAircraftInit));
+            exclude[] = {"ParachuteBase", QEGVAR(fastroping,helper), "ACE_friesBase", QEGVAR(refuel,helper)};
         };
     };
 };


### PR DESCRIPTION
```
[ACE] (markinglaser) INFO: Class B_Parachute_02_F does not have a pilot camera nor a turret that could be equipped with an IR marking laser.

