### PR TITLE
Compat_RF - Fix Scout40 UBC

### DIFF
--- a/addons/compat_rf/compat_rf_realisticnames/CfgVehicles.hpp
+++ b/addons/compat_rf/compat_rf_realisticnames/CfgVehicles.hpp
@@ -142,8 +142,8 @@ class CfgVehicles {
         displayName = SUBCSTRING(twinmortar_Name);
     };
 
-    class Helicopter_Base_F;
-    class UAV_RC40_Base_RF: Helicopter_Base_F {
+    class UAV_01_base_F;
+    class UAV_RC40_Base_RF: UAV_01_base_F {
         displayName = SUBCSTRING(rc40_base_Name);
     };
     class UAV_RC40_Base_Sensor_RF: UAV_RC40_Base_RF {


### PR DESCRIPTION
fix #11166
```
Updating base class 'UAV_01_base_F'->'Helicopter_Base_F', by 'z\ace\addons\compat_rf\compat_rf_realisticnames\config.cpp/CfgVehicles/UAV_RC40_Base_RF/' ('ace'/'ace_compat_rf_realisticnames') (original 'lxRF\air_rf\rc40\config.bin')
```