### PR TITLE
Nightvision - Fix script error when switching to thermals

### DIFF
--- a/addons/nightvision/functions/fnc_onVisionModeChanged.sqf
+++ b/addons/nightvision/functions/fnc_onVisionModeChanged.sqf
@@ -39,9 +39,9 @@ if (GVAR(effectScaling) == 0) exitWith {
 
 // Start PFEH when entering night vision mode:
 if (_visionMode > 0) then {
+    [true] call FUNC(setupDisplayEffects); // always reset effects (switching from NVG to Thermal)
     if (GVAR(PFID) == -1) then {
         GVAR(running) = true;
-        [true] call FUNC(setupDisplayEffects);
         [] call FUNC(refreshGoggleType);
         GVAR(PFID) = [LINKFUNC(pfeh), 0, []] call CBA_fnc_addPerFrameHandler;
         GVAR(firedEHs) = [

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -57,6 +57,9 @@ if (GVAR(defaultPositionBorder) isNotEqualTo []) then {
 };
 END_COUNTER(borderScaling);
 
+// Skip all other effects if just in thermal
+if (currentVisionMode _unit > 1) exitWith {};
+
 if (IS_MAGNIFIED isNotEqualTo GVAR(isUsingMagnification)) then {
     GVAR(isUsingMagnification) = IS_MAGNIFIED;
     GVAR(nextEffectsUpdate) = -1;

--- a/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
+++ b/addons/nightvision/functions/fnc_setupDisplayEffects.sqf
@@ -48,6 +48,7 @@ if (GVAR(fogScaling) > 0) then {
             0 setFog GVAR(priorFog);
             GVAR(priorFog) = nil;
         } else {
+            if (currentVisionMode _unit > 1) exitWith {}; // Don't error if switching directly to thermal
             ERROR("no fog backed up");
         };
 


### PR DESCRIPTION
```
_fogApply = linearConversion [0, 1, ace_nightvision_>
 Error position: <linearConversion [0, 1, ace_nightvision_>
 Error Type Any, expected Number
File z\ace\addons\nightvision\functions\fnc_pfeh.sqf..., line 165
```
fix script error when going directly to thermals
e.g. the MX binoc from ace or some mods that have vics with just thermals (no nvg first)

also skips all other effects if just in thermal

