### PR TITLE
Overheating - Fix not being able to cool weapons when sitting and inside vehicles

### DIFF
--- a/addons/overheating/CfgVehicles.hpp
+++ b/addons/overheating/CfgVehicles.hpp
@@ -30,16 +30,16 @@ class CfgVehicles {
                 };
                 class GVAR(CheckTemperatureSpareBarrels) {
                     displayName = CSTRING(CheckTemperatureSpareBarrelsShort);
-                    condition = QUOTE((_player) call FUNC(canCheckSpareBarrelsTemperatures));
+                    condition = QUOTE(_player call FUNC(canCheckSpareBarrelsTemperatures));
                     exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};
-                    statement = QUOTE([_player] call FUNC(checkSpareBarrelsTemperatures));
+                    statement = QUOTE(_player call FUNC(checkSpareBarrelsTemperatures));
                     showDisabled = 0;
                     icon = QUOTE(PATHTOF(UI\temp_ca.paa));
                 };
                 class GVAR(CoolWeaponWithItem) {
                     displayName = CSTRING(CoolWeaponWithItem);
                     condition = QUOTE(call FUNC(canCoolWeaponWithItem));
-                    exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};
+                    exceptions[] = {"isNotInside", "isNotSitting"};
                     statement = "true";
                     showDisabled = 0;
                     insertChildren = QUOTE(_player call FUNC(getConsumableChildren));
@@ -67,7 +67,7 @@ class CfgVehicles {
                 class GVAR(CoolWeaponWithItem) {
                     displayName = CSTRING(CoolWeaponWithItem);
                     condition = QUOTE(call FUNC(canCoolWeaponWithItem));
-                    exceptions[] = {"isNotInside", "isNotSwimming", "isNotSitting"};
+                    exceptions[] = {"isNotInside", "isNotSitting"};
                     statement = "true";
                     showDisabled = 0;
                     insertChildren = QUOTE(_player call FUNC(getConsumableChildren));

--- a/addons/overheating/functions/fnc_coolWeaponWithItem.sqf
+++ b/addons/overheating/functions/fnc_coolWeaponWithItem.sqf
@@ -94,5 +94,6 @@ private _fnc_condition = {
     _fnc_onSuccess,
     {}, //_fnc_onFailure,
     _consumeText,
-    _fnc_condition
+    _fnc_condition,
+    ["isNotInside", "isNotSitting"]
 ] call EFUNC(common,progressBar);

--- a/addons/overheating/initSettings.inc.sqf
+++ b/addons/overheating/initSettings.inc.sqf
@@ -6,8 +6,8 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     _category,
     true,
     1,
-    {},
-    true
+    {[QGVAR(enabled), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [
@@ -18,10 +18,9 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     1,
     {
         if (!GVAR(enabled)) exitWith {};
-        TRACE_2("reseting cache",GVAR(heatCoef),count GVAR(cacheAmmoData));
+        TRACE_2("resetting cache",GVAR(heatCoef),count GVAR(cacheAmmoData));
         GVAR(cacheAmmoData) = createHashMap;
-    },
-    false
+    }
 ] call CBA_fnc_addSetting;
 
 [
@@ -29,9 +28,7 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     [LSTRING(coolingCoef_displayName), LSTRING(coolingCoef_description)],
     _category,
     [0, 5, 1, 2],
-    1,
-    {},
-    true
+    1
 ] call CBA_fnc_addSetting;
 
 [
@@ -42,10 +39,9 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     1,
     {
         if (!GVAR(enabled)) exitWith {};
-        TRACE_2("reseting cache",GVAR(suppressorCoef),count GVAR(cacheSilencerData));
+        TRACE_2("resetting cache",GVAR(suppressorCoef),count GVAR(cacheSilencerData));
         GVAR(cacheSilencerData) = createHashMap;
-    },
-    false
+    }
 ] call CBA_fnc_addSetting;
 
 [
@@ -62,8 +58,8 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     _category,
     false,
     0,
-    {},
-    true
+    {[QGVAR(showParticleEffectsForEveryone), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [
@@ -72,8 +68,8 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     _category,
     true,
     1,
-    {},
-    true
+    {[QGVAR(overheatingDispersion), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [
@@ -114,8 +110,8 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     _category,
     false,
     1,
-    {},
-    true
+    {[QGVAR(unJamOnreload), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [
@@ -140,6 +136,6 @@ private _category = format ["ACE %1", localize LSTRING(DisplayName)];
     _category,
     [0, 5, 1, 2],
     1,
-    {},
-    true
+    {[QGVAR(cookoffCoef), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove ability to cool weapons when swimming, as it a) doesn't make sense and b) they cool well anyway.
- Add ability to cool weapons when inside vehicles and when sitting. Afaik this existed at some point, but `EFUNC(common,progressBar)` was missing the necessary exceptions to actually do it.
- Add restart notification to settings that require restarts to take effect.
- Minor code cleanup.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
