### PR TITLE
Laser – Adjust default laser beam divergence to 0.3 mrad

### DIFF
--- a/addons/laser/XEH_preInit.sqf
+++ b/addons/laser/XEH_preInit.sqf
@@ -9,7 +9,7 @@ PREP_RECOMPILE_END;
 // Laser default variables
 ACE_DEFAULT_LASER_CODE = 1111;
 ACE_DEFAULT_LASER_WAVELENGTH = 1550;
-ACE_DEFAULT_LASER_BEAMSPREAD = 1;
+ACE_DEFAULT_LASER_BEAMSPREAD = 0.15; // Not 0.15 mrad — this corresponds to ~0.3 mrad divergence
 
 GVAR(laserEmitters) = createHashMap;
 GVAR(trackedLaserTargets) = [];


### PR DESCRIPTION
Issue: 
- https://github.com/acemod/ACE3/issues/11136#issuecomment-3618606576
- https://github.com/acemod/ACE3/issues/11136#issuecomment-3618883856

**When merged this pull request will:**
- _Adjusts the default `ACE_DEFAULT_LASER_BEAMSPREAD` from **1.0 → 0.15** (0.3 mrad)_

_Note: The value `0.15` here is **not** in mrad. Based on in-game geometric testing, `0.15` corresponds to a physical divergence of **~0.3 mrad**._

---

## Real-World Laser Divergence Reference

| Platform / Device            | Divergence (mrad) | Notes / Source |
|------------------------------|-------------------|----------------|
| LITENING Pod                 | **~0.25**         | Manufacturer data |
| Sniper XR Pod                | **0.2–0.3**       | Lockheed Martin |
| ATFLIR Pod                   | **~0.3**          | U.S. Navy documentation |
| AH-64D/E (TADS)              | **~0.5**          | Estimate based on published research |
| Ka-52 / Mi-28N               | **0.6–0.7**       | Russian OEM descriptions |
| Ground JTAC LTD / SOFLAM     | **0.2–0.5**       | Raytheon SOFLAM spec |
| LTD / PEQ series (ground)    | **0.3–0.4**       | Typical IR LTD values |
| UAV Laser Payloads (MX-series) | **0.25–0.5**     | WESCAM MX-Series datasheets |

Values compiled with ChatGPT (Free Model) and confirmed with Gemini Thinking (Free Model).
---

## Reason for Selecting 0.3 mrad
Most LTD systems cluster around 0.2–0.3 mrad, so 0.3 mrad best represents the typical baseline, while higher values like 0.6–0.7 mrad seen on Ka-52/Mi-28N are exceptions rather than the norm.

---

### Note
- I am not very familiar with math, so I verified the divergence through in-game debugging and visual visualization of the beam.
- This PR **only updates the global default value**.  
  While setting detailed, per-platform beam divergence values would be more accurate, that level of data work and integration is **beyond what I can handle**.


### Visual Demonstration
The example below shows the maximum possible left- and right-side ray offsets generated, and the measured distance between them using the updated value 0.15(0.3mrad).
Please reference the red debug text:
“Distance: %1 m, Beam Diameter: %2 m”
![ArmA 3 2025 12 06 - 12 48 17 25 DVR mp4_20251206_131741 503](https://github.com/user-attachments/assets/e058c0bf-fcf2-403b-9086-bb3d782a7efa)
![ArmA 3 2025 12 06 - 12 48 17 25 DVR mp4_20251206_131825 345](https://github.com/user-attachments/assets/9e694db1-dfce-4593-9169-cc976a38f17a)
![ArmA 3 2025 12 06 - 12 48 17 25 DVR mp4_20251206_131851 748](https://github.com/user-attachments/assets/91db91b3-4278-4dfe-bcb5-774d2d35177f)


### Debug Code
_To visualize the beam diameter, insert the code at:_  
https://github.com/acemod/ACE3/blob/42e721182de65aa5ed14dd836d51d7f91e9fb9e3/addons/laser/functions/fnc_shootCone.sqf#L67
```sqf
private _endpoints = [];
{
    private _radOffset = _x;
    private _offset = [_vecRotateMap, _radOffset] call FUNC(rotateVectLine);
    private _offsetPos = _pos2 vectorAdd (_offset vectorMultiply (_divergence * 1));

    private _offsetVector = _pos vectorFromTo _offsetPos;
    TRACE_4("",_radOffset,_offset,_offsetPos,_offsetVector);
    private _result1 = [_pos, _offsetVector, _ignoreObj1] call FUNC(shootRay);
    _endpoints pushBack _result1#0;
} forEach [180,0];

#ifdef DRAW_LASER_INFO
if (count _endpoints == 2) then {
    TRACE_1("",_endpoints);
    _endpoints params ["_left", "_right"];
    private _midPoint = (_left vectorAdd _right) vectorMultiply 0.5;
    private _text = format ["Distance: %1 m, Beam Diameter: %2 m",_midPoint vectorDistance _pos, _left vectorDistance _right];
    drawLine3D [ASLToAGL _left vectorAdd [0,0,0.5], ASLToAGL _left, [1,0,0,1]];
    drawLine3D [ASLToAGL _right, ASLToAGL _right vectorAdd [0,0,0.5], [1,0,0,1]];
    drawLine3D [ASLToAGL _left vectorAdd [0,0,0.5], ASLToAGL _right vectorAdd [0,0,0.5], [1,0,0,1]];
    drawIcon3D ["\a3\ui_f\data\IGUI\Cfg\Cursors\selectover_ca.paa", [1, 0, 0, 1], ASLToAGL _midPoint vectorAdd [0,0,0.5], 1, 1, 0, _text, 0.4, 0.025, "TahomaB"];
};
#endif
```


### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
