### PR TITLE
Compat RHS_AFRF - Fix base classes

### DIFF
--- a/addons/medical_ai/stateMachine.inc.sqf
+++ b/addons/medical_ai/stateMachine.inc.sqf
@@ -31,7 +31,7 @@ GVAR(stateMachine) = [{call EFUNC(common,getLocalUnits)}, true] call CBA_statema
 
 
 [GVAR(stateMachine), "HealSelf", "Initial", { // Go back to initial state when done healing
-    !(call FUNC(isInjured)) && {(_this isNil QGVAR(currentTreatment))}
+    !(call FUNC(isInjured)) && {isNil {_this getVariable QGVAR(currentTreatment)}}
 }, {
     #ifdef DEBUG_MODE_FULL
     systemChat format ["%1 finished healing themself", _this];
@@ -39,7 +39,7 @@ GVAR(stateMachine) = [{call EFUNC(common,getLocalUnits)}, true] call CBA_statema
 }, "Initial"] call CBA_statemachine_fnc_addTransition;
 
 [GVAR(stateMachine), "HealSelf", "Injured", { // Stop treating when it's no more safe
-    !(call FUNC(isSafe)) && {(_this isNil QGVAR(currentTreatment))}
+    !(call FUNC(isSafe)) && {isNil {_this getVariable QGVAR(currentTreatment)}}
 }, {
     #ifdef DEBUG_MODE_FULL
     systemChat format ["%1 is no longer safe", _this];
@@ -48,7 +48,7 @@ GVAR(stateMachine) = [{call EFUNC(common,getLocalUnits)}, true] call CBA_statema
 
 
 [GVAR(stateMachine), "HealUnit", "Initial", { // Go back to initial state when done healing or it's no more safe to treat
-    !((call FUNC(wasRequested)) && FUNC(isSafe)) && {(_this isNil QGVAR(currentTreatment))}
+    !((call FUNC(wasRequested)) && FUNC(isSafe)) && {isNil {_this getVariable QGVAR(currentTreatment)}}
 }, {
     #ifdef DEBUG_MODE_FULL
     systemChat format ["%1 finished healing someone", _this];
@@ -56,7 +56,7 @@ GVAR(stateMachine) = [{call EFUNC(common,getLocalUnits)}, true] call CBA_statema
 }, "Initial"] call CBA_statemachine_fnc_addTransition;
 
 [GVAR(stateMachine), "HealUnit", "Injured", { // Treating yourself has priority
-    (call FUNC(isInjured)) && {(_this isNil QGVAR(currentTreatment))}
+    (call FUNC(isInjured)) && {isNil {_this getVariable QGVAR(currentTreatment)}}
 }, {
     #ifdef DEBUG_MODE_FULL
     systemChat format ["%1 was injured while healing someone", _this];

--- a/addons/medical_treatment/XEH_postInit.sqf
+++ b/addons/medical_treatment/XEH_postInit.sqf
@@ -83,7 +83,7 @@ if (["ace_trenches"] call EFUNC(common,isModLoaded)) then {
                     true
                 ] call CBA_fnc_notify;
             },
-            {!(_target isNil QGVAR(headstoneData))}
+            {!isNil {_target getVariable QGVAR(headstoneData)}}
         ] call EFUNC(interact_menu,createAction);
 
         [missionNamespace getVariable [QGVAR(graveClassname), "ACE_Grave"], 0, [], _checkHeadstoneAction] call EFUNC(interact_menu,addActionToClass);


### PR DESCRIPTION
Fixes
```
Note: 'z\ace\addons\compat_rhs_afrf3\config.cpp/CfgVehicles/rhs_btr_base.ace_interaction_anims' is declared, but definition was not found. Creating empty class (source: z\ace\addons\compat_rhs_afrf3\config.cpp)
Note: 'z\ace\addons\compat_rhs_afrf3\config.cpp/CfgVehicles/StaticWeapon/ACE_Actions.ACE_MainActions' is declared, but definition was not found. Creating empty class (source: z\ace\addons\compat_rhs_afrf3\config.cpp)
```