### PR TITLE
github workflow - try re-enabling hemtt annotate

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
       with:
-        annotate: false
+        annotate: true
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder


### PR DESCRIPTION
we disabled because we were getting double annotations, but now we don't get any

so going to try turning it back on for this workflow