### PR TITLE
Tools - Cleanup old hemtt configs

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -3,36 +3,6 @@ workshop = [
     "450814997", # CBA_A3
 ]
 
-[spe]
-extends = "default"
-dlc = [
-    "Spearhead 1944"
-]
-
-[vn]
-extends = "default"
-dlc = [
-    "S.O.G. Prairie Fire",
-]
-
-[ws]
-extends = "default"
-dlc = [
-    "Western Sahara",
-]
-
-[rf]
-extends = "default"
-dlc = [
-    "Reaction Forces"
-]
-
-[gm]
-extends = "default"
-dlc = [
-    "Global Mobilization - Cold War Germany"
-]
-
 [rhs]
 extends = "default"
 workshop = [

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -17,13 +17,3 @@ include = [
 
 [version]
 git_hash = 0
-
-# Unused in HEMTT v1.11 or higher, kept for backwards compatibility
-[asc]
-enabled = true
-exclude = [
-    ".inc.sqf",
-    "/dev/",
-    "common/functions/fnc_dummy.sqf",
-    "zeus/functions/fnc_zeusAttributes.sqf",
-]


### PR DESCRIPTION
Requires HEMTT 1.17.3+ (not yet released)
Cleans ups
```
 WARN ASC config is no longer used
 WARN launch preset `gm` is redundant, you can launch with `+gm` instead
```