### PR TITLE
Hearing - Add config value to limit weapon loudness, to Fix RHS miniguns

### DIFF
--- a/addons/compat_rhs_afrf3/compat_rhs_afrf3_hearing/CfgGlasses.hpp
+++ b/addons/compat_rhs_afrf3/compat_rhs_afrf3_hearing/CfgGlasses.hpp
@@ -1,0 +1,6 @@
+class CfgGlasses {
+    class G_Balaclava_blk;
+    class rhs_facewear_6m2: G_Balaclava_blk {
+        HEARING_PROTECTION_PELTOR;
+    };
+};

--- a/addons/compat_rhs_afrf3/compat_rhs_afrf3_hearing/CfgWeapons.hpp
+++ b/addons/compat_rhs_afrf3/compat_rhs_afrf3_hearing/CfgWeapons.hpp
@@ -25,4 +25,10 @@ class CfgWeapons {
     class rhs_6b48: rhs_6b47_bare {
         HEARING_PROTECTION_VICCREW;
     };
+
+    // Reduce loudness of high-ROF weapons
+    class gatling_30mm;
+    class rhs_weap_gsh30: gatling_30mm {
+        EGVAR(hearing,maxWeaponLoudness) = 0.7;
+    };
 };

--- a/addons/compat_rhs_afrf3/compat_rhs_afrf3_hearing/config.cpp
+++ b/addons/compat_rhs_afrf3/compat_rhs_afrf3_hearing/config.cpp
@@ -16,4 +16,5 @@ class CfgPatches {
     };
 };
 
+#include "CfgGlasses.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/compat_rhs_usf3/compat_rhs_usf3_hearing/CfgWeapons.hpp
+++ b/addons/compat_rhs_usf3/compat_rhs_usf3_hearing/CfgWeapons.hpp
@@ -171,4 +171,20 @@ class CfgWeapons {
     class RHS_jetpilot_usaf: H_HelmetB {
         HEARING_PROTECTION_VICCREW;
     };
+
+    // Reduce loudness of high-ROF weapons
+    class Gatling_30mm_Plane_CAS_01_F;
+    class RHS_weap_gau8: Gatling_30mm_Plane_CAS_01_F {
+        EGVAR(hearing,maxWeaponLoudness) = 0.8;
+    };
+
+    class HMG_127;
+    class RHS_weap_gau19: HMG_127 {
+        EGVAR(hearing,maxWeaponLoudness) = 0.25;
+    };
+
+    class MGunCore;
+    class M134_minigun: MGunCore {
+        EGVAR(hearing,maxWeaponLoudness) = 0.13;
+    };
 };

--- a/addons/hearing/functions/fnc_addEarPlugs.sqf
+++ b/addons/hearing/functions/fnc_addEarPlugs.sqf
@@ -48,7 +48,7 @@ if (isNil QGVAR(cacheMaxAmmoLoudness)) then {
 private _maxLoudness = GVAR(cacheMaxAmmoLoudness) getOrDefaultCall [_weapon, {
     // Get the weapon's compatible magazines, so that all magazines are cached
     // From all the loudness factors, take the max
-    private _maxLoudness = selectMax ((compatibleMagazines _weapon) apply {_x call FUNC(getAmmoLoudness)});
+    private _maxLoudness = selectMax ((compatibleMagazines _weapon) apply {[_x, _weapon] call FUNC(getAmmoLoudness)});
 
     // ace_gunbag_fnc_isMachineGun
     private _config = _weapon call CBA_fnc_getItemConfig;

--- a/addons/hearing/functions/fnc_firedNear.sqf
+++ b/addons/hearing/functions/fnc_firedNear.sqf
@@ -52,7 +52,7 @@ if (_magazine == "") exitWith {
 TRACE_6("mag",_magazine,_weapon,_muzzle,_ammo,_firer,_gunner);
 
 private _vehAttenuation = [EGVAR(common,playerVehAttenuation), 1] select (isNull objectParent ACE_player || {isTurnedOut ACE_player});
-private _loudness = _magazine call FUNC(getAmmoLoudness);
+private _loudness = [_magazine, _weapon] call FUNC(getAmmoLoudness);
 
 _loudness = _loudness * _audibleFireCoef;
 private _strength = _vehAttenuation * (_loudness - (_loudness / 50 * _distance)); // linear drop off

--- a/addons/hearing/functions/fnc_getAmmoLoudness.sqf
+++ b/addons/hearing/functions/fnc_getAmmoLoudness.sqf
@@ -28,7 +28,7 @@ GVAR(cacheAmmoLoudness) getOrDefaultCall [_magazine, {
     private _caliber = getNumber (_ammoConfig >> "ACE_caliber");
 
     _caliber = switch (true) do {
-        // If explicilty defined, use ACE_caliber
+        // If explicitly defined, use ACE_caliber
         case (inheritsFrom (_ammoConfig >> "ACE_caliber") isEqualTo _ammoConfig): {_caliber};
         case (_ammo isKindOf ["ShellBase", _cfgAmmo]): {80};
         case (_ammo isKindOf ["RocketBase", _cfgAmmo]): {200};
@@ -38,7 +38,7 @@ GVAR(cacheAmmoLoudness) getOrDefaultCall [_magazine, {
     };
 
     private _hearingDamageFactor = [_ammoConfig >> QGVAR(hearingDamageFactor), "NUMBER", 1] call CBA_fnc_getConfigEntry;
-    private _loudness = _hearingDamageFactor * (_caliber ^ 1.25 / 10) * (_initspeed / 1000) / 5;
+    private _loudness = _hearingDamageFactor * (_caliber ^ 1.25 / 10) * (_initSpeed / 1000) / 5;
     TRACE_6("building cache",_ammo,_magazine,_initSpeed,_caliber,_hearingDamageFactor,_loudness);
 
     _loudness

--- a/addons/hearing/functions/fnc_getAmmoLoudness.sqf
+++ b/addons/hearing/functions/fnc_getAmmoLoudness.sqf
@@ -6,6 +6,7 @@
  *
  * Arguments:
  * 0: Magazine <STRING>
+ * 1: Weapon <STRING> (optional)
  *
  * Return Value:
  * None
@@ -16,7 +17,7 @@
  * Public: No
  */
 
-params ["_magazine"];
+params ["_magazine", ["_weapon", ""]];
 
 GVAR(cacheAmmoLoudness) getOrDefaultCall [_magazine, {
     private _magazineConfig = configFile >> "CfgMagazines" >> _magazine;
@@ -39,6 +40,12 @@ GVAR(cacheAmmoLoudness) getOrDefaultCall [_magazine, {
 
     private _hearingDamageFactor = [_ammoConfig >> QGVAR(hearingDamageFactor), "NUMBER", 1] call CBA_fnc_getConfigEntry;
     private _loudness = _hearingDamageFactor * (_caliber ^ 1.25 / 10) * (_initSpeed / 1000) / 5;
+    
+    // Limit to max weapon loudness, if explicitly defined
+    if (_weapon != "" && {isNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(maxWeaponLoudness))}) then {
+        _loudness = _loudness min (getNumber (configFile >> "CfgWeapons" >> _weapon >> QGVAR(maxWeaponLoudness)));
+    };
+
     TRACE_6("building cache",_ammo,_magazine,_initSpeed,_caliber,_hearingDamageFactor,_loudness);
 
     _loudness

--- a/docs/wiki/framework/hearing-framework.md
+++ b/docs/wiki/framework/hearing-framework.md
@@ -34,3 +34,13 @@ class CfgAmmo {
     };
 };
 ```
+
+You can define an upper limit on a weapon's loudness regardless of ammo used, which can be useful on large caliber guns with high rates of fire.
+
+```cpp
+class CfgWeapons {
+    class MyLoudCannon {
+        ace_hearing_maxWeaponLoudness = 2;
+    };
+};
+```


### PR DESCRIPTION
**When merged this pull request will:**
- Add a config value to set an upper limit on a weapon's loudness, potentially more useful on weapons with high firing rates which reuse ammo types that would otherwise be too quiet on other guns, if tweaked with the existing ammo `hearingDamageFactor` value.
- Limit the loudness of RHS gatling guns and aircraft weapons using the new config value. Makes cannons like the Mi-8's [UPK-23](https://en.wikipedia.org/wiki/Gryazev-Shipunov_GSh-23) (23mm) gun pods and the A-10's GAU-8 more usable, since before they'd cause deafness in just a few seconds of consecutive firing, even while wearing vehicle crew earpro.
- Add Peltor Earpro to the RHSAFRF 6M2 earmuffs' facewear variant, where previously only the headgear variant provided earpro.