### PR TITLE
Ballistics - Add ballistic data for vanilla shotguns

### DIFF
--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -136,6 +136,18 @@ class CfgWeapons {
         initSpeed = -1.0;
     };
 
+    // Rifle_Long_Base_F Shotgun
+    // CZ-581
+    class sgun_HunterShotgun_01_base_F: Rifle_Long_Base_F {
+        ACE_barrelLength = 699.3; // https://www.imfdb.org/wiki/CZ-581
+        ACE_twistDirection = 0;
+    };
+
+    // CZ-581 (sawed off)
+    class sgun_HunterShotgun_01_sawedoff_base_F: sgun_HunterShotgun_01_base_F {
+        ACE_barrelLength = 349.7; // About half of original length
+    };
+
     // Rifle_Base_F
     // MX variants
     class arifle_MX_Base_F: Rifle_Base_F {};
@@ -360,6 +372,14 @@ class CfgWeapons {
         magazines[] += { // 6.5C Rechambering, only available for Grot MR
             "ACE_30Rnd_65_Creedmor_msbs_mag",
             "ACE_30Rnd_65x47_Scenar_msbs_mag"
+        };
+    };
+
+    // MSBS GROT UBS
+    class arifle_MSBS65_UBS_base_F: arifle_MSBS65_base_F {
+        class UBS_F: Rifle_Base_F {
+            ACE_barrelLength = 317; // https://modernfirearms.net/en/shotguns/u-s-a-shotguns/crye-six12-eng/
+            ACE_twistDirection = 0;
         };
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add ballistic data for CZ-581 and its sawed-off version
- Add ballistic data for MSBS Grot UBS

Sources (also linked in code comments):
- [imfdb](https://www.imfdb.org/wiki/CZ-581)
- [Modern Firearms](https://modernfirearms.net/en/shotguns/u-s-a-shotguns/crye-six12-eng/)
- [Picture from which I eyeballed the sawed-off length](https://imgur.com/a/arma-3-cz-581-sawed-off-estimated-barrel-length-Xgk2Noj)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
