### PR TITLE
Kestrel4500 - Display bearing relative to player's head direction

### DIFF
--- a/addons/kestrel4500/functions/fnc_generateOutputData.sqf
+++ b/addons/kestrel4500/functions/fnc_generateOutputData.sqf
@@ -61,7 +61,7 @@ private _textCenterLine6 = "";
 private _windSpeed = call FUNC(measureWindSpeed);
 private _windDir = (wind select 0) atan2 (wind select 1);
 
-private _playerDir = getDir ACE_player;
+private _playerDir = (ACE_player call CBA_fnc_headDir) select 0;
 private _playerAltitude = (getPosASL ACE_player) select 2;
 
 private _temperature = _playerAltitude call EFUNC(weather,calculateTemperatureAtHeight);


### PR DESCRIPTION
**When merged this pull request will:**
- Title. Pretty much a continuation of #10215, after I noticed today that the bearing indicator on `User Screen 1` was also relative to the player's body, instead of the head.