### PR TITLE
Scopes - Stop applying scope offsets to secondary muzzles

### DIFF
--- a/addons/scopes/functions/fnc_firedEH.sqf
+++ b/addons/scopes/functions/fnc_firedEH.sqf
@@ -20,6 +20,9 @@ TRACE_10("firedEH:",_unit,_weapon,_muzzle,_mode,_ammo,_magazine,_projectile,_veh
 
 if !(_ammo isKindOf "BulletBase") exitWith {};
 
+// Ignore secondary muzzles
+if (_weapon != _muzzle) exitWith {};
+
 private _weaponIndex = [_unit, currentWeapon _unit] call EFUNC(common,getWeaponIndex);
 if (_weaponIndex < 0) exitWith {};
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- As it is, the underslung shotgun's projectiles for the Promet/MSBS Grot deviate strongly from any scope used.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
