### PR TITLE
General - Fix remaining empty classes declared as extern

### DIFF
--- a/addons/dragon/CfgVehicles.hpp
+++ b/addons/dragon/CfgVehicles.hpp
@@ -1,8 +1,9 @@
 class CfgVehicles {
     class LandVehicle;
-    class StaticWeapon: LandVehicle    {
-        class Turrets;
-        class MainTurret;
+    class StaticWeapon: LandVehicle {
+        class Turrets {
+            class MainTurret;
+        };
         class ACE_Actions {
             class ACE_MainActions {};
         };

--- a/addons/dragon/CfgWeapons.hpp
+++ b/addons/dragon/CfgWeapons.hpp
@@ -4,9 +4,7 @@ class CfgWeapons {
     class missiles_titan;
     class Binocular;
     class Default;
-    class missiles_titan_static: missiles_titan {
-        class WeaponSlotsInfo;
-    };
+    class missiles_titan_static: missiles_titan {};
     class launch_Titan_F: launch_Titan_base {
         class WeaponSlotsInfo;
     };

--- a/addons/explosives/CfgMagazines.hpp
+++ b/addons/explosives/CfgMagazines.hpp
@@ -37,7 +37,7 @@ class CfgMagazines {
         GVAR(setupObject) = "ACE_Explosives_Place_APERSTripwireMine";
         class ACE_Triggers {
             SupportedTriggers[] = {"Tripwire"};
-            class Tripwire;
+            class Tripwire {};
         };
     };
     class ACE_FlareTripMine_Mag: APERSTripMine_Wire_Mag {
@@ -49,8 +49,8 @@ class CfgMagazines {
         class Library {libTextDesc = CSTRING(TripFlare_Description);};
         class ACE_Triggers {
             SupportedTriggers[] = {"Tripwire", "Tripwire_Airburst"};
-            class Tripwire;
-            class Tripwire_Airburst;
+            class Tripwire {};
+            class Tripwire_Airburst {};
         };
     };
     class ACE_FlareTripMine_Mag_Red: ACE_FlareTripMine_Mag {

--- a/addons/fcs/CfgOptics.hpp
+++ b/addons/fcs/CfgOptics.hpp
@@ -13,6 +13,7 @@
 
 class RscText;
 class RscControlsGroup;
+class RscControlsGroupNoScrollbars;
 class RscMapControl;
 
 class RscInGameUI {
@@ -27,7 +28,7 @@ class RscInGameUI {
     };
     class Rsc_ACE_Helo_UI_Turret: RscUnitInfo { // RscOptics_Heli_Attack_01_gunner
         onLoad = "[""onLoad"",_this,""RscUnitInfo"",'IGUI'] call    (uiNamespace getvariable 'BIS_fnc_initDisplay'); uiNamespace setVariable ['ACE_dlgRangefinder', _this select 0]; ((_this select 0) displayCtrl 151) ctrlSetTextColor [0, 0, 0, 0];";
-        class CA_IGUI_elements_group: RscControlsGroup {
+        class CA_IGUI_elements_group: RscControlsGroupNoScrollbars {
             class controls {
                 MACRO_RANGEFINDER
             };

--- a/addons/goggles/RscTitles.hpp
+++ b/addons/goggles/RscTitles.hpp
@@ -10,7 +10,7 @@ class RscTitles {
         movingEnable = 0;
         duration = 10e10;
         name = "RscACE_Goggles_BaseTitle";
-        class controls;
+        class controls {};
     };
 
     class RscACE_Goggles: RscACE_Goggles_BaseTitle {

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -477,7 +477,7 @@ class CfgVehicles {
         };
     };
     class APC_Wheeled_02_base_F: Wheeled_APC_F {
-        class GVAR(anims);
+        class GVAR(anims) {};
     };
     class APC_Wheeled_02_base_v2_F: APC_Wheeled_02_base_F {
         class GVAR(anims): GVAR(anims) {
@@ -591,7 +591,7 @@ class CfgVehicles {
     };
 
     class MBT_01_base_F: Tank_F {
-        class GVAR(anims);
+        class GVAR(anims) {};
     };
     class B_MBT_01_base_F: MBT_01_base_F {};
     class B_MBT_01_cannon_F: B_MBT_01_base_F {

--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -329,7 +329,7 @@ class CfgVehicles {
         // T100 Black Eagle
         // Assuming T80
         GVAR(fuelCapacity) = 1100;
-        class EGVAR(interaction,anims);
+        class EGVAR(interaction,anims) {};
     };
 
     class MBT_03_base_F: Tank_F {

--- a/addons/respawn/CfgVehicles.hpp
+++ b/addons/respawn/CfgVehicles.hpp
@@ -80,17 +80,17 @@ class CfgVehicles {
     class FlagCarrier;
     class Flag_NATO_F: FlagCarrier {
         class EventHandlers;
-        class ACE_Actions;
+        class ACE_Actions {};
     };
 
     class Flag_CSAT_F: FlagCarrier {
         class EventHandlers;
-        class ACE_Actions;
+        class ACE_Actions {};
     };
 
     class Flag_AAF_F: FlagCarrier {
         class EventHandlers;
-        class ACE_Actions;
+        class ACE_Actions {};
     };
 
     // static


### PR DESCRIPTION
fix
```
Note: 'z\ace\addons\goggles\config.cpp/RscTitles/RscACE_Goggles_BaseTitle.controls' is declared, but definition was not found. Creating empty class (source: z\ace\addons\goggles\config.cpp)
Note: 'z\ace\addons\interaction\config.cpp/CfgVehicles/APC_Wheeled_02_base_F.ace_interaction_anims' is declared, but definition was not found. Creating empty class (source: z\ace\addons\interaction\config.cpp)
Note: 'z\ace\addons\interaction\config.cpp/CfgVehicles/MBT_01_base_F.ace_interaction_anims' is declared, but definition was not found. Creating empty class (source: z\ace\addons\interaction\config.cpp)
Note: 'z\ace\addons\refuel\config.cpp/CfgVehicles/MBT_02_base_F.ace_interaction_anims' is declared, but definition was not found. Creating empty class (source: z\ace\addons\refuel\config.cpp)
Note: 'z\ace\addons\respawn\config.cpp/CfgVehicles/Flag_NATO_F.ACE_Actions' is declared, but definition was not found. Creating empty class (source: z\ace\addons\respawn\config.cpp)
Note: 'z\ace\addons\respawn\config.cpp/CfgVehicles/Flag_CSAT_F.ACE_Actions' is declared, but definition was not found. Creating empty class (source: z\ace\addons\respawn\config.cpp)
Note: 'z\ace\addons\respawn\config.cpp/CfgVehicles/Flag_AAF_F.ACE_Actions' is declared, but definition was not found. Creating empty class (source: z\ace\addons\respawn\config.cpp)
Note: 'z\ace\addons\explosives\config.cpp/CfgMagazines/APERSTripMine_Wire_Mag/ACE_Triggers.Tripwire' is declared, but definition was not found. Creating empty class (source: z\ace\addons\explosives\config.cpp)
Note: 'z\ace\addons\explosives\config.cpp/CfgMagazines/ACE_FlareTripMine_Mag/ACE_Triggers.Tripwire' is declared, but definition was not found. Creating empty class (source: z\ace\addons\explosives\config.cpp)
Note: 'z\ace\addons\explosives\config.cpp/CfgMagazines/ACE_FlareTripMine_Mag/ACE_Triggers.Tripwire_Airburst' is declared, but definition was not found. Creating empty class (source: z\ace\addons\explosives\config.cpp)
Updating base class RscControlsGroupNoScrollbars->RscControlsGroup, by z\ace\addons\fcs\config.cpp/RscInGameUI/Rsc_ACE_Helo_UI_Turret/CA_IGUI_elements_group/ (original (no unload))
Note: 'z\ace\addons\dragon\config.cpp/CfgWeapons/missiles_titan_static.WeaponSlotsInfo' is declared, but definition was not found. Creating empty class (source: z\ace\addons\dragon\config.cpp)
Note: 'z\ace\addons\dragon\config.cpp/CfgVehicles/StaticWeapon.MainTurret' is declared, but definition was not found. Creating empty class (source: z\ace\addons\dragon\config.cpp)
```