### PR TITLE
vehicleDamage - Change fnc_processHit AP Damage Reduction

### DIFF
--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -60,7 +60,7 @@ private _indirectHit = getNumber (_projectileConfig >> "indirectHit");
 if (_warheadType == WARHEAD_TYPE_AP) then {
     // Change damage based on projectile speed (doesn't do this in vanilla Arma believe it or not)
     if (!isNull _source && !("penetrator" in toLowerANSI _projectile)) then {
-        private _typicalSpeed = getNumber (_projectileConfig >> "typicalSpeed");
+        private _typicalSpeed = 100 max (getNumber (_projectileConfig >> "typicalSpeed"));
         private _airFriction = getNumber (_projectileConfig >> "airFriction");
         private _distance = _source distance _vehicle;
         private _tofCoef = _airFriction * _distance / _typicalSpeed;

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -20,8 +20,6 @@
  *
  * Public: No
  */
-#define COARSE_SIM_STEP 0.1
-#define COARSE_SIM_STEP_INV 10
 params ["_vehicle", "_hitPoint", "_hitIndex", "_addedDamage", "_projectile", "_source", "_instigator"];
 TRACE_7("processHit",_vehicle,_hitPoint,_hitIndex,_addedDamage,_projectile,_source,_instigator);
 
@@ -62,13 +60,11 @@ if (_warheadType == WARHEAD_TYPE_AP) then {
     // Change damage based on projectile speed (doesn't do this in vanilla Arma believe it or not)
     if (!isNull _source) then {
         private _typicalSpeed = getNumber (_projectileConfig >> "typicalSpeed");
-        private _dragSimCoef = COARSE_SIM_STEP * getNumber (_projectileConfig >> "airFriction");
+        private _airFriction = getNumber (_projectileConfig >> "airFriction");
         private _distance = _source distance _vehicle;
-        private _speed = _typicalSpeed;
-        for "_i" from 0 to (COARSE_SIM_STEP_INV * _distance / _typicalSpeed) do {
-            _speed = _speed + _dragSimCoef * _speed ^ 2;
-        };
-        _addedDamage = (1 - _projectileExplosive) * _addedDamage * _speed / _typicalSpeed;
+        private _tofCoef = _airFriction * _distance / _typicalSpeed;
+        private _damageMod = 1 / ((-_airFriction) ^ _tofCoef - _typicalSpeed * _tofCoef);
+        _addedDamage = (1 - _projectileExplosive) * _addedDamage * _damageMod;
     };
 };
 

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -61,8 +61,9 @@ if (_warheadType == WARHEAD_TYPE_AP) then {
     // Change damage based on projectile speed (doesn't do this in vanilla Arma believe it or not)
     if (!isNull _source) then {
         private _airFriction = getNumber (_projectileConfig >> "airFriction");
+        private _typicalSpeed = getNumber (_projectileConfig >> "typicalSpeed");
         private _distance = _source distance _vehicle;
-        _addedDamage = (1 - _projectileExplosive) * _addedDamage * exp (_airFriction * _distance);
+        _addedDamage = (1 - _projectileExplosive) * _addedDamage * exp (_airFriction * _distance / _typicalSpeed );
     };
 };
 

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -63,6 +63,7 @@ if (_warheadType == WARHEAD_TYPE_AP) then {
         private _airFriction = getNumber (_projectileConfig >> "airFriction");
         private _distance = _source distance _vehicle;
         private _tofCoef = _airFriction * _distance / _typicalSpeed;
+        // Modified logistics map upper bound, using estimated velocity / initial for damage mod
         private _damageMod = 1 / ((-_airFriction) ^ _tofCoef - _typicalSpeed * _tofCoef);
         _addedDamage = (1 - _projectileExplosive) * _addedDamage * _damageMod;
     };

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -20,7 +20,8 @@
  *
  * Public: No
  */
-
+#define COARSE_SIM_STEP 0.1
+#define COARSE_SIM_STEP_INV 10
 params ["_vehicle", "_hitPoint", "_hitIndex", "_addedDamage", "_projectile", "_source", "_instigator"];
 TRACE_7("processHit",_vehicle,_hitPoint,_hitIndex,_addedDamage,_projectile,_source,_instigator);
 
@@ -60,10 +61,14 @@ private _indirectHit = getNumber (_projectileConfig >> "indirectHit");
 if (_warheadType == WARHEAD_TYPE_AP) then {
     // Change damage based on projectile speed (doesn't do this in vanilla Arma believe it or not)
     if (!isNull _source) then {
-        private _airFriction = getNumber (_projectileConfig >> "airFriction");
         private _typicalSpeed = getNumber (_projectileConfig >> "typicalSpeed");
+        private _dragSimCoef = COARSE_SIM_STEP * getNumber (_projectileConfig >> "airFriction");
         private _distance = _source distance _vehicle;
-        _addedDamage = (1 - _projectileExplosive) * _addedDamage * exp (_airFriction * _distance / _typicalSpeed );
+        private _speed = _typicalSpeed;
+        for "_i" from 0 to (COARSE_SIM_STEP_INV * _distance / _typicalSpeed) do {
+            _speed = _speed + _dragSimCoef * _speed ^ 2;
+        };
+        _addedDamage = (1 - _projectileExplosive) * _addedDamage * _speed / _typicalSpeed;
     };
 };
 

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -64,7 +64,8 @@ if (_warheadType == WARHEAD_TYPE_AP) then {
         private _airFriction = getNumber (_projectileConfig >> "airFriction");
         private _distance = _source distance _vehicle;
         private _tofCoef = _airFriction * _distance / _typicalSpeed;
-        // Modified logistics map upper bound, using estimated speed / typical speed for damage mod
+        // Modified logistics map upper bound for v(n) = v(n-1) + dt * airFriction * v(n-1)^2
+        // Using estimated speed / typical speed for damage mod
         private _damageMod = 1 / ((-_airFriction) ^ _tofCoef - _typicalSpeed * _tofCoef);
         _addedDamage = (1 - _projectileExplosive) * _addedDamage * _damageMod;
     };

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -58,7 +58,7 @@ private _indirectHit = getNumber (_projectileConfig >> "indirectHit");
 
 if (_warheadType == WARHEAD_TYPE_AP) then {
     // Change damage based on projectile speed (doesn't do this in vanilla Arma believe it or not)
-    if (!isNull _source) then {
+    if (!isNull _source && !("penetrator" in toLowerANSI _projectile)) then {
         private _typicalSpeed = getNumber (_projectileConfig >> "typicalSpeed");
         private _airFriction = getNumber (_projectileConfig >> "airFriction");
         private _distance = _source distance _vehicle;


### PR DESCRIPTION
**When merged this pull request will:**
- Changes `_addedDamage` modification to work as a function of a very rough estimation of time of flight.
  - Current implementation relies on `_airFriction * _distance` resulting in large reductions in damage for projectiles with non-infinitesimal `"airFriction"` values. i.e., RHS uses penetrators for their AP ammo with airFriction of `-0.08` resulting in shots at 200m applying ~1e-7 damage
  - This doesn't account for projectile bounces or deflections, but neither did the old method.
  - Previous version reduced damage by typically by ~5% for typical AP projectiles at 1km, this results in damage reduction from 10% to 30% for typical AP projectiles at 1km

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
