### PR TITLE
Interaction - Fix showing weapon attachment icon

### DIFF
--- a/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
+++ b/addons/interaction/functions/fnc_switchWeaponAttachment.sqf
@@ -71,7 +71,11 @@ if (!_addNew) exitWith {};
 
     if (_unit != ACE_player) exitWith {};
 
-    [[getText (configFile >> "CfgWeapons" >> _newAttachment >> "picture"), 4], true] call CBA_fnc_notify;
+    private _itemPicture = getText (configFile >> "CfgWeapons" >> _newAttachment >> "picture");
+    if (!fileExists _itemPicture) then { _itemPicture = _itemPicture + ".paa"; }; // notify needs full path to exist, try adding .paa
+    if (fileExists _itemPicture) then {
+        [[_itemPicture, 4], true] call CBA_fnc_notify;
+    };
 
     playSound "click";
 }, [_unit, _weapon, _newAttachment], 1] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
e.g. GM G3 Bayonet
`"\gm\gm_weapons\gm_attachments\gm_muzzles\gm_bayonet_g3\data\ui\picture_gm_bayonet_g3_blk_ca"`
missing .paa, shows up as raw text
![20250706134009_1](https://github.com/user-attachments/assets/394c7b7d-47de-48fb-a2a3-4a125b2ee69e)
