### PR TITLE
CSW - Fix 2.20 mk6 illumination round

### DIFF
--- a/addons/csw/CfgMagazineGroups.hpp
+++ b/addons/csw/CfgMagazineGroups.hpp
@@ -63,6 +63,7 @@ class GVAR(groups) {
     };
     class ACE_1Rnd_82mm_Mo_Illum {
         ACE_1Rnd_82mm_Mo_Illum = 1;
+        8Rnd_82mm_Mo_Flare_white_illumination = 1;
         8Rnd_82mm_Mo_Flare_white = 1;
         rhs_mag_3vs25m_10 = 1;
     };

--- a/addons/mk6mortar/CfgMagazines.hpp
+++ b/addons/mk6mortar/CfgMagazines.hpp
@@ -29,8 +29,8 @@ class CfgMagazines {
         picture = QPATHTOF(UI\w_l16_ammo_smk_white_ca.paa);
         mass = 50;
     };
-    class 8Rnd_82mm_Mo_Flare_white;
-    class ACE_1Rnd_82mm_Mo_Illum: 8Rnd_82mm_Mo_Flare_white {
+    class 8Rnd_82mm_Mo_Flare_white_illumination;
+    class ACE_1Rnd_82mm_Mo_Illum: 8Rnd_82mm_Mo_Flare_white_illumination {
         count = 1;
         scope = 2;
         scopeCurator = 2;

--- a/addons/mk6mortar/functions/fnc_csw_getProxyWeapon.sqf
+++ b/addons/mk6mortar/functions/fnc_csw_getProxyWeapon.sqf
@@ -42,6 +42,7 @@ if (_proxyWeaponNeeded || GVAR(useAmmoHandling)) then {
             case (_xMag == "8Rnd_82mm_Mo_shells"): {"ACE_1Rnd_82mm_Mo_HE"};
             case (_xMag == "8Rnd_82mm_Mo_Smoke_white"): {"ACE_1Rnd_82mm_Mo_Smoke"};
             case (_xMag == "8Rnd_82mm_Mo_Flare_white"): {"ACE_1Rnd_82mm_Mo_Illum"};
+            case (_xMag == "8Rnd_82mm_Mo_Flare_white_illumination"): {"ACE_1Rnd_82mm_Mo_Illum"};
             case (_xMag == "8Rnd_82mm_Mo_guided"): {"ACE_1Rnd_82mm_Mo_HE_Guided"};
             case (_xMag == "8Rnd_82mm_Mo_LG"): {"ACE_1Rnd_82mm_Mo_HE_LaserGuided"};
                 default {""};


### PR DESCRIPTION
Fix #10986

Allows unloading the new illum rounds
Changes the CSW magazine to use the new ammo type


This does means both new and old vanilla flare mags will unload to the same ace mag
but our description for the round was always `[CSW] 82mm Illumination Round`
so I think this is fine, but I could also add a brand new mag if desired