### PR TITLE
Map - Add support for facewear with flashlights, fix wrong config lookups in some cases

### DIFF
--- a/addons/map/functions/fnc_compileFlashlightMenu.sqf
+++ b/addons/map/functions/fnc_compileFlashlightMenu.sqf
@@ -26,7 +26,7 @@ _unitLight params ["_flashlight", ""];
 
 //add all carried flashlight menus and on/off submenu actions
 {
-    private _cfg = (configFile >> "CfgWeapons" >> _x);
+    private _cfg = _x call CBA_fnc_getItemConfig;
     private _displayName = getText (_cfg >> "displayName");
     private _icon = getText (_cfg >> "picture");
 

--- a/addons/map/functions/fnc_flashlightGlow.sqf
+++ b/addons/map/functions/fnc_flashlightGlow.sqf
@@ -28,7 +28,11 @@ if (!isNull _glow) then {
 };
 
 if (_flashlightType isNotEqualTo "") then {
-    private _color = getText (configFile >> "CfgWeapons" >> _flashlightType >> "ItemInfo" >> "FlashLight" >> "ACE_Flashlight_Colour");
+    private _config = _flashlightType call CBA_fnc_getItemConfig;
+    if (isClass (_config >> "ItemInfo")) then {
+        _config = _config >> "ItemInfo";
+    };
+    private _color = getText (_config >> "FlashLight" >> "ACE_Flashlight_Colour");
     if !(_color in ["white", "red", "green", "blue", "yellow", "orange"]) then {_color = "white"};
     private _class = format ["ACE_FlashlightProxy_%1", _color];
 

--- a/addons/map/functions/fnc_getUnitFlashlights.sqf
+++ b/addons/map/functions/fnc_getUnitFlashlights.sqf
@@ -17,4 +17,5 @@
 
 params ["_unit"];
 
-([_unit, true] call CBA_fnc_uniqueUnitItems) select {_x call FUNC(isFlashlight)} // return
+// uniqueUnitItems doesn't include facewear
+(([_unit, true] call CBA_fnc_uniqueUnitItems) + [goggles _unit]) select {_x call FUNC(isFlashlight)} // return

--- a/addons/map/functions/fnc_isFlashlight.sqf
+++ b/addons/map/functions/fnc_isFlashlight.sqf
@@ -18,16 +18,18 @@
 params [["_class", "", [""]]];
 
 GVAR(flashlights) getOrDefaultCall [_class, {
-    private _items = ([_class] + (_class call CBA_fnc_switchableAttachments));
-    private _cfgWeapons = configFile >> "CfgWeapons";
+    private _items = [_class];
+    if (isClass (configFile >> "CfgWeapons" >> _class)) then {
+        _items append (_class call CBA_fnc_switchableAttachments);
+    };
 
     // if this item or any of the switchable items is a flashlight
     _items findIf {
-        private _weaponConfig = _cfgWeapons >> _x;
+        private _itemConfig = _x call CBA_fnc_getItemConfig;
 
         [
-            _weaponConfig >> "ItemInfo" >> "FlashLight",
-            _weaponConfig >> "FlashLight"
+            _itemConfig >> "ItemInfo" >> "FlashLight",
+            _itemConfig >> "FlashLight"
         ] findIf {
             isText (_x >> "ACE_Flashlight_Colour")
             || {!(getArray (_x >> "ambient") in [[], [0,0,0]]) && {getNumber (_x >> "irLight") == 0}}

--- a/addons/map/functions/fnc_needPlaySound.sqf
+++ b/addons/map/functions/fnc_needPlaySound.sqf
@@ -33,7 +33,12 @@ if (
     false
 };
 
-private _config = configFile >> "CfgWeapons" >> _flashlight >> "ItemInfo" >> "FlashLight";
+private _config = _flashlightType call CBA_fnc_getItemConfig;
+if (isClass (_config >> "ItemInfo")) then {
+    _config = _config >> "ItemInfo";
+};
+_config = _config >> "FlashLight";
+
 if (!isClass _config) exitWith {
     TRACE_1("weapon with unmountable flashlight",_flashlight);
     true

--- a/addons/map/functions/fnc_simulateMapLight.sqf
+++ b/addons/map/functions/fnc_simulateMapLight.sqf
@@ -58,7 +58,11 @@ if (_flashlight == "") then {
     private _mousePos = GVAR(mousePos);
 
     //flashlight settings
-    private _cfg = configFile >> "CfgWeapons" >> _flashlight >> "ItemInfo" >> "FlashLight";
+    private _cfg = _flashlight call CBA_fnc_getItemConfig;
+    if (isClass (_cfg >> "ItemInfo")) then {
+        _cfg = _cfg >> "ItemInfo";
+    };
+    _cfg = _cfg >> "FlashLight";
     private _size = [_cfg >> "ACE_Flashlight_Size", "number", DEFAULT_FLASHLIGHT_SIZE] call CBA_fnc_getConfigEntry;
     private _flashTex = [_cfg >> "ACE_Flashlight_Beam", "text", QPATHTOF(UI\Flashlight_beam_white_ca.paa)] call CBA_fnc_getConfigEntry;
     private _beamSize = (safeZoneW/safeZoneWAbs) * _screenSize / _size;


### PR DESCRIPTION
**When merged this pull request will:**
- Add support for facewear items having flashlights
- Fix some wrong config lookups from explicitly looking at `ItemInfo >> FlashLight` in some functions
  - The weapon versions of the flashlights have the FlashLight class defined in the weapon, since they have no ItemInfo class

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
