### PR TITLE
Interact Menu - Use List on MacOS

### DIFF
--- a/addons/interact_menu/functions/fnc_renderIcon.sqf
+++ b/addons/interact_menu/functions/fnc_renderIcon.sqf
@@ -38,7 +38,7 @@ if (_iconFile isEqualTo "") then {
     _iconFile = DEFAULT_ICON;
 };
 
-_text = if ([GVAR(useListMenu), GVAR(useListMenuSelf)] select GVAR(keyDownSelfAction)) then {
+_text = if ([GVAR(useListMenu), GVAR(useListMenuSelfActual)] select GVAR(keyDownSelfAction)) then {
     format ["<img image='%1' align='left' color='%2'/><t %3>%4</t>", _iconFile, _iconColor, _textSettings, _text]
 } else {
     format ["<img image='%1' align='center' color='%2'/><br/><t %3 align='center'>%4</t>", _iconFile, _iconColor, _textSettings, ("ace" callExtension ["break_line", [_text]]) select 0];
@@ -47,7 +47,7 @@ _text = if ([GVAR(useListMenu), GVAR(useListMenuSelf)] select GVAR(keyDownSelfAc
 [_ctrl, GVAR(iconCount), _text] call FUNC(ctrlSetParsedTextCached);
 GVAR(iconCount) = GVAR(iconCount) + 1;
 
-private _pos = if ([GVAR(useListMenu), GVAR(useListMenuSelf)] select GVAR(keyDownSelfAction)) then {
+private _pos = if ([GVAR(useListMenu), GVAR(useListMenuSelfActual)] select GVAR(keyDownSelfAction)) then {
     [(_sPos select 0) - (0.0095 * safeZoneW), (_sPos select 1) - (0.0095 * safeZoneW), 0.20 * safeZoneW, 0.035 * safeZoneW]
 } else {
     [(_sPos select 0) - (0.0750 * safeZoneW), (_sPos select 1) - (0.0095 * safeZoneW), 0.15 * safeZoneW, 0.100 * safeZoneW]

--- a/addons/interact_menu/functions/fnc_renderMenu.sqf
+++ b/addons/interact_menu/functions/fnc_renderMenu.sqf
@@ -89,7 +89,7 @@ if (_numChildren == 1) then {
 // Scale menu based on the amount of children
 private _scaleX = 1;
 private _scaleY = 1;
-private _useListMenu = [GVAR(useListMenu), GVAR(useListMenuSelf)] select GVAR(keyDownSelfAction);
+private _useListMenu = [GVAR(useListMenu), GVAR(useListMenuSelfActual)] select GVAR(keyDownSelfAction);
 if (_useListMenu) then {
     private _textSize = [0.75, 0.875, 1, 1.2, 1.4] select GVAR(textSize);
     _scaleX = _textSize * 0.17 * 1.1;

--- a/addons/interact_menu/functions/fnc_renderSelector.sqf
+++ b/addons/interact_menu/functions/fnc_renderSelector.sqf
@@ -29,7 +29,7 @@ if(GVAR(iconCount) > (count GVAR(iconCtrls))-1) then {
 
 private _ctrl = GVAR(iconCtrls) select GVAR(iconCount);
 
-private _pos = if ([GVAR(useListMenu), GVAR(useListMenuSelf)] select GVAR(keyDownSelfAction)) then {
+private _pos = if ([GVAR(useListMenu), GVAR(useListMenuSelfActual)] select GVAR(keyDownSelfAction)) then {
     [_ctrl, GVAR(iconCount), format ["<img image='%1' color='%2' size='1.6'/>", _icon, GVAR(selectorColorHex)]] call FUNC(ctrlSetParsedTextCached);
     [(_sPos select 0)-(GVAR(SELECTOR_LIST_X)*safeZoneW), (_sPos select 1)-(GVAR(SELECTOR_LIST_Y)*safeZoneW), GVAR(SELECTOR_LIST_W)*safeZoneW, GVAR(SELECTOR_LIST_H)*safeZoneW]
 } else {

--- a/addons/interact_menu/initSettings.inc.sqf
+++ b/addons/interact_menu/initSettings.inc.sqf
@@ -141,7 +141,10 @@ private _categoryColors = [_category, format ["| %1 |", LELSTRING(common,subcate
     LSTRING(UseListMenu),
     [_category, LELSTRING(Interaction,InteractionMenuSelf)],
     (productVersion select 6) == "OSX",
-    false
+    false,
+    {
+        GVAR(useListMenuSelfActual) = _this || {(productVersion select 6) == "OSX"}
+    }
 ] call CBA_fnc_addSetting;
 
 [


### PR DESCRIPTION
**When merged this pull request will:**
- Use List for Self Interact on MacOS

The circular view uses `break_line` from the extension, which isn't available on MacOS.

*Alternatively make List the default since it is superior...*

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
