### PR TITLE
Dragging - Fix units being stuck in carry animation and change default dropped stance

### DIFF
--- a/addons/dragging/functions/fnc_dropObject.sqf
+++ b/addons/dragging/functions/fnc_dropObject.sqf
@@ -50,11 +50,12 @@ if (_unit call EFUNC(common,isAwake)) then {
 // Release object
 detach _target;
 
+// Put unit into correct animation
 if (_target isKindOf "CAManBase") then {
-    if (_target getVariable ["ACE_isUnconscious", false]) then {
-        [_target, "unconscious", 2] call EFUNC(common,doAnimation);
+    if (_target call EFUNC(common,isAwake)) then {
+        [_target, "amovppnemstpsnonwnondnon", 2] call EFUNC(common,doAnimation);
     } else {
-        [_target, "", 2] call EFUNC(common,doAnimation);  //@todo "AinjPpneMrunSnonWnonDb_release" seems to fall back to unconsciousness anim.
+        [_target, "unconscious", 2] call EFUNC(common,doAnimation);
     };
 };
 

--- a/addons/dragging/functions/fnc_dropObject_carry.sqf
+++ b/addons/dragging/functions/fnc_dropObject_carry.sqf
@@ -48,16 +48,21 @@ if (_tryLoad && {!(_target isKindOf "CAManBase")} && {["ace_cargo"] call EFUNC(c
     detach _target;
 };
 
-// Fix anim when aborting carrying persons
-if (_target isKindOf "CAManBase" || {animationState _unit in CARRY_ANIMATIONS}) then {
-    if (isNull objectParent _unit && {_unit call EFUNC(common,isAwake)}) then {
-        [_unit, "", 2] call EFUNC(common,doAnimation);
-    };
-
-    if (_target getVariable ["ACE_isUnconscious", false]) then {
-        [_target, "unconscious", 2] call EFUNC(common,doAnimation);
+// Put unit into correct animation
+if (_target isKindOf "CAManBase") then {
+    if (_target call EFUNC(common,isAwake)) then {
+        [_target, "amovppnemstpsnonwnondnon", 2] call EFUNC(common,doAnimation);
     } else {
-        [_target, "", 2] call EFUNC(common,doAnimation);  //@todo
+        [_target, "unconscious", 2] call EFUNC(common,doAnimation);
+    };
+};
+
+// Fix anim when aborting carrying persons
+if (isNull objectParent _unit && {_unit call EFUNC(common,isAwake)}) then {
+    private _animationState = animationState _unit;
+
+    if (_animationState regexMatch "^acinpercmrunsnonwnond.*" || {_animationState in CARRY_ANIMATIONS}) then {
+        [_unit, "", 2] call EFUNC(common,doAnimation);
     };
 };
 

--- a/addons/dragging/functions/fnc_handleUnconscious.sqf
+++ b/addons/dragging/functions/fnc_handleUnconscious.sqf
@@ -41,7 +41,7 @@ if (_player getVariable [QGVAR(isCarrying), false]) then {
         [_unit, _carriedObject] call FUNC(dropObject_carry);
     };
 
-    // Handle waking up dragged unit
+    // Handle waking up carried unit
     if (_unit == _carriedObject) then {
         [_player, _carriedObject] call FUNC(dropObject_carry);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- If deleted units would be dropped, unit would remain stuck in carry animation - fixes #11315.
- When a unit is dropped (from carry or dragging), it will no longer default to a standing position, but instead go prone.
- Correct language.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
