### PR TITLE
Common - Make throwWeapon put weapon away

### DIFF
--- a/addons/common/functions/fnc_throwWeapon.sqf
+++ b/addons/common/functions/fnc_throwWeapon.sqf
@@ -45,5 +45,6 @@ _holder setVelocity _velocity;
 _holder addTorque (call CBA_fnc_randomVector3D vectorMultiply THROW_TORQUE);
 
 ["ACE_weaponThrown", [_unit, _holder, _data]] call CBA_fnc_localEvent;
+_unit action ["SwitchWeapon", _unit, _unit, 299];
 
 _holder // return


### PR DESCRIPTION
**When merged this pull request will:**
- Make `fnc_throwWeapon` put the next weapon away instead of selecting it
  - Common issue with ace fire is units throwing their weapon, pulling out another, and then immediately throwing that one. Made more sense IMO to add it to `fnc_throwWeapon` instead of `fnc_burnReaction` but I can change it if desired

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
