### PR TITLE
Interaction - Fix pardon EH

### DIFF
--- a/addons/interaction/XEH_postInit.sqf
+++ b/addons/interaction/XEH_postInit.sqf
@@ -3,7 +3,10 @@
 
 ACE_Modifier = 0;
 
-[QGVAR(pardon), {(_this select 0) addRating -rating (_this select 0)}] call CBA_fnc_addEventHandler;
+[QGVAR(pardon), {
+    params ["_unit"];
+    _unit addRating -rating _unit
+}] call CBA_fnc_addEventHandler;
 
 [QGVAR(getDown), {
     params ["_target"];


### PR DESCRIPTION
**When merged this pull request will:**
- The pardon EH expects an array to be passed, but fnc_pardon just passes the unit. Fixed by just using `params` so either an object or array can be passed

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
