### PR TITLE
Laser - Fix add null-safe guard

### DIFF
--- a/addons/laser/functions/fnc_dev_drawVisibleLaserTargets.sqf
+++ b/addons/laser/functions/fnc_dev_drawVisibleLaserTargets.sqf
@@ -52,7 +52,13 @@ private _testSeekerDir = vectorDirVisual _seekerVehicle;
         private _targetPosASL = getPosASL _targetObject;
         drawIcon3D ["\a3\ui_f\data\IGUI\Cfg\Cursors\select_target_ca.paa", [1,0,0,1], (ASLToAGL _targetPosASL), 0.5, 0.5, 0, "", 0.5, 0.025, "TahomaB"];
 
-        (_y call FUNC(findLaserSource)) params ["_laserPosASL", "_laserDir"];
+        (_y call FUNC(findLaserSource)) params ["_laserPosASL", "_laserDir"];    
+            
+        if (([_laserPosASL,_laserDir] isEqualTo []) || {[_laserPosASL,_laserDir] isEqualTo [-1,-1]}) then {
+            WARNING_2("Bad Laser Return [%1,%2]",_laserPosASL,_laserDir); 
+            continue;
+        };
+
         private _resultsRay = [_laserPosASL, _laserDir, _obj] call FUNC(shootRay);
 
         private _rayPos = _resultsRay select 0;

--- a/addons/laser/functions/fnc_findLaserSource.sqf
+++ b/addons/laser/functions/fnc_findLaserSource.sqf
@@ -23,6 +23,12 @@ _methodArgs params ["_ownerSelection"];
 // Get the laser target object stored in the unit
 private _targetObject = _vehicle getVariable [QGVAR(targetObject), objNull];
 private _targetPos = getPosASL _targetObject;
+
+if(isNull _targetObject) exitWith {
+    WARNING_1("Laser is null [%1]",_targetObject);
+    [-1,-1]
+};
+
 if (surfaceIsWater _targetPos && {(_targetPos select 2) < 0}) then {
     // Vanilla lasers seem to give position at ocean floor heigh, even though the x and y are correct??
     _targetPos set [2, 0.25];


### PR DESCRIPTION
**When merged this pull request will:**
- _Add null-safe guard to prevent referencing deleted laser objects after_

### Descript

This PR fixes an issue where rapidly toggling the ACE laser on/off causes the original laser object to be deleted, while the script still keeps a stale reference.

To prevent this, I added a null-safe guard that checks whether the stored laser object is still valid before using it.

### Note
I'm not entirely sure about the root cause of this issue.
It might be related to rendering or the engine’s object update order.
As I'm still a beginner, I addressed it in the simplest way I could by adding a basic safety check.

### Before / After Video
Before: https://youtu.be/QutVE1YstEg
After: https://youtu.be/MP3OL_54s8I


### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
