### PR TITLE
Markers - Fix script error on profiling branch (`radioChannelInfo`)

### DIFF
--- a/addons/markers/functions/fnc_getEnabledChannels.sqf
+++ b/addons/markers/functions/fnc_getEnabledChannels.sqf
@@ -27,7 +27,7 @@ for "_channelId" from 0 to 15 do {
     if (_channelId == 5) then {continue}; // Direct channel, ignore
     if (setCurrentChannel _channelId) then {
         if (_localize) then {
-            _enabledChannels pushBack (_engineChannels param [_channelId, (radioChannelInfo (_channelId - 5)) select 1]); // radioChannelInfo works off custom IDs only, offset engine channels
+            _enabledChannels pushBack (_engineChannels param [_channelId, (radioChannelInfo (_channelId - 5)) param [1, "#Unknown"]]); // radioChannelInfo works off custom IDs only, offset engine channels
         } else {
             _enabledChannels pushBack _channelId;
         };

--- a/addons/markers/functions/fnc_initInsertMarker.sqf
+++ b/addons/markers/functions/fnc_initInsertMarker.sqf
@@ -238,7 +238,7 @@
         };
 
         // engine channels (0-4) can use names directly, custom channels need an offset for radioChannelInfo
-        private _selectChannelName = CHANNEL_NAMES param [_selectChannel, radioChannelInfo (_selectChannel - 5) select 1];
+        private _selectChannelName = CHANNEL_NAMES param [_selectChannel, (radioChannelInfo (_selectChannel - 5)) param [1, "#Unknown"]];
 
         // select current channel in list box, must be done after lbDelete
         for "_j" from 0 to (lbSize _channel - 1) do {


### PR DESCRIPTION
```
21:15:22 File /z/ace/addons/markers/functions/fnc_getEnabledChannels.sqf..., line 30
21:15:22 Error in expression <, radioChannelInfo (_selectChannel - 5) select 1];
21:15:22   Error 0 elements provided, 2 expected
21:15:22 File /z/ace/addons/markers/functions/fnc_initInsertMarker.sqf..., line 241
```

radioChannelInfo -1 now returns []
so the select fails