### PR TITLE
Advanced Throwing - Add gunner as a parameter in Throw Fired XEH

### DIFF
--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -58,7 +58,7 @@ _unit setVariable [QGVAR(activeThrowable), _activeThrowable];
 deleteVehicle _activeThrowableOld;
 
 // Set _gunner for Throw Fired XEH
-_gunner = _unit;
+private _gunner = _unit;
 
 // Throw Fired XEH
 [QGVAR(throwFiredXEH), [

--- a/addons/advanced_throwing/functions/fnc_prime.sqf
+++ b/addons/advanced_throwing/functions/fnc_prime.sqf
@@ -57,6 +57,9 @@ private _activeThrowable = createVehicle [_throwableType, _activeThrowableOld, [
 _unit setVariable [QGVAR(activeThrowable), _activeThrowable];
 deleteVehicle _activeThrowableOld;
 
+// Set _gunner for Throw Fired XEH
+_gunner = _unit;
+
 // Throw Fired XEH
 [QGVAR(throwFiredXEH), [
     _unit, // unit
@@ -65,7 +68,8 @@ deleteVehicle _activeThrowableOld;
     _muzzle, // mode
     _throwableType, // ammo
     _throwableMag, // magazine
-    _activeThrowable // projectile
+    _activeThrowable, // projectile
+    _gunner // gunner
 ]] call CBA_fnc_globalEvent;
 
 // Set prime instigator


### PR DESCRIPTION
**When merged this pull request will:**
- _Add gunner as a parameter in Throw Fired XEH_
- _~Each change in a separate line~_

**Explain:**
According to the [BI wiki](https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#Fired), gunner is available as a parameter in Fired EH since 1.66.
This PR simply use `_unit` in `FUNC(prime)` as gunner, and the `_unit` is from: 
https://github.com/acemod/ACE3/blob/7adb188b854316defa076d4ecd9d8f1287ebb2d8/addons/advanced_throwing/functions/fnc_onMouseButtonDown.sqf#L45
https://github.com/acemod/ACE3/blob/7adb188b854316defa076d4ecd9d8f1287ebb2d8/addons/advanced_throwing/functions/fnc_throw.sqf#L24
So it should matches the BI wiki parameter explain "gunner whose weapons are firing"

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
