### PR TITLE
Spike - Fix not checking numeric value of attribute

### DIFF
--- a/addons/spike/functions/fnc_keyDown.sqf
+++ b/addons/spike/functions/fnc_keyDown.sqf
@@ -19,8 +19,9 @@
 private _currentWeapon = currentWeapon ACE_player;
 if !(GVAR(launcherWeapons) getOrDefaultCall [_currentWeapon, {
     private _weaponConfig = configFile >> "CfgWeapons" >> _currentWeapon;
+    private _weaponConfigEnabled = _weaponConfig >> QGVAR(enabled);
 
-    _weaponConfig == inheritsFrom (_weaponConfig >> QGVAR(enabled))
+    (_weaponConfig == inheritsFrom _weaponConfigEnabled) && {getNumber _weaponConfigEnabled == 1}
 }, true]) exitWith {};
 
 params ["_key", "_down"];


### PR DESCRIPTION
**When merged this pull request will:**
- Theoretical bug was introduced in #11265 - theoretical because it's only weapons that set `GVAR(enabled) = 0` that would be bugged, which ACE doesn't do - but other mods might.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
