### PR TITLE
missile_aim9 - Add dual rack aim-132

### DIFF
--- a/addons/missile_aim9/CfgMagazines.hpp
+++ b/addons/missile_aim9/CfgMagazines.hpp
@@ -112,6 +112,7 @@ class CfgMagazines {
     class GVAR(PylonRack_2Rnd_aim132): GVAR(PylonRack_1Rnd_aim132) {
         count = 2;
         displayName = CSTRING(aim132_2x);
+        hardpoints[] += {"B_ASRAAM_DUAL_RAIL"};
         model = "\A3\Weapons_F_Jets\Ammo\PylonPod_Missile_AA_08_DualRail_x2_F";
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title
- No aircraft in the game have `B_ASRAAM_DUAL_RAIL` configured as a hardpoint, doesn't influence balance unless intentional.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
