### PR TITLE
Missile Guidance - Remove damage changes for javelin

### DIFF
--- a/addons/missileguidance/CfgAmmo.hpp
+++ b/addons/missileguidance/CfgAmmo.hpp
@@ -33,9 +33,6 @@ class CfgAmmo {
         // Turn off arma crosshair-guidance
         manualControl = 0;
 
-        hit = 1400;         // default: 800
-        indirectHit = 20;
-        indirectHitRange = 2;
         // ACE uses these values
         //trackOversteer = 1;
         //trackLead = 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove very high hit value from ``ACE_Javelin_FGM148``

The ``hit = 1400`` was added 9-10 years ago with little justification, and it is a **massive** increase compared to what vanilla has in the parent class ``M_Titan_AT``, which has ``hit = 95``. This causes all weapons that use this missile to deal massive damage, achieving one-hit kills on basically any vehicle being targeted.

Considering the submunition penetrator (which was not around when this was originally added), this missile deals some ~2000 points of direct damage (hull damage) and penetrates some 900mm of RHA steel (``caliber = 60`` for the penetrator, inherited from vanilla).

Quick summary from my testing:

Before change:
- T-100 Varsuk, DIR mode: instant kill
- T-100 Varsuk, TOP mode: instant kill
- T-14 Armata, DIR mode: no damage due to ERA plates
- T-14 Armata, TOP mode: instant kill

After change:
- T-100 Varsuk, DIR mode: heavy damage
- T-100 Varsuk, TOP mode: heavy damage / instant kill
- T-14 Armata, DIR mode: no damage due to ERA plates
- T-14 Armata, TOP mode: heavy damage

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
