### PR TITLE
Sandbag - Fix XEH

### DIFF
--- a/addons/sandbag/CfgVehicles.hpp
+++ b/addons/sandbag/CfgVehicles.hpp
@@ -33,7 +33,10 @@ class CfgVehicles {
 
     class ThingX;
     class ACE_SandbagObject: ThingX {
-        XEH_DISABLED;
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers_base {};
+        };
+
         author = ECSTRING(common,ACETeam);
         scope = 2;
         side = 3;
@@ -86,6 +89,7 @@ class CfgVehicles {
     };
 
     class ACE_SandbagObject_NoGeo: ACE_SandbagObject {
+        XEH_DISABLED;
         scope = 1;
         model = QPATHTOF(data\ace_sandbag_nogeo.p3d);
     };


### PR DESCRIPTION
Fixes
```
[CBA] (xeh) WARNING: ACE_SandbagObject_NoGeo does not support Extended Event Handlers! Addon: ace
```
could instead just add `SLX_XEH_DISABLED = 1` but I don't see any harm in xeh on these