### PR TITLE
Tagging - Fix index OBOE for condition filtering

### DIFF
--- a/addons/tagging/functions/fnc_quickTag.sqf
+++ b/addons/tagging/functions/fnc_quickTag.sqf
@@ -47,7 +47,7 @@ if (GVAR(quickTag) == 3) then {
 };
 
 // Filter by Condition
-_possibleTags = _possibleTags select { [_unit, _unit] call (_x select 8) isEqualTo true };
+_possibleTags = _possibleTags select { [_unit, _unit] call (_x select 7) isEqualTo true };
 
 // Tag
 if (_possibleTags isNotEqualTo []) then {


### PR DESCRIPTION
**When merged this pull request will:**

Correct an off-by-one error for the index of conditions, fixes quick tagging by keybind

### IMPORTANT

- [x] If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [x] [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
