### PR TITLE
IntelItem - Fix: Intel Items lose Data when updating containers in arsenal

### DIFF
--- a/addons/intelitems/XEH_preInit.sqf
+++ b/addons/intelitems/XEH_preInit.sqf
@@ -37,23 +37,21 @@ if (hasInterface) then {
         private _unit = EGVAR(arsenal,center);
         private _allMags = (magazinesAmmoFull _unit) apply { toLower (_x#0) };
         private _exceptions = [];
-        // get old MagID's if any intel item is in loadout
+        // get previous MagID's of any intel items
         {
             private _className = toLower _x;
             if (_className in _allMags) then {
                 _exceptions pushBack [
                     _className,
-                    [_unit, _className] call CBA_fnc_getMagazineIndex,
-                    []
+                    [_unit, _className] call CBA_fnc_getMagazineIndex
                 ];
             };
         } forEach ["acex_intelitems_document", "acex_intelitems_notepad", "acex_intelitems_photo"];
 
-        diag_log format ['[CVO](debug)(XEH_preInit display opened) _init: %1', _exceptions];
-        // If anything has been found, store it in GVAR
         if (_exceptions isNotEqualTo []) then { GVAR(preservationDuringArsenal) = _exceptions; };
     }
 ] call CBA_fnc_addEventHandler;
+
 [
     QEGVAR(arsenal,displayClosed),
     {
@@ -63,22 +61,23 @@ if (hasInterface) then {
         private _exceptions = missionNamespace getVariable QGVAR(preservationDuringArsenal);
 
         // get new MagID's
-        { _x set [ 2, [EGVAR(arsenal,center), _x#0] call CBA_fnc_getMagazineIndex ]; } forEach _exceptions;
+        _exceptions = _exceptions apply { [_x#1, [EGVAR(arsenal,center), _x#0] call CBA_fnc_getMagazineIndex] };
 
         private _map = GVAR(intelMap);
         {
-            _x params ["", "_oldMagIDs", "_newMagIDs"];
+            _x params ["_oldMagIDs", "_newMagIDs"];
 
+            //limit loop to possible amount
             private _qtyNewMagIDs = count _newMagIDs;
             if (count _oldMagIDs > _qtyNewMagIDs) then { _oldMagIDs resize _qtyNewMagIDs; };
-            
+
             {
                 private _oldMagID = _x;
                 private _newMagID = _newMagIDs select _forEachIndex;
-                private _intelID = _map getVariable [_oldMagID, -1];
+                if (_oldMagID == _newMagID) then { continue };
 
+                private _intelID = _map getVariable [_oldMagID, -1];
                 if (_intelID == -1) then { continue };
-                diag_log format ['[CVO](debug)(XEH_preInit) _oldMagID: %1 - _newMagID: %2 - _intelID: %3', _oldMagID , _newMagID ,_intelID];
                 _map setVariable [_newMagID, _intelID, true];
                 
             } forEach _oldMagIDs;

--- a/addons/intelitems/XEH_preInit.sqf
+++ b/addons/intelitems/XEH_preInit.sqf
@@ -35,7 +35,7 @@ if (hasInterface) then {
     QEGVAR(arsenal,displayOpened),
     {
         private _unit = EGVAR(arsenal,center);
-        private _allMags = (magazinesAmmoFull _unit) apply { toLower (_x#0) };
+        private _allMags = (magazinesAmmoFull _unit) apply { toLowerANSI (_x#0) };
         private _exceptions = [];
         // get previous MagID's of any intel items
         {

--- a/addons/intelitems/XEH_preInit.sqf
+++ b/addons/intelitems/XEH_preInit.sqf
@@ -30,4 +30,62 @@ if (hasInterface) then {
     GVAR(controlsData) = createHashMap;
 };
 
+// Arsenal Eventhandler to preserve IntelItems Data
+[
+    QEGVAR(arsenal,displayOpened),
+    {
+        private _unit = EGVAR(arsenal,center);
+        private _allMags = (magazinesAmmoFull _unit) apply { toLower (_x#0) };
+        private _exceptions = [];
+        // get old MagID's if any intel item is in loadout
+        {
+            private _className = toLower _x;
+            if (_className in _allMags) then {
+                _exceptions pushBack [
+                    _className,
+                    [_unit, _className] call CBA_fnc_getMagazineIndex,
+                    []
+                ];
+            };
+        } forEach ["acex_intelitems_document", "acex_intelitems_notepad", "acex_intelitems_photo"];
+
+        diag_log format ['[CVO](debug)(XEH_preInit display opened) _init: %1', _exceptions];
+        // If anything has been found, store it in GVAR
+        if (_exceptions isNotEqualTo []) then { GVAR(preservationDuringArsenal) = _exceptions; };
+    }
+] call CBA_fnc_addEventHandler;
+[
+    QEGVAR(arsenal,displayClosed),
+    {
+        if (isNil QGVAR(preservationDuringArsenal)) exitWith {};
+        
+        // Check if any Intel Items are to be preserved
+        private _exceptions = missionNamespace getVariable QGVAR(preservationDuringArsenal);
+
+        // get new MagID's
+        { _x set [ 2, [EGVAR(arsenal,center), _x#0] call CBA_fnc_getMagazineIndex ]; } forEach _exceptions;
+
+        private _map = GVAR(intelMap);
+        {
+            _x params ["", "_oldMagIDs", "_newMagIDs"];
+
+            private _qtyNewMagIDs = count _newMagIDs;
+            if (count _oldMagIDs > _qtyNewMagIDs) then { _oldMagIDs resize _qtyNewMagIDs; };
+            
+            {
+                private _oldMagID = _x;
+                private _newMagID = _newMagIDs select _forEachIndex;
+                private _intelID = _map getVariable [_oldMagID, -1];
+
+                if (_intelID == -1) then { continue };
+                diag_log format ['[CVO](debug)(XEH_preInit) _oldMagID: %1 - _newMagID: %2 - _intelID: %3', _oldMagID , _newMagID ,_intelID];
+                _map setVariable [_newMagID, _intelID, true];
+                
+            } forEach _oldMagIDs;
+        } forEach _exceptions;
+
+        GVAR(preservationDuringArsenal) = nil;
+    }
+] call CBA_fnc_addEventHandler;
+
 ADDON = true;

--- a/addons/intelitems/XEH_preInit.sqf
+++ b/addons/intelitems/XEH_preInit.sqf
@@ -39,7 +39,7 @@ if (hasInterface) then {
         private _exceptions = [];
         // get previous MagID's of any intel items
         {
-            private _className = toLower _x;
+            private _className = toLowerANSI _x;
             if (_className in _allMags) then {
                 _exceptions pushBack [
                     _className,


### PR DESCRIPTION
- resolves #11049 
- Add EH for Arsenal Opened
    - get MagID's for each Intel Items and store in GVAR
- Add EH for Arsenal Closed
    - get old magID's, get magID's for each new IntelItems, get IntelID for each, add new magID to intelMal with previous intelID.
