### PR TITLE
Common - Fix calls to getVehicleCodriver

### DIFF
--- a/addons/common/functions/fnc_canGetInPosition.sqf
+++ b/addons/common/functions/fnc_canGetInPosition.sqf
@@ -152,7 +152,7 @@ switch (_position) do {
     };
 
     case "codriver" : {
-        private _positions = [typeOf _vehicle] call FUNC(getVehicleCodriver);
+        private _positions = [_vehicle] call FUNC(getVehicleCodriver);
 
         {
             if (alive _x) then {_positions deleteAt (_positions find (_vehicle getCargoIndex _x))};

--- a/addons/common/functions/fnc_getInPosition.sqf
+++ b/addons/common/functions/fnc_getInPosition.sqf
@@ -147,7 +147,7 @@ switch (_position) do {
     };
 
     case "codriver" : {
-        private _positions = [typeOf _vehicle] call FUNC(getVehicleCodriver);
+        private _positions = [_vehicle] call FUNC(getVehicleCodriver);
 
         {
             if (alive _x) then {_positions deleteAt (_positions find (_vehicle getCargoIndex _x))};


### PR DESCRIPTION
https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_getVehicleCodriver.sqf#L20
doesn't seem like the "codriver" case block ever gets used in ace