### PR TITLE
missile_aim9 - Fix pylonweapon for multi missile aim132s

### DIFF
--- a/addons/missile_aim9/CfgMagazines.hpp
+++ b/addons/missile_aim9/CfgMagazines.hpp
@@ -70,7 +70,6 @@ class CfgMagazines {
         displayName = CSTRING(aim132_2x);
         ammo = QGVAR(aim132);
         pylonWeapon = QGVAR(aim132);
-        hardpoints[] += {"B_ASRAAM_DUAL_RAIL"};
     };
 
     class GVAR(aim132_2Rnd_MI02): 2Rnd_AAA_missiles_MI02 {
@@ -78,7 +77,6 @@ class CfgMagazines {
         displayName = CSTRING(aim132_2x);
         ammo = QGVAR(aim132);
         pylonWeapon = QGVAR(aim132);
-        hardpoints[] += {"B_ASRAAM_DUAL_RAIL"};
     };
 
     class GVAR(aim132_2Rnd_MI06): 2Rnd_AAA_missiles_MI06 {
@@ -86,7 +84,6 @@ class CfgMagazines {
         displayName = CSTRING(aim132_2x);
         ammo = QGVAR(aim132);
         pylonWeapon = QGVAR(aim132);
-        hardpoints[] += {"B_ASRAAM_DUAL_RAIL"};
     };
 
     class GVAR(aim132_4Rnd): 4Rnd_AAA_missiles {
@@ -94,7 +91,6 @@ class CfgMagazines {
         displayName = CSTRING(aim132_4x);
         ammo = QGVAR(aim132);
         pylonWeapon = QGVAR(aim132);
-        hardpoints[] += {"B_ASRAAM_QUAD_RAIL"};
     };
 
     class GVAR(aim132_4Rnd_MI02): 4Rnd_AAA_missiles_MI02 {
@@ -102,7 +98,6 @@ class CfgMagazines {
         displayName = CSTRING(aim132_4x);
         ammo = QGVAR(aim132);
         pylonWeapon = QGVAR(aim132);
-        hardpoints[] += {"B_ASRAAM_QUAD_RAIL"};
     };
 
     class GVAR(PylonRack_1Rnd_aim132): PylonRack_1Rnd_AAA_missiles {


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Still no hardpoints configured as models do not work

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
