### PR TITLE
Missileguidance - Add Ignore to SACLOS Tracking

### DIFF
--- a/addons/missileguidance/functions/fnc_seekerType_SACLOS.sqf
+++ b/addons/missileguidance/functions/fnc_seekerType_SACLOS.sqf
@@ -61,7 +61,7 @@ private _distanceToProj = _shooterPos vectorDistance _projPos;
 private _testPointVector = vectorNormalized (_projPos vectorDiff _shooterPos);
 private _testDotProduct = (_lookDirection vectorDotProduct _testPointVector);
 
-private _testIntersections = lineIntersectsSurfaces [_shooterPos, _projPos, _shooter];
+private _testIntersections = lineIntersectsSurfaces [_shooterPos, _projPos, _shooter, _projectile];
 
 if ((_testDotProduct < (cos _seekerAngle)) || {_testIntersections isNotEqualTo []}) exitWith {
     // out of LOS of seeker


### PR DESCRIPTION
This PR adds the missile (`_projectile`) surfaces to be ignored for a check using `lineIntersectsSurfaces` in the SACLOS seeker function. Intersection happens occasionally and results in odd, unwanted behavior.

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
