### PR TITLE
Laser - Fix TGP Drift while Designating in AREA Track

### DIFF
--- a/addons/laser/functions/fnc_laserPointTrack.sqf
+++ b/addons/laser/functions/fnc_laserPointTrack.sqf
@@ -28,8 +28,8 @@ params ["_vehicle"];
         private _laserTargetPos = getPosASL (laserTarget _vehicle);
         private _pilotCameraPos = _vehicle modelToWorldVisualWorld (getPilotCameraPosition _vehicle);
         private _pilotCameraVector = _pilotCameraPos vectorFromTo _laserTargetPos;
-        private _laserDistance = _pilotCameraPos distance _laserTargetPos;
-        private _spotDistance = _spotPos distance _laserTargetPos;
+        private _laserDistance = _pilotCameraPos vectorDistance _laserTargetPos;
+        private _spotDistance = _spotPos vectorDistance _laserTargetPos;
         if (_spotDistance > 3.5) then {
             private _vehPos = getPosASL _vehicle;
             private _vectorToLaser = _pilotCameraPos vectorFromTo _laserTargetPos;

--- a/addons/laser/functions/fnc_laserPointTrack.sqf
+++ b/addons/laser/functions/fnc_laserPointTrack.sqf
@@ -25,13 +25,16 @@ params ["_vehicle"];
     (getPilotCameraTarget _vehicle) params ["_isTracking", "_spotPos", "_targetObj"];
     if (!_isTracking) exitWith {};
     if (isNull _targetObj) then {
-        private _laserTargetPos = getPosASL laserTarget _vehicle;
-        private _distance = _spotPos distance _laserTargetPos;
-        if (_distance > 0.15) then {
+        private _laserTargetPos = getPosASL (laserTarget _vehicle);
+        private _pilotCameraPos = _vehicle modelToWorldVisualWorld (getPilotCameraPosition _vehicle);
+        private _pilotCameraVector = _pilotCameraPos vectorFromTo _laserTargetPos;
+        private _laserDistance = _pilotCameraPos distance _laserTargetPos;
+        private _spotDistance = _spotPos distance _laserTargetPos;
+        if (_spotDistance > 3.5) then {
             private _vehPos = getPosASL _vehicle;
-            private _vectorToLaser = _vehPos vectorFromTo _laserTargetPos;
-            private _vectorToSpot = _vehPos vectorFromTo _spotPos;
-            if (acos (_vectorToLaser vectorCos _vectorToSpot) < 0.025) then {
+            private _vectorToLaser = _pilotCameraPos vectorFromTo _laserTargetPos;
+            private _vectorToSpot = _pilotCameraPos vectorFromTo _spotPos;
+            if (acos (_vectorToLaser vectorCos _vectorToSpot) < 0.015) then {
                 _vehicle setPilotCameraTarget _laserTargetPos;
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the TGP of aircraft drifting across terrain while laser designating in AREA track, mainly when looking far towards the sides of the aircraft.
  Ref https://github.com/acemod/ACE3/issues/10766#issuecomment-2693065582
  Fixes #10766 
  Fixes #9968