### PR TITLE
CSW - Add Vanilla M2 HMG Shield/Holosight Variants

### DIFF
--- a/addons/csw/CfgVehicles.hpp
+++ b/addons/csw/CfgVehicles.hpp
@@ -200,20 +200,39 @@ class CfgVehicles {
             ammoLoadTime = 7;
             ammoUnloadTime = 5;
         };
+        class AnimationSources;
     };
     class HMG_02_high_base_F: HMG_02_base_F {
-        class ADDON {
-            enabled = 1;
-            proxyWeapon = QGVAR(HMG_M2_Mounted);
-            magazineLocation = "_target selectionPosition 'magazine'";
-            disassembleWeapon = QGVAR(staticM2ShieldCarry); // carry weapon [CfgWeapons]
+        class ADDON: ADDON {
             disassembleTurret = QGVAR(m3Tripod); // turret [CfgVehicles]
-            desiredAmmo = 100;
-            ammoLoadTime = 7;
-            ammoUnloadTime = 5;
         };
     };
 
+    class B_HMG_02_F: HMG_02_base_F {
+        class AnimationSources: AnimationSources {
+            class Hide_Rail;
+            class Hide_Shield;
+        };
+    };
+    class B_HMG_02_high_F: HMG_02_high_base_F {
+        class AnimationSources: AnimationSources {
+            class Hide_Rail;
+            class Hide_Shield;
+        };
+    };
+
+    // HMG_02 Subvariants with different configured attachments
+    class GVAR(HMG_02_shield): B_HMG_02_F { M2_VARIANT_SHIELD; };
+    class GVAR(HMG_02_shield_high): B_HMG_02_high_F { M2_VARIANT_SHIELD; };
+
+    class GVAR(HMG_02_sight): B_HMG_02_F { M2_VARIANT_SIGHT; };
+    class GVAR(HMG_02_sight_high): B_HMG_02_high_F { M2_VARIANT_SIGHT; };
+
+    class GVAR(HMG_02_shield_sight): B_HMG_02_F { M2_VARIANT_SHIELD_AND_SIGHT; };
+    class GVAR(HMG_02_shield_sight_high): B_HMG_02_high_F { M2_VARIANT_SHIELD_AND_SIGHT; };
+
+    class GVAR(HMG_02_bare): B_HMG_02_F { M2_VARIANT_BARE; };
+    class GVAR(HMG_02_bare_high): B_HMG_02_high_F { M2_VARIANT_BARE; };
 
     class GMG_TriPod;
     class GMG_01_base_F: GMG_TriPod {

--- a/addons/csw/CfgWeapons.hpp
+++ b/addons/csw/CfgWeapons.hpp
@@ -182,16 +182,52 @@ class CfgWeapons {
     class GVAR(staticM2ShieldCarry): GVAR(staticHMGCarry) {
         class ADDON: ADDON {
             class assembleTo {
-                GVAR(m3Tripod) = "B_HMG_02_high_F";
-                GVAR(m3TripodLow) = "B_HMG_02_F";
+                GVAR(m3Tripod) = QGVAR(HMG_02_shield_high);
+                GVAR(m3TripodLow) = QGVAR(HMG_02_shield);
             };
         };
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 1000;
+            mass = M2_MASS + M2_SHIELD_MASS;
         };
         displayName = CSTRING(StaticM2ShieldBag_displayName);
         author = ECSTRING(common,ACETeam);
         picture = QPATHTOF(UI\StaticM2Shield_Icon_ca.paa);
+    };
+    class GVAR(staticM2ShieldSightCarry): GVAR(staticM2ShieldCarry) {
+        class ADDON: ADDON {
+            class assembleTo {
+                GVAR(m3Tripod) = QGVAR(HMG_02_shield_sight_high);
+                GVAR(m3TripodLow) = QGVAR(HMG_02_shield_sight);
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = M2_MASS + M2_SHIELD_MASS + M2_SIGHT_MASS;
+        };
+        displayName = CSTRING(StaticM2ShieldSightBag_displayName);
+    };
+    class GVAR(staticM2SightCarry): GVAR(staticM2ShieldCarry) {
+        class ADDON: ADDON {
+            class assembleTo {
+                GVAR(m3Tripod) = QGVAR(HMG_02_sight_high);
+                GVAR(m3TripodLow) = QGVAR(HMG_02_sight);
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = M2_MASS + M2_SIGHT_MASS;
+        };
+        displayName = CSTRING(StaticM2SightBag_displayName);
+    };
+    class GVAR(staticM2BareCarry): GVAR(staticM2ShieldCarry) {
+        class ADDON: ADDON {
+            class assembleTo {
+                GVAR(m3Tripod) = QGVAR(HMG_02_bare_high);
+                GVAR(m3TripodLow) = QGVAR(HMG_02_bare);
+            };
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = M2_MASS;
+        };
+        displayName = CSTRING(StaticM2BareBag_displayName);
     };
 
     class GVAR(staticGMGCarry): Launcher_Base_F {

--- a/addons/csw/config.cpp
+++ b/addons/csw/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
         units[] = {QGVAR(m3Tripod),QGVAR(m3TripodLow),QGVAR(kordTripod),QGVAR(kordTripodLow),QGVAR(sag30Tripod),QGVAR(m220Tripod),QGVAR(spg9Tripod),QGVAR(mortarBaseplate)};
-        weapons[] = {QGVAR(m3CarryTripod),QGVAR(m3CarryTripodLow),QGVAR(kordCarryTripod),QGVAR(kordCarryTripodLow),QGVAR(m220CarryTripod),QGVAR(spg9CarryTripod),QGVAR(sag30CarryTripod),QGVAR(carryMortarBaseplate),QGVAR(staticATCarry),QGVAR(staticAACarry),QGVAR(staticHMGCarry),QGVAR(staticM2ShieldCarry),QGVAR(staticGMGCarry),QGVAR(staticMortarCarry)};
+        weapons[] = {QGVAR(m3CarryTripod),QGVAR(m3CarryTripodLow),QGVAR(kordCarryTripod),QGVAR(kordCarryTripodLow),QGVAR(m220CarryTripod),QGVAR(spg9CarryTripod),QGVAR(sag30CarryTripod),QGVAR(carryMortarBaseplate),QGVAR(staticATCarry),QGVAR(staticAACarry),QGVAR(staticHMGCarry),QGVAR(staticM2ShieldCarry),QGVAR(staticM2ShieldSightCarry),QGVAR(staticM2SightCarry),QGVAR(staticM2BareCarry),QGVAR(staticGMGCarry),QGVAR(staticMortarCarry)};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_interaction"};
         author = ECSTRING(common,ACETeam);

--- a/addons/csw/script_component.hpp
+++ b/addons/csw/script_component.hpp
@@ -26,3 +26,8 @@
 #else
     #define TIME_PROGRESSBAR(X) ((X) * GVAR(progressBarTimeCoefficent))
 #endif
+
+// The following are calculated mass values for the Vanilla M2 HMG components (mass = pounds * 10)
+#define M2_MASS 840 // 84 pound M2 Browning
+#define M2_SIGHT_MASS 62 // 4.2 pound Trijicon MGRS + ~2 pound mounting adaptor
+#define M2_SHIELD_MASS 550 // 55 pound ~800x450x8 millimeter steel plate and mounting arms

--- a/addons/csw/script_config_macros_csw.hpp
+++ b/addons/csw/script_config_macros_csw.hpp
@@ -1,1 +1,30 @@
 #define CREATE_CSW_PROXY(weapon) class ##weapon; class GVAR(weapon): ##weapon { magazineReloadTime = 0.5; }
+
+#define M2_VARIANT_SHIELD class ADDON: ADDON { \
+        disassembleWeapon = QGVAR(staticM2ShieldCarry); \
+    }; \
+    class AnimationSources: AnimationSources { \
+        class Hide_Rail: Hide_Rail {initPhase = 1;}; \
+        class Hide_Shield: Hide_Shield {initPhase = 0;}; \
+    }
+#define M2_VARIANT_BARE class ADDON: ADDON { \
+        disassembleWeapon = QGVAR(staticM2BareCarry); \
+    }; \
+    class AnimationSources: AnimationSources { \
+        class Hide_Rail: Hide_Rail {initPhase = 1;}; \
+        class Hide_Shield: Hide_Shield {initPhase = 1;}; \
+    }
+#define M2_VARIANT_SIGHT class ADDON: ADDON { \
+        disassembleWeapon = QGVAR(staticM2SightCarry); \
+    }; \
+    class AnimationSources: AnimationSources { \
+        class Hide_Rail: Hide_Rail {initPhase = 0;}; \
+        class Hide_Shield: Hide_Shield {initPhase = 1;}; \
+    }
+#define M2_VARIANT_SHIELD_AND_SIGHT class ADDON: ADDON { \
+        disassembleWeapon = QGVAR(staticM2ShieldSightCarry); \
+    }; \
+    class AnimationSources: AnimationSources { \
+        class Hide_Rail: Hide_Rail {initPhase = 0;}; \
+        class Hide_Shield: Hide_Shield {initPhase = 0;}; \
+    }

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -407,6 +407,11 @@
             <Turkish>[CSW] Static XM312 Gun</Turkish>
             <Ukrainian>[CSW] Станковий XM312 кулемет</Ukrainian>
         </Key>
+        <Key ID="STR_ACE_CSW_StaticM2BareBag_displayName">
+            <English>[CSW] Static M2 w/o Attachments</English>
+            <Italian>[CSW] M2 Statico senza Accessori</Italian>
+            <German>[CSW] Statisches M2 ohne Schild</German>
+        </Key>
         <Key ID="STR_ACE_CSW_StaticM2ShieldBag_displayName">
             <English>[CSW] Static M2 w/ Shield</English>
             <Czech>[CSW] Statická zbraň M2 se štítem</Czech>
@@ -421,6 +426,16 @@
             <Japanese>[CSW] 設置型 防盾付き M2</Japanese>
             <Chinesesimp>[班组] 固定式防盾型 M2 重机枪</Chinesesimp>
             <Ukrainian>[CSW] Станковий M2 зі щитом</Ukrainian>
+        </Key>
+        <Key ID="STR_ACE_CSW_StaticM2ShieldSightBag_displayName">
+            <English>[CSW] Static M2 w/ Shield and Sight</English>
+            <Italian>[CSW] M2 Statico con Scudo e Ottica</Italian>
+            <German>[CSW] Statisches M2 mit Schild und Optik</German>
+        </Key>
+        <Key ID="STR_ACE_CSW_StaticM2SightBag_displayName">
+            <English>[CSW] Static M2 w/ Sight</English>
+            <Italian>[CSW] M2 Statico con ottica</Italian>
+            <German>[CSW] Statisches M2 mit Optik</German>
         </Key>
         <Key ID="STR_ACE_CSW_actionLink">
             <English>Link %1</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add several variants of the same Vanilla M2 static HMG, with different [AnimationSources](https://community.bistudio.com/wiki/Arma_3:_Vehicle_Customisation). This allows Weapon Teams to carry a variant without a shield and/or holosight if they don't require their benefits and want to save on weight.

**Feedback requested for:**
- [ ] Balance carried weapon weights.
ATM they are set to be realistic as per IRL M2 and Holosight weight + my estimations of the steel shield's weight. But maybe they could be made lighter to be more balanced, as IRL the separate shield could be offloaded to a second assistant gunner/ammo bearer.