### PR TITLE
Medical Damage - Readd interrupting of wound handling

### DIFF
--- a/addons/medical_damage/functions/fnc_woundReceived.sqf
+++ b/addons/medical_damage/functions/fnc_woundReceived.sqf
@@ -37,7 +37,8 @@ private _lastHandlerName = _woundHandlers select -1 select 0; // will usually be
     TRACE_2("Wound handler returned",_damageData,_handlerName);
 
     // Done
-    if (_handlerName == _lastHandlerName) then {
+    if (_handlerName == _lastHandlerName || {_damageData isEqualTo []}) then {
+        TRACE_2("Wound handling done",_damageData,_handlerName);
         break;
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Was accidentally removed in #10573. https://ace3.acemod.org/wiki/framework/medical-framework#44-wound-handler-function says this is supported, so either the docs need to be corrected or we add it back. Imo adding it back is easy enough and therefore a better solution.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
