### PR TITLE
SPE Compat - Add ability to use ACE wirecutters on SPE barbed wire objects

### DIFF
--- a/addons/compat_spe/CfgVehicles.hpp
+++ b/addons/compat_spe/CfgVehicles.hpp
@@ -4,4 +4,5 @@ class CfgVehicles {
     #include "CfgVehicles\spe_boxes.hpp"
     #include "CfgVehicles\tracked.hpp"
     #include "CfgVehicles\wheeled.hpp"
+    #include "CfgVehicles\barbed_wire.hpp"    
 };

--- a/addons/compat_spe/CfgVehicles/barbed_wire.hpp
+++ b/addons/compat_spe/CfgVehicles/barbed_wire.hpp
@@ -1,0 +1,17 @@
+	class SPE_fortifications_base;
+	class Land_SPE_BarbedWire_01: SPE_fortifications_base
+	{
+        GVAR(isFence) = 1;
+	};
+	class Land_SPE_BarbedWire_02: SPE_fortifications_base
+	{
+        GVAR(isFence) = 1;
+	};
+	class Land_SPE_BarbedWire_03: SPE_fortifications_base
+	{
+        GVAR(isFence) = 1;
+	};
+	class Land_SPE_BarbedWire_04: SPE_fortifications_base
+	{
+        GVAR(isFence) = 1;
+	};


### PR DESCRIPTION
**When merged this pull request will:**
- Add a new .hpp file in compat_spe addon called **barbed_wire.hpp** for CfgVehicles.hpp
- **barbed_wire.hpp** sets the GVAR(isFence) = 1; to the classes `Land_SPE_BarbedWire_01`, `Land_SPE_BarbedWire_02`, `Land_SPE_BarbedWire_03`, `Land_SPE_BarbedWire_04`
- This should allow the ACE wirecutters and child classes of it to cut into the SPE Barbed Wire obstacles

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
