### PR TITLE
Explosives - Taking bounding box into consideration when attaching

### DIFF
--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -209,7 +209,6 @@ GVAR(TweakedAngle) = 0;
             _virtualPosASL = if (_intersect isNotEqualTo []) then {
                _intersect params ["_posASL", "_normal"];
 
-
                 private _bbox = boundingBoxReal [_expSetupVehicle, "FireGeometry"];
                 private _offset = -((_bbox select 0) select 2);
                 _posASL vectorAdd (_normal vectorMultiply _offset);

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -201,7 +201,7 @@ GVAR(TweakedAngle) = 0;
             private _placeAngle = 0;
             private _expSetupVehicle = _setupObjectClass createVehicle [0, 0, 0]; //(_virtualPosASL call EFUNC(common,ASLToPosition));
             // Running it AGAIN in here because it needs the _expSetupVehicle Object for the boundingBox
-            _intersect = lineIntersectsSurfaces [
+            private _intersect = lineIntersectsSurfaces [
                 eyePos _unit,
                 _basePosASL vectorAdd (_lookDirVector vectorMultiply PLACE_RANGE_MAX),
                 _unit, _expSetupVehicle, true, 1, "FIRE", "GEOM"

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -209,9 +209,6 @@ GVAR(TweakedAngle) = 0;
             _virtualPosASL = if (_intersect isNotEqualTo []) then {
                _intersect params ["_posASL", "_normal"];
 
-                if (_normal isEqualTo [0,0,0]) then {
-                    _normal = surfaceNormal _posASL;
-                };
 
                 private _bbox = boundingBoxReal [_expSetupVehicle, "FireGeometry"];
                 private _offset = -((_bbox select 0) select 2);

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -213,7 +213,7 @@ GVAR(TweakedAngle) = 0;
                     _normal = surfaceNormal _posASL;
                 };
 
-                _bbox = boundingBoxReal [_expSetupVehicle, "FireGeometry"];
+                private _bbox = boundingBoxReal [_expSetupVehicle, "FireGeometry"];
                 _offset = -((_bbox select 0) select 2);
                 _posASL vectorAdd (_normal vectorMultiply _offset);
             } else {

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -207,8 +207,7 @@ GVAR(TweakedAngle) = 0;
                 _unit, _expSetupVehicle, true, 1, "FIRE", "GEOM"
             ] param [0, []];
             _virtualPosASL = if (_intersect isNotEqualTo []) then {
-                _posASL = _intersect select 0;
-                _normal = _intersect select 1;
+               _intersect params ["_posASL", "_normal"];
 
                 if (_normal isEqualTo [0,0,0]) then {
                     _normal = surfaceNormal _posASL;

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -200,6 +200,31 @@ GVAR(TweakedAngle) = 0;
         if (GVAR(placeAction) == PLACE_APPROVE) then {
             private _placeAngle = 0;
             private _expSetupVehicle = _setupObjectClass createVehicle [0, 0, 0]; //(_virtualPosASL call EFUNC(common,ASLToPosition));
+            //Running it AGAIN in here because it needs the _expSetupVehicle Object for the boundingBox
+            _intersect = lineIntersectsSurfaces [
+            eyePos _unit,
+            _basePosASL vectorAdd (_lookDirVector vectorMultiply PLACE_RANGE_MAX),
+            _unit,
+            _expSetupVehicle,
+            true,
+            1,
+            "FIRE",
+            "GEOM"
+            ] param [0, []];
+            _virtualPosASL = if (_intersect isNotEqualTo []) then {
+                _posASL = _intersect select 0;
+                _normal = _intersect select 1;
+
+                if (_normal isEqualTo [0,0,0]) then {
+                    _normal = surfaceNormal _posASL;
+                };
+
+                _bbox = boundingBoxReal [_expSetupVehicle, "FireGeometry"];
+                _offset = -((_bbox select 0) select 2);
+                _posASL vectorAdd (_normal vectorMultiply _offset);
+            } else {
+                _basePosASL vectorAdd (_lookDirVector vectorMultiply _distanceFromBase);
+            };
 
             TRACE_1("Planting Mass",getMass _expSetupVehicle);
 

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -214,7 +214,7 @@ GVAR(TweakedAngle) = 0;
                 };
 
                 private _bbox = boundingBoxReal [_expSetupVehicle, "FireGeometry"];
-                _offset = -((_bbox select 0) select 2);
+                private _offset = -((_bbox select 0) select 2);
                 _posASL vectorAdd (_normal vectorMultiply _offset);
             } else {
                 _basePosASL vectorAdd (_lookDirVector vectorMultiply _distanceFromBase);

--- a/addons/explosives/functions/fnc_setupExplosive.sqf
+++ b/addons/explosives/functions/fnc_setupExplosive.sqf
@@ -200,16 +200,11 @@ GVAR(TweakedAngle) = 0;
         if (GVAR(placeAction) == PLACE_APPROVE) then {
             private _placeAngle = 0;
             private _expSetupVehicle = _setupObjectClass createVehicle [0, 0, 0]; //(_virtualPosASL call EFUNC(common,ASLToPosition));
-            //Running it AGAIN in here because it needs the _expSetupVehicle Object for the boundingBox
+            // Running it AGAIN in here because it needs the _expSetupVehicle Object for the boundingBox
             _intersect = lineIntersectsSurfaces [
-            eyePos _unit,
-            _basePosASL vectorAdd (_lookDirVector vectorMultiply PLACE_RANGE_MAX),
-            _unit,
-            _expSetupVehicle,
-            true,
-            1,
-            "FIRE",
-            "GEOM"
+                eyePos _unit,
+                _basePosASL vectorAdd (_lookDirVector vectorMultiply PLACE_RANGE_MAX),
+                _unit, _expSetupVehicle, true, 1, "FIRE", "GEOM"
             ] param [0, []];
             _virtualPosASL = if (_intersect isNotEqualTo []) then {
                 _posASL = _intersect select 0;


### PR DESCRIPTION
Previously objects would clip into the object it was being place in:
<img width="639" height="530" alt="image" src="https://github.com/user-attachments/assets/647a50be-954c-48b9-9db9-fe13b0bb47e5" />

Now using their bounding box i move them so they stay right on the limit as if they were properly attached:
<img width="919" height="736" alt="image" src="https://github.com/user-attachments/assets/c42e63a2-562f-4901-b0fb-d7b4d3da60c4" />

Seems to work with most modded explosives (i didn't find one it didn't work with).

The "problem" with the fix is having to re-calculate the `_basePosASL ` when you can place it, because i need the Object from _expSetupVehicle to get the bounding box, feel free to give me directions on how to improve it.

also double check if i did this correctly because my fork path is ACE3>>MyUnitFork>>MyFork, so i had to create a branch, do a hard reset to upstream(ACE3) and then commit and publish, want to make sure it's all good.