### PR TITLE
Wardrobe - Fix dev function

### DIFF
--- a/addons/wardrobe/dev/compareContainerMaxLoad.sqf
+++ b/addons/wardrobe/dev/compareContainerMaxLoad.sqf
@@ -15,7 +15,7 @@
  * Public: No
  */
 
-private _allWardrobeItems = [true] call compile preprocessFileLineNumbers "z\ace\addons\wardrobe\dev\getAllWardrobeItems.sqf" select {
+private _allWardrobeItems = [false] call compile preprocessFileLineNumbers "z\ace\addons\wardrobe\dev\getAllWardrobeItems.sqf" select {
     switch (getNumber (_x >> "ItemInfo" >> "type")) do {
         case TYPE_GOGGLE: { false; };
         case TYPE_HEADGEAR: { false; };


### PR DESCRIPTION
**When merged this pull request will:**
- see https://discord.com/channels/976165959041679380/976224344881655818/1436131741101326336
- fixes
```sqf
23:24:14 Error in expression <ems.sqf" select {
switch (getNumber (_x >> "ItemInfo" >> "type")) do {
case 603:>
23:24:14   Error position: <>> "ItemInfo" >> "type")) do {
case 603:>
23:24:14   Error >>: Type String, expected Config entry
23:24:14 File z\ace\addons\wardrobe\dev\compareContainerMaxLoad.sqf..., line 19
23:24:14  ➥ Context:     [] L81 (DBUG\functions\console\exec\fn_exec.sqf)
    [] L81 (DBUG\functions\console\exec\fn_exec.sqf)
    [] L1 (new_1.sqf)
    [] L18 (z\ace\addons\wardrobe\dev\compareContainerMaxLoad.sqf)
    [] L19 (z\ace\addons\wardrobe\dev\compareContainerMaxLoad.sqf)
 <-     [] L24 (/DEV_TOOLS/functions/general/fn_addSchd.sqf)
    [] L76 (DBUG\functions\general\EHs\fn_eachFrame.sqf)
    [] L65 (DBUG\functions\general\EHs\fn_eachFrame.sqf)
    [] L68 (DBUG\functions\general\EHs\fn_eachFrame.sqf)
    [] L77 (DBUG\functions\console\exec\fn_exec.sqf)
    [] L80 (DBUG\functions\console\exec\fn_exec.sqf)
```

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
