### PR TITLE
Improve Aircraft - Fix turret returning to old stabilized position

### DIFF
--- a/addons/aircraft/XEH_postInit.sqf
+++ b/addons/aircraft/XEH_postInit.sqf
@@ -15,7 +15,7 @@ if (hasInterface) then {
         if (isNull _vehicle) exitWith {};
 
         private _turret = _vehicle unitTurret ACE_player;
-        if (_turret isEqualTo [] || {_turret isEqualTo [-1]}) exitWith {};
+        if (_turret in [[], [-1]]) exitWith {};
 
         private _opticsCfg = "true" configClasses (([typeOf _vehicle, _turret] call CBA_fnc_getTurret) >> "OpticsIn");
         private _count = count _opticsCfg;

--- a/addons/aircraft/XEH_postInit.sqf
+++ b/addons/aircraft/XEH_postInit.sqf
@@ -5,4 +5,28 @@
 
 if (hasInterface) then {
     ["ACE_controlledUAV", LINKFUNC(droneAddActions)] call CBA_fnc_addEventHandler;
+
+    // Fix turret returning to old stabilized position when zooming in from unstabilized mode to stabilized mode
+    addUserActionEventHandler ["zoomIn", "Activate", {
+        // In Zeus or Splendid Camera cameraView = "INTERNAL"
+        if (cameraView isNotEqualTo "GUNNER") exitWith {};
+
+        private _vehicle = objectParent ACE_player;
+        if (isNull _vehicle) exitWith {};
+
+        private _turret = _vehicle unitTurret ACE_player;
+        if (_turret isEqualTo [] || {_turret isEqualTo [-1]}) exitWith {};
+
+        private _opticsCfg = "true" configClasses (([typeOf _vehicle, _turret] call CBA_fnc_getTurret) >> "OpticsIn");
+        private _count = count _opticsCfg;
+        private _currOpticsMode = _vehicle getTurretOpticsMode _turret;
+        if (_count < 2 || {_currOpticsMode + 1 == _count}) exitWith {};
+
+        private _currStabilized = getNumber (_opticsCfg select _currOpticsMode >> "directionStabilized");
+        private _nextStabilized = getNumber (_opticsCfg select (_currOpticsMode + 1) >> "directionStabilized");
+        if (_currStabilized != 0 || {_nextStabilized != 1}) exitWith {};
+
+        _vehicle lockCameraTo [positionCameraToWorld [0, 0, 1000], _turret, true];
+        [{ _vehicle lockCameraTo [objNull, _turret, true]; }] call cba_fnc_execNextFrame;
+    }];
 };

--- a/addons/aircraft/XEH_postInit.sqf
+++ b/addons/aircraft/XEH_postInit.sqf
@@ -26,7 +26,7 @@ if (hasInterface) then {
         private _nextStabilized = getNumber (_opticsCfg select (_currOpticsMode + 1) >> "directionStabilized");
         if (_currStabilized != 0 || {_nextStabilized != 1}) exitWith {};
 
-        _vehicle lockCameraTo [positionCameraToWorld [0, 0, 1000], _turret, true];
+        _vehicle lockCameraTo [AGLToASL positionCameraToWorld [0, 0, 1000], _turret, true];
         [{ params ["_vehicle", "_turret"]; _vehicle lockCameraTo [objNull, _turret, true]; }, [_vehicle, _turret]] call CBA_fnc_execNextFrame;
     }];
 };

--- a/addons/aircraft/XEH_postInit.sqf
+++ b/addons/aircraft/XEH_postInit.sqf
@@ -27,6 +27,6 @@ if (hasInterface) then {
         if (_currStabilized != 0 || {_nextStabilized != 1}) exitWith {};
 
         _vehicle lockCameraTo [positionCameraToWorld [0, 0, 1000], _turret, true];
-        [{ _vehicle lockCameraTo [objNull, _turret, true]; }] call cba_fnc_execNextFrame;
+        [{ params ["_vehicle", "_turret"]; _vehicle lockCameraTo [objNull, _turret, true]; }, [_vehicle, _turret]] call CBA_fnc_execNextFrame;
     }];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix turret returning to old stabilized position when zooming in from unstabilized mode to stabilized mode
- Currently ace adds turret optics modes `ACE_Wide: ACE_WideUnstabilized`. When zooming in from ACE_WideUnstabilized to ACE_Wide (stabilized), the turret will return to where it was last stabilized. Thus if the player had previously slewed the camera while in ACE_WideUnstabilized, then on zoom-in the camera will move uncommanded.
- This pr checks for such an occurrence and prevents the move by locking the turret to the current target position for 1 frame then unlocking it.
- https://www.youtube.com/watch?v=KXQA1u3yoW8