### PR TITLE
Wardrobe - Fix: Issue with Backpacks not having "ItemInfo"

### DIFF
--- a/addons/wardrobe/functions/fnc_replace.sqf
+++ b/addons/wardrobe/functions/fnc_replace.sqf
@@ -38,6 +38,7 @@ if (_typeNumber isEqualTo 0) then {
     _typeNumber = switch (true) do {
         // CfgGlasses items do not have a ItemInfo subclass and therefore, will return 0
         case (isClass (configFile >> "CfgGlasses" >> _classOrigin)): { TYPE_GOGGLE };
+        case (getNumber (configFile >> "CfgVehicles" >> _classOrigin >> "isBackpack") isEqualTo 1): { TYPE_BACKPACK };
         default { 0 };
     };
 };


### PR DESCRIPTION
Solves the issue with Backpacks not having an itemInfo by adding a custom check for `... >> "isBackpack" isEqualTo 1`.

Successfully tested with temp config `BASE_PAIR(B_AssaultPack_cbr,B_AssaultPack_blk);`.