### PR TITLE
Fix color mapping for black/white cases

### DIFF
--- a/addons/frag/functions/fnc_dev_trackObj.sqf
+++ b/addons/frag/functions/fnc_dev_trackObj.sqf
@@ -32,8 +32,8 @@ private _colorArray = switch (toLowerANSI _color) do {
     case "orange": {[0.8, 0.518, 0, 1]};
     case "yellow": {[0.8, 0.8, 0, 1]};
     case "red": {[0.8, 0, 0, 1]};
-    case "black": {[1, 1, 1, 1]};
-    case "white": {[0, 0, 0, 1]};
+    case "white": {[1, 1, 1, 1]};
+    case "black": {[0, 0, 0, 1]};
     default {[0, 0.8, 0.8, 1]};
 };
 GVAR(dev_trackLines) set [getObjectID _object, [[getPosATL _object], _colorArray]];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the color values for black and white cases
- "black" now uses [1, 1, 1, 1]
- "white" now uses [0, 0, 0, 1]

This is my first pull request, so it may be lacking in some areas.

### IMPORTANT

- This contribution does not affect the documentation.
- Development Guidelines are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
