### PR TITLE
Compat Atlas - Add new addon for Atlas compatibility

### DIFF
--- a/addons/compat_atlas/$PBOPREFIX$
+++ b/addons/compat_atlas/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ace\addons\compat_atlas

--- a/addons/compat_atlas/compat_atlas_missile_manpad/CfgVehicles.hpp
+++ b/addons/compat_atlas/compat_atlas_missile_manpad/CfgVehicles.hpp
@@ -1,0 +1,30 @@
+class CfgVehicles {
+    class Tank_F;
+
+    class LT_01_base_F: Tank_F {
+        class Turrets;
+    };
+
+    class LT_01_AA_base_F: LT_01_base_F {
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+
+    class Atlas_B_G_LT_01_AA_F: LT_01_AA_base_F {
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                weapons[] = {"SmokeLauncher", QEGVAR(missile_manpad,FIM92), "HMG_127"};
+                magazines[] = {
+                    "SmokeLauncherMag", 
+                    QEGVAR(missile_manpad,stinger), 
+                    QEGVAR(missile_manpad,stinger), 
+                    "100Rnd_127x99_mag_Tracer_Red", 
+                    "100Rnd_127x99_mag_Tracer_Red", 
+                    "100Rnd_127x99_mag_Tracer_Red", 
+                    "100Rnd_127x99_mag_Tracer_Red"
+                };
+            };
+        };
+    };
+};

--- a/addons/compat_atlas/compat_atlas_missile_manpad/config.cpp
+++ b/addons/compat_atlas/compat_atlas_missile_manpad/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "A3_Atlas_Armor_F_Atlas_LT_01",
+            "ace_missile_manpad"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"ThomasAngel"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_atlas/compat_atlas_missile_manpad/script_component.hpp
+++ b/addons/compat_atlas/compat_atlas_missile_manpad/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT missile_manpad
+#define SUBCOMPONENT_BEAUTIFIED MANPAD
+#include "..\script_component.hpp"

--- a/addons/compat_atlas/config.cpp
+++ b/addons/compat_atlas/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "A3_Atlas_Data_F_Atlas_Loadorder",
+            "ace_common"
+        };
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(common,ACETeam);
+        authors[] = {"ThomasAngel"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring this addon
+        addonRootClass = "A3_Characters_F";
+    };
+};

--- a/addons/compat_atlas/script_component.hpp
+++ b/addons/compat_atlas/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT compat_atlas
+#define COMPONENT_BEAUTIFIED Atlas Compatibility
+
+#include "\z\ace\addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add a new compat mod for [Arma 3 Atlas](https://steamcommunity.com/sharedfiles/filedetails/?id=2225873516&searchtext=ATLAS) (Aegis expansion)
- Add correct magazines to ``Atlas_B_G_LT_01_AA_F`` (Bundeswehr Nyx AA variant)

The AA inherits the manpad weapon but overwrites the magazines, this fixes that.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
