### PR TITLE
Advanced Ballistics - Remove getPos from bullet trace

### DIFF
--- a/addons/advanced_ballistics/functions/fnc_handleFirePFH.sqf
+++ b/addons/advanced_ballistics/functions/fnc_handleFirePFH.sqf
@@ -23,7 +23,7 @@
         private _bulletPosition = getPosASL _bullet;
 
         if (_bulletTraceVisible && {vectorMagnitude _bulletVelocity > BULLET_TRACE_MIN_VELOCITY}) then {
-            drop ["\A3\data_f\ParticleEffects\Universal\Refract","","Billboard",1,0.1,getPos _bullet,[0,0,0],0,1.275,1,0,[0.02*_caliber,0.01*_caliber],[[0,0,0,0.65],[0,0,0,0.2]],[1,0],0,0,"","",""];
+            drop ["\A3\data_f\ParticleEffects\Universal\Refract","","Billboard",1,0.1,ASLToAGL _bulletPosition,[0,0,0],0,1.275,1,0,[0.02*_caliber,0.01*_caliber],[[0,0,0,0.65],[0,0,0,0.2]],[1,0],0,0,"","",""];
         };
 
         (


### PR DESCRIPTION
**When merged this pull request will:**
- Remove ``getPos`` from the bullet trace logic in favour of using the existing position in AGL format

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
