### PR TITLE
Scopes - Hide Arsenal stats when values are zeroed

### DIFF
--- a/addons/scopes/ACE_Arsenal_Stats.hpp
+++ b/addons/scopes/ACE_Arsenal_Stats.hpp
@@ -7,7 +7,7 @@ class EGVAR(arsenal,stats) {
         displayName = CSTRING(statHorizontalLimits);
         showText = 1;
         textStatement = QUOTE(params[ARR_2('_stat','_config')]; private _limits = getArray (_config >> _stat select 0); format [ARR_4('%1 / %2 MIL (∆ %3 MIL)',_limits select 0,_limits select 1,getNumber (_config >> _stat select 1))]);
-        condition = QUOTE(params[ARR_2('_stat','_config')]; (getArray (_config >> _stat select 0)) isNotEqualTo []);
+        condition = QUOTE(params[ARR_2('_stat','_config')]; private _limits = getArray (_config >> _stat select 0); _limits isNotEqualTo [] && {(_limits isNotEqualTo [ARR_2(0,0)])});
         tabs[] = {{}, {0}};
     };
     class ACE_scopeVerticalLimits: ACE_scopeHorizontalLimits {


### PR DESCRIPTION
**When merged this pull request will:**
- Hides the arsenal stat when the values have been zeroed to disable adjustments

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
