### PR TITLE
Compat SOG - Change multiplier of hearing damage from M134 magazines

### DIFF
--- a/addons/compat_sog/compat_sog_hearing/CfgMagazines.hpp
+++ b/addons/compat_sog/compat_sog_hearing/CfgMagazines.hpp
@@ -1,0 +1,6 @@
+class CfgMagazines {
+    class vn_vmagazine_mg;
+    class vn_m134_v_2000_mag: vn_vmagazine_mg {
+        EGVAR(hearing,maxLoudness) = 0.13;
+    };
+};

--- a/addons/compat_sog/compat_sog_hearing/config.cpp
+++ b/addons/compat_sog/compat_sog_hearing/config.cpp
@@ -21,3 +21,4 @@ class CfgPatches {
 };
 
 #include "CfgWeapons.hpp"
+#include "CfgMagazines.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Change the multiplier of SOG M134 magazines' `ace_hearing_maxLoudness` value, making it cause less hearing damage.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
