### PR TITLE
Minedetector - Improvement: Increase Radius of ACE_VMM3 

### DIFF
--- a/addons/minedetector/ACE_detector.hpp
+++ b/addons/minedetector/ACE_detector.hpp
@@ -2,7 +2,7 @@ class ACE_detector {
     class detectors {
         class ACE_VMM3 {
             detectorPosition[] = {1.3, -0.22, 0.4};
-            radius = 2.5;
+            radius = 3.5;
             sounds[] = {"ace_detector_1", "ace_detector_2", "ace_detector_3", "ace_detector_4"};
             soundDistances[] = {0, 0.5, 1.25, 2};
             soundIntervals[] = {0.5, 0.7, 0.85, 1};
@@ -10,6 +10,7 @@ class ACE_detector {
         };
         class ACE_VMH3: ACE_VMM3 {
             detectorPosition[] = {1, -0.32, 0.3};
+            radius = 2.5;
         };
     };
 };


### PR DESCRIPTION
## When merged this pull request will:
Boosts the radius of the ACE_VMM3 (the slightly heavier one) mine detector from 2.5 m to 3.5 m.


## Motivation:
In some missions combined with some Mods, like IEDD Notebook, IEDs and other explosives can be hard to spot.

Ace comes with 2 Minedetectors, the `ACE_VMM3` and the `ACE_VMH3`.
In gameplay-terms the only differnce between those two is that the `ACE_VMM3` is abit heavier, otherwise they're nearly identical (detectorPos slighly offset and different model).

Besides these with their rather short radius of 2.5 meters and the Vanilla Minedetector with its 15 meters + Radar screen, there is no inbetween.

Increasing the radius of one of the two mine detectors will provide mission makers with more options to find the balance for their mission.


Regarding the argument that this will make one detector superior over the other, i would like to point out the remote detonators from ACE_Explosives.

Comparing the M57 Firing Device `ACE_Clacker` with a range of 250 meters against the the M152 Firing Device `ACE_M26_Clacker` with a range of 5.000 meters, its easy to tell which one is the "clearly superior" version, yet they are both part of ace and provide the mission maker with options to adjust the players experience.