### PR TITLE
Overpressure - Fix possible null `_gunner` for helicopters

### DIFF
--- a/addons/overpressure/functions/fnc_firedEHBB.sqf
+++ b/addons/overpressure/functions/fnc_firedEHBB.sqf
@@ -18,7 +18,7 @@
 //IGNORE_PRIVATE_WARNING ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_gunner"];
 TRACE_8("firedEH:",_unit,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile,_gunner);
 
-private _shooter = [_gunner, _unit] select (isNil "_gunner");
+private _shooter = [_gunner, _unit] select ((isNil "_gunner") || {isNull _gunner});
 
 // Retrieve backblast values
 private _bbValues = [_weapon, _ammo, _magazine] call FUNC(getOverPressureValues);


### PR DESCRIPTION
same as #11160