### PR TITLE
Interaction - don't allow door interaction on cars

### DIFF
--- a/addons/interaction/functions/fnc_openDoor.sqf
+++ b/addons/interaction/functions/fnc_openDoor.sqf
@@ -22,6 +22,7 @@ _info params ["_house", "_door"];
 TRACE_2("openDoor",_house,_door);
 
 if (isNull _house) exitWith {};
+if (_house isKindOf "Car") exitWith {};
 
 if ((configProperties [configOf _house >> "UserActions"]) isEqualTo []) exitWith {
     TRACE_1("Ignore houses with no UserActions",typeOf _house); // Fix problem with Shoothouse Walls


### PR DESCRIPTION
**When merged this pull request will:**
- Prevents hiding car doors, notably affects the RF Ram

I'm not aware of any cars where this behavior is intentional

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
