### PR TITLE
Medical - Fix ace_medical_fnc_serializeState modifying unit medications array

### DIFF
--- a/addons/medical/functions/fnc_serializeState.sqf
+++ b/addons/medical/functions/fnc_serializeState.sqf
@@ -50,7 +50,7 @@ private _state = [] call CBA_fnc_createNamespace;
 ];
 
 // Convert medications time to offset
-private _medications =+ (_unit getVariable [VAR_MEDICATIONS, []]);
+private _medications = +(_unit getVariable [VAR_MEDICATIONS, []]);
 {
     _x set [1, _x#1 - CBA_missionTime];
 } forEach _medications;


### PR DESCRIPTION
**When merged this pull request will:**
- title

I noticed that running serializeState on a unit will modify the unit's medications array with the "time" offsets. Issue was due to arrays being references. Fixes issue #11308 