### PR TITLE
vehicle_damange - Tweak spam filter to allow submunition penetrators

### DIFF
--- a/addons/vehicle_damage/dev/viewHitpoints.sqf
+++ b/addons/vehicle_damage/dev/viewHitpoints.sqf
@@ -2,22 +2,28 @@
     private _targets = lineIntersectsWith [eyePos ACE_PLAYER, AGLToASL screenToWorld [0.5, 0.5], vehicle ACE_PLAYER, ACE_PLAYER, true];
     if (_targets isEqualTo []) exitWith {};
     private _target = _targets select -1;
-    private _center = _target modelToWorldVisualWorld getCenterOfMass _target;
 
-    private _selections = (_target selectionNames "HitPoints") select { (_target selectionPosition [_x, "HitPoints"]) isNotEqualTo [0, 0, 0] };
+    (getAllHitPointsDamage _target) params ["_hitpointNames", "_selectionNames", "_damages"];
     {
-        private _position = _center vectorAdd (_target selectionPosition [_x, "HitPoints"]);
-        private _damage = _target getHitPointDamage _x;
+        private _relativePosition = _target selectionPosition _x;
+        if (_relativePosition isEqualTo [0, 0, 0]) then { continue };
+        private _position = _target modelToWorldVisualWorld _relativePosition;
+        private _damage = _damages select _forEachIndex;
 
         drawIcon3D [
             "\a3\ui_f\data\IGUI\Cfg\Cursors\selectover_ca.paa",
-            vectorLinearConversion [0, 1, _damage, [1, 0, 0, 1], [1, 1, 1, 1]],
+            [
+                (vectorLinearConversion [0, 1, 1 - _damage, [1, 0, 0], [1, 1, 1]]) + [1],
+                [1, 1, 1, 1]
+            ],
             ASLToAGL _position,
-            0.2,
-            0.2,
+            0.6,
+            0.6,
             0,
-            "",
-            2
+            format ["%1=%2", _x, _damage],
+            true,
+            0.022,
+            "PuristaLight"
         ];
-    } forEach _selections;
+    } forEach _selectionNames;
 }] call CBA_fnc_addPerFrameHandler;

--- a/addons/vehicle_damage/dev/viewHitpoints.sqf
+++ b/addons/vehicle_damage/dev/viewHitpoints.sqf
@@ -5,6 +5,7 @@
 
     (getAllHitPointsDamage _target) params ["_hitpointNames", "_selectionNames", "_damages"];
     {
+        if (_x isEqualTo "") then { continue };
         private _relativePosition = _target selectionPosition _x;
         if (_relativePosition isEqualTo [0, 0, 0]) then { continue };
         private _position = _target modelToWorldVisualWorld _relativePosition;

--- a/addons/vehicle_damage/dev/viewHitpoints.sqf
+++ b/addons/vehicle_damage/dev/viewHitpoints.sqf
@@ -1,0 +1,23 @@
+[{
+    private _targets = lineIntersectsWith [eyePos ACE_PLAYER, AGLToASL screenToWorld [0.5, 0.5], vehicle ACE_PLAYER, ACE_PLAYER, true];
+    if (_targets isEqualTo []) exitWith {};
+    private _target = _targets select -1;
+    private _center = _target modelToWorldVisualWorld getCenterOfMass _target;
+
+    private _selections = (_target selectionNames "HitPoints") select { (_target selectionPosition [_x, "HitPoints"]) isNotEqualTo [0, 0, 0] };
+    {
+        private _position = _center vectorAdd (_target selectionPosition [_x, "HitPoints"]);
+        private _damage = _target getHitPointDamage _x;
+
+        drawIcon3D [
+            "\a3\ui_f\data\IGUI\Cfg\Cursors\selectover_ca.paa",
+            vectorLinearConversion [0, 1, _damage, [1, 0, 0, 1], [1, 1, 1, 1]],
+            ASLToAGL _position,
+            0.2,
+            0.2,
+            0,
+            "",
+            2
+        ];
+    } forEach _selections;
+}] call CBA_fnc_addPerFrameHandler;

--- a/addons/vehicle_damage/functions/fnc_handleVehicleDamage.sqf
+++ b/addons/vehicle_damage/functions/fnc_handleVehicleDamage.sqf
@@ -67,7 +67,6 @@ private _multHit = _vehicle getVariable [QGVAR(hitTime), createHashMap];
 
 private _key = format ["%1:%2", _projectile, _source];
 
-systemChat str ["should banng?", _projectile, _multHit];
 if !(_key in _multHit) then {
     _multHit set [_key, [CBA_missionTime, [_hitPoint]]];
 } else {
@@ -75,8 +74,6 @@ if !(_key in _multHit) then {
     _stateArray params ["_lastHitTime", "_hitArray"];
     private _hitPointInOldArray = _hitPoint in _hitArray;
     private _withinTime = CBA_missionTime <= _lastHitTime + CONST_TIME;
-
-    systemChat str ["bang!", _hitpointInOldArray, _withinTime, _projectile];
 
     if (_hitPointInOldArray && _withinTime) then {
         _ignoreHit = true;

--- a/addons/vehicle_damage/script_component.hpp
+++ b/addons/vehicle_damage/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\z\ace\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_VEHICLE_DAMAGE


### PR DESCRIPTION
**When merged this pull request will:**
- Apply better filter to allow penetrators to not be filtered if penetrating in the same frame

Instead of a global timer, it is per-penetrator and per-shooter. Some cases will still be grabbed. In practice, this makes CUP vs CUP and RHS vs CUP a _tiny_ bit better in terms of gameplay

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
