### PR TITLE
Missileguidance - Add local event for modification of seeker parameters

### DIFF
--- a/addons/missileguidance/functions/fnc_guidancePFH.sqf
+++ b/addons/missileguidance/functions/fnc_guidancePFH.sqf
@@ -20,6 +20,9 @@
 BEGIN_COUNTER(guidancePFH);
 
 params ["_args", "_pfID"];
+
+[QGVAR(guidanceTick),_args] call CBA_fnc_localEvent; // Raise local event for seeker modification API
+
 _args params ["_firedEH", "_launchParams", "_flightParams", "_seekerParams", "_stateParams", "_targetData", "_navigationStateParams"];
 _firedEH params ["_shooter","","","","_ammo","","_projectile"];
 _launchParams params ["","_targetLaunchParams","","","","","_navigationType"];

--- a/addons/missileguidance/functions/fnc_guidancePFH.sqf
+++ b/addons/missileguidance/functions/fnc_guidancePFH.sqf
@@ -21,7 +21,7 @@ BEGIN_COUNTER(guidancePFH);
 
 params ["_args", "_pfID"];
 
-[QGVAR(guidanceTick),_args] call CBA_fnc_localEvent; // Raise local event for seeker modification API
+[QGVAR(guidanceTick),_args] call CBA_fnc_localEvent; // This is not API, and may be broken in the future
 
 _args params ["_firedEH", "_launchParams", "_flightParams", "_seekerParams", "_stateParams", "_targetData", "_navigationStateParams"];
 _firedEH params ["_shooter","","","","_ammo","","_projectile"];


### PR DESCRIPTION
Entirely possible this isn't the best way to do it, but this is the least intrusive way I can think of - shifting everything to variables on the munition would be a fairly substantial change.

**When merged this pull request will:**
- title

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
