### PR TITLE
Laser – Fix seeker LOS failing

### DIFF
--- a/addons/laser/functions/fnc_seekerFindLaserSpot.sqf
+++ b/addons/laser/functions/fnc_seekerFindLaserSpot.sqf
@@ -148,11 +148,9 @@ if (_spots isNotEqualTo []) then {
             private _testIntersections = lineIntersectsSurfaces [_posASL, _testPos, _ignoreObj1, _ignoreObj2];
 
             // Ignore intersections near the spot to avoid false LOS blocks from vehicle surfaces
-            if (_testIntersections isNotEqualTo [] ) then {
-                _testIntersections = _testIntersections select { 
-                    _x params ["_intersectPosASL"];
-                    (_intersectPosASL vectorDistanceSqr _testPos) > 0.01;
-                };
+            _testIntersections = _testIntersections select { 
+                _x params ["_intersectPosASL"];
+                (_intersectPosASL vectorDistanceSqr _testPos) > 0.01;
             };
 
             if ([] isEqualTo _testIntersections) then {


### PR DESCRIPTION
Fixes #11136

**When merged this pull request will:**
- _Fix seeker LOS issues by filtering near-surface intersections that cause false obstructions during laser spot acquisition._

### Details

`lineIntersectsSurfaces` often reports collisions on the outer surface of a vehicle or object, even when the laser spot is actually unobstructed.  
This caused the seeker to incorrectly conclude that the spot was not visible.

To avoid this, intersections that are extremely close to the test target position are ignored:

```sqf
_testIntersections = _testIntersections select {
    (_intersectPosASL vectorDistanceSqr _testPos) > 0.01
};
```
### Notes

While this fix resolves the issue, I am not fully confident that this is the ideal or final approach.
I am not sure whether `0.01` is the correct value.

Additionally, during the initial ray generation for the laser hit point:
```sqf
_distance = (_posASL vectorDistance _intersectPosASL) - 0.005;
```
[`fnc_shootRay.sqf:L42`](https://github.com/acemod/ACE3/blob/dd293945223ec3b090e51a1e495fee6d1cbe53e9/addons/laser/functions/fnc_shootRay.sqf#L42)


it might be more appropriate to move the generated laser point slightly further back instead of filtering intersections. 
Determining which method is more accurate and robust is not entirely clear, so expert review and feedback would be greatly appreciated.


### Visual Demonstration
* Bug https://youtu.be/yzAUM3LvGcA 
* Seeker LOS Check Fail Bug Fix Test Value 0.1 https://youtu.be/SGpFVMbf5Ek
* Seeker LOS Check Fail Bug Fix Test Value 0.01 https://youtu.be/s91oweIRLXg
* Seeker LOS Check Fail Bug Fix Test Value 0.001 https://youtu.be/9EEKgjx29JQ
* Image From Bug
![TestBug mp4_20251205_221156 822](https://github.com/user-attachments/assets/de434840-bf7b-43fc-9a42-f7174250e3b8)

* Image From Seeker LOS Check Fail Bug Fix Test Value 0.01
![test0 01 mp4_20251205_213243 222](https://github.com/user-attachments/assets/6fcba390-7b8c-4565-96bf-5b8880682fd4)

### Testing Debug Code
Below is the code I used during debugging.  
Please insert it right after the line I modified.
``` sqf
#ifdef DRAW_LASER_INFO
    drawLine3D [ASLToAGL _posASL, ASLToAGL _testPos, [1,0,0,0.8]];   
    {
        _x params ["_intersectPosASL", "_surfaceNormal", "_intersectObj", "_parentObject", "_selectionNames", "_pathToBisurf"];
        TRACE_1("",_intersectPosASL);
        drawIcon3D ["\A3\ui_f\data\map\vehicleicons\iconMan_ca.paa", [1,1,0,1], (ASLToAGL _intersectPosASL), 0.5, 0.5, 0, "seekerLOSBlock", 0.5, 0.025, "TahomaB"];
    } forEach _testIntersections;         
#endif
```

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

