### PR TITLE
Rearm - Add pylon position check

### DIFF
--- a/addons/rearm/CfgAmmo.hpp
+++ b/addons/rearm/CfgAmmo.hpp
@@ -15,6 +15,30 @@ class CfgAmmo {
     class Missile_AA_03_F: Missile_AA_04_F {
         GVAR(dummy) = QGVAR(Missile_AA_03_F);
     };
+    class M_Air_AA: MissileBase {
+        GVAR(dummy) = QGVAR(M_Air_AA);
+    };
+    class M_Titan_AA;
+    class M_Zephyr: M_Titan_AA {
+        GVAR(dummy) = QGVAR(M_Zephyr);
+    };
+    class ammo_Missile_MediumRangeAABase;
+    class ammo_Missile_AMRAAM_C: ammo_Missile_MediumRangeAABase {
+        GVAR(dummy) = QGVAR(ammo_Missile_AMRAAM_C);
+    };
+    class ammo_Missile_AMRAAM_D: ammo_Missile_MediumRangeAABase {
+        GVAR(dummy) = QGVAR(ammo_Missile_AMRAAM_D);
+    };
+    class ammo_Missile_AA_R77: ammo_Missile_MediumRangeAABase {
+        GVAR(dummy) = QGVAR(ammo_Missile_AA_R77);
+    };
+    class ammo_Missile_ShortRangeAABase;
+    class ammo_Missile_BIM9X: ammo_Missile_ShortRangeAABase {
+        GVAR(dummy) = QGVAR(ammo_Missile_BIM9X);
+    };
+    class ammo_Missile_AA_R73: ammo_Missile_ShortRangeAABase {
+        GVAR(dummy) = QGVAR(ammo_Missile_AA_R73);
+    };
 
     class Rocket_04_HE_F: MissileBase {
         GVAR(caliber) = 70;
@@ -33,11 +57,25 @@ class CfgAmmo {
         GVAR(caliber) = 70;
         GVAR(dummy) = QGVAR(M_PG_AT);
     };
+    class M_Scalpel_AT: MissileBase {
+        GVAR(dummy) = QGVAR(M_Scalpel_AT);
+    };
     class Missile_AGM_02_F: MissileBase {
         GVAR(dummy) = QGVAR(Missile_AGM_02_F);
     };
     class Missile_AGM_01_F: Missile_AGM_02_F {
         GVAR(dummy) = QGVAR(Missile_AGM_01_F);
+    };
+    class ammo_Missile_AntiRadiationBase;
+    class ammo_Missile_HARM: ammo_Missile_AntiRadiationBase {
+        GVAR(dummy) = QGVAR(ammo_Missile_HARM);
+    };
+    class ammo_Missile_KH58: ammo_Missile_AntiRadiationBase {
+        GVAR(dummy) = QGVAR(ammo_Missile_KH58);
+    };
+    class ammo_Bomb_SmallDiameterBase;
+    class ammo_Bomb_SDB: ammo_Bomb_SmallDiameterBase {
+        GVAR(dummy) = QGVAR(ammo_Bomb_SDB);
     };
 
     class RocketCore;
@@ -180,6 +218,12 @@ class CfgAmmo {
 
     class Bo_Mk82: BombCore {
         GVAR(dummy) = QGVAR(Bo_Mk82);
+    };
+    class BombDemine_01_Ammo_F: BombCore {
+        GVAR(dummy) = QGVAR(BombDemine_01_Ammo_F);
+    };
+    class BombDemine_01_DummyAmmo_F: BombDemine_01_Ammo_F {
+        GVAR(dummy) = QGVAR(BombDemine_01_DummyAmmo_F);
     };
 
     class Bo_GBU12_LGB: ammo_Bomb_LaserGuidedBase {

--- a/addons/rearm/CfgVehicles.hpp
+++ b/addons/rearm/CfgVehicles.hpp
@@ -178,6 +178,12 @@ class CfgVehicles {
     class GVAR(Bo_Mk82): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Bomb_02_F";
     };
+    class GVAR(BombDemine_01_Ammo_F): GVAR(defaultCarriedObject) {
+        model = "\a3\Weapons_F_Orange\Ammo\BombDemine_01_F";
+    };
+    class GVAR(BombDemine_01_DummyAmmo_F): GVAR(defaultCarriedObject) {
+        model = "\a3\Weapons_F_Orange\Ammo\BombDemine_01_Dummy_F";
+    };
     class GVAR(Bomb_04_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Bomb_04_F.p3d";
     };
@@ -190,11 +196,44 @@ class CfgVehicles {
     class GVAR(Missile_AA_03_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Missile_AA_03_F.p3d";
     };
+    class GVAR(M_Air_AA): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_EPC\Ammo\M_Air_AA.p3d";
+    };
+    class GVAR(M_Zephyr): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F\Ammo\Missile_AA_02_F.p3d";
+    };
+    class GVAR(ammo_Missile_AMRAAM_C): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Jets\Ammo\Missile_AA_10_F";
+    };
+    class GVAR(ammo_Missile_AMRAAM_D): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Jets\Ammo\Missile_AA_06_F";
+    };
+    class GVAR(ammo_Missile_AA_R77): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Jets\Ammo\Missile_AA_05_F";
+    };
+    class GVAR(ammo_Missile_BIM9X): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Jets\Ammo\Missile_AA_08_F";
+    };
+    class GVAR(ammo_Missile_AA_R73): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Jets\Ammo\Missile_AA_07_F";
+    };
+    class GVAR(M_Scalpel_AT): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F\Ammo\Missile_AT_03_F";
+    };
     class GVAR(Missile_AGM_02_F): GVAR(defaultCarriedObject) {
-        model = "\A3\Weapons_F_EPC\Ammo\Missile_AGM_02_F.p3d";
+        model = "\A3\Weapons_F\Ammo\Missile_AT_02_F";
     };
     class GVAR(Missile_AGM_01_F): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F_EPC\Ammo\Missile_AGM_01_F.p3d";
+    };
+    class GVAR(ammo_Missile_HARM): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Sams\Ammo\Missile_AR_01_F.p3d";
+    };
+    class GVAR(ammo_Missile_KH58): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Sams\Ammo\Missile_AR_02_F.p3d";
+    };
+    class GVAR(ammo_Bomb_SDB): GVAR(defaultCarriedObject) {
+        model = "\A3\Weapons_F_Sams\Ammo\Bomb_05_F.p3d";
     };
     class GVAR(R_230mm_fly): GVAR(defaultCarriedObject) {
         model = "\A3\Weapons_F\Ammo\Missile_AT_02_F";

--- a/addons/rearm/functions/fnc_pickUpAmmo.sqf
+++ b/addons/rearm/functions/fnc_pickUpAmmo.sqf
@@ -45,5 +45,5 @@ if (GVAR(usePylonPosition) && {GVAR(level) > 0} && {typeOf _attachedDummy isNotE
             _dummy == _unit getVariable [QGVAR(dummy), objNull]
         }
     ] call EFUNC(interact_menu,createAction);
-    [_dummy , 0, [], _action] call ace_interact_menu_fnc_addActionToObject;
+    [_dummy , 0, [], _action] call EFUNC(interact_menu,addActionToObject);
 };

--- a/addons/rearm/functions/fnc_pickUpAmmo.sqf
+++ b/addons/rearm/functions/fnc_pickUpAmmo.sqf
@@ -44,6 +44,6 @@ if (GVAR(usePylonPosition) && {GVAR(level) > 0} && {typeOf _attachedDummy isNotE
             params ["_dummy", "_unit"];
             _dummy == _unit getVariable [QGVAR(dummy), objNull]
         }
-    ] call ace_interact_menu_fnc_createAction;
+    ] call EFUNC(interact_menu,createAction);
     [_dummy , 0, [], _action] call ace_interact_menu_fnc_addActionToObject;
 };

--- a/addons/rearm/functions/fnc_pickUpAmmo.sqf
+++ b/addons/rearm/functions/fnc_pickUpAmmo.sqf
@@ -28,3 +28,22 @@ private _nearUnits = _unit nearObjects ["CAManBase", 100];
 [QGVAR(makeDummyEH), [_dummy, [[-1,0,0],[0,0,1]]], _nearUnits] call CBA_fnc_targetEvent;
 
 _unit setVariable [QGVAR(dummy), _dummy];
+
+if (GVAR(usePylonPosition) && {GVAR(level) > 0} && {typeOf _attachedDummy isNotEqualTo QGVAR(defaultCarriedObject)}) then {
+    private _action = [
+        QGVAR(flipAmmo),
+        localize "STR_3DEN_Display3DEN_ControlsHint_Rotate",
+        "a3\ui_f_curator\Data\CfgWrapperUI\Cursors\curatorRotate_ca.paa",
+        {
+            params ["_dummy", "_unit"];
+            _dummy setVectorDirAndUp [
+                (_unit vectorWorldToModelVisual vectorDir _dummy) vectorMultiply -1,
+                [0,0,1]
+            ];
+        }, {
+            params ["_dummy", "_unit"];
+            _dummy == _unit getVariable [QGVAR(dummy), objNull]
+        }
+    ] call ace_interact_menu_fnc_createAction;
+    [_dummy , 0, [], _action] call ace_interact_menu_fnc_addActionToObject;
+};

--- a/addons/rearm/functions/fnc_rearm.sqf
+++ b/addons/rearm/functions/fnc_rearm.sqf
@@ -34,7 +34,60 @@ private _needRearmMagsOfClass = _needRearmMags select {(_x select 0) isEqualTo _
 if (_needRearmMagsOfClass isEqualTo []) exitWith {ERROR_2("Could not find turret for %1 in %2",_magazineClass,typeOf _target);};
 
 private _currentRearmableMag = _needRearmMagsOfClass select 0;
-_currentRearmableMag params ["", "_turretPath", "", "_pylon", "", "_magazineCount"];
+_currentRearmableMag params ["", "_turretPath", "_isPylon", "_pylon", "", "_magazineCount"];
+
+// If mag is pylon, pylon position enabled, level is not Entire Vehicle, munition model is not default box
+private _isMisaligned = false;
+if (_isPylon && {GVAR(usePylonPosition)} && {GVAR(level) > 0} && {typeOf _attachedDummy isNotEqualTo QGVAR(defaultCarriedObject)}) then {
+    _isMisaligned = true;
+    private _pylonDistance = GVAR(distance);
+    private _pylonPos = [0, 0, 0];
+    private _pylonDir = [0, 0, 0];
+
+    // Check if there are multiple rearmable pylons of the same magazine class, and if so, find the closest one to the munition
+    private _multipleRearmablePylons = _needRearmMagsOfClass param [1, []] param [2, false];
+    {
+        private _xNeedRearmMagsOfClass = _x;
+        private _xMagIndex = _forEachIndex;
+        _x params ["", "", "_xMagIsPylon", "_xMagPylonIndex"];
+        if !_xMagIsPylon then {continue;};
+
+        {
+            _x params ["_xPylonIndex", "", "", "", "", "", "_xPylonPosInfo", "_xPylonObj"];
+            if (_xPylonIndex != _xMagPylonIndex) then {continue;};
+            _xPylonPosInfo params ["_xPylonPos", "_xPylonDir"];
+            private _xPylonPosATL = _target modelToWorldVisual _xPylonPos;
+
+            private _xDistance = _xPylonPosATL distance _attachedDummy;
+            if (_xDistance < _pylonDistance) then {
+                _pylonDistance = _xDistance;
+                _currentRearmableMag = _needRearmMagsOfClass select _xMagIndex;
+                _pylonPos = _xPylonPosATL;
+                _pylonDir = _target vectorModelToWorldVisual _xPylonDir;
+            };
+        } forEach getAllPylonsInfo _target;
+    } forEach ([[_currentRearmableMag], _needRearmMagsOfClass] select _multipleRearmablePylons);
+
+    // Exit if munition is too far from pylon
+    #define MUNITION_DISTANCE 2
+    if (_pylonDistance > MUNITION_DISTANCE) exitWith {
+        [[LSTRING(Hint_MunitionDistance), _pylonDistance toFixed 1]] call EFUNC(common,displayTextStructured);
+    };
+
+    // Exit if munition is not aligned with pylon
+    #define MUNITION_ANGLE 5
+    private _pylonAngle = abs (180 - acos (_pylonDir vectorDotProduct (vectorNormalized vectorDir _attachedDummy)));
+    if (_pylonAngle > MUNITION_ANGLE) exitWith {
+        //hint format ["Munition not aligned with pylon. Angle: %1",_pylonAngle];
+        [[LSTRING(Hint_MunitionAngle), round _pylonAngle]] call EFUNC(common,displayTextStructured);
+    };
+
+    _isMisaligned = false;
+    hint ""; //
+};
+if (_isMisaligned) exitWith {};
+
+_currentRearmableMag params ["", "_turretPath", "_isPylon", "_pylon", "", "_magazineCount"];
 
 private _magazineDisplayName = _magazineClass call FUNC(getMagazineName);
 

--- a/addons/rearm/initSettings.inc.sqf
+++ b/addons/rearm/initSettings.inc.sqf
@@ -33,3 +33,13 @@ private _category = [ELSTRING(main,Category_Logistics), LLSTRING(DisplayName)];
     [10, 50, 20, 0],
     true // isGlobal
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(usePylonPosition), "CHECKBOX",
+    [LSTRING(RearmSettings_usePylonPosition_DisplayName), LSTRING(RearmSettings_usePylonPosition_Description)],
+    _category,
+    false,
+    true,
+    {[QGVAR(usePylonPosition), _this] call EFUNC(common,cbaSettings_settingChanged)},
+    false // Needs mission restart
+] call CBA_fnc_addSetting;

--- a/addons/rearm/stringtable.xml
+++ b/addons/rearm/stringtable.xml
@@ -65,6 +65,12 @@
             <Chinesesimp>已经没有剩余的弹药了。</Chinesesimp>
             <Ukrainian>Запас боєкомплекту порожній</Ukrainian>
         </Key>
+        <Key ID="STR_ACE_Rearm_Hint_MunitionDistance">
+            <English>Munition is too far from pylon. Distance: %1 m</English>
+        </Key>
+        <Key ID="STR_ACE_Rearm_Hint_MunitionAngle">
+            <English>Munition is not aligned with pylon. Angle: %1</English>
+        </Key>
         <Key ID="STR_ACE_Rearm_Hint_RearmedTriple">
             <English>Rearmed %1 rounds of %2 on %3</English>
             <Czech>Přezbrojeno % nábojů z %2 u %3</Czech>
@@ -640,6 +646,12 @@
             <Chinese>無限彈藥</Chinese>
             <Chinesesimp>无限弹药</Chinesesimp>
             <Ukrainian>Необмежений боєзапас</Ukrainian>
+        </Key>
+        <Key ID="STR_ACE_Rearm_RearmSettings_usePylonPosition_Description">
+            <English>When rearming a pylon, the munition must be held aligned at the pylon. Only applies if Rearm Amount is not Entire Vehicle.</English>
+        </Key>
+        <Key ID="STR_ACE_Rearm_RearmSettings_usePylonPosition_DisplayName">
+            <English>Use Pylon Position</English>
         </Key>
         <Key ID="STR_ACE_Rearm_RearmSettings_vehicle">
             <English>Entire Vehicle</English>

--- a/docs/wiki/feature/rearm.md
+++ b/docs/wiki/feature/rearm.md
@@ -64,6 +64,14 @@ To fully rearm 2000 rounds of 7.62mm machine gun, you need five ammo boxes.
 - Can check what magazines are loaded on supply vehicle
 
 
+## 2.3 Use Pylon Position (`ace_rearm_usePylonPosition`)
+Rearming a pylon magazine requires the player to position ammo object (missile or bomb) nearby and aligned with the correct pylon on the vehicle. This requirement takes effect if all of these conditions are met:
+- This setting Use Pylon Position is enabled
+- The setting Rearm Amount set to `Entire Magazine` or `Amount based on caliber`, not `Entire vehicle`
+- The magazine being rearmed is a pylon magazine
+- The ammobox is a munition model, not the default ammobox
+
+
 ## 3. FAQ
 
 ### Can I drop the ammo box?


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a check to see if the pylon ammo being held by the player is in the correct position and alignment near the pylon
- Adds checkbox setting to enable the check, default off
<img width="1259" height="739" alt="image" src="https://github.com/user-attachments/assets/35910da8-db74-4ce2-8840-cdd9e346a604" />

- Check will only activate if all conditions are met:
    - the current ammo is a pylon magazine and has a dummy model specified, not the default box
    - the setting is enabled
    - the Rearm Amount is not "Entire Vehicle", but one of "Entire Magazine" or "Based on Caliber"
- Shows ace-style hints if ammo is too far or misaligned. Should the limits be configurable in settings?
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d2a9f2ef-3297-45bb-96b7-932eae32dccb" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/7b8f3252-307e-4a19-a3b9-fcfff4bf4e75" />
- Adds interaction to flip the ammo object being held for easy of aligning
<img width="1881" height="828" alt="image" src="https://github.com/user-attachments/assets/4c2c4a02-098e-41d2-88f7-cbea58ef9626" />

- Adds dummy ammo objects for more base game pylon ammo types
https://www.youtube.com/watch?v=NrDE7nJSxCY