### PR TITLE
Compat Aegis - Fix T-14 commander MG not having ammo

### DIFF
--- a/addons/compat_aegis/compat_aegis_vehicles/CfgVehicles.hpp
+++ b/addons/compat_aegis/compat_aegis_vehicles/CfgVehicles.hpp
@@ -1,8 +1,20 @@
 class CfgVehicles {
-    class Tank;
+    class All;
+    class AllVehicles: All {
+        class NewTurret;
+    };
+    class Land: AllVehicles {};
+    class LandVehicle: Land {
+        class CommanderOptics: NewTurret {};
+    };
+    class Tank: LandVehicle {};
     class Tank_F: Tank {
         class Turrets {
-            class MainTurret;
+            class MainTurret: NewTurret {
+                class Turrets {
+                    class CommanderOptics: CommanderOptics {};
+                };
+            };
         };
     };
 
@@ -88,6 +100,22 @@ class CfgVehicles {
                     "200Rnd_762x51_Belt_Red",
                     "200Rnd_762x51_Belt_Red",
                     "4Rnd_120mm_LG_cannon_missiles" // Aegis adds laser-guided munitions
+                };
+            };
+        };
+    };
+
+    class MBT_04_base_F: Tank_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Turrets: Turrets {
+                    class CommanderOptics: CommanderOptics {
+                        // Overwrite the changes Aegis makes for the NSVT commander MG on the T-140 Ankara/T-14
+                        // Ideally would be kept as realistically as possible (so 127x108 ammo instead of 127x99),
+                        // but since it's been like this for a very long time, bad idea to change (will break missions with magazine loadouts)
+                        weapons[] = {"ACE_HMG_127_KORD", "SmokeLauncher"};
+                        magazines[] = {"500Rnd_127x99_mag_Tracer_Yellow", "SmokeLauncherMag"};
+                    };
                 };
             };
         };

--- a/addons/compat_aegis/compat_aegis_vehicles/config.cpp
+++ b/addons/compat_aegis/compat_aegis_vehicles/config.cpp
@@ -8,6 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "A3_Aegis_Armor_F_Aegis_MBT_01",
+            "A3_Aegis_Armor_F_Aegis_MBT_04",
             "A3_Aegis_Armor_F_Aegis_APC_Tracked_03",
             "ace_vehicles"
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Overwrite Aegis' changes back to ACE' changes.
- Correct MG would be the Kord with 12.7x108 mm ammo
  - ACE has the correct name, but wrong ammo (it's .50 BMG)
  - Aegis has correct ammo, but wrong name (NSVT instead of Kord)
  - I would have liked to change ACE to use 12.7x108 ammo instead, but as it's set to .50 BMG for quite a while now, I'm scared it would break missions with preexisting magazine loadouts.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
