### PR TITLE
Frag - Fix Spall not triggering for helicopter pilots due to _gunner null issue

### DIFF
--- a/addons/frag/functions/fnc_fired.sqf
+++ b/addons/frag/functions/fnc_fired.sqf
@@ -20,7 +20,7 @@
 TRACE_10("firedEH:",_unit,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile,_vehicle,_gunner,_turret);
 
 if (_ammo isEqualTo "" || {isNull _projectile} ||
-    !(if (isNil "_gunner") then {local _unit} else {local _gunner}) ||
+    !(if ((isNil "_gunner") || {isNull _gunner}) then {local _unit} else {local _gunner}) ||
     {_projectile getVariable [QGVAR(blacklisted), false]}) exitWith {
     TRACE_2("bad ammo or projectile, or blackList",_ammo,_projectile);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Add proper nil/null check for _gunner to fix Spall not triggering when firing from the pilot seat of helicopters.

### Note
- When firing from the pilot seat of helicopters, `_gunner` is `<NULL-object>`, which caused the spall fired handler to exit early.  

First, I tried:
``` sqf
isNil "_gunner" || isNull _gunner
``` 
but it did not work, so I changed it to:

``` sqf
(isNil "_gunner") || {isNull _gunner}
```  

### Visual Demonstration
- Before https://youtu.be/0GqMISJfAXY
- After https://youtu.be/1Mx_tLsyVgo

### IMPORTANT

- This change affects the Frag module behavior for vehicles, specifically helicopters, but does not affect documentation.
- Development guidelines for ACE3 have been followed.