### PR TITLE
Recoil - Reduce guided launcher recoil

### DIFF
--- a/addons/recoil/CfgRecoils.hpp
+++ b/addons/recoil/CfgRecoils.hpp
@@ -347,42 +347,42 @@ class CfgRecoils {
 
     class recoil_nlaw: recoil_default {
         muzzleOuter[] = {
-            2*MUZZLERIGHT_POS,
-            3*MUZZLECLIMB_POS,
-            1*MUZZLERIGHT_MAG,
-            0.5*MUZZLECLIMB_MAG
+            0.1*MUZZLERIGHT_POS,
+            0.2*MUZZLECLIMB_POS,
+            0.3*MUZZLERIGHT_MAG,
+            0.4*MUZZLECLIMB_MAG
         };
         kickBack[] = {
-            0.06*KICKBACK,
-            0.08*KICKBACK
+            0.0*KICKBACK,
+            0.05*KICKBACK
         };
         temporary = 0.08*MUZZLETEMP;
     };
 
     class recoil_titan_long: recoil_default {
         muzzleOuter[] = {
-            2*MUZZLERIGHT_POS,
-            3*MUZZLECLIMB_POS,
-            1*MUZZLERIGHT_MAG,
+            0.1*MUZZLERIGHT_POS,
+            0.2*MUZZLECLIMB_POS,
+            0.3*MUZZLERIGHT_MAG,
             0.5*MUZZLECLIMB_MAG
         };
         kickBack[] = {
-            0.1*KICKBACK,
-            0.12*KICKBACK
+            0.0*KICKBACK,
+            0.05*KICKBACK
         };
         temporary = 0.15*MUZZLETEMP;
     };
 
     class recoil_titan_short: recoil_default {
         muzzleOuter[] = {
-            2*MUZZLERIGHT_POS,
-            3*MUZZLECLIMB_POS,
-            1*MUZZLERIGHT_MAG,
+            0.1*MUZZLERIGHT_POS,
+            0.2*MUZZLECLIMB_POS,
+            0.3*MUZZLERIGHT_MAG,
             0.5*MUZZLECLIMB_MAG
         };
         kickBack[] = {
-            0.1*KICKBACK,
-            0.12*KICKBACK
+            0.0*KICKBACK,
+            0.05*KICKBACK
         };
         temporary = 0.12*MUZZLETEMP;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Reduce recoil for NLAW and the Spike variants

In real life, these weapons systems have very little to no recoil at all. And the slight recoil that they do have is very random in nature, and in many videos you can even see "negative recoil" (caused by the weapon or the operator over-compensating the recoil, idk), causing them to slightly lean forward or point the weapon slightly downwards. I don't think negative kickback (forwards momentum) is supported so I left the minimum at zero. Up and down variance is implemented by making the magnitudes greater than the climb rates.

- [Video of NLAW firing](https://www.youtube.com/watch?v=hupsUq-fzq8)
- [Video of mini-spike firing](https://www.youtube.com/watch?v=x4K4rkKz814)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
